### PR TITLE
feat: verify Hermes Agent runtime adapter

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -82,7 +82,7 @@ explicit word - the daemon just batches the notification.
 
 The daemon prefixes every injection with `FM_INJECT_MARK` (U+2063 INVISIBLE SEPARATOR), which has no normal keyboard keystroke and survives terminal transport as UTF-8 text.
 This is how firstmate tells a daemon escalation apart from a real message in the same pane.
-The marker travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, and grok.
+The marker travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, grok, and hermes.
 
 ## Busy-guard and composer guard
 

--- a/.agents/skills/firstmate-orca/SKILL.md
+++ b/.agents/skills/firstmate-orca/SKILL.md
@@ -13,7 +13,7 @@ It does not replace `AGENTS.md`, `docs/orca-backend.md`, or `harness-adapters`.
 
 Orca is a runtime backend, not an agent harness.
 The runtime backend owns the task endpoint and, for Orca, the task worktree.
-The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, or `grok`.
+The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, `grok`, or `hermes`.
 Load `harness-adapters` for harness-specific launch, interrupt, resume, trust-dialog, and skill-invocation facts.
 
 Implementation details, metadata fields, teardown guarantees, limitations, and smoke evidence live in `docs/orca-backend.md`.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and hermes.
 user-invocable: false
 metadata:
   internal: true
@@ -52,7 +52,7 @@ Use that value for interrupt, exit, resume, and skill-invocation facts.
 
 Every verified primary harness has an empirically validated hook path for the "no turn ends blind" guard.
 `claude` and `codex` block directly through Stop hooks that preserve exit status 2 and stderr from `bin/fm-turnend-guard.sh`.
-`opencode`, `pi`, and `grok` expose passive lifecycle callbacks for this purpose, so their tracked primary adapters force one bounded follow-up or resume when the shared predicate blocks.
+`opencode`, `pi`, `grok`, and `hermes` expose passive lifecycle callbacks for this purpose, so their tracked primary adapters force one bounded follow-up or resume when the shared predicate blocks.
 The exact hook files, commands, validation transcripts, scoping rules, and fail-open tradeoffs are owned by `docs/turnend-guard.md`.
 When changing any primary turn-end hook, validate the real harness behavior in a scratch project or throwaway home before trusting it, then update that doc and the relevant concise fact below.
 
@@ -61,6 +61,7 @@ When changing any primary turn-end hook, validate the real harness behavior in a
 Every verified primary harness also has a wired PreToolUse-equivalent hook that denies a watcher-arm anti-pattern (shell `&`, truncating pipe, bundling, broad `pkill -f fm-watch`) before it runs.
 `claude` and `codex` block directly through PreToolUse hooks; `grok` blocks the same way but requires every `$VAR` reference in its hook `command` string to carry an inline `:-default` or it fails to launch the hook entirely.
 `opencode` and `pi` block by throwing from `tool.execute.before` / returning `{block: true}` from `tool_call`.
+`hermes` blocks from its isolated home's `pre_tool_call` hook by returning the native `{"action":"block","message":"..."}` stdout shape.
 The exact hook files, commands, output-shaping quirks (Claude Code only honors the deny when stdout is empty), and validation transcripts are owned by `docs/arm-pretool-check.md`.
 When changing any primary PreToolUse hook, validate the real harness behavior in a scratch project before trusting it, then update that doc.
 
@@ -75,6 +76,7 @@ Full mechanics, scoping, dated commands, payloads, and fail-open evidence live i
 - `opencode`: verified on 1.17.18; `session.created` plus `client.session.promptAsync` starts the nudge turn in the TUI, while `opencode run` remains fail-open headless.
 - `pi`: verified native `session_start`; the existing primary extension handles `startup`, `new`, and `resume` and uses `pi.sendMessage` to inject context without racing a positional launch prompt.
 - `grok`: the 0.2.103 project `SessionStart` event fires with `source=new`, but stdout does not reach model context; the tracked project hook remains fail-open, and a global token-guarded fallback requires a captain decision.
+- `hermes`: the isolated primary home's `on_session_start` hook invokes `bin/fm-sessionstart-nudge.sh`; Hermes v0.19.0 shell-hook stdout is not a model-context channel, so this is fail-open and the initial Firstmate instructions remain authoritative.
 
 ## Primary watcher supervision
 
@@ -84,6 +86,7 @@ Claude and Grok use tracked background-notify cycles around `bin/fm-watch-arm.sh
 Codex uses bounded foreground checkpoints through `bin/fm-watch-checkpoint.sh` because Codex cannot reason while a foreground tool call is running.
 OpenCode uses `.opencode/plugins/fm-primary-watch-arm.js`, which coordinates with the turn-end guard plugin and wakes the TUI with `client.session.promptAsync`.
 Pi uses the tracked `.pi/extensions/fm-primary-turnend-guard.ts` plus the tracked `.pi/extensions/fm-primary-pi-watch.ts`, both project-local extensions Pi auto-discovers once trusted.
+Hermes uses bounded foreground checkpoints through `bin/fm-watch-checkpoint.sh`; its isolated primary home installs the turn-end and pre-tool safety hooks.
 When changing any primary watcher adapter, update `docs/supervision-protocols/`, `docs/turnend-guard.md` if a shared idle or turn-end hook changed, and the relevant concise fact below.
 
 ## Launch profile axes
@@ -108,6 +111,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-13 on Pi 0.80.6. `pi --help` advertises `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; `pi --print --model openai-codex/gpt-5.6-sol --thinking max 'Reply with exactly OK.'` completed successfully. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| hermes | `-m <model>` / `--model <model>` | none; omit | Verified on Hermes Agent v0.19.0 (2026-07-21). Active config supports `agent.reasoning_effort` but the launch CLI has no per-invocation effort flag. |
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
@@ -122,6 +126,7 @@ Natural language is acceptable if uncertain.
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) already handles this correctly by reading the cursor row; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
+- hermes: `/<skill>`, for example `/no-mistakes`. Verified on Hermes Agent v0.19.0 by invoking `/hermes-agent` with an inline instruction and receiving the requested `SKILL_OK` response.
 
 ## claude (VERIFIED)
 
@@ -305,3 +310,33 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## hermes (VERIFIED 2026-07-21, Hermes Agent v0.19.0)
+
+Launch with a positional prompt: `HERMES_HOME=<isolated-dir> hermes chat --yolo --accept-hooks --cli "$(cat <brief>)"`.
+Hermes's `--yolo` bypasses dangerous-command approvals and `--accept-hooks` auto-approves configured shell hooks.
+`--cli` forces the classic prompt_toolkit REPL.
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `Ctrl+C cancel` (shown in the running composer footer when a turn is running; idle shows bare `❯` prompt glyph) |
+| Exit command | `/quit` (`/exit` alias) |
+| Interrupt | single `Ctrl+C` (interrupts the current turn; a second `Ctrl+C` within 2 seconds force-exits) |
+| Skill invocation | `/<skill>` (e.g. `/no-mistakes`) |
+| Autonomy | `--yolo` (auto-approves tool execution without TTY prompt) |
+| Env marker | `HERMES_INTERACTIVE=1` (set for tool/child processes); session-specific `HERMES_SESSION_ID=<id>` |
+| Resume | `hermes --resume <session-id>` (id printed on exit) |
+
+Firstmate allocates an isolated per-task `HERMES_HOME` through `bin/fm-hermes-home.sh`, so the captain's real `~/.hermes/config.yaml` is never modified.
+Auth is copied opaquely from the configured source Hermes home when available, while existing isolated session data is preserved for resume.
+A crewmate home registers an `on_session_end` hook that touches the task's turn-end file.
+A Hermes secondmate receives the full primary hook set described below.
+
+**Primary-session guard fact (wired 2026-07-21).**
+Prepare a main primary's isolated home with `HERMES_PRIMARY_HOME=$(bin/fm-hermes-home.sh primary "${FM_HOME:-$PWD}/state/.hermes-primary")` and launch with `HERMES_HOME="$HERMES_PRIMARY_HOME" hermes chat --yolo --accept-hooks --cli` plus any model override.
+Hermes fires an `on_session_end` shell hook at every turn boundary (verified, v0.19.0, 2026-07-21).
+The event fires for every `run_conversation` turn and includes `session_id`, `task_id`, `turn_id`, `completed`, and `interrupted`.
+The callback is passive, so `bin/fm-turnend-guard-hermes.sh` runs the shared predicate and forces at most one follow-up with `hermes --resume <session-id> -z <guard-reason>` when supervision is missing.
+`HERMES_TURNEND_GUARD_ACTIVE=1` prevents recursion in the resumed turn.
+The isolated primary config also registers the session-start nudge on `on_session_start` and the watcher-arm seatbelt on terminal `pre_tool_call`.
+Hermes's primary watcher protocol uses bounded foreground `bin/fm-watch-checkpoint.sh` calls because background-task wake semantics are unverified.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
+  <id>.hermes/      Firstmate-owned isolated Hermes home with task or primary hooks and resumable session data; removed by teardown
   <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
   <id>.herdr-presentation  quarantinable attempt journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional disposable single-task presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
@@ -95,6 +96,7 @@ state/               volatile runtime signals; gitignored
   .pr-check-quarantine/  private non-runnable storage for checks neutralized by the non-executing migration
   .pr-check-migration.log  private per-task outcomes distinguishing rebuilt or canonically registered replacement polls, quarantined unarmed polls, and incomplete migrations
   .pr-check-migration-scan-v1  private marker proving the non-executing scan disabled every unsafe legacy check; .pr-check-migration-v1 separately records completed private repairs
+  .hermes-primary/  optional Firstmate-owned isolated home for a main Hermes primary session; prepared by bin/fm-hermes-home.sh
   x-watch.check.sh   generated X-mode relay poll shim; present only when opted in (section 14)
   x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)
   x-context/         generated X-mode durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
