### PR TITLE
feat(brief): add a concise current-state PR-description contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,6 +434,7 @@ Use its scaffold as the contract, then replace every `{TASK}` placeholder with a
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
+Every no-mistakes or direct-PR ship brief carries a PR-description contract owned by `bin/fm-brief.sh`: the description is a concise current-state summary for a quick review, never a chronological diary of commits and attempts.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -44,6 +44,10 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
+# The no-mistakes and direct-PR modes also carry a PR-description contract: the
+# PR description must read as a concise current-state summary for a 3-5 minute
+# review, not a chronological diary of attempts and commits. local-only never
+# opens a PR, so it does not carry this section.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -277,6 +281,20 @@ read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
 
+# Single owner of the PR-description contract text. Interpolated into the DOD
+# of every mode that actually produces a PR (direct-PR, no-mistakes); local-only
+# never opens one, so its DOD does not reference this variable.
+PR_DESCRIPTION_CONTRACT=$(cat <<'EOF'
+# PR description
+Write the PR description (or update it) as a concise, current-state summary: what a reviewer needs to approve the change, not a log of how you got there.
+Target a 3-5 minute read: short sections and bullets, not a wall of prose.
+Cover intent, the material behavior changes, reviewer-relevant safety or risk, how it was validated, deployment or rollback notes when they apply, and any genuinely unresolved considerations.
+Leave out chronological CI diaries, superseded claims, repeated failure-then-fix narratives, exhaustive internal helper or event lists, debugging transcripts, and duplicated evidence.
+Keep an exact command or example only when a reviewer or operator will actually need it to act.
+If you update the description later, rewrite the stale section in place rather than appending another dated addendum on top of an earlier one.
+EOF
+)
+
 case "$MODE" in
   direct-PR)
     SETUP2=""
