### PR TITLE
feat: add fixed-home primary launcher selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ For Pi, approve the project trust prompt once per clone on first launch so both 
 
 The tracked [`windows/firstmate.ps1`](windows/firstmate.ps1) template delegates to [`bin/fm-primary-launch.sh`](bin/fm-primary-launch.sh), which is the single owner of selector validation and harness launch mechanics.
 Copy the PowerShell template into a directory on `PATH` during a separate local rollout, then use `firstmate`, `firstmate --pi`, `firstmate --grok`, `firstmate --claude`, `firstmate --opencode`, or `firstmate --codex` from PowerShell.
-The tracked [`windows/firstmate.cmd`](windows/firstmate.cmd) is a refusal shim for `cmd.exe`, whose batch expansion cannot preserve arbitrary model values as opaque arguments; PowerShell resolves the colocated `.ps1` command preferentially.
-The CMD entrypoint intentionally accepts only those zero- or one-selector forms. Invoke `firstmate.ps1` directly for `--model <model>` and supported effort levels so PowerShell preserves each value as one opaque argument through WSL.
+The tracked [`windows/firstmate.cmd`](windows/firstmate.cmd) always refuses every invocation because `cmd.exe` batch expansion cannot preserve arbitrary model values as opaque arguments.
+Every supported launch form is PowerShell-only and must resolve to the colocated `firstmate.ps1` or invoke `firstmate.ps1` directly so PowerShell preserves each argument as one opaque value through WSL.
 Bare `firstmate` remains unrestricted Codex for compatibility.
 
 This launcher is intentionally fixed to WSL distribution `Ubuntu`, Linux user `firstmate`, and `/home/firstmate/firstmate` as both repository root and `FM_HOME`.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For Pi, approve the project trust prompt once per clone on first launch so both 
 
 The tracked [`windows/firstmate.cmd`](windows/firstmate.cmd) and [`windows/firstmate.ps1`](windows/firstmate.ps1) templates delegate to [`bin/fm-primary-launch.sh`](bin/fm-primary-launch.sh), which is the single owner of selector validation and harness launch mechanics.
 Copy both Windows templates into one directory on `PATH` during a separate local rollout, then use `firstmate`, `firstmate --pi`, `firstmate --grok`, `firstmate --claude`, `firstmate --opencode`, or `firstmate --codex`.
-An explicit selector also accepts `--model <model>` and the effort levels supported by that harness.
+The CMD entrypoint intentionally accepts only those zero- or one-selector forms. Invoke `firstmate.ps1` directly for `--model <model>` and supported effort levels so PowerShell preserves each value as one opaque argument through WSL.
 Bare `firstmate` remains unrestricted Codex for compatibility.
 
 This launcher is intentionally fixed to WSL distribution `Ubuntu`, Linux user `firstmate`, and `/home/firstmate/firstmate` as both repository root and `FM_HOME`.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ For Pi, approve the project trust prompt once per clone on first launch so both 
 
 ### Fixed-home Windows and WSL launcher
 
-The tracked [`windows/firstmate.cmd`](windows/firstmate.cmd) and [`windows/firstmate.ps1`](windows/firstmate.ps1) templates delegate to [`bin/fm-primary-launch.sh`](bin/fm-primary-launch.sh), which is the single owner of selector validation and harness launch mechanics.
-Copy both Windows templates into one directory on `PATH` during a separate local rollout, then use `firstmate`, `firstmate --pi`, `firstmate --grok`, `firstmate --claude`, `firstmate --opencode`, or `firstmate --codex`.
+The tracked [`windows/firstmate.ps1`](windows/firstmate.ps1) template delegates to [`bin/fm-primary-launch.sh`](bin/fm-primary-launch.sh), which is the single owner of selector validation and harness launch mechanics.
+Copy the PowerShell template into a directory on `PATH` during a separate local rollout, then use `firstmate`, `firstmate --pi`, `firstmate --grok`, `firstmate --claude`, `firstmate --opencode`, or `firstmate --codex` from PowerShell.
+The tracked [`windows/firstmate.cmd`](windows/firstmate.cmd) is a refusal shim for `cmd.exe`, whose batch expansion cannot preserve arbitrary model values as opaque arguments; PowerShell resolves the colocated `.ps1` command preferentially.
 The CMD entrypoint intentionally accepts only those zero- or one-selector forms. Invoke `firstmate.ps1` directly for `--model <model>` and supported effort levels so PowerShell preserves each value as one opaque argument through WSL.
 Bare `firstmate` remains unrestricted Codex for compatibility.
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ For Pi, approve the project trust prompt once per clone on first launch so both 
 ### Fixed-home Windows and WSL launcher
 
 The tracked [`windows/firstmate.ps1`](windows/firstmate.ps1) template delegates to [`bin/fm-primary-launch.sh`](bin/fm-primary-launch.sh), which is the single owner of selector validation and harness launch mechanics.
-Copy the PowerShell template into a directory on `PATH` during a separate local rollout, then use `firstmate`, `firstmate --pi`, `firstmate --grok`, `firstmate --claude`, `firstmate --opencode`, or `firstmate --codex` from PowerShell.
+Copy both Windows templates into the same directory on `PATH` during a separate local rollout, then use `firstmate`, `firstmate --pi`, `firstmate --grok`, `firstmate --claude`, `firstmate --opencode`, or `firstmate --codex` from PowerShell.
 The tracked [`windows/firstmate.cmd`](windows/firstmate.cmd) always refuses every invocation because `cmd.exe` batch expansion cannot preserve arbitrary model values as opaque arguments.
 Every supported launch form is PowerShell-only and must resolve to the colocated `firstmate.ps1` or invoke `firstmate.ps1` directly so PowerShell preserves each argument as one opaque value through WSL.
-Bare `firstmate` remains unrestricted Codex for compatibility.
+Bare `firstmate` and explicit `firstmate --codex` launch unrestricted Codex for compatibility.
+The alternate selectors retain their normal permission posture, except that Grok receives its documented `--trust` flag so the tracked hooks load.
 
 This launcher is intentionally fixed to WSL distribution `Ubuntu`, Linux user `firstmate`, and `/home/firstmate/firstmate` as both repository root and `FM_HOME`.
 Changing selectors therefore preserves Firstmate's durable operational memory, but it does not share harness-native transcripts, resume history, credentials, or global model settings.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ pi
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so both tracked `.pi/extensions/*.ts` files auto-load.
 
