### PR TITLE
fix(pi): clean up Calm transcript rendering

### DIFF
--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -1,10 +1,10 @@
-// Firstmate's session-local Pi tool-activity presentation toggle.
+// Firstmate's session-local Pi transcript presentation toggle.
 //
-// Compatibility boundary: Pi 0.80.10 exposes built-in ToolDefinitions, per-slot
-// renderers, renderShell: "self", session_start replacement reasons, and
-// ExtensionUIContext.setToolsExpanded(). The focused tests pin those assumptions.
-// Pi renders built-in read images outside those slots and exposes no safe global
-// renderer for custom or third-party tools, so those rows intentionally stay visible.
+// Compatibility boundary: Pi 0.81.1 exposes built-in ToolDefinitions, per-slot
+// renderers, renderShell: "self", session_start replacement reasons,
+// ExtensionUIContext.setToolsExpanded(), setWorkingVisible(), and
+// setHiddenThinkingLabel(). The focused tests pin those assumptions. Pi still
+// exposes no global renderer for built-in message rows or arbitrary custom tools.
 import type {
   ExtensionAPI,
   ToolDefinition,
@@ -21,6 +21,16 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Box, Container, getKeybindings, type Component } from "@earendil-works/pi-tui";
 import type { TSchema } from "typebox";
