### PR TITLE
fix(spawn): enforce filesystem-aware worktree isolation

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -700,9 +700,9 @@ fi
 filesystem_object_identity() {  # <path>
   local identity
   if [ "$(uname)" = Darwin ]; then
-    identity=$(stat -f '%d:%i' "$1" 2>/dev/null) || return 1
+    identity=$(stat -Lf '%d:%i' "$1" 2>/dev/null) || return 1
   else
-    identity=$(stat -c '%d:%i' "$1" 2>/dev/null) || return 1
+    identity=$(stat -Lc '%d:%i' "$1" 2>/dev/null) || return 1
   fi
   [ -n "$identity" ] || return 1
   printf '%s\n' "$identity"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -697,6 +697,18 @@ if [ "$KIND" = secondmate ]; then
   fi
 fi
 
+filesystem_object_identity() {  # <path>
+  local identity
+  if [ "$(uname)" = Darwin ]; then
+    identity=$(stat -f '%d:%i' "$1" 2>/dev/null) || return 1
+  else
+    identity=$(stat -c '%d:%i' "$1" 2>/dev/null) || return 1
+  fi
+  [ -n "$identity" ] || return 1
+  printf '%s\n' "$identity"
+}
+
+PROJ_IDENTITY=
 if [ "$KIND" = secondmate ]; then
   [ -n "$FIRSTMATE_HOME" ] || { echo "error: no firstmate home supplied or registered for $ID" >&2; exit 1; }
   PROJ_ABS=$(validate_firstmate_home_for_spawn "$ID" "$FIRSTMATE_HOME")
@@ -744,7 +756,16 @@ if [ "$KIND" = secondmate ]; then
     BRIEF="$DATA/$ID/brief.md"
   fi
 else
-  PROJ_ABS="$(cd "$(resolve_project_dir_arg "$PROJ")" && pwd)"
+  project_record=$(
+    cd "$(resolve_project_dir_arg "$PROJ")"
+    printf '%s\x1f' "$(pwd)"
+    filesystem_object_identity .
+  ) || {
+    echo "error: could not resolve primary project filesystem identity for $PROJ" >&2
+    exit 1
+  }
+  PROJ_ABS=${project_record%%$'\x1f'*}
+  PROJ_IDENTITY=${project_record#*$'\x1f'}
   WT=""
   BRIEF="$DATA/$ID/brief.md"
 fi
@@ -753,13 +774,18 @@ fi
 # Backend current-path reads and PROJ_ABS can spell the same directory through
 # different symlink aliases or letter casing. String canonicalization is not an
 # identity proof on every supported filesystem, so all isolation decisions use
-# Bash's device-and-inode-aware -ef predicate instead.
+# device-and-inode identity instead.
 same_filesystem_object() {  # <left-path> <right-path>
-  [ -e "$1" ] && [ -e "$2" ] && [ "$1" -ef "$2" ]
+  local left_identity right_identity
+  left_identity=$(filesystem_object_identity "$1") || return 1
+  right_identity=$(filesystem_object_identity "$2") || return 1
+  [ "$left_identity" = "$right_identity" ]
 }
 
-distinct_filesystem_objects() {  # <left-path> <right-path>
-  [ -e "$1" ] && [ -e "$2" ] && ! [ "$1" -ef "$2" ]
+distinct_from_primary() {  # <path>
+  local identity
+  identity=$(filesystem_object_identity "$1") || return 1
+  [ "$identity" != "$PROJ_IDENTITY" ]
 }
 
 git_worktree_root() {  # <path>
@@ -778,7 +804,7 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   local source=$1 inspect_target=$2 wt_top
   wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
   if [ -z "$wt_top" ] || ! same_filesystem_object "$WT" "$wt_top" \
-     || ! distinct_filesystem_objects "$wt_top" "$PROJ_ABS"; then
+     || ! distinct_from_primary "$wt_top"; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
@@ -1030,8 +1056,8 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # Compare directory identity, not path spelling. `pwd -P` removes symlinks but
   # can retain caller-supplied letter casing on a case-insensitive filesystem,
   # so string comparison can still mistake the unchanged primary directory for
-  # a worktree. Bash's -ef follows aliases and asks the filesystem whether both
-  # names identify the same object.
+  # a worktree. Device-and-inode identity follows aliases without depending on
+  # the primary pathname remaining stable during the spawn.
   #
   # A single read that is filesystem-distinct from the project is not proof the pane
   # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
@@ -1047,10 +1073,10 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   candidate=""
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ] && distinct_filesystem_objects "$p" "$PROJ_ABS"; then
+    if [ -n "$p" ] && distinct_from_primary "$p"; then
       p_top=$(git_worktree_root "$p" || true)
       if [ -n "$p_top" ] && same_filesystem_object "$p" "$p_top" \
-         && distinct_filesystem_objects "$p_top" "$PROJ_ABS"; then
+         && distinct_from_primary "$p_top"; then
         if [ -n "$candidate" ] && same_filesystem_object "$p_top" "$candidate"; then
           WT="$p_top"
           break

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -76,11 +76,10 @@
 #   config reread generations because the new agent reads the converged files.
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md task lifecycle); --secondmate records kind=secondmate and launches in a
-#   provisioned firstmate home; the default is kind=ship.
+#   provisioned firstmate home; the default is kind=ship. Ship/scout spawns wait for a
+#   filesystem-distinct git worktree root and record that resolved top-level path.
 #   Before a secondmate launch, the home is locally fast-forwarded to the primary
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
-#   Ship/scout spawns refuse to launch unless the resolved task path is a real
-#   git worktree root distinct from the primary project checkout.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -751,25 +750,16 @@ else
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
 
-# PROJ_ABS can still carry a symlinked path component (e.g. macOS's /tmp ->
-# /private/tmp) when it came from the ship/scout branch's logical `pwd` above.
-# Every backend's own current-path read (tmux's pane_current_path, herdr's
-# foreground_cwd, zellij/cmux's active pwd probe against the live shell) can
-# report the OS-level, physically-resolved cwd, so comparing it against a
-# still-symlinked PROJ_ABS can misfire both ways: false-negative (the poll
-# below never notices the pane left the project) or false-positive (the
-# isolation guard refuses a spawn that never actually tangled). Canonicalize
-# once here so every downstream comparison uses the same physical form
-# (docs/herdr-backend.md "Known gaps").
-PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
+# Backend current-path reads and PROJ_ABS can spell the same directory through
+# different symlink aliases or letter casing. String canonicalization is not an
+# identity proof on every supported filesystem, so all isolation decisions use
+# Bash's device-and-inode-aware -ef predicate instead.
+same_filesystem_object() {  # <left-path> <right-path>
+  [ -e "$1" ] && [ -e "$2" ] && [ "$1" -ef "$2" ]
+}
 
-real_path_or_raw() {  # <path>
-  local path=$1 real
-  if real=$(cd "$path" 2>/dev/null && pwd -P); then
-    printf '%s\n' "$real"
-  else
-    printf '%s\n' "$path"
-  fi
+git_worktree_root() {  # <path>
+  git -C "$1" rev-parse --show-toplevel 2>/dev/null
 }
 
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
@@ -781,18 +771,10 @@ real_path_or_raw() {  # <path>
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
 validate_spawn_worktree() {  # <source> <inspect-target>
-  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
-  wt_real=
-  if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
-    wt_real=
-  fi
-  proj_real=$PROJ_ABS_REAL
+  local source=$1 inspect_target=$2 wt_top
   wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
-  wt_top_real=
-  if ! wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P); then
-    wt_top_real=
-  fi
-  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
+  if [ -z "$wt_top" ] || ! same_filesystem_object "$WT" "$wt_top" \
+     || same_filesystem_object "$wt_top" "$PROJ_ABS"; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
@@ -1040,32 +1022,35 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # automatic-rename slips through), display-message -t <bad-name> falls back to the
   # active client's window, which would misread firstmate's OWN pane path as the
   # worktree and tangle a hook into the primary checkout. The window id never lies.
-  # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
-  # prefix would otherwise make the pane's OS-level cwd read differ from
-  # PROJ_ABS on the very first poll, before the pane has actually moved.
+  # Compare directory identity, not path spelling. `pwd -P` removes symlinks but
+  # can retain caller-supplied letter casing on a case-insensitive filesystem,
+  # so string comparison can still mistake the unchanged primary directory for
+  # a worktree. Bash's -ef follows aliases and asks the filesystem whether both
+  # names identify the same object.
   #
-  # A single read that already differs from PROJ_ABS_REAL is not proof the pane
+  # A single read that is filesystem-distinct from the project is not proof the pane
   # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
   # transiently reports an unrelated stale path (seen live as another real git
   # checkout entirely) before the shell catches up with treehouse get's cd. That
-  # stale path still passes the PROJ_ABS_REAL comparison and validate_spawn_worktree
-  # below (it resolves to a real, distinct worktree top-level too), so accepting it
+  # stale path can still pass validate_spawn_worktree below because it resolves
+  # to a real, distinct worktree top-level too, so accepting it
   # on one read alone silently records the wrong worktree= in state/<id>.meta. Require
-  # two consecutive reads to agree on the same non-project path before accepting it;
+  # two consecutive reads to identify the same non-project git root before accepting it;
   # a mismatch just becomes the new candidate rather than resetting the wait, so a
   # pane that is already settled by the first real read only costs the one existing
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
   candidate=""
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ]; then
-      p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
-        if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
-          WT="$p"
+    if [ -n "$p" ] && ! same_filesystem_object "$p" "$PROJ_ABS"; then
+      p_top=$(git_worktree_root "$p" || true)
+      if [ -n "$p_top" ] && same_filesystem_object "$p" "$p_top" \
+         && ! same_filesystem_object "$p_top" "$PROJ_ABS"; then
+        if [ -n "$candidate" ] && same_filesystem_object "$p_top" "$candidate"; then
+          WT="$p_top"
           break
         fi
-        candidate="$p_real"
+        candidate="$p_top"
       else
         candidate=""
       fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1235,7 +1235,7 @@ META_WINDOW=$T
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
   fi
-} > "$STATE/$ID.meta"
+} > "$STATE/$ID.meta" || exit 1
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -758,6 +758,10 @@ same_filesystem_object() {  # <left-path> <right-path>
   [ -e "$1" ] && [ -e "$2" ] && [ "$1" -ef "$2" ]
 }
 
+distinct_filesystem_objects() {  # <left-path> <right-path>
+  [ -e "$1" ] && [ -e "$2" ] && ! [ "$1" -ef "$2" ]
+}
+
 git_worktree_root() {  # <path>
   git -C "$1" rev-parse --show-toplevel 2>/dev/null
 }
@@ -774,7 +778,7 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   local source=$1 inspect_target=$2 wt_top
   wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
   if [ -z "$wt_top" ] || ! same_filesystem_object "$WT" "$wt_top" \
-     || same_filesystem_object "$wt_top" "$PROJ_ABS"; then
+     || ! distinct_filesystem_objects "$wt_top" "$PROJ_ABS"; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
@@ -1043,10 +1047,10 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   candidate=""
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ] && ! same_filesystem_object "$p" "$PROJ_ABS"; then
+    if [ -n "$p" ] && distinct_filesystem_objects "$p" "$PROJ_ABS"; then
       p_top=$(git_worktree_root "$p" || true)
       if [ -n "$p_top" ] && same_filesystem_object "$p" "$p_top" \
