### PR TITLE
docs: document Codex primary launch requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,29 @@ git clone https://github.com/kunchenguid/firstmate
 cd firstmate
 ```
 
-Then launch one of the co-primary harnesses; AGENTS.md takes over from there:
+Then launch a supported harness; AGENTS.md takes over from there:
 
 **Claude Code**
 
 ```sh
 claude
 ```
+
+**Codex**
+
+```sh
+codex -s danger-full-access
+```
+
+Codex primary sessions require `danger-full-access` because the normal sandbox places model-generated shell commands in an isolated PID namespace.
+That boundary prevents Firstmate's session-lock ancestry check from seeing the long-lived Codex process, so startup otherwise fails with this opaque message:
+
+```text
+error: cannot locate harness process in ancestry
+```
+
+Sandbox mode is separate from approval policy.
+To keep request-time approval prompts while disabling the sandbox, launch with `codex -s danger-full-access -a on-request`.
 
 **Grok**
 


### PR DESCRIPTION
## Intent

Create a clean replacement PR against crumgary/firstmate:main documenting the Codex primary launch requirement after closed PR #1. Modify README.md only. At the primary-session startup surface, add the exact command `codex -s danger-full-access`; briefly explain that Codex's normal sandbox places model-generated shell commands in an isolated PID namespace so Firstmate's session-lock ancestry check cannot see the long-lived Codex process; show the exact pre-change message `error: cannot locate harness process in ancestry` as a recognizable example; and keep sandbox mode distinct from approval policy, including the verified approval-preserving form `codex -s danger-full-access -a on-request`. The branch must be based on approved fork main SHA 51404137e8c4729670233cc31ff43eeae527b77c, must not use commits from rejected PR #1, and the PR description must explicitly say the change is documentation-only and supersedes closed PR #1.

## What Changed

- Added a **Codex** entry to the README Getting Started harness list documenting that primary sessions must launch with `codex -s danger-full-access`, because Codex's normal sandbox isolates model-generated shell commands in a separate PID namespace where Firstmate's session-lock ancestry check cannot see the long-lived Codex process.
- Included the exact pre-change failure message `error: cannot locate harness process in ancestry` as a recognizable example, and clarified that sandbox mode is distinct from approval policy by showing the approval-preserving form `codex -s danger-full-access -a on-request`.
- Reworded the launch intro from "co-primary harnesses" to "a supported harness". This is a documentation-only change (README.md only) that supersedes closed PR #1.

## Risk Assessment

✅ Low: A documentation-only, well-bounded README addition that faithfully satisfies every required intent criterion with accurate, unambiguous content and no code impact.

## Testing

Exercised the change as a documentation-only README edit: verified the git constraints (single README.md commit atop approved SHA 51404137, no PR #1 lineage), confirmed every required intent string appears at the primary-session startup surface, and verified the documented error message matches the real string emitted in bin/fm-lock.sh so the doc is accurate. Captured a rendered screenshot of the new section as reviewer-visible visual evidence. The intent's PR-description requirements (documentation-only, supersedes closed PR #1) could not be validated because no PR exists on this branch yet - that text is produced at PR-creation time and is outside the diff, so it is not verifiable from the branch here.

- Evidence: Rendered README Codex launch section (local file: <code>/tmp/no-mistakes-evidence/01KY5R34DGPV725WVVVTWWGE40/readme-codex-render.png</code>)
<details>
<summary>Evidence: Documented error matches source (bin/fm-lock.sh:52)</summary>

```text
bin/fm-lock.sh:52:me=$(harness_pid) || { echo "error: cannot locate harness process in ancestry" >&2; exit 1; }
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 51404137..614a442` — confirmed README.md is the only file changed (+17/-1)</code>
- <code>`git rev-parse 614a442^` == approved SHA 51404137 — branch based on approved fork main, single clean commit not built on PR #1</code>
- <code>`grep -F` on README.md for each required string: `codex -s danger-full-access`, `codex -s danger-full-access -a on-request`, `error: cannot locate harness process in ancestry`, `isolated PID namespace`, `session-lock ancestry check`, `Sandbox mode is separate from approval policy` — all present</code>
- <code>Cross-checked documented error string against source: `bin/fm-lock.sh:52` emits the identical `error: cannot locate harness process in ancestry` message</code>
- `Rendered the new README Getting Started section to a GitHub-style HTML page and captured a full-page screenshot via headless Chromium`
- <code>`git status --porcelain` — working tree clean, no transient artifacts left</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
