### PR TITLE
fix(harness): stop BSD basename spraying stderr on the ancestry walk

### DIFF
--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -36,10 +36,17 @@ detect_own() {
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
   # Layer 2: walk the parent chain and match the command name.
-  local pid=$$ comm args
+  local pid=$$ comm name args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
-    case "$(basename "$comm")" in
+    # Strip any directory prefix, then a login shell's leading '-' (ps reports a
+    # login shell as "-zsh"). Parameter expansion, not basename(1): BSD basename
+    # parses a leading dash as an option and fails with "illegal option -- z",
+    # spraying stderr on every walk from a login shell. GNU basename accepts it,
+    # so the noise is macOS/BSD-only.
+    name=${comm##*/}
+    name=${name#-}
+    case "$name" in
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -121,6 +121,7 @@ family_for_basename() {
     fm-cd-pretool-check.test.sh|fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-continuity-pretool-check.test.sh|fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-dispatch-select.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
+    fm-harness-detect-login-shell.test.sh|\
     fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
     fm-pi-primary-types.test.sh|\

--- a/tests/fm-harness-detect-login-shell.test.sh
+++ b/tests/fm-harness-detect-login-shell.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Behavior tests for harness auto-detection across a login shell in the parent chain.
+#
+# ps -o comm= reports a login shell as "-zsh" (leading dash). The chain walk used
+# to hand that straight to basename(1); BSD basename parses the leading "-z" as an
+# option and fails with "illegal option -- z", so every detection run from a login
+# shell sprayed stderr. GNU basename accepts it, making this macOS/BSD-only.
+#
+# The noise never changed a verdict - the walk continues past the failed
+# substitution - but it appears alongside spawn's genuine
+# "no launch template for harness 'unknown'" refusal and reads as its cause.
+# These tests pin both halves: no stderr noise, and verdicts unchanged.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-harness-detect-login-shell)
+HARNESS="$ROOT/bin/fm-harness.sh"
+
+# A fake ps driven by FM_FAKE_CHAIN="pid:comm:ppid,...". An unknown pid (the
+# script's real $$) resolves to the head of the chain, so a test can describe an
+# ancestry without knowing any live pid.
+make_fake_ps() {
+  local fakebin
+  fakebin=$(fm_fakebin "$TMP_ROOT")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field=""; want=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) field="$2"; shift 2 ;;
+    -p) want="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+emit() {
+  case "$field" in
+    comm=) printf '%s\n' "$1" ;;
+    args=) printf '%s\n' "$1" ;;
+    ppid=) printf '%s\n' "$2" ;;
+  esac
+}
+old=$IFS; IFS=','; set -f; ents=($FM_FAKE_CHAIN); IFS=$old; set +f
+for e in "${ents[@]}"; do
+  p="${e%%:*}"; rest="${e#*:}"; c="${rest%%:*}"; pp="${rest##*:}"
+  [ "$p" = "$want" ] && { emit "$c" "$pp"; exit 0; }
+done
+e="${ents[0]}"; rest="${e#*:}"; emit "${rest%%:*}" "${rest##*:}"
+SH
+  chmod +x "$fakebin/ps"
+  printf '%s\n' "$fakebin"
+}
+
+FAKEBIN=$(make_fake_ps)
+
+# detect <chain> -> echoes the verdict; stderr captured in $DETECT_ERR
+DETECT_ERR="$TMP_ROOT/stderr.txt"
+detect() {
+  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+      PATH="$FAKEBIN:$PATH" FM_FAKE_CHAIN="$1" FM_CONFIG_OVERRIDE="$TMP_ROOT/noconfig" \
+      bash "$HARNESS" 2>"$DETECT_ERR"
+}
+
+# --- 1. a login shell in the chain must not produce stderr noise -------------
+
+out=$(detect "100:-zsh:1")
+[ -s "$DETECT_ERR" ] \
+  && fail "login shell '-zsh' in the chain wrote to stderr: $(head -1 "$DETECT_ERR")"
+pass "login shell '-zsh' walks silently (no BSD basename 'illegal option' noise)"
+
+# --- 2. verdicts are unchanged ----------------------------------------------
+
+# A plain login shell genuinely has no harness ancestor: 'unknown' is correct.
+[ "$out" = "unknown" ] || fail "expected 'unknown' for a bare login shell, got '$out'"
+pass "bare login shell still resolves to 'unknown' (no harness in the ancestry)"
+
+# A harness ABOVE the login shell is still found - the dash never blocked the walk.
+out=$(detect "100:-zsh:200,200:claude:1")
+[ "$out" = "claude" ] || fail "expected 'claude' through a login shell, got '$out'"
+[ -s "$DETECT_ERR" ] && fail "detection through a login shell wrote to stderr"
+pass "harness above a login shell is still detected, silently"
+
+# --- 3. a directory prefix is still stripped (the basename behaviour kept) ---
+
+out=$(detect "100:/usr/local/bin/codex:1")
+[ "$out" = "codex" ] || fail "expected 'codex' from an absolute comm path, got '$out'"
+pass "absolute comm path still resolves to its basename"
+
+# The 'pi' arm is an exact match, so stripping must be exact too.
+out=$(detect "100:/opt/homebrew/bin/pi:1")
+[ "$out" = "pi" ] || fail "expected exact-match 'pi' from a path, got '$out'"
+pass "exact-match arm ('pi') still matches after prefix stripping"
+
+# --- 4. a login shell must not be mistaken for a harness --------------------
+
+out=$(detect "100:-bash:1")
+[ "$out" = "unknown" ] || fail "expected 'unknown' for '-bash', got '$out'"
+pass "login shell '-bash' is not mistaken for a harness"