@@ -153,7 +155,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `grok`, and `hermes`; never dispatch on an unverified adapter.
 If configured harness data names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-dispatch-select.sh` owns selector mechanics, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -143,8 +143,8 @@ fm_backend_tmux_current_command() {  # <target>
 # AGENTS.md's session-start guarantee closes). See docs/tmux-backend.md
 # "Agent liveness probe" for the empirical basis. Prints one of:
 #   alive   - the foreground command is one of the verified harness binaries
-#             (claude, codex, opencode, grok - each confirmed to run as its
-#             own process name, never wrapped by a generic interpreter).
+#             (claude, codex, opencode, grok, hermes - each confirmed to run
+#             as its own process name, never wrapped by a generic interpreter).
 #   dead    - the foreground command is a bare shell: nothing is running in
 #             the pane, so a prior agent process has exited.
 #   unknown - anything else, INCLUDING a bare "node"/"python" interpreter
@@ -160,7 +160,7 @@ fm_backend_tmux_agent_alive() {  # <target>
   comm=${comm#-}
   case "$comm" in
     '') printf 'unknown' ;;
-    *claude*|*codex*|*opencode*|*grok*) printf 'alive' ;;
+    *claude*|*codex*|*opencode*|*grok*|*hermes*) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     *) printf 'unknown' ;;
   esac

--- a/bin/fm-arm-pretool-check.sh
+++ b/bin/fm-arm-pretool-check.sh
@@ -11,11 +11,11 @@
 # See docs/arm-pretool-check.md for the complete contract and validation record.
 #
 # Usage:
-#   <PreToolUse JSON on stdin> | bin/fm-arm-pretool-check.sh
+#   <PreToolUse JSON on stdin> | bin/fm-arm-pretool-check.sh [--claude|--hermes]
 #   bin/fm-arm-pretool-check.sh --command '<cmd>' [--background true|false]
 #
 # Stdin mode extracts .toolInput.command for Grok or .tool_input.command for
-# Claude and Codex.
+# Claude, Codex, and Hermes.
 # CLI mode is used by OpenCode and Pi after their adapters extract the exact
 # command string.
 # --background remains accepted for compatibility, but harness-native tracked
@@ -23,14 +23,16 @@
 #
 # Exit/output contract:
 #   ALLOW - exit 0 and no output.
-#   DENY - exit 2, a Claude-shaped deny object on stderr, and a Grok-shaped
-#          deny object on stdout unless --claude was supplied.
+#   DENY - exit 2, a Claude-shaped deny object on stderr, plus either a
+#          Grok-shaped stdout object by default, a Hermes action object with
+#          --hermes, or no stdout with --claude.
 #   FAIL OPEN - malformed or empty stdin, missing jq for stdin transport,
 #               missing Node or policy owner, or an invalid policy response.
 #
 # Claude requires stdout to remain empty on deny.
 # Codex blocks on exit 2 and displays stderr.
 # Grok consumes the stdout decision object.
+# Hermes consumes the stdout action object.
 # OpenCode and Pi consume exit 2 plus stderr.
 set -u
 
@@ -38,16 +40,17 @@ CMD=""
 CMD_SET=0
 BACKGROUND=""
 CLAUDE_MODE=0
+HERMES_MODE=0
 
 usage() {
   cat <<'EOF'
-Usage: fm-arm-pretool-check.sh [--command <cmd>] [--background true|false] [--claude]
+Usage: fm-arm-pretool-check.sh [--command <cmd>] [--background true|false] [--claude|--hermes]
 
 With no --command, reads a PreToolUse-style JSON payload on stdin (Grok
-toolInput.command, or Claude/Codex tool_input.command).
+toolInput.command, or Claude/Codex/Hermes tool_input.command).
 Exits 0 to allow and 2 to deny.
-The deny reason is written to stderr, with a Grok decision object on stdout
-unless --claude is supplied.
+The deny reason is written to stderr, with a Grok decision object on stdout by
+default, a Hermes action object under --hermes, or no stdout under --claude.
 Malformed transport and an unavailable classifier runtime fail open.
 EOF
 }
@@ -76,6 +79,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --claude)
       CLAUDE_MODE=1
+      shift
+      ;;
+    --hermes)
+      HERMES_MODE=1
       shift
       ;;
     -h|--help)
@@ -169,5 +176,11 @@ json_escape() {
 DETAIL="[$CODE] $REASON"
 ESCAPED=$(json_escape "$DETAIL")
 printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"%s"}\n' "$ESCAPED" >&2
-[ "$CLAUDE_MODE" -eq 1 ] || printf '{"decision":"deny","reason":"%s"}\n' "$ESCAPED"
+if [ "$CLAUDE_MODE" -eq 0 ]; then
+  if [ "$HERMES_MODE" -eq 1 ]; then
+    printf '{"action":"block","message":"%s"}\n' "$ESCAPED"
+  else
+    printf '{"decision":"deny","reason":"%s"}\n' "$ESCAPED"
+  fi
+fi
 exit 2

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -455,7 +455,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     verdict=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null) || verdict="unknown"
     case "$harness" in
-      claude|codex|opencode|pi|grok) ;;
+      claude|codex|opencode|pi|grok|hermes) ;;
       *) [ "$verdict" = dead ] && verdict=unknown ;;
     esac
     case "$verdict" in
@@ -711,7 +711,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","hermes"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -720,6 +720,7 @@ crew_dispatch_validate() {
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" then false
+      elif $h == "hermes" then false
       else true
       end;
     def use_profiles($u):

--- a/bin/fm-cd-pretool-check.sh
+++ b/bin/fm-cd-pretool-check.sh
@@ -13,17 +13,18 @@
 # See docs/cd-guard.md for the complete contract and validation record.
 #
 # Usage:
-#   <PreToolUse JSON on stdin> | bin/fm-cd-pretool-check.sh
+#   <PreToolUse JSON on stdin> | bin/fm-cd-pretool-check.sh [--claude|--hermes]
 #   bin/fm-cd-pretool-check.sh --command '<cmd>'
 #
 # Stdin mode extracts .toolInput.command for Grok or .tool_input.command for
-# Claude and Codex. CLI mode is used by OpenCode and Pi after their adapters
-# extract the exact command string.
+# Claude, Codex, and Hermes. CLI mode is used by OpenCode and Pi after their
+# adapters extract the exact command string.
 #
 # Exit/output contract (identical shape to bin/fm-arm-pretool-check.sh):
 #   ALLOW - exit 0 and no output.
-#   DENY - exit 2, a Claude-shaped deny object on stderr, and a Grok-shaped
-#          deny object on stdout unless --claude was supplied.
+#   DENY - exit 2, a Claude-shaped deny object on stderr, plus either a
+#          Grok-shaped stdout object by default, a Hermes action object with
+#          --hermes, or no stdout with --claude.
 #   INERT - not the real primary checkout (a crewmate/scout task worktree or a
 #           non-firstmate repo): exit 0 with no output, exactly like ALLOW.
 #   FAIL OPEN - malformed or empty stdin, missing jq for stdin transport,
@@ -32,24 +33,26 @@
 # Claude requires stdout to remain empty on deny.
 # Codex blocks on exit 2 and displays stderr.
 # Grok consumes the stdout decision object.
+# Hermes consumes the stdout action object.
 # OpenCode and Pi consume exit 2 plus stderr.
 set -u
 
 CMD=""
 CMD_SET=0
 CLAUDE_MODE=0
+HERMES_MODE=0
 
 usage() {
   cat <<'EOF'
-Usage: fm-cd-pretool-check.sh [--command <cmd>] [--claude]
+Usage: fm-cd-pretool-check.sh [--command <cmd>] [--claude|--hermes]
 
 With no --command, reads a PreToolUse-style JSON payload on stdin (Grok
-toolInput.command, or Claude/Codex tool_input.command).
+toolInput.command, or Claude/Codex/Hermes tool_input.command).
 Fires only in the real primary firstmate checkout; it is a silent no-op in a
 crewmate/scout task worktree or any non-firstmate repo.
 Exits 0 to allow and 2 to deny a persistent top-level cwd change.
-The deny reason is written to stderr, with a Grok decision object on stdout
-unless --claude is supplied.
+The deny reason is written to stderr, with a Grok decision object on stdout by
+default, a Hermes action object under --hermes, or no stdout under --claude.
 Malformed transport and an unavailable classifier runtime fail open.
 EOF
 }
@@ -69,6 +72,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --claude)
       CLAUDE_MODE=1
+      shift
+      ;;
+    --hermes)
+      HERMES_MODE=1
       shift
       ;;
     -h|--help)
@@ -162,5 +169,11 @@ json_escape() {
 DETAIL="[$CODE] $REASON"
 ESCAPED=$(json_escape "$DETAIL")
 printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"%s"}\n' "$ESCAPED" >&2
-[ "$CLAUDE_MODE" -eq 1 ] || printf '{"decision":"deny","reason":"%s"}\n' "$ESCAPED"
+if [ "$CLAUDE_MODE" -eq 0 ]; then
+  if [ "$HERMES_MODE" -eq 1 ]; then
+    printf '{"action":"block","message":"%s"}\n' "$ESCAPED"
+  else
+    printf '{"decision":"deny","reason":"%s"}\n' "$ESCAPED"
+  fi
+fi
 exit 2

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -19,8 +19,11 @@
 # Model/effort come ONLY from this file - config/crew-harness stays a bare adapter
 # name and is never parsed for a model.
 # Detection layers: verified environment markers first, then process ancestry.
+# Env markers are exported and therefore inherited, so a nested worker can carry
+# its primary's marker alongside the one its own harness sets. A single marker is
+# conclusive; overlapping markers are resolved by process ancestry.
 # Record each newly verified env marker here. New harnesses add both an env-marker
-# check in detect_own Layer 1 and a process-name match in Layer 2.
+# check in detect_own Layer 1 and a process-name match in detect_by_ancestry.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -28,19 +31,8 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
-detect_own() {
-  # Layer 1: environment markers for verified harnesses.
-  # Hermes v0.19.0 sets HERMES_INTERACTIVE=1 (verified 2026-07-21) and is
-  # checked first because a Firstmate-launched Hermes worker can inherit its
-  # primary's marker.
-  [ "${HERMES_INTERACTIVE:-}" = "1" ] && { echo hermes; return; }
-  [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
-  [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
-  # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
-  # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
-  # is unambiguous when firstmate runs natively on grok.
-  [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
-  # Layer 2: walk the parent chain and match the command name.
+# Layer 2: walk the parent chain and match the command name.
+detect_by_ancestry() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
@@ -69,6 +61,44 @@ detect_own() {
     fi
   done
   echo unknown
+}
+
+detect_own() {
+  # Layer 1: environment markers for verified harnesses.
+  # Hermes v0.19.0 sets HERMES_INTERACTIVE=1 (verified 2026-07-21).
+  # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
+  # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this
+  # marker is unambiguous when firstmate runs natively on grok.
+  local marked='' count=0 own harness
+  if [ "${HERMES_INTERACTIVE:-}" = "1" ]; then marked="$marked hermes"; count=$((count + 1)); fi
+  if [ "${CLAUDECODE:-}" = "1" ]; then marked="$marked claude"; count=$((count + 1)); fi
+  if [ "${PI_CODING_AGENT:-}" = "true" ]; then marked="$marked pi"; count=$((count + 1)); fi
+  if [ "${GROK_AGENT:-}" = "1" ]; then marked="$marked grok"; count=$((count + 1)); fi
+
+  # Exactly one marker is conclusive, and no marker leaves ancestry as the only
+  # evidence. Both keep the pre-Hermes behavior byte for byte.
+  if [ "$count" -eq 1 ]; then
+    printf '%s\n' "${marked# }"
+    return
+  fi
+  own=$(detect_by_ancestry)
+  if [ "$count" -eq 0 ]; then
+    printf '%s\n' "$own"
+    return
+  fi
+  # Overlapping markers mean a nested worker inherited its primary's marker in
+  # one direction or the other. Process ancestry names the harness that actually
+  # owns this process tree, so it breaks the tie whenever it names a marked
+  # harness; a fixed order is the last resort when ancestry is inconclusive.
+  case " $marked " in
+    *" $own "*) printf '%s\n' "$own"; return ;;
+  esac
+  for harness in hermes claude pi grok; do
+    case " $marked " in
+      *" $harness "*) printf '%s\n' "$harness"; return ;;
+    esac
+  done
+  printf '%s\n' "$own"
 }
 
 # Resolve the effective crewmate harness: config/crew-harness (a bare adapter

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|hermes|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -19,7 +19,8 @@
 # Model/effort come ONLY from this file - config/crew-harness stays a bare adapter
 # name and is never parsed for a model.
 # Detection layers: verified environment markers first, then process ancestry.
-# Record each newly verified env marker here.
+# Record each newly verified env marker here. New harnesses add both an env-marker
+# check in detect_own Layer 1 and a process-name match in Layer 2.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -29,6 +30,10 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
+  # Hermes v0.19.0 sets HERMES_INTERACTIVE=1 (verified 2026-07-21) and is
+  # checked first because a Firstmate-launched Hermes worker can inherit its
+  # primary's marker.
+  [ "${HERMES_INTERACTIVE:-}" = "1" ] && { echo hermes; return; }
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
   # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
@@ -44,6 +49,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      *hermes*) echo hermes; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -53,6 +59,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *hermes*) echo hermes; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-hermes-home.sh
+++ b/bin/fm-hermes-home.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Build a Firstmate-owned isolated Hermes home without modifying ~/.hermes.
+# Usage: fm-hermes-home.sh task <target-home> <turn-ended-file>
+#        fm-hermes-home.sh primary <target-home> [<firstmate-root>]
+#
+# task registers one on_session_end hook that touches the task's turn-ended file.
+# primary registers the session-start nudge, passive turn-end guard, and terminal
+# pre_tool_call watcher-arm seatbelt from the named Firstmate root.
+# Existing session data under <target-home> is preserved for Hermes resume.
+# config.yaml and Firstmate's hook script are replaced idempotently.
+# A readable auth.json from HERMES_SOURCE_HOME, ambient HERMES_HOME, or
+# $HOME/.hermes (in that order) is copied with mode 0600 when present; absence
+# is allowed because providers may use ambient credentials.
+# The source Hermes home is never changed.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODE=${1:-}
+TARGET=${2:-}
+ARG3=${3:-}
+
+usage() {
+  sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "$MODE" in
+  task|primary) ;;
+  -h|--help) usage; exit 0 ;;
+  *) usage >&2; exit 2 ;;
+esac
+[ -n "$TARGET" ] || { usage >&2; exit 2; }
+case "$TARGET" in /*) ;; *) echo "error: Hermes target home must be absolute: $TARGET" >&2; exit 2 ;; esac
+[ ! -L "$TARGET" ] || { echo "error: Hermes target home cannot be a symlink: $TARGET" >&2; exit 1; }
+mkdir -p "$TARGET"
+TARGET=$(cd "$TARGET" && pwd -P)
+SOURCE=${HERMES_SOURCE_HOME:-${HERMES_HOME:-$HOME/.hermes}}
+if [ -d "$SOURCE" ]; then
+  SOURCE=$(cd "$SOURCE" && pwd -P)
+  [ "$TARGET" != "$SOURCE" ] || { echo "error: refusing to use the captain's Hermes home as Firstmate integration state" >&2; exit 1; }
+  if [ -f "$SOURCE/auth.json" ]; then
+    install -m 600 "$SOURCE/auth.json" "$TARGET/auth.json"
+  fi
+fi
+
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\''/g"
+  printf "'"
+}
+
+yaml_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/''/g"
+  printf "'"
+}
+
+if [ "$MODE" = task ]; then
+  TURNEND=$ARG3
+  case "$TURNEND" in /*.turn-ended) ;; *) echo "error: task mode requires an absolute .turn-ended path" >&2; exit 2 ;; esac
+  turnend_q=$(shell_quote "$TURNEND")
+  cat > "$TARGET/fm-on-session-end.sh" <<EOF
+#!/usr/bin/env bash
+set -u
+touch $turnend_q 2>/dev/null || true
+exit 0
+EOF
+  chmod 700 "$TARGET/fm-on-session-end.sh"
+  hook_q=$(yaml_quote "$TARGET/fm-on-session-end.sh")
+  cat > "$TARGET/config.yaml" <<EOF
+hooks:
+  on_session_end:
+    - command: $hook_q
+      timeout: 10
+hooks_auto_accept: true
+EOF
+else
+  ROOT=${ARG3:-$(cd "$SCRIPT_DIR/.." && pwd)}
+  case "$ROOT" in /*) ;; *) echo "error: Firstmate root must be absolute: $ROOT" >&2; exit 2 ;; esac
+  ROOT=$(cd "$ROOT" && pwd -P)
+  [ -x "$ROOT/bin/fm-sessionstart-nudge.sh" ] || { echo "error: not a Firstmate root: $ROOT" >&2; exit 1; }
+  start_q=$(yaml_quote "$ROOT/bin/fm-sessionstart-nudge.sh")
+  end_q=$(yaml_quote "$ROOT/bin/fm-turnend-guard-hermes.sh")
+  arm_q=$(yaml_quote "$ROOT/bin/fm-arm-pretool-check.sh --hermes")
+  cat > "$TARGET/config.yaml" <<EOF
+hooks:
+  on_session_start:
+    - command: $start_q
+      timeout: 10
+  on_session_end:
+    - command: $end_q
+      timeout: 300
+  pre_tool_call:
+    - matcher: terminal
+      command: $arm_q
+      timeout: 10
+hooks_auto_accept: true
+EOF
+fi
+chmod 600 "$TARGET/config.yaml"
+printf '%s\n' "$TARGET"

--- a/bin/fm-hermes-home.sh
+++ b/bin/fm-hermes-home.sh
@@ -17,7 +17,10 @@
 # $HOME/.hermes (in that order) is copied with mode 0600 when present; absence
 # is allowed because providers may use ambient credentials.
 # The source Hermes home is never changed.
+# Everything Firstmate writes into the home is created private (umask 077),
+# because the preserved config can carry provider credentials.
 set -eu
+umask 077
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODE=${1:-}
@@ -37,6 +40,7 @@ esac
 case "$TARGET" in /*) ;; *) echo "error: Hermes target home must be absolute: $TARGET" >&2; exit 2 ;; esac
 [ ! -L "$TARGET" ] || { echo "error: Hermes target home cannot be a symlink: $TARGET" >&2; exit 1; }
 mkdir -p "$TARGET"
+chmod 700 "$TARGET"
 TARGET=$(cd "$TARGET" && pwd -P)
 SOURCE=${HERMES_SOURCE_HOME:-${HERMES_HOME:-$HOME/.hermes}}
 SOURCE_CONFIG=
@@ -51,20 +55,40 @@ fi
 
 # Echo the source config with the two top-level keys Firstmate owns removed, so
 # the operator's provider, model, and MCP settings survive into the isolated
-# home while Firstmate's own hooks are the only ones Hermes ever loads. A
-# top-level key is a line starting in column 0; its block is every following
-# indented, list, or blank line. The source file is only ever read.
+# home while Firstmate's own hooks are the only ones Hermes ever loads.
+# A top-level key is any column-0 bare, "double-quoted", or 'single-quoted' key.
+# A stripped block runs until the NEXT top-level key, so a column-0 comment, a
+# --- document marker, or a list item inside the operator's hooks block can
+# never resume emission mid-block and leak the rest of it. The source file is
+# only ever read.
 emit_preserved_config() {
   [ -n "$SOURCE_CONFIG" ] || return 0
   awk '
-    /^[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]*:/ {
-      key = $0
-      sub(/[[:space:]]*:.*/, "", key)
-      skip = (key == "hooks" || key == "hooks_auto_accept")
-      if (skip) next
+    function keyname(line,   s) {
+      s = line
+      if (s ~ /^"[^"]*"[[:space:]]*:/) {
+        sub(/^"/, "", s); sub(/"[[:space:]]*:.*$/, "", s); return s
+      }
+      if (s ~ /^\047[^\047]*\047[[:space:]]*:/) {
+        sub(/^\047/, "", s); sub(/\047[[:space:]]*:.*$/, "", s); return s
+      }
+      if (s ~ /^[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]*:/) {
+        sub(/[[:space:]]*:.*$/, "", s); return s
+      }
+      return ""
     }
-    skip && (/^[[:space:]]/ || /^-/ || /^$/) { next }
-    { skip = 0; print }
+    {
+      if ($0 ~ /^[^[:space:]]/) {
+        k = keyname($0)
+        if (k != "") {
+          skip = (k == "hooks" || k == "hooks_auto_accept")
+          if (skip) next
+          print; next
+        }
+      }
+      if (skip) next
+      print
+    }
   ' "$SOURCE_CONFIG"
 }
 

--- a/bin/fm-hermes-home.sh
+++ b/bin/fm-hermes-home.sh
@@ -115,7 +115,7 @@ touch $turnend_q 2>/dev/null || true
 exit 0
 EOF
   chmod 700 "$TARGET/fm-on-session-end.sh"
-  hook_q=$(yaml_quote "$TARGET/fm-on-session-end.sh")
+  hook_q=$(yaml_quote "$(shell_quote "$TARGET/fm-on-session-end.sh")")
   {
     emit_preserved_config
     cat <<EOF
@@ -130,11 +130,13 @@ else
   ROOT=${ARG3:-$(cd "$SCRIPT_DIR/.." && pwd)}
   case "$ROOT" in /*) ;; *) echo "error: Firstmate root must be absolute: $ROOT" >&2; exit 2 ;; esac
   ROOT=$(cd "$ROOT" && pwd -P)
-  [ -x "$ROOT/bin/fm-sessionstart-nudge.sh" ] || { echo "error: not a Firstmate root: $ROOT" >&2; exit 1; }
-  start_q=$(yaml_quote "$ROOT/bin/fm-sessionstart-nudge.sh")
-  end_q=$(yaml_quote "$ROOT/bin/fm-turnend-guard-hermes.sh")
-  arm_q=$(yaml_quote "$ROOT/bin/fm-arm-pretool-check.sh --hermes")
-  cd_q=$(yaml_quote "$ROOT/bin/fm-cd-pretool-check.sh --hermes")
+  for script in fm-sessionstart-nudge.sh fm-turnend-guard-hermes.sh fm-arm-pretool-check.sh fm-cd-pretool-check.sh; do
+    [ -x "$ROOT/bin/$script" ] || { echo "error: missing required Hermes hook: $ROOT/bin/$script" >&2; exit 1; }
+  done
+  start_q=$(yaml_quote "$(shell_quote "$ROOT/bin/fm-sessionstart-nudge.sh")")
+  end_q=$(yaml_quote "$(shell_quote "$ROOT/bin/fm-turnend-guard-hermes.sh")")
+  arm_q=$(yaml_quote "$(shell_quote "$ROOT/bin/fm-arm-pretool-check.sh") --hermes")
+  cd_q=$(yaml_quote "$(shell_quote "$ROOT/bin/fm-cd-pretool-check.sh") --hermes")
   {
     emit_preserved_config
     cat <<EOF

--- a/bin/fm-hermes-home.sh
+++ b/bin/fm-hermes-home.sh
@@ -4,10 +4,15 @@
 #        fm-hermes-home.sh primary <target-home> [<firstmate-root>]
 #
 # task registers one on_session_end hook that touches the task's turn-ended file.
-# primary registers the session-start nudge, passive turn-end guard, and terminal
-# pre_tool_call watcher-arm seatbelt from the named Firstmate root.
+# primary registers the session-start nudge, passive turn-end guard, and the
+# terminal pre_tool_call watcher-arm and cd-guard seatbelts from the named
+# Firstmate root.
 # Existing session data under <target-home> is preserved for Hermes resume.
 # config.yaml and Firstmate's hook script are replaced idempotently.
+# Every top-level key of the source config.yaml except hooks and
+# hooks_auto_accept is carried over, so the operator's model, provider,
+# base_url, agent, and MCP settings reach Firstmate-launched sessions; Firstmate
+# owns only the two hook keys it appends.
 # A readable auth.json from HERMES_SOURCE_HOME, ambient HERMES_HOME, or
 # $HOME/.hermes (in that order) is copied with mode 0600 when present; absence
 # is allowed because providers may use ambient credentials.
@@ -20,7 +25,7 @@ TARGET=${2:-}
 ARG3=${3:-}
 
 usage() {
-  sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'
+  awk 'NR > 1 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "$0"
 }
 
 case "$MODE" in
@@ -34,13 +39,34 @@ case "$TARGET" in /*) ;; *) echo "error: Hermes target home must be absolute: $T
 mkdir -p "$TARGET"
 TARGET=$(cd "$TARGET" && pwd -P)
 SOURCE=${HERMES_SOURCE_HOME:-${HERMES_HOME:-$HOME/.hermes}}
+SOURCE_CONFIG=
 if [ -d "$SOURCE" ]; then
   SOURCE=$(cd "$SOURCE" && pwd -P)
   [ "$TARGET" != "$SOURCE" ] || { echo "error: refusing to use the captain's Hermes home as Firstmate integration state" >&2; exit 1; }
   if [ -f "$SOURCE/auth.json" ]; then
     install -m 600 "$SOURCE/auth.json" "$TARGET/auth.json"
   fi
+  [ ! -f "$SOURCE/config.yaml" ] || SOURCE_CONFIG="$SOURCE/config.yaml"
 fi
+
+# Echo the source config with the two top-level keys Firstmate owns removed, so
+# the operator's provider, model, and MCP settings survive into the isolated
+# home while Firstmate's own hooks are the only ones Hermes ever loads. A
+# top-level key is a line starting in column 0; its block is every following
+# indented, list, or blank line. The source file is only ever read.
+emit_preserved_config() {
+  [ -n "$SOURCE_CONFIG" ] || return 0
+  awk '
+    /^[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]*:/ {
+      key = $0
+      sub(/[[:space:]]*:.*/, "", key)
+      skip = (key == "hooks" || key == "hooks_auto_accept")
+      if (skip) next
+    }
+    skip && (/^[[:space:]]/ || /^-/ || /^$/) { next }
+    { skip = 0; print }
+  ' "$SOURCE_CONFIG"
+}
 
 shell_quote() {
   printf "'"
@@ -66,13 +92,16 @@ exit 0
 EOF
   chmod 700 "$TARGET/fm-on-session-end.sh"
   hook_q=$(yaml_quote "$TARGET/fm-on-session-end.sh")
-  cat > "$TARGET/config.yaml" <<EOF
+  {
+    emit_preserved_config
+    cat <<EOF
 hooks:
   on_session_end:
     - command: $hook_q
       timeout: 10
 hooks_auto_accept: true
 EOF
+  } > "$TARGET/config.yaml"
 else
   ROOT=${ARG3:-$(cd "$SCRIPT_DIR/.." && pwd)}
   case "$ROOT" in /*) ;; *) echo "error: Firstmate root must be absolute: $ROOT" >&2; exit 2 ;; esac
@@ -81,7 +110,10 @@ else
   start_q=$(yaml_quote "$ROOT/bin/fm-sessionstart-nudge.sh")
   end_q=$(yaml_quote "$ROOT/bin/fm-turnend-guard-hermes.sh")
   arm_q=$(yaml_quote "$ROOT/bin/fm-arm-pretool-check.sh --hermes")
-  cat > "$TARGET/config.yaml" <<EOF
+  cd_q=$(yaml_quote "$ROOT/bin/fm-cd-pretool-check.sh --hermes")
+  {
+    emit_preserved_config
+    cat <<EOF
 hooks:
   on_session_start:
     - command: $start_q
@@ -93,8 +125,12 @@ hooks:
     - matcher: terminal
       command: $arm_q
       timeout: 10
+    - matcher: terminal
+      command: $cd_q
+      timeout: 10
 hooks_auto_accept: true
 EOF
+  } > "$TARGET/config.yaml"
 fi
 chmod 600 "$TARGET/config.yaml"
 printf '%s\n' "$TARGET"

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,7 +15,7 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+HARNESS_RE='claude|codex|opencode|grok|hermes|^pi$'
 
 harness_pid() {
   local pid=$$ comm args

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -55,7 +55,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|hermes)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -96,9 +96,12 @@
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
+#     __HERMES_HOME__ absolute path to the Firstmate-owned isolated Hermes home
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
+# hermes uses bin/fm-hermes-home.sh to build an isolated HERMES_HOME under
+# state/<id>.hermes, so the captain's real ~/.hermes/config.yaml is never modified.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<backend-target> worktree=<path>
 # mode/yolo are resolved per-project from data/projects.md for ship/scout tasks;
 # secondmate spawns record mode=secondmate, yolo=off, home=, and projects=.
@@ -376,7 +379,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|hermes)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -437,6 +440,12 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # hermes (Hermes Agent v0.19.0): classic CLI with --yolo for autonomous
+    # operation and --accept-hooks to auto-approve configured shell hooks.
+    # --cli forces the classic prompt_toolkit REPL (verified, 2026-07-21).
+    # The isolated HERMES_HOME carries either the task turn-end notification or
+    # the secondmate primary hooks, so the captain's real config is never modified.
+    hermes) printf '%s' 'HERMES_HOME=__HERMES_HOME__ hermes chat --yolo --accept-hooks --cli __MODELFLAG__"$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -527,6 +536,9 @@ model_flag_for_harness() {
     claude|codex|opencode|pi|grok)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
+    hermes)
+      printf -- '-m %s ' "$(shell_quote "$model")"
+      ;;
   esac
 }
 
@@ -566,6 +578,9 @@ effort_flag_for_harness() {
     # opencode's interactive `opencode --prompt` launch has a verified --model
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
+    # hermes: no per-invocation effort flag (verified, Hermes v0.19.0, 2026-07-21).
+    # The active config supports agent.reasoning_effort, but there is no
+    # launch-flag equivalent, so effort is always omitted for this harness.
   esac
 }
 
@@ -1187,6 +1202,15 @@ EOF
   esac
 fi
 
+HERMES_TASK_HOME="$STATE_REAL/$ID.hermes"
+if [ "$HARNESS" = hermes ]; then
+  if [ "$KIND" = secondmate ]; then
+    "$SCRIPT_DIR/fm-hermes-home.sh" primary "$HERMES_TASK_HOME" "$PROJ_ABS" >/dev/null
+  else
+    "$SCRIPT_DIR/fm-hermes-home.sh" task "$HERMES_TASK_HOME" "$TURNEND" >/dev/null
+  fi
+fi
+
 # Per-project delivery mode + yolo flag (bin/fm-project-mode.sh; the project-management skill and AGENTS.md task lifecycle).
 # Recorded in meta so fm-teardown's safety check and the validate/merge stages can
 # branch on them. Mode governs ship tasks; a scout's deliverable is a report, not a
@@ -1260,6 +1284,8 @@ LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
+sq_hermes_home=$(shell_quote "$HERMES_TASK_HOME")
+LAUNCH=${LAUNCH//__HERMES_HOME__/$sq_hermes_home}
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -81,7 +81,7 @@ if [ -z "$HARNESS" ]; then
 fi
 
 case "$HARNESS" in
-  claude|codex|opencode|pi|grok) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
+  claude|codex|opencode|pi|grok|hermes) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
   *) HARNESS=unknown; SNIPPET="$DOC_DIR/unknown.md" ;;
 esac
 [ -f "$SNIPPET" ] || SNIPPET="$DOC_DIR/unknown.md"
@@ -148,6 +148,9 @@ repair_line() {
     grok)
       printf '%s%s\n' "$prefix" 'repair missing watcher supervision with bin/fm-watch-arm.sh as its own Grok tracked background task, never shell &.'
       ;;
+    hermes)
+      printf '%s%s%s%s\n' "$prefix" 'repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds ' "$checkpoint_seconds" '.'
+      ;;
     *)
       printf '%s%s\n' "$prefix" 'repair missing watcher supervision according to the session-start block for this harness; do not use shell &.'
       ;;
@@ -170,6 +173,9 @@ ordinary_wake_line() {
       ;;
     grok)
       printf '%s\n' '- Ordinary wake: re-arm exactly one bin/fm-watch-arm.sh Grok tracked background task as directed below.'
+      ;;
+    hermes)
+      printf '%s\n' '- Ordinary wake: take the next foreground bin/fm-watch-checkpoint.sh checkpoint as directed below.'
       ;;
     *)
       printf '%s\n' '- Ordinary wake: follow the continuation in the harness protocol below; do not use shell &.'

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -136,7 +136,7 @@ repair_line() {
     claude)
       printf '%s%s\n' "$prefix" 'repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task, never shell &.'
       ;;
-    codex)
+    codex|hermes)
       printf '%s%s%s%s\n' "$prefix" 'repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds ' "$checkpoint_seconds" '.'
       ;;
     pi)
@@ -147,9 +147,6 @@ repair_line() {
       ;;
     grok)
       printf '%s%s\n' "$prefix" 'repair missing watcher supervision with bin/fm-watch-arm.sh as its own Grok tracked background task, never shell &.'
-      ;;
-    hermes)
-      printf '%s%s%s%s\n' "$prefix" 'repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds ' "$checkpoint_seconds" '.'
       ;;
     *)
       printf '%s%s\n' "$prefix" 'repair missing watcher supervision according to the session-start block for this harness; do not use shell &.'
@@ -162,7 +159,7 @@ ordinary_wake_line() {
     claude)
       printf '%s\n' '- Ordinary wake: re-arm exactly one bin/fm-watch-arm.sh Claude Code background task as directed below.'
       ;;
-    codex)
+    codex|hermes)
       printf '%s\n' '- Ordinary wake: take the next foreground bin/fm-watch-checkpoint.sh checkpoint as directed below.'
       ;;
     pi)
@@ -173,9 +170,6 @@ ordinary_wake_line() {
       ;;
     grok)
       printf '%s\n' '- Ordinary wake: re-arm exactly one bin/fm-watch-arm.sh Grok tracked background task as directed below.'
-      ;;
-    hermes)
-      printf '%s\n' '- Ordinary wake: take the next foreground bin/fm-watch-checkpoint.sh checkpoint as directed below.'
       ;;
     *)
       printf '%s\n' '- Ordinary wake: follow the continuation in the harness protocol below; do not use shell &.'

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1014,6 +1014,7 @@ cleanup_firstmate_home_children() {
     remove_grok_turnend_auth "$sub_state" "$child_id"
     remove_pr_poll_artifacts "$sub_state" "$child_id" || return 1
     rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token"
+    rm -rf "$sub_state/$child_id.hermes" 2>/dev/null || true
   done
 }
 
@@ -1198,6 +1199,7 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
+rm -rf "$STATE/$ID.hermes" 2>/dev/null || true
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -63,7 +63,8 @@
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
 # (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+# hermes: "Ctrl+C cancel" in the running composer footer (verified, v0.19.0, 2026-07-21).
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|Ctrl\+C cancel'
 
 # fm_tmux_strip_ghost: thin adapter over the shared, fleet-wide ghost extractor
 # fm_composer_strip_ghost (bin/fm-composer-lib.sh). It drops de-emphasised

--- a/bin/fm-turnend-guard-hermes.sh
+++ b/bin/fm-turnend-guard-hermes.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Hermes on_session_end adapter for the Firstmate PRIMARY turn-end guard.
+#
+# Hermes v0.19.0 shell hooks are passive: their exit status does not block the
+# turn. This adapter runs the shared primary predicate and, when it returns 2,
+# forces one same-session follow-up with `hermes --resume <session-id> -z ...`.
+# HERMES_TURNEND_GUARD_ACTIVE bounds the adapter to one follow-up per turn.
+set -u
+
+PAYLOAD=$(cat 2>/dev/null || true)
+[ -n "$PAYLOAD" ] || exit 0
+[ -z "${HERMES_TURNEND_GUARD_ACTIVE:-}" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+command -v hermes >/dev/null 2>&1 || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null) || exit 0
+[ -n "$SESSION_ID" ] || exit 0
+
+ERR=$(mktemp "${TMPDIR:-/tmp}/fm-turnend-hermes.XXXXXX") || exit 0
+trap 'rm -f "$ERR"' EXIT
+
+printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-turnend-guard.sh" 2>"$ERR"
+RC=$?
+[ "$RC" -eq 2 ] || exit 0
+
+REASON=$(cat "$ERR" 2>/dev/null || true)
+[ -n "$REASON" ] || REASON='tasks in flight, no live watcher - repair missing watcher supervision according to the session-start operating block before ending the turn'
+
+HERMES_TURNEND_GUARD_ACTIVE=1 \
+  hermes --resume "$SESSION_ID" --yolo --accept-hooks \
+    -z "TURN WOULD END BLIND - supervision is off. Repair missing watcher supervision according to the session-start operating block before ending the turn.
+
+$REASON" >/dev/null 2>&1 || true
+exit 0

--- a/bin/fm-turnend-guard-hermes.sh
+++ b/bin/fm-turnend-guard-hermes.sh
@@ -3,7 +3,7 @@
 #
 # Hermes v0.19.0 shell hooks are passive: their exit status does not block the
 # turn. This adapter runs the shared primary predicate and, when it returns 2,
-# forces one same-session follow-up with `hermes --resume <session-id> -z ...`.
+# forces one independent follow-up with `hermes -z ...`.
 # HERMES_TURNEND_GUARD_ACTIVE bounds the adapter to one follow-up per turn.
 set -u
 
@@ -12,10 +12,9 @@ PAYLOAD=$(cat 2>/dev/null || true)
 [ -z "${HERMES_TURNEND_GUARD_ACTIVE:-}" ] || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
 command -v hermes >/dev/null 2>&1 || exit 0
+[ "$(printf '%s' "$PAYLOAD" | jq -r '.interrupted // false' 2>/dev/null)" != true ] || exit 0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null) || exit 0
-[ -n "$SESSION_ID" ] || exit 0
 
 ERR=$(mktemp "${TMPDIR:-/tmp}/fm-turnend-hermes.XXXXXX") || exit 0
 trap 'rm -f "$ERR"' EXIT
@@ -27,8 +26,13 @@ RC=$?
 REASON=$(cat "$ERR" 2>/dev/null || true)
 [ -n "$REASON" ] || REASON='tasks in flight, no live watcher - repair missing watcher supervision according to the session-start operating block before ending the turn'
 
-HERMES_TURNEND_GUARD_ACTIVE=1 \
-  hermes --resume "$SESSION_ID" --yolo --accept-hooks \
+FOLLOWUP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-turnend-hermes-home.XXXXXX") || exit 0
+trap 'rm -f "$ERR"; rm -rf "$FOLLOWUP_ROOT"' EXIT
+HERMES_SOURCE_HOME="${HERMES_HOME:-$HOME/.hermes}" \
+  "$SCRIPT_DIR/fm-hermes-home.sh" task "$FOLLOWUP_ROOT/home" "$FOLLOWUP_ROOT/followup.turn-ended" >/dev/null 2>&1 || exit 0
+
+HERMES_HOME="$FOLLOWUP_ROOT/home" HERMES_TURNEND_GUARD_ACTIVE=1 \
+  hermes --yolo --accept-hooks \
     -z "TURN WOULD END BLIND - supervision is off. Repair missing watcher supervision according to the session-start operating block before ending the turn.
 
 $REASON" >/dev/null 2>&1 || true

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -11,8 +11,8 @@
 # This script is push-based: verified harness turn-end hooks invoke it every time
 # the primary is about to end a turn.
 # Claude and codex can block directly by preserving exit status 2 and stderr.
-# OpenCode, pi, and grok adapters use the same predicate and force one bounded
-# follow-up because their turn-end events are passive.
+# OpenCode, pi, grok, and hermes adapters use the same predicate and force one
+# bounded follow-up because their turn-end events are passive.
 # See docs/turnend-guard.md for the per-harness mechanics, validation evidence,
 # and fail-open tradeoffs.
 #

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -115,7 +115,8 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
 # locale fragility of matching grok's braille spinner glyph directly).
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+# hermes: "Ctrl+C cancel" in the running composer footer (verified, v0.19.0, 2026-07-21).
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|Ctrl\+C cancel'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,7 +138,7 @@ The session-start bootstrap step surfaces either the active rule block or a conc
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and hermes while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ On `attached` it stays live across identity-matched successors, and an unexplain
 The arm layer records one bounded lifecycle row per observed cycle in `state/.watch-cycle-exits.log`; `state/.watch-triage.log` remains exclusively the absorbed-wake debug log.
 Pi and OpenCode verify session-lock ownership and launch one singleton successor from their child-close handlers before delivering an actionable wake prompt, with bounded exponential retry for failed restoration.
 Claude keeps its tracked background-task protocol and adds a narrow PreToolUse continuity gate that allows drain, arm recovery, and fail-closed teardown while refusing only other fleet commands when tasks are in flight and no identity-matched live watcher holds the home lock.
-The existing turn-end guard is unchanged and remains the final backstop for all five harness protocols.
+The existing turn-end guard is unchanged and remains the final backstop for all six harness protocols.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
 A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, or if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
 The drain script calls that guard after emptying the queue, which avoids repeating the queued-wakes warning for records it just consumed while still warning on stale watcher liveness.

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -33,11 +33,12 @@ It tokenizes the bytes and classifies lexical execution positions only.
 
 `bin/fm-arm-pretool-check.sh` supports these entry forms:
 
-- Stdin JSON at `.tool_input.command` for Claude and Codex.
+- Stdin JSON at `.tool_input.command` for Claude, Codex, and Hermes.
 - Stdin JSON at `.toolInput.command` for Grok.
 - `--command <exact string>` for OpenCode and Pi.
 - `--background` as a compatibility-only field that never changes the decision.
 - `--claude` to preserve Claude's stderr-only deny requirement.
+- `--hermes` to emit Hermes's native stdout `{"action":"block","message":"..."}` shape.
 
 The wrapper discovers the code root from its own location.
 The active firstmate home is `${FM_HOME:-<code-root>}`.
@@ -159,8 +160,10 @@ Prose may improve without changing adapter behavior.
 - Allow returns exit 0 with both streams empty.
 - Deny returns exit 2 and writes `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[code] reason"}` to stderr.
 - Default deny mode also writes `{"decision":"deny","reason":"[code] reason"}` to stdout for Grok.