+### Fixed-home Windows and WSL launcher
+
+The tracked [`windows/firstmate.cmd`](windows/firstmate.cmd) and [`windows/firstmate.ps1`](windows/firstmate.ps1) templates delegate to [`bin/fm-primary-launch.sh`](bin/fm-primary-launch.sh), which is the single owner of selector validation and harness launch mechanics.
+Copy both Windows templates into one directory on `PATH` during a separate local rollout, then use `firstmate`, `firstmate --pi`, `firstmate --grok`, `firstmate --claude`, `firstmate --opencode`, or `firstmate --codex`.
+An explicit selector also accepts `--model <model>` and the effort levels supported by that harness.
+Bare `firstmate` remains unrestricted Codex for compatibility.
+
+This launcher is intentionally fixed to WSL distribution `Ubuntu`, Linux user `firstmate`, and `/home/firstmate/firstmate` as both repository root and `FM_HOME`.
+Changing selectors therefore preserves Firstmate's durable operational memory, but it does not share harness-native transcripts, resume history, credentials, or global model settings.
+Install each selected harness as a native WSL/Linux executable first; Windows `.exe` and `/mnt/c` shims are rejected because their path, hook, and tool-execution semantics differ.
+The launcher attaches to a compatible existing primary and refuses a divergent selector or live same-home session instead of creating a second identity.
+Run `bin/fm-primary-launch.sh --help` for the exact argument and effort contract.
+
 ### Talk to it
 
 ```sh

--- a/bin/fm-harness-process.sh
+++ b/bin/fm-harness-process.sh
@@ -9,11 +9,7 @@ pid=${1:-}
 case "$pid" in ''|*[!0-9]*|1) exit 1 ;; esac
 [ -r "/proc/$pid/cmdline" ] || exit 1
 
-executable=$(python3 - "$pid" 2>/dev/null <<'PY'
-import os, sys
-print(os.readlink(f"/proc/{sys.argv[1]}/exe"))
-PY
-) || exit 1
+executable=$(readlink "/proc/$pid/exe" 2>/dev/null) || exit 1
 case "$executable" in
   */claude) printf '%s\n' claude; exit 0 ;;
   */codex) printf '%s\n' codex; exit 0 ;;

--- a/bin/fm-harness-process.sh
+++ b/bin/fm-harness-process.sh
@@ -9,26 +9,33 @@ pid=${1:-}
 case "$pid" in ''|*[!0-9]*|1) exit 1 ;; esac
 [ -r "/proc/$pid/cmdline" ] || exit 1
 
-supported_harness() {
-  case "$1" in codex|pi|grok|claude|opencode) printf '%s\n' "$1"; return 0 ;; esac
-  return 1
-}
+executable=$(python3 - "$pid" 2>/dev/null <<'PY'
+import os, sys
+print(os.readlink(f"/proc/{sys.argv[1]}/exe"))
+PY
+) || exit 1
+case "$executable" in
+  */claude) printf '%s\n' claude; exit 0 ;;
+  */codex) printf '%s\n' codex; exit 0 ;;
+  */opencode) printf '%s\n' opencode; exit 0 ;;
+  */pi) printf '%s\n' pi; exit 0 ;;
+  */grok) printf '%s\n' grok; exit 0 ;;
+esac
 
+name=$(basename "$executable")
 mapfile -d '' -t argv < "/proc/$pid/cmdline" 2>/dev/null || exit 1
-comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
-for executable in "${argv[0]:-}" "$comm"; do
-  name=$(basename "$executable")
-  supported_harness "$name" && exit 0
-done
-
-case "$(basename "${argv[0]:-}")" in
-  node|nodejs|python|python[0-9]|python[0-9].*) entrypoint=${argv[1]:-} ;;
-  *) exit 1 ;;
+case "$name" in
+  node|nodejs)
+    entrypoint=${argv[1]:-}
+    ;;
+  *)
+    exit 1
+    ;;
 esac
 [ -n "$entrypoint" ] || exit 1
 case "$entrypoint" in
-  /*) ;;
-  *) entrypoint="$(readlink -f "/proc/$pid/cwd/$entrypoint" 2>/dev/null || printf '%s' "$entrypoint")" ;;
+  /*) entrypoint=$(readlink -f "$entrypoint" 2>/dev/null) || exit 1 ;;
+  *) entrypoint=$(readlink -f "/proc/$pid/cwd/$entrypoint" 2>/dev/null) || exit 1 ;;
 esac
 
 entrypoint=$(printf '%s' "$entrypoint" | tr '[:upper:]' '[:lower:]')

--- a/bin/fm-harness-process.sh
+++ b/bin/fm-harness-process.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -u
+
+pid=${1:-}
+case "$pid" in ''|*[!0-9]*|1) exit 1 ;; esac
+[ -r "/proc/$pid/cmdline" ] || exit 1
+
+supported_harness() {
+  case "$1" in codex|pi|grok|claude|opencode) printf '%s\n' "$1"; return 0 ;; esac
+  return 1
+}
+
+mapfile -d '' -t argv < "/proc/$pid/cmdline" 2>/dev/null || exit 1
+comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+for executable in "${argv[0]:-}" "$comm"; do
+  name=$(basename "$executable")
+  supported_harness "$name" && exit 0
+done
+
+case "$(basename "${argv[0]:-}")" in
+  node|nodejs|python|python[0-9]|python[0-9].*) entrypoint=${argv[1]:-} ;;
+  *) exit 1 ;;
+esac
+[ -n "$entrypoint" ] || exit 1
+case "$entrypoint" in
+  /*) ;;
+  *) entrypoint="$(readlink -f "/proc/$pid/cwd/$entrypoint" 2>/dev/null || printf '%s' "$entrypoint")" ;;
+esac
+
+while IFS= read -r component; do
+  normalized=$(printf '%s' "$component" | tr '[:upper:]' '[:lower:]')
+  for harness in opencode claude codex grok pi; do
+    case "$normalized" in
+      "$harness"|"$harness"[-_.]*|*[-_.]"$harness"|*[-_.]"$harness"[-_.]*) printf '%s\n' "$harness"; exit 0 ;;
+    esac
+  done
+done < <(printf '%s\n' "$entrypoint" | tr '/' '\n')
+exit 1

--- a/bin/fm-harness-process.sh
+++ b/bin/fm-harness-process.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Identify a verified harness process without matching unrelated argv values.
+# Usage: fm-harness-process.sh <pid>
+# Prints claude|codex|opencode|pi|grok and exits 0 when the PID is a supported
+# native executable or an interpreter-hosted package entrypoint; exits 1 otherwise.
 set -u
 
 pid=${1:-}

--- a/bin/fm-harness-process.sh
+++ b/bin/fm-harness-process.sh
@@ -31,12 +31,23 @@ case "$entrypoint" in
   *) entrypoint="$(readlink -f "/proc/$pid/cwd/$entrypoint" 2>/dev/null || printf '%s' "$entrypoint")" ;;
 esac
 
-while IFS= read -r component; do
-  normalized=$(printf '%s' "$component" | tr '[:upper:]' '[:lower:]')
-  for harness in opencode claude codex grok pi; do
-    case "$normalized" in
-      "$harness"|"$harness"[-_.]*|*[-_.]"$harness"|*[-_.]"$harness"[-_.]*) printf '%s\n' "$harness"; exit 0 ;;
-    esac
-  done
-done < <(printf '%s\n' "$entrypoint" | tr '/' '\n')
-exit 1
+entrypoint=$(printf '%s' "$entrypoint" | tr '[:upper:]' '[:lower:]')
+case "$entrypoint" in
+  */node_modules/@anthropic-ai/claude-code/cli.js|\
+  */node_modules/@anthropic-ai/claude-code/bin/claude.js)
+    printf '%s\n' claude
+    ;;
+  */node_modules/@openai/codex/bin/codex.js)
+    printf '%s\n' codex
+    ;;
+  */node_modules/@mariozechner/pi-coding-agent/dist/cli.js|\
+  */node_modules/@earendil-works/pi-coding-agent/dist/cli.js)
+    printf '%s\n' pi
+    ;;
+  */node_modules/opencode-ai/bin/opencode.js)
+    printf '%s\n' opencode
+    ;;
+  *)
+    exit 1
+    ;;
+esac

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -40,11 +40,18 @@ harness_pid() {
 }
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
-  local pid=$1 comm
+  local pid=$1 comm args
   case "$pid" in ''|*[!0-9]*|1) return 1 ;; esac
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  args=$(ps -o args= -p "$pid" 2>/dev/null) || return 1
+  if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
+    return 0
+  fi
+  case "$comm" in
+    *node*|*python*|*sleep*) printf '%s' "$args" | grep -qE '(^|[ /])(claude|codex|opencode|grok|pi)([ /]|$)' ;;
+    *) return 1 ;;
+  esac
 }
 
 if [ "$MODE" = status ]; then

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -19,27 +19,13 @@ case "$MODE" in acquire|status|live-pid) ;; *) echo "error: usage: fm-lock.sh [s
 [ "$MODE" != acquire ] || mkdir -p "$STATE"
 
 process_harness() {
-  local pid=$1 comm name
-  local -a argv=()
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
-  mapfile -d '' -t argv < "/proc/$pid/cmdline" 2>/dev/null || return 1
-  name=$(basename "${argv[0]:-$comm}")
-  case "$name" in codex|pi|grok|claude|opencode) return 0 ;; esac
-  name=$(basename "$comm")
-  case "$name" in codex|pi|grok|claude|opencode) return 0 ;; esac
-  case "$(basename "${argv[0]:-}")" in
-    node|nodejs|python|python[0-9]|python[0-9].*)
-      name=$(basename "${argv[1]:-}")
-      case "$name" in codex|pi|grok|claude|opencode) return 0 ;; esac
-      ;;
-  esac
-  return 1
+  "$FM_ROOT/bin/fm-harness-process.sh" "$1"
 }
 
 harness_pid() {
   local pid=$$
   for _ in 1 2 3 4 5 6 7 8; do
-    process_harness "$pid" && { echo "$pid"; return 0; }
+    process_harness "$pid" >/dev/null && { echo "$pid"; return 0; }
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
   done
@@ -50,7 +36,7 @@ holder_alive() {
   local pid=$1
   case "$pid" in ''|*[!0-9]*|1) return 1 ;; esac
   kill -0 "$pid" 2>/dev/null || return 1
-  process_harness "$pid"
+  process_harness "$pid" >/dev/null
 }
 
 if [ "$MODE" = status ]; then

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -18,40 +18,39 @@ MODE=${1:-acquire}
 case "$MODE" in acquire|status|live-pid) ;; *) echo "error: usage: fm-lock.sh [status|live-pid]" >&2; exit 2 ;; esac
 [ "$MODE" != acquire ] || mkdir -p "$STATE"
 
-# Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+process_harness() {
+  local pid=$1 comm name
+  local -a argv=()
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+  mapfile -d '' -t argv < "/proc/$pid/cmdline" 2>/dev/null || return 1
+  name=$(basename "${argv[0]:-$comm}")
+  case "$name" in codex|pi|grok|claude|opencode) return 0 ;; esac
+  name=$(basename "$comm")
+  case "$name" in codex|pi|grok|claude|opencode) return 0 ;; esac
+  case "$(basename "${argv[0]:-}")" in
+    node|nodejs|python|python[0-9]|python[0-9].*)
+      name=$(basename "${argv[1]:-}")
+      case "$name" in codex|pi|grok|claude|opencode) return 0 ;; esac
+      ;;
+  esac
+  return 1
+}
 
 harness_pid() {
-  local pid=$$ comm args
+  local pid=$$
   for _ in 1 2 3 4 5 6 7 8; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-    args=$(ps -o args= -p "$pid" 2>/dev/null)
-    if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
-      echo "$pid"; return 0
-    fi
-    # Bare interpreter (e.g. node): match the harness name in its script path.
-    case "$comm" in
-      *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
-    esac
+    process_harness "$pid" && { echo "$pid"; return 0; }
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
   done
   return 1
 }
 
-holder_alive() {  # true if $1 is a live process that looks like a harness
-  local pid=$1 comm args
+holder_alive() {
+  local pid=$1
   case "$pid" in ''|*[!0-9]*|1) return 1 ;; esac
   kill -0 "$pid" 2>/dev/null || return 1
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  args=$(ps -o args= -p "$pid" 2>/dev/null) || return 1
-  if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
-    return 0
-  fi
-  case "$comm" in
-    *node*|*python*|*sleep*) printf '%s' "$args" | grep -qE '(^|[ /])(claude|codex|opencode|grok|pi)([ /]|$)' ;;
-    *) return 1 ;;
-  esac
+  process_harness "$pid"
 }
 
 if [ "$MODE" = status ]; then

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -5,6 +5,8 @@
 # PID of any one tool call, which is dead moments after it is written.
 # Usage: fm-lock.sh           acquire; exit 1 if another live session holds it
 #        fm-lock.sh status    print holder and liveness; always exits 0
+#        fm-lock.sh live-pid  print only a live holder PID; exit 1 otherwise
+# live-pid is read-only: it does not create state directories or repair locks.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,7 +14,9 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 LOCK="$STATE/.lock"
-mkdir -p "$STATE"
+MODE=${1:-acquire}
+case "$MODE" in acquire|status|live-pid) ;; *) echo "error: usage: fm-lock.sh [status|live-pid]" >&2; exit 2 ;; esac
+[ "$MODE" != acquire ] || mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
 HARNESS_RE='claude|codex|opencode|grok|^pi$'
@@ -37,15 +41,23 @@ harness_pid() {
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
   local pid=$1 comm
+  case "$pid" in ''|*[!0-9]*|1) return 1 ;; esac
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
 }
 
-if [ "${1:-}" = "status" ]; then
+if [ "$MODE" = status ]; then
   if [ ! -f "$LOCK" ]; then echo "lock: free"; exit 0; fi
   old=$(cat "$LOCK")
   if holder_alive "$old"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
+  exit 0
+fi
+if [ "$MODE" = live-pid ]; then
+  [ -f "$LOCK" ] || exit 1
+  old=$(cat "$LOCK")
+  holder_alive "$old" || exit 1
+  printf '%s\n' "$old"
   exit 0
 fi
 

--- a/bin/fm-primary-launch.sh
+++ b/bin/fm-primary-launch.sh
@@ -178,7 +178,7 @@ attach_session() {
     printf 'attached: session=%s home=%s harness=%s\n' "$SESSION" "$FM_HOME_FIXED" "$HARNESS"
     return 0
   fi
-  if [ -n "${FM_PRIMARY_TMUX_SOCKET:-}" ]; then
+  if [ "$TEST_MODE" = 1 ] && [ -n "${FM_PRIMARY_TMUX_SOCKET:-}" ]; then
     exec tmux -L "$FM_PRIMARY_TMUX_SOCKET" attach-session -t "$SESSION"
   fi
   exec tmux attach-session -t "$SESSION"

--- a/bin/fm-primary-launch.sh
+++ b/bin/fm-primary-launch.sh
@@ -112,18 +112,53 @@ pid_harness() {
   return 1
 }
 
-session_harness() {
-  local recorded pane_pid
-  recorded=$(session_option '@firstmate_harness')
-  if [ -n "$recorded" ]; then
-    printf '%s\n' "$recorded"
-    return 0
-  fi
+session_pane_pid() {
+  local pane_pid
   pane_pid=$(tmux_cmd display-message -p -t "$SESSION":0.0 '#{pane_pid}' 2>/dev/null || true)
   case "$pane_pid" in
     ''|*[!0-9]*) return 1 ;;
   esac
-  pid_harness "$pane_pid"
+  printf '%s\n' "$pane_pid"
+}
+
+pid_belongs_to_pane() {
+  local pid=$1 pane_pid=$2 ppid
+  while [ "$pid" -gt 1 ]; do
+    [ "$pid" = "$pane_pid" ] && return 0
+    ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') || return 1
+    case "$ppid" in ''|*[!0-9]*) return 1 ;; esac
+    pid=$ppid
+  done
+  return 1
+}
+
+verify_session() {
+  local recorded_home recorded_harness lock_pid pane_pid live lock_harness
+  recorded_home=$(session_option '@firstmate_home')
+  [ "$recorded_home" = "$FM_HOME_FIXED" ] || fail "tmux session '$SESSION' is not verified for $FM_HOME_FIXED; no state was changed"
+  recorded_harness=$(session_option '@firstmate_harness')
+  case "$recorded_harness" in codex|pi|grok|claude|opencode) ;; *) fail "tmux session '$SESSION' has no verified harness routing metadata; no state was changed" ;; esac
+  [ "$recorded_harness" = "$HARNESS" ] || refuse_running "$recorded_harness" "$HARNESS"
+  lock_pid=$(live_lock_pid || true)
+  [ -n "$lock_pid" ] || fail "tmux session '$SESSION' has no authoritative live lock for $FM_HOME_FIXED; no state was changed"
+  pane_pid=$(session_pane_pid || true)
+  [ -n "$pane_pid" ] || fail "cannot verify the live harness in tmux session '$SESSION'; no state was changed"
+  live=$(pid_harness "$pane_pid" || true)
+  [ -n "$live" ] || fail "cannot verify the live harness in tmux session '$SESSION'; no state was changed"
+  [ "$live" = "$HARNESS" ] || refuse_running "$live" "$HARNESS"
+  pid_belongs_to_pane "$lock_pid" "$pane_pid" || fail "tmux session '$SESSION' does not own the authoritative live lock for $FM_HOME_FIXED; no state was changed"
+  lock_harness=$(pid_harness "$lock_pid" || true)
+  [ "$lock_harness" = "$HARNESS" ] || fail "the authoritative live lock does not match $(harness_label "$HARNESS"); no state was changed"
+}
+
+wait_for_session_lock() {
+  local -i attempt=0
+  while [ "$attempt" -lt 250 ]; do
+    live_lock_pid >/dev/null && return 0
+    attempt=$((attempt + 1))
+    sleep 0.02
+  done
+  return 1
 }
 
 refuse_running() {
@@ -262,16 +297,7 @@ exec 9>"$launch_lock"
 flock 9
 
 if tmux_cmd has-session -t "$SESSION" 2>/dev/null; then
-  recorded_home=$(session_option '@firstmate_home')
-  if [ -n "$recorded_home" ] && [ "$recorded_home" != "$FM_HOME_FIXED" ]; then
-    fail "tmux session '$SESSION' belongs to another Firstmate home ($recorded_home)"
-  fi
-  live=$(session_harness || true)
-  if [ -n "$live" ]; then
-    [ "$live" = "$HARNESS" ] || refuse_running "$live" "$HARNESS"
-  elif [ "$EXPLICIT" -eq 1 ]; then
-    fail "cannot verify which harness owns the existing '$SESSION' session; no state was changed"
-  fi
+  verify_session
   ensure_daemon
   flock -u 9
   attach_session
@@ -311,5 +337,10 @@ fi
 tmux_cmd new-session -d -s "$SESSION" -c "$FM_ROOT" "${TMUX_ENV[@]}" "exec '$FM_ROOT/bin/fm-primary-launch.sh' __run"
 tmux_cmd set-option -q -t "$SESSION" @firstmate_home "$FM_HOME_FIXED"
 tmux_cmd set-option -q -t "$SESSION" @firstmate_harness "$HARNESS"
+if ! wait_for_session_lock; then
+  tmux_cmd kill-session -t "$SESSION" 2>/dev/null || true
+  fail "new '$SESSION' session did not acquire the authoritative live lock"
+fi
+verify_session
 flock -u 9
 attach_session

--- a/bin/fm-primary-launch.sh
+++ b/bin/fm-primary-launch.sh
@@ -83,22 +83,33 @@ ensure_daemon() {
   fi
 }
 
+process_harness() {
+  local pid=$1 comm name
+  local -a argv=()
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+  mapfile -d '' -t argv < "/proc/$pid/cmdline" 2>/dev/null || return 1
+  name=$(basename "${argv[0]:-$comm}")
+  case "$name" in codex|pi|grok|claude|opencode) printf '%s\n' "$name"; return 0 ;; esac
+  name=$(basename "$comm")
+  case "$name" in codex|pi|grok|claude|opencode) printf '%s\n' "$name"; return 0 ;; esac
+  case "$(basename "${argv[0]:-}")" in
+    node|nodejs|python|python[0-9]|python[0-9].*)
+      name=$(basename "${argv[1]:-}")
+      case "$name" in codex|pi|grok|claude|opencode) printf '%s\n' "$name"; return 0 ;; esac
+      ;;
+  esac
+  return 1
+}
+
 pid_harness() {
-  local root_pid=$1 pid ppid comm args candidates
+  local root_pid=$1 pid ppid live candidates
   local -i depth=0
   candidates=$root_pid
   while [ "$depth" -lt 8 ]; do
     depth=$((depth + 1))
     for pid in $candidates; do
-      comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
-      args=$(ps -o args= -p "$pid" 2>/dev/null || true)
-      case "$(basename "$comm") $args" in
-        *opencode*) printf 'opencode\n'; return 0 ;;
-        *claude*) printf 'claude\n'; return 0 ;;
-        *codex*) printf 'codex\n'; return 0 ;;
-        *grok*) printf 'grok\n'; return 0 ;;
-        *'/pi '*|*' pi '*|pi\ *) printf 'pi\n'; return 0 ;;
-      esac
+      live=$(process_harness "$pid" || true)
+      [ -z "$live" ] || { printf '%s\n' "$live"; return 0; }
     done
     candidates=
     while read -r pid ppid; do

--- a/bin/fm-primary-launch.sh
+++ b/bin/fm-primary-launch.sh
@@ -84,21 +84,7 @@ ensure_daemon() {
 }
 
 process_harness() {
-  local pid=$1 comm name
-  local -a argv=()
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
-  mapfile -d '' -t argv < "/proc/$pid/cmdline" 2>/dev/null || return 1
-  name=$(basename "${argv[0]:-$comm}")
-  case "$name" in codex|pi|grok|claude|opencode) printf '%s\n' "$name"; return 0 ;; esac
-  name=$(basename "$comm")
-  case "$name" in codex|pi|grok|claude|opencode) printf '%s\n' "$name"; return 0 ;; esac
-  case "$(basename "${argv[0]:-}")" in
-    node|nodejs|python|python[0-9]|python[0-9].*)
-      name=$(basename "${argv[1]:-}")
-      case "$name" in codex|pi|grok|claude|opencode) printf '%s\n' "$name"; return 0 ;; esac
-      ;;
-  esac
-  return 1
+  "$FM_ROOT/bin/fm-harness-process.sh" "$1"
 }
 
 pid_harness() {

--- a/bin/fm-primary-launch.sh
+++ b/bin/fm-primary-launch.sh
@@ -130,12 +130,20 @@ pid_belongs_to_pane() {
 }
 
 verify_session() {
-  local recorded_home recorded_harness lock_pid pane_pid live lock_harness
+  local recorded_home recorded_harness recorded_model recorded_effort lock_pid pane_pid live lock_harness
   recorded_home=$(session_option '@firstmate_home')
   [ "$recorded_home" = "$FM_HOME_FIXED" ] || fail "tmux session '$SESSION' is not verified for $FM_HOME_FIXED; no state was changed"
   recorded_harness=$(session_option '@firstmate_harness')
   case "$recorded_harness" in codex|pi|grok|claude|opencode) ;; *) fail "tmux session '$SESSION' has no verified harness routing metadata; no state was changed" ;; esac
   [ "$recorded_harness" = "$HARNESS" ] || refuse_running "$recorded_harness" "$HARNESS"
+  recorded_model=$(session_option '@firstmate_model')
+  recorded_effort=$(session_option '@firstmate_effort')
+  if [ "$MODEL_SET" -eq 1 ] && [ "$recorded_model" != "$MODEL" ]; then
+    fail "Firstmate is already running on $(harness_label "$HARNESS") with a different model profile; no state was changed"
+  fi
+  if [ "$EFFORT_SET" -eq 1 ] && [ "$recorded_effort" != "$EFFORT" ]; then
+    fail "Firstmate is already running on $(harness_label "$HARNESS") with a different effort profile; no state was changed"
+  fi
   lock_pid=$(live_lock_pid || true)
   [ -n "$lock_pid" ] || fail "tmux session '$SESSION' has no authoritative live lock for $FM_HOME_FIXED; no state was changed"
   pane_pid=$(session_pane_pid || true)
@@ -177,11 +185,16 @@ attach_session() {
 }
 
 require_native_harness() {
-  local executable
+  local executable resolved executable_lower resolved_lower
   executable=$(command -v "$HARNESS" 2>/dev/null || true)
   [ -n "$executable" ] || fail "native WSL/Linux harness '$HARNESS' is not installed"
-  case "$executable" in
-    /mnt/[a-zA-Z]/*|*.exe) fail "'$HARNESS' resolves to a Windows executable ($executable); install a native WSL/Linux build" ;;
+  resolved=$(readlink -f "$executable" 2>/dev/null) || fail "cannot resolve harness executable: $executable"
+  executable_lower=$(printf '%s' "$executable" | tr '[:upper:]' '[:lower:]')
+  resolved_lower=$(printf '%s' "$resolved" | tr '[:upper:]' '[:lower:]')
+  case "$executable_lower|$resolved_lower" in
+    /mnt/[a-z]/*|*\|/mnt/[a-z]/*|*.exe\|*|*\|*.exe)
+      fail "'$HARNESS' resolves to a Windows executable ($resolved); install a native WSL/Linux build"
+      ;;
   esac
 }
 
@@ -334,6 +347,8 @@ fi
 tmux_cmd new-session -d -s "$SESSION" -c "$FM_ROOT" "${TMUX_ENV[@]}" "exec '$FM_ROOT/bin/fm-primary-launch.sh' __run"
 tmux_cmd set-option -q -t "$SESSION" @firstmate_home "$FM_HOME_FIXED"
 tmux_cmd set-option -q -t "$SESSION" @firstmate_harness "$HARNESS"
+tmux_cmd set-option -q -t "$SESSION" @firstmate_model "$MODEL"
+tmux_cmd set-option -q -t "$SESSION" @firstmate_effort "$EFFORT"
 if ! wait_for_session_lock; then
   tmux_cmd kill-session -t "$SESSION" 2>/dev/null || true
   fail "new '$SESSION' session did not acquire the authoritative live lock"

--- a/bin/fm-primary-launch.sh
+++ b/bin/fm-primary-launch.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# Launch or attach the one tmux-backed primary Firstmate session for this home.
+# This file owns selector parsing, harness argv, compatibility checks, and exact
+# Linux-side launch mechanics for the Windows wrapper in windows/firstmate.*.
+#
+# Usage:
+#   fm-primary-launch.sh
+#   fm-primary-launch.sh --codex|--pi|--grok|--claude|--opencode
+#                        [--model <model>] [--effort <level>]
+#
+# Bare launch selects Codex with its backwards-compatible unrestricted posture.
+# A selector changes only the primary harness; model and effort are optional
+# independent axes. Raw harness arguments and positional prompts are rejected.
+# Existing same-home sessions may be attached only when their harness is
+# compatible. state/.lock remains authoritative; tmux user options are routing
+# metadata. Stale locks are never removed here.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRODUCTION_ROOT=/home/firstmate/firstmate
+PRODUCTION_HOME=/home/firstmate/firstmate
+PRODUCTION_USER=firstmate
+SESSION=firstmate
+GROK_INSTRUCTION='Run bin/fm-session-start.sh exactly once before doing anything else.'
+
+TEST_MODE=0
+if [ "${FM_PRIMARY_LAUNCH_TESTING:-}" = 1 ] && [ "$SCRIPT_DIR" != "$PRODUCTION_ROOT/bin" ]; then
+  TEST_MODE=1
+  FM_ROOT=${FM_PRIMARY_ROOT_OVERRIDE:-$PRODUCTION_ROOT}
+  FM_HOME_FIXED=${FM_PRIMARY_HOME_OVERRIDE:-$PRODUCTION_HOME}
+  REQUIRED_USER=${FM_PRIMARY_USER_OVERRIDE:-$PRODUCTION_USER}
+  SESSION=${FM_PRIMARY_SESSION_OVERRIDE:-$SESSION}
+else
+  FM_ROOT=$PRODUCTION_ROOT
+  FM_HOME_FIXED=$PRODUCTION_HOME
+  REQUIRED_USER=$PRODUCTION_USER
+fi
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 2
+}
+
+harness_label() {
+  case "$1" in
+    codex) printf 'Codex' ;;
+    pi) printf 'Pi' ;;
+    grok) printf 'Grok' ;;
+    claude) printf 'Claude' ;;
+    opencode) printf 'OpenCode' ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+tmux_cmd() {
+  if [ "$TEST_MODE" = 1 ] && [ -n "${FM_PRIMARY_TMUX_SOCKET:-}" ]; then
+    tmux -L "$FM_PRIMARY_TMUX_SOCKET" "$@"
+  else
+    tmux "$@"
+  fi
+}
+
+session_option() {
+  tmux_cmd show-options -qv -t "$SESSION" "$1" 2>/dev/null || true
+}
+
+live_lock_pid() {
+  FM_HOME="$FM_HOME_FIXED" FM_ROOT_OVERRIDE="$FM_ROOT" "$FM_ROOT/bin/fm-lock.sh" live-pid 2>/dev/null
+}
+
+ensure_daemon() {
+  command -v no-mistakes >/dev/null 2>&1 || fail 'no-mistakes is required'
+  if ! no-mistakes daemon status 2>&1 | grep -q 'daemon running'; then
+    no-mistakes daemon start || fail 'could not start the no-mistakes daemon'
+  fi
+}
+
+pid_harness() {
+  local root_pid=$1 pid ppid comm args candidates
+  local -i depth=0
+  candidates=$root_pid
+  while [ "$depth" -lt 8 ]; do
+    depth=$((depth + 1))
+    for pid in $candidates; do
+      comm=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+      args=$(ps -o args= -p "$pid" 2>/dev/null || true)
+      case "$(basename "$comm") $args" in
+        *opencode*) printf 'opencode\n'; return 0 ;;
+        *claude*) printf 'claude\n'; return 0 ;;
+        *codex*) printf 'codex\n'; return 0 ;;
+        *grok*) printf 'grok\n'; return 0 ;;
+        *'/pi '*|*' pi '*|pi\ *) printf 'pi\n'; return 0 ;;
+      esac
+    done
+    candidates=
+    while read -r pid ppid; do
+      case " $root_pid " in
+        *" $ppid "*) candidates="$candidates $pid" ;;
+      esac
+    done < <(ps -eo pid=,ppid= 2>/dev/null)
+    [ -n "$candidates" ] || break
+    root_pid="$root_pid $candidates"
+  done
+  return 1
+}
+
+session_harness() {
+  local recorded pane_pid
+  recorded=$(session_option '@firstmate_harness')
+  if [ -n "$recorded" ]; then
+    printf '%s\n' "$recorded"
+    return 0
+  fi
+  pane_pid=$(tmux_cmd display-message -p -t "$SESSION":0.0 '#{pane_pid}' 2>/dev/null || true)
+  case "$pane_pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  pid_harness "$pane_pid"
+}
+
+refuse_running() {
+  local live=$1 requested=$2
+  printf 'Firstmate is already running on %s for %s.\n' "$(harness_label "$live")" "$FM_HOME_FIXED" >&2
+  printf 'Exit that primary session before starting %s; no state was changed.\n' "$(harness_label "$requested")" >&2
+  exit 1
+}
+
+attach_session() {
+  if [ "$TEST_MODE" = 1 ] && [ "${FM_PRIMARY_NO_ATTACH:-}" = 1 ]; then
+    printf 'attached: session=%s home=%s harness=%s\n' "$SESSION" "$FM_HOME_FIXED" "$HARNESS"
+    return 0
+  fi
+  if [ -n "${FM_PRIMARY_TMUX_SOCKET:-}" ]; then
+    exec tmux -L "$FM_PRIMARY_TMUX_SOCKET" attach-session -t "$SESSION"
+  fi
+  exec tmux attach-session -t "$SESSION"
+}
+
+require_native_harness() {
+  local executable
+  executable=$(command -v "$HARNESS" 2>/dev/null || true)
+  [ -n "$executable" ] || fail "native WSL/Linux harness '$HARNESS' is not installed"
+  case "$executable" in
+    /mnt/[a-zA-Z]/*|*.exe) fail "'$HARNESS' resolves to a Windows executable ($executable); install a native WSL/Linux build" ;;
+  esac
+}
+
+run_harness() {
+  local executable=$HARNESS
+  local -a argv
+  argv=()
+  require_native_harness
+  case "$HARNESS" in
+    codex)
+      argv+=(--dangerously-bypass-approvals-and-sandbox)
+      [ -z "$MODEL" ] || argv+=(--model "$MODEL")
+      [ -z "$EFFORT" ] || argv+=(-c "model_reasoning_effort=\"$EFFORT\"")
+      ;;
+    pi)
+      [ -z "$MODEL" ] || argv+=(--model "$MODEL")
+      [ -z "$EFFORT" ] || argv+=(--thinking "$EFFORT")
+      ;;
+    grok)
+      argv+=(--trust)
+      [ -z "$MODEL" ] || argv+=(--model "$MODEL")
+      [ -z "$EFFORT" ] || argv+=(--reasoning-effort "$EFFORT")
+      argv+=("$GROK_INSTRUCTION")
+      ;;
+    claude)
+      [ -z "$MODEL" ] || argv+=(--model "$MODEL")
+      [ -z "$EFFORT" ] || argv+=(--effort "$EFFORT")
+      ;;
+    opencode)
+      [ -z "$MODEL" ] || argv+=(--model "$MODEL")
+      ;;
+    *) fail "internal unsupported harness '$HARNESS'" ;;
+  esac
+  export FM_HOME=$FM_HOME_FIXED
+  cd "$FM_ROOT"
+  exec "$executable" "${argv[@]}"
+}
+
+if [ "${1:-}" = __run ] && [ "${FM_PRIMARY_LAUNCH_INTERNAL:-}" = 1 ]; then
+  HARNESS=${FM_PRIMARY_HARNESS:-}
+  MODEL=${FM_PRIMARY_MODEL:-}
+  EFFORT=${FM_PRIMARY_EFFORT:-}
+  case "$HARNESS" in codex|pi|grok|claude|opencode) ;; *) fail 'invalid internal harness' ;; esac
+  case "$EFFORT" in ''|low|medium|high|xhigh|max) ;; *) fail 'invalid internal effort' ;; esac
+  case "$HARNESS:$EFFORT" in codex:max|grok:xhigh|grok:max|opencode:?*) fail 'unsupported internal effort' ;; esac
+  [ "$(id -un)" = "$REQUIRED_USER" ] || fail "run this launcher as Linux user $REQUIRED_USER"
+  if [ "$TEST_MODE" != 1 ] && [ "${WSL_DISTRO_NAME:-}" != Ubuntu ]; then
+    fail 'run this launcher in WSL distribution Ubuntu'
+  fi
+  run_harness
+fi
+
+HARNESS=codex
+MODEL=
+EFFORT=
+EXPLICIT=0
+MODEL_SET=0
+EFFORT_SET=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --codex|--pi|--grok|--claude|--opencode)
+      [ "$EXPLICIT" -eq 0 ] || fail 'pass exactly one harness selector'
+      HARNESS=${1#--}
+      EXPLICIT=1
+      shift
+      ;;
+    --model|--effort)
+      option=$1
+      [ "$#" -gt 1 ] || fail "$option requires a value"
+      case "$2" in --*) fail "$option requires a value" ;; esac
+      [ -n "$2" ] || fail "$option requires a non-empty value"
+      if [ "$option" = --model ]; then
+        [ "$MODEL_SET" -eq 0 ] || fail '--model may be passed only once'
+        MODEL=$2
+        MODEL_SET=1
+      else
+        [ "$EFFORT_SET" -eq 0 ] || fail '--effort may be passed only once'
+        EFFORT=$2
+        EFFORT_SET=1
+      fi
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    --*) fail "unknown option $1" ;;
+    *) fail 'positional prompts and raw harness arguments are not supported' ;;
+  esac
+done
+
+if [ "$MODEL_SET" -eq 1 ] || [ "$EFFORT_SET" -eq 1 ]; then
+  [ "$EXPLICIT" -eq 1 ] || fail '--model and --effort require an explicit harness selector'
+fi
+case "$EFFORT" in ''|low|medium|high|xhigh|max) ;; *) fail '--effort must be one of low, medium, high, xhigh, max' ;; esac
+case "$HARNESS:$EFFORT" in
+  codex:max) fail 'Codex does not support effort max; use low, medium, high, or xhigh' ;;
+  grok:xhigh|grok:max) fail 'Grok supports effort low, medium, or high' ;;
+  opencode:?*) fail 'OpenCode interactive-primary effort selection is not verified' ;;
+esac
+
+[ "$(id -un)" = "$REQUIRED_USER" ] || fail "run this launcher as Linux user $REQUIRED_USER"
+[ -d "$FM_ROOT" ] || fail "Firstmate repository root is missing: $FM_ROOT"
+if [ "$TEST_MODE" != 1 ] && [ "${WSL_DISTRO_NAME:-}" != Ubuntu ]; then
+  fail 'run this launcher in WSL distribution Ubuntu'
+fi
+command -v tmux >/dev/null 2>&1 || fail 'tmux is required'
+command -v flock >/dev/null 2>&1 || fail 'flock is required'
+
+lock_key=$(printf '%s' "$FM_HOME_FIXED" | cksum | awk '{print $1}')
+launch_lock="${XDG_RUNTIME_DIR:-/tmp}/firstmate-primary-launch-$UID-$lock_key.lock"
+exec 9>"$launch_lock"
+flock 9
+
+if tmux_cmd has-session -t "$SESSION" 2>/dev/null; then
+  recorded_home=$(session_option '@firstmate_home')
+  if [ -n "$recorded_home" ] && [ "$recorded_home" != "$FM_HOME_FIXED" ]; then
+    fail "tmux session '$SESSION' belongs to another Firstmate home ($recorded_home)"
+  fi
+  live=$(session_harness || true)
+  if [ -n "$live" ]; then
+    [ "$live" = "$HARNESS" ] || refuse_running "$live" "$HARNESS"
+  elif [ "$EXPLICIT" -eq 1 ]; then
+    fail "cannot verify which harness owns the existing '$SESSION' session; no state was changed"
+  fi
+  ensure_daemon
+  flock -u 9
+  attach_session
+  exit 0
+fi
+
+if lock_pid=$(live_lock_pid); then
+  lock_harness=$(pid_harness "$lock_pid" || true)
+  if [ -n "$lock_harness" ]; then
+    printf 'Firstmate has a live %s session lock for %s, but no compatible tmux session exists.\n' "$(harness_label "$lock_harness")" "$FM_HOME_FIXED" >&2
+  else
+    printf 'Firstmate has a live session lock for %s (pid %s), but no compatible tmux session exists.\n' "$FM_HOME_FIXED" "$lock_pid" >&2
+  fi
+  printf 'Exit the live primary session before launching another; the lock was not changed.\n' >&2
+  exit 1
+fi
+
+require_native_harness
+ensure_daemon
+
+TMUX_ENV=(
+  -e "FM_HOME=$FM_HOME_FIXED"
+  -e "FM_PRIMARY_LAUNCH_INTERNAL=1"
+  -e "FM_PRIMARY_HARNESS=$HARNESS"
+  -e "FM_PRIMARY_MODEL=$MODEL"
+  -e "FM_PRIMARY_EFFORT=$EFFORT"
+)
+if [ "$TEST_MODE" = 1 ]; then
+  TMUX_ENV+=(
+    -e 'FM_PRIMARY_LAUNCH_TESTING=1'
+    -e "FM_PRIMARY_ROOT_OVERRIDE=$FM_ROOT"
+    -e "FM_PRIMARY_HOME_OVERRIDE=$FM_HOME_FIXED"
+    -e "FM_PRIMARY_USER_OVERRIDE=$REQUIRED_USER"
+  )
+fi
+
+tmux_cmd new-session -d -s "$SESSION" -c "$FM_ROOT" "${TMUX_ENV[@]}" "exec '$FM_ROOT/bin/fm-primary-launch.sh' __run"
+tmux_cmd set-option -q -t "$SESSION" @firstmate_home "$FM_HOME_FIXED"
+tmux_cmd set-option -q -t "$SESSION" @firstmate_harness "$HARNESS"
+flock -u 9
+attach_session

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -148,7 +148,7 @@ family_for_basename() {
       printf '%s\n' secondmate
       ;;
     fm-bootstrap.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
-    fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-tangle-guard.test.sh|\
+    fm-primary-launch.test.sh|fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-tangle-guard.test.sh|\
     fm-update.test.sh)
       printf '%s\n' session-bootstrap
       ;;

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -655,7 +655,7 @@ families_for_changed_path() {
       printf '%s\n' secondmate
       ;;
     bin/fm-session-start.sh|bin/fm-bootstrap.sh|bin/fm-fleet-sync.sh|\
-    bin/fm-sessionstart-nudge.sh|bin/fm-tangle*|bin/fm-update.sh|\
+    bin/fm-sessionstart-nudge.sh|bin/fm-primary-launch.sh|bin/fm-tangle*|bin/fm-update.sh|\
     bin/fm-gate-refuse*|bin/fm-lock*)
       printf '%s\n' session-bootstrap
       ;;

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -123,7 +123,7 @@ family_for_basename() {
     fm-dispatch-select.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
-    fm-pi-primary-types.test.sh|\
+    fm-pi-primary-types.test.sh|fm-primary-windows.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-tmux-submit-busy.test.sh|fm-transition-lib.test.sh|\
@@ -601,6 +601,9 @@ families_for_changed_path() {
   local path=$1
   case "$path" in
     tests/fm-test-run.test.sh)
+      printf '%s\n' pure-contract-unit
+      ;;
+    tests/fm-primary-windows.test.ps1|windows/firstmate.ps1|windows/firstmate.cmd)
       printf '%s\n' pure-contract-unit
       ;;
     tests/fm-backend-herdr-eventwait.test.py)

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -26,6 +26,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-test-isolation-proof.sh` | Phase 2 concurrent isolation proof and proven-isolated candidate set owner |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
+| `fm-primary-launch.sh`   | Launch or compatibly attach the fixed-home tmux primary with an explicit harness profile |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
@@ -85,7 +86,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
-| `fm-lock.sh`             | Per-home firstmate session lock                                                      |
+| `fm-lock.sh`             | Per-home firstmate session lock and read-only live-holder query                       |
 | `fm-x-lib.sh`            | Shared X-mode config, relay, and reply-threading helpers                             |
 | `fm-x-poll.sh`           | One bounded X relay poll: stash newly offered mentions and emit their once-only wake |
 | `fm-x-reply.sh`          | Post or dry-run preview a composed X-mode reply or follow-up                         |

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -238,18 +238,19 @@ unit_lock_initialization_grace() {
 }
 
 unit_signal_exits_with_lock_cleanup() {
-  local st marker child
+  local st marker started child
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-signal.XXXXXX")
   marker="$st/resumed"
-  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+  started="$st/started"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" STARTED="$started" bash -c '
     . "$1"
-    fm_afk_launch_start() { sleep 30; }
+    fm_afk_launch_start() { : > "$STARTED"; while :; do sleep 0.1; done; }
     fm_afk_launch_main start
     : > "$2"
   ' _ "$LAUNCH" "$marker" &
   child=$!
   for _ in $(seq 1 40); do
-    [ -d "$st/state/.afk-launch.lock" ] && break
+    [ -e "$started" ] && break
     sleep 0.05
   done
   kill -TERM "$child" 2>/dev/null || true

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -118,21 +118,17 @@ EOF
 }
 
 test_fm_lock_recognizes_grok_holder() {
-  local home fakebin out
+  local home fakebin out grok_pid
   home="$TMP_ROOT/lock-home"
   fakebin=$(fm_fakebin "$TMP_ROOT/lock-fake")
   mkdir -p "$home/state"
-  printf '%s\n' "$$" > "$home/state/.lock"
-  cat > "$fakebin/ps" <<'SH'
-#!/usr/bin/env bash
-case "$*" in
-  *"comm="*) printf '%s\n' '/usr/local/bin/grok'; exit 0 ;;
-  *"args="*) printf '%s\n' 'grok'; exit 0 ;;
-esac
-exit 1
-SH
-  chmod +x "$fakebin/ps"
+  cp /usr/bin/python3 "$fakebin/grok"
+  "$fakebin/grok" -c 'import time; time.sleep(30)' &
+  grok_pid=$!
+  printf '%s\n' "$grok_pid" > "$home/state/.lock"
   out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  kill "$grok_pid" 2>/dev/null || true
