### PR TITLE
feat(bin): make dispatch profiles quota aware

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -20,7 +20,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
   For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.
   For `no-mistakes`, this also covers an installed version older than 1.31.2, because crewmate validation briefs delegate gate mechanics to no-mistakes' version-matched guidance.
   For `tasks-axi`, this also covers an installed build that fails the compatibility probe (`docs/configuration.md` "Backlog backend" owns the definition); `config/backlog-backend=manual` only suppresses the verbose `BOOTSTRAP_INFO: tasks-axi available` fact, not this missing-tool report.
-  For `quota-axi`, bootstrap requires it because crew-dispatch `quota-balanced` may call it; `bin/fm-dispatch-select.sh` still degrades at runtime when quota data is unavailable.
+  For `quota-axi`, bootstrap requires it because every crew-dispatch profile array calls it automatically; `bin/fm-dispatch-select.sh` still selects uniformly from valid candidates with OS-backed randomness when quota data is unavailable.
 - `MISSING_MANUAL: <tool> (instructions: <url>)` - tell the captain why the tool is required and give them the printed instructions URL, but do not pass the tool to `bin/fm-bootstrap.sh install`; wait for the captain to complete the manual installation, then rerun session start to confirm the dependency is present.
 - `BACKEND_INVALID: <name> (known: <names>)` - the resolved runtime backend has no verified dependency or lifecycle contract, so do not dispatch work until the invalid `FM_BACKEND` or `config/backend` value is corrected to one of the listed backends.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -52,8 +52,9 @@
 #          with update --archive-body and mv [<id>...]); an installed but
 #          incompatible build reports MISSING like no-mistakes. A compatible
 #          tasks-axi default backend is silent. quota-axi is required because
-#          crew-dispatch quota-balanced may call it; fm-dispatch-select.sh still
-#          degrades at runtime when quota data is unavailable.
+#          every crew-dispatch profile array calls it automatically;
+#          fm-dispatch-select.sh still uses OS-backed random selection across
+#          valid candidates when quota data is unavailable.
 #          X mode is OPTIONAL and inert unless FM_HOME/.env has a non-empty
 #          FMX_PAIRING_TOKEN. When opted in, bootstrap requires curl+jq, writes
 #          the relay poll shim and 30s cadence config, and prints an FMX line.
