### PR TITLE
fix: execute every PR body compliance event

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,4 +1,5 @@
 name: Require no-mistakes
+run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"
 
 on:
   pull_request:
@@ -9,8 +10,12 @@ on:
 permissions:
   contents: read
 
+# GitHub concurrency groups retain at most one pending run, replacing older
+# pending runs even when cancel-in-progress is false. Give body-bearing events
+# an immutable per-event group so first-time-fork approvals can never collapse
+# opened/edited checks. Keep synchronize/reopened coalescing as before.
 concurrency:
-  group: no-mistakes-required-${{ github.event.pull_request.number }}
+  group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,8 @@ We require this to reduce the maintainer's burden of reviewing and merging contr
 Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.
 
 A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes.
-Dependency bots are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
+It evaluates every PR opening and body edit independently, so a later edit cannot replace an earlier pending compliance check.
+GitHub Actions and Dependabot are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
 
 ## Workflow
 

--- a/tests/no-mistakes-required-workflow.test.sh
+++ b/tests/no-mistakes-required-workflow.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Contract and synthetic event replay for the PR body compliance workflow.
+# shellcheck disable=SC2016
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+WORKFLOW="$ROOT/.github/workflows/no-mistakes-required.yml"
+MARKER='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
+
+extract_signature_script() {
+  awk '
+    /^        run: \|$/ { capture=1; next }
+    capture && /^          / { sub(/^          /, ""); print; next }
+    capture { exit }
+  ' "$WORKFLOW"
+}
+
+signature_result() {
+  local body=$1 script
+  script=$(extract_signature_script)
+  PR_NUMBER=418 PR_AUTHOR=synthetic-fork-contributor PR_BODY="$body" bash -c "$script" >/dev/null 2>&1
+}
+
+render_group() {
+  local action=$1 run_id=$2
+  case "$action" in
+    opened|edited) printf 'no-mistakes-required-418-%s\n' "$run_id" ;;
+    synchronize|reopened) printf 'no-mistakes-required-418-head-change\n' ;;
+  esac
+}
+
+render_run_name() {
+  local action=$1 run_number=$2 run_id=$3
+  printf 'PR #418 body compliance - %s - event %s (run %s)\n' "$action" "$run_number" "$run_id"
+}
+
+test_signature_sequence_at_fixed_head() {
+  signature_result "Synthetic body\n$MARKER" || fail "signed opened event must succeed"
+  if signature_result 'Synthetic unsigned edit'; then
+    fail "unsigned edited event must fail"
+  fi
+  signature_result "Synthetic signed edit\n$MARKER" || fail "signed edited event must succeed"
+  pass "fixed-head signed opened, unsigned edited, signed edited yields 0/1/0"
+}
+
+test_event_identity_contract() {
+  local opened edited_one edited_two synchronize reopened
+  opened=$(render_group opened 9001)
+  edited_one=$(render_group edited 9002)
+  edited_two=$(render_group edited 9003)
+  synchronize=$(render_group synchronize 9004)
+  reopened=$(render_group reopened 9005)
+  [ "$opened" != "$edited_one" ] && [ "$opened" != "$edited_two" ] && [ "$edited_one" != "$edited_two" ] || \
+    fail "body events must have distinct immutable groups"
+  [ "$synchronize" = "$reopened" ] || fail "synchronize and reopened must share head-change"
+  case "$opened $edited_one $edited_two" in *head-change*) fail "body event reused head-change" ;; esac
+
+  assert_grep "group: no-mistakes-required-\${{ github.event.pull_request.number }}-\${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}" "$WORKFLOW" \
+    "workflow does not implement immutable body-event groups"
+  assert_grep 'cancel-in-progress: true' "$WORKFLOW" "workflow lost cancellation for coalesced head changes"
+  pass "body event groups are distinct while head changes remain coalesced"
+}
+
+test_run_names_are_ordered_and_unique() {
+  local first second
+  first=$(render_run_name edited 73 9002)
+  second=$(render_run_name edited 74 9003)
+  [ "$first" = 'PR #418 body compliance - edited - event 73 (run 9002)' ] || fail "first synthetic run name is incomplete"
+  [ "$second" = 'PR #418 body compliance - edited - event 74 (run 9003)' ] || fail "second synthetic run name is incomplete"
+  [ "$first" != "$second" ] || fail "distinct events must have unique run names"
+  assert_grep 'run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"' "$WORKFLOW" \
+    "workflow run name does not expose PR, action, monotonic run number, and immutable run ID"
+  pass "run names expose monotonic numbers and immutable IDs"
+}
+
+test_security_and_signature_contract_is_preserved() {
+  assert_grep '  pull_request:' "$WORKFLOW" "workflow must use pull_request"
+  assert_no_grep 'pull_request_target' "$WORKFLOW" "workflow must not use pull_request_target"
+  assert_grep '  contents: read' "$WORKFLOW" "contents permission must remain read-only"
+  assert_no_grep 'contents: write' "$WORKFLOW" "workflow must not gain contents write permission"
+  assert_no_grep 'secrets.' "$WORKFLOW" "workflow must not read secrets"
+  assert_no_grep 'actions/checkout' "$WORKFLOW" "workflow must not check out fork code"
+  assert_grep 'name: PR must be raised via no-mistakes' "$WORKFLOW" "stable required check name changed"
+  assert_grep "$MARKER" "$WORKFLOW" "signature marker changed"
+  assert_grep "github.event.pull_request.user.login != 'github-actions[bot]'" "$WORKFLOW" "github-actions bot exemption changed"
+  assert_grep "github.event.pull_request.user.login != 'dependabot[bot]'" "$WORKFLOW" "dependabot bot exemption changed"
+  assert_no_grep 'release-please[bot]' "$WORKFLOW" "Firstmate must not exempt release-please"
+  pass "fork, permission, check-name, marker, and bot-exemption contracts are preserved"
+}
+
+test_signature_sequence_at_fixed_head
+test_event_identity_contract
+test_run_names_are_ordered_and_unique
+test_security_and_signature_contract_is_preserved