@@ -285,6 +303,9 @@ case "$MODE" in
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
+
+$PR_DESCRIPTION_CONTRACT
+
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
@@ -312,6 +333,8 @@ EOF
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+
+$PR_DESCRIPTION_CONTRACT
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -136,6 +136,53 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+test_pr_description_contract_in_pr_producing_modes_only() {
+  local home id brief
+  home="$TMP_ROOT/pr-description-home"
+  write_registry "$home"
+
+  # no-mistakes (default) and direct-PR both open a PR, so both must carry the contract.
+  for id_proj in "brief-prdesc-nomistakes-e1:no-registry-proj" "brief-prdesc-directpr-e2:direct-proj"; do
+    id=${id_proj%%:*}
+    proj=${id_proj##*:}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "$proj" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_grep "# PR description" "$brief" \
+      "$id: brief missing the PR description contract heading"
+    assert_grep "concise, current-state summary" "$brief" \
+      "$id: brief lost the concise current-state requirement"
+    assert_grep "Target a 3-5 minute read" "$brief" \
+      "$id: brief lost the 3-5 minute review target"
+    assert_grep "Leave out chronological CI diaries" "$brief" \
+      "$id: brief lost the chronological-diary exclusion"
+    assert_grep "rewrite the stale section in place" "$brief" \
+      "$id: brief lost the rewrite-not-append update guidance"
+  done
+
+  # local-only never opens a PR, so it must not gain this section.
+  id="brief-prdesc-localonly-e3"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" local-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_no_grep "# PR description" "$brief" \
+    "local-only brief should not carry the PR description contract"
+
+  # Scout and secondmate briefs produce no PR body either.
+  id="brief-prdesc-scout-e4"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" no-registry-proj --scout >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_no_grep "# PR description" "$brief" \
+    "scout brief should not carry the PR description contract"
+
+  id="brief-prdesc-secondmate-e5"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='sample charter' \
+    "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_no_grep "# PR description" "$brief" \
+    "secondmate charter should not carry the PR description contract"
+
+  pass "fm-brief.sh: PR description contract appears only in PR-producing ship modes"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -347,6 +394,7 @@ test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_pr_description_contract_in_pr_producing_modes_only
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout


### PR DESCRIPTION
## Intent

Update Firstmate's shared tracked instructions so PR descriptions written by ship workers are concise, current-state summaries reviewable in 3-5 minutes, instead of chronological implementation diaries. The contract must: describe final behavior not the sequence of attempts/commits; use short sections/bullets; cover intent, material behavior changes, reviewer-relevant safety/risk, validation, deployment/rollback where applicable, and genuinely unresolved considerations; omit chronological CI diaries, superseded claims, repeated failure/fix narratives, exhaustive internal helper/event lists, debugging transcripts, and duplicated evidence; keep exact commands/examples only when needed; and on later updates rewrite stale sections instead of appending another historical addendum. It must reach ordinary ship workers in both the no-mistakes and direct-PR delivery paths, but explicitly NOT scout or secondmate briefs (which never produce a PR body), and NOT local-only (which never opens a PR either). AGENTS.md must stay concise: only a short one-line cross-reference/reinforcement was added there, per the firstmate-coding-guidelines one-owner rule - the full contract text lives exactly once, as a shared PR_DESCRIPTION_CONTRACT variable in bin/fm-brief.sh, interpolated into both the direct-PR and no-mistakes Definition-of-done heredocs so there is a single source of truth. Every existing safety/merge-authority/validation/status/worktree-isolation/delivery-mode instruction was preserved untouched. A new targeted test (test_pr_description_contract_in_pr_producing_modes_only) was added to tests/fm-brief.test.sh asserting the contract appears in generated no-mistakes and direct-PR briefs and is absent from local-only, scout, and secondmate briefs; this follows the suite's existing targeted-assertion style rather than full-text snapshots. bin/fm-lint.sh (shellcheck) and the full fm-brief.test.sh, fm-instruction-owners.test.sh, fm-secondmate-safety.test.sh, fm-subagent-pretool-check.test.sh, and fm-tangle-guard.test.sh suites were all run and pass.

## What Changed

- Added a single-source `PR_DESCRIPTION_CONTRACT` variable in `bin/fm-brief.sh`, interpolated into the Definition-of-done heredocs for both the no-mistakes and direct-PR modes, directing ship workers to write PR descriptions as concise 3–5 minute current-state summaries (intent, material behavior changes, safety/risk, validation, deploy/rollback, open considerations) rather than chronological diaries — and to rewrite stale sections in place instead of appending addenda. The contract is deliberately omitted from local-only, scout, and secondmate briefs, which never open a PR.
- Added a one-line cross-reference in `AGENTS.md` pointing to `bin/fm-brief.sh` as the owner of the contract, keeping a single source of truth.
- Added `test_pr_description_contract_in_pr_producing_modes_only` to `tests/fm-brief.test.sh`, asserting the contract appears in no-mistakes and direct-PR briefs and is absent from local-only, scout, and secondmate briefs.

## Risk Assessment

✅ Low: A small, well-scoped instruction/documentation change that adds a single-source PR-description contract to only the two PR-producing ship modes, preserves all existing instructions, and adds targeted test coverage; it fully satisfies the stated intent with no correctness, security, or regression concerns.

## Testing

Ran the new targeted test and the four other named suites (fm-brief, fm-instruction-owners, fm-secondmate-safety, fm-subagent-pretool-check, fm-tangle-guard) — all pass. Beyond the assertions, I drove bin/fm-brief.sh directly to produce actual briefs for all five delivery paths: the identical PR-description contract (concise current-state summary, 3-5 minute read target, chronological-diary exclusion, rewrite-in-place update rule) renders in both the no-mistakes and direct-PR briefs and is completely absent (0 occurrences) from local-only, scout, and secondmate briefs, confirming the single-source-of-truth interpolation reaches exactly the PR-producing modes and no others. Skipped fm-lint.sh/shellcheck per the no-linters rule. No working-tree artifacts were left behind.

<details>
<summary>Evidence: Rendered PR-description contract across all five delivery modes</summary>

`no-mistakes & direct-PR briefs both render the full '# PR description' contract; local-only, scout, and secondmate briefs each show 0 occurrences of '# PR description'.`

```text
=== Rendered 'PR description' section in the no-mistakes brief (demo-nomistakes) ===
# PR description
Write the PR description (or update it) as a concise, current-state summary: what a reviewer needs to approve the change, not a log of how you got there.
Target a 3-5 minute read: short sections and bullets, not a wall of prose.
Cover intent, the material behavior changes, reviewer-relevant safety or risk, how it was validated, deployment or rollback notes when they apply, and any genuinely unresolved considerations.
Leave out chronological CI diaries, superseded claims, repeated failure-then-fix narratives, exhaustive internal helper or event lists, debugging transcripts, and duplicated evidence.
Keep an exact command or example only when a reviewer or operator will actually need it to act.
If you update the description later, rewrite the stale section in place rather than appending another dated addendum on top of an earlier one.

=== Rendered 'PR description' section in the direct-PR brief (demo-directpr) ===
# PR description
Write the PR description (or update it) as a concise, current-state summary: what a reviewer needs to approve the change, not a log of how you got there.
Target a 3-5 minute read: short sections and bullets, not a wall of prose.
Cover intent, the material behavior changes, reviewer-relevant safety or risk, how it was validated, deployment or rollback notes when they apply, and any genuinely unresolved considerations.
Leave out chronological CI diaries, superseded claims, repeated failure-then-fix narratives, exhaustive internal helper or event lists, debugging transcripts, and duplicated evidence.
Keep an exact command or example only when a reviewer or operator will actually need it to act.
If you update the description later, rewrite the stale section in place rather than appending another dated addendum on top of an earlier one.

=== Modes that must NOT carry the contract ===
  demo-localonly: '# PR description' occurrences = 0
  demo-scout: '# PR description' occurrences = 0
  demo-secondmate: '# PR description' occurrences = 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` (full suite, incl. new `test_pr_description_contract_in_pr_producing_modes_only`)</code>
- `bash tests/fm-instruction-owners.test.sh`
- `bash tests/fm-secondmate-safety.test.sh`
- `bash tests/fm-subagent-pretool-check.test.sh`
- `bash tests/fm-tangle-guard.test.sh`
- <code>Generated real briefs via `bin/fm-brief.sh` for no-mistakes, direct-PR, local-only, --scout, and --secondmate modes and inspected the rendered `# PR description` section presence/absence</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