+- `--hermes` instead writes `{"action":"block","message":"[code] reason"}` to stdout for Hermes.
 - `--claude` suppresses stdout completely because Claude ignores a PreToolUse deny when stdout is nonempty.
 - Codex blocks on exit 2 and displays stderr.
+- Hermes consumes the `action=block` stdout object; its shell-hook bridge logs but does not rely on the nonzero exit.
 - OpenCode throws only when the checker exits 2.
 - Pi returns `{block: true}` only when the checker exits 2.
 
@@ -173,6 +176,7 @@ Prose may improve without changing adapter behavior.
 | Grok | `.toolInput.command` | `.grok/hooks/fm-primary-pretool-check.json` forwards stdin and Grok consumes the stdout `decision=deny` object. |
 | OpenCode | `output.args.command` | `.opencode/plugins/fm-primary-pretool-check.js` passes one `--command` argument and throws only for exit 2. |
 | Pi | `event.input.command` | `.pi/extensions/fm-primary-turnend-guard.ts` passes one `--command` argument and returns `{block: true}` only for exit 2. |
+| Hermes | `.tool_input.command` | `bin/fm-hermes-home.sh primary` registers the wrapper with `--hermes` for terminal `pre_tool_call`; Hermes v0.19.0 consumes the stdout `{"action":"block","message":"..."}` shape as a native block directive. |
 
 Grok project hooks require folder trust.
 Every shell variable reference in a Grok hook command must carry an inline default such as `${GROK_WORKSPACE_ROOT:-}` because Grok expands the raw hook command before `bash -lc` runs it.