-         && ! same_filesystem_object "$p_top" "$PROJ_ABS"; then
+         && distinct_filesystem_objects "$p_top" "$PROJ_ABS"; then
         if [ -n "$candidate" ] && same_filesystem_object "$p_top" "$candidate"; then
           WT="$p_top"
           break

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -778,6 +778,7 @@ validate_spawn_worktree() {  # <source> <inspect-target>
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
+  WT=$wt_top
 }
 
 # A stale presentation journal never grants launch authority.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -74,10 +74,8 @@
 #   secondmate receives the primary's read-only shared captain-preference file
 #   (fm-config-inherit-lib.sh). A successful launch clears pending inherited
 #   config reread generations because the new agent reads the converged files.
-#   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
-#   see AGENTS.md task lifecycle); --secondmate records kind=secondmate and launches in a
-#   provisioned firstmate home; the default is kind=ship. Ship/scout spawns wait for a
-#   filesystem-distinct git worktree root and record that resolved top-level path.
+#   --scout records kind=scout for a report-producing scratch worktree; --secondmate records
+#   kind=secondmate in its isolated home. Default ship/scout spawns wait for and record a filesystem-distinct Git worktree top-level (see AGENTS.md task lifecycle).
 #   Before a secondmate launch, the home is locally fast-forwarded to the primary
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
-For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+For ship and scout work, `fm-spawn.sh` refuses to launch unless filesystem identity proves that the resolved task path is a real git worktree root distinct from the project primary checkout, then records the verified Git top-level for task metadata and cleanup.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -51,7 +51,7 @@ See "Optional disposable single-task presentation spaces" below before enabling 
 Verify it works by spawning a trivial task with `--backend herdr` and confirming the task's meta records `backend=herdr` plus `herdr_session=`, `herdr_workspace_id=`, `herdr_tab_id=`, and `herdr_pane_id=`; the selected Herdr workspace should show the new `fm-<id>` tab.
 
 Limitations: herdr is experimental and still carries the open gaps documented below.
-Resolved backend evidence, including the 2026-07-06 symlinked-project-prefix isolation fix, is kept in the same follow-up log for auditability.
+Resolved backend evidence, including the 2026-07-21 filesystem-identity isolation fix that superseded the earlier symlink-prefix path normalization, is kept in the same follow-up log for auditability.
 
 ## Status: experimental
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -1023,14 +1023,37 @@ Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry
 
 ## Known gaps and follow-up notes
 
