### PR TITLE
fix(afk): refuse bare-shell supervisor targets and bound watcher shutdown

### DIFF
--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -79,6 +79,12 @@
 #                                   supported as supervisor backends; the daemon
 #                                   refuses loudly at startup rather than trying
 #                                   tmux primitives against a non-tmux pane.
+#          FM_SUPERVISOR_ALLOW_DEAD_TARGET
+#                                   test seam: when 1, a supervisor target that
+#                                   reads agent_alive=dead (a bare shell) downgrades
+#                                   from a startup refusal to a warn. For isolated
+#                                   E2E tests that simulate an agent pane with a
+#                                   shell-named process; never set in production.
 #          FM_INJECT_SKIP           |-prefixes force-self-handle bypassing
 #                                   classification (default "heartbeat"); empty
 #                                   disables. Use sparingly: it overrides the
@@ -94,6 +100,12 @@
 #                                   (default 300)
 #          FM_HOUSEKEEPING_TICK     seconds between housekeeping passes while
 #                                   the watcher is mid-cycle (default 15)
+#          FM_WATCHER_SHUTDOWN_GRACE_SECS
+#                                   seconds cleanup waits for the watcher child to
+#                                   exit on SIGTERM before SIGKILL (default 5).
+#                                   Bounds daemon shutdown inside fm-afk-launch
+#                                   stop's budget; the watcher cannot act on
+#                                   SIGTERM while in its external poll sleep.
 #          FM_BUSY_REGEX            OR-ed busy signatures (mirrors fm-watch.sh)
 #          FM_COMPOSER_IDLE_RE      empty-composer regex applied after dim-ghost
 #                                   and structural border stripping (default:
@@ -196,6 +208,15 @@ WEDGE_ALARM_NOTIFIER_PID=
 # bin/fm-tmux-lib.sh (FM_TMUX_BUSY_REGEX_DEFAULT / fm_tmux_composer_state);
 # FM_BUSY_REGEX still overrides the fallback busy set here, as before.
 INJECT_FAIL_SLEEP_DEFAULT=30
+# Seconds the daemon's cleanup waits for the watcher child to exit on SIGTERM
+# before escalating to SIGKILL. fm-watch.sh blocks its supervision cycle in an
+# external `sleep $FM_POLL`, and bash defers a trapped signal until that sleep
+# finishes, so SIGTERM can take up to FM_POLL (default 15) to act. Bounding this
+# wait keeps daemon shutdown well inside fm-afk-launch stop's 10s budget; the
+# watcher's durable state is the on-disk wake queue and suppression markers, so a
+# forced kill never loses work. FM_WATCHER_SHUTDOWN_GRACE_SECS=0 still forces one
+# final SIGKILL after the loop.
+WATCHER_SHUTDOWN_GRACE_SECS_DEFAULT=5
 INJECT_CONFIRM_RETRIES_DEFAULT=3
 INJECT_CONFIRM_SLEEP_DEFAULT=0.5
 CRASH_THRESHOLD_DEFAULT=10
