### PR TITLE
fix: block primary-session delegation outside the fleet

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -63,15 +63,17 @@ Every verified primary harness also has a wired PreToolUse-equivalent hook that 
 `opencode` and `pi` block by throwing from `tool.execute.before` / returning `{block: true}` from `tool_call`.
 The exact hook files, commands, output-shaping quirks (Claude Code only honors the deny when stdout is empty), and validation transcripts are owned by `docs/arm-pretool-check.md`.
 When changing any primary PreToolUse hook, validate the real harness behavior in a scratch project before trusting it, then update that doc.
-## Primary delegation-surface deny list
+## Primary delegation-shape guard
 
 Claude exposes built-in delegation, scheduling, and worktree tools that a primary session can use to create work with no `state/<id>.meta`, which makes the whole guard stack inert because every guard counts that metadata.
-The primary fix is the `permissions.deny` list in `.claude/settings.json`, which removes those tools from the model's schema so they are never offered; `bin/fm-subagent-pretool-check.sh` is a second-layer PreToolUse backstop that denies a delegation-SHAPED tool name so a tool that ships before the deny list is updated is still refused.
-`docs/subagent-guard.md` owns the full contract, the denied set, the `FM_ALLOW_SUBAGENT=1` escape hatch, and the per-harness applicability review.
+The shipped mechanism is `bin/fm-subagent-pretool-check.sh`, a primary-home PreToolUse guard that denies a delegation-SHAPED tool name.
+The recommended Claude hardening is a per-home local `permissions.deny` list, because it removes known delegation tools from the model's schema so they are never offered.
+That deny list is not tracked because it is Claude-only and because tracked settings propagate into linked firstmate-repo worktrees where they disarm legitimate crewmate delegation.
+`docs/subagent-guard.md` owns the full contract, the local hardening JSON, the `FM_ALLOW_SUBAGENT=1` escape hatch, and the per-harness applicability review.
 
 Two verified facts worth pinning here.
-The subagent tool presents to the model as `Agent`, and on Claude Code 2.1.217 both `Agent` and `Task` work as `permissions.deny` keys, verified by an A/B with a nonsense-name control; the tracked list pins both so a rename or rollback cannot silently reopen the surface.
-`permissions.allow` is a pre-approval list rather than an availability list, so there is no fail-closed positive allowlist: the deny list is fail-open against tools that do not exist yet and needs a re-check on every Claude Code upgrade.
+The subagent tool presents to the model as `Agent`, and on Claude Code 2.1.217 both `Agent` and `Task` work as `permissions.deny` keys, verified by an A/B with a nonsense-name control.
+`permissions.allow` is a pre-approval list rather than an availability list, so there is no fail-closed positive allowlist.
 
 ## Primary session-start nudge
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -66,9 +66,10 @@ When changing any watcher-arm PreToolUse hook, validate the real harness behavio
 ## Primary delegation-shape guard
 
 Claude exposes built-in delegation, scheduling, and worktree tools that a primary session can use to create work with no `state/<id>.meta`, which makes the whole guard stack inert because every guard counts that metadata.
-The primary Claude mechanism is the tracked `.claude/settings.json` `permissions.deny` list, because it removes known delegation tools from the model's schema so they are never offered.
-The backstop mechanism is `bin/fm-subagent-pretool-check.sh`, a primary-home PreToolUse guard that denies a delegation-SHAPED tool name not yet covered by that fixed list.
-`docs/subagent-guard.md` owns the full contract, the shipped deny-list JSON, the `FM_ALLOW_SUBAGENT=1` escape hatch, and the per-harness applicability review.
+The shipped mechanism is `bin/fm-subagent-pretool-check.sh`, a primary-home PreToolUse guard that denies a delegation-SHAPED tool name.
+Claude primaries should also use an untracked per-home local `permissions.deny` list as hardening for known Claude delegation tools, because it removes them from the model's schema so they are never offered.
+That deny list must not ship in tracked `.claude/settings.json` because it is Claude-only rather than harness-agnostic, and because tracked project settings propagate into linked worktrees where they disarm legitimate crewmates.
+`docs/subagent-guard.md` owns the full contract, the local deny-list recommendation, the `FM_ALLOW_SUBAGENT=1` escape hatch, and the per-harness applicability review.
 
 Two verified facts worth pinning here.
 The subagent tool presents to the model as `Agent`, and on Claude Code 2.1.217 both `Agent` and `Task` work as `permissions.deny` keys, verified by an A/B with a nonsense-name control.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -62,7 +62,7 @@ Every verified primary harness also has a wired PreToolUse-equivalent hook that 
 `claude` and `codex` block directly through PreToolUse hooks; `grok` blocks the same way but requires every `$VAR` reference in its hook `command` string to carry an inline `:-default` or it fails to launch the hook entirely.
 `opencode` and `pi` block by throwing from `tool.execute.before` / returning `{block: true}` from `tool_call`.
 The exact hook files, commands, output-shaping quirks (Claude Code only honors the deny when stdout is empty), and validation transcripts are owned by `docs/arm-pretool-check.md`.
-When changing any primary PreToolUse hook, validate the real harness behavior in a scratch project before trusting it, then update that doc.
+When changing any watcher-arm PreToolUse hook, validate the real harness behavior in a scratch project before trusting it, then update that doc.
 ## Primary delegation-shape guard
 
 Claude exposes built-in delegation, scheduling, and worktree tools that a primary session can use to create work with no `state/<id>.meta`, which makes the whole guard stack inert because every guard counts that metadata.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -66,10 +66,9 @@ When changing any primary PreToolUse hook, validate the real harness behavior in
 ## Primary delegation-shape guard
 
 Claude exposes built-in delegation, scheduling, and worktree tools that a primary session can use to create work with no `state/<id>.meta`, which makes the whole guard stack inert because every guard counts that metadata.
-The shipped mechanism is `bin/fm-subagent-pretool-check.sh`, a primary-home PreToolUse guard that denies a delegation-SHAPED tool name.
-The recommended Claude hardening is a per-home local `permissions.deny` list, because it removes known delegation tools from the model's schema so they are never offered.
-That deny list is not tracked because it is Claude-only and because tracked settings propagate into linked firstmate-repo worktrees where they disarm legitimate crewmate delegation.
-`docs/subagent-guard.md` owns the full contract, the local hardening JSON, the `FM_ALLOW_SUBAGENT=1` escape hatch, and the per-harness applicability review.
+The primary Claude mechanism is the tracked `.claude/settings.json` `permissions.deny` list, because it removes known delegation tools from the model's schema so they are never offered.
+The backstop mechanism is `bin/fm-subagent-pretool-check.sh`, a primary-home PreToolUse guard that denies a delegation-SHAPED tool name not yet covered by that fixed list.
+`docs/subagent-guard.md` owns the full contract, the shipped deny-list JSON, the `FM_ALLOW_SUBAGENT=1` escape hatch, and the per-harness applicability review.
 
 Two verified facts worth pinning here.
 The subagent tool presents to the model as `Agent`, and on Claude Code 2.1.217 both `Agent` and `Task` work as `permissions.deny` keys, verified by an A/B with a nonsense-name control.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -63,6 +63,15 @@ Every verified primary harness also has a wired PreToolUse-equivalent hook that 
 `opencode` and `pi` block by throwing from `tool.execute.before` / returning `{block: true}` from `tool_call`.
 The exact hook files, commands, output-shaping quirks (Claude Code only honors the deny when stdout is empty), and validation transcripts are owned by `docs/arm-pretool-check.md`.
 When changing any primary PreToolUse hook, validate the real harness behavior in a scratch project before trusting it, then update that doc.
