### PR TITLE
feat(bin): add fm-orchestrator.sh and fm-relaunch.sh for crewmate session resume

### DIFF
--- a/bin/fm-orchestrator.sh
+++ b/bin/fm-orchestrator.sh
@@ -259,9 +259,17 @@ cmd_check() {
     echo "error: $RELAUNCH_BIN not found or not executable; cannot fire" >&2
     exit 1
   }
+  local rc=0
+  set +e
   "$RELAUNCH_BIN" run
+  rc=$?
+  set -e
   mkdir -p "$STATE"
   date +%s > "$COOLDOWN_FILE"
+  if [ "$rc" -ne 0 ]; then
+    echo "error: $RELAUNCH_BIN run failed (exit $rc)" >&2
+    exit "$rc"
+  fi
   echo "check: fired session resume"
 }
 

--- a/bin/fm-orchestrator.sh
+++ b/bin/fm-orchestrator.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Periodic watchdog that resumes this firstmate home's supervision session on
+# its own once real pending work exists and no session already holds it -
+# the auto-fire counterpart to bin/fm-relaunch.sh's on-demand-only tool.
+# Usage: fm-orchestrator.sh install|status|uninstall|check [--help]
+#
+# Mechanism, the gating conditions that must all hold before a fire, and why
+# THIS tool is allowed a real recurring launchd trigger while fm-relaunch.sh
+# deliberately is not, are owned by docs/orchestrator-tool.md - this header
+# stays a pointer, not a restatement. fm-relaunch.sh's own resume mechanics
+# (terminal/trust-dialog/kickoff handshake) are that script's own; see its
+# --help and docs/relaunch-tool.md.
+#
+# macOS-only (launchd). Fails closed with a clear message on any other platform.
+set -eu
+
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+RELAUNCH_BIN="${FM_ORCHESTRATOR_RELAUNCH_BIN:-$SCRIPT_DIR/fm-relaunch.sh}"
+LOCK_BIN="${FM_ORCHESTRATOR_LOCK_BIN:-$SCRIPT_DIR/fm-lock.sh}"
+BACKEND_SH="${FM_ORCHESTRATOR_BACKEND_SH:-$SCRIPT_DIR/fm-backend.sh}"
+
+# Cooldown: minimum seconds between fires, so a relaunched session that
+# immediately hits the same limit and exits fast can never cause a tight
+# fire-loop off a recurring timer. Overridable only for tests.
+COOLDOWN_SECS="${FM_ORCHESTRATOR_COOLDOWN_SECS:-1800}"
+INTERVAL_SECS="${FM_ORCHESTRATOR_INTERVAL_SECS:-1800}"
+COOLDOWN_FILE="$STATE/.orchestrator-cooldown"
+
+usage() {
+  sed -n '2,12p' "$SCRIPT_PATH" | sed 's/^# \{0,1\}//'
+}
+
+fm_orch_require_macos() {
+  [ "$(uname -s)" = Darwin ] || {
+    echo "error: fm-orchestrator.sh is macOS-only (needs launchd); this platform is $(uname -s)" >&2
+    exit 1
+  }
+}
+
+# Label derivation mirrors fm-relaunch.sh's, with a distinct base label so the
+# two tools never collide on one launchd job.
+fm_orch_label() {
+  if [ "$FM_HOME" = "$FM_ROOT" ]; then
+    printf 'dev.firstmate.orchestrator'
+    return
+  fi
+  local slug
+  if command -v shasum >/dev/null 2>&1; then
+    slug=$(printf '%s' "$FM_HOME" | shasum -a 256 | cut -c1-8)
+  elif command -v sha256sum >/dev/null 2>&1; then
+    slug=$(printf '%s' "$FM_HOME" | sha256sum | cut -c1-8)
+  else
+    echo "error: need shasum or sha256sum to derive a per-home label" >&2
+    exit 1
+  fi
+  printf 'dev.firstmate.orchestrator.%s' "$slug"
+}
+
+LABEL="$(fm_orch_label)"
+DOMAIN="gui/$(id -u)"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+PLIST_PATH="$PLIST_DIR/$LABEL.plist"
+
+fm_orch_loaded() {
+  launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1
+}
+
+fm_orch_write_plist() {  # <out-path>
+  local out=$1
+  mkdir -p "$(dirname "$out")"
+  cat > "$out" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>$LABEL</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>$SCRIPT_PATH</string>
+		<string>check</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>$INTERVAL_SECS</integer>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>FM_HOME</key>
+		<string>$FM_HOME</string>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>$FM_HOME/state/fm-orchestrator.log</string>
+	<key>StandardErrorPath</key>
+	<string>$FM_HOME/state/fm-orchestrator.log</string>
+</dict>
+</plist>
+PLIST
+}
+
+cmd_install() {
+  fm_orch_require_macos
+  local tmp
+  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-orchestrator-plist.XXXXXX")
+  trap 'rm -f -- "$tmp"' EXIT
+  fm_orch_write_plist "$tmp"
+  if [ -f "$PLIST_PATH" ] && cmp -s "$tmp" "$PLIST_PATH" && fm_orch_loaded; then
+    rm -f -- "$tmp"
+    trap - EXIT
+    echo "installed: $LABEL already up to date and loaded (every ${INTERVAL_SECS}s)"
+    return 0
+  fi
+  if fm_orch_loaded; then
+    launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+  fi
+  mv -f -- "$tmp" "$PLIST_PATH"
+  trap - EXIT
+  chmod 0644 "$PLIST_PATH"
+  launchctl bootstrap "$DOMAIN" "$PLIST_PATH"
+  echo "installed: $LABEL ($PLIST_PATH), fires 'check' every ${INTERVAL_SECS}s"
+}
+
+cmd_status() {
+  fm_orch_require_macos
+  if [ ! -f "$PLIST_PATH" ]; then
+    echo "status: $LABEL not installed"
+    return 1
+  fi
+  local interval
+  interval=$(grep -A1 '<key>StartInterval</key>' "$PLIST_PATH" | tail -1 | sed -E 's/.*<integer>([0-9]+)<\/integer>.*/\1/')
+  echo "status: $LABEL installed at $PLIST_PATH, interval ${interval:-unknown}s"
+  if fm_orch_loaded; then
+    echo "status: loaded in $DOMAIN"
+  else
+    echo "status: NOT loaded in $DOMAIN (run install)"
+  fi
+  if [ -f "$COOLDOWN_FILE" ]; then
+    local last now remaining
+    last=$(cat "$COOLDOWN_FILE" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    remaining=$((last + COOLDOWN_SECS - now))
+    if [ "$remaining" -gt 0 ]; then
+      echo "status: last fired at epoch $last, cooldown active for ${remaining}s more"
+    else
+      echo "status: last fired at epoch $last, cooldown elapsed"
+    fi
+  else
+    echo "status: never fired (no cooldown record)"
+  fi
+}
+
+cmd_uninstall() {
+  fm_orch_require_macos
+  if fm_orch_loaded; then
+    launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+  fi
+  rm -f -- "$PLIST_PATH"
+  echo "uninstalled: $LABEL"
+}
+
+# fm_orch_session_alive: true if a live firstmate session already holds this
+# home's session lock. Reuses fm-lock.sh's own liveness mechanism verbatim
+# rather than inventing a second one (AGENTS.md section 3's session lock).
+fm_orch_session_alive() {
+  local out
+  out=$(FM_HOME="$FM_HOME" "$LOCK_BIN" status 2>/dev/null) || return 1
+  case "$out" in
+    *"held by live"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# fm_orch_wake_queue_pending: true if the durable wake queue is non-empty.
+fm_orch_wake_queue_pending() {
+  [ -s "$STATE/.wake-queue" ]
+}
+
+# fm_orch_stalled_task_pending: true if any recorded ship/scout task's backend
+# endpoint is not alive and its last known status is not terminal. Secondmates
+# are excluded: an idle secondmate is healthy persistent state, not a stall
+# (AGENTS.md section 6).
+fm_orch_stalled_task_pending() {
+  local meta id kind backend target status_file last
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    id=$(basename "$meta" .meta)
+    kind=$(sed -n 's/^kind=//p' "$meta" | tail -1)
+    [ "$kind" = secondmate ] && continue
+    backend=$(sed -n 's/^backend=//p' "$meta" | tail -1)
+    target=$(sed -n 's/^window=//p' "$meta" | tail -1)
+    [ -n "$backend" ] && [ -n "$target" ] || continue
+    status_file="$STATE/$id.status"
+    if [ -f "$status_file" ]; then
+      last=$(tail -1 "$status_file" 2>/dev/null || true)
+      case "$last" in
+        done:*|failed:*) continue ;;
+      esac
+    fi
+    if ! command -v fm_backend_agent_alive >/dev/null 2>&1 && [ -f "$BACKEND_SH" ]; then
+      # shellcheck disable=SC1090
+      . "$BACKEND_SH"
+    fi
+    if command -v fm_backend_agent_alive >/dev/null 2>&1; then
+      [ "$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null)" = alive ] && continue
+      return 0
+    fi
+  done
+  return 1
+}
+
+# fm_orch_backlog_pending: true if data/backlog.md has a Queued item with no
+# recorded blocker. Deliberately text-only (grep, no tasks-axi dependency) so
+# this stays a cheap, dependency-free gate; a false negative here just means a
+# clearable item waits one more cycle for the next heartbeat to catch it.
+fm_orch_backlog_pending() {
+  local backlog="$DATA/backlog.md"
+  [ -f "$backlog" ] || return 1
+  awk '
+    /^## Queued/ { inq=1; next }
+    /^## / { inq=0 }
+    inq && /^- / { print }
+  ' "$backlog" | grep -qv 'blocked-by:'
+}
+
+fm_orch_pending_work() {
+  fm_orch_wake_queue_pending && return 0
+  fm_orch_stalled_task_pending && return 0
+  fm_orch_backlog_pending && return 0
+  return 1
+}
+
+fm_orch_cooldown_active() {
+  [ -f "$COOLDOWN_FILE" ] || return 1
+  local last now
+  last=$(cat "$COOLDOWN_FILE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  [ $((now - last)) -lt "$COOLDOWN_SECS" ]
+}
+
+cmd_check() {
+  fm_orch_require_macos
+  if fm_orch_session_alive; then
+    echo "check: session already alive, nothing to do"
+    return 0
+  fi
+  if ! fm_orch_pending_work; then
+    echo "check: no pending work, nothing to do"
+    return 0
+  fi
+  if fm_orch_cooldown_active; then
+    echo "check: pending work found but cooldown active, skipping fire"
+    return 0
+  fi
+  [ -x "$RELAUNCH_BIN" ] || {
+    echo "error: $RELAUNCH_BIN not found or not executable; cannot fire" >&2
+    exit 1
+  }
+  "$RELAUNCH_BIN" run
+  mkdir -p "$STATE"
+  date +%s > "$COOLDOWN_FILE"
+  echo "check: fired session resume"
+}
+
+case "${1:-}" in
+  install) cmd_install ;;
+  status) cmd_status ;;
+  uninstall) cmd_uninstall ;;
+  check) cmd_check ;;
+  -h|--help) usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/bin/fm-relaunch.sh
+++ b/bin/fm-relaunch.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Resume this firstmate home's supervision session on demand, from a launchd
+# LaunchAgent that is registered but carries no automatic trigger.
+# Usage: fm-relaunch.sh install|status|uninstall|run [--help]
+#
+# Mechanism, safety property, and the AppleScript-driven trust-dialog and
+# kickoff-message handshake are owned by docs/relaunch-tool.md - this header
+# stays a pointer, not a restatement.
+#
+# macOS-only (launchd). Fails closed with a clear message on any other platform.
+set -eu
+
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+usage() {
+  sed -n '2,10p' "$SCRIPT_PATH" | sed 's/^# \{0,1\}//'
+}
+
+fm_relaunch_require_macos() {
+  [ "$(uname -s)" = Darwin ] || {
+    echo "error: fm-relaunch.sh is macOS-only (needs launchd); this platform is $(uname -s)" >&2
+    exit 1
+  }
+}
+
+# Label derivation: the default (unoverridden) home gets the bare label so a
+# fresh install cleanly supersedes the hand-built prototype job of the same
+# name; any home with an explicit FM_HOME (e.g. a secondmate) gets a stable
+# suffix derived from that path so multiple homes never collide on one label.
+fm_relaunch_label() {
+  if [ "$FM_HOME" = "$FM_ROOT" ]; then
+    printf 'dev.firstmate.relaunch'
+    return
+  fi
+  local slug
+  if command -v shasum >/dev/null 2>&1; then
+    slug=$(printf '%s' "$FM_HOME" | shasum -a 256 | cut -c1-8)
+  elif command -v sha256sum >/dev/null 2>&1; then
+    slug=$(printf '%s' "$FM_HOME" | sha256sum | cut -c1-8)
+  else
+    echo "error: need shasum or sha256sum to derive a per-home label" >&2
+    exit 1
+  fi
+  printf 'dev.firstmate.relaunch.%s' "$slug"
+}
+
+LABEL="$(fm_relaunch_label)"
+DOMAIN="gui/$(id -u)"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+PLIST_PATH="$PLIST_DIR/$LABEL.plist"
+
+fm_relaunch_loaded() {
+  launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1
+}
+
+fm_relaunch_write_plist() {  # <out-path>
+  local out=$1
+  mkdir -p "$(dirname "$out")"
+  cat > "$out" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>$LABEL</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>$SCRIPT_PATH</string>
+		<string>fire</string>
+	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>FM_HOME</key>
+		<string>$FM_HOME</string>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>$FM_HOME/state/fm-relaunch.log</string>
+	<key>StandardErrorPath</key>
+	<string>$FM_HOME/state/fm-relaunch.log</string>
+</dict>
+</plist>
+PLIST
+}
+
+cmd_install() {
+  fm_relaunch_require_macos
+  local tmp
+  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-relaunch-plist.XXXXXX")
+  trap 'rm -f -- "$tmp"' EXIT
+  fm_relaunch_write_plist "$tmp"
+  if [ -f "$PLIST_PATH" ] && cmp -s "$tmp" "$PLIST_PATH" && fm_relaunch_loaded; then
+    rm -f -- "$tmp"
+    trap - EXIT
+    echo "installed: $LABEL already up to date and loaded"
+    return 0
+  fi
+  if fm_relaunch_loaded; then
+    launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+  fi
+  mv -f -- "$tmp" "$PLIST_PATH"
+  trap - EXIT
+  chmod 0644 "$PLIST_PATH"
+  launchctl bootstrap "$DOMAIN" "$PLIST_PATH"
+  echo "installed: $LABEL ($PLIST_PATH), loaded with no automatic trigger"
+}
+
+cmd_status() {
+  fm_relaunch_require_macos
+  if [ ! -f "$PLIST_PATH" ]; then
+    echo "status: $LABEL not installed"
+    return 1
+  fi
+  if grep -Eq '<key>(RunAtLoad|StartInterval|StartCalendarInterval|WatchPaths|QueueDirectories|KeepAlive)</key>' "$PLIST_PATH"; then
+    echo "status: DANGER - $PLIST_PATH declares an automatic trigger key; reinstall to regenerate it safely" >&2
+    return 1
+  fi
+  echo "status: $LABEL installed at $PLIST_PATH, no automatic trigger key present"
+  if fm_relaunch_loaded; then
+    echo "status: loaded in $DOMAIN"
+  else
+    echo "status: NOT loaded in $DOMAIN (run install)"
+    return 1
+  fi
+}
+
+cmd_uninstall() {
+  fm_relaunch_require_macos
+  if fm_relaunch_loaded; then
+    launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+  fi
+  rm -f -- "$PLIST_PATH"
+  echo "uninstalled: $LABEL"
+}
+
+cmd_run() {
+  fm_relaunch_require_macos
+  [ -f "$PLIST_PATH" ] || {
+    echo "error: $LABEL is not installed; run 'fm-relaunch.sh install' first" >&2
+    exit 1
+  }
+  fm_relaunch_loaded || launchctl bootstrap "$DOMAIN" "$PLIST_PATH"
+  launchctl kickstart -k "$DOMAIN/$LABEL"
+  echo "fired: $LABEL"
+}
+
+# Invoked only as the launchd job's ProgramArguments target (see
+# fm_relaunch_write_plist); opens a terminal running claude in $FM_HOME and
+# drives the trust-dialog/kickoff handshake documented in docs/relaunch-tool.md.
+cmd_fire() {
+  fm_relaunch_require_macos
+  command -v osascript >/dev/null 2>&1 || {
+    echo "error: osascript not found; cannot open a terminal" >&2
+    exit 1
+  }
+  local target_dir quoted_cd script
+  target_dir=$FM_HOME
+  quoted_cd=$(printf '%q' "$target_dir")
+  script=$(cat <<APPLESCRIPT
+tell application "Terminal"
+  activate
+  do script "cd $quoted_cd && exec claude"
+end tell
+delay 2.5
+tell application "System Events"
+  tell process "Terminal"
+    set frontmost to true
+    key code 36
+    delay 1
+    keystroke "hi"
+    key code 36
+  end tell
+end tell
+APPLESCRIPT
+)
+  osascript -e "$script"
+}
+
+case "${1:-}" in
+  install) cmd_install ;;
+  status) cmd_status ;;
+  uninstall) cmd_uninstall ;;
+  run) cmd_run ;;
+  fire) cmd_fire ;;
+  -h|--help) usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/docs/orchestrator-tool.md
+++ b/docs/orchestrator-tool.md
@@ -1,0 +1,47 @@
+# Recurring resume watchdog (`bin/fm-orchestrator.sh`)
+
+`bin/fm-relaunch.sh` (`docs/relaunch-tool.md`) gives a captain a one-command way to resume a stalled firstmate session, but it registers a `launchd` job with no automatic trigger on purpose: nothing fires it but an explicit call.
+That is correct for a tool whose only job is "resume when a human asks."
+It is the wrong shape for the gap this tool closes: a shared account spend limit (or session usage window) can stall every in-flight worker AND the firstmate primary session at once, overnight, with no human awake to notice when it clears.
+`bin/fm-orchestrator.sh` is a second, distinct `launchd` job that IS allowed a real recurring `StartInterval`, so the fleet can come back to life on its own once the limit clears - without ever becoming a blind timer that opens sessions regardless of need.
+
+## Why this one is allowed to self-schedule and `fm-relaunch.sh` is not
+
+`fm-relaunch.sh`'s safety property is "registered but never self-triggering" - useful for an on-demand human convenience, useless for an unattended overnight recovery.
+This tool's safety property is different: every fire passes through two independent gates (below) before it is allowed to do anything, so a recurring timer can only ever open a session when a session is not already open AND there is real work for it to do.
+An idle, fully-caught-up fleet with a live limit is indistinguishable from an idle, fully-caught-up fleet with no limit at all - the gates make both cases a no-op, so the timer never manufactures work or opens a session "just because it fired."
+
+## The two gates, in order
+
+`bin/fm-orchestrator.sh check` (the `launchd` job's program) runs both gates every time it fires, in order, and only proceeds past both:
+
+1. **Liveness** - `fm_orch_session_alive` shells out to `bin/fm-lock.sh status` (the same session-lock mechanism `AGENTS.md` section 3 uses, not a second liveness signal) and checks for `held by live`. A live session means do nothing.
+2. **Worth resuming** - `fm_orch_pending_work` is true only if at least one of:
+   - the durable wake queue (`state/.wake-queue`) is non-empty;
+   - a recorded ship/scout task (`state/*.meta`, excluding `kind=secondmate`) has a non-terminal last status (its `state/<id>.status` tail is not `done:`/`failed:`) and its backend endpoint is not `alive` per `fm_backend_agent_alive` (`bin/fm-backend.sh`) - a stalled/orphaned worker;
+   - `data/backlog.md` has a `## Queued` item with no `blocked-by:` marker on its line.
+
+   No pending work means do nothing, even with no live session.
+
+Only "no live session" AND "pending work" together reach the fire step: `bin/fm-relaunch.sh run`.
+That existing tool owns the actual resume mechanics (terminal, trust dialog, kickoff message) - this tool never reimplements them.
+
+## Cooldown
+
+After a fire, `bin/fm-orchestrator.sh` writes the current epoch to `state/.orchestrator-cooldown` and refuses to fire again until `FM_ORCHESTRATOR_COOLDOWN_SECS` (default 1800) has elapsed, even if `check` runs again sooner.
+This exists because a relaunched session can itself immediately hit the same account limit and exit fast; without a cooldown, a recurring timer firing every `StartInterval` would retry in a tight loop.
+The cooldown is a simple timestamp file, not a lock - convergent and idempotent the same way `fm-relaunch.sh install` converges on repeated calls.
+
+## Never touches billing
+
+This tool only waits for a limit to clear and then resumes normal work, exactly like a human checking back later would.
+It never calls any billing/usage-credit surface and never attempts to raise or inspect a spend limit itself.
+
+## Label and interval
+
+The job label is `dev.firstmate.orchestrator` for the default (unoverridden) primary home, distinctly suffixed for a non-default `FM_HOME` (a secondmate home), using the same SHA-256 slug scheme as `fm-relaunch.sh` - see that tool's docs for the exact mechanism. `FM_ORCHESTRATOR_INTERVAL_SECS` (default 1800) controls the `StartInterval` written at `install` time; `launchd`'s practical polling granularity makes values much below that not meaningfully more responsive.
+
+## Commands
+
+See `bin/fm-orchestrator.sh --help` for the exact subcommand list; that header is the mechanics' one owner.
+`status` reports whether the job is installed and loaded, its configured interval, and the last fire/cooldown state.

--- a/docs/orchestrator-tool.md
+++ b/docs/orchestrator-tool.md
@@ -28,7 +28,8 @@ That existing tool owns the actual resume mechanics (terminal, trust dialog, kic
 
 ## Cooldown
 
-After a fire, `bin/fm-orchestrator.sh` writes the current epoch to `state/.orchestrator-cooldown` and refuses to fire again until `FM_ORCHESTRATOR_COOLDOWN_SECS` (default 1800) has elapsed, even if `check` runs again sooner.
+After a fire attempt, `bin/fm-orchestrator.sh` writes the current epoch to `state/.orchestrator-cooldown` and refuses to fire again until `FM_ORCHESTRATOR_COOLDOWN_SECS` (default 1800) has elapsed, even if `check` runs again sooner.
+The cooldown is recorded even when `bin/fm-relaunch.sh run` itself fails - a failed resume still counts against the cooldown, and `check` then propagates that failure's exit code rather than swallowing it - so a persistently broken resume cannot turn into a tight fire-loop either.
 This exists because a relaunched session can itself immediately hit the same account limit and exit fast; without a cooldown, a recurring timer firing every `StartInterval` would retry in a tight loop.
 The cooldown is a simple timestamp file, not a lock - convergent and idempotent the same way `fm-relaunch.sh install` converges on repeated calls.
 

--- a/docs/relaunch-tool.md
+++ b/docs/relaunch-tool.md
@@ -1,0 +1,53 @@
+# On-demand session resume (`bin/fm-relaunch.sh`)
+
+Firstmate's own supervision session is normally reachable only by manually opening a terminal and running `claude`.
+`bin/fm-relaunch.sh` gives a captain a one-command way to resume it later, without any risk of that resume happening on its own.
+
+## Why a launchd LaunchAgent with no trigger
+
+The tool registers a macOS `launchd` `LaunchAgent` job whose plist declares no `RunAtLoad`, `StartInterval`, `StartCalendarInterval`, or watch-path key.
+A `launchd` agent with none of those keys never starts itself; it only runs when something explicitly asks `launchd` to start it (`launchctl kickstart`/`launchctl start`).
+That is the tool's entire safety property: the job exists and can be fired on demand, but nothing - not a timer, not a login event, not a file change - can fire it without an explicit human or human-triggered call.
+`bin/fm-relaunch.sh install` never writes those keys under any code path, and `bin/fm-relaunch.sh status` re-checks the installed plist for them on every call as a standing self-check, not just at install time.
+`tests/fm-relaunch.test.sh` asserts the generated plist never contains them - a regression there would silently turn this into an auto-scheduler.
+
+## Label and multi-home isolation
+
+The job label is `dev.firstmate.relaunch` for the default (unoverridden) primary home, so a fresh `install` cleanly supersedes a hand-built prototype job of the same name.
+A home launched with an explicit `FM_HOME` (for example a secondmate home) gets a distinct label, `dev.firstmate.relaunch.<slug>`, where `<slug>` is a short SHA-256 hash of that `FM_HOME` path.
+This keeps multiple firstmate homes on one machine from colliding on a single `launchd` label while still deriving the label deterministically from state the tool already has, with no separate registry to keep in sync.
+
+## What `run` actually does
+
+`bin/fm-relaunch.sh run` calls `launchctl kickstart` on the installed job.
+The job's `ProgramArguments` point back at the same script with the internal `fire` action, which is where the actual resume happens:
+
+1. Opens a new Terminal.app window running `claude` in the target home (`cd "$FM_HOME" && exec claude`).
+2. Waits briefly for `claude` to boot, then sends a `Return` keystroke via `System Events`. This is a no-op against an empty prompt, but dismisses the one-time "Yes, I trust this folder" dialog `claude` can show in a not-yet-trusted directory - without it, the composer is not usable yet.
+3. Sends a short kickoff message ("hi") and `Return`.
+
+Step 3 exists because opening `claude` alone does not trigger its `SessionStart` hook: that only fires once a real first message reaches the composer.
+Once that message lands, firstmate's own session-start/recovery flow (`AGENTS.md` section 5, `stuck-crewmate-recovery`) takes over and reconciles any dead or stopped crewmate workers on its own - this tool does not duplicate that logic, it only gets a real session started so that flow can run.
+
+`fire` is invoked only as the launchd job's program, not documented as a normal subcommand a captain runs directly - use `run` (or `install` followed by a manual `launchctl kickstart` if the tool is unavailable) to trigger it through the safety-checked path.
+
+## Terminal support
+
+Only Terminal.app is driven today, via `osascript`/`System Events`, matching the original hand-built prototype.
+iTerm2 is not detected or driven; a captain who primarily uses iTerm2 can still use this tool, but the resumed session opens in a new Terminal.app window regardless of which terminal app was frontmost.
+
+## Idempotency
+
+`install` compares the freshly generated plist bytes against what is already on disk and skips the reload when they match and the job is already loaded, so running it repeatedly converges to one installed, loaded job with no duplicate plists and no `launchd` errors.
+When the plist needs to change (for example after an `FM_HOME` change) or the job was not loaded, `install` unloads the previous copy (if any) before installing the new one.
+
+## Superseding the hand-built prototype
+
+An earlier prototype was built directly on the captain's machine outside this repo: a `~/Library/LaunchAgents/dev.firstmate.relaunch.plist` loaded into `launchd` with no auto-trigger key, plus a private payload script.
+Neither file is tracked here - the LaunchAgent lives outside any repo and the payload script lived under a firstmate home's gitignored `config/`.
+Because this tool's default label is the same `dev.firstmate.relaunch`, running `bin/fm-relaunch.sh install` on that machine detects the existing loaded job under that label, unloads it, and installs this tool's plist in its place - no manual removal step is required first.
+The prototype's private payload script itself is left in place on disk (this tool does not touch files it did not create) and becomes dead weight once superseded; a captain who wants it gone can remove it by hand.
+
+## Commands
+
+See `bin/fm-relaunch.sh --help` for the exact subcommand list and flags; that header is the mechanics' one owner.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -92,3 +92,5 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-x-dismiss.sh`        | Dismiss a skipped X-mode mention at the relay without replying                       |
 | `fm-x-link.sh`           | Link a spawned task to its originating X-mode mention in task meta                   |
 | `fm-x-followup.sh`       | Detect, post, and cap completion follow-ups for an X-mode-linked task                |
+| `fm-relaunch.sh`         | On-demand session resume via launchd, deliberately no auto-trigger (see `docs/relaunch-tool.md`) |
+| `fm-orchestrator.sh`     | Recurring gated resume watchdog that calls `fm-relaunch.sh` (see `docs/orchestrator-tool.md`) |

--- a/tests/fm-orchestrator.test.sh
+++ b/tests/fm-orchestrator.test.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# fm-orchestrator.sh: recurring watchdog that fires bin/fm-relaunch.sh run only
+# when no session already holds the lock AND real pending work exists, then
+# self-throttles. Every test runs against fake HOME/launchctl/id/uname and
+# stub fm-lock.sh/fm-relaunch.sh/fm-backend.sh so it never touches the real
+# machine's launchd namespace, session lock, or a real backend.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BIN="$ROOT/bin/fm-orchestrator.sh"
+
+assert_present "$BIN" "bin/fm-orchestrator.sh is missing"
+[ -x "$BIN" ] || fail "bin/fm-orchestrator.sh must be executable"
+
+# fm_orch_case <name> <lock-output> -> sets up a fake HOME/FM_HOME/fakebin
+# world with a stub fm-lock.sh that always prints <lock-output>, and echoes
+# "<dir>\t<fm_home>\t<home>\t<fakebin>".
+fm_orch_case() {
+  local name=$1 lock_out=$2 dir fakebin home fm_home
+  dir=$(fm_test_tmproot "fm-orch-$name")
+  fakebin="$dir/fakebin"
+  home="$dir/home"
+  fm_home="$dir/fmhome"
+  mkdir -p "$fakebin" "$home/Library/LaunchAgents" "$fm_home/state" "$fm_home/data"
+
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' Darwin
+SH
+
+  cat > "$fakebin/id" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 501
+SH
+
+  cat > "$fakebin/launchctl" <<SH
+#!/usr/bin/env bash
+LOADED_DIR="\${FM_ORCH_TEST_LOADED_DIR:?}"
+mkdir -p "\$LOADED_DIR"
+case "\$1" in
+  bootstrap)
+    label=\$(awk '/<key>Label<\/key>/{getline; gsub(/.*<string>|<\/string>.*/,""); print; exit}' "\$3")
+    : > "\$LOADED_DIR/\$label"
+    exit 0
+    ;;
+  bootout)
+    label=\${2##*/}
+    rm -f -- "\$LOADED_DIR/\$label"
+    exit 0
+    ;;
+  print)
+    label=\${2##*/}
+    [ -f "\$LOADED_DIR/\$label" ] && exit 0
+    exit 1
+    ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$fakebin/uname" "$fakebin/id" "$fakebin/launchctl"
+
+  cat > "$dir/fm-lock.sh" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "$lock_out"
+SH
+  chmod +x "$dir/fm-lock.sh"
+
+  cat > "$dir/fm-relaunch.sh" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "relaunch-\$1" >> "\${FM_ORCH_TEST_FIRE_LOG:-/dev/null}"
+exit 0
+SH
+  chmod +x "$dir/fm-relaunch.sh"
+
+  printf '%s\t%s\t%s\t%s\n' "$dir" "$fm_home" "$home" "$fakebin"
+}
+
+# fm_orch_run <dir> <fm_home> <home> <fakebin> <args...>
+fm_orch_run() {
+  local dir=$1 fm_home=$2 home=$3 fakebin=$4
+  shift 4
+  FM_ORCH_TEST_LOADED_DIR="$dir/loaded" \
+    FM_ORCH_TEST_FIRE_LOG="$dir/fire.log" \
+    FM_ORCHESTRATOR_LOCK_BIN="$dir/fm-lock.sh" \
+    FM_ORCHESTRATOR_RELAUNCH_BIN="$dir/fm-relaunch.sh" \
+    FM_ORCHESTRATOR_BACKEND_SH="$dir/no-such-fm-backend.sh" \
+    FM_ORCHESTRATOR_COOLDOWN_SECS="${FM_ORCH_TEST_COOLDOWN:-1800}" \
+    FM_ROOT_OVERRIDE="$fm_home" FM_HOME="$fm_home" HOME="$home" PATH="$fakebin:$PATH" \
+    "$BIN" "$@"
+}
+
+test_help_lists_subcommands() {
+  local out
+  out=$(FM_HOME=/nonexistent "$BIN" --help)
+  assert_contains "$out" "install" "help must list install"
+  assert_contains "$out" "status" "help must list status"
+  assert_contains "$out" "uninstall" "help must list uninstall"
+  assert_contains "$out" "check" "help must list check"
+  pass "help lists install/status/uninstall/check"
+}
+
+test_unknown_subcommand_fails() {
+  local rc=0
+  FM_HOME=/nonexistent "$BIN" bogus >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 2 ] || fail "an unknown subcommand must exit 2 (got $rc)"
+  pass "unknown subcommand exits 2"
+}
+
+test_non_macos_fails_closed() {
+  local case_out dir fm_home home fakebin rc=0
+  case_out=$(fm_orch_case nonmac "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' Linux
+SH
+  fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 1 ] || fail "install on a non-macOS platform must fail closed (got $rc)"
+  pass "non-macOS platform fails closed"
+}
+
+test_install_declares_a_real_recurring_interval() {
+  local case_out dir fm_home home fakebin plist
+  case_out=$(fm_orch_case interval "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "install failed"
+  plist="$home/Library/LaunchAgents/dev.firstmate.orchestrator.plist"
+  assert_present "$plist" "install must write a plist at the default label path"
+  assert_grep '<key>StartInterval</key>' "$plist" \
+    "orchestrator plist MUST declare StartInterval - unlike fm-relaunch.sh, this tool is meant to self-schedule"
+  pass "generated plist declares a real recurring StartInterval"
+}
+
+test_install_is_idempotent() {
+  local case_out dir fm_home home fakebin plist sum1 sum2
+  case_out=$(fm_orch_case idempotent "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  plist="$home/Library/LaunchAgents/dev.firstmate.orchestrator.plist"
+  fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null || fail "first install failed"
+  sum1=$(cksum < "$plist")
+  fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null || fail "second install failed"
+  sum2=$(cksum < "$plist")
+  [ "$sum1" = "$sum2" ] || fail "repeated install must converge to the same plist bytes"
+  pass "install run twice converges safely"
+}
+
+test_uninstall_removes_plist_and_unloads() {
+  local case_out dir fm_home home fakebin plist
+  case_out=$(fm_orch_case uninstall "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  plist="$home/Library/LaunchAgents/dev.firstmate.orchestrator.plist"
+  fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null || fail "install failed"
+  fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" uninstall >/dev/null || fail "uninstall failed"
+  assert_absent "$plist" "uninstall must remove the plist"
+  [ ! -f "$dir/loaded/dev.firstmate.orchestrator" ] || fail "uninstall must unload the job"
+  pass "uninstall unloads and removes the plist cleanly"
+}
+
+test_status_before_install_reports_not_installed() {
+  local case_out dir fm_home home fakebin rc=0
+  case_out=$(fm_orch_case statusmissing "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" status >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || fail "status must fail when nothing is installed"
+  pass "status reports failure when not yet installed"
+}
+
+test_check_does_nothing_when_session_already_alive() {
+  local case_out dir fm_home home fakebin out
+  case_out=$(fm_orch_case alivesession "lock: held by live harness pid 123")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  # Plenty of pending work present - must still not fire, because a session is alive.
+  printf '1\tsig\tk\tv\n' > "$fm_home/state/.wake-queue"
+  out=$(fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" check) || fail "check must exit 0"
+  assert_contains "$out" "session already alive" "check must report the live-session short-circuit"
+  [ ! -f "$dir/fire.log" ] || fail "check must never fire fm-relaunch.sh when a session is already alive"
+  pass "check never fires a second session when one is already alive"
+}
+
+test_check_does_nothing_when_nothing_pending() {
+  local case_out dir fm_home home fakebin out
+  case_out=$(fm_orch_case idle "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  # No wake queue, no meta files, no backlog file at all: nothing pending.
+  out=$(fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" check) || fail "check must exit 0"
+  assert_contains "$out" "no pending work" "check must report the no-pending-work short-circuit"
+  [ ! -f "$dir/fire.log" ] || fail "check must never fire when an idle fleet has nothing pending"
+  pass "check never fires on an idle, fully-caught-up fleet"
+}
+
+test_check_fires_on_nonempty_wake_queue() {
+  local case_out dir fm_home home fakebin out
+  case_out=$(fm_orch_case wakequeue "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  printf '1\tsig\tk\tv\n' > "$fm_home/state/.wake-queue"
+  out=$(fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" check) || fail "check must exit 0"
+  assert_contains "$out" "fired session resume" "check must report firing"
+  assert_grep 'relaunch-run' "$dir/fire.log" "check must invoke fm-relaunch.sh run"
+  pass "check fires fm-relaunch.sh run on a non-empty wake queue"
+}
+
+test_check_fires_on_queued_backlog_item() {
+  local case_out dir fm_home home fakebin out
+  case_out=$(fm_orch_case backlogqueued "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  cat > "$fm_home/data/backlog.md" <<'MD'
+# Backlog
+
+## Queued
+- some-task: do the thing
+
+## Done
+- old-task: finished already
+MD
+  out=$(fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" check) || fail "check must exit 0"
+  assert_contains "$out" "fired session resume" "check must report firing"
+  pass "check fires on a queued backlog item with no blocker"
+}
+
+test_check_skips_blocked_backlog_item() {
+  local case_out dir fm_home home fakebin out
+  case_out=$(fm_orch_case backlogblocked "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  cat > "$fm_home/data/backlog.md" <<'MD'
+# Backlog
+
+## Queued
+- some-task: do the thing [blocked-by:other-task]
+MD
+  out=$(fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" check) || fail "check must exit 0"
+  assert_contains "$out" "no pending work" "a fully blocked queued item must not count as pending work"
+  pass "check does not fire on a queued backlog item whose blocker has not cleared"
+}
+
+test_check_fires_on_stalled_task_with_dead_backend() {
+  local case_out dir fm_home home fakebin out
+  case_out=$(fm_orch_case stalledtask "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  cat > "$fm_home/state/some-id.meta" <<'META'
+window=win1
+worktree=/tmp/wt
+project=demo
+harness=claude
+model=
+effort=
+kind=ship
+mode=no-mistakes
+yolo=false
+backend=tmux
+META
+  cat > "$dir/no-such-fm-backend.sh" <<'SH'
+fm_backend_agent_alive() { printf 'dead'; }
+SH
+  out=$(fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" check) || fail "check must exit 0"
+  assert_contains "$out" "fired session resume" "check must report firing"
+  pass "check fires when an in-flight task's backend endpoint is not alive"
+}
+
+test_check_ignores_task_with_terminal_status() {
+  local case_out dir fm_home home fakebin out
+  case_out=$(fm_orch_case terminaltask "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  cat > "$fm_home/state/some-id.meta" <<'META'
+window=win1
+kind=ship
+backend=tmux
+META
+  printf 'working: doing stuff\ndone: shipped\n' > "$fm_home/state/some-id.status"
+  cat > "$dir/no-such-fm-backend.sh" <<'SH'
+fm_backend_agent_alive() { printf 'dead'; }
+SH
+  out=$(fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" check) || fail "check must exit 0"
+  assert_contains "$out" "no pending work" "a task already reported done must not count as a stall even with a dead endpoint"
+  pass "check does not treat a terminal (done/failed) task as a stall"
+}
+
+test_check_cooldown_throttles_repeated_fires() {
+  local case_out dir fm_home home fakebin out1 out2
+  case_out=$(fm_orch_case cooldown "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  printf '1\tsig\tk\tv\n' > "$fm_home/state/.wake-queue"
+  FM_ORCH_TEST_COOLDOWN=1800 out1=$(fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" check) \
+    || fail "first check must exit 0"
+  assert_contains "$out1" "fired session resume" "first check must fire"
+  FM_ORCH_TEST_COOLDOWN=1800 out2=$(fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" check) \
+    || fail "second check must exit 0"
+  assert_contains "$out2" "cooldown active" "a second check inside the cooldown window must not fire again"
+  [ "$(grep -c 'relaunch-run' "$dir/fire.log")" -eq 1 ] \
+    || fail "fm-relaunch.sh run must be invoked exactly once across both checks"
+  pass "cooldown throttles a second fire within the cooldown window"
+}
+
+test_check_fires_again_after_cooldown_elapses() {
+  local case_out dir fm_home home fakebin out1 out2
+  case_out=$(fm_orch_case cooldownelapsed "lock: free")
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  printf '1\tsig\tk\tv\n' > "$fm_home/state/.wake-queue"
+  FM_ORCH_TEST_COOLDOWN=1 out1=$(fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" check) \
+    || fail "first check must exit 0"
+  assert_contains "$out1" "fired session resume" "first check must fire"
+  sleep 2
+  FM_ORCH_TEST_COOLDOWN=1 out2=$(fm_orch_run "$dir" "$fm_home" "$home" "$fakebin" check) \
+    || fail "second check must exit 0"
+  assert_contains "$out2" "fired session resume" "check must fire again once the cooldown window elapses"
+  [ "$(grep -c 'relaunch-run' "$dir/fire.log")" -eq 2 ] \
+    || fail "fm-relaunch.sh run must be invoked twice once cooldown elapsed"
+  pass "check fires again once the cooldown window has elapsed"
+}
+
+test_help_lists_subcommands
+test_unknown_subcommand_fails
+test_non_macos_fails_closed
+test_install_declares_a_real_recurring_interval
+test_install_is_idempotent
+test_uninstall_removes_plist_and_unloads
+test_status_before_install_reports_not_installed
+test_check_does_nothing_when_session_already_alive
+test_check_does_nothing_when_nothing_pending
+test_check_fires_on_nonempty_wake_queue
+test_check_fires_on_queued_backlog_item
+test_check_skips_blocked_backlog_item
+test_check_fires_on_stalled_task_with_dead_backend
+test_check_ignores_task_with_terminal_status
+test_check_cooldown_throttles_repeated_fires
+test_check_fires_again_after_cooldown_elapses

--- a/tests/fm-relaunch.test.sh
+++ b/tests/fm-relaunch.test.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# fm-relaunch.sh: on-demand session-resume LaunchAgent.
+#
+# The entire safety property of this tool is "registered but never
+# self-triggering" - a regression that adds RunAtLoad/StartInterval/
+# StartCalendarInterval/a watch key would silently turn it into an
+# auto-scheduler, which is exactly what the captain does not want. Every test
+# here runs against fake HOME/launchctl/osascript/id/uname stubs so it never
+# touches the real machine's launchd namespace.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BIN="$ROOT/bin/fm-relaunch.sh"
+
+assert_present "$BIN" "bin/fm-relaunch.sh is missing"
+[ -x "$BIN" ] || fail "bin/fm-relaunch.sh must be executable"
+
+# fm_relaunch_case <name> -> sets up a fake HOME/PATH world and echoes it as
+# "<dir>\t<fm_home>"; the caller runs "$BIN" with FM_HOME="$fm_home" and
+# PATH="$dir/fakebin:$PATH" and HOME="$dir/home".
+fm_relaunch_case() {
+  local name=$1 dir fakebin home fm_home
+  dir=$(fm_test_tmproot "fm-relaunch-$name")
+  fakebin="$dir/fakebin"
+  home="$dir/home"
+  fm_home="$dir/fmhome"
+  mkdir -p "$fakebin" "$home/Library/LaunchAgents" "$fm_home/state"
+
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' Darwin
+SH
+
+  cat > "$fakebin/id" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 501
+SH
+
+  # Fake launchctl: tracks "loaded" state in a marker file next to the plist so
+  # bootstrap/bootout/print/kickstart behave consistently across calls within
+  # one test, without ever touching a real launchd domain.
+  cat > "$fakebin/launchctl" <<'SH'
+#!/usr/bin/env bash
+LOADED_DIR="${FM_RELAUNCH_TEST_LOADED_DIR:?}"
+mkdir -p "$LOADED_DIR"
+case "$1" in
+  bootstrap)
+    label=$(awk '/<key>Label<\/key>/{getline; gsub(/.*<string>|<\/string>.*/,""); print; exit}' "$3")
+    : > "$LOADED_DIR/$label"
+    exit 0
+    ;;
+  bootout)
+    label=${2##*/}
+    rm -f -- "$LOADED_DIR/$label"
+    exit 0
+    ;;
+  print)
+    label=${2##*/}
+    [ -f "$LOADED_DIR/$label" ] && exit 0
+    exit 1
+    ;;
+  kickstart)
+    label=${3##*/}
+    if [ -f "$LOADED_DIR/$label" ]; then
+      printf '%s\n' kickstart >> "${FM_RELAUNCH_TEST_FIRE_LOG:-/dev/null}"
+      exit 0
+    fi
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SH
+
+  cat > "$fakebin/osascript" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' osascript-called >> "${FM_RELAUNCH_TEST_OSASCRIPT_LOG:-/dev/null}"
+exit 0
+SH
+
+  chmod +x "$fakebin/uname" "$fakebin/id" "$fakebin/launchctl" "$fakebin/osascript"
+  printf '%s\t%s\t%s\t%s\n' "$dir" "$fm_home" "$home" "$fakebin"
+}
+
+# fm_relaunch_run <dir> <fm_home> <home> <fakebin> <args...>
+# FM_ROOT_OVERRIDE is pinned to fm_home so this case's FM_HOME reads as the
+# default (unoverridden) primary home and claims the bare
+# dev.firstmate.relaunch label; test_nondefault_home_gets_a_distinct_label
+# deliberately diverges FM_HOME from FM_ROOT_OVERRIDE to exercise the other
+# branch.
+fm_relaunch_run() {
+  local dir=$1 fm_home=$2 home=$3 fakebin=$4
+  shift 4
+  FM_RELAUNCH_TEST_LOADED_DIR="$dir/loaded" \
+    FM_RELAUNCH_TEST_FIRE_LOG="$dir/fire.log" \
+    FM_RELAUNCH_TEST_OSASCRIPT_LOG="$dir/osascript.log" \
+    FM_ROOT_OVERRIDE="$fm_home" FM_HOME="$fm_home" HOME="$home" PATH="$fakebin:$PATH" \
+    "$BIN" "$@"
+}
+
+test_help_lists_subcommands() {
+  local out
+  out=$(FM_HOME=/nonexistent "$BIN" --help)
+  assert_contains "$out" "install" "help must list install"
+  assert_contains "$out" "status" "help must list status"
+  assert_contains "$out" "uninstall" "help must list uninstall"
+  assert_contains "$out" "run" "help must list run"
+  pass "help lists install/status/uninstall/run"
+}
+
+test_unknown_subcommand_fails() {
+  local rc=0
+  FM_HOME=/nonexistent "$BIN" bogus >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 2 ] || fail "an unknown subcommand must exit 2 (got $rc)"
+  pass "unknown subcommand exits 2"
+}
+
+test_non_macos_fails_closed() {
+  local case_out dir fm_home home fakebin rc=0
+  case_out=$(fm_relaunch_case nonmac)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' Linux
+SH
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 1 ] || fail "install on a non-macOS platform must fail closed (got $rc)"
+  pass "non-macOS platform fails closed rather than silently doing nothing"
+}
+
+test_install_never_writes_an_auto_trigger_key() {
+  local case_out dir fm_home home fakebin plist
+  case_out=$(fm_relaunch_case notrigger)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "install failed"
+  plist="$home/Library/LaunchAgents/dev.firstmate.relaunch.plist"
+  assert_present "$plist" "install must write a plist at the default label path"
+  for key in RunAtLoad StartInterval StartCalendarInterval WatchPaths QueueDirectories KeepAlive; do
+    assert_no_grep "<key>$key</key>" "$plist" \
+      "generated plist must never declare $key - that would make the job self-trigger"
+  done
+  pass "generated plist never declares an automatic-trigger key"
+}
+
+test_status_confirms_installed_and_no_trigger() {
+  local case_out dir fm_home home fakebin out
+  case_out=$(fm_relaunch_case statusok)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "install failed"
+  out=$(fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" status) \
+    || fail "status must exit 0 once installed and loaded"
+  assert_contains "$out" "no automatic trigger key present" "status must self-check for trigger keys"
+  assert_contains "$out" "loaded" "status must report loaded state"
+  pass "status confirms installed, loaded, and free of auto-trigger keys"
+}
+
+test_status_before_install_reports_not_installed() {
+  local case_out dir fm_home home fakebin rc=0
+  case_out=$(fm_relaunch_case statusmissing)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" status >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || fail "status must fail when nothing is installed"
+  pass "status reports failure when not yet installed"
+}
+
+test_install_is_idempotent() {
+  local case_out dir fm_home home fakebin plist sum1 sum2
+  case_out=$(fm_relaunch_case idempotent)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  plist="$home/Library/LaunchAgents/dev.firstmate.relaunch.plist"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "first install failed"
+  sum1=$(cksum < "$plist")
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "second install failed"
+  sum2=$(cksum < "$plist")
+  [ "$sum1" = "$sum2" ] || fail "repeated install must converge to the same plist bytes"
+  [ -f "$dir/loaded/dev.firstmate.relaunch" ] || fail "job must remain loaded after a repeated install"
+  pass "install run twice converges safely with no duplicate/diverging plist"
+}
+
+test_run_kickstarts_the_installed_job() {
+  local case_out dir fm_home home fakebin
+  case_out=$(fm_relaunch_case runfires)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "install failed"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" run >/dev/null \
+    || fail "run must succeed once installed"
+  assert_grep kickstart "$dir/fire.log" "run must fire the job via launchctl kickstart"
+  pass "run fires the installed job on demand via launchctl kickstart"
+}
+
+test_run_without_install_fails() {
+  local case_out dir fm_home home fakebin rc=0
+  case_out=$(fm_relaunch_case rununinstalled)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" run >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || fail "run must refuse when the job was never installed"
+  pass "run refuses when the job is not installed"
+}
+
+test_uninstall_removes_plist_and_unloads() {
+  local case_out dir fm_home home fakebin plist
+  case_out=$(fm_relaunch_case uninstall)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  plist="$home/Library/LaunchAgents/dev.firstmate.relaunch.plist"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "install failed"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" uninstall >/dev/null \
+    || fail "uninstall failed"
+  assert_absent "$plist" "uninstall must remove the plist"
+  [ ! -f "$dir/loaded/dev.firstmate.relaunch" ] || fail "uninstall must unload the job"
+  pass "uninstall unloads and removes the plist cleanly"
+}
+
+test_status_after_uninstall_reports_not_installed() {
+  local case_out dir fm_home home fakebin rc=0
+  case_out=$(fm_relaunch_case statusafteruninstall)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" install >/dev/null \
+    || fail "install failed"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" uninstall >/dev/null \
+    || fail "uninstall failed"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" status >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || fail "status must report failure after uninstall"
+  pass "status reports not-installed after uninstall"
+}
+
+test_nondefault_home_gets_a_distinct_label() {
+  local case_out dir fm_home home fakebin default_plist other_home
+  case_out=$(fm_relaunch_case distinctlabel)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  # FM_ROOT_OVERRIDE stays pinned to fm_home (the "primary home" for this
+  # case); pointing FM_HOME at a genuinely different directory (a secondmate
+  # home) must produce a distinctly-suffixed label instead of colliding with
+  # the primary home's bare dev.firstmate.relaunch label.
+  other_home="$fm_home/other-home"
+  mkdir -p "$other_home/state"
+  default_plist="$home/Library/LaunchAgents/dev.firstmate.relaunch.plist"
+  FM_RELAUNCH_TEST_LOADED_DIR="$dir/loaded" \
+    FM_RELAUNCH_TEST_FIRE_LOG="$dir/fire.log" \
+    FM_RELAUNCH_TEST_OSASCRIPT_LOG="$dir/osascript.log" \
+    FM_ROOT_OVERRIDE="$fm_home" FM_HOME="$other_home" HOME="$home" PATH="$fakebin:$PATH" \
+    "$BIN" install >/dev/null \
+    || fail "install for a non-default home failed"
+  assert_absent "$default_plist" "a non-default FM_HOME must not claim the bare dev.firstmate.relaunch label"
+  local suffixed=("$home/Library/LaunchAgents"/dev.firstmate.relaunch.*.plist)
+  [ -f "${suffixed[0]:-}" ] \
+    || fail "a non-default FM_HOME must get a distinctly-suffixed label"
+  pass "a home with an explicit FM_HOME gets a distinct label from the primary home"
+}
+
+test_fire_drives_terminal_via_osascript() {
+  local case_out dir fm_home home fakebin
+  case_out=$(fm_relaunch_case fire)
+  IFS=$'\t' read -r dir fm_home home fakebin <<<"$case_out"
+  fm_relaunch_run "$dir" "$fm_home" "$home" "$fakebin" fire >/dev/null \
+    || fail "fire must succeed"
+  assert_grep osascript-called "$dir/osascript.log" "fire must drive the terminal/claude/message handshake through osascript"
+  pass "fire opens a terminal and drives the kickoff handshake through osascript"
+}
+
+test_help_lists_subcommands
+test_unknown_subcommand_fails
+test_non_macos_fails_closed
+test_install_never_writes_an_auto_trigger_key
+test_status_confirms_installed_and_no_trigger
+test_status_before_install_reports_not_installed
+test_install_is_idempotent
+test_run_kickstarts_the_installed_job
+test_run_without_install_fails
+test_uninstall_removes_plist_and_unloads
+test_status_after_uninstall_reports_not_installed
+test_nondefault_home_gets_a_distinct_label
+test_fire_drives_terminal_via_osascript


### PR DESCRIPTION
## Intent

Add bin/fm-orchestrator.sh, a firstmate helper script for orchestrating multiple crewmate sessions. Code already went through a local no-mistakes review/test/lint/document cycle by the original author; final commit updated docs/scripts inventory to list both fm-relaunch.sh and fm-orchestrator.sh. Re-validating now only to push through the required no-mistakes gate (this fork/PR channel skipped that step originally).

## What Changed
- Added `bin/fm-relaunch.sh`, an on-demand session-resume helper with no auto-trigger.
- Added `bin/fm-orchestrator.sh`, a recurring watchdog that resumes crewmate sessions and records a cooldown timestamp even when the underlying `fm-relaunch.sh` run fails, propagating the error rather than swallowing it.
- Added test suites `tests/fm-orchestrator.test.sh` and `tests/fm-relaunch.test.sh`, plus docs (`docs/orchestrator-tool.md`, `docs/relaunch-tool.md`) and an updated `docs/scripts.md` inventory listing both new scripts.

## Risk Assessment

✅ Low: Self-contained macOS-only shell tool with two independent safety gates (session-liveness + pending-work), cooldown throttle, no billing/network side effects, matching docs and tests added, and final commit correctly lists both scripts in docs/scripts.md per user intent.

## Testing

Ran both dedicated test suites: fm-orchestrator.test.sh 16/16 pass covering install/uninstall/status/check-trigger logic including cooldown and stall detection; fm-relaunch.test.sh 13/13 pass covering install/run/uninstall/no-auto-trigger guarantees. Confirmed docs/scripts.md and docs/orchestrator-tool.md reference fm-orchestrator.sh per the final commit intent. No code changes needed. No product-level visual artifact produced since this is a headless bash CLI tool with no UI surface; CLI test transcripts serve as evidence.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-orchestrator.test.sh`
- `bash tests/fm-relaunch.test.sh`
- `grep -rl fm-orchestrator docs/`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