@@ -1376,6 +1397,43 @@ fm_super_main() {
     exit 1
   fi
 
+  # --- reject a bare-shell supervisor target (wrong pane, or agent exited) ---
+  # fm_backend_target_exists only proves the pane is PRESENT. A bare shell - a
+  # wrong tmux window such as "firstmate:0.0" instead of the agent's window, or
+  # an agent that has exited to its login shell - is present but is never an
+  # injectable agent composer: its composer reads pending/unknown, never empty,
+  # so inject_msg would defer every escalation until the max-defer wedge. Fail
+  # fast instead. fm_backend_agent_alive returns a CONFIDENT `dead` for a bare
+  # shell; refuse on that, mirroring fm-backend.sh's secondmate-liveness policy
+  # that gates on `dead` only. `unknown` (pi's generic node process, or an
+  # unreadable pane) only warns, so a real primary is never falsely refused.
+  # Test seam: FM_SUPERVISOR_ALLOW_DEAD_TARGET=1 downgrades the refusal to a warn,
+  # for isolated E2E tests that deliberately point the daemon at a process named
+  # like a shell to SIMULATE an agent composer (no external signal can tell that
+  # simulated pane apart from a real bare shell, so the opt-out is explicit). It
+  # is never set in production; the composer guard still prevents any injection
+  # into a shell regardless. See docs/tmux-backend.md "Agent liveness probe".
+  local supervisor_alive
+  supervisor_alive=$(fm_backend_agent_alive "$BACKEND" "$TARGET")
+  case "$supervisor_alive" in
+    dead)
+      if [ "${FM_SUPERVISOR_ALLOW_DEAD_TARGET:-0}" = 1 ]; then
+        echo "warn: supervisor target '$TARGET' agent_alive=dead but FM_SUPERVISOR_ALLOW_DEAD_TARGET=1 (a simulated pane); continuing" >&2
+        log "startup warn: target '$TARGET' agent_alive=dead but allow-dead opt-out set (backend=$BACKEND, target_source=$target_source)"
+      else
+        echo "error: supervisor target '$TARGET' is a bare shell, not an agent composer (agent_alive=dead); set FM_SUPERVISOR_TARGET to firstmate's own pane (auto-discovery via \$TMUX_PANE is preferred)" >&2
+        log "startup failed: target '$TARGET' is a bare shell (backend=$BACKEND, agent_alive=dead, target_source=$target_source)"
+        fm_lock_release "$LOCK" 2>/dev/null || true
+        rm -f "$PIDFILE" 2>/dev/null || true
+        exit 1
+      fi
+      ;;
+    unknown)
+      echo "warn: supervisor target '$TARGET' agent_alive=unknown (unreadable pane, or an agent whose process name is not confirmed); continuing - verify this is firstmate's own pane" >&2
+      log "startup warn: target '$TARGET' agent_alive=unknown (backend=$BACKEND, target_source=$target_source)"
+      ;;
+  esac
+
   local afk_status="off"
   afk_active "$STATE" && afk_status="on"
   log "daemon starting (pid $$); target=$TARGET; target_source=$target_source; backend=$BACKEND; backend_source=$backend_source; afk=$afk_status; inject_skip='${FM_INJECT_SKIP:-$INJECT_SKIP_DEFAULT}'; stale_escalate=${FM_STALE_ESCALATE_SECS:-$STALE_ESCALATE_SECS_DEFAULT}s; batch=${FM_ESCALATE_BATCH_SECS:-$ESCALATE_BATCH_SECS_DEFAULT}s"
@@ -1388,7 +1446,23 @@ fm_super_main() {
     wedge_alarm_stop_active_notifier
     escalate_flush "$STATE" 2>/dev/null || true
     if [ -n "${WATCHER_PID:-}" ]; then
-      kill "$WATCHER_PID" 2>/dev/null || true
+      # SIGTERM the watcher, then BOUND its shutdown so the daemon never blocks
+      # on the watcher's deferred SIGTERM-during-sleep latency (the watcher
+      # sleeps FM_POLL in an external `sleep`, and bash defers a trapped signal
+      # until that sleep finishes - without this bound the daemon's cleanup could
+      # wait the full poll, exceeding fm-afk-launch stop's budget and surfacing
+      # as "away-mode daemon did not exit after SIGTERM"). Short SIGTERM grace,
+      # then SIGKILL; the watcher is stateless from the daemon's view (durable
+      # state is the on-disk wake queue and suppression markers), so a forced
+      # kill never loses work. Bounded well inside stop's 10s budget.
+      kill -TERM "$WATCHER_PID" 2>/dev/null || true
+      local _w _grace="${FM_WATCHER_SHUTDOWN_GRACE_SECS:-$WATCHER_SHUTDOWN_GRACE_SECS_DEFAULT}"
+      case "$_grace" in ''|*[!0-9]*) _grace="$WATCHER_SHUTDOWN_GRACE_SECS_DEFAULT" ;; esac
+      for _w in $(seq 1 $((_grace * 4))); do
+        kill -0 "$WATCHER_PID" 2>/dev/null || break
+        sleep 0.25
+      done
+      kill -KILL "$WATCHER_PID" 2>/dev/null || true
       wait "$WATCHER_PID" 2>/dev/null || true
     fi
     if [ -n "${CUR_TMP:-}" ]; then

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -1021,6 +1021,14 @@ On entry the launcher drops the prior session's artifacts when the daemon is not
 This never drops a genuinely-pending escalation: the durable record is `state/.wake-queue` plus each crew's `state/<id>.status`, and any still-true condition is re-escalated by the daemon's heartbeat catch-all scan.
 Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry vs refresh, and the stop ordering asserting the daemon saw `state/.afk` present at SIGTERM).
 
