### PR TITLE
feat: shard portable tests and add bounded local parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,83 @@ jobs:
       # re-spell the shellcheck command here; keep CI and the pre-push gate on it.
       - run: bin/fm-lint.sh
 
-  tests:
-    name: Behavior tests
+  # Deterministic proof that portable parallel shards + portable serial + Herdr
+  # equal the complete tests/*.test.sh inventory with no missing or duplicates.
+  test-coverage:
+    name: Test coverage guard
     runs-on: ubuntu-latest
-    # Measured portable suite wall-clock is ~13-15+ minutes without Herdr.
-    # This cap is a hang tripwire for a stuck watcher or tmux test, not the
-    # expected end of a healthy suite (and not a substitute for green results).
-    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+      - name: Prove complete regression partition
+        run: bin/fm-test-run.sh --check-coverage
+
+  # Two duration-balanced portable parallel shards of the Phase 2 proven-isolated
+  # set only. Composition owner: bin/fm-test-run.sh (docs/fm-test-portable-shards.md).
+  tests-portable-parallel-1:
+    name: Behavior portable parallel 1
+    runs-on: ubuntu-latest
+    # Measured shard wall is ~1 min of serial sum on proven scripts; this cap is
+    # a hang tripwire with margin, not the expected healthy end of the lane.
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install pinned ShellCheck
+        run: |
+          set -eu
+          bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Run portable parallel shard 1
+        run: |
+          set -eu
+          mkdir -p "$RUNNER_TEMP/fm-test"
+          bin/fm-test-run.sh --lane portable-parallel-1 \
+            --json "$RUNNER_TEMP/fm-test/fm-test-timing-portable-parallel-1.json"
+      - name: Upload shard 1 timing artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fm-test-timing-portable-parallel-1
+          path: ${{ runner.temp }}/fm-test/fm-test-timing-portable-parallel-1.json
+          if-no-files-found: warn
+
+  tests-portable-parallel-2:
+    name: Behavior portable parallel 2
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install pinned ShellCheck
+        run: |
+          set -eu
+          bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Run portable parallel shard 2
+        run: |
+          set -eu
+          mkdir -p "$RUNNER_TEMP/fm-test"
+          bin/fm-test-run.sh --lane portable-parallel-2 \
+            --json "$RUNNER_TEMP/fm-test/fm-test-timing-portable-parallel-2.json"
+      - name: Upload shard 2 timing artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fm-test-timing-portable-parallel-2
+          path: ${{ runner.temp }}/fm-test/fm-test-timing-portable-parallel-2.json
+          if-no-files-found: warn
+
+  # Required portable serial remainder: watcher, lock, AFK, tmux, daemon,
+  # ambiguous, and other stateful tests. Real Herdr stays in tests-herdr.
+  tests-portable-serial:
+    name: Behavior portable serial
+    runs-on: ubuntu-latest
+    # Measured serial remainder is ~13 min wall without Herdr. Cap is a hang
+    # tripwire above observed p99 script cost and suite wall, not the expected
+    # healthy end (interim 25m full-suite slack reduced after sharding).
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
         with:
@@ -53,23 +123,18 @@ jobs:
           set -eu
           npm install -g tasks-axi
           tasks-axi --version
-      # Single owner of serial suite selection, timing markers, and aggregate
-      # failure. Do not re-spell a for-loop over tests/*.test.sh here.
-      # Real Herdr coverage lives in the dedicated required herdr job below;
-      # exclude that family here so portable green is never claimed as Herdr.
-      - name: Run portable behavior suite
+      - name: Run portable serial remainder
         run: |
           set -eu
           mkdir -p "$RUNNER_TEMP/fm-test"
-          bin/fm-test-run.sh --all \
-            --exclude-family real-herdr-gated \
-            --json "$RUNNER_TEMP/fm-test/fm-test-timing.json"
-      - name: Upload behavior timing artifact
+          bin/fm-test-run.sh --lane portable-serial \
+            --json "$RUNNER_TEMP/fm-test/fm-test-timing-portable-serial.json"
+      - name: Upload portable serial timing artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: fm-test-timing
-          path: ${{ runner.temp }}/fm-test/fm-test-timing.json
+          name: fm-test-timing-portable-serial
+          path: ${{ runner.temp }}/fm-test/fm-test-timing-portable-serial.json
           if-no-files-found: warn
 
   # Required real-Herdr lane: pinned install, serial real-herdr-gated family,
@@ -188,6 +253,45 @@ jobs:
             ${{ runner.temp }}/fm-test/fm-test-timing-herdr.json
             ${{ runner.temp }}/fm-herdr/sessions-before.json
             ${{ runner.temp }}/fm-herdr/default-server.log
