### PR TITLE
test: add deterministic finance batch acceptance evaluator

### DIFF
--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -284,6 +284,9 @@ families_for_changed_path() {
       printf '%s\n' real-herdr-gated
       printf '%s\n' backend-dispatch
       ;;
+    tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh)
+      printf '%s\n' "__script__:evaluate-finance-batch.test.sh"
+      ;;
     tests/*.test.sh)
       # A single test file change selects only that script via basename family
       # resolution in the caller; emit a marker family of __script__

--- a/tests/evaluate-finance-batch.test.sh
+++ b/tests/evaluate-finance-batch.test.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+EVALUATOR="$ROOT/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh"
+TMP_ROOT=$(fm_test_tmproot evaluate-finance-batch)
+
+make_case() {
+  local name=$1 dir="$TMP_ROOT/$1" project="$TMP_ROOT/$1/project"
+  mkdir -p "$project/inputs" "$project/out" "$dir/finance/bin"
+  git -C "$project" init -q
+  printf '{"approved":true}\n' > "$project/inputs/artifact.json"
+  printf '["source"]\n' > "$project/inputs/trusted.json"
+  printf '{"mark":1}\n' > "$project/inputs/market.json"
+  printf 'ignored-*\n' > "$project/.gitignore"
+  printf '# fixture\n' > "$project/README.md"
+  git -C "$project" add .
+  git -C "$project" -c user.name=fixture -c user.email=fixture@example.invalid commit -qm initial
+  cat > "$dir/finance/bin/finance-axi" <<'SH'
+#!/usr/bin/env bash
+if [ -n "${FAKE_VALIDATION+x}" ]; then
+  printf '%s\n' "$FAKE_VALIDATION"
+else
+  printf '%s\n' '{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":0},"diagnostics":[]}'
+fi
+SH
+  chmod +x "$dir/finance/bin/finance-axi"
+  printf '%s\n' "$dir"
+}
+
+snapshot_case() {
+  local dir=$1 project="$1/project"
+  "$EVALUATOR" snapshot "$project" "$project/out/result.json" "$dir/baseline" > "$dir/baseline.sha256"
+}
+
+evaluate_case() {
+  local dir=$1 project="$1/project"
+  FINANCE_HARNESS_HOME="$dir/finance" "$EVALUATOR" evaluate \
+    "$project" \
+    "$project/inputs/artifact.json" \
+    "$project/out/result.json" \
+    "$project/inputs/trusted.json" \
+    "$project/inputs/market.json" \
+    "$dir/baseline" \
+    "$(< "$dir/baseline.sha256")"
+}
+
+evaluate_case_with_validation() {
+  local dir=$1 validation=$2
+  FAKE_VALIDATION="$validation" evaluate_case "$dir"
+}
+
+expect_rejected() {
+  local label=$1
+  shift
+  if "$@" > "$TMP_ROOT/rejected.out" 2>&1; then
+    fail "$label was accepted"
+  fi
+  pass "$label is rejected"
+}
+
+test_valid_control() {
+  local dir
+  dir=$(make_case valid)
+  snapshot_case "$dir"
+  cp "$dir/project/inputs/artifact.json" "$dir/project/out/result.json"
+  evaluate_case "$dir" | grep -Fqx 'verdict=success' \
+    || fail "valid copied artifact did not pass"
+  pass "trusted snapshot accepts the one canonical copied artifact"
+}
+
+test_noncanonical_output_bypass() {
+  local dir project
+  dir=$(make_case noncanonical)
+  project="$dir/project"
+  snapshot_case "$dir"
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "noncanonical output bypass" env FINANCE_HARNESS_HOME="$dir/finance" \
+    "$EVALUATOR" evaluate "$project" \
+    "$project/inputs/artifact.json" "$project/inputs/artifact.json" \
+    "$project/inputs/trusted.json" "$project/inputs/market.json" "$dir/baseline" \
+    "$(< "$dir/baseline.sha256")"
+}
+
+test_snapshot_contract_bypasses() {
+  local dir project
+  dir=$(make_case snapshot-contract)
+  project="$dir/project"
+  expect_rejected "noncanonical snapshot output bypass" \
+    "$EVALUATOR" snapshot "$project" "$project/out/other.json" "$dir/baseline"
+  expect_rejected "in-project baseline bypass" \
+    "$EVALUATOR" snapshot "$project" "$project/out/result.json" "$project/baseline"
+  expect_rejected "evaluation without a trusted snapshot bypass" env \
+    FINANCE_HARNESS_HOME="$dir/finance" "$EVALUATOR" evaluate \
+    "$project" "$project/inputs/artifact.json" "$project/out/result.json" \
+    "$project/inputs/trusted.json" "$project/inputs/market.json" \
+    "$dir/missing-baseline" "$(printf '0%.0s' {1..64})"
+
+  snapshot_case "$dir"
+  expect_rejected "existing baseline replacement bypass" \
+    "$EVALUATOR" snapshot "$project" "$project/out/result.json" "$dir/baseline"
+}
+
+test_symlink_and_alias_bypasses() {
+  local dir project external
+  dir=$(make_case symlink)
+  project="$dir/project"
+  external="$dir/external-artifact.json"
+  cp "$project/inputs/artifact.json" "$external"
+  rm "$project/inputs/artifact.json"
+  ln -s "$external" "$project/inputs/artifact.json"
+  snapshot_case "$dir"
+  cp "$external" "$project/out/result.json"
+  expect_rejected "fixture input symlink bypass" evaluate_case "$dir"
+
+  dir=$(make_case trusted-symlink)
+  project="$dir/project"
+  external="$dir/external-trusted.json"
+  cp "$project/inputs/trusted.json" "$external"
+  rm "$project/inputs/trusted.json"
+  ln -s "$external" "$project/inputs/trusted.json"
+  snapshot_case "$dir"
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "trusted-sources symlink bypass" evaluate_case "$dir"
+
+  dir=$(make_case market-symlink)
+  project="$dir/project"
+  external="$dir/external-market.json"
+  cp "$project/inputs/market.json" "$external"
+  rm "$project/inputs/market.json"
+  ln -s "$external" "$project/inputs/market.json"
+  snapshot_case "$dir"
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "market-mark symlink bypass" evaluate_case "$dir"
+
+  dir=$(make_case output-symlink)
+  project="$dir/project"
+  external="$dir/external-output.json"
+  cp "$project/inputs/artifact.json" "$external"
+  snapshot_case "$dir"
+  ln -s "$external" "$project/out/result.json"
+  expect_rejected "output symlink bypass" evaluate_case "$dir"
+
+  dir=$(make_case alias)
+  project="$dir/project"
+  snapshot_case "$dir"
+  ln "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "input-output alias bypass" evaluate_case "$dir"
+}
+
+test_unapproved_side_effect_bypasses() {
+  local dir project
+  dir=$(make_case ignored)
+  project="$dir/project"
+  snapshot_case "$dir"
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  printf 'hidden\n' > "$project/ignored-workload"
+  expect_rejected "ignored side effect bypass" evaluate_case "$dir"
+
+  dir=$(make_case tracked)
+  project="$dir/project"
+  snapshot_case "$dir"
+  printf 'changed\n' >> "$project/README.md"
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "tracked side effect bypass" evaluate_case "$dir"
+
+  dir=$(make_case commit)
+  project="$dir/project"
+  snapshot_case "$dir"
+  git -C "$project" -c user.name=fixture -c user.email=fixture@example.invalid commit --allow-empty -qm workload
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "post-snapshot commit bypass" evaluate_case "$dir"
+
+  dir=$(make_case metadata)
+  project="$dir/project"
+  snapshot_case "$dir"
+  printf 'changed\n' >> "$project/.git/config"
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "Git metadata bypass" evaluate_case "$dir"
+
+  dir=$(make_case baseline-tamper)
+  project="$dir/project"
+  snapshot_case "$dir"
+  printf 'manifest=%064d\n' 0 >> "$dir/baseline"
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "baseline tamper bypass" evaluate_case "$dir"
+}
+
+test_permissive_json_bypasses() {
+  local dir project
+  dir=$(make_case missing-diagnostics)
+  project="$dir/project"
+  snapshot_case "$dir"
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "missing diagnostics bypass" evaluate_case_with_validation "$dir" \
+    '{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":0}}'
+  expect_rejected "non-object validation bypass" evaluate_case_with_validation "$dir" '[]'
+  expect_rejected "non-boolean ok bypass" evaluate_case_with_validation "$dir" \
+    '{"ok":1,"profile":"valuation-extract","summary":{"errors":0,"warnings":0},"diagnostics":[]}'
+  expect_rejected "wrong profile bypass" evaluate_case_with_validation "$dir" \
+    '{"ok":true,"profile":1,"summary":{"errors":0,"warnings":0},"diagnostics":[]}'
+  expect_rejected "non-object summary bypass" evaluate_case_with_validation "$dir" \
+    '{"ok":true,"profile":"valuation-extract","summary":[],"diagnostics":[]}'
+  expect_rejected "non-numeric errors bypass" evaluate_case_with_validation "$dir" \
+    '{"ok":true,"profile":"valuation-extract","summary":{"errors":"0","warnings":0},"diagnostics":[]}'
+  expect_rejected "non-numeric warnings bypass" evaluate_case_with_validation "$dir" \
+    '{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":"0"},"diagnostics":[]}'
+  expect_rejected "non-array diagnostics bypass" evaluate_case_with_validation "$dir" \
+    '{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":0},"diagnostics":{}}'
+  expect_rejected "nonempty diagnostics bypass" evaluate_case_with_validation "$dir" \
+    '{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":0},"diagnostics":[{"message":"failure"}]}'
+  expect_rejected "multiple validation documents bypass" evaluate_case_with_validation "$dir" \
+    $'{"ok":false}\n{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":0},"diagnostics":[]}'
+}
+
+test_valid_control
+test_noncanonical_output_bypass
+test_snapshot_contract_bypasses
+test_symlink_and_alias_bypasses
+test_unapproved_side_effect_bypasses
+test_permissive_json_bypasses

--- a/tests/evaluate-finance-batch.test.sh
+++ b/tests/evaluate-finance-batch.test.sh
@@ -123,7 +123,7 @@ test_resolved_path_contract() {
 }
 
 test_revision_and_side_effect_contract() {
-  local dir project expected
+  local abbreviated dir malformed project expected
   dir=$(make_case tracked)
   project="$dir/project"
   printf 'changed\n' >> "$project/README.md"
@@ -136,6 +136,18 @@ test_revision_and_side_effect_contract() {
   git -C "$project" -c user.name=fixture -c user.email=fixture@example.invalid commit --allow-empty -qm workload
   cp "$project/inputs/artifact.json" "$project/out/result.json"
   expect_rejected "changed HEAD" evaluate_case "$dir" "$expected"
+
+  dir=$(make_case revision-format)
+  project="$dir/project"
+  expected=$(git -C "$project" rev-parse HEAD)
+  abbreviated=${expected:0:12}
+  malformed=${expected:0:39}
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "symbolic revision" evaluate_case "$dir" HEAD
+  expect_rejected "abbreviated revision" evaluate_case "$dir" "$abbreviated"
+  expect_rejected "malformed revision length" evaluate_case "$dir" "$malformed"
+  evaluate_case "$dir" "$expected" | grep -Fqx 'verdict=success' \
+    || fail "full commit OID did not pass"
 
   dir=$(make_case untracked)
   project="$dir/project"

--- a/tests/evaluate-finance-batch.test.sh
+++ b/tests/evaluate-finance-batch.test.sh
@@ -123,7 +123,7 @@ test_resolved_path_contract() {
 }
 
 test_revision_and_side_effect_contract() {
-  local abbreviated dir malformed project expected
+  local abbreviated dir malformed project expected uppercase wrong_format_ref
   dir=$(make_case tracked)
   project="$dir/project"
   printf 'changed\n' >> "$project/README.md"
@@ -148,6 +148,12 @@ test_revision_and_side_effect_contract() {
   expect_rejected "malformed revision length" evaluate_case "$dir" "$malformed"
   evaluate_case "$dir" "$expected" | grep -Fqx 'verdict=success' \
     || fail "full commit OID did not pass"
+  uppercase=$(printf '%s' "$expected" | tr '[:lower:]' '[:upper:]')
+  evaluate_case "$dir" "$uppercase" | grep -Fqx 'verdict=success' \
+    || fail "uppercase full commit OID did not pass"
+  wrong_format_ref=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  git -C "$project" update-ref "refs/heads/$wrong_format_ref" "$expected"
+  expect_rejected "cross-format all-hex ref" evaluate_case "$dir" "$wrong_format_ref"
 
   dir=$(make_case untracked)
   project="$dir/project"

--- a/tests/evaluate-finance-batch.test.sh
+++ b/tests/evaluate-finance-batch.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Contract coverage for the bounded fleet-flow-finalization finance-batch evaluator.
 set -u
 
 # shellcheck source=tests/lib.sh

--- a/tests/evaluate-finance-batch.test.sh
+++ b/tests/evaluate-finance-batch.test.sh
@@ -9,7 +9,7 @@ EVALUATOR="$ROOT/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.s
 TMP_ROOT=$(fm_test_tmproot evaluate-finance-batch)
 
 make_case() {
-  local name=$1 dir="$TMP_ROOT/$1" project="$TMP_ROOT/$1/project"
+  local dir="$TMP_ROOT/$1" project="$TMP_ROOT/$1/project"
   mkdir -p "$project/inputs" "$project/out" "$dir/finance/bin"
   git -C "$project" init -q
   printf '{"approved":true}\n' > "$project/inputs/artifact.json"

--- a/tests/evaluate-finance-batch.test.sh
+++ b/tests/evaluate-finance-batch.test.sh
@@ -20,6 +20,17 @@ make_case() {
   git -C "$project" -c user.name=fixture -c user.email=fixture@example.invalid commit -qm initial
   cat > "$dir/finance/bin/finance-axi" <<'SH'
 #!/usr/bin/env bash
+artifact=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --artifact) artifact=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "${FAKE_FINANCE_MUTATION:-}" in
+  rewrite-output) printf '{"approved":false}\n' > "$artifact" ;;
+  tracked-file) printf 'changed\n' >> "$(dirname "$(dirname "$artifact")")/README.md" ;;
+esac
 if [ -n "${FAKE_VALIDATION+x}" ]; then
   printf '%s\n' "$FAKE_VALIDATION"
 else
@@ -30,21 +41,16 @@ SH
   printf '%s\n' "$dir"
 }
 
-snapshot_case() {
-  local dir=$1 project="$1/project"
-  "$EVALUATOR" snapshot "$project" "$project/out/result.json" "$dir/baseline" > "$dir/baseline.sha256"
-}
-
 evaluate_case() {
-  local dir=$1 project="$1/project"
-  FINANCE_HARNESS_HOME="$dir/finance" "$EVALUATOR" evaluate \
+  local dir=$1 project="$1/project" expected_revision
+  expected_revision=${2:-$(git -C "$project" rev-parse HEAD)}
+  FINANCE_HARNESS_HOME="$dir/finance" "$EVALUATOR" \
     "$project" \
     "$project/inputs/artifact.json" \
     "$project/out/result.json" \
     "$project/inputs/trusted.json" \
     "$project/inputs/market.json" \
-    "$dir/baseline" \
-    "$(< "$dir/baseline.sha256")"
+    "$expected_revision"
 }
 
 evaluate_case_with_validation() {
@@ -61,163 +67,132 @@ expect_rejected() {
   pass "$label is rejected"
 }
 
-test_valid_control() {
-  local dir
+test_valid_and_bounded_control() {
+  local dir project
   dir=$(make_case valid)
-  snapshot_case "$dir"
-  cp "$dir/project/inputs/artifact.json" "$dir/project/out/result.json"
+  project="$dir/project"
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
   evaluate_case "$dir" | grep -Fqx 'verdict=success' \
     || fail "valid copied artifact did not pass"
-  pass "trusted snapshot accepts the one canonical copied artifact"
-}
 
-test_noncanonical_output_bypass() {
-  local dir project
-  dir=$(make_case noncanonical)
+  dir=$(make_case ignored)
   project="$dir/project"
-  snapshot_case "$dir"
   cp "$project/inputs/artifact.json" "$project/out/result.json"
-  expect_rejected "noncanonical output bypass" env FINANCE_HARNESS_HOME="$dir/finance" \
-    "$EVALUATOR" evaluate "$project" \
-    "$project/inputs/artifact.json" "$project/inputs/artifact.json" \
-    "$project/inputs/trusted.json" "$project/inputs/market.json" "$dir/baseline" \
-    "$(< "$dir/baseline.sha256")"
+  printf 'accepted blind spot\n' > "$project/ignored-workload"
+  evaluate_case "$dir" | grep -Fqx 'verdict=success' \
+    || fail "bounded ignored-path blind spot did not remain accepted"
+  pass "canonical copied artifact passes the bounded evaluator"
 }
 
-test_snapshot_contract_bypasses() {
-  local dir project
-  dir=$(make_case snapshot-contract)
-  project="$dir/project"
-  expect_rejected "noncanonical snapshot output bypass" \
-    "$EVALUATOR" snapshot "$project" "$project/out/other.json" "$dir/baseline"
-  expect_rejected "in-project baseline bypass" \
-    "$EVALUATOR" snapshot "$project" "$project/out/result.json" "$project/baseline"
-  expect_rejected "evaluation without a trusted snapshot bypass" env \
-    FINANCE_HARNESS_HOME="$dir/finance" "$EVALUATOR" evaluate \
-    "$project" "$project/inputs/artifact.json" "$project/out/result.json" \
-    "$project/inputs/trusted.json" "$project/inputs/market.json" \
-    "$dir/missing-baseline" "$(printf '0%.0s' {1..64})"
-
-  snapshot_case "$dir"
-  expect_rejected "existing baseline replacement bypass" \
-    "$EVALUATOR" snapshot "$project" "$project/out/result.json" "$dir/baseline"
-}
-
-test_symlink_and_alias_bypasses() {
+test_resolved_path_contract() {
   local dir project external
-  dir=$(make_case symlink)
+  dir=$(make_case local-symlink)
+  project="$dir/project"
+  mv "$project/inputs/artifact.json" "$project/inputs/artifact-target.json"
+  ln -s artifact-target.json "$project/inputs/artifact.json"
+  git -C "$project" add -A
+  git -C "$project" -c user.name=fixture -c user.email=fixture@example.invalid commit -qm symlink
+  cp "$project/inputs/artifact-target.json" "$project/out/result.json"
+  evaluate_case "$dir" | grep -Fqx 'verdict=success' \
+    || fail "fixture-local input symlink did not pass"
+
+  dir=$(make_case external-symlink)
   project="$dir/project"
   external="$dir/external-artifact.json"
   cp "$project/inputs/artifact.json" "$external"
   rm "$project/inputs/artifact.json"
   ln -s "$external" "$project/inputs/artifact.json"
-  snapshot_case "$dir"
+  git -C "$project" add -A
+  git -C "$project" -c user.name=fixture -c user.email=fixture@example.invalid commit -qm symlink
   cp "$external" "$project/out/result.json"
-  expect_rejected "fixture input symlink bypass" evaluate_case "$dir"
+  expect_rejected "external fixture symlink" evaluate_case "$dir"
 
-  dir=$(make_case trusted-symlink)
+  dir=$(make_case noncanonical-output)
   project="$dir/project"
-  external="$dir/external-trusted.json"
-  cp "$project/inputs/trusted.json" "$external"
-  rm "$project/inputs/trusted.json"
-  ln -s "$external" "$project/inputs/trusted.json"
-  snapshot_case "$dir"
   cp "$project/inputs/artifact.json" "$project/out/result.json"
-  expect_rejected "trusted-sources symlink bypass" evaluate_case "$dir"
-
-  dir=$(make_case market-symlink)
-  project="$dir/project"
-  external="$dir/external-market.json"
-  cp "$project/inputs/market.json" "$external"
-  rm "$project/inputs/market.json"
-  ln -s "$external" "$project/inputs/market.json"
-  snapshot_case "$dir"
-  cp "$project/inputs/artifact.json" "$project/out/result.json"
-  expect_rejected "market-mark symlink bypass" evaluate_case "$dir"
-
-  dir=$(make_case output-symlink)
-  project="$dir/project"
-  external="$dir/external-output.json"
-  cp "$project/inputs/artifact.json" "$external"
-  snapshot_case "$dir"
-  ln -s "$external" "$project/out/result.json"
-  expect_rejected "output symlink bypass" evaluate_case "$dir"
+  expect_rejected "noncanonical output" env FINANCE_HARNESS_HOME="$dir/finance" \
+    "$EVALUATOR" "$project" "$project/inputs/artifact.json" \
+    "$project/inputs/artifact.json" "$project/inputs/trusted.json" \
+    "$project/inputs/market.json" "$(git -C "$project" rev-parse HEAD)"
 
   dir=$(make_case alias)
   project="$dir/project"
-  snapshot_case "$dir"
   ln "$project/inputs/artifact.json" "$project/out/result.json"
-  expect_rejected "input-output alias bypass" evaluate_case "$dir"
+  expect_rejected "input-output alias" evaluate_case "$dir"
+  pass "resolved fixture paths allow local symlinks and reject escapes"
 }
 
-test_unapproved_side_effect_bypasses() {
-  local dir project
-  dir=$(make_case ignored)
-  project="$dir/project"
-  snapshot_case "$dir"
-  cp "$project/inputs/artifact.json" "$project/out/result.json"
-  printf 'hidden\n' > "$project/ignored-workload"
-  expect_rejected "ignored side effect bypass" evaluate_case "$dir"
-
+test_revision_and_side_effect_contract() {
+  local dir project expected
   dir=$(make_case tracked)
   project="$dir/project"
-  snapshot_case "$dir"
   printf 'changed\n' >> "$project/README.md"
   cp "$project/inputs/artifact.json" "$project/out/result.json"
-  expect_rejected "tracked side effect bypass" evaluate_case "$dir"
+  expect_rejected "tracked side effect" evaluate_case "$dir"
 
-  dir=$(make_case commit)
+  dir=$(make_case revision)
   project="$dir/project"
-  snapshot_case "$dir"
+  expected=$(git -C "$project" rev-parse HEAD)
   git -C "$project" -c user.name=fixture -c user.email=fixture@example.invalid commit --allow-empty -qm workload
   cp "$project/inputs/artifact.json" "$project/out/result.json"
-  expect_rejected "post-snapshot commit bypass" evaluate_case "$dir"
+  expect_rejected "changed HEAD" evaluate_case "$dir" "$expected"
 
-  dir=$(make_case metadata)
+  dir=$(make_case untracked)
   project="$dir/project"
-  snapshot_case "$dir"
-  printf 'changed\n' >> "$project/.git/config"
   cp "$project/inputs/artifact.json" "$project/out/result.json"
-  expect_rejected "Git metadata bypass" evaluate_case "$dir"
+  printf 'extra\n' > "$project/extra-output"
+  expect_rejected "extra untracked side effect" evaluate_case "$dir"
 
-  dir=$(make_case baseline-tamper)
+  dir=$(make_case nested)
   project="$dir/project"
-  snapshot_case "$dir"
-  printf 'manifest=%064d\n' 0 >> "$dir/baseline"
-  cp "$project/inputs/artifact.json" "$project/out/result.json"
-  expect_rejected "baseline tamper bypass" evaluate_case "$dir"
+  mkdir -p "$project/nested/inputs" "$project/nested/out"
+  cp "$project/inputs/"*.json "$project/nested/inputs/"
+  cp "$project/nested/inputs/artifact.json" "$project/nested/out/result.json"
+  expect_rejected "nested project root" env FINANCE_HARNESS_HOME="$dir/finance" \
+    "$EVALUATOR" "$project/nested" "$project/nested/inputs/artifact.json" \
+    "$project/nested/out/result.json" "$project/nested/inputs/trusted.json" \
+    "$project/nested/inputs/market.json" "$(git -C "$project" rev-parse HEAD)"
 }
 
-test_permissive_json_bypasses() {
+test_finance_validator_mutations() {
   local dir project
-  dir=$(make_case missing-diagnostics)
+  dir=$(make_case finance-output-mutation)
   project="$dir/project"
-  snapshot_case "$dir"
   cp "$project/inputs/artifact.json" "$project/out/result.json"
-  expect_rejected "missing diagnostics bypass" evaluate_case_with_validation "$dir" \
+  expect_rejected "finance output mutation" env FAKE_FINANCE_MUTATION=rewrite-output \
+    FINANCE_HARNESS_HOME="$dir/finance" "$EVALUATOR" "$project" \
+    "$project/inputs/artifact.json" "$project/out/result.json" \
+    "$project/inputs/trusted.json" "$project/inputs/market.json" \
+    "$(git -C "$project" rev-parse HEAD)"
+
+  dir=$(make_case finance-tracked-mutation)
+  project="$dir/project"
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "finance tracked-file mutation" env FAKE_FINANCE_MUTATION=tracked-file \
+    FINANCE_HARNESS_HOME="$dir/finance" "$EVALUATOR" "$project" \
+    "$project/inputs/artifact.json" "$project/out/result.json" \
+    "$project/inputs/trusted.json" "$project/inputs/market.json" \
+    "$(git -C "$project" rev-parse HEAD)"
+}
+
+test_strict_finance_json_contract() {
+  local dir project
+  dir=$(make_case finance-json)
+  project="$dir/project"
+  cp "$project/inputs/artifact.json" "$project/out/result.json"
+  expect_rejected "missing diagnostics" evaluate_case_with_validation "$dir" \
     '{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":0}}'
-  expect_rejected "non-object validation bypass" evaluate_case_with_validation "$dir" '[]'
-  expect_rejected "non-boolean ok bypass" evaluate_case_with_validation "$dir" \
-    '{"ok":1,"profile":"valuation-extract","summary":{"errors":0,"warnings":0},"diagnostics":[]}'
-  expect_rejected "wrong profile bypass" evaluate_case_with_validation "$dir" \
-    '{"ok":true,"profile":1,"summary":{"errors":0,"warnings":0},"diagnostics":[]}'
-  expect_rejected "non-object summary bypass" evaluate_case_with_validation "$dir" \
-    '{"ok":true,"profile":"valuation-extract","summary":[],"diagnostics":[]}'
-  expect_rejected "non-numeric errors bypass" evaluate_case_with_validation "$dir" \
-    '{"ok":true,"profile":"valuation-extract","summary":{"errors":"0","warnings":0},"diagnostics":[]}'
-  expect_rejected "non-numeric warnings bypass" evaluate_case_with_validation "$dir" \
-    '{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":"0"},"diagnostics":[]}'
-  expect_rejected "non-array diagnostics bypass" evaluate_case_with_validation "$dir" \
-    '{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":0},"diagnostics":{}}'
-  expect_rejected "nonempty diagnostics bypass" evaluate_case_with_validation "$dir" \
-    '{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":0},"diagnostics":[{"message":"failure"}]}'
-  expect_rejected "multiple validation documents bypass" evaluate_case_with_validation "$dir" \
+  expect_rejected "non-object validation" evaluate_case_with_validation "$dir" '[]'
+  expect_rejected "wrong field types" evaluate_case_with_validation "$dir" \
+    '{"ok":1,"profile":"valuation-extract","summary":{"errors":"0","warnings":0},"diagnostics":{}}'
+  expect_rejected "nonempty diagnostics" evaluate_case_with_validation "$dir" \
+    '{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":0},"diagnostics":[{}]}'
+  expect_rejected "multiple validation documents" evaluate_case_with_validation "$dir" \
     $'{"ok":false}\n{"ok":true,"profile":"valuation-extract","summary":{"errors":0,"warnings":0},"diagnostics":[]}'
 }
 
-test_valid_control
-test_noncanonical_output_bypass
-test_snapshot_contract_bypasses
-test_symlink_and_alias_bypasses
-test_unapproved_side_effect_bypasses
-test_permissive_json_bypasses
+test_valid_and_bounded_control
+test_resolved_path_contract
+test_revision_and_side_effect_contract
+test_finance_validator_mutations
+test_strict_finance_json_contract

--- a/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh
+++ b/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Deterministic evaluator for the fleet-flow-finalization unattended LAB batch.
+# It accepts only one exact copied artifact as the workload side effect, then
+# validates that artifact with the external finance-harness v2 installation.
+set -euo pipefail
+
+if [ "$#" -ne 5 ]; then
+  echo "usage: evaluate-finance-batch.sh PROJECT INPUT OUTPUT TRUSTED_SOURCES MARKET_MARK" >&2
+  exit 2
+fi
+
+PROJECT=$1
+INPUT=$2
+OUTPUT=$3
+TRUSTED_SOURCES=$4
+MARKET_MARK=$5
+FINANCE_HARNESS_HOME=${FINANCE_HARNESS_HOME:-}
+
+[ -n "$FINANCE_HARNESS_HOME" ] || { echo "error: FINANCE_HARNESS_HOME is required" >&2; exit 2; }
+[ -x "$FINANCE_HARNESS_HOME/bin/finance-axi" ] || { echo "error: finance-axi is not executable" >&2; exit 2; }
+
+project_real=$(cd "$PROJECT" && pwd -P)
+input_real=$(cd "$(dirname "$INPUT")" && pwd -P)/$(basename "$INPUT")
+output_real=$(cd "$(dirname "$OUTPUT")" && pwd -P)/$(basename "$OUTPUT")
+trusted_real=$(cd "$(dirname "$TRUSTED_SOURCES")" && pwd -P)/$(basename "$TRUSTED_SOURCES")
+market_real=$(cd "$(dirname "$MARKET_MARK")" && pwd -P)/$(basename "$MARKET_MARK")
+
+for path in "$input_real" "$output_real" "$trusted_real" "$market_real"; do
+  case "$path" in
+    "$project_real"/*) ;;
+    *) echo "error: evaluator input escaped the assigned project: $path" >&2; exit 2 ;;
+  esac
+done
+
+cmp -s "$input_real" "$output_real" || { echo "error: output is not the exact approved artifact" >&2; exit 1; }
+
+status=$(git -C "$project_real" status --porcelain --untracked-files=all)
+[ "$status" = "?? out/result.json" ] || {
+  echo "error: workload side effects differ from the one allowed output" >&2
+  printf '%s\n' "$status" >&2
+  exit 1
+}
+
+trusted_sha=$(shasum -a 256 "$trusted_real" | awk '{print $1}')
+market_sha=$(shasum -a 256 "$market_real" | awk '{print $1}')
+validation=$(
+  "$FINANCE_HARNESS_HOME/bin/finance-axi" validate \
+    --artifact "$output_real" \
+    --profile valuation-extract \
+    --contract-id example-valuation \
+    --trusted-sources "$trusted_real" \
+    --trusted-sources-sha256 "$trusted_sha" \
+    --market-mark-input "$market_real" \
+    --market-mark-input-sha256 "$market_sha" \
+    --format json
+)
+
+printf '%s\n' "$validation" | jq -e '
+  .ok == true
+  and .profile == "valuation-extract"
+  and .summary.errors == 0
+  and .summary.warnings == 0
+  and (.diagnostics | length) == 0
+' >/dev/null
+
+cat <<'EOF'
+EVALUATOR=finance-harness-v2
+artifact_cmp=pass
+finance_ok=true
+errors=0
+warnings=0
+side_effects=out/result.json
+verdict=success
+EOF

--- a/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh
+++ b/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh
@@ -5,8 +5,7 @@
 set -euo pipefail
 
 usage() {
-  echo "usage: evaluate-finance-batch.sh snapshot PROJECT OUTPUT BASELINE" >&2
-  echo "       evaluate-finance-batch.sh evaluate PROJECT INPUT OUTPUT TRUSTED_SOURCES MARKET_MARK BASELINE BASELINE_SHA256" >&2
+  echo "usage: evaluate-finance-batch.sh PROJECT INPUT OUTPUT TRUSTED_SOURCES MARKET_MARK EXPECTED_REVISION" >&2
   exit 2
 }
 
@@ -21,94 +20,15 @@ canonical_dir() {
 }
 
 canonical_file() {
-  [ ! -L "$1" ] || fail_usage "symlinks are not allowed: $1"
   [ -f "$1" ] || fail_usage "regular file is required: $1"
-  local parent base
-  parent=$(canonical_dir "$(dirname "$1")")
-  base=$(basename "$1")
-  printf '%s/%s\n' "$parent" "$base"
-}
-
-canonical_candidate() {
-  [ ! -L "$1" ] || fail_usage "symlinks are not allowed: $1"
-  [ ! -e "$1" ] || fail_usage "path must not already exist: $1"
-  local parent base
-  parent=$(canonical_dir "$(dirname "$1")")
-  base=$(basename "$1")
-  printf '%s/%s\n' "$parent" "$base"
-}
-
-path_hash() {
-  printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
-}
-
-file_hash() {
-  shasum -a 256 "$1" | awk '{print $1}'
-}
-
-tree_hash() {
-  perl -MDigest::SHA -MFile::Find -e '
-    use strict;
-    use warnings;
-    my $exclude = shift @ARGV;
-    my @records;
-    while (@ARGV) {
-      my $label = shift @ARGV;
-      my $root = shift @ARGV;
-      find({
-        no_chdir => 1,
-        wanted => sub {
-          my $path = $File::Find::name;
-          return if $label eq "project" && $path eq $exclude;
-          my @st = lstat($path);
-          die "lstat $path: $!\n" unless @st;
-          my $rel = $path eq $root ? "." : substr($path, length($root) + 1);
-          my $kind;
-          if (-f _) {
-            open my $fh, "<", $path or die "open $path: $!\n";
-            binmode $fh;
-            $kind = "f:" . Digest::SHA->new(256)->addfile($fh)->hexdigest;
-            close $fh or die "close $path: $!\n";
-          } elsif (-d _) {
-            $kind = "d";
-          } elsif (-l _) {
-            my $target = readlink($path);
-            die "readlink $path: $!\n" unless defined $target;
-            $kind = "l:" . unpack("H*", $target);
-          } else {
-            $kind = "o:" . $st[6];
-          }
-          push @records, join("\0", $label, unpack("H*", $rel),
-            sprintf("%o", $st[2]), $st[4], $st[5], $kind) . "\0";
-        }
-      }, $root);
-    }
-    my $sha = Digest::SHA->new(256);
-    $sha->add($_) for sort @records;
-    print $sha->hexdigest, "\n";
-  ' "$@"
-}
-
-git_paths() {
-  GIT_DIR_REAL=$(git -C "$PROJECT_REAL" rev-parse --path-format=absolute --git-dir)
-  GIT_COMMON_REAL=$(git -C "$PROJECT_REAL" rev-parse --path-format=absolute --git-common-dir)
-  GIT_DIR_REAL=$(canonical_dir "$GIT_DIR_REAL")
-  GIT_COMMON_REAL=$(canonical_dir "$GIT_COMMON_REAL")
-  HEAD_OID=$(git -C "$PROJECT_REAL" rev-parse --verify 'HEAD^{commit}')
-}
-
-manifest_hash() {
-  if [ "$GIT_DIR_REAL" = "$GIT_COMMON_REAL" ]; then
-    tree_hash "$OUTPUT_REAL" project "$PROJECT_REAL" git "$GIT_DIR_REAL"
-  else
-    tree_hash "$OUTPUT_REAL" project "$PROJECT_REAL" git-dir "$GIT_DIR_REAL" git-common "$GIT_COMMON_REAL"
-  fi
-}
-
-require_outside_project() {
-  case "$1" in
-    "$PROJECT_REAL"|"$PROJECT_REAL"/*) fail_usage "baseline must be outside the assigned project" ;;
-  esac
+  local path
+  path=$(perl -MCwd=abs_path -e '
+    my $path = abs_path($ARGV[0]);
+    defined $path or exit 1;
+    print "$path\n";
+  ' "$1") || fail_usage "could not resolve file: $1"
+  [ -f "$path" ] || fail_usage "regular file is required: $path"
+  printf '%s\n' "$path"
 }
 
 require_fixture_file() {
@@ -120,133 +40,76 @@ require_fixture_file() {
   esac
 }
 
-write_snapshot() {
-  [ "$#" -eq 3 ] || usage
-  PROJECT_REAL=$(canonical_dir "$1")
-  OUTPUT_REAL=$(canonical_candidate "$2")
-  BASELINE_REAL=$(canonical_candidate "$3")
-  require_outside_project "$BASELINE_REAL"
-  [ "$OUTPUT_REAL" = "$PROJECT_REAL/out/result.json" ] \
-    || fail_usage "output must be PROJECT/out/result.json"
-  git_paths
-  case "$BASELINE_REAL" in
-    "$GIT_DIR_REAL"|"$GIT_DIR_REAL"/*|"$GIT_COMMON_REAL"|"$GIT_COMMON_REAL"/*)
-      fail_usage "baseline must be outside Git metadata"
-      ;;
-  esac
-  local snapshot
-  snapshot=$(manifest_hash)
-  (
-    umask 077
-    set -C
-    {
-      printf 'fleet-finance-baseline-v1\n'
-      printf 'project=%s\n' "$(path_hash "$PROJECT_REAL")"
-      printf 'output=%s\n' "$(path_hash "$OUTPUT_REAL")"
-      printf 'git_dir=%s\n' "$(path_hash "$GIT_DIR_REAL")"
-      printf 'git_common=%s\n' "$(path_hash "$GIT_COMMON_REAL")"
-      printf 'head=%s\n' "$HEAD_OID"
-      printf 'manifest=%s\n' "$snapshot"
-    } > "$BASELINE_REAL"
-  ) || fail_usage "could not create baseline: $BASELINE_REAL"
-  file_hash "$BASELINE_REAL"
-}
-
-baseline_value() {
-  sed -n "s/^$1=//p" "$BASELINE_REAL"
-}
-
-read_snapshot() {
-  [ "$(wc -l < "$BASELINE_REAL" | tr -d ' ')" = 7 ] \
-    || fail_usage "baseline has an invalid record count"
-  [ "$(sed -n '1p' "$BASELINE_REAL")" = fleet-finance-baseline-v1 ] \
-    || fail_usage "baseline has an invalid schema"
-  BASELINE_PROJECT=$(baseline_value project)
-  BASELINE_OUTPUT=$(baseline_value output)
-  BASELINE_GIT_DIR=$(baseline_value git_dir)
-  BASELINE_GIT_COMMON=$(baseline_value git_common)
-  BASELINE_HEAD=$(baseline_value head)
-  BASELINE_MANIFEST=$(baseline_value manifest)
-  for value in "$BASELINE_PROJECT" "$BASELINE_OUTPUT" "$BASELINE_GIT_DIR" \
-    "$BASELINE_GIT_COMMON" "$BASELINE_HEAD" "$BASELINE_MANIFEST"; do
-    case "$value" in
-      *[!0-9a-f]*|'') fail_usage "baseline contains an invalid value" ;;
-    esac
-  done
-  [ "${#BASELINE_PROJECT}" -eq 64 ] \
-    && [ "${#BASELINE_OUTPUT}" -eq 64 ] \
-    && [ "${#BASELINE_GIT_DIR}" -eq 64 ] \
-    && [ "${#BASELINE_GIT_COMMON}" -eq 64 ] \
-    && [ "${#BASELINE_MANIFEST}" -eq 64 ] \
-    || fail_usage "baseline contains an invalid digest"
-  [ "${#BASELINE_HEAD}" -eq 40 ] || [ "${#BASELINE_HEAD}" -eq 64 ] \
-    || fail_usage "baseline contains an invalid HEAD"
-}
-
-evaluate_batch() {
-  [ "$#" -eq 7 ] || usage
-  PROJECT_REAL=$(canonical_dir "$1")
-  INPUT_REAL=$(require_fixture_file "$2")
-  OUTPUT_REAL=$(require_fixture_file "$3")
-  TRUSTED_REAL=$(require_fixture_file "$4")
-  MARKET_REAL=$(require_fixture_file "$5")
-  BASELINE_REAL=$(canonical_file "$6")
-  BASELINE_SEAL=$7
-  require_outside_project "$BASELINE_REAL"
-  [ "$OUTPUT_REAL" = "$PROJECT_REAL/out/result.json" ] \
-    || fail_usage "output must be PROJECT/out/result.json"
-  [ ! "$INPUT_REAL" -ef "$OUTPUT_REAL" ] \
-    || fail_usage "input and output must not alias the same file"
-  case "$BASELINE_SEAL" in
-    *[!0-9a-f]*|'') fail_usage "baseline SHA-256 is invalid" ;;
-  esac
-  [ "${#BASELINE_SEAL}" -eq 64 ] || fail_usage "baseline SHA-256 is invalid"
-  [ "$(file_hash "$BASELINE_REAL")" = "$BASELINE_SEAL" ] \
-    || { echo "error: baseline changed after the trusted snapshot" >&2; exit 1; }
-  git_paths
-  read_snapshot
-  [ "$(path_hash "$PROJECT_REAL")" = "$BASELINE_PROJECT" ] \
-    && [ "$(path_hash "$OUTPUT_REAL")" = "$BASELINE_OUTPUT" ] \
-    && [ "$(path_hash "$GIT_DIR_REAL")" = "$BASELINE_GIT_DIR" ] \
-    && [ "$(path_hash "$GIT_COMMON_REAL")" = "$BASELINE_GIT_COMMON" ] \
-    || fail_usage "baseline does not describe this project"
-  [ "$HEAD_OID" = "$BASELINE_HEAD" ] \
-    || { echo "error: repository HEAD changed after the trusted snapshot" >&2; exit 1; }
-  [ "$(manifest_hash)" = "$BASELINE_MANIFEST" ] \
-    || { echo "error: workload side effects differ from the one allowed output" >&2; exit 1; }
+assert_output_and_manifest() {
+  local head status
   cmp -s "$INPUT_REAL" "$OUTPUT_REAL" \
     || { echo "error: output is not the exact approved artifact" >&2; exit 1; }
+  head=$(git -C "$PROJECT_REAL" rev-parse --verify 'HEAD^{commit}')
+  [ "$head" = "$EXPECTED_REVISION_REAL" ] \
+    || { echo "error: repository HEAD differs from the expected revision" >&2; exit 1; }
+  git -C "$PROJECT_REAL" diff --quiet "$EXPECTED_REVISION_REAL" -- \
+    || { echo "error: tracked files differ from the expected revision" >&2; exit 1; }
+  # Writes to gitignored paths and metadata-only changes are accepted by this bounded check.
+  status=$(git -C "$PROJECT_REAL" status --porcelain --untracked-files=all)
+  [ "$status" = "?? out/result.json" ] || {
+    echo "error: workload side effects differ from the one allowed output" >&2
+    printf '%s\n' "$status" >&2
+    exit 1
+  }
+}
 
-  local finance_harness_home trusted_sha market_sha validation
-  finance_harness_home=${FINANCE_HARNESS_HOME:-}
-  [ -n "$finance_harness_home" ] || fail_usage "FINANCE_HARNESS_HOME is required"
-  [ -x "$finance_harness_home/bin/finance-axi" ] || fail_usage "finance-axi is not executable"
-  trusted_sha=$(shasum -a 256 "$TRUSTED_REAL" | awk '{print $1}')
-  market_sha=$(shasum -a 256 "$MARKET_REAL" | awk '{print $1}')
-  validation=$(
-    "$finance_harness_home/bin/finance-axi" validate \
-      --artifact "$OUTPUT_REAL" \
-      --profile valuation-extract \
-      --contract-id example-valuation \
-      --trusted-sources "$TRUSTED_REAL" \
-      --trusted-sources-sha256 "$trusted_sha" \
-      --market-mark-input "$MARKET_REAL" \
-      --market-mark-input-sha256 "$market_sha" \
-      --format json
-  )
+[ "$#" -eq 6 ] || usage
+PROJECT_REAL=$(canonical_dir "$1")
+INPUT_REAL=$(require_fixture_file "$2")
+OUTPUT_REAL=$(require_fixture_file "$3")
+TRUSTED_REAL=$(require_fixture_file "$4")
+MARKET_REAL=$(require_fixture_file "$5")
+EXPECTED_REVISION=$6
 
-  printf '%s\n' "$validation" | jq -e -s '
-    length == 1
-    and (.[0] | type == "object")
-    and (.[0] | has("ok") and (.ok | type == "boolean") and .ok == true)
-    and (.[0] | has("profile") and (.profile | type == "string") and .profile == "valuation-extract")
-    and (.[0] | has("summary") and (.summary | type == "object"))
-    and (.[0].summary | has("errors") and (.errors | type == "number") and .errors == 0)
-    and (.[0].summary | has("warnings") and (.warnings | type == "number") and .warnings == 0)
-    and (.[0] | has("diagnostics") and (.diagnostics | type == "array") and (.diagnostics | length) == 0)
-  ' >/dev/null
+GIT_WORKTREE_REAL=$(canonical_dir "$(git -C "$PROJECT_REAL" rev-parse --show-toplevel)")
+[ "$PROJECT_REAL" = "$GIT_WORKTREE_REAL" ] \
+  || fail_usage "PROJECT must be the Git worktree root"
+[ "$OUTPUT_REAL" = "$PROJECT_REAL/out/result.json" ] \
+  || fail_usage "output must resolve to PROJECT/out/result.json"
+[ ! "$INPUT_REAL" -ef "$OUTPUT_REAL" ] \
+  || fail_usage "input and output must not alias the same file"
+EXPECTED_REVISION_REAL=$(git -C "$PROJECT_REAL" rev-parse --verify "${EXPECTED_REVISION}^{commit}") \
+  || fail_usage "expected revision does not resolve to a commit"
 
-  cat <<'EOF'
+FINANCE_HARNESS_HOME=${FINANCE_HARNESS_HOME:-}
+[ -n "$FINANCE_HARNESS_HOME" ] || fail_usage "FINANCE_HARNESS_HOME is required"
+[ -x "$FINANCE_HARNESS_HOME/bin/finance-axi" ] || fail_usage "finance-axi is not executable"
+
+assert_output_and_manifest
+
+trusted_sha=$(shasum -a 256 "$TRUSTED_REAL" | awk '{print $1}')
+market_sha=$(shasum -a 256 "$MARKET_REAL" | awk '{print $1}')
+validation=$(
+  "$FINANCE_HARNESS_HOME/bin/finance-axi" validate \
+    --artifact "$OUTPUT_REAL" \
+    --profile valuation-extract \
+    --contract-id example-valuation \
+    --trusted-sources "$TRUSTED_REAL" \
+    --trusted-sources-sha256 "$trusted_sha" \
+    --market-mark-input "$MARKET_REAL" \
+    --market-mark-input-sha256 "$market_sha" \
+    --format json
+)
+
+printf '%s\n' "$validation" | jq -e -s '
+  length == 1
+  and (.[0] | type == "object")
+  and (.[0] | has("ok") and (.ok | type == "boolean") and .ok == true)
+  and (.[0] | has("profile") and (.profile | type == "string") and .profile == "valuation-extract")
+  and (.[0] | has("summary") and (.summary | type == "object"))
+  and (.[0].summary | has("errors") and (.errors | type == "number") and .errors == 0)
+  and (.[0].summary | has("warnings") and (.warnings | type == "number") and .warnings == 0)
+  and (.[0] | has("diagnostics") and (.diagnostics | type == "array") and (.diagnostics | length) == 0)
+' >/dev/null
+
+assert_output_and_manifest
+
+cat <<'EOF'
 EVALUATOR=finance-harness-v2
 artifact_cmp=pass
 finance_ok=true
@@ -255,13 +118,3 @@ warnings=0
 side_effects=out/result.json
 verdict=success
 EOF
-}
-
-[ "$#" -ge 1 ] || usage
-mode=$1
-shift
-case "$mode" in
-  snapshot) write_snapshot "$@" ;;
-  evaluate) evaluate_batch "$@" ;;
-  *) usage ;;
-esac

--- a/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh
+++ b/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh
@@ -4,66 +4,249 @@
 # validates that artifact with the external finance-harness v2 installation.
 set -euo pipefail
 
-if [ "$#" -ne 5 ]; then
-  echo "usage: evaluate-finance-batch.sh PROJECT INPUT OUTPUT TRUSTED_SOURCES MARKET_MARK" >&2
+usage() {
+  echo "usage: evaluate-finance-batch.sh snapshot PROJECT OUTPUT BASELINE" >&2
+  echo "       evaluate-finance-batch.sh evaluate PROJECT INPUT OUTPUT TRUSTED_SOURCES MARKET_MARK BASELINE BASELINE_SHA256" >&2
   exit 2
-fi
-
-PROJECT=$1
-INPUT=$2
-OUTPUT=$3
-TRUSTED_SOURCES=$4
-MARKET_MARK=$5
-FINANCE_HARNESS_HOME=${FINANCE_HARNESS_HOME:-}
-
-[ -n "$FINANCE_HARNESS_HOME" ] || { echo "error: FINANCE_HARNESS_HOME is required" >&2; exit 2; }
-[ -x "$FINANCE_HARNESS_HOME/bin/finance-axi" ] || { echo "error: finance-axi is not executable" >&2; exit 2; }
-
-project_real=$(cd "$PROJECT" && pwd -P)
-input_real=$(cd "$(dirname "$INPUT")" && pwd -P)/$(basename "$INPUT")
-output_real=$(cd "$(dirname "$OUTPUT")" && pwd -P)/$(basename "$OUTPUT")
-trusted_real=$(cd "$(dirname "$TRUSTED_SOURCES")" && pwd -P)/$(basename "$TRUSTED_SOURCES")
-market_real=$(cd "$(dirname "$MARKET_MARK")" && pwd -P)/$(basename "$MARKET_MARK")
-
-for path in "$input_real" "$output_real" "$trusted_real" "$market_real"; do
-  case "$path" in
-    "$project_real"/*) ;;
-    *) echo "error: evaluator input escaped the assigned project: $path" >&2; exit 2 ;;
-  esac
-done
-
-cmp -s "$input_real" "$output_real" || { echo "error: output is not the exact approved artifact" >&2; exit 1; }
-
-status=$(git -C "$project_real" status --porcelain --untracked-files=all)
-[ "$status" = "?? out/result.json" ] || {
-  echo "error: workload side effects differ from the one allowed output" >&2
-  printf '%s\n' "$status" >&2
-  exit 1
 }
 
-trusted_sha=$(shasum -a 256 "$trusted_real" | awk '{print $1}')
-market_sha=$(shasum -a 256 "$market_real" | awk '{print $1}')
-validation=$(
-  "$FINANCE_HARNESS_HOME/bin/finance-axi" validate \
-    --artifact "$output_real" \
-    --profile valuation-extract \
-    --contract-id example-valuation \
-    --trusted-sources "$trusted_real" \
-    --trusted-sources-sha256 "$trusted_sha" \
-    --market-mark-input "$market_real" \
-    --market-mark-input-sha256 "$market_sha" \
-    --format json
-)
+fail_usage() {
+  echo "error: $1" >&2
+  exit 2
+}
 
-printf '%s\n' "$validation" | jq -e '
-  .ok == true
-  and .profile == "valuation-extract"
-  and .summary.errors == 0
-  and .summary.warnings == 0
-  and (.diagnostics | length) == 0
-' >/dev/null
+canonical_dir() {
+  [ -d "$1" ] || fail_usage "directory does not exist: $1"
+  (cd "$1" && pwd -P)
+}
 
-cat <<'EOF'
+canonical_file() {
+  [ ! -L "$1" ] || fail_usage "symlinks are not allowed: $1"
+  [ -f "$1" ] || fail_usage "regular file is required: $1"
+  local parent base
+  parent=$(canonical_dir "$(dirname "$1")")
+  base=$(basename "$1")
+  printf '%s/%s\n' "$parent" "$base"
+}
+
+canonical_candidate() {
+  [ ! -L "$1" ] || fail_usage "symlinks are not allowed: $1"
+  [ ! -e "$1" ] || fail_usage "path must not already exist: $1"
+  local parent base
+  parent=$(canonical_dir "$(dirname "$1")")
+  base=$(basename "$1")
+  printf '%s/%s\n' "$parent" "$base"
+}
+
+path_hash() {
+  printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+}
+
+file_hash() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+tree_hash() {
+  perl -MDigest::SHA -MFile::Find -e '
+    use strict;
+    use warnings;
+    my $exclude = shift @ARGV;
+    my @records;
+    while (@ARGV) {
+      my $label = shift @ARGV;
+      my $root = shift @ARGV;
+      find({
+        no_chdir => 1,
+        wanted => sub {
+          my $path = $File::Find::name;
+          return if $label eq "project" && $path eq $exclude;
+          my @st = lstat($path);
+          die "lstat $path: $!\n" unless @st;
+          my $rel = $path eq $root ? "." : substr($path, length($root) + 1);
+          my $kind;
+          if (-f _) {
+            open my $fh, "<", $path or die "open $path: $!\n";
+            binmode $fh;
+            $kind = "f:" . Digest::SHA->new(256)->addfile($fh)->hexdigest;
+            close $fh or die "close $path: $!\n";
+          } elsif (-d _) {
+            $kind = "d";
+          } elsif (-l _) {
+            my $target = readlink($path);
+            die "readlink $path: $!\n" unless defined $target;
+            $kind = "l:" . unpack("H*", $target);
+          } else {
+            $kind = "o:" . $st[6];
+          }
+          push @records, join("\0", $label, unpack("H*", $rel),
+            sprintf("%o", $st[2]), $st[4], $st[5], $kind) . "\0";
+        }
+      }, $root);
+    }
+    my $sha = Digest::SHA->new(256);
+    $sha->add($_) for sort @records;
+    print $sha->hexdigest, "\n";
+  ' "$@"
+}
+
+git_paths() {
+  GIT_DIR_REAL=$(git -C "$PROJECT_REAL" rev-parse --path-format=absolute --git-dir)
+  GIT_COMMON_REAL=$(git -C "$PROJECT_REAL" rev-parse --path-format=absolute --git-common-dir)
+  GIT_DIR_REAL=$(canonical_dir "$GIT_DIR_REAL")
+  GIT_COMMON_REAL=$(canonical_dir "$GIT_COMMON_REAL")
+  HEAD_OID=$(git -C "$PROJECT_REAL" rev-parse --verify 'HEAD^{commit}')
+}
+
+manifest_hash() {
+  if [ "$GIT_DIR_REAL" = "$GIT_COMMON_REAL" ]; then
+    tree_hash "$OUTPUT_REAL" project "$PROJECT_REAL" git "$GIT_DIR_REAL"
+  else
+    tree_hash "$OUTPUT_REAL" project "$PROJECT_REAL" git-dir "$GIT_DIR_REAL" git-common "$GIT_COMMON_REAL"
+  fi
+}
+
+require_outside_project() {
+  case "$1" in
+    "$PROJECT_REAL"|"$PROJECT_REAL"/*) fail_usage "baseline must be outside the assigned project" ;;
+  esac
+}
+
+require_fixture_file() {
+  local path
+  path=$(canonical_file "$1")
+  case "$path" in
+    "$PROJECT_REAL"/*) printf '%s\n' "$path" ;;
+    *) fail_usage "evaluator input escaped the assigned project: $path" ;;
+  esac
+}
+
+write_snapshot() {
+  [ "$#" -eq 3 ] || usage
+  PROJECT_REAL=$(canonical_dir "$1")
+  OUTPUT_REAL=$(canonical_candidate "$2")
+  BASELINE_REAL=$(canonical_candidate "$3")
+  require_outside_project "$BASELINE_REAL"
+  [ "$OUTPUT_REAL" = "$PROJECT_REAL/out/result.json" ] \
+    || fail_usage "output must be PROJECT/out/result.json"
+  git_paths
+  case "$BASELINE_REAL" in
+    "$GIT_DIR_REAL"|"$GIT_DIR_REAL"/*|"$GIT_COMMON_REAL"|"$GIT_COMMON_REAL"/*)
+      fail_usage "baseline must be outside Git metadata"
+      ;;
+  esac
+  local snapshot
+  snapshot=$(manifest_hash)
+  (
+    umask 077
+    set -C
+    {
+      printf 'fleet-finance-baseline-v1\n'
+      printf 'project=%s\n' "$(path_hash "$PROJECT_REAL")"
+      printf 'output=%s\n' "$(path_hash "$OUTPUT_REAL")"
+      printf 'git_dir=%s\n' "$(path_hash "$GIT_DIR_REAL")"
+      printf 'git_common=%s\n' "$(path_hash "$GIT_COMMON_REAL")"
+      printf 'head=%s\n' "$HEAD_OID"
+      printf 'manifest=%s\n' "$snapshot"
+    } > "$BASELINE_REAL"
+  ) || fail_usage "could not create baseline: $BASELINE_REAL"
+  file_hash "$BASELINE_REAL"
+}
+
+baseline_value() {
+  sed -n "s/^$1=//p" "$BASELINE_REAL"
+}
+
+read_snapshot() {
+  [ "$(wc -l < "$BASELINE_REAL" | tr -d ' ')" = 7 ] \
+    || fail_usage "baseline has an invalid record count"
+  [ "$(sed -n '1p' "$BASELINE_REAL")" = fleet-finance-baseline-v1 ] \
+    || fail_usage "baseline has an invalid schema"
+  BASELINE_PROJECT=$(baseline_value project)
+  BASELINE_OUTPUT=$(baseline_value output)
+  BASELINE_GIT_DIR=$(baseline_value git_dir)
+  BASELINE_GIT_COMMON=$(baseline_value git_common)
+  BASELINE_HEAD=$(baseline_value head)
+  BASELINE_MANIFEST=$(baseline_value manifest)
+  for value in "$BASELINE_PROJECT" "$BASELINE_OUTPUT" "$BASELINE_GIT_DIR" \
+    "$BASELINE_GIT_COMMON" "$BASELINE_HEAD" "$BASELINE_MANIFEST"; do
+    case "$value" in
+      *[!0-9a-f]*|'') fail_usage "baseline contains an invalid value" ;;
+    esac
+  done
+  [ "${#BASELINE_PROJECT}" -eq 64 ] \
+    && [ "${#BASELINE_OUTPUT}" -eq 64 ] \
+    && [ "${#BASELINE_GIT_DIR}" -eq 64 ] \
+    && [ "${#BASELINE_GIT_COMMON}" -eq 64 ] \
+    && [ "${#BASELINE_MANIFEST}" -eq 64 ] \
+    || fail_usage "baseline contains an invalid digest"
+  [ "${#BASELINE_HEAD}" -eq 40 ] || [ "${#BASELINE_HEAD}" -eq 64 ] \
+    || fail_usage "baseline contains an invalid HEAD"
+}
+
+evaluate_batch() {
+  [ "$#" -eq 7 ] || usage
+  PROJECT_REAL=$(canonical_dir "$1")
+  INPUT_REAL=$(require_fixture_file "$2")
+  OUTPUT_REAL=$(require_fixture_file "$3")
+  TRUSTED_REAL=$(require_fixture_file "$4")
+  MARKET_REAL=$(require_fixture_file "$5")
+  BASELINE_REAL=$(canonical_file "$6")
+  BASELINE_SEAL=$7
+  require_outside_project "$BASELINE_REAL"
+  [ "$OUTPUT_REAL" = "$PROJECT_REAL/out/result.json" ] \
+    || fail_usage "output must be PROJECT/out/result.json"
+  [ ! "$INPUT_REAL" -ef "$OUTPUT_REAL" ] \
+    || fail_usage "input and output must not alias the same file"
+  case "$BASELINE_SEAL" in
+    *[!0-9a-f]*|'') fail_usage "baseline SHA-256 is invalid" ;;
+  esac
+  [ "${#BASELINE_SEAL}" -eq 64 ] || fail_usage "baseline SHA-256 is invalid"
+  [ "$(file_hash "$BASELINE_REAL")" = "$BASELINE_SEAL" ] \
+    || { echo "error: baseline changed after the trusted snapshot" >&2; exit 1; }
+  git_paths
+  read_snapshot
+  [ "$(path_hash "$PROJECT_REAL")" = "$BASELINE_PROJECT" ] \
+    && [ "$(path_hash "$OUTPUT_REAL")" = "$BASELINE_OUTPUT" ] \
+    && [ "$(path_hash "$GIT_DIR_REAL")" = "$BASELINE_GIT_DIR" ] \
+    && [ "$(path_hash "$GIT_COMMON_REAL")" = "$BASELINE_GIT_COMMON" ] \
+    || fail_usage "baseline does not describe this project"
+  [ "$HEAD_OID" = "$BASELINE_HEAD" ] \
+    || { echo "error: repository HEAD changed after the trusted snapshot" >&2; exit 1; }
+  [ "$(manifest_hash)" = "$BASELINE_MANIFEST" ] \
+    || { echo "error: workload side effects differ from the one allowed output" >&2; exit 1; }
+  cmp -s "$INPUT_REAL" "$OUTPUT_REAL" \
+    || { echo "error: output is not the exact approved artifact" >&2; exit 1; }
+
+  local finance_harness_home trusted_sha market_sha validation
+  finance_harness_home=${FINANCE_HARNESS_HOME:-}
+  [ -n "$finance_harness_home" ] || fail_usage "FINANCE_HARNESS_HOME is required"
+  [ -x "$finance_harness_home/bin/finance-axi" ] || fail_usage "finance-axi is not executable"
+  trusted_sha=$(shasum -a 256 "$TRUSTED_REAL" | awk '{print $1}')
+  market_sha=$(shasum -a 256 "$MARKET_REAL" | awk '{print $1}')
+  validation=$(
+    "$finance_harness_home/bin/finance-axi" validate \
+      --artifact "$OUTPUT_REAL" \
+      --profile valuation-extract \
+      --contract-id example-valuation \
+      --trusted-sources "$TRUSTED_REAL" \
+      --trusted-sources-sha256 "$trusted_sha" \
+      --market-mark-input "$MARKET_REAL" \
+      --market-mark-input-sha256 "$market_sha" \
+      --format json
+  )
+
+  printf '%s\n' "$validation" | jq -e -s '
+    length == 1
+    and (.[0] | type == "object")
+    and (.[0] | has("ok") and (.ok | type == "boolean") and .ok == true)
+    and (.[0] | has("profile") and (.profile | type == "string") and .profile == "valuation-extract")
+    and (.[0] | has("summary") and (.summary | type == "object"))
+    and (.[0].summary | has("errors") and (.errors | type == "number") and .errors == 0)
+    and (.[0].summary | has("warnings") and (.warnings | type == "number") and .warnings == 0)
+    and (.[0] | has("diagnostics") and (.diagnostics | type == "array") and (.diagnostics | length) == 0)
+  ' >/dev/null
+
+  cat <<'EOF'
 EVALUATOR=finance-harness-v2
 artifact_cmp=pass
 finance_ok=true
@@ -72,3 +255,13 @@ warnings=0
 side_effects=out/result.json
 verdict=success
 EOF
+}
+
+[ "$#" -ge 1 ] || usage
+mode=$1
+shift
+case "$mode" in
+  snapshot) write_snapshot "$@" ;;
+  evaluate) evaluate_batch "$@" ;;
+  *) usage ;;
+esac

--- a/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh
+++ b/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh
@@ -73,6 +73,8 @@ GIT_WORKTREE_REAL=$(canonical_dir "$(git -C "$PROJECT_REAL" rev-parse --show-top
   || fail_usage "output must resolve to PROJECT/out/result.json"
 [ ! "$INPUT_REAL" -ef "$OUTPUT_REAL" ] \
   || fail_usage "input and output must not alias the same file"
+[[ "$EXPECTED_REVISION" =~ ^([0-9a-fA-F]{40}|[0-9a-fA-F]{64})$ ]] \
+  || fail_usage "expected revision must be a full commit OID"
 EXPECTED_REVISION_REAL=$(git -C "$PROJECT_REAL" rev-parse --verify "${EXPECTED_REVISION}^{commit}") \
   || fail_usage "expected revision does not resolve to a commit"
 

--- a/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh
+++ b/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh
@@ -73,10 +73,21 @@ GIT_WORKTREE_REAL=$(canonical_dir "$(git -C "$PROJECT_REAL" rev-parse --show-top
   || fail_usage "output must resolve to PROJECT/out/result.json"
 [ ! "$INPUT_REAL" -ef "$OUTPUT_REAL" ] \
   || fail_usage "input and output must not alias the same file"
-[[ "$EXPECTED_REVISION" =~ ^([0-9a-fA-F]{40}|[0-9a-fA-F]{64})$ ]] \
+OBJECT_FORMAT=$(git -C "$PROJECT_REAL" rev-parse --show-object-format) \
+  || fail_usage "could not determine repository object format"
+case "$OBJECT_FORMAT" in
+  sha1) OID_LENGTH=40 ;;
+  sha256) OID_LENGTH=64 ;;
+  *) fail_usage "unsupported repository object format: $OBJECT_FORMAT" ;;
+esac
+[[ "$EXPECTED_REVISION" =~ ^[0-9a-fA-F]+$ ]] \
+  && [ "${#EXPECTED_REVISION}" -eq "$OID_LENGTH" ] \
   || fail_usage "expected revision must be a full commit OID"
+EXPECTED_REVISION=$(printf '%s' "$EXPECTED_REVISION" | tr '[:upper:]' '[:lower:]')
 EXPECTED_REVISION_REAL=$(git -C "$PROJECT_REAL" rev-parse --verify "${EXPECTED_REVISION}^{commit}") \
   || fail_usage "expected revision does not resolve to a commit"
+[ "$EXPECTED_REVISION" = "$EXPECTED_REVISION_REAL" ] \
+  || fail_usage "expected revision must name the resolved commit directly"
 
 FINANCE_HARNESS_HOME=${FINANCE_HARNESS_HOME:-}
 [ -n "$FINANCE_HARNESS_HOME" ] || fail_usage "FINANCE_HARNESS_HOME is required"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -110,7 +110,8 @@ init_changed_fixture_repo() {
     fm-bearings-snapshot.test.sh \
     fm-backend-cmux.test.sh \
     fm-backend-zellij.test.sh \
-    fm-backend-orca.test.sh; do
+    fm-backend-orca.test.sh \
+    evaluate-finance-batch.test.sh; do
     printf '#!/usr/bin/env bash\n# tests/lib.sh\n' >"$repo/tests/$script"
     chmod +x "$repo/tests/$script"
   done
@@ -122,11 +123,13 @@ init_changed_fixture_repo() {
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
     >>"$repo/tests/fm-cd-pretool-check.test.sh"
   printf '# .pi/extensions/fm-primary-pi-watch.ts\n' >>"$repo/tests/fm-pi-watch-extension.test.sh"
-  mkdir -p "$repo/.agents/skills/example" "$repo/.claude" "$repo/.pi/extensions" "$repo/src"
+  mkdir -p "$repo/.agents/skills/example" "$repo/.claude" "$repo/.pi/extensions" \
+    "$repo/src" "$repo/tests/fixtures/fleet-flow-finalization"
   : >"$repo/.agents/skills/example/SKILL.md"
   : >"$repo/.claude/settings.json"
   : >"$repo/.pi/extensions/fm-primary-pi-watch.ts"
   : >"$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  : >"$repo/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh"
   : >"$repo/src/unmapped.ts"
   git -C "$repo" init -q
   git -C "$repo" add .
@@ -171,6 +174,13 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-pi-watch-extension.test.sh" "Pi source selects watcher coverage"
   git -C "$repo" add .agents .claude .pi
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm non-bin-source-change
+
+  printf '\n' >>"$repo/tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  [ "$listed" = "tests/evaluate-finance-batch.test.sh" ] \
+    || fail "finance evaluator fixture should select only its contract test, got: $listed"
+  git -C "$repo" add tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm evaluator-fixture-change
 
   printf '\n' >>"$repo/src/unmapped.ts"
   set +e


### PR DESCRIPTION
## Intent

Prove the captain-approved fleet dispatch model end to end and leave a durable acceptance record for the six specified bundles, without silently expanding scope when configured preconditions are absent. The evidence run produced 3 pass, 2 fail, and 1 gap; those follow-ups are captured separately and are intentionally not fixed on this branch. The tracked repository change is the deterministic finance-batch evaluator required to be committed before the one bounded OpenAI-only unattended LAB batch. It must enforce fixture-local inputs, exact artifact copying, the one allowed output side effect, and fail-closed finance-harness v2 validation. Preserve the evidence conclusions, including failed acceptance findings, rather than changing product routing or live configuration.

## What Changed

- Add a deterministic finance-batch evaluator that verifies fixture-local inputs, exact artifact copying, a pinned repository revision, and the single permitted output path.
- Fail closed unless finance-harness v2 returns one strictly valid, warning-free valuation result, with post-validation checks preventing artifact or repository mutations.
- Add contract coverage for accepted and rejected evaluator scenarios and map fixture changes to the targeted test in changed-test selection.

## Risk Assessment

✅ Low: Captain, the bounded evaluator now correctly binds full commit OIDs to the repository object format, and the complete branch review found no remaining material source or intent-conformance risks.

## Testing

After scoping the base-to-target change, focused evaluator and runner tests passed; direct SHA-1 and SHA-256 CLI runs demonstrated exact copying, sole visible output, revision binding, hashed finance inputs, success output, and fail-closed rejection paths. No live finance-harness v2 or six-bundle acceptance record was available, so that external replay remains the only evidence gap.

<details>
<summary>Evidence: Focused automated test transcript</summary>

```text
FM_TEST_BEGIN 2026-07-22T09:25:36Z tests/evaluate-finance-batch.test.sh family=unclassified expected_gate_skip=none
ok - canonical copied artifact passes the bounded evaluator
ok - external fixture symlink is rejected
ok - noncanonical output is rejected
ok - input-output alias is rejected
ok - resolved fixture paths allow local symlinks and reject escapes
ok - tracked side effect is rejected
ok - changed HEAD is rejected
ok - symbolic revision is rejected
ok - abbreviated revision is rejected
ok - malformed revision length is rejected
ok - cross-format all-hex ref is rejected
ok - extra untracked side effect is rejected
ok - nested project root is rejected
ok - finance output mutation is rejected
ok - finance tracked-file mutation is rejected
ok - missing diagnostics is rejected
ok - non-object validation is rejected
ok - wrong field types is rejected
ok - nonempty diagnostics is rejected
ok - multiple validation documents is rejected
FM_TEST_END 2026-07-22T09:25:40Z tests/evaluate-finance-batch.test.sh exit=0 duration_ms=3833 gate_skip=false
FM_TEST_BEGIN 2026-07-22T09:25:40Z tests/fm-test-run.test.sh family=pure-contract-unit expected_gate_skip=none
ok - exact suite coverage: --all lists every tests/*.test.sh once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - changed selection covers dependents and fails closed for unmapped source
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
ok - CI and CONTRIBUTING call the one-owner runner; no full-suite local Test
FM_TEST_END 2026-07-22T09:25:44Z tests/fm-test-run.test.sh exit=0 duration_ms=4198 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=8107
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=4198 failed=0
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=3833 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-test-run.test.sh duration_ms=4198
FM_TEST_SLOWEST rank=2 script=tests/evaluate-finance-batch.test.sh duration_ms=3833
```
</details>
<details>
<summary>Evidence: Direct SHA-1 evaluator acceptance transcript</summary>

```text
$ cp inputs/artifact.json out/result.json
$ evaluate-finance-batch.sh <fixture-local inputs> <full revision pin>
EVALUATOR=finance-harness-v2
artifact_cmp=pass
finance_ok=true
errors=0
warnings=0
side_effects=out/result.json
verdict=success
$ finance-axi arguments received
validate
--artifact
<case>/project/out/result.json
--profile
valuation-extract
--contract-id
example-valuation
--trusted-sources
<case>/project/inputs/trusted.json
--trusted-sources-sha256
3826f9880be5431a9c72ffa1e6a0f9ee632576e92d0f13b91a40903284773376
--market-mark-input
<case>/project/inputs/market.json
--market-mark-input-sha256
b9fb3bc81029bffcdbb2ef600821ae79ed36cecdd0650feb9a3cdddfef1cc972
--format
json
$ cmp -s inputs/artifact.json out/result.json; echo exact_copy=$?
exact_copy=0
$ git status --short --untracked-files=all
?? out/result.json
$ evaluator with FINANCE_HARNESS_HOME absent
error: FINANCE_HARNESS_HOME is required
exit=2
$ evaluator with a non-clean finance-harness v2 result
exit=1
$ evaluator after an extra untracked workload output appears
error: workload side effects differ from the one allowed output
?? extra-output.json
?? out/result.json
exit=1
```
</details>
<details>
<summary>Evidence: SHA-256 revision-pin acceptance transcript</summary>

```text
object_format=sha256
revision_length=64
EVALUATOR=finance-harness-v2
artifact_cmp=pass
finance_ok=true
errors=0
warnings=0
side_effects=out/result.json
verdict=success
$ evaluator with a 40-hex pseudo-pin in the SHA-256 repository
error: expected revision must be a full commit OID
exit=2
```
</details>
<details>
<summary>Evidence: Changed-test selection</summary>

```text
tests/fm-arm-pretool-check.test.sh
tests/fm-brief.test.sh
tests/fm-captain-translation-contract.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-composer-lib.test.sh
tests/fm-continuity-pretool-check.test.sh
tests/fm-crew-state.test.sh
tests/fm-decision-hold-lifecycle.test.sh
tests/fm-dispatch-select.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-grok-harness.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-install-herdr.test.sh
tests/fm-instruction-owners.test.sh
tests/fm-lint.test.sh
tests/fm-nm-test-contract.test.sh
tests/fm-no-mistakes-ownership.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-settle.test.sh
tests/fm-stow-contract.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-test-isolation-proof.test.sh
tests/fm-test-run.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-transition-lib.test.sh
tests/evaluate-finance-batch.test.sh
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (5m49s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (4) ✅</summary>

- 🚨 `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh:35` - The required &#34;exact artifact copying&#34; and &#34;one allowed output side effect&#34; are checked independently. `cmp` and finance validation use caller-supplied `OUTPUT`, while Git status only requires `out/result.json`; setting `OUTPUT` to the approved input can therefore validate the wrong file while an unrelated result satisfies the side-effect check. Require the canonical output to equal `$project_real/out/result.json`.
- 🚨 `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh:23` - The required &#34;fixture-local inputs&#34; guarantee is bypassable because only each parent directory is canonicalized. A local input symlink can reference an external file, and `out/result.json` can symlink to the input, passing containment, `cmp`, Git status, and validation without copying an artifact. Resolve complete paths and reject symlinks, non-regular files, and input/output aliasing.
- 🚨 `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh:37` - The required &#34;one allowed output side effect&#34; cannot be proven from this Git status comparison. Ignored files are omitted, and the workload could commit tracked changes or alter Git metadata while leaving only `out/result.json` dirty. Compare against an immutable pre-run revision or filesystem manifest that includes ignored paths and relevant repository metadata.
- 🚨 `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh:58` - The required &#34;fail-closed finance-harness v2 validation&#34; is contradicted by the permissive predicate. In `jq`, a missing or null `.diagnostics` has length zero, and a stream containing multiple JSON documents can succeed based on its final result. Require exactly one object and validate every required field&#39;s presence and type, including `diagnostics` as an array.

🔧 Fix: Harden finance evaluator acceptance guarantees
4 issues (3 errors, 1 warning) still open:
- 🚨 `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh:226` - The required &#34;exact artifact copying&#34; and &#34;one allowed output side effect&#34; are checked only before invoking `finance-axi`. That executable can rewrite `result.json` or modify other project/Git files and then emit accepted JSON, after which the evaluator still reports success. Re-run both `manifest_hash` and `cmp` after validation before printing the verdict.
- 🚨 `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh:81` - The required &#34;one allowed output side effect&#34; is not fully represented by this manifest. It records bytes, type, mode, UID, and GID, but omits timestamps, extended attributes, ACLs, inode identity, and link topology; operations such as touching a file, changing an xattr, or replacing it with a same-byte inode remain accepted. Extend the sealed snapshot to cover persistent filesystem metadata while exempting only the canonical output&#39;s expected changes.
- 🚨 `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh:92` - The required &#34;one allowed output side effect&#34; can be bypassed when `PROJECT` is a subdirectory of a larger Git worktree. The manifest covers only `PROJECT_REAL` and Git metadata, so an unstaged change or untracked file in a sibling directory changes neither hash and is accepted. Require `PROJECT_REAL` to equal the canonical Git worktree root, or snapshot the entire worktree.
- ⚠️ `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh:1` - The new fixture path is not integrated with the repository&#39;s changed-test selector. `families_for_changed_path` treats non-`*.test.sh` paths under `tests/` as unmapped, so `bin/fm-test-run.sh --changed` exits before selecting the new referencing test. Add an explicit mapping from this fixture to `evaluate-finance-batch.test.sh`.

🔧 Fix: Align finance evaluator with bounded acceptance contract
1 error still open:
- 🚨 `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh:76` - The required &#34;one allowed output side effect&#34; is not enforced when `EXPECTED_REVISION` is a movable ref. If configured as `HEAD`, a workload commit moves that ref before this post-run evaluator resolves it; both the HEAD equality and tracked-diff checks then pass despite the unauthorized commit. Require an immutable full 40- or 64-hex commit OID and reject symbolic refs.

🔧 Fix: Require immutable finance evaluator revision pins
1 error still open:
- 🚨 `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh:78` - The selected requirement to accept only an &#34;immutable full 40- or 64-hex commit OID and reject symbolic refs&#34; is not fully enforced. In a SHA-1 repository, a valid 64-hex ref name passes the regex and `rev-parse` can resolve it to its movable 40-hex target; the symmetric case applies to 40-hex refs in SHA-256 repositories. Require the supplied length to match the repository object format and compare its normalized lowercase value exactly with `EXPECTED_REVISION_REAL`.

🔧 Fix: Bind revision pins to repository object format
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh:94` - The evaluator and its fail-closed contract were demonstrated with an executable finance-harness stub, but FINANCE_HARNESS_HOME is unset, finance-axi is not on PATH, and the six-bundle LAB fixtures or durable 3-pass/2-fail/1-gap acceptance record are not present in this worktree. An actual finance-harness v2 replay therefore remains unverified. Provide that external harness and acceptance evidence, or decide that contract-level validation is sufficient for this branch.
- `git diff --name-status f6c281afb7a4b53b40ca919ff714a7d77ff0f030..fd3821861126749525e23f770f5513fae52a292a`
- `bin/fm-test-run.sh tests/evaluate-finance-batch.test.sh tests/fm-test-run.test.sh`
- `bin/fm-test-run.sh --list --changed --base f6c281afb7a4b53b40ca919ff714a7d77ff0f030`
- <code>Manual SHA-1 invocation of `tests/fixtures/fleet-flow-finalization/evaluate-finance-batch.sh` with fixture-local inputs, an exact copied artifact, a full revision pin, and a contract-checking finance-harness stub</code>
- <code>Manual rejection checks with `FINANCE_HARNESS_HOME` absent, a warning diagnostic, and an extra untracked output</code>
- <code>Manual invocation against `git init --object-format=sha256`, including acceptance of the 64-hex commit pin and rejection of a 40-hex pseudo-pin</code>
- <code>`command -v finance-axi` and `FINANCE_HARNESS_HOME` availability check</code>
- <code>`git status --porcelain` after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Remove unused finance batch test variable
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
