### PR TITLE
Add milestone-integration-review stage and pattern-triggers guide

### DIFF
--- a/.agents/skills/milestone-integration-review/SKILL.md
+++ b/.agents/skills/milestone-integration-review/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: milestone-integration-review
+description: >-
+  Agent-only procedure for the standing gap between "every issue in a milestone is individually green" and "ready for captain merge decision."
+  Use before presenting any multi-PR milestone (2+ open PRs from the same milestone, same project) as ready to merge.
+  Owns dispatching a dedicated integration-review pass and running fm-integration-review.sh to produce a reproducible merge-train transcript, before any individual PR's "checks green" is treated as proof the milestone composes.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# milestone-integration-review
+
+## Why this exists
+
+Isolated per-crewmate gates cannot prove that independently-green PRs compose.
+Each crewmate's `no-mistakes` run validates its own branch alone; it has no way to see the other PRs in the same milestone.
+Two individually-correct PRs can be mutually incompatible in a way no single PR's own CI will ever catch.
+A real cross-PR `NameError` shipped past four independent per-PR gates on 2026-07-21 before a dedicated review pass caught it - see the fusion-harness repo's `PROOF.md`/`BUGS_FOUND.md` for the full account.
+"Checks green" on GitHub, in most projects, means the CI that project actually has ran clean, often just secret scanning, not a test suite.
+It is never proof that N PRs merged together still work.
+
+## When to load this
+
+Before reporting any milestone as ready for the captain's merge decision, whenever that milestone has **2 or more open PRs**.
+A single-PR milestone doesn't need this - there's nothing to compose.
+Load it once all the milestone's individual issues have reached their own `done: PR ... checks green` state.
+
+## Procedure
+
+1. **Determine dependency order.**
+   If the milestone's plan (a fusion-harness `/fusion` output, a design doc, or explicit dependency notes in the issues) states an order, use it.
+   Otherwise default to issue-number order and flag the assumption in the report.
+2. **Identify the test command.**
+   Use the project's own documented test command (README, `AGENTS.md`, or ask the captain if genuinely unknown).
+   Do not guess a framework.
+3. **Run the merge-train check:**
+   ```
+   bin/fm-integration-review.sh <project> "<test-command>" <pr1> <pr2> ... <prN>
+   ```
+   in dependency order.
+   Save its full output - `tee` to a file, not just prose in a status line.
+   This transcript is the artifact; a captain-facing "N/N passing" claim needs a reproducible transcript behind it, the same discipline `verify-49-tests.txt` established in the 2026-07-21 run.
+4. **On a clean run (exit 0):** the milestone's PRs compose.
+   Report this to the captain alongside the transcript path, as part of the normal PR-ready escalation (AGENTS.md section 9).
+5. **On a merge conflict (exit 2):** this is expected, not an error in the process.
+   It means two PRs touch overlapping code, which any real merge would eventually need to resolve anyway.
+   Do not resolve it inside this script's disposable worktree and call it done.
+   Either dispatch this as its own scoped task - a crewmate or the captain resolves the conflict on the flagged branch, understanding what each PR intended, then a human or crewmate re-runs the full suite manually - or, if the fix is small and the ownership is unambiguous, brief the *original* PR whose merge-train position triggered the conflict to resolve it directly on its own branch and re-push.
+   That second path matches how 2026-07-21's #25 was fixed - the same crewmate reworked its own branch rather than a new task being spun up.
+   Either way, do not report the milestone ready until a full-suite green merge-train transcript exists.
+6. **On any other failure** (test command errors, a merge itself fails for reasons other than content conflicts): treat as `blocked:` per the standard status protocol and escalate.
+   Do not retry blindly.
+
+## What this is not
+
+This does not replace `no-mistakes` per-PR validation, and it is not itself a merge authority.
+It produces evidence; the captain still makes the merge call, and nothing in this procedure pushes to any default branch or merges any PR.
+It also does not decide dependency order on its own; that's either supplied by the plan that produced the milestone or made explicit and flagged if inferred.