@@ -722,14 +723,20 @@ crew_dispatch_validate() {
       elif $h == "opencode" then false
       else true
       end;
-    def use_profiles($u):
-      if ($u | type) == "array" then $u
-      elif ($u | type) == "object" then [$u]
+    def profiles($value):
+      if ($value | type) == "array" then $value
+      elif ($value | type) == "object" then [$value]
       else []
       end;
+    def configured_profiles:
+      ([(.rules // [])[]? | profiles(.use?)[]?]
+        + (if has("default") then [profiles(.default)[]?] else [] end));
+    def malformed_optional_fields($items):
+      ($items | any(has("model") and (((.model | type) != "string") or (.model | length) == 0)))
+      or ($items | any(has("effort") and (((.effort | type) != "string") or (.effort | length) == 0)));
     def bad_efforts:
-      ([(.rules // [])[]? | use_profiles(.use?)[]? | {h: .harness, e: .effort}]
-        + (if (.default? | type) == "object" then [{h: .default.harness, e: .default.effort}] else [] end))
+      configured_profiles
+      | map({h: .harness, e: .effort})
       | map(select(.e != null))
       | map(select((.h | type) == "string" and verified(.h)))
       | map(select(. as $p | effort_ok($p.h; $p.e) | not))
@@ -741,15 +748,20 @@ crew_dispatch_validate() {
     elif [(.rules // [])[]? | select((.when? | type) != "string" or (.when | length) == 0)] | length > 0 then "each rule needs non-empty when"
     elif [(.rules // [])[]? | select((.use? | type) != "object" and (.use? | type) != "array")] | length > 0 then "each rule needs use"
     elif [(.rules // [])[]? | select((.use? | type) == "array" and (.use | length) == 0)] | length > 0 then "each rule needs at least one use profile"
-    elif [(.rules // [])[]? | use_profiles(.use?)[]? | select(type != "object")] | length > 0 then "each use profile must be an object"
-    elif [(.rules // [])[]? | use_profiles(.use?)[]? | select((.harness? | type) != "string" or (.harness | length) == 0)] | length > 0 then "each use profile needs harness"
+    elif [(.rules // [])[]? | profiles(.use?)[]? | select(type != "object")] | length > 0 then "each use profile must be an object"
+    elif [(.rules // [])[]? | profiles(.use?)[]? | select((.harness? | type) != "string" or (.harness | length) == 0)] | length > 0 then "each use profile needs harness"
+    elif malformed_optional_fields([(.rules // [])[]? | profiles(.use?)[]?]) then "use profile model and effort must be non-empty strings when present"
     elif [(.rules // [])[]? | select(has("select") and ((.select? | type) != "string" or (.select | length) == 0))] | length > 0 then "select must be a non-empty string"
     elif [(.rules // [])[]? | .select? // empty | select(. != "quota-balanced")] | length > 0 then
       "unknown select: " + ([ (.rules // [])[]? | .select? // empty | select(. != "quota-balanced") ] | unique | join(", "))
-    elif has("default") and (.default | type) != "object" then "default must be an object"
-    elif has("default") and ((.default.harness? | type) != "string" or (.default.harness | length) == 0) then "default needs harness when present"
+    elif has("default") and ((.default | type) != "object" and (.default | type) != "array") then "default must be a profile object or non-empty profile array"
+    elif has("default") and ((.default | type) == "array" and (.default | length) == 0) then "default needs at least one profile"
+    elif has("default") and ([profiles(.default)[]? | select(type != "object")] | length) > 0 then "each default profile must be an object"
+    elif has("default") and ([profiles(.default)[]? | select((.harness? | type) != "string" or (.harness | length) == 0)] | length) > 0 then "each default profile needs harness"
+    elif has("default") and malformed_optional_fields([profiles(.default)[]?]) then "default profile model and effort must be non-empty strings when present"
     else
-      ([(.rules // [])[]? | use_profiles(.use?)[]?.harness] + [.default?.harness?]
+      (configured_profiles
+        | map(.harness)
         | map(select(. != null))
         | map(select(. as $h | verified($h) | not))
         | unique) as $bad_harnesses
@@ -771,15 +783,14 @@ crew_dispatch_validate() {
          elif ($p.effort? != null) then "/default"
          else "" end)
       + (if ($p.effort? != null) then "/" + ($p.effort | tostring) else "" end);
-    def use_label($r):
-      if ($r.use | type) == "array" then
-        ((if ($r.select? != null) then ($r.select | tostring) else "first" end)
-          + "[" + ([$r.use[] | profile(.)] | join(", ")) + "]")
-      else profile($r.use)
+    def profile_set($value; $selector):
+      if ($value | type) == "array" then
+        (($selector // "quota-balanced") + "[" + ([$value[] | profile(.)] | join(", ")) + "]")
+      else profile($value)
       end;
     (["BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json"]
-      + [(.rules // [])[]? | "BOOTSTRAP_INFO: crew dispatch rule: " + (.when | tostring) + " -> " + use_label(.)]
-      + (if (.default? | type) == "object" then ["BOOTSTRAP_INFO: crew dispatch default: " + profile(.default)] else [] end))
+      + [(.rules // [])[]? | "BOOTSTRAP_INFO: crew dispatch rule: " + (.when | tostring) + " -> " + profile_set(.use; .select?)]
+      + (if has("default") then ["BOOTSTRAP_INFO: crew dispatch default: " + profile_set(.default; null)] else [] end))
     | .[]
   ' "$file"
   fi

--- a/bin/fm-dispatch-select.sh
+++ b/bin/fm-dispatch-select.sh
@@ -1,34 +1,39 @@
 #!/usr/bin/env bash
-# Resolve one already-matched crew-dispatch rule to a concrete profile.
+# Resolve one already-matched crew-dispatch rule or default to a concrete profile.
 # Usage:
-#   fm-dispatch-select.sh [--select <strategy>] [--quota-json <file>] [<rule-or-use-json>]
+#   fm-dispatch-select.sh [--select <strategy>] [--quota-json <file>] [<rule-or-profile-json>]
 #
 # Input may be a full rule object with `use` and optional `select`, a single
-# profile object, or an ordered array of profile objects.
+# profile object, or a non-empty array of profile objects.
 # Output is one compact JSON profile object on stdout.
+# Selection diagnostics go to stderr and never alter the profile JSON.
 #
-# quota-balanced is deterministic, and this header is the single owner of its
-# contract:
-#   - It runs quota-axi --json (or the --quota-json fixture).
-#   - Per candidate vendor it takes the minimum percentRemaining across that
-#     vendor's GENERAL windows only - Claude five_hour and seven_day, Codex
-#     five_hour and weekly - ignoring model-scoped windows such as model:fable
-#     and model:codex_bengalfox:*.
-#   - The vendor with the higher minimum remaining quota wins; an exact tie
-#     between equally trusted candidates uses the first array element.
-#   - Stale-but-cached general-window numbers are usable, but a fresh candidate
-#     wins unless the stale candidate's minimum is at least the stale-clear
-#     margin higher (default 20 points - the definition of "clearly less
-#     constrained").
-#   - A vendor absent from quota output, or with no usable general windows, is
-#     unavailable; selection happens among available candidates.
-#   - If quota-axi is missing, exits non-zero, returns unparseable JSON, or no
-#     candidate is usable, the reason is logged to stderr and the first array
-#     element is printed - quota trouble never blocks dispatch.
+# This header is the single owner of quota-aware selection mechanics:
+#   - A profile object resolves to itself for backward compatibility.
+#   - Every profile array is quota-aware, whether or not it carries the legacy
+#     explicit `select: "quota-balanced"` strategy.
+#   - It runs the installed quota-axi --json (or the --quota-json fixture).
+#   - Candidates map to the quota provider and product their model consumes:
+#     direct Claude -> Claude, direct Codex -> Codex, direct Grok -> Grok Build,
+#     and Pi/OpenCode models prefixed anthropic/, openai-codex/, or xai/ ->
+#     Claude, Codex, or the xAI API product respectively.
+#   - A candidate's score is the minimum percentRemaining among its relevant
+#     general and matching model windows, or its exact Grok product window.
+#     Grok's aggregate credits window is used only when product windows are not
+#     exposed, so Grok Build and xAI API remain distinct.
+#   - Unscorable candidates never beat candidates with usable quota data.
+#   - Stale-but-cached numbers remain usable, but a fresh candidate wins unless
+#     the best stale score is at least the stale-clear margin higher (default
+#     20 points). Equal winning scores use a random tie-break.
+#   - If quota-axi is unavailable, fails, returns unusable data, or no candidate
+#     can be scored, selection falls back uniformly across every valid candidate
+#     using rejection sampling over a 32-bit value from /dev/urandom.
+#   - Runtime quota trouble never turns malformed profile JSON into a fallback;
+#     invalid input exits 2 with an actionable validation error.
 #
-# quota-balanced uses quota-axi --json unless --quota-json supplies a fixture.
 # FM_DISPATCH_QUOTA_AXI overrides the quota command.
 # FM_DISPATCH_STALE_CLEAR_MARGIN overrides the default 20 point stale margin.
+# FM_DISPATCH_RANDOM_SOURCE overrides /dev/urandom for deterministic tests only.
 set -u
 
 STALE_CLEAR_MARGIN=${FM_DISPATCH_STALE_CLEAR_MARGIN:-20}
@@ -92,6 +97,7 @@ done
 
 [ "${#ARGS[@]}" -le 1 ] || { echo "error: expected at most one JSON argument" >&2; exit 2; }
 command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 2; }
+command -v od >/dev/null 2>&1 || { echo "error: od is required for OS-backed random selection" >&2; exit 2; }
 
 if [ "${#ARGS[@]}" -eq 1 ]; then
   SPEC_JSON=${ARGS[0]}
@@ -103,21 +109,75 @@ profiles_json=$(printf '%s\n' "$SPEC_JSON" | jq -ec '
   (if type == "object" and has("use") then .use else . end)
   | if type == "array" then .
     elif type == "object" then [.]
-    else empty
+    else error("dispatch input must be a rule, profile, or profile array")
     end
 ' 2>/dev/null) || { echo "error: dispatch input must be a rule, profile, or profile array" >&2; exit 2; }
 
-profile_count=$(printf '%s\n' "$profiles_json" | jq 'length')
-[ "$profile_count" -gt 0 ] || { echo "error: dispatch profile array must not be empty" >&2; exit 2; }
+validation_error=$(printf '%s\n' "$profiles_json" | jq -r '
+  def verified($h): ["claude", "codex", "opencode", "pi", "grok"] | index($h);
+  def effort_ok($h; $e):
+    if $h == "claude" then ["low", "medium", "high", "xhigh", "max"] | index($e)
+    elif $h == "codex" then ["low", "medium", "high", "xhigh"] | index($e)
+    elif $h == "grok" then ["low", "medium", "high"] | index($e)
+    elif $h == "pi" then ["low", "medium", "high", "xhigh", "max"] | index($e)
+    elif $h == "opencode" then false
+    else false
+    end;
+  if length == 0 then "dispatch profile array must not be empty"
+  elif any(.[]; type != "object") then "each dispatch profile must be an object"
+  elif any(.[]; ((.harness? | type) != "string") or (.harness | length) == 0) then "each dispatch profile needs a non-empty harness"
+  elif any(.[]; has("model") and (((.model | type) != "string") or (.model | length) == 0)) then "dispatch profile model must be a non-empty string when present"
+  elif any(.[]; has("effort") and (((.effort | type) != "string") or (.effort | length) == 0)) then "dispatch profile effort must be a non-empty string when present"
+  elif any(.[]; .harness as $h | verified($h) | not) then "dispatch profile contains an unverified harness"
+  elif any(.[]; has("effort") and (. as $profile | effort_ok($profile.harness; $profile.effort) | not)) then "dispatch profile contains an unsupported harness/effort pair"
+  else empty
+  end
+')
+[ -z "$validation_error" ] || { echo "error: $validation_error" >&2; exit 2; }
 
-first_profile() {
-  printf '%s\n' "$profiles_json" | jq -c '
+clean_profile_at() {
+  local index=$1
+  printf '%s\n' "$profiles_json" | jq -c --argjson index "$index" '
     def clean($p):
       {harness: $p.harness}
       + (if ($p.model? | type) == "string" then {model: $p.model} else {} end)
       + (if ($p.effort? | type) == "string" then {effort: $p.effort} else {} end);
-    clean(.[0])
+    clean(.[$index])
   '
+}
+
+random_index() {
+  local count=$1 source raw ceiling attempts
+  source=${FM_DISPATCH_RANDOM_SOURCE:-/dev/urandom}
+  [ "$count" -gt 0 ] || return 1
+  [ -r "$source" ] || return 1
+  ceiling=$((4294967296 - (4294967296 % count)))
+  attempts=0
+  while [ "$attempts" -lt 32 ]; do
+    raw=$(LC_ALL=C od -An -N4 -tu4 "$source" 2>/dev/null | tr -d '[:space:]')
+    case "$raw" in
+      ''|*[!0-9]*) attempts=$((attempts + 1)); continue ;;
+    esac
+    if [ "$raw" -lt "$ceiling" ]; then
+      printf '%s\n' "$((raw % count))"
+      return 0
+    fi
+    attempts=$((attempts + 1))
+  done
+  return 1
+}
+
+random_profile() {
+  local reason count index
+  reason=$1
+  count=$(printf '%s\n' "$profiles_json" | jq 'length')
+  if ! index=$(random_index "$count"); then
+    echo "error: OS-backed random source is unavailable" >&2
+    exit 1
+  fi
+  log "$reason"
+  log "selection basis: random fallback"
+  clean_profile_at "$index"
 }
 
 select_strategy=$SELECT_OVERRIDE
@@ -126,109 +186,145 @@ if [ -z "$select_strategy" ]; then
     if type == "object" and has("use") and (.select? | type) == "string" then .select else "" end
   ' 2>/dev/null || true)
 fi
+if [ -n "$select_strategy" ] && [ "$select_strategy" != quota-balanced ]; then
+  echo "error: unknown select strategy '$select_strategy'" >&2
+  exit 2
+fi
 
-if [ "$select_strategy" != quota-balanced ]; then
-  if [ -n "$select_strategy" ]; then
-    log "unknown select strategy '$select_strategy'; using first profile"
-  fi
-  first_profile
+is_array=$(printf '%s\n' "$SPEC_JSON" | jq -r '
+  if type == "object" and has("use") then (.use | type) == "array" else type == "array" end
+')
+if [ "$is_array" != true ] && [ -z "$select_strategy" ]; then
+  log "selection basis: single profile"
+  clean_profile_at 0
   exit 0
 fi
 
 if [ -n "$QUOTA_JSON_FILE" ]; then
   if ! quota_json=$(cat "$QUOTA_JSON_FILE" 2>/dev/null); then
-    log "cannot read quota JSON; using first profile"
-    first_profile
+    random_profile "cannot read quota JSON"
     exit 0
   fi
 else
   quota_cmd=${FM_DISPATCH_QUOTA_AXI:-quota-axi}
   if ! command -v "$quota_cmd" >/dev/null 2>&1; then
-    log "quota-axi missing; using first profile"
-    first_profile
+    random_profile "quota-axi missing"
     exit 0
   fi
   quota_json=$("$quota_cmd" --json 2>/dev/null)
   quota_status=$?
   if [ "$quota_status" -ne 0 ]; then
-    log "quota-axi exited $quota_status; using first profile"
-    first_profile
+    random_profile "quota-axi exited $quota_status"
     exit 0
   fi
 fi
 
 if ! printf '%s\n' "$quota_json" | jq -e 'type == "object" and (.providers | type) == "array"' >/dev/null 2>&1; then
-  log "quota-axi returned unparseable JSON; using first profile"
-  first_profile
+  random_profile "quota-axi returned unparseable JSON"
   exit 0
 fi
 
 selection=$(printf '%s\n' "$quota_json" | jq -ec \
   --argjson profiles "$profiles_json" \
   --argjson margin "$STALE_CLEAR_MARGIN" '
-  def clean($p):
-    {harness: $p.harness}
-    + (if ($p.model? | type) == "string" then {model: $p.model} else {} end)
-    + (if ($p.effort? | type) == "string" then {effort: $p.effort} else {} end);
-  def provider_for($h): [.providers[]? | select(.provider == $h)][0];
-  def general_ids($h):
-    if $h == "claude" then ["five_hour", "seven_day"]
-    elif $h == "codex" then ["five_hour", "weekly"]
-    else []
+  def clean_text:
+    ascii_downcase | gsub("[^a-z0-9]"; "");
+  def model_name($model):
+    ($model | split("/") | last | split(":") | first);
+  def route($profile):
+    ($profile.harness // "") as $h
+    | ($profile.model // "") as $model
+    | if $h == "claude" then {provider: "claude", model: $model}
+      elif $h == "codex" then {provider: "codex", model: $model}
+      elif $h == "grok" then {provider: "grok", product: "grok_build", model: $model}
+      elif (($h == "pi" or $h == "opencode") and ($model | startswith("anthropic/"))) then
+        {provider: "claude", model: (model_name($model))}
+      elif (($h == "pi" or $h == "opencode") and ($model | startswith("openai-codex/"))) then
+        {provider: "codex", model: (model_name($model))}
+      elif (($h == "pi" or $h == "opencode") and ($model | startswith("xai/"))) then
+        {provider: "grok", product: "api", model: (model_name($model))}
+      else null
+      end;
+  def provider_for($id): [.providers[]? | select(.provider == $id)][0];
+  def model_window_matches($window; $model):
+    if (($window.kind? // "") != "model") or ($model | length) == 0 then false
+    else
+      (($window.id? // "") + " " + ($window.label? // "") | clean_text) as $scope
+      | ($model | clean_text) as $wanted
+      | (($scope | contains($wanted)) or ($wanted | contains($scope))
+        or (["fable", "opus", "haiku", "sonnet", "spark"]
+          | map(. as $family | ($scope | contains($family)) and ($wanted | contains($family)))
+          | any))
     end;
-  def candidate_metric($p; $i):
-    . as $root
-    | ($p.harness // "") as $h
-    | ($root | provider_for($h)) as $provider
-    | if ($provider == null) or ((general_ids($h) | length) == 0) then empty
+  def usable_percent($window):
+    (($window.percentRemaining? | type) == "number")
+    and ($window.percentRemaining >= 0)
+    and ($window.percentRemaining <= 100);
+  def relevant_windows($provider; $route):
+    (($provider.windows // []) | map(select(usable_percent(.)))) as $windows
+    | if $route.provider == "grok" then
+        ($windows | map(select(.id == ("product:" + $route.product)))) as $product_windows
+        | if ($product_windows | length) > 0 then $product_windows
+          else ($windows | map(select(.id == "credits")))
+          end
       else
-        (($provider.windows // [])
-          | map(. as $window
-            | select(((general_ids($h) | index($window.id)) != null)
-              and (($window.kind? // "") != "model")
-              and (($window.percentRemaining? | type) == "number")))) as $windows
+        $windows | map(select(
+          ((.kind? // "") == "session")
+          or ((.kind? // "") == "weekly")
+          or model_window_matches(.; $route.model)
+        ))
+      end;
+  def candidate_metric($profile; $index):
+    . as $root
+    | route($profile) as $route
+    | if $route == null then empty
+      else ($root | provider_for($route.provider)) as $provider
+      | if ($provider == null) or (["fresh", "stale"] | index($provider.state.status? // "") | not) then empty
+        else relevant_windows($provider; $route) as $windows
         | if ($windows | length) == 0 then empty
           else {
-            index: $i,
-            profile: clean($p),
-            harness: $h,
-            min: ($windows | map(.percentRemaining) | min),
+            index: $index,
+            score: ($windows | map(.percentRemaining) | min),
             fresh: (($provider.state.status? // "") == "fresh")
           }
           end
+        end
       end;
-  def better($a; $b):
-    if $a == null then $b
-    elif $b == null then $a
-    elif ($b.min > $a.min) then $b
-    elif ($b.min == $a.min and $b.index < $a.index) then $b
-    else $a
-    end;
-  def best_by_min($xs): reduce $xs[] as $x (null; better(.; $x));
+  def best_score($items): if ($items | length) == 0 then null else ($items | map(.score) | max) end;
   . as $quota_root
-  | ([$profiles | to_entries[] | . as $entry | ($quota_root | candidate_metric($entry.value; $entry.key))]) as $candidates
-  | if ($candidates | length) == 0 then {
-      fallback: true,
-      reason: "no usable quota windows for candidate vendors",
-      profile: clean($profiles[0])
-    }
+  | ([$profiles | to_entries[] | . as $entry
+      | ($quota_root | candidate_metric($entry.value; $entry.key))]) as $candidates
+  | if ($candidates | length) == 0 then {fallback: true}
     else
-      (best_by_min($candidates | map(select(.fresh)))) as $fresh_best
-      | (best_by_min($candidates | map(select(.fresh | not)))) as $stale_best
+      ($candidates | map(select(.fresh))) as $fresh
+      | ($candidates | map(select(.fresh | not))) as $stale
+      | best_score($fresh) as $fresh_best
+      | best_score($stale) as $stale_best
       | (if $fresh_best != null and $stale_best != null then
-          if $stale_best.min >= ($fresh_best.min + $margin) then $stale_best else $fresh_best end
-        elif $fresh_best != null then $fresh_best
-        else $stale_best
-        end) as $chosen
-      | {fallback: false, profile: $chosen.profile}
+          if $stale_best >= ($fresh_best + $margin) then {items: $stale, score: $stale_best}
+          else {items: $fresh, score: $fresh_best}
+          end
+        elif $fresh_best != null then {items: $fresh, score: $fresh_best}
+        else {items: $stale, score: $stale_best}
+        end) as $winning
+      | {fallback: false, indices: [$winning.items[] | select(.score == $winning.score) | .index]}
     end
 ' 2>/dev/null) || {
-  log "quota-axi data could not be evaluated; using first profile"
-  first_profile
+  random_profile "quota-axi data could not be evaluated"
   exit 0
 }
 
 if [ "$(printf '%s\n' "$selection" | jq -r '.fallback')" = true ]; then
-  log "$(printf '%s\n' "$selection" | jq -r '.reason'); using first profile"
+  random_profile "no usable quota windows for candidates"
+  exit 0
 fi
-printf '%s\n' "$selection" | jq -c '.profile'
+
+winner_indices=$(printf '%s\n' "$selection" | jq -c '.indices')
+winner_count=$(printf '%s\n' "$winner_indices" | jq 'length')
+if ! winner_offset=$(random_index "$winner_count"); then
+  echo "error: OS-backed random source is unavailable" >&2
+  exit 1
+fi
+winner_index=$(printf '%s\n' "$winner_indices" | jq -r --argjson offset "$winner_offset" '.[$offset]')
+log "selection basis: quota-selected"
+clean_profile_at "$winner_index"

--- a/bin/fm-dispatch-select.sh
+++ b/bin/fm-dispatch-select.sh
@@ -260,17 +260,24 @@ selection=$(printf '%s\n' "$quota_json" | jq -ec \
     (($window.percentRemaining? | type) == "number")
     and ($window.percentRemaining >= 0)
     and ($window.percentRemaining <= 100);
+  def general_window_matches($window; $provider):
+    if $provider == "claude" then ["five_hour", "seven_day"] | index($window.id? // "") != null
+    elif $provider == "codex" then ["five_hour", "weekly"] | index($window.id? // "") != null
+    else false
+    end;
   def relevant_windows($provider; $route):
-    (($provider.windows // []) | map(select(usable_percent(.)))) as $windows
+    ($provider.windows // []) as $all_windows
+    | ($all_windows | map(select(usable_percent(.)))) as $windows
     | if $route.provider == "grok" then
         ($windows | map(select(.id == ("product:" + $route.product)))) as $product_windows
         | if ($product_windows | length) > 0 then $product_windows
-          else ($windows | map(select(.id == "credits")))
+          elif ($all_windows | map(select((.id? // "") | startswith("product:"))) | length) == 0 then
+            ($windows | map(select(.id == "credits")))
+          else []
           end
       else
         $windows | map(select(
-          ((.kind? // "") == "session")
-          or ((.kind? // "") == "weekly")
+          general_window_matches(.; $route.provider)
           or model_window_matches(.; $route.model)
         ))
       end;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,7 +134,7 @@ Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`,
 Crewmate and scout dispatch can stay on the static crewmate harness resolved by `config/crew-harness`, or it can use local dispatch profiles in `config/crew-dispatch.json`.
 The dispatch file is intentionally judgment-based: firstmate reads the natural-language rules at intake, chooses the best matching rule, resolves that rule directly or through a supported selector, and passes only concrete `--harness`, `--model`, and `--effort` axes to `fm-spawn.sh`.
 The shell scripts validate the JSON shape and verified harness/effort combinations, and `fm-dispatch-select.sh` owns quota-aware array selection plus OS-backed random fallback, but they do not parse task intent or match the natural-language rules.
-The session-start bootstrap step surfaces either the active rule block or a concise invalid-config line at startup.
+The session-start bootstrap step keeps valid dispatch configuration silent unless verbose facts are enabled and surfaces a concise invalid-config line when validation fails.
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,7 @@ Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`,
 
 Crewmate and scout dispatch can stay on the static crewmate harness resolved by `config/crew-harness`, or it can use local dispatch profiles in `config/crew-dispatch.json`.
 The dispatch file is intentionally judgment-based: firstmate reads the natural-language rules at intake, chooses the best matching rule, resolves that rule directly or through a supported selector, and passes only concrete `--harness`, `--model`, and `--effort` axes to `fm-spawn.sh`.
-The shell scripts validate the JSON shape and verified harness/effort combinations, and `fm-dispatch-select.sh` owns deterministic selector behavior, but they do not parse task intent or match the natural-language rules.
+The shell scripts validate the JSON shape and verified harness/effort combinations, and `fm-dispatch-select.sh` owns quota-aware array selection plus OS-backed random fallback, but they do not parse task intent or match the natural-language rules.
 The session-start bootstrap step surfaces either the active rule block or a concise invalid-config line at startup.
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,24 +208,27 @@ This section is the single owner of the canonical schema and its per-field seman
       "why": "<optional rationale that helps firstmate choose>"
     }
   ],
-  "default": { "harness": "<adapter>", "model": "<optional model>", "effort": "<optional effort>" }
+  "default": [
+    { "harness": "<adapter>", "model": "<optional model>", "effort": "<optional effort>" }
+  ]
 }
 ```
 
 Per rule, `when` and `use` are required.
-`use` may be a single profile object or an ordered array of profile objects; the single-object form stays fully backward-compatible, and every profile needs `harness`.
-`use.model`, `use.effort`, and `why` are optional.
-`select` is optional and currently supports `quota-balanced`.
-Absent `select` means use the first array element, or the only object in the single-object form; the first array element is the deterministic tie-break and the ultimate fallback.
-`default` is optional.
+Both `use` and the optional top-level `default` accept either one profile object or a non-empty array of profile objects.
+The single-object form stays fully backward-compatible, and every profile needs `harness`.
+Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
+Every profile array is an implicit quota-aware choice and does not need a selector property.
+`select: "quota-balanced"` remains accepted on rules for compatibility and has the same behavior as an implicit array choice.
+If no dispatch rule fits, firstmate resolves `default` through the same object-or-array selection path before falling back to `config/crew-harness`.
 If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
-`quota-balanced` selection is deterministic and implemented by `bin/fm-dispatch-select.sh`, whose header owns the general-window rules, the 20 point stale-clear freshness margin, vendor-availability handling, and the degrade-to-first-element fallbacks; quota trouble never blocks dispatch.
+Quota-aware selection is implemented by `bin/fm-dispatch-select.sh`, whose header owns provider and product mapping, relevant-window scoring, the stale-clear freshness margin, random tie-breaking, OS-backed random operational fallback, and safe selection-basis diagnostics.
+Quota-data trouble never blocks dispatch, but malformed profile configuration remains an actionable validation error.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.
 Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstrap emits `BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json` plus one `BOOTSTRAP_INFO:` fact per rule and default profile.
-Malformed JSON, an unverified harness, a malformed array profile, an unknown `select`, or an effort value unsupported by that harness is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
-If no dispatch rule fits, firstmate uses the dispatch profile `default` when present, then falls back to `config/crew-harness`.
+Malformed JSON, an empty or malformed rule/default array, an unverified harness, an unknown `select`, or an effort value unsupported by that harness is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
 Because the spawn backstop is gated by file presence, any fallback path after a missing match, validation error, or missing `jq` still passes a resolved harness explicitly until the file is fixed or removed.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
 
@@ -247,7 +250,7 @@ When `config/crew-dispatch.json` exists, bootstrap also requires `jq` for dispat
 When X mode is opted in, bootstrap also requires `curl` and `jq` before arming the relay poll shim.
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.
 An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
-An absent `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; `bin/fm-dispatch-select.sh` still degrades to the first profile at runtime when quota data is unavailable.
+An absent `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; `bin/fm-dispatch-select.sh` still selects uniformly from the valid candidate array with an OS-backed random source when quota data is unavailable.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,7 +227,7 @@ Quota-aware selection is implemented by `bin/fm-dispatch-select.sh`, whose heade
 Quota-data trouble never blocks dispatch, but malformed profile configuration remains an actionable validation error.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.
-Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstrap emits `BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json` plus one `BOOTSTRAP_INFO:` fact per rule and default profile.
+Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstrap emits `BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json`, one `BOOTSTRAP_INFO:` fact per rule, and one fact for the optional default profile set.
 Malformed JSON, an empty or malformed rule/default array, an unverified harness, an unknown `select`, or an effort value unsupported by that harness is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
 Because the spawn backstop is gated by file presence, any fallback path after a missing match, validation error, or missing `jq` still passes a resolved harness explicitly until the file is fixed or removed.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
@@ -239,7 +239,7 @@ It installs automatically supported tools only after you say go; manual-only too
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
 The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
 This section is the single owner of that universal toolchain list; backend guides' prerequisites point here and add only their backend-specific tools.
-In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-balanced dispatch.
+In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-aware array dispatch.
 The per-backend delta is required only for the backend resolved from `FM_BACKEND`, then `config/backend`, then runtime auto-detection, then default `tmux`, so a home is never told to install a tool an inactive backend or feature would need.
 That delta is owned in code by `fm_backend_required_tools` in `bin/fm-backend.sh`: the resolved backend's own session-provider CLI (`tmux`, `herdr`, `zellij`, `orca`, or `cmux`), `jq` for the JSON-emitting experimental adapters (`herdr`, `zellij`, `cmux`) whose spawn and liveness paths parse the backend's JSON output, and the `treehouse` worktree provider for every session-provider-only backend (`tmux`, `herdr`, `zellij`, `cmux`).
 Backend tool availability uses the adapter's own executable resolver, so bootstrap and spawn agree on supported non-`PATH` locations such as cmux's bundled CLI.

--- a/docs/examples/crew-dispatch.json
+++ b/docs/examples/crew-dispatch.json
@@ -16,9 +16,11 @@
         { "harness": "claude", "model": "claude-sonnet-5", "effort": "high" },
         { "harness": "codex", "model": "gpt-5.5", "effort": "high" }
       ],
-      "select": "quota-balanced",
-      "why": "Use a strong coding profile for broad design and implementation work."
+      "why": "Arrays are quota-aware automatically, so use a strong coding profile with the most available relevant quota."
     }
   ],
-  "default": { "harness": "codex", "model": "gpt-5.5", "effort": "medium" }
+  "default": [
+    { "harness": "codex", "model": "gpt-5.5", "effort": "medium" },
+    { "harness": "pi", "model": "anthropic/claude-sonnet-5", "effort": "medium" }
+  ]
 }

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -36,7 +36,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervision-instructions.sh` | Render the session-start primary-harness supervision block or the one-line repair instruction |
 | `fm-home-seed.sh`        | Transactionally provision a secondmate home and maintain `data/secondmates.md`       |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
-| `fm-dispatch-select.sh`  | Resolve a matched crew-dispatch rule to one concrete profile, owning `quota-balanced` selection |
+| `fm-dispatch-select.sh`  | Resolve a dispatch rule/default to one profile, owning quota-aware arrays and random fallback |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer-content classification for all backends          |

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -730,7 +730,7 @@ test_crew_dispatch_active_rules_are_verbose_bootstrap_info() {
   case_dir="$TMP_ROOT/dispatch-active"
   mkdir -p "$case_dir/home/config"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
-  printf '%s\n' '{"rules":[{"when":"fresh news","use":{"harness":"grok"},"why":"current context"},{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}],"select":"quota-balanced"}],"default":{"harness":"claude","model":"haiku","effort":"low"}}' > "$case_dir/home/config/crew-dispatch.json"
+  printf '%s\n' '{"rules":[{"when":"fresh news","use":{"harness":"grok"},"why":"current context"},{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}]},{"when":"legacy feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"quota-balanced"}],"default":[{"harness":"pi","model":"anthropic/claude-sonnet-5","effort":"high"},{"harness":"grok","model":"grok-4.5","effort":"high"}]}' > "$case_dir/home/config/crew-dispatch.json"
   fakebin=$(make_fake_toolchain "$case_dir")
   add_real_jq "$fakebin"
 
@@ -741,7 +741,7 @@ test_crew_dispatch_active_rules_are_verbose_bootstrap_info() {
   out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_BOOTSTRAP_VERBOSE_FACTS=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
 
-  expect=$'BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json\nBOOTSTRAP_INFO: crew dispatch rule: fresh news -> grok\nBOOTSTRAP_INFO: crew dispatch rule: big feature -> quota-balanced[claude/claude-sonnet-5/high, codex/gpt-5.5/high]\nBOOTSTRAP_INFO: crew dispatch default: claude/haiku/low'
+  expect=$'BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json\nBOOTSTRAP_INFO: crew dispatch rule: fresh news -> grok\nBOOTSTRAP_INFO: crew dispatch rule: big feature -> quota-balanced[claude/claude-sonnet-5/high, codex/gpt-5.5/high]\nBOOTSTRAP_INFO: crew dispatch rule: legacy feature -> quota-balanced[claude, codex]\nBOOTSTRAP_INFO: crew dispatch default: quota-balanced[pi/anthropic/claude-sonnet-5/high, grok/grok-4.5/high]'
   [ "$out" = "$expect" ] || fail "active dispatch verbose info block mismatch"$'\n'"expected: $expect"$'\n'"actual:   $out"
   pass "bootstrap surfaces active crew-dispatch rules only as verbose BOOTSTRAP_INFO"
 }
@@ -778,10 +778,18 @@ pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi",
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
 array use with quota-balanced is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}],"select":"quota-balanced"}]}^empty^
 array use without select is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}]}]}^empty^
+one-element array use is accepted^{"rules":[{"when":"focused feature","use":[{"harness":"claude"}]}]}^empty^
+default array is accepted^{"default":[{"harness":"pi","model":"anthropic/claude-sonnet-5"},{"harness":"grok"}]}^empty^
+one-element default array is accepted^{"default":[{"harness":"codex"}]}^empty^
 empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each rule needs at least one use profile
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
+array profile with malformed model is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","model":5}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - use profile model and effort must be non-empty strings when present
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
 array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+empty default array is flagged^{"default":[]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - default needs at least one profile
+non-object default array entry is flagged^{"default":["codex"]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile must be an object
+default array profile without harness is flagged^{"default":[{"model":"gpt-5.5"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile needs harness
+default array malformed effort is flagged^{"default":[{"harness":"codex","effort":3}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - default profile model and effort must be non-empty strings when present
 ROWS
   pass "bootstrap validates crew-dispatch.json and reports malformed or unverified configs"
 }

--- a/tests/fm-dispatch-select.test.sh
+++ b/tests/fm-dispatch-select.test.sh
@@ -171,6 +171,8 @@ test_most_constrained_relevant_window_scores_candidate() {
   {"provider":"codex","state":{"status":"fresh"},"windows":[
     {"id":"five_hour","kind":"session","percentRemaining":30},
     {"id":"weekly","kind":"weekly","percentRemaining":30},
+    {"id":"code_review_five_hour","label":"code review session","kind":"session","percentRemaining":1},
+    {"id":"code_review_weekly","label":"code review week","kind":"weekly","percentRemaining":1},
     {"id":"model:other:5h","label":"Unrelated preview session","kind":"model","percentRemaining":1}
   ]}
 ]}
@@ -179,6 +181,27 @@ JSON
     '[{"harness":"claude","model":"claude-fable-5"},{"harness":"codex","model":"gpt-5.5"}]' 2>/dev/null)
   assert_profile "$out" '{"harness":"codex","model":"gpt-5.5"}' "matching model window was not included or unrelated model window was included"
   pass "candidate score uses its most constrained general or matching model quota window"
+}
+
+test_grok_aggregate_fallback_requires_no_product_windows() {
+  local quota out
+  quota="$TMP_ROOT/grok-partial-products.json"
+  cat > "$quota" <<'JSON'
+{"schemaVersion":2,"providers":[
+  {"provider":"grok","state":{"status":"fresh"},"windows":[
+    {"id":"credits","kind":"credits","percentRemaining":100},
+    {"id":"product:grok_build","kind":"credits","percentRemaining":90}
+  ]},
+  {"provider":"claude","state":{"status":"fresh"},"windows":[
+    {"id":"five_hour","kind":"session","percentRemaining":5},
+    {"id":"seven_day","kind":"weekly","percentRemaining":5}
+  ]}
+]}
+JSON
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" \
+    '[{"harness":"pi","model":"xai/grok-4.5"},{"harness":"claude"}]' 2>/dev/null)
+  assert_profile "$out" '{"harness":"claude"}' "xAI API route used aggregate credits despite exposed product windows"
+  pass "Grok aggregate credits are used only when product windows are absent"
 }
 
 test_stale_cache_needs_clear_margin_to_beat_fresh() {
@@ -294,6 +317,7 @@ test_legacy_explicit_selector_stays_compatible
 test_equal_winners_use_os_random_tie_break
 test_provider_and_product_mapping_through_wrappers
 test_most_constrained_relevant_window_scores_candidate
+test_grok_aggregate_fallback_requires_no_product_windows
 test_stale_cache_needs_clear_margin_to_beat_fresh
 test_partial_quota_data_prefers_scorable_candidate
 test_operational_quota_failures_use_uniform_random_fallback

--- a/tests/fm-dispatch-select.test.sh
+++ b/tests/fm-dispatch-select.test.sh
@@ -1,5 +1,24 @@
 #!/usr/bin/env bash
-# Behavior tests for deterministic crew-dispatch profile selection.
+# Behavior tests for quota-aware crew-dispatch profile selection.
+#
+# End-user reproduction before the fix:
+# - Initiating input: a non-empty profile array in rule use or top-level default.
+# - Expected: startup accepts both locations and dispatch consults quota-axi.
+# - Observed: startup rejected a default array, while a rule array without
+#   select silently chose its first element without calling quota-axi.
+# - Masking condition: a single profile object worked, and an explicit
+#   quota-balanced rule array took the quota path.
+# - Visible symptom: an actionable-looking startup invalid-config line for a
+#   valid default array, or first-profile dispatch despite better usable quota.
+# - Earliest divergence: bootstrap restricted default to object while use had an
+#   array normalizer; selector gated quota lookup on explicit select rather than
+#   the already-normalized input being an array.
+# - History: 7a42707 added rule arrays and explicit quota-balanced selection;
+#   8cd90fe moved the contract owner without changing that asymmetric behavior.
+# - Smallest counterfactual: adding select changed a rule array to quota-aware
+#   selection but could not make the same array valid under default.
+# - Disconfirming evidence: object defaults, object rule uses, and explicit
+#   quota-balanced rule arrays all followed their proven paths successfully.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -8,12 +27,17 @@ set -u
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 TMP_ROOT=$(fm_test_tmproot fm-dispatch-select-tests)
 mkdir -p "$TMP_ROOT"
+RANDOM_ZERO="$TMP_ROOT/random-zero"
+RANDOM_ONE="$TMP_ROOT/random-one"
+printf '\000\000\000\000' > "$RANDOM_ZERO"
+printf '\001\001\001\001' > "$RANDOM_ONE"
 
 write_quota() {
   local file=$1 claude_status=$2 claude_five=$3 claude_week=$4 codex_status=$5 codex_five=$6 codex_week=$7
   mkdir -p "$(dirname "$file")"
   cat > "$file" <<JSON
 {
+  "schemaVersion": 2,
   "providers": [
     {
       "provider": "claude",
@@ -21,7 +45,7 @@ write_quota() {
       "windows": [
         { "id": "five_hour", "kind": "session", "percentRemaining": $claude_five },
         { "id": "seven_day", "kind": "weekly", "percentRemaining": $claude_week },
-        { "id": "model:fable", "kind": "model", "percentRemaining": 100 }
+        { "id": "model:fable", "label": "Fable week", "kind": "model", "percentRemaining": 100 }
       ]
     },
     {
@@ -30,7 +54,7 @@ write_quota() {
       "windows": [
         { "id": "five_hour", "kind": "session", "percentRemaining": $codex_five },
         { "id": "weekly", "kind": "weekly", "percentRemaining": $codex_week },
-        { "id": "model:codex_bengalfox:5h", "kind": "model", "percentRemaining": 100 }
+        { "id": "model:codex_bengalfox:5h", "label": "GPT-5.3-Codex-Spark session", "kind": "model", "percentRemaining": 100 }
       ]
     }
   ]
@@ -40,120 +64,189 @@ JSON
 
 profiles='[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}]'
 
-test_higher_min_vendor_wins() {
-  local quota out
+assert_profile() {
+  local actual=$1 expected=$2 message=$3
+  [ "$actual" = "$expected" ] || fail "$message, got: $actual"
+}
+
+test_implicit_array_picks_higher_min_provider() {
+  local quota out err
   quota="$TMP_ROOT/higher.json"
   write_quota "$quota" fresh 80 30 fresh 70 60
-  out=$("$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced --quota-json "$quota" "$profiles")
-  [ "$out" = '{"harness":"codex","model":"gpt-5.5","effort":"high"}' ] \
-    || fail "higher-min vendor should win, got: $out"
-  pass "quota-balanced picks the candidate with the higher general-window minimum"
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" "$profiles" 2>"$TMP_ROOT/higher.err")
+  err=$(cat "$TMP_ROOT/higher.err")
+  assert_profile "$out" '{"harness":"codex","model":"gpt-5.5","effort":"high"}' "higher-min provider should win"
+  assert_contains "$err" "selection basis: quota-selected" "quota selection basis was not exposed"
+  pass "every profile array implicitly picks the least constrained scorable provider"
 }
 
-test_exact_tie_uses_first_profile() {
+test_rule_array_without_select_invokes_quota_axi() {
+  local fakebin marker out rule
+  fakebin=$(fm_fakebin "$TMP_ROOT/implicit-command")
+  marker="$TMP_ROOT/implicit-command/called"
+  cat > "$fakebin/quota-axi" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" > '$marker'
+cat <<'JSON'
+{"schemaVersion":2,"providers":[{"provider":"claude","state":{"status":"fresh"},"windows":[{"id":"five_hour","kind":"session","percentRemaining":10}]},{"provider":"codex","state":{"status":"fresh"},"windows":[{"id":"five_hour","kind":"session","percentRemaining":90}]}]}
+JSON
+SH
+  chmod +x "$fakebin/quota-axi"
+  rule='{"when":"big work","use":[{"harness":"claude"},{"harness":"codex"}]}'
+  out=$(PATH="$fakebin:$BASE_PATH" FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" "$rule" 2>/dev/null)
+  assert_profile "$out" '{"harness":"codex"}' "implicit rule array should use quota data"
+  assert_contains "$(cat "$marker")" "--json" "implicit array did not invoke quota-axi --json"
+  pass "rule arrays need no select property to invoke installed quota-axi"
+}
+
+test_legacy_explicit_selector_stays_compatible() {
   local quota out
+  quota="$TMP_ROOT/legacy.json"
+  write_quota "$quota" fresh 90 80 fresh 70 60
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced --quota-json "$quota" "$profiles" 2>/dev/null)
+  assert_profile "$out" '{"harness":"claude","model":"claude-sonnet-5","effort":"high"}' "legacy explicit selector changed behavior"
+
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" \
+    '{"when":"big work","use":[{"harness":"claude"},{"harness":"codex"}],"select":"quota-balanced"}' 2>/dev/null)
+  assert_profile "$out" '{"harness":"claude"}' "legacy rule selector changed behavior"
+  pass "legacy select quota-balanced forms remain compatible"
+}
+
+test_equal_winners_use_os_random_tie_break() {
+  local quota first second
   quota="$TMP_ROOT/tie.json"
   write_quota "$quota" fresh 90 50 fresh 60 50
-  out=$("$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced --quota-json "$quota" "$profiles")
-  [ "$out" = '{"harness":"claude","model":"claude-sonnet-5","effort":"high"}' ] \
-    || fail "exact tie should pick first profile, got: $out"
-  pass "quota-balanced exact tie uses the first ordered profile"
+  first=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" "$profiles" 2>/dev/null)
+  second=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ONE" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" "$profiles" 2>/dev/null)
+  assert_profile "$first" '{"harness":"claude","model":"claude-sonnet-5","effort":"high"}' "zero random fixture should choose first tie winner"
+  assert_profile "$second" '{"harness":"codex","model":"gpt-5.5","effort":"high"}' "nonzero random fixture should choose second tie winner"
+  pass "equal quota winners use the OS-backed random tie-break"
 }
 
-test_quota_missing_falls_back_to_first() {
-  local fakebin out err status
+test_provider_and_product_mapping_through_wrappers() {
+  local quota out
+  quota="$TMP_ROOT/routes.json"
+  cat > "$quota" <<'JSON'
+{
+  "schemaVersion": 2,
+  "providers": [
+    {"provider":"claude","state":{"status":"fresh"},"windows":[{"id":"five_hour","kind":"session","percentRemaining":45},{"id":"seven_day","kind":"weekly","percentRemaining":40}]},
+    {"provider":"codex","state":{"status":"fresh"},"windows":[{"id":"five_hour","kind":"session","percentRemaining":55},{"id":"weekly","kind":"weekly","percentRemaining":50}]},
+    {"provider":"grok","state":{"status":"fresh"},"windows":[
+      {"id":"credits","kind":"credits","percentRemaining":1},
+      {"id":"product:api","kind":"credits","percentRemaining":75},
+      {"id":"product:grok_build","kind":"credits","percentRemaining":25}
+    ]}
+  ]
+}
+JSON
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" \
+    '[{"harness":"claude"},{"harness":"pi","model":"openai-codex/gpt-5.5"}]' 2>/dev/null)
+  assert_profile "$out" '{"harness":"pi","model":"openai-codex/gpt-5.5"}' "Pi OpenAI Codex route was not scored as Codex"
+
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" \
+    '[{"harness":"pi","model":"anthropic/claude-sonnet-5"},{"harness":"codex"}]' 2>/dev/null)
+  assert_profile "$out" '{"harness":"codex"}' "Pi Anthropic route was not scored as Claude"
+
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" \
+    '[{"harness":"pi","model":"xai/grok-4.5"},{"harness":"grok","model":"grok-4.5"}]' 2>/dev/null)
+  assert_profile "$out" '{"harness":"pi","model":"xai/grok-4.5"}' "Pi xAI API should use product:api rather than Grok Build or aggregate credits"
+
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" \
+    '[{"harness":"grok"},{"harness":"claude"}]' 2>/dev/null)
+  assert_profile "$out" '{"harness":"claude"}' "direct Grok should use product:grok_build"
+  pass "direct and Pi-wrapped candidates map to consumed Claude, Codex, xAI API, and Grok Build quota"
+}
+
+test_most_constrained_relevant_window_scores_candidate() {
+  local quota out
+  quota="$TMP_ROOT/scoped.json"
+  cat > "$quota" <<'JSON'
+{"schemaVersion":2,"providers":[
+  {"provider":"claude","state":{"status":"fresh"},"windows":[
+    {"id":"five_hour","kind":"session","percentRemaining":90},
+    {"id":"seven_day","kind":"weekly","percentRemaining":80},
+    {"id":"model:fable","label":"Fable week","kind":"model","percentRemaining":5}
+  ]},
+  {"provider":"codex","state":{"status":"fresh"},"windows":[
+    {"id":"five_hour","kind":"session","percentRemaining":30},
+    {"id":"weekly","kind":"weekly","percentRemaining":30},
+    {"id":"model:other:5h","label":"Unrelated preview session","kind":"model","percentRemaining":1}
+  ]}
+]}
+JSON
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" \
+    '[{"harness":"claude","model":"claude-fable-5"},{"harness":"codex","model":"gpt-5.5"}]' 2>/dev/null)
+  assert_profile "$out" '{"harness":"codex","model":"gpt-5.5"}' "matching model window was not included or unrelated model window was included"
+  pass "candidate score uses its most constrained general or matching model quota window"
+}
+
+test_stale_cache_needs_clear_margin_to_beat_fresh() {
+  local quota out
+  quota="$TMP_ROOT/stale-margin.json"
+  write_quota "$quota" stale 85 70 fresh 65 60
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" "$profiles" 2>/dev/null)
+  assert_profile "$out" '{"harness":"codex","model":"gpt-5.5","effort":"high"}' "fresh provider should win below stale margin"
+
+  write_quota "$quota" stale 90 85 fresh 65 60
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" "$profiles" 2>/dev/null)
+  assert_profile "$out" '{"harness":"claude","model":"claude-sonnet-5","effort":"high"}' "stale provider should win after clearing margin"
+  pass "stale cached quota retains the documented freshness margin"
+}
+
+test_partial_quota_data_prefers_scorable_candidate() {
+  local quota out
+  quota="$TMP_ROOT/partial.json"
+  cat > "$quota" <<'JSON'
+{"schemaVersion":2,"providers":[{"provider":"codex","state":{"status":"fresh"},"windows":[{"id":"five_hour","kind":"session","percentRemaining":4}]}]}
+JSON
+  out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ZERO" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" "$profiles" 2>/dev/null)
+  assert_profile "$out" '{"harness":"codex","model":"gpt-5.5","effort":"high"}' "unscorable first candidate beat usable Codex data"
+  pass "partial quota data picks the best scorable candidate instead of an unscorable candidate"
+}
+
+assert_random_fallback_chooses_second() {
+  local out_file=$1 err_file=$2
+  shift 2
+  FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ONE" "$@" >"$out_file" 2>"$err_file"
+  assert_profile "$(cat "$out_file")" '{"harness":"codex","model":"gpt-5.5","effort":"high"}' "random fallback fixture should choose the second candidate"
+  assert_contains "$(cat "$err_file")" "selection basis: random fallback" "random fallback basis was not exposed"
+}
+
+test_operational_quota_failures_use_uniform_random_fallback() {
+  local fakebin quota
   fakebin=$(fm_fakebin "$TMP_ROOT/missing")
-  out=$(PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced "$profiles" 2>"$TMP_ROOT/missing.err")
-  status=$?
-  err=$(cat "$TMP_ROOT/missing.err")
-  expect_code 0 "$status" "missing quota-axi should not fail dispatch"
-  [ "$out" = '{"harness":"claude","model":"claude-sonnet-5","effort":"high"}' ] \
-    || fail "missing quota-axi should fall back to first, got: $out"
-  assert_contains "$err" "quota-axi missing" "missing quota-axi fallback should be logged"
-  pass "quota-axi missing falls back to the first profile and logs"
-}
+  assert_random_fallback_chooses_second "$TMP_ROOT/missing.out" "$TMP_ROOT/missing.err" \
+    env PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-dispatch-select.sh" "$profiles"
+  assert_contains "$(cat "$TMP_ROOT/missing.err")" "quota-axi missing" "missing quota-axi reason was not logged"
 
-test_quota_error_falls_back_to_first() {
-  local fakebin out err status
   fakebin=$(fm_fakebin "$TMP_ROOT/error")
   cat > "$fakebin/quota-axi" <<'SH'
 #!/usr/bin/env bash
 exit 42
 SH
   chmod +x "$fakebin/quota-axi"
-  out=$(PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced "$profiles" 2>"$TMP_ROOT/error.err")
-  status=$?
-  err=$(cat "$TMP_ROOT/error.err")
-  expect_code 0 "$status" "quota-axi error should not fail dispatch"
-  [ "$out" = '{"harness":"claude","model":"claude-sonnet-5","effort":"high"}' ] \
-    || fail "quota-axi error should fall back to first, got: $out"
-  assert_contains "$err" "quota-axi exited 42" "quota-axi error fallback should be logged"
-  pass "quota-axi non-zero exit falls back to the first profile and logs"
-}
+  assert_random_fallback_chooses_second "$TMP_ROOT/error.out" "$TMP_ROOT/error.err" \
+    env PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-dispatch-select.sh" "$profiles"
+  assert_contains "$(cat "$TMP_ROOT/error.err")" "quota-axi exited 42" "quota-axi error reason was not logged"
 
-test_bad_quota_json_falls_back_to_first() {
-  local quota out err
   quota="$TMP_ROOT/bad.json"
-  printf '%s\n' 'not-json' > "$quota"
-  out=$("$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced --quota-json "$quota" "$profiles" 2>"$TMP_ROOT/bad.err")
-  err=$(cat "$TMP_ROOT/bad.err")
-  [ "$out" = '{"harness":"claude","model":"claude-sonnet-5","effort":"high"}' ] \
-    || fail "bad quota JSON should fall back to first, got: $out"
-  assert_contains "$err" "unparseable JSON" "bad quota JSON fallback should be logged"
-  pass "unparseable quota JSON falls back to the first profile and logs"
+  printf '%s\n' not-json > "$quota"
+  assert_random_fallback_chooses_second "$TMP_ROOT/bad.out" "$TMP_ROOT/bad.err" \
+    "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" "$profiles"
+  assert_contains "$(cat "$TMP_ROOT/bad.err")" "unparseable JSON" "bad quota JSON reason was not logged"
+
+  printf '%s\n' '{"schemaVersion":2,"providers":[]}' > "$quota"
+  assert_random_fallback_chooses_second "$TMP_ROOT/empty.out" "$TMP_ROOT/empty.err" \
+    "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" "$profiles"
+  assert_contains "$(cat "$TMP_ROOT/empty.err")" "no usable quota windows" "wholly unusable quota reason was not logged"
+  pass "missing, failed, malformed, and wholly unusable quota data use OS-backed random fallback"
 }
 
-test_stale_with_cache_needs_clear_margin_to_beat_fresh() {
-  local quota out
-  quota="$TMP_ROOT/stale-margin.json"
-  write_quota "$quota" stale 85 70 fresh 65 60
-  out=$("$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced --quota-json "$quota" "$profiles")
-  [ "$out" = '{"harness":"codex","model":"gpt-5.5","effort":"high"}' ] \
-    || fail "fresh vendor should win when stale lead is below margin, got: $out"
-
-  write_quota "$quota" stale 90 85 fresh 65 60
-  out=$("$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced --quota-json "$quota" "$profiles")
-  [ "$out" = '{"harness":"claude","model":"claude-sonnet-5","effort":"high"}' ] \
-    || fail "stale vendor should win when lead clears margin, got: $out"
-  pass "stale cached quota is usable only when it clears the documented margin over fresh"
-}
-
-test_vendor_absent_or_unusable_falls_back_conservatively() {
-  local quota out err
-  quota="$TMP_ROOT/absent.json"
-  cat > "$quota" <<'JSON'
-{
-  "providers": [
-    {
-      "provider": "codex",
-      "state": { "status": "fresh" },
-      "windows": [
-        { "id": "five_hour", "kind": "session", "percentRemaining": 40 },
-        { "id": "weekly", "kind": "weekly", "percentRemaining": 50 }
-      ]
-    }
-  ]
-}
-JSON
-  out=$("$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced --quota-json "$quota" "$profiles")
-  [ "$out" = '{"harness":"codex","model":"gpt-5.5","effort":"high"}' ] \
-    || fail "available candidate should win over absent vendor, got: $out"
-
-  cat > "$quota" <<'JSON'
-{ "providers": [] }
-JSON
-  out=$("$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced --quota-json "$quota" "$profiles" 2>"$TMP_ROOT/none.err")
-  err=$(cat "$TMP_ROOT/none.err")
-  [ "$out" = '{"harness":"claude","model":"claude-sonnet-5","effort":"high"}' ] \
-    || fail "no usable vendors should fall back to first, got: $out"
-  assert_contains "$err" "no usable quota windows" "no usable vendor fallback should be logged"
-  pass "absent or unusable vendors resolve to an available candidate or the first fallback"
-}
-
-test_backward_compatible_first_selection() {
-  local fakebin marker out single array_rule
-  fakebin=$(fm_fakebin "$TMP_ROOT/no-call")
-  marker="$TMP_ROOT/quota-called"
+test_single_profile_and_one_element_array() {
+  local fakebin marker out err
+  fakebin=$(fm_fakebin "$TMP_ROOT/single")
+  marker="$TMP_ROOT/single/called"
   cat > "$fakebin/quota-axi" <<SH
 #!/usr/bin/env bash
 printf called > '$marker'
@@ -161,26 +254,50 @@ exit 1
 SH
   chmod +x "$fakebin/quota-axi"
 
-  single='{"harness":"grok","model":"grok-4","effort":"high"}'
-  out=$(PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-dispatch-select.sh" "$single")
-  [ "$out" = '{"harness":"grok","model":"grok-4","effort":"high"}' ] \
-    || fail "single-object use should resolve to itself, got: $out"
+  out=$(PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-dispatch-select.sh" '{"harness":"grok","model":"grok-4.5","effort":"high"}' 2>/dev/null)
+  assert_profile "$out" '{"harness":"grok","model":"grok-4.5","effort":"high"}' "single profile object should resolve to itself"
+  [ ! -e "$marker" ] || fail "single profile object should not invoke quota-axi"
 
-  array_rule='{"when":"big work","use":[{"harness":"claude","effort":"high"},{"harness":"codex","effort":"high"}]}'
-  out=$(PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-dispatch-select.sh" "$array_rule")
-  [ "$out" = '{"harness":"claude","effort":"high"}' ] \
-    || fail "array without select should resolve to first, got: $out"
-  [ ! -e "$marker" ] || fail "quota-axi should not be called without quota-balanced select"
-  pass "single-object use and no-select arrays preserve first-profile selection"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ONE" "$ROOT/bin/fm-dispatch-select.sh" \
+    '[{"harness":"grok","model":"grok-4.5","effort":"high"}]' 2>"$TMP_ROOT/one.err")
+  err=$(cat "$TMP_ROOT/one.err")
+  assert_profile "$out" '{"harness":"grok","model":"grok-4.5","effort":"high"}' "one-element array should remain selectable"
+  [ -e "$marker" ] || fail "one-element array should invoke quota-axi"
+  assert_contains "$err" "selection basis: random fallback" "one-element operational fallback basis was not logged"
+  pass "single objects remain backward compatible and one-element arrays remain quota-aware"
 }
 
-test_higher_min_vendor_wins
-test_exact_tie_uses_first_profile
-test_quota_missing_falls_back_to_first
-test_quota_error_falls_back_to_first
-test_bad_quota_json_falls_back_to_first
-test_stale_with_cache_needs_clear_margin_to_beat_fresh
-test_vendor_absent_or_unusable_falls_back_conservatively
-test_backward_compatible_first_selection
+test_malformed_profile_arrays_are_validation_errors() {
+  local body expect out status n
+  n=0
+  while IFS='^' read -r body expect; do
+    n=$((n + 1))
+    out=$(FM_DISPATCH_RANDOM_SOURCE="$RANDOM_ONE" "$ROOT/bin/fm-dispatch-select.sh" "$body" 2>&1)
+    status=$?
+    expect_code 2 "$status" "malformed profile array should exit 2"
+    assert_contains "$out" "$expect" "malformed profile array did not explain validation error"
+    assert_not_contains "$out" "random fallback" "malformed profile array incorrectly used operational fallback"
+  done <<'ROWS'
+[]^must not be empty
+["claude"]^must be an object
+[{"model":"claude-sonnet-5"}]^needs a non-empty harness
+[{"harness":"claude","model":3}]^model must be a non-empty string
+[{"harness":"spaceship"}]^contains an unverified harness
+[{"harness":"codex","effort":"max"}]^contains an unsupported harness/effort pair
+ROWS
+  pass "malformed arrays stay actionable validation errors and never enter random fallback"
+}
+
+test_implicit_array_picks_higher_min_provider
+test_rule_array_without_select_invokes_quota_axi
+test_legacy_explicit_selector_stays_compatible
+test_equal_winners_use_os_random_tie_break
+test_provider_and_product_mapping_through_wrappers
+test_most_constrained_relevant_window_scores_candidate
+test_stale_cache_needs_clear_margin_to_beat_fresh
+test_partial_quota_data_prefers_scorable_candidate
+test_operational_quota_failures_use_uniform_random_fallback
+test_single_profile_and_one_element_array
+test_malformed_profile_arrays_are_validation_errors
 
 echo "# all fm-dispatch-select tests passed"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -347,6 +347,40 @@ test_pi_threads_model_and_max_effort() {
   pass "pi receives --model and --thinking max profile flags"
 }
 
+test_quota_selected_default_array_reaches_spawn() {
+  local rec id quota random selected diagnostic harness model effort out status launch
+  id=profile-selected-default-z17
+  rec=$(make_spawn_case profile-selected-default claude "$id")
+  read_case_record "$rec"
+  cat > "$HOME_DIR/config/crew-dispatch.json" <<'JSON'
+{"default":[{"harness":"claude","model":"claude-sonnet-5","effort":"low"},{"harness":"codex","model":"gpt-5.5","effort":"high"}]}
+JSON
+  quota="$CASE_DIR/quota.json"
+  random="$CASE_DIR/random"
+  printf '\000\000\000\000' > "$random"
+  cat > "$quota" <<'JSON'
+{"schemaVersion":2,"providers":[{"provider":"claude","state":{"status":"fresh"},"windows":[{"id":"five_hour","kind":"session","percentRemaining":10}]},{"provider":"codex","state":{"status":"fresh"},"windows":[{"id":"five_hour","kind":"session","percentRemaining":90}]}]}
+JSON
+
+  selected=$(FM_DISPATCH_RANDOM_SOURCE="$random" "$ROOT/bin/fm-dispatch-select.sh" --quota-json "$quota" \
+    "$(jq -c .default "$HOME_DIR/config/crew-dispatch.json")" 2>"$CASE_DIR/selection.err")
+  diagnostic=$(cat "$CASE_DIR/selection.err")
+  harness=$(printf '%s\n' "$selected" | jq -r .harness)
+  model=$(printf '%s\n' "$selected" | jq -r .model)
+  effort=$(printf '%s\n' "$selected" | jq -r .effort)
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness "$harness" --model "$model" --effort "$effort")
+  status=$?
+
+  expect_code 0 "$status" "quota-selected default-array profile should reach spawn"
+  assert_contains "$diagnostic" "selection basis: quota-selected" "selection did not expose its quota basis"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.5 high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex --model 'gpt-5.5' -c 'model_reasoning_effort=\"high\"'" \
+    "quota-selected default profile did not reach the concrete launch"
+  pass "top-level default array resolves through quota selection into the real spawn path"
+}
+
 test_batch_forwards_shared_profile_flags() {
   local rec id1 id2 out status
   id1=profile-batch-a-z9
@@ -398,6 +432,7 @@ test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
 test_pi_threads_model_and_max_effort
+test_quota_selected_default_array_reaches_spawn
 test_batch_forwards_shared_profile_flags
 test_active_dispatch_profile_does_not_block_secondmate_launch
 


### PR DESCRIPTION
## Intent

Implement the captain-authorized quota-aware dispatch contract throughout Firstmate. Preserve single-profile compatibility; accept non-empty profile arrays for both rule use and top-level default; make every array implicitly quota-aware while retaining explicit select: quota-balanced compatibility; invoke current installed quota-axi JSON; map direct Claude/Codex/Grok Build and Pi-wrapped Anthropic/OpenAI Codex/xAI API to the quota provider and product actually consumed; score the most constrained relevant quota window with stale-data safeguards; prefer usable quota over unscorable candidates; and use simple uniform OS-backed random selection for operational quota-data failure or equal winners. Keep malformed configuration as actionable validation errors, expose quota-selected versus random-fallback basis without altering profile JSON or exposing quota details, update startup validation and all consumers, review harness/runtime integration surfaces, add focused and closest end-to-end regressions, and avoid reservations, concurrency accounting, anti-stampede machinery, or elaborate weighting. Ship through the normal no-mistakes PR path without merging.

## What Changed

- Make non-empty rule and default profile arrays implicitly quota-aware while preserving single-profile and explicit `select: "quota-balanced"` compatibility.
- Map direct and Pi-wrapped harness profiles to their consumed quota provider and product, score the most constrained relevant window with stale-data safeguards, and prefer candidates with usable quota.
- Add OS-backed uniform random selection for tied winners or operational quota failures, selection-basis diagnostics, stricter startup validation, documentation, and regression coverage.

## Risk Assessment

✅ Low: The follow-up correctly restricts Claude and Codex general windows and prevents aggregate Grok scoring when any product-scoped windows are exposed, resolving the prior defects without introducing new material risks.

## Testing

Inspected the target diff, passed the focused selector, bootstrap, and real spawn-path regressions, then captured CLI evidence proving implicit arrays invoke `quota-axi --json`, installed quota-axi 0.1.11 works end-to-end, operational failures randomize safely, malformed input fails actionably, and selection diagnostics reveal no quota details.

<details>
<summary>Evidence: Quota-aware dispatch CLI evidence</summary>

<code>CLI transcript shows implicit quota selection, `quota-axi --json` invocation, random fallback, actionable malformed-input rejection, and compatibility with installed quota-axi 0.1.11.</code>

```text
$ implicit top-level default array through installed quota-axi command
{"harness":"codex","model":"gpt-5.5","effort":"high"}
quota-axi invocation: --json
diagnostic: fm-dispatch-select: selection basis: quota-selected

$ operational failure uses uniform random fallback across valid profiles
{"harness":"codex"}
diagnostic: fm-dispatch-select: quota-axi missing;fm-dispatch-select: selection basis: random fallback;

$ malformed configuration remains an actionable error, not a fallback
error: each dispatch profile needs a non-empty harness
exit: 2

$ compatibility check against the currently installed quota-axi JSON surface
quota-axi version: 0.1.11
quota-axi JSON contract accepted: yes
$ selector using the currently installed quota-axi (raw quota details intentionally suppressed)
{"harness":"codex","model":"gpt-5.5","effort":"high"}
diagnostic: fm-dispatch-select: selection basis: quota-selected
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-dispatch-select.sh:271` - Intent requires scoring the &#34;most constrained relevant quota window,&#34; but this accepts every `session` or `weekly` window. Current quota-axi also emits Codex code-review windows with those kinds, so exhausted code-review quota can incorrectly suppress a Codex build candidate. Restrict general windows to the provider&#39;s build-consumed IDs, then add matching model windows.
- 🚨 `bin/fm-dispatch-select.sh:267` - Intent requires mapping xAI API and Grok Build to the product actually consumed, but when the requested product window is absent this falls back to aggregate credits even if other product windows are present. That makes a candidate scorable from the wrong quota scope and contradicts the documented &#34;only when product windows are not exposed&#34; safeguard. Use aggregate credits only when no product-scoped windows exist at all.

🔧 Fix: Fix quota window and Grok product scoping
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 673b6ad39d01183a19c5bd8a52675a2ee8ea06e6..acc1edd7781744b9fcdd16237c87e4a8e254c8d5` to identify the affected product boundary.</code>
- `./tests/fm-dispatch-select.test.sh`
- `./tests/fm-bootstrap.test.sh`
- `./tests/fm-spawn-dispatch-profile.test.sh`
- <code>Manually invoked `bin/fm-dispatch-select.sh` with a top-level profile array and a deterministic `quota-axi --json` fixture, verifying quota-selected output and basis.</code>
- `Manually forced missing quota data with a deterministic OS-random fixture, verifying uniform random fallback and basis.`
- `Manually submitted a malformed profile array, verifying an actionable exit-2 validation error without fallback.`
- <code>Checked `quota-axi --version` and validated the installed `quota-axi --json` schema with `jq`.</code>
- <code>Invoked `bin/fm-dispatch-select.sh` against installed quota-axi 0.1.11, suppressing raw quota details while verifying a quota-selected profile and diagnostic basis.</code>
- <code>Confirmed `git status --short` remained clean after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