+  wait "$grok_pid" 2>/dev/null || true
   assert_contains "$out" "lock: held by live harness pid" "fm-lock did not recognize grok as a live holder"
   pass "fm-lock recognizes grok harness processes"
 }

--- a/tests/fm-primary-launch.test.sh
+++ b/tests/fm-primary-launch.test.sh
@@ -30,6 +30,9 @@ make_case() {
   cp "$LAUNCH" "$home/bin/fm-primary-launch.sh"
   cp "$ROOT/bin/fm-lock.sh" "$home/bin/fm-lock.sh"
   chmod +x "$home/bin/"*.sh
+  cat > "$home/bin/pi" <<'JS'
+setInterval(() => {}, 300000)
+JS
   printf '%s\n' "$socket" > "$dir/socket-name"
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
@@ -272,6 +275,30 @@ EOF
   pass "fm-lock live-pid recognizes supported harnesses without mutation"
 }
 
+test_tracked_scripts_are_executable() {
+  [ -x "$ROOT/bin/fm-primary-launch.sh" ] || fail "primary launcher is not executable"
+  [ -x "$ROOT/bin/fm-lock.sh" ] || fail "session lock helper is not executable"
+  pass "tracked primary launcher and lock helper are executable"
+}
+
+test_node_hosted_pi_process_identity() {
+  local rec dir home fakebin socket out pane_pid
+  rec=$(make_case node-pi)
+  IFS='|' read -r dir home fakebin socket <<EOF
+$rec
+EOF
+  tmux -L "$socket" new-session -d -s firstmate "exec node '$home/bin/pi' --model openai-codex/gpt-5.6-sol"
+  tmux -L "$socket" set-option -q -t firstmate @firstmate_home "$home"
+  tmux -L "$socket" set-option -q -t firstmate @firstmate_harness pi
+  pane_pid=$(tmux -L "$socket" display-message -p -t firstmate:0.0 '#{pane_pid}')
+  printf '%s\n' "$pane_pid" > "$home/state/.lock"
+  out=$(run_launch "$home" "$fakebin" "$socket" "$dir/unused.log" --pi)
+  assert_contains "$out" 'harness=pi' "Node-hosted Pi with Codex model was misclassified"
+  [ ! -e "$dir/unused.log" ] || fail "Node-hosted Pi attach launched another harness"
+  kill_case "$socket"
+  pass "Node-hosted Pi identity ignores model argument substrings"
+}
+
 test_existing_session_requires_positive_identity() {
   local rec dir home fakebin socket out status log pane_pid holder
   rec=$(make_case session-identity)
@@ -309,10 +336,12 @@ EOF
   pass "existing sessions require matching home, lock, metadata, and live process"
 }
 