### PR DESCRIPTION
## Intent

Ship the captain-authorized Firstmate portion of the fleet-wide PR-body compliance-event rollout. Apply only the canonical two-hunk behavior from no-mistakes PR 558: add the canonical run name and isolate every opened or edited event by immutable github.run_id while keeping synchronize and reopened coalesced under head-change with cancel-in-progress true. Preserve Firstmate's narrower github-actions and dependabot bot exemptions, pull_request read-only security boundary, stable check name and signature marker, and all unrelated behavior. Retain synthetic fixed-head 0/1/0 replay, event-group, run-name, and security regression coverage. The PR title must be exactly fix: execute every PR body compliance event. Do not merge, release, deploy, self-update, or make unrelated changes.

## What Changed

- Run every opened and edited PR-body compliance event in an immutable, run-specific concurrency group with descriptive run names, while keeping synchronize and reopened events coalesced.
- Document independent compliance checks while preserving the read-only security boundary, bot exemptions, stable check name, and signature marker.
- Add regression coverage for the fixed-head 0/1/0 signature replay, event grouping, run names, and security contracts.

## Risk Assessment

✅ Low: The workflow change exactly matches the canonical PR 558 behavior, remains narrowly scoped, preserves the required security and compatibility invariants, and includes the required regression coverage.

## Testing

Inspected the supplied base-to-target workflow change and exact commit subject, ran the focused shell regression, directly replayed the extracted workflow script and rendered its event identities into a reviewer-visible transcript, checked for an existing PR, and confirmed a clean worktree. All locally testable behavior passed; actual PR-title verification is deferred because no PR exists. No screenshot was applicable because the changed end-user surface is GitHub Actions execution and naming, represented by the direct transcript.

<details>
<summary>Evidence: PR-body compliance event replay transcript</summary>

```text
Firstmate PR-body compliance event replay
Workflow: .github/workflows/no-mistakes-required.yml

Fixed-head event replay (same synthetic PR/head, body changes only)
  action=opened body=signed   exit=0 output=Found no-mistakes signature in PR #418 body.
  action=edited body=unsigned exit=1 output=::error::This PR was not raised through no-mistakes.

Contributions to this repository must be submitted via 'git push no-mistakes'.
That pipeline runs the required review/test/lint/CI steps and writes a
deterministic '## Pipeline' section into the PR body containing:

    Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

See CONTRIBUTING.md for setup and the full workflow.

PR author: synthetic-fork-contributor
  action=edited body=signed   exit=0 output=Found no-mistakes signature in PR #418 body.

Workflow event identity template
concurrency:
  group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
  cancel-in-progress: true


Rendered event identities for PR #418
  action=opened      run_id=9001 group=no-mistakes-required-418-9001
    run-name=PR #418 body compliance - opened - event 71 (run 9001)
  action=edited      run_id=9002 group=no-mistakes-required-418-9002
    run-name=PR #418 body compliance - edited - event 72 (run 9002)
  action=edited      run_id=9003 group=no-mistakes-required-418-9003
    run-name=PR #418 body compliance - edited - event 73 (run 9003)
  action=synchronize run_id=9004 group=no-mistakes-required-418-head-change
    run-name=PR #418 body compliance - synchronize - event 74 (run 9004)
  action=reopened    run_id=9005 group=no-mistakes-required-418-head-change
    run-name=PR #418 body compliance - reopened - event 75 (run 9005)

Canonical run-name template
run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"

Preserved security, check, marker, and narrow bot exemptions
  pull_request:
permissions:
  contents: read
    name: PR must be raised via no-mistakes
      github.event.pull_request.user.login != 'github-actions[bot]' &&
      github.event.pull_request.user.login != 'dependabot[bot]'
          marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
  forbidden-surface scan: clear (no pull_request_target, write permission, secrets, checkout, or release-please exemption)
```
</details>
<details>
<summary>Evidence: Current branch PR lookup</summary>

```text
count: 0
pull_requests: []
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (3m44s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ The target commit subject is exactly `fix: execute every PR body compliance event`, but no GitHub PR exists for this branch. Therefore the required actual PR title cannot be verified during this read-only test step. Decide whether commit-title evidence is sufficient for now or require PR-title verification after the PR is created.
- `bin/fm-session-start.sh`
- `git diff --find-renames --find-copies --unified=100 6db3b09b34dc23787969416bc4dde37adb02ac94..efd52d3d87719393baeee4402c5086f928d038ea -- .github/workflows/no-mistakes-required.yml tests/no-mistakes-required-workflow.test.sh`
- `git log -1 --format='%H%n%s%n%b' efd52d3d87719393baeee4402c5086f928d038ea`
- `bash tests/no-mistakes-required-workflow.test.sh`
- <code>Extracted the checked-in workflow `run: |` script with `awk`, replayed signed/unsigned/signed PR bodies through `bash -c`, and captured the direct 0/1/0 output.</code>
- `Rendered opened, edited, synchronize, and reopened concurrency groups and canonical run names into the evidence transcript.`
- `gh-axi pr list --head fm/fm-compliance-event-rollout-a1`
- `shasum -a 256 /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY6VHZ56E6A15YAYH4PP4Z2N/pr-body-compliance-event-replay.txt`
- <code>`git status --short` before and after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
