### PR TITLE
feat(bin): add fm-relaunch.sh for on-demand session resume

### DIFF
--- a/bin/fm-relaunch.sh
+++ b/bin/fm-relaunch.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Resume this firstmate home's supervision session on demand, from a launchd
+# LaunchAgent that is registered but carries no automatic trigger.
+# Usage: fm-relaunch.sh install|status|uninstall|run [--help]
+#
+# Mechanism, safety property, and the AppleScript-driven trust-dialog and
+# kickoff-message handshake are owned by docs/relaunch-tool.md - this header
+# stays a pointer, not a restatement.
+#
+# macOS-only (launchd). Fails closed with a clear message on any other platform.
+set -eu
+
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+usage() {
+  sed -n '2,10p' "$SCRIPT_PATH" | sed 's/^# \{0,1\}//'
+}
+
+fm_relaunch_require_macos() {
+  [ "$(uname -s)" = Darwin ] || {
+    echo "error: fm-relaunch.sh is macOS-only (needs launchd); this platform is $(uname -s)" >&2
+    exit 1
+  }
+}
+
+# Label derivation: the default (unoverridden) home gets the bare label so a
+# fresh install cleanly supersedes the hand-built prototype job of the same
+# name; any home with an explicit FM_HOME (e.g. a secondmate) gets a stable
+# suffix derived from that path so multiple homes never collide on one label.
+fm_relaunch_label() {
+  if [ "$FM_HOME" = "$FM_ROOT" ]; then
+    printf 'dev.firstmate.relaunch'
+    return
+  fi
+  local slug
+  if command -v shasum >/dev/null 2>&1; then
+    slug=$(printf '%s' "$FM_HOME" | shasum -a 256 | cut -c1-8)
+  elif command -v sha256sum >/dev/null 2>&1; then
+    slug=$(printf '%s' "$FM_HOME" | sha256sum | cut -c1-8)
+  else
+    echo "error: need shasum or sha256sum to derive a per-home label" >&2
+    exit 1
+  fi
+  printf 'dev.firstmate.relaunch.%s' "$slug"
+}
+
+LABEL="$(fm_relaunch_label)"
+DOMAIN="gui/$(id -u)"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+PLIST_PATH="$PLIST_DIR/$LABEL.plist"
+
+fm_relaunch_loaded() {
+  launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1
+}
+
+fm_relaunch_write_plist() {  # <out-path>
+  local out=$1
+  mkdir -p "$(dirname "$out")"
+  cat > "$out" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>$LABEL</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>$SCRIPT_PATH</string>
+		<string>fire</string>
+	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>FM_HOME</key>
+		<string>$FM_HOME</string>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>$FM_HOME/state/fm-relaunch.log</string>
+	<key>StandardErrorPath</key>
+	<string>$FM_HOME/state/fm-relaunch.log</string>
+</dict>
+</plist>
+PLIST
+}
+
+cmd_install() {
+  fm_relaunch_require_macos
+  local tmp
+  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-relaunch-plist.XXXXXX")
+  trap 'rm -f -- "$tmp"' EXIT
+  fm_relaunch_write_plist "$tmp"
+  if [ -f "$PLIST_PATH" ] && cmp -s "$tmp" "$PLIST_PATH" && fm_relaunch_loaded; then
+    rm -f -- "$tmp"
+    trap - EXIT
+    echo "installed: $LABEL already up to date and loaded"
+    return 0
+  fi
+  if fm_relaunch_loaded; then
+    launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+  fi
+  mv -f -- "$tmp" "$PLIST_PATH"
+  trap - EXIT
+  chmod 0644 "$PLIST_PATH"
+  launchctl bootstrap "$DOMAIN" "$PLIST_PATH"
+  echo "installed: $LABEL ($PLIST_PATH), loaded with no automatic trigger"
+}
+
+cmd_status() {
+  fm_relaunch_require_macos
+  if [ ! -f "$PLIST_PATH" ]; then
+    echo "status: $LABEL not installed"
+    return 1
+  fi
+  if grep -Eq '<key>(RunAtLoad|StartInterval|StartCalendarInterval|WatchPaths|QueueDirectories|KeepAlive)</key>' "$PLIST_PATH"; then
+    echo "status: DANGER - $PLIST_PATH declares an automatic trigger key; reinstall to regenerate it safely" >&2
+    return 1
+  fi
+  echo "status: $LABEL installed at $PLIST_PATH, no automatic trigger key present"
+  if fm_relaunch_loaded; then
+    echo "status: loaded in $DOMAIN"
+  else
+    echo "status: NOT loaded in $DOMAIN (run install)"
+    return 1
+  fi
+}
+
+cmd_uninstall() {
+  fm_relaunch_require_macos
+  if fm_relaunch_loaded; then
+    launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+  fi
+  rm -f -- "$PLIST_PATH"
+  echo "uninstalled: $LABEL"
+}
+
+cmd_run() {
+  fm_relaunch_require_macos
+  [ -f "$PLIST_PATH" ] || {
+    echo "error: $LABEL is not installed; run 'fm-relaunch.sh install' first" >&2
+    exit 1
+  }
+  fm_relaunch_loaded || launchctl bootstrap "$DOMAIN" "$PLIST_PATH"
+  launchctl kickstart -k "$DOMAIN/$LABEL"
+  echo "fired: $LABEL"
+}
+
+# Invoked only as the launchd job's ProgramArguments target (see
+# fm_relaunch_write_plist); opens a terminal running claude in $FM_HOME and
+# drives the trust-dialog/kickoff handshake documented in docs/relaunch-tool.md.
+cmd_fire() {
+  fm_relaunch_require_macos
+  command -v osascript >/dev/null 2>&1 || {
+    echo "error: osascript not found; cannot open a terminal" >&2
+    exit 1
+  }
+  local target_dir quoted_cd script
+  target_dir=$FM_HOME
+  quoted_cd=$(printf '%q' "$target_dir")
+  script=$(cat <<APPLESCRIPT
+tell application "Terminal"
+  activate
+  do script "cd $quoted_cd && exec claude"
+end tell
+delay 2.5
+tell application "System Events"
+  tell process "Terminal"
+    set frontmost to true
+    key code 36
+    delay 1
+    keystroke "hi"
+    key code 36
+  end tell
+end tell
+APPLESCRIPT
+)
+  osascript -e "$script"
+}
+
+case "${1:-}" in
+  install) cmd_install ;;
+  status) cmd_status ;;
+  uninstall) cmd_uninstall ;;
+  run) cmd_run ;;
+  fire) cmd_fire ;;
+  -h|--help) usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/bin/fm-relaunch.sh
+++ b/bin/fm-relaunch.sh
@@ -155,27 +155,29 @@ cmd_fire() {
     echo "error: osascript not found; cannot open a terminal" >&2
     exit 1
   }