@@ -237,10 +241,18 @@ Native supervision paths were also validated in the same scratch project:
 
 Every native-path automatic marker was present and every deny sentinel remained absent.
 
+### Hermes v0.19.0 isolated-hook validation, 2026-07-21
+
+The Firstmate-owned home was generated under `/tmp/fm-hermes-adapter.<random>/home`; the captain's real Hermes config was not changed.
+The command was `HERMES_HOME="$tmp/home" hermes hooks test pre_tool_call --for-tool terminal --payload-file "$tmp/payload.json"`.
+The payload file contained `{"tool_name":"terminal","args":{"command":"bin/fm-watch-arm.sh &"}}`.
+Hermes reported `exit=2`, stdout `{"action":"block","message":"[watcher-background] a protected watcher command cannot run in an asynchronous shell list or through nohup/disown"}`, and parsed wire shape `{"action": "block", "message": "[watcher-background] a protected watcher command cannot run in an asynchronous shell list or through nohup/disown"}`.
+This verifies the exact Hermes payload field, matcher, output shape, and native block parsing without executing the denied command.
+
 ## Automated validation
 
 `tests/fm-arm-pretool-check.test.sh` owns the adversarial acceptance matrix.
-Every row runs through Codex-shaped stdin, Claude-shaped stdin, Grok-shaped stdin, OpenCode-shaped CLI, and Pi-shaped CLI entry forms.
+Every row runs through Codex-shaped stdin, Claude-shaped stdin, Grok-shaped stdin, Hermes-shaped stdin, OpenCode-shaped CLI, and Pi-shaped CLI entry forms.
 The suite also verifies real newline bytes, direct classifier reason codes, comments, heredoc data, malformed and unsupported protected syntax, constructed dynamic payloads, malformed transport fail-open behavior, missing runtime fail-open behavior, output shapes, and exact adapter field forwarding plus exit-2 mapping.
 
 Run:

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -258,6 +258,24 @@ So Hermes delivers `.tool_input.command`, matching the "Harness wiring" table ab
 Hermes reported `exit=2`, stdout `{"action":"block","message":"[watcher-background] a protected watcher command cannot run in an asynchronous shell list or through nohup/disown"}`, and parsed wire shape `{"action": "block", "message": "[watcher-background] a protected watcher command cannot run in an asynchronous shell list or through nohup/disown"}`.
 This verifies the exact Hermes payload field, matcher, output shape, and native block parsing without executing the denied command.
 
+### Hermes v0.19.0 two-hook `pre_tool_call` validation, 2026-07-21
+
+The Firstmate primary home registers **two** entries under `pre_tool_call`, both with `matcher: terminal`: the watcher-arm seatbelt and the cd-guard.
+That both entries actually run was validated live in an isolated `HERMES_HOME`, with each hook appending its name to a shared log so execution is observable independently of the reported directive.
+
+`hermes hooks list` reported `Configured shell hooks (2 total)` with both entries listed under a single `[pre_tool_call]` heading.
+Three `hermes hooks test pre_tool_call --for-tool terminal` runs all printed `Firing 2 hook(s)` and all logged both hook names:
+
+| Case | arm hook | cd hook | Result |
+| --- | --- | --- | --- |
+| A | exit 0 | exit 0 | Both fired, no directive, tool allowed. |
+| B | exit 2 `action=block` | exit 0 | Both fired, `{"action": "block", "message": "[watcher-background] ARM BLOCK"}` parsed. |
+| C | exit 0 | exit 2 `action=block` | Both fired, `{"action": "block", "message": "[persistent-cd] CD BLOCK"}` parsed. |
+
+Neither entry shadows the other in either order.
+This matches the owner in `hermes_cli/plugins.py`: `_get_pre_tool_call_directive_details` calls `invoke_hook("pre_tool_call", ...)`, which fans out to every matching hook and returns a list, then scans that list so "the first valid directive wins" - a block from any position is honored, and hooks with no directive are ignored rather than terminating the scan.
+So registering the cd-guard beside the watcher-arm seatbelt neither disables the cd-guard nor regresses watcher-arm safety.
+
 ## Automated validation
 
 `tests/fm-arm-pretool-check.test.sh` owns the adversarial acceptance matrix.

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -246,6 +246,15 @@ Every native-path automatic marker was present and every deny sentinel remained 
 The Firstmate-owned home was generated under `/tmp/fm-hermes-adapter.<random>/home`; the captain's real Hermes config was not changed.
 The command was `HERMES_HOME="$tmp/home" hermes hooks test pre_tool_call --for-tool terminal --payload-file "$tmp/payload.json"`.
 The payload file contained `{"tool_name":"terminal","args":{"command":"bin/fm-watch-arm.sh &"}}`.
+
+That file supplies the internal hook **kwargs**, not the wire payload. `hermes hooks test` routes it through the same `_serialize_payload` the live hook sites use (`agent/shell_hooks.py`), which renames the `args` kwarg to the `tool_input` field. Re-captured live on 2026-07-21 with a probe hook that dumped its stdin, the bytes Hermes actually pipes to the hook are:
+
+```json
+{"hook_event_name":"pre_tool_call","tool_name":"terminal","tool_input":{"command":"bin/fm-watch-arm.sh &"},"session_id":"test-session","cwd":"...","extra":{"task_id":"test-task","tool_call_id":"test-call"}}
+```
+
+So Hermes delivers `.tool_input.command`, matching the "Harness wiring" table above and the `jq` extraction in `bin/fm-arm-pretool-check.sh`; `args` never appears on the wire. `tests/fm-arm-pretool-check.test.sh` replays this full envelope rather than a reduced synthetic one.
+
 Hermes reported `exit=2`, stdout `{"action":"block","message":"[watcher-background] a protected watcher command cannot run in an asynchronous shell list or through nohup/disown"}`, and parsed wire shape `{"action": "block", "message": "[watcher-background] a protected watcher command cannot run in an asynchronous shell list or through nohup/disown"}`.
 This verifies the exact Hermes payload field, matcher, output shape, and native block parsing without executing the denied command.
 

--- a/docs/cd-guard.md
+++ b/docs/cd-guard.md
@@ -74,11 +74,12 @@ It does not permit `cd /home/project`, because an absolute-path `cd` remains a p
 
 ## Transport and fail-open behavior
 
-`bin/fm-cd-pretool-check.sh` supports all five harness entry shapes used by the tracked adapters:
+`bin/fm-cd-pretool-check.sh` supports all six harness entry shapes used by the tracked adapters:
 
 - Claude sends stdin JSON at `.tool_input.command` and adds `--claude` to preserve Claude's stderr-only deny requirement.
 - Codex sends stdin JSON at `.tool_input.command` without `--claude`.
 - Grok sends stdin JSON at `.toolInput.command`.
+- Hermes sends stdin JSON at `.tool_input.command` and adds `--hermes` so the deny renders as the native `{"action":"block","message":"..."}` object; `bin/fm-hermes-home.sh primary` registers it as a second terminal `pre_tool_call` hook beside the watcher-arm seatbelt.
 - OpenCode sends the exact command string through `--command <exact string>`.
 - Pi sends the exact command string through `--command <exact string>`.
 

--- a/docs/cd-guard.md
+++ b/docs/cd-guard.md
@@ -79,7 +79,7 @@ It does not permit `cd /home/project`, because an absolute-path `cd` remains a p
 - Claude sends stdin JSON at `.tool_input.command` and adds `--claude` to preserve Claude's stderr-only deny requirement.
 - Codex sends stdin JSON at `.tool_input.command` without `--claude`.
 - Grok sends stdin JSON at `.toolInput.command`.
-- Hermes sends stdin JSON at `.tool_input.command` and adds `--hermes` so the deny renders as the native `{"action":"block","message":"..."}` object; `bin/fm-hermes-home.sh primary` registers it as a second terminal `pre_tool_call` hook beside the watcher-arm seatbelt.
+- Hermes sends stdin JSON at `.tool_input.command` and adds `--hermes` so the deny renders as the native `{"action":"block","message":"..."}` object; `bin/fm-hermes-home.sh primary` registers it as a second terminal `pre_tool_call` hook beside the watcher-arm seatbelt. Hermes v0.19.0 runs every hook registered for an event and honors a block from any of them, so the two seatbelts coexist without either shadowing the other - see the two-hook validation record in `docs/arm-pretool-check.md`.
 - OpenCode sends the exact command string through `--command <exact string>`.
 - Pi sends the exact command string through `--command <exact string>`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,12 +164,12 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+claude, codex, opencode, pi, grok, and hermes are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
-Claude and Grok use background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
+Claude and Grok use background-notify cycles, Codex and Hermes use bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.
 When it is absent or contains `default`, crewmates mirror the firstmate's own harness.
 `config/secondmate-harness` is a separate local, gitignored file containing the adapter the primary uses to launch secondmate agents, optionally followed by model and effort tokens on the same line.
@@ -185,6 +185,8 @@ Those inherited values are defaults and rules only; `fm-spawn` still permits a c
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
+For Hermes, `bin/fm-hermes-home.sh` builds a Firstmate-owned isolated home containing the appropriate task or primary hooks and copies `auth.json` when available without modifying `~/.hermes`.
+`fm-spawn.sh` provisions that home automatically for workers; a main Hermes primary prepares `state/.hermes-primary` with the same helper before launch.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)
 

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -1,7 +1,7 @@
 # Orca Backend
 
 Orca is an experimental runtime backend for firstmate.
-It is distinct from the crewmate harness: the harness is the agent process firstmate launches (`claude`, `codex`, `opencode`, `pi`, or `grok`), while Orca owns the task worktree and terminal endpoint underneath that process.
+It is distinct from the crewmate harness: the harness is the agent process firstmate launches (`claude`, `codex`, `opencode`, `pi`, `grok`, or `hermes`), while Orca owns the task worktree and terminal endpoint underneath that process.
 Firstmate agents operating this backend should load the agent-only [`firstmate-orca`](../.agents/skills/firstmate-orca/SKILL.md) checklist before switching to Orca, spawning or supervising Orca-backed work, smoke-testing, debugging task state, or reconciling Orca metadata.
 
 ## Setup

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -24,7 +24,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
-| `fm-turnend-guard-hermes.sh` | Hermes `on_session_end` adapter that forces one bounded same-session resume    |
+| `fm-turnend-guard-hermes.sh` | Hermes `on_session_end` adapter that forces one bounded isolated follow-up     |
 | `fm-hermes-home.sh`      | Provision a Firstmate-owned isolated Hermes home and hooks, never touching `~/.hermes` |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -24,6 +24,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
+| `fm-turnend-guard-hermes.sh` | Hermes `on_session_end` adapter that forces one bounded same-session resume    |
+| `fm-hermes-home.sh`      | Provision a Firstmate-owned isolated Hermes home and hooks, never touching `~/.hermes` |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |
 | `fm-continuity-pretool-check.sh` | Narrow Claude recovery gate when in-flight work has no live watcher lock (docs/arm-pretool-check.md) |

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -24,6 +24,7 @@ Every path exits 0, including malformed state and adapter errors, because Claude
 | OpenCode | `.opencode/plugins/fm-primary-sessionstart-nudge.js` listens for `session.created`, runs the wrapper once per session id, and calls `client.session.promptAsync` only when the wrapper prints a nudge. | Verified in the interactive TUI on OpenCode 1.17.18 and intentionally fail-open in headless `opencode run`. |
 | Pi | `.pi/extensions/fm-primary-turnend-guard.ts` handles `session_start` reasons `startup`, `new`, and `resume`, then injects the wrapper output with `pi.sendMessage`. | The custom message enters model context without racing an initial positional prompt, and the changed extension passes strict TypeScript checking on Pi 0.80.10. |
 | Grok | `.grok/hooks/fm-primary-sessionstart-nudge.json` registers a project `SessionStart` hook and invokes the wrapper through inline-defaulted `${GROK_WORKSPACE_ROOT:-}`. | The project event fires on Grok 0.2.103, but hook stdout does not reach model context, so this path is documented fail-open. |
+| Hermes | `bin/fm-hermes-home.sh primary` registers the wrapper as an `on_session_start` shell hook in a Firstmate-owned isolated Hermes home. | Hermes v0.19.0 fires the hook, but its shell-hook return protocol does not inject ordinary stdout into model context, so this path is fail-open and the initial Firstmate instructions remain authoritative. |
 
 The OpenCode nudge runs only on `session.created`.
 The watcher-arm and turn-end guard plugins run later on `session.idle`, and the turn-end guard continues to let the watcher coordinator act first, so the three plugins do not race for one lifecycle event.
@@ -72,6 +73,15 @@ Without folder hook trust it does not load, and with trust its stdout is current
 The known guaranteed-loading alternative is the global token-guarded hook pattern in `bin/fm-spawn.sh`, but installing files under `~/.grok/hooks/` expands trust and writes outside the repository.
 Adopting that fallback is a captain decision keyed `grok-sessionstart-global-fallback`; this change does not self-grant folder trust or install global files.
 
+### Hermes Agent v0.19.0
+
+Validation used Firstmate-owned isolated homes under `/tmp`; the captain's real Hermes config was not changed.
+`HERMES_HOME="$tmp/home" hermes hooks list` reported three configured hooks, including `on_session_start` pointing at `bin/fm-sessionstart-nudge.sh` with timeout 10.
+A second isolated config registered a mode-0700 nudge script that printed `Run bin/fm-session-start.sh now.`.
+`HERMES_HOME="$tmp" hermes hooks test on_session_start` reported `exit=0`, `stdout: Run bin/fm-session-start.sh now.`, and `parsed: <none>`.
+This verifies native event registration and execution while confirming that ordinary hook stdout is not injected through Hermes's shell-hook response protocol.
+The transport is therefore a fail-open nudge; AGENTS.md remains the session-start authority.
+
 ### OpenCode 1.17.18
 
 Headless command run:
@@ -107,5 +117,5 @@ The underlying Claude SessionStart stdout injection and Pi `session_start` event
 
 `tests/fm-sessionstart-nudge.test.sh` proves wrapper silence for both gate signals, an unmarked linked worktree, a missing state directory, and an already-owned lock.
 It proves exact one-line output for a plain primary and a marked linked secondmate primary.
-It also verifies tracked wrapper registration for Claude, Codex, OpenCode, Pi, and Grok.
+It also verifies tracked wrapper registration for Claude, Codex, OpenCode, Pi, Grok, and Hermes.
 `tests/fm-turnend-guard.test.sh` continues to cover the same shared primary scope through the turn-end path.

--- a/docs/supervision-protocols/hermes.md
+++ b/docs/supervision-protocols/hermes.md
@@ -1,0 +1,15 @@
+Mode: Hermes foreground checkpoint.
+
+When this session owns supervision and away mode is not active:
+1. Drain first with `bin/fm-wake-drain.sh`.
+2. Source `__FM_X_MODE_ENV__` first when X mode is active.
+3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds 180`.
+4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
+5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Hermes, then start the next checkpoint.
+6. Never use shell `&` for firstmate watcher supervision.
+7. Do not run `bin/fm-watch-arm.sh` as Hermes's normal supervision command.
+   If it is ever shelled anyway, a backgrounded, piped, or bundled anti-pattern is denied by the `pre_tool_call` seatbelt (`bin/fm-arm-pretool-check.sh`) registered in the Firstmate-owned isolated Hermes home.
+8. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
+
+Hermes cannot reason while a foreground terminal tool call is running.
+The bounded checkpoint returns control regularly without depending on unverified background-task wake semantics.

--- a/docs/supervision-protocols/hermes.md
+++ b/docs/supervision-protocols/hermes.md
@@ -3,13 +3,14 @@ Mode: Hermes foreground checkpoint.
 When this session owns supervision and away mode is not active:
 1. Drain first with `bin/fm-wake-drain.sh`.
 2. Source `__FM_X_MODE_ENV__` first when X mode is active.
-3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds 180`.
+3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
 4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
 5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Hermes, then start the next checkpoint.
 6. Never use shell `&` for firstmate watcher supervision.
 7. Do not run `bin/fm-watch-arm.sh` as Hermes's normal supervision command.
    If it is ever shelled anyway, a backgrounded, piped, or bundled anti-pattern is denied by the `pre_tool_call` seatbelt (`bin/fm-arm-pretool-check.sh`) registered in the Firstmate-owned isolated Hermes home.