-- **RESOLVED: worktree-discovery isolation guard's symlinked-project-prefix false refusal.** Originally discovered while building the runtime-backend-auto-detection real smoke test (`tests/fm-backend-autodetect-smoke.test.sh`), which needed a scratch project.
-  `fm-spawn.sh`'s `PROJ_ABS` was a LOGICAL `cd && pwd` (symlink components kept), while herdr's `foreground_cwd` (and real tmux's `pane_current_path`, on the same OS-level cwd primitive) report the PHYSICALLY resolved path.
-  When the project itself lived under a symlinked directory (e.g. macOS's `/tmp` -> `/private/tmp`), the very first worktree-discovery poll saw two different strings for the identical starting directory and the isolation guard false-refused the spawn as "not isolated" before `treehouse get` ever moved the pane - backend-agnostic, not specific to herdr.
-  Fixed 2026-07-06 (backlog `fm-spawn-symlink-guard-s8`): `bin/fm-spawn.sh` now canonicalizes once into `PROJ_ABS_REAL` (`cd "$PROJ_ABS" && pwd -P`) right after `PROJ_ABS` is resolved, canonicalizes each observed pane cwd for the worktree-discovery comparison, and uses `PROJ_ABS_REAL` in `validate_spawn_worktree`'s own primary-vs-worktree comparison instead of recomputing from the still-symlinked `PROJ_ABS`.
-  This removes both failure directions: a symlinked prefix can no longer false-refuse an isolated spawn, and, since both sides are physically resolved for comparison, a genuinely tangled spawn (worktree resolves to the same physical directory as the project) still correctly refuses.
-  Verified with GNU bash 5.3.9(1)-release (aarch64-apple-darwin25.3.0) and git 2.53.0 on macOS (Darwin 25.5.0): added `tests/fm-backend.test.sh:test_spawn_symlinked_project_prefix_avoids_false_refusal`, which drives the real `bin/fm-spawn.sh` against fake-tmux panes whose first `pane_current_path` poll returns both the project's `pwd -P`-resolved physical path and its logical symlink-preserving path while `PROJ_ABS` is reached through a synthetic symlinked prefix (`ln -s <real> <link>`, project passed as `<link>/proj`).
-  Confirmed the test reproduces the original bug against the pre-fix script (`git stash` the `bin/fm-spawn.sh` change and rerun: `not ok - fm-spawn.sh should succeed for a project reached through a symlinked prefix` / `error: treehouse get did not yield an isolated worktree ...`), and passes against the fix (`bash tests/fm-backend.test.sh` reports `ok - fm-spawn.sh: a project reached through a symlinked prefix (e.g. macOS /tmp -> /private/tmp) does not trip the isolation guard's false refusal`, with the rest of that suite's assertions unaffected).
-  `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` passes clean on the changed scripts.
+- **RESOLVED: worktree discovery now compares filesystem identity across symlink and case aliases.**
+  The 2026-07-06 symlink-prefix fix physically resolved path strings before comparison after a backend current-path read and `PROJ_ABS` used different symlink spellings.
+  The 2026-07-21 Herdr incident proved that string canonicalization was still insufficient on case-insensitive macOS filesystems.
+  Herdr 0.7.3 could return the unchanged primary project directory with different letter casing, two stable reads accepted that spelling as the worktree before `treehouse get` finished, and the string-based final validator could accept it too.
+  The shell later entered the correct Treehouse worktree, but `worktree=` metadata, printed output, and teardown's Treehouse return target retained the primary path alias.
+  `bin/fm-spawn.sh` now uses Bash's filesystem-aware `-ef` predicate for project-vs-current-path, consecutive-candidate, candidate-vs-git-root, and final primary-vs-worktree identity checks.
+  Each acceptable current path must resolve to its own `git rev-parse --show-toplevel`, identify that exact root, remain filesystem-distinct from the primary, and repeat on the next poll before `WT` records the git top-level rather than the backend's current-path spelling.
+  `validate_spawn_worktree` independently repeats the root and primary identity checks, so Orca's direct worktree result receives the same refusal even though Orca bypasses the Treehouse settle loop.
+  Tmux, Herdr, Zellij, and cmux retain their existing current-path adapters and share the corrected Treehouse loop, while Orca retains its provider path and uses the corrected shared validator.
+  Deterministic coverage in `tests/fm-spawn-worktree-settle.test.sh` uses native case aliasing on case-insensitive filesystems and an equivalent differently-cased symlink on case-sensitive CI.
+  The regression returns a case-variant primary alias twice before the real worktree, asserts at least four polls, verifies the isolated git root in metadata, runs scout teardown, and verifies `treehouse return --force` receives only that isolated root.
+  A fake-Orca case separately proves that the final validator rejects a case-variant primary alias and cleans up the response-derived terminal and worktree IDs.
+  The existing symlink-prefix regression in `tests/fm-backend.test.sh` continues to cover physical and logical initial current-path spellings and now expects the resolved git top-level in spawn output.
+  Verification ran on 2026-07-21 with GNU bash 3.2.57(1)-release, git 2.50.1 (Apple Git-155), and Darwin 25.3.0 on arm64 macOS.
+  Exact commands and results were:
+
+  ```text
+  $ bash tests/fm-spawn-worktree-settle.test.sh
+  ok - a single transient stale pane_current_path read is not accepted as the worktree
+  ok - an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle
+  ok - case-variant primary cwd aliases cannot win the settle race or become metadata/cleanup targets
+  ok - validate_spawn_worktree independently rejects a case-variant primary alias by filesystem identity
+  # all fm-spawn-worktree-settle tests passed
+
+  $ bash tests/fm-backend.test.sh
+  ok - fm-spawn.sh: a project reached through a symlinked prefix (e.g. macOS /tmp -> /private/tmp) does not trip the isolation guard's false refusal
+  [... all remaining assertions passed ...]
+
+  $ bin/fm-lint.sh
+  fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
+  ```
 - **RESOLVED: a restart's restored-layout husk no longer needs a manual pane close before respawn.** See "Respawn idempotency: a restored task tab is a husk, not a duplicate" above for the fix (`fm_backend_herdr_pane_agent_state`, `fm_backend_herdr_create_task`'s close-and-replace).
   Left over from that fix: the `dead` (`pane_not_found`) husk classification is exercised only at the unit level, never against the real binary - killing a pane's process on a live server was observed to make herdr reap the whole tab immediately (never leaving a dead-but-still-listed pane for the duplicate check to find), and a real session restart was never observed to produce one either.
   It remains a conservative, defensively-coded path for a herdr failure mode (e.g. a restored process that fails to start) nobody has reproduced against the real binary yet.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -1028,13 +1028,14 @@ Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry
   The 2026-07-21 Herdr incident proved that string canonicalization was still insufficient on case-insensitive macOS filesystems.
   Herdr 0.7.3 could return the unchanged primary project directory with different letter casing, two stable reads accepted that spelling as the worktree before `treehouse get` finished, and the string-based final validator could accept it too.
   The shell later entered the correct Treehouse worktree, but `worktree=` metadata, printed output, and teardown's Treehouse return target retained the primary path alias.
-  `bin/fm-spawn.sh` now uses Bash's filesystem-aware `-ef` predicate for project-vs-current-path, consecutive-candidate, candidate-vs-git-root, and final primary-vs-worktree identity checks.
+  `bin/fm-spawn.sh` now pins the primary checkout's dereferenced device-and-inode identity from its open directory with BSD/GNU `stat -L`, then uses dereferenced device-and-inode identities for project-vs-current-path, consecutive-candidate, candidate-vs-git-root, and final primary-vs-worktree checks.
   Each acceptable current path must resolve to its own `git rev-parse --show-toplevel`, identify that exact root, remain filesystem-distinct from the primary, and repeat on the next poll before `WT` records the git top-level rather than the backend's current-path spelling.
   `validate_spawn_worktree` independently repeats the root and primary identity checks, so Orca's direct worktree result receives the same refusal even though Orca bypasses the Treehouse settle loop.
   Tmux, Herdr, Zellij, and cmux retain their existing current-path adapters and share the corrected Treehouse loop, while Orca retains its provider path and uses the corrected shared validator.
   Deterministic coverage in `tests/fm-spawn-worktree-settle.test.sh` uses native case aliasing on case-insensitive filesystems and an equivalent differently-cased symlink on case-sensitive CI.
   The regression returns a case-variant primary alias twice before the real worktree, asserts at least four polls, verifies the isolated git root in metadata, runs scout teardown, and verifies `treehouse return --force` receives only that isolated root.
   A fake-Orca case separately proves that the final validator rejects a case-variant primary alias and cleans up the response-derived terminal and worktree IDs.
+  Two rename-race cases remove the primary pathname after its identity is pinned and prove that neither the Treehouse settle loop nor Orca's final validator can accept the renamed primary checkout as isolated.
   `tests/fm-backend-orca.test.sh` separately proves that an accepted Orca worktree symlink is normalized to its resolved git top-level in spawn output and metadata.
   The existing symlink-prefix regression in `tests/fm-backend.test.sh` continues to cover physical and logical initial current-path spellings and now expects the resolved git top-level in spawn output.
   Initial verification ran on 2026-07-21 and focused re-verification ran on 2026-07-22 with GNU bash 3.2.57(1)-release, git 2.50.1 (Apple Git-155), and Darwin 25.3.0 on arm64 macOS.
@@ -1046,6 +1047,8 @@ Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry
   ok - an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle
   ok - case-variant primary cwd aliases cannot win the settle race or become metadata/cleanup targets
   ok - validate_spawn_worktree independently rejects a case-variant primary alias by filesystem identity
+  ok - settle loop requires positive filesystem distinction from an existing primary path
+  ok - validator requires positive filesystem distinction from an existing primary path
   # all fm-spawn-worktree-settle tests passed
 
   $ bash tests/fm-backend.test.sh

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -1035,9 +1035,10 @@ Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry
   Deterministic coverage in `tests/fm-spawn-worktree-settle.test.sh` uses native case aliasing on case-insensitive filesystems and an equivalent differently-cased symlink on case-sensitive CI.
   The regression returns a case-variant primary alias twice before the real worktree, asserts at least four polls, verifies the isolated git root in metadata, runs scout teardown, and verifies `treehouse return --force` receives only that isolated root.
   A fake-Orca case separately proves that the final validator rejects a case-variant primary alias and cleans up the response-derived terminal and worktree IDs.
+  `tests/fm-backend-orca.test.sh` separately proves that an accepted Orca worktree symlink is normalized to its resolved git top-level in spawn output and metadata.
   The existing symlink-prefix regression in `tests/fm-backend.test.sh` continues to cover physical and logical initial current-path spellings and now expects the resolved git top-level in spawn output.
-  Verification ran on 2026-07-21 with GNU bash 3.2.57(1)-release, git 2.50.1 (Apple Git-155), and Darwin 25.3.0 on arm64 macOS.
-  Exact commands and results were:
+  Initial verification ran on 2026-07-21 and focused re-verification ran on 2026-07-22 with GNU bash 3.2.57(1)-release, git 2.50.1 (Apple Git-155), and Darwin 25.3.0 on arm64 macOS.
+  Exact focused commands and representative results were:
 
   ```text
   $ bash tests/fm-spawn-worktree-settle.test.sh
@@ -1049,6 +1050,10 @@ Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry
 
   $ bash tests/fm-backend.test.sh
   ok - fm-spawn.sh: a project reached through a symlinked prefix (e.g. macOS /tmp -> /private/tmp) does not trip the isolation guard's false refusal
+  [... all remaining assertions passed ...]
+
+  $ bash tests/fm-backend-orca.test.sh
+  ok - fm-spawn.sh --backend orca: resolves aliased worktree, records metadata, launches harness
   [... all remaining assertions passed ...]
 
   $ bin/fm-lint.sh

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -55,7 +55,7 @@ backend=orca
 window=fm-<id>
 terminal=<orca terminal handle>
 orca_worktree_id=<orca worktree id>
-worktree=<absolute path to the Orca-created git worktree>
+worktree=<verified Git top-level of the Orca-created worktree>
 ```
 
 `window=` remains the shared firstmate alias used by selector-driven supervision tools after a task selector has resolved through metadata.
@@ -69,9 +69,10 @@ Spawn:
 
 1. Ensure the project repo is registered in Orca, adding it with `orca repo add --path` when needed.
 2. Create an independent Orca worktree with `orca worktree create --repo id:<repo> --name fm-<id> --no-parent --setup skip`.
-3. Reuse the terminal returned by Orca worktree creation only when it appears in the verified `result.terminal.handle` shape, or create a titled terminal in that worktree when Orca returns only the worktree.
-4. Install firstmate's per-harness turn-end hooks in the Orca worktree.
-5. Write metadata, then send `GOTMPDIR` export and the selected harness launch through the recorded Orca terminal.
+3. Resolve Orca's returned worktree path to its actual Git top-level and refuse the spawn unless filesystem identity proves that root is distinct from the primary checkout.
+4. Reuse the terminal returned by Orca worktree creation only when it appears in the verified `result.terminal.handle` shape, or create a titled terminal in that verified worktree when Orca returns only the worktree.
+5. Install firstmate's per-harness turn-end hooks in the verified worktree.
+6. Write the verified Git top-level to metadata, then send `GOTMPDIR` export and the selected harness launch through the recorded Orca terminal.
 
 Operation routing:
 
@@ -109,7 +110,8 @@ Fake-Orca tests cover:
 - helper parsing for repo registration, worktree creation, verified implicit-terminal reuse, terminal creation, terminal sends, and worktree removal;
 - rejection of undocumented terminal-handle result shapes;
 - runtime readiness gating through `orca status --json`;
-- `fm-spawn.sh --backend orca` metadata creation and harness launch;
+- `fm-spawn.sh --backend orca` normalization of an aliased worktree path to its verified Git top-level in output and metadata before harness launch;
+- independent rejection of primary-checkout filesystem aliases by the shared final worktree validator;
 - `fm-peek.sh`, `fm-send.sh`, and `fm-crew-state.sh` routing through recorded Orca metadata;
 - slash-command popup placeholder handling that requires a second Enter before `fm-send.sh` reports submission;
 - scout teardown releasing an Orca worktree through `orca worktree rm`;

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -46,8 +46,8 @@ export FM_GATE_REFUSE_BYPASS=1
 # TMP_ROOT is physically resolved (mktemp -d "$(pwd -P)"-relative) to keep this
 # real-herdr smoke fixture free of unrelated OS symlink noise.
 # The old fm-spawn bug that originally motivated this fixture shape was fixed in
-# fm-spawn-symlink-guard-s8: fm-spawn.sh now normalizes PROJ_ABS and observed
-# backend cwd reads before the worktree-discovery comparison.
+# fm-spawn-symlink-guard-s8; fm-spawn now compares dereferenced filesystem
+# identity rather than path spellings during worktree discovery.
 # The dedicated regression is
 # tests/fm-backend.test.sh:test_spawn_symlinked_project_prefix_avoids_false_refusal.
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-backend-autodetect-smoke.XXXXXX")

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -36,6 +36,7 @@ mkdir -p "$FAKEBIN"
 REAL_MOVER="$ROOT/bin/backends/herdr-workspace-move.py"
 export REAL_HERDR REAL_TREEHOUSE REAL_MOVER HERDR_CALL_LOG TREEHOUSE_CALL_LOG MOVE_CALL_LOG FOCUS_AUDIT_LOG HERDR_ORIGINAL_PATH HERDR_LAB_HELPER
 export ACTIVE_SEEDED_CONTROL POST_CREATE_ABORT_CONTROL TMP_ROOT
+export POST_CREATE_ABORT_STATE POST_CREATE_ABORT_A_WT POST_CREATE_ABORT_B_WT
 
 # Log every production-adapter call, remove its already-validated trailing
 # session flag, and send the operation through the lab helper so that helper
@@ -179,7 +180,14 @@ if [ "$status" -eq 0 ] && [ "${1:-} ${2:-}" = "pane get" ] && [ -d "$POST_CREATE
   for task_dir in "$POST_CREATE_ABORT_CONTROL"/abort-*; do
     [ -d "$task_dir" ] || continue
     [ "${3:-}" = "$(cat "$task_dir/task-pane" 2>/dev/null || true)" ] || continue
-    out=$(printf '%s' "$out" | jq --arg cwd "$POST_CREATE_ABORT_CONTROL/not-a-worktree" '.result.pane.foreground_cwd = $cwd')
+    task=${task_dir##*/}
+    case "$task" in
+      abort-a) abort_wt=$POST_CREATE_ABORT_A_WT ;;
+      abort-b) abort_wt=$POST_CREATE_ABORT_B_WT ;;
+      *) exit 1 ;;
+    esac
+    out=$(printf '%s' "$out" | jq --arg cwd "$abort_wt" '.result.pane.foreground_cwd = $cwd')
+    mkdir -p "$POST_CREATE_ABORT_STATE/$task.meta"
     break
   done
 fi
@@ -469,6 +477,12 @@ printf 'Projection abort fixture A.\n' > "$HOME_DIR/data/abort-a/brief.md"
 printf 'Projection abort fixture B.\n' > "$HOME_DIR/data/abort-b/brief.md"
 printf 'Projection lock contention fixture.\n' > "$HOME_DIR/data/lock-contended/brief.md"
 make_project "$PROJECT_DIR"
+POST_CREATE_ABORT_STATE="$HOME_DIR/state"
+POST_CREATE_ABORT_A_WT="$TMP_ROOT/abort-a-worktree"
+POST_CREATE_ABORT_B_WT="$TMP_ROOT/abort-b-worktree"
+git -C "$PROJECT_DIR" worktree add -q -b abort-a-fixture "$POST_CREATE_ABORT_A_WT"
+git -C "$PROJECT_DIR" worktree add -q -b abort-b-fixture "$POST_CREATE_ABORT_B_WT"
+export POST_CREATE_ABORT_STATE POST_CREATE_ABORT_A_WT POST_CREATE_ABORT_B_WT
 
 # Keep one ordinary primary task live so the durable firstmate workspace is
 # first and remains present while disposable workers are projected around it.
@@ -746,10 +760,10 @@ spawn_task abort-b "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/abort-b.out" 2> "$TMP
 ABORT_B_PID=$!
 if wait "$ABORT_A_PID"; then fail "post-create abort fixture A unexpectedly succeeded"; fi
 if wait "$ABORT_B_PID"; then fail "post-create abort fixture B unexpectedly succeeded"; fi
-grep -F "did not yield an isolated worktree" "$TMP_ROOT/abort-a.err" >/dev/null 2>&1 \
-  || fail "post-create abort fixture A did not reach the armed validation failure"
-grep -F "did not yield an isolated worktree" "$TMP_ROOT/abort-b.err" >/dev/null 2>&1 \
-  || fail "post-create abort fixture B did not reach the armed validation failure"
+grep -F "Is a directory" "$TMP_ROOT/abort-a.err" >/dev/null 2>&1 \
+  || fail "post-create abort fixture A did not reach the armed metadata failure"
+grep -F "Is a directory" "$TMP_ROOT/abort-b.err" >/dev/null 2>&1 \
+  || fail "post-create abort fixture B did not reach the armed metadata failure"
 ABORT_A_PANE=$(cat "$POST_CREATE_ABORT_CONTROL/abort-a/task-pane")
 ABORT_B_PANE=$(cat "$POST_CREATE_ABORT_CONTROL/abort-b/task-pane")
 ABORT_SEQUENCE=$(sed -n "$((ABORT_FOCUS_START + 1)),\$p" "$FOCUS_AUDIT_LOG" | awk -F '\t' -v a="$ABORT_A_PANE" -v b="$ABORT_B_PANE" '
@@ -776,8 +790,9 @@ for ABORT_PANE in "$ABORT_A_PANE" "$ABORT_B_PANE"; do
     fail "serialized post-create abort cleanup left exact task pane $ABORT_PANE alive"
   fi
 done
-[ ! -e "$HOME_DIR/state/abort-a.meta" ] && [ ! -e "$HOME_DIR/state/abort-b.meta" ] \
-  || fail "post-create abort fixtures published task metadata before launch"
+[ ! -f "$HOME_DIR/state/abort-a.meta" ] && [ ! -f "$HOME_DIR/state/abort-b.meta" ] \
+  || fail "post-create abort fixtures published regular task metadata before launch"
+rm -rf "$HOME_DIR/state/abort-a.meta" "$HOME_DIR/state/abort-b.meta"
 rm -rf "$POST_CREATE_ABORT_CONTROL"
 rm -f "$HOME_DIR/state/abort-a.herdr-presentation" "$HOME_DIR/state/abort-b.herdr-presentation"
 pass "real Herdr lab: concurrent post-create abort cleanup stays serialized with exact focus restoration"

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -58,8 +58,8 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (requi
 # low-noise scratch fixture shape used by
 # tests/fm-backend-autodetect-smoke.test.sh.
 # fm-spawn no longer needs this as a symlink workaround: fm-spawn-symlink-guard-s8
-# canonicalized project and backend cwd comparisons in the worktree-discovery
-# poll.
+# led to filesystem-identity comparisons for project and backend cwd reads in
+# the worktree-discovery poll.
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-herdr-e2e.XXXXXX")
 SESSION="fm-lab-herdr-e2e-$$"
 export HERDR_SESSION="$SESSION"

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -470,7 +470,7 @@ test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails() {
 }
 
 test_spawn_writes_orca_metadata_and_launches_harness() {
-  local proj wt data state config id out log
+  local proj wt wt_alias wt_top data state config id out log
   id="orcaspawnz1"
   proj="$TMP_ROOT/spawn-project"
   wt="$TMP_ROOT/spawn-wt"
@@ -478,6 +478,9 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   state="$TMP_ROOT/spawn-state"
   config="$TMP_ROOT/spawn-config"
   fm_git_worktree "$proj" "$wt" "fm/$id"
+  wt_top=$(git -C "$wt" rev-parse --show-toplevel)
+  wt_alias="$TMP_ROOT/spawn-wt-alias"
+  ln -s "$wt" "$wt_alias"
   mkdir -p "$data/$id" "$state" "$config"
   printf 'brief\n' > "$data/$id/brief.md"
   touch "$state/.last-watcher-beat"
@@ -485,19 +488,20 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   log="$LOG"
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-spawn"}}}\n' > "$RESP/2.out"
-  printf '{"ok":true,"result":{"worktree":{"id":"wt-spawn","path":"%s"},"terminal":{"handle":"term-spawn"}}}\n' "$wt" > "$RESP/3.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-spawn","path":"%s"},"terminal":{"handle":"term-spawn"}}}\n' "$wt_alias" > "$RESP/3.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --backend orca 2>&1 )
   expect_code 0 $? "fm-spawn.sh --backend orca should succeed with fake Orca"$'\n'"$out"
-  assert_contains "$out" "spawned $id harness=claude kind=ship mode=no-mistakes yolo=off window=fm-$id worktree=$wt" \
+  assert_contains "$out" "spawned $id harness=claude kind=ship mode=no-mistakes yolo=off window=fm-$id worktree=$wt_top" \
     "spawn output missing Orca window/worktree summary"
   assert_grep "backend=orca" "$state/$id.meta" "meta missing backend=orca"
   assert_grep "window=fm-$id" "$state/$id.meta" "meta missing stable Orca window alias"
   assert_grep "terminal=term-spawn" "$state/$id.meta" "meta missing terminal handle"
   assert_grep "orca_worktree_id=wt-spawn" "$state/$id.meta" "meta missing Orca worktree id"
-  assert_grep "worktree=$wt" "$state/$id.meta" "meta missing Orca worktree path"
+  assert_grep "worktree=$wt_top" "$state/$id.meta" "meta missing resolved Orca worktree path"
+  assert_no_grep "worktree=$wt_alias" "$state/$id.meta" "meta retained Orca's worktree alias"
   assert_not_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''create' \
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
   assert_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-spawn'$'\x1f''--text'$'\x1f''export GOTMPDIR=/tmp/fm-orcaspawnz1/gotmp'$'\x1f''--enter'$'\x1f''--json' \
@@ -505,7 +509,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
   assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions" \
     "spawn did not send the selected harness launch command through Orca"
   rm -rf "/tmp/fm-$id"
-  pass "fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness"
+  pass "fm-spawn.sh --backend orca: resolves aliased worktree, records metadata, launches harness"
 }
 
 test_spawn_refuses_orca_secondmate_before_home_mutation() {

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -796,17 +796,13 @@ run_spawn_case() {  # <bin-root> <fakebin> <log> <state> <data> <config> <proj> 
 # --- symlinked project prefix must not false-refuse the isolation guard -----
 #
 # docs/herdr-backend.md "Known gaps": a real backend's pane_current_path read
-# (tmux, herdr) reports the OS-level PHYSICALLY-resolved cwd. When the project
-# itself lives under a symlinked prefix (e.g. macOS's /tmp -> /private/tmp),
-# fm-spawn.sh's PROJ_ABS - a logical `cd && pwd` - differs string-for-string
-# from that physical read even before treehouse moves the pane at all, so the
-# worktree-discovery poll used to mistake an UNMOVED pane for one that had
-# already left the project, handing validate_spawn_worktree the project's own
-# directory as "the worktree" and tripping its false isolation refusal.
+# can spell the unchanged project through a different symlink alias.
+# The filesystem-identity comparison must treat that as an UNMOVED pane rather
+# than handing validate_spawn_worktree the project's own directory as a
+# purported worktree.
 # make_spawn_symlink_fakebin's tmux stub returns an unmoved project path on the
 # first pane_current_path poll, then the real worktree path from the second poll
-# onward, so this test fails loudly if the PROJ_ABS/PROJ_ABS_REAL
-# canonicalization in bin/fm-spawn.sh ever regresses.
+# onward, so this test fails loudly if the identity comparison regresses.
 make_spawn_symlink_fakebin() {  # <dir> <initial-project-path> <worktree-path> -> echoes fakebin dir
   local dir=$1 initial_path=$2 wt=$3 fb="$1/fakebin" counter="$1/poll-count"
   mkdir -p "$fb"
@@ -837,7 +833,7 @@ SH
 }
 
 run_spawn_symlink_case() {  # <label> <physical|logical>
-  local label=$1 first_reply=$2 real_root link_root proj wt id fb data state config log out rc proj_phys initial_path
+  local label=$1 first_reply=$2 real_root link_root proj wt wt_top id fb data state config log out rc proj_phys initial_path
   real_root="$TMP_ROOT/symlink-real-$label"; link_root="$TMP_ROOT/symlink-link-$label"
   mkdir -p "$real_root"
   ln -s "$real_root" "$link_root"
@@ -845,11 +841,11 @@ run_spawn_symlink_case() {  # <label> <physical|logical>
   wt="$TMP_ROOT/symlink-wt-$label"
   id="spawnsymlink$label"
   fm_git_worktree "$real_root/proj" "$wt" "fm/$id"
+  wt_top=$(git -C "$wt" rev-parse --show-toplevel)
   # TMP_ROOT itself can already sit behind an OS-level symlink (e.g. macOS's
   # /var -> /private/var), so resolve the fakebin's "physical" reply with
-  # pwd -P rather than string concatenation - it must match exactly what
-  # fm-spawn.sh's own PROJ_ABS_REAL computes, including any symlink layers
-  # ABOVE this test's own synthetic real_root/link_root pair.
+  # pwd -P rather than string concatenation to include any symlink layers
+  # above this test's own synthetic real_root/link_root pair.
   proj_phys=$(cd "$real_root/proj" && pwd -P)
   case "$first_reply" in
     physical) initial_path=$proj_phys ;;
@@ -867,7 +863,7 @@ run_spawn_symlink_case() {  # <label> <physical|logical>
   out=$(run_spawn_case "$ROOT" "$fb" "$log" "$state" "$data" "$config" "$proj" -- "$id" "$proj" claude 2>&1)
   rc=$?
   expect_code 0 "$rc" "fm-spawn.sh should succeed for a project reached through a symlinked prefix when the backend reports $first_reply cwd"$'\n'"$out"
-  assert_contains "$out" "worktree=$wt" \
+  assert_contains "$out" "worktree=$wt_top" \
     "fm-spawn.sh did not resolve a symlinked-prefix project to its real worktree when the backend reports $first_reply cwd"
 
   rm -rf "/tmp/fm-$id"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Regression test for the fm-spawn.sh treehouse-get worktree-detection settle
-# loop (bin/fm-spawn.sh, the `for _ in $(seq 1 60)` loop after `treehouse get`).
+# Regression tests for fm-spawn.sh's treehouse-get worktree-detection settle
+# loop and the independent validate_spawn_worktree safety check.
 #
 # On some tmux/WSL setups a brand-new window's pane_current_path transiently
 # reports a stale, unrelated-but-real path on the very first poll, before the
@@ -8,16 +8,18 @@
 # path still passes the loop's "differs from the project" check and
 # validate_spawn_worktree's "is a real, distinct worktree" check (it IS a real
 # git checkout, just the wrong one), so a naive single-read loop silently
-# records the wrong worktree= in state/<id>.meta. This test simulates that
-# transient-then-settled pane_current_path sequence with a fake tmux and
-# asserts the recorded worktree resolves to the real, settled worktree, never
-# the stale first read.
+# records the wrong worktree= in state/<id>.meta.
+# The same string-based path logic also let a case-variant spelling of the
+# unchanged primary directory win on a case-insensitive filesystem.
+# These tests simulate both sequences and assert that metadata and teardown
+# use the real, settled git top-level, never a stale or primary path alias.
 set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-worktree-settle)
 
 # make_settle_fakebin <dir> builds a fake tmux whose `#{pane_current_path}`
@@ -54,8 +56,63 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ -n "${FM_FAKE_TREEHOUSE_LOG:-}" ]; then
+  { printf 'treehouse'; for a in "$@"; do printf '\x1f%s' "$a"; done; printf '\n'; } >> "$FM_FAKE_TREEHOUSE_LOG"
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+  fm_fake_exit0 "$fakebin" sleep
   printf '%s\n' "$fakebin"
+}
+
+add_nonisolated_orca_fake() {  # <fakebin>
+  local fakebin=$1
+  cat > "$fakebin/orca" <<'SH'
+#!/usr/bin/env bash
+set -u
+{ printf 'orca'; for a in "$@"; do printf '\x1f%s' "$a"; done; printf '\n'; } >> "${FM_FAKE_ORCA_LOG:?}"
+case "${1:-} ${2:-}" in
+  'status --json')
+    printf '{"ok":true,"result":{"runtime":{"reachable":true,"state":"ready"}}}\n'
+    ;;
+  'repo show')
+    exit 1
+    ;;
+  'repo add')
+    printf '{"ok":true,"result":{"repo":{"id":"repo-primary-alias"}}}\n'
+    ;;
+  'worktree create')
+    printf '{"ok":true,"result":{"worktree":{"id":"wt-primary-alias","path":"%s"},"terminal":{"handle":"term-primary-alias"}}}\n' \
+      "${FM_FAKE_ORCA_WORKTREE_PATH:?}"
+    ;;
+  'terminal close'|'worktree rm')
+    printf '{"ok":true,"result":{}}\n'
+    ;;
+  *)
+    printf '{"ok":true,"result":{}}\n'
+    ;;
+esac
+SH
+  chmod +x "$fakebin/orca"
+}
+
+# Print a differently-cased spelling of <dir> that identifies the same
+# directory on every supported test filesystem. A case-insensitive filesystem
+# resolves it natively; a case-sensitive filesystem gets an equivalent symlink.
+case_variant_dir_alias() {  # <dir>
+  local dir=$1 parent base variant alias
+  parent=$(dirname "$dir")
+  base=$(basename "$dir")
+  variant=$(printf '%s' "$base" | tr '[:lower:]' '[:upper:]')
+  [ "$variant" != "$base" ] || fail "case-variant fixture needs an alphabetic directory basename: $base"
+  alias="$parent/$variant"
+  [ -e "$alias" ] || ln -s "$dir" "$alias"
+  [ "$alias" -ef "$dir" ] || fail "case-variant fixture does not identify the source directory: $alias"
+  printf '%s\n' "$alias"
 }
 
 # make_settle_case <name> <id> <stale_reads> builds a home, a primary project