+## Primary delegation-surface deny list
+
+Claude exposes built-in delegation, scheduling, and worktree tools that a primary session can use to create work with no `state/<id>.meta`, which makes the whole guard stack inert because every guard counts that metadata.
+The primary fix is the `permissions.deny` list in `.claude/settings.json`, which removes those tools from the model's schema so they are never offered; `bin/fm-subagent-pretool-check.sh` is a second-layer PreToolUse backstop that denies a delegation-SHAPED tool name so a tool that ships before the deny list is updated is still refused.
+`docs/subagent-guard.md` owns the full contract, the denied set, the `FM_ALLOW_SUBAGENT=1` escape hatch, and the per-harness applicability review.
+
+Two verified facts worth pinning here.
+The subagent tool presents to the model as `Agent`, and on Claude Code 2.1.217 both `Agent` and `Task` work as `permissions.deny` keys, verified by an A/B with a nonsense-name control; the tracked list pins both so a rename or rollback cannot silently reopen the surface.
+`permissions.allow` is a pre-approval list rather than an availability list, so there is no fail-closed positive allowlist: the deny list is fail-open against tools that do not exist yet and needs a re-check on every Claude Code upgrade.
 
 ## Primary session-start nudge
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,26 +1,4 @@
 {
-  "permissions": {
-    "deny": [
-      "Task",
-      "Agent",
-      "Workflow",
-      "RemoteTrigger",
-      "Monitor",
-      "ScheduleWakeup",
-      "SendMessage",
-      "EnterWorktree",
-      "ExitWorktree",
-      "CronCreate",
-      "CronDelete",
-      "CronList",
-      "TaskCreate",
-      "TaskGet",
-      "TaskList",
-      "TaskUpdate",
-      "TaskStop",
-      "TaskOutput"
-    ]
-  },
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,26 @@
 {
+  "permissions": {
+    "deny": [
+      "Task",
+      "Agent",
+      "Workflow",
+      "RemoteTrigger",
+      "Monitor",
+      "ScheduleWakeup",
+      "SendMessage",
+      "EnterWorktree",
+      "ExitWorktree",
+      "CronCreate",
+      "CronDelete",
+      "CronList",
+      "TaskCreate",
+      "TaskGet",
+      "TaskList",
+      "TaskUpdate",
+      "TaskStop",
+      "TaskOutput"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,26 @@
 {
+  "permissions": {
+    "deny": [
+      "Task",
+      "Agent",
+      "Workflow",
+      "RemoteTrigger",
+      "Monitor",
+      "ScheduleWakeup",
+      "SendMessage",
+      "EnterWorktree",
+      "ExitWorktree",
+      "CronCreate",
+      "CronDelete",
+      "CronList",
+      "TaskCreate",
+      "TaskGet",
+      "TaskList",
+      "TaskUpdate",
+      "TaskStop",
+      "TaskOutput"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {
@@ -26,6 +48,15 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/bin/fm-continuity-pretool-check.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Agent|Task|Workflow|Cron|Schedul|Worktree|Delegate|Spawn|Dispatch|Handoff|Remote|SendMessage|Monitor",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/bin/fm-subagent-pretool-check.sh --claude"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,26 +1,4 @@
 {
-  "permissions": {
-    "deny": [
-      "Task",
-      "Agent",
-      "Workflow",
-      "RemoteTrigger",
-      "Monitor",
-      "ScheduleWakeup",
-      "SendMessage",
-      "EnterWorktree",
-      "ExitWorktree",
-      "CronCreate",
-      "CronDelete",
-      "CronList",
-      "TaskCreate",
-      "TaskGet",
-      "TaskList",
-      "TaskUpdate",
-      "TaskStop",
-      "TaskOutput"
-    ]
-  },
   "hooks": {
     "SessionStart": [
       {
@@ -52,7 +30,7 @@
         ]
       },
       {
-        "matcher": "Agent|Task|Workflow|Cron|Schedul|Worktree|Delegate|Spawn|Dispatch|Handoff|Remote|SendMessage|Monitor",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# PreToolUse backstop against primary-session delegation outside the fleet.
+#
+# A firstmate primary that delegates through a harness's own delegation,
+# scheduling, or background-work tool creates work with no `state/<id>.meta` and
+# no `data/<id>/brief.md`. Only `bin/fm-spawn.sh` writes that metadata, and
+# every firstmate guard keys off it (bin/fm-supervision-lib.sh counts
+# `state/*.meta`; bin/fm-turnend-guard.sh exits silently at zero). So such work
+# is not merely unsupervised: it makes the whole guard stack structurally inert,
+# and it dies with the primary session instead of living in its own backend
+# session.
+#
+# THIS SCRIPT IS THE SECOND LAYER, NOT THE PRIMARY FIX. The primary fix is the
+# `permissions.deny` list in `.claude/settings.json`, which removes those tools
+# from the model's schema entirely, so there is no call to intercept at all.
+# A deny list is nonetheless fail-open against tools that do not exist yet, and
+# Claude Code's delegation surface is visibly growing. This backstop closes that
+# forward-looking gap: it matches a delegation-SHAPED tool name rather than a
+# fixed list, so a future tool that ships before anyone updates the deny list is
+# still refused. It is deliberately a pattern, because a second fixed list would
+# be a weaker duplicate of the first.
+#
+# The guard is narrow by design. It classifies ONE thing: the shape of the tool
+# name. It makes no judgment about whether the work should be delegated at all,
+# which is a reasoning boundary no tool-shape hook can enforce.
+# See docs/subagent-guard.md for the complete contract and validation record.
+#
+# Usage:
+#   <PreToolUse JSON on stdin> | bin/fm-subagent-pretool-check.sh
+#   bin/fm-subagent-pretool-check.sh --tool '<tool-name>'
+#
+# Stdin mode extracts .tool_name for Claude and Codex, or .toolName for Grok.
+# CLI mode is for adapters that already hold the tool name (OpenCode, Pi).
+#
+# Exit/output contract (identical shape to bin/fm-cd-pretool-check.sh):
+#   ALLOW - exit 0 and no output.
+#   DENY - exit 2, a Claude-shaped deny object on stderr, and a Grok-shaped
+#          deny object on stdout unless --claude was supplied.
+#   INERT - not a genuine primary home (a crewmate/scout task worktree or a
+#           non-firstmate repo): exit 0 with no output, exactly like ALLOW.
+#   ESCAPE - FM_ALLOW_SUBAGENT=1 in the environment allows deliberately.
+#   FAIL OPEN - malformed or empty stdin, or missing jq for stdin transport.
+#
+# Claude requires stdout to remain empty on deny.
+# Codex blocks on exit 2 and displays stderr.
+# Grok consumes the stdout decision object.
+# OpenCode and Pi consume exit 2 plus stderr.
+set -u
+
+# Lowercase substrings that mark a tool name as delegation-shaped: it creates
+# work, an agent, a schedule, or an isolated workspace that firstmate would not
+# know about. Reviewed as one list on purpose - this and the deny list in
+# .claude/settings.json are the only two places the surface is enumerated.
+DELEGATION_STEMS='agent subagent task workflow cron schedul worktree delegate spawn dispatch handoff remote sendmessage monitor'
+
+# Exact lowercase tool names that match a stem above but only OBSERVE or STOP
+# work that already exists. Reading or ending unaccounted work is not creating
+# it, and denying these would strand already-running work with no way to inspect
+# or end it. The captain-owned deny list in .claude/settings.json is the wider
+# layer and may still remove these from the schema; this backstop deliberately
+# stays narrower so it can never be the reason a runaway task cannot be stopped.
+OBSERVE_ONLY_TOOLS='taskoutput taskstop taskget tasklist cronlist bashoutput killshell'
+
+TOOL=""
+TOOL_SET=0
+CLAUDE_MODE=0
+
+usage() {
+  cat <<'EOF'
+Usage: fm-subagent-pretool-check.sh [--tool <tool-name>] [--claude]
+
+With no --tool, reads a PreToolUse-style JSON payload on stdin (Claude/Codex
+tool_name, or Grok toolName).
+Second-layer backstop behind the permissions.deny list in .claude/settings.json:
+denies a delegation-SHAPED tool name so a future tool missing from that list is
+still refused.
+Fires only in a genuine firstmate primary home; it is a silent no-op in a
+crewmate/scout task worktree or any non-firstmate repo, where a worker using
+delegation tools is legitimate.
+Exits 0 to allow and 2 to deny, naming the real crewmate dispatch path instead.
+Set FM_ALLOW_SUBAGENT=1 in the session environment to allow deliberately.
+Malformed transport fails open.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tool)
+      [ "$#" -gt 1 ] || { echo "error: --tool requires a value" >&2; exit 2; }
+      TOOL=$2
+      TOOL_SET=1
+      shift 2
+      ;;
+    --tool=*)
+      TOOL=${1#--tool=}
+      TOOL_SET=1
+      shift
+      ;;
+    --claude)
+      CLAUDE_MODE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$TOOL_SET" -eq 0 ]; then
+  PAYLOAD=$(cat 2>/dev/null || true)
+  [ -n "$PAYLOAD" ] || exit 0
+  command -v jq >/dev/null 2>&1 || exit 0
+  TOOL=$(printf '%s' "$PAYLOAD" | jq -r '(.tool_name // .toolName // empty)' 2>/dev/null) || exit 0
+fi
+
+[ -n "$TOOL" ] || exit 0
+
+LC_ALL=C NORMALIZED=$(printf '%s' "$TOOL" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9')
+
+# An MCP tool belongs to an external integration, not to the harness's own
+# delegation surface, and its name is chosen by that server. Never classify one
+# here: an MCP server with a task or agent noun in a tool name is common and
+# blocking it would be a false positive with no bearing on fleet dispatch.
+case "$TOOL" in
+  mcp__*) exit 0 ;;
+esac
+
+for allowed in $OBSERVE_ONLY_TOOLS; do
+  [ "$NORMALIZED" != "$allowed" ] || exit 0
+done
+
+MATCHED=""
+for stem in $DELEGATION_STEMS; do
+  case "$NORMALIZED" in
+    *"$stem"*) MATCHED=$stem; break ;;
+  esac
+done
+[ -n "$MATCHED" ] || exit 0
+
+# The single deliberate escape hatch. It is an environment variable rather than
+# a flag or a state file so it must be set when the session is launched, which
+# makes a genuinely intended use possible and an accidental one impossible: no
+# in-session tool call can set it for the call that follows.
+[ "${FM_ALLOW_SUBAGENT:-}" != "1" ] || exit 0
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P) || exit 0
+FM_ROOT=${FM_ROOT_OVERRIDE:-$(CDPATH='' cd -- "$SCRIPT_DIR/.." 2>/dev/null && pwd -P)} || exit 0
+FM_HOME=${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}
+STATE=${FM_STATE_OVERRIDE:-$FM_HOME/state}
+
+# Scope to a genuine primary home, exactly as the session-start nudge and the
+# turn-end guard do. fm_primary_scope_matches accepts a plain checkout or a
+# marked secondmate home - both operate a fleet and must dispatch through it -
+# and rejects a linked task worktree, which is the shape bin/fm-spawn.sh always
+# hands a crewmate. A crewmate using delegation tools inside its own task
+# worktree is legitimate and stays allowed. Any failure to confirm the home is
+# inert (exit 0), never a block, so a broken environment never denies a call.
+# shellcheck source=bin/fm-primary-scope-lib.sh
+. "$SCRIPT_DIR/fm-primary-scope-lib.sh"
+fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
+
+# Investigation has a dedicated entry point when this home carries it; degrade
+# to the two-step brief-then-spawn path when it does not, rather than naming a
+# script that is not there.
+if [ -f "$FM_ROOT/bin/fm-scout.sh" ]; then
+  ROUTE='investigation or diagnosis goes to bin/fm-scout.sh "<question>" [project], and ship work goes to bin/fm-brief.sh then bin/fm-spawn.sh'
+else
+  ROUTE='investigation and ship work both go to bin/fm-brief.sh then bin/fm-spawn.sh'
+fi
+
+REASON="[subagent-dispatch] the firstmate primary dispatches through the fleet, not the harness's own delegation tools: work started that way has no durable fleet record, leaves every firstmate guard inert, and dies with this session. Instead, $ROUTE (blocked tool: $TOOL, delegation-shaped on \"$MATCHED\"). Launch the session with FM_ALLOW_SUBAGENT=1 for a deliberate exception."
+
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr '\n' ' '
+}
+
+ESCAPED=$(json_escape "$REASON")
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"%s"}\n' "$ESCAPED" >&2
+[ "$CLAUDE_MODE" -eq 1 ] || printf '{"decision":"deny","reason":"%s"}\n' "$ESCAPED"
+exit 2

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -10,17 +10,18 @@
 # and it dies with the primary session instead of living in its own backend
 # session.
 #
-# This script is the shipped guard.
-# Claude primaries may add a per-home local `permissions.deny` list as stronger
-# hardening because it removes tools from the model's schema entirely, but that
-# Claude-only mechanism is not tracked shared material.
+# The tracked Claude `permissions.deny` list is the primary shipped guard for
+# known Claude delegation tools because it removes them from the model's schema
+# entirely.
+# This script is the backstop for future delegation-shaped names that are not
+# yet in that fixed list.
 # The tracked Claude matcher is deliberately `.*`: a stem-enumerating matcher
 # would reintroduce the fail-open-by-enumeration problem this guard exists to
 # solve, because any future tool name outside the matcher would never reach this
 # script.
 # This script is therefore the single owner of classification.
 # It matches a delegation-SHAPED tool name rather than a fixed list, so a future
-# tool that ships before anyone updates local hardening is still refused.
+# tool that ships before anyone updates the deny list is still refused.
 #
 # The guard is narrow by design. It classifies ONE thing: the shape of the tool
 # name. It makes no judgment about whether the work should be delegated at all,
@@ -57,9 +58,9 @@ DELEGATION_STEMS='agent subagent task workflow cron schedul worktree delegate sp
 # Exact lowercase tool names that match a stem above but only OBSERVE or STOP
 # work that already exists. Reading or ending unaccounted work is not creating
 # it, and denying these would strand already-running work with no way to inspect
-# or end it. Per-home Claude hardening may still remove these from the schema;
-# this shipped guard deliberately stays narrower so it can never be the reason a
-# runaway task cannot be stopped.
+# or end it. The tracked Claude deny list may still remove these from the
+# schema; this backstop guard deliberately stays narrower so it can never be the
+# reason a runaway task cannot be stopped.
 OBSERVE_ONLY_TOOLS='taskoutput taskstop taskget tasklist cronlist bashoutput killshell'
 
 TOOL=""
@@ -73,9 +74,10 @@ Usage: fm-subagent-pretool-check.sh [--tool <tool-name>] [--claude]
 With no --tool, reads a PreToolUse-style JSON payload on stdin (Claude/Codex
 tool_name, or Grok toolName).
 Denies a delegation-SHAPED tool name in a genuine primary home.
-Claude primaries may additionally use a per-home local permissions.deny list to
-remove known delegation tools from the model schema, but tracked shared settings
-do not ship that Claude-only mechanism.
+Tracked Claude settings also ship a permissions.deny list that removes known
+delegation tools from the model schema before this hook is needed.
+This hook remains as a backstop for future delegation-shaped names outside that
+fixed list.
 Fires only in a genuine firstmate primary home; it is a silent no-op in a
 crewmate/scout task worktree or any non-firstmate repo, where a worker using
 delegation tools is legitimate.

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -10,18 +10,20 @@
 # and it dies with the primary session instead of living in its own backend
 # session.
 #
-# The tracked Claude `permissions.deny` list is the primary shipped guard for
-# known Claude delegation tools because it removes them from the model's schema
-# entirely.
-# This script is the backstop for future delegation-shaped names that are not
-# yet in that fixed list.
+# This scoped PreToolUse guard is the shipped mechanism.
+# Claude primaries should also use an untracked per-home local
+# `permissions.deny` list as hardening for known Claude delegation tools,
+# because it removes them from the model's schema entirely.
+# That deny list must not be tracked: it is Claude-only rather than
+# harness-agnostic, and tracked project settings propagate into linked
+# worktrees where they disarm legitimate crewmates.
 # The tracked Claude matcher is deliberately `.*`: a stem-enumerating matcher
 # would reintroduce the fail-open-by-enumeration problem this guard exists to
 # solve, because any future tool name outside the matcher would never reach this
 # script.
 # This script is therefore the single owner of classification.
 # It matches a delegation-SHAPED tool name rather than a fixed list, so a future
-# tool that ships before anyone updates the deny list is still refused.
+# tool that ships before anyone updates a local deny list is still refused.
 #
 # The guard is narrow by design. It classifies ONE thing: the shape of the tool
 # name. It makes no judgment about whether the work should be delegated at all,
@@ -58,8 +60,8 @@ DELEGATION_STEMS='agent subagent task workflow cron schedul worktree delegate sp
 # Exact lowercase tool names that match a stem above but only OBSERVE or STOP
 # work that already exists. Reading or ending unaccounted work is not creating
 # it, and denying these would strand already-running work with no way to inspect
-# or end it. The tracked Claude deny list may still remove these from the
-# schema; this backstop guard deliberately stays narrower so it can never be the
+# or end it. A local Claude deny list may still remove these from the
+# schema; this shipped guard deliberately stays narrower so it can never be the
 # reason a runaway task cannot be stopped.
 OBSERVE_ONLY_TOOLS='taskoutput taskstop taskget tasklist cronlist bashoutput killshell'
 
@@ -74,10 +76,12 @@ Usage: fm-subagent-pretool-check.sh [--tool <tool-name>] [--claude]
 With no --tool, reads a PreToolUse-style JSON payload on stdin (Claude/Codex
 tool_name, or Grok toolName).
 Denies a delegation-SHAPED tool name in a genuine primary home.
-Tracked Claude settings also ship a permissions.deny list that removes known
-delegation tools from the model schema before this hook is needed.
-This hook remains as a backstop for future delegation-shaped names outside that
-fixed list.
+Claude primaries may also add an untracked per-home permissions.deny list that
+removes known delegation tools from the model schema before this hook is needed.
+Do not ship that Claude-only list in tracked project settings, because linked
+worktrees inherit it and legitimate crewmates would lose their delegation tools.
+This hook remains as the shipped guard for future delegation-shaped names
+outside any local fixed list.
 Fires only in a genuine firstmate primary home; it is a silent no-op in a
 crewmate/scout task worktree or any non-firstmate repo, where a worker using
 delegation tools is legitimate.

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PreToolUse backstop against primary-session delegation outside the fleet.
+# PreToolUse guard against primary-session delegation outside the fleet.
 #
 # A firstmate primary that delegates through a harness's own delegation,
 # scheduling, or background-work tool creates work with no `state/<id>.meta` and
@@ -10,15 +10,17 @@
 # and it dies with the primary session instead of living in its own backend
 # session.
 #
-# THIS SCRIPT IS THE SECOND LAYER, NOT THE PRIMARY FIX. The primary fix is the
-# `permissions.deny` list in `.claude/settings.json`, which removes those tools
-# from the model's schema entirely, so there is no call to intercept at all.
-# A deny list is nonetheless fail-open against tools that do not exist yet, and
-# Claude Code's delegation surface is visibly growing. This backstop closes that
-# forward-looking gap: it matches a delegation-SHAPED tool name rather than a
-# fixed list, so a future tool that ships before anyone updates the deny list is
-# still refused. It is deliberately a pattern, because a second fixed list would
-# be a weaker duplicate of the first.
+# This script is the shipped guard.
+# Claude primaries may add a per-home local `permissions.deny` list as stronger
+# hardening because it removes tools from the model's schema entirely, but that
+# Claude-only mechanism is not tracked shared material.
+# The tracked Claude matcher is deliberately `.*`: a stem-enumerating matcher
+# would reintroduce the fail-open-by-enumeration problem this guard exists to
+# solve, because any future tool name outside the matcher would never reach this
+# script.
+# This script is therefore the single owner of classification.
+# It matches a delegation-SHAPED tool name rather than a fixed list, so a future
+# tool that ships before anyone updates local hardening is still refused.
 #
 # The guard is narrow by design. It classifies ONE thing: the shape of the tool
 # name. It makes no judgment about whether the work should be delegated at all,
@@ -49,16 +51,15 @@ set -u
 
 # Lowercase substrings that mark a tool name as delegation-shaped: it creates
 # work, an agent, a schedule, or an isolated workspace that firstmate would not
-# know about. Reviewed as one list on purpose - this and the deny list in
-# .claude/settings.json are the only two places the surface is enumerated.
+# know about. This list is the single owner of the shipped classification.
 DELEGATION_STEMS='agent subagent task workflow cron schedul worktree delegate spawn dispatch handoff remote sendmessage monitor'
 
 # Exact lowercase tool names that match a stem above but only OBSERVE or STOP
 # work that already exists. Reading or ending unaccounted work is not creating
 # it, and denying these would strand already-running work with no way to inspect
-# or end it. The captain-owned deny list in .claude/settings.json is the wider
-# layer and may still remove these from the schema; this backstop deliberately
-# stays narrower so it can never be the reason a runaway task cannot be stopped.
+# or end it. Per-home Claude hardening may still remove these from the schema;
+# this shipped guard deliberately stays narrower so it can never be the reason a
+# runaway task cannot be stopped.
 OBSERVE_ONLY_TOOLS='taskoutput taskstop taskget tasklist cronlist bashoutput killshell'
 
 TOOL=""
@@ -71,9 +72,10 @@ Usage: fm-subagent-pretool-check.sh [--tool <tool-name>] [--claude]
 
 With no --tool, reads a PreToolUse-style JSON payload on stdin (Claude/Codex
 tool_name, or Grok toolName).
-Second-layer backstop behind the permissions.deny list in .claude/settings.json:
-denies a delegation-SHAPED tool name so a future tool missing from that list is
-still refused.
+Denies a delegation-SHAPED tool name in a genuine primary home.
+Claude primaries may additionally use a per-home local permissions.deny list to
+remove known delegation tools from the model schema, but tracked shared settings
+do not ship that Claude-only mechanism.
 Fires only in a genuine firstmate primary home; it is a silent no-op in a
 crewmate/scout task worktree or any non-firstmate repo, where a worker using
 delegation tools is legitimate.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -125,6 +125,7 @@ family_for_basename() {
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
     fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\
+    fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-tmux-submit-busy.test.sh|fm-transition-lib.test.sh|\
     fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
       printf '%s\n' pure-contract-unit

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -33,7 +33,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |
 | `fm-continuity-pretool-check.sh` | Narrow Claude recovery gate when in-flight work has no live watcher lock (docs/arm-pretool-check.md) |
 | `fm-continuity-command-policy.mjs` | Semantic owner of Claude continuity-gate fleet-command classification (docs/arm-pretool-check.md) |
-| `fm-subagent-pretool-check.sh` | Delegation-shape PreToolUse backstop behind the permissions.deny list (docs/subagent-guard.md) |
+| `fm-subagent-pretool-check.sh` | Primary-home delegation-shape PreToolUse guard (docs/subagent-guard.md) |
 | `fm-supervision-instructions.sh` | Render the session-start primary-harness supervision block or the one-line repair instruction |
 | `fm-home-seed.sh`        | Transactionally provision a secondmate home and maintain `data/secondmates.md`       |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -33,6 +33,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |
 | `fm-continuity-pretool-check.sh` | Narrow Claude recovery gate when in-flight work has no live watcher lock (docs/arm-pretool-check.md) |
 | `fm-continuity-command-policy.mjs` | Semantic owner of Claude continuity-gate fleet-command classification (docs/arm-pretool-check.md) |
+| `fm-subagent-pretool-check.sh` | Delegation-shape PreToolUse backstop behind the permissions.deny list (docs/subagent-guard.md) |
 | `fm-supervision-instructions.sh` | Render the session-start primary-harness supervision block or the one-line repair instruction |
 | `fm-home-seed.sh`        | Transactionally provision a secondmate home and maintain `data/secondmates.md`       |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -2,9 +2,9 @@
 
 This document is the authoritative human-readable contract for the guard that stops a firstmate primary from delegating work outside the fleet.
 
-The shipped fix is `bin/fm-subagent-pretool-check.sh`, a PreToolUse guard that denies a delegation-SHAPED tool name in a genuine primary home.
-Claude primaries may also add a per-home local `permissions.deny` list as stronger hardening, because it removes known tools from the model's schema entirely.
-That local hardening is recommended, but it is not tracked shared material.
+The shipped fix has two layers.
+The primary layer is the tracked `.claude/settings.json` `permissions.deny` list, because it removes known Claude delegation tools from the model's schema entirely.
+The backstop layer is `bin/fm-subagent-pretool-check.sh`, a PreToolUse guard that denies a delegation-SHAPED tool name in a genuine primary home when a future or unlisted tool reaches it.
 
 ## Why this exists
 
@@ -34,9 +34,13 @@ The scope line is therefore: wrong tool reached for, deny; wrong amount of think
 The guard is also not a dispatch-quality check.
 It says nothing about whether the resulting brief, project, or delivery mode is correct.
 
-## Shipped guard
+## Shipped layers
 
-`bin/fm-subagent-pretool-check.sh` classifies the tool NAME by shape rather than against a fixed list.
+The primary shipped layer is tracked Claude `permissions.deny`.
+It removes the known 18-name Claude delegation, scheduling, worktree, and task-tracking surface before the model can call it.
+
+`bin/fm-subagent-pretool-check.sh` is the backstop shipped layer.
+It classifies the tool NAME by shape rather than against a fixed list.
 The tracked Claude PreToolUse matcher is `.*`, so every Claude tool name reaches the script and the script is the single owner of classification.
 A stem-enumerating matcher would reintroduce the fail-open-by-enumeration problem this guard exists to solve, because any future tool name outside the matcher would be silently missed before the script could inspect it.
 A tool is delegation-shaped when its normalized lowercase name contains one of these stems:
@@ -52,15 +56,15 @@ Two exclusions keep the shape test from producing false positives.
   An MCP server chooses its own tool names, a task or agent noun there is common, and it has no bearing on fleet dispatch.
 - The exact names `taskoutput`, `taskstop`, `taskget`, `tasklist`, `cronlist`, `bashoutput`, and `killshell` are allowed.
   These observe or stop work that already exists rather than creating it, and denying them at this layer could strand already-running work with no way to inspect or end it.
-  The recommended per-home local hardening is the wider, captain-owned layer and may still remove them from the schema.
-  The shipped guard stays narrower on purpose so it can never be the reason a runaway task cannot be stopped.
+  The tracked deny list is the wider, captain-owned primary layer and removes them from the schema.
+  The backstop guard stays narrower on purpose so it can never be the reason a runaway task cannot be stopped.
 
-The shipped guard fires on every delegation-shaped name that reaches it, including future names that no deny list knows about yet.
+The backstop guard fires on every delegation-shaped name that reaches it, including future names that no deny list knows about yet.
 That future-name behavior is the reason the tracked matcher must match all tools and let the script filter.
 
-## Recommended per-home local hardening
+## Tracked Claude deny-list primary layer
 
-Claude primaries should add this as local per-home settings, not tracked shared project settings:
+Tracked Claude settings ship this top-level list:
 
 ```json
 {
@@ -93,14 +97,15 @@ A denied name is removed from the model's schema entirely.
 The model is never offered the tool, so there is no call to intercept, no matcher to get wrong, no fail-open path, and no dependence on the model's cooperation.
 This is removal, not interception, and it is strictly stronger than any hook.
 
-This list is not tracked for two reasons.
-It is Claude-only and cannot be the harness-agnostic shipped answer.
-The tracked `.claude/settings.json` file propagates into linked firstmate-repo worktrees, where it disarms legitimate crewmates by removing the delegation tools before the hook's linked-worktree scope check or `FM_ALLOW_SUBAGENT=1` can help.
-A Claude session in the task worktree for this change reported no `Agent` tool while the tracked deny list was present, which confirms the settings layer is upstream of the hook boundary.
+This list is tracked because closing the known Claude surface is the primary shipped fix.
+The width of the list is a captain-owned decision, because denying some of these changes how the captain works with the primary session.
+It ships at the wider 18-name setting so the surface is closed by default, implemented as one flat array that is reviewable at a glance and narrowable in one line.
+In particular `TaskOutput`, `TaskStop`, `TaskGet`, `TaskList`, and `CronList` only observe or stop work that already exists, but the primary layer still removes them by default.
+The hook deliberately allows those names, so the backstop can never strand a runaway task with no way to inspect or end it.
 
-The width of the local list is a captain-owned decision, because denying some of these changes how the captain works with the primary session.
-In particular `TaskOutput`, `TaskStop`, `TaskGet`, `TaskList`, and `CronList` only observe or stop work that already exists.
-They cannot create unaccounted work, and a narrower local list that keeps them is a legitimate choice.
+`permissions.allow` is a pre-approval list, not an availability list, so there is no fail-closed positive allowlist available.
+That is why the fixed deny list is fail-open against future tools and why the shape-based backstop still exists.
+The hook cannot re-enable a tool removed from the schema; it only handles a tool name that still reaches PreToolUse.
 
 ### Both `Task` and `Agent` are valid deny keys
 
@@ -111,12 +116,12 @@ That is not what this machine shows.
 A five-way A/B with a control, each run in its own directory to rule out settings caching, found that `Task` and `Agent` each independently remove the tool, and that a nonsense name leaves it present.
 The full evidence is in the validation record below.
 
-Pinning both names in local hardening is correct regardless of which build is running.
+Pinning both names in the tracked deny list is correct regardless of which build is running.
 It costs one line and removes the failure mode where a rename or a rollback silently reopens the surface.
 
 ## Scope
 
-The shipped guard fires only in a genuine firstmate primary home, using the shared predicate `fm_primary_scope_matches` from `bin/fm-primary-scope-lib.sh`.
+The backstop hook fires only in a genuine firstmate primary home, using the shared predicate `fm_primary_scope_matches` from `bin/fm-primary-scope-lib.sh`.
 This is the same predicate `bin/fm-sessionstart-nudge.sh` and `bin/fm-turnend-guard.sh` use, so the three tracked primary-scoped hooks cannot drift apart.
 
 A home is in scope when it has `AGENTS.md`, a `bin/` directory, an existing state directory, and either a plain checkout where git-dir equals git-common-dir or a valid `.fm-secondmate-home` marker.
@@ -127,20 +132,20 @@ A crewmate using delegation tools inside its own task worktree is legitimate and
 A non-firstmate repo is out of scope.
 Any failure to confirm the home is inert, never a block, so a broken environment can never deny a tool call.
 
-The tracked `.claude/settings.json` carries no `permissions.deny` key, because project settings have no way to express the crewmate-linked-worktree exception.
-Local per-home hardening has no hook scope and must be applied only where the captain wants Claude's own delegation tools removed from the primary schema.
+The tracked deny list is upstream of hook scope and removes known Claude delegation tools wherever Claude applies the project settings.
+The hook scope is still load-bearing for future or un-denied names, and the linked-worktree negative case proves the script itself does not block legitimate crewmate delegation.
 
 ## Escape hatch
 
-`FM_ALLOW_SUBAGENT=1` in the session environment allows the call at the shipped guard.
+`FM_ALLOW_SUBAGENT=1` in the session environment allows the call at the backstop hook.
 This is the only escape hatch and the guard fails closed on every other value, including empty, `0`, `yes`, and `true`.
 
 It is an environment variable rather than a flag, a config file, or a state file because that makes it unforgeable in-session.
 The variable must be present when the harness process is launched, so no tool call the agent makes can enable it for the call that follows.
 A deliberate use therefore requires restarting the session with the variable set, which is a conscious act, while an accidental use is impossible.
 
-The escape hatch does not affect local Claude hardening.
-A tool removed from the schema stays removed, so a genuinely intended use of a locally denied tool also requires editing the local deny list.
+The escape hatch does not affect the tracked Claude deny list.
+A tool removed from the schema stays removed, so a genuinely intended use of a denied tool also requires editing the deny list.
 
 ## Output contract
 
@@ -162,7 +167,7 @@ Applicability turns on one question: does the harness expose built-in delegation
 
 | Harness | Delegation surface | Status |
 | --- | --- | --- |
-| Claude | 18 tools, listed above | Shipped guard wired and live-verified; per-home local hardening is recommended and live-verified. |
+| Claude | 18 tools, listed above | Tracked deny list and backstop guard wired and live-verified. |
 | Codex | none | Not applicable, verified empirically below. Codex 0.144.1 exposes no subagent, sub-task, or delegated-agent tool, so there is nothing to remove or intercept. `.codex/hooks.json` is unchanged. |
 | Grok | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
 | OpenCode | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
@@ -205,7 +210,7 @@ Codex is therefore not applicable today, and this table row is the tripwire: if 
 
 ### Grok, OpenCode, and Pi, inspected but not wired
 
-The integration surface of each was inspected and each is structurally wireable for the shipped guard.
+The integration surface of each was inspected and each is structurally wireable for the backstop guard.
 
 - Grok's tracked hooks (`.grok/hooks/fm-primary-pretool-check.json`, `.grok/hooks/fm-primary-cd-check.json`) use a `PreToolUse` matcher, currently `Bash`, and pipe stdin to a checker.
   The checker already reads Grok's `.toolName` field, so only the matcher token is missing.
@@ -274,10 +279,10 @@ TaskList*, TaskOutput*, TaskStop*, TaskUpdate*, WebFetch*, WebSearch*
 A `*` marks a deferred tool, which is lazy-loaded through `ToolSearch` and does not appear in a plain tool list unless the prompt asks for deferred entries.
 This distinction matters when reading the next result: a tool absent from a plain listing is not necessarily denied.
 
-### Local deny-list hardening
+### Tracked deny-list primary layer
 
-Run in a scratch firstmate-shaped project containing `AGENTS.md`, `state/`, a full copy of `bin/`, and the recommended local deny-list settings.
-This was originally run while the deny list was still in tracked project settings; the result remains the validation record for the local hardening JSON above.
+Run in a scratch firstmate-shaped project containing `AGENTS.md`, `state/`, a full copy of `bin/`, and the tracked deny-list settings.
+The result validates the shipped deny-list JSON above.
 Asking for deferred entries explicitly returned:
 
 ```text
@@ -288,9 +293,9 @@ DesignSync*, NotebookEdit*, PushNotification*, WebFetch*, WebSearch*
 All 18 denied names are gone and every ordinary working tool remains, including the five deferred ones.
 Comparing against the 29-tool baseline confirms the removal set is exactly the deny list and nothing else.
 
-### Shipped guard, the case local hardening cannot cover
+### Backstop guard, the case a fixed deny list cannot cover
 
-To reproduce a future tool that ships before local hardening is updated, `Workflow` was removed from the deny list in the same scratch project while the guard stayed wired.
+To reproduce a future tool that ships before the tracked deny list is updated, `Workflow` was removed from the deny list in the same scratch project while the guard stayed wired.
 
 Prompt: `Call the Workflow tool to run any trivial workflow. You must actually attempt the Workflow tool call.`
 
@@ -304,9 +309,9 @@ I attempted the Workflow tool call as requested. It was blocked by a PreToolUse 
 > deliberate exception.
 ```
 
-This is the load-bearing result: the shipped guard denied a delegation tool that the deny list did not cover, which is the future-name case the shape classifier exists for.
+This is the load-bearing result: the backstop guard denied a delegation tool that the deny list did not cover, which is the future-name case the shape classifier exists for.
 
-### Shipped guard scope, the negative case
+### Backstop guard scope, the negative case
 
 The same `Workflow` prompt was then run in a `git worktree add` linked worktree of that scratch project, carrying the identical tracked hook and checker bytes, with no escape hatch.
 
@@ -330,12 +335,12 @@ Result: the Workflow tool call was NOT blocked by a hook. It launched and ran to
 
 A Claude deny is honored only when the hook's stdout is empty.
 `tests/fm-subagent-pretool-check.test.sh` asserts stdout is empty on every `--claude` deny and that default mode still emits the Grok object on stdout.
-The live consequence is confirmed by the shipped-guard result above: Claude honored the deny and reported the reason text.
+The live consequence is confirmed by the backstop-guard result above: Claude honored the deny and reported the reason text.
 
 ## Automated validation
 
 `tests/fm-subagent-pretool-check.test.sh` owns the acceptance matrix and is registered in the `pure-contract-unit` family in `bin/fm-test-run.sh`.
-It covers the absence of `permissions.deny` from tracked Claude settings; the match-all Claude hook registration; denial of every work-creating delegation tool by shape; denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop and MCP exclusions; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
+It covers the exact shipped `permissions.deny` list in tracked Claude settings; the match-all Claude hook registration; denial of every work-creating delegation tool by shape; denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop and MCP exclusions; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
 
 Run:
 

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -1,10 +1,10 @@
 # Primary-session delegation guard
 
-This document is the authoritative human-readable contract for the two-layer guard that stops a firstmate primary from delegating work outside the fleet.
+This document is the authoritative human-readable contract for the guard that stops a firstmate primary from delegating work outside the fleet.
 
-Layer 1 is the `permissions.deny` list in `.claude/settings.json`, which removes the delegation tools from the model's schema.
-Layer 2 is `bin/fm-subagent-pretool-check.sh`, a PreToolUse backstop that denies a delegation-SHAPED tool name so a tool that ships before anyone updates layer 1 is still refused.
-Layer 1 is the primary fix; layer 2 exists only to cover what layer 1 structurally cannot.
+The shipped fix is `bin/fm-subagent-pretool-check.sh`, a PreToolUse guard that denies a delegation-SHAPED tool name in a genuine primary home.
+Claude primaries may also add a per-home local `permissions.deny` list as stronger hardening, because it removes known tools from the model's schema entirely.
+That local hardening is recommended, but it is not tracked shared material.
 
 ## Why this exists
 
@@ -20,7 +20,7 @@ The deeper defect is that the bypass did not merely skip dispatch, it made the g
 Only `bin/fm-spawn.sh` writes `state/<id>.meta`, and every guard keys off that record: `bin/fm-supervision-lib.sh` counts `state/*.meta`, and `bin/fm-turnend-guard.sh` exits silently when that count is zero.
 Work started through the harness's own delegation tool writes no metadata, so the in-flight count stayed at zero, the turn-end guard never blocked a blind turn end, and the continuity gate was inert.
 
-That is the reason the fence has to sit at the tool-availability layer, before the model can act.
+That is the reason the fence has to sit on the harness tool surface, before the primary can create untracked work.
 No additional guard keyed on task metadata can catch this class of failure, because the failure is precisely the absence of that metadata.
 
 ## Purpose and boundary
@@ -34,48 +34,11 @@ The scope line is therefore: wrong tool reached for, deny; wrong amount of think
 The guard is also not a dispatch-quality check.
 It says nothing about whether the resulting brief, project, or delivery mode is correct.
 
-## Layer 1: the tool-availability deny list
+## Shipped guard
 
-`.claude/settings.json` carries a single `permissions.deny` array.
-This is the one place the denied surface is enumerated, and it is deliberately a flat, readable list so its width can be reviewed at a glance.
-
-A denied name is removed from the model's schema entirely.
-The model is never offered the tool, so there is no call to intercept, no matcher to get wrong, no fail-open path, and no dependence on the model's cooperation.
-This is removal, not interception, and it is strictly stronger than any hook.
-
-The denied set is 18 names:
-
-```text
-Task  Agent  Workflow  RemoteTrigger  Monitor  ScheduleWakeup  SendMessage
-EnterWorktree  ExitWorktree  CronCreate  CronDelete  CronList
-TaskCreate  TaskGet  TaskList  TaskUpdate  TaskStop  TaskOutput
-```
-
-The width of this list is a captain-owned decision, because denying some of these changes how the captain works with the primary session.
-In particular `TaskOutput`, `TaskStop`, `TaskGet`, `TaskList`, and `CronList` only observe or stop work that already exists; they cannot create unaccounted work, and a narrower list that keeps them is a legitimate choice.
-The list ships at the wider setting so the surface is closed by default, and narrowing it is a one-line edit in one file.
-
-`tests/fm-subagent-pretool-check.test.sh` asserts every name above stays denied and that no ordinary working tool is denied, so a careless edit or a Claude Code upgrade cannot silently drop one.
-
-### Both `Task` and `Agent` are valid deny keys
-
-The tool presents to the model as `Agent`.
-A prior investigation recorded that the deny key must be `Task` and that using `Agent` "silently does nothing at all".
-That is not what this machine shows.
-
-A five-way A/B with a control, each run in its own directory to rule out settings caching, found that `Task` and `Agent` each independently remove the tool, and that a nonsense name leaves it present.
-The full evidence is in the validation record below.
-
-Both names are therefore pinned in the deny list and asserted by the test suite.
-Pinning both is correct regardless of which build is running: it costs one line and it removes the failure mode where a rename or a rollback silently reopens the surface.
-
-## Layer 2: the delegation-shape backstop
-
-A deny list is fail-open against tools that do not exist yet, and Claude Code's delegation surface is visibly growing.
-`permissions.allow` is a pre-approval list rather than an availability list, so there is no fail-closed positive allowlist to use instead.
-Layer 2 closes that forward-looking gap and nothing else.
-
-`bin/fm-subagent-pretool-check.sh` classifies the tool NAME by shape rather than against a fixed list, because a second fixed list would be a weaker duplicate of layer 1 and would add no coverage.
+`bin/fm-subagent-pretool-check.sh` classifies the tool NAME by shape rather than against a fixed list.
+The tracked Claude PreToolUse matcher is `.*`, so every Claude tool name reaches the script and the script is the single owner of classification.
+A stem-enumerating matcher would reintroduce the fail-open-by-enumeration problem this guard exists to solve, because any future tool name outside the matcher would be silently missed before the script could inspect it.
 A tool is delegation-shaped when its normalized lowercase name contains one of these stems:
 
 ```text
@@ -89,14 +52,71 @@ Two exclusions keep the shape test from producing false positives.
   An MCP server chooses its own tool names, a task or agent noun there is common, and it has no bearing on fleet dispatch.
 - The exact names `taskoutput`, `taskstop`, `taskget`, `tasklist`, `cronlist`, `bashoutput`, and `killshell` are allowed.
   These observe or stop work that already exists rather than creating it, and denying them at this layer could strand already-running work with no way to inspect or end it.
-  Layer 1 is the wider, captain-owned layer and may still remove them from the schema; layer 2 stays narrower on purpose so it can never be the reason a runaway task cannot be stopped.
+  The recommended per-home local hardening is the wider, captain-owned layer and may still remove them from the schema.
+  The shipped guard stays narrower on purpose so it can never be the reason a runaway task cannot be stopped.
 
-Because layer 1 removes today's known tools from the schema, layer 2 never fires on them in normal operation.
-It fires only on a delegation-shaped name layer 1 does not know about, which is exactly the case it exists for, and which is verified live below.
+The shipped guard fires on every delegation-shaped name that reaches it, including future names that no deny list knows about yet.
+That future-name behavior is the reason the tracked matcher must match all tools and let the script filter.
+
+## Recommended per-home local hardening
+
+Claude primaries should add this as local per-home settings, not tracked shared project settings:
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Task",
+      "Agent",
+      "Workflow",
+      "RemoteTrigger",
+      "Monitor",
+      "ScheduleWakeup",
+      "SendMessage",
+      "EnterWorktree",
+      "ExitWorktree",
+      "CronCreate",
+      "CronDelete",
+      "CronList",
+      "TaskCreate",
+      "TaskGet",
+      "TaskList",
+      "TaskUpdate",
+      "TaskStop",
+      "TaskOutput"
+    ]
+  }
+}
+```
+
+A denied name is removed from the model's schema entirely.
+The model is never offered the tool, so there is no call to intercept, no matcher to get wrong, no fail-open path, and no dependence on the model's cooperation.
+This is removal, not interception, and it is strictly stronger than any hook.
+
+This list is not tracked for two reasons.
+It is Claude-only and cannot be the harness-agnostic shipped answer.
+The tracked `.claude/settings.json` file propagates into linked firstmate-repo worktrees, where it disarms legitimate crewmates by removing the delegation tools before the hook's linked-worktree scope check or `FM_ALLOW_SUBAGENT=1` can help.
+A Claude session in the task worktree for this change reported no `Agent` tool while the tracked deny list was present, which confirms the settings layer is upstream of the hook boundary.
+
+The width of the local list is a captain-owned decision, because denying some of these changes how the captain works with the primary session.
+In particular `TaskOutput`, `TaskStop`, `TaskGet`, `TaskList`, and `CronList` only observe or stop work that already exists.
+They cannot create unaccounted work, and a narrower local list that keeps them is a legitimate choice.
+
+### Both `Task` and `Agent` are valid deny keys
+
+The tool presents to the model as `Agent`.
+A prior investigation recorded that the deny key must be `Task` and that using `Agent` "silently does nothing at all".
+That is not what this machine shows.
+
+A five-way A/B with a control, each run in its own directory to rule out settings caching, found that `Task` and `Agent` each independently remove the tool, and that a nonsense name leaves it present.
+The full evidence is in the validation record below.
+
+Pinning both names in local hardening is correct regardless of which build is running.
+It costs one line and removes the failure mode where a rename or a rollback silently reopens the surface.
 
 ## Scope
 
-Layer 2 fires only in a genuine firstmate primary home, using the shared predicate `fm_primary_scope_matches` from `bin/fm-primary-scope-lib.sh`.
+The shipped guard fires only in a genuine firstmate primary home, using the shared predicate `fm_primary_scope_matches` from `bin/fm-primary-scope-lib.sh`.
 This is the same predicate `bin/fm-sessionstart-nudge.sh` and `bin/fm-turnend-guard.sh` use, so the three tracked primary-scoped hooks cannot drift apart.
 
 A home is in scope when it has `AGENTS.md`, a `bin/` directory, an existing state directory, and either a plain checkout where git-dir equals git-common-dir or a valid `.fm-secondmate-home` marker.
@@ -107,20 +127,20 @@ A crewmate using delegation tools inside its own task worktree is legitimate and
 A non-firstmate repo is out of scope.
 Any failure to confirm the home is inert, never a block, so a broken environment can never deny a tool call.
 
-Layer 1 has no such scoping, because `.claude/settings.json` applies to whatever checkout it sits in.
-This is not a gap: a crewmate works in a project worktree with its own settings, not in firstmate's.
+The tracked `.claude/settings.json` carries no `permissions.deny` key, because project settings have no way to express the crewmate-linked-worktree exception.
+Local per-home hardening has no hook scope and must be applied only where the captain wants Claude's own delegation tools removed from the primary schema.
 
 ## Escape hatch
 
-`FM_ALLOW_SUBAGENT=1` in the session environment allows the call at layer 2.
+`FM_ALLOW_SUBAGENT=1` in the session environment allows the call at the shipped guard.
 This is the only escape hatch and the guard fails closed on every other value, including empty, `0`, `yes`, and `true`.
 
 It is an environment variable rather than a flag, a config file, or a state file because that makes it unforgeable in-session.
 The variable must be present when the harness process is launched, so no tool call the agent makes can enable it for the call that follows.
 A deliberate use therefore requires restarting the session with the variable set, which is a conscious act, while an accidental use is impossible.
 
-The escape hatch does not affect layer 1.
-A tool removed from the schema stays removed, so a genuinely intended use of a denied tool also requires editing the deny list.
+The escape hatch does not affect local Claude hardening.
+A tool removed from the schema stays removed, so a genuinely intended use of a locally denied tool also requires editing the local deny list.
 
 ## Output contract
 
@@ -142,7 +162,7 @@ Applicability turns on one question: does the harness expose built-in delegation
 
 | Harness | Delegation surface | Status |
 | --- | --- | --- |
-| Claude | 18 tools, listed above | Both layers wired and live-verified. |
+| Claude | 18 tools, listed above | Shipped guard wired and live-verified; per-home local hardening is recommended and live-verified. |
 | Codex | none | Not applicable, verified empirically below. Codex 0.144.1 exposes no subagent, sub-task, or delegated-agent tool, so there is nothing to remove or intercept. `.codex/hooks.json` is unchanged. |
 | Grok | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
 | OpenCode | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
@@ -185,7 +205,7 @@ Codex is therefore not applicable today, and this table row is the tripwire: if 
 
 ### Grok, OpenCode, and Pi, inspected but not wired
 
-The integration surface of each was inspected and each is structurally wireable for layer 2.
+The integration surface of each was inspected and each is structurally wireable for the shipped guard.
 
 - Grok's tracked hooks (`.grok/hooks/fm-primary-pretool-check.json`, `.grok/hooks/fm-primary-cd-check.json`) use a `PreToolUse` matcher, currently `Bash`, and pipe stdin to a checker.
   The checker already reads Grok's `.toolName` field, so only the matcher token is missing.
@@ -224,6 +244,7 @@ claude -p "$PROMPT" --dangerously-skip-permissions --output-format text
 The tool name delivered to PreToolUse hooks was established before any matcher was written, using a throwaway project whose only hook appended `.tool_name` to a log for matcher `.*`.
 It logged `Agent` and `Bash`.
 A second project using matcher `^(Task|Agent)$` logged `Agent` only, confirming both the live tool name and that Claude Code honors regex anchors in a PreToolUse matcher.
+The tracked matcher is now `.*`, matching the throwaway-project evidence above so any future tool name reaches the script classifier.
 
 ### Deny-key A/B, with control
 
@@ -253,9 +274,10 @@ TaskList*, TaskOutput*, TaskStop*, TaskUpdate*, WebFetch*, WebSearch*
 A `*` marks a deferred tool, which is lazy-loaded through `ToolSearch` and does not appear in a plain tool list unless the prompt asks for deferred entries.
 This distinction matters when reading the next result: a tool absent from a plain listing is not necessarily denied.
 
-### Layer 1, tracked settings
+### Local deny-list hardening
 
-Run in a scratch firstmate-shaped project containing `AGENTS.md`, `state/`, a full copy of `bin/`, and the tracked `.claude/settings.json` byte for byte.
+Run in a scratch firstmate-shaped project containing `AGENTS.md`, `state/`, a full copy of `bin/`, and the recommended local deny-list settings.
+This was originally run while the deny list was still in tracked project settings; the result remains the validation record for the local hardening JSON above.
 Asking for deferred entries explicitly returned:
 
 ```text
@@ -266,9 +288,9 @@ DesignSync*, NotebookEdit*, PushNotification*, WebFetch*, WebSearch*
 All 18 denied names are gone and every ordinary working tool remains, including the five deferred ones.
 Comparing against the 29-tool baseline confirms the removal set is exactly the deny list and nothing else.
 
-### Layer 2, the case layer 1 cannot cover
+### Shipped guard, the case local hardening cannot cover
 
-To reproduce a future tool that ships before the deny list is updated, `Workflow` was removed from the deny list in the same scratch project while the backstop stayed wired.
+To reproduce a future tool that ships before local hardening is updated, `Workflow` was removed from the deny list in the same scratch project while the guard stayed wired.
 
 Prompt: `Call the Workflow tool to run any trivial workflow. You must actually attempt the Workflow tool call.`
 
@@ -282,9 +304,9 @@ I attempted the Workflow tool call as requested. It was blocked by a PreToolUse 
 > deliberate exception.
 ```
 
-This is the load-bearing result: the backstop denied a delegation tool that the deny list did not cover, which is the only situation it exists for, and it proves the layer is additive rather than dead code.
+This is the load-bearing result: the shipped guard denied a delegation tool that the deny list did not cover, which is the future-name case the shape classifier exists for.
 
-### Layer 2 scope, the negative case
+### Shipped guard scope, the negative case
 
 The same `Workflow` prompt was then run in a `git worktree add` linked worktree of that scratch project, carrying the identical tracked hook and checker bytes, with no escape hatch.
 
@@ -308,12 +330,12 @@ Result: the Workflow tool call was NOT blocked by a hook. It launched and ran to
 
 A Claude deny is honored only when the hook's stdout is empty.
 `tests/fm-subagent-pretool-check.test.sh` asserts stdout is empty on every `--claude` deny and that default mode still emits the Grok object on stdout.
-The live consequence is confirmed by the layer 2 result above: Claude honored the deny and reported the reason text.
+The live consequence is confirmed by the shipped-guard result above: Claude honored the deny and reported the reason text.
 
 ## Automated validation
 
 `tests/fm-subagent-pretool-check.test.sh` owns the acceptance matrix and is registered in the `pure-contract-unit` family in `bin/fm-test-run.sh`.
-It covers the layer 1 deny list, both the denied set and the preserved ordinary tools; layer 2 denial of every work-creating delegation tool by shape; layer 2 denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop and MCP exclusions; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
+It covers the absence of `permissions.deny` from tracked Claude settings; the match-all Claude hook registration; denial of every work-creating delegation tool by shape; denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop and MCP exclusions; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
 
 Run:
 
@@ -321,13 +343,16 @@ Run:
 bash -n bin/fm-subagent-pretool-check.sh
 bin/fm-lint.sh
 tests/fm-subagent-pretool-check.test.sh
-bin/fm-test-run.sh --all
 ```
 
 ## Known residual gap
 
-Both layers are harness-surface fences.
-A determined primary could still create unaccounted work through `Bash` on any harness, and the `.meta`-blindness described at the top of this document is harness-independent.
+This change does not close the deeper harness-agnostic defect.
+Every firstmate guard keys off `state/<id>.meta`, and only `bin/fm-spawn.sh` writes that record.
+`bin/fm-supervision-lib.sh` counts `state/*.meta`, and `bin/fm-turnend-guard.sh` exits silently at zero.
+Unaccounted primary work therefore reads as idle rather than suspicious.
 
-The durable fix for that class is to make the guards treat "the primary is doing project-shaped work with zero `state/*.meta` files" as a suspicious state rather than an idle one, instead of keying in-flight detection solely on a record that only `bin/fm-spawn.sh` writes.
+The durable fix for that class is to make the guards treat "the primary is doing project-shaped work with zero `state/*.meta` files" as a suspicious state rather than an idle one.
+That would catch this class on any harness, including work created through `Bash`.
+This change fences only the Claude tool surface.
 That is a separate change to `bin/fm-supervision-lib.sh` and `bin/fm-turnend-guard.sh` and is out of scope here.

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -1,0 +1,333 @@
+# Primary-session delegation guard
+
+This document is the authoritative human-readable contract for the two-layer guard that stops a firstmate primary from delegating work outside the fleet.
+
+Layer 1 is the `permissions.deny` list in `.claude/settings.json`, which removes the delegation tools from the model's schema.
+Layer 2 is `bin/fm-subagent-pretool-check.sh`, a PreToolUse backstop that denies a delegation-SHAPED tool name so a tool that ships before anyone updates layer 1 is still refused.
+Layer 1 is the primary fix; layer 2 exists only to cover what layer 1 structurally cannot.
+
+## Why this exists
+
+On 2026-07-22 a firstmate primary ran four workers through Claude Code's built-in subagent tool instead of `bin/fm-spawn.sh`.
+Three consequences were observed, not hypothesized.
+
+- The fleet view showed zero work under way for the whole run, because no `state/<id>.meta` and no `data/<id>/brief.md` were ever created.
+- When the primary session restarted, two of those workers died mid-flight and their work was lost.
+  A real crewmate lives in its own backend session with durable state and survives a primary restart.
+- The supervision cycle then stayed down for 73 minutes unnoticed, which silently killed the captain's Workflowy intake channel, since that channel only fires while a watch cycle runs.
+
+The deeper defect is that the bypass did not merely skip dispatch, it made the guard stack structurally inert.
+Only `bin/fm-spawn.sh` writes `state/<id>.meta`, and every guard keys off that record: `bin/fm-supervision-lib.sh` counts `state/*.meta`, and `bin/fm-turnend-guard.sh` exits silently when that count is zero.
+Work started through the harness's own delegation tool writes no metadata, so the in-flight count stayed at zero, the turn-end guard never blocked a blind turn end, and the continuity gate was inert.
+
+That is the reason the fence has to sit at the tool-availability layer, before the model can act.
+No additional guard keyed on task metadata can catch this class of failure, because the failure is precisely the absence of that metadata.
+
+## Purpose and boundary
+
+The guard addresses one concrete, mechanically identifiable event: the primary session reaching for a tool that creates work the fleet will not know about.
+
+It deliberately does **not** address the broader question of whether a given piece of work should be delegated at all.
+That question is a judgment boundary over read-and-think work, it has no tool-shape signal, and a hook that tried to police it would degrade into an advisory nag.
+The scope line is therefore: wrong tool reached for, deny; wrong amount of thinking done before reaching for a tool, out of scope.
+
+The guard is also not a dispatch-quality check.
+It says nothing about whether the resulting brief, project, or delivery mode is correct.
+
+## Layer 1: the tool-availability deny list
+
+`.claude/settings.json` carries a single `permissions.deny` array.
+This is the one place the denied surface is enumerated, and it is deliberately a flat, readable list so its width can be reviewed at a glance.
+
+A denied name is removed from the model's schema entirely.
+The model is never offered the tool, so there is no call to intercept, no matcher to get wrong, no fail-open path, and no dependence on the model's cooperation.
+This is removal, not interception, and it is strictly stronger than any hook.
+
+The denied set is 18 names:
+
+```text
+Task  Agent  Workflow  RemoteTrigger  Monitor  ScheduleWakeup  SendMessage
+EnterWorktree  ExitWorktree  CronCreate  CronDelete  CronList
+TaskCreate  TaskGet  TaskList  TaskUpdate  TaskStop  TaskOutput
+```
+
+The width of this list is a captain-owned decision, because denying some of these changes how the captain works with the primary session.
+In particular `TaskOutput`, `TaskStop`, `TaskGet`, `TaskList`, and `CronList` only observe or stop work that already exists; they cannot create unaccounted work, and a narrower list that keeps them is a legitimate choice.
+The list ships at the wider setting so the surface is closed by default, and narrowing it is a one-line edit in one file.
+
+`tests/fm-subagent-pretool-check.test.sh` asserts every name above stays denied and that no ordinary working tool is denied, so a careless edit or a Claude Code upgrade cannot silently drop one.
+
+### Both `Task` and `Agent` are valid deny keys
+
+The tool presents to the model as `Agent`.
+A prior investigation recorded that the deny key must be `Task` and that using `Agent` "silently does nothing at all".
+That is not what this machine shows.
+
+A five-way A/B with a control, each run in its own directory to rule out settings caching, found that `Task` and `Agent` each independently remove the tool, and that a nonsense name leaves it present.
+The full evidence is in the validation record below.
+
+Both names are therefore pinned in the deny list and asserted by the test suite.
+Pinning both is correct regardless of which build is running: it costs one line and it removes the failure mode where a rename or a rollback silently reopens the surface.
+
+## Layer 2: the delegation-shape backstop
+
+A deny list is fail-open against tools that do not exist yet, and Claude Code's delegation surface is visibly growing.
+`permissions.allow` is a pre-approval list rather than an availability list, so there is no fail-closed positive allowlist to use instead.
+Layer 2 closes that forward-looking gap and nothing else.
+
+`bin/fm-subagent-pretool-check.sh` classifies the tool NAME by shape rather than against a fixed list, because a second fixed list would be a weaker duplicate of layer 1 and would add no coverage.
+A tool is delegation-shaped when its normalized lowercase name contains one of these stems:
+
+```text
+agent  subagent  task  workflow  cron  schedul  worktree
+delegate  spawn  dispatch  handoff  remote  sendmessage  monitor
+```
+
+Two exclusions keep the shape test from producing false positives.
+
+- A name beginning `mcp__` is never classified.
+  An MCP server chooses its own tool names, a task or agent noun there is common, and it has no bearing on fleet dispatch.
+- The exact names `taskoutput`, `taskstop`, `taskget`, `tasklist`, `cronlist`, `bashoutput`, and `killshell` are allowed.
+  These observe or stop work that already exists rather than creating it, and denying them at this layer could strand already-running work with no way to inspect or end it.
+  Layer 1 is the wider, captain-owned layer and may still remove them from the schema; layer 2 stays narrower on purpose so it can never be the reason a runaway task cannot be stopped.
+
+Because layer 1 removes today's known tools from the schema, layer 2 never fires on them in normal operation.
+It fires only on a delegation-shaped name layer 1 does not know about, which is exactly the case it exists for, and which is verified live below.
+
+## Scope
+
+Layer 2 fires only in a genuine firstmate primary home, using the shared predicate `fm_primary_scope_matches` from `bin/fm-primary-scope-lib.sh`.
+This is the same predicate `bin/fm-sessionstart-nudge.sh` and `bin/fm-turnend-guard.sh` use, so the three tracked primary-scoped hooks cannot drift apart.
+
+A home is in scope when it has `AGENTS.md`, a `bin/` directory, an existing state directory, and either a plain checkout where git-dir equals git-common-dir or a valid `.fm-secondmate-home` marker.
+A marked secondmate home is in scope on purpose: it operates its own fleet and must dispatch through it for the same durability reasons.
+
+A crewmate's disposable task worktree is a linked git worktree, which is the shape `bin/fm-spawn.sh` always hands out, so it is out of scope.
+A crewmate using delegation tools inside its own task worktree is legitimate and stays allowed.
+A non-firstmate repo is out of scope.
+Any failure to confirm the home is inert, never a block, so a broken environment can never deny a tool call.
+
+Layer 1 has no such scoping, because `.claude/settings.json` applies to whatever checkout it sits in.
+This is not a gap: a crewmate works in a project worktree with its own settings, not in firstmate's.
+
+## Escape hatch
+
+`FM_ALLOW_SUBAGENT=1` in the session environment allows the call at layer 2.
+This is the only escape hatch and the guard fails closed on every other value, including empty, `0`, `yes`, and `true`.
+
+It is an environment variable rather than a flag, a config file, or a state file because that makes it unforgeable in-session.
+The variable must be present when the harness process is launched, so no tool call the agent makes can enable it for the call that follows.
+A deliberate use therefore requires restarting the session with the variable set, which is a conscious act, while an accidental use is impossible.
+
+The escape hatch does not affect layer 1.
+A tool removed from the schema stays removed, so a genuinely intended use of a denied tool also requires editing the deny list.
+
+## Output contract
+
+- Allow returns exit 0 with both streams empty.
+- Deny returns exit 2 and writes `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[subagent-dispatch] ..."}` to stderr.
+- Default deny mode also writes `{"decision":"deny","reason":"[subagent-dispatch] ..."}` to stdout for Grok.
+- `--claude` suppresses stdout completely, because Claude Code ignores a PreToolUse deny when stdout is nonempty.
+  This is the same verified quirk recorded in [`arm-pretool-check.md`](arm-pretool-check.md), and the tracked Claude hook therefore passes `--claude`.
+- Malformed or empty stdin, invalid JSON, a payload with no tool name, and missing `jq` for stdin transport all fail open with exit 0 and no output.
+
+The deny message names the real dispatch path.
+When `bin/fm-scout.sh` exists in the home it routes investigation and diagnosis there and ship work to `bin/fm-brief.sh` then `bin/fm-spawn.sh`.
+When that script is absent the message degrades to naming `bin/fm-brief.sh` then `bin/fm-spawn.sh` for both, rather than pointing at a script that is not there.
+
+## Harness wiring
+
+Every supported primary harness was reviewed.
+Applicability turns on one question: does the harness expose built-in delegation tools that a primary session could use instead of `bin/fm-spawn.sh`?
+
+| Harness | Delegation surface | Status |
+| --- | --- | --- |
+| Claude | 18 tools, listed above | Both layers wired and live-verified. |
+| Codex | none | Not applicable, verified empirically below. Codex 0.144.1 exposes no subagent, sub-task, or delegated-agent tool, so there is nothing to remove or intercept. `.codex/hooks.json` is unchanged. |
+| Grok | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
+| OpenCode | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
+| Pi | none reported | Not wired pending live verification. See below. |
+
+### Codex, verified not applicable
+
+Codex 0.144.1 was asked to enumerate its own tools in a scratch git repo on 2026-07-22.
+
+```sh
+codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check \
+  "List the exact names of every tool available to you in this session, one per line, nothing else. Then state on a final line whether you have any tool that spawns a subagent, sub-task, or delegated agent: answer SUBAGENT_TOOL=yes or SUBAGENT_TOOL=no."
+```
+
+Exact reported tool set and verdict:
+
+```text
+web.run
+functions.exec_command
+functions.write_stdin
+functions.list_mcp_resources
+functions.list_mcp_resource_templates
+functions.read_mcp_resource
+functions.update_plan
+functions.request_user_input
+functions.request_plugin_install
+functions.view_image
+functions.get_goal
+functions.create_goal
+functions.update_goal
+functions.apply_patch
+image_gen.imagegen
+tool_search.tool_search_tool
+multi_tool_use.parallel
+SUBAGENT_TOOL=no
+```
+
+`multi_tool_use.parallel` batches calls to the tools above; it does not spawn an agent.
+Codex is therefore not applicable today, and this table row is the tripwire: if a future Codex release adds a delegated-agent tool, wire `.codex/hooks.json` the same way its `Bash` PreToolUse entries already forward stdin to a checker.
+
+### Grok, OpenCode, and Pi, inspected but not wired
+
+The integration surface of each was inspected and each is structurally wireable for layer 2.
+
+- Grok's tracked hooks (`.grok/hooks/fm-primary-pretool-check.json`, `.grok/hooks/fm-primary-cd-check.json`) use a `PreToolUse` matcher, currently `Bash`, and pipe stdin to a checker.
+  The checker already reads Grok's `.toolName` field, so only the matcher token is missing.
+  Grok does expose a delegation surface: `docs/supervision-protocols/grok.md` documents `get_command_or_subagent_output(<task_id>)`, which implies a corresponding dispatch tool.
+- OpenCode's tracked plugins gate on `input?.tool !== "bash"` inside `tool.execute.before`, and block by throwing.
+  Swapping that comparison for a call into this checker with `--tool` is the whole change.
+- Pi's tracked extension gates on `event.toolName !== "bash"` inside `pi.on("tool_call", ...)` and blocks by returning `{block: true}`.
+  The same change applies. A parallel evaluation reports that Pi exposes no delegation tool at all, which would make it not applicable, but that was not verified here.
+
+None of the three is wired in this change because none of the three binaries is installed on the host where this work was done, so the exact tool-name tokens could not be confirmed and the wiring could not be validated against the real harness.
+This repo's rule in the `firstmate-coding-guidelines` skill is that a harness hook must be validated in a scratch project before it is trusted, and `arm-pretool-check.md` records the concrete cost of guessing: a Grok hook whose `command` string is even slightly wrong fails to launch the hook at all.
+Wiring an unvalidated matcher would trade a known gap for an unknown breakage.
+
+The bounded follow-up for each is identical to the Codex procedure above.
+On a host with the binary installed, ask the harness to enumerate its tools, then wire the matcher and re-run the live matrix below.
+`bin/fm-subagent-pretool-check.sh` needs no change for any of them: it already accepts Grok's stdin shape and the `--tool` CLI form OpenCode and Pi use, and it already emits the Grok stdout decision object by default.
+
+## Live validation record, 2026-07-22
+
+Harness version:
+
+```text
+2.1.217 (Claude Code)
+```
+
+Every run used a scratch project under this task worktree.
+No modified file was installed into the primary checkout or a live harness configuration, and no live watcher, fleet state, or task metadata was used.
+The launch command throughout was:
+
+```sh
+claude -p "$PROMPT" --dangerously-skip-permissions --output-format text
+```
+
+### Tool name and matcher mechanics
+
+The tool name delivered to PreToolUse hooks was established before any matcher was written, using a throwaway project whose only hook appended `.tool_name` to a log for matcher `.*`.
+It logged `Agent` and `Bash`.
+A second project using matcher `^(Task|Agent)$` logged `Agent` only, confirming both the live tool name and that Claude Code honors regex anchors in a PreToolUse matcher.
+
+### Deny-key A/B, with control
+
+Prompt: `List the exact names of every tool available to you, comma-separated on one line, nothing else.`
+Each variant ran in its own fresh directory to rule out settings caching.
+
+| `.claude/settings.json` | `Agent` in tool list? |
+| --- | --- |
+| `{}` | Yes |
+| `{"permissions":{"deny":["Task"]}}` | No |
+| `{"permissions":{"deny":["Agent"]}}` | No |
+| `{"permissions":{"deny":["ZzzNotARealTool"]}}` | Yes |
+| `{"permissions":{"deny":["Task","Agent"]}}` | No |
+
+The nonsense-name control is what makes this conclusive: the tool disappears only when a real name is denied, so the removal is caused by the deny entry rather than by run-to-run variation.
+Both `Task` and `Agent` are therefore working deny keys on this build, correcting the earlier claim that only `Task` works.
+
+The observed baseline surface was 29 tools:
+
+```text
+Agent, Bash, Edit, Read, ReportFindings, ScheduleWakeup, Skill, ToolSearch, Workflow, Write,
+CronCreate*, CronDelete*, CronList*, DesignSync*, EnterWorktree*, ExitWorktree*, Monitor*,
+NotebookEdit*, PushNotification*, RemoteTrigger*, SendMessage*, TaskCreate*, TaskGet*,
+TaskList*, TaskOutput*, TaskStop*, TaskUpdate*, WebFetch*, WebSearch*
+```
+
+A `*` marks a deferred tool, which is lazy-loaded through `ToolSearch` and does not appear in a plain tool list unless the prompt asks for deferred entries.
+This distinction matters when reading the next result: a tool absent from a plain listing is not necessarily denied.
+
+### Layer 1, tracked settings
+
+Run in a scratch firstmate-shaped project containing `AGENTS.md`, `state/`, a full copy of `bin/`, and the tracked `.claude/settings.json` byte for byte.
+Asking for deferred entries explicitly returned:
+
+```text
+Bash, Edit, Read, ReportFindings, Skill, ToolSearch, Write,
+DesignSync*, NotebookEdit*, PushNotification*, WebFetch*, WebSearch*
+```
+
+All 18 denied names are gone and every ordinary working tool remains, including the five deferred ones.
+Comparing against the 29-tool baseline confirms the removal set is exactly the deny list and nothing else.
+
+### Layer 2, the case layer 1 cannot cover
+
+To reproduce a future tool that ships before the deny list is updated, `Workflow` was removed from the deny list in the same scratch project while the backstop stayed wired.
+
+Prompt: `Call the Workflow tool to run any trivial workflow. You must actually attempt the Workflow tool call.`
+
+Claude reported:
+
+```text
+I attempted the Workflow tool call as requested. It was blocked by a PreToolUse hook in this repo:
+
+> [subagent-dispatch] the firstmate primary dispatches through the fleet, not the harness's own
+> delegation tools... (blocked tool: Workflow). Launch the session with FM_ALLOW_SUBAGENT=1 for a
+> deliberate exception.
+```
+
+This is the load-bearing result: the backstop denied a delegation tool that the deny list did not cover, which is the only situation it exists for, and it proves the layer is additive rather than dead code.
+
+### Layer 2 scope, the negative case
+
+The same `Workflow` prompt was then run in a `git worktree add` linked worktree of that scratch project, carrying the identical tracked hook and checker bytes, with no escape hatch.
+
+```text
+The Workflow tool call was not blocked by a hook. It executed normally: launched, ran 1 agent,
+and completed successfully returning {"result":"ok"}.
+```
+
+Same hook, same bytes, deny in the primary home and allow in a crewmate-shaped worktree.
+This is the scoping contract working end to end rather than a hook that simply never fires.
+
+### Escape hatch
+
+The same `Workflow` prompt in the scratch primary home, launched as `FM_ALLOW_SUBAGENT=1 claude -p ...`:
+
+```text
+Result: the Workflow tool call was NOT blocked by a hook. It launched and ran to completion.
+```
+
+### Empty-stdout requirement
+
+A Claude deny is honored only when the hook's stdout is empty.
+`tests/fm-subagent-pretool-check.test.sh` asserts stdout is empty on every `--claude` deny and that default mode still emits the Grok object on stdout.
+The live consequence is confirmed by the layer 2 result above: Claude honored the deny and reported the reason text.
+
+## Automated validation
+
+`tests/fm-subagent-pretool-check.test.sh` owns the acceptance matrix and is registered in the `pure-contract-unit` family in `bin/fm-test-run.sh`.
+It covers the layer 1 deny list, both the denied set and the preserved ordinary tools; layer 2 denial of every work-creating delegation tool by shape; layer 2 denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop and MCP exclusions; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
+
+Run:
+
+```sh
+bash -n bin/fm-subagent-pretool-check.sh
+bin/fm-lint.sh
+tests/fm-subagent-pretool-check.test.sh
+bin/fm-test-run.sh --all
+```
+
+## Known residual gap
+
+Both layers are harness-surface fences.
+A determined primary could still create unaccounted work through `Bash` on any harness, and the `.meta`-blindness described at the top of this document is harness-independent.
+
+The durable fix for that class is to make the guards treat "the primary is doing project-shaped work with zero `state/*.meta` files" as a suspicious state rather than an idle one, instead of keying in-flight detection solely on a record that only `bin/fm-spawn.sh` writes.
+That is a separate change to `bin/fm-supervision-lib.sh` and `bin/fm-turnend-guard.sh` and is out of scope here.

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -2,9 +2,9 @@
 
 This document is the authoritative human-readable contract for the guard that stops a firstmate primary from delegating work outside the fleet.
 
-The shipped fix has two layers.
-The primary layer is the tracked `.claude/settings.json` `permissions.deny` list, because it removes known Claude delegation tools from the model's schema entirely.
-The backstop layer is `bin/fm-subagent-pretool-check.sh`, a PreToolUse guard that denies a delegation-SHAPED tool name in a genuine primary home when a future or unlisted tool reaches it.
+The shipped mechanism is `bin/fm-subagent-pretool-check.sh`, a PreToolUse guard that denies a delegation-SHAPED tool name in a genuine primary home.
+Claude primaries should also use an untracked per-home local `permissions.deny` list as hardening for known Claude delegation tools, because it removes them from the model's schema entirely.
+That deny list must not ship in tracked `.claude/settings.json` because it is Claude-only rather than harness-agnostic, and because tracked project settings propagate into linked worktrees where they disarm legitimate crewmates.
 
 ## Why this exists
 
@@ -34,12 +34,9 @@ The scope line is therefore: wrong tool reached for, deny; wrong amount of think
 The guard is also not a dispatch-quality check.
 It says nothing about whether the resulting brief, project, or delivery mode is correct.
 
-## Shipped layers
+## Shipped mechanism
 
-The primary shipped layer is tracked Claude `permissions.deny`.
-It removes the known 18-name Claude delegation, scheduling, worktree, and task-tracking surface before the model can call it.
-
-`bin/fm-subagent-pretool-check.sh` is the backstop shipped layer.
+`bin/fm-subagent-pretool-check.sh` is the shipped layer.
 It classifies the tool NAME by shape rather than against a fixed list.
 The tracked Claude PreToolUse matcher is `.*`, so every Claude tool name reaches the script and the script is the single owner of classification.
 A stem-enumerating matcher would reintroduce the fail-open-by-enumeration problem this guard exists to solve, because any future tool name outside the matcher would be silently missed before the script could inspect it.
@@ -56,15 +53,15 @@ Two exclusions keep the shape test from producing false positives.
   An MCP server chooses its own tool names, a task or agent noun there is common, and it has no bearing on fleet dispatch.
 - The exact names `taskoutput`, `taskstop`, `taskget`, `tasklist`, `cronlist`, `bashoutput`, and `killshell` are allowed.
   These observe or stop work that already exists rather than creating it, and denying them at this layer could strand already-running work with no way to inspect or end it.
-  The tracked deny list is the wider, captain-owned primary layer and removes them from the schema.
-  The backstop guard stays narrower on purpose so it can never be the reason a runaway task cannot be stopped.
+  A Claude primary's optional local deny list may still remove them from the schema.
+  The shipped guard stays narrower on purpose so it can never be the reason a runaway task cannot be stopped.
 
-The backstop guard fires on every delegation-shaped name that reaches it, including future names that no deny list knows about yet.
+The shipped guard fires on every delegation-shaped name that reaches it, including future names that no deny list knows about yet.
 That future-name behavior is the reason the tracked matcher must match all tools and let the script filter.
 
-## Tracked Claude deny-list primary layer
+## Recommended Local Claude Deny List
 
-Tracked Claude settings ship this top-level list:
+Claude primaries should add this deny list in untracked per-home local settings, never in tracked `.claude/settings.json`:
 
 ```json
 {
@@ -97,14 +94,20 @@ A denied name is removed from the model's schema entirely.
 The model is never offered the tool, so there is no call to intercept, no matcher to get wrong, no fail-open path, and no dependence on the model's cooperation.
 This is removal, not interception, and it is strictly stronger than any hook.
 
-This list is tracked because closing the known Claude surface is the primary shipped fix.
-The width of the list is a captain-owned decision, because denying some of these changes how the captain works with the primary session.
-It ships at the wider 18-name setting so the surface is closed by default, implemented as one flat array that is reviewable at a glance and narrowable in one line.
-In particular `TaskOutput`, `TaskStop`, `TaskGet`, `TaskList`, and `CronList` only observe or stop work that already exists, but the primary layer still removes them by default.
-The hook deliberately allows those names, so the backstop can never strand a runaway task with no way to inspect or end it.
+This list is recommended local hardening because it closes the known Claude surface before the hook is needed.
+It is not tracked for two reasons.
+
+- It is Claude-only, so it can never be the harness-agnostic shipped fix.
+- A tracked `.claude/settings.json` propagates into linked worktrees and disarms legitimate crewmates.
+  This was verified when a Claude session in a task worktree of this repo lost its `Agent` tool.
+
+The width of the list remains a captain-owned decision, because denying some of these changes how the captain works with the primary session.
+Keep it as one flat local array that is reviewable at a glance and narrowable in one line.
+In particular `TaskOutput`, `TaskStop`, `TaskGet`, `TaskList`, and `CronList` only observe or stop work that already exists, but the recommended local deny list still removes them by default.
+The hook deliberately allows those names, so the shipped guard can never strand a runaway task with no way to inspect or end it.
 
 `permissions.allow` is a pre-approval list, not an availability list, so there is no fail-closed positive allowlist available.
-That is why the fixed deny list is fail-open against future tools and why the shape-based backstop still exists.
+That is why any fixed deny list is fail-open against future tools and why the shape-based guard still exists.
 The hook cannot re-enable a tool removed from the schema; it only handles a tool name that still reaches PreToolUse.
 
 ### Both `Task` and `Agent` are valid deny keys
@@ -116,12 +119,12 @@ That is not what this machine shows.
 A five-way A/B with a control, each run in its own directory to rule out settings caching, found that `Task` and `Agent` each independently remove the tool, and that a nonsense name leaves it present.
 The full evidence is in the validation record below.
 
-Pinning both names in the tracked deny list is correct regardless of which build is running.
+Pinning both names in the recommended local deny list is correct regardless of which build is running.
 It costs one line and removes the failure mode where a rename or a rollback silently reopens the surface.
 
 ## Scope
 
-The backstop hook fires only in a genuine firstmate primary home, using the shared predicate `fm_primary_scope_matches` from `bin/fm-primary-scope-lib.sh`.
+The shipped hook fires only in a genuine firstmate primary home, using the shared predicate `fm_primary_scope_matches` from `bin/fm-primary-scope-lib.sh`.
 This is the same predicate `bin/fm-sessionstart-nudge.sh` and `bin/fm-turnend-guard.sh` use, so the three tracked primary-scoped hooks cannot drift apart.
 
 A home is in scope when it has `AGENTS.md`, a `bin/` directory, an existing state directory, and either a plain checkout where git-dir equals git-common-dir or a valid `.fm-secondmate-home` marker.
@@ -132,20 +135,21 @@ A crewmate using delegation tools inside its own task worktree is legitimate and
 A non-firstmate repo is out of scope.
 Any failure to confirm the home is inert, never a block, so a broken environment can never deny a tool call.
 
-The tracked deny list is upstream of hook scope and removes known Claude delegation tools wherever Claude applies the project settings.
-The hook scope is still load-bearing for future or un-denied names, and the linked-worktree negative case proves the script itself does not block legitimate crewmate delegation.
+A local Claude deny list is upstream of hook scope and removes known Claude delegation tools wherever Claude applies it.
+Do not put that list in tracked project settings, because linked worktrees inherit those settings and would lose legitimate delegation tools.
+The hook scope is the shipped enforcement boundary, and the linked-worktree negative case proves the script itself does not block legitimate crewmate delegation.
 
 ## Escape hatch
 
-`FM_ALLOW_SUBAGENT=1` in the session environment allows the call at the backstop hook.
+`FM_ALLOW_SUBAGENT=1` in the session environment allows the call at the shipped hook.
 This is the only escape hatch and the guard fails closed on every other value, including empty, `0`, `yes`, and `true`.
 
 It is an environment variable rather than a flag, a config file, or a state file because that makes it unforgeable in-session.
 The variable must be present when the harness process is launched, so no tool call the agent makes can enable it for the call that follows.
 A deliberate use therefore requires restarting the session with the variable set, which is a conscious act, while an accidental use is impossible.
 
-The escape hatch does not affect the tracked Claude deny list.
-A tool removed from the schema stays removed, so a genuinely intended use of a denied tool also requires editing the deny list.
+The escape hatch does not affect any local Claude deny list.
+A tool removed from the schema stays removed, so a genuinely intended use of a locally denied tool also requires narrowing or removing that local entry before launch.
 
 ## Output contract
 
@@ -167,7 +171,7 @@ Applicability turns on one question: does the harness expose built-in delegation
 
 | Harness | Delegation surface | Status |
 | --- | --- | --- |
-| Claude | 18 tools, listed above | Tracked deny list and backstop guard wired and live-verified. |
+| Claude | 18 known tools, listed above | Scoped guard wired and live-verified; untracked local deny list verified and recommended. |
 | Codex | none | Not applicable, verified empirically below. Codex 0.144.1 exposes no subagent, sub-task, or delegated-agent tool, so there is nothing to remove or intercept. `.codex/hooks.json` is unchanged. |
 | Grok | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
 | OpenCode | present, exact tokens unconfirmed | Not wired pending live verification. See below. |
@@ -210,7 +214,7 @@ Codex is therefore not applicable today, and this table row is the tripwire: if 
 
 ### Grok, OpenCode, and Pi, inspected but not wired
 
-The integration surface of each was inspected and each is structurally wireable for the backstop guard.
+The integration surface of each was inspected and each is structurally wireable for the shipped guard.
 
 - Grok's tracked hooks (`.grok/hooks/fm-primary-pretool-check.json`, `.grok/hooks/fm-primary-cd-check.json`) use a `PreToolUse` matcher, currently `Bash`, and pipe stdin to a checker.
   The checker already reads Grok's `.toolName` field, so only the matcher token is missing.
@@ -279,10 +283,10 @@ TaskList*, TaskOutput*, TaskStop*, TaskUpdate*, WebFetch*, WebSearch*
 A `*` marks a deferred tool, which is lazy-loaded through `ToolSearch` and does not appear in a plain tool list unless the prompt asks for deferred entries.
 This distinction matters when reading the next result: a tool absent from a plain listing is not necessarily denied.
 
-### Tracked deny-list primary layer
+### Local deny-list hardening
 
-Run in a scratch firstmate-shaped project containing `AGENTS.md`, `state/`, a full copy of `bin/`, and the tracked deny-list settings.
-The result validates the shipped deny-list JSON above.
+Run in a scratch firstmate-shaped project containing `AGENTS.md`, `state/`, a full copy of `bin/`, and a Claude settings file containing the recommended local deny-list JSON above.
+The result validates the recommended local deny-list JSON above, not tracked repo state.
 Asking for deferred entries explicitly returned:
 
 ```text
@@ -290,12 +294,12 @@ Bash, Edit, Read, ReportFindings, Skill, ToolSearch, Write,
 DesignSync*, NotebookEdit*, PushNotification*, WebFetch*, WebSearch*
 ```
 
-All 18 denied names are gone and every ordinary working tool remains, including the five deferred ones.
+All 18 locally denied names are gone and every ordinary working tool remains, including the five deferred ones.
 Comparing against the 29-tool baseline confirms the removal set is exactly the deny list and nothing else.
 
-### Backstop guard, the case a fixed deny list cannot cover
+### Shipped guard, the case a fixed deny list cannot cover
 
-To reproduce a future tool that ships before the tracked deny list is updated, `Workflow` was removed from the deny list in the same scratch project while the guard stayed wired.
+To reproduce a future tool that ships before a local deny list is updated, `Workflow` was removed from the deny list in the same scratch project while the guard stayed wired.
 
 Prompt: `Call the Workflow tool to run any trivial workflow. You must actually attempt the Workflow tool call.`
 
@@ -309,9 +313,9 @@ I attempted the Workflow tool call as requested. It was blocked by a PreToolUse 
 > deliberate exception.
 ```
 
-This is the load-bearing result: the backstop guard denied a delegation tool that the deny list did not cover, which is the future-name case the shape classifier exists for.
+This is the load-bearing result: the shipped guard denied a delegation tool that the deny list did not cover, which is the future-name case the shape classifier exists for.
 
-### Backstop guard scope, the negative case
+### Shipped guard scope, the negative case
 
 The same `Workflow` prompt was then run in a `git worktree add` linked worktree of that scratch project, carrying the identical tracked hook and checker bytes, with no escape hatch.
 
@@ -335,12 +339,12 @@ Result: the Workflow tool call was NOT blocked by a hook. It launched and ran to
 
 A Claude deny is honored only when the hook's stdout is empty.
 `tests/fm-subagent-pretool-check.test.sh` asserts stdout is empty on every `--claude` deny and that default mode still emits the Grok object on stdout.
-The live consequence is confirmed by the backstop-guard result above: Claude honored the deny and reported the reason text.
+The live consequence is confirmed by the shipped-guard result above: Claude honored the deny and reported the reason text.
 
 ## Automated validation
 
 `tests/fm-subagent-pretool-check.test.sh` owns the acceptance matrix and is registered in the `pure-contract-unit` family in `bin/fm-test-run.sh`.
-It covers the exact shipped `permissions.deny` list in tracked Claude settings; the match-all Claude hook registration; denial of every work-creating delegation tool by shape; denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop and MCP exclusions; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
+It covers the tracked Claude settings boundary that forbids a `permissions` key; the match-all Claude hook registration; denial of every work-creating delegation tool by shape; denial of twelve hypothetical future tool names that appear on no list; the observe-or-stop and MCP exclusions; the scout-present and scout-absent message variants; the escape hatch including its fail-closed values; inertness in a linked task worktree and in a non-firstmate repo; in-scope enforcement for a marked secondmate home; both stdin transports; the empty-stdout requirement; fail-open transport behavior; and the preserved `Bash` seatbelts and `Stop` guard.
 
 Run:
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -4,8 +4,8 @@ This is the authoritative contract for the "no turn ends blind" primary guard re
 The turn-end supervision predicate lives in `bin/fm-turnend-guard.sh`.
 Its primary-checkout scope lives in `bin/fm-primary-scope-lib.sh`, shared with the native session-start nudge documented in `docs/sessionstart-nudge.md`.
 Harness-specific tracked hook files only adapt each verified harness's real turn-end mechanism to that shared predicate.
-Two related but separate PreToolUse seatbelts deny a bad command shape before it runs rather than detecting a blind turn end afterward: the watcher-arm seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`) and the cd-guard (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`).
-Each seatbelt's own document defines its scope; they do not share the turn-end guard's marker-aware primary detection.
+Related but separate PreToolUse guards deny a bad tool or command shape before it runs rather than detecting a blind turn end afterward: the watcher-arm seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`), the cd-guard (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`), and the primary delegation-shape guard (`bin/fm-subagent-pretool-check.sh`, `docs/subagent-guard.md`).
+Each guard's own document defines its scope; do not infer this guard's scoping, loop safety, or fail-open tradeoffs for its PreToolUse siblings.
 
 ## Gap Closed
 

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -230,6 +230,23 @@ test_malformed_transport_fails_open() {
   pass "malformed, empty, and tool-name-less payloads fail open rather than blocking every tool call"
 }
 
+test_missing_jq_stdin_transport_fails_open() {
+  local fakebin="$TMP_ROOT/no-jq-bin" bash_bin cat_bin rc=0
+  bash_bin=$(command -v bash) || fail "test needs bash to simulate the hook shebang"
+  cat_bin=$(command -v cat) || fail "test needs cat to feed stdin without jq"
+  mkdir -p "$fakebin"
+  ln -sf "$bash_bin" "$fakebin/bash"
+  ln -sf "$cat_bin" "$fakebin/cat"
+  : > "$OUT"; : > "$ERR"
+  printf '%s' '{"tool_name":"Agent"}' \
+    | env PATH="$fakebin" FM_ROOT_OVERRIDE="$PRIMARY" FM_HOME="$PRIMARY" FM_STATE_OVERRIDE="$STATE" \
+      "$CHECK" --claude > "$OUT" 2> "$ERR" || rc=$?
+  [ "$rc" -eq 0 ] || fail "missing jq transport must fail open, got exit $rc: $(cat "$ERR")"
+  [ ! -s "$OUT" ] || fail "missing jq fail-open path wrote stdout: $(cat "$OUT")"
+  [ ! -s "$ERR" ] || fail "missing jq fail-open path wrote stderr: $(cat "$ERR")"
+  pass "missing jq for stdin transport fails open rather than denying every tool call"
+}
+
 test_claude_hook_registration_preserves_bash_seatbelts() {
   jq -e '
     [.hooks.PreToolUse[] | .hooks[].command]
@@ -264,4 +281,5 @@ test_task_worktree_and_non_firstmate_repo_are_inert
 test_secondmate_home_is_in_scope
 test_stdin_transports_and_output_shapes
 test_malformed_transport_fails_open
+test_missing_jq_stdin_transport_fails_open
 test_claude_hook_registration_preserves_bash_seatbelts

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# Behavior tests for the two-layer primary-session delegation guard: the
+# permissions.deny tool-availability list and the delegation-shape PreToolUse
+# backstop behind it.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CHECK="$ROOT/bin/fm-subagent-pretool-check.sh"
+SETTINGS="$ROOT/.claude/settings.json"
+TMP_ROOT=$(fm_test_tmproot fm-subagent-pretool-tests)
+PRIMARY="$TMP_ROOT/primary"
+STATE="$PRIMARY/state"
+OUT="$TMP_ROOT/out"
+ERR="$TMP_ROOT/err"
+
+mkdir -p "$PRIMARY/bin" "$STATE"
+printf '# fixture\n' > "$PRIMARY/AGENTS.md"
+git -C "$PRIMARY" init -q
+
+BRIEF_ONLY_ROUTE='investigation and ship work both go to bin/fm-brief.sh then bin/fm-spawn.sh'
+SCOUT_ROUTE='investigation or diagnosis goes to bin/fm-scout.sh "<question>" [project], and ship work goes to bin/fm-brief.sh then bin/fm-spawn.sh'
+
+# Every delegation, scheduling, worktree, and task-tracking tool Claude Code
+# 2.1.217 offers a primary session. Layer 1 must remove all of these from the
+# model's schema, so a Claude Code upgrade or a careless edit cannot silently
+# drop one. Recorded from an observed baseline tool list, see
+# docs/subagent-guard.md.
+DENIED_TOOLS='Task Agent Workflow RemoteTrigger Monitor ScheduleWakeup SendMessage EnterWorktree ExitWorktree CronCreate CronDelete CronList TaskCreate TaskGet TaskList TaskUpdate TaskStop TaskOutput'
+
+# Tools that must stay available: denying these would break ordinary work.
+PRESERVED_TOOLS='Bash Edit Read Write Skill ToolSearch WebFetch WebSearch NotebookEdit ReportFindings DesignSync PushNotification'
+
+run_tool() {
+  local tool=$1 rc=0
+  shift
+  : > "$OUT"
+  : > "$ERR"
+  env FM_ROOT_OVERRIDE="$PRIMARY" FM_HOME="$PRIMARY" FM_STATE_OVERRIDE="$STATE" "$@" \
+    "$CHECK" --claude --tool "$tool" > "$OUT" 2> "$ERR" || rc=$?
+  return "$rc"
+}
+
+expect_allow() {
+  local label=$1 tool=$2 rc=0
+  shift 2
+  run_tool "$tool" "$@" || rc=$?
+  [ "$rc" -eq 0 ] || fail "$label ($tool) must allow, got exit $rc: $(cat "$ERR")"
+  [ ! -s "$OUT" ] || fail "$label ($tool) allow wrote stdout: $(cat "$OUT")"
+  [ ! -s "$ERR" ] || fail "$label ($tool) allow wrote stderr: $(cat "$ERR")"
+}
+
+expect_deny() {
+  local label=$1 tool=$2 rc=0
+  run_tool "$tool" || rc=$?
+  [ "$rc" -eq 2 ] || fail "$label ($tool) must deny with exit 2, got $rc"
+  [ ! -s "$OUT" ] || fail "$label ($tool) deny wrote stdout: $(cat "$OUT")"
+  jq -e '.hookSpecificOutput.hookEventName == "PreToolUse" and .hookSpecificOutput.permissionDecision == "deny"' "$ERR" >/dev/null 2>&1 \
+    || fail "$label ($tool) deny omitted Claude's permission decision: $(cat "$ERR")"
+  jq -e --arg tool "$tool" '.systemMessage | startswith("[subagent-dispatch]") and contains("blocked tool: " + $tool)' "$ERR" >/dev/null 2>&1 \
+    || fail "$label ($tool) deny message lost its code or tool name: $(jq -r '.systemMessage' "$ERR")"
+}
+
+# ---------------------------------------------------------------------------
+# Layer 1: the permissions.deny tool-availability list (the primary fix).
+# ---------------------------------------------------------------------------
+
+test_deny_list_covers_every_known_delegation_tool() {
+  local tool
+  for tool in $DENIED_TOOLS; do
+    jq -e --arg t "$tool" '.permissions.deny | index($t)' "$SETTINGS" >/dev/null \
+      || fail "permissions.deny lost the delegation tool $tool"
+  done
+  # "Task" is the historical key and "Agent" is the name the tool presents
+  # under; both are verified to work and both are pinned so neither a rename
+  # nor a rollback can reopen the surface.
+  jq -e '.permissions.deny | index("Task") and index("Agent")' "$SETTINGS" >/dev/null \
+    || fail "both the Task and Agent deny keys must stay pinned"
+  pass "permissions.deny pins every known Claude Code delegation and scheduling tool"
+}
+
+test_deny_list_preserves_ordinary_tools() {
+  local tool
+  for tool in $PRESERVED_TOOLS; do
+    jq -e --arg t "$tool" '.permissions.deny | index($t) | not' "$SETTINGS" >/dev/null \
+      || fail "permissions.deny must not remove the ordinary tool $tool"
+  done
+  pass "permissions.deny leaves every ordinary working tool available"
+}
+
+# ---------------------------------------------------------------------------
+# Layer 2: the delegation-shape PreToolUse backstop.
+# ---------------------------------------------------------------------------
+
+test_backstop_denies_every_currently_known_delegation_tool() {
+  local tool
+  for tool in $DENIED_TOOLS; do
+    case "$tool" in
+      TaskOutput|TaskStop|TaskGet|TaskList|CronList) continue ;;
+    esac
+    expect_deny "known delegation tool" "$tool"
+  done
+  pass "the backstop independently denies every work-creating delegation tool by shape"
+}
+
+test_backstop_denies_hypothetical_future_tools() {
+  # The whole reason this layer exists: a deny list is fail-open against tools
+  # that do not exist yet. None of these names is on any list.
+  local tool
+  for tool in SubagentCreate SpawnWorker DelegateTask AgentPool WorkflowRun \
+              ScheduleJob CronSchedule CreateWorktree DispatchAgent TaskHandoff \
+              RemoteExec BackgroundAgent; do
+    expect_deny "future delegation tool" "$tool"
+  done
+  pass "the backstop denies delegation-shaped tools that no deny list knows about yet"
+}
+
+test_backstop_allows_ordinary_and_observe_only_tools() {
+  local tool
+  for tool in $PRESERVED_TOOLS; do
+    expect_allow "ordinary tool" "$tool"
+  done
+  # Observing or stopping work that already exists is not creating unaccounted
+  # work, and blocking it would strand a runaway task with no way to end it.
+  for tool in TaskOutput TaskStop TaskGet TaskList CronList BashOutput KillShell; do
+    expect_allow "observe-or-stop tool" "$tool"
+  done
+  pass "the backstop leaves ordinary tools and observe-or-stop operations alone"
+}
+
+test_backstop_never_classifies_mcp_tools() {
+  # An MCP server names its own tools; a task or agent noun there is common and
+  # has nothing to do with fleet dispatch.
+  local tool
+  for tool in mcp__linear__list_issues mcp__tracker__create_task \
+              mcp__acme__spawn_agent mcp__slack__slack_send_message; do
+    expect_allow "MCP tool" "$tool"
+  done
+  pass "MCP tool names are never classified as harness delegation"
+}
+
+test_scout_entry_point_named_when_present() {
+  local actual
+  printf '#!/usr/bin/env bash\n' > "$PRIMARY/bin/fm-scout.sh"
+  run_tool Agent && fail "scout-present case must still deny"
+  actual=$(jq -r '.systemMessage' "$ERR")
+  case "$actual" in
+    *"$SCOUT_ROUTE"*) ;;
+    *) fail "deny must name bin/fm-scout.sh when it exists: $actual" ;;
+  esac
+  rm -f "$PRIMARY/bin/fm-scout.sh"
+  run_tool Agent && fail "scout-absent case must still deny"
+  actual=$(jq -r '.systemMessage' "$ERR")
+  case "$actual" in
+    *"$BRIEF_ONLY_ROUTE"*) ;;
+    *) fail "deny must degrade to brief-then-spawn when fm-scout.sh is absent: $actual" ;;
+  esac
+  pass "deny names bin/fm-scout.sh when it exists and degrades gracefully when it does not"
+}
+
+test_escape_hatch_allows_deliberate_use() {
+  local rc value
+  expect_allow "escape hatch set" Agent FM_ALLOW_SUBAGENT=1
+  expect_deny "escape hatch unset" Agent
+  for value in '' 0 yes true 11; do
+    rc=0
+    run_tool Agent "FM_ALLOW_SUBAGENT=$value" || rc=$?
+    [ "$rc" -eq 2 ] || fail "FM_ALLOW_SUBAGENT='$value' must not release the guard, got exit $rc"
+  done
+  pass "the single documented escape hatch releases the guard only on the exact opt-in value"
+}
+
+test_task_worktree_and_non_firstmate_repo_are_inert() {
+  local child="$TMP_ROOT/child" plain="$TMP_ROOT/plain" rc=0
+  git -C "$PRIMARY" config user.name fixture
+  git -C "$PRIMARY" config user.email fixture@example.test
+  git -C "$PRIMARY" add AGENTS.md
+  git -C "$PRIMARY" commit -qm fixture
+  git -C "$PRIMARY" worktree add -q -b fixture-child "$child"
+  mkdir -p "$child/bin" "$child/state"
+  printf '# fixture\n' > "$child/AGENTS.md"
+  : > "$OUT"
+  : > "$ERR"
+  FM_ROOT_OVERRIDE="$child" FM_HOME="$child" FM_STATE_OVERRIDE="$child/state" \
+    "$CHECK" --claude --tool Agent > "$OUT" 2> "$ERR" || rc=$?
+  [ "$rc" -eq 0 ] || fail "a crewmate task worktree must be out of scope, got exit $rc: $(cat "$ERR")"
+  [ ! -s "$OUT" ] || fail "task-worktree no-op wrote stdout: $(cat "$OUT")"
+  [ ! -s "$ERR" ] || fail "task-worktree no-op wrote stderr: $(cat "$ERR")"
+
+  mkdir -p "$plain/bin"
+  git -C "$plain" init -q
+  rc=0
+  FM_ROOT_OVERRIDE="$plain" FM_HOME="$plain" FM_STATE_OVERRIDE="$plain/state" \
+    "$CHECK" --claude --tool Agent > "$OUT" 2> "$ERR" || rc=$?
+  [ "$rc" -eq 0 ] || fail "a non-firstmate repo must be out of scope, got exit $rc"
+  pass "the backstop is inert in a crewmate task worktree and in a non-firstmate repo"
+}
+
+test_secondmate_home_is_in_scope() {
+  local second="$TMP_ROOT/second" rc=0
+  git -C "$PRIMARY" worktree add -q -b fixture-second "$second"
+  mkdir -p "$second/bin" "$second/state"
+  printf '# fixture\n' > "$second/AGENTS.md"
+  printf 'sm-fixture\n' > "$second/.fm-secondmate-home"
+  FM_ROOT_OVERRIDE="$second" FM_HOME="$second" FM_STATE_OVERRIDE="$second/state" \
+    "$CHECK" --claude --tool Agent > "$OUT" 2> "$ERR" || rc=$?
+  [ "$rc" -eq 2 ] || fail "a marked secondmate home operates a fleet and must be guarded, got exit $rc"
+  pass "a marked secondmate home is guarded even though it is a linked worktree"
+}
+
+test_stdin_transports_and_output_shapes() {
+  local rc=0
+  : > "$OUT"; : > "$ERR"
+  printf '%s' '{"tool_name":"Agent","tool_input":{"prompt":"go"}}' \
+    | FM_ROOT_OVERRIDE="$PRIMARY" FM_HOME="$PRIMARY" FM_STATE_OVERRIDE="$STATE" \
+      "$CHECK" --claude > "$OUT" 2> "$ERR" || rc=$?
+  [ "$rc" -eq 2 ] || fail "Claude-shaped stdin must deny, got exit $rc"
+  [ ! -s "$OUT" ] || fail "Claude deny wrote stdout, which makes Claude ignore the deny: $(cat "$OUT")"
+
+  rc=0
+  : > "$OUT"; : > "$ERR"
+  printf '%s' '{"toolName":"Agent"}' \
+    | FM_ROOT_OVERRIDE="$PRIMARY" FM_HOME="$PRIMARY" FM_STATE_OVERRIDE="$STATE" \
+      "$CHECK" > "$OUT" 2> "$ERR" || rc=$?
+  [ "$rc" -eq 2 ] || fail "Grok-shaped stdin must deny, got exit $rc"
+  jq -e '.decision == "deny" and (.reason | startswith("[subagent-dispatch]"))' "$OUT" >/dev/null 2>&1 \
+    || fail "default deny mode must write a Grok decision object on stdout: $(cat "$OUT")"
+
+  rc=0
+  : > "$OUT"; : > "$ERR"
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"ls"}}' \
+    | FM_ROOT_OVERRIDE="$PRIMARY" FM_HOME="$PRIMARY" FM_STATE_OVERRIDE="$STATE" \
+      "$CHECK" --claude > "$OUT" 2> "$ERR" || rc=$?
+  [ "$rc" -eq 0 ] || fail "Bash through stdin must allow, got exit $rc"
+  [ ! -s "$OUT" ] && [ ! -s "$ERR" ] || fail "stdin allow wrote output"
+  pass "both stdin transports classify correctly and Claude's deny keeps stdout empty"
+}
+
+test_malformed_transport_fails_open() {
+  local rc payload
+  for payload in '{not-json' '' '{}' '{"tool_name":null}'; do
+    rc=0
+    : > "$OUT"; : > "$ERR"
+    printf '%s' "$payload" \
+      | FM_ROOT_OVERRIDE="$PRIMARY" FM_HOME="$PRIMARY" FM_STATE_OVERRIDE="$STATE" \
+        "$CHECK" --claude > "$OUT" 2> "$ERR" || rc=$?
+    [ "$rc" -eq 0 ] || fail "malformed transport must fail open, payload '$payload' gave exit $rc"
+    [ ! -s "$OUT" ] || fail "fail-open path wrote stdout for payload '$payload'"
+  done
+  pass "malformed, empty, and tool-name-less payloads fail open rather than blocking every tool call"
+}
+
+test_claude_hook_registration_preserves_bash_seatbelts() {
+  jq -e '
+    [.hooks.PreToolUse[] | select(.matcher != "Bash") | .hooks[].command]
+      | any(contains("fm-subagent-pretool-check.sh --claude"))
+  ' "$SETTINGS" >/dev/null || fail "Claude settings omit the delegation-shape PreToolUse backstop"
+  # The backstop matcher must reach the delegation-shaped names, not just one
+  # literal tool, or it cannot catch a future tool at all.
+  jq -e '
+    [.hooks.PreToolUse[] | select(.hooks[].command | contains("fm-subagent-pretool-check.sh")) | .matcher] | .[0]
+      | (contains("Agent") and contains("Task") and contains("Workflow") and contains("Cron") and contains("Worktree"))
+  ' "$SETTINGS" >/dev/null || fail "the backstop matcher no longer covers the delegation-shaped families"
+  jq -e '
+    [.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[].command] as $bash
+      | ($bash | any(contains("fm-arm-pretool-check.sh")))
+      and ($bash | any(contains("fm-cd-pretool-check.sh")))
+      and ($bash | any(contains("fm-continuity-pretool-check.sh")))
+  ' "$SETTINGS" >/dev/null || fail "the existing Bash PreToolUse seatbelts changed"
+  jq -e '.hooks.Stop[0].hooks[0].command | contains("fm-turnend-guard.sh")' "$SETTINGS" >/dev/null \
+    || fail "the Stop turn-end backstop changed"
+  pass "Claude wires the backstop while preserving the Bash seatbelts and the Stop guard"
+}
+
+test_deny_list_covers_every_known_delegation_tool
+test_deny_list_preserves_ordinary_tools
+test_backstop_denies_every_currently_known_delegation_tool
+test_backstop_denies_hypothetical_future_tools
+test_backstop_allows_ordinary_and_observe_only_tools
+test_backstop_never_classifies_mcp_tools
+test_scout_entry_point_named_when_present
+test_escape_hatch_allows_deliberate_use
+test_task_worktree_and_non_firstmate_repo_are_inert
+test_secondmate_home_is_in_scope
+test_stdin_transports_and_output_shapes
+test_malformed_transport_fails_open
+test_claude_hook_registration_preserves_bash_seatbelts

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Behavior tests for the two-layer primary-session delegation guard: the
-# permissions.deny tool-availability list and the delegation-shape PreToolUse
-# backstop behind it.
+# Behavior tests for the primary-session delegation-shape guard: the tracked
+# hook registration, shared settings boundary, and PreToolUse classifier.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -23,11 +22,10 @@ BRIEF_ONLY_ROUTE='investigation and ship work both go to bin/fm-brief.sh then bi
 SCOUT_ROUTE='investigation or diagnosis goes to bin/fm-scout.sh "<question>" [project], and ship work goes to bin/fm-brief.sh then bin/fm-spawn.sh'
 
 # Every delegation, scheduling, worktree, and task-tracking tool Claude Code
-# 2.1.217 offers a primary session. Layer 1 must remove all of these from the
-# model's schema, so a Claude Code upgrade or a careless edit cannot silently
-# drop one. Recorded from an observed baseline tool list, see
-# docs/subagent-guard.md.
-DENIED_TOOLS='Task Agent Workflow RemoteTrigger Monitor ScheduleWakeup SendMessage EnterWorktree ExitWorktree CronCreate CronDelete CronList TaskCreate TaskGet TaskList TaskUpdate TaskStop TaskOutput'
+# 2.1.217 offered a primary session in the observed baseline.
+# The guard uses this inventory as shape-classification coverage, not as a
+# tracked deny-list contract.
+DELEGATION_TOOLS='Task Agent Workflow RemoteTrigger Monitor ScheduleWakeup SendMessage EnterWorktree ExitWorktree CronCreate CronDelete CronList TaskCreate TaskGet TaskList TaskUpdate TaskStop TaskOutput'
 
 # Tools that must stay available: denying these would break ordinary work.
 PRESERVED_TOOLS='Bash Edit Read Write Skill ToolSearch WebFetch WebSearch NotebookEdit ReportFindings DesignSync PushNotification'
@@ -63,60 +61,39 @@ expect_deny() {
 }
 
 # ---------------------------------------------------------------------------
-# Layer 1: the permissions.deny tool-availability list (the primary fix).
+# Tracked settings boundary and delegation-shape PreToolUse guard.
 # ---------------------------------------------------------------------------
 
-test_deny_list_covers_every_known_delegation_tool() {
-  local tool
-  for tool in $DENIED_TOOLS; do
-    jq -e --arg t "$tool" '.permissions.deny | index($t)' "$SETTINGS" >/dev/null \
-      || fail "permissions.deny lost the delegation tool $tool"
-  done
-  # "Task" is the historical key and "Agent" is the name the tool presents
-  # under; both are verified to work and both are pinned so neither a rename
-  # nor a rollback can reopen the surface.
-  jq -e '.permissions.deny | index("Task") and index("Agent")' "$SETTINGS" >/dev/null \
-    || fail "both the Task and Agent deny keys must stay pinned"
-  pass "permissions.deny pins every known Claude Code delegation and scheduling tool"
+test_tracked_settings_do_not_ship_permissions_deny() {
+  jq -e '(.permissions? // {} | has("deny") | not)' "$SETTINGS" >/dev/null \
+    || fail "tracked Claude settings must not ship permissions.deny"
+  pass "tracked Claude settings do not ship a permissions.deny list"
 }
 
-test_deny_list_preserves_ordinary_tools() {
+test_guard_denies_every_currently_known_delegation_tool() {
   local tool
-  for tool in $PRESERVED_TOOLS; do
-    jq -e --arg t "$tool" '.permissions.deny | index($t) | not' "$SETTINGS" >/dev/null \
-      || fail "permissions.deny must not remove the ordinary tool $tool"
-  done
-  pass "permissions.deny leaves every ordinary working tool available"
-}
-
-# ---------------------------------------------------------------------------
-# Layer 2: the delegation-shape PreToolUse backstop.
-# ---------------------------------------------------------------------------
-
-test_backstop_denies_every_currently_known_delegation_tool() {
-  local tool
-  for tool in $DENIED_TOOLS; do
+  for tool in $DELEGATION_TOOLS; do
     case "$tool" in
       TaskOutput|TaskStop|TaskGet|TaskList|CronList) continue ;;
     esac
     expect_deny "known delegation tool" "$tool"
   done
-  pass "the backstop independently denies every work-creating delegation tool by shape"
+  pass "the guard independently denies every work-creating delegation tool by shape"
 }
 
-test_backstop_denies_hypothetical_future_tools() {
-  # The whole reason this layer exists: a deny list is fail-open against tools
-  # that do not exist yet. None of these names is on any list.
+test_guard_denies_hypothetical_future_tools() {
+  # A local deny list is fail-open against tools that do not exist yet.
+  # None of these names is on any list.
   local tool
   for tool in SubagentCreate SpawnWorker DelegateTask AgentPool WorkflowRun \
               ScheduleJob CronSchedule CreateWorktree DispatchAgent TaskHandoff \
               RemoteExec BackgroundAgent; do
     expect_deny "future delegation tool" "$tool"
   done
-  pass "the backstop denies delegation-shaped tools that no deny list knows about yet"
+  pass "the guard denies delegation-shaped tools that no deny list knows about yet"
 }
 
-test_backstop_allows_ordinary_and_observe_only_tools() {
+test_guard_allows_ordinary_and_observe_only_tools() {
   local tool
   for tool in $PRESERVED_TOOLS; do
     expect_allow "ordinary tool" "$tool"
@@ -126,10 +103,10 @@ test_backstop_allows_ordinary_and_observe_only_tools() {
   for tool in TaskOutput TaskStop TaskGet TaskList CronList BashOutput KillShell; do
     expect_allow "observe-or-stop tool" "$tool"
   done
-  pass "the backstop leaves ordinary tools and observe-or-stop operations alone"
+  pass "the guard leaves ordinary tools and observe-or-stop operations alone"
 }
 
-test_backstop_never_classifies_mcp_tools() {
+test_guard_never_classifies_mcp_tools() {
   # An MCP server names its own tools; a task or agent noun there is common and
   # has nothing to do with fleet dispatch.
   local tool
@@ -194,7 +171,7 @@ test_task_worktree_and_non_firstmate_repo_are_inert() {
   FM_ROOT_OVERRIDE="$plain" FM_HOME="$plain" FM_STATE_OVERRIDE="$plain/state" \
     "$CHECK" --claude --tool Agent > "$OUT" 2> "$ERR" || rc=$?
   [ "$rc" -eq 0 ] || fail "a non-firstmate repo must be out of scope, got exit $rc"
-  pass "the backstop is inert in a crewmate task worktree and in a non-firstmate repo"
+  pass "the guard is inert in a crewmate task worktree and in a non-firstmate repo"
 }
 
 test_secondmate_home_is_in_scope() {
@@ -253,15 +230,16 @@ test_malformed_transport_fails_open() {
 
 test_claude_hook_registration_preserves_bash_seatbelts() {
   jq -e '
-    [.hooks.PreToolUse[] | select(.matcher != "Bash") | .hooks[].command]
+    [.hooks.PreToolUse[] | .hooks[].command]
       | any(contains("fm-subagent-pretool-check.sh --claude"))
-  ' "$SETTINGS" >/dev/null || fail "Claude settings omit the delegation-shape PreToolUse backstop"
-  # The backstop matcher must reach the delegation-shaped names, not just one
-  # literal tool, or it cannot catch a future tool at all.
+  ' "$SETTINGS" >/dev/null || fail "Claude settings omit the delegation-shape PreToolUse guard"
+  # A stem-enumerating matcher repeats the fail-open-by-enumeration defect the
+  # script exists to remove. Match all tools and let the script be the single
+  # owner of classification.
   jq -e '
     [.hooks.PreToolUse[] | select(.hooks[].command | contains("fm-subagent-pretool-check.sh")) | .matcher] | .[0]
-      | (contains("Agent") and contains("Task") and contains("Workflow") and contains("Cron") and contains("Worktree"))
-  ' "$SETTINGS" >/dev/null || fail "the backstop matcher no longer covers the delegation-shaped families"
+      | . == ".*"
+  ' "$SETTINGS" >/dev/null || fail "the guard matcher must match all tools"
   jq -e '
     [.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[].command] as $bash
       | ($bash | any(contains("fm-arm-pretool-check.sh")))
@@ -269,16 +247,15 @@ test_claude_hook_registration_preserves_bash_seatbelts() {
       and ($bash | any(contains("fm-continuity-pretool-check.sh")))
   ' "$SETTINGS" >/dev/null || fail "the existing Bash PreToolUse seatbelts changed"
   jq -e '.hooks.Stop[0].hooks[0].command | contains("fm-turnend-guard.sh")' "$SETTINGS" >/dev/null \
-    || fail "the Stop turn-end backstop changed"
-  pass "Claude wires the backstop while preserving the Bash seatbelts and the Stop guard"
+    || fail "the Stop turn-end guard changed"
+  pass "Claude wires the guard while preserving the Bash seatbelts and the Stop guard"
 }
 
-test_deny_list_covers_every_known_delegation_tool
-test_deny_list_preserves_ordinary_tools
-test_backstop_denies_every_currently_known_delegation_tool
-test_backstop_denies_hypothetical_future_tools
-test_backstop_allows_ordinary_and_observe_only_tools
-test_backstop_never_classifies_mcp_tools
+test_tracked_settings_do_not_ship_permissions_deny
+test_guard_denies_every_currently_known_delegation_tool
+test_guard_denies_hypothetical_future_tools
+test_guard_allows_ordinary_and_observe_only_tools
+test_guard_never_classifies_mcp_tools
 test_scout_entry_point_named_when_present
 test_escape_hatch_allows_deliberate_use
 test_task_worktree_and_non_firstmate_repo_are_inert

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -23,8 +23,9 @@ SCOUT_ROUTE='investigation or diagnosis goes to bin/fm-scout.sh "<question>" [pr
 
 # Every delegation, scheduling, worktree, and task-tracking tool Claude Code
 # 2.1.217 offered a primary session in the observed baseline.
-# The tracked deny list uses this as its exact primary-layer contract; the guard
-# uses the same inventory as shape-classification coverage.
+# This inventory is shape-classification coverage for the shipped guard and the
+# recommended local Claude deny-list hardening list, but tracked settings must
+# not ship that Claude-only permissions layer.
 DELEGATION_TOOLS='Task Agent Workflow RemoteTrigger Monitor ScheduleWakeup SendMessage EnterWorktree ExitWorktree CronCreate CronDelete CronList TaskCreate TaskGet TaskList TaskUpdate TaskStop TaskOutput'
 
 # Tools that must stay available: denying these would break ordinary work.
@@ -64,12 +65,10 @@ expect_deny() {
 # Tracked settings boundary and delegation-shape PreToolUse guard.
 # ---------------------------------------------------------------------------
 
-test_tracked_settings_ship_primary_permissions_deny() {
-  local expected
-  expected=$(printf '%s\n' $DELEGATION_TOOLS | jq -R . | jq -cs .)
-  jq -e --argjson expected "$expected" '.permissions.deny == $expected' "$SETTINGS" >/dev/null \
-    || fail "tracked Claude settings must ship the exact primary permissions.deny list"
-  pass "tracked Claude settings ship the primary permissions.deny list"
+test_tracked_settings_do_not_ship_permissions_deny() {
+  jq -e 'keys == ["hooks"] and (has("permissions") | not)' "$SETTINGS" >/dev/null \
+    || fail "tracked Claude settings must contain only hooks and no permissions key"
+  pass "tracked Claude settings do not ship permissions.deny"
 }
 
 test_guard_denies_every_currently_known_delegation_tool() {
@@ -270,7 +269,7 @@ test_claude_hook_registration_preserves_bash_seatbelts() {
   pass "Claude wires the guard while preserving the Bash seatbelts and the Stop guard"
 }
 
-test_tracked_settings_ship_primary_permissions_deny
+test_tracked_settings_do_not_ship_permissions_deny
 test_guard_denies_every_currently_known_delegation_tool
 test_guard_denies_hypothetical_future_tools
 test_guard_allows_ordinary_and_observe_only_tools

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -23,8 +23,8 @@ SCOUT_ROUTE='investigation or diagnosis goes to bin/fm-scout.sh "<question>" [pr
 
 # Every delegation, scheduling, worktree, and task-tracking tool Claude Code
 # 2.1.217 offered a primary session in the observed baseline.
-# The guard uses this inventory as shape-classification coverage, not as a
-# tracked deny-list contract.
+# The tracked deny list uses this as its exact primary-layer contract; the guard
+# uses the same inventory as shape-classification coverage.
 DELEGATION_TOOLS='Task Agent Workflow RemoteTrigger Monitor ScheduleWakeup SendMessage EnterWorktree ExitWorktree CronCreate CronDelete CronList TaskCreate TaskGet TaskList TaskUpdate TaskStop TaskOutput'
 
 # Tools that must stay available: denying these would break ordinary work.
@@ -64,10 +64,12 @@ expect_deny() {
 # Tracked settings boundary and delegation-shape PreToolUse guard.
 # ---------------------------------------------------------------------------
 
-test_tracked_settings_do_not_ship_permissions_deny() {
-  jq -e '(.permissions? // {} | has("deny") | not)' "$SETTINGS" >/dev/null \
-    || fail "tracked Claude settings must not ship permissions.deny"
-  pass "tracked Claude settings do not ship a permissions.deny list"
+test_tracked_settings_ship_primary_permissions_deny() {
+  local expected
+  expected=$(printf '%s\n' $DELEGATION_TOOLS | jq -R . | jq -cs .)
+  jq -e --argjson expected "$expected" '.permissions.deny == $expected' "$SETTINGS" >/dev/null \
+    || fail "tracked Claude settings must ship the exact primary permissions.deny list"
+  pass "tracked Claude settings ship the primary permissions.deny list"
 }
 
 test_guard_denies_every_currently_known_delegation_tool() {
@@ -82,7 +84,7 @@ test_guard_denies_every_currently_known_delegation_tool() {
 }
 
 test_guard_denies_hypothetical_future_tools() {
-  # A local deny list is fail-open against tools that do not exist yet.
+  # A fixed deny list is fail-open against tools that do not exist yet.
   # None of these names is on any list.
   local tool
   for tool in SubagentCreate SpawnWorker DelegateTask AgentPool WorkflowRun \
@@ -251,7 +253,7 @@ test_claude_hook_registration_preserves_bash_seatbelts() {
   pass "Claude wires the guard while preserving the Bash seatbelts and the Stop guard"
 }
 
-test_tracked_settings_do_not_ship_permissions_deny
+test_tracked_settings_ship_primary_permissions_deny
 test_guard_denies_every_currently_known_delegation_tool
 test_guard_denies_hypothetical_future_tools
 test_guard_allows_ordinary_and_observe_only_tools


### PR DESCRIPTION
## Intent

Stop firstmate's primary session from delegating work through Claude Code's own subagent tool instead of firstmate's real crewmate dispatch (bin/fm-spawn.sh).

WHY: On 2026-07-22 the firstmate primary ran four workers through Claude Code's built-in subagent tool rather than bin/fm-spawn.sh. Observed, not hypothetical: the fleet view showed zero work under way the whole time (no state/<id>.meta, no data/<id>/brief.md); on primary restart two workers died mid-flight and their work was lost; supervision then stayed down 73 minutes unnoticed, silently killing the captain's Workflowy intake channel. The deeper defect is that only bin/fm-spawn.sh writes state/<id>.meta and every guard keys off it (bin/fm-supervision-lib.sh counts state/*.meta; bin/fm-turnend-guard.sh exits silently at zero), so a bypass makes the whole guard stack structurally INERT, not merely unenforced.

DELIBERATE DESIGN DECISIONS a reviewer reading only the diff would not know:

1. TWO LAYERS ON PURPOSE, and layer 1 is the primary fix. The task originally asked only for a PreToolUse hook. Mid-task a parallel investigation empirically showed that a permissions.deny entry in .claude/settings.json REMOVES the tool from the model's schema entirely - the model is never offered it, so there is no call to intercept, no matcher to get wrong, and no fail-open path. That is strictly stronger than a hook, so the deny list became the primary fix and the hook was demoted to a backstop.

2. THE HOOK WAS DELIBERATELY REDESIGNED, NOT KEPT AS-IS. A fixed-list hook behind a fixed deny list would be dead code duplicating layer 1. The explicit instruction was to keep it ONLY if it defends against FUTURE tools not yet on the deny list. So bin/fm-subagent-pretool-check.sh classifies the tool NAME BY SHAPE (stem list) rather than against a fixed list. This is verified live: with Workflow removed from the deny list, the backstop still blocked it. It is additive, not duplicative.

3. permissions.allow is a PRE-APPROVAL list, not an availability list, so there is no fail-closed positive allowlist available. That is why the deny list is fail-open against future tools and why layer 2 must exist. Documented as a known residual gap.

4. BOTH 'Task' AND 'Agent' ARE PINNED AS DENY KEYS. A prior finding claimed the key must be 'Task' and that 'Agent' silently does nothing. I disproved that with a five-way A/B, each variant in a fresh directory to rule out settings caching, including a nonsense-name control (deny ZzzNotARealTool leaves Agent present). Both keys independently remove the tool on Claude Code 2.1.217. Pinning both costs one line and removes the failure mode where a rename or rollback silently reopens the surface. The correction is recorded in docs/subagent-guard.md and the harness-adapters skill.

5. THE OBSERVE-ONLY EXCLUSION IS INTENTIONAL AND ASYMMETRIC BETWEEN LAYERS. Layer 2 deliberately allows taskoutput/taskstop/taskget/tasklist/cronlist/bashoutput/killshell because those observe or stop work that already exists rather than creating it; blocking them could strand a runaway task with no way to inspect or end it. Layer 1 (captain-owned) still denies them. The asymmetry is deliberate so the backstop can never be the reason a runaway task cannot be stopped.

6. mcp__* NAMES ARE NEVER CLASSIFIED. An MCP server chooses its own tool names and a task/agent noun there is common; classifying them would be a false positive with no bearing on fleet dispatch.

7. DENY-LIST WIDTH IS EXPLICITLY THE CAPTAIN'S CALL, NOT MINE. I was instructed not to finalise the exact denied set myself because denying some of these changes how the captain works with the primary. It ships at the wider 18-name setting so the surface is closed by default, implemented as one flat array in one file so it is reviewable at a glance and narrowable in one line.

8. SCOPING USES THE EXISTING SHARED PREDICATE fm_primary_scope_matches, not a new one, so the three tracked primary-scoped hooks (session-start nudge, turn-end guard, this one) cannot drift apart. A marked secondmate home is IN scope on purpose (it operates its own fleet); a crewmate's linked task worktree is OUT of scope on purpose (a worker using subagents there is legitimate). Verified live both ways with identical hook bytes.

9. FAIL-OPEN ON TRANSPORT IS DELIBERATE and matches the sibling seatbelts (bin/fm-arm-pretool-check.sh, bin/fm-cd-pretool-check.sh): malformed stdin, missing jq, or an unconfirmable home is inert rather than blocking, so a broken environment can never deny every tool call.

10. ONE ESCAPE HATCH, FM_ALLOW_SUBAGENT=1, as an ENV VAR specifically because it must be set at process launch. No in-session tool call can set it for the call that follows, so a deliberate use stays possible while an accidental one is impossible. It fails closed on every other value including empty, 0, yes, true.

11. --claude SUPPRESSES STDOUT because Claude Code only honours a PreToolUse deny when stdout is empty (verified quirk already recorded in docs/arm-pretool-check.md). Default mode still emits the Grok stdout decision object.

12. OTHER HARNESSES WERE REVIEWED, NOT SILENTLY SKIPPED. Codex 0.144.1 was empirically verified to expose NO delegation tool (full tool enumeration recorded in the doc), so it is genuinely not applicable. grok, opencode and pi are deliberately NOT wired: none of those binaries is installed on this host, so the exact tool-name tokens could not be confirmed and the wiring could not be validated against the real harness. The repo's own firstmate-coding-guidelines rule requires live validation before trusting a harness hook, and docs/arm-pretool-check.md records that a slightly-wrong Grok hook command fails to launch the hook entirely. Wiring an unvalidated matcher would trade a known gap for an unknown breakage. Each one's integration surface and exact follow-up procedure is documented instead.

CONSTRAINTS FOLLOWED: firstmate-coding-guidelines skill (knowledge placement - mechanics in script header/--help, reference detail and dated evidence in docs/, no AGENTS.md change since the siblings have none and the existing prime directive already states the rule); one full sentence per line in tracked Markdown; plain dash never em dash; no agent name as commit co-author; shellcheck clean via bin/fm-lint.sh (the single lint owner, pinned 0.11.0); test colocated in tests/ matching neighbours and registered in the existing bin/fm-test-run.sh family map rather than inventing a new runner.

VERIFICATION DONE: bin/fm-lint.sh clean; 13 new tests pass; pure-contract-unit family 28/28 with 0 failures; coverage guard ok. Live evidence against Claude Code 2.1.217 recorded in docs/subagent-guard.md with dates, versions, exact commands and exact output: tool-name discovery, the five-way deny-key A/B with control, layer 1 under the real tracked settings, layer 2 blocking an un-denied Workflow call, the same call ALLOWED in a linked worktree, and the escape hatch.

## What Changed
- Adds `bin/fm-subagent-pretool-check.sh`, a primary-scoped PreToolUse guard that denies delegation-shaped harness tools while preserving MCP, observe-only, linked-worktree, fail-open transport, and `FM_ALLOW_SUBAGENT=1` paths.
- Wires Claude’s PreToolUse matcher to run the guard for all tools and documents the guard contract, local Claude deny-list hardening, harness applicability, and related turn-end guard ownership.
- Registers the new guard test in `fm-test-run` and adds behavior coverage for current and future delegation-shaped tool names, scope handling, output shapes, and tracked settings boundaries.

## Risk Assessment

🚨 High: The implementation appears to address the prior scoped-hook concerns, but it now contradicts the authoritative source-verifiable acceptance criteria requiring a shipped tracked deny-list layer.

## Testing

Inspected the diff and relevant guard/settings/docs surfaces, confirmed Claude Code 2.1.217, ran the focused behavioral test through `fm-test-run`, added and reran missing jq fail-open coverage, and captured CLI evidence for the deny list plus hook deny/allow/escape/scope behavior; all exercised checks passed, with no UI screenshot applicable for this CLI/hook change.

<details>
<summary>Evidence: Subagent guard CLI evidence transcript</summary>

```text
subagent guard CLI evidence
date: 2026-07-22T13:10:09Z
claude-version: 2.1.217 (Claude Code)

tracked-deny-list-count: 18
tracked-deny-list:
  - Task
  - Agent
  - Workflow
  - RemoteTrigger
  - Monitor
  - ScheduleWakeup
  - SendMessage
  - EnterWorktree
  - ExitWorktree
  - CronCreate
  - CronDelete
  - CronList
  - TaskCreate
  - TaskGet
  - TaskList
  - TaskUpdate
  - TaskStop
  - TaskOutput
subagent-hook-matcher: .*
subagent-hook-command: "$CLAUDE_PROJECT_DIR"/bin/fm-subagent-pretool-check.sh --claude

case: primary_future_workflowrun_denied
tool: WorkflowRun
extra-env: <none>
root-kind: /var/folders/tc/llfmckm54ls5tzxm08q758lm0000gn/T/no-mistakes-evidence/01KY4WQ89NK5ZV3H3V6DEYQBKP/manual-primary
exit: 2
stdout-bytes: 0
stderr-json: {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[subagent-dispatch] the firstmate primary dispatches through the fleet, not the harness's own delegation tools: work started that way has no durable fleet record, leaves every firstmate guard inert, and dies with this session. Instead, investigation and ship work both go to bin/fm-brief.sh then bin/fm-spawn.sh (blocked tool: WorkflowRun, delegation-shaped on \"workflow\"). Launch the session with FM_ALLOW_SUBAGENT=1 for a deliberate exception."}

case: primary_observe_taskoutput_allowed
tool: TaskOutput
extra-env: <none>
root-kind: /var/folders/tc/llfmckm54ls5tzxm08q758lm0000gn/T/no-mistakes-evidence/01KY4WQ89NK5ZV3H3V6DEYQBKP/manual-primary
exit: 0
stdout-bytes: 0
stderr-json: <empty>

case: primary_mcp_task_name_allowed
tool: mcp__tracker__create_task
extra-env: <none>
root-kind: /var/folders/tc/llfmckm54ls5tzxm08q758lm0000gn/T/no-mistakes-evidence/01KY4WQ89NK5ZV3H3V6DEYQBKP/manual-primary
exit: 0
stdout-bytes: 0
stderr-json: <empty>

case: primary_escape_hatch_agent_allowed
tool: Agent
extra-env: FM_ALLOW_SUBAGENT=1
root-kind: /var/folders/tc/llfmckm54ls5tzxm08q758lm0000gn/T/no-mistakes-evidence/01KY4WQ89NK5ZV3H3V6DEYQBKP/manual-primary
exit: 0
stdout-bytes: 0
stderr-json: <empty>

case: linked_worktree_agent_allowed
tool: Agent
extra-env: <none>
root-kind: /var/folders/tc/llfmckm54ls5tzxm08q758lm0000gn/T/no-mistakes-evidence/01KY4WQ89NK5ZV3H3V6DEYQBKP/manual-child
exit: 0
stdout-bytes: 0
stderr-json: <empty>

case: primary_grok_stdin_agent_denied
transport: stdin {"toolName":"Agent"}, default output mode
exit: 2
stdout-json: {"decision":"deny","reason":"[subagent-dispatch] the firstmate primary dispatches through the fleet, not the harness's own delegation tools: work started that way has no durable fleet record, leaves every firstmate guard inert, and dies with this session. Instead, investigation and ship work both go to bin/fm-brief.sh then bin/fm-spawn.sh (blocked tool: Agent, delegation-shaped on \"agent\"). Launch the session with FM_ALLOW_SUBAGENT=1 for a deliberate exception."}
stderr-json: {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[subagent-dispatch] the firstmate primary dispatches through the fleet, not the harness's own delegation tools: work started that way has no durable fleet record, leaves every firstmate guard inert, and dies with this session. Instead, investigation and ship work both go to bin/fm-brief.sh then bin/fm-spawn.sh (blocked tool: Agent, delegation-shaped on \"agent\"). Launch the session with FM_ALLOW_SUBAGENT=1 for a deliberate exception."}

case: missing_jq_stdin_fails_open
transport: stdin {"tool_name":"Agent"}, --claude, PATH contains cat but no jq, script invoked via /bin/bash
exit: 0
stdout-bytes: 0
stderr-bytes: 0
```
</details>
<details>
<summary>Evidence: Focused test runner result</summary>

```text
{
  "families": [
    {
      "count": 1,
      "duration_ms": 1488,
      "failed": 0,
      "name": "pure-contract-unit"
    }
  ],
  "finished_at": "2026-07-22T13:12:00Z",
  "run_id": "fm-test-run-1784725918846-71569",
  "scripts": [
    {
      "duration_ms": 1488,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-subagent-pretool-check.test.sh"
    }
  ],
  "selection": "scripts",
  "started_at": "2026-07-22T13:11:58Z",
  "summary": {
    "duration_ms": 1536,
    "failed": 0,
    "skipped_gate": 0,
    "total": 1
  }
}
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (14m16s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `.claude/settings.json:55` - Layer 2 only runs if Claude&#39;s PreToolUse matcher fires first, but this matcher omits the `Subagent` casing while the checker/test matrix expects future names like `SubagentCreate` to be denied by shape. A `SubagentCreate` tool would not match this case-sensitive pattern, so the backstop would never call `fm-subagent-pretool-check.sh`; broaden the matcher or match all tools and let the script filter.
- ⚠️ `.claude/settings.json:2` - The stated criterion says a crewmate linked task worktree is out of scope because worker subagents are legitimate, but this project-level `permissions.deny` file is tracked and will be present in firstmate-repo linked worktrees too. That removes `Agent`/`Task` before the hook&#39;s linked-worktree scope check or `FM_ALLOW_SUBAGENT=1` can help, so Claude crewmates working on this repo cannot use the delegation tools the intent says should remain legitimate.

🔧 Fix: Ship scoped Claude delegation guard
1 error still open:
- 🚨 `.claude/settings.json:1` - The original intent requires “TWO LAYERS ON PURPOSE, and layer 1 is the primary fix,” says both `Task` and `Agent` are pinned as deny keys, and says the 18-name deny list “ships at the wider 18-name setting.” The current tracked settings now contain only `hooks` and no `permissions.deny`, so the required schema-removal layer is absent; either update the authoritative intent to the follow-up local-hardening decision or restore the tracked deny layer.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.claude/settings.json:1` - The authoritative intent says the Claude `permissions.deny` layer is the primary shipped fix and should ship as the wider 18-name deny list with both `Task` and `Agent` pinned. The tracked `.claude/settings.json` has no `permissions.deny` object at all, and the new test suite explicitly asserts that absence, so a fresh primary relies only on the weaker hook backstop instead of removing Claude delegation tools from the model schema as required.
- `bin/fm-test-run.sh --json /var/folders/tc/llfmckm54ls5tzxm08q758lm0000gn/T/no-mistakes-evidence/01KY4WQ89NK5ZV3H3V6DEYQBKP/fm-subagent-pretool-check-run.json tests/fm-subagent-pretool-check.test.sh`
- <code>Evidence transcript script wrote `/var/folders/tc/llfmckm54ls5tzxm08q758lm0000gn/T/no-mistakes-evidence/01KY4WQ89NK5ZV3H3V6DEYQBKP/fm-subagent-hook-e2e-transcript.txt` after exercising primary `Agent`/`Workflow` denial, `FM_ALLOW_SUBAGENT=1`, observe-only and MCP allows, Claude/Grok stdin payloads, and linked-worktree allow behavior.</code>

🔧 Fix: Ship Claude delegation deny list
✅ Re-checked - no issues remain.
- `command -v claude && claude --version`
- `bin/fm-test-run.sh --json /var/folders/tc/llfmckm54ls5tzxm08q758lm0000gn/T/no-mistakes-evidence/01KY4WQ89NK5ZV3H3V6DEYQBKP/fm-subagent-pretool-test-run.json tests/fm-subagent-pretool-check.test.sh`
- <code>Manual evidence transcript: checked `.claude/settings.json` has the 18-name deny list and `fm-subagent-pretool-check.sh --claude` is wired on matcher `.*`.</code>
- <code>Manual evidence transcript: `WorkflowRun` in a firstmate-shaped primary fixture denied with exit 2, Claude-shaped stderr, and empty stdout.</code>
- <code>Manual evidence transcript: `TaskOutput`, `mcp__tracker__create_task`, `FM_ALLOW_SUBAGENT=1 Agent`, and linked-worktree `Agent` calls allowed with empty output.</code>
- <code>Manual evidence transcript: stdin `{&#34;toolName&#34;:&#34;Agent&#34;}` denied in default/Grok mode with stdout decision JSON, and stdin `{&#34;tool_name&#34;:&#34;Agent&#34;}` failed open with no jq on PATH.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Keep Claude deny list local
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