-  local target_dir quoted_cd script
+  local target_dir script
   target_dir=$FM_HOME
-  quoted_cd=$(printf '%q' "$target_dir")
-  script=$(cat <<APPLESCRIPT
-tell application "Terminal"
-  activate
-  do script "cd $quoted_cd && exec claude"
-end tell
-delay 2.5
-tell application "System Events"
-  tell process "Terminal"
-    set frontmost to true
-    key code 36
-    delay 1
-    keystroke "hi"
-    key code 36
+  script=$(cat <<'APPLESCRIPT'
+on run argv
+  set targetDir to item 1 of argv
+  tell application "Terminal"
+    activate
+    do script "cd " & quoted form of targetDir & " && exec claude"
   end tell
-end tell
+  delay 2.5
+  tell application "System Events"
+    tell process "Terminal"
+      set frontmost to true
+      key code 36
+      delay 1
+      keystroke "hi"
+      key code 36
+    end tell
+  end tell
+end run
 APPLESCRIPT
 )
-  osascript -e "$script"
+  osascript -e "$script" -- "$target_dir"
 }
 
 case "${1:-}" in

--- a/docs/relaunch-tool.md
+++ b/docs/relaunch-tool.md
@@ -1,0 +1,53 @@
+# On-demand session resume (`bin/fm-relaunch.sh`)
+
+Firstmate's own supervision session is normally reachable only by manually opening a terminal and running `claude`.
+`bin/fm-relaunch.sh` gives a captain a one-command way to resume it later, without any risk of that resume happening on its own.
+
+## Why a launchd LaunchAgent with no trigger
+
+The tool registers a macOS `launchd` `LaunchAgent` job whose plist declares no `RunAtLoad`, `StartInterval`, `StartCalendarInterval`, or watch-path key.
+A `launchd` agent with none of those keys never starts itself; it only runs when something explicitly asks `launchd` to start it (`launchctl kickstart`/`launchctl start`).
+That is the tool's entire safety property: the job exists and can be fired on demand, but nothing - not a timer, not a login event, not a file change - can fire it without an explicit human or human-triggered call.
+`bin/fm-relaunch.sh install` never writes those keys under any code path, and `bin/fm-relaunch.sh status` re-checks the installed plist for them on every call as a standing self-check, not just at install time.
+`tests/fm-relaunch.test.sh` asserts the generated plist never contains them - a regression there would silently turn this into an auto-scheduler.
+
+## Label and multi-home isolation
+
+The job label is `dev.firstmate.relaunch` for the default (unoverridden) primary home, so a fresh `install` cleanly supersedes a hand-built prototype job of the same name.
+A home launched with an explicit `FM_HOME` (for example a secondmate home) gets a distinct label, `dev.firstmate.relaunch.<slug>`, where `<slug>` is a short SHA-256 hash of that `FM_HOME` path.
+This keeps multiple firstmate homes on one machine from colliding on a single `launchd` label while still deriving the label deterministically from state the tool already has, with no separate registry to keep in sync.
+
+## What `run` actually does
+
+`bin/fm-relaunch.sh run` calls `launchctl kickstart` on the installed job.
+The job's `ProgramArguments` point back at the same script with the internal `fire` action, which is where the actual resume happens:
+
+1. Opens a new Terminal.app window running `claude` in the target home (`cd "$FM_HOME" && exec claude`).
+2. Waits briefly for `claude` to boot, then sends a `Return` keystroke via `System Events`. This is a no-op against an empty prompt, but dismisses the one-time "Yes, I trust this folder" dialog `claude` can show in a not-yet-trusted directory - without it, the composer is not usable yet.
+3. Sends a short kickoff message ("hi") and `Return`.
+
+Step 3 exists because opening `claude` alone does not trigger its `SessionStart` hook: that only fires once a real first message reaches the composer.
+Once that message lands, firstmate's own session-start/recovery flow (`AGENTS.md` section 5, `stuck-crewmate-recovery`) takes over and reconciles any dead or stopped crewmate workers on its own - this tool does not duplicate that logic, it only gets a real session started so that flow can run.
+
+`fire` is invoked only as the launchd job's program, not documented as a normal subcommand a captain runs directly - use `run` (or `install` followed by a manual `launchctl kickstart` if the tool is unavailable) to trigger it through the safety-checked path.
+
+## Terminal support
+
+Only Terminal.app is driven today, via `osascript`/`System Events`, matching the original hand-built prototype.
+iTerm2 is not detected or driven; a captain who primarily uses iTerm2 can still use this tool, but the resumed session opens in a new Terminal.app window regardless of which terminal app was frontmost.
+
+## Idempotency
+
+`install` compares the freshly generated plist bytes against what is already on disk and skips the reload when they match and the job is already loaded, so running it repeatedly converges to one installed, loaded job with no duplicate plists and no `launchd` errors.
+When the plist needs to change (for example after an `FM_HOME` change) or the job was not loaded, `install` unloads the previous copy (if any) before installing the new one.
+
+## Superseding the hand-built prototype
+
+An earlier prototype was built directly on the captain's machine outside this repo: a `~/Library/LaunchAgents/dev.firstmate.relaunch.plist` loaded into `launchd` with no auto-trigger key, plus a private payload script.
+Neither file is tracked here - the LaunchAgent lives outside any repo and the payload script lived under a firstmate home's gitignored `config/`.
+Because this tool's default label is the same `dev.firstmate.relaunch`, running `bin/fm-relaunch.sh install` on that machine detects the existing loaded job under that label, unloads it, and installs this tool's plist in its place - no manual removal step is required first.
+The prototype's private payload script itself is left in place on disk (this tool does not touch files it did not create) and becomes dead weight once superseded; a captain who wants it gone can remove it by hand.
+
+## Commands
+
+See `bin/fm-relaunch.sh --help` for the exact subcommand list and flags; that header is the mechanics' one owner.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -92,3 +92,4 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-x-dismiss.sh`        | Dismiss a skipped X-mode mention at the relay without replying                       |
 | `fm-x-link.sh`           | Link a spawned task to its originating X-mode mention in task meta                   |
 | `fm-x-followup.sh`       | Detect, post, and cap completion follow-ups for an X-mode-linked task                |
