### PR TITLE
feat(bin): mark spawned agents with FM_MANAGED=1 for hook detection

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1240,6 +1240,11 @@ LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
+# FM_MANAGED=1 marks this process as firstmate-launched so downstream framework
+# notification hooks can skip human-facing alerts (macOS banner/sound) for it.
+# A per-launch env prefix, same mechanism as CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION
+# above: it never touches the captain's own primary session or global config.
+LAUNCH="FM_MANAGED=1 $LAUNCH"
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,6 +182,8 @@ An explicit `--model` or `--effort` overrides the matching token from `config/se
 When `config/crew-dispatch.json` exists, crewmate and scout spawns require an explicit resolved harness instead of automatically falling back to `config/crew-harness`.
 The inherited-local-material contract is owned by `secondmate-provisioning`; for harness behavior, its propagated config items make a secondmate's own crewmates, dispatch profiles, and backlog backend use the primary values.
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
+`fm-spawn.sh` prefixes every launch - crewmate, scout, and secondmate, on every harness, including raw launch-command spawns - with `FM_MANAGED=1`, so framework notification hooks running inside a spawned agent can recognize a firstmate-managed session and skip human-facing alerts such as a macOS banner or sound.
+Like every per-launch env prefix, it applies only to firstmate-launched agents and never touches the captain's own primary session or global config.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -118,7 +118,7 @@ test_no_profile_keeps_claude_launch_unchanged() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
+  expected="FM_MANAGED=1 CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch changed"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and keeps the claude launch byte-identical"
 }
@@ -204,7 +204,7 @@ test_active_dispatch_profile_allows_raw_launch_command() {
   assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default
   launch=$(cat "$LAUNCH_LOG")
-  [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
+  [ "$launch" = "FM_MANAGED=1 custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
   pass "active crew-dispatch profile allows the raw launch-command escape hatch"
 }
 
@@ -384,6 +384,39 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
   pass "active crew-dispatch profile does not block secondmate launches"
 }
 
+test_fm_managed_marks_ship_scout_and_secondmate_launches() {
+  local rec id out status launch sm
+  id=fm-managed-ship-z17
+  rec=$(make_spawn_case fm-managed-ship claude "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "ship spawn should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "FM_MANAGED=1" "ship launch missing FM_MANAGED=1"
+
+  id=fm-managed-scout-z18
+  rec=$(make_spawn_case fm-managed-scout claude "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --scout)
+  status=$?
+  expect_code 0 "$status" "scout spawn should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "FM_MANAGED=1" "scout launch missing FM_MANAGED=1"
+
+  id=fm-managed-secondmate-z19
+  rec=$(make_spawn_case fm-managed-secondmate codex "$id")
+  read_case_record "$rec"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$sm" --secondmate)
+  status=$?
+  expect_code 0 "$status" "secondmate spawn should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "FM_MANAGED=1" "secondmate launch missing FM_MANAGED=1"
+  pass "fm-spawn marks ship, scout, and secondmate launches with FM_MANAGED=1"
+}
+
 test_no_profile_keeps_claude_launch_unchanged
 test_active_dispatch_profile_requires_explicit_harness_for_ship
 test_active_dispatch_profile_requires_explicit_harness_for_scout
@@ -400,5 +433,6 @@ test_opencode_threads_model_and_ignores_effort_axis
 test_pi_threads_model_and_max_effort
 test_batch_forwards_shared_profile_flags
 test_active_dispatch_profile_does_not_block_secondmate_launch
+test_fm_managed_marks_ship_scout_and_secondmate_launches
 
 echo "# all fm-spawn-dispatch-profile tests passed"


### PR DESCRIPTION
## What Changed

- `bin/fm-spawn.sh` now prefixes every launch command — crewmate, scout, and secondmate, on every harness, including raw launch-command spawns — with `FM_MANAGED=1`, so framework notification hooks running inside a spawned agent can recognize a firstmate-managed session and skip human-facing alerts (macOS banner/sound). It uses the same per-launch env-prefix mechanism as the existing `FM_*` secondmate overrides, so it never touches the captain's primary session or global config; per the review note, for raw launch commands the prefix only scopes to the first simple command, matching that existing mechanism's behavior.
- Updated `tests/fm-spawn-dispatch-profile.test.sh` to expect the marker in existing launch-line assertions and added a test covering ship, scout, and secondmate launches.
- Documented the marker in `docs/configuration.md`.

## Risk Assessment

✅ Low: A one-line env-prefix added at the single launch choke point with all launch paths (ship, scout, secondmate, raw) covered by new tests, no in-repo behavior depends on the variable, and no other tests assert exact launch strings that could go stale.

## Testing

Completed 1 recorded test check.

- Outcome: ⏭️ skipped across 1 run (32m5s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-spawn.sh:1247` - FM_MANAGED=1 is applied as a shell env-prefix on the typed launch line, so for raw launch commands (the unverified-adapter escape hatch) it only scopes to the first simple command — a compound raw command like `cd x &amp;&amp; agent` or an `env -i` wrapper would not propagate the marker to the agent process. This matches the existing behavior of the secondmate FM_* override prefixes and is an inherent limit of the mechanism, not a regression.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
