### PR TITLE
feat(pi): add session-local calm mode

### DIFF
--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -50,6 +50,8 @@ type StandardShellState = {
 
 export default function (pi: ExtensionAPI) {
   let calm = false;
+  let exportRendering = false;
+  let removeTerminalInputHandler: (() => void) | undefined;
 
   function registerBuiltIn<TParams extends TSchema, TDetails, TState>(
     factory: DefinitionFactory<TParams, TDetails, TState>,
@@ -118,6 +120,7 @@ export default function (pi: ExtensionAPI) {
         theme: RenderTheme<TParams, TDetails, TState>,
         context: RenderContext<TParams, TDetails, TState>,
       ) {
+        if (exportRendering) return originalRenderCall(args, theme, context);
         if (calm) return new Container();
         if (originalSelfShell) return originalRenderCall(args, theme, context);
 
@@ -135,6 +138,7 @@ export default function (pi: ExtensionAPI) {
         theme: RenderTheme<TParams, TDetails, TState>,
         context: RenderContext<TParams, TDetails, TState>,
       ) {
+        if (exportRendering) return originalRenderResult(result, options, theme, context);
         if (calm) return new Container();
         if (originalSelfShell) return originalRenderResult(result, options, theme, context);
 
@@ -157,8 +161,21 @@ export default function (pi: ExtensionAPI) {
   registerBuiltIn(createFindToolDefinition);
   registerBuiltIn(createLsToolDefinition);
 
-  pi.on("session_start", () => {
+  pi.on("session_start", (_event, ctx) => {
     calm = false;
+    exportRendering = false;
+    removeTerminalInputHandler?.();
+    removeTerminalInputHandler = ctx.ui.onTerminalInput((data) => {
+      if (!calm || (data !== "\r" && data !== "\n")) return;
+
+      const input = ctx.ui.getEditorText().trim();
+      if (input !== "/export" && !input.startsWith("/export ")) return;
+
+      exportRendering = true;
+      setTimeout(() => {
+        exportRendering = false;
+      }, 0);
+    });
   });
 
   pi.registerCommand("calm", {

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -19,7 +19,7 @@ import {
   createReadToolDefinition,
   createWriteToolDefinition,
 } from "@earendil-works/pi-coding-agent";
-import { Box, Container, type Component } from "@earendil-works/pi-tui";
+import { Box, Container, getKeybindings, type Component } from "@earendil-works/pi-tui";
 import type { TSchema } from "typebox";
 
 type DefinitionFactory<TParams extends TSchema, TDetails, TState> = (
@@ -166,10 +166,16 @@ export default function (pi: ExtensionAPI) {
     exportRendering = false;
     removeTerminalInputHandler?.();
     removeTerminalInputHandler = ctx.ui.onTerminalInput((data) => {
-      if (!calm || (data !== "\r" && data !== "\n")) return;
+      if (!calm || !getKeybindings().matches(data, "tui.input.submit")) return;
 
       const input = ctx.ui.getEditorText().trim();
-      if (input !== "/export" && !input.startsWith("/export ")) return;
+      if (
+        input !== "/share" &&
+        input !== "/export" &&
+        !input.startsWith("/export ")
+      ) {
+        return;
+      }
 
       exportRendering = true;
       setTimeout(() => {

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -1,0 +1,181 @@
+// Firstmate's session-local Pi tool-activity presentation toggle.
+//
+// Compatibility boundary: Pi 0.80.10 exposes built-in ToolDefinitions, per-slot
+// renderers, renderShell: "self", session_start replacement reasons, and
+// ExtensionUIContext.setToolsExpanded(). The focused tests pin those assumptions.
+// Pi renders built-in read images outside those slots and exposes no safe global
+// renderer for custom or third-party tools, so those rows intentionally stay visible.
+import type {
+  ExtensionAPI,
+  ToolDefinition,
+  ToolRenderResultOptions,
+} from "@earendil-works/pi-coding-agent";
+import {
+  createBashToolDefinition,
+  createEditToolDefinition,
+  createFindToolDefinition,
+  createGrepToolDefinition,
+  createLsToolDefinition,
+  createReadToolDefinition,
+  createWriteToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import { Box, Container, type Component } from "@earendil-works/pi-tui";
+import type { TSchema } from "typebox";
+
+type DefinitionFactory<TParams extends TSchema, TDetails, TState> = (
+  cwd: string,
+) => ToolDefinition<TParams, TDetails, TState>;
+
+type RenderContext<TParams extends TSchema, TDetails, TState> = Parameters<
+  NonNullable<ToolDefinition<TParams, TDetails, TState>["renderCall"]>
+>[2];
+
+type RenderArgs<TParams extends TSchema, TDetails, TState> = Parameters<
+  NonNullable<ToolDefinition<TParams, TDetails, TState>["renderCall"]>
+>[0];
+
+type RenderTheme<TParams extends TSchema, TDetails, TState> = Parameters<
+  NonNullable<ToolDefinition<TParams, TDetails, TState>["renderCall"]>
+>[1];
+
+type RenderResult<TParams extends TSchema, TDetails, TState> = Parameters<
+  NonNullable<ToolDefinition<TParams, TDetails, TState>["renderResult"]>
+>[0];
+
+type StandardShellState = {
+  shell?: Box;
+  call?: Component;
+  result?: Component;
+};
+
+export default function (pi: ExtensionAPI) {
+  let calm = false;
+
+  function registerBuiltIn<TParams extends TSchema, TDetails, TState>(
+    factory: DefinitionFactory<TParams, TDetails, TState>,
+  ): void {
+    const definitions = new Map<string, ToolDefinition<TParams, TDetails, TState>>();
+    const definitionFor = (cwd: string): ToolDefinition<TParams, TDetails, TState> => {
+      let definition = definitions.get(cwd);
+      if (!definition) {
+        definition = factory(cwd);
+        definitions.set(cwd, definition);
+      }
+      return definition;
+    };
+
+    const original = definitionFor(process.cwd());
+    const originalRenderCall = original.renderCall;
+    const originalRenderResult = original.renderResult;
+    const originalSelfShell = original.renderShell === "self";
+    const standardShells = new WeakMap<object, StandardShellState>();
+
+    if (!originalRenderCall || !originalRenderResult) {
+      throw new Error(`Firstmate calm mode requires both render slots for Pi built-in tool ${original.name}`);
+    }
+
+    const shellStateFor = (
+      context: RenderContext<TParams, TDetails, TState>,
+    ): StandardShellState => {
+      const rowState = context.state as object;
+      let shellState = standardShells.get(rowState);
+      if (!shellState) {
+        shellState = {};
+        standardShells.set(rowState, shellState);
+      }
+      return shellState;
+    };
+
+    const refreshStandardShell = (
+      state: StandardShellState,
+      theme: RenderTheme<TParams, TDetails, TState>,
+      context: RenderContext<TParams, TDetails, TState>,
+    ): Box => {
+      const background = context.isPartial
+        ? (text: string) => theme.bg("toolPendingBg", text)
+        : context.isError
+          ? (text: string) => theme.bg("toolErrorBg", text)
+          : (text: string) => theme.bg("toolSuccessBg", text);
+      const shell = state.shell ?? new Box(1, 1, background);
+      state.shell = shell;
+      shell.setBgFn(background);
+      shell.clear();
+      if (state.call) shell.addChild(state.call);
+      if (state.result) shell.addChild(state.result);
+      return shell;
+    };
+
+    pi.registerTool({
+      ...original,
+      renderShell: "self",
+
+      async execute(toolCallId, params, signal, onUpdate, ctx) {
+        return definitionFor(ctx.cwd).execute(toolCallId, params, signal, onUpdate, ctx);
+      },
+
+      renderCall(
+        args: RenderArgs<TParams, TDetails, TState>,
+        theme: RenderTheme<TParams, TDetails, TState>,
+        context: RenderContext<TParams, TDetails, TState>,
+      ) {
+        if (calm) return new Container();
+        if (originalSelfShell) return originalRenderCall(args, theme, context);
+
+        const state = shellStateFor(context);
+        state.call = originalRenderCall(args, theme, {
+          ...context,
+          lastComponent: state.call,
+        });
+        return refreshStandardShell(state, theme, context);
+      },
+
+      renderResult(
+        result: RenderResult<TParams, TDetails, TState>,
+        options: ToolRenderResultOptions,
+        theme: RenderTheme<TParams, TDetails, TState>,
+        context: RenderContext<TParams, TDetails, TState>,
+      ) {
+        if (calm) return new Container();
+        if (originalSelfShell) return originalRenderResult(result, options, theme, context);
+
+        const state = shellStateFor(context);
+        state.result = originalRenderResult(result, options, theme, {
+          ...context,
+          lastComponent: state.result,
+        });
+        refreshStandardShell(state, theme, context);
+        return new Container();
+      },
+    });
+  }
+
+  registerBuiltIn(createReadToolDefinition);
+  registerBuiltIn(createBashToolDefinition);
+  registerBuiltIn(createEditToolDefinition);
+  registerBuiltIn(createWriteToolDefinition);
+  registerBuiltIn(createGrepToolDefinition);
+  registerBuiltIn(createFindToolDefinition);
+  registerBuiltIn(createLsToolDefinition);
+
+  pi.on("session_start", () => {
+    calm = false;
+  });
+
+  pi.registerCommand("calm", {
+    description:
+      "Toggle built-in call and text-result rows; built-in read images and custom/third-party tool rows stay visible.",
+    handler: async (_args, ctx) => {
+      calm = !calm;
+
+      // Setting the current expansion value is Pi's supported transcript-wide
+      // redraw path. It revisits existing tool rows without changing Ctrl+O state.
+      ctx.ui.setToolsExpanded(ctx.ui.getToolsExpanded());
+      ctx.ui.notify(
+        calm
+          ? "Tool activity is hidden where supported; built-in read images and custom/third-party tool rows remain visible."
+          : "Tool activity is visible.",
+        "info",
+      );
+    },
+  });
+}

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Every Pi session starts with calm mode off and tool activity visible; `/calm` is
 Toggling off restores ordinary rendering, and `Ctrl+O` expansion behavior stays unchanged.
 Built-in `read` images on image-capable terminals and custom or third-party tool rows remain visible because Pi 0.80.10 does not expose those rows to supported extension renderers.
 The toggle changes only interactive rendering, not tool execution, model context, session storage, exports, or diagnostics.
+The version-scoped feasibility evidence for keeping this feature Pi-only is recorded in [docs/calm-mode-feasibility.md](docs/calm-mode-feasibility.md).
 
 ### Talk to it
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,11 @@ pi
 ```
 
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
-For Pi, approve the project trust prompt once per clone on first launch so both tracked `.pi/extensions/*.ts` files auto-load.
+For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
+Every Pi session starts with calm mode off and tool activity visible; `/calm` is a session-local toggle that hides all seven built-in call shells and text-result rows, including existing rows.
+Toggling off restores ordinary rendering, and `Ctrl+O` expansion behavior stays unchanged.
+Built-in `read` images on image-capable terminals and custom or third-party tool rows remain visible because Pi 0.80.10 does not expose those rows to supported extension renderers.
+The toggle changes only interactive rendering, not tool execution, model context, session storage, exports, or diagnostics.
 
 ### Talk to it
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -117,8 +117,9 @@ now_ms() {
 # unclassified so new tests are still runnable and visible in summaries.
 family_for_basename() {
   case "$1" in
-    fm-arm-pretool-check.test.sh|fm-brief.test.sh|fm-captain-translation-contract.test.sh|\
-    fm-cd-pretool-check.test.sh|fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
+    fm-arm-pretool-check.test.sh|fm-brief.test.sh|fm-calm-pi-extension.test.sh|\
+    fm-captain-translation-contract.test.sh|fm-cd-pretool-check.test.sh|\
+    fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-continuity-pretool-check.test.sh|fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-dispatch-select.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -1,0 +1,52 @@
+# Calm-mode harness feasibility
+
+This document owns the version-scoped feasibility evidence for implementing Firstmate calm mode in each verified harness.
+The README owns the user-facing `/calm` usage and limitation contract.
+
+## Required extension surface
+
+A qualifying implementation must auto-load from the trusted project, keep the toggle session-local, redraw already-rendered built-in tool rows, restore the harness's ordinary rendering, and leave tool execution, model context, session storage, exports, diagnostics, and expansion state unchanged.
+Replacing a built-in tool, patching harness internals, filtering persisted events, or claiming coverage outside a supported renderer does not satisfy that boundary.
+
+## Verification record
+
+The following inspection was performed on 2026-07-22.
+
+```text
+$ claude --version
+2.1.216 (Claude Code)
+$ codex --version
+codex-cli 0.144.6
+$ opencode --version
+1.17.18
+$ pi --version
+0.80.10
+$ grok --version
+grok 0.2.106 (bde89716f679)
+```
+
+The inspected commands were `claude --help`, `claude plugin --help`, `claude plugin validate --help`, `codex --help`, `codex plugin --help`, `codex features list`, `opencode --help`, `opencode debug --help`, `opencode debug config`, `pi --help`, `grok --help`, and `grok plugin --help`.
+The inspection also covered the tracked project hook and plugin definitions for all five harnesses and Pi 0.80.10's installed public TypeScript declarations.
+
+| Harness | Conclusion | Evidence |
+| --- | --- | --- |
+| Claude Code 2.1.216 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or a transcript-wide redraw API. |
+| Codex CLI 0.144.6 | Not feasible through the inspected supported project surface. | The tracked hooks expose session, pre-tool, and stop handling, while the plugin and feature inventories expose no TUI tool-row renderer or transcript redraw control. |
+| OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer. A same-name custom tool can replace a built-in tool, but that changes the tool definition and execution path rather than presentation alone. |
+| Pi 0.80.10 | Feasible and implemented. | Public declarations expose `registerTool`, `ToolDefinition.renderCall`, `ToolDefinition.renderResult`, `renderShell`, `setToolsExpanded`, terminal input handling, and extension commands. The focused renderer test and interactive terminal E2E exercise the supported path. |
+| Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract. `--minimal` changes the session's overall screen mode and does not provide selective, reversible transcript-row control. |
+
+These conclusions are deliberately limited to the named versions and supported surfaces.
+They do not claim that a harness can never add the required renderer API.
+
+## Pi verification
+
+`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock Pi renderers, verifies all seven built-ins, exercises already-rendered rows, checks the disclosed image and custom-tool boundaries, covers session reset reasons, proves exports remain ordinary, and drives a genuine interactive terminal session.
+`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi 0.80.10 declarations.
+
+The relevant commands are:
+
+```sh
+tests/fm-calm-pi-extension.test.sh
+tests/fm-pi-primary-types.test.sh
+```

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -39,6 +39,8 @@ test_static_contract() {
   assert_contains "$text" 'calm = false' "Pi calm extension does not default to visible tool activity"
   assert_contains "$text" 'ctx.ui.setToolsExpanded(ctx.ui.getToolsExpanded())' "Pi calm extension does not redraw existing rows while preserving Ctrl+O state"
   assert_contains "$text" 'ctx.ui.onTerminalInput' "Pi calm extension does not scope hiding to interactive rendering"
+  assert_contains "$text" 'getKeybindings().matches(data, "tui.input.submit")' "Pi calm export boundary ignores the active submit keybinding"
+  assert_contains "$text" 'input !== "/share"' "Pi calm export boundary does not cover /share"
   assert_contains "$text" 'renderShell: "self"' "Pi calm extension cannot remove the complete tool shell"
   assert_contains "$text" 'built-in read images and custom/third-party tool rows stay visible' "Pi calm command description does not disclose both visibility boundaries"
   assert_contains "$text" 'built-in read images and custom/third-party tool rows remain visible' "Pi calm enabled status does not disclose both visibility boundaries"
@@ -76,7 +78,7 @@ import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const packageRoot = process.env.PI_PACKAGE_DIR;
-const [{ ToolExecutionComponent }, { initTheme, theme }, { Text, setCapabilities }, { createToolHtmlRenderer }] = await Promise.all([
+const [{ ToolExecutionComponent }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }] = await Promise.all([
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/tool-execution.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/theme/theme.js`).href),
   import(pathToFileURL(`${packageRoot}/node_modules/@earendil-works/pi-tui/dist/index.js`).href),
@@ -245,29 +247,46 @@ const commandContext = {
 
 await handlers.get("session_start")({ reason: "startup" }, commandContext);
 await calmCommand.handler("", commandContext);
-editorText = "/export calm.html";
+async function assertStockHtmlRendering(command, submitData) {
+  editorText = command;
+  terminalInputHandler(submitData);
+  const htmlRenderer = createToolHtmlRenderer({
+    getToolDefinition: (name) => tools.find((tool) => tool.name === name),
+    theme,
+    cwd: process.cwd(),
+  });
+  for (const [name, args, result] of cases.filter(([toolName]) => toolName === "grep" || toolName === "find")) {
+    const toolCallId = `${command}-${name}`;
+    const callHtml = htmlRenderer.renderCall(toolCallId, name, args);
+    const resultHtml = htmlRenderer.renderResult(
+      toolCallId,
+      name,
+      result.content,
+      result.details,
+      result.isError,
+    );
+    if (!callHtml || !resultHtml?.expanded) {
+      throw new Error(`${name} disappeared from ${command} HTML while calm mode was on`);
+    }
+  }
+  editorText = "";
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+await assertStockHtmlRendering("/export calm.html", "\r");
+getKeybindings().setUserBindings({ "tui.input.submit": "alt+s" });
+editorText = "/export remapped.html";
 terminalInputHandler("\r");
-const htmlRenderer = createToolHtmlRenderer({
+const unmatchedRenderer = createToolHtmlRenderer({
   getToolDefinition: (name) => tools.find((tool) => tool.name === name),
   theme,
   cwd: process.cwd(),
 });
-for (const [name, args, result] of cases.filter(([toolName]) => toolName === "grep" || toolName === "find")) {
-  const toolCallId = `export-${name}`;
-  const callHtml = htmlRenderer.renderCall(toolCallId, name, args);
-  const resultHtml = htmlRenderer.renderResult(
-    toolCallId,
-    name,
-    result.content,
-    result.details,
-    result.isError,
-  );
-  if (!callHtml || !resultHtml?.expanded) {
-    throw new Error(`${name} disappeared from HTML export while calm mode was on`);
-  }
+if (unmatchedRenderer.renderCall("unmatched-submit", "grep", { pattern: "alpha", path: "." })) {
+  throw new Error("ordinary non-submit input activated HTML export rendering");
 }
 editorText = "";
-await new Promise((resolve) => setTimeout(resolve, 0));
+await assertStockHtmlRendering("/share", "\x1bs");
 for (const { name, actual } of rows) {
   const rendered = actual.render(100);
   if (rendered.length !== 0) {
@@ -360,6 +379,7 @@ test_interactive_terminal_e2e() {
   restored_snapshot="$TMP_ROOT/restored.txt"
   mkdir -p "$project/.pi/extensions" "$config"
   cp "$EXT" "$project/.pi/extensions/fm-calm.ts"
+  printf '%s\n' '{"tui.input.submit":"alt+s"}' >"$config/keybindings.json"
   now=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
   cat >"$session_file" <<JSON
 {"type":"session","version":3,"id":"11111111-1111-4111-8111-111111111111","timestamp":"$now","cwd":"$project"}
@@ -386,7 +406,7 @@ JSON
   assert_contains "$(cat "$expanded_snapshot")" "CALM_E2E_OUTPUT" "ordinary Ctrl+O expansion hid tool activity while calm mode was off"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
   wait_for_text "$hidden_snapshot" "Tool activity is hidden where supported; built-in read images and custom/third-party tool rows remain visible." \
     || fail "/calm did not report hidden tool activity and its visibility boundaries"
   assert_not_contains "$(cat "$hidden_snapshot")" "CALM_E2E_OUTPUT" "/calm left tool result output in the transcript"
@@ -397,7 +417,7 @@ JSON
   assert_contains "$(cat "$hidden_snapshot")" "The deterministic tool example is complete." "/calm removed assistant conversation after a tool"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/export $export_file"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
   wait_for_text "$export_snapshot" "Session exported to: $export_file" \
     || fail "/export did not complete while calm mode was on"
   node - "$export_file" <<'JS' || fail "calm-mode HTML export omitted grep or find rendering"
@@ -412,7 +432,7 @@ for (const id of ["call_grep_e2e", "call_find_e2e"]) {
 JS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
   wait_for_text "$restored_snapshot" "Tool activity is visible." \
     || fail "second /calm did not report visible tool activity"
   assert_contains "$(cat "$restored_snapshot")" "CALM_E2E_OUTPUT" "second /calm did not restore tool result output"
@@ -421,8 +441,8 @@ JS
   hash_after=$(shasum -a 256 "$session_file" | awk '{print $1}')
   [ "$hash_before" = "$hash_after" ] || fail "/calm changed the persisted session or context data"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/quit"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
-  pass "Pi calm text-row E2E proves default-off, hide, redraw restoration, unchanged persistence, and ordinary Ctrl+O behavior"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  pass "Pi calm text-row E2E proves remapped-submit export, default-off, hide, redraw restoration, unchanged persistence, and ordinary Ctrl+O behavior"
 }
 
 test_static_contract

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# Focused rendering, lifecycle, persistence, and interactive TUI checks for /calm.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-calm-pi-extension)
+EXT="$ROOT/.pi/extensions/fm-calm.ts"
+PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
+TMUX_SOCKET="fm-calm-$$"
+TMUX_SESSION="fm-calm-e2e"
+
+cleanup() {
+  if command -v tmux >/dev/null 2>&1; then
+    tmux -L "$TMUX_SOCKET" kill-server 2>/dev/null || true
+  fi
+  fm_test_cleanup
+}
+trap cleanup EXIT
+
+wait_for_text() {
+  local file=$1 text=$2 i=0
+  while [ "$i" -lt 120 ]; do
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - >"$file" 2>/dev/null || true
+    grep -Fq "$text" "$file" 2>/dev/null && return 0
+    sleep 0.05
+    i=$((i + 1))
+  done
+  return 1
+}
+
+test_static_contract() {
+  local text
+  assert_present "$EXT" "tracked Pi calm extension is missing"
+  text=$(cat "$EXT")
+  assert_contains "$text" 'pi.registerCommand("calm"' "Pi calm extension does not register /calm"
+  assert_contains "$text" 'pi.on("session_start"' "Pi calm extension does not reset on every session start"
+  assert_contains "$text" 'calm = false' "Pi calm extension does not default to visible tool activity"
+  assert_contains "$text" 'ctx.ui.setToolsExpanded(ctx.ui.getToolsExpanded())' "Pi calm extension does not redraw existing rows while preserving Ctrl+O state"
+  assert_contains "$text" 'renderShell: "self"' "Pi calm extension cannot remove the complete tool shell"
+  assert_contains "$text" 'built-in read images and custom/third-party tool rows stay visible' "Pi calm command description does not disclose both visibility boundaries"
+  assert_contains "$text" 'built-in read images and custom/third-party tool rows remain visible' "Pi calm enabled status does not disclose both visibility boundaries"
+  assert_not_contains "$text" 'appendEntry' "Pi calm extension persists its session-local toggle"
+  assert_not_contains "$text" 'sendMessage' "Pi calm extension changes model context"
+  for name in Read Bash Edit Write Grep Find Ls; do
+    assert_contains "$text" "create${name}ToolDefinition" "Pi calm extension does not wrap the $name built-in"
+  done
+  pass "Pi calm extension has the default-off, redraw, seven-built-in text-row, and explicit limitation contract"
+}
+
+test_rendering_and_session_lifecycle() {
+  local fixture out status version
+  if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    echo "skip: node or npm not found for Pi calm renderer test"
+    return 0
+  fi
+  if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+    echo "skip: installed @earendil-works/pi-coding-agent package not found"
+    return 0
+  fi
+  version=$(node -p "require('$PI_PACKAGE_DIR/package.json').version")
+  [ "$version" = "0.80.10" ] || fail "Pi calm compatibility assumptions require Pi 0.80.10, found $version"
+
+  fixture="$TMP_ROOT/renderer"
+  mkdir -p "$fixture/node_modules/@earendil-works"
+  cp "$EXT" "$fixture/fm-calm.ts"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/node_modules/typebox"
+  printf '%s\n' '{"type":"module"}' >"$fixture/package.json"
+
+  out=$(cd "$fixture" && EXT="$fixture/fm-calm.ts" PI_PACKAGE_DIR="$PI_PACKAGE_DIR" node --input-type=module 2>&1 <<'JS'
+import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const packageRoot = process.env.PI_PACKAGE_DIR;
+const [{ ToolExecutionComponent }, { initTheme }, { Text, setCapabilities }] = await Promise.all([
+  import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/tool-execution.js`).href),
+  import(pathToFileURL(`${packageRoot}/dist/modes/interactive/theme/theme.js`).href),
+  import(pathToFileURL(`${packageRoot}/node_modules/@earendil-works/pi-tui/dist/index.js`).href),
+]);
+initTheme("dark");
+setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+
+const tools = [];
+const handlers = new Map();
+let calmCommand;
+const pi = {
+  appendEntry() {
+    throw new Error("calm mode must not persist extension state");
+  },
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand(name, command) {
+    if (name === "calm") calmCommand = command;
+  },
+  registerTool(tool) {
+    tools.push(tool);
+  },
+};
+const extension = await import(`${pathToFileURL(process.env.EXT).href}?test=${Date.now()}`);
+extension.default(pi);
+
+const names = tools.map((tool) => tool.name);
+const expectedNames = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+if (JSON.stringify(names) !== JSON.stringify(expectedNames)) {
+  throw new Error(`unexpected wrapped built-ins: ${names.join(",")}`);
+}
+if (!calmCommand || !handlers.has("session_start")) {
+  throw new Error("calm command or session lifecycle handler was not registered");
+}
+if (
+  calmCommand.description !==
+  "Toggle built-in call and text-result rows; built-in read images and custom/third-party tool rows stay visible."
+) {
+  throw new Error(`calm command description does not disclose both visibility boundaries: ${calmCommand.description}`);
+}
+
+writeFileSync("sample.txt", "alpha\n");
+const cases = [
+  ["read", { path: "sample.txt" }, { content: [{ type: "text", text: "alpha" }], details: {}, isError: false }],
+  ["bash", { command: "printf 'CALM_RENDER_OUTPUT\\n'" }, { content: [{ type: "text", text: "CALM_RENDER_OUTPUT" }], details: {}, isError: false }],
+  ["edit", { path: "sample.txt", edits: [{ oldText: "alpha", newText: "beta" }] }, { content: [{ type: "text", text: "Successfully replaced 1 block(s) in sample.txt." }], details: { diff: "-alpha\n+beta", patch: "", firstChangedLine: 1 }, isError: false }],
+  ["write", { path: "sample.txt", content: "beta\n" }, { content: [{ type: "text", text: "Successfully wrote 5 bytes to sample.txt" }], details: undefined, isError: false }],
+  ["grep", { pattern: "alpha", path: "." }, { content: [{ type: "text", text: "sample.txt:1:alpha" }], details: {}, isError: false }],
+  ["find", { pattern: "*.txt", path: "." }, { content: [{ type: "text", text: "sample.txt" }], details: {}, isError: false }],
+  ["ls", { path: "." }, { content: [{ type: "text", text: "sample.txt" }], details: {}, isError: false }],
+];
+const renderUi = { requestRender() {} };
+const rows = [];
+for (const [name, args, result] of cases) {
+  const wrapped = tools.find((tool) => tool.name === name);
+  const baseline = new ToolExecutionComponent(name, `baseline-${name}`, args, { showImages: false }, undefined, renderUi, process.cwd());
+  const actual = new ToolExecutionComponent(name, `wrapped-${name}`, args, { showImages: false }, wrapped, renderUi, process.cwd());
+  for (const row of [baseline, actual]) {
+    row.markExecutionStarted();
+    row.setArgsComplete();
+    row.updateResult(result);
+  }
+  const collapsedExpected = baseline.render(100);
+  const collapsedActual = actual.render(100);
+  if (JSON.stringify(collapsedActual) !== JSON.stringify(collapsedExpected)) {
+    throw new Error(`${name} collapsed rendering changed while calm mode was off`);
+  }
+  baseline.setExpanded(true);
+  actual.setExpanded(true);
+  const expandedExpected = baseline.render(100);
+  const expandedActual = actual.render(100);
+  if (JSON.stringify(expandedActual) !== JSON.stringify(expandedExpected)) {
+    throw new Error(`${name} expanded rendering changed while calm mode was off`);
+  }
+  rows.push({ name, baseline, actual });
+}
+
+const customDefinition = {
+  name: "third_party_tool",
+  label: "Third party tool",
+  description: "Custom-tool boundary probe",
+  parameters: { type: "object", properties: {} },
+  renderShell: "self",
+  async execute() {
+    return { content: [{ type: "text", text: "CUSTOM_RESULT" }], details: {} };
+  },
+  renderCall() {
+    return new Text("CUSTOM_CALL", 0, 0);
+  },
+  renderResult() {
+    return new Text("CUSTOM_RESULT", 0, 0);
+  },
+};
+const customRow = new ToolExecutionComponent(
+  "third_party_tool",
+  "custom-row",
+  {},
+  { showImages: false },
+  customDefinition,
+  renderUi,
+  process.cwd(),
+);
+customRow.markExecutionStarted();
+customRow.setArgsComplete();
+customRow.updateResult({ content: [{ type: "text", text: "CUSTOM_RESULT" }], details: {}, isError: false });
+
+setCapabilities({ images: "iterm2", trueColor: true, hyperlinks: true });
+const imageRow = new ToolExecutionComponent(
+  "read",
+  "read-image-row",
+  { path: "pixel.png" },
+  { showImages: true },
+  tools.find((tool) => tool.name === "read"),
+  renderUi,
+  process.cwd(),
+);
+imageRow.markExecutionStarted();
+imageRow.setArgsComplete();
+imageRow.updateResult({
+  content: [
+    {
+      type: "image",
+      data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+      mimeType: "image/png",
+    },
+  ],
+  details: {},
+  isError: false,
+});
+imageRow.setExpanded(true);
+const imageVisibleBefore = imageRow.render(100);
+if (!imageVisibleBefore.join("\n").includes("\x1b]1337;File=")) {
+  throw new Error("image-capable Pi fixture did not render the built-in read image boundary");
+}
+
+let expanded = true;
+let notification = "";
+const sessionEntries = [{ type: "message", message: { role: "toolResult", content: "kept" } }];
+const entriesBefore = JSON.stringify(sessionEntries);
+const commandContext = {
+  sessionManager: { getEntries: () => sessionEntries },
+  ui: {
+    getToolsExpanded: () => expanded,
+    setToolsExpanded(value) {
+      if (value !== expanded) throw new Error("/calm changed the ordinary Ctrl+O expansion state");
+      for (const row of rows) row.actual.setExpanded(value);
+      customRow.setExpanded(value);
+      imageRow.setExpanded(value);
+    },
+    notify(message) {
+      notification = message;
+    },
+  },
+};
+
+await calmCommand.handler("", commandContext);
+for (const { name, actual } of rows) {
+  const rendered = actual.render(100);
+  if (rendered.length !== 0) {
+    throw new Error(`${name} left residual tool rows while calm mode was on: ${JSON.stringify(rendered)}`);
+  }
+}
+const calmImageOutput = imageRow.render(100).join("\n");
+if (!calmImageOutput.includes("\x1b]1337;File=")) {
+  throw new Error("calm mode hid the disclosed built-in read image boundary");
+}
+if (calmImageOutput.includes("pixel.png")) {
+  throw new Error("calm mode left the built-in read call shell beside the disclosed image output");
+}
+if (!customRow.render(100).join("\n").includes("CUSTOM_CALL")) {
+  throw new Error("calm mode incorrectly claimed or applied custom-tool coverage");
+}
+if (
+  notification !==
+  "Tool activity is hidden where supported; built-in read images and custom/third-party tool rows remain visible."
+) {
+  throw new Error(`unexpected hidden status: ${notification}`);
+}
+if (JSON.stringify(sessionEntries) !== entriesBefore) {
+  throw new Error("calm mode changed session entries or model context");
+}
+
+// The image-boundary probe changed terminal capabilities after the original
+// stock renders, so refresh the stock comparison under the same capabilities.
+for (const { baseline } of rows) baseline.setExpanded(expanded);
+await calmCommand.handler("", commandContext);
+for (const { name, baseline, actual } of rows) {
+  if (JSON.stringify(actual.render(100)) !== JSON.stringify(baseline.render(100))) {
+    throw new Error(`${name} did not restore the expanded standard renderer`);
+  }
+}
+if (JSON.stringify(imageRow.render(100)) !== JSON.stringify(imageVisibleBefore)) {
+  throw new Error("built-in read image row did not restore its ordinary call shell and image output");
+}
+if (notification !== "Tool activity is visible.") {
+  throw new Error(`unexpected visible status: ${notification}`);
+}
+
+for (const reason of ["startup", "new", "resume", "fork", "reload"]) {
+  await calmCommand.handler("", commandContext);
+  await handlers.get("session_start")({ reason }, commandContext);
+  for (const row of rows) row.actual.setExpanded(expanded);
+  for (const { name, baseline, actual } of rows) {
+    if (JSON.stringify(actual.render(100)) !== JSON.stringify(baseline.render(100))) {
+      throw new Error(`${reason} session did not begin with calm mode off for ${name}`);
+    }
+  }
+}
+
+const readWrapper = tools.find((tool) => tool.name === "read");
+const { createReadToolDefinition } = await import(pathToFileURL(`${packageRoot}/dist/index.js`).href);
+const originalRead = createReadToolDefinition(process.cwd());
+const executeContext = { cwd: process.cwd() };
+const [originalResult, wrappedResult] = await Promise.all([
+  originalRead.execute("original-read", { path: "sample.txt" }, undefined, undefined, executeContext),
+  readWrapper.execute("wrapped-read", { path: "sample.txt" }, undefined, undefined, executeContext),
+]);
+if (JSON.stringify(wrappedResult) !== JSON.stringify(originalResult)) {
+  throw new Error("calm wrapper changed built-in read execution or result data");
+}
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "Pi calm renderer and lifecycle contract failed: $out"
+  [ -z "$out" ] || fail "Pi calm renderer test printed output: $out"
+  pass "Pi calm preserves standard rendering and execution, hides seven built-in call and text rows, keeps read images and custom rows visible, and resets per session"
+}
+
+test_interactive_terminal_e2e() {
+  local project config session_file default_snapshot expanded_snapshot hidden_snapshot restored_snapshot hash_before hash_after now version
+  if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
+    echo "skip: pi or tmux not found for Pi calm interactive E2E"
+    return 0
+  fi
+  version=$(pi --version 2>/dev/null || true)
+  [ "$version" = "0.80.10" ] || fail "Pi calm interactive E2E requires Pi 0.80.10, found $version"
+
+  project="$TMP_ROOT/e2e-project"
+  config="$TMP_ROOT/e2e-config"
+  session_file="$TMP_ROOT/calm-session.jsonl"
+  default_snapshot="$TMP_ROOT/default.txt"
+  expanded_snapshot="$TMP_ROOT/expanded.txt"
+  hidden_snapshot="$TMP_ROOT/hidden.txt"
+  restored_snapshot="$TMP_ROOT/restored.txt"
+  mkdir -p "$project/.pi/extensions" "$config"
+  cp "$EXT" "$project/.pi/extensions/fm-calm.ts"
+  now=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  cat >"$session_file" <<JSON
+{"type":"session","version":3,"id":"11111111-1111-4111-8111-111111111111","timestamp":"$now","cwd":"$project"}
+{"type":"message","id":"a0000001","parentId":null,"timestamp":"$now","message":{"role":"user","content":[{"type":"text","text":"Show a deterministic tool example."}],"timestamp":1}}
+{"type":"message","id":"a0000002","parentId":"a0000001","timestamp":"$now","message":{"role":"assistant","content":[{"type":"text","text":"I will run one command."},{"type":"toolCall","id":"call_calm_e2e","name":"bash","arguments":{"command":"printf 'CALM_E2E_OUTPUT\\n'"}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":2}}
+{"type":"message","id":"a0000003","parentId":"a0000002","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_calm_e2e","toolName":"bash","content":[{"type":"text","text":"CALM_E2E_OUTPUT"}],"details":{},"isError":false,"timestamp":3}}
+{"type":"message","id":"a0000004","parentId":"a0000003","timestamp":"$now","message":{"role":"assistant","content":[{"type":"text","text":"The deterministic tool example is complete."}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":4}}
+JSON
+
+  tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 120 -y 40 \
+    "cd '$project' && env PI_CODING_AGENT_DIR='$config' PI_OFFLINE=1 pi --approve --no-skills --no-prompt-templates --no-context-files --session '$session_file'; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 30"
+  wait_for_text "$default_snapshot" "The deterministic tool example is complete." \
+    || fail "Pi calm E2E did not reach the restored session transcript"
+  assert_contains "$(cat "$default_snapshot")" "CALM_E2E_OUTPUT" "calm mode was not off by default"
+  assert_contains "$(cat "$default_snapshot")" "fm-calm.ts" "project-local Pi calm extension did not auto-load"
+  hash_before=$(shasum -a 256 "$session_file" | awk '{print $1}')
+
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-o
+  wait_for_text "$expanded_snapshot" "escape to interrupt" \
+    || fail "Ctrl+O did not retain Pi's ordinary startup and tool expansion behavior"
+  assert_contains "$(cat "$expanded_snapshot")" "CALM_E2E_OUTPUT" "ordinary Ctrl+O expansion hid tool activity while calm mode was off"
+
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  wait_for_text "$hidden_snapshot" "Tool activity is hidden where supported; built-in read images and custom/third-party tool rows remain visible." \
+    || fail "/calm did not report hidden tool activity and its visibility boundaries"
+  assert_not_contains "$(cat "$hidden_snapshot")" "CALM_E2E_OUTPUT" "/calm left tool result output in the transcript"
+  assert_not_contains "$(cat "$hidden_snapshot")" "\$ printf" "/calm left the tool-call row in the transcript"
+  assert_contains "$(cat "$hidden_snapshot")" "I will run one command." "/calm removed assistant conversation before a tool"
+  assert_contains "$(cat "$hidden_snapshot")" "The deterministic tool example is complete." "/calm removed assistant conversation after a tool"
+
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  wait_for_text "$restored_snapshot" "Tool activity is visible." \
+    || fail "second /calm did not report visible tool activity"
+  assert_contains "$(cat "$restored_snapshot")" "CALM_E2E_OUTPUT" "second /calm did not restore tool result output"
+  assert_contains "$(cat "$restored_snapshot")" "escape to interrupt" "/calm changed the active Ctrl+O expansion state"
+
+  hash_after=$(shasum -a 256 "$session_file" | awk '{print $1}')
+  [ "$hash_before" = "$hash_after" ] || fail "/calm changed the persisted session or context data"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/quit"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  pass "Pi calm text-row E2E proves default-off, hide, redraw restoration, unchanged persistence, and ordinary Ctrl+O behavior"
+}
+
+test_static_contract
+test_rendering_and_session_lifecycle
+test_interactive_terminal_e2e

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -38,6 +38,7 @@ test_static_contract() {
   assert_contains "$text" 'pi.on("session_start"' "Pi calm extension does not reset on every session start"
   assert_contains "$text" 'calm = false' "Pi calm extension does not default to visible tool activity"
   assert_contains "$text" 'ctx.ui.setToolsExpanded(ctx.ui.getToolsExpanded())' "Pi calm extension does not redraw existing rows while preserving Ctrl+O state"
+  assert_contains "$text" 'ctx.ui.onTerminalInput' "Pi calm extension does not scope hiding to interactive rendering"
   assert_contains "$text" 'renderShell: "self"' "Pi calm extension cannot remove the complete tool shell"
   assert_contains "$text" 'built-in read images and custom/third-party tool rows stay visible' "Pi calm command description does not disclose both visibility boundaries"
   assert_contains "$text" 'built-in read images and custom/third-party tool rows remain visible' "Pi calm enabled status does not disclose both visibility boundaries"
@@ -75,10 +76,11 @@ import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const packageRoot = process.env.PI_PACKAGE_DIR;
-const [{ ToolExecutionComponent }, { initTheme }, { Text, setCapabilities }] = await Promise.all([
+const [{ ToolExecutionComponent }, { initTheme, theme }, { Text, setCapabilities }, { createToolHtmlRenderer }] = await Promise.all([
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/tool-execution.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/theme/theme.js`).href),
   import(pathToFileURL(`${packageRoot}/node_modules/@earendil-works/pi-tui/dist/index.js`).href),
+  import(pathToFileURL(`${packageRoot}/dist/core/export-html/tool-renderer.js`).href),
 ]);
 initTheme("dark");
 setCapabilities({ images: null, trueColor: true, hyperlinks: false });
@@ -214,12 +216,21 @@ if (!imageVisibleBefore.join("\n").includes("\x1b]1337;File=")) {
 
 let expanded = true;
 let notification = "";
+let editorText = "";
+let terminalInputHandler;
 const sessionEntries = [{ type: "message", message: { role: "toolResult", content: "kept" } }];
 const entriesBefore = JSON.stringify(sessionEntries);
 const commandContext = {
   sessionManager: { getEntries: () => sessionEntries },
   ui: {
+    getEditorText: () => editorText,
     getToolsExpanded: () => expanded,
+    onTerminalInput(handler) {
+      terminalInputHandler = handler;
+      return () => {
+        if (terminalInputHandler === handler) terminalInputHandler = undefined;
+      };
+    },
     setToolsExpanded(value) {
       if (value !== expanded) throw new Error("/calm changed the ordinary Ctrl+O expansion state");
       for (const row of rows) row.actual.setExpanded(value);
@@ -232,7 +243,31 @@ const commandContext = {
   },
 };
 
+await handlers.get("session_start")({ reason: "startup" }, commandContext);
 await calmCommand.handler("", commandContext);
+editorText = "/export calm.html";
+terminalInputHandler("\r");
+const htmlRenderer = createToolHtmlRenderer({
+  getToolDefinition: (name) => tools.find((tool) => tool.name === name),
+  theme,
+  cwd: process.cwd(),
+});
+for (const [name, args, result] of cases.filter(([toolName]) => toolName === "grep" || toolName === "find")) {
+  const toolCallId = `export-${name}`;
+  const callHtml = htmlRenderer.renderCall(toolCallId, name, args);
+  const resultHtml = htmlRenderer.renderResult(
+    toolCallId,
+    name,
+    result.content,
+    result.details,
+    result.isError,
+  );
+  if (!callHtml || !resultHtml?.expanded) {
+    throw new Error(`${name} disappeared from HTML export while calm mode was on`);
+  }
+}
+editorText = "";
+await new Promise((resolve) => setTimeout(resolve, 0));
 for (const { name, actual } of rows) {
   const rendered = actual.render(100);
   if (rendered.length !== 0) {
@@ -306,7 +341,7 @@ JS
 }
 
 test_interactive_terminal_e2e() {
-  local project config session_file default_snapshot expanded_snapshot hidden_snapshot restored_snapshot hash_before hash_after now version
+  local project config session_file export_file default_snapshot expanded_snapshot hidden_snapshot export_snapshot restored_snapshot hash_before hash_after now version
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi calm interactive E2E"
     return 0
@@ -317,9 +352,11 @@ test_interactive_terminal_e2e() {
   project="$TMP_ROOT/e2e-project"
   config="$TMP_ROOT/e2e-config"
   session_file="$TMP_ROOT/calm-session.jsonl"
+  export_file="$TMP_ROOT/calm-export.html"
   default_snapshot="$TMP_ROOT/default.txt"
   expanded_snapshot="$TMP_ROOT/expanded.txt"
   hidden_snapshot="$TMP_ROOT/hidden.txt"
+  export_snapshot="$TMP_ROOT/export.txt"
   restored_snapshot="$TMP_ROOT/restored.txt"
   mkdir -p "$project/.pi/extensions" "$config"
   cp "$EXT" "$project/.pi/extensions/fm-calm.ts"
@@ -329,7 +366,10 @@ test_interactive_terminal_e2e() {
 {"type":"message","id":"a0000001","parentId":null,"timestamp":"$now","message":{"role":"user","content":[{"type":"text","text":"Show a deterministic tool example."}],"timestamp":1}}
 {"type":"message","id":"a0000002","parentId":"a0000001","timestamp":"$now","message":{"role":"assistant","content":[{"type":"text","text":"I will run one command."},{"type":"toolCall","id":"call_calm_e2e","name":"bash","arguments":{"command":"printf 'CALM_E2E_OUTPUT\\n'"}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":2}}
 {"type":"message","id":"a0000003","parentId":"a0000002","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_calm_e2e","toolName":"bash","content":[{"type":"text","text":"CALM_E2E_OUTPUT"}],"details":{},"isError":false,"timestamp":3}}
-{"type":"message","id":"a0000004","parentId":"a0000003","timestamp":"$now","message":{"role":"assistant","content":[{"type":"text","text":"The deterministic tool example is complete."}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":4}}
+{"type":"message","id":"a0000004","parentId":"a0000003","timestamp":"$now","message":{"role":"assistant","content":[{"type":"toolCall","id":"call_grep_e2e","name":"grep","arguments":{"pattern":"CALM_EXPORT_GREP","path":"."}},{"type":"toolCall","id":"call_find_e2e","name":"find","arguments":{"pattern":"CALM_EXPORT_FIND*","path":"."}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":4}}
+{"type":"message","id":"a0000005","parentId":"a0000004","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_grep_e2e","toolName":"grep","content":[{"type":"text","text":"sample.txt:1:CALM_EXPORT_GREP"}],"details":{},"isError":false,"timestamp":5}}
+{"type":"message","id":"a0000006","parentId":"a0000005","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_find_e2e","toolName":"find","content":[{"type":"text","text":"CALM_EXPORT_FIND.txt"}],"details":{},"isError":false,"timestamp":6}}
+{"type":"message","id":"a0000007","parentId":"a0000006","timestamp":"$now","message":{"role":"assistant","content":[{"type":"text","text":"The deterministic tool example is complete."}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":7}}
 JSON
 
   tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 120 -y 40 \
@@ -350,9 +390,26 @@ JSON
   wait_for_text "$hidden_snapshot" "Tool activity is hidden where supported; built-in read images and custom/third-party tool rows remain visible." \
     || fail "/calm did not report hidden tool activity and its visibility boundaries"
   assert_not_contains "$(cat "$hidden_snapshot")" "CALM_E2E_OUTPUT" "/calm left tool result output in the transcript"
+  assert_not_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_GREP" "/calm left the grep row in the transcript"
+  assert_not_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_FIND" "/calm left the find row in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "\$ printf" "/calm left the tool-call row in the transcript"
   assert_contains "$(cat "$hidden_snapshot")" "I will run one command." "/calm removed assistant conversation before a tool"
   assert_contains "$(cat "$hidden_snapshot")" "The deterministic tool example is complete." "/calm removed assistant conversation after a tool"
+
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/export $export_file"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  wait_for_text "$export_snapshot" "Session exported to: $export_file" \
+    || fail "/export did not complete while calm mode was on"
+  node - "$export_file" <<'JS' || fail "calm-mode HTML export omitted grep or find rendering"
+const html = require("node:fs").readFileSync(process.argv[2], "utf8");
+const match = html.match(/<script id="session-data" type="application\/json">([^<]+)<\/script>/);
+if (!match) process.exit(1);
+const session = JSON.parse(Buffer.from(match[1], "base64").toString("utf8"));
+for (const id of ["call_grep_e2e", "call_find_e2e"]) {
+  const rendered = session.renderedTools?.[id];
+  if (!rendered?.callHtml || !rendered?.resultHtmlExpanded) process.exit(1);
+}
+JS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Strict no-emit contract check for both tracked Pi primary extensions.
+# Strict no-emit contract check for the tracked Firstmate Pi extensions.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -12,8 +12,10 @@ if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
   echo "skip: installed @earendil-works/pi-coding-agent package not found"
   exit 0
 fi
-if [ ! -d "$PI_PACKAGE_DIR/node_modules/typebox" ] || [ ! -d "$PI_PACKAGE_DIR/node_modules/@types/node" ]; then
-  echo "not ok - installed Pi package is missing typebox or Node declarations" >&2
+if [ ! -d "$PI_PACKAGE_DIR/node_modules/typebox" ] || \
+   [ ! -d "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" ] || \
+   [ ! -d "$PI_PACKAGE_DIR/node_modules/@types/node" ]; then
+  echo "not ok - installed Pi package is missing pi-tui, typebox, or Node declarations" >&2
   exit 1
 fi
 
@@ -24,9 +26,11 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/node_modules/@types"
+cp "$ROOT/.pi/extensions/fm-calm.ts" "$TMP_ROOT/fm-calm.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
 ln -s "$PI_PACKAGE_DIR" "$TMP_ROOT/node_modules/@earendil-works/pi-coding-agent"
+ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$TMP_ROOT/node_modules/@earendil-works/pi-tui"
 ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$TMP_ROOT/node_modules/typebox"
 ln -s "$PI_PACKAGE_DIR/node_modules/@types/node" "$TMP_ROOT/node_modules/@types/node"
 
@@ -51,4 +55,4 @@ JSON
 
 tsc -p "$TMP_ROOT/tsconfig.json" || exit 1
 version=$(jq -r '.version' "$PI_PACKAGE_DIR/package.json" 2>/dev/null || printf 'unknown')
-printf 'ok - Pi primary extensions pass strict no-emit typecheck against Pi %s\n' "$version"
+printf 'ok - tracked Pi extensions pass strict no-emit typecheck against Pi %s\n' "$version"


### PR DESCRIPTION
## Intent

Implement and ship the captain-authorized Firstmate /calm feature as a tracked, auto-loaded project-local Pi extension using only Pi 0.80.10 supported APIs. The toggle must be session-local and default off for startup, new, resumed, forked, reloaded, or replaced sessions; while enabled it must hide all seven built-in tool call shells and text-result rows, including already-rendered entries, and toggling off must restore ordinary rendering without changing Ctrl+O expansion. Preserve tool execution, model context, session storage, exports, and diagnostics. The captain explicitly accepted and required plain disclosure that built-in read images on image-capable terminals and custom or third-party tool rows remain visible; disclose both limitations in the command description, enabled notification, automated tests, and user docs, and do not patch Pi internals or claim global coverage. Include focused real-renderer tests, a genuine interactive terminal E2E, strict Pi-version compatibility coverage, and evidence-backed feasibility conclusions for Claude Code, Codex CLI, OpenCode, Pi, and Grok CLI without implementing non-Pi harnesses.

## What Changed

- Add an auto-loaded, session-local Pi `/calm` toggle that hides and restores all seven built-in tool call and text-result rows without changing `Ctrl+O` expansion.
- Preserve tool execution, context, storage, exports, and diagnostics while clearly retaining visible read images and custom or third-party tool rows.
- Add Pi 0.80.10 renderer, type, and interactive terminal coverage, plus version-scoped feasibility findings for all supported harnesses.

## Risk Assessment

✅ Low: Captain, the revised change cleanly covers `/export`, `/share`, and active remapped submit bindings using Pi 0.80.10 supported APIs, with no additional material source risks found.

## Testing

Focused renderer, lifecycle, compatibility, persistence, export, and real-terminal tests passed on Pi 0.80.10. Actual pane transcripts and HTML export were preserved instead of a bitmap screenshot because the product surface is a text-mode terminal, but the required evidence-backed feasibility conclusions for Claude Code, Codex CLI, OpenCode, and Grok CLI are absent.

<details>
<summary>Evidence: Hidden terminal state</summary>

`Actual Pi 0.80.10 pane capture showing /calm enabled, conversation retained, tool rows hidden, and both limitations disclosed.`

```text

 pi v0.80.10
 escape to interrupt
 ctrl+c to clear
 ctrl+c twice to exit
 ctrl+d to exit (empty)
 ctrl+z to suspend
 ctrl+k to delete to end
 shift+tab to cycle thinking level
 ctrl+p/shift+ctrl+p to cycle models
 ctrl+l to select model
 ctrl+o to expand tools
 ctrl+t to expand thinking
 ctrl+g for external editor
 / for commands
 ! to run bash
 !! to run bash (no context)
 option+enter to queue follow-up
 option+up to edit all queued messages
 ctrl+v to paste image (with text fallback)
 drop files to attach

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  project

/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY6755KP7XW9WACM95NWF3SM/e2e-raw-2/e2e-project/.
pi/extensions/fm-calm.ts


 Show a deterministic tool example.


 I will run one command.

 The deterministic tool example is complete.

 Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
   /Users/kunchen/.nvm/versions/node/v24.13.1/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md
   /Users/kunchen/.nvm/versions/node/v24.13.1/lib/node_modules/@earendil-works/pi-coding-agent/docs/models.md

 Tool activity is hidden where supported; built-in read images and custom/third-party tool rows remain visible.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY6755KP7XW9WACM95NWF3SM/e2e-raw-2/e2e-project
↑5 ↓3 0.0%/0 (auto)                                                                                              unknown
```
</details>
<details>
<summary>Evidence: Restored terminal state</summary>

`Actual pane capture showing tool shells and results restored after toggling /calm off, with Ctrl+O still expanded.`

```text

 pi v0.80.10
 escape to interrupt
 ctrl+c to clear
 ctrl+c twice to exit
 ctrl+d to exit (empty)
 ctrl+z to suspend
 ctrl+k to delete to end
 shift+tab to cycle thinking level
 ctrl+p/shift+ctrl+p to cycle models
 ctrl+l to select model
 ctrl+o to expand tools
 ctrl+t to expand thinking
 ctrl+g for external editor
 / for commands
 ! to run bash
 !! to run bash (no context)
 option+enter to queue follow-up
 option+up to edit all queued messages
 ctrl+v to paste image (with text fallback)
 drop files to attach

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  project

/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY6755KP7XW9WACM95NWF3SM/e2e-raw-2/e2e-project/.
pi/extensions/fm-calm.ts


 Show a deterministic tool example.


 I will run one command.


 $ printf 'CALM_E2E_OUTPUT
 '

 CALM_E2E_OUTPUT



 grep /CALM_EXPORT_GREP/ in .

 sample.txt:1:CALM_EXPORT_GREP



 find CALM_EXPORT_FIND* in .

 CALM_EXPORT_FIND.txt


 The deterministic tool example is complete.

 Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
   /Users/kunchen/.nvm/versions/node/v24.13.1/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md
   /Users/kunchen/.nvm/versions/node/v24.13.1/lib/node_modules/@earendil-works/pi-coding-agent/docs/models.md

 Tool activity is visible.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY6755KP7XW9WACM95NWF3SM/e2e-raw-2/e2e-project
↑5 ↓3 0.0%/0 (auto)                                                                                              unknown
```
</details>
<details>
<summary>Evidence: Calm-mode HTML export</summary>

`Real Pi HTML export retaining rendered grep and find calls and expanded results while calm mode was enabled.`

```text
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Session Export</title>
  <style>
    :root {
      --accent: #8abeb7;
      --border: #5f87ff;
      --borderAccent: #00d7ff;
      --borderMuted: #505050;
      --success: #b5bd68;
      --error: #cc6666;
      --warning: #ffff00;
      --muted: #808080;
      --dim: #666666;
      --text: #d4d4d4;
      --thinkingText: #808080;
      --selectedBg: #3a3a4a;
      --userMessageBg: #343541;
      --userMessageText: #d4d4d4;
      --customMessageBg: #2d2838;
      --customMessageText: #d4d4d4;
      --customMessageLabel: #9575cd;
      --toolPendingBg: #282832;
      --toolSuccessBg: #283228;
      --toolErrorBg: #3c2828;
      --toolTitle: #d4d4d4;
      --toolOutput: #808080;
      --mdHeading: #f0c674;
      --mdLink: #81a2be;
      --mdLinkUrl: #666666;
      --mdCode: #8abeb7;
      --mdCodeBlock: #b5bd68;
      --mdCodeBlockBorder: #808080;
      --mdQuote: #808080;
      --mdQuoteBorder: #808080;
      --mdHr: #808080;
      --mdListBullet: #8abeb7;
      --toolDiffAdded: #b5bd68;
      --toolDiffRemoved: #cc6666;
      --toolDiffContext: #808080;
      --syntaxComment: #6A9955;
      --syntaxKeyword: #569CD6;
      --syntaxFunction: #DCDCAA;
      --syntaxVariable: #9CDCFE;
      --syntaxString: #CE9178;
      --syntaxNumber: #B5CEA8;
      --syntaxType: #4EC9B0;
      --syntaxOperator: #D4D4D4;
      --syntaxPunctuation: #D4D4D4;
      --thinkingOff: #505050;
      --thinkingMinimal: #6e6e6e;
      --thinkingLow: #5f87af;
      --thinkingMedium: #81a2be;
      --thinkingHigh: #b294bb;
      --thinkingXhigh: #d183e8;
      --thinkingMax: #ff5fff;
      --bashMode: #b5bd68;
      --exportPageBg: #18181e;
      --exportCardBg: #1e1e24;
      --exportInfoBg: #3c3728;
      --body-bg: #18181e;
      --container-bg: #1e1e24;
      --info-bg: #3c3728;
    }

    * { margin: 0; padding: 0; box-sizing: border-box; }

    :root {
      --line-height: 18px; /* 12px font * 1.5 */
      --sidebar-width: 400px;
      --sidebar-min-width: 240px;
      --sidebar-max-width: 840px;
      --sidebar-resizer-width: 6px;
    }

    body {
      font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
      font-size: 12px;
      line-height: var(--line-height);
      color: var(--text);
      background: var(--body-bg);
    }

    body.sidebar-resizing {
      cursor: col-resize;
      user-select: none;
    }

    #app {
      display: flex;
      min-height: 100vh;
    }

    /* Sidebar */
    #sidebar {
      width: var(--sidebar-width);
      min-width: var(--sidebar-width);
      max-width: var(--sidebar-width);
      background: var(--container-bg);
      flex-shrink: 0;
      display: flex;
      flex-direction: column;
      position: sticky;
      top: 0;
      height: 100vh;
      border-right: 1px solid var(--dim);
    }

    #sidebar-resizer {
      width: var(--sidebar-resizer-width);
      flex-shrink: 0;
      position: sticky;
      top: 0;
      height: 100vh;
      cursor: col-resize;
      touch-action: none;
      background: transparent;
      border-right: 1px solid transparent;
    }

    #sidebar-resizer:hover,
    body.sidebar-resizing #sidebar-resizer {
      background: var(--selectedBg);
      border-right-color: var(--dim);
    }

    .sidebar-header {
      padding: 8px 12px;
      flex-shrink: 0;
    }

    .sidebar-controls {
      padding: 8px 8px 4px 8px;
    }

    .sidebar-search {
      width: 100%;
      box-sizing: border-box;
      padding: 4px 8px;
      font-size: 11px;
      font-family: inherit;
      background: var(--body-bg);
      color: var(--text);
      border: 1px solid var(--dim);
      border-radius: 3px;
    }

    .sidebar-filters {
      display: flex;
      padding: 4px 8px 8px 8px;
      gap: 4px;
      align-items: center;
      flex-wrap: wrap;
    }

    .sidebar-search:focus {
      outline: none;
      border-color: var(--accent);
    }

    .sidebar-search::placeholder {
      color: var(--muted);
    }

    .filter-btn {
      padding: 3px 8px;
      font-size: 10px;
      font-family: inherit;
      background: transparent;
      color: var(--muted);
      border: 1px solid var(--dim);
      border-radius: 3px;
      cursor: pointer;
    }

    .filter-btn:hover {
      color: var(--text);
      border-color: var(--text);
    }

    .filter-btn.active {
      background: var(--accent);
      color: var(--body-bg);
      border-color: var(--accent);
    }

    .sidebar-close {
      display: none;
      padding: 3px 8px;
      font-size: 12px;
      font-family: inherit;
      background: transparent;
      color: var(--muted);
      border: 1px solid var(--dim);
      border-radius: 3px;
      cursor: pointer;
      margin-left: auto;
    }

    .sidebar-close:hover {
      color: var(--text);
      border-color: var(--text);
    }

    .tree-container {
      flex: 1;
      overflow: auto;
      padding: 4px 0;
    }

    .tree-node {
      padding: 0 8px;
      cursor: pointer;
      display: flex;
      align-items: baseline;
      font-size: 11px;
      line-height: 13px;
      white-space: nowrap;
    }

    .tree-node:hover {
      background: var(--selectedBg);
    }

    .tree-node.active {
      background: var(--selectedBg);
    }

    .tree-node.active .tree-content {
      font-weight: bold;
    }

    .tree-node.in-path {
      background: color-mix(in srgb, var(--accent) 10%, transparent);
    }

    .tree-node:not(.in-path) {
      opacity: 0.5;
    }

    .tree-node:not(.in-path):hover {
      opacity: 1;
    }

    .tree-prefix {
      color: var(--muted);
      flex-shrink: 0;
      font-family: monospace;
      white-space: pre;
    }

    .tree-marker {
      color: var(--accent);
      flex-shrink: 0;
    }

    .tree-content {
      color: var(--text);
    }

    .tree-role-user {
      color: var(--accent);
    }

    .tree-role-skill {
      color: var(--customMessageLabel);
    }

    .tree-role-assistant {
      color: var(--success);
    }

    .tree-role-tool {
      color: var(--muted);
    }

    .tree-muted {
      color: var(--muted);
    }

    .tree-error {
      color: var(--error);
    }

    .tree-compaction {
      color: var(--borderAccent);
    }

    .tree-branch-summary {
      color: var(--warning);
    }

    .tree-custom-message {
      color: var(--customMessageLabel);
    }

    .tree-status {
      padding: 4px 12px;
      font-size: 10px;
      color: var(--muted);
      flex-shrink: 0;
    }

    /* Main content */
    #content {
      flex: 1;
      min-width: 0;
      overflow-y: auto;
      padding: var(--line-height) calc(var(--line-height) * 2);
      display: flex;
      flex-direction: column;
      align-items: center;
    }

    #content > * {
      width: 100%;
      max-width: 800px;
    }

    /* Help bar */
    .help-bar {
      font-size: 11px;
      color: var(--warning);
      margin-bottom: var(--line-height);
      display: flex;
      align-items: center;
      justify-content: space-between;
      flex-wrap: wrap;
      gap: 12px;
    }

    .help-hint {
      flex: 1 1 240px;
    }

    .help-actions {
      display: flex;
      align-items: center;
      flex-wrap: wrap;
      gap: 8px;
    }

    .header-toggle-btn,
    .download-json-btn {
      font-size: 10px;
      padding: 2px 8px;
      background: var(--container-bg);
      border: 1px solid var(--border);
      border-radius: 3px;
      color: var(--text);
      cursor: pointer;
      font-family: inherit;
    }

    .header-toggle-btn:hover,
    .download-json-btn:hover {
      background: var(--hover);
      border-color: var(--borderAccent);
    }

    /* Header */
    .header {
      background: var(--container-bg);
      border-radius: 4px;
      padding: var(--line-height);
      margin-bottom: var(--line-height);
    }

    .header h1 {
      font-size: 12px;
      font-weight: bold;
      color: var(--borderAccent);
      margin-bottom: var(--line-height);
    }

    .header-info {
      display: flex;
      flex-direction: column;
      gap: 0;
     

... [267322 bytes truncated] ...

ine code: escape HTML
          codespan(token) {
            return `<code>${escapeHtml(token.text)}</code>`;
          }
        }
      });

      // Simple marked parse (escaping handled in renderers)
      function safeMarkedParse(text) {
        return marked.parse(text);
      }

      // Search input
      const searchInput = document.getElementById('tree-search');
      searchInput.addEventListener('input', (e) => {
        searchQuery = e.target.value;
        forceTreeRerender();
      });

      // Filter buttons
      document.querySelectorAll('.filter-btn').forEach(btn => {
        btn.addEventListener('click', () => {
          document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
          btn.classList.add('active');
          filterMode = btn.dataset.filter;
          forceTreeRerender();
        });
      });

      // Sidebar toggle
      const sidebar = document.getElementById('sidebar');
      const overlay = document.getElementById('sidebar-overlay');
      const hamburger = document.getElementById('hamburger');
      const sidebarResizer = document.getElementById('sidebar-resizer');
      const SIDEBAR_WIDTH_STORAGE_KEY = 'pi-share:v1:sidebar-width';
      const MIN_CONTENT_WIDTH = 320;

      function isMobileLayout() {
        return window.matchMedia('(max-width: 900px)').matches;
      }

      function getSidebarBounds() {
        const rootStyles = getComputedStyle(document.documentElement);
        const minWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-min-width')) || 240;
        const maxWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-max-width')) || 720;
        const viewportMaxWidth = window.innerWidth - MIN_CONTENT_WIDTH;
        return {
          minWidth,
          maxWidth: Math.max(minWidth, Math.min(maxWidth, viewportMaxWidth))
        };
      }

      function clampSidebarWidth(width) {
        const { minWidth, maxWidth } = getSidebarBounds();
        return Math.max(minWidth, Math.min(maxWidth, width));
      }

      function applySidebarWidth(width) {
        document.documentElement.style.setProperty('--sidebar-width', `${Math.round(clampSidebarWidth(width))}px`);
      }

      function loadSidebarWidth() {
        try {
          const raw = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
          if (raw === null) return null;
          const width = Number(raw);
          return Number.isFinite(width) ? width : null;
        } catch {
          return null;
        }
      }

      function saveSidebarWidth(width) {
        try {
          localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(Math.round(clampSidebarWidth(width))));
        } catch {
          // Ignore storage failures (e.g. private browsing restrictions)
        }
      }

      function setupSidebarResize() {
        const savedWidth = loadSidebarWidth();
        if (savedWidth !== null) {
          applySidebarWidth(savedWidth);
        }

        if (!sidebarResizer) return;

        let cleanupDrag = null;

        const stopDrag = (pointerId) => {
          if (cleanupDrag) {
            cleanupDrag(pointerId);
            cleanupDrag = null;
          }
        };

        sidebarResizer.addEventListener('pointerdown', (e) => {
          if (isMobileLayout()) return;

          e.preventDefault();
          const startX = e.clientX;
          const startWidth = sidebar.getBoundingClientRect().width;
          document.body.classList.add('sidebar-resizing');
          sidebarResizer.setPointerCapture?.(e.pointerId);

          const onPointerMove = (event) => {
            applySidebarWidth(startWidth + (event.clientX - startX));
          };

          cleanupDrag = (pointerIdToRelease) => {
            document.body.classList.remove('sidebar-resizing');
            sidebarResizer.releasePointerCapture?.(pointerIdToRelease);
            window.removeEventListener('pointermove', onPointerMove);
            window.removeEventListener('pointerup', onPointerUp);
            window.removeEventListener('pointercancel', onPointerCancel);
            saveSidebarWidth(sidebar.getBoundingClientRect().width);
          };

          const onPointerUp = (event) => stopDrag(event.pointerId);
          const onPointerCancel = (event) => stopDrag(event.pointerId);

          window.addEventListener('pointermove', onPointerMove);
          window.addEventListener('pointerup', onPointerUp);
          window.addEventListener('pointercancel', onPointerCancel);
        });

        sidebarResizer.addEventListener('dblclick', () => {
          if (isMobileLayout()) return;
          applySidebarWidth(400);
          saveSidebarWidth(400);
        });

        window.addEventListener('resize', () => {
          if (isMobileLayout()) return;
          applySidebarWidth(sidebar.getBoundingClientRect().width);
        });
      }

      setupSidebarResize();

      hamburger.addEventListener('click', () => {
        sidebar.classList.add('open');
        overlay.classList.add('open');
        hamburger.style.display = 'none';
      });

      const closeSidebar = () => {
        sidebar.classList.remove('open');
        overlay.classList.remove('open');
        hamburger.style.display = '';
      };

      overlay.addEventListener('click', closeSidebar);
      document.getElementById('sidebar-close').addEventListener('click', closeSidebar);

      // Toggle states
      let thinkingExpanded = true;
      let toolOutputsExpanded = false;

      const toggleThinking = () => {
        thinkingExpanded = !thinkingExpanded;
        document.querySelectorAll('.thinking-text').forEach(el => {
          el.style.display = thinkingExpanded ? '' : 'none';
        });
        document.querySelectorAll('.thinking-collapsed').forEach(el => {
          el.style.display = thinkingExpanded ? 'none' : 'block';
        });
      };

      const toggleToolOutputs = () => {
        toolOutputsExpanded = !toolOutputsExpanded;
        document.querySelectorAll('.tool-output.expandable').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
        document.querySelectorAll('.compaction').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
        document.querySelectorAll('.skill-invocation').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
      };

      const attachHeaderHandlers = () => {
        document.querySelector('[data-action="toggle-thinking"]')?.addEventListener('click', toggleThinking);
        document.querySelector('[data-action="toggle-tools"]')?.addEventListener('click', toggleToolOutputs);
      };

      const isEditableTarget = (element) => {
        if (!element) return false;
        const tagName = element.tagName;
        if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT' || tagName === 'BUTTON') {
          return true;
        }
        return element.isContentEditable || Boolean(element.closest?.('[contenteditable="true"]'));
      };

      // Keyboard shortcuts
      document.addEventListener('keydown', (e) => {
        if (e.key === 'Escape') {
          searchInput.value = '';
          searchQuery = '';
          navigateTo(leafId, 'bottom');
        }

        if (isEditableTarget(document.activeElement)) {
          return;
        }

        const key = e.key.toLowerCase();
        if (key === 't') {
          e.preventDefault();
          toggleThinking();
        } else if (key === 'o') {
          e.preventDefault();
          toggleToolOutputs();
        }
      });

      // Initial render
      // If URL has targetId, scroll to that specific message; otherwise stay at top
      if (leafId) {
        if (urlTargetId && byId.has(urlTargetId)) {
          // Deep link: navigate to leaf and scroll to target message
          navigateTo(leafId, 'target', urlTargetId);
        } else {
          navigateTo(leafId, 'none');
        }
      } else if (entries.length > 0) {
        // Fallback: use last entry if no leafId
        navigateTo(entries[entries.length - 1].id, 'none');
      }
    })();

  </script>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Focused validation log</summary>

`Focused renderer, lifecycle, and interactive E2E checks passed.`

```text
ok - Pi calm extension has the default-off, redraw, seven-built-in text-row, and explicit limitation contract
ok - Pi calm preserves standard rendering and execution, hides seven built-in call and text rows, keeps read images and custom rows visible, and resets per session
ok - Pi calm text-row E2E proves remapped-submit export, default-off, hide, redraw restoration, unchanged persistence, and ordinary Ctrl+O behavior
```
</details>
<details>
<summary>Evidence: Pi compatibility log</summary>

`Strict no-emit compatibility check passed against Pi 0.80.10.`

```text
ok - tracked Pi extensions pass strict no-emit typecheck against Pi 0.80.10
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (5m6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `.pi/extensions/fm-calm.ts:121` - When calm mode is enabled, these registered renderers return empty components. Pi&#39;s HTML exporter reuses registered renderers for `grep` and `find`, so `/export` omits those calls and results. This contradicts the required &#34;Preserve ... exports&#34; behavior and README&#39;s claim that exports remain unchanged. Ensure export rendering bypasses calm mode.
- 🚨 `README.md:105` - The required &#34;evidence-backed feasibility conclusions for Claude Code, Codex CLI, OpenCode, Pi, and Grok CLI&#34; are absent. The changed documentation covers only the Pi implementation and provides no evidence or conclusions for the other four harnesses.

🔧 Fix: Preserve Pi HTML exports during calm mode
1 error still open:
- 🚨 `.pi/extensions/fm-calm.ts:169` - The export bypass only recognizes default Enter on `/export`. Pi also calls the same HTML exporter from `/share`, and supported remapped submit keys need not emit `&#34;\r&#34;` or `&#34;\n&#34;`; in either path `exportRendering` remains false, so calm mode still removes `grep` and `find` rendering from the generated HTML. This contradicts the required &#34;Preserve ... exports&#34; behavior and the instruction that HTML exports always use stock renderers.

🔧 Fix: Preserve calm exports across submit bindings and share
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `README.md:105` - The authoritative intent requires evidence-backed feasibility conclusions for Claude Code, Codex CLI, OpenCode, Pi, and Grok CLI. The target contains Pi implementation/testing and user documentation, but no tracked feasibility conclusions or evidence for the four non-Pi harnesses. Captain, that required deliverable cannot be validated until it is added or its intended tracked location is identified.
- <code>`pi --version` and `tmux -V` confirmed Pi 0.80.10 and tmux 3.6a.</code>
- <code>`tests/fm-calm-pi-extension.test.sh` exercised the real renderer, all seven built-ins, custom-tool and read-image boundaries, every supported session-start reason, unchanged execution/context/persistence, exports, remapped submit, and a genuine tmux-driven terminal interaction.</code>
- <code>`tests/fm-pi-primary-types.test.sh` performed the strict no-emit check against Pi 0.80.10.</code>
- `An evidence-preserving tmux rerun captured default, expanded, hidden, exported, and restored terminal states. Its first exact export-path matcher wrapped because of the mandated long evidence path; rerunning with only that evidence matcher shortened completed successfully.`
- <code>A Node inspection of `calm-export.html` verified call and expanded-result HTML for both the grep and find fixtures.</code>
- <code>`git status --short` confirmed testing left the source worktree unchanged.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