--- a/.agents/skills/pattern-triggers/SKILL.md
+++ b/.agents/skills/pattern-triggers/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: pattern-triggers
+description: >-
+  Agent-only reference mapping a captain's request-shape language (opinion, plan, build, review, team) onto a concrete dispatch pattern.
+  Use during intake, alongside the existing Ship/Scout classification in AGENTS.md section 7, whenever the captain's phrasing signals one of the named patterns below rather than a plain ship or scout request.
+  This skill decides HOW MANY agents to dispatch and in what shape; it does not replace the project resolution or Ship/Scout classification steps that already happen during intake.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# pattern-triggers
+
+## Why this exists
+
+AGENTS.md section 7 already classifies every request as Ship or Scout.
+That classification answers "does this change a project."
+It does not answer "how many independent perspectives does this need, and does the result need to be synthesized before it's useful."
+This skill answers that second question, for requests whose phrasing signals a known shape.
+The five patterns below are not new capabilities; they are named, repeatable combinations of dispatch primitives firstmate already has, given the same names the fusion-harness Pi extension uses for the same underlying idea, since firstmate is fusion-harness's pattern applied at the fleet-management scale rather than the single-session scale.
+
+## The five patterns
+
+### opinion
+
+**Recognize:** "give me your opinion on X," "what do you think about X," "opinion:", "how would you compare X."
+**Shape:** two Scout tasks, different harness/model per `config/crew-dispatch.json`'s planning-tier routing, same prompt, dispatched in parallel.
+Neither task sees the other's output.
+**Deliverable:** both reports, presented side by side, unedited.
+No synthesis, no recommendation from firstmate beyond what each report says on its own.
+**When not to use this:** the captain wants one clear answer, not two perspectives to weigh.
+Use a single Scout instead.
+
+### plan / fusion
+
+**Recognize:** "plan X," "fusion:", "figure out how to X," any request for a milestone, roadmap, or multi-step breakdown where the scope is not already fully specified.
+**Shape:** two Scout tasks (same routing as opinion) propose independently, open-ended, no shared scope between them.
+A third step, run by firstmate itself or a dedicated synthesis Scout, reads both proposals plus the actual project state and produces one reconciled plan.
+**Deliverable:** the reconciled plan, with explicit attribution for which proposal contributed which part, and an explicit note of what each proposal got right or missed.
+**Known cost, from the 2026-07-21 run:** open-ended two-worker proposals can diverge completely from what the captain actually wants, discarding real time/cost on the divergent halves.
+If the scope is already known and narrow, skip straight to a single well-briefed Ship or Scout task instead of this pattern - fusion planning earns its cost on genuinely open, ambiguous scope, not on well-specified work.
+
+### build / ship
+
+**Recognize:** "build X," "ship X," "implement X," "fix X" - ordinary Ship classification, already covered by AGENTS.md section 7.
+No new behavior; listed here only so the five patterns read as a complete set from the captain's side.
+
+### review
+
+**Recognize:** "review X," "critique X," "find problems with X," "check my work on X," any request to evaluate existing work rather than produce or plan new work.
+**Shape:** one dedicated Scout task, explicitly framed as adversarial: verify claims against the actual artifact (code, PR diff, doc), not just restate what the artifact already says about itself.
+**Escalation, for higher-stakes review:** dispatch a second review pass on a **different model family** than the first.
+The 2026-07-21 run found a real bug that survived four same-family review passes and was only caught once a cross-family pass ran - see `firstmate-data/data/sdlc-milestone-review/report.md` and the fusion-harness repo's `BUGS_FOUND.md` for the evidence.
+Default to single-pass review; escalate to cross-family only when the captain asks for higher confidence, or the work is high-stakes (production infrastructure, security-relevant, or explicitly flagged as needing extra scrutiny).
+
+### team / milestone
+
+**Recognize:** "run the team on X," "swarm X," any request that names or implies multiple related issues delivered together as one unit, or an explicit milestone.
+**Shape:** the full pipeline exercised on 2026-07-21: `plan`/`fusion` produces the milestone and its issues, each issue dispatches as its own Ship task (potentially to different harnesses/models per `config/crew-dispatch.json`, weighted by the issue's own difficulty), then `milestone-integration-review` runs before any PR-ready escalation reaches the captain.
+**This is the pattern that most needs the milestone-integration-review skill.**
+Never report a multi-issue milestone ready without it - see that skill for why.
+
+## What this skill does not decide
+
+Project resolution, Ship-vs-Scout classification, delivery mode (`no-mistakes`/`direct-PR`/`local-only`), and secondmate routing are all unchanged, decided exactly as AGENTS.md section 7 already specifies.
+This skill only decides how many agents and what shape, layered on top of that existing classification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,8 @@ Classify the deliverable:
 - **Ship** is the default and produces a project change through the selected delivery mode.
 - **Scout** produces knowledge in `data/<id>/report.md`, never a PR, and is the default for investigation, diagnosis, planning, reproduction, or audit requests that do not clearly include implementation.
 
+When the captain's phrasing signals a named request shape - opinion, plan/fusion, review, or team/milestone - load `pattern-triggers` before dispatching; it decides how many agents and what shape on top of the Ship/Scout classification above, not instead of it.
+
 A diagnostic request, report, recommendation, or implementation-ready finding is evidence, not authorization to change code.
 Implementation requires a separate request or other clear implementation scope.
 Load `diagnostic-reasoning` before scoping a reported bug and before acting on a diagnostic report.
@@ -289,6 +291,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 ### PR ready, landing, and teardown
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
+When a milestone has 2 or more of its own PRs individually reaching `done`, load `milestone-integration-review` before reporting the milestone ready - a PR's own "checks green" never proves it composes with the milestone's other PRs.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
@@ -464,6 +467,8 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `pattern-triggers` - load during intake when the captain's phrasing signals opinion, plan/fusion, review, or team/milestone rather than a plain ship or scout request.
+- `milestone-integration-review` - load before reporting a multi-PR milestone (2+ open PRs) ready for the captain's merge decision.
 
 ## 14. X mode
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Firstmate's skills live in two separate places with different audiences:
 ## Documentation
 
 - [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
+- [docs/interaction-patterns.md](docs/interaction-patterns.md) - how to phrase a request so firstmate dispatches the right shape of work: opinion, plan, build, review, or team.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - setup guide for the tmux reference backend: prerequisites, attaching, and watching crew windows.

--- a/bin/fm-integration-review.sh
+++ b/bin/fm-integration-review.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Merge a set of individually-green PRs against one project in a disposable
+# worktree, in a declared dependency order, and run the project's real test
+# suite after each merge. This is the standing fix for the finding that
+# isolated per-crewmate gates (each PR validated alone via no-mistakes) cannot
+# by themselves prove that N independently-green PRs actually compose - a
+# real cross-PR NameError shipped past four independent per-PR gates in the
+# 2026-07-21 sdlc-demo run before a dedicated review pass caught it.
+#
+# This script is the artifact-producing half of that fix: given an explicit
+# PR list and dependency order, it produces a disposable merge-train branch
+# and a saved, reproducible test transcript. It does not decide whether the
+# result is acceptable and it never merges anything to the project's default
+# branch - that decision belongs to the captain, informed by this script's
+# output, per the milestone-integration-review skill.
+#
+# Usage:
+#   fm-integration-review.sh <project-dir-or-name> <test-command> <pr-number>...
+#
+# <project-dir-or-name> resolves the same way fm-fleet-sync.sh resolves it:
+#   a path (absolute or relative to caller's cwd), or a bare "<name>" /
+#   "projects/<name>" form resolved against this home's projects dir
+#   ($FM_HOME/projects, or $FM_PROJECTS_OVERRIDE).
+# <test-command> is run verbatim (via `sh -c`) after each merge step, from the
+#   worktree root - e.g. "python3 -m pytest tests/ -q" or "npm test".
+# <pr-number>... is the ordered list of PR numbers to merge, in the order to
+#   merge them - the caller (a milestone-integration-review dispatch, or the
+#   captain) decides that order; this script does not infer dependencies.
+#
+# On any merge conflict, the script stops and reports it rather than
+# resolving it - conflict resolution across independently-built PRs requires
+# understanding what each side intended, which is exactly the judgment this
+# script is not meant to automate. Re-run after a human or a dispatched
+# crewmate resolves the conflict on the merge-train branch directly.
+#
+# Output: a transcript on stdout (safe to redirect - `tee` it to a saved file
+# for the same durable-evidence reason `verify-49-tests.txt` exists in the
+# 2026-07-21 run: a captain-facing "N/N passing" claim needs a reproducible
+# artifact behind it, not prose). Exit 0 iff every merge was clean and every
+# test-command run exited 0. The worktree is left in place on both success and
+# failure for inspection; nothing is torn down automatically.
+set -eu
+
+usage() {
+  awk '/^# Usage:/{f=1} f{print substr($0,3)} /^set -eu/{exit}' "$0"
+  exit "${1:-0}"
+}
+
+[ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ] && usage 0
+[ $# -ge 3 ] || {
+  echo "error: need <project-dir-or-name> <test-command> <pr-number>..." >&2
+  usage 1
+}
+
+PROJECT_ARG=$1
+TEST_CMD=$2
+shift 2
+PR_NUMBERS=("$@")
+
+# Resolve the project directory the same way fm-fleet-sync.sh does.
+resolve_project_dir() {
+  local arg=$1
+  case "$arg" in
+    /*) printf '%s\n' "$arg"; return 0 ;;
+  esac
+  local projects_root="${FM_PROJECTS_OVERRIDE:-${FM_HOME:-}/projects}"
+  local name=$arg
+  case "$arg" in
+    projects/*) name=${arg#projects/} ;;
+  esac
+  if [ -n "$projects_root" ] && [ -d "$projects_root/$name" ]; then
+    printf '%s\n' "$projects_root/$name"
+    return 0
+  fi
+  if [ -d "$arg" ]; then
+    printf '%s\n' "$(cd "$arg" && pwd)"
+    return 0
+  fi
+  echo "error: cannot resolve project '$arg' (checked '$projects_root/$name' and cwd-relative path)" >&2
+  return 1
+}
+
+PROJECT_DIR=$(resolve_project_dir "$PROJECT_ARG")
+[ -d "$PROJECT_DIR/.git" ] || { echo "error: '$PROJECT_DIR' is not a git repo" >&2; exit 1; }
+
+REMOTE_URL=$(git -C "$PROJECT_DIR" remote get-url origin)
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/fm-integration-review.XXXXXX")
+trap 'echo "worktree left at: $WORK"' EXIT
+
+echo "=== fm-integration-review: $PROJECT_ARG, PRs: ${PR_NUMBERS[*]} ==="
+echo "=== cloning fresh into $WORK/repo ==="
+git clone -q "$REMOTE_URL" "$WORK/repo"
+cd "$WORK/repo"
+
+FETCH_REFSPECS=()
+BRANCH_NAMES=()
+for pr in "${PR_NUMBERS[@]}"; do
+  FETCH_REFSPECS+=("pull/$pr/head:pr$pr")
+  BRANCH_NAMES+=("pr$pr")
+done
+
+echo "=== fetching PR heads: ${FETCH_REFSPECS[*]} ==="
+git fetch -q origin "${FETCH_REFSPECS[@]}"
+
+BASE=$(git merge-base main "${BRANCH_NAMES[0]}")
+echo "=== base: $BASE ==="
+git checkout -q -b integration-review-train "$BASE"
+
+echo "--- baseline ($BASE) ---"
+sh -c "$TEST_CMD"
+
+for i in "${!BRANCH_NAMES[@]}"; do
+  pr=${PR_NUMBERS[$i]}
+  branch=${BRANCH_NAMES[$i]}
+  echo "=== merging PR #$pr ($branch) ==="
+  if ! git merge -q --no-edit "$branch"; then
+    echo "CONFLICT merging PR #$pr - stopping. Resolve on branch integration-review-train in $WORK/repo and re-run the test command manually; this script does not auto-resolve conflicts." >&2
+    exit 2
+  fi
+  echo "--- test after PR #$pr ---"
+  sh -c "$TEST_CMD"
+done
+
+echo "=== all ${#PR_NUMBERS[@]} PRs merged clean, tests green after every step ==="
+echo "worktree: $WORK/repo (left in place; nothing pushed, nothing merged to $PROJECT_ARG)"

--- a/docs/interaction-patterns.md
+++ b/docs/interaction-patterns.md
@@ -1,0 +1,58 @@
+# Interaction patterns: how to talk to firstmate
+
+How to phrase a request to the captain so firstmate dispatches the right shape of work.
+The [README](../README.md) covers install and the basic chat loop; this document covers the specific vocabulary that triggers each named dispatch pattern.
+Agent-facing detail (exact routing, exact skill names) lives in `.agents/skills/pattern-triggers/SKILL.md`; this is the human-facing companion.
+
+## Why patterns, not commands
+
+firstmate is not a slash-command tool.
+You talk to it in plain language, the way you'd brief a project manager.
+The five patterns below are not new syntax to memorize; they're names for five shapes of work firstmate can already dispatch, so you can ask for the shape you want instead of getting whatever shape firstmate guesses.
+Each one maps onto the same architect/builder/fusion idea fusion-harness uses inside a single Pi session, just applied at the scale of a real fleet of crewmate agents in real git worktrees producing real PRs.
+
+## The five patterns
+
+### "Give me your opinion on X"
+
+Two independent takes, side by side, no merge.
+Use when you want to see how two different models/harnesses approach the same open question, or when you don't yet trust either answer alone.
+You get both full reports; nothing is filtered or summarized on your behalf.
+
+**Example:** "Opinion: should we use polling or webhooks for the sync job?"
+
+### "Plan X" / "Figure out how to X"
+
+Two independent proposals, then one reconciled plan.
+Use when the scope is genuinely open, not when you already know what you want built.
+If you already know the four things you want, just say so directly, brief and dispatch is faster and cheaper than fusion planning.
+This pattern earns its cost on ambiguity, not on well-specified work - a real run on 2026-07-21 spent about ten minutes and thirty cents on two workers proposing entirely different, both-wrong milestones before the third synthesis step reconciled them into the right one, because the request was genuinely open-ended.
+
+**Example:** "Plan the next milestone for the payments service" (open) vs. "Build a `/refund` endpoint that reverses a charge and emails a confirmation" (already scoped - just ask for this directly, skip planning).
+
+### "Build X" / "Ship X" / "Fix X"
+
+The ordinary path.
+One crewmate, its own isolated worktree, the project's normal delivery pipeline, a PR when done.
+This is the default; most requests should just look like this.
+
+### "Review X" / "Check my work on X"
+
+A dedicated critique pass against something that already exists - code, a PR, a document, a decision.
+Different from asking a question: review means "find what's wrong with this," not "tell me about this."
+For higher-stakes work, ask for a second review on a different model family explicitly - a real cross-family review on 2026-07-21 caught a genuine bug that four same-family review passes in a row had all missed.
+
+**Example:** "Review PR 42 before I merge it" vs., for something you want extra confidence on, "Review PR 42, then get a second opinion from a different model."
+
+### "Run the team on X" / a request that's really several related pieces of work
+
+The full pipeline: plan produces a milestone and its issues, each issue ships as its own parallel task, then everything is checked to make sure the pieces actually work together before you're asked to approve anything.
+That last step matters and is easy to skip by accident: on 2026-07-21, four issues each individually passed their own tests, and two of them were still incompatible with each other in a way nothing but a dedicated cross-issue check caught.
+If firstmate ever reports a multi-piece milestone ready without mentioning that check, ask whether it ran.
+
+**Example:** "Run the team on the observability milestone - stats, threading, TTL batching, and the sweeper."
+
+## What you don't need to specify
+
+Which project (firstmate resolves this from context or asks if it's ambiguous), which harness or model builds it (routed automatically by task type and difficulty), or the delivery mode (already configured per project).
+You only need to signal the *shape* - how many perspectives, whether it's new work or a check on existing work, whether it's one piece or several that need to compose.

--- a/tests/fm-integration-review.test.sh
+++ b/tests/fm-integration-review.test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-integration-review.sh.
+#
+# fm-integration-review.sh clones a project fresh, fetches the given PR heads,
+# merges them in the given order into a disposable worktree, and runs a
+# caller-supplied test command after each merge.
+# This suite pins two behaviors: a clean multi-PR merge exits 0 and runs the
+# test command after every step, and a real content conflict stops the script
+# (exit 2) without resolving it and without touching the project's own remote.
+#
+# All fixtures are local: a bare repo stands in for the forge, and
+# refs/pull/N/head is fabricated by hand the way a real forge would populate
+# it, so this suite makes no network calls.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+fm_git_identity fmtest fmtest@example.invalid
+
+TMP_ROOT=$(fm_test_tmproot fm-integration-review-tests)
+
+# new_origin: a bare repo with a main branch holding one base commit.
+# Returns the bare repo's path on stdout.
+new_origin() {
+  local name=$1
+  local origin="$TMP_ROOT/$name-origin.git"
+  local seed="$TMP_ROOT/$name-seed"
+  git init -q --bare "$origin"
+  git init -q "$seed"
+  (
+    cd "$seed" || exit 1
+    fm_git_identity fmtest fmtest@example.invalid
+    git checkout -q -b main
+    printf 'base\n' > base.txt
+    git add base.txt
+    git commit -q -m "base"
+    git remote add origin "$origin"
+    git push -q origin main
+  )
+  printf '%s\n' "$origin"
+}
+
+# fabricate_pr: create a branch on top of main in a throwaway clone of
+# $origin, push it, then point refs/pull/<n>/head at its tip - the same shape
+# a real forge exposes for an open PR, built locally instead of over the
+# network.
+fabricate_pr() {
+  local origin=$1
+  local n=$2
+  local file=$3
+  local content=$4
+  local work="$TMP_ROOT/pr-$n-work-$$-$RANDOM"
+  git clone -q "$origin" "$work"
+  (
+    cd "$work" || exit 1
+    fm_git_identity fmtest fmtest@example.invalid
+    git checkout -q -b "pr-$n-branch" main
+    printf '%s\n' "$content" > "$file"
+    git add "$file"
+    git commit -q -m "pr $n"
+    git push -q origin "HEAD:refs/pull/$n/head"
+  )
+  rm -rf "$work"
+}
+
+# new_project_dir: a working clone of $origin with a project-shaped .git
+# directory, the form fm-integration-review.sh's resolve_project_dir accepts
+# as an absolute path.
+new_project_dir() {
+  local origin=$1
+  local name=$2
+  local dir="$TMP_ROOT/$name-project"
+  git clone -q "$origin" "$dir"
+  printf '%s\n' "$dir"
+}
+
+SCRIPT="$ROOT/bin/fm-integration-review.sh"
+
+# --- test: two non-conflicting PRs merge clean, test command runs each step -
+
+origin=$(new_origin clean)
+fabricate_pr "$origin" 1 file-a.txt "from pr 1"
+fabricate_pr "$origin" 2 file-b.txt "from pr 2"
+project=$(new_project_dir "$origin" clean)
+
+marker="$TMP_ROOT/clean-run-count"
+: > "$marker"
+out=$("$SCRIPT" "$project" "printf run >> '$marker'" 1 2 2>&1)
+code=$?
+
+[ "$code" -eq 0 ] || fail "clean merge-train exited $code, expected 0: $out"
+echo "$out" | grep -q "all 2 PRs merged clean" || fail "success line missing from output: $out"
+runs=$(grep -o run "$marker" | wc -l | tr -d ' ')
+[ "$runs" = "3" ] || fail "expected test command to run 3 times (baseline + 2 merges), got $runs"
+
+pass "clean multi-PR merge-train exits 0 and runs the test command after every step"
+
+# --- test: a real content conflict stops the script without resolving it ---
+
+origin=$(new_origin conflict)
+fabricate_pr "$origin" 10 shared.txt "pr 10's version"
+fabricate_pr "$origin" 11 shared.txt "pr 11's version"
+project=$(new_project_dir "$origin" conflict)
+
+before_sha=$(git -C "$project" rev-parse origin/main)
+
+out=$("$SCRIPT" "$project" "true" 10 11 2>&1)
+code=$?
+
+[ "$code" -eq 2 ] || fail "conflicting merge-train exited $code, expected 2: $out"
+echo "$out" | grep -q "CONFLICT merging PR #11" || fail "conflict line missing from output: $out"
+echo "$out" | grep -qi "does not auto-resolve" || fail "script did not state its no-auto-resolve contract: $out"
+
+after_sha=$(git -C "$project" rev-parse origin/main)
+[ "$before_sha" = "$after_sha" ] || fail "project's own origin/main moved during a review run - nothing should ever push back"
+
+pass "a real merge conflict stops the script (exit 2) without resolving it or touching the project's own remote"


### PR DESCRIPTION
## Summary

Isolated per-crewmate gates cannot prove that independently-green PRs actually compose. On a real run (2026-07-21, sdlc-demo milestone), 4 crewmates each independently passed their own `no-mistakes` gate, but 2 of those PRs were mutually incompatible in a way no single PR's own CI could ever catch - a silent `NameError` invisible until a dedicated cross-PR review pass merged all 4 branches and re-ran the suite.

This PR makes that review a standing pipeline stage instead of an ad hoc extra dispatch:

- **`bin/fm-integration-review.sh`** - merges a milestone's PRs in dependency order in a disposable worktree, running the real test suite after every step. Stops on a real conflict rather than guessing a resolution. Shellcheck-clean, colocated test suite (`tests/fm-integration-review.test.sh`, fully local fixtures, no network calls).
- **`.agents/skills/milestone-integration-review/SKILL.md`** - tells firstmate when to run it: before any 2+ PR milestone is reported ready for the captain's merge decision.
- **`.agents/skills/pattern-triggers/SKILL.md`** + **`docs/interaction-patterns.md`** - names five request shapes (opinion, plan/fusion, build, review, team) so a captain can ask for the dispatch shape they want (how many agents, what shape) instead of getting whatever firstmate infers. Layers on top of the existing Ship/Scout classification in `AGENTS.md` section 7, doesn't replace it.

Both new skills are wired into `AGENTS.md`'s trigger index (section 13) and their relevant operating sections, per `firstmate-coding-guidelines` (one-owner rule, size discipline, trigger hygiene).

## Evidence

The full run this is based on, including the review chain that converged on this diagnosis (an original peer-review agent, an adversarial critique pass, and two rounds of cross-model-family review), is documented in a separate repo: [`PROOF.md`](https://github.com/davidmarkgardiner/fusion-harness/blob/main/PROOF.md) and [`BUGS_FOUND.md`](https://github.com/davidmarkgardiner/fusion-harness/blob/main/BUGS_FOUND.md) in `davidmarkgardiner/fusion-harness`.

`fm-integration-review.sh` was also run for real against the actual PRs from that run and correctly stopped on the real merge conflict rather than resolving it silently, exactly per its documented contract.

## Test plan

- [x] `bash bin/fm-lint.sh` - clean, pinned shellcheck 0.11.0
- [x] `bash tests/fm-integration-review.test.sh` - both cases pass (clean multi-PR merge exits 0 and runs the test command after every step; a real conflict stops the script at exit 2 without resolving it or touching the project's own remote)
- [x] End-to-end run against real PRs (davidmarkgardiner/sdlc-demo #22-#25) - correctly merged 3 clean, correctly stopped on the real conflict at PR #25