### PR TITLE
feat(bin): detect a real Chromium binary in bootstrap

### DIFF
--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -486,8 +486,22 @@ install_cmd() {
     no-mistakes) echo "curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh" ;;
     gh-axi|chrome-devtools-axi|lavish-axi) echo "npm install -g $1 && $1 setup hooks" ;;
     tasks-axi|quota-axi) echo "npm install -g $1" ;;
+    chromium) echo "npx --yes playwright install-deps chromium" ;;
     *) return 1 ;;
   esac
+}
+
+# chrome-devtools-axi's headless launches need a real Chromium binary plus its
+# OS-level shared-library dependencies, not just the axi package itself
+# (chromium-toolchain-r7k). No single binary name is universal across install
+# methods (a system package, a Playwright-managed install, etc.), so check
+# every name actually seen in the wild rather than pinning one.
+chromium_binary_present() {
+  local candidate
+  for candidate in chromium chromium-browser google-chrome google-chrome-stable; do
+    command -v "$candidate" >/dev/null 2>&1 && return 0
+  done
+  return 1
 }
 
 manual_install_url() {
@@ -831,6 +845,9 @@ if command -v no-mistakes >/dev/null 2>&1 && ! no_mistakes_compatible; then
 fi
 if command -v tasks-axi >/dev/null 2>&1 && ! fm_tasks_axi_compatible; then
   echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
+fi
+if ! chromium_binary_present; then
+  echo "MISSING: chromium (install: $(install_cmd chromium))"
 fi
 gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
 # Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -349,15 +349,31 @@ SH
 }
 
 test_chromium_binary_detection() {
-  local case_dir fakebin out expected candidate
+  local case_dir fakebin bash_env out expected candidate
   expected="MISSING: chromium (install: npx --yes playwright install-deps chromium)"
 
+  # A runner may have a real chromium/chromium-browser/google-chrome(-stable)
+  # already on its system PATH (e.g. a CI image with a bundled browser for
+  # other jobs), so removing only our fake stub is not enough to prove the
+  # missing case: mask every candidate name the same way the git-required
+  # case above masks a real git.
   case_dir="$TMP_ROOT/chromium-missing"
   mkdir -p "$case_dir/home/config"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   fakebin=$(make_fake_toolchain "$case_dir")
   rm -f "$fakebin/chromium"
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  bash_env="$case_dir/no-chromium.bash"
+  cat > "$bash_env" <<'SH'
+command() {
+  if [ "${1:-}" = -v ]; then
+    case "${2:-}" in
+      chromium|chromium-browser|google-chrome|google-chrome-stable) return 1 ;;
+    esac
+  fi
+  builtin command "$@"
+}
+SH
+  out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   assert_contains "$out" "$expected" "a missing Chromium binary should report MISSING: chromium with an install command"
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -38,7 +38,7 @@ unset TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_SESSION HERDR_SOCKET_PATH \
 make_fake_toolchain() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
-  fm_fake_exit0 "$fakebin" tmux node gh-axi chrome-devtools-axi lavish-axi
+  fm_fake_exit0 "$fakebin" tmux node gh-axi chrome-devtools-axi lavish-axi chromium
   cat > "$fakebin/gh" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = auth ] && [ "${2:-}" = status ]; then
@@ -346,6 +346,41 @@ SH
   expected="MISSING: git (install: brew install git  # or the platform's package manager)"
   [ "$out" = "$expected" ] || fail "missing git should report the supported install instruction, got: $out"
   pass "bootstrap requires git with an install instruction"