+          if-no-files-found: warn
+
+  # Aggregate per-lane timing into one summary artifact for critical-path review.
+  tests-timing-aggregate:
+    name: Behavior timing aggregate
+    runs-on: ubuntu-latest
+    needs:
+      - tests-portable-parallel-1
+      - tests-portable-parallel-2
+      - tests-portable-serial
+      - tests-herdr
+    if: always()
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download lane timing artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: fm-test-timing-*
+          path: ${{ runner.temp }}/fm-test-aggregate
+          merge-multiple: true
+      - name: Build aggregate timing summary
+        run: |
+          set -eu
+          mkdir -p "$RUNNER_TEMP/fm-test"
+          shopt -s nullglob
+          inputs=("$RUNNER_TEMP"/fm-test-aggregate/fm-test-timing-*.json)
+          if [ "${#inputs[@]}" -eq 0 ]; then
+            echo "::warning::no per-lane timing JSON found to aggregate"
+            exit 0
+          fi
+          bin/fm-test-run.sh --aggregate-json \
+            "$RUNNER_TEMP/fm-test/fm-test-timing-aggregate.json" \
+            "${inputs[@]}"
+      - name: Upload aggregate timing artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fm-test-timing-aggregate
+          path: ${{ runner.temp }}/fm-test/fm-test-timing-aggregate.json
           if-no-files-found: warn
 
   macos-stock-bash:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,23 +72,27 @@ Check and test the toolbelt before pushing:
 for script in bin/*.sh bin/backends/*.sh; do bash -n "$script"; done   # syntax-check the toolbelt
 bin/fm-lint.sh   # lint the toolbelt and behavior tests; the single owner CI and the no-mistakes gate both run
 bin/fm-test-run.sh tests/<subject>.test.sh   # one script (primary local focus path, timed)
-bin/fm-test-run.sh --family pure-contract-unit   # one declared family (serial, timed)
+bin/fm-test-run.sh --family pure-contract-unit   # ordinary family-scoped local path (serial, timed)
 bin/fm-test-run.sh --changed   # conservative changed-file-informed set (never silent full suite)
-bin/fm-test-run.sh --all   # intentional complete suite (optional local full run)
-bin/fm-test-isolation-proof.sh --list   # proven parallel candidate set (Phase 2; not production sharding)
-bin/fm-test-isolation-proof.sh --jobs 4 --json /tmp/fm-isolation-proof.json   # concurrent isolation proof only
+bin/fm-test-run.sh --proven-isolated --jobs 4   # explicit local parallel of the proven set only (default is serial)
+bin/fm-test-run.sh --lane portable-serial   # portable serial remainder (watcher/AFK/tmux/stateful)
+bin/fm-test-run.sh --check-coverage   # prove portable shards + serial + Herdr equal the full inventory
+bin/fm-test-run.sh --all   # deliberate complete regression (optional local full walk; not no-mistakes Test)
+bin/fm-test-isolation-proof.sh --list   # proven parallel candidate set (Phase 2 owner)
+bin/fm-test-isolation-proof.sh --jobs 4 --json /tmp/fm-isolation-proof.json   # re-run concurrent isolation proof only
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then an actionable signal)
 ```
 
-`bin/fm-test-run.sh` is the single owner of serial behavior-suite selection, per-script timing markers, family totals, and the optional JSON timing artifact.
-Its header and `--help` own the flags, family labels, and changed-file map; this section only documents the entry points.
-`bin/fm-test-isolation-proof.sh` is the single owner of the Phase 2 concurrent isolation proof for a bounded, audited portable candidate set.
-It does not enable production CI sharding or general local `--jobs` on the serial runner; see `docs/fm-test-isolation-proof.md` for the archived candidate set, concurrency, and results.
+`bin/fm-test-run.sh` is the single owner of behavior-suite selection, portable CI lane composition, optional local `--jobs` for the proven-isolated set only, per-script timing markers, family totals, the coverage guard, and the optional JSON timing artifact.
+Its header and `--help` own the flags, family labels, lanes, and changed-file map; this section only documents the entry points.
+`bin/fm-test-isolation-proof.sh` remains the single owner of the Phase 2 concurrent isolation proof and the exact proven candidate set; see `docs/fm-test-isolation-proof.md`.
+Portable shard balance evidence lives in `docs/fm-test-portable-shards.md`.
 Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk.
-CI owns the broad portable and required real-Herdr lane composition in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
-Use `bin/fm-test-run.sh --help` for the exact family exclusion and required gate-skip flags when reproducing either lane locally.
+Family selection is the ordinary local path; `--all` is deliberate full regression only.
+CI owns broad regression across required portable parallel shards, the portable serial lane, the Herdr lane, lint, invariants, the coverage guard, and macOS snapshot compatibility in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+Use `bin/fm-test-run.sh --help` for lane names, `--jobs` rules, and required gate-skip flags when reproducing a lane locally.
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.
 The [Herdr backend guide](docs/herdr-backend.md) owns the lane's safety and isolation rationale, including why live harness credential tests remain opt-in.

--- a/bin/fm-test-isolation-proof.sh
+++ b/bin/fm-test-isolation-proof.sh
@@ -3,12 +3,12 @@
 # behavior-test candidates (Phase 2 pre-shard gate).
 #
 # This is the single owner of the proven parallel candidate set, the concurrent
-# proof run, and the isolation checks that must pass before any production CI
-# sharding or general local --jobs land (those are a later phase).
+# proof run, and the isolation checks that admitted that set. Production
+# portable CI shards and bounded local fm-test-run.sh --jobs for this exact set
+# are owned by bin/fm-test-run.sh (docs/fm-test-portable-shards.md).
 #
 # It does NOT:
-#   - change CI Behavior sharding
-#   - add --jobs to bin/fm-test-run.sh
+#   - compose production CI shard membership (fm-test-run.sh owns that partition)
 #   - run real Herdr, real default-server tmux, watcher lock races, AFK, live
 #     harnesses, or GUI backends
 #

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1277,14 +1277,11 @@ else
     work="$RUN_TMP/w$idx"
     rc=$(cat "$work/exit" 2>/dev/null || echo 1)
     duration=$(cat "$work/duration_ms" 2>/dev/null || echo 0)
-    out="$work/stdout"
+    out="$work/output"
     end_iso=$(now_iso)
     # Replay captured output after the worker finishes so markers stay ordered.
     if [ -s "$out" ]; then
       cat "$out"
-    fi
-    if [ -s "$work/stderr" ]; then
-      cat "$work/stderr" >&2 || true
     fi
     mode=$(stat -f %Lp "$work" 2>/dev/null || stat -c %a "$work" 2>/dev/null || echo unknown)
     case "$mode" in
@@ -1340,7 +1337,7 @@ else
         FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND 2>/dev/null || true
       cd "$ROOT" || exit 1
       begin_ms=$(now_ms)
-      bash "$script" >"$work/stdout" 2>"$work/stderr"
+      bash "$script" >"$work/output" 2>&1
       rc=$?
       end_ms=$(now_ms)
       duration=$((end_ms - begin_ms))

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1,20 +1,27 @@
 #!/usr/bin/env bash
-# fm-test-run.sh - single owner of Firstmate's serial behavior-test runner.
+# fm-test-run.sh - single owner of Firstmate's behavior-test runner, lane
+# composition for portable CI shards, local --jobs for the proven-isolated set,
+# timing markers, and the complete-regression coverage guard.
 #
-# Replaces duplicated `for test_script in tests/*.test.sh` loops in CONTRIBUTING
-# and the CI Behavior job. This phase is intentionally serial: no sharding and
-# no local --jobs parallelism.
-#
-# Selection modes (exactly one of: --all, --family, --changed, or script paths):
+# Selection modes (exactly one of: --all, --family, --changed, --lane,
+# --proven-isolated, or script paths):
 #   fm-test-run.sh --all
 #   fm-test-run.sh --family <name>
 #   fm-test-run.sh --changed [--base <git-ref>]
+#   fm-test-run.sh --lane portable-parallel-1|portable-parallel-2|portable-serial
+#   fm-test-run.sh --proven-isolated
 #   fm-test-run.sh tests/<name>.test.sh [more scripts...]
 #
 # Inspection (no execution):
 #   fm-test-run.sh --list --all
 #   fm-test-run.sh --list --family <name>
+#   fm-test-run.sh --list --lane portable-parallel-1
 #   fm-test-run.sh --list-families
+#   fm-test-run.sh --list-lanes
+#   fm-test-run.sh --check-coverage
+#
+# Aggregation (no suite execution):
+#   fm-test-run.sh --aggregate-json <out.json> <lane.json> [more lane.json...]
 #
 # Options:
 #   --json <path>   write a deterministic timing artifact after the run
@@ -22,13 +29,18 @@
 #   --base <ref>    with --changed, compare against this ref (default: origin/main)
 #   --exclude-family <name>
 #                   drop scripts whose primary family matches <name> after selection
-#                   (repeatable; used by the portable CI job to leave real Herdr
-#                   coverage to the dedicated required lane)
+#                   (repeatable; portable CI lanes exclude real-herdr-gated so the
+#                   dedicated required Herdr lane owns that coverage)
 #   --fail-on-gate-skip <token>
 #                   after each script, fail the run if any output line contains
 #                   "skip: <token>" (e.g. --fail-on-gate-skip 'herdr not found').
 #                   The required Herdr CI lane uses this so a missing pin cannot
 #                   silently pass as a gate skip.
+#   --jobs N        run the selected scripts with up to N concurrent workers.
+#                   Default is 1 (serial). N>1 is allowed only when every
+#                   selected script is in the Phase 2 proven-isolated set
+#                   (bin/fm-test-isolation-proof.sh --list). Cap is 8. Stateful
+#                   families never schedule under --jobs.
 #   -h, --help      print this header
 #
 # Per-script machine-parseable markers (stdout):
@@ -44,7 +56,10 @@
 # --fail-on-gate-skip token appears. Other gate skips (first meaningful line
 # matching ^skip:) remain successful and are counted as skipped_gate.
 #
-# Family labels and the changed-file map live in this script only (one owner).
+# Family labels, the changed-file map, and production portable-shard composition
+# live in this script only (one owner). The proven-isolated candidate set remains
+# owned by bin/fm-test-isolation-proof.sh; portable parallel shards are a
+# duration-balanced partition of that exact set (see docs/fm-test-portable-shards.md).
 # --changed is conservative: it over-selects related families rather than
 # under-selecting, and never expands to the complete suite unless --all.
 set -eu
@@ -55,12 +70,18 @@ cd "$ROOT" || exit 1
 MODE=
 LIST_ONLY=0
 LIST_FAMILIES=0
+LIST_LANES=0
+CHECK_COVERAGE=0
+AGGREGATE_OUT=
 FAMILY=
+LANE=
 BASE_REF=origin/main
 JSON_PATH=
 SCRIPTS=()
 EXCLUDE_FAMILIES=()
 FAIL_ON_GATE_SKIP=
+JOBS=1
+JOBS_MAX=8
 
 usage() {
   awk '
@@ -193,6 +214,307 @@ zellij
 orca
 unclassified
 EOF
+}
+
+list_known_lanes() {
+  cat <<'EOF'
+portable-parallel-1
+portable-parallel-2
+portable-serial
+real-herdr-gated
+EOF
+}
+
+# Exact Phase 2 proven-isolated candidate set (same paths as
+# bin/fm-test-isolation-proof.sh --list). Do not expand without a new concurrent
+# isolation proof archive.
+list_proven_isolated() {
+  cat <<'EOF'
+tests/fm-arm-pretool-check.test.sh
+tests/fm-backend-herdr.test.sh
+tests/fm-brief.test.sh
+tests/fm-captain-translation-contract.test.sh
+tests/fm-cd-pretool-check.test.sh
+tests/fm-composer-ghost.test.sh
+tests/fm-composer-lib.test.sh
+tests/fm-crew-state.test.sh
+tests/fm-decision-hold-lifecycle.test.sh
+tests/fm-dispatch-select.test.sh
+tests/fm-ensure-agents-md.test.sh
+tests/fm-grok-harness.test.sh
+tests/fm-herdr-lab.test.sh
+tests/fm-instruction-owners.test.sh
+tests/fm-lint.test.sh
+tests/fm-nm-test-contract.test.sh
+tests/fm-no-mistakes-ownership.test.sh
+tests/fm-pi-primary-types.test.sh
+tests/fm-pr-merge.test.sh
+tests/fm-review-diff.test.sh
+tests/fm-send-popup-settle.test.sh
+tests/fm-send-settle.test.sh
+tests/fm-send-strict.test.sh
+tests/fm-spawn-batch.test.sh
+tests/fm-stow-contract.test.sh
+tests/fm-supervision-instructions.test.sh
+tests/fm-test-run.test.sh
+tests/fm-tmux-submit-busy.test.sh
+tests/fm-transition-lib.test.sh
+tests/fm-x-mode.test.sh
+EOF
+}
+
+# Portable parallel shard 1: LPT balance of the proven-isolated set using
+# Phase 1 serial duration averages from CI timing artifacts on main after
+# #825/#832/#834 (docs/fm-test-portable-shards.md). Execution order is longest
+# first so wall-clock stays near the balanced sum.
+list_portable_parallel_1() {
+  cat <<'EOF'
+tests/fm-arm-pretool-check.test.sh
+tests/fm-cd-pretool-check.test.sh
+tests/fm-backend-herdr.test.sh
+tests/fm-pr-merge.test.sh
+tests/fm-test-run.test.sh
+tests/fm-send-popup-settle.test.sh
+tests/fm-review-diff.test.sh
+tests/fm-brief.test.sh
+tests/fm-dispatch-select.test.sh
+tests/fm-ensure-agents-md.test.sh
+tests/fm-instruction-owners.test.sh
+tests/fm-pi-primary-types.test.sh
+tests/fm-transition-lib.test.sh
+tests/fm-composer-lib.test.sh
+tests/fm-stow-contract.test.sh
+EOF
+}
+
+# Portable parallel shard 2: the complementary LPT half of the proven set.
+list_portable_parallel_2() {
+  cat <<'EOF'
+tests/fm-decision-hold-lifecycle.test.sh
+tests/fm-x-mode.test.sh
+tests/fm-herdr-lab.test.sh
+tests/fm-crew-state.test.sh
+tests/fm-grok-harness.test.sh
+tests/fm-spawn-batch.test.sh
+tests/fm-send-strict.test.sh
+tests/fm-tmux-submit-busy.test.sh
+tests/fm-composer-ghost.test.sh
+tests/fm-send-settle.test.sh
+tests/fm-supervision-instructions.test.sh
+tests/fm-lint.test.sh
+tests/fm-nm-test-contract.test.sh
+tests/fm-captain-translation-contract.test.sh
+tests/fm-no-mistakes-ownership.test.sh
+EOF
+}
+
+is_proven_isolated_script() {
+  local want=$1 line
+  while IFS= read -r line; do
+    [ "$line" = "$want" ] && return 0
+  done < <(list_proven_isolated)
+  return 1
+}
+
+select_proven_isolated() {
+  local s
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    add_script "$s"
+  done < <(list_proven_isolated)
+}
+
+select_lane() {
+  local want=$1 s base fam found=0
+  case "$want" in
+    portable-parallel-1)
+      while IFS= read -r s; do
+        [ -n "$s" ] || continue
+        add_script "$s"
+        found=1
+      done < <(list_portable_parallel_1)
+      ;;
+    portable-parallel-2)
+      while IFS= read -r s; do
+        [ -n "$s" ] || continue
+        add_script "$s"
+        found=1
+      done < <(list_portable_parallel_2)
+      ;;
+    portable-serial)
+      # Everything in the complete suite that is not proven-isolated and not
+      # real-herdr-gated. Watcher/lock/AFK/tmux/daemon/ambiguous/stateful work
+      # stays here, serial only.
+      while IFS= read -r s; do
+        [ -n "$s" ] || continue
+        base=$(basename "$s")
+        fam=$(family_for_basename "$base")
+        if [ "$fam" = "real-herdr-gated" ]; then
+          continue
+        fi
+        if is_proven_isolated_script "$s"; then
+          continue
+        fi
+        add_script "$s"
+        found=1
+      done < <(all_repo_tests)
+      ;;
+    real-herdr-gated)
+      select_family real-herdr-gated
+      found=1
+      ;;
+    *)
+      die "unknown lane '$want' (see --list-lanes)"
+      ;;
+  esac
+  [ "$found" -eq 1 ] || die "lane '$want' selected no tests"
+}
+
+run_coverage_guard() {
+  local tmp missing extra a b
+  local -a saved_scripts=()
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-coverage.XXXXXX")
+
+  all_repo_tests | LC_ALL=C sort -u >"$tmp/all"
+  list_proven_isolated | LC_ALL=C sort -u >"$tmp/proven"
+  list_portable_parallel_1 | LC_ALL=C sort -u >"$tmp/s1"
+  list_portable_parallel_2 | LC_ALL=C sort -u >"$tmp/s2"
+
+  cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort | uniq -d >"$tmp/shard_dups"
+  if [ -s "$tmp/shard_dups" ]; then
+    log "coverage guard: portable parallel shards share scripts:"
+    cat "$tmp/shard_dups" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
+  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  if [ -n "$missing" ] || [ -n "$extra" ]; then
+    log "coverage guard: portable shards must equal the proven-isolated set"
+    [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
+    [ -z "$extra" ] || { log "extra beyond proven:"; printf '%s\n' "$extra" >&2; }
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  # Serial + Herdr lane listings without disturbing a caller's selection.
+  saved_scripts=("${SCRIPTS[@]+"${SCRIPTS[@]}"}")
+  SCRIPTS=()
+  select_lane portable-serial
+  printf '%s\n' "${SCRIPTS[@]+"${SCRIPTS[@]}"}" | LC_ALL=C sort -u >"$tmp/serial"
+  SCRIPTS=()
+  select_family real-herdr-gated
+  printf '%s\n' "${SCRIPTS[@]+"${SCRIPTS[@]}"}" | LC_ALL=C sort -u >"$tmp/herdr"
+  SCRIPTS=("${saved_scripts[@]+"${saved_scripts[@]}"}")
+
+  for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
+    a=${pair%%:*}
+    b=${pair#*:}
+    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    if [ -s "$tmp/overlap" ]; then
+      log "coverage guard: overlap between $a and $b:"
+      cat "$tmp/overlap" >&2
+      rm -rf "$tmp"
+      return 1
+    fi
+  done
+
+  cat "$tmp/shards_union" "$tmp/serial" "$tmp/herdr" | LC_ALL=C sort >"$tmp/union_raw"
+  uniq -d "$tmp/union_raw" >"$tmp/union_dups"
+  if [ -s "$tmp/union_dups" ]; then
+    log "coverage guard: duplicate scripts across lanes:"
+    cat "$tmp/union_dups" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
+  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  if [ -n "$missing" ] || [ -n "$extra" ]; then
+    log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
+    [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
+    [ -z "$extra" ] || { log "extra beyond inventory:"; printf '%s\n' "$extra" >&2; }
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  if [ -x "$ROOT/bin/fm-test-isolation-proof.sh" ]; then
+    "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
+    if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
+      log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
+      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      rm -rf "$tmp"
+      return 1
+    fi
+  fi
+
+  printf 'FM_TEST_COVERAGE ok total=%s parallel=%s serial=%s herdr=%s\n' \
+    "$(wc -l <"$tmp/all" | tr -d ' ')" \
+    "$(wc -l <"$tmp/shards_union" | tr -d ' ')" \
+    "$(wc -l <"$tmp/serial" | tr -d ' ')" \
+    "$(wc -l <"$tmp/herdr" | tr -d ' ')"
+  rm -rf "$tmp"
+  return 0
+}
+
+aggregate_timing_json() {
+  local out=$1
+  shift
+  [ "$#" -gt 0 ] || die "--aggregate-json requires at least one input timing JSON"
+  command -v python3 >/dev/null 2>&1 || die "--aggregate-json requires python3"
+  python3 - "$out" "$@" <<'PY'
+import json, sys
+from pathlib import Path
+
+out = Path(sys.argv[1])
+inputs = [Path(p) for p in sys.argv[2:]]
+lanes = []
+all_scripts = []
+failed = 0
+skipped = 0
+total = 0
+wall_ms = 0
+for path in inputs:
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    summary = doc.get("summary") or {}
+    lane = {
+        "path": str(path),
+        "run_id": doc.get("run_id"),
+        "selection": doc.get("selection"),
+        "started_at": doc.get("started_at"),
+        "finished_at": doc.get("finished_at"),
+        "summary": summary,
+    }
+    lanes.append(lane)
+    total += int(summary.get("total") or 0)
+    failed += int(summary.get("failed") or 0)
+    skipped += int(summary.get("skipped_gate") or 0)
+    wall_ms = max(wall_ms, int(summary.get("duration_ms") or 0))
+    for s in doc.get("scripts") or []:
+        row = dict(s)
+        row["lane_selection"] = doc.get("selection")
+        row["lane_run_id"] = doc.get("run_id")
+        all_scripts.append(row)
+
+all_scripts.sort(key=lambda s: (-int(s.get("duration_ms") or 0), s.get("path") or ""))
+agg = {
+    "kind": "aggregate",
+    "lanes": lanes,
+    "summary": {
+        "lanes": len(lanes),
+        "total": total,
+        "failed": failed,
+        "skipped_gate": skipped,
+        "critical_path_duration_ms": wall_ms,
+    },
+    "scripts": all_scripts,
+    "slowest": all_scripts[:15],
+}
+out.parent.mkdir(parents=True, exist_ok=True)
+out.write_text(json.dumps(agg, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(f"FM_TEST_AGGREGATE lanes={len(lanes)} total={total} failed={failed} skipped_gate={skipped} critical_path_duration_ms={wall_ms}")
+PY
 }
 
 all_repo_tests() {
@@ -365,6 +687,10 @@ families_for_changed_path() {
     .github/workflows/ci.yml|.no-mistakes.yaml)
       printf '%s\n' pure-contract-unit
       printf '%s\n' real-herdr-gated
+      ;;
+    docs/fm-test-portable-shards.md|docs/fm-test-isolation-proof.md|\
+    docs/fm-test-isolation-proof.json)
+      printf '%s\n' pure-contract-unit
       ;;
     .github/*|.tasks.toml|AGENTS.md|CLAUDE.md|CONTRIBUTING.md|\
     docs/configuration.md|docs/supervision-protocols/*)
@@ -578,6 +904,24 @@ while [ "$#" -gt 0 ]; do
       FAMILY=${1#--family=}
       shift
       ;;
+    --lane)
+      [ -z "$MODE" ] || die "only one selection mode is allowed"
+      [ "$#" -gt 1 ] || die "--lane requires a name (see --list-lanes)"
+      MODE=lane
+      LANE=$2
+      shift 2
+      ;;
+    --lane=*)
+      [ -z "$MODE" ] || die "only one selection mode is allowed"
+      MODE=lane
+      LANE=${1#--lane=}
+      shift
+      ;;
+    --proven-isolated)
+      [ -z "$MODE" ] || die "only one selection mode is allowed"
+      MODE=proven-isolated
+      shift
+      ;;
     --changed)
       [ -z "$MODE" ] || die "only one selection mode is allowed"
       MODE=changed
@@ -601,6 +945,15 @@ while [ "$#" -gt 0 ]; do
       JSON_PATH=${1#--json=}
       shift
       ;;
+    --jobs)
+      [ "$#" -gt 1 ] || die "--jobs requires a positive integer"
+      JOBS=$2
+      shift 2
+      ;;
+    --jobs=*)
+      JOBS=${1#--jobs=}
+      shift
+      ;;
     --list)
       LIST_ONLY=1
       shift
@@ -608,6 +961,22 @@ while [ "$#" -gt 0 ]; do
     --list-families)
       LIST_FAMILIES=1
       shift
+      ;;
+    --list-lanes)
+      LIST_LANES=1
+      shift
+      ;;
+    --check-coverage)
+      CHECK_COVERAGE=1
+      shift
+      ;;
+    --aggregate-json)
+      [ "$#" -gt 1 ] || die "--aggregate-json requires an output path"
+      AGGREGATE_OUT=$2
+      shift 2
+      # Remaining args after options will be collected as inputs below via MODE.
+      # For aggregation we accept only input JSON paths as free args after this.
+      MODE=aggregate
       ;;
     --exclude-family)
       [ "$#" -gt 1 ] || die "--exclude-family requires a name"
@@ -642,7 +1011,9 @@ while [ "$#" -gt 0 ]; do
       die "unknown option: $1"
       ;;
     *)
-      if [ -z "$MODE" ] || [ "$MODE" = scripts ]; then
+      if [ "${MODE:-}" = "aggregate" ]; then
+        SCRIPTS+=("$1")
+      elif [ -z "$MODE" ] || [ "$MODE" = scripts ]; then
         MODE=scripts
         SCRIPTS+=("$1")
       else
@@ -658,6 +1029,32 @@ if [ "$LIST_FAMILIES" -eq 1 ]; then
   exit 0
 fi
 
+if [ "$LIST_LANES" -eq 1 ]; then
+  list_known_lanes
+  exit 0
+fi
+
+if [ "$CHECK_COVERAGE" -eq 1 ]; then
+  run_coverage_guard
+  exit $?
+fi
+
+if [ "${MODE:-}" = "aggregate" ]; then
+  [ -n "$AGGREGATE_OUT" ] || die "--aggregate-json requires an output path"
+  [ "${#SCRIPTS[@]}" -gt 0 ] || die "--aggregate-json requires at least one input timing JSON"
+  for s in "${SCRIPTS[@]}"; do
+    [ -f "$s" ] || die "aggregate input not found: $s"
+  done
+  aggregate_timing_json "$AGGREGATE_OUT" "${SCRIPTS[@]}"
+  exit 0
+fi
+
+case "$JOBS" in
+  ''|*[!0-9]*) die "--jobs must be a positive integer" ;;
+esac
+[ "$JOBS" -ge 1 ] || die "--jobs must be >= 1"
+[ "$JOBS" -le "$JOBS_MAX" ] || die "--jobs is capped at $JOBS_MAX (got $JOBS)"
+
 case "${MODE:-}" in
   all)
     select_all
@@ -666,6 +1063,14 @@ case "${MODE:-}" in
   family)
     select_family "$FAMILY"
     SELECTION_DESC="family=$FAMILY"
+    ;;
+  lane)
+    select_lane "$LANE"
+    SELECTION_DESC="lane=$LANE"
+    ;;
+  proven-isolated)
+    select_proven_isolated
+    SELECTION_DESC="proven-isolated"
     ;;
   changed)
     select_changed "$BASE_REF"
@@ -681,7 +1086,7 @@ case "${MODE:-}" in
     SELECTION_DESC="scripts"
     ;;
   *)
-    die "select with --all, --family <name>, --changed, or one or more script paths (see --help)"
+    die "select with --all, --family <name>, --lane <name>, --proven-isolated, --changed, or one or more script paths (see --help)"
     ;;
 esac
 
@@ -691,6 +1096,9 @@ if [ "${#EXCLUDE_FAMILIES[@]}" -gt 0 ]; then
 fi
 if [ -n "$FAIL_ON_GATE_SKIP" ]; then
   SELECTION_DESC="${SELECTION_DESC};fail-on-gate-skip=$FAIL_ON_GATE_SKIP"
+fi
+if [ "$JOBS" -gt 1 ]; then
+  SELECTION_DESC="${SELECTION_DESC};jobs=$JOBS"
 fi
 
 if [ "$LIST_ONLY" -eq 1 ]; then
@@ -721,6 +1129,15 @@ for s in "${SCRIPTS[@]}"; do
   [ -f "$s" ] || die "test script not found: $s"
   [ -x "$s" ] || [ -r "$s" ] || die "test script not readable: $s"
 done
+
+# --jobs N>1 only for the proven-isolated set. Stateful families stay serial.
+if [ "$JOBS" -gt 1 ]; then
+  for s in "${SCRIPTS[@]}"; do
+    if ! is_proven_isolated_script "$s"; then
+      die "--jobs $JOBS refused: $s is not in the proven-isolated set (see bin/fm-test-isolation-proof.sh --list). Stateful families stay serial."
+    fi
+  done
+fi
 
 RUN_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run.XXXXXX")
 RECORDS="$RUN_TMP/records.tsv"
@@ -767,35 +1184,13 @@ family_bump() {
   mv "$tmp" "$FAMILIES_TSV"
 }
 
-for script in "${SCRIPTS[@]}"; do
+record_script_result() {
+  local script=$1 rc=$2 duration=$3 out=$4 end_iso=$5
+  local base family expected gate_skip fail_delta
   base=$(basename "$script")
   family=$(family_for_basename "$base")
   expected=$(expected_gate_skip_for_family "$family")
-  out="$RUN_TMP/out.$TOTAL"
-  begin_iso=$(now_iso)
-  begin_ms=$(now_ms)
 
-  printf 'FM_TEST_BEGIN %s %s family=%s expected_gate_skip=%s\n' \
-    "$begin_iso" "$script" "$family" "$expected"
-
-  set +e
-  # Stream live output while retaining a copy for gate-skip detection.
-  # PIPESTATUS[0] is the test script; tee's exit is ignored for aggregate.
-  bash "$script" 2>&1 | tee "$out"
-  rc=${PIPESTATUS[0]}
-  set -e
-  : "${rc:=1}"
-
-  end_ms=$(now_ms)
-  end_iso=$(now_iso)
-  duration=$((end_ms - begin_ms))
-  if [ "$duration" -lt 0 ]; then
-    duration=0
-  fi
-
-  # Required-lane hard fail: a configured skip token anywhere in the output is
-  # a failure even when the script itself exited 0 (classic "skip: herdr not
-  # found" gate). Retries are not used as a green strategy.
   if [ -n "$FAIL_ON_GATE_SKIP" ] && detect_gate_skip_token "$out" "$FAIL_ON_GATE_SKIP"; then
     log "required gate skip token seen in $script: skip: $FAIL_ON_GATE_SKIP"
     rc=1
@@ -821,7 +1216,125 @@ for script in "${SCRIPTS[@]}"; do
     "$script" "$family" "$expected" "$rc" "$duration" "$gate_skip" >>"$RECORDS"
   family_bump "$family" "$duration" "$fail_delta"
   TOTAL=$((TOTAL + 1))
-done
+}
+
+run_one_serial() {
+  local script=$1
+  local base family expected out begin_iso begin_ms end_ms end_iso duration rc
+  base=$(basename "$script")
+  family=$(family_for_basename "$base")
+  expected=$(expected_gate_skip_for_family "$family")
+  out="$RUN_TMP/out.$TOTAL"
+  begin_iso=$(now_iso)
+  begin_ms=$(now_ms)
+
+  printf 'FM_TEST_BEGIN %s %s family=%s expected_gate_skip=%s\n' \
+    "$begin_iso" "$script" "$family" "$expected"
+
+  set +e
+  # Stream live output while retaining a copy for gate-skip detection.
+  # PIPESTATUS[0] is the test script; tee's exit is ignored for aggregate.
+  bash "$script" 2>&1 | tee "$out"
+  rc=${PIPESTATUS[0]}
+  set -e
+  : "${rc:=1}"
+
+  end_ms=$(now_ms)
+  end_iso=$(now_iso)
+  duration=$((end_ms - begin_ms))
+  if [ "$duration" -lt 0 ]; then
+    duration=0
+  fi
+  record_script_result "$script" "$rc" "$duration" "$out" "$end_iso"
+}
+
+if [ "$JOBS" -eq 1 ]; then
+  for script in "${SCRIPTS[@]}"; do
+    run_one_serial "$script"
+  done
+else
+  # Bounded concurrent execution for proven-isolated scripts only. Each worker
+  # gets a private mode-0700 TMPDIR so mktemp roots cannot collide. Retries are
+  # never used as a green strategy.
+  declare -a WORKER_PIDS=()
+  declare -a WORKER_IDX=()
+  declare -a WORKER_SCRIPTS=()
+  worker_n=0
+
+  wait_one_job_worker() {
+    local pid idx work script rc duration mode out end_iso
+    pid=${WORKER_PIDS[0]}
+    idx=${WORKER_IDX[0]}
+    script=${WORKER_SCRIPTS[0]}
+    WORKER_PIDS=("${WORKER_PIDS[@]:1}")
+    WORKER_IDX=("${WORKER_IDX[@]:1}")
+    WORKER_SCRIPTS=("${WORKER_SCRIPTS[@]:1}")
+    set +e
+    wait "$pid"
+    set -e
+    work="$RUN_TMP/w$idx"
+    rc=$(cat "$work/exit" 2>/dev/null || echo 1)
+    duration=$(cat "$work/duration_ms" 2>/dev/null || echo 0)
+    out="$work/stdout"
+    end_iso=$(now_iso)
+    # Replay captured output after the worker finishes so markers stay ordered.
+    if [ -s "$out" ]; then
+      cat "$out"
+    fi
+    if [ -s "$work/stderr" ]; then
+      cat "$work/stderr" >&2 || true
+    fi
+    mode=$(stat -f %Lp "$work" 2>/dev/null || stat -c %a "$work" 2>/dev/null || echo unknown)
+    case "$mode" in
+      700|0700) ;;
+      *)
+        log "isolation failure: worker root mode is $mode, expected 0700 ($work)"
+        rc=1
+        ;;
+    esac
+    record_script_result "$script" "$rc" "$duration" "$out" "$end_iso"
+  }
+
+  for script in "${SCRIPTS[@]}"; do
+    while [ "${#WORKER_PIDS[@]}" -ge "$JOBS" ]; do
+      wait_one_job_worker
+    done
+    worker_n=$((worker_n + 1))
+    work="$RUN_TMP/w$worker_n"
+    mkdir -p "$work/tmp"
+    chmod 0700 "$work" "$work/tmp" || die "could not chmod 0700 worker root $work"
+    base=$(basename "$script")
+    family=$(family_for_basename "$base")
+    expected=$(expected_gate_skip_for_family "$family")
+    printf 'FM_TEST_BEGIN %s %s family=%s expected_gate_skip=%s\n' \
+      "$(now_iso)" "$script" "$family" "$expected"
+    (
+      set +e
+      export TMPDIR="$work/tmp"
+      export TMP="$work/tmp"
+      unset FM_HOME FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_ROOT_OVERRIDE \
+        FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND 2>/dev/null || true
+      cd "$ROOT" || exit 1
+      begin_ms=$(now_ms)
+      bash "$script" >"$work/stdout" 2>"$work/stderr"
+      rc=$?
+      end_ms=$(now_ms)
+      duration=$((end_ms - begin_ms))
+      if [ "$duration" -lt 0 ]; then
+        duration=0
+      fi
+      printf '%s\n' "$rc" >"$work/exit"
+      printf '%s\n' "$duration" >"$work/duration_ms"
+      exit 0
+    ) &
+    WORKER_PIDS+=("$!")
+    WORKER_IDX+=("$worker_n")
+    WORKER_SCRIPTS+=("$script")
+  done
+  while [ "${#WORKER_PIDS[@]}" -gt 0 ]; do
+    wait_one_job_worker
+  done
+fi
 
 RUN_FINISHED_ISO=$(now_iso)
 RUN_FINISHED_MS=$(now_ms)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1260,15 +1260,17 @@ else
   declare -a WORKER_IDX=()
   declare -a WORKER_SCRIPTS=()
   worker_n=0
+  active_workers=0
 
   wait_one_job_worker() {
-    local pid idx work script rc duration mode out end_iso
-    pid=${WORKER_PIDS[0]}
-    idx=${WORKER_IDX[0]}
-    script=${WORKER_SCRIPTS[0]}
-    WORKER_PIDS=("${WORKER_PIDS[@]:1}")
-    WORKER_IDX=("${WORKER_IDX[@]:1}")
-    WORKER_SCRIPTS=("${WORKER_SCRIPTS[@]:1}")
+    local slot=$1 pid idx work script rc duration mode out end_iso
+    pid=${WORKER_PIDS[$slot]}
+    idx=${WORKER_IDX[$slot]}
+    script=${WORKER_SCRIPTS[$slot]}
+    unset 'WORKER_PIDS[slot]'
+    unset 'WORKER_IDX[slot]'
+    unset 'WORKER_SCRIPTS[slot]'
+    active_workers=$((active_workers - 1))
     set +e
     wait "$pid"
     set -e
@@ -1295,9 +1297,31 @@ else
     record_script_result "$script" "$rc" "$duration" "$out" "$end_iso"
   }
 
+  worker_pid_is_running() {
+    local want=$1 running
+    while IFS= read -r running; do
+      [ "$running" = "$want" ] && return 0
+    done < <(jobs -r -p)
+    return 1
+  }
+
+  wait_one_completed_job_worker() {
+    local slot work
+    while :; do
+      for slot in "${!WORKER_PIDS[@]}"; do
+        work="$RUN_TMP/w${WORKER_IDX[$slot]}"
+        if [ -f "$work/exit" ] || ! worker_pid_is_running "${WORKER_PIDS[$slot]}"; then
+          wait_one_job_worker "$slot"
+          return
+        fi
+      done
+      sleep 0.01
+    done
+  }
+
   for script in "${SCRIPTS[@]}"; do
-    while [ "${#WORKER_PIDS[@]}" -ge "$JOBS" ]; do
-      wait_one_job_worker
+    while [ "$active_workers" -ge "$JOBS" ]; do
+      wait_one_completed_job_worker
     done
     worker_n=$((worker_n + 1))
     work="$RUN_TMP/w$worker_n"
@@ -1323,16 +1347,17 @@ else
       if [ "$duration" -lt 0 ]; then
         duration=0
       fi
-      printf '%s\n' "$rc" >"$work/exit"
       printf '%s\n' "$duration" >"$work/duration_ms"
+      printf '%s\n' "$rc" >"$work/exit"
       exit 0
     ) &
-    WORKER_PIDS+=("$!")
-    WORKER_IDX+=("$worker_n")
-    WORKER_SCRIPTS+=("$script")
+    WORKER_PIDS[worker_n]=$!
+    WORKER_IDX[worker_n]=$worker_n
+    WORKER_SCRIPTS[worker_n]=$script
+    active_workers=$((active_workers + 1))
   done
-  while [ "${#WORKER_PIDS[@]}" -gt 0 ]; do
-    wait_one_job_worker
+  while [ "$active_workers" -gt 0 ]; do
+    wait_one_completed_job_worker
   done
 fi
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1283,7 +1283,7 @@ else
     if [ -s "$out" ]; then
       cat "$out"
     fi
-    mode=$(stat -f %Lp "$work" 2>/dev/null || stat -c %a "$work" 2>/dev/null || echo unknown)
+    mode=$(stat -c %a "$work" 2>/dev/null || stat -f %Lp "$work" 2>/dev/null || echo unknown)
     case "$mode" in
       700|0700) ;;
       *)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,9 +109,10 @@ See [`wedge-alarm.md`](wedge-alarm.md) for the channel reference and macOS verif
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
 That evidence policy is specific to the firstmate repo: target projects may legitimately commit `.no-mistakes/evidence/` from their own no-mistakes pipeline, but firstmate keeps `.no-mistakes/` local and CI rejects tracked entries under that path.
 It does not set `commands.test` to a complete `tests/*.test.sh` walk.
-Local no-mistakes Test stays intent-targeted; [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) owns the broad portable and required real-Herdr lane composition.
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for local test entry points, `bin/fm-test-run.sh --help` for exact selection mechanics, and [herdr-backend.md](herdr-backend.md) for the real-Herdr lane's verification and isolation rationale.
-The Phase 2 concurrent isolation proof for the portable parallel candidate set is owned by `bin/fm-test-isolation-proof.sh` and archived in [fm-test-isolation-proof.md](fm-test-isolation-proof.md); it does not enable production CI sharding.
+Local no-mistakes Test stays intent-targeted; [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) owns the broad portable parallel shards, portable serial lane, and required real-Herdr lane composition.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for local test entry points, `bin/fm-test-run.sh --help` for exact selection, lane, and `--jobs` mechanics, and [herdr-backend.md](herdr-backend.md) for the real-Herdr lane's verification and isolation rationale.
+The Phase 2 concurrent isolation proof for the portable parallel candidate set is owned by `bin/fm-test-isolation-proof.sh` and archived in [fm-test-isolation-proof.md](fm-test-isolation-proof.md).
+Phase 4 portable shard balance and coverage rules are in [fm-test-portable-shards.md](fm-test-portable-shards.md).
 
 ## Captain Preferences (data/captain.md / data/captain-shared.md)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,10 +109,8 @@ See [`wedge-alarm.md`](wedge-alarm.md) for the channel reference and macOS verif
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
 That evidence policy is specific to the firstmate repo: target projects may legitimately commit `.no-mistakes/evidence/` from their own no-mistakes pipeline, but firstmate keeps `.no-mistakes/` local and CI rejects tracked entries under that path.
 It does not set `commands.test` to a complete `tests/*.test.sh` walk.
-Local no-mistakes Test stays intent-targeted; [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) owns the broad portable parallel shards, portable serial lane, and required real-Herdr lane composition.
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for local test entry points, `bin/fm-test-run.sh --help` for exact selection, lane, and `--jobs` mechanics, and [herdr-backend.md](herdr-backend.md) for the real-Herdr lane's verification and isolation rationale.
-The Phase 2 concurrent isolation proof for the portable parallel candidate set is owned by `bin/fm-test-isolation-proof.sh` and archived in [fm-test-isolation-proof.md](fm-test-isolation-proof.md).
-Phase 4 portable shard balance and coverage rules are in [fm-test-portable-shards.md](fm-test-portable-shards.md).
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the firstmate-specific local test policy and entry points.
+Portable shard evidence and coverage rules are in [fm-test-portable-shards.md](fm-test-portable-shards.md), and [herdr-backend.md](herdr-backend.md) owns the real-Herdr lane's verification and isolation rationale.
 
 ## Captain Preferences (data/captain.md / data/captain-shared.md)
 

--- a/docs/fm-test-isolation-proof.md
+++ b/docs/fm-test-isolation-proof.md
@@ -2,7 +2,8 @@
 
 This document is the archived concurrent isolation proof for the portable parallel candidate set.
 It is the human-readable companion to `bin/fm-test-isolation-proof.sh`.
-Production CI sharding and general local `fm-test-run.sh --jobs` remain **off** until a later phase explicitly enables them.
+Phase 4 production portable shards and bounded local `fm-test-run.sh --jobs` for this exact set are owned by `bin/fm-test-run.sh` and documented in [fm-test-portable-shards.md](fm-test-portable-shards.md).
+The archived proof JSON below still records the Phase 2 proof-time flags (`production_sharding_enabled` / `fm_test_run_jobs_enabled` false at proof time).
 
 ## Owner
 
@@ -156,12 +157,12 @@ Every candidate exited 0 under concurrency=4.
 Policy: a script that fails only under concurrency is **removed** from the candidate set and investigated.
 It is never retried into green, skipped more broadly, or weakened in assertions.
 
-## What this phase does not do
+## What this phase did not do (Phase 2 scope)
 
-- No production CI Behavior matrix / shard jobs
-- No `bin/fm-test-run.sh --jobs`
-- No Herdr install lane (Phase 3+)
-- No complete-suite local re-run as part of this proof (focused matrix only)
+- Did not land production CI Behavior matrix / shard jobs (Phase 4)
+- Did not add general `bin/fm-test-run.sh --jobs` (Phase 4 enables it only for this proven set)
+- Did not land the Herdr install lane (Phase 3)
+- Did not re-run the complete local suite as part of this proof (focused matrix only)
 
 ## How to re-run
 

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -78,18 +78,16 @@ Measured serial remainder wall (from the same Phase 1 artifacts, excluding Herdr
 
 CI runs that guard as a required job (`test-coverage`).
 
+## Timing artifacts
+
+Every portable shard, the portable serial lane, and the Herdr lane upload their runner-generated timing JSON even when the behavior run reports failures.
+The dependent aggregate job runs after all four lanes, combines every available lane JSON through `bin/fm-test-run.sh --aggregate-json`, and uploads one summary artifact for critical-path review.
+The workflow in `.github/workflows/ci.yml` owns the exact artifact names and aggregation wiring.
+
 ## Local entry points
 
-| Command | Role |
-|---|---|
-| `bin/fm-test-run.sh tests/<name>.test.sh` | Primary local focus path |
-| `bin/fm-test-run.sh --family <name>` | Ordinary family-scoped local path |
-| `bin/fm-test-run.sh --proven-isolated --jobs N` | Explicit local parallel of the proven set only (default stays serial; N capped at 8) |
-| `bin/fm-test-run.sh --lane portable-serial` | Local portable serial remainder |
-| `bin/fm-test-run.sh --all` | Deliberate complete regression (optional local full walk) |
-
-Normal no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a full `tests/*.test.sh` walk.
-CI owns broad regression across the required portable shards, portable serial lane, Herdr lane, lint, invariants, coverage guard, and macOS snapshot job.
+[CONTRIBUTING.md](../CONTRIBUTING.md) owns the local test policy and common entry points.
+`bin/fm-test-run.sh --help` owns exact lane names, selection flags, and bounded `--jobs` mechanics.
 
 ## Timeouts
 

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -1,0 +1,109 @@
+# Firstmate portable test shards (Phase 4)
+
+This document records how the two portable parallel CI shards were balanced from measured evidence.
+Composition and execution are owned by `bin/fm-test-run.sh` (`--lane portable-parallel-1` / `portable-parallel-2` / `portable-serial`).
+The proven-isolated candidate set remains owned by `bin/fm-test-isolation-proof.sh`.
+
+## Inputs
+
+| Input | Owner / source |
+|---|---|
+| Proven-isolated set (30 scripts) | `bin/fm-test-isolation-proof.sh --list` and `docs/fm-test-isolation-proof.md` |
+| Phase 1 serial durations | CI timing artifacts `fm-test-timing` from main after #825 / #832 / #834 |
+| Real-Herdr family | `bin/fm-test-run.sh --family real-herdr-gated` (dedicated required CI lane) |
+
+Phase 1 averages used for balance (mean of available serial `duration_ms` across those artifacts):
+
+| duration_ms (avg) | script |
+|---:|---|
+| 29639 | `tests/fm-arm-pretool-check.test.sh` |
+| 25402 | `tests/fm-decision-hold-lifecycle.test.sh` |
+| 19428 | `tests/fm-x-mode.test.sh` |
+| 14979 | `tests/fm-cd-pretool-check.test.sh` |
+| 9339 | `tests/fm-backend-herdr.test.sh` |
+| 6885 | `tests/fm-herdr-lab.test.sh` |
+| 5127 | `tests/fm-crew-state.test.sh` |
+| 4044 | `tests/fm-pr-merge.test.sh` |
+| 3922 | `tests/fm-grok-harness.test.sh` |
+| 2492 | `tests/fm-test-run.test.sh` |
+| 1901 | `tests/fm-send-popup-settle.test.sh` |
+| 1234 | `tests/fm-spawn-batch.test.sh` |
+| 851 | `tests/fm-send-strict.test.sh` |
+| 791 | `tests/fm-review-diff.test.sh` |
+| 627 | `tests/fm-tmux-submit-busy.test.sh` |
+| 525 | `tests/fm-brief.test.sh` |
+| 321 | `tests/fm-composer-ghost.test.sh` |
+| 283 | `tests/fm-dispatch-select.test.sh` |
+| 276 | `tests/fm-send-settle.test.sh` |
+| 189 | `tests/fm-ensure-agents-md.test.sh` |
+| 175 | `tests/fm-supervision-instructions.test.sh` |
+| 138 | `tests/fm-instruction-owners.test.sh` |
+| 133 | `tests/fm-lint.test.sh` |
+| 108 | `tests/fm-pi-primary-types.test.sh` |
+| 106 | `tests/fm-nm-test-contract.test.sh` |
+| 67 | `tests/fm-transition-lib.test.sh` |
+| 64 | `tests/fm-captain-translation-contract.test.sh` |
+| 48 | `tests/fm-composer-lib.test.sh` |
+| 36 | `tests/fm-stow-contract.test.sh` |
+| 28 | `tests/fm-no-mistakes-ownership.test.sh` |
+
+## Balancing method
+
+Longest-processing-time (LPT) assignment onto two workers using the Phase 1 averages above.
+Do not rebalance alphabetically or by family intuition.
+Shard execution order is longest-first so wall-clock tracks the balanced sum.
+
+| Lane | Script count | Sum of Phase 1 averages |
+|---|---:|---:|
+| `portable-parallel-1` | 15 | 64579 ms (~64.6 s) |
+| `portable-parallel-2` | 15 | 64579 ms (~64.6 s) |
+| imbalance | | 0 ms |
+
+Exact ordered membership is the heredoc lists in `bin/fm-test-run.sh` (`list_portable_parallel_1` / `list_portable_parallel_2`).
+
+## Portable serial remainder
+
+`portable-serial` is every `tests/*.test.sh` that is neither proven-isolated nor `real-herdr-gated`.
+That keeps watcher, lock, AFK, real tmux, daemon, secondmate lifecycle, bootstrap, live-harness opt-in (default skip), GUI backends, and other stateful or unproven work serial.
+Measured serial remainder wall (from the same Phase 1 artifacts, excluding Herdr) is about **13 minutes**.
+
+## Coverage guard
+
+`bin/fm-test-run.sh --check-coverage` proves:
+
+1. The two portable parallel shards are a partition of the proven-isolated set.
+2. Proven-isolated embeds match `bin/fm-test-isolation-proof.sh --list`.
+3. Union of portable parallel shards + portable serial + real-Herdr family equals the complete `tests/*.test.sh` inventory.
+4. Those four partitions are pairwise disjoint (no missing scripts, no duplicates).
+
+CI runs that guard as a required job (`test-coverage`).
+
+## Local entry points
+
+| Command | Role |
+|---|---|
+| `bin/fm-test-run.sh tests/<name>.test.sh` | Primary local focus path |
+| `bin/fm-test-run.sh --family <name>` | Ordinary family-scoped local path |
+| `bin/fm-test-run.sh --proven-isolated --jobs N` | Explicit local parallel of the proven set only (default stays serial; N capped at 8) |
+| `bin/fm-test-run.sh --lane portable-serial` | Local portable serial remainder |
+| `bin/fm-test-run.sh --all` | Deliberate complete regression (optional local full walk) |
+
+Normal no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a full `tests/*.test.sh` walk.
+CI owns broad regression across the required portable shards, portable serial lane, Herdr lane, lint, invariants, coverage guard, and macOS snapshot job.
+
+## Timeouts
+
+| Job | timeout-minutes | Rationale |
+|---|---:|---|
+| portable parallel 1/2 | 10 | Measured shard sum ~1 min; hang tripwire with margin |
+| portable serial | 20 | Measured ~13 min remainder; reduced from interim 25m full-portable slack after sharding |
+| Herdr | 40 | Unchanged hang tripwire for the real-Herdr lane |
+
+Timeouts remain hang tripwires, not expected healthy ends of green suites.
+Do not raise them as a substitute for green results, retries, or weaker assertions.
+
+## What this phase does not do
+
+- Does not expand the proven-isolated set without a new concurrent isolation proof.
+- Does not parallelize watcher, AFK, real Herdr, real tmux, or other stateful families.
+- Does not start rollout verification; that waits until this PR is green and merged.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -22,7 +22,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |
 | `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |
-| `fm-test-run.sh`         | Serial behavior-test runner: selection, timing markers, family totals, JSON artifact |
+| `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
+| `fm-test-isolation-proof.sh` | Phase 2 concurrent isolation proof and proven-isolated candidate set owner |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |

--- a/tests/fm-install-herdr.test.sh
+++ b/tests/fm-install-herdr.test.sh
@@ -82,8 +82,14 @@ test_ci_wires_installers_and_required_lane() {
     "CI Herdr lane must fail on herdr-not-found"
   assert_grep 'family real-herdr-gated' "$CI" \
     "CI Herdr lane must run only the real-herdr-gated family"
-  assert_grep 'exclude-family real-herdr-gated' "$CI" \
-    "portable CI lane must exclude real-herdr-gated once the Herdr job owns it"
+  assert_grep 'lane portable-parallel-1' "$CI" \
+    "portable CI must run parallel shard 1"
+  assert_grep 'lane portable-parallel-2' "$CI" \
+    "portable CI must run parallel shard 2"
+  assert_grep 'lane portable-serial' "$CI" \
+    "portable CI must run the serial remainder"
+  assert_grep 'fm-test-run.sh --check-coverage' "$CI" \
+    "CI must prove portable lanes and Herdr partition the complete inventory"
   # Live harness credential tests must stay out of the default Herdr lane.
   assert_no_grep 'live-harness-optin' "$CI" \
     "CI must not run live-harness-optin in the required Herdr lane"

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -73,7 +73,7 @@ test_ci_installs_and_logs_the_pinned_version() {
   # CI must derive the version from the one owner (never hardcode a divergent
   # number) and log the resolved version as parity evidence.
   assert_grep "VERSION=\"\$(\"\$ROOT/bin/fm-lint.sh\" --required-version)\"" "$INSTALLER" "installer must read the version fm-lint.sh pins"
-  [ "$(grep -Fc "bin/fm-install-shellcheck.sh \"\$RUNNER_TEMP/bin\"" "$CI")" -eq 2 ] || fail "both CI jobs must use the shared ShellCheck installer"
+  [ "$(grep -Fc "bin/fm-install-shellcheck.sh \"\$RUNNER_TEMP/bin\"" "$CI")" -eq 4 ] || fail "lint and all three portable behavior jobs must use the shared ShellCheck installer"
   assert_grep "ACTUAL_SHA256=\$(sha256sum" "$INSTALLER" "installer must calculate the ShellCheck archive checksum"
   assert_grep "[ \"\$ACTUAL_SHA256\" = \"\$SHA256\" ]" "$INSTALLER" "installer must verify the ShellCheck archive checksum"
   assert_grep "\"\$DESTINATION/shellcheck\" --version" "$INSTALLER" "installer must log the resolved ShellCheck version as evidence"

--- a/tests/fm-nm-test-contract.test.sh
+++ b/tests/fm-nm-test-contract.test.sh
@@ -95,9 +95,16 @@ test_nm_has_no_complete_local_test_command() {
 
 test_ci_still_runs_broad_behavior_suite() {
   assert_present "$CI" "ci.yml is missing"
-  # Behavior job still runs every portable behavior script via the one owner.
-  grep -Fq 'bin/fm-test-run.sh --all' "$CI" \
-    || fail "CI Behavior job must invoke bin/fm-test-run.sh --all"
+  # Portable shards and the serial remainder cover every portable behavior
+  # script through the one owner, with a deterministic inventory guard.
+  grep -Fq 'bin/fm-test-run.sh --lane portable-parallel-1' "$CI" \
+    || fail "CI must invoke portable parallel shard 1 through fm-test-run.sh"
+  grep -Fq 'bin/fm-test-run.sh --lane portable-parallel-2' "$CI" \
+    || fail "CI must invoke portable parallel shard 2 through fm-test-run.sh"
+  grep -Fq 'bin/fm-test-run.sh --lane portable-serial' "$CI" \
+    || fail "CI must invoke the portable serial remainder through fm-test-run.sh"
+  grep -Fq 'bin/fm-test-run.sh --check-coverage' "$CI" \
+    || fail "CI must prove complete lane coverage through fm-test-run.sh"
   # Guard against regression to an uninstrumented inline loop that drops timing.
   if grep -Eq 'for test_script in tests/\*\.test\.sh' "$CI"; then
     fail "CI Behavior must not re-spell an inline tests/*.test.sh loop; use fm-test-run.sh"
@@ -111,7 +118,7 @@ test_ci_still_runs_broad_behavior_suite() {
     || fail "CI must retain the repo invariants job"
   grep -Fq 'tests-herdr:' "$CI" \
     || fail "CI must retain the required Herdr Behavior job"
-  pass "CI still owns the broad behavior suite and companion jobs"
+  pass "CI still owns partitioned broad behavior coverage and companion jobs"
 }
 
 test_nm_yaml_tracked

--- a/tests/fm-test-isolation-proof.test.sh
+++ b/tests/fm-test-isolation-proof.test.sh
@@ -3,10 +3,10 @@
 # isolation proof harness.
 #
 # These tests assert the candidate-set contract, serial exclusions, aggregate
-# failure reporting, and that production CI sharding / fm-test-run --jobs are
-# still off. They deliberately do NOT re-run the full concurrent candidate
-# matrix on every invocation (that matrix is owned by the harness itself and
-# archived under docs/fm-test-isolation-proof.md after a deliberate proof run).
+# failure reporting, and that Phase 4 production shards consume this exact set.
+# They deliberately do NOT re-run the full concurrent candidate matrix on every
+# invocation (that matrix is owned by the harness itself and archived under
+# docs/fm-test-isolation-proof.md after a deliberate proof run).
 set -u
 
 # shellcheck disable=SC1091
@@ -181,24 +181,32 @@ SH
   pass "aggregate failure reporting survives concurrency"
 }
 
-test_production_sharding_still_off() {
+test_phase4_consumes_proven_set_only() {
   assert_present "$CI" "ci.yml missing"
-  # Behavior remains a single serial fm-test-run --all job (no matrix shards).
-  grep -Fq 'bin/fm-test-run.sh --all' "$CI" \
-    || fail "CI Behavior must still call serial bin/fm-test-run.sh --all"
-  if grep -E 'strategy:[[:space:]]*$' "$CI" >/dev/null 2>&1; then
-    # Only fail if a Behavior-related matrix appears; lint/macos jobs stay simple.
-    if grep -A20 'name: Behavior tests' "$CI" | grep -q 'matrix:'; then
-      fail "CI Behavior must not enable production sharding in Phase 2"
-    fi
-  fi
-  # Serial runner header must still refuse general --jobs.
-  grep -Fq 'no local --jobs parallelism' "$RUNNER" \
-    || fail "fm-test-run.sh must still document no local --jobs"
-  if grep -E '^[[:space:]]*--jobs\)' "$RUNNER" >/dev/null 2>&1; then
-    fail "fm-test-run.sh must not grow production --jobs in Phase 2"
-  fi
-  pass "production CI sharding and fm-test-run --jobs remain off"
+  assert_present "$RUNNER" "fm-test-run.sh missing"
+  # Phase 4 portable parallel lanes must exist and use lane selection, not --all.
+  grep -Fq 'bin/fm-test-run.sh --lane portable-parallel-1' "$CI" \
+    || fail "CI portable parallel 1 must use --lane portable-parallel-1"
+  grep -Fq 'bin/fm-test-run.sh --lane portable-parallel-2' "$CI" \
+    || fail "CI portable parallel 2 must use --lane portable-parallel-2"
+  grep -Fq 'bin/fm-test-run.sh --lane portable-serial' "$CI" \
+    || fail "CI portable serial must use --lane portable-serial"
+  # Shard union must equal this harness's proven list.
+  local proven shards
+  proven=$("$PROOF" --list | LC_ALL=C sort -u)
+  shards=$(
+    {
+      "$RUNNER" --list --lane portable-parallel-1
+      "$RUNNER" --list --lane portable-parallel-2
+    } | LC_ALL=C sort -u
+  )
+  [ "$proven" = "$shards" ] \
+    || fail "portable parallel shards must equal isolation-proof --list exactly"
+  # Local --jobs is bounded to this proven set (refuse is contract-tested in
+  # fm-test-run.test.sh); the option must exist.
+  grep -E '^[[:space:]]*--jobs\)' "$RUNNER" >/dev/null 2>&1 \
+    || fail "fm-test-run.sh must expose bounded --jobs after Phase 4"
+  pass "Phase 4 portable shards consume the proven-isolated set only"
 }
 
 test_docs_record_proof_owner() {
@@ -206,7 +214,7 @@ test_docs_record_proof_owner() {
   grep -Fq 'bin/fm-test-isolation-proof.sh' "$PROOF_DOC" \
     || fail "proof doc must name the harness owner"
   grep -Fq 'production_sharding_enabled' "$PROOF_DOC" \
-    || fail "proof doc must record that production sharding is off"
+    || fail "proof doc must record the archived proof-time sharding flag"
   grep -Fq 'concurrency' "$PROOF_DOC" \
     || fail "proof doc must record concurrency"
   assert_present "$CONTRIB" "CONTRIBUTING.md missing"
@@ -222,5 +230,5 @@ test_extra_hermetic_candidates_present
 test_list_exclusions_documents_reasons
 test_family_map_labels_this_contract
 test_aggregate_failure_under_concurrency
-test_production_sharding_still_off
+test_phase4_consumes_proven_set_only
 test_docs_record_proof_owner

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -475,27 +475,52 @@ test_jobs_requires_proven_isolated() {
 }
 
 test_jobs_parallel_scheduler_and_failure_propagation() {
-  local tmp a b rc begin_n end_n
+  local tmp repo runner evidence a b c rc begin_n end_n
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-jobs-sched.XXXXXX")
-  # Two of the fastest proven-isolated scripts (Phase 1 averages < 50ms each).
+  repo="$tmp/repo"
+  runner="$repo/bin/fm-test-run.sh"
+  evidence="$tmp/evidence"
   a=tests/fm-no-mistakes-ownership.test.sh
   b=tests/fm-stow-contract.test.sh
-  [ -f "$ROOT/$a" ] && [ -f "$ROOT/$b" ] || { rm -rf "$tmp"; fail "fast proven fixtures missing"; }
+  c=tests/fm-lint.test.sh
+  mkdir -p "$repo/bin" "$repo/tests" "$evidence"
+  cp "$RUNNER" "$runner"
+  cat >"$repo/$a" <<'SH'
+#!/usr/bin/env bash
+sleep 0.5
+touch "$SCHED_EVIDENCE/slow-done"
+echo "ok - slow fixture"
+SH
+  cat >"$repo/$b" <<'SH'
+#!/usr/bin/env bash
+sleep 0.05
+echo "ok - fast fixture"
+SH
+  cat >"$repo/$c" <<'SH'
+#!/usr/bin/env bash
+if [ -e "$SCHED_EVIDENCE/slow-done" ]; then
+  echo "not ok - scheduler waited for oldest worker"
+  exit 1
+fi
+echo "ok - replacement fixture started before slow fixture finished"
+SH
+  chmod +x "$runner" "$repo/$a" "$repo/$b" "$repo/$c"
   set +e
-  "$RUNNER" --jobs 2 --json "$tmp/timing.json" "$a" "$b" >"$tmp/out" 2>"$tmp/err"
+  SCHED_EVIDENCE="$evidence" "$runner" --jobs 2 --json "$tmp/timing.json" \
+    "$a" "$b" "$c" >"$tmp/out" 2>"$tmp/err"
   rc=$?
   set -e
-  [ "$rc" -eq 0 ] || { cat "$tmp/out" "$tmp/err"; rm -rf "$tmp"; fail "jobs=2 on two proven scripts should pass"; }
+  [ "$rc" -eq 0 ] || { cat "$tmp/out" "$tmp/err"; rm -rf "$tmp"; fail "jobs=2 must refill the first completed slot"; }
   begin_n=$(grep -c '^FM_TEST_BEGIN ' "$tmp/out" || true)
   end_n=$(grep -c '^FM_TEST_END ' "$tmp/out" || true)
-  [ "$begin_n" -eq 2 ] || fail "expected 2 BEGIN markers, got $begin_n"
-  [ "$end_n" -eq 2 ] || fail "expected 2 END markers, got $end_n"
-  grep -q 'FM_TEST_SUMMARY total=2 failed=0' "$tmp/out" \
+  [ "$begin_n" -eq 3 ] || fail "expected 3 BEGIN markers, got $begin_n"
+  [ "$end_n" -eq 3 ] || fail "expected 3 END markers, got $end_n"
+  grep -q 'FM_TEST_SUMMARY total=3 failed=0' "$tmp/out" \
     || fail "summary missing for jobs run: $(grep FM_TEST_SUMMARY "$tmp/out")"
   python3 -c '
 import json,sys
 doc=json.load(open(sys.argv[1]))
-assert doc["summary"]["total"]==2
+assert doc["summary"]["total"]==3
 assert doc["summary"]["failed"]==0
 assert "jobs=2" in doc["selection"]
 ' "$tmp/timing.json" || { rm -rf "$tmp"; fail "jobs JSON artifact wrong"; }
@@ -508,28 +533,23 @@ exit 1
 SH
   chmod +x "$tmp/fail.test.sh"
   set +e
-  "$RUNNER" --jobs 2 "$a" "$tmp/fail.test.sh" >"$tmp/out3" 2>"$tmp/err3"
+  "$runner" --jobs 2 "$a" "$tmp/fail.test.sh" >"$tmp/out3" 2>"$tmp/err3"
   rc=$?
   set -e
   [ "$rc" -eq 2 ] || fail "jobs with non-proven fail fixture must refuse before run, got $rc"
 
-  # Parallel failure propagation among proven paths: replace one proven script
-  # temporarily with a failing body, run jobs=2, always restore.
-  cp "$ROOT/$b" "$tmp/backup-b"
-  # shellcheck disable=SC2064
-  trap 'mv "$tmp/backup-b" "$ROOT/$b" 2>/dev/null || true; rm -rf "$tmp"' RETURN
-  cat >"$ROOT/$b" <<'SH'
+  # Parallel failure propagation stays inside the private runner fixture.
+  cat >"$repo/$b" <<'SH'
 #!/usr/bin/env bash
 echo "not ok - deliberate proven-set fail"
 exit 1
 SH
-  chmod +x "$ROOT/$b"
+  chmod +x "$repo/$b"
+  rm -f "$evidence/slow-done"
   set +e
-  "$RUNNER" --jobs 2 "$a" "$b" >"$tmp/out4" 2>"$tmp/err4"
+  SCHED_EVIDENCE="$evidence" "$runner" --jobs 2 "$a" "$b" >"$tmp/out4" 2>"$tmp/err4"
   rc=$?
   set -e
-  mv "$tmp/backup-b" "$ROOT/$b"
-  trap - RETURN
   [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "jobs aggregate must be non-zero when a proven worker fails"; }
   grep -q 'FM_TEST_SUMMARY total=2 failed=1' "$tmp/out4" \
     || { rm -rf "$tmp"; fail "jobs failure summary wrong: $(grep FM_TEST_SUMMARY "$tmp/out4")"; }

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -475,7 +475,7 @@ test_jobs_requires_proven_isolated() {
 }
 
 test_jobs_parallel_scheduler_and_failure_propagation() {
-  local tmp repo runner evidence a b c rc begin_n end_n
+  local tmp repo runner evidence a b c d rc begin_n end_n
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-jobs-sched.XXXXXX")
   repo="$tmp/repo"
   runner="$repo/bin/fm-test-run.sh"
@@ -483,6 +483,7 @@ test_jobs_parallel_scheduler_and_failure_propagation() {
   a=tests/fm-no-mistakes-ownership.test.sh
   b=tests/fm-stow-contract.test.sh
   c=tests/fm-lint.test.sh
+  d=tests/fm-supervision-instructions.test.sh
   mkdir -p "$repo/bin" "$repo/tests" "$evidence"
   cp "$RUNNER" "$runner"
   cat >"$repo/$a" <<'SH'
@@ -553,6 +554,27 @@ SH
   [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "jobs aggregate must be non-zero when a proven worker fails"; }
   grep -q 'FM_TEST_SUMMARY total=2 failed=1' "$tmp/out4" \
     || { rm -rf "$tmp"; fail "jobs failure summary wrong: $(grep FM_TEST_SUMMARY "$tmp/out4")"; }
+
+  cat >"$repo/$d" <<'SH'
+#!/usr/bin/env bash
+echo "skip: herdr not found" >&2
+exit 0
+SH
+  chmod +x "$repo/$d"
+  set +e
+  "$runner" --jobs 2 --fail-on-gate-skip 'herdr not found' "$d" >"$tmp/out5" 2>"$tmp/err5"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "parallel stderr gate skip must hard-fail"; }
+  grep -q 'FM_TEST_SUMMARY total=1 failed=1' "$tmp/out5" \
+    || { rm -rf "$tmp"; fail "parallel stderr hard-fail summary wrong: $(grep FM_TEST_SUMMARY "$tmp/out5")"; }
+
+  "$runner" --jobs 2 "$d" >"$tmp/out6" 2>"$tmp/err6" \
+    || { rm -rf "$tmp"; fail "ordinary parallel stderr gate skip must remain successful"; }
+  grep -Eq '^FM_TEST_END .+ exit=0 duration_ms=[0-9]+ gate_skip=true$' "$tmp/out6" \
+    || { rm -rf "$tmp"; fail "parallel stderr gate skip was not recorded"; }
+  grep -q 'FM_TEST_SUMMARY total=1 failed=0 skipped_gate=1' "$tmp/out6" \
+    || { rm -rf "$tmp"; fail "parallel stderr skip summary wrong: $(grep FM_TEST_SUMMARY "$tmp/out6")"; }
 
   rm -rf "$tmp"
   pass "jobs scheduler runs proven scripts; failure propagates; non-proven refused"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -475,17 +475,30 @@ test_jobs_requires_proven_isolated() {
 }
 
 test_jobs_parallel_scheduler_and_failure_propagation() {
-  local tmp repo runner evidence a b c d rc begin_n end_n
+  local tmp repo runner evidence fake_bin a b c d rc begin_n end_n
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-jobs-sched.XXXXXX")
   repo="$tmp/repo"
   runner="$repo/bin/fm-test-run.sh"
   evidence="$tmp/evidence"
+  fake_bin="$tmp/fake-bin"
   a=tests/fm-no-mistakes-ownership.test.sh
   b=tests/fm-stow-contract.test.sh
   c=tests/fm-lint.test.sh
   d=tests/fm-supervision-instructions.test.sh
-  mkdir -p "$repo/bin" "$repo/tests" "$evidence"
+  mkdir -p "$repo/bin" "$repo/tests" "$evidence" "$fake_bin"
   cp "$RUNNER" "$runner"
+  cat >"$fake_bin/stat" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "-c" ] && [ "$2" = "%a" ]; then
+  printf '700\n'
+  exit 0
+fi
+if [ "$1" = "-f" ] && [ "$2" = "%Lp" ]; then
+  printf '  File: "%s"\n    ID: fake Namelen: 255 Type: ext2/ext3\n700\n' "$3"
+  exit 0
+fi
+exit 1
+SH
   cat >"$repo/$a" <<'SH'
 #!/usr/bin/env bash
 sleep 0.5
@@ -505,9 +518,10 @@ if [ -e "$SCHED_EVIDENCE/slow-done" ]; then
 fi
 echo "ok - replacement fixture started before slow fixture finished"
 SH
-  chmod +x "$runner" "$repo/$a" "$repo/$b" "$repo/$c"
+  chmod +x "$runner" "$repo/$a" "$repo/$b" "$repo/$c" "$fake_bin/stat"
   set +e
-  SCHED_EVIDENCE="$evidence" "$runner" --jobs 2 --json "$tmp/timing.json" \
+  PATH="$fake_bin:$PATH" SCHED_EVIDENCE="$evidence" \
+    "$runner" --jobs 2 --json "$tmp/timing.json" \
     "$a" "$b" "$c" >"$tmp/out" 2>"$tmp/err"
   rc=$?
   set -e

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Contract tests for bin/fm-test-run.sh - the single owner of serial behavior
-# suite selection, timing markers, JSON artifacts, and aggregate exit status.
+# Contract tests for bin/fm-test-run.sh - the single owner of behavior suite
+# selection, portable lane composition, proven-isolated --jobs, timing markers,
+# JSON artifacts, coverage guard, and aggregate exit status.
 #
-# These tests intentionally exercise the runner with fixtures and --list, not
-# the complete Firstmate suite.
+# These tests intentionally exercise the runner with fixtures, --list, and
+# focused scheduler checks, not the complete Firstmate suite.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -355,10 +356,20 @@ test_exclude_family() {
 test_ci_and_docs_call_the_owner() {
   assert_present "$CI" "ci.yml missing"
   assert_present "$CONTRIB" "CONTRIBUTING.md missing"
-  grep -Fq 'bin/fm-test-run.sh --all' "$CI" \
-    || fail "CI Behavior must invoke bin/fm-test-run.sh --all"
-  grep -Fq -- '--exclude-family real-herdr-gated' "$CI" \
-    || fail "portable CI Behavior must exclude real-herdr-gated"
+  grep -Fq 'tests-portable-parallel-1:' "$CI" \
+    || fail "CI must define portable parallel shard 1"
+  grep -Fq 'tests-portable-parallel-2:' "$CI" \
+    || fail "CI must define portable parallel shard 2"
+  grep -Fq 'tests-portable-serial:' "$CI" \
+    || fail "CI must define the portable serial lane"
+  grep -Fq 'bin/fm-test-run.sh --lane portable-parallel-1' "$CI" \
+    || fail "CI shard 1 must invoke --lane portable-parallel-1"
+  grep -Fq 'bin/fm-test-run.sh --lane portable-parallel-2' "$CI" \
+    || fail "CI shard 2 must invoke --lane portable-parallel-2"
+  grep -Fq 'bin/fm-test-run.sh --lane portable-serial' "$CI" \
+    || fail "CI portable serial must invoke --lane portable-serial"
+  grep -Fq 'bin/fm-test-run.sh --check-coverage' "$CI" \
+    || fail "CI must run the coverage guard"
   grep -Fq 'tests-herdr:' "$CI" \
     || fail "CI must define the required tests-herdr job"
   grep -Fq 'bin/fm-test-run.sh --family real-herdr-gated' "$CI" \
@@ -371,29 +382,202 @@ test_ci_and_docs_call_the_owner() {
     || fail "Herdr CI job must install via bin/fm-install-treehouse.sh"
   grep -Fq 'bin/fm-herdr-ci-cleanup.sh' "$CI" \
     || fail "Herdr CI job must use bounded lab cleanup"
-  grep -Fq 'timeout-minutes: 25' "$CI" \
-    || fail "CI Behavior timeout-minutes must be 25 (hang tripwire)"
+  grep -Fq 'tests-timing-aggregate:' "$CI" \
+    || fail "CI must aggregate per-lane timing artifacts"
+  grep -Fq 'timeout-minutes: 20' "$CI" \
+    || fail "portable serial hang tripwire must be timeout-minutes: 20"
+  grep -Fq 'timeout-minutes: 10' "$CI" \
+    || fail "portable parallel shards must keep a hang tripwire (10m)"
+  # Interim full-suite 25m portable timeout must not remain after sharding.
+  if grep -Eq 'timeout-minutes: 25' "$CI"; then
+    fail "CI still has interim timeout-minutes: 25 after portable sharding"
+  fi
   # Stale "~2-3 minutes" claim must not remain.
   if grep -Eq '2-3 minutes' "$CI"; then
     fail "CI workflow still claims the suite finishes in ~2-3 minutes"
   fi
-  # No retry-green strategy on either Behavior lane.
+  # No retry-green strategy on Behavior lanes.
   if grep -Eqi 'retry:|max-attempts:|continue-on-error:\s*true' "$CI"; then
     fail "CI must not use retries or continue-on-error as a green strategy"
   fi
   grep -Fq 'fm-test-timing' "$CI" \
-    || fail "CI must upload the timing artifact"
+    || fail "CI must upload timing artifacts"
   grep -Fq 'bin/fm-test-run.sh --all' "$CONTRIB" \
     || fail "CONTRIBUTING must document bin/fm-test-run.sh --all"
   grep -Fq 'bin/fm-test-run.sh --family' "$CONTRIB" \
     || fail "CONTRIBUTING must document family selection"
   grep -Fq 'bin/fm-test-run.sh --changed' "$CONTRIB" \
     || fail "CONTRIBUTING must document changed-file selection"
+  grep -Fq 'bin/fm-test-run.sh --proven-isolated --jobs' "$CONTRIB" \
+    || fail "CONTRIBUTING must document proven-isolated --jobs"
+  grep -Fq 'intent-targeted' "$CONTRIB" \
+    || fail "CONTRIBUTING must document intent-targeted no-mistakes Test"
   # Do not restore a complete-suite commands.test.
   if grep -E '^[[:space:]]*test:[[:space:]].*tests/\*\.test\.sh' "$ROOT/.no-mistakes.yaml" >/dev/null 2>&1; then
     fail ".no-mistakes.yaml must not set a full-suite commands.test"
   fi
   pass "CI and CONTRIBUTING call the one-owner runner; no full-suite local Test"
+}
+
+test_portable_shard_union_and_coverage_guard() {
+  local s1 s2 proven serial herdr all_count union_count overlap out first
+  s1=$("$RUNNER" --list --lane portable-parallel-1)
+  s2=$("$RUNNER" --list --lane portable-parallel-2)
+  proven=$("$RUNNER" --list --proven-isolated)
+  serial=$("$RUNNER" --list --lane portable-serial)
+  herdr=$("$RUNNER" --list --family real-herdr-gated)
+  [ -n "$s1" ] && [ -n "$s2" ] || fail "portable parallel shards must be non-empty"
+  # Shards disjoint.
+  overlap=$(comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
+  [ -z "$overlap" ] || fail "portable parallel shards overlap: $overlap"
+  # Union of shards equals proven-isolated.
+  [ "$(printf '%s\n' "$s1" "$s2" | LC_ALL=C sort -u)" = \
+    "$(printf '%s\n' "$proven" | LC_ALL=C sort -u)" ] \
+    || fail "shard union must equal proven-isolated set"
+  # No herdr in portable lanes.
+  printf '%s\n' "$s1" "$s2" "$serial" | grep -Fq 'tests/fm-backend-herdr-smoke.test.sh' \
+    && fail "portable lanes must not include real-herdr-gated smoke"
+  printf '%s\n' "$herdr" | grep -Fq 'tests/fm-backend-herdr-smoke.test.sh' \
+    || fail "herdr family must include smoke"
+  out=$("$RUNNER" --check-coverage)
+  assert_contains "$out" "FM_TEST_COVERAGE ok" "coverage guard success marker"
+  all_count=$("$RUNNER" --list --all | wc -l | tr -d ' ')
+  union_count=$(printf '%s\n' "$s1" "$s2" "$serial" "$herdr" | LC_ALL=C sort -u | wc -l | tr -d ' ')
+  [ "$union_count" = "$all_count" ] \
+    || fail "union of lanes ($union_count) must equal --all ($all_count)"
+  # No duplicates across the four partitions.
+  [ "$(printf '%s\n' "$s1" "$s2" "$serial" "$herdr" | LC_ALL=C sort | uniq -d | wc -l | tr -d ' ')" = "0" ] \
+    || fail "lanes must not duplicate scripts"
+  # LPT order: first script of shard 1 is the longest proven script.
+  first=$(printf '%s\n' "$s1" | head -n 1)
+  [ "$first" = "tests/fm-arm-pretool-check.test.sh" ] \
+    || fail "shard 1 must start with longest proven script, got $first"
+  pass "portable shard union, disjointness, and coverage guard hold"
+}
+
+test_jobs_requires_proven_isolated() {
+  local tmp rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-jobs.XXXXXX")
+  set +e
+  "$RUNNER" --jobs 2 --lane portable-serial >"$tmp/out" 2>"$tmp/err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "--jobs with portable-serial must refuse (exit 2), got $rc"
+  grep -Fq 'not in the proven-isolated set' "$tmp/err" \
+    || fail "--jobs refusal message missing: $(cat "$tmp/err")"
+  set +e
+  "$RUNNER" --jobs 2 tests/fm-watcher-lock.test.sh >"$tmp/out2" 2>"$tmp/err2"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "--jobs on watcher-lock must refuse, got $rc"
+  rm -rf "$tmp"
+  pass "--jobs refuses non-proven / stateful selections"
+}
+
+test_jobs_parallel_scheduler_and_failure_propagation() {
+  local tmp a b rc begin_n end_n
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-jobs-sched.XXXXXX")
+  # Two of the fastest proven-isolated scripts (Phase 1 averages < 50ms each).
+  a=tests/fm-no-mistakes-ownership.test.sh
+  b=tests/fm-stow-contract.test.sh
+  [ -f "$ROOT/$a" ] && [ -f "$ROOT/$b" ] || { rm -rf "$tmp"; fail "fast proven fixtures missing"; }
+  set +e
+  "$RUNNER" --jobs 2 --json "$tmp/timing.json" "$a" "$b" >"$tmp/out" 2>"$tmp/err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || { cat "$tmp/out" "$tmp/err"; rm -rf "$tmp"; fail "jobs=2 on two proven scripts should pass"; }
+  begin_n=$(grep -c '^FM_TEST_BEGIN ' "$tmp/out" || true)
+  end_n=$(grep -c '^FM_TEST_END ' "$tmp/out" || true)
+  [ "$begin_n" -eq 2 ] || fail "expected 2 BEGIN markers, got $begin_n"
+  [ "$end_n" -eq 2 ] || fail "expected 2 END markers, got $end_n"
+  grep -q 'FM_TEST_SUMMARY total=2 failed=0' "$tmp/out" \
+    || fail "summary missing for jobs run: $(grep FM_TEST_SUMMARY "$tmp/out")"
+  python3 -c '
+import json,sys
+doc=json.load(open(sys.argv[1]))
+assert doc["summary"]["total"]==2
+assert doc["summary"]["failed"]==0
+assert "jobs=2" in doc["selection"]
+' "$tmp/timing.json" || { rm -rf "$tmp"; fail "jobs JSON artifact wrong"; }
+
+  # Non-proven path is refused before any worker starts (no race masking).
+  cat >"$tmp/fail.test.sh" <<'SH'
+#!/usr/bin/env bash
+echo "not ok - deliberate fail"
+exit 1
+SH
+  chmod +x "$tmp/fail.test.sh"
+  set +e
+  "$RUNNER" --jobs 2 "$a" "$tmp/fail.test.sh" >"$tmp/out3" 2>"$tmp/err3"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "jobs with non-proven fail fixture must refuse before run, got $rc"
+
+  # Parallel failure propagation among proven paths: replace one proven script
+  # temporarily with a failing body, run jobs=2, always restore.
+  cp "$ROOT/$b" "$tmp/backup-b"
+  # shellcheck disable=SC2064
+  trap 'mv "$tmp/backup-b" "$ROOT/$b" 2>/dev/null || true; rm -rf "$tmp"' RETURN
+  cat >"$ROOT/$b" <<'SH'
+#!/usr/bin/env bash
+echo "not ok - deliberate proven-set fail"
+exit 1
+SH
+  chmod +x "$ROOT/$b"
+  set +e
+  "$RUNNER" --jobs 2 "$a" "$b" >"$tmp/out4" 2>"$tmp/err4"
+  rc=$?
+  set -e
+  mv "$tmp/backup-b" "$ROOT/$b"
+  trap - RETURN
+  [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "jobs aggregate must be non-zero when a proven worker fails"; }
+  grep -q 'FM_TEST_SUMMARY total=2 failed=1' "$tmp/out4" \
+    || { rm -rf "$tmp"; fail "jobs failure summary wrong: $(grep FM_TEST_SUMMARY "$tmp/out4")"; }
+
+  rm -rf "$tmp"
+  pass "jobs scheduler runs proven scripts; failure propagates; non-proven refused"
+}
+
+test_aggregate_json() {
+  local tmp a b
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-aggjson.XXXXXX")
+  cat >"$tmp/a.json" <<'JSON'
+{
+  "run_id": "a",
+  "selection": "lane=portable-parallel-1",
+  "started_at": "2026-07-22T00:00:00Z",
+  "finished_at": "2026-07-22T00:01:00Z",
+  "summary": {"total": 1, "failed": 0, "skipped_gate": 0, "duration_ms": 1000},
+  "scripts": [{"path": "tests/a.test.sh", "family": "pure-contract-unit", "duration_ms": 1000, "exit": 0, "gate_skip": false}]
+}
+JSON
+  cat >"$tmp/b.json" <<'JSON'
+{
+  "run_id": "b",
+  "selection": "lane=portable-serial",
+  "started_at": "2026-07-22T00:00:00Z",
+  "finished_at": "2026-07-22T00:02:00Z",
+  "summary": {"total": 2, "failed": 1, "skipped_gate": 0, "duration_ms": 2000},
+  "scripts": [
+    {"path": "tests/b.test.sh", "family": "afk", "duration_ms": 1500, "exit": 1, "gate_skip": false},
+    {"path": "tests/c.test.sh", "family": "afk", "duration_ms": 500, "exit": 0, "gate_skip": false}
+  ]
+}
+JSON
+  out=$("$RUNNER" --aggregate-json "$tmp/out.json" "$tmp/a.json" "$tmp/b.json")
+  assert_contains "$out" "FM_TEST_AGGREGATE lanes=2 total=3 failed=1" "aggregate summary line"
+  python3 -c '
+import json,sys
+doc=json.load(open(sys.argv[1]))
+assert doc["kind"]=="aggregate"
+assert doc["summary"]["lanes"]==2
+assert doc["summary"]["total"]==3
+assert doc["summary"]["failed"]==1
+assert doc["summary"]["critical_path_duration_ms"]==2000
+assert len(doc["scripts"])==3
+' "$tmp/out.json" || { rm -rf "$tmp"; fail "aggregate JSON shape wrong"; }
+  rm -rf "$tmp"
+  pass "aggregate-json merges lane timing artifacts"
 }
 
 test_list_all_exact_suite_coverage
@@ -408,3 +592,7 @@ test_gate_skip_accounting
 test_fail_on_gate_skip_token
 test_exclude_family
 test_ci_and_docs_call_the_owner
+test_portable_shard_union_and_coverage_guard
+test_jobs_requires_proven_isolated
+test_jobs_parallel_scheduler_and_failure_propagation
+test_aggregate_json


### PR DESCRIPTION
## Intent

Implement Phase 4 of the captain-approved Firstmate test and CI acceleration plan after timing (#825), isolation proof (#832), and required Herdr lane (#838).

Balance the exact Phase 2 proven-isolated set into two portable parallel CI shards using Phase 1 measured durations (LPT, not alphabetical). Keep one required portable serial lane for watcher, lock, AFK, tmux, daemon, ambiguous, and other stateful tests. Exclude real-Herdr from portable lanes (dedicated Herdr lane is already required). Add a deterministic coverage guard proving union of portable shards + portable serial + Herdr equals the complete tests/*.test.sh inventory with no missing or duplicate scripts. Require every shard, serial lane, Herdr lane, lint, invariant, macOS, and coverage-guard job. Preserve per-lane timing artifacts and an aggregate summary. Add bounded local --jobs N only for the proven-isolated set (default serial; stateful families stay serial). Document that normal no-mistakes Test stays intent-targeted, family selection is the ordinary local path, and --all is deliberate full regression. Remove only interim timeout slack that post-sharding evidence makes unnecessary; keep hang tripwires with margin. Do not start rollout verification.

## What Changed

- Split the proven-isolated portable test set into two LPT-balanced CI shards while keeping stateful tests serial and real-Herdr coverage in its dedicated lane.
- Extend `fm-test-run.sh` with portable lane selection, deterministic coverage checks, timing aggregation, and bounded local parallelism for proven-isolated tests.
- Preserve per-lane timing artifacts, add an aggregate CI summary, tighten portable timeouts, and document the sharding evidence and local test policy.

## Risk Assessment

✅ Low: The latest fix preserves combined output in parallel mode, resolves the prior scheduler and contract-test defects, and the complete branch now satisfies the source-verifiable Phase 4 requirements without material remaining risks.

## Testing

Focused contracts passed; an actual 30-script `--jobs 4` run initially found and prompted correction of one stale test assertion, then passed with complete timing JSON. Manual acceptance checks proved the 91-script inventory partitions exactly into 30 parallel, 52 portable-serial, and 9 Herdr scripts; independently reproduced two equal 64,579 ms LPT shards; and confirmed a stateful watcher test is refused under parallel execution. Evidence is CLI transcript and JSON because this change has no rendered UI surface.

<details>
<summary>Evidence: CLI acceptance evidence</summary>

<code>FM_TEST_COVERAGE ok total=91 parallel=30 serial=52 herdr=9&#10;LPT_MATCH shard1_count=15 shard1_ms=64579 shard2_count=15 shard2_ms=64579 imbalance_ms=0&#10;STATEFUL_REFUSAL exit=2 expected=2&#10;TIMING_JSON selection=proven-isolated;jobs=4 total=30 failed=0 skipped_gate=0 duration_ms=94238 script_records=30</code>

```text
$ bin/fm-test-run.sh --check-coverage
FM_TEST_COVERAGE ok total=91 parallel=30 serial=52 herdr=9

$ independently recompute two-worker LPT from the documented Phase 1 durations and compare exact lane order
LPT_MATCH shard1_count=15 shard1_ms=64579 shard2_count=15 shard2_ms=64579 imbalance_ms=0

$ bin/fm-test-run.sh --jobs 4 tests/fm-watcher-lock.test.sh
fm-test-run: --jobs 4 refused: tests/fm-watcher-lock.test.sh is not in the proven-isolated set (see bin/fm-test-isolation-proof.sh --list). Stateful families stay serial.
STATEFUL_REFUSAL exit=2 expected=2

$ timing JSON summary from the successful real 30-script run
TIMING_JSON selection=proven-isolated;jobs=4 total=30 failed=0 skipped_gate=0 duration_ms=94238 script_records=30
```
</details>
<details>
<summary>Evidence: Focused contract tests</summary>

```text
$ bash tests/fm-test-run.test.sh
ok - exact suite coverage: --all lists every tests/*.test.sh once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - changed selection covers dependents and fails closed for unmapped source
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
ok - CI and CONTRIBUTING call the one-owner runner; no full-suite local Test
ok - portable shard union, disjointness, and coverage guard hold
ok - --jobs refuses non-proven / stateful selections
ok - jobs scheduler runs proven scripts; failure propagates; non-proven refused
ok - aggregate-json merges lane timing artifacts

$ bash tests/fm-test-isolation-proof.test.sh
ok - candidate --list is non-empty, sorted, unique, and real
ok - serial classes remain excluded from the parallel candidate set
ok - candidate set exactly matches the archived isolation proof
ok - audited fake-backend / stub-network extras are candidates
ok - exclusion list documents serial reasons
ok - isolation-proof contract test is family-mapped
ok - aggregate failure reporting survives concurrency
ok - Phase 4 portable shards consume the proven-isolated set only
ok - docs archive the isolation-proof owner and posture

$ bash tests/fm-nm-test-contract.test.sh
ok - .no-mistakes.yaml is present and tracked
ok - commands.lint stays pinned to bin/fm-lint.sh
ok - no-mistakes does not configure a complete local Test command
ok - CI still owns partitioned broad behavior coverage and companion jobs

$ bash tests/fm-install-herdr.test.sh
ok - Herdr installer pins exact version, asset, checksum, and protocol floor
ok - Treehouse installer pins exact version, asset, and checksum
ok - cleanup is bounded to job-owned fm-lab-* sessions
ok - CI wires pinned installers into a required serial Herdr lane
```
</details>
<details>
<summary>Evidence: Successful real jobs=4 run</summary>

```text
FM_TEST_BEGIN 2026-07-22T07:24:58Z tests/fm-arm-pretool-check.test.sh family=pure-contract-unit expected_gate_skip=none
FM_TEST_BEGIN 2026-07-22T07:24:58Z tests/fm-backend-herdr.test.sh family=backend-dispatch expected_gate_skip=none
FM_TEST_BEGIN 2026-07-22T07:24:58Z tests/fm-brief.test.sh family=pure-contract-unit expected_gate_skip=none
FM_TEST_BEGIN 2026-07-22T07:24:58Z tests/fm-captain-translation-contract.test.sh family=pure-contract-unit expected_gate_skip=none
ok - section 9 owns the positive captain-facing translation contract
ok - scout remains allowed in private captain chat
ok - compressed safety labels require concrete plain renderings
ok - section 9 maps high-risk internal vocabulary families
ok - captain chat rejects verbatim internal evidence while private reports stay precise
ok - outward-facing skill handoffs point to the section 9 owner
ok - skills cross-reference section 9 instead of duplicating the mapping list
FM_TEST_END 2026-07-22T07:24:58Z tests/fm-captain-translation-contract.test.sh exit=0 duration_ms=88 gate_skip=false
FM_TEST_BEGIN 2026-07-22T07:24:58Z tests/fm-cd-pretool-check.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm-brief.sh: bash -n succeeds
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
FM_TEST_END 2026-07-22T07:24:59Z tests/fm-brief.test.sh exit=0 duration_ms=894 gate_skip=false
FM_TEST_BEGIN 2026-07-22T07:24:59Z tests/fm-composer-ghost.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm_tmux_strip_ghost drops dim/faint runs, keeps normal and bold text
ok - fm_tmux_strip_ghost handles combined SGR, ESC[22m, and reset-then-dim
ok - fm_tmux_strip_ghost keeps bright colored text with 2 payloads
ok - fm_tmux_strip_ghost drops a dark/muted truecolor foreground (grok placeholder)
ok - fm_pane_input_pending: a dim ghost-only composer is NOT pending
ok - fm_pane_input_pending: dim ghost inside a bordered composer is NOT pending
ok - fm_pane_input_pending: normal-intensity typed text is still pending
ok - fm_pane_input_pending: bright colored text with 2 payloads is still pending
ok - fm_pane_input_pending: a dark truecolor ghost-only composer (grok placeholder) is NOT pending
ok - fm_tmux_composer_state: dark truecolor shell prompts read unknown
ok - fm_pane_input_pending: real text plus a trailing ghost run is still pending
ok - fm-peek output is escape-free (no raw -e bytes reach firstmate context)
FM_TEST_END 2026-07-22T07:25:01Z tests/fm-composer-ghost.test.sh exit=0 duration_ms=2400 gate_skip=false
FM_TEST_BEGIN 2026-07-22T07:25:01Z tests/fm-composer-lib.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: a known idle placeholder reads empty, before and after glyph stripping
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
FM_TEST_END 2026-07-22T07:25:01Z tests/fm-composer-lib.test.sh exit=0 duration_ms=60 gate_skip=false
FM_TEST_BEGIN 2026-07-22T07:25:01Z tests/fm-crew-state.test.sh family=pure-contract-unit expected_gate_skip=none
ok - cd-guard acceptance matrix: 63 cases x 5 harness entry forms, block/allow all correct
ok - cd-guard: fires in a secondmate home (its own primary session is a primary)
ok - cd-guard: inert in a crewmate/scout task worktree (linked git worktree)
ok - cd-guard: inert in a non-firstmate repo (no AGENTS.md)
ok - cd-guard: inert when not inside a git repo
ok - cd-guard: reproduces the cwd leak and denies the exact command that causes it
ok - cd-guard: fails open on empty stdin
ok - cd-guard: fails open on unparseable stdin JSON
ok - cd-guard: fails open (never blocks) when node is missing
ok - cd-guard: fails open on the stdin path when jq is missing
ok - cd-guard: prefilter fast-allows (skips node) when no cd/pushd/popd substring is present
ok - cd-guard: fm-cd-command-policy.mjs CLI honors the deny/allow output contract
ok - .claude/settings.json: PreToolUse invokes the cd-guard alongside the arm guard
ok - .codex/hooks.json: PreToolUse invokes the cd-guard alongside the arm guard
ok - .grok primary cd hook: PreToolUse invokes the cd-guard
ok - .opencode cd plugin: tool.execute.before invokes the cd-guard and blocks by throwing
ok - .pi primary extension: tool_call runs the cd-guard alongside the watcher-arm check
ok - bin/fm-cd-pretool-check.sh is shellcheck-clean
FM_TEST_END 2026-07-22T07:25:23Z tests/fm-cd-pretool-check.test.sh exit=0 duration_ms=24607 gate_skip=false
FM_TEST_BEGIN 2026-07-22T07:25:23Z tests/fm-decision-hold-lifecycle.test.sh family=pure-contract-unit expected_gate_skip=none
ok - active run-step is authoritative
ok - stale needs-decision over active run is superseded
ok - stale blocked over active run is superseded
ok - genuine parked run is not flagged superseded
ok - scalar gate parked run is not flagged superseded
ok - gate block parked run is not flagged superseded
ok - ci-ready status log beats monitoring run
ok - ci-monitoring run with checks already green surfaces done
ok - top-level ci status uses ci log green marker
ok - terminal no-checks ci-monitor marker surfaces done
ok - base-advance rearm after green stays working
ok - pending no-checks ci-monitor marker stays working
ok - ci-monitoring run with checks not yet green stays working
ok - a fresh issue after an earlier green reading is not masked
ok - stale checks-green status log does not mask CI relapse
ok - ci fixing is not overridden by an earlier green marker
ok - top-level fixing is not overridden by a stale ci running row
ok - top-level fixing is not overridden by a stale done log
ok - terminal passed run is authoritative
ok - terminal failed run is authoritative
ok - cross-branch run is attributed via the real runs list
ok - cross-branch attribution picks the branch's most recent row
ok - coarse run does not probe another branch's ci log
ok - another branch's run is ignored, falls back
ok - no run + busy pane reads working from the pane
ok - herdr unknown native state falls back to backend capture busy regex
ok - herdr idle agent_status is corroborated by the pane text, not trusted outright
ok - herdr idle agent_status with a genuinely idle pane stays not-busy (no regression for a human-blocked agent)
ok - no run + idle pane uses the status-log verb
ok - no run + idle pane parses keyed status syntax
ok - no run + idle pane on a paused: status reports state: paused with its reason
ok - no run + idle pane honors the configured paused verb
ok - a trailing resolved: event does not corrupt state render (idle stays idle)
ok - dead window ignores stale status log
ok - closed 

... [38761 bytes truncated] ...

ng
ok - fm-x-poll rejects an unsafe request_id (path-traversal guard)
ok - fm-x-reply posts a request-bound answer and echoes only the request_id
ok - fm-x-reply accepts the reply via --text-file and stdin (safe, unexpanded)
ok - fm-x-reply exits non-zero on a non-2xx relay response
ok - fm-x-reply cleans up auth header temp files on interrupted posts
ok - fm-x-reply rejects missing arguments with a usage error
ok - fm-x-reply --help makes image support discoverable
ok - fm-x-reply rejects whitespace-only reply text
ok - fm-x-reply dry-run records the would-be reply and never posts
ok - fm-x-reply dry-run works without a token
ok - fm-x-reply honors FMX_DRY_RUN from .env
ok - fm-x-reply lets an explicitly empty dry-run env override .env
ok - fm-x-reply dry-run fails when it cannot record the preview
ok - fm-x-reply dry-run publishes outbox records only through private guarded artifacts
ok - fmx_split_thread: word-boundary, fence-aware, within-limit, numbered, lossless, capped
ok - fm-x-reply keeps a concise reply as a single unnumbered tweet
ok - fm-x-reply auto-splits a long reply into a numbered thread (texts[])
ok - fm-x-reply uses the Discord inbox platform budget instead of the X tweet budget
ok - fm-x-reply keeps numeric X requests on the X tweet budget
ok - fm-x-reply prefers an explicit relay-provided reply limit
ok - fm-x-reply rejects unsafe inbox context artifacts
ok - fm-x-reply clamps a below-floor max to 50 characters
ok - fm-x-reply posts a thread payload (texts[]) to the relay
ok - fm-x-reply --image posts an image object on answer
ok - fm-x-reply streams large image payloads outside curl argv
ok - fm-x-reply dry-run records compact image metadata for threaded replies
ok - fm-x-reply cleans image and payload temp files
ok - fm-x-reply --image rejects missing and unsupported image paths clearly
ok - fm-x-reply --followup posts to /connector/followup with the same request-bound body
ok - fm-x-reply maps a followup_unavailable follow-up 409 to exit 9
ok - fm-x-reply maps every follow-up 409 to exit 9 even without the marker
ok - fm-x-reply treats answer-endpoint 409 as a generic failure
ok - fm-x-reply --followup --image posts an image object
ok - fm-x-reply --followup is accepted in any position and leaves the answer path default
ok - fm-x-reply --followup dry-run marks the endpoint without changing the answer path
ok - fm-x-reply --followup auto-splits a long follow-up into a marked thread
ok - fm-x-reply followup dry-run keeps endpoint marker and compact image metadata
ok - fm-x-poll records the durable per-request reply context from the relay payload
ok - context registry publishes records only through private guarded artifacts
ok - context registry reads only private single-link artifacts
ok - private artifact publisher is compatible with the system bash path
ok - context registry retention is bounded to the seven-day follow-up window
ok - context registry rewrites preserve the first-seen timestamp
ok - context retention starts only when a live initial answer succeeds
ok - a delayed Discord follow-up stays one message after inbox cleanup via the durable registry
ok - an X follow-up over 280 still splits correctly after inbox cleanup
ok - every unresolved follow-up is refused before posting
ok - a partial registry platform combines with the relay's authoritative budget
ok - concurrent requests each recover their own platform/budget with no cross-overwrite
ok - fm-x-dismiss clears the durable per-request context (a dismissed mention gets no follow-up)
ok - fm-x-dismiss posts a request-bound dismiss and echoes only the request_id
ok - fm-x-dismiss dry-run records the would-be body and never posts
ok - fm-x-dismiss dry-run works without a token
ok - fm-x-dismiss dry-run publishes outbox records only through private guarded artifacts
ok - fm-x-dismiss exits non-zero on a non-2xx relay response
ok - fm-x-dismiss exits non-zero on a transport failure
ok - fm-x-dismiss rejects an unsafe request_id (path-traversal guard)
ok - fm-x-dismiss rejects missing or extra arguments with a usage error
ok - fm-x-link records and refreshes the X-request link without disturbing meta
ok - fm-x-link records Discord platform context so follow-ups keep the Discord budget
ok - fm-x-link resolves the platform by request_id so a post-cleanup link keeps the Discord budget
ok - fm-x-link warns loudly and the follow-up is held (not wrongly split) when the platform is unknown
ok - fm-x-link paired carry flags preserve a prior task's follow-up binding onto a successor
ok - fm-x-link recovery relink preserves Discord platform context after inbox drain
ok - fm-x-link rejects malformed or unpaired carry flags
ok - meta rewrites are independent of TMPDIR
ok - fm-x-link rejects unsafe ids, missing meta, and missing arguments
ok - fm-x-followup --check reports postable / not-linked correctly
ok - fm-x-followup --check prunes a link past the 7-day window
ok - fm-x-followup --check prunes a link that already reached the follow-up cap
ok - fm-x-followup posts a follow-up, increments the counter, and keeps the link under the cap
ok - fm-x-followup --final clears the link after one post regardless of the remaining count
ok - fm-x-followup clears the link once the third follow-up reaches the cap
ok - fm-x-followup --image forwards the attachment through fm-x-reply --followup
ok - fm-x-followup keeps the link and counter when the post fails
ok - fm-x-followup tombstones the link when a post-success counter write fails
ok - fm-x-followup treats a relay cap/window rejection as an already-exhausted link, not a retry
ok - fm-x-followup skips silently and clears the link past the 7-day window
ok - fm-x-followup is a no-op for a task with no X link
ok - fm-x-followup dry-run records the follow-up and increments the counter, keeping the link
ok - fm-x-followup dry-run --final clears the link just as a live post would
ok - fm-x-followup rejects malformed invocations
ok - bootstrap activates X mode from an .env token, idempotently
ok - bootstrap reports missing X-mode dependencies before arming
ok - bootstrap does not report X mode on when activation artifacts cannot be written
ok - bootstrap rejects linked X artifacts without touching their targets
ok - bootstrap is inert without a non-empty .env token (non-X users unaffected)
ok - bootstrap cleans up X artifacts on opt-out and is silent once off
ok - bootstrap reports failed X artifact cleanup on opt-out
FM_TEST_END 2026-07-22T07:26:32Z tests/fm-x-mode.test.sh exit=0 duration_ms=38406 gate_skip=false
FM_TEST_SUMMARY total=30 failed=0 skipped_gate=0 duration_ms=94238
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=3 duration_ms=50422 failed=0
FM_TEST_SUMMARY_FAMILY family=pr-forge count=3 duration_ms=53393 failed=0
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=24 duration_ms=169223 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-backend-herdr.test.sh duration_ms=46501
FM_TEST_SLOWEST rank=2 script=tests/fm-arm-pretool-check.test.sh duration_ms=38505
FM_TEST_SLOWEST rank=3 script=tests/fm-x-mode.test.sh duration_ms=38406
FM_TEST_SLOWEST rank=4 script=tests/fm-decision-hold-lifecycle.test.sh duration_ms=29522
FM_TEST_SLOWEST rank=5 script=tests/fm-cd-pretool-check.test.sh duration_ms=24607
FM_TEST_SLOWEST rank=6 script=tests/fm-crew-state.test.sh duration_ms=24541
FM_TEST_SLOWEST rank=7 script=tests/fm-herdr-lab.test.sh duration_ms=15033
FM_TEST_SLOWEST rank=8 script=tests/fm-pr-merge.test.sh duration_ms=10703
FM_TEST_SLOWEST rank=9 script=tests/fm-test-run.test.sh duration_ms=10655
FM_TEST_SLOWEST rank=10 script=tests/fm-send-popup-settle.test.sh duration_ms=6720
FM_TEST_SLOWEST rank=11 script=tests/fm-grok-harness.test.sh duration_ms=5942
FM_TEST_SLOWEST rank=12 script=tests/fm-review-diff.test.sh duration_ms=4284
FM_TEST_SLOWEST rank=13 script=tests/fm-send-settle.test.sh duration_ms=2815
FM_TEST_SLOWEST rank=14 script=tests/fm-tmux-submit-busy.test.sh duration_ms=2787
FM_TEST_SLOWEST rank=15 script=tests/fm-send-strict.test.sh duration_ms=2471
fm-test-run: wrote timing artifact: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY4AJ1DWSAAQ5VG8JA6S0KE1/proven-isolated-jobs4-retry.json
```
</details>
<details>
<summary>Evidence: Successful jobs=4 timing JSON</summary>

```text
{
  "families": [
    {
      "count": 3,
      "duration_ms": 50422,
      "failed": 0,
      "name": "backend-dispatch"
    },
    {
      "count": 3,
      "duration_ms": 53393,
      "failed": 0,
      "name": "pr-forge"
    },
    {
      "count": 24,
      "duration_ms": 169223,
      "failed": 0,
      "name": "pure-contract-unit"
    }
  ],
  "finished_at": "2026-07-22T07:26:32Z",
  "run_id": "fm-test-run-1784705098318-98267",
  "scripts": [
    {
      "duration_ms": 88,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-captain-translation-contract.test.sh"
    },
    {
      "duration_ms": 894,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-brief.test.sh"
    },
    {
      "duration_ms": 2400,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-composer-ghost.test.sh"
    },
    {
      "duration_ms": 60,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-composer-lib.test.sh"
    },
    {
      "duration_ms": 24607,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-cd-pretool-check.test.sh"
    },
    {
      "duration_ms": 24541,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-crew-state.test.sh"
    },
    {
      "duration_ms": 1031,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-dispatch-select.test.sh"
    },
    {
      "duration_ms": 543,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-ensure-agents-md.test.sh"
    },
    {
      "duration_ms": 5942,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-grok-harness.test.sh"
    },
    {
      "duration_ms": 38505,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-arm-pretool-check.test.sh"
    },
    {
      "duration_ms": 321,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-instruction-owners.test.sh"
    },
    {
      "duration_ms": 666,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-lint.test.sh"
    },
    {
      "duration_ms": 184,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-nm-test-contract.test.sh"
    },
    {
      "duration_ms": 40,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-no-mistakes-ownership.test.sh"
    },
    {
      "duration_ms": 1225,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-pi-primary-types.test.sh"
    },
    {
      "duration_ms": 46501,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "backend-dispatch",
      "gate_skip": false,
      "path": "tests/fm-backend-herdr.test.sh"
    },
    {
      "duration_ms": 4284,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pr-forge",
      "gate_skip": false,
      "path": "tests/fm-review-diff.test.sh"
    },
    {
      "duration_ms": 15033,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-herdr-lab.test.sh"
    },
    {
      "duration_ms": 10703,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pr-forge",
      "gate_skip": false,
      "path": "tests/fm-pr-merge.test.sh"
    },
    {
      "duration_ms": 2815,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-send-settle.test.sh"
    },
    {
      "duration_ms": 29522,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-decision-hold-lifecycle.test.sh"
    },
    {
      "duration_ms": 92,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-stow-contract.test.sh"
    },
    {
      "duration_ms": 2471,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "backend-dispatch",
      "gate_skip": false,
      "path": "tests/fm-send-strict.test.sh"
    },
    {
      "duration_ms": 394,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-supervision-instructions.test.sh"
    },
    {
      "duration_ms": 1450,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "backend-dispatch",
      "gate_skip": false,
      "path": "tests/fm-spawn-batch.test.sh"
    },
    {
      "duration_ms": 158,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-transition-lib.test.sh"
    },
    {
      "duration_ms": 6720,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-send-popup-settle.test.sh"
    },
    {
      "duration_ms": 2787,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-tmux-submit-busy.test.sh"
    },
    {
      "duration_ms": 10655,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-test-run.test.sh"
    },
    {
      "duration_ms": 38406,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pr-forge",
      "gate_skip": false,
      "path": "tests/fm-x-mode.test.sh"
    }
  ],
  "selection": "proven-isolated;jobs=4",
  "started_at": "2026-07-22T07:24:58Z",
  "summary": {
    "duration_ms": 94238,
    "failed": 0,
    "skipped_gate": 0,
    "total": 30
  }
}
```
</details>
- Evidence: Initial stale-contract failure (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY4AJ1DWSAAQ5VG8JA6S0KE1/proven-isolated-jobs4.txt</code>)
<details>
<summary>Evidence: Corrected lint-contract retry</summary>

```text
$ bash tests/fm-lint.test.sh
ok - one-owner lint script exists and is executable
ok - fm-lint.sh is the sole authoritative definition at CI-default severity
ok - CI lint job calls the one-owner script, not an inline command
ok - no-mistakes pre-push lint calls the one-owner script
ok - fm-lint.sh pins an explicit ShellCheck version (0.11.0)
ok - CI installs and logs the pinned ShellCheck version from the one owner
ok - fm-lint.sh refuses to lint under a non-pinned ShellCheck version
ok - fm-lint.sh catches a real lint defect the old no-op gate passed
ok - fm-lint.sh ignores ambient ShellCheck options
ok - fm-lint.sh passes a clean fixture
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- 🚨 `.github/workflows/ci.yml:58` - The new lane invocations remove the old `--all --exclude-family real-herdr-gated` CI command, but `tests/fm-nm-test-contract.test.sh` still requires `bin/fm-test-run.sh --all` and `tests/fm-install-herdr.test.sh` still requires `exclude-family real-herdr-gated`. Both contract tests will fail in the new shards. Update them to validate the lane partition and Herdr exclusion instead of the obsolete literals.
- 🚨 `tests/fm-test-run.test.sh:521` - The required criterion says &#34;Add bounded local --jobs N only for the proven-isolated set,&#34; but this new test overwrites `tests/fm-stow-contract.test.sh` in the shared checkout while both it and `fm-test-run.test.sh` remain members of that set. A concurrent `--proven-isolated --jobs N` run can therefore execute the overwritten file or race its restoration, invalidating the isolation proof. Please replace this with a private/injected failure fixture that does not mutate another proven test.
- ⚠️ `bin/fm-test-run.sh:1266` - The scheduler always waits for the oldest launched PID, even when later workers have already finished. A single slow first worker leaves completed slots idle and turns the measured list into waves, substantially reducing the intended local parallel acceleration. Reap any completed worker or use a fixed bounded worker queue while preserving portable Bash support.

🔧 Fix: Captain, fix CI contracts and completion-order worker scheduling
1 warning still open:
- ⚠️ `bin/fm-test-run.sh:1343` - Parallel workers separate stderr from stdout, but `record_script_result` scans only the stdout file. Consequently `--fail-on-gate-skip` and ordinary gate-skip accounting ignore any `skip:` line emitted on stderr, unlike serial execution&#39;s combined `2&gt;&amp;1` stream and the documented &#34;any output line&#34; contract. Capture a combined worker stream or scan both files before recording the result.

🔧 Fix: Captain, preserve stderr gate-skip detection in parallel tests
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff f6c281afb7a4b53b40ca919ff714a7d77ff0f030..55396a2396a3154bab158b349b82aa205c64a308` and `bin/fm-test-run.sh --help`.</code>
- `bash tests/fm-test-run.test.sh`
- `bash tests/fm-test-isolation-proof.test.sh`
- `bash tests/fm-nm-test-contract.test.sh`
- `bash tests/fm-install-herdr.test.sh`
- <code>Initial `bin/fm-test-run.sh --proven-isolated --jobs 4 --json .../proven-isolated-jobs4.json`, which exposed the stale lint CI-job-count assertion.</code>
- <code>`bash tests/fm-lint.test.sh` after the test-only correction.</code>
- <code>Retry `bin/fm-test-run.sh --proven-isolated --jobs 4 --json .../proven-isolated-jobs4-retry.json`.</code>
- `bin/fm-test-run.sh --check-coverage`
- <code>Independently recomputed two-worker LPT assignment from `docs/fm-test-portable-shards.md` and compared exact ordered membership with both `--list --lane` outputs.</code>
- <code>`bin/fm-test-run.sh --jobs 4 tests/fm-watcher-lock.test.sh`, verifying refusal with exit 2.</code>
- <code>Inspected the successful timing JSON and ran `git status --short` plus `git ls-files --others --exclude-standard` to confirm only the intentional test correction remains.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
