### PR TITLE
fix(bin): make fm-teardown's landed-work proof forge-agnostic

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -10,9 +10,23 @@
 # upstream-contribution PRs pushed to a fork satisfy this in any mode), OR - for a
 # normal ship task whose commits are not so reachable - when its PR is merged and
 # GitHub reports a PR head that contains the current local work, or its content is
-# already present in the up-to-date default branch. This recognizes the common
+# already present in the up-to-date default branch, or every commit on no remote is
+# present by patch id in - and still present in the current content of - the
+# up-to-date default branch. This recognizes the common
 # squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
 # on a remote yet the change is fully in main.
+# The three proofs are independent and additive, and each refuses when inconclusive:
+#   - pr_is_merged        forge API, GitHub only today
+#   - content_in_default  pure git, survives squash, inconclusive on a merge conflict
+#   - patches_in_default  pure git, forge-agnostic, rescues the conflicting-advance
+#                         case above; the only patch-id proof available on Bitbucket
+#                         Cloud, which publishes no PR head ref to fetch. A patch id
+#                         match is not enough on a whole branch - the unpushed stack
+#                         must also roll back out of the default branch's tree,
+#                         newest commit first, so a landed-then-reverted change
+#                         refuses. FM_LANDED_PATCH_SCAN_LIMIT (default 1000; 0 or a
+#                         non-numeric value means unbounded) bounds how far back the
+#                         default branch is scanned
 # The PR itself is resolved from the task's recorded pr= when present, or - when
 # no pr= was ever recorded (e.g. a yolo-authorized merge on a repo with no PR CI,
 # where the usual "checks green" fm-pr-check.sh trigger never fires) - by looking
@@ -596,6 +610,14 @@ elif [ "$FORCE" != "--force" ] && fm_pf_relay_active "$FM_HOME"; then
   PUBLIC_FOLLOWUP_RELAY_ACTIVE=1
 fi
 
