### PR TITLE
fix(bin): enforce clone identity at spawn and verify recorded worktree on recovery resume

### DIFF
--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -31,6 +31,8 @@ Do not sweep another home's endpoints or infer ownership from a matching window 
 
 Before relaunch, prove that no live agent still owns the recorded task and that the existing worktree remains available.
 Preserve its uncommitted changes and commits, keep the same task identity, and resume or relaunch the recorded harness in that existing worktree with the same brief plus a concise progress note.
+After any harness resume, run `bin/fm-recovery-verify.sh <id>` before sending instructions or allowing project mutation; its header and `--help` own the exact live-cwd and clone-identity checks.
+If that verification refuses, exit the resumed agent and relaunch a fresh harness process in the recorded worktree instead of continuing the historical session.
 Do not use a fresh generic spawn while the recorded worktree is unaccounted for, because allocating another worktree can split one task across two copies.
 If the worktree or ownership cannot be reconciled safely, leave all state intact and report the task failed or blocked with the conflicting evidence.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; ship/scout also record project_git_common_dir=, the selected-clone identity checked by fm-recovery-verify.sh; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
   <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
@@ -248,7 +248,7 @@ Write the task-specific brief under section 11 before spawning.
 ### Dispatch and supervision handoff
 
 Spawn only through `bin/fm-spawn.sh` after the profile and backend checks in section 4.
-The spawn must resolve a genuine isolated task worktree distinct from the primary checkout; a failed isolation assertion stops the task.
+The spawn must resolve a genuine isolated task worktree distinct from the primary checkout and owned by the selected clone's canonical Git common directory; a failed isolation assertion stops the task.
 After spawning, confirm the worker is processing the brief, handle any trust dialog through `harness-adapters`, and record ship or scout work as under way.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.
 

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -101,6 +101,32 @@ fm_backend_tmux_current_path() {  # <target>
   tmux display-message -p -t "$1" '#{pane_current_path}' 2>/dev/null
 }
 
+# fm_backend_tmux_resolve_window_id: resolve a recorded `session:window`
+# target to the exactly-one live stable window id it names, without tmux's
+# own -t name resolution - display-message with a lost or renamed window
+# name falls back to the active client's window (the hazard documented at
+# fm-spawn.sh's worktree-detection poll), which a verifier must never
+# inherit. Lists the session's windows and requires exactly one whose name
+# (or id) equals the target's window part; zero or multiple matches fail so
+# callers that must not guess can fail closed.
+fm_backend_tmux_resolve_window_id() {  # <session:window> -> prints the window id
+  local target=$1 ses name ids
+  case "$target" in
+    ?*:?*) ;;
+    *) return 1 ;;
+  esac
+  ses=${target%%:*}
+  name=${target#*:}
+  ids=$(tmux list-windows -t "$ses" -F '#{window_id} #{window_name}' 2>/dev/null |
+    awk -v n="$name" '$1 == n || substr($0, index($0, " ") + 1) == n { print $1 }' |
+    sort -u)
+  [ -n "$ids" ] || return 1
+  case "$ids" in
+    *$'\n'*) return 1 ;;
+  esac
+  printf '%s\n' "$ids"
+}
+
 # fm_backend_tmux_send_text_line: send one line of TEXT then Enter, with no
 # composer verification - used for the fixed spawn-time commands
 # (`treehouse get`, the GOTMPDIR export) that already ran this exact sequence

--- a/bin/fm-recovery-verify.sh
+++ b/bin/fm-recovery-verify.sh
@@ -8,9 +8,9 @@
 # This command reads the live foreground process cwd from the recorded backend,
 # then requires its Git top-level to equal worktree= and its canonical Git
 # common directory to equal project_git_common_dir=.
-# A missing field, unreadable backend cwd, unsupported live-cwd backend, path
-# mismatch, or clone-identity mismatch fails closed and requires a fresh launch
-# in the recorded worktree instead of continuing the resumed session.
+# A missing field, a lost or ambiguous backend endpoint, unreadable backend
+# cwd, unsupported live-cwd backend, path mismatch, or clone-identity mismatch
+# fails closed and requires a fresh launch in the recorded worktree instead.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -75,7 +75,14 @@ TARGET=$(fm_backend_target_of_meta "$META")
 fm_backend_source "$BACKEND" || exit 1
 
 case "$BACKEND" in
-  tmux) ACTUAL=$(fm_backend_tmux_current_path "$TARGET" || true) ;;
+  tmux)
+    WINDOW_ID=$(fm_backend_tmux_resolve_window_id "$TARGET" || true)
+    if [ -z "$WINDOW_ID" ]; then
+      echo "error: task $ID tmux target '$TARGET' does not resolve to exactly one live window; refusing recovery resume" >&2
+      exit 1
+    fi
+    ACTUAL=$(fm_backend_tmux_current_path "$WINDOW_ID" || true)
+    ;;
   herdr) ACTUAL=$(fm_backend_herdr_current_path "$TARGET" || true) ;;
   zellij|orca|cmux)
     echo "error: backend=$BACKEND does not expose a verified passive live foreground cwd; refusing recovery resume for task $ID" >&2