+import {
+  calmPresentationHides,
+  calmPresentationIsActive,
+  classifyFirstmateSyntheticInput,
+  deliverFirstmateSyntheticInput,
+  FIRSTMATE_CALM_PRESENTATION_EVENT,
+  registerFirstmateSyntheticPresentation,
+  setCalmPresentation,
+  setCalmStockExportRendering,
+} from "./lib/fm-calm-visibility.ts";
 
 type DefinitionFactory<TParams extends TSchema, TDetails, TState> = (
   cwd: string,
@@ -49,9 +59,17 @@ type StandardShellState = {
 };
 
 export default function (pi: ExtensionAPI) {
-  let calm = false;
   let exportRendering = false;
   let removeTerminalInputHandler: (() => void) | undefined;
+
+  const publishPresentationState = (): void => {
+    pi.events.emit(FIRSTMATE_CALM_PRESENTATION_EVENT, {
+      active: calmPresentationIsActive(),
+      stockExportRendering: exportRendering,
+    });
+  };
+
+  registerFirstmateSyntheticPresentation(pi);
 
   function registerBuiltIn<TParams extends TSchema, TDetails, TState>(
     factory: DefinitionFactory<TParams, TDetails, TState>,
@@ -121,7 +139,7 @@ export default function (pi: ExtensionAPI) {
         context: RenderContext<TParams, TDetails, TState>,
       ) {
         if (exportRendering) return originalRenderCall(args, theme, context);
-        if (calm) return new Container();
+        if (calmPresentationHides("assistant-tool-call")) return new Container();
         if (originalSelfShell) return originalRenderCall(args, theme, context);
 
         const state = shellStateFor(context);
@@ -139,7 +157,7 @@ export default function (pi: ExtensionAPI) {
         context: RenderContext<TParams, TDetails, TState>,
       ) {
         if (exportRendering) return originalRenderResult(result, options, theme, context);
-        if (calm) return new Container();
+        if (calmPresentationHides("tool-result")) return new Container();
         if (originalSelfShell) return originalRenderResult(result, options, theme, context);
 
         const state = shellStateFor(context);
@@ -161,12 +179,29 @@ export default function (pi: ExtensionAPI) {
   registerBuiltIn(createFindToolDefinition);
   registerBuiltIn(createLsToolDefinition);
 
+  pi.on("input", (event) => {
+    if (event.images && event.images.length > 0) return { action: "continue" };
+    const kind = classifyFirstmateSyntheticInput(event.text);
+    if (!kind) return { action: "continue" };
+
+    deliverFirstmateSyntheticInput(pi, event.text, kind, {
+      deliverAs: event.streamingBehavior ?? "followUp",
+      triggerTurn: true,
+    });
+    return { action: "handled" };
+  });
+
   pi.on("session_start", (_event, ctx) => {
-    calm = false;
     exportRendering = false;
+    setCalmPresentation(false);
+    setCalmStockExportRendering(false);
+    publishPresentationState();
+    ctx.ui.setWorkingVisible(true);
+    ctx.ui.setHiddenThinkingLabel();
+    ctx.ui.setStatus("firstmate-calm", undefined);
     removeTerminalInputHandler?.();
     removeTerminalInputHandler = ctx.ui.onTerminalInput((data) => {
-      if (!calm || !getKeybindings().matches(data, "tui.input.submit")) return;
+      if (!getKeybindings().matches(data, "tui.input.submit")) return;
 
       const input = ctx.ui.getEditorText().trim();
       if (
@@ -178,27 +213,35 @@ export default function (pi: ExtensionAPI) {
       }
 
       exportRendering = true;
+      setCalmStockExportRendering(true);
+      publishPresentationState();
       setTimeout(() => {
         exportRendering = false;
+        setCalmStockExportRendering(false);
+        publishPresentationState();
+        const expanded = ctx.ui.getToolsExpanded();
+        ctx.ui.setToolsExpanded(!expanded);
+        ctx.ui.setToolsExpanded(expanded);
       }, 0);
     });
   });
 
   pi.registerCommand("calm", {
-    description:
-      "Toggle built-in call and text-result rows; built-in read images and custom/third-party tool rows stay visible.",
+    description: "Toggle Firstmate's supported conversation-only transcript presentation.",
     handler: async (_args, ctx) => {
-      calm = !calm;
+      const active = !calmPresentationIsActive();
+      setCalmPresentation(active);
+      publishPresentationState();
+      ctx.ui.setWorkingVisible(!active);
+      ctx.ui.setHiddenThinkingLabel(active ? "" : undefined);
+      ctx.ui.setStatus("firstmate-calm", active ? "calm transcript" : undefined);
 
-      // Setting the current expansion value is Pi's supported transcript-wide
-      // redraw path. It revisits existing tool rows without changing Ctrl+O state.
-      ctx.ui.setToolsExpanded(ctx.ui.getToolsExpanded());
-      ctx.ui.notify(
-        calm
-          ? "Tool activity is hidden where supported; built-in read images and custom/third-party tool rows remain visible."
-          : "Tool activity is visible.",
-        "info",
-      );
+      // Cycling expansion and restoring its original value is Pi's supported
+      // transcript-wide redraw path for both tool rows and custom entries.
+      // Both writes happen in one command turn, so Ctrl+O state is unchanged.
+      const expanded = ctx.ui.getToolsExpanded();
+      ctx.ui.setToolsExpanded(!expanded);
+      ctx.ui.setToolsExpanded(expanded);
     },
   });
 }

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -5,6 +5,7 @@
 // ExtensionUIContext.setToolsExpanded(), setWorkingVisible(), and
 // setHiddenThinkingLabel(). The focused tests pin those assumptions. Pi still
 // exposes no global renderer for built-in message rows or arbitrary custom tools.
+import { readFileSync } from "node:fs";
 import type {
   ExtensionAPI,
   ToolDefinition,
@@ -27,6 +28,7 @@ import {
   classifyFirstmateSyntheticInput,
   deliverFirstmateSyntheticInput,
   FIRSTMATE_CALM_PRESENTATION_EVENT,
+  FIRSTMATE_PI_LAUNCH_BRIEF_ENV,
   registerFirstmateSyntheticPresentation,
   setCalmPresentation,
   setCalmStockExportRendering,
@@ -60,7 +62,17 @@ type StandardShellState = {
 
 export default function (pi: ExtensionAPI) {
   let exportRendering = false;
+  let launchBriefContent: string | undefined;
   let removeTerminalInputHandler: (() => void) | undefined;
+
+  const launchBriefPath = process.env[FIRSTMATE_PI_LAUNCH_BRIEF_ENV];
+  if (launchBriefPath) {
+    try {
+      launchBriefContent = readFileSync(launchBriefPath, "utf8").replace(/\n+$/, "");
+    } catch {
+      launchBriefContent = undefined;
+    }
+  }
 
   const publishPresentationState = (): void => {
     pi.events.emit(FIRSTMATE_CALM_PRESENTATION_EVENT, {
@@ -181,8 +193,9 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("input", (event) => {
     if (event.images && event.images.length > 0) return { action: "continue" };
-    const kind = classifyFirstmateSyntheticInput(event.text);
+    const kind = classifyFirstmateSyntheticInput(event.text, launchBriefContent);
     if (!kind) return { action: "continue" };
+    if (kind === "launch-brief") launchBriefContent = undefined;
 
     deliverFirstmateSyntheticInput(pi, event.text, kind, {
       deliverAs: event.streamingBehavior ?? "followUp",

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -249,12 +249,22 @@ export default function (pi: ExtensionAPI) {
       ctx.ui.setHiddenThinkingLabel(active ? "" : undefined);
       ctx.ui.setStatus("firstmate-calm", active ? "calm transcript" : undefined);
 
-      // Cycling expansion and restoring its original value is Pi's supported
-      // transcript-wide redraw path for both tool rows and custom entries.
-      // Both writes happen in one command turn, so Ctrl+O state is unchanged.
       const expanded = ctx.ui.getToolsExpanded();
-      ctx.ui.setToolsExpanded(!expanded);
-      ctx.ui.setToolsExpanded(expanded);
+      if (active) {
+        ctx.ui.setToolsExpanded(!expanded);
+        ctx.ui.setToolsExpanded(expanded);
+      } else {
+        const leafId = ctx.sessionManager.getLeafId();
+        if (leafId) {
+          await ctx.navigateTree(leafId);
+        } else {
+          ctx.ui.setToolsExpanded(!expanded);
+          ctx.ui.setToolsExpanded(expanded);
+        }
+        if (ctx.ui.getToolsExpanded() !== expanded) {
+          ctx.ui.setToolsExpanded(expanded);
+        }
+      }
     },
   });
 }

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -191,14 +191,20 @@ export default function (pi: ExtensionAPI) {
   registerBuiltIn(createFindToolDefinition);
   registerBuiltIn(createLsToolDefinition);
 
-  pi.on("input", (event) => {
+  pi.on("input", (event, ctx) => {
     if (event.images && event.images.length > 0) return { action: "continue" };
     const kind = classifyFirstmateSyntheticInput(event.text, launchBriefContent);
     if (!kind) return { action: "continue" };
     if (kind === "launch-brief") launchBriefContent = undefined;
 
+    const redrawPresentation = (): void => {
+      const expanded = ctx.ui.getToolsExpanded();
+      ctx.ui.setToolsExpanded(!expanded);
+      ctx.ui.setToolsExpanded(expanded);
+    };
     deliverFirstmateSyntheticInput(pi, event.text, kind, {
       deliverAs: event.streamingBehavior ?? "followUp",
+      redrawPresentation,
       triggerTurn: true,
     });
     return { action: "handled" };
@@ -250,21 +256,8 @@ export default function (pi: ExtensionAPI) {
       ctx.ui.setStatus("firstmate-calm", active ? "calm transcript" : undefined);
 
       const expanded = ctx.ui.getToolsExpanded();
-      if (active) {
-        ctx.ui.setToolsExpanded(!expanded);
-        ctx.ui.setToolsExpanded(expanded);
-      } else {
-        const leafId = ctx.sessionManager.getLeafId();
-        if (leafId) {
-          await ctx.navigateTree(leafId);
-        } else {
-          ctx.ui.setToolsExpanded(!expanded);
-          ctx.ui.setToolsExpanded(expanded);
-        }
-        if (ctx.ui.getToolsExpanded() !== expanded) {
-          ctx.ui.setToolsExpanded(expanded);
-        }
-      }
+      ctx.ui.setToolsExpanded(!expanded);
+      ctx.ui.setToolsExpanded(expanded);
     },
   });
 }

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -4,8 +4,14 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
+import { Box, Container, Text, type Component } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import {
+  type CalmPresentationState,
+  calmTranscriptClassIsVisible,
+  FIRSTMATE_CALM_PRESENTATION_EVENT,
+} from "./lib/fm-calm-visibility.ts";
 
 type ArmResult = {
   ok: boolean;
@@ -18,6 +24,36 @@ type CloseClassification = {
   kind: "actionable" | "failure";
   message: string;
 };
+
+type WatchToolShellState = {
+  shell?: Box;
+  call?: Component;
+  result?: Component;
+};
+
+type WatchToolRenderContext = {
+  isError: boolean;
+  isPartial: boolean;
+};
+
+function refreshWatchToolShell(
+  state: WatchToolShellState,
+  theme: Theme,
+  context: WatchToolRenderContext,
+): Box {
+  const background = context.isPartial
+    ? (text: string) => theme.bg("toolPendingBg", text)
+    : context.isError
+      ? (text: string) => theme.bg("toolErrorBg", text)
+      : (text: string) => theme.bg("toolSuccessBg", text);
+  const shell = state.shell ?? new Box(1, 1, background);
+  state.shell = shell;
+  shell.setBgFn(background);
+  shell.clear();
+  if (state.call) shell.addChild(state.call);
+  if (state.result) shell.addChild(state.result);
+  return shell;
+}
 
 const extensionFile = fileURLToPath(import.meta.url);
 const extensionDir = dirname(extensionFile);
@@ -126,6 +162,22 @@ function classifyClose(stdout: string, stderr: string, code: number | null, sign
 }
 
 export default function (pi: ExtensionAPI) {
+  let calmPresentation: CalmPresentationState = {
+    active: false,
+    stockExportRendering: false,
+  };
+  pi.events?.on?.(FIRSTMATE_CALM_PRESENTATION_EVENT, (data) => {
+    const next = data as Partial<CalmPresentationState>;
+    calmPresentation = {
+      active: next.active === true,
+      stockExportRendering: next.stockExportRendering === true,
+    };
+  });
+  const calmHides = (itemClass: Parameters<typeof calmTranscriptClassIsVisible>[0]): boolean =>
+    calmPresentation.active &&
+    !calmPresentation.stockExportRendering &&
+    !calmTranscriptClassIsVisible(itemClass);
+
   function stopArm(): void {
     stopping = true;
     if (retryTimer) clearTimeout(retryTimer);
@@ -377,6 +429,32 @@ export default function (pi: ExtensionAPI) {
       "Call fm_watch_arm_pi only for the first required cycle or after a notification says the cycle is missing, failed, or unhealthy. Do not call it after ordinary work, turn completion, or ordinary signal, stale, check, or heartbeat handling because the Pi extension owns re-arming. Never run bin/fm-watch-arm.sh through bash.",
     ],
     parameters: Type.Object({}),
+    renderShell: "self",
+    renderCall: (_args, theme, context) => {
+      if (calmHides("assistant-tool-call")) return new Container();
+      if (calmPresentation.stockExportRendering) {
+        return new Text(theme.fg("toolTitle", theme.bold("fm_watch_arm_pi")), 0, 0);
+      }
+      const state = context.state as WatchToolShellState;
+      state.call = new Text(theme.fg("toolTitle", theme.bold("fm_watch_arm_pi")), 0, 0);
+      return refreshWatchToolShell(state, theme, context);
+    },
+    renderResult: (result, _options, theme, context) => {
+      if (calmHides("tool-result")) return new Container();
+      const output = result.content
+        .filter((item) => item.type === "text")
+        .map((item) => item.text)
+        .join("\n");
+      if (calmPresentation.stockExportRendering) {
+        return new Text(theme.fg("toolOutput", output), 0, 0);
+      }
+      const state = context.state as WatchToolShellState;
+      state.result = output
+        ? new Text(theme.fg("toolOutput", output), 0, 0)
+        : new Container();
+      refreshWatchToolShell(state, theme, context);
+      return new Container();
+    },
     execute: async () => {
       const result = startArm();
       return {

--- a/.pi/extensions/lib/fm-calm-visibility.ts
+++ b/.pi/extensions/lib/fm-calm-visibility.ts
@@ -66,6 +66,7 @@ export type FirstmateSyntheticKind =
 
 type SyntheticDeliveryOptions = {
   deliverAs?: "steer" | "followUp" | "nextTurn";
+  redrawPresentation?: () => void;
   triggerTurn?: boolean;
 };
 
@@ -75,6 +76,7 @@ type FirstmateSyntheticPresentation = {
 };
 
 let calm = false;
+let mountingSyntheticPresentation = false;
 let stockExportRendering = false;
 
 export function calmTranscriptClassIsVisible(itemClass: CalmTranscriptClass): boolean {
@@ -127,7 +129,12 @@ export function registerFirstmateSyntheticPresentation(pi: ExtensionAPI): void {
   pi.registerEntryRenderer<FirstmateSyntheticPresentation>(
     FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE,
     (entry) => {
-      if (calmPresentationHides("synthetic-user")) return undefined;
+      if (
+        calmPresentationHides("synthetic-user") &&
+        !mountingSyntheticPresentation
+      ) {
+        return undefined;
+      }
       const data = entry.data;
       if (!data || typeof data.content !== "string") return undefined;
       return new UserMessageComponent(data.content, getMarkdownTheme());
@@ -141,10 +148,19 @@ export function deliverFirstmateSyntheticInput(
   kind: FirstmateSyntheticKind,
   options: SyntheticDeliveryOptions = {},
 ): void {
-  pi.appendEntry<FirstmateSyntheticPresentation>(FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE, {
-    content,
-    kind,
-  });
+  const mountForRedraw =
+    calmPresentationHides("synthetic-user") &&
+    options.redrawPresentation !== undefined;
+  mountingSyntheticPresentation = mountForRedraw;
+  try {
+    pi.appendEntry<FirstmateSyntheticPresentation>(FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE, {
+      content,
+      kind,
+    });
+  } finally {
+    mountingSyntheticPresentation = false;
+  }
+  if (mountForRedraw) options.redrawPresentation?.();
   pi.sendMessage(
     {
       customType: FIRSTMATE_SYNTHETIC_CONTEXT_TYPE,

--- a/.pi/extensions/lib/fm-calm-visibility.ts
+++ b/.pi/extensions/lib/fm-calm-visibility.ts
@@ -1,0 +1,151 @@
+import {
+  getMarkdownTheme,
+  type ExtensionAPI,
+  UserMessageComponent,
+} from "@earendil-works/pi-coding-agent";
+
+export const CALM_TRANSCRIPT_CLASSES = [
+  "genuine-user-prompt",
+  "genuine-agent-response",
+  "assistant-thinking",
+  "assistant-tool-call",
+  "tool-result",
+  "tool-image",
+  "user-bash",
+  "skill-invocation",
+  "custom-message",
+  "custom-entry",
+  "compaction-summary",
+  "branch-summary",
+  "working-status",
+  "command-status",
+  "system-notice",
+  "cache-notice",
+  "project-trust-warning",
+  "synthetic-user",
+  "synthetic-assistant",
+  "unknown",
+] as const;
+
+export type CalmTranscriptClass = (typeof CALM_TRANSCRIPT_CLASSES)[number];
+
+const CALM_VISIBLE_CLASSES = new Set<CalmTranscriptClass>([
+  "genuine-user-prompt",
+  "genuine-agent-response",
+]);
+
+const FIRSTMATE_SESSIONSTART_NUDGE =
+  "Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.";
+const FIRSTMATE_WATCHER_PREFIX = "FIRSTMATE WATCHER WAKE: ";
+const FIRSTMATE_WATCHER_SUFFIX =
+  "\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.";
+const FIRSTMATE_TURNEND_PREFIX =
+  "TURN WOULD END BLIND - supervision is off. " +
+  "The watcher cycle is missing, failed, or unhealthy. " +
+  "Follow the harness recovery instruction below before ending the turn.\n\n";
+const FM_INJECT_MARK = "\u2063";
+const FM_FROMFIRST_MARK = "[fm-from-firstmate]\u2063";
+
+export const FIRSTMATE_SYNTHETIC_CONTEXT_TYPE = "firstmate-synthetic-input";
+export const FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE = "firstmate-synthetic-input-presentation";
+export const FIRSTMATE_CALM_PRESENTATION_EVENT = "firstmate:calm-presentation";
+
+export type CalmPresentationState = {
+  active: boolean;
+  stockExportRendering: boolean;
+};
+
+export type FirstmateSyntheticKind =
+  | "session-start"
+  | "watcher"
+  | "turn-end-guard"
+  | "away-supervisor"
+  | "from-firstmate";
+
+type FirstmateSyntheticPresentation = {
+  content: string;
+  kind: FirstmateSyntheticKind;
+};
+
+type SyntheticDeliveryOptions = {
+  deliverAs?: "steer" | "followUp" | "nextTurn";
+  triggerTurn?: boolean;
+};
+
+let calm = false;
+let stockExportRendering = false;
+
+export function calmTranscriptClassIsVisible(itemClass: CalmTranscriptClass): boolean {
+  return CALM_VISIBLE_CLASSES.has(itemClass);
+}
+
+export function setCalmPresentation(active: boolean): void {
+  calm = active;
+}
+
+export function setCalmStockExportRendering(active: boolean): void {
+  stockExportRendering = active;
+}
+
+export function calmPresentationIsActive(): boolean {
+  return calm;
+}
+
+export function calmPresentationHides(itemClass: CalmTranscriptClass): boolean {
+  return calm && !stockExportRendering && !calmTranscriptClassIsVisible(itemClass);
+}
+
+export function classifyFirstmateSyntheticInput(content: string): FirstmateSyntheticKind | undefined {
+  if (content === FIRSTMATE_SESSIONSTART_NUDGE) return "session-start";
+  if (content.startsWith(FM_INJECT_MARK)) return "away-supervisor";
+  if (content.startsWith(FM_FROMFIRST_MARK) && content.length > FM_FROMFIRST_MARK.length) {
+    return "from-firstmate";
+  }
+  if (
+    content.startsWith(FIRSTMATE_WATCHER_PREFIX) &&
+    content.endsWith(FIRSTMATE_WATCHER_SUFFIX) &&
+    content.length > FIRSTMATE_WATCHER_PREFIX.length + FIRSTMATE_WATCHER_SUFFIX.length
+  ) {
+    return "watcher";
+  }
+  if (
+    content.startsWith(FIRSTMATE_TURNEND_PREFIX) &&
+    content.length > FIRSTMATE_TURNEND_PREFIX.length
+  ) {
+    return "turn-end-guard";
+  }
+  return undefined;
+}
+
+export function registerFirstmateSyntheticPresentation(pi: ExtensionAPI): void {
+  pi.registerEntryRenderer<FirstmateSyntheticPresentation>(
+    FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE,
+    (entry) => {
+      if (calmPresentationHides("synthetic-user")) return undefined;
+      const data = entry.data;
+      if (!data || typeof data.content !== "string") return undefined;
+      return new UserMessageComponent(data.content, getMarkdownTheme());
+    },
+  );
+}
+
+export function deliverFirstmateSyntheticInput(
+  pi: ExtensionAPI,
+  content: string,
+  kind: FirstmateSyntheticKind,
+  options: SyntheticDeliveryOptions = {},
+): void {
+  pi.appendEntry<FirstmateSyntheticPresentation>(FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE, {
+    content,
+    kind,
+  });
+  pi.sendMessage(
+    {
+      customType: FIRSTMATE_SYNTHETIC_CONTEXT_TYPE,
+      content,
+      display: false,
+      details: { kind },
+    },
+    options,
+  );
+}

--- a/.pi/extensions/lib/fm-calm-visibility.ts
+++ b/.pi/extensions/lib/fm-calm-visibility.ts
@@ -3,7 +3,6 @@ import {
   type ExtensionAPI,
   UserMessageComponent,
 } from "@earendil-works/pi-coding-agent";
-import { Container } from "@earendil-works/pi-tui";
 
 export const CALM_TRANSCRIPT_CLASSES = [
   "genuine-user-prompt",
@@ -48,6 +47,7 @@ const FM_INJECT_MARK = "\u2063";
 const FM_FROMFIRST_MARK = "[fm-from-firstmate]\u2063";
 
 export const FIRSTMATE_SYNTHETIC_CONTEXT_TYPE = "firstmate-synthetic-input";
+export const FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE = "firstmate-synthetic-input-presentation";
 export const FIRSTMATE_CALM_PRESENTATION_EVENT = "firstmate:calm-presentation";
 export const FIRSTMATE_PI_LAUNCH_BRIEF_ENV = "FM_FIRSTMATE_PI_LAUNCH_BRIEF";
 
@@ -67,6 +67,11 @@ export type FirstmateSyntheticKind =
 type SyntheticDeliveryOptions = {
   deliverAs?: "steer" | "followUp" | "nextTurn";
   triggerTurn?: boolean;
+};
+
+type FirstmateSyntheticPresentation = {
+  content: string;
+  kind: FirstmateSyntheticKind;
 };
 
 let calm = false;
@@ -119,18 +124,13 @@ export function classifyFirstmateSyntheticInput(
 }
 
 export function registerFirstmateSyntheticPresentation(pi: ExtensionAPI): void {
-  pi.registerMessageRenderer(
-    FIRSTMATE_SYNTHETIC_CONTEXT_TYPE,
-    (message) => {
-      if (calmPresentationHides("synthetic-user")) return new Container();
-      const content =
-        typeof message.content === "string"
-          ? message.content
-          : message.content
-              .filter((item) => item.type === "text")
-              .map((item) => item.text)
-              .join("\n");
-      return new UserMessageComponent(content, getMarkdownTheme());
+  pi.registerEntryRenderer<FirstmateSyntheticPresentation>(
+    FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE,
+    (entry) => {
+      if (calmPresentationHides("synthetic-user")) return undefined;
+      const data = entry.data;
+      if (!data || typeof data.content !== "string") return undefined;
+      return new UserMessageComponent(data.content, getMarkdownTheme());
     },
   );
 }
@@ -141,11 +141,15 @@ export function deliverFirstmateSyntheticInput(
   kind: FirstmateSyntheticKind,
   options: SyntheticDeliveryOptions = {},
 ): void {
+  pi.appendEntry<FirstmateSyntheticPresentation>(FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE, {
+    content,
+    kind,
+  });
   pi.sendMessage(
     {
       customType: FIRSTMATE_SYNTHETIC_CONTEXT_TYPE,
       content,
-      display: true,
+      display: false,
       details: { kind },
     },
     options,

--- a/.pi/extensions/lib/fm-calm-visibility.ts
+++ b/.pi/extensions/lib/fm-calm-visibility.ts
@@ -3,6 +3,7 @@ import {
   type ExtensionAPI,
   UserMessageComponent,
 } from "@earendil-works/pi-coding-agent";
+import { Container } from "@earendil-works/pi-tui";
 
 export const CALM_TRANSCRIPT_CLASSES = [
   "genuine-user-prompt",
@@ -47,8 +48,8 @@ const FM_INJECT_MARK = "\u2063";
 const FM_FROMFIRST_MARK = "[fm-from-firstmate]\u2063";
 
 export const FIRSTMATE_SYNTHETIC_CONTEXT_TYPE = "firstmate-synthetic-input";
-export const FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE = "firstmate-synthetic-input-presentation";
 export const FIRSTMATE_CALM_PRESENTATION_EVENT = "firstmate:calm-presentation";
+export const FIRSTMATE_PI_LAUNCH_BRIEF_ENV = "FM_FIRSTMATE_PI_LAUNCH_BRIEF";
 
 export type CalmPresentationState = {
   active: boolean;
@@ -60,12 +61,8 @@ export type FirstmateSyntheticKind =
   | "watcher"
   | "turn-end-guard"
   | "away-supervisor"
-  | "from-firstmate";
-
-type FirstmateSyntheticPresentation = {
-  content: string;
-  kind: FirstmateSyntheticKind;
-};
+  | "from-firstmate"
+  | "launch-brief";
 
 type SyntheticDeliveryOptions = {
   deliverAs?: "steer" | "followUp" | "nextTurn";
@@ -95,7 +92,11 @@ export function calmPresentationHides(itemClass: CalmTranscriptClass): boolean {
   return calm && !stockExportRendering && !calmTranscriptClassIsVisible(itemClass);
 }
 
-export function classifyFirstmateSyntheticInput(content: string): FirstmateSyntheticKind | undefined {
+export function classifyFirstmateSyntheticInput(
+  content: string,
+  launchBriefContent?: string,
+): FirstmateSyntheticKind | undefined {
+  if (launchBriefContent !== undefined && content === launchBriefContent) return "launch-brief";
   if (content === FIRSTMATE_SESSIONSTART_NUDGE) return "session-start";
   if (content.startsWith(FM_INJECT_MARK)) return "away-supervisor";
   if (content.startsWith(FM_FROMFIRST_MARK) && content.length > FM_FROMFIRST_MARK.length) {
@@ -118,13 +119,18 @@ export function classifyFirstmateSyntheticInput(content: string): FirstmateSynth
 }
 
 export function registerFirstmateSyntheticPresentation(pi: ExtensionAPI): void {
-  pi.registerEntryRenderer<FirstmateSyntheticPresentation>(
-    FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE,
-    (entry) => {
-      if (calmPresentationHides("synthetic-user")) return undefined;
-      const data = entry.data;
-      if (!data || typeof data.content !== "string") return undefined;
-      return new UserMessageComponent(data.content, getMarkdownTheme());
+  pi.registerMessageRenderer(
+    FIRSTMATE_SYNTHETIC_CONTEXT_TYPE,
+    (message) => {
+      if (calmPresentationHides("synthetic-user")) return new Container();
+      const content =
+        typeof message.content === "string"
+          ? message.content
+          : message.content
+              .filter((item) => item.type === "text")
+              .map((item) => item.text)
+              .join("\n");
+      return new UserMessageComponent(content, getMarkdownTheme());
     },
   );
 }
@@ -135,15 +141,11 @@ export function deliverFirstmateSyntheticInput(
   kind: FirstmateSyntheticKind,
   options: SyntheticDeliveryOptions = {},
 ): void {
-  pi.appendEntry<FirstmateSyntheticPresentation>(FIRSTMATE_SYNTHETIC_PRESENTATION_TYPE, {
-    content,
-    kind,
-  });
   pi.sendMessage(
     {
       customType: FIRSTMATE_SYNTHETIC_CONTEXT_TYPE,
       content,
-      display: false,
+      display: true,
       details: { kind },
     },
     options,

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ For Grok, `--trust` is needed once per clone so project hooks and the turn-end g
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
 Every Pi session starts with calm mode off; `/calm` is a session-local conversation-focused transcript toggle.
 While active, it uses Pi's supported presentation APIs to hide the live working row, collapsed thinking labels, all seven built-in tool shells, the Firstmate watcher tool shell, and known Firstmate-injected inputs.
-Those injected inputs remain in model context and session storage, while a TUI-only custom entry lets Calm hide and restore them without changing delivery.
+Every injected input remains in model context and session storage.
+Inputs that ordinarily render as user rows use a TUI-only custom entry so Calm can hide and restore their presentation without changing delivery; the session-start nudge remains on its existing non-displayed custom-message path.
 Toggling off restores ordinary rendering, and `Ctrl+O` expansion behavior stays unchanged.
 Tool execution, model context, session storage, diagnostics, and `/export` and `/share` operation remain unchanged; Pi's exporter omits synthetic control inputs because its supported renderer surface cannot preserve their stock user styling without leaving live transcript gaps.
 Pi 0.81.1 still exposes no global transcript filter, so expanded reasoning, its reserved spacing, built-in tool images, user-bash rows, skill and summary rows, status notices, and arbitrary custom-tool or extension rows remain supported-API boundaries.

--- a/README.md
+++ b/README.md
@@ -103,11 +103,13 @@ pi
 
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
-Every Pi session starts with calm mode off and tool activity visible; `/calm` is a session-local toggle that hides all seven built-in call shells and text-result rows, including existing rows.
+Every Pi session starts with calm mode off; `/calm` is a session-local conversation-focused transcript toggle.
+While active, it uses Pi's supported presentation APIs to hide the live working row, collapsed thinking labels, all seven built-in tool shells, the Firstmate watcher tool shell, and known Firstmate-injected inputs.
+Those injected inputs remain in model context and session storage, while a separate TUI-only presentation entry lets Calm hide and restore them without changing delivery.
 Toggling off restores ordinary rendering, and `Ctrl+O` expansion behavior stays unchanged.
-Built-in `read` images on image-capable terminals and custom or third-party tool rows remain visible because Pi 0.80.10 does not expose those rows to supported extension renderers.
-The toggle changes only interactive rendering, not tool execution, model context, session storage, exports, or diagnostics.
-The version-scoped feasibility evidence for keeping this feature Pi-only is recorded in [docs/calm-mode-feasibility.md](docs/calm-mode-feasibility.md).
+Tool execution, model context, session storage, diagnostics, `/export`, and `/share` remain unchanged.
+Pi 0.81.1 still exposes no global transcript filter, so expanded reasoning, its reserved spacing, built-in tool images, user-bash rows, skill and summary rows, status notices, and arbitrary custom-tool or extension rows remain supported-API boundaries.
+The version-scoped feasibility evidence and complete render taxonomy are recorded in [docs/calm-mode-feasibility.md](docs/calm-mode-feasibility.md).
 
 ### Talk to it
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For Grok, `--trust` is needed once per clone so project hooks and the turn-end g
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
 Every Pi session starts with calm mode off; `/calm` is a session-local conversation-focused transcript toggle.
 While active, it uses Pi's supported presentation APIs to hide the live working row, collapsed thinking labels, all seven built-in tool shells, the Firstmate watcher tool shell, and known Firstmate-injected inputs.
-Those injected inputs remain in model context and session storage, while a separate TUI-only presentation entry lets Calm hide and restore them without changing delivery.
+Those injected inputs remain in model context and session storage as display-bearing custom messages whose TUI renderer lets Calm hide and restore them without changing delivery or export content.
 Toggling off restores ordinary rendering, and `Ctrl+O` expansion behavior stays unchanged.
 Tool execution, model context, session storage, diagnostics, `/export`, and `/share` remain unchanged.
 Pi 0.81.1 still exposes no global transcript filter, so expanded reasoning, its reserved spacing, built-in tool images, user-bash rows, skill and summary rows, status notices, and arbitrary custom-tool or extension rows remain supported-API boundaries.

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ For Grok, `--trust` is needed once per clone so project hooks and the turn-end g
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
 Every Pi session starts with calm mode off; `/calm` is a session-local conversation-focused transcript toggle.
 While active, it uses Pi's supported presentation APIs to hide the live working row, collapsed thinking labels, all seven built-in tool shells, the Firstmate watcher tool shell, and known Firstmate-injected inputs.
-Those injected inputs remain in model context and session storage as display-bearing custom messages whose TUI renderer lets Calm hide and restore them without changing delivery or export content.
+Those injected inputs remain in model context and session storage, while a TUI-only custom entry lets Calm hide and restore them without changing delivery.
 Toggling off restores ordinary rendering, and `Ctrl+O` expansion behavior stays unchanged.
-Tool execution, model context, session storage, diagnostics, `/export`, and `/share` remain unchanged.
+Tool execution, model context, session storage, diagnostics, and `/export` and `/share` operation remain unchanged; Pi's exporter omits synthetic control inputs because its supported renderer surface cannot preserve their stock user styling without leaving live transcript gaps.
 Pi 0.81.1 still exposes no global transcript filter, so expanded reasoning, its reserved spacing, built-in tool images, user-bash rows, skill and summary rows, status notices, and arbitrary custom-tool or extension rows remain supported-API boundaries.
 The version-scoped feasibility evidence and complete render taxonomy are recorded in [docs/calm-mode-feasibility.md](docs/calm-mode-feasibility.md).
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -97,6 +97,7 @@
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
+#     __PIBRIEFENV__ shell assignment identifying the unchanged Pi positional brief
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
@@ -430,9 +431,9 @@ launch_template() {
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(cat __BRIEF__)"' ;;
     pi)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(cat __BRIEF__)"'
+        printf '%s' '__PIBRIEFENV__ pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(cat __BRIEF__)"'
       else
-        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(cat __BRIEF__)"'
+        printf '%s' '__PIBRIEFENV__ pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(cat __BRIEF__)"'
       fi
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
@@ -1257,6 +1258,8 @@ sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
+PIBRIEFENV=
+[ "$HARNESS" != pi ] || PIBRIEFENV="FM_FIRSTMATE_PI_LAUNCH_BRIEF=$sq_brief"
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
@@ -1266,6 +1269,7 @@ LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
+LAUNCH=${LAUNCH//__PIBRIEFENV__/$PIBRIEFENV}
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -1,16 +1,112 @@
 # Calm-mode harness feasibility
 
-This document owns the version-scoped feasibility evidence for implementing Firstmate calm mode in each verified harness.
+This document owns the version-scoped feasibility evidence, Pi transcript taxonomy, and supported-API boundaries for Firstmate calm mode.
 The README owns the user-facing `/calm` usage and limitation contract.
 
 ## Required extension surface
 
-A qualifying implementation must auto-load from the trusted project, keep the toggle session-local, redraw already-rendered built-in tool rows, restore the harness's ordinary rendering, and leave tool execution, model context, session storage, exports, diagnostics, and expansion state unchanged.
-Replacing a built-in tool, patching harness internals, filtering persisted events, or claiming coverage outside a supported renderer does not satisfy that boundary.
+A qualifying implementation must auto-load from the trusted project, keep the toggle session-local, redraw already-rendered controllable rows, restore ordinary rendering, and leave delivery, tool execution, model context, session storage, exports, diagnostics, and expansion state unchanged.
+The governing presentation policy allows only genuine original user prompts and genuine user-facing assistant text.
+Changing persisted context to remove hidden content, filtering provider context, patching installed harness code, or claiming coverage outside a supported renderer does not satisfy that boundary.
 
-## Verification record
+## Pi 0.81.1 end-to-end reproduction
 
-The following inspection was performed on 2026-07-22.
+The current installed and regression-supported Pi version was verified on 2026-07-22.
+
+```text
+$ pi --version
+0.81.1
+```
+
+A real isolated Pi TUI ran at 180 columns by 44 rows with the tracked Calm and watcher extensions, an isolated `FM_HOME`, and a live home-owned watcher cycle.
+The model called `fm_watch_arm_pi`, the real tool returned `watcher: started Pi extension arm child 1`, and a `done:` status write caused the watcher extension to inject `FIRSTMATE WATCHER WAKE: signal: ...` followed by the stable drain instruction.
+Before Calm, the captured transcript contained the genuine user prompt, the full watcher tool shell, the synthetic user-role wake, four collapsed `Thinking...` labels, built-in tool rows from wake handling, and the final assistant response.
+After `/calm`, the existing seven built-in tool rows disappeared, but the watcher tool shell, synthetic wake, and all four `Thinking...` labels remained.
+
+The observed causal separation was:
+
+| Row | Initiating trigger | Masking condition | Visible symptom |
+| --- | --- | --- | --- |
+| Collapsed thinking | A model assistant turn contained non-empty `thinking` content. | Pi's thinking setting was collapsed, so `AssistantMessageComponent` rendered its configured hidden-thinking label instead of full reasoning; Calm previously touched only tool definitions. | One italic `Thinking...` row remained for each reasoning-bearing assistant turn. |
+| Firstmate watcher tool | The model called the tracked `fm_watch_arm_pi` custom tool. | Calm overrode only Pi's seven built-ins, while this tool followed Pi's custom-tool fallback renderer. | The full custom call and result shell remained. |
+| Synthetic watcher input | The live watcher closed on an actionable signal and `fm-primary-pi-watch.ts` called `sendUserMessage`. | Pi stored and rendered the injected content as an ordinary `user` role with no origin renderer hook. | The wake prefix and stable drain instruction looked like a captain-authored prompt. |
+
+The proven comparison path was a built-in text tool.
+Calm already owned both of that tool's supported renderer slots and switched its shell to `renderShell: "self"`, so returning empty components removed the complete row and `setToolsExpanded` redrew existing tool components.
+The earliest divergence for the watcher was its separate custom fallback definition, and the earliest divergence for thinking and user-role injections was Pi's built-in message component path rather than `ToolExecutionComponent`.
+
+The smallest counterfactuals produced these results:
+
+- Calling `setWorkingVisible(false)` removed the live working row without reserving space.
+- Calling `setHiddenThinkingLabel("")` removed every collapsed `Thinking...` label, but Pi's `AssistantMessageComponent` retained one leading spacer for each reasoning-bearing message.
+- Expanding thinking still rendered full reasoning because Pi exposes no supported getter or setter for the transcript-wide thinking expansion state.
+- Adding supported empty renderer slots to a scratch copy of `fm_watch_arm_pi` removed its row while the real watcher still started and the model still returned `PROBE_COMPLETE`.
+- Delivering a scratch custom message with `display: false` still produced the model response `SYNTHETIC_DELIVERED` and persisted the full custom message in session JSONL.
+- Pairing that hidden context message with a TUI-only custom entry allowed Calm to hide and restore the synthetic user presentation with no content loss.
+
+The disconfirming checks deliberately retained contradictory evidence.
+An arbitrary third-party custom tool and a built-in read image remain visible because Pi exposes neither a global tool renderer nor image-row control.
+An expanded thinking fixture remains visible, and an empty collapsed-thinking label leaves blank spacing, so this implementation does not claim complete reasoning-row removal.
+An ordinary user prompt beginning with `FIRSTMATE WATCHER WAKE:` but lacking the exact authoritative suffix remains visible, disproving a broad prefix-only classifier.
+
+## Central visibility and injection policy
+
+`.pi/extensions/lib/fm-calm-visibility.ts` is the single owner of the allowlist-style transcript policy and Firstmate synthetic-input classifier.
+Only `genuine-user-prompt` and `genuine-agent-response` are policy-visible.
+Every other audited class is policy-hidden even when Pi currently lacks a supported renderer for enforcing that result.
+
+The classifier recognizes only these authoritative Firstmate forms:
+
+| Form | Authoritative source | Classification evidence |
+| --- | --- | --- |
+| Session-start nudge | `.pi/extensions/fm-primary-turnend-guard.ts` via `bin/fm-sessionstart-nudge.sh` | Exact complete nudge text; Pi already sends it as a non-displayed custom message. |
+| Watcher notification | `.pi/extensions/fm-primary-pi-watch.ts` | Exact `FIRSTMATE WATCHER WAKE: ` prefix plus the complete stable drain suffix and non-empty wake content. |
+| Turn-end guard | `.pi/extensions/fm-primary-turnend-guard.ts` | Exact complete guard paragraph plus non-empty guard diagnostics. |
+| Away supervisor | `bin/fm-supervise-daemon.sh` | Leading U+2063 `FM_INJECT_MARK`, which normal terminal typing cannot produce. |
+| From-firstmate request | `bin/fm-marker-lib.sh` through `bin/fm-send.sh` | Exact `[fm-from-firstmate]` plus U+2063 marker and non-empty request content. |
+
+Positive fixtures cover every form in that table.
+Near-miss fixtures cover the visible watcher phrase without its suffix, a modified drain instruction, a guard-like captain question, visible marker labels without U+2063, an unmarked supervisor phrase, and the session-start wording without its authoritative punctuation.
+
+Known synthetic inputs are rerouted only at Pi input presentation time.
+Their full text is persisted in a non-displayed custom message that Pi converts back to an ordinary user message for provider context, and a TUI-only custom entry restores stock user styling while Calm is off.
+This preserves handling and context while giving Calm a supported row renderer.
+Cycling tool expansion and restoring its original value rebuilds those custom entries and leaves final `Ctrl+O` state unchanged.
+
+## Complete currently reachable Pi transcript taxonomy
+
+The taxonomy was derived from Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations.
+The test fixture enumerates every class below through the centralized policy, and the interactive fixture exercises the screenshot classes plus positive and negative synthetic user presentation.
+
+| Policy class | Pi transcript path | Calm result on Pi 0.81.1 |
+| --- | --- | --- |
+| `genuine-user-prompt` | `UserMessageComponent` | Visible. |
+| `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
+| `assistant-thinking` | Working indicator and thinking content in `AssistantMessageComponent` | Live working row and collapsed labels hidden; expanded reasoning and reserved collapsed spacing remain unsupported boundaries. |
+| `assistant-tool-call` | `ToolExecutionComponent` | Seven built-ins and `fm_watch_arm_pi` hidden; arbitrary custom tools remain an unsupported boundary. |
+| `tool-result` | `ToolExecutionComponent` | Text results for the controlled tools hidden; arbitrary custom results remain an unsupported boundary. |
+| `tool-image` | Image children appended outside tool renderer slots | Unsupported boundary; remains visible. |
+| `user-bash` | `BashExecutionComponent` for `!` and `!!` | Unsupported boundary; remains visible. |
+| `skill-invocation` | `SkillInvocationMessageComponent` plus parsed user text | Unsupported boundary; remains visible. |
+| `custom-message` | `CustomMessageComponent` when `display` is true | Firstmate's known synthetic context messages use `display: false`; arbitrary extension messages remain an unsupported boundary. |
+| `custom-entry` | `CustomEntryComponent` with a registered renderer | Firstmate's synthetic presentation entry is hidden; arbitrary extension entries remain an unsupported boundary. |
+| `compaction-summary` | `CompactionSummaryMessageComponent` | Unsupported boundary; remains visible. |
+| `branch-summary` | `BranchSummaryMessageComponent` | Unsupported boundary; remains visible. |
+| `working-status` | `WorkingStatusIndicator` | Hidden through `setWorkingVisible(false)`. |
+| `command-status` | Interactive command result and status rows | Calm emits no enable notice, but generic Pi command rows remain an unsupported boundary. |
+| `system-notice` | `showStatus`, `showError`, compaction, retry, and startup warning rows | Unsupported boundary; remains visible. |
+| `cache-notice` | Non-persisted cache-miss `Text` row | Unsupported boundary; remains visible. |
+| `project-trust-warning` | Non-persisted startup `Text` row | Unsupported boundary; remains visible. |
+| `synthetic-user` | Firstmate extension `sendUserMessage` or terminal-injected input | All authoritative Firstmate forms are rerouted to hidden context plus a controllable presentation entry. |
+| `synthetic-assistant` | No authoritative Firstmate source found | Policy-hidden, but Pi exposes no generic assistant-role renderer. |
+| `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
+
+The installed extension API has no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container access, or generic custom-tool wrapper.
+Runtime prototype replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching were rejected as unsupported or preservation-breaking workarounds.
+
+## Cross-harness verification record
+
+The original five-harness inspection was performed on 2026-07-22, with Pi reverified at 0.81.1 for this change.
 
 ```text
 $ claude --version
@@ -20,29 +116,26 @@ codex-cli 0.144.6
 $ opencode --version
 1.17.18
 $ pi --version
-0.80.10
+0.81.1
 $ grok --version
 grok 0.2.106 (bde89716f679)
 ```
 
-The inspected commands were `claude --help`, `claude plugin --help`, `claude plugin validate --help`, `codex --help`, `codex plugin --help`, `codex features list`, `opencode --help`, `opencode debug --help`, `opencode debug config`, `pi --help`, `grok --help`, and `grok plugin --help`.
-The inspection also covered the tracked project hook and plugin definitions for all five harnesses and Pi 0.80.10's installed public TypeScript declarations.
-
 | Harness | Conclusion | Evidence |
 | --- | --- | --- |
-| Claude Code 2.1.216 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or a transcript-wide redraw API. |
+| Claude Code 2.1.216 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or transcript-wide redraw API. |
 | Codex CLI 0.144.6 | Not feasible through the inspected supported project surface. | The tracked hooks expose session, pre-tool, and stop handling, while the plugin and feature inventories expose no TUI tool-row renderer or transcript redraw control. |
-| OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer. A same-name custom tool can replace a built-in tool, but that changes the tool definition and execution path rather than presentation alone. |
-| Pi 0.80.10 | Feasible and implemented. | Public declarations expose `registerTool`, `ToolDefinition.renderCall`, `ToolDefinition.renderResult`, `renderShell`, `setToolsExpanded`, terminal input handling, and extension commands. The focused renderer test and interactive terminal E2E exercise the supported path. |
-| Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract. `--minimal` changes the session's overall screen mode and does not provide selective, reversible transcript-row control. |
+| OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer; same-name tool replacement changes execution rather than presentation alone. |
+| Pi 0.81.1 | Partially feasible and implemented to the supported boundary. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and transcript-wide expansion redraws, but not built-in message containers or generic tool and status rows. |
+| Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract; `--minimal` changes the whole screen mode rather than selected transcript rows. |
 
 These conclusions are deliberately limited to the named versions and supported surfaces.
-They do not claim that a harness can never add the required renderer API.
+They do not claim that a harness can never add the missing renderer API.
 
-## Pi verification
+## Regression coverage
 
-`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock Pi renderers, verifies all seven built-ins, exercises already-rendered rows, checks the disclosed image and custom-tool boundaries, covers session reset reasons, proves exports remain ordinary, and drives a genuine interactive terminal session.
-`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi 0.80.10 declarations.
+`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool and synthetic rows, checks the image and generic custom-tool boundaries, covers every policy class and synthetic fixture, covers session reset reasons, proves exports remain ordinary, and drives a genuine 180 by 44 interactive terminal fixture.
+`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi 0.81.1 declarations.
 
 The relevant commands are:
 

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -45,6 +45,8 @@ The smallest counterfactuals produced these results:
 - Pairing that hidden context message with a TUI-only custom entry allowed Calm to hide and restore the synthetic user presentation with no content loss.
 - Pi's `CustomMessageComponent` unconditionally adds a leading spacer before invoking a registered message renderer, so returning an empty component cannot hide the whole row.
 - Pi's `CustomEntryComponent` adds spacing only when its renderer returns content, so an undefined Calm renderer result removes the complete live row without a residual gap.
+- Pi does not mount a `CustomEntryComponent` whose initial renderer result is undefined, so disabling Calm rebuilds the current persisted leaf through `ExtensionCommandContext.navigateTree()` to restore entries received while Calm was active.
+- Navigating to the current leaf is a session-data no-op in Pi 0.81.1, while interactive mode clears and reconstructs the transcript from persisted entries; Pi adds its ordinary navigation status row as an unsupported generic command-status boundary.
 - Pi's HTML exporter ignores plain custom entries and `display: false` custom messages and does not invoke TUI renderers, so synthetic control inputs cannot retain stock user styling in exported or shared HTML through Pi 0.81.1's supported API.
 
 The disconfirming checks deliberately retained contradictory evidence.
@@ -94,7 +96,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | `user-bash` | `BashExecutionComponent` for `!` and `!!` | Unsupported boundary; remains visible. |
 | `skill-invocation` | `SkillInvocationMessageComponent` plus parsed user text | Unsupported boundary; remains visible. |
 | `custom-message` | `CustomMessageComponent` when `display` is true | Firstmate's known synthetic context messages use `display: false`; arbitrary extension messages remain an unsupported boundary. |
-| `custom-entry` | `CustomEntryComponent` with a registered renderer | Firstmate's synthetic presentation entry is hidden without a residual spacer; arbitrary extension entries remain an unsupported boundary. |
+| `custom-entry` | `CustomEntryComponent` with a registered renderer | Firstmate's synthetic presentation entry is hidden without a residual spacer and restored through a current-leaf transcript rebuild; arbitrary extension entries remain an unsupported boundary. |
 | `compaction-summary` | `CompactionSummaryMessageComponent` | Unsupported boundary; remains visible. |
 | `branch-summary` | `BranchSummaryMessageComponent` | Unsupported boundary; remains visible. |
 | `working-status` | `WorkingStatusIndicator` | Hidden through `setWorkingVisible(false)`. |
@@ -131,7 +133,7 @@ grok 0.2.106 (bde89716f679)
 | Claude Code 2.1.216 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or transcript-wide redraw API. |
 | Codex CLI 0.144.6 | Not feasible through the inspected supported project surface. | The tracked hooks expose session, pre-tool, and stop handling, while the plugin and feature inventories expose no TUI tool-row renderer or transcript redraw control. |
 | OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer; same-name tool replacement changes execution rather than presentation alone. |
-| Pi 0.81.1 | Partially feasible and implemented to the supported boundary. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and transcript-wide expansion redraws, but not built-in message containers or generic tool and status rows. |
+| Pi 0.81.1 | Partially feasible and implemented to the supported boundary. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, expansion redraws, and current-leaf transcript reconstruction, but not built-in message containers or generic tool and status rows. |
 | Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract; `--minimal` changes the whole screen mode rather than selected transcript rows. |
 
 These conclusions are deliberately limited to the named versions and supported surfaces.
@@ -139,7 +141,7 @@ They do not claim that a harness can never add the missing renderer API.
 
 ## Regression coverage
 
-`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool and synthetic rows, checks the gapless custom-entry host, covers every policy class and synthetic fixture, covers session reset reasons, asserts the rendered export DOM, and drives a genuine 180 by 44 interactive terminal fixture.
+`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool and synthetic rows, checks the gapless custom-entry host, restores an entry received while Calm is active through the supported current-leaf lifecycle, covers every policy class and synthetic fixture, covers session reset reasons, asserts the rendered export DOM, and drives a genuine 180 by 44 interactive terminal fixture.
 `tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi 0.81.1 declarations.
 
 The relevant commands are:

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -18,10 +18,11 @@ $ pi --version
 0.81.1
 ```
 
-A real isolated Pi TUI ran at 180 columns by 44 rows with the tracked Calm and watcher extensions, an isolated `FM_HOME`, and a live home-owned watcher cycle.
+The pre-cleanup reproduction used a real isolated Pi TUI at 180 columns by 44 rows with the tracked Calm and watcher extensions, an isolated `FM_HOME`, and a live home-owned watcher cycle.
 The model called `fm_watch_arm_pi`, the real tool returned `watcher: started Pi extension arm child 1`, and a `done:` status write caused the watcher extension to inject `FIRSTMATE WATCHER WAKE: signal: ...` followed by the stable drain instruction.
-Before Calm, the captured transcript contained the genuine user prompt, the full watcher tool shell, the synthetic user-role wake, four collapsed `Thinking...` labels, built-in tool rows from wake handling, and the final assistant response.
-After `/calm`, the existing seven built-in tool rows disappeared, but the watcher tool shell, synthetic wake, and all four `Thinking...` labels remained.
+With Calm off, the captured transcript contained the genuine user prompt, the full watcher tool shell, the synthetic user-role wake, four collapsed `Thinking...` labels, built-in tool rows from wake handling, and the final assistant response.
+With the pre-cleanup implementation's Calm mode on, the existing seven built-in tool rows disappeared, but the watcher tool shell, synthetic wake, and all four `Thinking...` labels remained.
+The final screenshot-scale regression reproduced the same transcript after the cleanup and verified that Calm removed those remaining controlled rows while retaining the genuine prompt, a watcher-shaped genuine near-miss prompt, and the genuine assistant responses.
 
 The observed causal separation was:
 
@@ -76,8 +77,9 @@ The classifier recognizes only these authoritative Firstmate forms:
 Positive fixtures cover every form in that table.
 Near-miss fixtures cover the visible watcher phrase without its suffix, a modified drain instruction, a guard-like captain question, visible marker labels without U+2063, an unmarked supervisor phrase, the session-start wording without its authoritative punctuation, and launch-brief text without the per-process origin.
 
-Known synthetic inputs are rerouted only at Pi input presentation time.
+Synthetic inputs that would otherwise render as user rows are rerouted only at Pi input presentation time.
 Their full text is persisted in a non-displayed custom message that Pi converts back to an ordinary user message for provider context, and a TUI-only custom entry restores stock user styling while Calm is off.
+The session-start nudge already uses a non-displayed custom message at its authoritative source, so it remains on that existing hidden presentation path while retaining model context and session persistence.
 The custom-entry host omits the complete row when the renderer returns undefined under Calm, including its normally conditional leading spacer.
 Cycling tool expansion and restoring its original value rebuilds those custom entries and leaves final `Ctrl+O` state unchanged.
 Exported and shared HTML retain genuine user prompts, genuine assistant responses, and ordinary tool rendering, while omitting the synthetic presentation entry and hidden context message at the documented Pi 0.81.1 exporter boundary.
@@ -106,7 +108,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | `system-notice` | `showStatus`, `showError`, compaction, retry, and startup warning rows | Unsupported boundary; remains visible. |
 | `cache-notice` | Non-persisted cache-miss `Text` row | Unsupported boundary; remains visible. |
 | `project-trust-warning` | Non-persisted startup `Text` row | Unsupported boundary; remains visible. |
-| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, or Firstmate-generated Pi positional brief | All authoritative Firstmate forms are rerouted to hidden context plus a gapless controllable presentation entry. |
+| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Forms that ordinarily render as user rows are rerouted to hidden context plus a gapless controllable presentation entry; the session-start nudge retains its existing non-displayed custom-message path. |
 | `synthetic-assistant` | No authoritative Firstmate source found | Policy-hidden, but Pi exposes no generic assistant-role renderer. |
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -41,8 +41,8 @@ The smallest counterfactuals produced these results:
 - Calling `setHiddenThinkingLabel("")` removed every collapsed `Thinking...` label, but Pi's `AssistantMessageComponent` retained one leading spacer for each reasoning-bearing message.
 - Expanding thinking still rendered full reasoning because Pi exposes no supported getter or setter for the transcript-wide thinking expansion state.
 - Adding supported empty renderer slots to a scratch copy of `fm_watch_arm_pi` removed its row while the real watcher still started and the model still returned `PROBE_COMPLETE`.
-- Delivering a scratch custom message with `display: false` still produced the model response `SYNTHETIC_DELIVERED` and persisted the full custom message in session JSONL.
-- Pairing that hidden context message with a TUI-only custom entry allowed Calm to hide and restore the synthetic user presentation with no content loss.
+- Delivering a scratch custom message with `display: true` still produced the model response `SYNTHETIC_DELIVERED`, persisted the full custom message in session JSONL, and kept it in HTML exports.
+- Registering a custom-message renderer allowed Calm to hide and restore that same context-bearing row with no content loss or exporter-invisible parallel entry.
 
 The disconfirming checks deliberately retained contradictory evidence.
 An arbitrary third-party custom tool and a built-in read image remain visible because Pi exposes neither a global tool renderer nor image-row control.
@@ -64,14 +64,15 @@ The classifier recognizes only these authoritative Firstmate forms:
 | Turn-end guard | `.pi/extensions/fm-primary-turnend-guard.ts` | Exact complete guard paragraph plus non-empty guard diagnostics. |
 | Away supervisor | `bin/fm-supervise-daemon.sh` | Leading U+2063 `FM_INJECT_MARK`, which normal terminal typing cannot produce. |
 | From-firstmate request | `bin/fm-marker-lib.sh` through `bin/fm-send.sh` | Exact `[fm-from-firstmate]` plus U+2063 marker and non-empty request content. |
+| Pi launch brief | `bin/fm-spawn.sh` | Per-process `FM_FIRSTMATE_PI_LAUNCH_BRIEF` path identifies the exact unchanged positional brief content after the launch shell's standard trailing-newline removal; the match is consumed once. |
 
 Positive fixtures cover every form in that table.
-Near-miss fixtures cover the visible watcher phrase without its suffix, a modified drain instruction, a guard-like captain question, visible marker labels without U+2063, an unmarked supervisor phrase, and the session-start wording without its authoritative punctuation.
+Near-miss fixtures cover the visible watcher phrase without its suffix, a modified drain instruction, a guard-like captain question, visible marker labels without U+2063, an unmarked supervisor phrase, the session-start wording without its authoritative punctuation, and launch-brief text without the per-process origin.
 
 Known synthetic inputs are rerouted only at Pi input presentation time.
-Their full text is persisted in a non-displayed custom message that Pi converts back to an ordinary user message for provider context, and a TUI-only custom entry restores stock user styling while Calm is off.
-This preserves handling and context while giving Calm a supported row renderer.
-Cycling tool expansion and restoring its original value rebuilds those custom entries and leaves final `Ctrl+O` state unchanged.
+Their full text is persisted in one display-bearing custom message that Pi converts back to an ordinary user message for provider context and includes in `/export` and `/share`.
+A registered message renderer gives that same row stock user styling in the live TUI while Calm is off and an empty presentation while Calm is on.
+Cycling tool expansion and restoring its original value rebuilds those custom messages and leaves final `Ctrl+O` state unchanged.
 
 ## Complete currently reachable Pi transcript taxonomy
 
@@ -88,8 +89,8 @@ The test fixture enumerates every class below through the centralized policy, an
 | `tool-image` | Image children appended outside tool renderer slots | Unsupported boundary; remains visible. |
 | `user-bash` | `BashExecutionComponent` for `!` and `!!` | Unsupported boundary; remains visible. |
 | `skill-invocation` | `SkillInvocationMessageComponent` plus parsed user text | Unsupported boundary; remains visible. |
-| `custom-message` | `CustomMessageComponent` when `display` is true | Firstmate's known synthetic context messages use `display: false`; arbitrary extension messages remain an unsupported boundary. |
-| `custom-entry` | `CustomEntryComponent` with a registered renderer | Firstmate's synthetic presentation entry is hidden; arbitrary extension entries remain an unsupported boundary. |
+| `custom-message` | `CustomMessageComponent` when `display` is true | Firstmate's known synthetic context messages use a registered renderer and are hidden; arbitrary extension messages remain an unsupported boundary. |
+| `custom-entry` | `CustomEntryComponent` with a registered renderer | No Calm-owned entry is required; arbitrary extension entries remain an unsupported boundary. |
 | `compaction-summary` | `CompactionSummaryMessageComponent` | Unsupported boundary; remains visible. |
 | `branch-summary` | `BranchSummaryMessageComponent` | Unsupported boundary; remains visible. |
 | `working-status` | `WorkingStatusIndicator` | Hidden through `setWorkingVisible(false)`. |
@@ -97,7 +98,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | `system-notice` | `showStatus`, `showError`, compaction, retry, and startup warning rows | Unsupported boundary; remains visible. |
 | `cache-notice` | Non-persisted cache-miss `Text` row | Unsupported boundary; remains visible. |
 | `project-trust-warning` | Non-persisted startup `Text` row | Unsupported boundary; remains visible. |
-| `synthetic-user` | Firstmate extension `sendUserMessage` or terminal-injected input | All authoritative Firstmate forms are rerouted to hidden context plus a controllable presentation entry. |
+| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, or Firstmate-generated Pi positional brief | All authoritative Firstmate forms are rerouted to one context- and export-bearing message with a controllable live renderer. |
 | `synthetic-assistant` | No authoritative Firstmate source found | Policy-hidden, but Pi exposes no generic assistant-role renderer. |
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -5,7 +5,7 @@ The README owns the user-facing `/calm` usage and limitation contract.
 
 ## Required extension surface
 
-A qualifying implementation must auto-load from the trusted project, keep the toggle session-local, redraw already-rendered controllable rows, restore ordinary rendering, and leave delivery, tool execution, model context, session storage, exports, diagnostics, and expansion state unchanged.
+A qualifying implementation must auto-load from the trusted project, keep the toggle session-local, redraw already-rendered controllable rows, restore ordinary rendering, and leave delivery, tool execution, model context, session storage, export and share operation, diagnostics, and expansion state unchanged.
 The governing presentation policy allows only genuine original user prompts and genuine user-facing assistant text.
 Changing persisted context to remove hidden content, filtering provider context, patching installed harness code, or claiming coverage outside a supported renderer does not satisfy that boundary.
 
@@ -41,8 +41,11 @@ The smallest counterfactuals produced these results:
 - Calling `setHiddenThinkingLabel("")` removed every collapsed `Thinking...` label, but Pi's `AssistantMessageComponent` retained one leading spacer for each reasoning-bearing message.
 - Expanding thinking still rendered full reasoning because Pi exposes no supported getter or setter for the transcript-wide thinking expansion state.
 - Adding supported empty renderer slots to a scratch copy of `fm_watch_arm_pi` removed its row while the real watcher still started and the model still returned `PROBE_COMPLETE`.
-- Delivering a scratch custom message with `display: true` still produced the model response `SYNTHETIC_DELIVERED`, persisted the full custom message in session JSONL, and kept it in HTML exports.
-- Registering a custom-message renderer allowed Calm to hide and restore that same context-bearing row with no content loss or exporter-invisible parallel entry.
+- Delivering a scratch custom message with `display: false` still produced the model response `SYNTHETIC_DELIVERED` and persisted the full custom message in session JSONL.
+- Pairing that hidden context message with a TUI-only custom entry allowed Calm to hide and restore the synthetic user presentation with no content loss.
+- Pi's `CustomMessageComponent` unconditionally adds a leading spacer before invoking a registered message renderer, so returning an empty component cannot hide the whole row.
+- Pi's `CustomEntryComponent` adds spacing only when its renderer returns content, so an undefined Calm renderer result removes the complete live row without a residual gap.
+- Pi's HTML exporter ignores plain custom entries and `display: false` custom messages and does not invoke TUI renderers, so synthetic control inputs cannot retain stock user styling in exported or shared HTML through Pi 0.81.1's supported API.
 
 The disconfirming checks deliberately retained contradictory evidence.
 An arbitrary third-party custom tool and a built-in read image remain visible because Pi exposes neither a global tool renderer nor image-row control.
@@ -70,9 +73,10 @@ Positive fixtures cover every form in that table.
 Near-miss fixtures cover the visible watcher phrase without its suffix, a modified drain instruction, a guard-like captain question, visible marker labels without U+2063, an unmarked supervisor phrase, the session-start wording without its authoritative punctuation, and launch-brief text without the per-process origin.
 
 Known synthetic inputs are rerouted only at Pi input presentation time.
-Their full text is persisted in one display-bearing custom message that Pi converts back to an ordinary user message for provider context and includes in `/export` and `/share`.
-A registered message renderer gives that same row stock user styling in the live TUI while Calm is off and an empty presentation while Calm is on.
-Cycling tool expansion and restoring its original value rebuilds those custom messages and leaves final `Ctrl+O` state unchanged.
+Their full text is persisted in a non-displayed custom message that Pi converts back to an ordinary user message for provider context, and a TUI-only custom entry restores stock user styling while Calm is off.
+The custom-entry host omits the complete row when the renderer returns undefined under Calm, including its normally conditional leading spacer.
+Cycling tool expansion and restoring its original value rebuilds those custom entries and leaves final `Ctrl+O` state unchanged.
+Exported and shared HTML retain genuine user prompts, genuine assistant responses, and ordinary tool rendering, while omitting the synthetic presentation entry and hidden context message at the documented Pi 0.81.1 exporter boundary.
 
 ## Complete currently reachable Pi transcript taxonomy
 
@@ -89,8 +93,8 @@ The test fixture enumerates every class below through the centralized policy, an
 | `tool-image` | Image children appended outside tool renderer slots | Unsupported boundary; remains visible. |
 | `user-bash` | `BashExecutionComponent` for `!` and `!!` | Unsupported boundary; remains visible. |
 | `skill-invocation` | `SkillInvocationMessageComponent` plus parsed user text | Unsupported boundary; remains visible. |
-| `custom-message` | `CustomMessageComponent` when `display` is true | Firstmate's known synthetic context messages use a registered renderer and are hidden; arbitrary extension messages remain an unsupported boundary. |
-| `custom-entry` | `CustomEntryComponent` with a registered renderer | No Calm-owned entry is required; arbitrary extension entries remain an unsupported boundary. |
+| `custom-message` | `CustomMessageComponent` when `display` is true | Firstmate's known synthetic context messages use `display: false`; arbitrary extension messages remain an unsupported boundary. |
+| `custom-entry` | `CustomEntryComponent` with a registered renderer | Firstmate's synthetic presentation entry is hidden without a residual spacer; arbitrary extension entries remain an unsupported boundary. |
 | `compaction-summary` | `CompactionSummaryMessageComponent` | Unsupported boundary; remains visible. |
 | `branch-summary` | `BranchSummaryMessageComponent` | Unsupported boundary; remains visible. |
 | `working-status` | `WorkingStatusIndicator` | Hidden through `setWorkingVisible(false)`. |
@@ -98,7 +102,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | `system-notice` | `showStatus`, `showError`, compaction, retry, and startup warning rows | Unsupported boundary; remains visible. |
 | `cache-notice` | Non-persisted cache-miss `Text` row | Unsupported boundary; remains visible. |
 | `project-trust-warning` | Non-persisted startup `Text` row | Unsupported boundary; remains visible. |
-| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, or Firstmate-generated Pi positional brief | All authoritative Firstmate forms are rerouted to one context- and export-bearing message with a controllable live renderer. |
+| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, or Firstmate-generated Pi positional brief | All authoritative Firstmate forms are rerouted to hidden context plus a gapless controllable presentation entry. |
 | `synthetic-assistant` | No authoritative Firstmate source found | Policy-hidden, but Pi exposes no generic assistant-role renderer. |
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
@@ -135,7 +139,7 @@ They do not claim that a harness can never add the missing renderer API.
 
 ## Regression coverage
 
-`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool and synthetic rows, checks the image and generic custom-tool boundaries, covers every policy class and synthetic fixture, covers session reset reasons, proves exports remain ordinary, and drives a genuine 180 by 44 interactive terminal fixture.
+`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool and synthetic rows, checks the gapless custom-entry host, covers every policy class and synthetic fixture, covers session reset reasons, asserts the rendered export DOM, and drives a genuine 180 by 44 interactive terminal fixture.
 `tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi 0.81.1 declarations.
 
 The relevant commands are:

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -45,8 +45,10 @@ The smallest counterfactuals produced these results:
 - Pairing that hidden context message with a TUI-only custom entry allowed Calm to hide and restore the synthetic user presentation with no content loss.
 - Pi's `CustomMessageComponent` unconditionally adds a leading spacer before invoking a registered message renderer, so returning an empty component cannot hide the whole row.
 - Pi's `CustomEntryComponent` adds spacing only when its renderer returns content, so an undefined Calm renderer result removes the complete live row without a residual gap.
-- Pi does not mount a `CustomEntryComponent` whose initial renderer result is undefined, so disabling Calm rebuilds the current persisted leaf through `ExtensionCommandContext.navigateTree()` to restore entries received while Calm was active.
-- Navigating to the current leaf is a session-data no-op in Pi 0.81.1, while interactive mode clears and reconstructs the transcript from persisted entries; Pi adds its ordinary navigation status row as an unsupported generic command-status boundary.
+- Pi does not add a `CustomEntryComponent` whose initial renderer result is undefined, while a component already added to the chat remains mounted after a later expansion rebuild clears all of its children.
+- Synthetic delivery therefore mounts its presentation synchronously before Pi's `entry_appended` event returns, then immediately cycles the supported expansion state so Calm removes the host spacer and content while retaining the zero-height parent for later restoration.
+- Pi coalesces those synchronous render requests, so the genuine interactive fixture shows neither the temporary presentation nor a blank gap.
+- Whole-transcript reconstruction was rejected because it drops non-persisted diagnostics and adds an unrelated navigation status row.
 - Pi's HTML exporter ignores plain custom entries and `display: false` custom messages and does not invoke TUI renderers, so synthetic control inputs cannot retain stock user styling in exported or shared HTML through Pi 0.81.1's supported API.
 
 The disconfirming checks deliberately retained contradictory evidence.
@@ -96,7 +98,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | `user-bash` | `BashExecutionComponent` for `!` and `!!` | Unsupported boundary; remains visible. |
 | `skill-invocation` | `SkillInvocationMessageComponent` plus parsed user text | Unsupported boundary; remains visible. |
 | `custom-message` | `CustomMessageComponent` when `display` is true | Firstmate's known synthetic context messages use `display: false`; arbitrary extension messages remain an unsupported boundary. |
-| `custom-entry` | `CustomEntryComponent` with a registered renderer | Firstmate's synthetic presentation entry is hidden without a residual spacer and restored through a current-leaf transcript rebuild; arbitrary extension entries remain an unsupported boundary. |
+| `custom-entry` | `CustomEntryComponent` with a registered renderer | Firstmate's synthetic presentation entry is mounted synchronously, rebuilt to zero children without a residual spacer, and restored by the ordinary expansion redraw; arbitrary extension entries remain an unsupported boundary. |
 | `compaction-summary` | `CompactionSummaryMessageComponent` | Unsupported boundary; remains visible. |
 | `branch-summary` | `BranchSummaryMessageComponent` | Unsupported boundary; remains visible. |
 | `working-status` | `WorkingStatusIndicator` | Hidden through `setWorkingVisible(false)`. |
@@ -133,7 +135,7 @@ grok 0.2.106 (bde89716f679)
 | Claude Code 2.1.216 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or transcript-wide redraw API. |
 | Codex CLI 0.144.6 | Not feasible through the inspected supported project surface. | The tracked hooks expose session, pre-tool, and stop handling, while the plugin and feature inventories expose no TUI tool-row renderer or transcript redraw control. |
 | OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer; same-name tool replacement changes execution rather than presentation alone. |
-| Pi 0.81.1 | Partially feasible and implemented to the supported boundary. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, expansion redraws, and current-leaf transcript reconstruction, but not built-in message containers or generic tool and status rows. |
+| Pi 0.81.1 | Partially feasible and implemented to the supported boundary. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws, but not built-in message containers or generic tool and status rows. |
 | Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract; `--minimal` changes the whole screen mode rather than selected transcript rows. |
 
 These conclusions are deliberately limited to the named versions and supported surfaces.
@@ -141,7 +143,7 @@ They do not claim that a harness can never add the missing renderer API.
 
 ## Regression coverage
 
-`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool and synthetic rows, checks the gapless custom-entry host, restores an entry received while Calm is active through the supported current-leaf lifecycle, covers every policy class and synthetic fixture, covers session reset reasons, asserts the rendered export DOM, and drives a genuine 180 by 44 interactive terminal fixture.
+`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool and synthetic rows, checks the gapless mounted custom-entry lifecycle, preserves a transient diagnostic while restoring an entry received under Calm, covers every policy class and synthetic fixture, covers session reset reasons, asserts the rendered export DOM, and drives a genuine 180 by 44 interactive terminal fixture.
 `tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi 0.81.1 declarations.
 
 The relevant commands are:

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -65,8 +65,9 @@ test_static_contract() {
   assert_contains "$text" 'setCalmPresentation(false)' "Pi calm extension does not default to stock transcript presentation"
   assert_contains "$text" 'ctx.ui.setToolsExpanded(!expanded)' "Pi calm extension does not redraw existing custom entries"
   assert_contains "$text" 'ctx.ui.setToolsExpanded(expanded)' "Pi calm extension does not restore Ctrl+O state after redraw"
-  assert_contains "$text" 'ctx.sessionManager.getLeafId()' "Pi calm extension does not resolve the persisted transcript leaf"
-  assert_contains "$text" 'await ctx.navigateTree(leafId)' "Pi calm extension does not rebuild entries skipped while Calm was active"
+  assert_not_contains "$text" 'ctx.navigateTree' "Pi calm extension reconstructs the transcript and drops transient diagnostics"
+  assert_contains "$visibility" 'mountingSyntheticPresentation' "Pi calm visibility policy cannot mount entries received while hidden"
+  assert_contains "$visibility" 'options.redrawPresentation' "Pi calm synthetic delivery does not retain mounted hidden entries"
   assert_contains "$text" 'ctx.ui.setWorkingVisible(!active)' "Pi calm extension does not hide the live working row"
   assert_contains "$text" 'ctx.ui.setHiddenThinkingLabel(active ? "" : undefined)' "Pi calm extension does not hide collapsed thinking labels"
   assert_contains "$text" 'pi.on("input"' "Pi calm extension does not classify input-origin Firstmate injections"
@@ -130,6 +131,7 @@ const tools = [];
 const handlers = new Map();
 const entryRenderers = new Map();
 const appendedEntries = [];
+const mountedPresentationComponents = [];
 const sentMessages = [];
 const eventListeners = new Map();
 let calmCommand;
@@ -145,7 +147,13 @@ const pi = {
     },
   },
   appendEntry(customType, data) {
-    appendedEntries.push({ customType, data });
+    const entry = { customType, data };
+    appendedEntries.push(entry);
+    const renderer = entryRenderers.get(customType);
+    if (!renderer) return;
+    const component = new CustomEntryComponent(entry, renderer);
+    component.setExpanded(expanded);
+    if (component.hasContent()) mountedPresentationComponents.push(component);
   },
   sendMessage(message, options) {
     sentMessages.push({ message, options });
@@ -378,38 +386,11 @@ let editorText = "";
 let terminalInputHandler;
 let workingVisible;
 let hiddenThinkingLabel = "unset";
-const navigationTargets = [];
-const rebuiltPresentationComponents = [];
 const statuses = new Map();
 const sessionEntries = [{ type: "message", message: { role: "toolResult", content: "kept" } }];
 const entriesBefore = JSON.stringify(sessionEntries);
 const commandContext = {
-  sessionManager: {
-    getEntries: () => sessionEntries,
-    getLeafId: () => "current-leaf",
-  },
-  async navigateTree(targetId) {
-    navigationTargets.push(targetId);
-    for (const row of rows) {
-      row.actual.setExpanded(!expanded);
-      row.actual.setExpanded(expanded);
-    }
-    watchActual.setExpanded(!expanded);
-    watchActual.setExpanded(expanded);
-    customRow.setExpanded(!expanded);
-    customRow.setExpanded(expanded);
-    imageRow.setExpanded(!expanded);
-    imageRow.setExpanded(expanded);
-    rebuiltPresentationComponents.length = 0;
-    const renderer = entryRenderers.get("firstmate-synthetic-input-presentation");
-    for (const entry of appendedEntries) {
-      if (entry.customType !== "firstmate-synthetic-input-presentation") continue;
-      const component = new CustomEntryComponent(entry, renderer);
-      component.setExpanded(expanded);
-      if (component.hasContent()) rebuiltPresentationComponents.push(component);
-    }
-    return { cancelled: false };
-  },
+  sessionManager: { getEntries: () => sessionEntries },
   ui: {
     getEditorText: () => editorText,
     getToolsExpanded: () => expanded,
@@ -431,6 +412,9 @@ const commandContext = {
       watchActual.setExpanded(value);
       customRow.setExpanded(value);
       imageRow.setExpanded(value);
+      for (const component of mountedPresentationComponents) {
+        component.setExpanded(value);
+      }
     },
     setWorkingVisible(value) {
       workingVisible = value;
@@ -623,7 +607,10 @@ const activePresentationComponent = new CustomEntryComponent(
 activePresentationComponent.setExpanded(expanded);
 if (
   activePresentationComponent.hasContent() ||
-  activePresentationComponent.render(100).length !== 0
+  activePresentationComponent.render(100).length !== 0 ||
+  mountedPresentationComponents.length !== 3 ||
+  mountedPresentationComponents[2].hasContent() ||
+  mountedPresentationComponents[2].render(100).length !== 0
 ) {
   throw new Error("synthetic input received while Calm was active left a row or blank gap");
 }
@@ -631,14 +618,12 @@ if (
 for (const { baseline } of rows) baseline.setExpanded(expanded);
 await calmCommand.handler("", commandContext);
 if (
-  navigationTargets.length !== 1 ||
-  navigationTargets[0] !== "current-leaf" ||
-  rebuiltPresentationComponents.length !== 3 ||
-  !rebuiltPresentationComponents.some((component) =>
+  mountedPresentationComponents.length !== 3 ||
+  !mountedPresentationComponents.some((component) =>
     component.render(100).join("\n").includes("/tmp/active-probe.status")
   )
 ) {
-  throw new Error("turning Calm off did not immediately rebuild a synthetic row received while active");
+  throw new Error("turning Calm off did not restore the mounted synthetic row received while active");
 }
 for (const { name, baseline, actual } of rows) {
   if (JSON.stringify(actual.render(100)) !== JSON.stringify(baseline.render(100))) {
@@ -693,7 +678,7 @@ JS
 }
 
 test_interactive_terminal_e2e() {
-  local project config session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot active_before_boundary active_hidden_boundary export_snapshot restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait
+  local project config session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot active_hidden_boundary export_snapshot restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi calm interactive E2E"
     return 0
@@ -711,7 +696,6 @@ test_interactive_terminal_e2e() {
   hidden_snapshot="$TMP_ROOT/hidden.txt"
   active_before_snapshot="$TMP_ROOT/active-before.txt"
   active_hidden_snapshot="$TMP_ROOT/active-hidden.txt"
-  active_before_boundary="$TMP_ROOT/active-before-boundary.txt"
   active_hidden_boundary="$TMP_ROOT/active-hidden-boundary.txt"
   export_snapshot="$TMP_ROOT/export.txt"
   restored_snapshot="$TMP_ROOT/restored.txt"
@@ -721,17 +705,20 @@ test_interactive_terminal_e2e() {
   cp "$WATCH_EXT" "$project/.pi/extensions/fm-primary-pi-watch.ts"
   cat >"$project/.pi/extensions/fm-calm-e2e-inject.ts" <<'TS'
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { deliverFirstmateSyntheticInput } from "./lib/fm-calm-visibility.ts";
 
 export default function (pi: ExtensionAPI): void {
+  pi.registerCommand("calm-diagnostic-e2e", {
+    description: "Add the Calm transient diagnostic fixture.",
+    handler: async (_args, ctx) => {
+      ctx.ui.notify("CALM_TRANSIENT_DIAGNOSTIC", "warning");
+    },
+  });
   pi.registerCommand("calm-inject-e2e", {
     description: "Inject the Calm lifecycle fixture.",
     handler: async () => {
-      deliverFirstmateSyntheticInput(
-        pi,
+      pi.sendUserMessage(
         "FIRSTMATE WATCHER WAKE: signal: /tmp/active-probe.status\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.",
-        "watcher",
-        { deliverAs: "followUp", triggerTurn: false },
+        { deliverAs: "followUp" },
       );
     },
   });
@@ -788,7 +775,21 @@ JSON
   assert_contains "$(cat "$hidden_snapshot")" "I will run one command." "/calm removed assistant conversation before a tool"
   assert_contains "$(cat "$hidden_snapshot")" "The deterministic tool example is complete." "/calm removed assistant conversation after a tool"
 
-  tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$active_before_snapshot"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm-diagnostic-e2e"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  active_screen_wait=0
+  while [ "$active_screen_wait" -lt 120 ]; do
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$active_before_snapshot"
+    if grep -Fq "Warning: CALM_TRANSIENT_DIAGNOSTIC" "$active_before_snapshot" &&
+      ! grep -Fq "/calm-diagnostic-e2e" "$active_before_snapshot"; then
+      break
+    fi
+    sleep 0.05
+    active_screen_wait=$((active_screen_wait + 1))
+  done
+  assert_contains "$(cat "$active_before_snapshot")" "Warning: CALM_TRANSIENT_DIAGNOSTIC" "transient diagnostic fixture was not shown"
+  assert_not_contains "$(cat "$active_before_snapshot")" "/calm-diagnostic-e2e" "transient diagnostic command did not leave the editor"
+
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm-inject-e2e"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
   active_wait=0
@@ -801,20 +802,21 @@ JSON
   active_screen_wait=0
   while [ "$active_screen_wait" -lt 120 ]; do
     tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$active_hidden_snapshot"
-    ! grep -Fq "/calm-inject-e2e" "$active_hidden_snapshot" && break
+    if grep -Fq "Error: Unknown provider: unknown" "$active_hidden_snapshot" &&
+      ! grep -Fq "/calm-inject-e2e" "$active_hidden_snapshot"; then
+      break
+    fi
     sleep 0.05
     active_screen_wait=$((active_screen_wait + 1))
   done
   assert_not_contains "$(cat "$active_hidden_snapshot")" "/calm-inject-e2e" "synthetic lifecycle command did not leave the editor"
   assert_not_contains "$(cat "$active_hidden_snapshot")" "/tmp/active-probe.status" "Calm showed a synthetic row received while active"
-  awk '/The deterministic tool example is complete\./ { capture = 1 } capture { print } capture && /^─/ { exit }' \
-    "$active_before_snapshot" >"$active_before_boundary"
-  awk '/The deterministic tool example is complete\./ { capture = 1 } capture { print } capture && /^─/ { exit }' \
+  assert_contains "$(cat "$active_hidden_snapshot")" "Warning: CALM_TRANSIENT_DIAGNOSTIC" "synthetic arrival lost its preceding transient diagnostic"
+  assert_contains "$(cat "$active_hidden_snapshot")" "Error: Unknown provider: unknown" "synthetic delivery did not produce its transient offline diagnostic"
+  awk '/Warning: CALM_TRANSIENT_DIAGNOSTIC/ { capture = 1 } capture { print } /Error: Unknown provider: unknown/ { exit }' \
     "$active_hidden_snapshot" >"$active_hidden_boundary"
-  if ! cmp -s "$active_before_boundary" "$active_hidden_boundary"; then
-    diff -u "$active_before_boundary" "$active_hidden_boundary" >&2 || true
-    fail "Calm changed the screenshot or left a gap for a synthetic row received while active"
-  fi
+  [ "$(wc -l <"$active_hidden_boundary" | tr -d ' ')" -eq 3 ] \
+    || fail "Calm left a blank transcript gap between diagnostics around a synthetic row received while active"
   hash_before=$(shasum -a 256 "$session_file" | awk '{print $1}')
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/export $export_file"
@@ -874,6 +876,9 @@ JS
     || fail "second /calm did not restore a synthetic row received while Calm was active"
   assert_contains "$(cat "$restored_snapshot")" "fm_watch_arm_pi" "second /calm did not restore the Firstmate watcher tool shell"
   assert_contains "$(cat "$restored_snapshot")" "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "second /calm did not restore the synthetic Firstmate user row"
+  assert_contains "$(cat "$restored_snapshot")" "Warning: CALM_TRANSIENT_DIAGNOSTIC" "second /calm dropped a transient diagnostic"
+  assert_contains "$(cat "$restored_snapshot")" "Error: Unknown provider: unknown" "second /calm dropped the synthetic delivery diagnostic"
+  assert_not_contains "$(cat "$restored_snapshot")" "Navigated to selected point" "second /calm added a navigation status row"
   assert_contains "$(cat "$restored_snapshot")" "Thinking..." "second /calm did not restore Pi's collapsed thinking labels"
   assert_contains "$(cat "$restored_snapshot")" "escape to interrupt" "/calm changed the active Ctrl+O expansion state"
 

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -65,6 +65,8 @@ test_static_contract() {
   assert_contains "$text" 'setCalmPresentation(false)' "Pi calm extension does not default to stock transcript presentation"
   assert_contains "$text" 'ctx.ui.setToolsExpanded(!expanded)' "Pi calm extension does not redraw existing custom entries"
   assert_contains "$text" 'ctx.ui.setToolsExpanded(expanded)' "Pi calm extension does not restore Ctrl+O state after redraw"
+  assert_contains "$text" 'ctx.sessionManager.getLeafId()' "Pi calm extension does not resolve the persisted transcript leaf"
+  assert_contains "$text" 'await ctx.navigateTree(leafId)' "Pi calm extension does not rebuild entries skipped while Calm was active"
   assert_contains "$text" 'ctx.ui.setWorkingVisible(!active)' "Pi calm extension does not hide the live working row"
   assert_contains "$text" 'ctx.ui.setHiddenThinkingLabel(active ? "" : undefined)' "Pi calm extension does not hide collapsed thinking labels"
   assert_contains "$text" 'pi.on("input"' "Pi calm extension does not classify input-origin Firstmate injections"
@@ -376,11 +378,38 @@ let editorText = "";
 let terminalInputHandler;
 let workingVisible;
 let hiddenThinkingLabel = "unset";
+const navigationTargets = [];
+const rebuiltPresentationComponents = [];
 const statuses = new Map();
 const sessionEntries = [{ type: "message", message: { role: "toolResult", content: "kept" } }];
 const entriesBefore = JSON.stringify(sessionEntries);
 const commandContext = {
-  sessionManager: { getEntries: () => sessionEntries },
+  sessionManager: {
+    getEntries: () => sessionEntries,
+    getLeafId: () => "current-leaf",
+  },
+  async navigateTree(targetId) {
+    navigationTargets.push(targetId);
+    for (const row of rows) {
+      row.actual.setExpanded(!expanded);
+      row.actual.setExpanded(expanded);
+    }
+    watchActual.setExpanded(!expanded);
+    watchActual.setExpanded(expanded);
+    customRow.setExpanded(!expanded);
+    customRow.setExpanded(expanded);
+    imageRow.setExpanded(!expanded);
+    imageRow.setExpanded(expanded);
+    rebuiltPresentationComponents.length = 0;
+    const renderer = entryRenderers.get("firstmate-synthetic-input-presentation");
+    for (const entry of appendedEntries) {
+      if (entry.customType !== "firstmate-synthetic-input-presentation") continue;
+      const component = new CustomEntryComponent(entry, renderer);
+      component.setExpanded(expanded);
+      if (component.hasContent()) rebuiltPresentationComponents.push(component);
+    }
+    return { cancelled: false };
+  },
   ui: {
     getEditorText: () => editorText,
     getToolsExpanded: () => expanded,
@@ -571,10 +600,46 @@ if (JSON.stringify(sessionEntries) !== entriesBefore) {
   throw new Error("calm mode changed session entries or model context");
 }
 
-// The image-boundary probe changed terminal capabilities after the original
-// stock renders, so refresh the stock comparison under the same capabilities.
+const activeWatcherMessage =
+  "FIRSTMATE WATCHER WAKE: signal: /tmp/active-probe.status\n\n" +
+  "Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.";
+const activeSyntheticResult = await inputHandler({
+  text: activeWatcherMessage,
+  images: undefined,
+  source: "extension",
+  streamingBehavior: "followUp",
+}, commandContext);
+if (
+  activeSyntheticResult?.action !== "handled" ||
+  appendedEntries.length !== 3 ||
+  sentMessages.length !== 3
+) {
+  throw new Error("synthetic input received while Calm was active was not delivered");
+}
+const activePresentationComponent = new CustomEntryComponent(
+  appendedEntries[2],
+  presentationRenderer,
+);
+activePresentationComponent.setExpanded(expanded);
+if (
+  activePresentationComponent.hasContent() ||
+  activePresentationComponent.render(100).length !== 0
+) {
+  throw new Error("synthetic input received while Calm was active left a row or blank gap");
+}
+
 for (const { baseline } of rows) baseline.setExpanded(expanded);
 await calmCommand.handler("", commandContext);
+if (
+  navigationTargets.length !== 1 ||
+  navigationTargets[0] !== "current-leaf" ||
+  rebuiltPresentationComponents.length !== 3 ||
+  !rebuiltPresentationComponents.some((component) =>
+    component.render(100).join("\n").includes("/tmp/active-probe.status")
+  )
+) {
+  throw new Error("turning Calm off did not immediately rebuild a synthetic row received while active");
+}
 for (const { name, baseline, actual } of rows) {
   if (JSON.stringify(actual.render(100)) !== JSON.stringify(baseline.render(100))) {
     throw new Error(`${name} did not restore the expanded standard renderer`);
@@ -628,7 +693,7 @@ JS
 }
 
 test_interactive_terminal_e2e() {
-  local project config session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot export_snapshot restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait
+  local project config session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot active_before_boundary active_hidden_boundary export_snapshot restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi calm interactive E2E"
     return 0
@@ -644,12 +709,34 @@ test_interactive_terminal_e2e() {
   default_snapshot="$TMP_ROOT/default.txt"
   expanded_snapshot="$TMP_ROOT/expanded.txt"
   hidden_snapshot="$TMP_ROOT/hidden.txt"
+  active_before_snapshot="$TMP_ROOT/active-before.txt"
+  active_hidden_snapshot="$TMP_ROOT/active-hidden.txt"
+  active_before_boundary="$TMP_ROOT/active-before-boundary.txt"
+  active_hidden_boundary="$TMP_ROOT/active-hidden-boundary.txt"
   export_snapshot="$TMP_ROOT/export.txt"
   restored_snapshot="$TMP_ROOT/restored.txt"
   mkdir -p "$project/.pi/extensions/lib" "$config"
   cp "$EXT" "$project/.pi/extensions/fm-calm.ts"
   cp "$VISIBILITY" "$project/.pi/extensions/lib/fm-calm-visibility.ts"
   cp "$WATCH_EXT" "$project/.pi/extensions/fm-primary-pi-watch.ts"
+  cat >"$project/.pi/extensions/fm-calm-e2e-inject.ts" <<'TS'
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { deliverFirstmateSyntheticInput } from "./lib/fm-calm-visibility.ts";
+
+export default function (pi: ExtensionAPI): void {
+  pi.registerCommand("calm-inject-e2e", {
+    description: "Inject the Calm lifecycle fixture.",
+    handler: async () => {
+      deliverFirstmateSyntheticInput(
+        pi,
+        "FIRSTMATE WATCHER WAKE: signal: /tmp/active-probe.status\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.",
+        "watcher",
+        { deliverAs: "followUp", triggerTurn: false },
+      );
+    },
+  });
+}
+TS
   printf '%s\n' '{"tui.input.submit":"alt+s"}' >"$config/keybindings.json"
   printf '%s\n' '{"hideThinkingBlock":true}' >"$config/settings.json"
   now=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
@@ -678,8 +765,6 @@ JSON
   assert_contains "$(cat "$default_snapshot")" "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "Calm-off transcript did not show the synthetic Firstmate presentation row"
   assert_contains "$(cat "$default_snapshot")" "Thinking..." "reasoning fixture did not render Pi's collapsed thinking label"
   assert_contains "$(cat "$default_snapshot")" "fm-calm.ts" "project-local Pi calm extension did not auto-load"
-  hash_before=$(shasum -a 256 "$session_file" | awk '{print $1}')
-
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-o
   wait_for_text "$expanded_snapshot" "escape to interrupt" \
     || fail "Ctrl+O did not retain Pi's ordinary startup and tool expansion behavior"
@@ -702,6 +787,35 @@ JSON
   assert_contains "$(cat "$hidden_snapshot")" "FIRSTMATE WATCHER WAKE: can you explain this phrase?" "/calm hid a genuine near-miss user prompt"
   assert_contains "$(cat "$hidden_snapshot")" "I will run one command." "/calm removed assistant conversation before a tool"
   assert_contains "$(cat "$hidden_snapshot")" "The deterministic tool example is complete." "/calm removed assistant conversation after a tool"
+
+  tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$active_before_snapshot"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm-inject-e2e"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  active_wait=0
+  while ! grep -Fq "/tmp/active-probe.status" "$session_file" 2>/dev/null && [ "$active_wait" -lt 120 ]; do
+    sleep 0.05
+    active_wait=$((active_wait + 1))
+  done
+  grep -Fq "/tmp/active-probe.status" "$session_file" \
+    || fail "synthetic lifecycle fixture was not received while Calm was active"
+  active_screen_wait=0
+  while [ "$active_screen_wait" -lt 120 ]; do
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$active_hidden_snapshot"
+    ! grep -Fq "/calm-inject-e2e" "$active_hidden_snapshot" && break
+    sleep 0.05
+    active_screen_wait=$((active_screen_wait + 1))
+  done
+  assert_not_contains "$(cat "$active_hidden_snapshot")" "/calm-inject-e2e" "synthetic lifecycle command did not leave the editor"
+  assert_not_contains "$(cat "$active_hidden_snapshot")" "/tmp/active-probe.status" "Calm showed a synthetic row received while active"
+  awk '/The deterministic tool example is complete\./ { capture = 1 } capture { print } capture && /^─/ { exit }' \
+    "$active_before_snapshot" >"$active_before_boundary"
+  awk '/The deterministic tool example is complete\./ { capture = 1 } capture { print } capture && /^─/ { exit }' \
+    "$active_hidden_snapshot" >"$active_hidden_boundary"
+  if ! cmp -s "$active_before_boundary" "$active_hidden_boundary"; then
+    diff -u "$active_before_boundary" "$active_hidden_boundary" >&2 || true
+    fail "Calm changed the screenshot or left a gap for a synthetic row received while active"
+  fi
+  hash_before=$(shasum -a 256 "$session_file" | awk '{print $1}')
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/export $export_file"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
@@ -756,6 +870,8 @@ JS
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
   wait_for_text "$restored_snapshot" "CALM_E2E_OUTPUT" \
     || fail "second /calm did not restore tool result output"
+  wait_for_text "$restored_snapshot" "/tmp/active-probe.status" \
+    || fail "second /calm did not restore a synthetic row received while Calm was active"
   assert_contains "$(cat "$restored_snapshot")" "fm_watch_arm_pi" "second /calm did not restore the Firstmate watcher tool shell"
   assert_contains "$(cat "$restored_snapshot")" "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "second /calm did not restore the synthetic Firstmate user row"
   assert_contains "$(cat "$restored_snapshot")" "Thinking..." "second /calm did not restore Pi's collapsed thinking labels"

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -50,6 +50,7 @@ test_static_contract() {
   assert_contains "$text" 'ctx.ui.onTerminalInput' "Pi calm extension does not scope export rendering to terminal submissions"
   assert_contains "$text" 'getKeybindings().matches(data, "tui.input.submit")' "Pi calm export boundary ignores the active submit keybinding"
   assert_contains "$text" 'input !== "/share"' "Pi calm export boundary does not cover /share"
+  assert_contains "$text" 'FIRSTMATE_PI_LAUNCH_BRIEF_ENV' "Pi calm extension does not consume authoritative launch-brief origin"
   assert_contains "$text" 'renderShell: "self"' "Pi calm extension cannot remove complete built-in tool shells"
   assert_contains "$visibility" 'CALM_VISIBLE_CLASSES' "Pi calm policy does not centralize its visibility allowlist"
   assert_contains "$visibility" 'classifyFirstmateSyntheticInput' "Pi calm policy does not centralize synthetic-input classification"
@@ -97,11 +98,14 @@ const [{ ToolExecutionComponent }, { initTheme, theme }, { Text, getKeybindings,
 ]);
 initTheme("dark");
 setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+const launchBrief = "You are the persistent secondmate.\nRead the charter and wait.";
+writeFileSync("launch-brief.md", `${launchBrief}\n`);
+process.env.FM_FIRSTMATE_PI_LAUNCH_BRIEF = `${process.cwd()}/launch-brief.md`;
 
 const tools = [];
 const handlers = new Map();
 const entryRenderers = new Map();
-const appendedEntries = [];
+const messageRenderers = new Map();
 const sentMessages = [];
 const eventListeners = new Map();
 let calmCommand;
@@ -116,9 +120,6 @@ const pi = {
       eventListeners.set(name, listeners);
     },
   },
-  appendEntry(customType, data) {
-    appendedEntries.push({ customType, data });
-  },
   sendMessage(message, options) {
     sentMessages.push({ message, options });
   },
@@ -132,6 +133,9 @@ const pi = {
   },
   registerEntryRenderer(customType, renderer) {
     entryRenderers.set(customType, renderer);
+  },
+  registerMessageRenderer(customType, renderer) {
+    messageRenderers.set(customType, renderer);
   },
   registerTool(tool) {
     tools.push(tool);
@@ -182,6 +186,12 @@ for (const [kind, content] of positiveSyntheticFixtures) {
   if (visibility.classifyFirstmateSyntheticInput(content) !== kind) {
     throw new Error(`Firstmate synthetic fixture was not classified as ${kind}`);
   }
+}
+if (visibility.classifyFirstmateSyntheticInput(launchBrief, launchBrief) !== "launch-brief") {
+  throw new Error("authoritatively identified Pi launch brief was not classified");
+}
+if (visibility.classifyFirstmateSyntheticInput(launchBrief) !== undefined) {
+  throw new Error("unmarked genuine text matching a brief was hidden");
 }
 const nearMissGenuineFixtures = [
   "Run bin/fm-session-start.sh now, exactly once, before executing any other instructions.",
@@ -235,10 +245,10 @@ for (const [name, args, result] of cases) {
 
 const watchPi = {
   ...pi,
-  appendEntry() {},
   sendMessage() {},
   registerCommand() {},
   registerEntryRenderer() {},
+  registerMessageRenderer() {},
 };
 const watchExtension = await import(`${pathToFileURL(process.env.WATCH_EXT).href}?test=${Date.now()}`);
 watchExtension.default(watchPi);
@@ -382,39 +392,62 @@ if (workingVisible !== true || hiddenThinkingLabel !== undefined) {
   throw new Error("session start did not restore Pi's stock working and thinking presentation");
 }
 const inputHandler = handlers.get("input")[0];
+const launchBriefResult = await inputHandler({
+  text: launchBrief,
+  images: undefined,
+  source: "interactive",
+  streamingBehavior: undefined,
+}, commandContext);
+if (
+  launchBriefResult?.action !== "handled" ||
+  sentMessages.length !== 1 ||
+  sentMessages[0].message.details.kind !== "launch-brief" ||
+  sentMessages[0].message.content !== launchBrief
+) {
+  throw new Error("Pi positional launch brief was not consumed through its exact origin path");
+}
+const repeatedBriefResult = await inputHandler({
+  text: launchBrief,
+  images: undefined,
+  source: "interactive",
+  streamingBehavior: undefined,
+}, commandContext);
+if (repeatedBriefResult?.action !== "continue" || sentMessages.length !== 1) {
+  throw new Error("consumed launch origin hid a later genuine matching prompt");
+}
 const syntheticResult = await inputHandler({
   text: watcherMessage,
   images: undefined,
   source: "extension",
   streamingBehavior: "followUp",
 }, commandContext);
-if (syntheticResult?.action !== "handled" || appendedEntries.length !== 1 || sentMessages.length !== 1) {
-  throw new Error("known Firstmate synthetic input was not rerouted through presentation-only delivery");
+if (syntheticResult?.action !== "handled" || sentMessages.length !== 2) {
+  throw new Error("known Firstmate synthetic input was not rerouted through controllable delivery");
 }
 if (
-  sentMessages[0].message.content !== watcherMessage ||
-  sentMessages[0].message.display !== false ||
-  sentMessages[0].options.triggerTurn !== true ||
-  sentMessages[0].options.deliverAs !== "followUp"
+  sentMessages[1].message.content !== watcherMessage ||
+  sentMessages[1].message.display !== true ||
+  sentMessages[1].options.triggerTurn !== true ||
+  sentMessages[1].options.deliverAs !== "followUp"
 ) {
   throw new Error("synthetic input delivery or context semantics changed");
 }
-const presentationRenderer = entryRenderers.get("firstmate-synthetic-input-presentation");
+const presentationRenderer = messageRenderers.get("firstmate-synthetic-input");
 if (!presentationRenderer) throw new Error("synthetic presentation renderer was not registered");
 const presentationEntry = {
-  data: { content: watcherMessage, kind: "watcher" },
+  content: watcherMessage,
+  details: { kind: "watcher" },
 };
-if (!presentationRenderer(presentationEntry, { expanded }, theme)?.render(100).join("\n").includes("FIRSTMATE WATCHER WAKE")) {
+if (!presentationRenderer(presentationEntry, { expanded }, theme).render(100).join("\n").includes("FIRSTMATE WATCHER WAKE")) {
   throw new Error("Calm-off synthetic presentation did not use a stock user-message row");
 }
-const appendedBeforeNearMiss = appendedEntries.length;
 const nearMissResult = await inputHandler({
   text: nearMissGenuineFixtures[1],
   images: undefined,
   source: "interactive",
   streamingBehavior: undefined,
 }, commandContext);
-if (nearMissResult?.action !== "continue" || appendedEntries.length !== appendedBeforeNearMiss) {
+if (nearMissResult?.action !== "continue" || sentMessages.length !== 2) {
   throw new Error("genuine near-miss input was intercepted");
 }
 
@@ -422,7 +455,7 @@ await calmCommand.handler("", commandContext);
 if (expanded !== true || workingVisible !== false || hiddenThinkingLabel !== "" || statuses.get("firstmate-calm") !== "calm transcript") {
   throw new Error("Calm did not apply its supported working, thinking, and footer presentation controls");
 }
-if (presentationRenderer(presentationEntry, { expanded }, theme) !== undefined) {
+if (presentationRenderer(presentationEntry, { expanded }, theme).render(100).length !== 0) {
   throw new Error("Calm left a synthetic Firstmate presentation entry visible");
 }
 for (const { name, actual } of rows) {
@@ -515,7 +548,7 @@ if (JSON.stringify(watchActual.render(100)) !== JSON.stringify(watchBaseline.ren
 if (workingVisible !== true || hiddenThinkingLabel !== undefined || statuses.get("firstmate-calm") !== undefined) {
   throw new Error("turning Calm off did not restore stock presentation controls");
 }
-if (!presentationRenderer(presentationEntry, { expanded }, theme)) {
+if (!presentationRenderer(presentationEntry, { expanded }, theme).render(100).join("\n").includes("FIRSTMATE WATCHER WAKE")) {
   throw new Error("turning Calm off did not restore synthetic user-row presentation");
 }
 
@@ -584,8 +617,7 @@ test_interactive_terminal_e2e() {
 {"type":"message","id":"a0000006","parentId":"a0000005","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_find_e2e","toolName":"find","content":[{"type":"text","text":"CALM_EXPORT_FIND.txt"}],"details":{},"isError":false,"timestamp":6}}
 {"type":"message","id":"a0000007","parentId":"a0000006","timestamp":"$now","message":{"role":"assistant","content":[{"type":"thinking","thinking":"third internal reasoning block"},{"type":"toolCall","id":"call_watch_e2e","name":"fm_watch_arm_pi","arguments":{}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":7}}
 {"type":"message","id":"a0000008","parentId":"a0000007","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_watch_e2e","toolName":"fm_watch_arm_pi","content":[{"type":"text","text":"watcher: started Pi extension arm child 1"}],"details":{"ok":true,"message":"watcher: started Pi extension arm child 1"},"isError":false,"timestamp":8}}
-{"type":"custom","id":"a0000009","parentId":"a0000008","timestamp":"$now","customType":"firstmate-synthetic-input-presentation","data":{"content":"FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\\n\\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","kind":"watcher"}}
-{"type":"custom_message","id":"a0000010","parentId":"a0000009","timestamp":"$now","customType":"firstmate-synthetic-input","content":"FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\\n\\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","display":false,"details":{"kind":"watcher"}}
+{"type":"custom_message","id":"a0000010","parentId":"a0000008","timestamp":"$now","customType":"firstmate-synthetic-input","content":"FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\\n\\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","display":true,"details":{"kind":"watcher"}}
 {"type":"message","id":"a0000011","parentId":"a0000010","timestamp":"$now","message":{"role":"user","content":[{"type":"text","text":"FIRSTMATE WATCHER WAKE: can you explain this phrase?"}],"timestamp":11}}
 {"type":"message","id":"a0000012","parentId":"a0000011","timestamp":"$now","message":{"role":"assistant","content":[{"type":"text","text":"The deterministic tool example is complete."}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":12}}
 JSON
@@ -640,6 +672,8 @@ for (const id of ["call_grep_e2e", "call_find_e2e", "call_watch_e2e"]) {
 const entries = session.session?.entries ?? session.entries ?? [];
 const serialized = JSON.stringify(entries);
 if (!serialized.includes("firstmate-synthetic-input") || !serialized.includes("/tmp/probe.status")) process.exit(1);
+const synthetic = entries.find((entry) => entry.type === "custom_message" && entry.customType === "firstmate-synthetic-input");
+if (!synthetic?.display) process.exit(1);
 JS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -7,6 +7,8 @@ set -u
 
 TMP_ROOT=$(fm_test_tmproot fm-calm-pi-extension)
 EXT="$ROOT/.pi/extensions/fm-calm.ts"
+VISIBILITY="$ROOT/.pi/extensions/lib/fm-calm-visibility.ts"
+WATCH_EXT="$ROOT/.pi/extensions/fm-primary-pi-watch.ts"
 PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
 TMUX_SOCKET="fm-calm-$$"
 TMUX_SESSION="fm-calm-e2e"
@@ -31,25 +33,32 @@ wait_for_text() {
 }
 
 test_static_contract() {
-  local text
+  local text visibility watch
   assert_present "$EXT" "tracked Pi calm extension is missing"
+  assert_present "$VISIBILITY" "tracked Pi calm visibility policy is missing"
   text=$(cat "$EXT")
+  visibility=$(cat "$VISIBILITY")
+  watch=$(cat "$WATCH_EXT")
   assert_contains "$text" 'pi.registerCommand("calm"' "Pi calm extension does not register /calm"
   assert_contains "$text" 'pi.on("session_start"' "Pi calm extension does not reset on every session start"
-  assert_contains "$text" 'calm = false' "Pi calm extension does not default to visible tool activity"
-  assert_contains "$text" 'ctx.ui.setToolsExpanded(ctx.ui.getToolsExpanded())' "Pi calm extension does not redraw existing rows while preserving Ctrl+O state"
-  assert_contains "$text" 'ctx.ui.onTerminalInput' "Pi calm extension does not scope hiding to interactive rendering"
+  assert_contains "$text" 'setCalmPresentation(false)' "Pi calm extension does not default to stock transcript presentation"
+  assert_contains "$text" 'ctx.ui.setToolsExpanded(!expanded)' "Pi calm extension does not redraw existing custom entries"
+  assert_contains "$text" 'ctx.ui.setToolsExpanded(expanded)' "Pi calm extension does not restore Ctrl+O state after redraw"
+  assert_contains "$text" 'ctx.ui.setWorkingVisible(!active)' "Pi calm extension does not hide the live working row"
+  assert_contains "$text" 'ctx.ui.setHiddenThinkingLabel(active ? "" : undefined)' "Pi calm extension does not hide collapsed thinking labels"
+  assert_contains "$text" 'pi.on("input"' "Pi calm extension does not classify input-origin Firstmate injections"
+  assert_contains "$text" 'ctx.ui.onTerminalInput' "Pi calm extension does not scope export rendering to terminal submissions"
   assert_contains "$text" 'getKeybindings().matches(data, "tui.input.submit")' "Pi calm export boundary ignores the active submit keybinding"
   assert_contains "$text" 'input !== "/share"' "Pi calm export boundary does not cover /share"
-  assert_contains "$text" 'renderShell: "self"' "Pi calm extension cannot remove the complete tool shell"
-  assert_contains "$text" 'built-in read images and custom/third-party tool rows stay visible' "Pi calm command description does not disclose both visibility boundaries"
-  assert_contains "$text" 'built-in read images and custom/third-party tool rows remain visible' "Pi calm enabled status does not disclose both visibility boundaries"
-  assert_not_contains "$text" 'appendEntry' "Pi calm extension persists its session-local toggle"
-  assert_not_contains "$text" 'sendMessage' "Pi calm extension changes model context"
+  assert_contains "$text" 'renderShell: "self"' "Pi calm extension cannot remove complete built-in tool shells"
+  assert_contains "$visibility" 'CALM_VISIBLE_CLASSES' "Pi calm policy does not centralize its visibility allowlist"
+  assert_contains "$visibility" 'classifyFirstmateSyntheticInput' "Pi calm policy does not centralize synthetic-input classification"
+  assert_contains "$watch" 'calmHides("assistant-tool-call")' "Firstmate watcher tool does not participate in Calm presentation"
+  assert_contains "$watch" 'renderShell: "self"' "Firstmate watcher tool cannot remove its complete shell"
   for name in Read Bash Edit Write Grep Find Ls; do
     assert_contains "$text" "create${name}ToolDefinition" "Pi calm extension does not wrap the $name built-in"
   done
-  pass "Pi calm extension has the default-off, redraw, seven-built-in text-row, and explicit limitation contract"
+  pass "Pi calm extension has one default-off visibility policy, supported redraw controls, and the Firstmate watcher-tool integration"
 }
 
 test_rendering_and_session_lifecycle() {
@@ -63,17 +72,19 @@ test_rendering_and_session_lifecycle() {
     return 0
   fi
   version=$(node -p "require('$PI_PACKAGE_DIR/package.json').version")
-  [ "$version" = "0.80.10" ] || fail "Pi calm compatibility assumptions require Pi 0.80.10, found $version"
+  [ "$version" = "0.81.1" ] || fail "Pi calm compatibility assumptions require Pi 0.81.1, found $version"
 
   fixture="$TMP_ROOT/renderer"
-  mkdir -p "$fixture/node_modules/@earendil-works"
+  mkdir -p "$fixture/home" "$fixture/lib" "$fixture/node_modules/@earendil-works"
   cp "$EXT" "$fixture/fm-calm.ts"
+  cp "$VISIBILITY" "$fixture/lib/fm-calm-visibility.ts"
+  cp "$WATCH_EXT" "$fixture/fm-primary-pi-watch.ts"
   ln -s "$PI_PACKAGE_DIR" "$fixture/node_modules/@earendil-works/pi-coding-agent"
   ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/node_modules/@earendil-works/pi-tui"
   ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/node_modules/typebox"
   printf '%s\n' '{"type":"module"}' >"$fixture/package.json"
 
-  out=$(cd "$fixture" && EXT="$fixture/fm-calm.ts" PI_PACKAGE_DIR="$PI_PACKAGE_DIR" node --input-type=module 2>&1 <<'JS'
+  out=$(cd "$fixture" && EXT="$fixture/fm-calm.ts" WATCH_EXT="$fixture/fm-primary-pi-watch.ts" FM_HOME="$fixture/home" PI_PACKAGE_DIR="$PI_PACKAGE_DIR" node --input-type=module 2>&1 <<'JS'
 import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -89,16 +100,38 @@ setCapabilities({ images: null, trueColor: true, hyperlinks: false });
 
 const tools = [];
 const handlers = new Map();
+const entryRenderers = new Map();
+const appendedEntries = [];
+const sentMessages = [];
+const eventListeners = new Map();
 let calmCommand;
 const pi = {
-  appendEntry() {
-    throw new Error("calm mode must not persist extension state");
+  events: {
+    emit(name, data) {
+      for (const listener of eventListeners.get(name) ?? []) listener(data);
+    },
+    on(name, listener) {
+      const listeners = eventListeners.get(name) ?? [];
+      listeners.push(listener);
+      eventListeners.set(name, listeners);
+    },
+  },
+  appendEntry(customType, data) {
+    appendedEntries.push({ customType, data });
+  },
+  sendMessage(message, options) {
+    sentMessages.push({ message, options });
   },
   on(event, handler) {
-    handlers.set(event, handler);
+    const eventHandlers = handlers.get(event) ?? [];
+    eventHandlers.push(handler);
+    handlers.set(event, eventHandlers);
   },
   registerCommand(name, command) {
     if (name === "calm") calmCommand = command;
+  },
+  registerEntryRenderer(customType, renderer) {
+    entryRenderers.set(customType, renderer);
   },
   registerTool(tool) {
     tools.push(tool);
@@ -106,20 +139,62 @@ const pi = {
 };
 const extension = await import(`${pathToFileURL(process.env.EXT).href}?test=${Date.now()}`);
 extension.default(pi);
+const visibility = await import(`${pathToFileURL(`${process.cwd()}/lib/fm-calm-visibility.ts`).href}?policy=${Date.now()}`);
 
 const names = tools.map((tool) => tool.name);
 const expectedNames = ["read", "bash", "edit", "write", "grep", "find", "ls"];
 if (JSON.stringify(names) !== JSON.stringify(expectedNames)) {
   throw new Error(`unexpected wrapped built-ins: ${names.join(",")}`);
 }
-if (!calmCommand || !handlers.has("session_start")) {
-  throw new Error("calm command or session lifecycle handler was not registered");
+if (!calmCommand || !handlers.has("session_start") || !handlers.has("input")) {
+  throw new Error("calm command, input classifier, or session lifecycle handler was not registered");
 }
 if (
   calmCommand.description !==
-  "Toggle built-in call and text-result rows; built-in read images and custom/third-party tool rows stay visible."
+  "Toggle Firstmate's supported conversation-only transcript presentation."
 ) {
-  throw new Error(`calm command description does not disclose both visibility boundaries: ${calmCommand.description}`);
+  throw new Error(`unexpected calm command description: ${calmCommand.description}`);
+}
+
+for (const itemClass of visibility.CALM_TRANSCRIPT_CLASSES) {
+  const visible = visibility.calmTranscriptClassIsVisible(itemClass);
+  const expected = itemClass === "genuine-user-prompt" || itemClass === "genuine-agent-response";
+  if (visible !== expected) {
+    throw new Error(`Calm allowlist classified ${itemClass} as visible=${visible}`);
+  }
+}
+const watcherMessage =
+  "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\n\n" +
+  "Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.";
+const turnEndMessage =
+  "TURN WOULD END BLIND - supervision is off. " +
+  "The watcher cycle is missing, failed, or unhealthy. " +
+  "Follow the harness recovery instruction below before ending the turn.\n\n" +
+  "watcher: FAILED - probe";
+const positiveSyntheticFixtures = [
+  ["session-start", "Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions."],
+  ["watcher", watcherMessage],
+  ["turn-end-guard", turnEndMessage],
+  ["away-supervisor", "\u2063Supervisor escalate (1 event(s)): done"],
+  ["from-firstmate", "[fm-from-firstmate]\u2063[fm-corr:abc] inspect the report"],
+];
+for (const [kind, content] of positiveSyntheticFixtures) {
+  if (visibility.classifyFirstmateSyntheticInput(content) !== kind) {
+    throw new Error(`Firstmate synthetic fixture was not classified as ${kind}`);
+  }
+}
+const nearMissGenuineFixtures = [
+  "Run bin/fm-session-start.sh now, exactly once, before executing any other instructions.",
+  "FIRSTMATE WATCHER WAKE: can you explain this phrase?",
+  "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\n\nRun bin/fm-wake-drain.sh when convenient.",
+  "TURN WOULD END BLIND - can you make this warning friendlier?",
+  "Supervisor escalate (1 event(s)): is this wording clear?",
+  "[fm-from-firstmate] inspect this visible label",
+];
+for (const content of nearMissGenuineFixtures) {
+  if (visibility.classifyFirstmateSyntheticInput(content) !== undefined) {
+    throw new Error(`genuine near-miss input was hidden: ${content}`);
+  }
 }
 
 writeFileSync("sample.txt", "alpha\n");
@@ -156,6 +231,54 @@ for (const [name, args, result] of cases) {
     throw new Error(`${name} expanded rendering changed while calm mode was off`);
   }
   rows.push({ name, baseline, actual });
+}
+
+const watchPi = {
+  ...pi,
+  appendEntry() {},
+  sendMessage() {},
+  registerCommand() {},
+  registerEntryRenderer() {},
+};
+const watchExtension = await import(`${pathToFileURL(process.env.WATCH_EXT).href}?test=${Date.now()}`);
+watchExtension.default(watchPi);
+const watchTool = tools.find((tool) => tool.name === "fm_watch_arm_pi");
+if (!watchTool) throw new Error("Firstmate watcher extension did not register fm_watch_arm_pi");
+const stockWatchTool = { ...watchTool };
+delete stockWatchTool.renderCall;
+delete stockWatchTool.renderResult;
+delete stockWatchTool.renderShell;
+const watchArgs = {};
+const watchResult = {
+  content: [{ type: "text", text: "watcher: started Pi extension arm child 1" }],
+  details: { ok: true, message: "watcher: started Pi extension arm child 1" },
+  isError: false,
+};
+const watchBaseline = new ToolExecutionComponent(
+  "fm_watch_arm_pi",
+  "watch-baseline",
+  watchArgs,
+  { showImages: false },
+  stockWatchTool,
+  renderUi,
+  process.cwd(),
+);
+const watchActual = new ToolExecutionComponent(
+  "fm_watch_arm_pi",
+  "watch-actual",
+  watchArgs,
+  { showImages: false },
+  watchTool,
+  renderUi,
+  process.cwd(),
+);
+for (const row of [watchBaseline, watchActual]) {
+  row.markExecutionStarted();
+  row.setArgsComplete();
+  row.updateResult(watchResult);
+}
+if (JSON.stringify(watchActual.render(100)) !== JSON.stringify(watchBaseline.render(100))) {
+  throw new Error("Firstmate watcher tool changed stock rendering while Calm was off");
 }
 
 const customDefinition = {
@@ -217,9 +340,11 @@ if (!imageVisibleBefore.join("\n").includes("\x1b]1337;File=")) {
 }
 
 let expanded = true;
-let notification = "";
 let editorText = "";
 let terminalInputHandler;
+let workingVisible;
+let hiddenThinkingLabel = "unset";
+const statuses = new Map();
 const sessionEntries = [{ type: "message", message: { role: "toolResult", content: "kept" } }];
 const entriesBefore = JSON.stringify(sessionEntries);
 const commandContext = {
@@ -233,20 +358,78 @@ const commandContext = {
         if (terminalInputHandler === handler) terminalInputHandler = undefined;
       };
     },
+    setHiddenThinkingLabel(value) {
+      hiddenThinkingLabel = value;
+    },
+    setStatus(key, value) {
+      statuses.set(key, value);
+    },
     setToolsExpanded(value) {
-      if (value !== expanded) throw new Error("/calm changed the ordinary Ctrl+O expansion state");
+      expanded = value;
       for (const row of rows) row.actual.setExpanded(value);
+      watchActual.setExpanded(value);
       customRow.setExpanded(value);
       imageRow.setExpanded(value);
     },
-    notify(message) {
-      notification = message;
+    setWorkingVisible(value) {
+      workingVisible = value;
     },
   },
 };
 
-await handlers.get("session_start")({ reason: "startup" }, commandContext);
+await handlers.get("session_start")[0]({ reason: "startup" }, commandContext);
+if (workingVisible !== true || hiddenThinkingLabel !== undefined) {
+  throw new Error("session start did not restore Pi's stock working and thinking presentation");
+}
+const inputHandler = handlers.get("input")[0];
+const syntheticResult = await inputHandler({
+  text: watcherMessage,
+  images: undefined,
+  source: "extension",
+  streamingBehavior: "followUp",
+}, commandContext);
+if (syntheticResult?.action !== "handled" || appendedEntries.length !== 1 || sentMessages.length !== 1) {
+  throw new Error("known Firstmate synthetic input was not rerouted through presentation-only delivery");
+}
+if (
+  sentMessages[0].message.content !== watcherMessage ||
+  sentMessages[0].message.display !== false ||
+  sentMessages[0].options.triggerTurn !== true ||
+  sentMessages[0].options.deliverAs !== "followUp"
+) {
+  throw new Error("synthetic input delivery or context semantics changed");
+}
+const presentationRenderer = entryRenderers.get("firstmate-synthetic-input-presentation");
+if (!presentationRenderer) throw new Error("synthetic presentation renderer was not registered");
+const presentationEntry = {
+  data: { content: watcherMessage, kind: "watcher" },
+};
+if (!presentationRenderer(presentationEntry, { expanded }, theme)?.render(100).join("\n").includes("FIRSTMATE WATCHER WAKE")) {
+  throw new Error("Calm-off synthetic presentation did not use a stock user-message row");
+}
+const appendedBeforeNearMiss = appendedEntries.length;
+const nearMissResult = await inputHandler({
+  text: nearMissGenuineFixtures[1],
+  images: undefined,
+  source: "interactive",
+  streamingBehavior: undefined,
+}, commandContext);
+if (nearMissResult?.action !== "continue" || appendedEntries.length !== appendedBeforeNearMiss) {
+  throw new Error("genuine near-miss input was intercepted");
+}
+
 await calmCommand.handler("", commandContext);
+if (expanded !== true || workingVisible !== false || hiddenThinkingLabel !== "" || statuses.get("firstmate-calm") !== "calm transcript") {
+  throw new Error("Calm did not apply its supported working, thinking, and footer presentation controls");
+}
+if (presentationRenderer(presentationEntry, { expanded }, theme) !== undefined) {
+  throw new Error("Calm left a synthetic Firstmate presentation entry visible");
+}
+for (const { name, actual } of rows) {
+  if (actual.render(100).length !== 0) {
+    throw new Error(`${name} was not hidden before export rendering`);
+  }
+}
 async function assertStockHtmlRendering(command, submitData) {
   editorText = command;
   terminalInputHandler(submitData);
@@ -255,7 +438,11 @@ async function assertStockHtmlRendering(command, submitData) {
     theme,
     cwd: process.cwd(),
   });
-  for (const [name, args, result] of cases.filter(([toolName]) => toolName === "grep" || toolName === "find")) {
+  const exportCases = [
+    ...cases.filter(([toolName]) => toolName === "grep" || toolName === "find"),
+    ["fm_watch_arm_pi", watchArgs, watchResult],
+  ];
+  for (const [name, args, result] of exportCases) {
     const toolCallId = `${command}-${name}`;
     const callHtml = htmlRenderer.renderCall(toolCallId, name, args);
     const resultHtml = htmlRenderer.renderResult(
@@ -301,13 +488,10 @@ if (calmImageOutput.includes("pixel.png")) {
   throw new Error("calm mode left the built-in read call shell beside the disclosed image output");
 }
 if (!customRow.render(100).join("\n").includes("CUSTOM_CALL")) {
-  throw new Error("calm mode incorrectly claimed or applied custom-tool coverage");
+  throw new Error("calm mode incorrectly claimed or applied generic custom-tool coverage");
 }
-if (
-  notification !==
-  "Tool activity is hidden where supported; built-in read images and custom/third-party tool rows remain visible."
-) {
-  throw new Error(`unexpected hidden status: ${notification}`);
+if (watchActual.render(100).length !== 0) {
+  throw new Error("Calm left the fm_watch_arm_pi call/result shell visible");
 }
 if (JSON.stringify(sessionEntries) !== entriesBefore) {
   throw new Error("calm mode changed session entries or model context");
@@ -325,13 +509,19 @@ for (const { name, baseline, actual } of rows) {
 if (JSON.stringify(imageRow.render(100)) !== JSON.stringify(imageVisibleBefore)) {
   throw new Error("built-in read image row did not restore its ordinary call shell and image output");
 }
-if (notification !== "Tool activity is visible.") {
-  throw new Error(`unexpected visible status: ${notification}`);
+if (JSON.stringify(watchActual.render(100)) !== JSON.stringify(watchBaseline.render(100))) {
+  throw new Error("fm_watch_arm_pi did not restore its stock call/result shell");
+}
+if (workingVisible !== true || hiddenThinkingLabel !== undefined || statuses.get("firstmate-calm") !== undefined) {
+  throw new Error("turning Calm off did not restore stock presentation controls");
+}
+if (!presentationRenderer(presentationEntry, { expanded }, theme)) {
+  throw new Error("turning Calm off did not restore synthetic user-row presentation");
 }
 
 for (const reason of ["startup", "new", "resume", "fork", "reload"]) {
   await calmCommand.handler("", commandContext);
-  await handlers.get("session_start")({ reason }, commandContext);
+  await handlers.get("session_start")[0]({ reason }, commandContext);
   for (const row of rows) row.actual.setExpanded(expanded);
   for (const { name, baseline, actual } of rows) {
     if (JSON.stringify(actual.render(100)) !== JSON.stringify(baseline.render(100))) {
@@ -356,7 +546,7 @@ JS
   status=$?
   [ "$status" -eq 0 ] || fail "Pi calm renderer and lifecycle contract failed: $out"
   [ -z "$out" ] || fail "Pi calm renderer test printed output: $out"
-  pass "Pi calm preserves standard rendering and execution, hides seven built-in call and text rows, keeps read images and custom rows visible, and resets per session"
+  pass "Pi calm centralizes transcript visibility, preserves execution/export data, hides built-ins plus fm_watch_arm_pi and Firstmate injections, and resets per session"
 }
 
 test_interactive_terminal_e2e() {
@@ -366,7 +556,7 @@ test_interactive_terminal_e2e() {
     return 0
   fi
   version=$(pi --version 2>/dev/null || true)
-  [ "$version" = "0.80.10" ] || fail "Pi calm interactive E2E requires Pi 0.80.10, found $version"
+  [ "$version" = "0.81.1" ] || fail "Pi calm interactive E2E requires Pi 0.81.1, found $version"
 
   project="$TMP_ROOT/e2e-project"
   config="$TMP_ROOT/e2e-config"
@@ -377,26 +567,37 @@ test_interactive_terminal_e2e() {
   hidden_snapshot="$TMP_ROOT/hidden.txt"
   export_snapshot="$TMP_ROOT/export.txt"
   restored_snapshot="$TMP_ROOT/restored.txt"
-  mkdir -p "$project/.pi/extensions" "$config"
+  mkdir -p "$project/.pi/extensions/lib" "$config"
   cp "$EXT" "$project/.pi/extensions/fm-calm.ts"
+  cp "$VISIBILITY" "$project/.pi/extensions/lib/fm-calm-visibility.ts"
+  cp "$WATCH_EXT" "$project/.pi/extensions/fm-primary-pi-watch.ts"
   printf '%s\n' '{"tui.input.submit":"alt+s"}' >"$config/keybindings.json"
+  printf '%s\n' '{"hideThinkingBlock":true}' >"$config/settings.json"
   now=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
   cat >"$session_file" <<JSON
 {"type":"session","version":3,"id":"11111111-1111-4111-8111-111111111111","timestamp":"$now","cwd":"$project"}
 {"type":"message","id":"a0000001","parentId":null,"timestamp":"$now","message":{"role":"user","content":[{"type":"text","text":"Show a deterministic tool example."}],"timestamp":1}}
-{"type":"message","id":"a0000002","parentId":"a0000001","timestamp":"$now","message":{"role":"assistant","content":[{"type":"text","text":"I will run one command."},{"type":"toolCall","id":"call_calm_e2e","name":"bash","arguments":{"command":"printf 'CALM_E2E_OUTPUT\\n'"}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":2}}
+{"type":"message","id":"a0000002","parentId":"a0000001","timestamp":"$now","message":{"role":"assistant","content":[{"type":"thinking","thinking":"first internal reasoning block"},{"type":"text","text":"I will run one command."},{"type":"toolCall","id":"call_calm_e2e","name":"bash","arguments":{"command":"printf 'CALM_E2E_OUTPUT\\n'"}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":2}}
 {"type":"message","id":"a0000003","parentId":"a0000002","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_calm_e2e","toolName":"bash","content":[{"type":"text","text":"CALM_E2E_OUTPUT"}],"details":{},"isError":false,"timestamp":3}}
-{"type":"message","id":"a0000004","parentId":"a0000003","timestamp":"$now","message":{"role":"assistant","content":[{"type":"toolCall","id":"call_grep_e2e","name":"grep","arguments":{"pattern":"CALM_EXPORT_GREP","path":"."}},{"type":"toolCall","id":"call_find_e2e","name":"find","arguments":{"pattern":"CALM_EXPORT_FIND*","path":"."}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":4}}
+{"type":"message","id":"a0000004","parentId":"a0000003","timestamp":"$now","message":{"role":"assistant","content":[{"type":"thinking","thinking":"second internal reasoning block"},{"type":"toolCall","id":"call_grep_e2e","name":"grep","arguments":{"pattern":"CALM_EXPORT_GREP","path":"."}},{"type":"toolCall","id":"call_find_e2e","name":"find","arguments":{"pattern":"CALM_EXPORT_FIND*","path":"."}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":4}}
 {"type":"message","id":"a0000005","parentId":"a0000004","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_grep_e2e","toolName":"grep","content":[{"type":"text","text":"sample.txt:1:CALM_EXPORT_GREP"}],"details":{},"isError":false,"timestamp":5}}
 {"type":"message","id":"a0000006","parentId":"a0000005","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_find_e2e","toolName":"find","content":[{"type":"text","text":"CALM_EXPORT_FIND.txt"}],"details":{},"isError":false,"timestamp":6}}
-{"type":"message","id":"a0000007","parentId":"a0000006","timestamp":"$now","message":{"role":"assistant","content":[{"type":"text","text":"The deterministic tool example is complete."}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":7}}
+{"type":"message","id":"a0000007","parentId":"a0000006","timestamp":"$now","message":{"role":"assistant","content":[{"type":"thinking","thinking":"third internal reasoning block"},{"type":"toolCall","id":"call_watch_e2e","name":"fm_watch_arm_pi","arguments":{}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":7}}
+{"type":"message","id":"a0000008","parentId":"a0000007","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_watch_e2e","toolName":"fm_watch_arm_pi","content":[{"type":"text","text":"watcher: started Pi extension arm child 1"}],"details":{"ok":true,"message":"watcher: started Pi extension arm child 1"},"isError":false,"timestamp":8}}
+{"type":"custom","id":"a0000009","parentId":"a0000008","timestamp":"$now","customType":"firstmate-synthetic-input-presentation","data":{"content":"FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\\n\\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","kind":"watcher"}}
+{"type":"custom_message","id":"a0000010","parentId":"a0000009","timestamp":"$now","customType":"firstmate-synthetic-input","content":"FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\\n\\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","display":false,"details":{"kind":"watcher"}}
+{"type":"message","id":"a0000011","parentId":"a0000010","timestamp":"$now","message":{"role":"user","content":[{"type":"text","text":"FIRSTMATE WATCHER WAKE: can you explain this phrase?"}],"timestamp":11}}
+{"type":"message","id":"a0000012","parentId":"a0000011","timestamp":"$now","message":{"role":"assistant","content":[{"type":"text","text":"The deterministic tool example is complete."}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":12}}
 JSON
 
-  tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 120 -y 40 \
+  tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 180 -y 44 \
     "cd '$project' && env PI_CODING_AGENT_DIR='$config' PI_OFFLINE=1 pi --approve --no-skills --no-prompt-templates --no-context-files --session '$session_file'; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 30"
   wait_for_text "$default_snapshot" "The deterministic tool example is complete." \
     || fail "Pi calm E2E did not reach the restored session transcript"
   assert_contains "$(cat "$default_snapshot")" "CALM_E2E_OUTPUT" "calm mode was not off by default"
+  assert_contains "$(cat "$default_snapshot")" "fm_watch_arm_pi" "Calm-off transcript did not show the Firstmate watcher tool"
+  assert_contains "$(cat "$default_snapshot")" "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "Calm-off transcript did not show the synthetic Firstmate presentation row"
+  assert_contains "$(cat "$default_snapshot")" "Thinking..." "reasoning fixture did not render Pi's collapsed thinking label"
   assert_contains "$(cat "$default_snapshot")" "fm-calm.ts" "project-local Pi calm extension did not auto-load"
   hash_before=$(shasum -a 256 "$session_file" | awk '{print $1}')
 
@@ -407,12 +608,19 @@ JSON
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
-  wait_for_text "$hidden_snapshot" "Tool activity is hidden where supported; built-in read images and custom/third-party tool rows remain visible." \
-    || fail "/calm did not report hidden tool activity and its visibility boundaries"
+  wait_for_text "$hidden_snapshot" "calm transcript" \
+    || fail "/calm did not activate its footer status"
   assert_not_contains "$(cat "$hidden_snapshot")" "CALM_E2E_OUTPUT" "/calm left tool result output in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_GREP" "/calm left the grep row in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_FIND" "/calm left the find row in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "\$ printf" "/calm left the tool-call row in the transcript"
+  assert_not_contains "$(cat "$hidden_snapshot")" "Thinking..." "/calm left collapsed thinking labels in the transcript"
+  assert_not_contains "$(cat "$hidden_snapshot")" "fm_watch_arm_pi" "/calm left the Firstmate watcher tool call shell in the transcript"
+  assert_not_contains "$(cat "$hidden_snapshot")" "watcher: started Pi extension arm child" "/calm left the Firstmate watcher tool result in the transcript"
+  assert_not_contains "$(cat "$hidden_snapshot")" "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "/calm left a synthetic Firstmate user-role presentation in the transcript"
+  assert_not_contains "$(cat "$hidden_snapshot")" "Tool activity is hidden where supported" "/calm appended its own command-status row"
+  assert_contains "$(cat "$hidden_snapshot")" "Show a deterministic tool example." "/calm removed a genuine user prompt"
+  assert_contains "$(cat "$hidden_snapshot")" "FIRSTMATE WATCHER WAKE: can you explain this phrase?" "/calm hid a genuine near-miss user prompt"
   assert_contains "$(cat "$hidden_snapshot")" "I will run one command." "/calm removed assistant conversation before a tool"
   assert_contains "$(cat "$hidden_snapshot")" "The deterministic tool example is complete." "/calm removed assistant conversation after a tool"
 
@@ -420,29 +628,34 @@ JSON
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
   wait_for_text "$export_snapshot" "Session exported to: $export_file" \
     || fail "/export did not complete while calm mode was on"
-  node - "$export_file" <<'JS' || fail "calm-mode HTML export omitted grep or find rendering"
+  node - "$export_file" <<'JS' || fail "calm-mode HTML export omitted hidden tool or synthetic-message data"
 const html = require("node:fs").readFileSync(process.argv[2], "utf8");
 const match = html.match(/<script id="session-data" type="application\/json">([^<]+)<\/script>/);
 if (!match) process.exit(1);
 const session = JSON.parse(Buffer.from(match[1], "base64").toString("utf8"));
-for (const id of ["call_grep_e2e", "call_find_e2e"]) {
+for (const id of ["call_grep_e2e", "call_find_e2e", "call_watch_e2e"]) {
   const rendered = session.renderedTools?.[id];
   if (!rendered?.callHtml || !rendered?.resultHtmlExpanded) process.exit(1);
 }
+const entries = session.session?.entries ?? session.entries ?? [];
+const serialized = JSON.stringify(entries);
+if (!serialized.includes("firstmate-synthetic-input") || !serialized.includes("/tmp/probe.status")) process.exit(1);
 JS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
-  wait_for_text "$restored_snapshot" "Tool activity is visible." \
-    || fail "second /calm did not report visible tool activity"
-  assert_contains "$(cat "$restored_snapshot")" "CALM_E2E_OUTPUT" "second /calm did not restore tool result output"
+  wait_for_text "$restored_snapshot" "CALM_E2E_OUTPUT" \
+    || fail "second /calm did not restore tool result output"
+  assert_contains "$(cat "$restored_snapshot")" "fm_watch_arm_pi" "second /calm did not restore the Firstmate watcher tool shell"
+  assert_contains "$(cat "$restored_snapshot")" "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "second /calm did not restore the synthetic Firstmate user row"
+  assert_contains "$(cat "$restored_snapshot")" "Thinking..." "second /calm did not restore Pi's collapsed thinking labels"
   assert_contains "$(cat "$restored_snapshot")" "escape to interrupt" "/calm changed the active Ctrl+O expansion state"
 
   hash_after=$(shasum -a 256 "$session_file" | awk '{print $1}')
   [ "$hash_before" = "$hash_after" ] || fail "/calm changed the persisted session or context data"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/quit"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
-  pass "Pi calm text-row E2E proves remapped-submit export, default-off, hide, redraw restoration, unchanged persistence, and ordinary Ctrl+O behavior"
+  pass "Pi calm screenshot-scale E2E hides thinking labels, built-ins, fm_watch_arm_pi, and Firstmate injections while preserving genuine conversation, exports, persistence, and Ctrl+O"
 }
 
 test_static_contract

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -32,6 +32,27 @@ wait_for_text() {
   return 1
 }
 
+find_chrome() {
+  local candidate
+  if [ -n "${FM_CHROME_BIN:-}" ] && [ -x "$FM_CHROME_BIN" ]; then
+    printf '%s\n' "$FM_CHROME_BIN"
+    return 0
+  fi
+  for candidate in \
+    google-chrome \
+    google-chrome-stable \
+    chromium \
+    chromium-browser \
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
 test_static_contract() {
   local text visibility watch
   assert_present "$EXT" "tracked Pi calm extension is missing"
@@ -90,7 +111,8 @@ import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const packageRoot = process.env.PI_PACKAGE_DIR;
-const [{ ToolExecutionComponent }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }] = await Promise.all([
+const [{ CustomEntryComponent }, { ToolExecutionComponent }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }] = await Promise.all([
+  import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/custom-entry.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/tool-execution.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/theme/theme.js`).href),
   import(pathToFileURL(`${packageRoot}/node_modules/@earendil-works/pi-tui/dist/index.js`).href),
@@ -105,7 +127,7 @@ process.env.FM_FIRSTMATE_PI_LAUNCH_BRIEF = `${process.cwd()}/launch-brief.md`;
 const tools = [];
 const handlers = new Map();
 const entryRenderers = new Map();
-const messageRenderers = new Map();
+const appendedEntries = [];
 const sentMessages = [];
 const eventListeners = new Map();
 let calmCommand;
@@ -120,6 +142,9 @@ const pi = {
       eventListeners.set(name, listeners);
     },
   },
+  appendEntry(customType, data) {
+    appendedEntries.push({ customType, data });
+  },
   sendMessage(message, options) {
     sentMessages.push({ message, options });
   },
@@ -133,9 +158,6 @@ const pi = {
   },
   registerEntryRenderer(customType, renderer) {
     entryRenderers.set(customType, renderer);
-  },
-  registerMessageRenderer(customType, renderer) {
-    messageRenderers.set(customType, renderer);
   },
   registerTool(tool) {
     tools.push(tool);
@@ -245,10 +267,10 @@ for (const [name, args, result] of cases) {
 
 const watchPi = {
   ...pi,
+  appendEntry() {},
   sendMessage() {},
   registerCommand() {},
   registerEntryRenderer() {},
-  registerMessageRenderer() {},
 };
 const watchExtension = await import(`${pathToFileURL(process.env.WATCH_EXT).href}?test=${Date.now()}`);
 watchExtension.default(watchPi);
@@ -400,6 +422,7 @@ const launchBriefResult = await inputHandler({
 }, commandContext);
 if (
   launchBriefResult?.action !== "handled" ||
+  appendedEntries.length !== 1 ||
   sentMessages.length !== 1 ||
   sentMessages[0].message.details.kind !== "launch-brief" ||
   sentMessages[0].message.content !== launchBrief
@@ -412,7 +435,11 @@ const repeatedBriefResult = await inputHandler({
   source: "interactive",
   streamingBehavior: undefined,
 }, commandContext);
-if (repeatedBriefResult?.action !== "continue" || sentMessages.length !== 1) {
+if (
+  repeatedBriefResult?.action !== "continue" ||
+  appendedEntries.length !== 1 ||
+  sentMessages.length !== 1
+) {
   throw new Error("consumed launch origin hid a later genuine matching prompt");
 }
 const syntheticResult = await inputHandler({
@@ -421,24 +448,33 @@ const syntheticResult = await inputHandler({
   source: "extension",
   streamingBehavior: "followUp",
 }, commandContext);
-if (syntheticResult?.action !== "handled" || sentMessages.length !== 2) {
+if (
+  syntheticResult?.action !== "handled" ||
+  appendedEntries.length !== 2 ||
+  sentMessages.length !== 2
+) {
   throw new Error("known Firstmate synthetic input was not rerouted through controllable delivery");
 }
 if (
   sentMessages[1].message.content !== watcherMessage ||
-  sentMessages[1].message.display !== true ||
+  sentMessages[1].message.display !== false ||
   sentMessages[1].options.triggerTurn !== true ||
   sentMessages[1].options.deliverAs !== "followUp"
 ) {
   throw new Error("synthetic input delivery or context semantics changed");
 }
-const presentationRenderer = messageRenderers.get("firstmate-synthetic-input");
+const presentationRenderer = entryRenderers.get("firstmate-synthetic-input-presentation");
 if (!presentationRenderer) throw new Error("synthetic presentation renderer was not registered");
 const presentationEntry = {
-  content: watcherMessage,
-  details: { kind: "watcher" },
+  customType: "firstmate-synthetic-input-presentation",
+  data: { content: watcherMessage, kind: "watcher" },
 };
-if (!presentationRenderer(presentationEntry, { expanded }, theme).render(100).join("\n").includes("FIRSTMATE WATCHER WAKE")) {
+const presentationComponent = new CustomEntryComponent(presentationEntry, presentationRenderer);
+presentationComponent.setExpanded(expanded);
+if (
+  !presentationComponent.hasContent() ||
+  !presentationComponent.render(100).join("\n").includes("FIRSTMATE WATCHER WAKE")
+) {
   throw new Error("Calm-off synthetic presentation did not use a stock user-message row");
 }
 const nearMissResult = await inputHandler({
@@ -447,7 +483,11 @@ const nearMissResult = await inputHandler({
   source: "interactive",
   streamingBehavior: undefined,
 }, commandContext);
-if (nearMissResult?.action !== "continue" || sentMessages.length !== 2) {
+if (
+  nearMissResult?.action !== "continue" ||
+  appendedEntries.length !== 2 ||
+  sentMessages.length !== 2
+) {
   throw new Error("genuine near-miss input was intercepted");
 }
 
@@ -455,8 +495,9 @@ await calmCommand.handler("", commandContext);
 if (expanded !== true || workingVisible !== false || hiddenThinkingLabel !== "" || statuses.get("firstmate-calm") !== "calm transcript") {
   throw new Error("Calm did not apply its supported working, thinking, and footer presentation controls");
 }
-if (presentationRenderer(presentationEntry, { expanded }, theme).render(100).length !== 0) {
-  throw new Error("Calm left a synthetic Firstmate presentation entry visible");
+presentationComponent.setExpanded(!expanded);
+if (presentationComponent.hasContent() || presentationComponent.render(100).length !== 0) {
+  throw new Error("Calm left a synthetic Firstmate presentation row or spacer visible");
 }
 for (const { name, actual } of rows) {
   if (actual.render(100).length !== 0) {
@@ -548,7 +589,11 @@ if (JSON.stringify(watchActual.render(100)) !== JSON.stringify(watchBaseline.ren
 if (workingVisible !== true || hiddenThinkingLabel !== undefined || statuses.get("firstmate-calm") !== undefined) {
   throw new Error("turning Calm off did not restore stock presentation controls");
 }
-if (!presentationRenderer(presentationEntry, { expanded }, theme).render(100).join("\n").includes("FIRSTMATE WATCHER WAKE")) {
+presentationComponent.setExpanded(expanded);
+if (
+  !presentationComponent.hasContent() ||
+  !presentationComponent.render(100).join("\n").includes("FIRSTMATE WATCHER WAKE")
+) {
   throw new Error("turning Calm off did not restore synthetic user-row presentation");
 }
 
@@ -583,7 +628,7 @@ JS
 }
 
 test_interactive_terminal_e2e() {
-  local project config session_file export_file default_snapshot expanded_snapshot hidden_snapshot export_snapshot restored_snapshot hash_before hash_after now version
+  local project config session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot export_snapshot restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi calm interactive E2E"
     return 0
@@ -595,6 +640,7 @@ test_interactive_terminal_e2e() {
   config="$TMP_ROOT/e2e-config"
   session_file="$TMP_ROOT/calm-session.jsonl"
   export_file="$TMP_ROOT/calm-export.html"
+  export_dom="$TMP_ROOT/calm-export-dom.html"
   default_snapshot="$TMP_ROOT/default.txt"
   expanded_snapshot="$TMP_ROOT/expanded.txt"
   hidden_snapshot="$TMP_ROOT/hidden.txt"
@@ -617,7 +663,8 @@ test_interactive_terminal_e2e() {
 {"type":"message","id":"a0000006","parentId":"a0000005","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_find_e2e","toolName":"find","content":[{"type":"text","text":"CALM_EXPORT_FIND.txt"}],"details":{},"isError":false,"timestamp":6}}
 {"type":"message","id":"a0000007","parentId":"a0000006","timestamp":"$now","message":{"role":"assistant","content":[{"type":"thinking","thinking":"third internal reasoning block"},{"type":"toolCall","id":"call_watch_e2e","name":"fm_watch_arm_pi","arguments":{}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":7}}
 {"type":"message","id":"a0000008","parentId":"a0000007","timestamp":"$now","message":{"role":"toolResult","toolCallId":"call_watch_e2e","toolName":"fm_watch_arm_pi","content":[{"type":"text","text":"watcher: started Pi extension arm child 1"}],"details":{"ok":true,"message":"watcher: started Pi extension arm child 1"},"isError":false,"timestamp":8}}
-{"type":"custom_message","id":"a0000010","parentId":"a0000008","timestamp":"$now","customType":"firstmate-synthetic-input","content":"FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\\n\\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","display":true,"details":{"kind":"watcher"}}
+{"type":"custom","id":"a0000009","parentId":"a0000008","timestamp":"$now","customType":"firstmate-synthetic-input-presentation","data":{"content":"FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\\n\\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","kind":"watcher"}}
+{"type":"custom_message","id":"a0000010","parentId":"a0000009","timestamp":"$now","customType":"firstmate-synthetic-input","content":"FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\\n\\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","display":false,"details":{"kind":"watcher"}}
 {"type":"message","id":"a0000011","parentId":"a0000010","timestamp":"$now","message":{"role":"user","content":[{"type":"text","text":"FIRSTMATE WATCHER WAKE: can you explain this phrase?"}],"timestamp":11}}
 {"type":"message","id":"a0000012","parentId":"a0000011","timestamp":"$now","message":{"role":"assistant","content":[{"type":"text","text":"The deterministic tool example is complete."}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":12}}
 JSON
@@ -660,7 +707,7 @@ JSON
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
   wait_for_text "$export_snapshot" "Session exported to: $export_file" \
     || fail "/export did not complete while calm mode was on"
-  node - "$export_file" <<'JS' || fail "calm-mode HTML export omitted hidden tool or synthetic-message data"
+  node - "$export_file" <<'JS' || fail "calm-mode HTML export lost tool data or persisted synthetic provenance"
 const html = require("node:fs").readFileSync(process.argv[2], "utf8");
 const match = html.match(/<script id="session-data" type="application\/json">([^<]+)<\/script>/);
 if (!match) process.exit(1);
@@ -673,7 +720,36 @@ const entries = session.session?.entries ?? session.entries ?? [];
 const serialized = JSON.stringify(entries);
 if (!serialized.includes("firstmate-synthetic-input") || !serialized.includes("/tmp/probe.status")) process.exit(1);
 const synthetic = entries.find((entry) => entry.type === "custom_message" && entry.customType === "firstmate-synthetic-input");
-if (!synthetic?.display) process.exit(1);
+if (!synthetic || synthetic.display) process.exit(1);
+JS
+  chrome=$(find_chrome) || fail "Chrome or Chromium is required for rendered export DOM assertions"
+  "$chrome" \
+    --headless=new \
+    --disable-gpu \
+    --no-sandbox \
+    --user-data-dir="$TMP_ROOT/chrome-profile" \
+    --virtual-time-budget=2000 \
+    --dump-dom \
+    "file://$export_file" >"$export_dom" 2>/dev/null &
+  chrome_pid=$!
+  chrome_wait=0
+  while kill -0 "$chrome_pid" 2>/dev/null && [ "$chrome_wait" -lt 100 ]; do
+    grep -Fq '</html>' "$export_dom" 2>/dev/null && break
+    sleep 0.1
+    chrome_wait=$((chrome_wait + 1))
+  done
+  kill "$chrome_pid" 2>/dev/null || true
+  wait "$chrome_pid" 2>/dev/null || true
+  grep -Fq '</html>' "$export_dom" 2>/dev/null \
+    || fail "could not render calm-mode HTML export DOM"
+  node - "$export_dom" <<'JS' || fail "rendered export DOM violated the Calm conversation boundary"
+const dom = require("node:fs").readFileSync(process.argv[2], "utf8");
+const messages = dom.match(/<div id="messages">([\s\S]*?)<\/main>/)?.[1];
+if (!messages) process.exit(1);
+if (!/<div class="user-message"[^>]*>[\s\S]*Show a deterministic tool example\./.test(messages)) process.exit(1);
+if (!/<div class="assistant-message"[^>]*>[\s\S]*The deterministic tool example is complete\./.test(messages)) process.exit(1);
+if (messages.includes('<div class="hook-message"')) process.exit(1);
+if (messages.includes("[firstmate-synthetic-input]")) process.exit(1);
 JS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -105,7 +105,9 @@ wait_pid_dead() {
 
 mkdir -p "$LAB"
 git clone -q "$ROOT" "$PROJECT"
+mkdir -p "$PROJECT/.pi/extensions/lib"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$PROJECT/.pi/extensions/fm-primary-pi-watch.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$PROJECT/.pi/extensions/lib/fm-calm-visibility.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts"
 cp "$ROOT/bin/fm-watch-arm.sh" "$PROJECT/bin/fm-watch-arm.sh"
 cp "$ROOT/bin/fm-supervision-instructions.sh" "$PROJECT/bin/fm-supervision-instructions.sh"

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -25,10 +25,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/node_modules/@types"
+mkdir -p "$TMP_ROOT/lib" "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/node_modules/@types"
 cp "$ROOT/.pi/extensions/fm-calm.ts" "$TMP_ROOT/fm-calm.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$TMP_ROOT/lib/fm-calm-visibility.ts"
 ln -s "$PI_PACKAGE_DIR" "$TMP_ROOT/node_modules/@earendil-works/pi-coding-agent"
 ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$TMP_ROOT/node_modules/@earendil-works/pi-tui"
 ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$TMP_ROOT/node_modules/typebox"
@@ -49,7 +50,7 @@ cat > "$TMP_ROOT/tsconfig.json" <<'JSON'
     "target": "ES2022",
     "types": ["node"]
   },
-  "include": ["*.ts"]
+  "include": ["*.ts", "lib/*.ts"]
 }
 JSON
 

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -14,8 +14,35 @@ export NODE_NO_WARNINGS=1
 
 install_pi_watch_extension_fixture() {
   local repo=$1
-  mkdir -p "$repo/.pi/extensions" "$repo/node_modules/typebox"
+  mkdir -p \
+    "$repo/.pi/extensions/lib" \
+    "$repo/node_modules/@earendil-works/pi-coding-agent" \
+    "$repo/node_modules/@earendil-works/pi-tui" \
+    "$repo/node_modules/typebox"
   cp "$EXT" "$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$repo/.pi/extensions/lib/fm-calm-visibility.ts"
+  cat > "$repo/node_modules/@earendil-works/pi-coding-agent/package.json" <<'JSON'
+{"name":"@earendil-works/pi-coding-agent","type":"module","exports":"./index.js"}
+JSON
+  cat > "$repo/node_modules/@earendil-works/pi-coding-agent/index.js" <<'JS'
+export function getMarkdownTheme() { return {}; }
+export class UserMessageComponent {
+  render() { return []; }
+  invalidate() {}
+}
+JS
+  cat > "$repo/node_modules/@earendil-works/pi-tui/package.json" <<'JSON'
+{"name":"@earendil-works/pi-tui","type":"module","exports":"./index.js"}
+JSON
+  cat > "$repo/node_modules/@earendil-works/pi-tui/index.js" <<'JS'
+export class Box {
+  addChild() {}
+  clear() {}
+  setBgFn() {}
+}
+export class Container {}
+export class Text {}
+JS
   cat > "$repo/node_modules/typebox/package.json" <<'JSON'
 {"name":"typebox","type":"module","exports":"./index.js"}
 JSON

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -344,6 +344,8 @@ test_pi_threads_model_and_max_effort() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "pi --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
     "pi launch did not thread the requested model and max thinking level"
+  assert_contains "$launch" "FM_FIRSTMATE_PI_LAUNCH_BRIEF='" \
+    "pi launch did not identify the unchanged positional brief for Calm"
   pass "pi receives --model and --thinking max profile flags"
 }
 


### PR DESCRIPTION
## Intent

Implement and ship the captain-authorized Calm cleanup independently from Ahoy. When Calm is on, the Pi transcript must show only genuine original user prompts and genuine user-facing agent responses, using one centralized allowlist-style visibility policy across every reachable Pi transcript/render class and every authoritative Firstmate injection path. Hide repeated collapsed Thinking labels where supported, the fm_watch_arm_pi call/result shell, built-in text-tool rows, and all known synthetic Firstmate user-role messages while preserving actual delivery and handling, model context, session persistence, diagnostics, export/share, supervision, and the existing image and arbitrary custom-tool boundaries. Use conservative tested heuristics only where origin metadata is absent, with positive fixtures for every supported synthetic form and near-miss genuine-message negatives. Verify against real supported Pi 0.81.1 APIs and a genuine isolated interactive E2E at screenshot scale. Calm off must restore stock rendering and unchanged Ctrl+O behavior. Audit and document the complete transcript and injection taxonomy, visible trigger/masking/symptom distinctions, counterfactual and disconfirming evidence, and every exact supported-API boundary, without patching installed Pi internals or claiming unsupported generic custom-tool/thinking coverage. Review the real terminal for gaps, stale backgrounds, malformed redraws, and flicker, turn the reproduction into regression coverage, and keep presentation filtering separate from delivery/context/session/export/share/supervision behavior.

## What Changed

- Centralize Pi Calm visibility rules and hide supported thinking, working, built-in tool, watcher tool, and known synthetic Firstmate input rows.
- Preserve synthetic input delivery, model context, session storage, diagnostics, stock Calm-off rendering, and export/share behavior while identifying Pi launch briefs at their source.
- Document Pi 0.81.1 transcript boundaries and expand focused and interactive regression coverage for classification, redraw, restoration, and exported conversations.

## Risk Assessment

✅ Low: The targeted synchronous mount followed by a supported expansion redraw resolves the live-arrival restoration defect without transcript reconstruction, diagnostic loss, residual spacing, or Ctrl+O state changes.

## Testing

Targeted validation passed: repository inspection, strict Pi 0.81.1 API compilation, centralized visibility and classifier fixtures, watcher and launch-path tests, a real screenshot-scale Calm TUI round trip with rendered export and persistence checks, and a credentialed live watcher delivery/handling E2E all succeeded; reviewer-visible evidence was preserved and transient worktree artifacts were cleaned.

- Evidence: Pi 0.81.1 Calm-on vs Calm-off terminal evidence (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY6MHEAQVVQNSWXVK8Q7T95B/calm-terminal-e2e.png</code>)
<details>
<summary>Evidence: Rendered terminal comparison</summary>

```text
<!doctype html><meta charset="utf-8"><title>Firstmate Calm Pi 0.81.1 E2E evidence</title><style>html{background:#111318;color:#e6e7eb;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}body{margin:0;padding:28px;display:grid;gap:28px}h1,h2,p{margin:0}h1{font:700 24px system-ui;color:#fff}section{border:1px solid #343943;border-radius:12px;overflow:hidden;background:#171a20}header{padding:18px 20px;border-bottom:1px solid #343943;display:grid;gap:8px}h2{font:700 17px system-ui;color:#fff}p{font:14px/1.45 system-ui;color:#aeb4c0}pre{margin:0;padding:18px 20px;white-space:pre;overflow:auto;font-size:12px;line-height:1.25;color:#e9ebef;background:#0d0f13}</style><body><h1>Firstmate Calm cleanup - genuine Pi 0.81.1, 180 x 44 TUI</h1><section><header><h2>Calm on - conversation-only transcript</h2><p>Tool calls, tool results, collapsed Thinking labels, fm_watch_arm_pi, and the authoritative watcher wake are absent. Genuine prompts and assistant text remain.</p></header><pre>
 pi v0.81.1
 escape to interrupt
 ctrl+c to clear
 ctrl+c twice to exit
 ctrl+d to exit (empty)
 ctrl+z to suspend
 ctrl+k to delete to end
 shift+tab to cycle thinking level
 ctrl+p/shift+ctrl+p to cycle models
 ctrl+l to select model
 ctrl+o to expand tools
 ctrl+t to expand thinking
 ctrl+g for external editor
 / for commands
 ! to run bash
 !! to run bash (no context)
 option+enter to queue follow-up
 option+up to edit all queued messages
 ctrl+v to paste image (with text fallback)
 drop files to attach

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  project
    /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-calm-pi-extension.cDpun3/e2e-project/.pi/extensions/fm-calm-e2e-inject.ts
    /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-calm-pi-extension.cDpun3/e2e-project/.pi/extensions/fm-calm.ts
    /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-calm-pi-extension.cDpun3/e2e-project/.pi/extensions/fm-primary-pi-watch.ts


 Show a deterministic tool example.




 I will run one command.






 FIRSTMATE WATCHER WAKE: can you explain this phrase?


 The deterministic tool example is complete.

 Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
   /Users/kunchen/.nvm/versions/node/v24.13.1/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md
   /Users/kunchen/.nvm/versions/node/v24.13.1/lib/node_modules/@earendil-works/pi-coding-agent/docs/models.md

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-calm-pi-extension.cDpun3/e2e-project
↑7 ↓4 0.0%/0 (auto)                                                                                                                                                          unknown
calm transcript
</pre></section>
<section><header><h2>Calm off - stock transcript restored</h2><p>The original Pi rows return, including Thinking labels, tool shells, synthetic presentation, diagnostics, and the unchanged Ctrl+O expanded-state footer.</p></header><pre>
 pi v0.81.1
 escape to interrupt
 ctrl+c to clear
 ctrl+c twice to exit
 ctrl+d to exit (empty)
 ctrl+z to suspend
 ctrl+k to delete to end
 shift+tab to cycle thinking level
 ctrl+p/shift+ctrl+p to cycle models
 ctrl+l to select model
 ctrl+o to expand tools
 ctrl+t to expand thinking
 ctrl+g for external editor
 / for commands
 ! to run bash
 !! to run bash (no context)
 option+enter to queue follow-up
 option+up to edit all queued messages
 ctrl+v to paste image (with text fallback)
 drop files to attach

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  project
    /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-calm-pi-extension.cDpun3/e2e-project/.pi/extensions/fm-calm-e2e-inject.ts
    /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-calm-pi-extension.cDpun3/e2e-project/.pi/extensions/fm-calm.ts
    /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-calm-pi-extension.cDpun3/e2e-project/.pi/extensions/fm-primary-pi-watch.ts


 Show a deterministic tool example.


 Thinking...

 I will run one command.


 $ printf 'CALM_E2E_OUTPUT
 '

 CALM_E2E_OUTPUT


 Thinking...


 grep /CALM_EXPORT_GREP/ in .

 sample.txt:1:CALM_EXPORT_GREP



 find CALM_EXPORT_FIND* in .

 CALM_EXPORT_FIND.txt


 Thinking...


 fm_watch_arm_pi
 watcher: started Pi extension arm child 1



 FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status

 Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.



 FIRSTMATE WATCHER WAKE: can you explain this phrase?


 The deterministic tool example is complete.

 Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
   /Users/kunchen/.nvm/versions/node/v24.13.1/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md
   /Users/kunchen/.nvm/versions/node/v24.13.1/lib/node_modules/@earendil-works/pi-coding-agent/docs/models.md

 Warning: CALM_TRANSIENT_DIAGNOSTIC


 FIRSTMATE WATCHER WAKE: signal: /tmp/active-probe.status

 Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.


 Error: Unknown provider: unknown

 Session exported to: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-calm-pi-extension.cDpun3/calm-export.html

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-calm-pi-extension.cDpun3/e2e-project
↑7 ↓4 0.0%/0 (auto)                                                                                                                                                          unknown
</pre></section></body>
```
</details>
<details>
<summary>Evidence: Pi HTML export produced while Calm was active</summary>

```text
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Session Export</title>
  <style>
    :root {
      --accent: #8abeb7;
      --border: #5f87ff;
      --borderAccent: #00d7ff;
      --borderMuted: #505050;
      --success: #b5bd68;
      --error: #cc6666;
      --warning: #ffff00;
      --muted: #808080;
      --dim: #666666;
      --text: #d4d4d4;
      --thinkingText: #808080;
      --selectedBg: #3a3a4a;
      --userMessageBg: #343541;
      --userMessageText: #d4d4d4;
      --customMessageBg: #2d2838;
      --customMessageText: #d4d4d4;
      --customMessageLabel: #9575cd;
      --toolPendingBg: #282832;
      --toolSuccessBg: #283228;
      --toolErrorBg: #3c2828;
      --toolTitle: #d4d4d4;
      --toolOutput: #808080;
      --mdHeading: #f0c674;
      --mdLink: #81a2be;
      --mdLinkUrl: #666666;
      --mdCode: #8abeb7;
      --mdCodeBlock: #b5bd68;
      --mdCodeBlockBorder: #808080;
      --mdQuote: #808080;
      --mdQuoteBorder: #808080;
      --mdHr: #808080;
      --mdListBullet: #8abeb7;
      --toolDiffAdded: #b5bd68;
      --toolDiffRemoved: #cc6666;
      --toolDiffContext: #808080;
      --syntaxComment: #6A9955;
      --syntaxKeyword: #569CD6;
      --syntaxFunction: #DCDCAA;
      --syntaxVariable: #9CDCFE;
      --syntaxString: #CE9178;
      --syntaxNumber: #B5CEA8;
      --syntaxType: #4EC9B0;
      --syntaxOperator: #D4D4D4;
      --syntaxPunctuation: #D4D4D4;
      --thinkingOff: #505050;
      --thinkingMinimal: #6e6e6e;
      --thinkingLow: #5f87af;
      --thinkingMedium: #81a2be;
      --thinkingHigh: #b294bb;
      --thinkingXhigh: #d183e8;
      --thinkingMax: #ff5fff;
      --bashMode: #b5bd68;
      --exportPageBg: #18181e;
      --exportCardBg: #1e1e24;
      --exportInfoBg: #3c3728;
      --body-bg: #18181e;
      --container-bg: #1e1e24;
      --info-bg: #3c3728;
    }

    * { margin: 0; padding: 0; box-sizing: border-box; }

    :root {
      --line-height: 18px; /* 12px font * 1.5 */
      --sidebar-width: 400px;
      --sidebar-min-width: 240px;
      --sidebar-max-width: 840px;
      --sidebar-resizer-width: 6px;
    }

    body {
      font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
      font-size: 12px;
      line-height: var(--line-height);
      color: var(--text);
      background: var(--body-bg);
    }

    body.sidebar-resizing {
      cursor: col-resize;
      user-select: none;
    }

    #app {
      display: flex;
      min-height: 100vh;
    }

    /* Sidebar */
    #sidebar {
      width: var(--sidebar-width);
      min-width: var(--sidebar-width);
      max-width: var(--sidebar-width);
      background: var(--container-bg);
      flex-shrink: 0;
      display: flex;
      flex-direction: column;
      position: sticky;
      top: 0;
      height: 100vh;
      border-right: 1px solid var(--dim);
    }

    #sidebar-resizer {
      width: var(--sidebar-resizer-width);
      flex-shrink: 0;
      position: sticky;
      top: 0;
      height: 100vh;
      cursor: col-resize;
      touch-action: none;
      background: transparent;
      border-right: 1px solid transparent;
    }

    #sidebar-resizer:hover,
    body.sidebar-resizing #sidebar-resizer {
      background: var(--selectedBg);
      border-right-color: var(--dim);
    }

    .sidebar-header {
      padding: 8px 12px;
      flex-shrink: 0;
    }

    .sidebar-controls {
      padding: 8px 8px 4px 8px;
    }

    .sidebar-search {
      width: 100%;
      box-sizing: border-box;
      padding: 4px 8px;
      font-size: 11px;
      font-family: inherit;
      background: var(--body-bg);
      color: var(--text);
      border: 1px solid var(--dim);
      border-radius: 3px;
    }

    .sidebar-filters {
      display: flex;
      padding: 4px 8px 8px 8px;
      gap: 4px;
      align-items: center;
      flex-wrap: wrap;
    }

    .sidebar-search:focus {
      outline: none;
      border-color: var(--accent);
    }

    .sidebar-search::placeholder {
      color: var(--muted);
    }

    .filter-btn {
      padding: 3px 8px;
      font-size: 10px;
      font-family: inherit;
      background: transparent;
      color: var(--muted);
      border: 1px solid var(--dim);
      border-radius: 3px;
      cursor: pointer;
    }

    .filter-btn:hover {
      color: var(--text);
      border-color: var(--text);
    }

    .filter-btn.active {
      background: var(--accent);
      color: var(--body-bg);
      border-color: var(--accent);
    }

    .sidebar-close {
      display: none;
      padding: 3px 8px;
      font-size: 12px;
      font-family: inherit;
      background: transparent;
      color: var(--muted);
      border: 1px solid var(--dim);
      border-radius: 3px;
      cursor: pointer;
      margin-left: auto;
    }

    .sidebar-close:hover {
      color: var(--text);
      border-color: var(--text);
    }

    .tree-container {
      flex: 1;
      overflow: auto;
      padding: 4px 0;
    }

    .tree-node {
      padding: 0 8px;
      cursor: pointer;
      display: flex;
      align-items: baseline;
      font-size: 11px;
      line-height: 13px;
      white-space: nowrap;
    }

    .tree-node:hover {
      background: var(--selectedBg);
    }

    .tree-node.active {
      background: var(--selectedBg);
    }

    .tree-node.active .tree-content {
      font-weight: bold;
    }

    .tree-node.in-path {
      background: color-mix(in srgb, var(--accent) 10%, transparent);
    }

    .tree-node:not(.in-path) {
      opacity: 0.5;
    }

    .tree-node:not(.in-path):hover {
      opacity: 1;
    }

    .tree-prefix {
      color: var(--muted);
      flex-shrink: 0;
      font-family: monospace;
      white-space: pre;
    }

    .tree-marker {
      color: var(--accent);
      flex-shrink: 0;
    }

    .tree-content {
      color: var(--text);
    }

    .tree-role-user {
      color: var(--accent);
    }

    .tree-role-skill {
      color: var(--customMessageLabel);
    }

    .tree-role-assistant {
      color: var(--success);
    }

    .tree-role-tool {
      color: var(--muted);
    }

    .tree-muted {
      color: var(--muted);
    }

    .tree-error {
      color: var(--error);
    }

    .tree-compaction {
      color: var(--borderAccent);
    }

    .tree-branch-summary {
      color: var(--warning);
    }

    .tree-custom-message {
      color: var(--customMessageLabel);
    }

    .tree-status {
      padding: 4px 12px;
      font-size: 10px;
      color: var(--muted);
      flex-shrink: 0;
    }

    /* Main content */
    #content {
      flex: 1;
      min-width: 0;
      overflow-y: auto;
      padding: var(--line-height) calc(var(--line-height) * 2);
      display: flex;
      flex-direction: column;
      align-items: center;
    }

    #content > * {
      width: 100%;
      max-width: 800px;
    }

    /* Help bar */
    .help-bar {
      font-size: 11px;
      color: var(--warning);
      margin-bottom: var(--line-height);
      display: flex;
      align-items: center;
      justify-content: space-between;
      flex-wrap: wrap;
      gap: 12px;
    }

    .help-hint {
      flex: 1 1 240px;
    }

    .help-actions {
      display: flex;
      align-items: center;
      flex-wrap: wrap;
      gap: 8px;
    }

    .header-toggle-btn,
    .download-json-btn {
      font-size: 10px;
      padding: 2px 8px;
      background: var(--container-bg);
      border: 1px solid var(--border);
      border-radius: 3px;
      color: var(--text);
      cursor: pointer;
      font-family: inherit;
    }

    .header-toggle-btn:hover,
    .download-json-btn:hover {
      background: var(--hover);
      border-color: var(--borderAccent);
    }

    /* Header */
    .header {
      background: var(--container-bg);
      border-radius: 4px;
      padding: var(--line-height);
      margin-bottom: var(--line-height);
    }

    .header h1 {
      font-size: 12px;
      font-weight: bold;
      color: var(--borderAccent);
      margin-bottom: var(--line-height);
    }

    .header-info {
      display: flex;
      flex-direction: column;
      gap: 0;
     

... [273190 bytes truncated] ...

ine code: escape HTML
          codespan(token) {
            return `<code>${escapeHtml(token.text)}</code>`;
          }
        }
      });

      // Simple marked parse (escaping handled in renderers)
      function safeMarkedParse(text) {
        return marked.parse(text);
      }

      // Search input
      const searchInput = document.getElementById('tree-search');
      searchInput.addEventListener('input', (e) => {
        searchQuery = e.target.value;
        forceTreeRerender();
      });

      // Filter buttons
      document.querySelectorAll('.filter-btn').forEach(btn => {
        btn.addEventListener('click', () => {
          document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
          btn.classList.add('active');
          filterMode = btn.dataset.filter;
          forceTreeRerender();
        });
      });

      // Sidebar toggle
      const sidebar = document.getElementById('sidebar');
      const overlay = document.getElementById('sidebar-overlay');
      const hamburger = document.getElementById('hamburger');
      const sidebarResizer = document.getElementById('sidebar-resizer');
      const SIDEBAR_WIDTH_STORAGE_KEY = 'pi-share:v1:sidebar-width';
      const MIN_CONTENT_WIDTH = 320;

      function isMobileLayout() {
        return window.matchMedia('(max-width: 900px)').matches;
      }

      function getSidebarBounds() {
        const rootStyles = getComputedStyle(document.documentElement);
        const minWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-min-width')) || 240;
        const maxWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-max-width')) || 720;
        const viewportMaxWidth = window.innerWidth - MIN_CONTENT_WIDTH;
        return {
          minWidth,
          maxWidth: Math.max(minWidth, Math.min(maxWidth, viewportMaxWidth))
        };
      }

      function clampSidebarWidth(width) {
        const { minWidth, maxWidth } = getSidebarBounds();
        return Math.max(minWidth, Math.min(maxWidth, width));
      }

      function applySidebarWidth(width) {
        document.documentElement.style.setProperty('--sidebar-width', `${Math.round(clampSidebarWidth(width))}px`);
      }

      function loadSidebarWidth() {
        try {
          const raw = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
          if (raw === null) return null;
          const width = Number(raw);
          return Number.isFinite(width) ? width : null;
        } catch {
          return null;
        }
      }

      function saveSidebarWidth(width) {
        try {
          localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(Math.round(clampSidebarWidth(width))));
        } catch {
          // Ignore storage failures (e.g. private browsing restrictions)
        }
      }

      function setupSidebarResize() {
        const savedWidth = loadSidebarWidth();
        if (savedWidth !== null) {
          applySidebarWidth(savedWidth);
        }

        if (!sidebarResizer) return;

        let cleanupDrag = null;

        const stopDrag = (pointerId) => {
          if (cleanupDrag) {
            cleanupDrag(pointerId);
            cleanupDrag = null;
          }
        };

        sidebarResizer.addEventListener('pointerdown', (e) => {
          if (isMobileLayout()) return;

          e.preventDefault();
          const startX = e.clientX;
          const startWidth = sidebar.getBoundingClientRect().width;
          document.body.classList.add('sidebar-resizing');
          sidebarResizer.setPointerCapture?.(e.pointerId);

          const onPointerMove = (event) => {
            applySidebarWidth(startWidth + (event.clientX - startX));
          };

          cleanupDrag = (pointerIdToRelease) => {
            document.body.classList.remove('sidebar-resizing');
            sidebarResizer.releasePointerCapture?.(pointerIdToRelease);
            window.removeEventListener('pointermove', onPointerMove);
            window.removeEventListener('pointerup', onPointerUp);
            window.removeEventListener('pointercancel', onPointerCancel);
            saveSidebarWidth(sidebar.getBoundingClientRect().width);
          };

          const onPointerUp = (event) => stopDrag(event.pointerId);
          const onPointerCancel = (event) => stopDrag(event.pointerId);

          window.addEventListener('pointermove', onPointerMove);
          window.addEventListener('pointerup', onPointerUp);
          window.addEventListener('pointercancel', onPointerCancel);
        });

        sidebarResizer.addEventListener('dblclick', () => {
          if (isMobileLayout()) return;
          applySidebarWidth(400);
          saveSidebarWidth(400);
        });

        window.addEventListener('resize', () => {
          if (isMobileLayout()) return;
          applySidebarWidth(sidebar.getBoundingClientRect().width);
        });
      }

      setupSidebarResize();

      hamburger.addEventListener('click', () => {
        sidebar.classList.add('open');
        overlay.classList.add('open');
        hamburger.style.display = 'none';
      });

      const closeSidebar = () => {
        sidebar.classList.remove('open');
        overlay.classList.remove('open');
        hamburger.style.display = '';
      };

      overlay.addEventListener('click', closeSidebar);
      document.getElementById('sidebar-close').addEventListener('click', closeSidebar);

      // Toggle states
      let thinkingExpanded = true;
      let toolOutputsExpanded = false;

      const toggleThinking = () => {
        thinkingExpanded = !thinkingExpanded;
        document.querySelectorAll('.thinking-text').forEach(el => {
          el.style.display = thinkingExpanded ? '' : 'none';
        });
        document.querySelectorAll('.thinking-collapsed').forEach(el => {
          el.style.display = thinkingExpanded ? 'none' : 'block';
        });
      };

      const toggleToolOutputs = () => {
        toolOutputsExpanded = !toolOutputsExpanded;
        document.querySelectorAll('.tool-output.expandable').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
        document.querySelectorAll('.compaction').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
        document.querySelectorAll('.skill-invocation').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
      };

      const attachHeaderHandlers = () => {
        document.querySelector('[data-action="toggle-thinking"]')?.addEventListener('click', toggleThinking);
        document.querySelector('[data-action="toggle-tools"]')?.addEventListener('click', toggleToolOutputs);
      };

      const isEditableTarget = (element) => {
        if (!element) return false;
        const tagName = element.tagName;
        if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT' || tagName === 'BUTTON') {
          return true;
        }
        return element.isContentEditable || Boolean(element.closest?.('[contenteditable="true"]'));
      };

      // Keyboard shortcuts
      document.addEventListener('keydown', (e) => {
        if (e.key === 'Escape') {
          searchInput.value = '';
          searchQuery = '';
          navigateTo(leafId, 'bottom');
        }

        if (isEditableTarget(document.activeElement)) {
          return;
        }

        const key = e.key.toLowerCase();
        if (key === 't') {
          e.preventDefault();
          toggleThinking();
        } else if (key === 'o') {
          e.preventDefault();
          toggleToolOutputs();
        }
      });

      // Initial render
      // If URL has targetId, scroll to that specific message; otherwise stay at top
      if (leafId) {
        if (urlTargetId && byId.has(urlTargetId)) {
          // Deep link: navigate to leaf and scroll to target message
          navigateTo(leafId, 'target', urlTargetId);
        } else {
          navigateTo(leafId, 'none');
        }
      } else if (entries.length > 0) {
        // Fallback: use last entry if no leafId
        navigateTo(entries[entries.length - 1].id, 'none');
      }
    })();

  </script>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Gap-free hidden live-injection boundary</summary>

<code>Warning: CALM_TRANSIENT_DIAGNOSTIC&#10;&#10;Error: Unknown provider: unknown</code>

```text
 Warning: CALM_TRANSIENT_DIAGNOSTIC

 Error: Unknown provider: unknown
```
</details>
<details>
<summary>Evidence: Persisted Pi session proving presentation-only filtering</summary>

```text
{"type":"session","version":3,"id":"11111111-1111-4111-8111-111111111111","timestamp":"2026-07-23T05:26:37.000Z","cwd":"/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-calm-pi-extension.cDpun3/e2e-project"}
{"type":"message","id":"a0000001","parentId":null,"timestamp":"2026-07-23T05:26:37.000Z","message":{"role":"user","content":[{"type":"text","text":"Show a deterministic tool example."}],"timestamp":1}}
{"type":"message","id":"a0000002","parentId":"a0000001","timestamp":"2026-07-23T05:26:37.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"first internal reasoning block"},{"type":"text","text":"I will run one command."},{"type":"toolCall","id":"call_calm_e2e","name":"bash","arguments":{"command":"printf 'CALM_E2E_OUTPUT\n'"}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":2}}
{"type":"message","id":"a0000003","parentId":"a0000002","timestamp":"2026-07-23T05:26:37.000Z","message":{"role":"toolResult","toolCallId":"call_calm_e2e","toolName":"bash","content":[{"type":"text","text":"CALM_E2E_OUTPUT"}],"details":{},"isError":false,"timestamp":3}}
{"type":"message","id":"a0000004","parentId":"a0000003","timestamp":"2026-07-23T05:26:37.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"second internal reasoning block"},{"type":"toolCall","id":"call_grep_e2e","name":"grep","arguments":{"pattern":"CALM_EXPORT_GREP","path":"."}},{"type":"toolCall","id":"call_find_e2e","name":"find","arguments":{"pattern":"CALM_EXPORT_FIND*","path":"."}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":4}}
{"type":"message","id":"a0000005","parentId":"a0000004","timestamp":"2026-07-23T05:26:37.000Z","message":{"role":"toolResult","toolCallId":"call_grep_e2e","toolName":"grep","content":[{"type":"text","text":"sample.txt:1:CALM_EXPORT_GREP"}],"details":{},"isError":false,"timestamp":5}}
{"type":"message","id":"a0000006","parentId":"a0000005","timestamp":"2026-07-23T05:26:37.000Z","message":{"role":"toolResult","toolCallId":"call_find_e2e","toolName":"find","content":[{"type":"text","text":"CALM_EXPORT_FIND.txt"}],"details":{},"isError":false,"timestamp":6}}
{"type":"message","id":"a0000007","parentId":"a0000006","timestamp":"2026-07-23T05:26:37.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"third internal reasoning block"},{"type":"toolCall","id":"call_watch_e2e","name":"fm_watch_arm_pi","arguments":{}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":7}}
{"type":"message","id":"a0000008","parentId":"a0000007","timestamp":"2026-07-23T05:26:37.000Z","message":{"role":"toolResult","toolCallId":"call_watch_e2e","toolName":"fm_watch_arm_pi","content":[{"type":"text","text":"watcher: started Pi extension arm child 1"}],"details":{"ok":true,"message":"watcher: started Pi extension arm child 1"},"isError":false,"timestamp":8}}
{"type":"custom","id":"a0000009","parentId":"a0000008","timestamp":"2026-07-23T05:26:37.000Z","customType":"firstmate-synthetic-input-presentation","data":{"content":"FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","kind":"watcher"}}
{"type":"custom_message","id":"a0000010","parentId":"a0000009","timestamp":"2026-07-23T05:26:37.000Z","customType":"firstmate-synthetic-input","content":"FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","display":false,"details":{"kind":"watcher"}}
{"type":"message","id":"a0000011","parentId":"a0000010","timestamp":"2026-07-23T05:26:37.000Z","message":{"role":"user","content":[{"type":"text","text":"FIRSTMATE WATCHER WAKE: can you explain this phrase?"}],"timestamp":11}}
{"type":"message","id":"a0000012","parentId":"a0000011","timestamp":"2026-07-23T05:26:37.000Z","message":{"role":"assistant","content":[{"type":"text","text":"The deterministic tool example is complete."}],"api":"anthropic-messages","provider":"anthropic","model":"claude-sonnet-4-5","usage":{"input":2,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":12}}
{"type":"thinking_level_change","id":"e0a7b259","parentId":"a0000012","timestamp":"2026-07-23T05:26:37.962Z","thinkingLevel":"off"}
{"type":"custom","customType":"firstmate-synthetic-input-presentation","data":{"content":"FIRSTMATE WATCHER WAKE: signal: /tmp/active-probe.status\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","kind":"watcher"},"id":"bf05a175","parentId":"e0a7b259","timestamp":"2026-07-23T05:26:38.476Z"}
{"type":"custom_message","customType":"firstmate-synthetic-input","content":"FIRSTMATE WATCHER WAKE: signal: /tmp/active-probe.status\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.","display":false,"details":{"kind":"watcher"},"id":"d6e16da2","parentId":"bf05a175","timestamp":"2026-07-23T05:26:38.476Z"}
{"type":"message","id":"f934688b","parentId":"d6e16da2","timestamp":"2026-07-23T05:26:38.477Z","message":{"role":"assistant","content":[],"api":"unknown","provider":"unknown","model":"unknown","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"error","errorMessage":"Unknown provider: unknown","timestamp":1784784398477}}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (4) ✅</summary>

- 🚨 `.pi/extensions/lib/fm-calm-visibility.ts:138` - The required criterion says `/export` and `/share` must remain unchanged. This reroutes synthetic user messages into a plain custom entry plus a `display: false` custom message. Pi 0.81.1&#39;s HTML exporter ignores plain custom entries and renders custom messages only when `display` is true, so watcher and guard prompts disappear from exported/shared conversations instead of retaining stock user-message rendering. Either preserve them in exports or explicitly approve this behavior change.
- 🚨 `.pi/extensions/lib/fm-calm-visibility.ts:58` - The intent requires hiding &#34;all known synthetic Firstmate user-role messages&#34; across &#34;every authoritative Firstmate injection path.&#34; The exhaustive kind union and classifier omit the generated brief that `fm-spawn.sh` passes to Pi secondmates as a positional user prompt. Because seeded secondmate homes load Calm, `/calm` leaves that Firstmate-authored brief visible as though it were genuine captain input. Confirm whether briefs are deliberately excluded, or add an origin marker, classification, and positive/near-miss fixtures.

🔧 Fix: Captain, preserve Calm exports and classify Pi launch briefs
2 errors still open:
- 🚨 `.pi/extensions/lib/fm-calm-visibility.ts:148` - The requested fix requires stock synthetic user-message rendering in `/export` and `/share`, but `display: true` only makes Pi&#39;s HTML exporter emit a `hook-message` with a visible `[firstmate-synthetic-input]` label. Pi 0.81.1 does not apply the registered TUI message renderer during HTML export, so the exported/shared row still differs from the stock user row. The E2E checks only the persisted `display` flag and does not verify the exported DOM or appearance.
- 🚨 `.pi/extensions/lib/fm-calm-visibility.ts:125` - The intent explicitly requires reviewing and preventing transcript gaps. Returning an empty `Container` here does not remove the complete row because Pi&#39;s `CustomMessageComponent` unconditionally prepends a `Spacer(1)` before invoking this renderer. Every hidden synthetic input therefore leaves a blank transcript line under Calm, and the renderer-only test bypasses that outer component. Use a presentation path that can suppress the whole component or explicitly approve the residual gaps.

🔧 Fix: Captain, eliminate Calm gaps and verify exported conversations
1 error still open:
- 🚨 `.pi/extensions/lib/fm-calm-visibility.ts:130` - The requirement says &#34;Calm off must restore stock rendering,&#34; including &#34;for subsequently delivered inputs.&#34; If a synthetic input arrives while Calm is active, this renderer returns undefined, and Pi 0.81.1 permanently skips adding that CustomEntryComponent because it initially has no content. The later setToolsExpanded redraw only rebuilds mounted components, so disabling Calm cannot reveal the row until a session reload. The test constructs its component before enabling Calm and misses this path. Preserve a gapless mounted representation or explicitly rebuild persisted presentation entries when Calm is disabled.

🔧 Fix: Restore Calm rows received while active
1 error still open:
- 🚨 `.pi/extensions/fm-calm.ts:259` - The intent requires preserving diagnostics and restoring stock rendering. Pi 0.81.1&#39;s `ctx.navigateTree()` wrapper unconditionally clears the entire chat container, rebuilds only reconstructable session rows, and adds `Navigated to selected point`, even when core navigation no-ops for the current leaf. Disabling Calm therefore deletes transient errors, warnings, extension notices, and other non-persisted diagnostics while adding a new status row. The regression mock models only the desired component rebuild, not this real clear-and-replace behavior. Use a refresh path that preserves transient rows, or explicitly approve this diagnostic loss and altered Calm-off transcript.

🔧 Fix: Preserve diagnostics during Calm restoration
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --short` and `git diff --stat 82a79439d1d6f4ce2c16e0a25a7fff027b6abe0d..7aec7b23b46f1cd1b87827c2e8a8282fed77e43e`</code>
- `tests/fm-calm-pi-extension.test.sh`
- `tests/fm-pi-primary-types.test.sh`
- `tests/fm-pi-watch-extension.test.sh`
- `tests/fm-spawn-dispatch-profile.test.sh`
- `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh`
- `Fresh Pi 0.81.1 180x44 TUI evidence rerun preserving Calm-on, live-injection boundary, Calm-off, rendered export, and persisted-session artifacts`
- <code>Rendered and visually inspected `calm-terminal-e2e.png`</code>
- <code>Verified testing left no tracked changes or `.pi-live-e2e.*` directory</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