@@ -75,6 +132,7 @@ make_settle_case() {
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
   printf 'codex\n' > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
+  wt=$(cd "$wt" && pwd -P)
   fm_git_init_commit "$stale"
   mkdir -p "$home/data/$id"
   printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
@@ -90,6 +148,7 @@ EOF
 
 run_settle_spawn() {
   local id=$1
+  shift
   FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
@@ -97,7 +156,7 @@ run_settle_spawn() {
     FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
     PATH="$FAKEBIN_DIR:$PATH" \
-    "$SPAWN" "$id" "$PROJ_DIR" 2>&1
+    "$SPAWN" "$id" "$PROJ_DIR" "$@" 2>&1
 }
 
 # A single stale first read (the exact incident) must not be accepted: the
@@ -141,7 +200,87 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+# Herdr can report the unchanged primary directory with letter casing that
+# differs from the physical project spelling on case-insensitive macOS.
+# Use that native alias where available and an equivalent symlink on
+# case-sensitive CI, then require two alias reads before the real worktree.
+# The spawn must wait through both primary-directory replies, record the git
+# top-level reached afterward, and hand exactly that path to teardown.
+test_case_variant_primary_alias_waits_for_real_worktree_and_cleanup_target() {
+  local rec id out status project_alias polls teardown_log teardown_out
+  id=settle-case-alias-z3
+  rec=$(make_settle_case settle-case-alias "$id" 2)
+  read_settle_record "$rec"
+  project_alias=$(case_variant_dir_alias "$PROJ_DIR")
+  STALE_DIR=$project_alias
+
+  out=$(run_settle_spawn "$id" --scout)
+  status=$?
+  expect_code 0 "$status" "spawn should wait through case-variant primary replies and accept the real worktree"$'\n'"$out"
+  polls=$(cat "$COUNTFILE")
+  [ "$polls" -ge 4 ] || fail "spawn accepted the case-variant primary alias before the real worktree transition (polls=$polls)"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the actual isolated git top-level"
+  assert_no_grep "worktree=$project_alias" "$HOME_DIR/state/$id.meta" \
+    "meta recorded the case-variant primary alias"
+
+  printf 'case-variant isolation findings\n' > "$HOME_DIR/data/$id/report.md"
+  printf 'decisions_reviewed=1\ndecision_keys=\n' >> "$HOME_DIR/state/$id.meta"
+  teardown_log="$HOME_DIR/treehouse-teardown.log"
+  : > "$teardown_log"
+  teardown_out=$(
+    FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+      FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+      FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+      FM_FAKE_TREEHOUSE_LOG="$teardown_log" PATH="$FAKEBIN_DIR:$PATH" \
+      "$TEARDOWN" "$id" 2>&1
+  )
+  status=$?
+  expect_code 0 "$status" "teardown should consume the recorded isolated worktree"$'\n'"$teardown_out"
+  assert_contains "$(cat "$teardown_log")" $'treehouse\x1freturn\x1f--force\x1f'"$WT_DIR" \
+    "teardown did not target the actual isolated worktree"
+  assert_not_contains "$(cat "$teardown_log")" "$project_alias" \
+    "teardown targeted the case-variant primary alias"
+  pass "case-variant primary cwd aliases cannot win the settle race or become metadata/cleanup targets"
+}
+
+# Orca supplies its worktree path directly and therefore bypasses the settle
+# loop. The shared final validator must independently reject the primary by
+# filesystem identity even when Orca returns a case-variant alias.
+test_validator_refuses_case_variant_primary_alias_without_settle_loop() {
+  local rec id out status project_alias orca_log
+  id=validate-case-alias-z4
+  rec=$(make_settle_case validate-case-alias "$id" 0)
+  read_settle_record "$rec"
+  project_alias=$(case_variant_dir_alias "$PROJ_DIR")
+  orca_log="$HOME_DIR/orca.log"
+  : > "$orca_log"
+  add_nonisolated_orca_fake "$FAKEBIN_DIR"
+
+  out=$(
+    FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+      FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+      FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_ORCA_LOG="$orca_log" \
+      FM_FAKE_ORCA_WORKTREE_PATH="$project_alias" PATH="$FAKEBIN_DIR:$PATH" \
+      "$SPAWN" "$id" "$PROJ_DIR" --harness codex --backend orca 2>&1
+  )
+  status=$?
+  expect_code 1 "$status" "validator should refuse Orca's case-variant primary alias"
+  assert_contains "$out" "orca worktree create did not yield an isolated worktree" \
+    "validator did not report the isolation refusal"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "validator published metadata for the primary checkout alias"
+  assert_contains "$(cat "$orca_log")" $'orca\x1fterminal\x1fclose\x1f--terminal\x1fterm-primary-alias' \
+    "validation abort did not close Orca's implicit terminal"
+  assert_contains "$(cat "$orca_log")" $'orca\x1fworktree\x1frm\x1f--worktree\x1fid:wt-primary-alias' \
+    "validation abort did not remove Orca's claimed worktree"
+  pass "validate_spawn_worktree independently rejects a case-variant primary alias by filesystem identity"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
+test_case_variant_primary_alias_waits_for_real_worktree_and_cleanup_target
+test_validator_refuses_case_variant_primary_alias_without_settle_loop
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -39,6 +39,9 @@ case "$*" in
     [ -f "$countfile" ] && n=$(cat "$countfile")
     n=$((n + 1))
     printf '%s\n' "$n" > "$countfile"
+    if [ "$n" -eq 1 ] && [ -n "${FM_FAKE_RENAME_FROM:-}" ]; then
+      mv "$FM_FAKE_RENAME_FROM" "${FM_FAKE_RENAME_TO:?FM_FAKE_RENAME_TO unset}"
+    fi
     if [ "$n" -le "${FM_FAKE_PANE_STALE_READS:-0}" ]; then
       printf '%s\n' "${FM_FAKE_PANE_STALE:-}"
     else
@@ -86,6 +89,9 @@ case "${1:-} ${2:-}" in
     printf '{"ok":true,"result":{"repo":{"id":"repo-primary-alias"}}}\n'
     ;;
   'worktree create')
+    if [ -n "${FM_FAKE_RENAME_FROM:-}" ]; then
+      mv "$FM_FAKE_RENAME_FROM" "${FM_FAKE_RENAME_TO:?FM_FAKE_RENAME_TO unset}"
+    fi
     printf '{"ok":true,"result":{"worktree":{"id":"wt-primary-alias","path":"%s"},"terminal":{"handle":"term-primary-alias"}}}\n' \
       "${FM_FAKE_ORCA_WORKTREE_PATH:?}"
     ;;
@@ -278,9 +284,60 @@ test_validator_refuses_case_variant_primary_alias_without_settle_loop() {
   pass "validate_spawn_worktree independently rejects a case-variant primary alias by filesystem identity"
 }
 
+test_settle_loop_refuses_missing_primary_identity() {
+  local rec id out status renamed_project
+  id=settle-missing-primary-z5
+  rec=$(make_settle_case settle-missing-primary "$id" 60)
+  read_settle_record "$rec"
+  renamed_project="$(dirname "$PROJ_DIR")/renamed-primary"
+  STALE_DIR=$renamed_project
+
+  out=$(
+    FM_FAKE_RENAME_FROM="$PROJ_DIR" FM_FAKE_RENAME_TO="$renamed_project" \
+      run_settle_spawn "$id" 2>&1
+  )
+  status=$?
+  expect_code 1 "$status" "settle loop should refuse to infer distinction after the primary path disappears"
+  assert_contains "$out" "treehouse get did not enter a worktree" \
+    "settle loop accepted the renamed primary checkout as isolated"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "settle loop published metadata after losing the primary identity path"
+  pass "settle loop requires positive filesystem distinction from an existing primary path"
+}
+
+test_validator_refuses_missing_primary_identity() {
+  local rec id out status renamed_project orca_log
+  id=validate-missing-primary-z6
+  rec=$(make_settle_case validate-missing-primary "$id" 0)
+  read_settle_record "$rec"
+  renamed_project="$(dirname "$PROJ_DIR")/renamed-primary"
+  orca_log="$HOME_DIR/orca.log"
+  : > "$orca_log"
+  add_nonisolated_orca_fake "$FAKEBIN_DIR"
+
+  out=$(
+    FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+      FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+      FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_ORCA_LOG="$orca_log" \
+      FM_FAKE_RENAME_FROM="$PROJ_DIR" FM_FAKE_RENAME_TO="$renamed_project" \
+      FM_FAKE_ORCA_WORKTREE_PATH="$renamed_project" PATH="$FAKEBIN_DIR:$PATH" \
+      "$SPAWN" "$id" "$PROJ_DIR" --harness codex --backend orca 2>&1
+  )
+  status=$?
+  expect_code 1 "$status" "validator should refuse to infer distinction after the primary path disappears"
+  assert_contains "$out" "orca worktree create did not yield an isolated worktree" \
+    "validator accepted the renamed primary checkout as isolated"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "validator published metadata after losing the primary identity path"
+  pass "validator requires positive filesystem distinction from an existing primary path"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
 test_case_variant_primary_alias_waits_for_real_worktree_and_cleanup_target
 test_validator_refuses_case_variant_primary_alias_without_settle_loop
+test_settle_loop_refuses_missing_primary_identity
+test_validator_refuses_missing_primary_identity
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -170,6 +170,7 @@ exit 0
 SH
   chmod +x "$fakebin/tmux"
   fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_exit0 "$fakebin" sleep
   printf '%s\n' "$fakebin"
 }
 
@@ -198,13 +199,13 @@ test_spawn_isolation_abort() {
   # Abort: the pane resolves to a plain non-git directory (not a worktree at all).
   out=$(run_spawn "$home" abort-notgit-dd4 "$proj" "$TMP_ROOT/spawn-notgit" "$fakebin"); status=$?
   expect_code 1 "$status" "spawn into a non-worktree dir should abort"
-  assert_contains "$out" "did not yield an isolated worktree" "non-worktree spawn lacked the isolation error"
+  assert_contains "$out" "did not enter a worktree" "non-worktree spawn lacked the isolation error"
   assert_absent "$home/state/abort-notgit-dd4.meta" "aborted spawn must not record meta"
 
   # Abort: the pane resolves INTO the primary checkout (a subdir of PROJ_ABS).
   out=$(run_spawn "$home" abort-primary-ee5 "$proj" "$proj/sub" "$fakebin"); status=$?
   expect_code 1 "$status" "spawn landing inside the primary checkout should abort"
-  assert_contains "$out" "did not yield an isolated worktree" "primary-checkout spawn lacked the isolation error"
+  assert_contains "$out" "did not enter a worktree" "primary-checkout spawn lacked the isolation error"
 
   # Proceed: the pane resolves to a genuine, isolated worktree.
   out=$(run_spawn "$home" ok-isolated-ff6 "$proj" "$TMP_ROOT/spawn-wt" "$fakebin"); status=$?

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -437,14 +437,21 @@ test_watch_restart_rejects_reused_pid() {
 }
 
 test_watch_restart_attaches_to_healthy_peer() {
-  local dir state fakebin out peer identity armpid status i
+  local dir state fakebin out peer peer_ready identity armpid status i
   dir=$(make_case restart-healthy-peer)
   state="$dir/state"
   fakebin="$dir/fakebin"
   out="$dir/restart.out"
   mark_pr_check_migration_complete "$state"
-  node -e 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 300000)' &
+  peer_ready="$dir/peer-ready"
+  node -e 'process.on("SIGTERM", () => {}); require("fs").writeFileSync(process.argv[1], "ready\n"); setTimeout(() => {}, 300000)' "$peer_ready" &
   peer=$!
+  i=0
+  while [ "$i" -lt 80 ] && [ ! -f "$peer_ready" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -f "$peer_ready" ] || fail "TERM-resistant peer did not become ready"
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"


### PR DESCRIPTION
## Intent

Revalidate and ship the preserved filesystem-aware spawn isolation fix at bcf3f55c. Review only the intended filesystem-identity isolation behavior: case variants, symlink aliases, and other filesystem-equivalent spellings of the primary Firstmate project must never be mistaken for an isolated task worktree; spawning must wait for a positively distinct real Git worktree and record its actual canonical Git top-level for metadata, output, and cleanup; validate_spawn_worktree must independently reject primary-project filesystem identity; and successful isolated Orca paths must normalize to the verified canonical Git top-level. Preserve tmux, Herdr, Zellij, Orca, and cmux behavior, deterministic case-sensitive-CI-safe regression coverage, owning script/help and Herdr incident/verification documentation, and the named non-default Herdr lab safety contract. Push only through the configured https://github.com/jwajd/firstmate.git fork and open a PR against kunchenguid/firstmate; never push directly to upstream and never merge.

## What Changed

- Compare spawn paths using pinned, dereferenced filesystem identities so case variants, symlink aliases, and disappearing primary paths cannot be mistaken for isolated worktrees.
- Require stable, filesystem-distinct Git roots and normalize accepted Treehouse and Orca paths to the canonical Git top-level used by output, metadata, and cleanup.
- Add deterministic regression coverage for alias and rename races, Orca validation and cleanup, and document the filesystem-aware isolation behavior and verification.

## Risk Assessment

✅ Low: Captain, the final range cleanly implements fail-closed filesystem identity isolation, canonical Orca normalization, backend preservation, regression coverage, and accurate owning documentation.

## Testing

After the parallel attempt was correctly rejected by the repository’s isolation guard, all six focused suites passed serially, including the real Herdr lab and its default-session safety tripwire; manual CLI evidence additionally demonstrated case-alias rejection, canonical metadata/cleanup targeting, and successful Orca path normalization. No UI evidence was applicable because this is a CLI/runtime isolation change.

<details>
<summary>Evidence: Case-variant primary alias: spawn, metadata, and cleanup transcript</summary>

```text
SCENARIO: backend reports a case-variant alias of the primary checkout twice before entering a real linked worktree
primary=/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T//fm-spawn-worktree-settle.at8SZZ/evidence-case-alias/project
reported_primary_alias=/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T//fm-spawn-worktree-settle.at8SZZ/evidence-case-alias/PROJECT
expected_git_top_level=/private/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T/fm-spawn-worktree-settle.at8SZZ/evidence-case-alias/wt

SPAWN CLI OUTPUT
warn: no registry at /var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T//fm-spawn-worktree-settle.at8SZZ/evidence-case-alias/home/data/projects.md; defaulting project to no-mistakes off
spawned evidence-case-alias harness=codex kind=scout mode=no-mistakes yolo=off window=firstmate:fm-evidence-case-alias worktree=/private/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T/fm-spawn-worktree-settle.at8SZZ/evidence-case-alias/wt

OBSERVED POLLS
count=4 (four reads means the primary alias was rejected and the real worktree was confirmed twice)

PERSISTED METADATA
window=firstmate:fm-evidence-case-alias
worktree=/private/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T/fm-spawn-worktree-settle.at8SZZ/evidence-case-alias/wt
project=/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T/fm-spawn-worktree-settle.at8SZZ/evidence-case-alias/project
kind=scout

TEARDOWN CLI OUTPUT
teardown evidence-case-alias complete (window firstmate:fm-evidence-case-alias, worktree /private/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T/fm-spawn-worktree-settle.at8SZZ/evidence-case-alias/wt)
Backlog: evidence-case-alias just finished. Run tasks-axi done evidence-case-alias --report data/evidence-case-alias/report.md, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.

RECORDED CLEANUP COMMAND (unit separator rendered as spaces)
treehouse return --force /private/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T/fm-spawn-worktree-settle.at8SZZ/evidence-case-alias/wt

RESULT: spawn metadata and cleanup both used the verified canonical Git top-level, never the primary alias.
```
</details>
<details>
<summary>Evidence: Successful Orca alias normalization transcript</summary>

```text
SCENARIO: Orca returns a symlink alias for a genuine isolated Git worktree
orca_returned_path=/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T/tmp.xYfmar22SR/worktree-alias
verified_git_top_level=/private/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T/tmp.xYfmar22SR/worktree

SPAWN CLI OUTPUT
spawned orca-alias-evidence harness=claude kind=ship mode=no-mistakes yolo=off window=fm-orca-alias-evidence worktree=/private/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T/tmp.xYfmar22SR/worktree

PERSISTED ORCA METADATA
window=fm-orca-alias-evidence
worktree=/private/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T/tmp.xYfmar22SR/worktree
project=/var/folders/99/btkfmn_n49sgxgngbn30_tqw0000gn/T/tmp.xYfmar22SR/project
backend=orca
orca_worktree_id=wt-evidence
terminal=term-evidence

PATH CHECK
PASS: metadata contains the verified canonical Git top-level and does not retain Orca's alias.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-spawn.sh:777` - The intent requires spawning to wait for a “positively distinct real Git worktree.” However, `same_filesystem_object` returns false both for distinct objects and when either path no longer exists, while this validator—and the negated checks at lines 1046/1049—treat false as proof of distinction. If the primary alias is renamed or removed during spawning, its physical checkout can pass as distinct and become the hook, metadata, output, and cleanup target. Require both paths to exist before accepting a negative `-ef` result, or use a fail-closed tri-state distinction helper throughout.

🔧 Fix: Require positive filesystem distinction during spawn isolation
1 error still open:
- 🚨 `bin/fm-spawn.sh:762` - The intent requires spawning to wait for a “positively distinct real Git worktree,” but this helper performs separate pathname lookups: `[ -e &#34;$1&#34; ] &amp;&amp; [ -e &#34;$2&#34; ] &amp;&amp; ! [ &#34;$1&#34; -ef &#34;$2&#34; ]`. If either path disappears after its existence check but before `-ef`, lookup failure makes `-ef` false and the negation incorrectly succeeds. The new tests rename the primary before entering the helper, so they do not cover this intra-helper race. Pin the primary identity or use a comparison that explicitly distinguishes lookup failure from unequal identity.

🔧 Fix: Pin primary filesystem identity across spawn races
1 error still open:
- 🚨 `bin/fm-spawn.sh:703` - The intent requires symlink-equivalent paths to preserve isolation behavior and successful isolated Orca paths to normalize to the canonical Git top-level. BSD and GNU `stat` report the symlink’s own inode unless `-L` is used, unlike the previous `-ef` comparison. Consequently, an Orca path that symlinks to a valid isolated worktree is compared against the physical `git --show-toplevel` target as two different objects and rejected instead of normalized. Dereference links with `stat -Lf` on Darwin and `stat -Lc` on GNU.

🔧 Fix: Dereference filesystem aliases during spawn identity checks
1 warning still open:
- ⚠️ `docs/herdr-backend.md:1031` - The intent requires preserving the owning Herdr incident/verification documentation, but this added text now incorrectly says spawn uses Bash `-ef`; the final implementation pins dereferenced device/inode identities with `stat -L`. Its “exact” transcript also omits the two new missing-primary regressions, so it no longer documents or evidences the code being shipped. Update the mechanism description and focused verification results.

🔧 Fix: Refresh Herdr filesystem identity verification evidence
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-status 673b6ad39d01183a19c5bd8a52675a2ee8ea06e6..7006523ff935b2f6b2eb5c1408746a7220db2f6e`
- <code>`bin/fm-test-run.sh --jobs 4 …` — safely refused because the settle suite is not proven parallel-isolated; retried serially</code>
- `bin/fm-test-run.sh tests/fm-spawn-worktree-settle.test.sh tests/fm-backend.test.sh tests/fm-backend-orca.test.sh tests/fm-tangle-guard.test.sh tests/fm-watcher-lock.test.sh tests/fm-backend-herdr-presentation-e2e.test.sh`
- `Manual shared-backend spawn through a case-variant primary alias; inspected poll count, persisted metadata, teardown output, and Treehouse cleanup target`
- `Manual successful Orca spawn returning a symlinked worktree path; inspected CLI output and persisted Orca metadata for canonical Git-top-level normalization`
- <code>`git status --short --branch &amp;&amp; git rev-parse HEAD` — confirmed target commit and no source changes</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