--- a/bin/fm-recovery-verify.sh
+++ b/bin/fm-recovery-verify.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Verify a resumed ordinary task before firstmate sends it any instruction that
+# could mutate its project.
+# Usage: fm-recovery-verify.sh <task-id>
+#
+# New task metadata contains project_git_common_dir=, written by fm-spawn.sh
+# from the selected project clone; legacy metadata derives it from project=.
+# This command reads the live foreground process cwd from the recorded backend,
+# then requires its Git top-level to equal worktree= and its canonical Git
+# common directory to equal project_git_common_dir=.
+# A missing field, unreadable backend cwd, unsupported live-cwd backend, path
+# mismatch, or clone-identity mismatch fails closed and requires a fresh launch
+# in the recorded worktree instead of continuing the resumed session.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+usage() {
+  sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  '') usage >&2; exit 2 ;;
+esac
+[ "$#" -eq 1 ] || { usage >&2; exit 2; }
+
+ID=$1
+case "$ID" in
+  *[!A-Za-z0-9._-]*|'') echo "error: invalid task id" >&2; exit 2 ;;
+esac
+
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-worktree-identity-lib.sh
+. "$SCRIPT_DIR/fm-worktree-identity-lib.sh"
+
+META="$STATE/$ID.meta"
+[ -f "$META" ] || { echo "error: no task metadata for $ID; refusing recovery resume" >&2; exit 1; }
+
+KIND=$(fm_meta_get "$META" kind)
+case "$KIND" in
+  ship|scout) ;;
+  *) echo "error: task $ID is kind=${KIND:-unknown}; recovery resume verification is only defined for ordinary ship/scout tasks" >&2; exit 1 ;;
+esac
+
+WT=$(fm_meta_get "$META" worktree)
+EXPECTED_COMMON=$(fm_meta_get "$META" project_git_common_dir)
+[ -n "$WT" ] || { echo "error: task $ID metadata has no worktree=; refusing recovery resume" >&2; exit 1; }
+if [ -z "$EXPECTED_COMMON" ]; then
+  PROJECT=$(fm_meta_get "$META" project)
+  EXPECTED_COMMON=$(fm_git_common_dir_canonical "$PROJECT" 2>/dev/null || true)
+fi
+[ -n "$EXPECTED_COMMON" ] || { echo "error: task $ID metadata has no usable selected-clone identity; refusing recovery resume" >&2; exit 1; }
+
+WT_ROOT=$(fm_git_worktree_root_canonical "$WT") || {
+  echo "error: task $ID recorded worktree is not an available Git worktree: $WT" >&2
+  exit 1
+}
+WT_COMMON=$(fm_git_common_dir_canonical "$WT") || {
+  echo "error: task $ID recorded worktree clone identity cannot be resolved: $WT" >&2
+  exit 1
+}
+if [ "$WT_COMMON" != "$EXPECTED_COMMON" ]; then
+  echo "error: task $ID recorded worktree belongs to clone '$WT_COMMON', not recorded selected clone '$EXPECTED_COMMON'; refusing recovery resume" >&2
+  exit 1
+fi
+
+BACKEND=$(fm_backend_of_meta "$META")
+TARGET=$(fm_backend_target_of_meta "$META")
+[ -n "$TARGET" ] || { echo "error: task $ID metadata has no backend target; refusing recovery resume" >&2; exit 1; }
+fm_backend_source "$BACKEND" || exit 1
+
+case "$BACKEND" in
+  tmux) ACTUAL=$(fm_backend_tmux_current_path "$TARGET" || true) ;;
+  herdr) ACTUAL=$(fm_backend_herdr_current_path "$TARGET" || true) ;;
+  zellij|orca|cmux)
+    echo "error: backend=$BACKEND does not expose a verified passive live foreground cwd; refusing recovery resume for task $ID" >&2
+    exit 1
+    ;;
+  *)
+    echo "error: backend=$BACKEND has no verified recovery cwd check; refusing recovery resume for task $ID" >&2
+    exit 1
+    ;;
+esac
+
+[ -n "$ACTUAL" ] || { echo "error: could not read task $ID live foreground cwd from backend=$BACKEND target=$TARGET; refusing recovery resume" >&2; exit 1; }
+if ! fm_git_path_matches_worktree_identity "$ACTUAL" "$WT_ROOT" "$EXPECTED_COMMON"; then
+  ACTUAL_ROOT=$(fm_git_worktree_root_canonical "$ACTUAL" 2>/dev/null || printf 'none')
+  ACTUAL_COMMON=$(fm_git_common_dir_canonical "$ACTUAL" 2>/dev/null || printf 'none')
+  echo "error: resumed task $ID foreground cwd '$ACTUAL' resolves to worktree '$ACTUAL_ROOT' and clone '$ACTUAL_COMMON', expected worktree '$WT_ROOT' and selected clone '$EXPECTED_COMMON'; exit this resumed agent and relaunch fresh in '$WT_ROOT'" >&2
+  exit 1
+fi
+
+printf 'verified task %s worktree=%s clone=%s\n' "$ID" "$WT_ROOT" "$EXPECTED_COMMON"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -83,7 +83,8 @@
 #   Before a secondmate launch, the home is locally fast-forwarded to the primary
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
-#   git worktree root distinct from the primary project checkout.
+#   git worktree root distinct from the primary project checkout and attached
+#   to that selected clone's canonical Git common directory.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -138,6 +139,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-worktree-identity-lib.sh
+. "$SCRIPT_DIR/fm-worktree-identity-lib.sh"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
 # a direct report (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
@@ -220,6 +223,7 @@ if [ "$BACKEND" = orca ]; then
   fm_backend_orca_runtime_check || exit 1
 fi
 ORCA_ABORT_CLEANUP=0