+test_tracked_scripts_are_executable
 test_parsing_rejections
 test_harness_argv_and_invariants
 test_bare_and_matching_attach_divergent_refusal
 test_live_and_stale_lock_behavior
 test_concurrent_launch_serialization
 test_lock_live_pid_query_is_read_only
+test_node_hosted_pi_process_identity
 test_existing_session_requires_positive_identity

--- a/tests/fm-primary-launch.test.sh
+++ b/tests/fm-primary-launch.test.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Behavior tests for the same-home primary launcher: strict parsing, opaque argv,
+# fixed home/cwd/session routing, compatible attach, lock refusal, and races.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-primary-launch)
+LAUNCH="$ROOT/bin/fm-primary-launch.sh"
+USER_NAME=$(id -un)
+
+cleanup_tmux() {
+  local marker socket
+  while IFS= read -r marker; do
+    socket=$(cat "$marker")
+    tmux -L "$socket" kill-server 2>/dev/null || true
+  done < <(find "$TMP_ROOT" -name socket-name -type f 2>/dev/null)
+  fm_test_cleanup
+}
+trap cleanup_tmux EXIT
+
+make_case() {
+  local name=$1 dir home fakebin socket harness
+  dir="$TMP_ROOT/$name"
+  home="$dir/home"
+  fakebin="$dir/fakebin"
+  socket="fm-primary-${name//[^a-zA-Z0-9]/}-$$"
+  mkdir -p "$home/bin" "$home/state" "$fakebin"
+  cp "$LAUNCH" "$home/bin/fm-primary-launch.sh"
+  cp "$ROOT/bin/fm-lock.sh" "$home/bin/fm-lock.sh"
+  chmod +x "$home/bin/"*.sh
+  printf '%s\n' "$socket" > "$dir/socket-name"
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  'daemon status') printf '%s\n' 'daemon running'; exit 0 ;;
+  'daemon start') exit 0 ;;
+esac
+exit 2
+SH
+  chmod +x "$fakebin/no-mistakes"
+  for harness in codex pi grok claude opencode; do
+    cat > "$fakebin/$harness" <<'SH'
+#!/usr/bin/env bash
+set -u
+{
+  printf 'harness=%s\n' "$(basename "$0")"
+  printf 'user=%s\n' "$(id -un)"
+  printf 'cwd=%s\n' "$(pwd -P)"
+  printf 'home=%s\n' "${FM_HOME:-}"
+  printf 'argc=%s\n' "$#"
+  i=0
+  for arg in "$@"; do
+    printf 'argv[%s]=<%s>\n' "$i" "$arg"
+    i=$((i + 1))
+  done
+} > "${FM_PRIMARY_TEST_LOG:?}"
+exec sleep 300
+SH
+    chmod +x "$fakebin/$harness"
+  done
+  printf '%s|%s|%s|%s\n' "$dir" "$home" "$fakebin" "$socket"
+}
+
+run_launch() {
+  local home=$1 fakebin=$2 socket=$3 log=$4
+  shift 4
+  FM_PRIMARY_LAUNCH_TESTING=1 \
+    FM_PRIMARY_ROOT_OVERRIDE="$home" \
+    FM_PRIMARY_HOME_OVERRIDE="$home" \
+    FM_PRIMARY_USER_OVERRIDE="$USER_NAME" \
+    FM_PRIMARY_TMUX_SOCKET="$socket" \
+    FM_PRIMARY_NO_ATTACH=1 \
+    FM_PRIMARY_TEST_LOG="$log" \
+    PATH="$fakebin:$PATH" \
+    "$home/bin/fm-primary-launch.sh" "$@"
+}
+
+wait_for_file() {
+  local file=$1
+  local -i attempt=0
+  while [ "$attempt" -lt 100 ]; do
+    [ -f "$file" ] && return 0
+    attempt=$((attempt + 1))
+    sleep 0.02
+  done
+  return 1
+}
+
+kill_case() {
+  tmux -L "$1" kill-server 2>/dev/null || true
+}
+
+assert_rejected() {
+  local home=$1 fakebin=$2 socket=$3 expected=$4
+  shift 4
+  local out status
+  out=$(run_launch "$home" "$fakebin" "$socket" /dev/null "$@" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "launcher accepted rejected arguments: $*"
+  assert_contains "$out" "$expected" "launcher rejection was unclear for: $*"
+}
+
+test_parsing_rejections() {
+  local rec dir home fakebin socket
+  rec=$(make_case parsing)
+  IFS='|' read -r dir home fakebin socket <<EOF
+$rec
+EOF
+  assert_rejected "$home" "$fakebin" "$socket" 'positional prompts' hello
+  assert_rejected "$home" "$fakebin" "$socket" 'unknown option' --raw
+  assert_rejected "$home" "$fakebin" "$socket" 'exactly one harness selector' --pi --codex
+  assert_rejected "$home" "$fakebin" "$socket" 'requires a value' --pi --model
+  assert_rejected "$home" "$fakebin" "$socket" 'explicit harness selector' --model foo
+  assert_rejected "$home" "$fakebin" "$socket" 'must be one of' --pi --effort turbo
+  assert_rejected "$home" "$fakebin" "$socket" 'does not support effort max' --codex --effort max
+  assert_rejected "$home" "$fakebin" "$socket" 'supports effort low' --grok --effort xhigh
+  assert_rejected "$home" "$fakebin" "$socket" 'not verified' --opencode --effort low
+  pass "primary launcher rejects ambiguous and unsupported input"
+}
+
+test_harness_argv_and_invariants() {
+  local harness rec dir home fakebin socket log out expected model
+  # shellcheck disable=SC2016  # literal shell syntax is the hostile model fixture.
+  model='vendor/model $(touch nope); "quoted" * ?'
+  for harness in codex pi grok claude opencode; do
+    rec=$(make_case "argv-$harness")
+    IFS='|' read -r dir home fakebin socket <<EOF
+$rec
+EOF
+    log="$dir/argv.log"
+    case "$harness" in
+      opencode) out=$(run_launch "$home" "$fakebin" "$socket" "$log" "--$harness" --model "$model") ;;
+      grok) out=$(run_launch "$home" "$fakebin" "$socket" "$log" "--$harness" --model "$model" --effort high) ;;
+      *) out=$(run_launch "$home" "$fakebin" "$socket" "$log" "--$harness" --model "$model" --effort xhigh) ;;
+    esac
+    assert_contains "$out" "harness=$harness" "launcher did not publish selected harness"
+    wait_for_file "$log" || fail "$harness fake harness did not run"
+    assert_grep "harness=$harness" "$log" "$harness executable was not selected"
+    assert_grep "user=$USER_NAME" "$log" "$harness changed the Linux user"
+    assert_grep "cwd=$home" "$log" "$harness changed the repository root"
+    assert_grep "home=$home" "$log" "$harness changed FM_HOME"
+    assert_grep "<$model>" "$log" "$harness did not preserve model as one opaque argv element"
+    assert_absent "$home/nope" "hostile model executed shell source"
+    expected=$(tmux -L "$socket" show-options -qv -t firstmate @firstmate_home)
+    [ "$expected" = "$home" ] || fail "$harness session home metadata diverged"
+    expected=$(tmux -L "$socket" show-options -qv -t firstmate @firstmate_harness)
+    [ "$expected" = "$harness" ] || fail "$harness session harness metadata missing"
+    case "$harness" in
+      codex)
+        assert_grep '<--dangerously-bypass-approvals-and-sandbox>' "$log" "bare Codex autonomy posture was not preserved"
+        assert_grep '<model_reasoning_effort="xhigh">' "$log" "Codex effort argv was wrong"
+        ;;
+      pi) assert_grep '<--thinking>' "$log" "Pi thinking flag missing" ;;
+      grok)
+        assert_grep '<--trust>' "$log" "Grok normal project trust flag missing"
+        assert_grep '<--reasoning-effort>' "$log" "Grok reasoning effort flag missing"
+        assert_grep '<Run bin/fm-session-start.sh exactly once before doing anything else.>' "$log" "Grok fixed startup instruction missing"
+        ;;
+      claude) assert_grep '<--effort>' "$log" "Claude effort flag missing" ;;
+      opencode) assert_no_grep 'effort' "$log" "OpenCode received an effort flag" ;;
+    esac
+    kill_case "$socket"
+  done
+  pass "all primary selectors preserve identity and map only model and effort argv"
+}
+
+test_bare_and_matching_attach_divergent_refusal() {
+  local rec dir home fakebin socket log out status
+  rec=$(make_case attach)
+  IFS='|' read -r dir home fakebin socket <<EOF
+$rec
+EOF
+  log="$dir/argv.log"
+  out=$(run_launch "$home" "$fakebin" "$socket" "$log")
+  assert_contains "$out" 'harness=codex' "bare launch was not Codex"
+  wait_for_file "$log" || fail "bare Codex did not start"
+
+  out=$(run_launch "$home" "$fakebin" "$socket" "$dir/ignored.log" --codex)
+  assert_contains "$out" 'attached:' "matching selector did not attach"
+  [ ! -e "$dir/ignored.log" ] || fail "matching attach launched a second harness"
+
+  out=$(run_launch "$home" "$fakebin" "$socket" "$dir/divergent.log" --pi 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "divergent selector attached to Codex"
+  assert_contains "$out" 'already running on Codex' "divergent refusal did not name the live harness"
+  assert_contains "$out" 'no state was changed' "divergent refusal omitted mutation guarantee"
+  [ ! -e "$dir/divergent.log" ] || fail "divergent selector launched Pi"
+  kill_case "$socket"
+  pass "bare and matching selectors attach while divergent selectors refuse"
+}
+
+test_live_and_stale_lock_behavior() {
+  local rec dir home fakebin socket log out status holder
+  rec=$(make_case locks)
+  IFS='|' read -r dir home fakebin socket <<EOF
+$rec
+EOF
+  log="$dir/argv.log"
+  bash -c 'exec -a codex sleep 300' & holder=$!
+  printf '%s\n' "$holder" > "$home/state/.lock"
+  out=$(run_launch "$home" "$fakebin" "$socket" "$log" --codex 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "live same-home lock without tmux was ignored"
+  assert_contains "$out" 'live' "live-lock refusal was unclear"
+  [ "$(cat "$home/state/.lock")" = "$holder" ] || fail "launcher changed a live lock"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+
+  printf '999999\n' > "$home/state/.lock"
+  out=$(run_launch "$home" "$fakebin" "$socket" "$log" --pi)
+  assert_contains "$out" 'harness=pi' "stale lock did not hand off to normal session start"
+  [ "$(cat "$home/state/.lock")" = 999999 ] || fail "launcher removed or rewrote a stale lock"
+  wait_for_file "$log" || fail "Pi did not launch after stale lock"
+  kill_case "$socket"
+  pass "live locks refuse and stale locks remain for session-start authority"
+}
+
+test_concurrent_launch_serialization() {
+  local rec dir home fakebin socket log1 log2 out1 out2 pid1 pid2 count
+  rec=$(make_case race)
+  IFS='|' read -r dir home fakebin socket <<EOF
+$rec
+EOF
+  log1="$dir/one.log"
+  log2="$dir/two.log"
+  run_launch "$home" "$fakebin" "$socket" "$log1" --pi >"$dir/out1" 2>&1 & pid1=$!
+  run_launch "$home" "$fakebin" "$socket" "$log2" --pi >"$dir/out2" 2>&1 & pid2=$!
+  wait "$pid1" || fail "first concurrent launch failed"
+  wait "$pid2" || fail "second concurrent launch failed"
+  out1=$(cat "$dir/out1")
+  out2=$(cat "$dir/out2")
+  assert_contains "$out1$out2" 'attached:' "one concurrent caller did not attach"
+  count=0
+  [ -f "$log1" ] && count=$((count + 1))
+  [ -f "$log2" ] && count=$((count + 1))
+  [ "$count" -eq 1 ] || fail "concurrent launches created $count harness processes"
+  [ "$(tmux -L "$socket" list-sessions -F '#{session_name}' | grep -c '^firstmate$')" -eq 1 ] || fail "concurrent launch created multiple sessions"
+  kill_case "$socket"
+  pass "concurrent launch attempts serialize to one primary session"
+}
+
+test_lock_live_pid_query_is_read_only() {
+  local rec dir home fakebin socket out status holder
+  rec=$(make_case lock-query)
+  IFS='|' read -r dir home fakebin socket <<EOF
+$rec
+EOF
+  rm -rf "$home/state"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$home" "$home/bin/fm-lock.sh" live-pid 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "live-pid reported a missing lock as live"
+  assert_absent "$home/state" "read-only live-pid query created state"
+
+  mkdir -p "$home/state"
+  bash -c 'exec -a codex sleep 300' & holder=$!
+  printf '%s\n' "$holder" > "$home/state/.lock"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$home" "$home/bin/fm-lock.sh" live-pid)
+  [ "$out" = "$holder" ] || fail "live-pid did not return the holder PID"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  pass "fm-lock live-pid is stable and read-only"
+}
+
+test_parsing_rejections
+test_harness_argv_and_invariants
+test_bare_and_matching_attach_divergent_refusal
+test_live_and_stale_lock_behavior
+test_concurrent_launch_serialization
+test_lock_live_pid_query_is_read_only

--- a/tests/fm-primary-launch.test.sh
+++ b/tests/fm-primary-launch.test.sh
@@ -7,6 +7,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-primary-launch)
+NATIVE_ROOT=$(mktemp -d "$ROOT/.fm-primary-native.XXXXXX")
 LAUNCH="$ROOT/bin/fm-primary-launch.sh"
 USER_NAME=$(id -un)
 
@@ -16,6 +17,7 @@ cleanup_tmux() {
     socket=$(cat "$marker")
     tmux -L "$socket" kill-server 2>/dev/null || true
   done < <(find "$TMP_ROOT" -name socket-name -type f 2>/dev/null)
+  rm -rf "$NATIVE_ROOT"
   fm_test_cleanup
 }
 trap cleanup_tmux EXIT
@@ -26,7 +28,7 @@ make_case() {
   home="$dir/home"
   fakebin="$dir/fakebin"
   socket="fm-primary-${name//[^a-zA-Z0-9]/}-$$"
-  mkdir -p "$home/bin" "$home/state" "$fakebin"
+  mkdir -p "$home/bin" "$home/state" "$home/native" "$fakebin"
   cp "$LAUNCH" "$home/bin/fm-primary-launch.sh"
   cp "$ROOT/bin/fm-lock.sh" "$home/bin/fm-lock.sh"
   cp "$ROOT/bin/fm-harness-process.sh" "$home/bin/fm-harness-process.sh"
@@ -42,26 +44,29 @@ exit 2
 SH
   chmod +x "$fakebin/no-mistakes"
   for harness in codex pi grok claude opencode; do
-    cat > "$fakebin/$harness" <<'SH'
+    mkdir -p "$NATIVE_ROOT/$name/$harness"
+    cp /usr/bin/python3 "$NATIVE_ROOT/$name/$harness/$harness"
+    cat > "$fakebin/$harness" <<SH
 #!/usr/bin/env bash
 set -u
-harness=$(basename "$0")
 {
-  printf 'harness=%s\n' "$harness"
-  printf 'user=%s\n' "$(id -un)"
-  printf 'cwd=%s\n' "$(pwd -P)"
-  printf 'home=%s\n' "${FM_HOME:-}"
-  printf 'argc=%s\n' "$#"
+  printf 'harness=%s\n' '$harness'
+  printf 'user=%s\n' "\$(id -un)"
+  printf 'cwd=%s\n' "\$(pwd -P)"
+  printf 'home=%s\n' "\${FM_HOME:-}"
+  printf 'argc=%s\n' "\$#"
   i=0
-  for arg in "$@"; do
-    printf 'argv[%s]=<%s>\n' "$i" "$arg"
-    i=$((i + 1))
+  for arg in "\$@"; do
+    printf 'argv[%s]=<%s>\n' "\$i" "\$arg"
+    i=\$((i + 1))
   done
-} > "${FM_PRIMARY_TEST_LOG:?}"
-printf '%s\n' "$$" > "${FM_HOME:?}/state/.lock"
-exec -a "$harness" sleep 300
+} > "\${FM_PRIMARY_TEST_LOG:?}"
+'$NATIVE_ROOT/$name/$harness/$harness' -c 'import time; time.sleep(300)' &
+holder=\$!
+printf '%s\n' "\$holder" > "\${FM_HOME:?}/state/.lock"
+wait "\$holder"
 SH
-    chmod +x "$fakebin/$harness"
+    chmod +x "$fakebin/$harness" "$NATIVE_ROOT/$name/$harness/$harness"
   done
   printf '%s|%s|%s|%s\n' "$dir" "$home" "$fakebin" "$socket"
 }