+### Daemon shutdown bounds the watcher wait (2026-07-22, backend-independent)
+
+`bin/fm-watch.sh` blocks each supervision cycle in an external `sleep $FM_POLL` (default 15) and traps SIGTERM with `trap 'exit 1'`, but bash defers a trapped signal until the currently-running external command finishes, so SIGTERM to the watcher is not acted on for up to `FM_POLL` seconds.
+The daemon's cleanup `wait`ed that watcher child without a bound, so on `bin/fm-afk-launch.sh stop` the daemon could block roughly `FM_POLL` (15s) and exceed stop's 10s SIGTERM budget, surfacing as `away-mode daemon did not exit after SIGTERM; preserving lifecycle state` (the daemon did exit shortly after; a later `stop` then found it absent).
+The daemon's cleanup now SIGKILLs the watcher after a short grace (`FM_WATCHER_SHUTDOWN_GRACE_SECS`, default 5), well inside the 10s budget; the watcher's durable state is the on-disk wake queue and suppression markers, so a forced kill never loses work.
+Verified with GNU bash 5.3.15(1)-release and tmux 3.7b on macOS (Darwin): a minimal `trap 'exit' TERM; sleep 15` fired its trap only once the external sleep completed (~14s after SIGTERM), and a real-daemon `fm-afk-launch.sh stop` completed in 6.35s (it was ~10.4s with the timeout message before the fix).
+Regression: `tests/fm-afk-launch.test.sh::e2e_tmux_daemon_stop_bounded_inside_budget`, which uses the real daemon (not the sleeper placeholder) so a watcher child actually exists.
+
 ## Known gaps and follow-up notes
 
 - **RESOLVED: worktree-discovery isolation guard's symlinked-project-prefix false refusal.** Originally discovered while building the runtime-backend-auto-detection real smoke test (`tests/fm-backend-autodetect-smoke.test.sh`), which needed a scratch project.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -77,6 +77,13 @@ It reads tmux's own `#{pane_current_command}`, which reports the pane's live for
 Agent liveness and composer safety are separate checks.
 During away-mode escalation delivery, `fm_tmux_composer_state` sends a bare shell glyph on an unbordered row to the shared composer classifier as `unknown`, and the daemon injects only into an affirmatively `empty` composer; see [Composer-emptiness safety](herdr-backend.md#composer-emptiness-safety-2026-07-10-fleet-wide-across-all-four-backends).
 
+**Away-mode daemon startup refuses a bare-shell supervisor target (2026-07-22).**
+`fm_backend_target_exists` only proves a pane is present, so an explicit `FM_SUPERVISOR_TARGET` that resolved to the wrong tmux window (a bash shell, not the agent's window) passed the daemon's startup validation; the composer guard then read that shell as `pending`/`unknown` and deferred every escalation until the max-defer wedge.
+The daemon's startup now also calls this probe and refuses a confidently `dead` target (logs `startup failed: ... bare shell`, exits 1, releases the lock and pidfile), mirroring the secondmate-liveness policy of gating on `dead` only.
+`unknown` (pi's generic `node`, or an unreadable pane) warns and continues, so a real primary is never falsely refused.
+A process named like a shell that an isolated E2E test uses to SIMULATE an agent pane also reads `dead` (no external signal can tell it apart from a real bare shell), so `FM_SUPERVISOR_ALLOW_DEAD_TARGET=1` downgrades the refusal to a warn for that test-scoped case; it is never set in production, and the composer guard still prevents any injection into a shell regardless.
+Regression: `tests/fm-daemon.test.sh::test_daemon_refuses_bare_shell_supervisor_target`, `::test_daemon_does_not_refuse_unknown_supervisor_target`, and `::test_daemon_allow_dead_opt_out_permits_simulated_pane` (real tmux, real daemon executed directly).
+
 ## Submit acknowledgement: "landed" is empty (with one busy-queue exception)
 
 The shared `fm_tmux_submit_enter_core` (`bin/fm-tmux-lib.sh`) types the message once, then retries Enter (Enter only, never a retype) until the composer clears.

--- a/tests/fm-afk-inject-e2e.test.sh
+++ b/tests/fm-afk-inject-e2e.test.sh
@@ -169,6 +169,7 @@ start_daemon() {
   FM_INJECT_CONFIRM_SLEEP=0.3 \
   FM_INJECT_CONFIRM_RETRIES=5 \
   FM_STALE_ESCALATE_SECS=999999 \
+  FM_SUPERVISOR_ALLOW_DEAD_TARGET=1 \
   nohup "$DAEMON" >"$STATE_DIR/daemon.out" 2>"$STATE_DIR/daemon.err" &
   DAEMON_PID=$!
   # Wait for the daemon to start and acquire the lock.

--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -281,6 +281,7 @@ start_daemon() {
   FM_INJECT_CONFIRM_SLEEP=0.5 \
   FM_INJECT_CONFIRM_RETRIES=6 \
   FM_STALE_ESCALATE_SECS=999999 \
+  FM_SUPERVISOR_ALLOW_DEAD_TARGET=1 \
   nohup "$DAEMON" >"$STATE_DIR/daemon.out" 2>"$STATE_DIR/daemon.err" &
   DAEMON_PID=$!
   wait_daemon_started daemon "$log_start"
@@ -492,6 +493,7 @@ test_scenario_d_max_defer() {
   FM_INJECT_CONFIRM_SLEEP=0.3 \
   FM_INJECT_CONFIRM_RETRIES=2 \
   FM_STALE_ESCALATE_SECS=999999 \
+  FM_SUPERVISOR_ALLOW_DEAD_TARGET=1 \
   nohup "$DAEMON" >"$STATE_DIR/daemon.out" 2>"$STATE_DIR/daemon.err" &
   DAEMON_PID=$!
   wait_daemon_started "Scenario D daemon" "$log_start"

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -860,6 +860,62 @@ e2e_tmux() {
   rm -rf "$home_tmp" 2>/dev/null || true
 }
 
+# E2E tmux: daemon stop completes inside fm-afk-launch stop's budget even when
+# the watcher child is mid poll-sleep (task afk-daemon-reliability-scout,
+# defect 2). fm-watch.sh blocks in an external `sleep $FM_POLL` and bash defers a
+# trapped SIGTERM until that sleep finishes, so without a bounded cleanup wait the
+# daemon could block ~FM_POLL (15s) and exceed stop's 10s SIGTERM budget. Uses the
+# REAL daemon (no FM_AFK_LAUNCH_ENTRY sleeper) so a watcher child actually exists;
+# the existing stop tests use a sleeper that has no watcher and so cannot catch
+# this. The supervised pane runs `sleep` (agent_alive=unknown) so it passes the
+# daemon's bare-shell startup guard but is never injected into.
+e2e_tmux_daemon_stop_bounded_inside_budget() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (stop-budget e2e)"; return 0; }
+  local sup_session home_tmp sup_pane rec t0 t1 elapsed out i pid ready=0
+  sup_session="fm-afk-stop-budget-$$"
+  home_tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-stop-budget-home.XXXXXX")
+  tmux new-session -d -s "$sup_session" "exec sleep 600" 2>/dev/null || { fail "stop-budget e2e: could not create supervisor session"; rm -rf "$home_tmp"; return 0; }
+  TRACK_TMUX_SESSIONS="$TRACK_TMUX_SESSIONS $sup_session"
+  sup_pane=$(tmux display-message -p -t "$sup_session" '#{pane_id}' 2>/dev/null)
+
+  # REAL daemon (no FM_AFK_LAUNCH_ENTRY override) so it spawns a watcher child.
+  FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" \
+    FM_SUPERVISOR_TARGET="$sup_pane" FM_SUPERVISOR_BACKEND=tmux \
+    "$LAUNCH" start >/dev/null 2>&1
+  # Wait for the daemon process to be live (pidfile pid alive = past startup).
+  for i in $(seq 1 50); do
+    pid=$(cat "$home_tmp/state/.supervise-daemon.pid" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then ready=1; break; fi
+    sleep 0.1
+  done
+  rec=$(cut -f2 "$home_tmp/state/.afk-daemon-terminal" 2>/dev/null || true)
+  TRACK_TMUX_SESSIONS="$TRACK_TMUX_SESSIONS $rec"
+  if [ "$ready" -ne 1 ]; then
+    fail "stop-budget e2e: real daemon did not become ready (start failed)"
+    FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" "$LAUNCH" stop >/dev/null 2>&1 || true
+    tmux kill-session -t "$sup_session" 2>/dev/null || true
+    [ -n "$rec" ] && tmux kill-session -t "$rec" 2>/dev/null || true
+    rm -rf "$home_tmp"; return 0
+  fi
+
+  t0=$(date +%s.%N)
+  out=$(FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" "$LAUNCH" stop 2>&1)
+  t1=$(date +%s.%N)
+  elapsed=$(awk -v a="$t0" -v b="$t1" 'BEGIN{printf "%.2f", b-a}')
+  # Fix B: stop must complete well inside the 10s SIGTERM budget and report a
+  # normal stop, NOT "did not exit after SIGTERM". Without the fix this took
+  # ~10.4s and printed the timeout message (the watcher's deferred SIGTERM kept
+  # the daemon's cleanup wait past the budget).
+  if awk -v e="$elapsed" 'BEGIN{exit !(e < 9)}' && printf '%s' "$out" | grep -q 'away mode stopped'; then
+    pass "stop-budget e2e: daemon stop completed in ${elapsed}s inside the budget (watcher shutdown bounded)"
+  else
+    fail "stop-budget e2e: stop exceeded budget or did not report stopped (elapsed=${elapsed}s out=$(printf '%s' "$out"))"
+  fi
+  tmux kill-session -t "$sup_session" 2>/dev/null || true
+  [ -n "$rec" ] && tmux kill-session -t "$rec" 2>/dev/null || true
+  rm -rf "$home_tmp" 2>/dev/null || true
+}
+
 unit_clear_stale
 unit_fresh_vs_refresh
 unit_stop_ordering
@@ -893,5 +949,6 @@ unit_incomplete_restore_retains_backup
 unit_flag_write_failure_aborts
 e2e_herdr
 e2e_tmux
+e2e_tmux_daemon_stop_bounded_inside_budget
 
 [ "$FAILED" -eq 0 ] || exit 1

--- a/tests/fm-afk-pi-herdr-return-e2e.test.sh
+++ b/tests/fm-afk-pi-herdr-return-e2e.test.sh
@@ -124,6 +124,7 @@ export FM_CHECK_INTERVAL=999999
 export FM_MAX_DEFER_SECS=3
 export FM_STALE_ESCALATE_SECS=999999
 export FM_WEDGE_ALARM_EXEC='$TMP_ROOT/wedge-recorder'
+export FM_SUPERVISOR_ALLOW_DEAD_TARGET=1
 exec '$ROOT/bin/fm-afk-start.sh'
 EOF
 chmod +x "$TMP_ROOT/daemon-entry"

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -849,6 +849,133 @@ test_tmux_composer_state_bordered_and_agent_rows_are_empty() {
   pass "fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty"
 }
 
+# Startup fail-fast for a bare-shell supervisor target (task
+# afk-daemon-reliability-scout, defect 1). fm_backend_target_exists only proves
+# the pane is PRESENT; a bare shell (a wrong tmux window, or an agent that exited
+# to its login shell) is present but never an injectable agent composer, so
+# before this fix every escalation deferred until the max-defer wedge. The daemon
+# must now refuse a confidently-dead target at startup. Real tmux (gated), real
+# daemon executed directly so the assertion is the actual startup decision.
+test_daemon_refuses_bare_shell_supervisor_target() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon bare-shell refusal)"; return 0; }
+  local sess home pane rc log verdict=""
+  sess="fm-daemon-bareshell-$$"
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-daemon-bareshell.XXXXXX")
+  log="$home/state/.supervise-daemon.log"
+  # lib.sh's fail() exits the process, so capture a verdict, clean up
+  # unconditionally, then pass/fail last (no unreachable cleanup).
+  if tmux new-session -d -s "$sess" 2>/dev/null; then
+    pane=$(tmux display-message -p -t "$sess" '#{pane_id}' 2>/dev/null)
+    sleep 0.5  # let the login shell render so pane_current_command reads as a shell
+    # A fresh pane runs the login shell -> fm_backend_agent_alive returns dead.
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      FM_SUPERVISOR_TARGET="$pane" FM_SUPERVISOR_BACKEND=tmux \
+      timeout 10 "$DAEMON" >/dev/null 2>&1
+    rc=$?
+    if [ "$rc" -eq 1 ] && grep -q 'bare shell' "$log" 2>/dev/null \
+       && [ ! -e "$home/state/.supervise-daemon.pid" ]; then
+      verdict="daemon refuses a bare-shell supervisor target at startup (fail fast, no wedge)"
+    else
+      verdict="FAIL|daemon did not refuse a bare-shell target (rc=$rc log=$(cat "$log" 2>/dev/null))"
+    fi
+  else
+    verdict="FAIL|bare-shell refusal: could not create tmux session"
+  fi
+  tmux kill-session -t "$sess" 2>/dev/null || true
+  rm -rf "$home"
+  case "$verdict" in
+    FAIL\|*) fail "${verdict#FAIL|}" ;;
+    *) pass "$verdict" ;;
+  esac
+}
+
+# The other side of defect 1's fix: an `unknown` agent_alive verdict (pi's generic
+# node process, an unreadable pane, or any non-shell command) must NOT be refused,
+# so a real primary is never falsely blocked. The daemon passes startup (logs
+# "daemon starting", which is emitted only AFTER the bare-shell check) and does
+# not log a bare-shell refusal. Real tmux; the pane runs `sleep` (not a shell) so
+# pane_current_command is unknown.
+test_daemon_does_not_refuse_unknown_supervisor_target() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon unknown-target policy)"; return 0; }
+  local sess home pane log dpid i watcher verdict=""
+  sess="fm-daemon-unknown-$$"
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-daemon-unknown.XXXXXX")
+  log="$home/state/.supervise-daemon.log"
+  if tmux new-session -d -s "$sess" "exec sleep 300" 2>/dev/null; then
+    pane=$(tmux display-message -p -t "$sess" '#{pane_id}' 2>/dev/null)
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      FM_SUPERVISOR_TARGET="$pane" FM_SUPERVISOR_BACKEND=tmux \
+      "$DAEMON" >/dev/null 2>&1 &
+    dpid=$!
+    for i in $(seq 1 50); do
+      grep -q 'daemon starting' "$log" 2>/dev/null && break
+      kill -0 "$dpid" 2>/dev/null || break
+      sleep 0.1
+    done
+    if grep -q 'daemon starting' "$log" 2>/dev/null \
+       && ! grep -q 'bare shell' "$log" 2>/dev/null; then
+      verdict="daemon does not refuse an unknown supervisor target (warns only; pi/node primaries are not blocked)"
+    else
+      verdict="FAIL|daemon refused or did not start against an unknown target (log=$(cat "$log" 2>/dev/null))"
+    fi
+    # Cleanup: SIGTERM the daemon; Fix B bounds its watcher shutdown. Capture the
+    # watcher child first so a regression cannot orphan it.
+    watcher=$(pgrep -P "$dpid" 2>/dev/null | head -1 || true)
+    kill -TERM "$dpid" 2>/dev/null || true
+    for i in $(seq 1 60); do kill -0 "$dpid" 2>/dev/null || break; sleep 0.1; done
+    kill -KILL "$dpid" 2>/dev/null || true
+    [ -n "$watcher" ] && kill -KILL "$watcher" 2>/dev/null || true
+    wait "$dpid" 2>/dev/null || true
+  else
+    verdict="FAIL|unknown-target: could not create tmux session"
+  fi
+  tmux kill-session -t "$sess" 2>/dev/null || true
+  rm -rf "$home"
+  case "$verdict" in
+    FAIL\|*) fail "${verdict#FAIL|}" ;;
+    *) pass "$verdict" ;;
+  esac
+}
+
+# The test seam for defect 1's startup refusal: FM_SUPERVISOR_ALLOW_DEAD_TARGET=1
+# downgrades a confident `dead` refusal to a warn, so an isolated E2E test can
+# point the daemon at a shell-named process that SIMULATES an agent pane (no
+# external signal can tell that apart from a real bare shell). The daemon must
+# pass startup (log "daemon starting") and not log a bare-shell refusal. Real
+# tmux; the pane is the login shell (dead), the opt-out is set.
+test_daemon_allow_dead_opt_out_permits_simulated_pane() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon allow-dead opt-out)"; return 0; }
+  local sess home pane rc log verdict=""
+  sess="fm-daemon-allowdead-$$"
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-daemon-allowdead.XXXXXX")
+  log="$home/state/.supervise-daemon.log"
+  if tmux new-session -d -s "$sess" 2>/dev/null; then
+    pane=$(tmux display-message -p -t "$sess" '#{pane_id}' 2>/dev/null)
+    sleep 0.5
+    # timeout returns 124 when the daemon ran past the budget (i.e. it did NOT
+    # refuse at startup and entered the loop); a refusal would be exit 1.
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      FM_SUPERVISOR_TARGET="$pane" FM_SUPERVISOR_BACKEND=tmux \
+      FM_SUPERVISOR_ALLOW_DEAD_TARGET=1 \
+      timeout 4 "$DAEMON" >/dev/null 2>&1
+    rc=$?
+    if [ "$rc" -eq 124 ] && grep -q 'daemon starting' "$log" 2>/dev/null \
+       && ! grep -q 'startup failed:.*bare shell' "$log" 2>/dev/null; then
+      verdict="daemon allows a dead target with FM_SUPERVISOR_ALLOW_DEAD_TARGET=1 (simulated-pane test seam)"
+    else
+      verdict="FAIL|allow-dead opt-out did not permit a dead target (rc=$rc log=$(cat "$log" 2>/dev/null))"
+    fi
+  else
+    verdict="FAIL|allow-dead: could not create tmux session"
+  fi
+  tmux kill-session -t "$sess" 2>/dev/null || true
+  rm -rf "$home"
+  case "$verdict" in
+    FAIL\|*) fail "${verdict#FAIL|}" ;;
+    *) pass "$verdict" ;;
+  esac
+}
+
 test_tmux_composer_state_requires_matching_box_borders() {
   local dir fakebin capture line out
   dir=$(make_supercase composer-decorated-shell)
@@ -1807,3 +1934,6 @@ test_inject_msg_herdr_composer_guard_defers
 test_inject_msg_herdr_pane_gone_defers
 test_inject_msg_herdr_submits_through_backend_dispatch
 test_inject_msg_defers_on_dead_shell_unknown
+test_daemon_refuses_bare_shell_supervisor_target
+test_daemon_does_not_refuse_unknown_supervisor_target
+test_daemon_allow_dead_opt_out_permits_simulated_pane


### PR DESCRIPTION
## What

Two away-mode supervision reliability repairs, both reproduced and root-caused in scout `afk-daemon-reliability-scout` (report in that task), implemented on the daemon only — no broad runtime-backend redesign, no manual target guessing, no broad tmux sweeps.

### 1. Fail fast at startup for a confidently dead/bare-shell supervisor target
`fm_backend_target_exists` only proved the pane was **present**, so an explicit `FM_SUPERVISOR_TARGET` pointing at a bare shell (e.g. the wrong tmux window such as `firstmate:0.0`, or an agent that had exited to its login shell) passed startup validation. The composer guard then read that shell as `pending`/`unknown` and deferred every escalation until the max-defer wedge (~300 s).

The daemon's startup now also probes `fm_backend_agent_alive` (`bin/fm-supervise-daemon.sh`):
- `dead` → refuse fast (log `startup failed: ... bare shell`, exit 1, release lock + pidfile), mirroring the secondmate-liveness policy that gates on `dead` only;
- `unknown` (pi's generic `node`, or an unreadable pane) → warn and continue, so a real primary is never falsely refused.

The composer guard is unchanged — it is what correctly prevented typing into a shell; this just surfaces the problem immediately instead of at the max-defer wedge.

**Test seam:** `FM_SUPERVISOR_ALLOW_DEAD_TARGET=1` downgrades the refusal to a warn. No external signal can distinguish an isolated E2E test's *simulated* agent pane (a shell-named process drawing a composer) from a real bare shell, so the opt-out is explicit. It is never set in production, and the composer guard still prevents any injection into a shell regardless.

### 2. Bound watcher shutdown so AFK stop completes inside its budget
The daemon's cleanup `wait()`ed its watcher child without a bound. `fm-watch.sh` blocks each cycle in an external `sleep $FM_POLL` (default 15) and bash defers a trapped SIGTERM until that sleep finishes, so on `fm-afk-launch.sh stop` the daemon could block ~`FM_POLL` and exceed stop's 10 s SIGTERM budget — surfacing as `away-mode daemon did not exit after SIGTERM; preserving lifecycle state` (the daemon did exit shortly after; a later `stop` found it absent).

Cleanup now SIGKILLs the watcher after a short grace (`FM_WATCHER_SHUTDOWN_GRACE_SECS`, default 5), well inside the 10 s budget. The watcher's durable state is the on-disk wake queue and suppression markers, so a forced kill never loses work.

## Why these are the right scope
- Defect 1 root cause is **caller target selection** (wrong explicit target) + **weak startup validation** (presence-only). The proven path is `$TMUX_PANE` auto-discovery; the fix makes a wrong-but-existing target fail fast.
- Defect 2 root cause is **daemon shutdown signaling** (the watcher's deferred SIGTERM during external sleep + the daemon's unbounded wait). The "terminal-close warning" on the later `stop` is a benign consequence (the detached session auto-collapses on pane-process exit), not a separate defect.

## Verification
- Reproduced both defects in isolated homes pre-fix (defect 1: a bash pane passes `target_exists`, reads composer `pending`; defect 2: `stop` = 10.4 s with the timeout message; minimal `trap … TERM; sleep 15` fires its trap only once the external sleep completes).
- Post-fix:
  - defect 1: `stop` completes in ~6.3–6.5 s with the normal "away mode stopped" line;
  - defect 2: a bare-shell target is refused at startup (exit 1, no pidfile).
- `bin/fm-lint.sh` (pinned shellcheck 0.11.0, CI's gate): clean.
- Regression tests added:
  - `tests/fm-daemon.test.sh`: `test_daemon_refuses_bare_shell_supervisor_target`, `test_daemon_does_not_refuse_unknown_supervisor_target`, `test_daemon_allow_dead_opt_out_permits_simulated_pane` (real tmux, real daemon executed directly);
  - `tests/fm-afk-launch.test.sh`: `e2e_tmux_daemon_stop_bounded_inside_budget` (real daemon, not the sleeper placeholder, so a watcher child actually exists).
- Existing daemon/inject E2E suites pass; the simulated-agent-pane suites set the new opt-out (`tests/fm-afk-inject-e2e.test.sh`, `tests/fm-afk-inject-herdr-e2e.test.sh`, `tests/fm-afk-pi-herdr-return-e2e.test.sh`).
- Evidence recorded in `docs/tmux-backend.md` ("Agent liveness probe") and `docs/herdr-backend.md` ("Daemon shutdown bounds the watcher wait").

## Notes
- Scoped to `bin/fm-supervise-daemon.sh` (both fixes) + tests + docs. No change to the shared watcher poll loop (a broader interruptible-sleep improvement for the always-on path is noted as out of scope).
- Based on current `main` (rebased; #841 landed in the meantime).