+ORCA_ABORT_METADATA_ALLOWED=1
 ORCA_WORKTREE_ID=
 ORCA_TERMINAL=
 HERDR_PROJECTION_ABORT_CLEANUP=0
@@ -277,12 +281,15 @@ spawn_abort_cleanup() {
     fi
     if [ -n "${ORCA_WORKTREE_ID:-}" ]; then
       if ! fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null; then
-        mkdir -p "$STATE" 2>/dev/null || true
-        if [ -d "$STATE" ]; then
+        if [ "$ORCA_ABORT_METADATA_ALLOWED" = 1 ]; then
+          mkdir -p "$STATE" 2>/dev/null || true
+        fi
+        if [ "$ORCA_ABORT_METADATA_ALLOWED" = 1 ] && [ -d "$STATE" ]; then
           {
             echo "window=$W"
             echo "worktree=${WT:-}"
             echo "project=$PROJ_ABS"
+            [ -z "${PROJECT_GIT_COMMON_DIR:-}" ] || echo "project_git_common_dir=$PROJECT_GIT_COMMON_DIR"
             echo "harness=$HARNESS"
             echo "kind=$KIND"
             echo "mode=${MODE:-no-mistakes}"
@@ -294,6 +301,8 @@ spawn_abort_cleanup() {
             echo "orca_worktree_id=$ORCA_WORKTREE_ID"
             [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
           } > "$STATE/$ID.meta" 2>/dev/null || true
+        else
+          echo "error: failed to remove unvalidated Orca worktree $ORCA_WORKTREE_ID; task metadata remains unpublished because clone identity was not accepted" >&2
         fi
       fi
     fi
@@ -766,6 +775,34 @@ fi
 # once here so every downstream comparison uses the same physical form
 # (docs/herdr-backend.md "Known gaps").
 PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
+PROJECT_GIT_COMMON_DIR=
+if [ "$KIND" != secondmate ]; then
+  PROJECT_GIT_COMMON_DIR=$(fm_git_common_dir_canonical "$PROJ_ABS") || {
+    echo "error: selected project clone has no resolvable canonical Git common directory: $PROJ_ABS; refusing to create a task endpoint" >&2
+    exit 1
+  }
+  if [ -f "$STATE/$ID.meta" ]; then
+    RECORDED_PROJECT_GIT_COMMON_DIR=$(fm_meta_get "$STATE/$ID.meta" project_git_common_dir)
+    if [ -z "$RECORDED_PROJECT_GIT_COMMON_DIR" ]; then
+      RECORDED_PROJECT=$(fm_meta_get "$STATE/$ID.meta" project)
+      RECORDED_PROJECT_GIT_COMMON_DIR=$(fm_git_common_dir_canonical "$RECORDED_PROJECT" 2>/dev/null || true)
+    fi
+    [ -n "$RECORDED_PROJECT_GIT_COMMON_DIR" ] || {
+      echo "error: existing metadata for $ID has no usable selected-clone identity; refusing recovery spawn until the recorded project and worktree are reconciled" >&2
+      exit 1
+    }
+    if [ "$RECORDED_PROJECT_GIT_COMMON_DIR" != "$PROJECT_GIT_COMMON_DIR" ]; then
+      echo "error: recovery spawn for $ID selected clone '$PROJECT_GIT_COMMON_DIR', but task metadata records clone '$RECORDED_PROJECT_GIT_COMMON_DIR'; refusing to cross the task's clone boundary" >&2
+      exit 1
+    fi
+    RECORDED_WT=$(fm_meta_get "$STATE/$ID.meta" worktree)
+    RECORDED_WT_COMMON=$(fm_git_common_dir_canonical "$RECORDED_WT" 2>/dev/null || true)
+    if [ "$RECORDED_WT_COMMON" != "$PROJECT_GIT_COMMON_DIR" ]; then
+      echo "error: recovery spawn for $ID recorded worktree '${RECORDED_WT:-none}' belongs to clone '${RECORDED_WT_COMMON:-unresolved}', not selected clone '$PROJECT_GIT_COMMON_DIR'; refusing to launch" >&2
+      exit 1
+    fi
+  fi
+fi
 
 real_path_or_raw() {  # <path>
   local path=$1 real
@@ -785,7 +822,7 @@ real_path_or_raw() {  # <path>
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
 validate_spawn_worktree() {  # <source> <inspect-target>
-  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
+  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real wt_common
   wt_real=
   if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
     wt_real=
@@ -798,6 +835,11 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
   if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
+    exit 1
+  fi
+  wt_common=$(fm_git_common_dir_canonical "$WT" 2>/dev/null || true)
+  if [ -z "$wt_common" ] || [ "$wt_common" != "$PROJECT_GIT_COMMON_DIR" ]; then
+    echo "error: $source yielded worktree '$wt_real' owned by clone '${wt_common:-unresolved}', but task $ID selected clone '$PROJECT_GIT_COMMON_DIR' from '$PROJ_ABS'; refusing before hooks, agent launch, or metadata publication. Inspect the shared worktree pool binding for target $inspect_target" >&2
     exit 1
   fi
 }
@@ -1077,7 +1119,9 @@ EOF
       echo "error: orca did not return a worktree id/path for $W" >&2
       exit 1
     fi
+    ORCA_ABORT_METADATA_ALLOWED=0
     validate_spawn_worktree "orca worktree create" "$W"
+    ORCA_ABORT_METADATA_ALLOWED=1
     if [ -z "$ORCA_TERMINAL" ]; then
       ORCA_TERMINAL=$(fm_backend_orca_terminal_create "$ORCA_WORKTREE_ID" "$W") || exit 1
     fi
@@ -1304,10 +1348,12 @@ fi
 
 META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
+set +e
 {
   echo "window=$META_WINDOW"
   echo "worktree=$WT"
   echo "project=$PROJ_ABS"
+  [ -z "$PROJECT_GIT_COMMON_DIR" ] || echo "project_git_common_dir=$PROJECT_GIT_COMMON_DIR"
   echo "harness=$HARNESS"
   echo "kind=$KIND"
   echo "mode=$MODE"
@@ -1343,6 +1389,12 @@ META_WINDOW=$T
     echo "projects=$SECONDMATE_PROJECTS"
   fi
 } > "$STATE/$ID.meta"
+META_WRITE_STATUS=$?
+set -e
+if [ "$META_WRITE_STATUS" -ne 0 ]; then
+  echo "error: could not publish task metadata for $ID" >&2
+  exit 1
+fi
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -162,7 +162,8 @@ family_for_basename() {
       ;;
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
-    fm-spawn-dispatch-profile.test.sh|fm-spawn-worktree-settle.test.sh)
+    fm-spawn-clone-identity.test.sh|fm-spawn-dispatch-profile.test.sh|\
+    fm-spawn-worktree-settle.test.sh)
       printf '%s\n' backend-dispatch
       ;;
     fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
@@ -670,7 +671,8 @@ families_for_changed_path() {
     bin/fm-x-*|bin/fm-check*)
       printf '%s\n' pr-forge
       ;;
-    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-dispatch-select.sh|bin/fm-harness.sh|\
+    bin/fm-spawn.sh|bin/fm-recovery-verify.sh|bin/fm-worktree-identity-lib.sh|\
+    bin/fm-send.sh|bin/fm-dispatch-select.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit

--- a/bin/fm-worktree-identity-lib.sh
+++ b/bin/fm-worktree-identity-lib.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# fm-worktree-identity-lib.sh - canonical Git clone/worktree identity helpers.
+#
+# A linked worktree belongs to the selected project clone only when both resolve
+# to the same physical git common directory.
+# Remote URLs and repository names are not clone identity because two homes may
+# intentionally clone the same remote into independent object stores.
+
+fm_git_common_dir_canonical() {  # <path>
+  local path=$1 common
+  common=$(git -C "$path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+  [ -d "$common" ] || return 1
+  (cd "$common" 2>/dev/null && pwd -P)
+}
+
+fm_git_worktree_root_canonical() {  # <path>
+  local path=$1 top
+  top=$(git -C "$path" rev-parse --show-toplevel 2>/dev/null) || return 1
+  [ -d "$top" ] || return 1
+  (cd "$top" 2>/dev/null && pwd -P)
+}
+
+fm_git_path_matches_worktree_identity() {  # <path> <expected-worktree-root> <expected-common-dir>
+  local path=$1 expected_root=$2 expected_common=$3 actual_root actual_common
+  actual_root=$(fm_git_worktree_root_canonical "$path") || return 1
+  actual_common=$(fm_git_common_dir_canonical "$path") || return 1
+  [ "$actual_root" = "$expected_root" ] && [ "$actual_common" = "$expected_common" ]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,7 +112,8 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
-For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real Git worktree root that is distinct from the project primary checkout and has the selected clone's canonical Git common directory.
+The spawn records that clone identity in task metadata, and `fm-recovery-verify.sh` checks it against a resumed agent's live foreground cwd before recovery permits project mutation.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -38,6 +38,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervision-instructions.sh` | Render the session-start primary-harness supervision block or the one-line repair instruction |
 | `fm-home-seed.sh`        | Transactionally provision a secondmate home and maintain `data/secondmates.md`       |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
+| `fm-recovery-verify.sh`  | Fail closed unless a resumed task's live cwd matches its recorded worktree and selected clone identity |
 | `fm-dispatch-select.sh`  | Resolve a dispatch rule/default to one profile, owning quota-aware arrays and random fallback |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
@@ -67,6 +68,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
+| `fm-worktree-identity-lib.sh` | Canonical Git common-directory and worktree-root identity helpers                |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |

--- a/tests/fm-spawn-clone-identity.test.sh
+++ b/tests/fm-spawn-clone-identity.test.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Regression coverage for fm-spawn's selected-clone identity boundary and the
+# recovery verifier's post-resume live-cwd check.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+RECOVERY_VERIFY="$ROOT/bin/fm-recovery-verify.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-clone-identity)
+
+make_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  display-message)
+    for arg in "$@"; do
+      case "$arg" in
+        *pane_current_path*) printf '%s\n' "${FM_FAKE_ACTUAL_CWD:-}"; exit 0 ;;
+      esac
+    done
+    printf 'firstmate\n'
+    ;;
+  list-windows|has-session|set-window-option|kill-window) ;;
+  new-session) ;;
+  new-window) printf '@71\n' ;;
+  send-keys)
+    for arg in "$@"; do
+      case "$arg" in
+        *claude*) : > "${FM_FAKE_AGENT_MARKER:?}" ;;
+      esac
+    done
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+make_fixture() {
+  local seed remote home_a home_b project_a project_b pool
+  seed="$TMP_ROOT/seed"
+  remote="$TMP_ROOT/remote.git"
+  home_a="$TMP_ROOT/home-a"
+  home_b="$TMP_ROOT/home-b"
+  project_a="$home_a/projects/shared"
+  project_b="$home_b/projects/shared"
+  pool="$TMP_ROOT/shared-pool"
+  fm_git_init_commit "$seed"
+  git clone --quiet --bare "$seed" "$remote"
+  mkdir -p "$home_a/projects" "$home_b/projects" "$pool"
+  git clone --quiet "file://$remote" "$project_a"
+  git clone --quiet "file://$remote" "$project_b"
+  git -C "$project_a" worktree add --quiet -b owned-task "$pool/owned-slot"
+  git -C "$project_b" worktree add --quiet -b foreign-task "$pool/foreign-slot"
+  printf '%s\n' "$home_a|$project_a|$pool/owned-slot|$project_b|$pool/foreign-slot"
+}
+
+IFS='|' read -r HOME_A PROJECT_A OWNED_WT PROJECT_B FOREIGN_WT <<EOF
+$(make_fixture)
+EOF
+REMOTE_A=$(git -C "$PROJECT_A" remote get-url origin)
+REMOTE_B=$(git -C "$PROJECT_B" remote get-url origin)
+[ "$REMOTE_A" = "$REMOTE_B" ] || fail "fixture clones do not share one remote identity"
+COMMON_A=$(git -C "$PROJECT_A" rev-parse --path-format=absolute --git-common-dir)
+COMMON_B=$(git -C "$PROJECT_B" rev-parse --path-format=absolute --git-common-dir)
+[ "$COMMON_A" != "$COMMON_B" ] || fail "fixture clones unexpectedly share one Git common directory"
+FAKEBIN=$(make_fakebin "$TMP_ROOT/fake")
+mkdir -p "$HOME_A/data" "$HOME_A/state" "$HOME_A/config"
+printf 'claude\n' > "$HOME_A/config/crew-harness"
+touch "$HOME_A/state/.last-watcher-beat"
+
+run_spawn() {
+  local id=$1 pane_path=$2 marker=$3
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_A" \
+    FM_STATE_OVERRIDE="$HOME_A/state" FM_DATA_OVERRIDE="$HOME_A/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_A/projects" FM_CONFIG_OVERRIDE="$HOME_A/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_ACTUAL_CWD="$pane_path" FM_FAKE_AGENT_MARKER="$marker" \
+    PATH="$FAKEBIN:$PATH" \
+    "$SPAWN" "$id" "$PROJECT_A" 2>&1
+}
+
+test_foreign_pooled_worktree_is_rejected_before_launch_or_meta() {
+  local id marker out rc
+  id=foreign-clone-reject
+  marker="$TMP_ROOT/$id-agent-started"
+  mkdir -p "$HOME_A/data/$id"
+  printf 'brief\n' > "$HOME_A/data/$id/brief.md"
+
+  out=$(run_spawn "$id" "$FOREIGN_WT" "$marker")
+  rc=$?
+
+  [ "$rc" -ne 0 ] || fail "foreign pooled worktree should be rejected"
+  assert_contains "$out" "owned by clone" "foreign-clone refusal did not name the ownership mismatch"
+  assert_contains "$out" "before hooks, agent launch, or metadata publication" "foreign-clone refusal was not actionable about the safety boundary"
+  assert_absent "$marker" "agent launch occurred before foreign-clone rejection"
+  assert_absent "$HOME_A/state/$id.meta" "metadata was published before foreign-clone rejection"
+  assert_absent "$FOREIGN_WT/.claude/settings.local.json" "worktree hook was installed before foreign-clone rejection"
+  assert_absent "/tmp/fm-$id" "task temp state was created before foreign-clone rejection"
+  pass "a foreign worktree from the same remote and shared pool namespace is rejected before hooks, launch, or metadata"
+}
+
+test_owned_worktree_records_selected_clone_identity() {
+  local id marker out rc expected_common
+  id=owned-clone-accept
+  marker="$TMP_ROOT/$id-agent-started"
+  mkdir -p "$HOME_A/data/$id"
+  printf 'brief\n' > "$HOME_A/data/$id/brief.md"
+
+  out=$(run_spawn "$id" "$OWNED_WT" "$marker")
+  rc=$?
+
+  expect_code 0 "$rc" "owned pooled worktree spawn should succeed: $out"
+  expected_common=$(git -C "$PROJECT_A" rev-parse --path-format=absolute --git-common-dir)
+  expected_common=$(cd "$expected_common" && pwd -P)
+  assert_present "$marker" "owned worktree did not reach agent launch"
+  assert_grep "project_git_common_dir=$expected_common" "$HOME_A/state/$id.meta" "task metadata did not record selected clone identity"
+  rm -rf "/tmp/fm-$id"
+  pass "an owned pooled worktree records the selected clone identity in metadata"
+}
+
+write_recovery_meta() {
+  local id=$1 common
+  common=$(git -C "$PROJECT_A" rev-parse --path-format=absolute --git-common-dir)
+  common=$(cd "$common" && pwd -P)
+  fm_write_meta "$HOME_A/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "worktree=$OWNED_WT" \
+    "project=$PROJECT_A" \
+    "project_git_common_dir=$common" \
+    "harness=grok" \
+    "kind=ship"
+}
+
+run_recovery_verify() {
+  local id=$1 actual=$2
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_A" FM_STATE_OVERRIDE="$HOME_A/state" \
+    FM_CONFIG_OVERRIDE="$HOME_A/config" TMUX="fake,1,0" \
+    FM_FAKE_ACTUAL_CWD="$actual" PATH="$FAKEBIN:$PATH" \
+    "$RECOVERY_VERIFY" "$id" 2>&1
+}
+
+test_resume_historical_foreign_cwd_is_rejected() {
+  local id out rc
+  id=resume-foreign-cwd
+  write_recovery_meta "$id"
+
+  out=$(run_recovery_verify "$id" "$FOREIGN_WT")
+  rc=$?
+
+  [ "$rc" -ne 0 ] || fail "recovery verifier should reject a resumed historical foreign cwd"
+  assert_contains "$out" "exit this resumed agent and relaunch fresh" "resume refusal did not provide the safe recovery action"
+  assert_contains "$out" "$FOREIGN_WT" "resume refusal did not identify the actual historical cwd"
+  pass "recovery refuses a resumed agent whose historical cwd crosses the selected clone boundary"
+}
+
+test_resume_recorded_worktree_is_accepted() {
+  local id out rc
+  id=resume-owned-cwd
+  write_recovery_meta "$id"
+
+  out=$(run_recovery_verify "$id" "$OWNED_WT")
+  rc=$?
+
+  expect_code 0 "$rc" "recovery verifier should accept the recorded worktree: $out"
+  assert_contains "$out" "verified task $id" "successful recovery verification did not report the task"
+  pass "recovery accepts a resumed agent only in its recorded worktree and selected clone"
+}
+
+test_foreign_pooled_worktree_is_rejected_before_launch_or_meta
+test_owned_worktree_records_selected_clone_identity
+test_resume_historical_foreign_cwd_is_rejected
+test_resume_recorded_worktree_is_accepted
+
+echo "# all fm-spawn-clone-identity tests passed"