+| `fm-relaunch.sh`         | Install, run, status-check, and uninstall an on-demand launchd job that resumes this home, never self-triggering (docs/relaunch-tool.md) |

--- a/tests/fm-relaunch.test.sh
+++ b/tests/fm-relaunch.test.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# fm-relaunch.sh: on-demand session-resume LaunchAgent.
+#
+# The entire safety property of this tool is "registered but never
+# self-triggering" - a regression that adds RunAtLoad/StartInterval/
+# StartCalendarInterval/a watch key would silently turn it into an
+# auto-scheduler, which is exactly what the captain does not want. Every test
+# here runs against fake HOME/launchctl/osascript/id/uname stubs so it never
+# touches the real machine's launchd namespace.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BIN="$ROOT/bin/fm-relaunch.sh"
+
+assert_present "$BIN" "bin/fm-relaunch.sh is missing"
+[ -x "$BIN" ] || fail "bin/fm-relaunch.sh must be executable"
+
+# fm_relaunch_case <name> -> sets up a fake HOME/PATH world and echoes it as
+# "<dir>\t<fm_home>"; the caller runs "$BIN" with FM_HOME="$fm_home" and
+# PATH="$dir/fakebin:$PATH" and HOME="$dir/home".
+fm_relaunch_case() {
+  local name=$1 dir fakebin home fm_home
+  dir=$(fm_test_tmproot "fm-relaunch-$name")
+  fakebin="$dir/fakebin"
+  home="$dir/home"
+  fm_home="$dir/fmhome"
+  mkdir -p "$fakebin" "$home/Library/LaunchAgents" "$fm_home/state"
+
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' Darwin
+SH
+
+  cat > "$fakebin/id" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 501
+SH
+
+  # Fake launchctl: tracks "loaded" state in a marker file next to the plist so
+  # bootstrap/bootout/print/kickstart behave consistently across calls within
+  # one test, without ever touching a real launchd domain.
+  cat > "$fakebin/launchctl" <<'SH'
+#!/usr/bin/env bash
+LOADED_DIR="${FM_RELAUNCH_TEST_LOADED_DIR:?}"
+mkdir -p "$LOADED_DIR"
+case "$1" in
+  bootstrap)
+    label=$(awk '/<key>Label<\/key>/{getline; gsub(/.*<string>|<\/string>.*/,""); print; exit}' "$3")
+    : > "$LOADED_DIR/$label"
+    exit 0
+    ;;
+  bootout)
+    label=${2##*/}
+    rm -f -- "$LOADED_DIR/$label"
+    exit 0
+    ;;
+  print)
+    label=${2##*/}
+    [ -f "$LOADED_DIR/$label" ] && exit 0
+    exit 1
+    ;;
+  kickstart)
+    label=${3##*/}
+    if [ -f "$LOADED_DIR/$label" ]; then
+      printf '%s\n' kickstart >> "${FM_RELAUNCH_TEST_FIRE_LOG:-/dev/null}"
+      exit 0
+    fi
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SH
+
+  cat > "$fakebin/osascript" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' osascript-called >> "${FM_RELAUNCH_TEST_OSASCRIPT_LOG:-/dev/null}"
+exit 0
+SH
+
+  chmod +x "$fakebin/uname" "$fakebin/id" "$fakebin/launchctl" "$fakebin/osascript"
+  printf '%s\t%s\t%s\t%s\n' "$dir" "$fm_home" "$home" "$fakebin"
+}
+
+# fm_relaunch_run <dir> <fm_home> <home> <fakebin> <args...>
+# FM_ROOT_OVERRIDE is pinned to fm_home so this case's FM_HOME reads as the
+# default (unoverridden) primary home and claims the bare
+# dev.firstmate.relaunch label; test_nondefault_home_gets_a_distinct_label
+# deliberately diverges FM_HOME from FM_ROOT_OVERRIDE to exercise the other
+# branch.
+fm_relaunch_run() {
+  local dir=$1 fm_home=$2 home=$3 fakebin=$4
+  shift 4
+  FM_RELAUNCH_TEST_LOADED_DIR="$dir/loaded" \
+    FM_RELAUNCH_TEST_FIRE_LOG="$dir/fire.log" \
+    FM_RELAUNCH_TEST_OSASCRIPT_LOG="$dir/osascript.log" \
+    FM_ROOT_OVERRIDE="$fm_home" FM_HOME="$fm_home" HOME="$home" PATH="$fakebin:$PATH" \
+    "$BIN" "$@"
+}
+
+test_help_lists_subcommands() {
+  local out
+  out=$(FM_HOME=/nonexistent "$BIN" --help)
+  assert_contains "$out" "install" "help must list install"
+  assert_contains "$out" "status" "help must list status"
+  assert_contains "$out" "uninstall" "help must list uninstall"
+  assert_contains "$out" "run" "help must list run"
+  pass "help lists install/status/uninstall/run"
+}
+
+test_unknown_subcommand_fails() {
+  local rc=0
+  FM_HOME=/nonexistent "$BIN" bogus >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 2 ] || fail "an unknown subcommand must exit 2 (got $rc)"
+  pass "unknown subcommand exits 2"
+}
+
+test_non_macos_fails_closed() {
+  local case_out dir fm_home home fakebin rc=0
+  case_out=$(fm_relaunch_case nonmac)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' Linux
+SH
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 1 ] || fail "install on a non-macOS platform must fail closed (got $rc)"
+  pass "non-macOS platform fails closed rather than silently doing nothing"
+}
+
+test_install_never_writes_an_auto_trigger_key() {
+  local case_out dir fm_home home fakebin plist
+  case_out=$(fm_relaunch_case notrigger)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "install failed"
+  plist="$home/Library/LaunchAgents/dev.firstmate.relaunch.plist"
+  assert_present "$plist" "install must write a plist at the default label path"
+  for key in RunAtLoad StartInterval StartCalendarInterval WatchPaths QueueDirectories KeepAlive; do
+    assert_no_grep "<key>$key</key>" "$plist" \
+      "generated plist must never declare $key - that would make the job self-trigger"
+  done
+  pass "generated plist never declares an automatic-trigger key"
+}
+
+test_status_confirms_installed_and_no_trigger() {
+  local case_out dir fm_home home fakebin out
+  case_out=$(fm_relaunch_case statusok)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "install failed"
+  out=$(fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" status) \
+    || fail "status must exit 0 once installed and loaded"
+  assert_contains "$out" "no automatic trigger key present" "status must self-check for trigger keys"
+  assert_contains "$out" "loaded" "status must report loaded state"
+  pass "status confirms installed, loaded, and free of auto-trigger keys"
+}
+
+test_status_before_install_reports_not_installed() {
+  local case_out dir fm_home home fakebin rc=0
+  case_out=$(fm_relaunch_case statusmissing)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" status >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || fail "status must fail when nothing is installed"
+  pass "status reports failure when not yet installed"
+}
+
+test_install_is_idempotent() {
+  local case_out dir fm_home home fakebin plist sum1 sum2
+  case_out=$(fm_relaunch_case idempotent)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  plist="$home/Library/LaunchAgents/dev.firstmate.relaunch.plist"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "first install failed"
+  sum1=$(cksum < "$plist")
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "second install failed"
+  sum2=$(cksum < "$plist")
+  [ "$sum1" = "$sum2" ] || fail "repeated install must converge to the same plist bytes"
+  [ -f "$dir/loaded/dev.firstmate.relaunch" ] || fail "job must remain loaded after a repeated install"
+  pass "install run twice converges safely with no duplicate/diverging plist"
+}
+
+test_run_kickstarts_the_installed_job() {
+  local case_out dir fm_home home fakebin
+  case_out=$(fm_relaunch_case runfires)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "install failed"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" run >/dev/null \
+    || fail "run must succeed once installed"
+  assert_grep kickstart "$dir/fire.log" "run must fire the job via launchctl kickstart"
+  pass "run fires the installed job on demand via launchctl kickstart"
+}
+
+test_run_without_install_fails() {
+  local case_out dir fm_home home fakebin rc=0
+  case_out=$(fm_relaunch_case rununinstalled)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" run >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || fail "run must refuse when the job was never installed"
+  pass "run refuses when the job is not installed"
+}
+
+test_uninstall_removes_plist_and_unloads() {
+  local case_out dir fm_home home fakebin plist
+  case_out=$(fm_relaunch_case uninstall)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  plist="$home/Library/LaunchAgents/dev.firstmate.relaunch.plist"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "install failed"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" uninstall >/dev/null \
+    || fail "uninstall failed"
+  assert_absent "$plist" "uninstall must remove the plist"
+  [ ! -f "$dir/loaded/dev.firstmate.relaunch" ] || fail "uninstall must unload the job"
+  pass "uninstall unloads and removes the plist cleanly"
+}
+
+test_status_after_uninstall_reports_not_installed() {
+  local case_out dir fm_home home fakebin rc=0
+  case_out=$(fm_relaunch_case statusafteruninstall)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "install failed"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" uninstall >/dev/null \
+    || fail "uninstall failed"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" status >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || fail "status must report failure after uninstall"
+  pass "status reports not-installed after uninstall"
+}
+
+test_nondefault_home_gets_a_distinct_label() {
+  local case_out dir fm_home home fakebin default_plist other_home
+  case_out=$(fm_relaunch_case distinctlabel)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  # FM_ROOT_OVERRIDE stays pinned to fm_home (the "primary home" for this
+  # case); pointing FM_HOME at a genuinely different directory (a secondmate
+  # home) must produce a distinctly-suffixed label instead of colliding with
+  # the primary home's bare dev.firstmate.relaunch label.
+  other_home="$fm_home/other-home"
+  mkdir -p "$other_home/state"
+  default_plist="$home/Library/LaunchAgents/dev.firstmate.relaunch.plist"
+  FM_RELAUNCH_TEST_LOADED_DIR="$dir/loaded" \
+    FM_RELAUNCH_TEST_FIRE_LOG="$dir/fire.log" \
+    FM_RELAUNCH_TEST_OSASCRIPT_LOG="$dir/osascript.log" \
+    FM_ROOT_OVERRIDE="$fm_home" FM_HOME="$other_home" HOME="$home" PATH="$fakebin:$PATH" \
+    "$BIN" install >/dev/null \
+    || fail "install for a non-default home failed"
+  assert_absent "$default_plist" "a non-default FM_HOME must not claim the bare dev.firstmate.relaunch label"
+  local suffixed=("$home/Library/LaunchAgents"/dev.firstmate.relaunch.*.plist)
+  [ -f "${suffixed[0]:-}" ] \
+    || fail "a non-default FM_HOME must get a distinctly-suffixed label"
+  pass "a home with an explicit FM_HOME gets a distinct label from the primary home"
+}
+
+test_fire_drives_terminal_via_osascript() {
+  local case_out dir fm_home home fakebin
+  case_out=$(fm_relaunch_case fire)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" fire >/dev/null \
+    || fail "fire must succeed"
+  assert_grep osascript-called "$dir/osascript.log" "fire must drive the terminal/claude/message handshake through osascript"
+  pass "fire opens a terminal and drives the kickoff handshake through osascript"
+}
+
+test_help_lists_subcommands
+test_unknown_subcommand_fails
+test_non_macos_fails_closed
+test_install_never_writes_an_auto_trigger_key
+test_status_confirms_installed_and_no_trigger
+test_status_before_install_reports_not_installed
+test_install_is_idempotent
+test_run_kickstarts_the_installed_job
+test_run_without_install_fails
+test_uninstall_removes_plist_and_unloads
+test_status_after_uninstall_reports_not_installed
+test_nondefault_home_gets_a_distinct_label
+test_fire_drives_terminal_via_osascript


### PR DESCRIPTION
## Intent

Developer (acting as an autonomous crewmate managed by "firstmate") tasked the agent with converting a hand-built prototype (a launchd LaunchAgent plist plus a payload script that opens Terminal running `claude`) into a proper, tracked repo tool: `bin/fm-relaunch.sh` with install/run/status/uninstall subcommands. The core requirement was safety: the generated launchd job must never self-trigger (no RunAtLoad, StartInterval, StartCalendarInterval, or watch-path keys) and can only fire via explicit `launchctl kickstart/start`, since the captain explicitly did not want an unattended auto-starting session. Requirements included idempotent install, macOS-only support with clear failure elsewhere, a colocated test file mocking system commands (launchctl/osascript/uname/id) that specifically asserts the forbidden auto-trigger keys are absent, documentation in `docs/relaunch-tool.md` per the "one-owner rule" (avoiding duplicating narrative in the script header or AGENTS.md), and cleanly superseding the existing same-named LaunchAgent without leaving conflicting duplicate jobs. The developer also required the work go through the `no-mistakes` validation pipeline (review, test, lint, document, push, PR) before completion, explicitly avoiding `--yes` so ask-user decisions remain with the human, and directed the agent to escalate rather than fix infrastructure blockers (spend limits, push permission errors) itself. A real security finding (AppleScript injection via unescaped `$quoted_cd` in the osascript call) was caught and fixed during the pipeline's review step. The developer (captain) ultimately resolved a GitHub push-permission blocker by forking and pushing manually, opening PR #894.</summary>
</invoke>

## What Changed

- Add `bin/fm-relaunch.sh` with install/run/status/uninstall subcommands, generating a launchd LaunchAgent that opens Terminal running `claude` — the plist deliberately omits RunAtLoad, StartInterval, StartCalendarInterval, and watch-path keys so the job only fires via explicit `launchctl kickstart/start`, macOS-only with a clear failure message elsewhere.
- Fix an AppleScript injection risk by passing `FM_HOME` to `osascript` as an argv parameter instead of interpolating it into the quoted script string.
- Add `tests/fm-relaunch.test.sh`, mocking `launchctl`/`osascript`/`uname`/`id` to cover install idempotency, safety-key absence, and subcommand behavior.
- Document the tool in `docs/relaunch-tool.md` and add a row for it in `docs/scripts.md`.

## Risk Assessment

✅ Low: Small self-contained script+tests+docs; core safety invariant (no launchd auto-trigger keys) verified present and tested; prior AppleScript injection already fixed via argv passing.

## Testing

Ran the colocated mocked test suite (all 13 assertions pass, including the no-auto-trigger-key assertion) and additionally did a real, non-mocked install/status/uninstall cycle against actual launchctl/launchd on this macOS machine to confirm the generated LaunchAgent plist truly has no RunAtLoad/StartInterval/StartCalendarInterval/WatchPaths/QueueDirectories/KeepAlive keys and cleanly unloads; did not fire cmd_fire for real since that opens a live Terminal window/osascript trust dialog, which the mocked test already exercises safely.

<details>
<summary>Evidence: manual install output</summary>

```text
installed: dev.firstmate.relaunch (/Users/a/Library/LaunchAgents/dev.firstmate.relaunch.plist), loaded with no automatic trigger
```
</details>
<details>
<summary>Evidence: manual status output</summary>

```text
status: dev.firstmate.relaunch installed at /Users/a/Library/LaunchAgents/dev.firstmate.relaunch.plist, no automatic trigger key present
status: loaded in gui/501
```
</details>
<details>
<summary>Evidence: generated plist (real launchd install)</summary>

```text
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>Label</key>
	<string>dev.firstmate.relaunch</string>
	<key>ProgramArguments</key>
	<array>
		<string>/Users/a/.no-mistakes/worktrees/6f88afbe7805/01KY78YWKRD02VK9Y2W68SJDJK/bin/fm-relaunch.sh</string>
		<string>fire</string>
	</array>
	<key>EnvironmentVariables</key>
	<dict>
		<key>FM_HOME</key>
		<string>/tmp/fm-relaunch-manual.fqNet1</string>
	</dict>
	<key>StandardOutPath</key>
	<string>/tmp/fm-relaunch-manual.fqNet1/state/fm-relaunch.log</string>
	<key>StandardErrorPath</key>
	<string>/tmp/fm-relaunch-manual.fqNet1/state/fm-relaunch.log</string>
</dict>
</plist>
```
</details>
<details>
<summary>Evidence: manual uninstall output</summary>

```text
uninstalled: dev.firstmate.relaunch
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-relaunch.test.sh (13 mocked subcommand/safety tests, all ok)`
- `manual: FM_ROOT_OVERRIDE=<tmp> bin/fm-relaunch.sh install/status/uninstall against real launchctl on this Mac, inspected generated plist in ~/Library/LaunchAgents for absence of auto-trigger keys`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