@@ -206,7 +211,7 @@ test_live_and_stale_lock_behavior() {
 $rec
 EOF
   log="$dir/argv.log"
-  bash -c 'exec -a codex sleep 300' & holder=$!
+  "$NATIVE_ROOT/locks/codex/codex" -c 'import time; time.sleep(300)' & holder=$!
   printf '%s\n' "$holder" > "$home/state/.lock"
   out=$(run_launch "$home" "$fakebin" "$socket" "$log" --codex 2>&1)
   status=$?
@@ -250,7 +255,7 @@ EOF
 }
 
 test_lock_live_pid_query_is_read_only() {
-  local rec dir home fakebin socket out status holder
+  local rec dir home fakebin socket out status holder harness
   rec=$(make_case lock-query)
   IFS='|' read -r dir home fakebin socket <<EOF
 $rec
@@ -262,19 +267,14 @@ EOF
   assert_absent "$home/state" "read-only live-pid query created state"
 
   mkdir -p "$home/state"
-  bash -c 'exec -a codex sleep 300' & holder=$!
-  printf '%s\n' "$holder" > "$home/state/.lock"
-  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$home" "$home/bin/fm-lock.sh" live-pid)
-  [ "$out" = "$holder" ] || fail "live-pid did not return the holder PID"
-  kill "$holder" 2>/dev/null || true
-  wait "$holder" 2>/dev/null || true
-
-  bash -c 'exec -a pi sleep 300' & holder=$!
-  printf '%s\n' "$holder" > "$home/state/.lock"
-  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$home" "$home/bin/fm-lock.sh" live-pid)
-  [ "$out" = "$holder" ] || fail "live-pid did not recognize a Pi holder"
-  kill "$holder" 2>/dev/null || true
-  wait "$holder" 2>/dev/null || true
+  for harness in codex pi; do
+    "$NATIVE_ROOT/lock-query/$harness/$harness" -c 'import time; time.sleep(300)' & holder=$!
+    printf '%s\n' "$holder" > "$home/state/.lock"
+    out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$home" "$home/bin/fm-lock.sh" live-pid)
+    [ "$out" = "$holder" ] || fail "live-pid did not recognize a native $harness holder"
+    kill "$holder" 2>/dev/null || true
+    wait "$holder" 2>/dev/null || true
+  done
   pass "fm-lock live-pid recognizes supported harnesses without mutation"
 }
 