--- a/tests/fm-spawn-clone-identity.test.sh
+++ b/tests/fm-spawn-clone-identity.test.sh
@@ -25,7 +25,8 @@ case "${1:-}" in
     done
     printf 'firstmate\n'
     ;;
-  list-windows|has-session|set-window-option|kill-window) ;;
+  list-windows) [ -z "${FM_FAKE_WINDOW_LIST:-}" ] || printf '%s\n' "$FM_FAKE_WINDOW_LIST" ;;
+  has-session|set-window-option|kill-window) ;;
   new-session) ;;
   new-window) printf '@71\n' ;;
   send-keys)
@@ -140,10 +141,11 @@ write_recovery_meta() {
 }
 
 run_recovery_verify() {
-  local id=$1 actual=$2
+  local id=$1 actual=$2 windows=${3-"@71 fm-$1"}
   FM_ROOT_OVERRIDE='' FM_HOME="$HOME_A" FM_STATE_OVERRIDE="$HOME_A/state" \
     FM_CONFIG_OVERRIDE="$HOME_A/config" TMUX="fake,1,0" \
-    FM_FAKE_ACTUAL_CWD="$actual" PATH="$FAKEBIN:$PATH" \
+    FM_FAKE_ACTUAL_CWD="$actual" FM_FAKE_WINDOW_LIST="$windows" \
+    PATH="$FAKEBIN:$PATH" \
     "$RECOVERY_VERIFY" "$id" 2>&1
 }
 
