### PR TITLE
ci: install tasks-axi in portable test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,11 @@ jobs:
           set -eu
           bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Install tasks-axi
+        run: |
+          set -eu
+          npm install -g tasks-axi
+          tasks-axi --version
       - name: Run portable parallel shard 1
         run: |
           set -eu
@@ -78,6 +83,11 @@ jobs:
           set -eu
           bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Install tasks-axi
+        run: |
+          set -eu
+          npm install -g tasks-axi
+          tasks-axi --version
       - name: Run portable parallel shard 2
         run: |
           set -eu

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -366,6 +366,18 @@ test_ci_and_docs_call_the_owner() {
     || fail "CI shard 1 must invoke --lane portable-parallel-1"
   grep -Fq 'bin/fm-test-run.sh --lane portable-parallel-2' "$CI" \
     || fail "CI shard 2 must invoke --lane portable-parallel-2"
+  local shard job_body
+  for shard in 1 2; do
+    job_body=$(awk -v job="  tests-portable-parallel-$shard:" '
+      $0 == job { in_job=1; next }
+      in_job && /^  [a-zA-Z0-9_-]+:/ { exit }
+      in_job { print }
+    ' "$CI")
+    printf '%s\n' "$job_body" | grep -Fq 'npm install -g tasks-axi' \
+      || fail "CI portable parallel shard $shard must install tasks-axi"
+    printf '%s\n' "$job_body" | grep -Fq 'tasks-axi --version' \
+      || fail "CI portable parallel shard $shard must verify tasks-axi"
+  done
   grep -Fq 'bin/fm-test-run.sh --lane portable-serial' "$CI" \
     || fail "CI portable serial must invoke --lane portable-serial"
   grep -Fq 'bin/fm-test-run.sh --check-coverage' "$CI" \


### PR DESCRIPTION
## Intent

Fix the captain-authorized portable-parallel CI coverage regression introduced after PR #841. Reproduce the real portable-parallel-2 path where fm-decision-hold-lifecycle silently skips without tasks-axi, install tasks-axi symmetrically in both portable parallel CI jobs so shard rebalancing remains safe, and add focused workflow-contract coverage for both jobs. Preserve the exact complete regression inventory and coverage guard, do not roll back sharding or redesign lane composition, and prove the decision-hold test executes with gate_skip=false in the representative lane. Review affected CI integration surfaces and ship through a green PR without merging it.

## What Changed

- Install and verify `tasks-axi` in both portable parallel CI shards so tasks-axi-dependent tests execute after shard rebalancing.
- Extend the CI workflow contract test to require the installation and version check in each parallel shard.
- Preserve the existing lane composition and complete regression coverage guard.

## Risk Assessment

✅ Low: The change is narrowly scoped, installs and verifies tasks-axi symmetrically before both portable parallel lanes, and adds focused contract coverage without altering shard composition or the complete-inventory guard.

## Testing

Inspected both parallel CI job changes, reproduced the original silent skip, passed focused workflow-contract coverage, ran the actual portable-parallel-2 shard with zero gate skips and direct evidence of `gate_skip=false`, confirmed the unchanged complete 91-test coverage partition, and verified the worktree remained clean. No visual artifact was needed because this is a CI and CLI-only change.

<details>
<summary>Evidence: Regression reproduction and fixed behavior</summary>

```text
Without tasks-axi: `skip: tasks-axi not found`. Updated shard: decision-hold test completed with `exit=0 ... gate_skip=false`.
```
</details>
<details>
<summary>Evidence: Portable-parallel-2 transcript</summary>

```text
FM_TEST_BEGIN 2026-07-22T18:21:11Z tests/fm-decision-hold-lifecycle.test.sh family=pure-contract-unit expected_gate_skip=none
ok - report-only unresolved decision is reproduced and completion refuses before loss
ok - non-forced scout teardown always requires durable inventory verification
ok - captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close
ok - completion and verification validate origins before constructing paths
ok - ended visual review follows the same decision-hold completion owner
ok - resolved findings and decision-like prose do not create false holds
ok - terminal single-owner stale status decisions do not block empty inventory
ok - main-home and secondmate-home captain holds remain correctly routed
ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
FM_TEST_END 2026-07-22T18:21:37Z tests/fm-decision-hold-lifecycle.test.sh exit=0 duration_ms=26054 gate_skip=false
FM_TEST_BEGIN 2026-07-22T18:21:37Z tests/fm-x-mode.test.sh family=pr-forge expected_gate_skip=none
ok - fm-x-poll is a hard no-op without a token (inert default)
ok - fm-x-poll treats an explicitly empty env token as configured
ok - fm-x-poll stays silent on HTTP 204 (the common case)
ok - fm-x-poll lets an explicitly empty relay env override .env
ok - fm-x-poll surfaces auth/config errors once and clears on recovery
ok - fm-x-poll diagnostic markers use private guarded publication
ok - fm-x-poll stashes the question and prints the compact marker
ok - fm-x-poll wakes once per durable request offer across inbox cleanup
ok - fm-x-poll retains offer claim diagnostics until recovery
ok - fm-x-poll preserves in_reply_to conversation context in the inbox
ok - fm-x-poll reports inbox commit failures without emitting a mention wake
ok - fm-x-poll publishes inbox records only through private guarded artifacts
ok - fm-x-poll requires a non-empty question before waking
ok - fm-x-poll rejects an unsafe request_id (path-traversal guard)
ok - fm-x-reply posts a request-bound answer and echoes only the request_id
ok - fm-x-reply accepts the reply via --text-file and stdin (safe, unexpanded)
ok - fm-x-reply exits non-zero on a non-2xx relay response
ok - fm-x-reply cleans up auth header temp files on interrupted posts
ok - fm-x-reply rejects missing arguments with a usage error
ok - fm-x-reply --help makes image support discoverable
ok - fm-x-reply rejects whitespace-only reply text
ok - fm-x-reply dry-run records the would-be reply and never posts
ok - fm-x-reply dry-run works without a token
ok - fm-x-reply honors FMX_DRY_RUN from .env
ok - fm-x-reply lets an explicitly empty dry-run env override .env
ok - fm-x-reply dry-run fails when it cannot record the preview
ok - fm-x-reply dry-run publishes outbox records only through private guarded artifacts
ok - fmx_split_thread: word-boundary, fence-aware, within-limit, numbered, lossless, capped
ok - fm-x-reply keeps a concise reply as a single unnumbered tweet
ok - fm-x-reply auto-splits a long reply into a numbered thread (texts[])
ok - fm-x-reply uses the Discord inbox platform budget instead of the X tweet budget
ok - fm-x-reply keeps numeric X requests on the X tweet budget
ok - fm-x-reply prefers an explicit relay-provided reply limit
ok - fm-x-reply rejects unsafe inbox context artifacts
ok - fm-x-reply clamps a below-floor max to 50 characters
ok - fm-x-reply posts a thread payload (texts[]) to the relay
ok - fm-x-reply --image posts an image object on answer
ok - fm-x-reply streams large image payloads outside curl argv
ok - fm-x-reply dry-run records compact image metadata for threaded replies
ok - fm-x-reply cleans image and payload temp files
ok - fm-x-reply --image rejects missing and unsupported image paths clearly
ok - fm-x-reply --followup posts to /connector/followup with the same request-bound body
ok - fm-x-reply maps a followup_unavailable follow-up 409 to exit 9
ok - fm-x-reply maps every follow-up 409 to exit 9 even without the marker
ok - fm-x-reply treats answer-endpoint 409 as a generic failure
ok - fm-x-reply --followup --image posts an image object
ok - fm-x-reply --followup is accepted in any position and leaves the answer path default
ok - fm-x-reply --followup dry-run marks the endpoint without changing the answer path
ok - fm-x-reply --followup auto-splits a long follow-up into a marked thread
ok - fm-x-reply followup dry-run keeps endpoint marker and compact image metadata
ok - fm-x-poll records the durable per-request reply context from the relay payload
ok - context registry publishes records only through private guarded artifacts
ok - context registry reads only private single-link artifacts
ok - private artifact publisher is compatible with the system bash path
ok - context registry retention is bounded to the seven-day follow-up window
ok - context registry rewrites preserve the first-seen timestamp
ok - context retention starts only when a live initial answer succeeds
ok - a delayed Discord follow-up stays one message after inbox cleanup via the durable registry
ok - an X follow-up over 280 still splits correctly after inbox cleanup
ok - every unresolved follow-up is refused before posting
ok - a partial registry platform combines with the relay's authoritative budget
ok - concurrent requests each recover their own platform/budget with no cross-overwrite
ok - fm-x-dismiss clears the durable per-request context (a dismissed mention gets no follow-up)
ok - fm-x-dismiss posts a request-bound dismiss and echoes only the request_id
ok - fm-x-dismiss dry-run records the would-be body and never posts
ok - fm-x-dismiss dry-run works without a token
ok - fm-x-dismiss dry-run publishes outbox records only through private guarded artifacts
ok - fm-x-dismiss exits non-zero on a non-2xx relay response
ok - fm-x-dismiss exits non-zero on a transport failure
ok - fm-x-dismiss rejects an unsafe request_id (path-traversal guard)
ok - fm-x-dismiss rejects missing or extra arguments with a usage error
ok - fm-x-link records and refreshes the X-request link without disturbing meta
ok - fm-x-link records Discord platform context so follow-ups keep the Discord budget
ok - fm-x-link resolves the platform by request_id so a post-cleanup link keeps the Discord budget
ok - fm-x-link warns loudly and the follow-up is held (not wrongly split) when the platform is unknown
ok - fm-x-link paired carry flags preserve a prior task's follow-up binding onto a successor
ok - fm-x-link recovery relink preserves Discord platform context after inbox drain
ok - fm-x-link rejects malformed or unpaired carry flags
ok - meta rewrites are independent of TMPDIR
ok - fm-x-link rejects unsafe ids, missing meta, and missing arguments
ok - fm-x-followup --check reports postable / not-linked correctly
ok - fm-x-followup --check prunes a link past the 7-day window
ok - fm-x-followup --check prunes a link that already reached the follow-up cap
ok - fm-x-followup posts a follow-up, increments the counter, and keeps the link under the cap
ok - fm-x-followup --final clears the link after one post regardless of the remaining count
ok - fm-x-followup clears the link once the third follow-up reaches the cap
ok - fm-x-followup --image forwards the attachment through fm-x-reply --followup
ok - fm-x-followup keeps the link and counter when the post fails
ok - fm-x-followup tombstones the link when a post-success counter write fails
ok - fm-x-followup treats a relay cap/window rejection as an already-exhausted link, not a retry
ok - fm-x-followup skips silently and clears the link past the 7-day window
ok - fm-x-followup is a no-op for a task with no X link
ok - fm-x-followup dry-run records the follow-up and increments the counter, keeping the link
ok - fm-x-followup dry-run --final clears the link just as a live post would
ok - fm-x-followup rejects malformed invocations
ok - bootstrap activates X mode from an .env token, idempotently
ok - bootstrap reports missing X-mode dependencies before arming
ok - bootstrap does not report X mode on when activation artifacts cannot be written
ok - bootstrap rejects linked X artifacts without touching their targets
ok - boot

... [4292 bytes truncated] ...

ND 2026-07-22T18:23:02Z tests/fm-grok-harness.test.sh exit=0 duration_ms=6783 gate_skip=false
FM_TEST_BEGIN 2026-07-22T18:23:02Z tests/fm-spawn-batch.test.sh family=backend-dispatch expected_gate_skip=none
ok - batch dispatch re-execs and reports every id=repo pair
ok - batch detection: single pair batches, non-pair rejected, single-task and slash-id stay single
ok - projects/ paths are scoped through the firstmate home for single-task spawn
FM_TEST_END 2026-07-22T18:23:03Z tests/fm-spawn-batch.test.sh exit=0 duration_ms=997 gate_skip=false
FM_TEST_BEGIN 2026-07-22T18:23:03Z tests/fm-send-strict.test.sh family=backend-dispatch expected_gate_skip=none
ok - fm-send strict: exact task/lane ids resolve through home metadata
ok - fm-send strict: unset FM_HOME fails before target resolution
ok - fm-send strict: unresolvable selectors do not fall back to tmux
ok - fm-send strict: prefixless herdr pane ids are rejected before tmux fallback
ok - fm-send strict: unmatched single-colon explicit targets must verify live before sending
ok - fm-send strict: healthy fm-<id> sends still type once and submit
FM_TEST_END 2026-07-22T18:23:05Z tests/fm-send-strict.test.sh exit=0 duration_ms=2107 gate_skip=false
FM_TEST_BEGIN 2026-07-22T18:23:05Z tests/fm-tmux-submit-busy.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm_tmux_submit_enter_core: busy pane + pending composer returns empty (message queued)
ok - fm_tmux_submit_enter_core: idle pane + pending composer stays pending (genuine swallow preserved)
ok - fm_tmux_submit_enter_core: busy pane clears composer on first Enter - returns empty
ok - fm_tmux_submit_enter_core: idle pane clears composer on first Enter - returns empty as before
FM_TEST_END 2026-07-22T18:23:07Z tests/fm-tmux-submit-busy.test.sh exit=0 duration_ms=2349 gate_skip=false
FM_TEST_BEGIN 2026-07-22T18:23:07Z tests/fm-composer-ghost.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm_tmux_strip_ghost drops dim/faint runs, keeps normal and bold text
ok - fm_tmux_strip_ghost handles combined SGR, ESC[22m, and reset-then-dim
ok - fm_tmux_strip_ghost keeps bright colored text with 2 payloads
ok - fm_tmux_strip_ghost drops a dark/muted truecolor foreground (grok placeholder)
ok - fm_pane_input_pending: a dim ghost-only composer is NOT pending
ok - fm_pane_input_pending: dim ghost inside a bordered composer is NOT pending
ok - fm_pane_input_pending: normal-intensity typed text is still pending
ok - fm_pane_input_pending: bright colored text with 2 payloads is still pending
ok - fm_pane_input_pending: a dark truecolor ghost-only composer (grok placeholder) is NOT pending
ok - fm_tmux_composer_state: dark truecolor shell prompts read unknown
ok - fm_pane_input_pending: real text plus a trailing ghost run is still pending
ok - fm-peek output is escape-free (no raw -e bytes reach firstmate context)
FM_TEST_END 2026-07-22T18:23:09Z tests/fm-composer-ghost.test.sh exit=0 duration_ms=2159 gate_skip=false
FM_TEST_BEGIN 2026-07-22T18:23:09Z tests/fm-send-settle.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm-send: a successful text send pauses the default 1s after submit
ok - fm-send: FM_SEND_SETTLE=0 produces no settle pause
ok - fm-send: the settle pause is tunable via FM_SEND_SETTLE
ok - fm-send: the --key path never pauses (settle scoped to text submit)
FM_TEST_END 2026-07-22T18:23:11Z tests/fm-send-settle.test.sh exit=0 duration_ms=1931 gate_skip=false
FM_TEST_BEGIN 2026-07-22T18:23:11Z tests/fm-supervision-instructions.test.sh family=pure-contract-unit expected_gate_skip=none
ok - renderer prints exactly the selected harness block
ok - renderer falls back to unknown.md for unverified harness names
ok - renderer includes read-only, afk, and effective x-mode current-state stanzas
ok - renderer repair-line mode is harness-aware and honors conditional state
ok - renderer distinguishes ordinary wake continuation from failure recovery
ok - grok supervision is Claude-shaped background notify with passive Stop-hook backstop
ok - grok rendered command sources the effective x-mode config
ok - pi supervision snippet renders the effective extension path
FM_TEST_END 2026-07-22T18:23:12Z tests/fm-supervision-instructions.test.sh exit=0 duration_ms=328 gate_skip=false
FM_TEST_BEGIN 2026-07-22T18:23:12Z tests/fm-lint.test.sh family=pure-contract-unit expected_gate_skip=none
ok - one-owner lint script exists and is executable
ok - fm-lint.sh is the sole authoritative definition at CI-default severity
ok - CI lint job calls the one-owner script, not an inline command
ok - no-mistakes pre-push lint calls the one-owner script
ok - fm-lint.sh pins an explicit ShellCheck version (0.11.0)
ok - CI installs and logs the pinned ShellCheck version from the one owner
ok - fm-lint.sh refuses to lint under a non-pinned ShellCheck version
ok - fm-lint.sh catches a real lint defect the old no-op gate passed
ok - fm-lint.sh ignores ambient ShellCheck options
ok - fm-lint.sh passes a clean fixture
FM_TEST_END 2026-07-22T18:23:13Z tests/fm-lint.test.sh exit=0 duration_ms=1239 gate_skip=false
FM_TEST_BEGIN 2026-07-22T18:23:13Z tests/fm-nm-test-contract.test.sh family=pure-contract-unit expected_gate_skip=none
ok - .no-mistakes.yaml is present and tracked
ok - commands.lint stays pinned to bin/fm-lint.sh
ok - no-mistakes does not configure a complete local Test command
ok - CI still owns partitioned broad behavior coverage and companion jobs
FM_TEST_END 2026-07-22T18:23:13Z tests/fm-nm-test-contract.test.sh exit=0 duration_ms=205 gate_skip=false
FM_TEST_BEGIN 2026-07-22T18:23:13Z tests/fm-captain-translation-contract.test.sh family=pure-contract-unit expected_gate_skip=none
ok - section 9 owns the positive captain-facing translation contract
ok - scout remains allowed in private captain chat
ok - compressed safety labels require concrete plain renderings
ok - section 9 maps high-risk internal vocabulary families
ok - captain chat rejects verbatim internal evidence while private reports stay precise
ok - outward-facing skill handoffs point to the section 9 owner
ok - skills cross-reference section 9 instead of duplicating the mapping list
FM_TEST_END 2026-07-22T18:23:13Z tests/fm-captain-translation-contract.test.sh exit=0 duration_ms=94 gate_skip=false
FM_TEST_BEGIN 2026-07-22T18:23:13Z tests/fm-no-mistakes-ownership.test.sh family=pure-contract-unit expected_gate_skip=none
ok - Validate contract assigns the complete synchronous driver loop to the initiating task worker
ok - Validate contract forbids Firstmate from responding directly for a crew-owned run
FM_TEST_END 2026-07-22T18:23:14Z tests/fm-no-mistakes-ownership.test.sh exit=0 duration_ms=41 gate_skip=false
FM_TEST_SUMMARY total=15 failed=0 skipped_gate=0 duration_ms=122654
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=2 duration_ms=3104 failed=0
FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=44529 failed=0
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=12 duration_ms=74408 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-x-mode.test.sh duration_ms=44529
FM_TEST_SLOWEST rank=2 script=tests/fm-decision-hold-lifecycle.test.sh duration_ms=26054
FM_TEST_SLOWEST rank=3 script=tests/fm-crew-state.test.sh duration_ms=19908
FM_TEST_SLOWEST rank=4 script=tests/fm-herdr-lab.test.sh duration_ms=13317
FM_TEST_SLOWEST rank=5 script=tests/fm-grok-harness.test.sh duration_ms=6783
FM_TEST_SLOWEST rank=6 script=tests/fm-tmux-submit-busy.test.sh duration_ms=2349
FM_TEST_SLOWEST rank=7 script=tests/fm-composer-ghost.test.sh duration_ms=2159
FM_TEST_SLOWEST rank=8 script=tests/fm-send-strict.test.sh duration_ms=2107
FM_TEST_SLOWEST rank=9 script=tests/fm-send-settle.test.sh duration_ms=1931
FM_TEST_SLOWEST rank=10 script=tests/fm-lint.test.sh duration_ms=1239
FM_TEST_SLOWEST rank=11 script=tests/fm-spawn-batch.test.sh duration_ms=997
FM_TEST_SLOWEST rank=12 script=tests/fm-supervision-instructions.test.sh duration_ms=328
FM_TEST_SLOWEST rank=13 script=tests/fm-nm-test-contract.test.sh duration_ms=205
FM_TEST_SLOWEST rank=14 script=tests/fm-captain-translation-contract.test.sh duration_ms=94
FM_TEST_SLOWEST rank=15 script=tests/fm-no-mistakes-ownership.test.sh duration_ms=41
```
</details>
<details>
<summary>Evidence: Portable-parallel-2 timing JSON</summary>

```text
{
  "families": [
    {
      "count": 2,
      "duration_ms": 3104,
      "failed": 0,
      "name": "backend-dispatch"
    },
    {
      "count": 1,
      "duration_ms": 44529,
      "failed": 0,
      "name": "pr-forge"
    },
    {
      "count": 12,
      "duration_ms": 74408,
      "failed": 0,
      "name": "pure-contract-unit"
    }
  ],
  "finished_at": "2026-07-22T18:23:14Z",
  "run_id": "fm-test-run-1784744471413-53902",
  "scripts": [
    {
      "duration_ms": 26054,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-decision-hold-lifecycle.test.sh"
    },
    {
      "duration_ms": 44529,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pr-forge",
      "gate_skip": false,
      "path": "tests/fm-x-mode.test.sh"
    },
    {
      "duration_ms": 13317,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-herdr-lab.test.sh"
    },
    {
      "duration_ms": 19908,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-crew-state.test.sh"
    },
    {
      "duration_ms": 6783,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-grok-harness.test.sh"
    },
    {
      "duration_ms": 997,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "backend-dispatch",
      "gate_skip": false,
      "path": "tests/fm-spawn-batch.test.sh"
    },
    {
      "duration_ms": 2107,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "backend-dispatch",
      "gate_skip": false,
      "path": "tests/fm-send-strict.test.sh"
    },
    {
      "duration_ms": 2349,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-tmux-submit-busy.test.sh"
    },
    {
      "duration_ms": 2159,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-composer-ghost.test.sh"
    },
    {
      "duration_ms": 1931,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-send-settle.test.sh"
    },
    {
      "duration_ms": 328,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-supervision-instructions.test.sh"
    },
    {
      "duration_ms": 1239,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-lint.test.sh"
    },
    {
      "duration_ms": 205,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-nm-test-contract.test.sh"
    },
    {
      "duration_ms": 94,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-captain-translation-contract.test.sh"
    },
    {
      "duration_ms": 41,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-no-mistakes-ownership.test.sh"
    }
  ],
  "selection": "lane=portable-parallel-2",
  "started_at": "2026-07-22T18:21:11Z",
  "summary": {
    "duration_ms": 122654,
    "failed": 0,
    "skipped_gate": 0,
    "total": 15
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-test-run.test.sh`
- `PATH=/etc/profiles/per-user/kunchen/bin:/usr/bin:/bin tests/fm-decision-hold-lifecycle.test.sh`
- `bin/fm-test-run.sh --lane portable-parallel-2 --json /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY5GV5V3PN2J7M4ZN70FN1YH/fm-test-timing-portable-parallel-2.json | tee /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY5GV5V3PN2J7M4ZN70FN1YH/portable-parallel-2-transcript.log`
- `bin/fm-test-run.sh --check-coverage`
- `jq '{summary, decision_hold: (.scripts[] | select(.path == "tests/fm-decision-hold-lifecycle.test.sh"))}' .../fm-test-timing-portable-parallel-2.json`
- `git diff --exit-code 673b6ad39d01183a19c5bd8a52675a2ee8ea06e6..ceddcba244bd4f90cdaae70f309df0b0350427d9 -- bin/fm-test-run.sh`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