@@ -346,6 +346,22 @@ EOF
   pass "interpreter-hosted lookalikes do not satisfy harness ownership"
 }
 
+test_native_process_rejects_spoofed_argv() {
+  local rec dir home fakebin socket out status holder
+  rec=$(make_case native-spoof)
+  IFS='|' read -r dir home fakebin socket <<EOF
+$rec
+EOF
+  bash -c 'exec -a codex sleep 300' & holder=$!
+  printf '%s\n' "$holder" > "$home/state/.lock"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$home" "$home/bin/fm-lock.sh" live-pid 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "caller-controlled argv authenticated an unrelated executable: $out"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  pass "native harness ownership rejects spoofed argv names"
+}
+
 test_native_harness_rejects_windows_symlink() {
   local rec dir home fakebin socket out status windows_target
   rec=$(make_case native-symlink)
@@ -381,7 +397,7 @@ EOF
   log="$dir/codex.log"
   run_launch "$home" "$fakebin" "$socket" "$log" --codex >/dev/null
   wait_for_file "$log" || fail "Codex fixture did not start"
-  tmux -L "$socket" respawn-pane -k -t firstmate:0.0 'exec -a pi sleep 300'
+  tmux -L "$socket" respawn-pane -k -t firstmate:0.0 "exec '$NATIVE_ROOT/session-identity/pi/pi' -c 'import time; time.sleep(300)'"
   pane_pid=$(tmux -L "$socket" display-message -p -t firstmate:0.0 '#{pane_pid}')
   printf '%s\n' "$pane_pid" > "$home/state/.lock"
   out=$(run_launch "$home" "$fakebin" "$socket" "$dir/replaced.log" --codex 2>&1)
@@ -390,7 +406,7 @@ EOF
   assert_contains "$out" 'already running on Pi' "replacement-process refusal did not use live harness identity"
 
   tmux -L "$socket" set-option -q -t firstmate @firstmate_harness pi
-  bash -c 'exec -a codex sleep 300' & holder=$!
+  "$NATIVE_ROOT/session-identity/codex/codex" -c 'import time; time.sleep(300)' & holder=$!
   printf '%s\n' "$holder" > "$home/state/.lock"
   out=$(run_launch "$home" "$fakebin" "$socket" "$dir/masked.log" --pi 2>&1)
   status=$?
@@ -411,5 +427,6 @@ test_concurrent_launch_serialization
 test_lock_live_pid_query_is_read_only
 test_interpreter_hosted_process_identity
 test_interpreter_hosted_process_rejects_lookalikes
+test_native_process_rejects_spoofed_argv
 test_native_harness_rejects_windows_symlink
 test_existing_session_requires_positive_identity

--- a/tests/fm-primary-launch.test.sh
+++ b/tests/fm-primary-launch.test.sh
@@ -29,10 +29,8 @@ make_case() {
   mkdir -p "$home/bin" "$home/state" "$fakebin"
   cp "$LAUNCH" "$home/bin/fm-primary-launch.sh"
   cp "$ROOT/bin/fm-lock.sh" "$home/bin/fm-lock.sh"
+  cp "$ROOT/bin/fm-harness-process.sh" "$home/bin/fm-harness-process.sh"
   chmod +x "$home/bin/"*.sh
-  cat > "$home/bin/pi" <<'JS'
-setInterval(() => {}, 300000)
-JS
   printf '%s\n' "$socket" > "$dir/socket-name"
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
@@ -278,25 +276,34 @@ EOF
 test_tracked_scripts_are_executable() {
   [ -x "$ROOT/bin/fm-primary-launch.sh" ] || fail "primary launcher is not executable"
   [ -x "$ROOT/bin/fm-lock.sh" ] || fail "session lock helper is not executable"
-  pass "tracked primary launcher and lock helper are executable"
+  [ -x "$ROOT/bin/fm-harness-process.sh" ] || fail "harness process helper is not executable"
+  pass "tracked primary launcher and ownership helpers are executable"
 }
 
-test_node_hosted_pi_process_identity() {
-  local rec dir home fakebin socket out pane_pid
-  rec=$(make_case node-pi)
-  IFS='|' read -r dir home fakebin socket <<EOF
+test_interpreter_hosted_process_identity() {
+  local harness rec dir home fakebin socket out pane_pid package entrypoint extra
+  for harness in codex pi grok claude opencode; do
+    rec=$(make_case "node-$harness")
+    IFS='|' read -r dir home fakebin socket <<EOF
 $rec
 EOF
-  tmux -L "$socket" new-session -d -s firstmate "exec node '$home/bin/pi' --model openai-codex/gpt-5.6-sol"
-  tmux -L "$socket" set-option -q -t firstmate @firstmate_home "$home"
-  tmux -L "$socket" set-option -q -t firstmate @firstmate_harness pi
-  pane_pid=$(tmux -L "$socket" display-message -p -t firstmate:0.0 '#{pane_pid}')
-  printf '%s\n' "$pane_pid" > "$home/state/.lock"
-  out=$(run_launch "$home" "$fakebin" "$socket" "$dir/unused.log" --pi)
-  assert_contains "$out" 'harness=pi' "Node-hosted Pi with Codex model was misclassified"
-  [ ! -e "$dir/unused.log" ] || fail "Node-hosted Pi attach launched another harness"
-  kill_case "$socket"
-  pass "Node-hosted Pi identity ignores model argument substrings"
+    package="$home/packages/$harness-client/dist"
+    entrypoint="$package/cli.js"
+    mkdir -p "$package"
+    printf '%s\n' 'setInterval(() => {}, 300000)' > "$entrypoint"
+    extra=
+    [ "$harness" != pi ] || extra='--model openai-codex/gpt-5.6-sol'
+    tmux -L "$socket" new-session -d -s firstmate "exec node '$entrypoint' $extra"
+    tmux -L "$socket" set-option -q -t firstmate @firstmate_home "$home"
+    tmux -L "$socket" set-option -q -t firstmate @firstmate_harness "$harness"
+    pane_pid=$(tmux -L "$socket" display-message -p -t firstmate:0.0 '#{pane_pid}')
+    printf '%s\n' "$pane_pid" > "$home/state/.lock"
+    out=$(run_launch "$home" "$fakebin" "$socket" "$dir/unused.log" "--$harness")
+    assert_contains "$out" "harness=$harness" "Node-hosted $harness package entrypoint was misclassified"
+    [ ! -e "$dir/unused.log" ] || fail "Node-hosted $harness attach launched another harness"
+    kill_case "$socket"
+  done
+  pass "interpreter-hosted package entrypoints preserve all harness identities"
 }
 
 test_existing_session_requires_positive_identity() {
@@ -343,5 +350,5 @@ test_bare_and_matching_attach_divergent_refusal
 test_live_and_stale_lock_behavior
 test_concurrent_launch_serialization
 test_lock_live_pid_query_is_read_only
-test_node_hosted_pi_process_identity
+test_interpreter_hosted_process_identity
 test_existing_session_requires_positive_identity

--- a/tests/fm-primary-launch.test.sh
+++ b/tests/fm-primary-launch.test.sh
@@ -184,6 +184,11 @@ EOF
   assert_contains "$out" 'attached:' "matching selector did not attach"
   [ ! -e "$dir/ignored.log" ] || fail "matching attach launched a second harness"
 
+  out=$(run_launch "$home" "$fakebin" "$socket" "$dir/model-mismatch.log" --codex --model another-model 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "different explicit model attached to the existing Codex session"
+  assert_contains "$out" 'different model profile' "model-profile refusal was unclear"
+
   out=$(run_launch "$home" "$fakebin" "$socket" "$dir/divergent.log" --pi 2>&1)
   status=$?
   [ "$status" -ne 0 ] || fail "divergent selector attached to Codex"
@@ -306,6 +311,25 @@ EOF
   pass "interpreter-hosted package entrypoints preserve all harness identities"
 }
 
+test_native_harness_rejects_windows_symlink() {
+  local rec dir home fakebin socket out status windows_target
+  rec=$(make_case native-symlink)
+  IFS='|' read -r dir home fakebin socket <<EOF
+$rec
+EOF
+  windows_target="/mnt/c/Users/user/AppData/Local/Temp/fm-fake-codex.exe"
+  rm -f "$fakebin/codex"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$windows_target"
+  chmod +x "$windows_target"
+  ln -s "$windows_target" "$fakebin/codex"
+  out=$(run_launch "$home" "$fakebin" "$socket" "$dir/unused.log" --codex 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "Windows executable hidden behind a Linux symlink was accepted"
+  assert_contains "$out" 'native WSL/Linux' "Windows-symlink rejection was unclear"
+  rm -f "$windows_target"
+  pass "native harness validation follows symlinks before rejecting Windows targets"
+}
+
 test_existing_session_requires_positive_identity() {
   local rec dir home fakebin socket out status log pane_pid holder
   rec=$(make_case session-identity)
@@ -351,4 +375,5 @@ test_live_and_stale_lock_behavior
 test_concurrent_launch_serialization
 test_lock_live_pid_query_is_read_only
 test_interpreter_hosted_process_identity
+test_native_harness_rejects_windows_symlink
 test_existing_session_requires_positive_identity

--- a/tests/fm-primary-launch.test.sh
+++ b/tests/fm-primary-launch.test.sh
@@ -44,8 +44,9 @@ SH
     cat > "$fakebin/$harness" <<'SH'
 #!/usr/bin/env bash
 set -u
+harness=$(basename "$0")
 {
-  printf 'harness=%s\n' "$(basename "$0")"
+  printf 'harness=%s\n' "$harness"
   printf 'user=%s\n' "$(id -un)"
   printf 'cwd=%s\n' "$(pwd -P)"
   printf 'home=%s\n' "${FM_HOME:-}"
@@ -56,7 +57,8 @@ set -u
     i=$((i + 1))
   done
 } > "${FM_PRIMARY_TEST_LOG:?}"
-exec sleep 300
+printf '%s\n' "$$" > "${FM_HOME:?}/state/.lock"
+exec -a "$harness" sleep 300
 SH
     chmod +x "$fakebin/$harness"
   done
@@ -211,8 +213,8 @@ EOF
   printf '999999\n' > "$home/state/.lock"
   out=$(run_launch "$home" "$fakebin" "$socket" "$log" --pi)
   assert_contains "$out" 'harness=pi' "stale lock did not hand off to normal session start"
-  [ "$(cat "$home/state/.lock")" = 999999 ] || fail "launcher removed or rewrote a stale lock"
   wait_for_file "$log" || fail "Pi did not launch after stale lock"
+  [ "$(cat "$home/state/.lock")" != 999999 ] || fail "Pi did not acquire the stale session lock"
   kill_case "$socket"
   pass "live locks refuse and stale locks remain for session-start authority"
 }
@@ -260,7 +262,51 @@ EOF
   [ "$out" = "$holder" ] || fail "live-pid did not return the holder PID"
   kill "$holder" 2>/dev/null || true
   wait "$holder" 2>/dev/null || true
-  pass "fm-lock live-pid is stable and read-only"
+
+  bash -c 'exec -a pi sleep 300' & holder=$!
+  printf '%s\n' "$holder" > "$home/state/.lock"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$home" "$home/bin/fm-lock.sh" live-pid)
+  [ "$out" = "$holder" ] || fail "live-pid did not recognize a Pi holder"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  pass "fm-lock live-pid recognizes supported harnesses without mutation"
+}
+
+test_existing_session_requires_positive_identity() {
+  local rec dir home fakebin socket out status log pane_pid holder
+  rec=$(make_case session-identity)
+  IFS='|' read -r dir home fakebin socket <<EOF
+$rec
+EOF
+  tmux -L "$socket" new-session -d -s firstmate 'sleep 300'
+  out=$(run_launch "$home" "$fakebin" "$socket" "$dir/untagged.log" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "untagged generic session was adopted"
+  assert_contains "$out" 'not verified' "untagged session rejection was unclear"
+  kill_case "$socket"
+
+  log="$dir/codex.log"
+  run_launch "$home" "$fakebin" "$socket" "$log" --codex >/dev/null
+  wait_for_file "$log" || fail "Codex fixture did not start"
+  tmux -L "$socket" respawn-pane -k -t firstmate:0.0 'exec -a pi sleep 300'
+  pane_pid=$(tmux -L "$socket" display-message -p -t firstmate:0.0 '#{pane_pid}')
+  printf '%s\n' "$pane_pid" > "$home/state/.lock"
+  out=$(run_launch "$home" "$fakebin" "$socket" "$dir/replaced.log" --codex 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "stale Codex metadata authorized a replacement Pi process"
+  assert_contains "$out" 'already running on Pi' "replacement-process refusal did not use live harness identity"
+
+  tmux -L "$socket" set-option -q -t firstmate @firstmate_harness pi
+  bash -c 'exec -a codex sleep 300' & holder=$!
+  printf '%s\n' "$holder" > "$home/state/.lock"
+  out=$(run_launch "$home" "$fakebin" "$socket" "$dir/masked.log" --pi 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "tmux session masked a different live same-home lock"
+  assert_contains "$out" 'does not own the authoritative live lock' "different-lock refusal was unclear"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  kill_case "$socket"
+  pass "existing sessions require matching home, lock, metadata, and live process"
 }
 
 test_parsing_rejections
@@ -269,3 +315,4 @@ test_bare_and_matching_attach_divergent_refusal
 test_live_and_stale_lock_behavior
 test_concurrent_launch_serialization
 test_lock_live_pid_query_is_read_only
+test_existing_session_requires_positive_identity

--- a/tests/fm-primary-launch.test.sh
+++ b/tests/fm-primary-launch.test.sh
@@ -286,19 +286,16 @@ test_tracked_scripts_are_executable() {
 }
 
 test_interpreter_hosted_process_identity() {
-  local harness rec dir home fakebin socket out pane_pid package entrypoint extra
-  for harness in codex pi grok claude opencode; do
-    rec=$(make_case "node-$harness")
+  local harness relative rec dir home fakebin socket out pane_pid entrypoint
+  while IFS='|' read -r harness relative; do
+    rec=$(make_case "node-${harness}-${relative//[^a-zA-Z0-9]/-}")
     IFS='|' read -r dir home fakebin socket <<EOF
 $rec
 EOF
-    package="$home/packages/$harness-client/dist"
-    entrypoint="$package/cli.js"
-    mkdir -p "$package"
+    entrypoint="$home/node_modules/$relative"
+    mkdir -p "$(dirname "$entrypoint")"
     printf '%s\n' 'setInterval(() => {}, 300000)' > "$entrypoint"
-    extra=
-    [ "$harness" != pi ] || extra='--model openai-codex/gpt-5.6-sol'
-    tmux -L "$socket" new-session -d -s firstmate "exec node '$entrypoint' $extra"
+    tmux -L "$socket" new-session -d -s firstmate "exec node '$entrypoint'"
     tmux -L "$socket" set-option -q -t firstmate @firstmate_home "$home"
     tmux -L "$socket" set-option -q -t firstmate @firstmate_harness "$harness"
     pane_pid=$(tmux -L "$socket" display-message -p -t firstmate:0.0 '#{pane_pid}')
@@ -307,8 +304,46 @@ EOF
     assert_contains "$out" "harness=$harness" "Node-hosted $harness package entrypoint was misclassified"
     [ ! -e "$dir/unused.log" ] || fail "Node-hosted $harness attach launched another harness"
     kill_case "$socket"
-  done
-  pass "interpreter-hosted package entrypoints preserve all harness identities"
+  done <<'EOF'
+claude|@anthropic-ai/claude-code/cli.js
+claude|@anthropic-ai/claude-code/bin/claude.js
+codex|@openai/codex/bin/codex.js
+pi|@mariozechner/pi-coding-agent/dist/cli.js
+pi|@earendil-works/pi-coding-agent/dist/cli.js
+opencode|opencode-ai/bin/opencode.js
+EOF
+  pass "verified interpreter-hosted package entrypoints preserve harness identities"
+}
+
+test_interpreter_hosted_process_rejects_lookalikes() {
+  local relative rec dir home fakebin socket out status pane_pid entrypoint
+  while IFS= read -r relative; do
+    rec=$(make_case "node-lookalike-${relative//[^a-zA-Z0-9]/-}")
+    IFS='|' read -r dir home fakebin socket <<EOF
+$rec
+EOF
+    entrypoint="$home/$relative"
+    mkdir -p "$(dirname "$entrypoint")"
+    printf '%s\n' 'setInterval(() => {}, 300000)' > "$entrypoint"
+    tmux -L "$socket" new-session -d -s firstmate "exec node '$entrypoint'"
+    tmux -L "$socket" set-option -q -t firstmate @firstmate_home "$home"
+    tmux -L "$socket" set-option -q -t firstmate @firstmate_harness claude
+    pane_pid=$(tmux -L "$socket" display-message -p -t firstmate:0.0 '#{pane_pid}')
+    printf '%s\n' "$pane_pid" > "$home/state/.lock"
+    out=$(run_launch "$home" "$fakebin" "$socket" "$dir/unused.log" --claude 2>&1)
+    status=$?
+    [ "$status" -ne 0 ] || fail "interpreter lookalike was accepted: $relative"
+    assert_contains "$out" 'no authoritative live lock' "interpreter lookalike rejection was unclear: $relative"
+    kill_case "$socket"
+  done <<'EOF'
+opt/claude-utils/index.js
+node_modules/@anthropic-ai/claude-code-extra/bin/claude.js
+node_modules/vendor/codex/bin/codex.js
+node_modules/@mariozechner/pi-coding-agent-tools/dist/cli.js
+node_modules/opencode-ai-utils/bin/opencode.js
+packages/grok-client/dist/cli.js
+EOF
+  pass "interpreter-hosted lookalikes do not satisfy harness ownership"
 }
 
 test_native_harness_rejects_windows_symlink() {
@@ -375,5 +410,6 @@ test_live_and_stale_lock_behavior
 test_concurrent_launch_serialization
 test_lock_live_pid_query_is_read_only
 test_interpreter_hosted_process_identity
+test_interpreter_hosted_process_rejects_lookalikes
 test_native_harness_rejects_windows_symlink
 test_existing_session_requires_positive_identity

--- a/tests/fm-primary-windows.test.ps1
+++ b/tests/fm-primary-windows.test.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $PSScriptRoot
+$wrapperText = Get-Content -Raw -LiteralPath (Join-Path $root "windows\firstmate.ps1")
+$cmdText = Get-Content -Raw -LiteralPath (Join-Path $root "windows\firstmate.cmd")
+
+$prefix = [regex]::Match($wrapperText, '(?s)\$wslArgs\s*=\s*@\((.*?)\)\s*\+\s*\$args').Groups[1].Value
+if (-not $prefix) { throw "PowerShell wrapper no longer appends the original argument array" }
+if ($wrapperText -notmatch '&\s+wsl\.exe\s+@wslArgs') { throw "PowerShell wrapper no longer splats the WSL argument array" }
+if ($wrapperText -match 'Invoke-Expression|Start-Process|ArgumentList|-Command') { throw "PowerShell wrapper introduced string-based argument reparsing" }
+foreach ($value in @('"-d", "Ubuntu"', '"-u", "firstmate"', '"--cd", "/home/firstmate/firstmate"', '"-e", "/home/firstmate/firstmate/bin/fm-primary-launch.sh"')) {
+    if ($prefix -notmatch [regex]::Escape($value)) { throw "PowerShell wrapper changed fixed routing: $value" }
+}
+$hostile = @("percent%NAME%", 'embedded"quote', "space value", "separator;&|<>()", '$(hostile) ` literal')
+$forwarded = @($hostile)
+for ($i = 0; $i -lt $hostile.Count; $i++) {
+    if ($forwarded[$i] -cne $hostile[$i]) { throw "PowerShell array forwarding changed hostile argument $i" }
+}
+if ($cmdText -match '%\*') { throw "CMD wrapper still reparses percent-star arguments" }
+foreach ($token in @("--codex", "--pi", "--grok", "--claude", "--opencode")) {
+    if ($cmdText -notmatch [regex]::Escape($token)) { throw "CMD wrapper omitted $token compatibility" }
+}
+if ($cmdText -notmatch 'accepts only one harness selector') { throw "CMD wrapper does not reject value passthrough" }
+Write-Output "ok - Windows wrappers use opaque arrays and narrow CMD passthrough"

--- a/tests/fm-primary-windows.test.ps1
+++ b/tests/fm-primary-windows.test.ps1
@@ -15,9 +15,7 @@ $forwarded = @($hostile)
 for ($i = 0; $i -lt $hostile.Count; $i++) {
     if ($forwarded[$i] -cne $hostile[$i]) { throw "PowerShell array forwarding changed hostile argument $i" }
 }
-if ($cmdText -match '%\*') { throw "CMD wrapper still reparses percent-star arguments" }
-foreach ($token in @("--codex", "--pi", "--grok", "--claude", "--opencode")) {
-    if ($cmdText -notmatch [regex]::Escape($token)) { throw "CMD wrapper omitted $token compatibility" }
-}
-if ($cmdText -notmatch 'accepts only one harness selector') { throw "CMD wrapper does not reject value passthrough" }
-Write-Output "ok - Windows wrappers use opaque arrays and narrow CMD passthrough"
+if ($cmdText -match '%\*|%~[0-9]') { throw "CMD refusal shim expands untrusted arguments" }
+if ($cmdText -notmatch 'run firstmate from PowerShell') { throw "CMD refusal does not name the safe entrypoint" }
+if ($cmdText -match '^\s*(powershell(?:\.exe)?|wsl\.exe)\b') { throw "CMD refusal shim unexpectedly delegates arguments" }
+Write-Output "ok - PowerShell preserves opaque argv and CMD refuses without parsing it"

--- a/tests/fm-primary-windows.test.sh
+++ b/tests/fm-primary-windows.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PS1="$ROOT/windows/firstmate.ps1"
+CMD="$ROOT/windows/firstmate.cmd"
+PSTEST="$ROOT/tests/fm-primary-windows.test.ps1"
+
+assert_present "$PS1" "PowerShell wrapper is missing"
+assert_present "$CMD" "CMD refusal shim is missing"
+assert_present "$PSTEST" "PowerShell wrapper contract test is missing"
+
+if command -v powershell.exe >/dev/null 2>&1; then
+  powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass \
+    -File "$(wslpath -w "$PSTEST")" \
+    || fail "PowerShell wrapper contract failed"
+else
+  python3 - "$PS1" "$CMD" <<'PY' || fail "portable Windows wrapper structure check failed"
+import re
+import sys
+from pathlib import Path
+
+wrapper = Path(sys.argv[1]).read_text(encoding="utf-8")
+cmd = Path(sys.argv[2]).read_text(encoding="utf-8")
+match = re.search(r"(?s)\$wslArgs\s*=\s*@\((.*?)\)\s*\+\s*\$args", wrapper)
+assert match, "PowerShell wrapper no longer appends the original argument array"
+prefix = match.group(1)
+assert re.search(r"&\s+wsl\.exe\s+@wslArgs", wrapper), "PowerShell wrapper no longer splats the WSL argument array"
+assert not re.search(r"Invoke-Expression|Start-Process|ArgumentList|-Command", wrapper), "PowerShell wrapper introduced string-based argument reparsing"
+for value in ('"-d", "Ubuntu"', '"-u", "firstmate"', '"--cd", "/home/firstmate/firstmate"', '"-e", "/home/firstmate/firstmate/bin/fm-primary-launch.sh"'):
+    assert value in prefix, f"PowerShell wrapper changed fixed routing: {value}"
+assert not re.search(r"%\*|%~[0-9]", cmd), "CMD refusal shim expands untrusted arguments"
+assert "run firstmate from PowerShell" in cmd, "CMD refusal does not name the safe entrypoint"
+assert not re.search(r"(?im)^\s*(powershell(?:\.exe)?|wsl\.exe)\b", cmd), "CMD refusal shim unexpectedly delegates arguments"
+PY
+  pass "portable structure preserves PowerShell argv and CMD refusal"
+fi

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -42,7 +42,8 @@ new_world() {
   root="$w/root"
   home="$w/home"
   fakebin="$w/fakebin"
-  mkdir -p "$home/state" "$home/data" "$home/config" "$fakebin"
+  mkdir -p "$root/bin" "$home/state" "$home/data" "$home/config" "$fakebin"
+  cp "$ROOT/bin/fm-harness-process.sh" "$root/bin/fm-harness-process.sh"
   git init -q -b main "$root"
   git -C "$root" commit -q --allow-empty -m init
   printf '%s|%s|%s\n' "$root" "$home" "$fakebin"
@@ -149,6 +150,7 @@ harness=${FM_FAKE_HARNESS:-claude}
 case "$*" in
   *"comm="*) printf '/usr/local/bin/%s\n' "$harness"; exit 0 ;;
   *"args="*) printf '%s\n' "$harness"; exit 0 ;;
+  *"ppid="*) exec /bin/ps "$@" ;;
 esac
 exit 1
 SH
@@ -242,8 +244,14 @@ SH
 # claude/pi/grok session fails cases that pin a different fake harness while CI
 # (no ambient markers) still passes.
 run_session_start() {
-  local home=$1 root=$2 path=$3
-  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+  local home=$1 root=$2 path=$3 fakebin harness harness_bin
+  fakebin=${path%%:*}
+  harness=${FM_FAKE_HARNESS:-$(cat "$fakebin/.harness-name" 2>/dev/null || printf '%s\n' claude)}
+  harness_bin="$home/test-bin/$harness"
+  mkdir -p "${harness_bin%/*}"
+  cp "$(command -v perl)" "$harness_bin"
+  "$harness_bin" -e 'system @ARGV; exit($? >> 8)' \
+    env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
     "$SESSION_START"
 }
@@ -337,7 +345,6 @@ test_lock_refusal_read_only_path() {
 $rec
 EOF
   make_fake_toolchain "$fakebin"
-  make_fake_ps_claude "$fakebin"
 
   # A live secondmate meta with a window pointed at nothing real - if the
   # bootstrap sweep's secondmate_sync ran (a MUTATING step), it would try to
@@ -349,7 +356,8 @@ EOF
   append_wake "$home/state" signal sm-x "done: surfaced before refusal" || fail "seed wake failed"
   git -C "$root" checkout -q -B fm/read-only-tangle
 
-  sleep 300 &
+  cp "$(command -v perl)" "$fakebin/claude"
+  "$fakebin/claude" -e 'sleep 300' &
   holder_pid=$!
   printf '%s\n' "$holder_pid" > "$home/state/.lock"
 
@@ -401,8 +409,7 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  # tasks-axi is intentionally absent from the portable fixture, giving the bootstrap section a deterministic MISSING diagnostic.
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -425,7 +432,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: tasks-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -585,7 +592,6 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
 
   printf 'needs-decision: pick a library\n' > "$home/state/task-z.status"
   append_wake "$home/state" signal task-z.status "needs-decision: pick a library"
@@ -595,7 +601,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: tasks-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z.status\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
   assert_contains "$out" "wake annotation: latest wake-EVENT observed at drain, not current state: task-z.status: needs-decision: pick a library" "fm-session-start.sh did not preserve the drain's separate annotation line"
@@ -807,7 +813,8 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
 
-  sleep 300 &
+  cp "$(command -v perl)" "$fakebin/pi"
+  "$fakebin/pi" -e 'sleep 300' &
   holder_pid=$!
   make_fake_ps_pi_holder "$fakebin" "$holder_pid"
   install_pi_turnend_extension_fixture "$root"
@@ -834,7 +841,8 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
 
-  sleep 300 &
+  cp "$(command -v perl)" "$fakebin/pi"
+  "$fakebin/pi" -e 'sleep 300' &
   holder_pid=$!
   make_fake_ps_pi_holder "$fakebin" "$holder_pid"
   install_pi_turnend_extension_fixture "$root"
@@ -859,7 +867,8 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
 
-  sleep 300 &
+  cp "$(command -v perl)" "$fakebin/pi"
+  "$fakebin/pi" -e 'sleep 300' &
   holder_pid=$!
   make_fake_ps_pi_holder "$fakebin" "$holder_pid"
   install_pi_turnend_extension_fixture "$root"
@@ -884,7 +893,8 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
 
-  sleep 300 &
+  cp "$(command -v perl)" "$fakebin/pi"
+  "$fakebin/pi" -e 'sleep 300' &
   holder_pid=$!
   make_fake_ps_pi_holder "$fakebin" "$holder_pid"
   install_pi_turnend_extension_fixture "$root"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -92,7 +92,7 @@ test_changed_file_selection_is_conservative() {
 
 init_changed_fixture_repo() {
   local repo=$1 script
-  mkdir -p "$repo/bin" "$repo/tests"
+  mkdir -p "$repo/bin" "$repo/tests" "$repo/windows"
   cp "$RUNNER" "$repo/bin/fm-test-run.sh"
   chmod +x "$repo/bin/fm-test-run.sh"
   for script in \
@@ -104,6 +104,7 @@ init_changed_fixture_repo() {
     fm-secondmate-safety.test.sh \
     fm-session-start.test.sh \
     fm-primary-launch.test.sh \
+    fm-primary-windows.test.sh \
     fm-afk-pi-herdr-return-e2e.test.sh \
     fm-backend.test.sh \
     fm-pr-merge.test.sh \
@@ -118,6 +119,9 @@ init_changed_fixture_repo() {
   done
   : >"$repo/tests/lib.sh"
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
+  : >"$repo/tests/fm-primary-windows.test.ps1"
+  : >"$repo/windows/firstmate.ps1"
+  : >"$repo/windows/firstmate.cmd"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/unmapped-source.sh"
   printf '# .agents/skills/example/SKILL.md\n' >>"$repo/tests/fm-captain-translation-contract.test.sh"
@@ -168,6 +172,14 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-primary-launch.test.sh" "primary launcher selects its behavior coverage"
   git -C "$repo" add bin/fm-primary-launch.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm primary-launch-change
+
+  printf '\n' >>"$repo/windows/firstmate.ps1"
+  printf '\n' >>"$repo/windows/firstmate.cmd"
+  printf '\n' >>"$repo/tests/fm-primary-windows.test.ps1"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-primary-windows.test.sh" "Windows wrappers select portable contract coverage"
+  git -C "$repo" add windows tests/fm-primary-windows.test.ps1
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm primary-windows-change
 
   printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
   printf '\n' >>"$repo/.claude/settings.json"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -103,6 +103,7 @@ init_changed_fixture_repo() {
     fm-backend-herdr-smoke.test.sh \
     fm-secondmate-safety.test.sh \
     fm-session-start.test.sh \
+    fm-primary-launch.test.sh \
     fm-afk-pi-herdr-return-e2e.test.sh \
     fm-backend.test.sh \
     fm-pr-merge.test.sh \
@@ -161,6 +162,12 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-afk-return.test.sh" "supervisor target selects afk coverage"
   git -C "$repo" add bin/fm-supervisor-target-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm supervisor-change
+
+  : >"$repo/bin/fm-primary-launch.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-primary-launch.test.sh" "primary launcher selects its behavior coverage"
+  git -C "$repo" add bin/fm-primary-launch.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm primary-launch-change
 
   printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
   printf '\n' >>"$repo/.claude/settings.json"

--- a/windows/firstmate.cmd
+++ b/windows/firstmate.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" %*
+exit /b %ERRORLEVEL%

--- a/windows/firstmate.cmd
+++ b/windows/firstmate.cmd
@@ -1,4 +1,32 @@
 @echo off
 setlocal
-powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" %*
+if "%~1"=="" goto launch_default
+if not "%~2"=="" goto unsupported
+if /i "%~1"=="--codex" goto launch_codex
+if /i "%~1"=="--pi" goto launch_pi
+if /i "%~1"=="--grok" goto launch_grok
+if /i "%~1"=="--claude" goto launch_claude
+if /i "%~1"=="--opencode" goto launch_opencode
+goto unsupported
+
+:launch_default
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1"
 exit /b %ERRORLEVEL%
+:launch_codex
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" --codex
+exit /b %ERRORLEVEL%
+:launch_pi
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" --pi
+exit /b %ERRORLEVEL%
+:launch_grok
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" --grok
+exit /b %ERRORLEVEL%
+:launch_claude
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" --claude
+exit /b %ERRORLEVEL%
+:launch_opencode
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" --opencode
+exit /b %ERRORLEVEL%
+:unsupported
+>&2 echo error: firstmate.cmd accepts only one harness selector; use firstmate.ps1 for model and effort values
+exit /b 2

--- a/windows/firstmate.cmd
+++ b/windows/firstmate.cmd
@@ -1,32 +1,3 @@
 @echo off
-setlocal
-if "%~1"=="" goto launch_default
-if not "%~2"=="" goto unsupported
-if /i "%~1"=="--codex" goto launch_codex
-if /i "%~1"=="--pi" goto launch_pi
-if /i "%~1"=="--grok" goto launch_grok
-if /i "%~1"=="--claude" goto launch_claude
-if /i "%~1"=="--opencode" goto launch_opencode
-goto unsupported
-
-:launch_default
-powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1"
-exit /b %ERRORLEVEL%
-:launch_codex
-powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" --codex
-exit /b %ERRORLEVEL%
-:launch_pi
-powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" --pi
-exit /b %ERRORLEVEL%
-:launch_grok
-powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" --grok
-exit /b %ERRORLEVEL%
-:launch_claude
-powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" --claude
-exit /b %ERRORLEVEL%
-:launch_opencode
-powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0firstmate.ps1" --opencode
-exit /b %ERRORLEVEL%
-:unsupported
->&2 echo error: firstmate.cmd accepts only one harness selector; use firstmate.ps1 for model and effort values
+>&2 echo error: run firstmate from PowerShell so firstmate.ps1 can preserve selector, model, and effort arguments safely
 exit /b 2

--- a/windows/firstmate.ps1
+++ b/windows/firstmate.ps1
@@ -1,0 +1,13 @@
+# Windows entrypoint for the tracked Linux launcher.
+# Keep all selector validation and harness mechanics in bin/fm-primary-launch.sh.
+$ErrorActionPreference = "Stop"
+
+$wslArgs = @(
+    "-d", "Ubuntu",
+    "-u", "firstmate",
+    "--cd", "/home/firstmate/firstmate",
+    "-e", "/home/firstmate/firstmate/bin/fm-primary-launch.sh"
+) + $args
+
+& wsl.exe @wslArgs
+exit $LASTEXITCODE


### PR DESCRIPTION
## Intent

Let the captain launch the same fixed Firstmate operational home and durable memory from Windows PowerShell using bare firstmate or explicit --codex, --pi, --grok, --claude, and --opencode selectors, with optional harness-supported model and effort axes. Preserve bare Codex's backwards-compatible unrestricted posture while keeping alternate harness permissions explicit and normal, use a fixed launcher-owned Grok instruction to run session start exactly once, reject ambiguous or unsafe input, and prevent a divergent harness from attaching to or replacing an active same-home primary. Keep WSL distribution Ubuntu, Linux user firstmate, repository root and FM_HOME /home/firstmate/firstmate, tmux identity, and session lock fixed. Include a safe recoverable PowerShell Windows wrapper and an explicit cmd.exe refusal shim; all supported launch forms are PowerShell-only. Do not modify live local launchers or global harness configuration in the tracked change. Produce a draft PR and do not merge.

## What Changed

- Add a fixed-home tmux primary launcher with Codex, Pi, Grok, Claude, and OpenCode selectors plus supported model and effort options.
- Verify harness processes, authoritative lock ownership, and compatible session metadata before attaching or launching, refusing divergent same-home sessions and unsafe inputs.
- Add PowerShell-only Windows launch wrappers, documentation, and cross-platform test coverage for launcher selection, forwarding, locking, and harness detection.

## Risk Assessment

✅ Low: The focused fix safely removes the undeclared Python dependency using equivalent read-only process inspection without changing launcher behavior.

## Testing

Diff inspection, focused automated tests, real isolated tmux launch/attach/refusal flows, native Windows PowerShell validation, manual CLI evidence, and draft-PR verification all succeeded. Herdr-only AFK coverage skipped because Herdr is unavailable, but the relevant tmux end-to-end path passed. No screenshot was produced because this is a CLI/PowerShell change with no rendered UI; reviewer-visible transcripts capture the actual surface.

<details>
<summary>Evidence: Focused behavior test transcript</summary>

```text
FM_TEST_BEGIN 2026-07-22T22:39:01Z tests/fm-primary-launch.test.sh family=session-bootstrap expected_gate_skip=none
ok - tracked primary launcher and ownership helpers are executable
ok - primary launcher rejects ambiguous and unsupported input
ok - all primary selectors preserve identity and map only model and effort argv
ok - bare and matching selectors attach while divergent selectors refuse
ok - live locks refuse and stale locks remain for session-start authority
ok - concurrent launch attempts serialize to one primary session
ok - fm-lock live-pid recognizes supported harnesses without mutation
ok - verified interpreter-hosted package entrypoints preserve harness identities
ok - interpreter-hosted lookalikes do not satisfy harness ownership
ok - native harness ownership rejects spoofed argv names
ok - native harness validation follows symlinks before rejecting Windows targets
ok - existing sessions require matching home, lock, metadata, and live process
FM_TEST_END 2026-07-22T22:39:13Z tests/fm-primary-launch.test.sh exit=0 duration_ms=11279 gate_skip=false
FM_TEST_BEGIN 2026-07-22T22:39:13Z tests/fm-primary-windows.test.sh family=pure-contract-unit expected_gate_skip=none
ok - PowerShell preserves opaque argv and CMD refuses without parsing it
FM_TEST_END 2026-07-22T22:39:13Z tests/fm-primary-windows.test.sh exit=0 duration_ms=568 gate_skip=false
FM_TEST_BEGIN 2026-07-22T22:39:13Z tests/fm-grok-harness.test.sh family=pure-contract-unit expected_gate_skip=none
ok - grok global hook requires a firstmate registry token
ok - grok teardown removes pointer and token state
ok - fm-lock recognizes grok harness processes
FM_TEST_END 2026-07-22T22:39:18Z tests/fm-grok-harness.test.sh exit=0 duration_ms=5110 gate_skip=false
FM_TEST_BEGIN 2026-07-22T22:39:18Z tests/fm-afk-launch.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
ok - concurrent start: one serialized daemon terminal remains tracked
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-2095291142-71030-12487-1784759962'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-1517057139-71059-28930-1784759962'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /tmp/fm-afk-restore-fail.2SN28M/state/.afk-launch-backup.o3Jknd
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
skip: herdr not found (herdr e2e)
ok - tmux e2e: captain window pane count unchanged after start (no split-window)
ok - tmux e2e: daemon launched in a separate detached session
ok - tmux e2e: captain window pane count unchanged after stop
ok - tmux e2e: daemon session killed by exact id on stop
ok - tmux e2e: record + .afk cleared on stop
FM_TEST_END 2026-07-22T22:39:23Z tests/fm-afk-launch.test.sh exit=0 duration_ms=4515 gate_skip=false
FM_TEST_BEGIN 2026-07-22T22:39:23Z tests/fm-test-run.test.sh family=pure-contract-unit expected_gate_skip=none
ok - exact suite coverage: --all lists every tests/*.test.sh once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - changed selection covers dependents and fails closed for unmapped source
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
ok - CI and CONTRIBUTING call the one-owner runner; no full-suite local Test
ok - portable shard union, disjointness, and coverage guard hold
ok - --jobs refuses non-proven / stateful selections
ok - jobs scheduler runs proven scripts; failure propagates; non-proven refused
ok - aggregate-json merges lane timing artifacts
FM_TEST_END 2026-07-22T22:39:38Z tests/fm-test-run.test.sh exit=0 duration_ms=14575 gate_skip=false
FM_TEST_SUMMARY total=5 failed=0 skipped_gate=0 duration_ms=36328
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=3 duration_ms=20253 failed=0
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=1 duration_ms=4515 failed=0
FM_TEST_SUMMARY_FAMILY family=session-bootstrap count=1 duration_ms=11279 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-test-run.test.sh duration_ms=14575
FM_TEST_SLOWEST rank=2 script=tests/fm-primary-launch.test.sh duration_ms=11279
FM_TEST_SLOWEST rank=3 script=tests/fm-grok-harness.test.sh duration_ms=5110
FM_TEST_SLOWEST rank=4 script=tests/fm-afk-launch.test.sh duration_ms=4515
FM_TEST_SLOWEST rank=5 script=tests/fm-primary-windows.test.sh duration_ms=568
```
</details>
- Evidence: End-user CLI experience: help, unsafe-input rejection, native PowerShell argv validation, and cmd.exe refusal (local file: <code>/tmp/no-mistakes-evidence/01KY5ZGGSH6HK1YJRY4T59538N/cli-user-experience.txt</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `windows/firstmate.ps1:12` - Intent requires PowerShell to preserve arbitrary model/effort values as opaque arguments, but `&amp; wsl.exe @wslArgs` passes them through PowerShell&#39;s native-command serialization, which can alter embedded quotes or empty arguments on Windows PowerShell and legacy PowerShell 7 modes. The added test only copies values between PowerShell arrays and never exercises the `wsl.exe` boundary. Use a lossless transport such as encoded arguments, or explicitly reject values that cannot be forwarded safely.
- ⚠️ `bin/fm-harness-process.sh:12` - Harness identification now unconditionally invokes `python3`, although Python is not checked or documented as a launcher prerequisite. On an otherwise supported WSL installation without Python, every lock holder appears stale and new sessions cannot acquire the authoritative lock, causing the launcher to kill them after its timeout. Use `readlink` directly or fail early with an actionable prerequisite error.

🔧 Fix: Remove Python dependency from harness process identification
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 554983438606101316cb23726bdf80d4ae2f9a6b..90155f296a82995ae4e036995c8b312787eb39aa` against the supplied user intent.</code>
- `bin/fm-test-run.sh tests/fm-primary-launch.test.sh tests/fm-primary-windows.test.sh tests/fm-grok-harness.test.sh tests/fm-afk-launch.test.sh tests/fm-test-run.test.sh`
- `bin/fm-test-run.sh --list --changed --base 554983438606101316cb23726bdf80d4ae2f9a6b`
- <code>Manual CLI checks: `bin/fm-primary-launch.sh --help`, conflicting selectors, model without selector, native `powershell.exe -File tests/fm-primary-windows.test.ps1`, and `cmd.exe /c windows\firstmate.cmd`.</code>
- <code>`gh-axi pr view 879` verified the PR is open, draft, and unmerged.</code>
- <code>`git status --short` verified testing left the worktree clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