@@ -159,6 +161,32 @@ test_resume_historical_foreign_cwd_is_rejected() {
   assert_contains "$out" "exit this resumed agent and relaunch fresh" "resume refusal did not provide the safe recovery action"
   assert_contains "$out" "$FOREIGN_WT" "resume refusal did not identify the actual historical cwd"
   pass "recovery refuses a resumed agent whose historical cwd crosses the selected clone boundary"
+}
+
+test_resume_lost_window_name_fails_closed() {
+  local id out rc
+  id=resume-lost-window
+  write_recovery_meta "$id"
+
+  out=$(run_recovery_verify "$id" "$OWNED_WT" $'@71 renamed-away\n@72 unrelated')
+  rc=$?
+
+  [ "$rc" -ne 0 ] || fail "recovery verifier should fail closed when the recorded window name is lost, even if a name-fallback read would report the recorded worktree"
+  assert_contains "$out" "does not resolve to exactly one live window" "lost-window refusal did not name the endpoint resolution failure"
+  pass "recovery fails closed on a lost or renamed tmux window name instead of falling back to the active client"
+}
+
+test_resume_ambiguous_window_name_fails_closed() {
+  local id out rc
+  id=resume-ambiguous-window
+  write_recovery_meta "$id"
+
+  out=$(run_recovery_verify "$id" "$OWNED_WT" $'@71 fm-resume-ambiguous-window\n@72 fm-resume-ambiguous-window')
+  rc=$?
+
+  [ "$rc" -ne 0 ] || fail "recovery verifier should fail closed on an ambiguous recorded window name"
+  assert_contains "$out" "does not resolve to exactly one live window" "ambiguous-window refusal did not name the endpoint resolution failure"
+  pass "recovery fails closed when the recorded window name matches more than one live window"
 }
 
 test_resume_recorded_worktree_is_accepted() {
@@ -177,6 +205,8 @@ test_resume_recorded_worktree_is_accepted() {
 test_foreign_pooled_worktree_is_rejected_before_launch_or_meta
 test_owned_worktree_records_selected_clone_identity
 test_resume_historical_foreign_cwd_is_rejected
+test_resume_lost_window_name_fails_closed
+test_resume_ambiguous_window_name_fails_closed
 test_resume_recorded_worktree_is_accepted
 
 echo "# all fm-spawn-clone-identity tests passed"


### PR DESCRIPTION
## Intent

Fix the confirmed cross-home worktree-pool isolation defect in Firstmate's shared tooling. A ship/scout spawn must canonicalize Git common-directory identity for the selected project clone and proposed worktree, reject a foreign home's pooled worktree before hooks, agent launch, or task metadata publication, and record the selected clone identity for recovery. Recovery or harness resume paths that can restore historical cwd, especially Grok resume, must verify the live agent cwd, Git top-level, and repository identity against the recorded worktree before any project mutation, failing closed and requiring a fresh launch when they differ. Add regressions using two independent clones of the same remote under one shared pool namespace and a simulated historical-cwd restoration. Keep the fix Firstmate-side without changing Treehouse, preserve supported backend behavior, keep shell scripts shellcheck-clean, use one sentence per line in Markdown, avoid incident restatement beyond the operational contract, base and target main, and never add an agent co-author.

## What Changed

- `bin/fm-spawn.sh` now canonicalizes the Git common-directory identity of the selected project clone and the proposed worktree (via new `bin/fm-worktree-identity-lib.sh`), rejects a foreign home's pooled worktree before any hooks, agent launch, or task metadata publication, and records the selected clone identity as `project_git_common_dir=` in task metadata for recovery.
- New `bin/fm-recovery-verify.sh` checks a resumed task's live agent cwd, Git top-level, and repository identity against the recorded worktree before any project mutation; it resolves the recovery tmux target to a unique live window id (new helper in `bin/backends/tmux.sh`) and fails closed — requiring a fresh launch — on missing fields, lost/ambiguous windows, unreadable cwd, or identity mismatch. The stuck-crewmate-recovery skill now requires running this verification after any harness resume.
- Added `tests/fm-spawn-clone-identity.test.sh` (6 regressions covering foreign-pool rejection, clone-identity metadata, historical-cwd resume rejection, lost/ambiguous window fail-closed, and owned-worktree acceptance) and documented the spawn clone-identity boundary in `AGENTS.md`, `docs/architecture.md`, and `docs/scripts.md`.

## Risk Assessment

✅ Low: The round-2 commit cleanly resolves the only actionable prior finding by resolving the recorded tmux target to exactly one live stable window id with fail-closed zero/ambiguous handling, adds focused regressions for lost and ambiguous window names, and introduces no new material risk across the re-inspected branch.

## Testing

Ran the new clone-identity regression suite plus the surrounding spawn/backend/orca/test-runner suites (all green), then demonstrated the fix end-to-end with a real two-clone shared-pool fixture: fm-spawn.sh refuses the foreign clone's pooled worktree before hooks, launch, or metadata, records the selected clone identity for the owned worktree, and fm-recovery-verify.sh fails closed on a simulated historical-cwd restoration and on lost/ambiguous tmux windows while accepting the recorded worktree; transcript captured as evidence and demo fixtures cleaned up. Shellcheck was not run per testing-stage rules.

<details>
<summary>Evidence: End-to-end CLI transcript: two-clone shared-pool spawn refusal, clone-identity metadata, and recovery fail-closed/verify scenarios</summary>

```text
=== Fixture: two independent clones of ONE remote sharing one worktree-pool namespace ===
home-a and home-b origin:  file:///tmp/fm-clone-identity-demo.GIweT5/remote.git  (identical remote URL)
home-a clone common dir:   /private/tmp/fm-clone-identity-demo.GIweT5/home-a/projects/shared/.git
home-b clone common dir:   /private/tmp/fm-clone-identity-demo.GIweT5/home-b/projects/shared/.git
pool slots: shared-pool/owned-slot (home-a's worktree), shared-pool/foreign-slot (home-b's worktree)

=== 1. Spawn resolving to the FOREIGN home's pooled worktree: refused before hooks/launch/metadata ===
$ fm-spawn.sh demo-foreign home-a/projects/shared   # pool hands back home-b's foreign-slot
error: treehouse get yielded worktree '/private/tmp/fm-clone-identity-demo.GIweT5/shared-pool/foreign-slot' owned by clone '/private/tmp/fm-clone-identity-demo.GIweT5/home-b/projects/shared/.git', but task demo-foreign selected clone '/private/tmp/fm-clone-identity-demo.GIweT5/home-a/projects/shared/.git' from '/tmp/fm-clone-identity-demo.GIweT5/home-a/projects/shared'; refusing before hooks, agent launch, or metadata publication. Inspect the shared worktree pool binding for target firstmate:fm-demo-foreign
exit code: 1
agent launched?          no
task metadata published? no

=== 2. Spawn into the OWNED pooled worktree: succeeds and records selected clone identity ===
$ fm-spawn.sh demo-owned home-a/projects/shared   # pool hands back home-a's owned-slot
warn: no registry at /tmp/fm-clone-identity-demo.GIweT5/home-a/data/projects.md; defaulting shared to no-mistakes off
spawned demo-owned harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-owned worktree=/tmp/fm-clone-identity-demo.GIweT5/shared-pool/owned-slot
exit code: 0
agent launched?          YES
--- state/demo-owned.meta (selected clone identity recorded for recovery) ---
window=firstmate:fm-demo-owned
worktree=/tmp/fm-clone-identity-demo.GIweT5/shared-pool/owned-slot
project=/tmp/fm-clone-identity-demo.GIweT5/home-a/projects/shared
project_git_common_dir=/private/tmp/fm-clone-identity-demo.GIweT5/home-a/projects/shared/.git
harness=claude
kind=ship

=== 3. Recovery resume (Grok-style historical-cwd restoration): live cwd is the FOREIGN worktree -> fail closed ===
$ fm-recovery-verify.sh demo-owned   # backend pane cwd restored to home-b's foreign-slot
error: resumed task demo-owned foreground cwd '/tmp/fm-clone-identity-demo.GIweT5/shared-pool/foreign-slot' resolves to worktree '/private/tmp/fm-clone-identity-demo.GIweT5/shared-pool/foreign-slot' and clone '/private/tmp/fm-clone-identity-demo.GIweT5/home-b/projects/shared/.git', expected worktree '/private/tmp/fm-clone-identity-demo.GIweT5/shared-pool/owned-slot' and selected clone '/private/tmp/fm-clone-identity-demo.GIweT5/home-a/projects/shared/.git'; exit this resumed agent and relaunch fresh in '/private/tmp/fm-clone-identity-demo.GIweT5/shared-pool/owned-slot'
exit code: 1

=== 4. Recovery resume: recorded tmux window name lost/renamed -> fail closed (no active-client fallback) ===
$ fm-recovery-verify.sh demo-owned   # window renamed away
error: task demo-owned tmux target 'firstmate:fm-demo-owned' does not resolve to exactly one live window; refusing recovery resume
exit code: 1

=== 5. Recovery resume: live cwd matches recorded worktree AND selected clone -> verified ===
$ fm-recovery-verify.sh demo-owned
verified task demo-owned worktree=/private/tmp/fm-clone-identity-demo.GIweT5/shared-pool/owned-slot clone=/private/tmp/fm-clone-identity-demo.GIweT5/home-a/projects/shared/.git
exit code: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-recovery-verify.sh:78` - fm-recovery-verify.sh reads the resumed task&#39;s live cwd via `tmux display-message -p -t` against the name-based `window=` target from meta (fm_backend_target_of_meta returns &#34;$SES:$W&#34;, bin/fm-spawn.sh:889). fm-spawn.sh:1085&#39;s own comment documents that display-message with a lost/renamed window name falls back to the active client&#39;s window — the reason the spawn settle-poll targets the stable window id ($WID) instead. In the verifier the common failure direction is a spurious refusal (fail closed), but a false accept exists: if the task window&#39;s name is lost and the active client&#39;s pane happens to be inside the recorded worktree (plausible while an operator inspects that worktree during recovery), verification passes while the actual resumed agent runs elsewhere. Harden by resolving the window name to exactly one live window id (failing closed on zero or ambiguous matches) before reading pane_current_path.
- ℹ️ `.agents/skills/stuck-crewmate-recovery/SKILL.md:34` - The resume-side verification is enforced procedurally: SKILL.md:34 instructs the recovering agent to run bin/fm-recovery-verify.sh after any harness resume, but nothing mechanically gates fm-send instruction delivery on a passed verification. Since resumes are agent-operated, the skill is the available Firstmate-side seam; noting that the fail-closed guarantee for Grok resume still relies on the operating agent following the skill.
- ℹ️ `bin/fm-spawn.sh:301` - ORCA_ABORT_METADATA_ALLOWED=0 spans the entire validate_spawn_worktree call, so when an unvalidated Orca worktree cannot be removed during abort, fallback metadata is now skipped for both the new clone-identity failure and the pre-existing isolation failure. The leaked Orca worktree is reported only on stderr and is no longer discoverable from state by later teardown/fleet-sync. This is a deliberate consequence of the no-metadata-before-validation boundary, but operators lose the previous state breadcrumb for the isolation-failure mode.

🔧 Fix: resolve recovery tmux target to unique window id, fail closed
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-clone-identity.test.sh` — all 6 regression tests pass (foreign-pool rejection, clone-identity metadata, historical-cwd resume rejection, lost/ambiguous window fail-closed, owned-worktree acceptance)</code>
- <code>`bin/fm-test-run.sh tests/fm-spawn-batch.test.sh tests/fm-spawn-dispatch-profile.test.sh tests/fm-spawn-worktree-settle.test.sh tests/fm-backend.test.sh tests/fm-backend-tmux-smoke.test.sh tests/fm-spawn-clone-identity.test.sh` — backend-dispatch family, failed=0</code>
- <code>`bin/fm-test-run.sh tests/fm-backend-orca.test.sh tests/fm-test-run.test.sh` — orca abort-metadata paths and runner family mapping, failed=0</code>
- <code>Manual end-to-end CLI demo: built two independent clones of one remote under a shared worktree-pool namespace, ran real `bin/fm-spawn.sh` (foreign slot refused with no agent launch/metadata/hooks; owned slot succeeds and records project_git_common_dir=) and real `bin/fm-recovery-verify.sh` (foreign historical cwd refused, lost window name fails closed, recorded worktree verifies)</code>
- <code>Checked `git log 593e3a2..b190820` commit messages for agent co-author trailers (none) and confirmed Markdown doc changes use one sentence per line with no Treehouse-side edits</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