+}
+
+test_chromium_binary_detection() {
+  local case_dir fakebin out expected candidate
+  expected="MISSING: chromium (install: npx --yes playwright install-deps chromium)"
+
+  case_dir="$TMP_ROOT/chromium-missing"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  rm -f "$fakebin/chromium"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  assert_contains "$out" "$expected" "a missing Chromium binary should report MISSING: chromium with an install command"
+
+  case_dir="$TMP_ROOT/chromium-present"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ -z "$out" ] || fail "a present chromium binary should not be reported missing, got: $out"
+
+  for candidate in chromium-browser google-chrome google-chrome-stable; do
+    case_dir="$TMP_ROOT/chromium-alt-$candidate"
+    mkdir -p "$case_dir/home/config"
+    printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+    fakebin=$(make_fake_toolchain "$case_dir")
+    rm -f "$fakebin/chromium"
+    fm_fake_exit0 "$fakebin" "$candidate"
+    out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+      FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+    assert_not_contains "$out" "MISSING: chromium" "a $candidate binary on PATH should satisfy the Chromium detection"
+  done
+  pass "bootstrap detects a real Chromium binary under any known name and reports MISSING: chromium otherwise"
 }
 
 test_orca_backend_gates_orca_tool_only_when_selected() {
@@ -789,6 +824,7 @@ ROWS
 test_bootstrap_reporting
 test_no_mistakes_min_version
 test_git_is_required_with_supported_install_instruction
+test_chromium_binary_detection
 test_orca_backend_gates_orca_tool_only_when_selected
 test_session_provider_backends_do_not_require_tmux
 test_session_provider_backends_gate_own_cli_not_tmux


### PR DESCRIPTION
## Intent

Add real Chromium binary detection to bin/fm-bootstrap.sh's tool-detection machinery. Chromium was documented (chromium-toolchain-r7k, PR #704) as a required toolchain item for chrome-devtools-axi's headless launches but bootstrap never actually checked for it. Added a chromium_binary_present() helper that checks candidate binary names (chromium, chromium-browser, google-chrome, google-chrome-stable) since no single name is universal across install methods (system package vs Playwright-managed install), wired into the existing install_cmd/MISSING: reporting convention used by every other tool in the script (install command is 'npx --yes playwright install-deps chromium', matching the doc PR's documented manual remediation). This is a fleet-wide framework change scoped only to the detection gap - it deliberately does not touch docs/configuration.md, which is owned by the separate still-open PR #704. Extended tests/fm-bootstrap.test.sh with a new test_chromium_binary_detection covering missing, present, and each alternate binary name, and stubbed a fake chromium binary into the shared make_fake_toolchain fixture so existing silent-output test cases remain silent. Ran bin/fm-lint.sh (shellcheck 0.11.0) clean before committing.

## What Changed

- Added a `chromium_binary_present()` helper to `bin/fm-bootstrap.sh` that checks for any of `chromium`, `chromium-browser`, `google-chrome`, or `google-chrome-stable` on PATH, since no single binary name is universal across install methods (system package vs. Playwright-managed install).
- Wired the check into the existing `install_cmd`/`MISSING:` reporting convention, emitting `MISSING: chromium (install: npx --yes playwright install-deps chromium)` when no candidate binary is found.
- Extended `tests/fm-bootstrap.test.sh` with `test_chromium_binary_detection`, covering the missing case, the present case, and each alternate binary name, and stubbed a fake chromium binary into the shared `make_fake_toolchain` fixture so existing silent-output test cases remain silent.

## Risk Assessment

✅ Low: Small, well-bounded addition (one detection helper + one MISSING line + matching tests) that follows the script's existing install_cmd/MISSING conventions, is unconditional in a way consistent with chrome-devtools-axi already being a universal COMMON_TOOLS entry, and matches every constraint in the stated intent (candidate names, install command, non-touching of docs/configuration.md, test fixture updates).

## Testing

Ran the full fm-bootstrap test suite (22/22 pass, including the new test_chromium_binary_detection covering missing/present/alternate-name cases), then independently reproduced the end-user CLI experience by invoking bin/fm-bootstrap.sh directly with a fake toolchain: with no Chromium-family binary on PATH it prints MISSING: chromium with the documented playwright install command, and adding a chromium-browser stub makes that line disappear while other MISSING lines stay unaffected — confirming the detection helper and its wiring into the MISSING: reporting convention work end-to-end as the author intended.

<details>
<summary>Evidence: Manual CLI transcript: bootstrap output with/without a chromium-family binary on PATH</summary>

```text
=== Scenario A: no chromium binary on PATH ===
MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)
MISSING: no-mistakes (install: curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh)
MISSING: tasks-axi (install: npm install -g tasks-axi)
MISSING: quota-axi (install: npm install -g quota-axi)
MISSING: chromium (install: npx --yes playwright install-deps chromium)

=== Scenario B: a real-shaped chromium-browser binary added to PATH ===
MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)
MISSING: no-mistakes (install: curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh)
MISSING: tasks-axi (install: npm install -g tasks-axi)
MISSING: quota-axi (install: npm install -g quota-axi)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-bootstrap.sh:8` - The file header comment documents every special-cased MISSING behavior (treehouse&#39;s lease-support check, no-mistakes&#39; version check, tasks-axi/quota-axi&#39;s version+feature gate) but wasn&#39;t updated to mention the new unconditional &#39;MISSING: chromium&#39; check, which is likewise a bespoke check outside the COMMON_TOOLS/BACKEND_TOOLS loop. Worth a one-line addition alongside the existing treehouse/no-mistakes/tasks-axi notes so the header remains a complete contract of the script&#39;s output lines.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-bootstrap.test.sh` — full suite, 22/22 tests pass including new `test_chromium_binary_detection` (missing/present/each alternate name)</code>
- <code>Manual CLI run of `bin/fm-bootstrap.sh` (not via test harness) with a fake toolchain and no chromium-family binary on PATH: real output includes `MISSING: chromium (install: npx --yes playwright install-deps chromium)`</code>
- <code>Same manual run after adding a `chromium-browser` stub to PATH: the MISSING: chromium line disappears while unrelated MISSING lines (treehouse, no-mistakes, tasks-axi, quota-axi) are unchanged</code>
- `Confirmed no chromium/chromium-browser/google-chrome/google-chrome-stable exists on this machine's real PATH, so Scenario A reflects genuine (non-stubbed) absence`
- <code>`git status --porcelain` after testing — worktree left clean, no stray artifacts</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ docs/configuration.md&#39;s universal-toolchain list (line 237) still doesn&#39;t mention chromium as a chrome-devtools-axi dependency; this change intentionally leaves that to the still-open PR #704, which owns that doc per the stated intent, so no edit was made here.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