-8. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
+8. Never leave the primary checkout with a persistent top-level `cd` into a project clone; the sibling `pre_tool_call` cd-guard (`bin/fm-cd-pretool-check.sh`) denies it before it runs.
+9. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
 
 Hermes cannot reason while a foreground terminal tool call is running.
 The bounded checkpoint returns control regularly without depending on unverified background-task wake semantics.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -111,7 +111,7 @@ Verified the same session: a persisting parent process running a child command (
 
 The classifier (`fm_backend_tmux_agent_alive`) maps the observed name to `alive`, `dead`, or `unknown`:
 
-- `alive` - the name contains `claude`, `codex`, `opencode`, or `grok`. All four were confirmed to run as their own literal process name (`ps -ef`, 2026-07-07): `claude` and `codex` and `opencode` are each a native compiled binary (`file` reports Mach-O), so their `comm` is their own binary name with no interpreter wrapper to hide behind.
+- `alive` - the name contains `claude`, `codex`, `opencode`, `grok`, or `hermes`. The first four were confirmed to run as their own literal process name (`ps -ef`, 2026-07-07): `claude` and `codex` and `opencode` are each a native compiled binary (`file` reports Mach-O), so their `comm` is their own binary name with no interpreter wrapper to hide behind. Hermes Agent v0.19.0 was verified on 2026-07-21 with `awk '/^(Name|Pid|PPid):/{print}' /proc/$PPID/status`; despite its Python launcher, the live process reported `Name: hermes`.
 - `dead` - the name is a bare shell (`zsh`, `bash`, `sh`, `dash`, `ash`, `ksh`, `mksh`, `tcsh`, `csh`, `fish`).
 - `unknown` - anything else, including an unreadable pane.
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -47,16 +47,21 @@ All verified primary harnesses have a tracked integration:
 - `grok`: `.grok/hooks/fm-primary-turnend-guard.json` registers a `Stop` hook that invokes `bin/fm-turnend-guard-grok.sh`.
   The adapter runs the shared guard and, when it returns 2, invokes `grok --resume <sessionId> -p <guard-reason>` with `GROK_TURNEND_GUARD_ACTIVE=1`.
   It does not pass `--permission-mode`, so the passive Stop hook cannot grant stronger tool permissions than Grok's resumed-session default.
+- `hermes`: `bin/fm-hermes-home.sh primary` registers `bin/fm-turnend-guard-hermes.sh` as an `on_session_end` hook in a Firstmate-owned isolated Hermes home.
+  Hermes Agent v0.19.0 fires this passive callback at every completed or interrupted turn and includes `session_id`, `turn_id`, `completed`, and `interrupted` (verified 2026-07-21).
+  The adapter runs the shared guard and, when it returns 2, invokes `hermes --resume <session-id> -z <guard-reason>` with `HERMES_TURNEND_GUARD_ACTIVE=1`.
+  `fm-spawn.sh` provisions the same primary hook set for Hermes secondmates, while a main primary prepares its isolated home with the helper before launch.
+  No path modifies the captain's real `~/.hermes/config.yaml`.
 
 Claude and Codex support a direct blocking Stop hook.
 For those harnesses, exit status 2 plus stderr from `bin/fm-turnend-guard.sh` blocks the stop and feeds the reason back into the model.
 Both payloads include `stop_hook_active`; when it is true, the shared guard exits 0 so the harness can end after one forced continuation.
 
-OpenCode, Pi, and Grok expose passive lifecycle callbacks for this purpose.
+OpenCode, Pi, Grok, and Hermes expose passive lifecycle callbacks for this purpose.
 Their adapters fail open at the hook boundary to avoid corrupting a user session, but they force one follow-up turn when the shared predicate blocks.
 Each adapter carries its own in-process or environment loop guard so the forced follow-up does not recursively schedule another follow-up.
 Pi keeps that latch active across every internal tool turn and clears it only when the generated guard follow-up reaches `agent_settled`, or immediately when follow-up delivery fails.
-If a passive adapter cannot call its SDK method, cannot find `grok`, or cannot recover the Grok session id, it fails open and relies on the pull-based `fm-guard.sh` warning at the next fleet command.
+If a passive adapter cannot call its SDK method, cannot find its resume binary, or cannot recover the session id, it fails open and relies on the pull-based `fm-guard.sh` warning at the next fleet command.
 That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it points back to the active harness protocol instead of hardcoding one background-arm command.
 
 ## Empirical Validation
@@ -113,6 +118,15 @@ Project-local Grok hooks did not fire in scratch single mode without a trust gra
 The primary integration therefore requires the primary firstmate checkout to be trusted for Grok hooks, which can be done with `/hooks-trust` or launch-time `--trust`.
 If Grok declines to load project hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 
+Hermes Agent v0.19.0 was validated on 2026-07-21 with an isolated `HERMES_HOME` under `/tmp/fm-hermes-harness-scout-k7`; the captain's real Hermes config was not changed.
+The isolated config registered an executable marker script under `hooks.on_session_end` with timeout 10 and `hooks_auto_accept: true`.
+The launch command was `HERMES_HOME=/tmp/fm-hermes-harness-scout-k7 hermes chat --yolo --accept-hooks --cli -m gpt-5.6-sol --provider openai-codex`.
+One normal turn wrote `{"completed": true, "event": "on_session_end", "interrupted": false, "session_id": "20260721_215506_081d4f", "turn_id": "20260721_215506_081d4f:20260721_215506_081d4f:eb9710de"}`.
+One turn interrupted with a single `Ctrl+C` wrote `{"completed": false, "event": "on_session_end", "interrupted": true, "session_id": "20260721_215506_081d4f", "turn_id": "20260721_215506_081d4f:20260721_215506_081d4f:3f25d8cf"}`.
+`/quit` wrote no third marker.
+This proves one callback per completed or interrupted turn and no callback for ordinary session exit.
+The tracked passive adapter additionally uses the live-help `-z/--oneshot` prompt option with the separately verified `hermes --resume <session-id>` path to force one bounded guard follow-up.
+
 **2026-07-09 update:** grok 0.2.93 broke the `.grok/hooks/fm-primary-turnend-guard.json` Stop hook with `hook not executed: required env var(s) not set: ${root}`, because grok's own `${VAR}` expansion over the raw `command` string does not tolerate a bare local variable assigned earlier in the same `bash -lc` script.
 The hook command was fixed to reference `${GROK_WORKSPACE_ROOT:-}` directly everywhere instead of assigning it to `$root` first, and re-validated against grok 0.2.93 to fire and complete cleanly.
 See `docs/arm-pretool-check.md`'s "Harness wiring" section for the same Grok expansion requirement; that document's Grok hook shares the same fix.
@@ -148,6 +162,7 @@ No Herdr command was issued and no fleet state was touched; the experiment wrote
 
 ## Tests
 
-`tests/fm-turnend-guard.test.sh` covers the shared predicate, primary scoping (including a secondmate's own home being guarded like the main primary while its child worktrees stay exempt), `FM_HOME` and `FM_STATE_OVERRIDE` precedence, Pi logical-run latch behavior for no-tool and multi-tool runs, fail-open behavior without `jq`, tracked hook registration for all five harnesses, and the Grok adapter's forced-resume loop guard and permission-mode regression.
+`tests/fm-turnend-guard.test.sh` covers the shared predicate, primary scoping (including a secondmate's own home being guarded like the main primary while its child worktrees stay exempt), `FM_HOME` and `FM_STATE_OVERRIDE` precedence, Pi logical-run latch behavior for no-tool and multi-tool runs, fail-open behavior without `jq`, the original tracked hook registrations, and the Grok adapter's forced-resume loop guard and permission-mode regression.
+`tests/fm-hermes-harness.test.sh` covers the isolated Hermes primary hook set, passive forced-resume loop guard, task notification, busy/idle classification, detection, and liveness.
 The default behavior suite does not invoke live language-model harnesses.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` opts into the isolated interactive Pi regression recorded above.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -125,7 +125,12 @@ One normal turn wrote `{"completed": true, "event": "on_session_end", "interrupt
 One turn interrupted with a single `Ctrl+C` wrote `{"completed": false, "event": "on_session_end", "interrupted": true, "session_id": "20260721_215506_081d4f", "turn_id": "20260721_215506_081d4f:20260721_215506_081d4f:3f25d8cf"}`.
 `/quit` wrote no third marker.
 This proves one callback per completed or interrupted turn and no callback for ordinary session exit.
-The tracked passive adapter additionally uses the live-help `-z/--oneshot` prompt option with the separately verified `hermes --resume <session-id>` path to force one bounded guard follow-up.
+The `on_session_end` payload carries the session id at top-level `.session_id`, which is the field `bin/fm-turnend-guard-hermes.sh` reads.
+
+The forced-resume composition was then validated end to end on 2026-07-21 against Hermes Agent v0.19.0, in an isolated `HERMES_HOME` under `/tmp` with the captain's real Hermes config unchanged.
+`--resume` and `-z` are both top-level `hermes` options, not `hermes chat` options, so the adapter correctly omits the `chat` subcommand; `hermes --help` lists `hermes [-h] [--version] [-z PROMPT] ... [--resume SESSION]`.
+A first turn ran `hermes -z 'Reply with exactly the word HERMESONE and nothing else.' --yolo --accept-hooks --cli` and printed `HERMESONE`; `hermes sessions list` recorded session `20260721_235227_db6f0a`.
+The exact adapter composition `hermes --resume 20260721_235227_db6f0a --yolo --accept-hooks -z '<prompt>'` then exited 0 and printed `RESUMED-HERMESONE`, proving the flags parse, the process terminates rather than blocking, and the prior turn's context was genuinely restored into the same session.
 
 **2026-07-09 update:** grok 0.2.93 broke the `.grok/hooks/fm-primary-turnend-guard.json` Stop hook with `hook not executed: required env var(s) not set: ${root}`, because grok's own `${VAR}` expansion over the raw `command` string does not tolerate a bare local variable assigned earlier in the same `bash -lc` script.
 The hook command was fixed to reference `${GROK_WORKSPACE_ROOT:-}` directly everywhere instead of assigning it to `$root` first, and re-validated against grok 0.2.93 to fire and complete cleanly.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -125,12 +125,15 @@ One normal turn wrote `{"completed": true, "event": "on_session_end", "interrupt
 One turn interrupted with a single `Ctrl+C` wrote `{"completed": false, "event": "on_session_end", "interrupted": true, "session_id": "20260721_215506_081d4f", "turn_id": "20260721_215506_081d4f:20260721_215506_081d4f:3f25d8cf"}`.
 `/quit` wrote no third marker.
 This proves one callback per completed or interrupted turn and no callback for ordinary session exit.
-The `on_session_end` payload carries the session id at top-level `.session_id`, which is the field `bin/fm-turnend-guard-hermes.sh` reads.
+`bin/fm-turnend-guard-hermes.sh` exits without a follow-up when that payload reports top-level `interrupted: true`, so an operator interrupt stays interrupted.
 
 The forced-resume composition was then validated end to end on 2026-07-21 against Hermes Agent v0.19.0, in an isolated `HERMES_HOME` under `/tmp` with the captain's real Hermes config unchanged.
 `--resume` and `-z` are both top-level `hermes` options, not `hermes chat` options, so the adapter correctly omits the `chat` subcommand; `hermes --help` lists `hermes [-h] [--version] [-z PROMPT] ... [--resume SESSION]`.
 A first turn ran `hermes -z 'Reply with exactly the word HERMESONE and nothing else.' --yolo --accept-hooks --cli` and printed `HERMESONE`; `hermes sessions list` recorded session `20260721_235227_db6f0a`.
 The exact adapter composition `hermes --resume 20260721_235227_db6f0a --yolo --accept-hooks -z '<prompt>'` then exited 0 and printed `RESUMED-HERMESONE`, proving the flags parse, the process terminates rather than blocking, and the prior turn's context was genuinely restored into the same session.
+
+Concurrent resume was tested on 2026-07-22 with Hermes Agent v0.19.0 in an isolated home. Two overlapping `hermes --resume 20260722_144759_df9e51 ... -z` processes both exited 0 and printed their requested sentinels, but session export retained only the later prompt under `20260722_145454_706c44`; the earlier follow-up state was lost. The adapter therefore does not resume the still-live hook session.
+The safe alternative was verified by running the primary turn and its one-shot follow-up concurrently in separate isolated Hermes homes. Both exited 0, and session export retained both prompts under distinct IDs (`20260722_145624_8aa1b2` and `20260722_145634_88891f`). The adapter now provisions a private temporary follow-up home through `fm-hermes-home.sh`, runs `hermes -z` there, and removes it afterward; the active primary session store and the operator's real Hermes home are never written by the follow-up.
 
 **2026-07-09 update:** grok 0.2.93 broke the `.grok/hooks/fm-primary-turnend-guard.json` Stop hook with `hook not executed: required env var(s) not set: ${root}`, because grok's own `${VAR}` expansion over the raw `command` string does not tolerate a bare local variable assigned earlier in the same `bash -lc` script.
 The hook command was fixed to reference `${GROK_WORKSPACE_ROOT:-}` directly everywhere instead of assigning it to `$root` first, and re-validated against grok 0.2.93 to fire and complete cleanly.
@@ -168,6 +171,6 @@ No Herdr command was issued and no fleet state was touched; the experiment wrote
 ## Tests
 
 `tests/fm-turnend-guard.test.sh` covers the shared predicate, primary scoping (including a secondmate's own home being guarded like the main primary while its child worktrees stay exempt), `FM_HOME` and `FM_STATE_OVERRIDE` precedence, Pi logical-run latch behavior for no-tool and multi-tool runs, fail-open behavior without `jq`, the original tracked hook registrations, and the Grok adapter's forced-resume loop guard and permission-mode regression.
-`tests/fm-hermes-harness.test.sh` covers the isolated Hermes primary hook set, passive forced-resume loop guard, task notification, busy/idle classification, detection, and liveness.
+`tests/fm-hermes-harness.test.sh` covers the isolated Hermes primary hook set, interrupt handling, isolated one-shot follow-up, task notification, busy/idle classification, detection, and liveness.
 The default behavior suite does not invoke live language-model harnesses.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` opts into the isolated interactive Pi regression recorded above.

--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -166,6 +166,11 @@ run_matrix_entry() {
       printf '%s' "$payload" | "$CHECK" >"$out_file" 2>"$err_file"
       rc=$?
       ;;
+    hermes)
+      payload=$(jq -cn --arg command "$cmd" '{tool_name:"terminal",tool_input:{command:$command}}')
+      printf '%s' "$payload" | "$CHECK" --hermes >"$out_file" 2>"$err_file"
+      rc=$?
+      ;;
     opencode|pi)
       "$CHECK" --command "$cmd" >"$out_file" 2>"$err_file"
       rc=$?
@@ -190,16 +195,19 @@ run_matrix_entry() {
   elif [ "$entry" = grok ]; then
     jq -e '.decision == "deny"' "$out_file" >/dev/null 2>&1 \
       || fail "$id via grok deny must carry decision=deny on stdout: $(cat "$out_file")"
+  elif [ "$entry" = hermes ]; then
+    jq -e '.action == "block" and (.message | length > 0)' "$out_file" >/dev/null 2>&1 \
+      || fail "$id via hermes deny must carry action=block on stdout: $(cat "$out_file")"
   fi
 }
 
 test_full_acceptance_matrix() {
   local i entry
   for ((i = 0; i < ${#MATRIX_IDS[@]}; i++)); do
-    for entry in codex claude grok opencode pi; do
+    for entry in codex claude grok hermes opencode pi; do
       run_matrix_entry "${MATRIX_IDS[$i]}" "${MATRIX_EXPECTED[$i]}" "$entry" "${MATRIX_COMMANDS[$i]}"
     done
-    pass "matrix ${MATRIX_IDS[$i]}: ${MATRIX_EXPECTED[$i]} through all five entry forms"
+    pass "matrix ${MATRIX_IDS[$i]}: ${MATRIX_EXPECTED[$i]} through all six entry forms"
   done
 }
 
@@ -425,13 +433,25 @@ test_default_mode_stdout_has_grok_json_on_deny() {
   pass "default mode: stdout carries Grok-shaped decision JSON on deny"
 }
 
-test_allow_is_silent_both_modes() {
-  local out1 out2
+test_hermes_mode_stdout_has_action_block_on_deny() {
+  local out rc
+  out=$("$CHECK" --hermes --command 'bin/fm-watch-arm.sh &' 2>/dev/null)
+  rc=$?
+  [ "$rc" -eq 2 ] || fail "--hermes deny must exit 2, got $rc"
+  printf '%s' "$out" | jq -e '.action == "block" and (.message | test("\\[watcher-background\\]"))' >/dev/null 2>&1 \
+    || fail "--hermes deny must put Hermes action=block JSON on stdout: $out"
+  pass "--hermes: stdout carries native action=block JSON on deny"
+}
+
+test_allow_is_silent_all_modes() {
+  local out1 out2 out3
   out1=$("$CHECK" --command 'exec bin/fm-watch-arm.sh' 2>&1)
   out2=$("$CHECK" --claude --command 'exec bin/fm-watch-arm.sh' 2>&1)
+  out3=$("$CHECK" --hermes --command 'exec bin/fm-watch-arm.sh' 2>&1)
   [ -z "$out1" ] || fail "default allow must be silent, got: $out1"
   [ -z "$out2" ] || fail "--claude allow must be silent, got: $out2"
-  pass "allow is silent on both stdout and stderr in default and --claude mode"
+  [ -z "$out3" ] || fail "--hermes allow must be silent, got: $out3"
+  pass "allow is silent in default, --claude, and --hermes modes"
 }
 
 # --- harness wiring: each adapter invokes the shared checker -----------------
@@ -451,6 +471,16 @@ test_grok_pretool_hook_wired() {
   matcher=$(jq -r '.hooks.PreToolUse[0].matcher // empty' "$settings")
   [ "$matcher" = "Bash" ] || fail "grok pretool hook must matcher-scope to Bash, got: $matcher"
   pass ".grok primary hook: PreToolUse hook invokes the shared checker"
+}
+
+test_hermes_pretool_hook_wired() {
+  local home="$MATRIX_TMP/hermes-primary" config
+  HERMES_SOURCE_HOME="$MATRIX_TMP/no-hermes-source" "$ROOT/bin/fm-hermes-home.sh" primary "$home" "$ROOT" >/dev/null
+  config=$(cat "$home/config.yaml")
+  assert_contains "$config" 'pre_tool_call:' "Hermes primary config does not register pre_tool_call"
+  assert_contains "$config" 'matcher: terminal' "Hermes pretool hook is not terminal-scoped"
+  assert_contains "$config" 'fm-arm-pretool-check.sh --hermes' "Hermes pretool hook does not invoke the checker in Hermes mode"
+  pass "Hermes primary config wires terminal pre_tool_call to the shared checker"
 }
 
 test_grok_turnend_hook_uses_safe_var_pattern() {
@@ -549,8 +579,10 @@ test_failopen_missing_jq
 test_failopen_missing_node
 test_claude_mode_stdout_empty_on_deny
 test_default_mode_stdout_has_grok_json_on_deny
-test_allow_is_silent_both_modes
+test_hermes_mode_stdout_has_action_block_on_deny
+test_allow_is_silent_all_modes
 test_grok_pretool_hook_wired
+test_hermes_pretool_hook_wired
 test_grok_turnend_hook_uses_safe_var_pattern
 test_claude_settings_pretool_hook_wired
 test_codex_hooks_pretool_wired

--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -3,8 +3,10 @@
 # Behavior tests for the watcher-arm PreToolUse seatbelt (docs/arm-pretool-check.md).
 #
 # bin/fm-arm-command-policy.mjs is the single owner of command classification.
-# This suite drives the stable shell transport through all five harness entry
+# This suite drives the stable shell transport through all six harness entry
 # forms and asserts the per-harness wiring contract without spawning a harness.
+# The Hermes row replays the exact wire payload Hermes v0.19.0 pipes to a
+# pre_tool_call hook, captured live and recorded in docs/arm-pretool-check.md.
 # Empirical harness evidence lives in docs/arm-pretool-check.md.
 set -u
 
@@ -167,7 +169,17 @@ run_matrix_entry() {
       rc=$?
       ;;
     hermes)
-      payload=$(jq -cn --arg command "$cmd" '{tool_name:"terminal",tool_input:{command:$command}}')
+      # Full Hermes v0.19.0 wire envelope: agent/shell_hooks.py serializes the
+      # internal `args` kwarg to the `tool_input` field, and adds hook_event_name,
+      # session_id, cwd, and extra alongside it.
+      payload=$(jq -cn --arg command "$cmd" '{
+        hook_event_name:"pre_tool_call",
+        tool_name:"terminal",
+        tool_input:{command:$command},
+        session_id:"20260721_235227_db6f0a",
+        cwd:"/tmp/fm-hermes",
+        extra:{task_id:"test-task",tool_call_id:"test-call"}
+      }')
       printf '%s' "$payload" | "$CHECK" --hermes >"$out_file" 2>"$err_file"
       rc=$?
       ;;

--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -491,7 +491,7 @@ test_hermes_pretool_hook_wired() {
   config=$(cat "$home/config.yaml")
   assert_contains "$config" 'pre_tool_call:' "Hermes primary config does not register pre_tool_call"
   assert_contains "$config" 'matcher: terminal' "Hermes pretool hook is not terminal-scoped"
-  assert_contains "$config" 'fm-arm-pretool-check.sh --hermes' "Hermes pretool hook does not invoke the checker in Hermes mode"
+  assert_contains "$config" "fm-arm-pretool-check.sh'' --hermes" "Hermes pretool hook does not invoke the checker in Hermes mode"
   pass "Hermes primary config wires terminal pre_tool_call to the shared checker"
 }
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -776,6 +776,8 @@ unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","us
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
+hermes without effort is accepted^{"rules":[{"when":"hermes work","use":{"harness":"hermes","model":"gpt-5.6-sol"}}]}^empty^
+unsupported hermes effort is flagged^{"rules":[{"when":"hermes work","use":{"harness":"hermes","model":"gpt-5.6-sol","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: hermes:high
 array use with quota-balanced is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}],"select":"quota-balanced"}]}^empty^
 array use without select is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}]}]}^empty^
 empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each rule needs at least one use profile

--- a/tests/fm-cd-pretool-check.test.sh
+++ b/tests/fm-cd-pretool-check.test.sh
@@ -166,6 +166,18 @@ run_matrix_entry() {
       printf '%s' "$payload" | "$CHECK" >"$out_file" 2>"$err_file"
       rc=$?
       ;;
+    hermes)
+      payload=$(jq -cn --arg command "$cmd" '{
+        hook_event_name:"pre_tool_call",
+        tool_name:"terminal",
+        tool_input:{command:$command},
+        session_id:"20260721_235227_db6f0a",
+        cwd:"/tmp/fm-hermes",
+        extra:{task_id:"test-task",tool_call_id:"test-call"}
+      }')
+      printf '%s' "$payload" | "$CHECK" --hermes >"$out_file" 2>"$err_file"
+      rc=$?
+      ;;
     opencode|pi)
       "$CHECK" --command "$cmd" >"$out_file" 2>"$err_file"
       rc=$?
@@ -190,17 +202,20 @@ run_matrix_entry() {
   elif [ "$entry" = grok ]; then
     jq -e '.decision == "deny"' "$out_file" >/dev/null 2>&1 \
       || fail "$id via grok deny must carry decision=deny on stdout: $(cat "$out_file")"
+  elif [ "$entry" = hermes ]; then
+    jq -e '.action == "block" and (.message | test("\\[persistent-cd\\]"))' "$out_file" >/dev/null 2>&1 \
+      || fail "$id via hermes deny must carry the native action=block object on stdout: $(cat "$out_file")"
   fi
 }
 
 test_full_acceptance_matrix() {
   local i entry
   for ((i = 0; i < ${#MATRIX_IDS[@]}; i++)); do
-    for entry in codex claude grok opencode pi; do
+    for entry in codex claude grok hermes opencode pi; do
       run_matrix_entry "${MATRIX_IDS[$i]}" "${MATRIX_EXPECTED[$i]}" "$entry" "${MATRIX_COMMANDS[$i]}"
     done
   done
-  pass "cd-guard acceptance matrix: ${#MATRIX_IDS[@]} cases x 5 harness entry forms, block/allow all correct"
+  pass "cd-guard acceptance matrix: ${#MATRIX_IDS[@]} cases x 6 harness entry forms, block/allow all correct"
 }
 
 # --- primary-checkout scoping ----------------------------------------------
@@ -410,6 +425,18 @@ test_grok_wiring() {
   pass ".grok primary cd hook: PreToolUse invokes the cd-guard"
 }
 
+test_hermes_wiring() {
+  local home config
+  home="$TMP_ROOT/hermes-home"
+  HERMES_SOURCE_HOME="$TMP_ROOT/hermes-absent-source" \
+    "$ROOT/bin/fm-hermes-home.sh" primary "$home" "$ROOT" >/dev/null
+  config=$(cat "$home/config.yaml")
+  assert_contains "$config" 'fm-cd-pretool-check.sh --hermes' "hermes primary home must register the cd-guard with native output shaping"
+  assert_contains "$config" 'fm-arm-pretool-check.sh --hermes' "hermes cd hook must not displace the watcher-arm hook"
+  assert_contains "$config" 'matcher: terminal' "hermes cd hook must be terminal-scoped"
+  pass "fm-hermes-home.sh primary: pre_tool_call invokes the cd-guard alongside the arm guard"
+}
+
 test_opencode_wiring() {
   local plugin content
   plugin="$ROOT/.opencode/plugins/fm-primary-cd-check.js"
@@ -456,6 +483,7 @@ test_policy_cli_direct
 test_claude_wiring
 test_codex_wiring
 test_grok_wiring
+test_hermes_wiring
 test_opencode_wiring
 test_pi_wiring
 test_scripts_are_shellcheck_clean

--- a/tests/fm-cd-pretool-check.test.sh
+++ b/tests/fm-cd-pretool-check.test.sh
@@ -431,8 +431,8 @@ test_hermes_wiring() {
   HERMES_SOURCE_HOME="$TMP_ROOT/hermes-absent-source" \
     "$ROOT/bin/fm-hermes-home.sh" primary "$home" "$ROOT" >/dev/null
   config=$(cat "$home/config.yaml")
-  assert_contains "$config" 'fm-cd-pretool-check.sh --hermes' "hermes primary home must register the cd-guard with native output shaping"
-  assert_contains "$config" 'fm-arm-pretool-check.sh --hermes' "hermes cd hook must not displace the watcher-arm hook"
+  assert_contains "$config" "fm-cd-pretool-check.sh'' --hermes" "hermes primary home must register the cd-guard with native output shaping"
+  assert_contains "$config" "fm-arm-pretool-check.sh'' --hermes" "hermes cd hook must not displace the watcher-arm hook"
   assert_contains "$config" 'matcher: terminal' "hermes cd hook must be terminal-scoped"
   pass "fm-hermes-home.sh primary: pre_tool_call invokes the cd-guard alongside the arm guard"
 }

--- a/tests/fm-hermes-harness.test.sh
+++ b/tests/fm-hermes-harness.test.sh
@@ -18,6 +18,15 @@ file_mode() {
   if [ "$(uname)" = Darwin ]; then stat -f %Lp "$1"; else stat -c %a "$1"; fi
 }
 
+# A real YAML loader proves the generated config still parses; the leak
+# assertions themselves run everywhere.
+YAML_LOADER=none
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+  YAML_LOADER=python3
+elif command -v ruby >/dev/null 2>&1 && ruby -ryaml -e '' >/dev/null 2>&1; then
+  YAML_LOADER=ruby
+fi
+
 # Build a fake ps that reports one harness as the immediate parent and then
 # stops the ancestry walk, so marker overlap is resolved against known ancestry.
 fake_ancestry() {
@@ -133,16 +142,75 @@ test_usage_states_the_isolation_guarantee() {
   pass "Hermes home usage renders its complete header"
 }
 
-test_cd_guard_renders_hermes_block_shape() {
-  local out rc
-  out=$("$ROOT/bin/fm-cd-pretool-check.sh" --hermes --command 'cd projects/foo' 2>/dev/null)
-  rc=$?
-  if [ "$rc" -eq 2 ]; then
-    assert_contains "$out" '"action":"block"' "Hermes cd-guard deny must use the native action object"
-  else
-    [ -z "$out" ] || fail "Hermes cd-guard allow must leave stdout empty, got: $out"
-  fi
-  pass "cd-guard speaks the Hermes native block shape"
+# The operator's hooks block must never leak into the Firstmate-owned config,
+# and what survives must stay loadable YAML. Each fixture ends the hooks block
+# with a column-0 shape that a line-oriented stripper can mistake for the end of
+# that block: a comment, a document marker, and a quoted key.
+test_preserved_config_never_leaks_operator_hooks() {
+  local case_dir source target n=0 fixture
+  for fixture in comment marker quoted; do
+    n=$((n + 1))
+    case_dir="$TMP_ROOT/leak-$fixture"
+    source="$case_dir/source"
+    target="$case_dir/home"
+    mkdir -p "$source"
+    case "$fixture" in
+      comment)
+        cat > "$source/config.yaml" <<'YAML'
+hooks:
+# operator's own note pinned at column 0
+  on_session_end:
+    - command: '/captain/leak.sh'
+      timeout: 10
+model:
+  default: gpt-5.6-sol
+YAML
+        ;;
+      marker)
+        cat > "$source/config.yaml" <<'YAML'
+model:
+  default: gpt-5.6-sol
+hooks:
+---
+  on_session_start:
+    - command: '/captain/leak.sh'
+YAML
+        ;;
+      quoted)
+        cat > "$source/config.yaml" <<'YAML'
+model:
+  default: gpt-5.6-sol
+"hooks":
+  on_session_start:
+    - command: '/captain/leak.sh'
+hooks_auto_accept: false
+YAML
+        ;;
+    esac
+    HERMES_SOURCE_HOME="$source" "$HOME_HELPER" primary "$target" "$ROOT" >/dev/null
+    assert_no_grep '/captain/leak.sh' "$target/config.yaml" \
+      "operator hook leaked through the $fixture fixture into the isolated config"
+    assert_grep 'fm-turnend-guard-hermes.sh' "$target/config.yaml" \
+      "$fixture fixture lost Firstmate's own turn-end hook"
+    if [ "$YAML_LOADER" = python3 ]; then
+      python3 -c 'import sys,yaml; yaml.safe_load(open(sys.argv[1]))' "$target/config.yaml" \
+        || fail "$fixture fixture produced a config Hermes cannot parse"
+    elif [ "$YAML_LOADER" = ruby ]; then
+      ruby -ryaml -e 'YAML.safe_load(File.read(ARGV[0]))' "$target/config.yaml" \
+        || fail "$fixture fixture produced a config Hermes cannot parse"
+    fi
+  done
+  pass "preserved config strips whole hook blocks across $n column-0 boundary shapes"
+}
+
+test_home_and_config_are_private_from_creation() {
+  local source="$TMP_ROOT/perm-source" target="$TMP_ROOT/perm-home"
+  mkdir -p "$source"
+  printf 'model:\n  provider: openai-codex\n' > "$source/config.yaml"
+  HERMES_SOURCE_HOME="$source" "$HOME_HELPER" primary "$target" "$ROOT" >/dev/null
+  [ "$(file_mode "$target")" = 700 ] || fail "isolated Hermes home must be mode 0700, got $(file_mode "$target")"
+  [ "$(file_mode "$target/config.yaml")" = 600 ] || fail "isolated Hermes config must be mode 0600"
+  pass "isolated Hermes home and config are private"
 }
 
 test_busy_and_idle_classification() {
@@ -203,7 +271,8 @@ test_env_detection
 test_task_home_isolated_and_resumable
 test_primary_home_has_all_hooks
 test_usage_states_the_isolation_guarantee
-test_cd_guard_renders_hermes_block_shape
+test_preserved_config_never_leaks_operator_hooks
+test_home_and_config_are_private_from_creation
 test_busy_and_idle_classification
 test_passive_guard_forces_one_resume
 test_fm_lock_recognizes_hermes_holder

--- a/tests/fm-hermes-harness.test.sh
+++ b/tests/fm-hermes-harness.test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Behavior tests for the Hermes v0.19.0 harness adapter.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=bin/fm-composer-lib.sh
+. "$ROOT/bin/fm-composer-lib.sh"
+# shellcheck source=bin/fm-tmux-lib.sh
+. "$ROOT/bin/fm-tmux-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-hermes-harness)
+fm_git_identity fmtest fmtest@example.invalid
+HOME_HELPER="$ROOT/bin/fm-hermes-home.sh"
+GUARD="$ROOT/bin/fm-turnend-guard-hermes.sh"
+
+file_mode() {
+  if [ "$(uname)" = Darwin ]; then stat -f %Lp "$1"; else stat -c %a "$1"; fi
+}
+
+test_env_detection() {
+  local out
+  out=$(CLAUDECODE=1 PI_CODING_AGENT=true GROK_AGENT=1 HERMES_INTERACTIVE=1 "$ROOT/bin/fm-harness.sh")
+  [ "$out" = hermes ] || fail "HERMES_INTERACTIVE=1 should outrank inherited primary markers, got '$out'"
+  pass "fm-harness detects Hermes's verified marker ahead of inherited primary markers"
+}
+
+test_task_home_isolated_and_resumable() {
+  local source="$TMP_ROOT/source" target="$TMP_ROOT/task-home" turnend="$TMP_ROOT/task.turn-ended"
+  mkdir -p "$source"
+  printf '%s\n' 'opaque-auth' > "$source/auth.json"
+  printf '%s\n' 'captain-config-sentinel' > "$source/config.yaml"
+  HERMES_SOURCE_HOME="$source" "$HOME_HELPER" task "$target" "$turnend" >/dev/null
+  [ "$(cat "$source/config.yaml")" = captain-config-sentinel ] || fail "Hermes source config was modified"
+  [ "$(cat "$target/auth.json")" = opaque-auth ] || fail "Hermes auth was not copied opaquely"
+  [ "$(file_mode "$target/auth.json")" = 600 ] || fail "copied Hermes auth must be mode 0600"
+  [ "$(file_mode "$target/config.yaml")" = 600 ] || fail "isolated Hermes config must be mode 0600"
+  assert_grep 'on_session_end:' "$target/config.yaml" "task home lacks on_session_end"
+  "$target/fm-on-session-end.sh"
+  assert_present "$turnend" "task on_session_end hook did not touch its marker"
+
+  printf '%s\n' 'session-survives' > "$target/session.db"
+  HERMES_SOURCE_HOME="$source" "$HOME_HELPER" task "$target" "$turnend" >/dev/null
+  [ "$(cat "$target/session.db")" = session-survives ] || fail "Hermes home regeneration destroyed resume state"
+  pass "Hermes task home preserves source config and isolated resume state"
+}
+
+test_primary_home_has_all_hooks() {
+  local source="$TMP_ROOT/primary-source" target="$TMP_ROOT/primary-home" config
+  mkdir -p "$source"
+  HERMES_SOURCE_HOME="$source" "$HOME_HELPER" primary "$target" "$ROOT" >/dev/null
+  config=$(cat "$target/config.yaml")
+  assert_contains "$config" 'on_session_start:' "Hermes primary home lacks session-start enforcement"
+  assert_contains "$config" 'fm-sessionstart-nudge.sh' "Hermes primary session-start hook misses the shared wrapper"
+  assert_contains "$config" 'on_session_end:' "Hermes primary home lacks turn-end protection"
+  assert_contains "$config" 'fm-turnend-guard-hermes.sh' "Hermes primary turn-end hook misses its adapter"
+  assert_contains "$config" 'pre_tool_call:' "Hermes primary home lacks watcher-arm safety protection"
+  assert_contains "$config" 'matcher: terminal' "Hermes pre-tool hook is not terminal-scoped"
+  assert_contains "$config" 'fm-arm-pretool-check.sh --hermes' "Hermes pre-tool hook misses native output shaping"
+  pass "Hermes isolated primary home wires session start, turn end, and pre-tool safety"
+}
+
+test_busy_and_idle_classification() {
+  local state
+  printf '%s' '⚕ ❯ msg=interrupt · /queue · /bg · /steer · Ctrl+C cancel' \
+    | grep -qE "$FM_TMUX_BUSY_REGEX_DEFAULT" || fail "Hermes busy footer did not match the fleet busy regex"
+  state=$(fm_composer_classify_content 0 '❯')
+  [ "$state" = empty ] || fail "Hermes bare idle prompt should classify empty, got '$state'"
+  pass "Hermes busy footer and bare idle composer classify correctly"
+}
+
+test_passive_guard_forces_one_resume() {
+  local primary="$TMP_ROOT/primary" fakebin log payload out rc
+  fakebin=$(fm_fakebin "$TMP_ROOT/fake")
+  log="$TMP_ROOT/hermes-resume.log"
+  mkdir -p "$primary/bin" "$primary/state" "$primary/config"
+  : > "$primary/AGENTS.md"
+  git init -q "$primary"
+  git -C "$primary" commit -q --allow-empty -m init
+  printf '%s\n' 'window=fake' > "$primary/state/inflight.meta"
+  cat > "$fakebin/hermes" <<'SH'
+#!/usr/bin/env bash
+printf 'active=%s args=%s\n' "${HERMES_TURNEND_GUARD_ACTIVE:-}" "$*" >> "$FM_HERMES_TEST_LOG"
+exit 0
+SH
+  chmod +x "$fakebin/hermes"
+  payload='{"session_id":"20260721_214600_e8ae23","extra":{"completed":true,"interrupted":false}}'
+  out=$(printf '%s' "$payload" | FM_ROOT_OVERRIDE="$primary" FM_HOME="$primary" \
+    FM_HERMES_TEST_LOG="$log" PATH="$fakebin:$PATH" "$GUARD" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "Hermes passive guard adapter"
+  [ -z "$out" ] || fail "Hermes passive guard adapter must be silent, got: $out"
+  assert_grep 'active=1 args=--resume 20260721_214600_e8ae23 --yolo --accept-hooks -z TURN WOULD END BLIND' "$log" \
+    "Hermes guard did not force a loop-guarded same-session resume"
+  pass "Hermes passive turn-end guard forces one bounded resumed follow-up"
+}
+
+test_fm_lock_recognizes_hermes_holder() {
+  local home="$TMP_ROOT/lock-home" fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/lock-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/home/user/.local/bin/hermes'; exit 0 ;;
+  *"args="*) printf '%s\n' 'hermes chat --yolo --accept-hooks --cli'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid" "fm-lock did not recognize Hermes as a live holder"
+  pass "fm-lock recognizes Hermes harness processes"
+}
+
+test_env_detection
+test_task_home_isolated_and_resumable
+test_primary_home_has_all_hooks
+test_busy_and_idle_classification
+test_passive_guard_forces_one_resume
+test_fm_lock_recognizes_hermes_holder

--- a/tests/fm-hermes-harness.test.sh
+++ b/tests/fm-hermes-harness.test.sh
@@ -81,7 +81,7 @@ test_env_detection() {
 }
 
 test_task_home_isolated_and_resumable() {
-  local source="$TMP_ROOT/source" target="$TMP_ROOT/task-home" turnend="$TMP_ROOT/task.turn-ended"
+  local source="$TMP_ROOT/source" target="$TMP_ROOT/task home" turnend="$TMP_ROOT/task.turn-ended"
   mkdir -p "$source"
   printf '%s\n' 'opaque-auth' > "$source/auth.json"
   cat > "$source/config.yaml" <<'YAML'
@@ -107,6 +107,8 @@ YAML
   [ "$(file_mode "$target/auth.json")" = 600 ] || fail "copied Hermes auth must be mode 0600"
   [ "$(file_mode "$target/config.yaml")" = 600 ] || fail "isolated Hermes config must be mode 0600"
   assert_grep 'on_session_end:' "$target/config.yaml" "task home lacks on_session_end"
+  assert_grep "command: '''$target/fm-on-session-end.sh'''" "$target/config.yaml" \
+    "task hook command must survive a Hermes home containing spaces"
   "$target/fm-on-session-end.sh"
   assert_present "$turnend" "task on_session_end hook did not touch its marker"
 
@@ -130,9 +132,52 @@ test_primary_home_has_all_hooks() {
   assert_contains "$config" 'fm-turnend-guard-hermes.sh' "Hermes primary turn-end hook misses its adapter"
   assert_contains "$config" 'pre_tool_call:' "Hermes primary home lacks watcher-arm safety protection"
   assert_contains "$config" 'matcher: terminal' "Hermes pre-tool hook is not terminal-scoped"
-  assert_contains "$config" 'fm-arm-pretool-check.sh --hermes' "Hermes pre-tool hook misses native output shaping"
-  assert_contains "$config" 'fm-cd-pretool-check.sh --hermes' "Hermes primary home lacks cd-guard parity with every other harness"
+  assert_contains "$config" "fm-arm-pretool-check.sh'' --hermes" "Hermes pre-tool hook misses native output shaping"
+  assert_contains "$config" "fm-cd-pretool-check.sh'' --hermes" "Hermes primary home lacks cd-guard parity with every other harness"
   pass "Hermes isolated primary home wires session start, turn end, and pre-tool safety"
+}
+
+test_primary_hook_commands_support_spaces() {
+  local source="$TMP_ROOT/spaced-source" target="$TMP_ROOT/spaced-home" root="$TMP_ROOT/first mate" script
+  mkdir -p "$source" "$root/bin"
+  printf 'model:\n  provider: openai-codex\n' > "$source/config.yaml"
+  for script in fm-sessionstart-nudge.sh fm-turnend-guard-hermes.sh fm-arm-pretool-check.sh fm-cd-pretool-check.sh; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$root/bin/$script"
+    chmod +x "$root/bin/$script"
+  done
+
+  HERMES_SOURCE_HOME="$source" "$HOME_HELPER" primary "$target" "$root" >/dev/null
+  assert_grep "command: '''$root/bin/fm-sessionstart-nudge.sh'''" "$target/config.yaml" \
+    "session-start hook path is not shell-quoted"
+  assert_grep "command: '''$root/bin/fm-turnend-guard-hermes.sh'''" "$target/config.yaml" \
+    "turn-end hook path is not shell-quoted"
+  assert_grep "command: '''$root/bin/fm-arm-pretool-check.sh'' --hermes'" "$target/config.yaml" \
+    "watcher-arm hook path is not shell-quoted"
+  assert_grep "command: '''$root/bin/fm-cd-pretool-check.sh'' --hermes'" "$target/config.yaml" \
+    "cd-guard hook path is not shell-quoted"
+  pass "Hermes primary hook commands shell-quote roots containing spaces"
+}
+
+test_primary_home_requires_every_safety_script() {
+  local source="$TMP_ROOT/required-source" missing root target script out rc
+  mkdir -p "$source"
+  printf 'model:\n  provider: openai-codex\n' > "$source/config.yaml"
+  for missing in fm-sessionstart-nudge.sh fm-turnend-guard-hermes.sh fm-arm-pretool-check.sh fm-cd-pretool-check.sh; do
+    root="$TMP_ROOT/missing-$missing"
+    target="$TMP_ROOT/missing-$missing-home"
+    mkdir -p "$root/bin"
+    for script in fm-sessionstart-nudge.sh fm-turnend-guard-hermes.sh fm-arm-pretool-check.sh fm-cd-pretool-check.sh; do
+      printf '#!/usr/bin/env bash\nexit 0\n' > "$root/bin/$script"
+      chmod +x "$root/bin/$script"
+    done
+    rm "$root/bin/$missing"
+    out=$(HERMES_SOURCE_HOME="$source" "$HOME_HELPER" primary "$target" "$root" 2>&1)
+    rc=$?
+    expect_code 1 "$rc" "Hermes primary home missing $missing"
+    assert_contains "$out" "$missing" "missing-script error did not identify $missing"
+    assert_absent "$target/config.yaml" "Hermes published hooks before validating $missing"
+  done
+  pass "Hermes primary home requires every safety hook script"
 }
 
 test_usage_states_the_isolation_guarantee() {
@@ -222,30 +267,42 @@ test_busy_and_idle_classification() {
   pass "Hermes busy footer and bare idle composer classify correctly"
 }
 
-test_passive_guard_forces_one_resume() {
-  local primary="$TMP_ROOT/primary" fakebin log payload out rc
+test_passive_guard_forces_one_safe_followup() {
+  local primary="$TMP_ROOT/primary" source_home="$TMP_ROOT/current-hermes-home" fakebin followup_home log payload out rc
   fakebin=$(fm_fakebin "$TMP_ROOT/fake")
   log="$TMP_ROOT/hermes-resume.log"
-  mkdir -p "$primary/bin" "$primary/state" "$primary/config"
+  mkdir -p "$primary/bin" "$primary/state" "$primary/config" "$source_home"
+  printf 'model:\n  provider: openai-codex\n' > "$source_home/config.yaml"
   : > "$primary/AGENTS.md"
   git init -q "$primary"
   git -C "$primary" commit -q --allow-empty -m init
   printf '%s\n' 'window=fake' > "$primary/state/inflight.meta"
   cat > "$fakebin/hermes" <<'SH'
 #!/usr/bin/env bash
-printf 'active=%s args=%s\n' "${HERMES_TURNEND_GUARD_ACTIVE:-}" "$*" >> "$FM_HERMES_TEST_LOG"
+printf 'home=%s active=%s args=%s\n' "${HERMES_HOME:-}" "${HERMES_TURNEND_GUARD_ACTIVE:-}" "$*" >> "$FM_HERMES_TEST_LOG"
 exit 0
 SH
   chmod +x "$fakebin/hermes"
   payload='{"session_id":"20260721_214600_e8ae23","extra":{"completed":true,"interrupted":false}}'
-  out=$(printf '%s' "$payload" | FM_ROOT_OVERRIDE="$primary" FM_HOME="$primary" \
+  out=$(printf '%s' "$payload" | FM_ROOT_OVERRIDE="$primary" FM_HOME="$primary" HERMES_HOME="$source_home" \
     FM_HERMES_TEST_LOG="$log" PATH="$fakebin:$PATH" "$GUARD" 2>&1)
   rc=$?
   expect_code 0 "$rc" "Hermes passive guard adapter"
   [ -z "$out" ] || fail "Hermes passive guard adapter must be silent, got: $out"
-  assert_grep 'active=1 args=--resume 20260721_214600_e8ae23 --yolo --accept-hooks -z TURN WOULD END BLIND' "$log" \
-    "Hermes guard did not force a loop-guarded same-session resume"
-  pass "Hermes passive turn-end guard forces one bounded resumed follow-up"
+  assert_grep 'active=1 args=--yolo --accept-hooks -z TURN WOULD END BLIND' "$log" \
+    "Hermes guard did not force a loop-guarded independent follow-up"
+  assert_no_grep --resume "$log" "Hermes guard must not resume a session that is still live"
+  assert_no_grep "home=$source_home " "$log" "Hermes guard must not share the live session store"
+  followup_home=$(sed -n 's/^home=\([^ ]*\) active=.*/\1/p' "$log")
+  [ -n "$followup_home" ] || fail "Hermes guard did not select an isolated follow-up home"
+  assert_absent "$followup_home" "Hermes guard left its isolated follow-up home behind"
+
+  : > "$log"
+  payload='{"session_id":"20260721_214600_e8ae23","completed":false,"interrupted":true}'
+  printf '%s' "$payload" | FM_ROOT_OVERRIDE="$primary" FM_HOME="$primary" HERMES_HOME="$source_home" \
+    FM_HERMES_TEST_LOG="$log" PATH="$fakebin:$PATH" "$GUARD" >/dev/null 2>&1
+  [ ! -s "$log" ] || fail "Hermes turn-end guard must respect an operator interrupt"
+  pass "Hermes passive turn-end guard starts a safe follow-up but respects interrupts"
 }
 
 test_fm_lock_recognizes_hermes_holder() {
@@ -270,9 +327,11 @@ SH
 test_env_detection
 test_task_home_isolated_and_resumable
 test_primary_home_has_all_hooks
+test_primary_hook_commands_support_spaces
+test_primary_home_requires_every_safety_script
 test_usage_states_the_isolation_guarantee
 test_preserved_config_never_leaks_operator_hooks
 test_home_and_config_are_private_from_creation
 test_busy_and_idle_classification
-test_passive_guard_forces_one_resume
+test_passive_guard_forces_one_safe_followup
 test_fm_lock_recognizes_hermes_holder

--- a/tests/fm-hermes-harness.test.sh
+++ b/tests/fm-hermes-harness.test.sh
@@ -18,20 +18,82 @@ file_mode() {
   if [ "$(uname)" = Darwin ]; then stat -f %Lp "$1"; else stat -c %a "$1"; fi
 }
 
+# Build a fake ps that reports one harness as the immediate parent and then
+# stops the ancestry walk, so marker overlap is resolved against known ancestry.
+fake_ancestry() {
+  local dir=$1 comm=$2 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *"comm="*) printf '%s\n' '/usr/local/bin/$comm'; exit 0 ;;
+  *"ppid="*) printf '%s\n' '1'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  printf '%s\n' "$fakebin"
+}
+
+# The suite itself runs under a harness, so every case clears the ambient
+# markers and sets only the ones under test.
+harness_under() {
+  local fakebin=$1; shift
+  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u HERMES_INTERACTIVE \
+    PATH="$fakebin:$PATH" "$@" "$ROOT/bin/fm-harness.sh"
+}
+
 test_env_detection() {
-  local out
-  out=$(CLAUDECODE=1 PI_CODING_AGENT=true GROK_AGENT=1 HERMES_INTERACTIVE=1 "$ROOT/bin/fm-harness.sh")
-  [ "$out" = hermes ] || fail "HERMES_INTERACTIVE=1 should outrank inherited primary markers, got '$out'"
-  pass "fm-harness detects Hermes's verified marker ahead of inherited primary markers"
+  local out anc_hermes anc_claude anc_grok anc_none
+  anc_hermes=$(fake_ancestry "$TMP_ROOT/anc-hermes" hermes)
+  anc_claude=$(fake_ancestry "$TMP_ROOT/anc-claude" claude)
+  anc_grok=$(fake_ancestry "$TMP_ROOT/anc-grok" grok)
+  anc_none=$(fake_ancestry "$TMP_ROOT/anc-none" bash)
+
+  out=$(harness_under "$anc_none" HERMES_INTERACTIVE=1)
+  [ "$out" = hermes ] || fail "a lone HERMES_INTERACTIVE=1 marker must detect hermes, got '$out'"
+  out=$(harness_under "$anc_none" CLAUDECODE=1)
+  [ "$out" = claude ] || fail "a lone CLAUDECODE=1 marker must detect claude, got '$out'"
+
+  # Overlapping markers are the nested case: ancestry, not marker order, decides.
+  out=$(harness_under "$anc_hermes" CLAUDECODE=1 HERMES_INTERACTIVE=1)
+  [ "$out" = hermes ] || fail "a hermes worker under a claude primary must detect hermes, got '$out'"
+
+  out=$(harness_under "$anc_claude" CLAUDECODE=1 HERMES_INTERACTIVE=1)
+  [ "$out" = claude ] || fail "a claude worker under a hermes primary must detect claude, got '$out'"
+
+  out=$(harness_under "$anc_grok" GROK_AGENT=1 HERMES_INTERACTIVE=1)
+  [ "$out" = grok ] || fail "a grok worker under a hermes primary must detect grok, got '$out'"
+
+  # Inconclusive ancestry keeps a deterministic fixed order.
+  out=$(harness_under "$anc_none" CLAUDECODE=1 HERMES_INTERACTIVE=1)
+  [ "$out" = hermes ] || fail "unknown ancestry must fall back to the fixed order, got '$out'"
+  pass "fm-harness resolves overlapping harness markers by ancestry in both directions"
 }
 
 test_task_home_isolated_and_resumable() {
   local source="$TMP_ROOT/source" target="$TMP_ROOT/task-home" turnend="$TMP_ROOT/task.turn-ended"
   mkdir -p "$source"
   printf '%s\n' 'opaque-auth' > "$source/auth.json"
-  printf '%s\n' 'captain-config-sentinel' > "$source/config.yaml"
+  cat > "$source/config.yaml" <<'YAML'
+model:
+  default: gpt-5.6-sol
+  provider: openai-codex
+agent:
+  reasoning_effort: medium
+hooks:
+  on_session_end:
+    - command: '/captain/only.sh'
+      timeout: 10
+hooks_auto_accept: false
+YAML
   HERMES_SOURCE_HOME="$source" "$HOME_HELPER" task "$target" "$turnend" >/dev/null
-  [ "$(cat "$source/config.yaml")" = captain-config-sentinel ] || fail "Hermes source config was modified"
+  assert_grep '/captain/only.sh' "$source/config.yaml" "Hermes source config was modified"
+  assert_grep 'default: gpt-5.6-sol' "$target/config.yaml" "isolated task home dropped the operator model default"
+  assert_grep 'provider: openai-codex' "$target/config.yaml" "isolated task home dropped the operator provider"
+  assert_grep 'reasoning_effort: medium' "$target/config.yaml" "isolated task home dropped the operator agent settings"
+  assert_grep 'hooks_auto_accept: true' "$target/config.yaml" "isolated task home must force hook auto-accept"
+  assert_no_grep '/captain/only.sh' "$target/config.yaml" "isolated task home inherited the operator's own hooks"
   [ "$(cat "$target/auth.json")" = opaque-auth ] || fail "Hermes auth was not copied opaquely"
   [ "$(file_mode "$target/auth.json")" = 600 ] || fail "copied Hermes auth must be mode 0600"
   [ "$(file_mode "$target/config.yaml")" = 600 ] || fail "isolated Hermes config must be mode 0600"
@@ -48,8 +110,11 @@ test_task_home_isolated_and_resumable() {
 test_primary_home_has_all_hooks() {
   local source="$TMP_ROOT/primary-source" target="$TMP_ROOT/primary-home" config
   mkdir -p "$source"
+  printf 'model:\n  default: gpt-5.6-sol\n  provider: openai-codex\n' > "$source/config.yaml"
   HERMES_SOURCE_HOME="$source" "$HOME_HELPER" primary "$target" "$ROOT" >/dev/null
   config=$(cat "$target/config.yaml")
+  assert_contains "$config" 'default: gpt-5.6-sol' "Hermes primary home dropped the operator model default"
+  assert_contains "$config" 'provider: openai-codex' "Hermes primary home dropped the operator provider"
   assert_contains "$config" 'on_session_start:' "Hermes primary home lacks session-start enforcement"
   assert_contains "$config" 'fm-sessionstart-nudge.sh' "Hermes primary session-start hook misses the shared wrapper"
   assert_contains "$config" 'on_session_end:' "Hermes primary home lacks turn-end protection"
@@ -57,7 +122,27 @@ test_primary_home_has_all_hooks() {
   assert_contains "$config" 'pre_tool_call:' "Hermes primary home lacks watcher-arm safety protection"
   assert_contains "$config" 'matcher: terminal' "Hermes pre-tool hook is not terminal-scoped"
   assert_contains "$config" 'fm-arm-pretool-check.sh --hermes' "Hermes pre-tool hook misses native output shaping"
+  assert_contains "$config" 'fm-cd-pretool-check.sh --hermes' "Hermes primary home lacks cd-guard parity with every other harness"
   pass "Hermes isolated primary home wires session start, turn end, and pre-tool safety"
+}
+
+test_usage_states_the_isolation_guarantee() {
+  local out
+  out=$("$HOME_HELPER" --help)
+  assert_contains "$out" "The source Hermes home is never changed." "usage truncated the isolation guarantee"
+  pass "Hermes home usage renders its complete header"
+}
+
+test_cd_guard_renders_hermes_block_shape() {
+  local out rc
+  out=$("$ROOT/bin/fm-cd-pretool-check.sh" --hermes --command 'cd projects/foo' 2>/dev/null)
+  rc=$?
+  if [ "$rc" -eq 2 ]; then
+    assert_contains "$out" '"action":"block"' "Hermes cd-guard deny must use the native action object"
+  else
+    [ -z "$out" ] || fail "Hermes cd-guard allow must leave stdout empty, got: $out"
+  fi
+  pass "cd-guard speaks the Hermes native block shape"
 }
 
 test_busy_and_idle_classification() {
@@ -117,6 +202,8 @@ SH
 test_env_detection
 test_task_home_isolated_and_resumable
 test_primary_home_has_all_hooks
+test_usage_states_the_isolation_guarantee
+test_cd_guard_renders_hermes_block_shape
 test_busy_and_idle_classification
 test_passive_guard_forces_one_resume
 test_fm_lock_recognizes_hermes_holder

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -466,6 +466,31 @@ spawn_secondmate_capture() {
     "$ROOT/bin/fm-spawn.sh" "$id" "$home" "$@" --secondmate
 }
 
+test_spawn_hermes_secondmate_gets_primary_hooks() {
+  local w sm launchlog launch config
+  w="$TMP_ROOT/spawn-hermes-primary-hooks"
+  sm="$w/sm"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config"
+  make_seeded_home "$sm" sm
+  cp "$ROOT/bin/fm-sessionstart-nudge.sh" "$ROOT/bin/fm-turnend-guard-hermes.sh" \
+    "$ROOT/bin/fm-arm-pretool-check.sh" "$sm/bin/"
+  chmod +x "$sm/bin/"*.sh
+
+  HERMES_SOURCE_HOME="$w/no-hermes-source" \
+    spawn_secondmate_capture "$w" sm "$sm" "$launchlog" --harness hermes --model gpt-5.6-sol --effort high >/dev/null 2>&1
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "HERMES_HOME='$w/home/state/sm.hermes' hermes chat --yolo --accept-hooks --cli -m 'gpt-5.6-sol'" \
+    "Hermes secondmate launch lacks isolated home, autonomy flags, or model override"
+  assert_not_contains "$launch" "--effort" "Hermes secondmate launch emitted an unsupported effort flag"
+  config=$(cat "$w/home/state/sm.hermes/config.yaml")
+  assert_contains "$config" 'on_session_start:' "Hermes secondmate lacks session-start hook"
+  assert_contains "$config" "$sm/bin/fm-sessionstart-nudge.sh" "Hermes secondmate session-start hook points outside its home"
+  assert_contains "$config" "$sm/bin/fm-turnend-guard-hermes.sh" "Hermes secondmate turn-end hook points outside its home"
+  assert_contains "$config" "$sm/bin/fm-arm-pretool-check.sh --hermes" "Hermes secondmate pre-tool hook points outside its home"
+  pass "Hermes secondmate spawn installs the isolated primary hook set and omits effort"
+}
+
 # A bare "<harness>" secondmate-harness file (today's format) must launch with
 # NO --model/--effort flag at all, and meta must keep recording model=default,
 # effort=default - the core backward-compat requirement of the new format.
@@ -2052,6 +2077,7 @@ test_spawn_backward_compat_crew_fallback
 test_spawn_bare_backward_compat
 test_spawn_explicit_harness_wins
 test_spawn_unverified_secondmate_harness_refused
+test_spawn_hermes_secondmate_gets_primary_hooks
 test_spawn_bare_harness_no_model_effort_flag
 test_spawn_secondmate_harness_model_token
 test_spawn_secondmate_harness_model_and_effort_tokens

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -474,7 +474,7 @@ test_spawn_hermes_secondmate_gets_primary_hooks() {
   mkdir -p "$w/home/config"
   make_seeded_home "$sm" sm
   cp "$ROOT/bin/fm-sessionstart-nudge.sh" "$ROOT/bin/fm-turnend-guard-hermes.sh" \
-    "$ROOT/bin/fm-arm-pretool-check.sh" "$sm/bin/"
+    "$ROOT/bin/fm-arm-pretool-check.sh" "$ROOT/bin/fm-cd-pretool-check.sh" "$sm/bin/"
   chmod +x "$sm/bin/"*.sh
 
   HERMES_SOURCE_HOME="$w/no-hermes-source" \
@@ -487,7 +487,8 @@ test_spawn_hermes_secondmate_gets_primary_hooks() {
   assert_contains "$config" 'on_session_start:' "Hermes secondmate lacks session-start hook"
   assert_contains "$config" "$sm/bin/fm-sessionstart-nudge.sh" "Hermes secondmate session-start hook points outside its home"
   assert_contains "$config" "$sm/bin/fm-turnend-guard-hermes.sh" "Hermes secondmate turn-end hook points outside its home"
-  assert_contains "$config" "$sm/bin/fm-arm-pretool-check.sh --hermes" "Hermes secondmate pre-tool hook points outside its home"
+  assert_contains "$config" "$sm/bin/fm-arm-pretool-check.sh'' --hermes" "Hermes secondmate pre-tool hook points outside its home"
+  assert_contains "$config" "$sm/bin/fm-cd-pretool-check.sh'' --hermes" "Hermes secondmate cd-guard hook points outside its home"
   pass "Hermes secondmate spawn installs the isolated primary hook set and omits effort"
 }
 

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -85,6 +85,10 @@ test_tmux_agent_alive_classifies() {
   [ "$(PATH="$fb:$BASE_PATH" bash -c '. "$0/bin/fm-backend.sh"; fm_backend_source tmux; fm_backend_tmux_agent_alive sess:win' "$ROOT")" = alive ] \
     || fail "a live grok foreground process should classify as alive"
 
+  fb=$(make_probe_tmux "$TMP_ROOT/tmux-hermes" hermes)
+  [ "$(PATH="$fb:$BASE_PATH" bash -c '. "$0/bin/fm-backend.sh"; fm_backend_source tmux; fm_backend_tmux_agent_alive sess:win' "$ROOT")" = alive ] \
+    || fail "a live hermes foreground process should classify as alive"
+
   fb=$(make_probe_tmux "$TMP_ROOT/tmux-zsh" zsh)
   [ "$(PATH="$fb:$BASE_PATH" bash -c '. "$0/bin/fm-backend.sh"; fm_backend_source tmux; fm_backend_tmux_agent_alive sess:win' "$ROOT")" = dead ] \
     || fail "a bare zsh foreground process should classify as dead"

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -143,7 +143,7 @@ EOF
 }
 
 test_tracked_harness_registration() {
-  local command pi_plugin opencode_plugin
+  local command pi_plugin opencode_plugin hermes_home
   jq -e '.hooks.SessionStart | length == 1' "$ROOT/.claude/settings.json" >/dev/null \
     || fail "Claude SessionStart hook is not registered exactly once"
   jq -e '.hooks.SessionStart[0].matcher == "startup|resume|clear"' "$ROOT/.claude/settings.json" >/dev/null \
@@ -176,7 +176,12 @@ test_tracked_harness_registration() {
   assert_contains "$opencode_plugin" 'fm-sessionstart-nudge.sh' "OpenCode plugin does not invoke the wrapper"
   assert_contains "$opencode_plugin" 'promptAsync' "OpenCode plugin does not prompt the nudge turn"
 
-  pass "all five verified harnesses register the shared session-start nudge"
+  hermes_home="$TMP_ROOT/hermes-primary-home"
+  HERMES_SOURCE_HOME="$TMP_ROOT/no-hermes-source" "$ROOT/bin/fm-hermes-home.sh" primary "$hermes_home" "$ROOT" >/dev/null
+  assert_grep 'on_session_start:' "$hermes_home/config.yaml" "Hermes primary config does not register on_session_start"
+  assert_grep 'fm-sessionstart-nudge.sh' "$hermes_home/config.yaml" "Hermes on_session_start does not invoke the wrapper"
+
+  pass "all six verified harnesses register the shared session-start nudge"
 }
 
 test_genuine_primary_nudges

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -88,7 +88,8 @@ run_spawn() {
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
-    FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
+    FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" \
+    HERMES_SOURCE_HOME="$home/hermes-source" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
 
@@ -330,6 +331,29 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   pass "opencode receives --model and omits the unsupported effort axis"
 }
 
+test_hermes_threads_model_and_omits_effort() {
+  local rec id out status launch hermes_home
+  id=profile-hermes-z17
+  rec=$(make_spawn_case profile-hermes claude "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness hermes --model gpt-5.6-sol --effort high)
+  status=$?
+  expect_code 0 "$status" "Hermes spawn with model and unsupported effort should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" hermes gpt-5.6-sol high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "HERMES_HOME='$HOME_DIR/state/$id.hermes' hermes chat --yolo --accept-hooks --cli -m 'gpt-5.6-sol'" \
+    "Hermes launch did not use the isolated home, classic CLI, autonomy flags, and model override"
+  assert_not_contains "$launch" "--effort" "Hermes launch emitted an unsupported effort flag"
+  assert_not_contains "$launch" "reasoning_effort" "Hermes launch emitted an unsupported reasoning effort override"
+  hermes_home="$HOME_DIR/state/$id.hermes"
+  assert_grep 'on_session_end:' "$hermes_home/config.yaml" "Hermes task home lacks the turn-end hook"
+  "$hermes_home/fm-on-session-end.sh"
+  assert_present "$HOME_DIR/state/$id.turn-ended" "Hermes turn-end hook did not touch the task marker"
+  pass "Hermes receives model override, omits effort, and wires per-turn notification"
+}
+
 test_pi_threads_model_and_max_effort() {
   local rec id out status launch
   id=profile-pi-z8
@@ -397,6 +421,7 @@ test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
+test_hermes_threads_model_and_omits_effort
 test_pi_threads_model_and_max_effort
 test_batch_forwards_shared_profile_flags
 test_active_dispatch_profile_does_not_block_secondmate_launch

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -107,6 +107,19 @@ test_grok_is_background_notify() {
   pass "grok supervision is Claude-shaped background notify with passive Stop-hook backstop"
 }
 
+test_hermes_is_foreground_checkpoint() {
+  local out
+  out=$(FM_CODEX_WATCH_CHECKPOINT=23 "$RENDER" --harness hermes)
+  assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: hermes" "Hermes heading missing"
+  assert_contains "$out" "Mode: Hermes foreground checkpoint." "Hermes snippet missing foreground mode"
+  assert_contains "$out" "bin/fm-watch-checkpoint.sh --seconds 180" "Hermes snippet missing bounded checkpoint"
+  assert_contains "$out" "pre_tool_call" "Hermes snippet missing watcher-arm seatbelt"
+  assert_not_contains "$out" "background-notify" "Hermes snippet must not claim unverified background wake semantics"
+  out=$(FM_CODEX_WATCH_CHECKPOINT=23 "$RENDER" --harness hermes --repair-line)
+  assert_contains "$out" "bin/fm-watch-checkpoint.sh --seconds 23" "Hermes repair line did not use checkpoint helper and env override"
+  pass "Hermes supervision uses bounded foreground checkpoints"
+}
+
 test_grok_command_sources_effective_config() {
   local home config out
   home="$TMP_ROOT/grok-home"
@@ -139,5 +152,6 @@ test_conditional_stanzas
 test_repair_lines
 test_ordinary_wake_lines_are_distinct_from_repair
 test_grok_is_background_notify
+test_hermes_is_foreground_checkpoint
 test_grok_command_sources_effective_config
 test_pi_snippet_uses_effective_extension_path

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -112,7 +112,7 @@ test_hermes_is_foreground_checkpoint() {
   out=$(FM_CODEX_WATCH_CHECKPOINT=23 "$RENDER" --harness hermes)
   assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: hermes" "Hermes heading missing"
   assert_contains "$out" "Mode: Hermes foreground checkpoint." "Hermes snippet missing foreground mode"
-  assert_contains "$out" 'bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"' "Hermes snippet must honor the operator checkpoint override like codex"
+  assert_contains "$out" "bin/fm-watch-checkpoint.sh --seconds \"\${FM_CODEX_WATCH_CHECKPOINT:-180}\"" "Hermes snippet must honor the operator checkpoint override like codex"
   assert_contains "$out" "pre_tool_call" "Hermes snippet missing watcher-arm seatbelt"
   assert_contains "$out" "bin/fm-cd-pretool-check.sh" "Hermes snippet missing cd-guard seatbelt"
   assert_not_contains "$out" "background-notify" "Hermes snippet must not claim unverified background wake semantics"

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -112,8 +112,9 @@ test_hermes_is_foreground_checkpoint() {
   out=$(FM_CODEX_WATCH_CHECKPOINT=23 "$RENDER" --harness hermes)
   assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: hermes" "Hermes heading missing"
   assert_contains "$out" "Mode: Hermes foreground checkpoint." "Hermes snippet missing foreground mode"
-  assert_contains "$out" "bin/fm-watch-checkpoint.sh --seconds 180" "Hermes snippet missing bounded checkpoint"
+  assert_contains "$out" 'bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"' "Hermes snippet must honor the operator checkpoint override like codex"
   assert_contains "$out" "pre_tool_call" "Hermes snippet missing watcher-arm seatbelt"
+  assert_contains "$out" "bin/fm-cd-pretool-check.sh" "Hermes snippet missing cd-guard seatbelt"
   assert_not_contains "$out" "background-notify" "Hermes snippet must not claim unverified background wake semantics"
   out=$(FM_CODEX_WATCH_CHECKPOINT=23 "$RENDER" --harness hermes --repair-line)
   assert_contains "$out" "bin/fm-watch-checkpoint.sh --seconds 23" "Hermes repair line did not use checkpoint helper and env override"


### PR DESCRIPTION
## Summary
- add Hermes Agent v0.19.0 detection, isolated runtime homes, launch profiles, liveness, hooks, and supervision
- preserve operator config while validating and shell-quoting every generated safety hook
- avoid unsafe concurrent session resume by running interrupted-aware turn-end follow-ups in disposable isolated Hermes homes

## Validation
- live Hermes v0.19.0: overlapping `--resume` processes reproduced lost session state; overlapping primary/follow-up runs in separate isolated homes both exited 0 and persisted distinct sessions
- `bash tests/fm-hermes-harness.test.sh`
- `bash tests/fm-supervision-instructions.test.sh`
- `bash tests/fm-cd-pretool-check.test.sh`
- `bash tests/fm-arm-pretool-check.test.sh`
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-sessionstart-nudge.test.sh`
- `bash tests/fm-bootstrap.test.sh`
- `env -u HERMES_INTERACTIVE bash tests/fm-secondmate-harness.test.sh`
- `env -u HERMES_INTERACTIVE bash tests/fm-secondmate-liveness.test.sh`
- `bin/fm-lint.sh`

Claude was not invoked; this used the captain-authorized Hermes-only direct-PR path.