+# How many of the default branch's most recent commits the patch-id landed-work
+# proof will hash. Bounds teardown's cost on a long-lived branch off a busy default
+# branch; see unpushed_patches_are_in_ref for why truncation is a safe direction.
+# A non-numeric override, and 0, both mean "unbounded": they are the two natural
+# spellings of "no limit" and must not behave oppositely (0 as a real limit would
+# empty the range and silently disable the proof).
+LANDED_PATCH_SCAN_LIMIT=${FM_LANDED_PATCH_SCAN_LIMIT:-1000}
+
 default_branch() {
   local ref branch
   ref=$(git -C "$PROJ" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
@@ -770,10 +792,18 @@ pr_number_from_branch() {
   printf '%s' "$n"
 }
 
+# Extract a PR number from a recorded pr= target. Accepts a bare number and both
+# forge URL grammars: GitHub's /pull/<n> and Bitbucket's /pull-requests/<n>.
+# /pull/ is NOT a substring of /pull-requests/, so a single GitHub-shaped match
+# silently failed on every Bitbucket URL.
 pr_number_from_target() {
   local target=$1 n
   case "$target" in
     '' ) return 1 ;;
+    *"/pull-requests/"*)
+      n=${target##*/pull-requests/}
+      n=${n%%[!0-9]*}
+      ;;
     *"/pull/"*)
       n=${target##*/pull/}
       n=${n%%[!0-9]*}
@@ -787,11 +817,26 @@ pr_number_from_target() {
   printf '%s' "$n"
 }
 
+# True only when origin is a forge PROVEN to publish no refs/pull/<n>/head - today
+# just Bitbucket Cloud, which has no PR ref namespace at all (refs/pull-requests/
+# is a Bitbucket Server feature). Deliberately a deny-list, not a github.com
+# allow-list: an unrecognized host (GitHub Enterprise, a mirror) keeps attempting
+# the fetch, so this change only ever removes a fetch that could not have worked.
+origin_publishes_no_github_pr_refs() {
+  local url
+  url=$(git -C "$WT" remote get-url origin 2>/dev/null) || return 1
+  case "$url" in
+    *bitbucket.org[:/]*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 ensure_commit_object() {
   local target=$1 commit=$2 n
   git -C "$WT" cat-file -e "$commit^{commit}" 2>/dev/null && return 0
   n=$(pr_number_from_target "$target") || return 1
   git -C "$WT" remote get-url origin >/dev/null 2>&1 || return 1
+  origin_publishes_no_github_pr_refs && return 1
   git -C "$WT" fetch --quiet origin "refs/pull/$n/head" >/dev/null 2>&1 || return 1
   git -C "$WT" cat-file -e "$commit^{commit}" 2>/dev/null
 }
@@ -800,32 +845,123 @@ patch_id_for_commit() {
   local commit=$1
   git -C "$WT" show --pretty=medium --no-ext-diff "$commit" 2>/dev/null \
     | git patch-id --stable 2>/dev/null \
-    | awk 'NR == 1 { print $1 }'
+    | awk 'NR == 1 && $1 ~ /^[0-9a-f]+$/ && $1 !~ /^0+$/ { print $1 }'
 }
 
-unpushed_patches_are_in_pr_head() {
-  local pr_head=$1 current base pr_patch_ids commit patch_id unpushed
-  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
-  base=$(git -C "$WT" merge-base "$current" "$pr_head" 2>/dev/null) || return 1
-  pr_patch_ids=$(
-    git -C "$WT" log --format=%H "$base..$pr_head" -- 2>/dev/null \
-      | while IFS= read -r commit; do
-          patch_id_for_commit "$commit"
-        done \
-      | sed '/^$/d' \
-      | sort -u
-  ) || return 1
-  [ -n "$pr_patch_ids" ] || return 1
-  unpushed=$(git -C "$WT" log --format=%H HEAD --not --remotes -- 2>/dev/null) || return 1
-  [ -n "$unpushed" ] || return 1
+# Every patch id in <base>..<ref>, hashed in ONE pass: `git log -p` streams the
+# whole range into a single `git patch-id`, which emits one line per commit that
+# has a diff. Commits with no diff of their own (merges, empty commits) emit
+# nothing and so contribute no id - they can never make an unpushed commit match.
+# <limit>, when non-empty, caps how many of the range's most recent commits are read.
+patch_ids_in_range() {
+  local base=$1 ref=$2 limit=$3
+  if [ -n "$limit" ]; then
+    git -C "$WT" log -p --no-ext-diff --format='commit %H' --max-count="$limit" "$base..$ref" -- 2>/dev/null
+  else
+    git -C "$WT" log -p --no-ext-diff --format='commit %H' "$base..$ref" -- 2>/dev/null
+  fi \
+    | git patch-id --stable 2>/dev/null \
+    | awk '$1 ~ /^[0-9a-f]+$/ && $1 !~ /^0+$/ { print $1 }' \
+    | sort -u
+}
+
+# A throwaway index holding <ref>'s tree, for the rollback walk below. Echoes its
+# path; the caller removes it. Never touches the real worktree or its index - every
+# git call that reads or writes it is pointed at it through GIT_INDEX_FILE.
+rollback_index_for_ref() {
+  local ref=$1 index
+  index=$(mktemp "${TMPDIR:-/tmp}/fm-teardown-index.XXXXXX") || return 1
+  rm -f -- "$index"
+  if ! GIT_INDEX_FILE="$index" git -C "$WT" read-tree "$ref^{tree}" >/dev/null 2>&1; then
+    rm -f -- "$index"
+    return 1
+  fi
+  printf '%s\n' "$index"
+}
+
+# Roll <commit> back out of <index>, which starts at the landed ref's tree and is
+# walked newest-first, so by the time this is reached the commit's own descendants
+# have already been undone and the index holds exactly the intermediate state that
+# commit produced. Reverse-applying therefore succeeds only while that commit's change
+# is genuinely still present in the landed ref - a change that was applied and later
+# reverted cannot roll back. Persisting each application (no --check) is what makes a
+# replayed multi-commit stack verifiable: each commit is tested against its own
+# predecessor state, not the ref's final tree.
+# The diff is streamed straight into git apply; round-tripping it through a shell
+# variable would strip the trailing newlines that binary payloads and blank final
+# hunk lines depend on. An empty diff (a merge, an empty commit) is no valid patch,
+# so git apply fails and the caller refuses.
+# The check stays per-commit and per-file, far narrower than content_in_default's
+# whole-branch 3-way merge, so it still answers when that merge is inconclusive.
+rollback_commit_from_index() {
+  local commit=$1 index=$2
+  git -C "$WT" show --no-ext-diff --binary --format=%n "$commit" 2>/dev/null \
+    | GIT_INDEX_FILE="$index" git -C "$WT" apply --cached --reverse - >/dev/null 2>&1
+}
+
+# The unpushed-commit walk: newest-first, each commit's patch id must be in
+# <landed_patch_ids>, and - when <index> is non-empty - its change must also still
+# roll back out of that index. Returns non-zero on the FIRST failure of either test,
+# so a partly-landed stack never gets further evaluation.
+unpushed_commits_are_accounted_for() {
+  local landed_patch_ids=$1 unpushed=$2 index=$3 commit patch_id
   while IFS= read -r commit; do
     [ -n "$commit" ] || continue
     patch_id=$(patch_id_for_commit "$commit") || return 1
     [ -n "$patch_id" ] || return 1
-    printf '%s\n' "$pr_patch_ids" | grep -qxF "$patch_id" || return 1
+    printf '%s\n' "$landed_patch_ids" | grep -qxF "$patch_id" || return 1
+    if [ -n "$index" ]; then
+      rollback_commit_from_index "$commit" "$index" || return 1
+    fi
   done <<EOF
 $unpushed
 EOF
+}
+
+# Forge-agnostic core of the patch-id proof: is every commit the worktree holds
+# that lives on no remote also present, by patch id, in <landed_ref>'s history
+# since its merge-base with HEAD? <landed_ref> is any ref that provably holds
+# landed work - a fetched GitHub PR head, or the up-to-date default branch on any
+# forge. The default-branch source is what makes this usable on Bitbucket Cloud,
+# which publishes no PR head ref to fetch.
+# Every inconclusive outcome returns non-zero so the caller refuses: no HEAD, no
+# merge-base, an empty comparison range, an unreadable patch id, or any single
+# unpushed commit whose patch id is absent from the range.
+# <limit>, when non-empty and greater than zero, caps how many of the range's most
+# recent commits are hashed. A PR head range is naturally small and passes no limit;
+# a default-branch range is not. Truncation can only lose a match, never invent one,
+# so the bound errs toward refusing.
+# <require_present>, when "yes", additionally requires each matching unpushed commit's
+# change to still be present in <landed_ref>'s current content, proved by rolling the
+# whole unpushed stack back out of one shared throwaway index seeded from that ref's
+# tree (see rollback_commit_from_index). A patch id alone proves only that the diff was
+# once applied; on a whole default branch that is not enough, because the change may
+# since have been reverted, and hard-resetting the worktree would then destroy the only
+# copy. A rollback that cannot be completed for any reason - an unbuildable index, a
+# conflict, a corrupt or empty patch, a failed git call - is a refusal, never a pass.
+unpushed_patches_are_in_ref() {
+  local landed_ref=$1 limit=${2:-} require_present=${3:-no} current base landed_patch_ids unpushed index='' rc=0
+  case "$limit" in
+    ''|*[!0-9]*) limit= ;;
+    *) [ "$limit" -gt 0 ] || limit= ;;
+  esac
+  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
+  base=$(git -C "$WT" merge-base "$current" "$landed_ref" 2>/dev/null) || return 1
+  landed_patch_ids=$(patch_ids_in_range "$base" "$landed_ref" "$limit") || return 1
+  [ -n "$landed_patch_ids" ] || return 1
+  # --topo-order, not git log's commit-date default: the rollback walk below needs a
+  # child undone before its parent, and committer dates can be skewed (rebase
+  # --committer-date-is-author-date, git am, clock drift across worktrees).
+  unpushed=$(git -C "$WT" log --topo-order --format=%H HEAD --not --remotes -- 2>/dev/null) || return 1
+  [ -n "$unpushed" ] || return 1
+  if [ "$require_present" = yes ]; then
+    index=$(rollback_index_for_ref "$landed_ref") || return 1
+  fi
+  unpushed_commits_are_accounted_for "$landed_patch_ids" "$unpushed" "$index" || rc=1
+  if [ -n "$index" ]; then
+    rm -f -- "$index"
+  fi
+  return "$rc"
 }
 
 # Is the worktree's PR merged for local work contained in that PR? Resolves the
@@ -853,7 +989,24 @@ pr_is_merged() {
   ensure_commit_object "$target" "$head" || return 1
   current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
   git -C "$WT" merge-base --is-ancestor "$current" "$head" 2>/dev/null && return 0
-  unpushed_patches_are_in_pr_head "$head"
+  unpushed_patches_are_in_ref "$head"
+}
+
+# Resolve an up-to-date ref for the project's default branch, fetching from origin
+# when there is one so a stale remote-tracking ref cannot decide the outcome.
+# Echoes the ref name; returns non-zero when it cannot be resolved, so every
+# caller treats an unresolvable default branch as inconclusive.
+default_ref_up_to_date() {
+  local name
+  name=$(default_branch) || return 1
+  if git -C "$WT" remote get-url origin >/dev/null 2>&1; then
+    git -C "$WT" fetch --quiet origin "+refs/heads/$name:refs/remotes/origin/$name" >/dev/null 2>&1 || return 1
+    printf '%s\n' "refs/remotes/origin/$name"
+  elif git -C "$WT" rev-parse --quiet --verify "refs/heads/$name" >/dev/null 2>&1; then
+    printf '%s\n' "refs/heads/$name"
+  else
+    return 1
+  fi
 }
 
 # Is the branch's content already present in the up-to-date default branch? Fetches
@@ -864,16 +1017,8 @@ pr_is_merged() {
 # "added". Returns non-zero when inconclusive (no default ref, or a merge conflict),
 # so the caller refuses rather than guesses.
 content_in_default() {
-  local name ref default_tree merged_tree
-  name=$(default_branch) || return 1
-  if git -C "$WT" remote get-url origin >/dev/null 2>&1; then
-    git -C "$WT" fetch --quiet origin "+refs/heads/$name:refs/remotes/origin/$name" >/dev/null 2>&1 || return 1
-    ref="refs/remotes/origin/$name"
-  elif git -C "$WT" rev-parse --quiet --verify "refs/heads/$name" >/dev/null 2>&1; then
-    ref="refs/heads/$name"
-  else
-    return 1
-  fi
+  local ref default_tree merged_tree
+  ref=$(default_ref_up_to_date) || return 1
   default_tree=$(git -C "$WT" rev-parse --quiet --verify "$ref^{tree}" 2>/dev/null) || return 1
   [ -n "$default_tree" ] || return 1
   merged_tree=$(git -C "$WT" merge-tree --write-tree "$ref" HEAD 2>/dev/null) || return 1
@@ -881,15 +1026,37 @@ content_in_default() {
   [ "$merged_tree" = "$default_tree" ]
 }
 
+# The patch-id proof, taking its comparison range from the up-to-date default
+# branch instead of a PR head ref. Needs no forge API and no PR ref namespace, so
+# it is the only patch-id proof available on Bitbucket Cloud, and it is also the
+# one that still works on GitHub when no PR is recorded or `gh` is unavailable.
+# It rescues the case content_in_default cannot decide: the branch's commits were
+# replayed onto the default branch, but the default branch has since advanced in a
+# way that conflicts with the branch, making the 3-way merge inconclusive.
+# Unlike the PR-head range - which is only ever the commits being merged - a whole
+# default branch also contains the commits that UNDID things, so a patch id match on
+# its own would accept work that landed and was then reverted. Each match must
+# therefore also still be present in the default branch's current content.
+# Returns non-zero whenever the default branch cannot be resolved or any unpushed
+# commit is missing from it, so an inconclusive result still refuses.
+patches_in_default() {
+  local ref
+  ref=$(default_ref_up_to_date) || return 1
+  unpushed_patches_are_in_ref "$ref" "$LANDED_PATCH_SCAN_LIMIT" yes
+}
+
 # Has the worktree's committed work actually LANDED, though its commits are not
 # reachable from any remote-tracking branch? True when a merged PR proves the
 # current local work is contained in the PR head, OR the content is already in the
-# default branch (fallback, which also covers the no-PR and gh-error paths). False
-# only for genuinely unlanded work.
+# default branch (fallback, which also covers the no-PR and gh-error paths), OR
+# every unpushed commit is present by patch id in the default branch. False only
+# for genuinely unlanded work. Each proof is independent and additive: order only
+# decides which one answers first, never whether unlanded work can pass.
 work_is_landed() {
   local branch=$1
   pr_is_merged "$branch" && return 0
-  content_in_default
+  content_in_default && return 0
+  patches_in_default
 }
 
 backlog_refresh_reminder() {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -592,6 +592,7 @@ FM_WEDGE_DEMAND_INSPECT_COUNT=3    # consecutive provably-working stale escalati
 FM_WATCH_TRIAGE_LOG_MAX_BYTES=262144   # size cap for the watcher's absorbed-wake debug log
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=     # optional seconds allowed for bootstrap's best-effort clone refresh; unset/blank defaults to max(20, 5 + 3 * origin-backed-project-count)
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
+FM_LANDED_PATCH_SCAN_LIMIT=1000          # most recent default-branch commits hashed by fm-teardown.sh's patch-id landed-work proof; 0 or a non-numeric value means unbounded, and truncation only makes teardown refuse
 FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh treats a leftover worktree git index.lock as provably stale
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature

--- a/docs/gitlab-merge-watch.md
+++ b/docs/gitlab-merge-watch.md
@@ -197,4 +197,4 @@ It refuses a GitLab merge request URL rather than sending it to the wrong forge,
 
 A GitLab task records no `pr_head=`.
 `gh` exposes the head commit as a selectable field, while plain `glab` exposes it only inside its JSON output, which would need a JSON processor firstmate does not require.
-Both consumers already treat it as optional: `bin/fm-teardown.sh` reads the head from the forge at teardown rather than from metadata and falls back to its provider-agnostic content check, and `bin/fm-review-diff.sh` resolves the head from the remote when none is recorded.
+Both consumers already treat it as optional: `bin/fm-teardown.sh` reads the head from the forge at teardown rather than from metadata and falls back to its provider-agnostic content and patch-id landed-work proofs (owned by `bin/fm-teardown.sh`'s header), and `bin/fm-review-diff.sh` resolves the head from the remote when none is recorded.

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -39,6 +39,19 @@
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
 #
+# Forge-agnostic patch-id proof (no PR head ref exists, as on Bitbucket Cloud). The
+# GitHub PR-head range is unchanged and stays covered by (g), (m), (n) and (k).
+#   (z1) patch replayed and still present + conflicting advance -> ALLOW  (default range)
+#   (z2) same shape, patch never replayed                       -> REFUSE (safety)
+#   (z2b) same shape, patch replayed then reverted on default   -> REFUSE (content gone)
+#   (z2c) replayed two-commit stack, still present on default   -> ALLOW  (stack rollback)
+#   (z2d) same stack, only the first commit replayed            -> REFUSE (safety)
+#   (z2e) replayed binary + blank-line-terminated diffs         -> ALLOW  (no patch mangling)
+#   (z3) same shape plus one further unpushed commit            -> REFUSE (total containment)
+#   (z4a) same shape, scan limit truncates the landed commit -> REFUSE (bounded scan)
+#   (z4) Bitbucket origin                                       -> no refs/pull fetch
+#   (z5) /pull/ and /pull-requests/ PR URLs                      -> both parse to 7
+#
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
 #   (r) provably-stale index.lock (old mtime, no live holder) -> lock removed, ALLOW
@@ -301,6 +314,179 @@ commit_tree_from_wt_head() {
   local case_dir=$1 parent=$2 msg=$3 tree
   tree=$(git -C "$case_dir/wt" rev-parse "$parent^{tree}") || return 1
   printf '%s\n' "$msg" | git -C "$case_dir/wt" commit-tree "$tree" -p "$parent"
+}
+
+# Build the shape the forge-agnostic patch-id proof exists for. Leaves:
+#   origin/main      = baseline -> replayed <file>=<content> -> other.txt advance
+#   origin/side-work = baseline -> other.txt=side
+#   worktree         = baseline -> other.txt=side -> <file>=<content>  (last unpushed)
+# The branch's own <file> commit is reachable from no remote and its patch IS on the
+# default branch, still present in its current content. The conflict that makes
+# content_in_default inconclusive comes from other.txt, which both sides changed
+# differently - and that commit is safe to discard because it lives on origin/side-work.
+# So only the patch-id proof can answer, and answering yes loses nothing.
+# landed=no skips the replay, leaving genuinely unlanded work with the same conflict.
+# landed=reverted replays the patch and then undoes it, so the patch id is in the
+# range but the content is NOT in the default branch any more.
+# Args: case_dir file content [landed]
+setup_replayed_patch_with_conflicting_advance() {
+  local case_dir=$1 file=$2 content=$3 landed=${4:-yes} tmp
+  wt_commit_file "$case_dir" "$file" baseline "baseline $file"
+  push_conflict_baseline "$case_dir"
+  # The branch's own work: never pushed anywhere.
+  wt_commit_file "$case_dir" "$file" "$content" "branch change"
+
+  tmp=$(clone_origin_for_advance "$case_dir")
+  if [ "$landed" != no ]; then
+    # Replay the identical diff on main. patch-id hashes the diff only, so this
+    # commit carries the same patch id as the branch's own commit.
+    commit_in_clone "$tmp" "replayed change" "$file" "$content"
+  fi
+  if [ "$landed" = reverted ]; then
+    commit_in_clone "$tmp" "revert replayed change" "$file" baseline
+  fi
+  push_conflicting_advance "$tmp"
+}
+
+# Baseline other.txt, push it to origin/main, then add a commit that main will later
+# contradict - pushed to origin/side-work so it counts as landed-on-a-remote and the
+# patch-id proof never has to vouch for it. It exists purely to make
+# content_in_default's whole-branch 3-way merge conflict. Args: case_dir
+push_conflict_baseline() {
+  local case_dir=$1
+  wt_commit_file "$case_dir" other.txt baseline "baseline other.txt"
+  git -C "$case_dir/wt" push -q origin "HEAD:refs/heads/main"
+  git -C "$case_dir/project" fetch -q origin main
+  wt_commit_file "$case_dir" other.txt side "side work"
+  git -C "$case_dir/wt" push -q origin "HEAD:refs/heads/side-work"
+  git -C "$case_dir/wt" fetch -q origin
+}
+
+# A scratch clone of origin in which to build the default branch's own history.
+# Echoes its path. Args: case_dir
+clone_origin_for_advance() {
+  local case_dir=$1 tmp
+  tmp="$case_dir/_advance"
+  git clone -q "$case_dir/origin.git" "$tmp"
+  printf '%s\n' "$tmp"
+}
+
+# Commit file=content in the scratch clone. Args: tmp message file content
+commit_in_clone() {
+  local tmp=$1 msg=$2 file=$3 content=$4
+  printf '%s\n' "$content" > "$tmp/$file"
+  git -C "$tmp" add -- "$file"
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "$msg"
+}
+
+# Advance main past the branch in a way that conflicts with the side-work commit,
+# push it, and drop the scratch clone. Args: tmp
+push_conflicting_advance() {
+  local tmp=$1
+  commit_in_clone "$tmp" "advance main" other.txt "advanced past the branch"
+  git -C "$tmp" push -q origin HEAD:main
+  rm -rf "$tmp"
+}
+
+# A replayed multi-commit STACK, the flow the patch-id proof mainly serves (a squash
+# merge produces one combined commit that matches no individual branch commit, so
+# content_in_default owns those). Branch = C1 adds foo.ts containing "a", C2 rewrites
+# it to "a\nb"; both are replayed onto main in order and are still present there.
+# Verifying C1 requires undoing C2 first, because C1's post-image is an intermediate
+# state the default branch's final tree no longer holds.
+# landed=partial replays only C1, leaving C2 landed nowhere. Args: case_dir [landed]
+setup_replayed_stack_with_conflicting_advance() {
+  local case_dir=$1 landed=${2:-all} tmp
+  push_conflict_baseline "$case_dir"
+  wt_commit_file "$case_dir" foo.ts a "add foo.ts"
+  printf '%s\n' a b > "$case_dir/wt/foo.ts"
+  git -C "$case_dir/wt" add -- foo.ts
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "extend foo.ts"
+
+  tmp=$(clone_origin_for_advance "$case_dir")
+  commit_in_clone "$tmp" "replayed add foo.ts" foo.ts a
+  if [ "$landed" = all ]; then
+    printf '%s\n' a b > "$tmp/foo.ts"
+    git -C "$tmp" add -- foo.ts
+    git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "replayed extend foo.ts"
+  fi
+  push_conflicting_advance "$tmp"
+}
+
+# Two replayed commits whose diffs are newline-fragile: one text diff whose final hunk
+# line is an empty context line, and one that adds a binary file (whose patch carries
+# base85 blocks terminated by blank lines). Both are still present on main, so the
+# proof must succeed - anything that round-trips these diffs through a shell variable
+# mangles their trailing newlines and refuses instead. Args: case_dir
+setup_replayed_fragile_diffs_with_conflicting_advance() {
+  local case_dir=$1 tmp
+  printf '%s\n\n' keep > "$case_dir/wt/trail.txt"
+  git -C "$case_dir/wt" add -- trail.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "baseline trail.txt"
+  push_conflict_baseline "$case_dir"
+
+  printf '%s\n\n' changed > "$case_dir/wt/trail.txt"
+  git -C "$case_dir/wt" add -- trail.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "trailing-blank-line change"
+  printf '\000\001\002binary\000' > "$case_dir/wt/blob.bin"
+  git -C "$case_dir/wt" add -- blob.bin
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "add binary blob"
+
+  tmp=$(clone_origin_for_advance "$case_dir")
+  printf '%s\n\n' changed > "$tmp/trail.txt"
+  git -C "$tmp" add -- trail.txt
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "replayed trailing-blank-line change"
+  printf '\000\001\002binary\000' > "$tmp/blob.bin"
+  git -C "$tmp" add -- blob.bin
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "replayed binary blob"
+  push_conflicting_advance "$tmp"
+}
+
+# Replace git with a wrapper that logs every fetch invocation to $FM_FETCH_LOG and,
+# when $FM_FAKE_ORIGIN_URL is set, reports that URL for `remote get-url origin`.
+# The URL is faked rather than really set so the rest of the case stays hermetic
+# against the local bare origin. Args: case_dir
+add_fetch_logging_git() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/git" <<'SH'
+#!/usr/bin/env bash
+real=${REAL_GIT_FOR_TEST:-/usr/bin/git}
+for a in "$@"; do
+  if [ "$a" = fetch ]; then
+    [ -n "${FM_FETCH_LOG:-}" ] && printf '%s\n' "$*" >> "$FM_FETCH_LOG"
+    break
+  fi
+done
+if [ -n "${FM_FAKE_ORIGIN_URL:-}" ]; then
+  case " $* " in
+    *" remote get-url origin "*) printf '%s\n' "$FM_FAKE_ORIGIN_URL"; exit 0 ;;
+  esac
+fi
+exec "$real" "$@"
+SH
+  chmod +x "$case_dir/fakebin/git"
+}
+
+# Report PR $2 as merged with a head commit that exists in no local repository, so
+# ensure_commit_object must decide whether to attempt a refs/pull fetch for it.
+# Args: case_dir pr_url
+add_gh_pr_merged_with_unfetchable_head() {
+  local case_dir=$1 pr_url=$2
+  cat > "$case_dir/fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr view")
+    case " $* " in
+      *"state,headRefOid"*)
+        printf '%s\t%s\n' 'MERGED' '0123456789abcdef0123456789abcdef01234567' ; exit 0 ;;
+    esac
+    ;;
+esac
+echo "error: pull request not found" >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/gh"
+  printf 'pr=%s\n' "$pr_url" >> "$case_dir/state/task-x1.meta"
 }
 
 land_equivalent_patch_on_origin_branch() {
@@ -2591,6 +2777,208 @@ EOF
   pass "the run abort and the leaked-process reap both complete before the destructive worktree return"
 }
 
+test_patch_id_proof_uses_default_branch_when_no_pr_head_exists() {
+  local case_dir rc
+  case_dir=$(make_case patch-id-default-range)
+  write_meta "$case_dir" no-mistakes ship
+  # The Bitbucket shape: no pr= recorded, no PR head ref anywhere to fetch, and the
+  # default branch has advanced past the branch in a conflicting way, so the content
+  # proof is inconclusive. The branch's patch IS on the default branch.
+  setup_replayed_patch_with_conflicting_advance "$case_dir" shared.txt branch-change
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "patch-id-default-range: teardown should succeed on the default-branch patch-id proof"
+  ! grep -q REFUSED "$case_dir/stderr" \
+    || fail "patch-id-default-range: teardown printed a REFUSED line"
+  pass "patch-id proof takes its range from the default branch when no PR head ref exists (Bitbucket shape)"
+}
+
+test_patch_id_default_range_still_refuses_genuinely_unlanded_work() {
+  local case_dir rc
+  case_dir=$(make_case patch-id-default-range-unlanded)
+  write_meta "$case_dir" no-mistakes ship
+  # Identical to the case above except the branch's patch was never replayed onto
+  # the default branch. Both git proofs must stay inconclusive and teardown refuse.
+  setup_replayed_patch_with_conflicting_advance "$case_dir" shared.txt branch-change no
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "patch-id-default-range-unlanded: teardown must refuse genuinely unlanded work"
+  grep -q REFUSED "$case_dir/stderr" \
+    || fail "patch-id-default-range-unlanded: no REFUSED line in stderr"
+  pass "default-branch patch-id proof still refuses work that never landed (regression guard)"
+}
+
+test_patch_id_default_range_refuses_a_reverted_patch() {
+  local case_dir rc
+  case_dir=$(make_case patch-id-default-range-reverted)
+  write_meta "$case_dir" no-mistakes ship
+  # The default branch applied the branch's exact diff and then REVERTED it, so its
+  # patch id is in the scanned range while the content is gone. The only surviving
+  # copy is the unpushed local commit: a patch-id match alone must not authorize
+  # hard-resetting it away.
+  setup_replayed_patch_with_conflicting_advance "$case_dir" shared.txt branch-change reverted
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "patch-id-default-range-reverted: teardown must refuse a landed-then-reverted patch"
+  grep -q REFUSED "$case_dir/stderr" \
+    || fail "patch-id-default-range-reverted: no REFUSED line in stderr"
+  pass "default-branch patch-id proof refuses a patch the default branch has since reverted"
+}
+
+test_patch_id_default_range_allows_replayed_stack() {
+  local case_dir rc
+  case_dir=$(make_case patch-id-default-range-stack)
+  write_meta "$case_dir" no-mistakes ship
+  # A two-commit stack replayed onto the default branch and still present there.
+  # Only a newest-first rollback can confirm the older commit, whose post-image the
+  # default branch's final tree no longer holds.
+  setup_replayed_stack_with_conflicting_advance "$case_dir"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "patch-id-default-range-stack: teardown should succeed for a fully replayed stack"
+  ! grep -q REFUSED "$case_dir/stderr" \
+    || fail "patch-id-default-range-stack: teardown printed a REFUSED line"
+  pass "default-branch patch-id proof confirms a replayed multi-commit stack, not just a single commit"
+}
+
+test_patch_id_default_range_refuses_partly_replayed_stack() {
+  local case_dir rc
+  case_dir=$(make_case patch-id-default-range-stack-partial)
+  write_meta "$case_dir" no-mistakes ship
+  # Only the stack's first commit was replayed; the second landed nowhere.
+  setup_replayed_stack_with_conflicting_advance "$case_dir" partial
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "patch-id-default-range-stack-partial: a partly replayed stack must refuse"
+  grep -q REFUSED "$case_dir/stderr" \
+    || fail "patch-id-default-range-stack-partial: no REFUSED line in stderr"
+  pass "default-branch patch-id proof refuses a stack whose later commits never landed"
+}
+
+test_patch_id_default_range_allows_newline_fragile_diffs() {
+  local case_dir rc
+  case_dir=$(make_case patch-id-default-range-fragile)
+  write_meta "$case_dir" no-mistakes ship
+  # A binary diff and a text diff ending in an empty context line, both replayed and
+  # still present. Mangling their trailing newlines would refuse landed work.
+  setup_replayed_fragile_diffs_with_conflicting_advance "$case_dir"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "patch-id-default-range-fragile: newline-fragile diffs must not refuse landed work"
+  ! grep -q REFUSED "$case_dir/stderr" \
+    || fail "patch-id-default-range-fragile: teardown printed a REFUSED line"
+  pass "default-branch patch-id proof handles binary and blank-line-terminated diffs without spurious refusal"
+}
+
+test_patch_id_default_range_refuses_when_only_some_commits_landed() {
+  local case_dir rc
+  case_dir=$(make_case patch-id-default-range-partial)
+  write_meta "$case_dir" no-mistakes ship
+  setup_replayed_patch_with_conflicting_advance "$case_dir" shared.txt branch-change
+  # One further unpushed commit that exists nowhere but here. Containment must be
+  # total: a single missing patch id refuses the whole worktree.
+  wt_commit_file "$case_dir" extra.txt local-only "local follow-up"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "patch-id-default-range-partial: teardown must refuse when one unpushed commit is missing"
+  grep -q REFUSED "$case_dir/stderr" \
+    || fail "patch-id-default-range-partial: no REFUSED line in stderr"
+  pass "default-branch patch-id proof refuses when any single unpushed commit is absent from the default branch"
+}
+
+test_patch_id_default_range_scan_limit_errs_toward_refusing() {
+  local case_dir rc
+  case_dir=$(make_case patch-id-default-range-limit)
+  write_meta "$case_dir" no-mistakes ship
+  setup_replayed_patch_with_conflicting_advance "$case_dir" shared.txt branch-change
+  # The replayed commit is the second-newest on the default branch, so a scan limit
+  # of 1 truncates it out of the range. Truncation must lose the match and refuse,
+  # never be treated as "not found, therefore fine".
+  set +e
+  FM_LANDED_PATCH_SCAN_LIMIT=1 \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "patch-id-default-range-limit: a truncated scan must refuse"
+  grep -q REFUSED "$case_dir/stderr" \
+    || fail "patch-id-default-range-limit: no REFUSED line in stderr"
+  pass "default-branch patch-id scan limit errs toward refusing when it truncates the landed commit"
+}
+
+test_bitbucket_origin_skips_github_pr_head_fetch() {
+  local case_dir rc log
+  case_dir=$(make_case bitbucket-no-pr-ref-fetch)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  add_fetch_logging_git "$case_dir"
+  add_gh_pr_merged_with_unfetchable_head "$case_dir" \
+    "https://bitbucket.org/example/repo/pull-requests/7"
+  log="$case_dir/fetch.log"; : > "$log"
+
+  set +e
+  FM_FETCH_LOG="$log" FM_FAKE_ORIGIN_URL="https://bitbucket.org/example/repo.git" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "bitbucket-no-pr-ref-fetch: unlanded work must still refuse"
+  ! grep -q 'refs/pull/' "$log" \
+    || fail "bitbucket-no-pr-ref-fetch: attempted a GitHub PR-head fetch on a Bitbucket remote: $(cat "$log")"
+  pass "a Bitbucket origin never attempts the GitHub-shaped refs/pull PR-head fetch"
+}
+
+test_pr_number_parses_both_forge_url_forms() {
+  local case_dir url form log
+  for form in pull pull-requests; do
+    case_dir=$(make_case "pr-number-$form")
+    write_meta "$case_dir" no-mistakes ship
+    wt_commit_file "$case_dir" feature.txt hello "add feature"
+    add_fetch_logging_git "$case_dir"
+    url="https://github.com/example/repo/$form/7"
+    add_gh_pr_merged_with_unfetchable_head "$case_dir" "$url"
+    log="$case_dir/fetch.log"; : > "$log"
+
+    set +e
+    FM_FETCH_LOG="$log" run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+    set -e
+
+    # A logged refs/pull/7/head fetch proves the PR number was parsed out of the
+    # URL; before the fix, /pull-requests/ matched nothing and no fetch happened.
+    grep -q 'refs/pull/7/head' "$log" \
+      || fail "pr-number-$form: PR number was not parsed from $url: $(cat "$log")"
+  done
+  pass "pr_number_from_target parses both /pull/ and /pull-requests/ URL forms"
+}
+
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
@@ -2649,3 +3037,13 @@ test_process_spawned_during_grace_is_reaped_on_later_pass
 test_persistent_scan_refuses_after_bounded_retries
 test_process_exit_during_identity_lookup_does_not_refuse
 test_run_abort_precedes_process_reap_precedes_worktree_removal
+test_patch_id_proof_uses_default_branch_when_no_pr_head_exists
+test_patch_id_default_range_still_refuses_genuinely_unlanded_work
+test_patch_id_default_range_refuses_a_reverted_patch
+test_patch_id_default_range_allows_replayed_stack
+test_patch_id_default_range_refuses_partly_replayed_stack
+test_patch_id_default_range_allows_newline_fragile_diffs
+test_patch_id_default_range_refuses_when_only_some_commits_landed
+test_patch_id_default_range_scan_limit_errs_toward_refusing
+test_bitbucket_origin_skips_github_pr_head_fetch
+test_pr_number_parses_both_forge_url_forms


### PR DESCRIPTION
## Intent

Upstream contribution from the mattwwatson/firstmate fork: make fm-teardown.sh's landed-work proof forge-agnostic by adding a default-branch patch-id proof (bounded, revert-safe), accepting Bitbucket /pull-requests/<n> PR URLs, and skipping GitHub-shaped refs/pull/* fetches on forges that do not publish them, so teardown refuses correctly on any forge. The new tests/fm-teardown.test.sh suite runs in the portable serial lane unless maintainers prefer shard placement; it passes isolated on the upstream base (42/42 locally).

## What Changed
- `bin/fm-teardown.sh` gains a third, forge-agnostic landed-work proof: `work_is_landed` now falls through to `patches_in_default`, which checks that every unpushed commit is present by patch id in the up-to-date default branch **and** still rolls back out of that branch's current tree (via a throwaway index, walked newest-first), so squash-merged work on any forge is recognized while landed-then-reverted work still refuses. The default-branch scan is bounded by a new `FM_LANDED_PATCH_SCAN_LIMIT` knob (default 1000; 0 or non-numeric means unbounded), documented in `docs/configuration.md`.
- PR resolution is no longer GitHub-shaped only: `pr_number_from_target` accepts Bitbucket `/pull-requests/<n>` URLs, and `ensure_commit_object` skips the `refs/pull/<n>/head` fetch when origin is Bitbucket Cloud, which publishes no such refs (deny-list, so unrecognized hosts keep trying the fetch).
- Adds a `tests/fm-teardown.test.sh` suite (42 cases, runs in the portable-serial lane, verified 42/42 by the pipeline's Test stage with a negative control against the base commit) and points `docs/gitlab-merge-watch.md` at both content and patch-id fallback proofs.

## Risk Assessment

⚠️ Medium: The change widens the allow-path of a gate that authorizes destroying unpushed local work and leans on subtle git plumbing semantics (patch-id normalization, reverse binary apply, topo-order rollback), but every inconclusive path I traced refuses, the new proof requires both patch-id containment and a still-present rollback proof, and ten targeted tests cover the dangerous edges — safe to merge once the pipeline's test step confirms the suite passes.

## Testing

Ran the full 42-case fm-teardown suite isolated (all pass, exit 0) and confirmed its portable-serial lane placement; proved the new forge-agnostic cases fail on the upstream base script (so they test the fix, not vacuously pass); then demonstrated the end-user behavior with a CLI transcript of the real fm-teardown.sh on Bitbucket-shaped repos — allowing squash-merged work via the default-branch patch-id proof with no GitHub-shaped refs/pull fetches, and refusing both never-landed and landed-then-reverted work. No UI surface is involved (CLI-only change), so the transcript is the reviewer-visible artifact.

<details>
<summary>Evidence: Bitbucket end-to-end teardown CLI transcript (ALLOW + 2 REFUSE scenarios, fetch log)</summary>

```text

=== SCENARIO 1: Bitbucket Cloud, PR squash-merged then branch deleted (should ALLOW) ===
origin url: https://bitbucket.org/example/repo.git (no refs/pull/* namespace)
recorded pr= https://bitbucket.org/example/repo/pull-requests/7
-- unpushed commit on the task worktree (reachable from no remote):
40940f8 branch change
4611965 side work
-- fm-teardown task-x1:
/var/folders/mz/9drvc3ms7w9c8vzk0j1gj2vm0000gp/T//fm-teardown-demo.0HG00x/bb-squash-merged/project: synced 0468049..cf5c08d
teardown task-x1 complete (window fm-task-x1, worktree /var/folders/mz/9drvc3ms7w9c8vzk0j1gj2vm0000gp/T//fm-teardown-demo.0HG00x/bb-squash-merged/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --pr https://bitbucket.org/example/repo/pull-requests/7, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
[exit status: 0]
-- fetches attempted during teardown (must contain NO refs/pull/*):
   git -C /var/folders/mz/9drvc3ms7w9c8vzk0j1gj2vm0000gp/T//fm-teardown-demo.0HG00x/bb-squash-merged/wt fetch --quiet origin +refs/heads/main:refs/remotes/origin/main
   git -C /var/folders/mz/9drvc3ms7w9c8vzk0j1gj2vm0000gp/T//fm-teardown-demo.0HG00x/bb-squash-merged/wt fetch --quiet origin +refs/heads/main:refs/remotes/origin/main
   git -C /var/folders/mz/9drvc3ms7w9c8vzk0j1gj2vm0000gp/T//fm-teardown-demo.0HG00x/bb-squash-merged/project fetch origin --prune --quiet

=== SCENARIO 2: same shape but the patch NEVER landed on main (must REFUSE) ===
-- fm-teardown task-x1:
REFUSED: worktree /var/folders/mz/9drvc3ms7w9c8vzk0j1gj2vm0000gp/T//fm-teardown-demo.0HG00x/bb-unlanded/wt has work not on any remote and not landed.
unpushed commits:
0bdb85a branch change
Push the branch, land its PR, or get the captain's explicit OK to discard, then --force.
[exit status: 1]
-- worktree preserved after refusal: yes

=== SCENARIO 3: patch landed on main but was later REVERTED (must REFUSE) ===
-- default branch history on the forge:
   e29d605 main advances (conflicts with branch)
   afd6ee2 Revert PR #7
   3eed4f9 squash-merged PR #7
   d8e6ae1 baseline other.txt
   ae52182 baseline shared.txt
   582eaaf origin baseline
-- fm-teardown task-x1:
REFUSED: worktree /var/folders/mz/9drvc3ms7w9c8vzk0j1gj2vm0000gp/T//fm-teardown-demo.0HG00x/bb-reverted/wt has work not on any remote and not landed.
unpushed commits:
fad8c7f branch change
Push the branch, land its PR, or get the captain's explicit OK to discard, then --force.
[exit status: 1]
-- worktree preserved after refusal: yes

=== done ===
```
</details>
<details>
<summary>Evidence: Demo script that builds the Bitbucket-shaped sandboxes and drives the real bin/fm-teardown.sh</summary>

```text
#!/usr/bin/env bash
# End-to-end demo of fm-teardown.sh's forge-agnostic landed-work proof.
# Builds real git sandboxes shaped like a Bitbucket Cloud squash-merge flow
# (origin URL on bitbucket.org, NO refs/pull/* namespace, no GitHub PR data)
# and runs the REAL bin/fm-teardown.sh against them, printing the exact CLI
# output an end user would see.
set -u

ROOT=$1          # firstmate checkout
DEMO=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-demo.XXXXXX")
trap 'rm -rf "$DEMO"' EXIT
export GIT_AUTHOR_NAME=demo GIT_AUTHOR_EMAIL=demo@example.invalid
export GIT_COMMITTER_NAME=demo GIT_COMMITTER_EMAIL=demo@example.invalid

hr() { printf '\n=== %s ===\n' "$1"; }

# Build one sandbox: bare origin + project clone + task worktree, with mocks so
# teardown's post-check steps (treehouse/tmux) and forge lookups (gh/gh-axi:
# "no PR found", as on a forge with no gh) are hermetic.
make_case() {
  local name=$1 case_dir=$DEMO/$1 fakebin
  fakebin="$case_dir/fakebin"
  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
  printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/treehouse"
  printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/tmux"
  cat > "$fakebin/gh-axi" <<'SH'
#!/usr/bin/env bash
case "${1:-} ${2:-}" in
  "pr list") printf '%s\n' "count: 0 (showing first 0)" "pull_requests[]: []" ; exit 0 ;;
  "pr view") echo "error: pull request not found" >&2 ; exit 1 ;;
esac
exit 0
SH
  cp "$fakebin/gh-axi" "$fakebin/gh"
  # git wrapper: report a bitbucket.org origin URL and log every fetch, so the
  # transcript can prove no GitHub-shaped refs/pull/* fetch is ever attempted.
  cat > "$fakebin/git" <<SH
#!/usr/bin/env bash
real=\$(PATH=\${PATH#*fakebin:} command -v git)
case " \$* " in
  *" fetch "*) printf '%s\n' "git \$*" >> "$case_dir/fetch.log" ;;
  *" remote get-url origin "*) printf '%s\n' "https://bitbucket.org/example/repo.git"; exit 0 ;;
esac
exec "\$real" "\$@"
SH
  chmod +x "$fakebin/treehouse" "$fakebin/tmux" "$fakebin/gh-axi" "$fakebin/gh" "$fakebin/git"

  git init -q --bare "$case_dir/origin.git"
  git -C "$case_dir/origin.git" symbolic-ref HEAD refs/heads/main
  git clone -q "$case_dir/origin.git" "$case_dir/_seed" 2>/dev/null
  git -C "$case_dir/_seed" commit -q --allow-empty -m "origin baseline"
  git -C "$case_dir/_seed" push -q origin main
  rm -rf "$case_dir/_seed"
  git clone -q "$case_dir/origin.git" "$case_dir/project"
  git -C "$case_dir/project" remote set-head origin main 2>/dev/null || true
  git -C "$case_dir/project" worktree add -q -b fm/task-x1 "$case_dir/wt" main
  touch "$case_dir/state/.last-watcher-beat"
  { printf '%s\n' "window=fm-task-x1" "worktree=$case_dir/wt" \
      "project=$case_dir/project" "kind=ship" "mode=no-mistakes"
    [ -n "${2:-}" ] && printf 'pr=%s\n' "$2"
  } > "$case_dir/state/task-x1.meta"
  printf '%s\n' "$case_dir"
}

wt_commit_file() {
  local case_dir=$1 file=$2 content=$3 msg=$4
  printf '%s\n' "$content" > "$case_dir/wt/$file"
  git -C "$case_dir/wt" add -- "$file"
  git -C "$case_dir/wt" commit -q -m "$msg"
}

# The Bitbucket Cloud squash-merge shape:
#   origin/main = baseline -> [replayed patch] -> [revert?] -> conflicting advance
#   worktree    = baseline -> side work (pushed to side-work) -> patch (UNPUSHED)
# content_in_default is inconclusive (other.txt conflicts), and Bitbucket Cloud
# publishes no PR head ref — only the new default-branch patch-id proof can answer.
shape_case() {
  local case_dir=$1 landed=$2 tmp
  wt_commit_file "$case_dir" shared.txt baseline "baseline shared.txt"
  wt_commit_file "$case_dir" other.txt baseline "baseline other.txt"
  git -C "$case_dir/wt" push -q origin HEAD:refs/heads/main
  git -C "$case_dir/project" fetch -q origin main
  wt_commit_file "$case_dir" other.txt side "side work"
  git -C "$case_dir/wt" push -q origin HEAD:refs/heads/side-work
  git -C "$case_dir/wt" fetch -q origin
  wt_commit_file "$case_dir" shared.txt branch-change "branch change"   # never pushed

  tmp="$case_dir/_advance"
  git clone -q "$case_dir/origin.git" "$tmp"
  if [ "$landed" != no ]; then
    printf '%s\n' branch-change > "$tmp/shared.txt"
    git -C "$tmp" add shared.txt && git -C "$tmp" commit -q -m "squash-merged PR #7"
  fi
  if [ "$landed" = reverted ]; then
    printf '%s\n' baseline > "$tmp/shared.txt"
    git -C "$tmp" add shared.txt && git -C "$tmp" commit -q -m "Revert PR #7"
  fi
  printf '%s\n' "advanced past the branch" > "$tmp/other.txt"
  git -C "$tmp" add other.txt && git -C "$tmp" commit -q -m "main advances (conflicts with branch)"
  git -C "$tmp" push -q origin HEAD:main
  rm -rf "$tmp"
}

run_teardown() {
  local case_dir=$1 rc
  set +e
  FM_GATE_REFUSE_BYPASS=1 \
  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" \
  FM_CONFIG_OVERRIDE="$case_dir/config" PATH="$case_dir/fakebin:$PATH" \
    "$ROOT/bin/fm-teardown.sh" task-x1
  rc=$?
  set -e
  echo "[exit status: $rc]"
}

hr "SCENARIO 1: Bitbucket Cloud, PR squash-merged then branch deleted (should ALLOW)"
echo "origin url: https://bitbucket.org/example/repo.git (no refs/pull/* namespace)"
echo "recorded pr= https://bitbucket.org/example/repo/pull-requests/7"
case1=$(make_case bb-squash-merged "https://bitbucket.org/example/repo/pull-requests/7")
shape_case "$case1" yes
echo "-- unpushed commit on the task worktree (reachable from no remote):"
git -C "$case1/wt" log --oneline origin/main..HEAD -- | head -3
echo "-- fm-teardown task-x1:"
run_teardown "$case1"
echo "-- fetches attempted during teardown (must contain NO refs/pull/*):"
sed 's/^/   /' "$case1/fetch.log"

hr "SCENARIO 2: same shape but the patch NEVER landed on main (must REFUSE)"
case2=$(make_case bb-unlanded "https://bitbucket.org/example/repo/pull-requests/7")
shape_case "$case2" no
echo "-- fm-teardown task-x1:"
run_teardown "$case2"
echo "-- worktree preserved after refusal: $(test -d "$case2/wt" && echo yes || echo NO)"

hr "SCENARIO 3: patch landed on main but was later REVERTED (must REFUSE)"
case3=$(make_case bb-reverted "https://bitbucket.org/example/repo/pull-requests/7")
shape_case "$case3" reverted
echo "-- default branch history on the forge:"
git -C "$case3/origin.git" log --oneline main | sed 's/^/   /'
echo "-- fm-teardown task-x1:"
run_teardown "$case3"
echo "-- worktree preserved after refusal: $(test -d "$case3/wt" && echo yes || echo NO)"

hr "done"
```
</details>
<details>
<summary>Evidence: Base-commit negative control (new tests fail on old fm-teardown.sh)</summary>

```text
with bin/fm-teardown.sh @ 4497181 (base) + new test suite:
not ok - patch-id-default-range: teardown should succeed on the default-branch patch-id proof: expected exit 0, got 1
suite-exit=1

restored to f7ce2c4: suite 42/42 ok, exit 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-teardown.sh:552` - work_is_landed&#39;s fall-through path fetches the default branch twice: content_in_default and patches_in_default each call default_ref_up_to_date, which re-runs `git fetch origin +refs/heads/&lt;name&gt;:refs/remotes/origin/&lt;name&gt;`. On every refusal and every patch-id rescue this doubles the network round-trip and adds a second transient-failure point. The comments state the proofs are deliberately independent and additive, and both failure modes are fail-safe (refuse), so this is a deliberate tradeoff worth acknowledging rather than an issue to fix; resolving the ref once in work_is_landed and passing it down would remove the duplicate fetch if it ever matters.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-teardown.test.sh` isolated on the branch — 42/42 ok, exit 0 (matches the intent&#39;s 42/42 claim)</code>
- <code>`bin/fm-test-run.sh --list --lane portable-serial` — confirms tests/fm-teardown.test.sh is selected by the portable-serial lane (pr-forge family)</code>
- <code>Negative control: checked out base-commit `bin/fm-teardown.sh` (4497181) under the new test suite — first forge-agnostic case fails (expected exit 0, got 1), suite exit 1; restored to f7ce2c4 and re-verified suite exit 0</code>
- <code>Manual end-to-end demo (`bitbucket-teardown-demo.sh`) driving the real `bin/fm-teardown.sh` against Bitbucket-shaped sandboxes: squash-merged+conflicting-advance → ALLOW (exit 0) via default-branch patch-id proof; never-landed → REFUSED (exit 1, worktree preserved); landed-then-reverted → REFUSED (exit 1, worktree preserved); fetch log shows no refs/pull/* fetch on a bitbucket.org origin and the /pull-requests/7 PR URL is accepted</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