### PR DESCRIPTION
## Intent

Make a failed spawn on macOS **diagnosable**. Today the harness detector emits a spurious
`basename: illegal option -- z` immediately above spawn's genuine refusal, and the two adjacent
lines read as cause and effect. They aren't related at all — but a reader can't tell that from
the output, so the first thing they investigate is the wrong thing.

This is a **diagnostics** change. It fixes no behaviour and changes no verdict.

## When this bites

Detection short-circuits on Layer 1 env markers, so this never fires when `CLAUDECODE=1`
(or `PI_CODING_AGENT` / `GROK_AGENT`) is set. It bites when detection falls through to the
Layer 2 ancestry walk **on a BSD userland**:

- a harness that sets no env marker (codex / opencode) on macOS
- any direct CLI invocation of `fm-harness.sh` or `fm-spawn.sh` from a terminal
- any spawn whose parent chain reaches the user's **login shell**

`ps -o comm=` reports a login shell with a leading dash (`-zsh`), and BSD `basename` parses that
`-z` as an option:

```console
$ basename -zsh
basename: illegal option -- z
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]
```

GNU `basename` accepts it, so Linux users never see this and it doesn't show up in CI.

## Outcome

What a macOS user sees on a refused spawn today:

```
basename: illegal option -- z
error: no launch template for harness 'unknown' (from config/crew-harness or detection)
```

What they see after this change:

```
error: no launch template for harness 'unknown' (from config/crew-harness or detection)
```

The remaining line is true, actionable, and points at the real fix (set `config/crew-harness`,
or pass a launch command). The removed line pointed at nothing.

## Evidence this is noise-only, not behaviour

Worth stating explicitly, because I originally got this wrong myself and don't want to hand
anyone a rationale I can't back.

`fm-harness.sh` runs `set -u` **without** `set -e`, and `fm-spawn.sh` invokes it as a
**subprocess** (`HARNESS=$("$FM_ROOT/bin/fm-harness.sh" crew)`), so `fm-spawn.sh`'s `set -eu`
never propagates in. A failed `$(basename …)` yields an empty string, matches no `case` arm, and
the walk simply **continues to the next ancestor**.

Verified against a faked `ps` so the ancestry could be controlled:

| Simulated ancestry | Verdict | stderr (before) |
|---|---|---|
| `-zsh` only | `unknown` — correct, no harness present | `basename: illegal option -- z` |
| `-zsh` → `claude` | **`claude`** — detected *through* the dash | `basename: illegal option -- z` |
| `zsh` → `claude` | `claude` | *(clean)* |

Row 2 is decisive: the dash never blocked detection. And row 1 shows `unknown` was the *correct*
answer — a dispatch from a plain login shell genuinely has no harness in its ancestry.

**Why I know the confusion is real, not hypothetical.** Downstream we hit exactly this output,
read the two lines as cause→effect, and pursued "BSD `basename` breaks harness detection" as the
root cause. It isn't. The actual cause was mundane — a crew harness that was never configured,
so detection was consulted at all. The misleading line is what sent the investigation sideways,
and it will do the same to the next person.

## Change

Take the command name with parameter expansion instead of `basename(1)`:

```sh
name=${comm##*/}   # strip any directory prefix (what basename gave us)
name=${name#-}     # strip a login shell's leading dash
```

Immune to option parsing by construction — there is no argv to misparse. Behaviour is otherwise
deliberately identical: an absolute `comm` still reduces to its basename, and the exact-match arm
(`pi`) still matches exactly.

(It also drops one fork per ancestor. Minor — each iteration still forks `ps` twice plus `tr`, so
this is roughly a quarter of an already-cheap loop, not a meaningful speedup. Noted for accuracy,
not offered as a reason to merge.)

## Tests

New `tests/fm-harness-detect-login-shell.test.sh` (6 assertions), registered in the
`pure-contract-unit` family. It drives a faked `ps` via the existing `fm_fakebin` shim so an
ancestry can be described without depending on the real process tree, and pins **both** halves —
no stderr noise, **and** verdicts unchanged:

- a login shell in the chain produces no stderr
- a bare login shell still resolves to `unknown` (no harness in the ancestry)
- a harness *above* a login shell is still detected, silently
- an absolute `comm` path still resolves to its basename
- the exact-match `pi` arm still matches after stripping
- `-bash` is not mistaken for a harness

**Verified to fail without the fix** — the test is not decorative:

```
not ok - login shell '-zsh' in the chain wrote to stderr: basename: illegal option -- z
```

## Checks

- `shellcheck --norc` clean on all three touched files (0.11.0, the pinned/CI version)
- `bin/fm-test-run.sh` on the affected suites — `fm-harness-detect-login-shell` (6),
  `fm-secondmate-harness` (27), `fm-secondmate-liveness` (10), `fm-session-start` (20),
  `fm-turnend-guard` (40), `fm-test-run` (10) — **113 ok, 0 failures**
- `fm-backend` shows 1 failure (`old fm-teardown.sh (scout, report present)` —
  `fm-decision-hold: compatible tasks-axi is required`, local `tasks-axi 0.1.2`). It is
  **pre-existing and environmental**: reproduced identically with this change reverted.

Tested on macOS (BSD userland), which is where the defect is observable.
