### PR TITLE
fix(bin): make captain decision lookup archive-aware

### DIFF
--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -20,8 +20,8 @@
 # active record first and falls back to the configured or default Done archive.
 # Active records therefore shadow archive history, while every hold, dependency,
 # update, unblock, and close mutation remains active-backlog-only.
-# A true inclusive NOT_FOUND is treated as absence, but a missing archive flag or
-# malformed lookup result reports the required archive-aware tasks-axi contract.
+# Only exit 1 with the canonical three-line NOT_FOUND envelope is treated as
+# absence; every other failure reports the required archive-aware contract.
 #
 # Usage:
 #   fm-decision-hold.sh id <origin-id> <decision-key>
@@ -136,7 +136,7 @@ output_field_count() {  # <show-output> <field>
 }
 
 task_show_durable() {  # <id>; sets TASK_SHOW_DURABLE_OUTPUT; 1 means true absence
-  local id=$1 output source shown_id field
+  local id=$1 output source shown_id field status expected
   TASK_SHOW_DURABLE_OUTPUT=''
   require_archive_lookup
   if output=$(tasks_axi show "$id" --include-archive --full 2>&1); then
@@ -155,9 +155,11 @@ task_show_durable() {  # <id>; sets TASK_SHOW_DURABLE_OUTPUT; 1 means true absen
     esac
     TASK_SHOW_DURABLE_OUTPUT=$output
     return 0
+  else
+    status=$?
   fi
-  if [ "$(output_line_count "$output" 'code: NOT_FOUND')" = 1 ] \
-    && [ "$(output_line_count "$output" task:)" = 0 ]; then
+  expected=$(printf 'error: "Task \\"%s\\" not found in this backlog"\ncode: NOT_FOUND\nhelp[1]: Run \140tasks-axi list\140 to see existing tasks' "$id")
+  if [ "$status" = 1 ] && [ "$output" = "$expected" ]; then
     return 1
   fi
   fail "tasks-axi show <id> --include-archive --full failed incompatibly for $id"

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -146,7 +146,7 @@ task_show_durable() {  # <id>; sets TASK_SHOW_DURABLE_OUTPUT; 1 means true absen
     if [ "$(output_line_count "$output" task:)" != 1 ] || [ "$shown_id" != "$id" ]; then
       fail "tasks-axi show <id> --include-archive --full returned malformed output for $id"
     fi
-    for field in id source state held kind hold_kind body; do
+    for field in id source title state held kind hold_kind body; do
       [ "$(output_field_count "$output" "$field")" = 1 ] \
         || fail "tasks-axi show <id> --include-archive --full returned malformed output for $id"
     done

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -11,8 +11,9 @@
 # decision record has been linked to existing dependent work.
 #
 # A hold identity is <origin-id>-decision-<decision-key>. Origin ids and decision
-# keys must already be privacy-safe slugs. Repeating `hold` with the same identity
-# is idempotent. A different decision key creates a different backlog identity.
+# keys must already be privacy-safe slugs. Repeating `hold` with the same active
+# unresolved identity is idempotent. A different decision key creates a different
+# backlog identity.
 # All backlog mutations run in the active FM_HOME, which keeps main-home and
 # secondmate-home ownership aligned with the work that discovered the decision.
 # Durable decision-identity reads use the explicit read-only

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -15,6 +15,13 @@
 # is idempotent. A different decision key creates a different backlog identity.
 # All backlog mutations run in the active FM_HOME, which keeps main-home and
 # secondmate-home ownership aligned with the work that discovered the decision.
+# Durable decision-identity reads use the explicit read-only
+# `tasks-axi show <id> --include-archive --full` contract, which selects the
+# active record first and falls back to the configured or default Done archive.
+# Active records therefore shadow archive history, while every hold, dependency,
+# update, unblock, and close mutation remains active-backlog-only.
+# A true inclusive NOT_FOUND is treated as absence, but a missing archive flag or
+# malformed lookup result reports the required archive-aware tasks-axi contract.
 #
 # Usage:
 #   fm-decision-hold.sh id <origin-id> <decision-key>
@@ -110,6 +117,52 @@ task_show() {  # <id>
   tasks_axi show "$1" --full 2>/dev/null
 }
 
+TASK_SHOW_DURABLE_OUTPUT=''
+
+require_archive_lookup() {
+  local help
+  help=$(tasks_axi show --help 2>&1) \
+    || fail "tasks-axi show <id> --include-archive --full is required for durable decision lookup"
+  printf '%s\n' "$help" | grep -F -- '--include-archive' >/dev/null \
+    || fail "tasks-axi show <id> --include-archive --full is required for durable decision lookup"
+}
+
+output_line_count() {  # <output> <exact-line>
+  printf '%s\n' "$1" | awk -v expected="$2" '$0 == expected { count++ } END { print count + 0 }'
+}
+
+output_field_count() {  # <show-output> <field>
+  printf '%s\n' "$1" | awk -v prefix="  $2: " 'index($0, prefix) == 1 { count++ } END { print count + 0 }'
+}
+
+task_show_durable() {  # <id>; sets TASK_SHOW_DURABLE_OUTPUT; 1 means true absence
+  local id=$1 output source shown_id field
+  TASK_SHOW_DURABLE_OUTPUT=''
+  require_archive_lookup
+  if output=$(tasks_axi show "$id" --include-archive --full 2>&1); then
+    shown_id=$(show_field "$output" id)
+    source=$(show_field "$output" source)
+    if [ "$(output_line_count "$output" task:)" != 1 ] || [ "$shown_id" != "$id" ]; then
+      fail "tasks-axi show <id> --include-archive --full returned malformed output for $id"
+    fi
+    for field in id source state held kind hold_kind body; do
+      [ "$(output_field_count "$output" "$field")" = 1 ] \
+        || fail "tasks-axi show <id> --include-archive --full returned malformed output for $id"
+    done
+    case "$source" in
+      active|archive) : ;;
+      *) fail "tasks-axi show <id> --include-archive --full returned malformed output for $id" ;;
+    esac
+    TASK_SHOW_DURABLE_OUTPUT=$output
+    return 0
+  fi
+  if [ "$(output_line_count "$output" 'code: NOT_FOUND')" = 1 ] \
+    && [ "$(output_line_count "$output" task:)" = 0 ]; then
+    return 1
+  fi
+  fail "tasks-axi show <id> --include-archive --full failed incompatibly for $id"
+}
+
 show_field() {  # <show-output> <field>
   local output=$1 field=$2
   printf '%s\n' "$output" | sed -n "s/^  $field: //p" | head -1
@@ -172,7 +225,8 @@ verify_hold_active() {  # <hold-id>
 
 verify_hold_resolved() {  # <hold-id>
   local id=$1 show state kind body
-  show=$(task_show "$id") || return 1
+  task_show_durable "$id" || return 1
+  show=$TASK_SHOW_DURABLE_OUTPUT
   state=$(show_field "$show" state)
   kind=$(show_field "$show" kind)
   body=$(show_field "$show" body)
@@ -186,7 +240,8 @@ verify_hold_resolved() {  # <hold-id>
 
 verify_hold_durable() {  # <hold-id>
   local id=$1 show state held kind hold_kind body
-  show=$(task_show "$id") || fail "captain decision $id is absent from $FM_HOME/data/backlog.md"
+  task_show_durable "$id" || fail "captain decision $id is absent from the active backlog and Done archive"
+  show=$TASK_SHOW_DURABLE_OUTPUT
   state=$(show_field "$show" state)
   held=$(show_field "$show" held)
   kind=$(show_field "$show" kind)
@@ -229,7 +284,7 @@ command_id() {
 }
 
 command_hold() {
-  local origin=${1:-} key=${2:-} title='' reason='' repo='' id show state kind existing_title body
+  local origin=${1:-} key=${2:-} title='' reason='' repo='' id show source state kind existing_title body
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   shift 2
   while [ "$#" -gt 0 ]; do
@@ -249,10 +304,13 @@ command_hold() {
   require_tasks_axi
   origin_exists_here "$origin" || fail "origin $origin is not owned by the active home $FM_HOME"
   id=$(hold_id "$origin" "$key")
-  if show=$(task_show "$id"); then
+  if task_show_durable "$id"; then
+    show=$TASK_SHOW_DURABLE_OUTPUT
+    source=$(show_field "$show" source)
     state=$(show_field "$show" state)
     kind=$(show_field "$show" kind)
     existing_title=$(show_field "$show" title)
+    [ "$source" != archive ] || fail "captain decision $id is archived and cannot be mutated; use a new decision key for a new decision"
     [ "$state" != "done" ] || fail "captain decision $id is already durably resolved; use a new decision key for a new decision"
     [ "$kind" = captain ] || fail "existing backlog identity $id is not kind captain"
     [ "$existing_title" = "$title" ] || fail "existing captain hold $id has a different title"
@@ -394,7 +452,7 @@ command_resolve() {
   require_tasks_axi
   id=$(hold_id "$origin" "$key")
   if verify_hold_resolved "$id"; then
-    hold_show=$(task_show "$id")
+    hold_show=$TASK_SHOW_DURABLE_OUTPUT
     hold_body=$(show_field "$hold_show" body)
     verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv"
     printf 'resolved: %s\n' "$id"

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -77,6 +77,7 @@ ok - active decision identity shadows archive history
 ok - genuine active-and-archive miss remains absent
 ok - missing tasks-axi archive capability is distinct from absence
 ok - malformed tasks-axi archive output is distinct from absence
+ok - duplicate title output refuses active hold mutation
 ok - code-only NOT_FOUND envelope refuses hold creation
 ok - wrong-status NOT_FOUND envelope refuses hold creation
 

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -6,17 +6,19 @@ This document records the deterministic mechanism, structured surfaces, and priv
 ## Mechanism
 
 `bin/fm-decision-hold.sh` is the only lifecycle command for an investigation or visual review's unresolved captain decisions.
-The command runs tasks-axi in the active `FM_HOME`, so the existing backlog remains the only durable work database and a secondmate-owned decision stays in the secondmate home.
+The command runs tasks-axi in the active `FM_HOME`, so its backlog and Done archive remain the only durable work database and a secondmate-owned decision stays in the secondmate home.
 It never reads report bodies, review artifacts, terminal output, or chat.
+Durable decision-identity checks select the active backlog record first and use the configured or default Done archive only as a read-only fallback.
+An active record therefore remains canonical when the same identity also exists in archive history, while a missing archive-aware capability or malformed result remains an integration failure rather than apparent absence.
 
 The `hold` subcommand maps an originating work id and stable decision key to `<origin-id>-decision-<decision-key>`.
-It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold <id> --reason <reason> --kind captain` on every retry.
-It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
+It creates a kind `captain` backlog item only when the identity is absent from both active and archived history, and invokes `tasks-axi hold <id> --reason <reason> --kind captain` on each permitted active retry.
+It rejects an identity collision, a changed title, attempts to reopen an already resolved identity, and every mutation of an archived identity.
 
 The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
 A post-teardown visual review can complete against the surviving report and durable holds without recreating volatile task metadata.
 It accepts `--none` as an explicit semantic inventory result, not as inferred absence.
-It verifies every listed identity against tasks-axi before recording completion.
+It verifies every listed identity through the active-first durable lookup before recording completion.
 For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` transfer event only after the matching backlog hold is durable.
 `bin/fm-classify-lib.sh` recognizes that transfer as closing the live status copy without claiming that the captain has answered it.
 
@@ -25,7 +27,7 @@ The `--force` path remains the explicit captain-approved discard escape hatch.
 
 The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
 It records the decision digest and routed task identities as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
-An exact retry can finish a partial routing operation, while a changed decision or routed-task set is rejected.
+An exact retry can finish a partial active routing operation or confirm a matching archived resolution without mutation, while a changed decision or routed-task set is rejected.
 A failed intermediate step leaves the hold open.
 
 ## Structured read surfaces
@@ -43,11 +45,13 @@ The projection remains read-only and does not inspect historical prose.
 Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Archive-aware durable identity lookup verification date: 2026-07-23.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
 The initial Bearings snapshot correctly has no open decision, and the new teardown gate refuses to erase the source.
 A later regression covers tasks-axi's quoted multi-entry `blocked_by` output so `resolve` matches the first, middle, and last ids and rejects a genuinely absent id.
+The archive regression uses synthetic records to cover active-first selection, configured and default archive fallback, archived retry and mutation boundaries, true misses, incompatible tool behavior, and a privacy-safe probe of the active local tasks-axi pin.
 
 The final verification commands and their exact summarized outputs follow.
 
@@ -62,6 +66,19 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
+
+$ bash tests/fm-decision-hold-archive.test.sh
+ok - active local tasks-axi pin exposes the privacy-safe archive lookup contract
+ok - real-binary helpers isolate HOME and tasks-axi overrides
+ok - active durable decision wins before archive fallback
+ok - default archive fallback supports read-only retries and refuses archived mutation
+ok - durable lookup follows the configured archive path
+ok - active decision identity shadows archive history
+ok - genuine active-and-archive miss remains absent
+ok - missing tasks-axi archive capability is distinct from absence
+ok - malformed tasks-axi archive output is distinct from absence
+ok - code-only NOT_FOUND envelope refuses hold creation
+ok - wrong-status NOT_FOUND envelope refuses hold creation
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/tests/fm-decision-hold-archive.test.sh
+++ b/tests/fm-decision-hold-archive.test.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Focused integration tests for archive-aware durable captain-decision lookup.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-decision-hold-archive)
+TASKS_AXI_BIN=$(command -v tasks-axi || true)
+
+[ -n "$TASKS_AXI_BIN" ] || { echo "skip: tasks-axi not found"; exit 0; }
+
+make_home() {  # <name> [archive-path|default]
+  local archive=${2:-data/done-archive.md} home="$TMP_ROOT/$1" fakebin
+  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
+  if [ "$archive" = default ]; then
+    cat > "$home/.tasks.toml" <<'EOF'
+backend = "markdown"
+
+[markdown]
+path = "data/backlog.md"
+done_keep = 10
+EOF
+  else
+    mkdir -p "$home/$(dirname "$archive")"
+    cat > "$home/.tasks.toml" <<EOF
+backend = "markdown"
+
+[markdown]
+path = "data/backlog.md"
+archive = "$archive"
+done_keep = 10
+EOF
+  fi
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+
+## Queued
+
+## Done
+EOF
+  fakebin=$(fm_fakebin "$home")
+  fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
+  printf '%s\n' "$home"
+}
+
+tasks_in() {  # <home> <tasks-axi args...>
+  local home=$1
+  shift
+  (cd "$home" && "$TASKS_AXI_BIN" "$@")
+}
+
+run_decisions() {  # <home> <command args...>
+  local home=$1
+  shift
+  PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" \
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" "$ROOT/bin/fm-decision-hold.sh" "$@"
+}
+
+write_origin_meta() {  # <home> <origin> <keys>
+  local home=$1 origin=$2 keys=$3
+  fm_write_meta "$home/state/$origin.meta" \
+    "window=fixture" \
+    "worktree=$home/projects/sample" \
+    "project=$home/projects/sample" \
+    "harness=pi" \
+    "kind=scout" \
+    "mode=scout" \
+    "decisions_reviewed=1" \
+    "decision_keys=$keys"
+}
+
+resolved_body() {  # [digest] [routes]
+  local digest=${1:-fixture-digest} routes=${2:-sample-route-work}
+  printf 'Resolution recorded by fm-decision-hold.\nDecision digest: %s\nRouted identities: %s\n\nCaptain decision:\nUse the synthetic route.\n\nRouted work:\n- %s' \
+    "$digest" "$routes" "$routes"
+}
+
+create_resolved() {  # <home> <id> [body]
+  local home=$1 id=$2 body=${3:-}
+  [ -n "$body" ] || body=$(resolved_body)
+  tasks_in "$home" add "$id" "Synthetic resolved decision" --kind captain --repo sample >/dev/null \
+    || fail "could not create resolved decision fixture"
+  tasks_in "$home" update "$id" --body "$body" >/dev/null \
+    || fail "could not write resolved decision fixture"
+  tasks_in "$home" "done" "$id" --no-prune >/dev/null \
+    || fail "could not close resolved decision fixture"
+}
+
+archive_all_done() {  # <home>
+  tasks_in "$1" prune --keep 0 >/dev/null || fail "could not archive resolved decision fixture"
+}
+
+file_digest() {  # <path>
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+test_live_pin_exposes_archive_contract() {
+  local help home active archive ordinary_rc=0
+  help=$("$TASKS_AXI_BIN" show --help 2>&1) || fail "installed tasks-axi show help failed"
+  assert_contains "$help" "--include-archive" \
+    "installed tasks-axi does not expose the audited archive lookup flag"
+
+  home=$(make_home live-pin-contract default)
+  create_resolved "$home" active-decision
+  create_resolved "$home" archive-decision
+  archive_all_done "$home"
+  tasks_in "$home" add active-decision "Synthetic active shadow" --kind captain --repo sample >/dev/null
+  active=$(tasks_in "$home" show active-decision --include-archive --full) \
+    || fail "installed tasks-axi did not return the active shadow"
+  archive=$(tasks_in "$home" show archive-decision --include-archive --full) \
+    || fail "installed tasks-axi did not return the archived fixture"
+  assert_contains "$active" "source: active" "installed tasks-axi lost active-first provenance"
+  assert_contains "$archive" "source: archive" "installed tasks-axi lost archive provenance"
+  tasks_in "$home" show archive-decision --full > "$home/ordinary.out" 2>&1 || ordinary_rc=$?
+  expect_code 1 "$ordinary_rc" "ordinary show must remain active-only"
+  assert_grep "code: NOT_FOUND" "$home/ordinary.out" "ordinary archive miss lost NOT_FOUND"
+  pass "active local tasks-axi pin exposes the privacy-safe archive lookup contract"
+}
+
+test_active_hit_does_not_read_archive() {
+  local home origin id
+  home=$(make_home active-hit default)
+  origin=sample-active-review
+  id="$origin-decision-route"
+  write_origin_meta "$home" "$origin" route
+  create_resolved "$home" "$id"
+  mkdir "$home/data/done-archive.md"
+  run_decisions "$home" verify "$origin" >/dev/null \
+    || fail "active resolved decision did not verify without reading the archive"
+  pass "active durable decision wins before archive fallback"
+}
+
+test_default_archive_fallback_and_active_only_mutation() {
+  local home origin id decision digest before_active before_archive after_active after_archive output
+  home=$(make_home default-archive default)
+  origin=sample-default-review
+  id="$origin-decision-route"
+  write_origin_meta "$home" "$origin" route
+  printf 'Use the synthetic route.\n' > "$home/decision.txt"
+  decision=$(cat "$home/decision.txt")
+  digest=$(printf '%s' "$decision" | shasum -a 256 | awk '{print $1}')
+  create_resolved "$home" "$id" "$(resolved_body "$digest" sample-route-work)"
+  archive_all_done "$home"
+  tasks_in "$home" add sample-route-work "Synthetic routed work" --kind ship --repo sample >/dev/null
+  run_decisions "$home" hold "$origin" layout --title "Choose synthetic layout" \
+    --reason "captain layout pending" --repo sample >/dev/null \
+    || fail "could not create the later active decision fixture"
+  run_decisions "$home" complete "$origin" route layout >/dev/null \
+    || fail "completion did not accept archived history plus the later active decision"
+  run_decisions "$home" verify "$origin" >/dev/null \
+    || fail "default Done archive did not satisfy durable verification"
+  before_active=$(file_digest "$home/data/backlog.md")
+  before_archive=$(file_digest "$home/data/done-archive.md")
+  output=$(run_decisions "$home" resolve "$origin" route --decision-file "$home/decision.txt" \
+    --routed-to sample-route-work 2> "$home/retry.err") \
+    || fail "exact archived resolution retry was not idempotent: $(cat "$home/retry.err")"
+  assert_contains "$output" "resolved: $id" "archived resolution retry lost its identity"
+  after_active=$(file_digest "$home/data/backlog.md")
+  after_archive=$(file_digest "$home/data/done-archive.md")
+  [ "$before_active" = "$after_active" ] || fail "archived resolution retry mutated the active backlog"
+  [ "$before_archive" = "$after_archive" ] || fail "archived resolution retry mutated the Done archive"
+
+  if run_decisions "$home" hold "$origin" route --title "Synthetic resolved decision" \
+    --reason "captain route pending" --repo sample > "$home/hold.out" 2> "$home/hold.err"; then
+    fail "archived decision became eligible for hold mutation"
+  fi
+  assert_grep "is archived and cannot be mutated" "$home/hold.err" \
+    "archived hold retry did not report its active-only mutation boundary"
+  [ "$before_active" = "$(file_digest "$home/data/backlog.md")" ] \
+    || fail "archived hold retry created an active duplicate"
+  [ "$before_archive" = "$(file_digest "$home/data/done-archive.md")" ] \
+    || fail "archived hold retry rewrote the Done archive"
+  pass "default archive fallback supports read-only retries and refuses archived mutation"
+}
+
+test_configured_archive_path() {
+  local home origin id archive
+  home=$(make_home configured-archive history/captain-decisions.md)
+  origin=sample-configured-review
+  id="$origin-decision-route"
+  archive="$home/history/captain-decisions.md"
+  write_origin_meta "$home" "$origin" route
+  create_resolved "$home" "$id"
+  archive_all_done "$home"
+  assert_present "$archive" "tasks-axi did not use the configured archive path"
+  assert_absent "$home/data/done-archive.md" "configured archive unexpectedly fell back to the default path"
+  run_decisions "$home" verify "$origin" >/dev/null \
+    || fail "configured Done archive did not satisfy durable verification"
+  pass "durable lookup follows the configured archive path"
+}
+
+test_active_shadow_blocks_archive_resolution() {
+  local home origin id
+  home=$(make_home active-shadow default)
+  origin=sample-shadow-review
+  id="$origin-decision-route"
+  write_origin_meta "$home" "$origin" route
+  create_resolved "$home" "$id"
+  archive_all_done "$home"
+  tasks_in "$home" add "$id" "Synthetic active shadow" --kind captain --repo sample >/dev/null
+  if run_decisions "$home" verify "$origin" > "$home/verify.out" 2> "$home/verify.err"; then
+    fail "valid archive history hid an invalid active shadow"
+  fi
+  assert_grep "neither actively held nor durably resolved" "$home/verify.err" \
+    "active shadow did not retain canonical first-match behavior"
+  pass "active decision identity shadows archive history"
+}
+
+test_true_miss_remains_absent() {
+  local home origin
+  home=$(make_home true-miss default)
+  origin=sample-missing-review
+  write_origin_meta "$home" "$origin" route
+  if run_decisions "$home" verify "$origin" > "$home/verify.out" 2> "$home/verify.err"; then
+    fail "genuinely absent decision passed durable verification"
+  fi
+  assert_grep "is absent from the active backlog and Done archive" "$home/verify.err" \
+    "true inclusive miss did not retain an absence result"
+  assert_no_grep "malformed output" "$home/verify.err" "true miss was misclassified as malformed output"
+  pass "genuine active-and-archive miss remains absent"
+}
+
+test_missing_capability_is_not_reported_as_absence() {
+  local home origin id
+  home=$(make_home missing-capability default)
+  origin=sample-old-tool-review
+  id="$origin-decision-route"
+  write_origin_meta "$home" "$origin" route
+  create_resolved "$home" "$id"
+  cat > "$home/fakebin/tasks-axi" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = show ] && [ "${2:-}" = --help ]; then
+  printf 'usage: tasks-axi show <id> [--full]\n'
+  exit 0
+fi
+exec "$REAL_TASKS_AXI" "$@"
+EOF
+  chmod +x "$home/fakebin/tasks-axi"
+  if run_decisions "$home" verify "$origin" > "$home/verify.out" 2> "$home/verify.err"; then
+    fail "decision verification accepted tasks-axi without archive lookup"
+  fi
+  assert_grep "tasks-axi show <id> --include-archive --full is required" "$home/verify.err" \
+    "missing archive capability did not report the concrete tool requirement"
+  assert_no_grep "is absent from" "$home/verify.err" \
+    "missing archive capability was falsely reported as decision absence"
+  pass "missing tasks-axi archive capability is distinct from absence"
+}
+
+test_malformed_tool_output_is_not_reported_as_absence() {
+  local home origin id
+  home=$(make_home malformed-output default)
+  origin=sample-malformed-tool-review
+  id="$origin-decision-route"
+  write_origin_meta "$home" "$origin" route
+  create_resolved "$home" "$id"
+  cat > "$home/fakebin/tasks-axi" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = show ] && [ "\${2:-}" = "$id" ] && [ "\${3:-}" = --include-archive ]; then
+  printf 'task:\n  id: %s\n  source: archive\n' "$id"
+  exit 0
+fi
+exec "\$REAL_TASKS_AXI" "\$@"
+EOF
+  chmod +x "$home/fakebin/tasks-axi"
+  if run_decisions "$home" verify "$origin" > "$home/verify.out" 2> "$home/verify.err"; then
+    fail "malformed archive lookup output passed durable verification"
+  fi
+  assert_grep "returned malformed output for $id" "$home/verify.err" \
+    "malformed archive lookup did not report its concrete incompatibility"
+  assert_no_grep "is absent from" "$home/verify.err" \
+    "malformed archive lookup was falsely reported as decision absence"
+  pass "malformed tasks-axi archive output is distinct from absence"
+}
+
+test_live_pin_exposes_archive_contract
+test_active_hit_does_not_read_archive
+test_default_archive_fallback_and_active_only_mutation
+test_configured_archive_path
+test_active_shadow_blocks_archive_resolution
+test_true_miss_remains_absent
+test_missing_capability_is_not_reported_as_absence
+test_malformed_tool_output_is_not_reported_as_absence

--- a/tests/fm-decision-hold-archive.test.sh
+++ b/tests/fm-decision-hold-archive.test.sh
@@ -11,6 +11,14 @@ TASKS_AXI_BIN=$(command -v tasks-axi || true)
 
 [ -n "$TASKS_AXI_BIN" ] || { echo "skip: tasks-axi not found"; exit 0; }
 
+tasks_axi_has_archive_lookup() {
+  local help probe_home="$TMP_ROOT/pin-probe-home"
+  mkdir -p "$probe_home"
+  help=$(env -u TASKS_AXI_FILE -u TASKS_AXI_BACKEND \
+    HOME="$probe_home" "$TASKS_AXI_BIN" show --help 2>&1) || return 1
+  printf '%s\n' "$help" | grep -F -- '--include-archive' >/dev/null
+}
+
 make_home() {  # <name> [archive-path|default]
   local archive=${2:-data/done-archive.md} home="$TMP_ROOT/$1" fakebin
   mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects" "$home/user-home"
@@ -49,21 +57,19 @@ tasks_in() {  # <home> <tasks-axi args...>
   local home=$1
   shift
   (
-    unset TASKS_AXI_FILE TASKS_AXI_BACKEND
     cd "$home" || exit 1
-    HOME="$home/user-home" "$TASKS_AXI_BIN" "$@"
+    env -u TASKS_AXI_FILE -u TASKS_AXI_BACKEND \
+      HOME="$home/user-home" "$TASKS_AXI_BIN" "$@"
   )
 }
 
 run_decisions() {  # <home> <command args...>
   local home=$1
   shift
-  (
-    unset TASKS_AXI_FILE TASKS_AXI_BACKEND
+  env -u TASKS_AXI_FILE -u TASKS_AXI_BACKEND \
     PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" HOME="$home/user-home" \
-      FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
-      FM_CONFIG_OVERRIDE="$home/config" "$ROOT/bin/fm-decision-hold.sh" "$@"
-  )
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" "$ROOT/bin/fm-decision-hold.sh" "$@"
 }
 
 write_origin_meta() {  # <home> <origin> <keys>
@@ -317,6 +323,10 @@ test_malformed_tool_output_is_not_reported_as_absence() {
   create_resolved "$home" "$id"
   cat > "$home/fakebin/tasks-axi" <<EOF
 #!/usr/bin/env bash
+if [ "\${1:-}" = show ] && [ "\${2:-}" = --help ]; then
+  printf 'usage: tasks-axi show <id> [--include-archive] [--full]\n'
+  exit 0
+fi
 if [ "\${1:-}" = show ] && [ "\${2:-}" = "$id" ] && [ "\${3:-}" = --include-archive ]; then
   printf 'task:\n  id: %s\n  source: archive\n' "$id"
   exit 0
@@ -344,11 +354,21 @@ test_duplicate_title_output_refuses_hold_mutation() {
     || fail "could not create active decision fixture"
   cat > "$home/fakebin/tasks-axi" <<EOF
 #!/usr/bin/env bash
+if [ "\${1:-}" = show ] && [ "\${2:-}" = --help ]; then
+  printf 'usage: tasks-axi show <id> [--include-archive] [--full]\n'
+  exit 0
+fi
 if [ "\${1:-}" = show ] && [ "\${2:-}" = "$id" ] && [ "\${3:-}" = --include-archive ] && [ "\${4:-}" = --full ]; then
-  "\$REAL_TASKS_AXI" "\$@"
-  status=\$?
-  [ "\$status" -eq 0 ] || exit "\$status"
+  printf 'task:\n'
+  printf '  id: %s\n' "$id"
+  printf '  source: active\n'
+  printf '  title: Choose synthetic route\n'
   printf '  title: Duplicate synthetic title\n'
+  printf '  state: queued\n'
+  printf '  held: no\n'
+  printf '  kind: captain\n'
+  printf '  hold_kind: "-"\n'
+  printf '  body: ""\n'
   exit 0
 fi
 if [ "\${1:-}" = hold ] && [ "\${2:-}" = "$id" ]; then
@@ -379,6 +399,10 @@ test_code_only_not_found_refuses_hold_creation() {
   write_origin_meta "$home" "$origin" route
   cat > "$home/fakebin/tasks-axi" <<'EOF'
 #!/usr/bin/env bash
+if [ "${1:-}" = show ] && [ "${2:-}" = --help ]; then
+  printf 'usage: tasks-axi show <id> [--include-archive] [--full]\n'
+  exit 0
+fi
 if [ "${1:-}" = show ] && [ "${3:-}" = --include-archive ] && [ "${4:-}" = --full ]; then
   printf 'code: NOT_FOUND\n'
   exit 1
@@ -406,6 +430,10 @@ test_wrong_status_not_found_refuses_hold_creation() {
   write_origin_meta "$home" "$origin" route
   cat > "$home/fakebin/tasks-axi" <<'EOF'
 #!/usr/bin/env bash
+if [ "${1:-}" = show ] && [ "${2:-}" = --help ]; then
+  printf 'usage: tasks-axi show <id> [--include-archive] [--full]\n'
+  exit 0
+fi
 if [ "${1:-}" = show ] && [ "${3:-}" = --include-archive ] && [ "${4:-}" = --full ]; then
   printf 'error: "Task \\"%s\\" not found in this backlog"\n' "${2:-}"
   printf 'code: NOT_FOUND\n'
@@ -427,13 +455,17 @@ EOF
   pass "wrong-status NOT_FOUND envelope refuses hold creation"
 }
 
-test_live_pin_exposes_archive_contract
-test_real_binary_helpers_ignore_ambient_configuration
-test_active_hit_does_not_read_archive
-test_default_archive_fallback_and_active_only_mutation
-test_configured_archive_path
-test_active_shadow_blocks_archive_resolution
-test_true_miss_remains_absent
+if tasks_axi_has_archive_lookup; then
+  test_live_pin_exposes_archive_contract
+  test_real_binary_helpers_ignore_ambient_configuration
+  test_active_hit_does_not_read_archive
+  test_default_archive_fallback_and_active_only_mutation
+  test_configured_archive_path
+  test_active_shadow_blocks_archive_resolution
+  test_true_miss_remains_absent
+else
+  printf 'ok - active local tasks-axi pin archive integration # SKIP capability unavailable\n'
+fi
 test_missing_capability_is_not_reported_as_absence
 test_malformed_tool_output_is_not_reported_as_absence
 test_duplicate_title_output_refuses_hold_mutation

--- a/tests/fm-decision-hold-archive.test.sh
+++ b/tests/fm-decision-hold-archive.test.sh
@@ -334,6 +334,43 @@ EOF
   pass "malformed tasks-axi archive output is distinct from absence"
 }
 
+test_duplicate_title_output_refuses_hold_mutation() {
+  local home origin id before
+  home=$(make_home duplicate-title default)
+  origin=sample-duplicate-title-review
+  id="$origin-decision-route"
+  write_origin_meta "$home" "$origin" route
+  tasks_in "$home" add "$id" "Choose synthetic route" --kind captain --repo sample >/dev/null \
+    || fail "could not create active decision fixture"
+  cat > "$home/fakebin/tasks-axi" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = show ] && [ "\${2:-}" = "$id" ] && [ "\${3:-}" = --include-archive ] && [ "\${4:-}" = --full ]; then
+  "\$REAL_TASKS_AXI" "\$@"
+  status=\$?
+  [ "\$status" -eq 0 ] || exit "\$status"
+  printf '  title: Duplicate synthetic title\n'
+  exit 0
+fi
+if [ "\${1:-}" = hold ] && [ "\${2:-}" = "$id" ]; then
+  printf '%s\n' "\$*" >> "$home/hold-invocations"
+fi
+exec "\$REAL_TASKS_AXI" "\$@"
+EOF
+  chmod +x "$home/fakebin/tasks-axi"
+  before=$(file_digest "$home/data/backlog.md")
+  if run_decisions "$home" hold "$origin" route --title "Choose synthetic route" \
+    --reason "captain route pending" --repo sample > "$home/hold.out" 2> "$home/hold.err"; then
+    fail "duplicate title output allowed hold mutation"
+  fi
+  assert_grep "returned malformed output for $id" "$home/hold.err" \
+    "duplicate title output did not report malformed archive lookup"
+  assert_absent "$home/hold-invocations" \
+    "duplicate title output reached the active hold mutation"
+  [ "$before" = "$(file_digest "$home/data/backlog.md")" ] \
+    || fail "duplicate title output changed the active backlog"
+  pass "duplicate title output refuses active hold mutation"
+}
+
 test_code_only_not_found_refuses_hold_creation() {
   local home origin id before
   home=$(make_home code-only-not-found default)
@@ -399,5 +436,6 @@ test_active_shadow_blocks_archive_resolution
 test_true_miss_remains_absent
 test_missing_capability_is_not_reported_as_absence
 test_malformed_tool_output_is_not_reported_as_absence
+test_duplicate_title_output_refuses_hold_mutation
 test_code_only_not_found_refuses_hold_creation
 test_wrong_status_not_found_refuses_hold_creation

--- a/tests/fm-decision-hold-archive.test.sh
+++ b/tests/fm-decision-hold-archive.test.sh
@@ -13,7 +13,7 @@ TASKS_AXI_BIN=$(command -v tasks-axi || true)
 
 make_home() {  # <name> [archive-path|default]
   local archive=${2:-data/done-archive.md} home="$TMP_ROOT/$1" fakebin
-  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects" "$home/user-home"
   if [ "$archive" = default ]; then
     cat > "$home/.tasks.toml" <<'EOF'
 backend = "markdown"
@@ -48,15 +48,22 @@ EOF
 tasks_in() {  # <home> <tasks-axi args...>
   local home=$1
   shift
-  (cd "$home" && "$TASKS_AXI_BIN" "$@")
+  (
+    unset TASKS_AXI_FILE TASKS_AXI_BACKEND
+    cd "$home" || exit 1
+    HOME="$home/user-home" "$TASKS_AXI_BIN" "$@"
+  )
 }
 
 run_decisions() {  # <home> <command args...>
   local home=$1
   shift
-  PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" \
-    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
-    FM_CONFIG_OVERRIDE="$home/config" "$ROOT/bin/fm-decision-hold.sh" "$@"
+  (
+    unset TASKS_AXI_FILE TASKS_AXI_BACKEND
+    PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" HOME="$home/user-home" \
+      FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+      FM_CONFIG_OVERRIDE="$home/config" "$ROOT/bin/fm-decision-hold.sh" "$@"
+  )
 }
 
 write_origin_meta() {  # <home> <origin> <keys>
@@ -118,6 +125,58 @@ test_live_pin_exposes_archive_contract() {
   expect_code 1 "$ordinary_rc" "ordinary show must remain active-only"
   assert_grep "code: NOT_FOUND" "$home/ordinary.out" "ordinary archive miss lost NOT_FOUND"
   pass "active local tasks-axi pin exposes the privacy-safe archive lookup contract"
+}
+
+test_real_binary_helpers_ignore_ambient_configuration() {
+  local home ambient origin id env_before home_before
+  home=$(make_home ambient-config default)
+  ambient="$TMP_ROOT/operator-config"
+  origin=sample-ambient-review
+  id="$origin-decision-route"
+  mkdir -p "$ambient/user-home/.tasks-axi"
+  cat > "$ambient/user-home/.tasks-axi/config.toml" <<EOF
+backend = "markdown"
+
+[markdown]
+path = "$ambient/home-backlog.md"
+archive = "$ambient/home-archive.md"
+done_keep = 10
+EOF
+  cat > "$ambient/home-backlog.md" <<'EOF'
+## In flight
+
+## Queued
+
+## Done
+EOF
+  cp "$ambient/home-backlog.md" "$ambient/env-backlog.md"
+  env_before=$(file_digest "$ambient/env-backlog.md")
+  home_before=$(file_digest "$ambient/home-backlog.md")
+  write_origin_meta "$home" "$origin" route
+
+  HOME="$ambient/user-home" create_resolved "$home" "$id"
+  HOME="$ambient/user-home" archive_all_done "$home"
+  assert_present "$home/data/done-archive.md" "disposable HOME lost the default archive"
+  assert_absent "$ambient/home-archive.md" "ambient HOME redirected the Done archive"
+
+  HOME="$ambient/user-home" TASKS_AXI_FILE="$ambient/env-backlog.md" \
+    TASKS_AXI_BACKEND=unsupported tasks_in "$home" add ambient-direct \
+    "Synthetic direct fixture" --kind ship --repo sample >/dev/null \
+    || fail "tasks_in inherited ambient tasks-axi overrides"
+  HOME="$ambient/user-home" TASKS_AXI_FILE="$ambient/env-backlog.md" \
+    TASKS_AXI_BACKEND=unsupported run_decisions "$home" hold "$origin" layout \
+    --title "Choose ambient-safe layout" --reason "captain layout pending" \
+    --repo sample >/dev/null \
+    || fail "run_decisions inherited ambient tasks-axi overrides"
+
+  assert_grep "ambient-direct" "$home/data/backlog.md" "direct fixture missed its isolated backlog"
+  assert_grep "$origin-decision-layout" "$home/data/backlog.md" \
+    "decision fixture missed its isolated backlog"
+  [ "$env_before" = "$(file_digest "$ambient/env-backlog.md")" ] \
+    || fail "ambient TASKS_AXI_FILE backlog was mutated"
+  [ "$home_before" = "$(file_digest "$ambient/home-backlog.md")" ] \
+    || fail "ambient HOME backlog was mutated"
+  pass "real-binary helpers isolate HOME and tasks-axi overrides"
 }
 
 test_active_hit_does_not_read_archive() {
@@ -275,7 +334,64 @@ EOF
   pass "malformed tasks-axi archive output is distinct from absence"
 }
 
+test_code_only_not_found_refuses_hold_creation() {
+  local home origin id before
+  home=$(make_home code-only-not-found default)
+  origin=sample-code-only-review
+  id="$origin-decision-route"
+  write_origin_meta "$home" "$origin" route
+  cat > "$home/fakebin/tasks-axi" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = show ] && [ "${3:-}" = --include-archive ] && [ "${4:-}" = --full ]; then
+  printf 'code: NOT_FOUND\n'
+  exit 1
+fi
+exec "$REAL_TASKS_AXI" "$@"
+EOF
+  chmod +x "$home/fakebin/tasks-axi"
+  before=$(file_digest "$home/data/backlog.md")
+  if run_decisions "$home" hold "$origin" route --title "Choose synthetic route" \
+    --reason "captain route pending" --repo sample > "$home/hold.out" 2> "$home/hold.err"; then
+    fail "code-only NOT_FOUND envelope allowed hold creation"
+  fi
+  assert_grep "failed incompatibly for $id" "$home/hold.err" \
+    "code-only NOT_FOUND envelope lost its integration error"
+  [ "$before" = "$(file_digest "$home/data/backlog.md")" ] \
+    || fail "code-only NOT_FOUND envelope created an active duplicate"
+  pass "code-only NOT_FOUND envelope refuses hold creation"
+}
+
+test_wrong_status_not_found_refuses_hold_creation() {
+  local home origin id before
+  home=$(make_home wrong-status-not-found default)
+  origin=sample-wrong-status-review
+  id="$origin-decision-route"
+  write_origin_meta "$home" "$origin" route
+  cat > "$home/fakebin/tasks-axi" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = show ] && [ "${3:-}" = --include-archive ] && [ "${4:-}" = --full ]; then
+  printf 'error: "Task \\"%s\\" not found in this backlog"\n' "${2:-}"
+  printf 'code: NOT_FOUND\n'
+  printf 'help[1]: Run `tasks-axi list` to see existing tasks\n'
+  exit 2
+fi
+exec "$REAL_TASKS_AXI" "$@"
+EOF
+  chmod +x "$home/fakebin/tasks-axi"
+  before=$(file_digest "$home/data/backlog.md")
+  if run_decisions "$home" hold "$origin" route --title "Choose synthetic route" \
+    --reason "captain route pending" --repo sample > "$home/hold.out" 2> "$home/hold.err"; then
+    fail "wrong-status NOT_FOUND envelope allowed hold creation"
+  fi
+  assert_grep "failed incompatibly for $id" "$home/hold.err" \
+    "wrong-status NOT_FOUND envelope lost its integration error"
+  [ "$before" = "$(file_digest "$home/data/backlog.md")" ] \
+    || fail "wrong-status NOT_FOUND envelope created an active duplicate"
+  pass "wrong-status NOT_FOUND envelope refuses hold creation"
+}
+
 test_live_pin_exposes_archive_contract
+test_real_binary_helpers_ignore_ambient_configuration
 test_active_hit_does_not_read_archive
 test_default_archive_fallback_and_active_only_mutation
 test_configured_archive_path
@@ -283,3 +399,5 @@ test_active_shadow_blocks_archive_resolution
 test_true_miss_remains_absent
 test_missing_capability_is_not_reported_as_absence
 test_malformed_tool_output_is_not_reported_as_absence
+test_code_only_not_found_refuses_hold_creation
+test_wrong_status_not_found_refuses_hold_creation

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -15,9 +15,54 @@ TASKS_AXI_BIN=$(command -v tasks-axi || true)
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
 command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found"; exit 0; }
 
+# These pre-existing lifecycle cases use active records only. Keep their real
+# tasks-axi mutations while supplying the new durable-read envelope explicitly,
+# so an older ambient release cannot mask unrelated lifecycle coverage.
+write_active_archive_lookup_shim() {  # <fakebin>
+  local fakebin=$1
+  cat > "$fakebin/tasks-axi" <<'EOF'
+#!/usr/bin/env bash
+set -u
+
+if [ "${1:-}" = show ] && [ "${2:-}" = --help ]; then
+  output=$("$REAL_TASKS_AXI" "$@" 2>&1)
+  status=$?
+  printf '%s\n' "$output"
+  [ "$status" -eq 0 ] || exit "$status"
+  printf '%s\n' "$output" | grep -F -- '--include-archive' >/dev/null \
+    || printf '  --include-archive\n'
+  exit 0
+fi
+
+if [ "${1:-}" = show ] && [ "${3:-}" = --include-archive ] && [ "${4:-}" = --full ]; then
+  output=$("$REAL_TASKS_AXI" show "${2:-}" --full 2>&1)
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    printf '%s\n' "$output"
+    exit "$status"
+  fi
+  printf '%s\n' "$output" | awk '
+    { print }
+    /^  id: / { print "  source: active" }
+  '
+  exit 0
+fi
+
+if [ "${1:-}" = unblock ] && [ "${2:-}" = sample-route-implementation ] \
+  && [ -f "$FM_HOME/enable-unblock-failure" ] \
+  && [ ! -f "$FM_HOME/unblock-failed-once" ]; then
+  : > "$FM_HOME/unblock-failed-once"
+  exit 1
+fi
+
+exec "$REAL_TASKS_AXI" "$@"
+EOF
+  chmod +x "$fakebin/tasks-axi"
+}
+
 make_home() {  # <name>
   local home="$TMP_ROOT/$1" fakebin
-  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects" "$home/user-home"
   cp "$ROOT/.tasks.toml" "$home/.tasks.toml"
   cat > "$home/data/backlog.md" <<'EOF'
 ## In flight
@@ -28,20 +73,23 @@ make_home() {  # <name>
 EOF
   fakebin=$(fm_fakebin "$home")
   fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
+  write_active_archive_lookup_shim "$fakebin"
   printf '%s\n' "$home"
 }
 
 run_bearings() {  # <home>
   local home=$1
-  PATH="$home/fakebin:$PATH" FM_HOME="$home" FM_BEARINGS_NOW=2026-07-14T12:00:00Z \
-    "$BEARINGS" --json
+  env -u TASKS_AXI_FILE -u TASKS_AXI_BACKEND \
+    PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" HOME="$home/user-home" \
+    FM_HOME="$home" FM_BEARINGS_NOW=2026-07-14T12:00:00Z "$BEARINGS" --json
 }
 
 run_teardown() {  # <home> <id>
   local home=$1 id=$2
-  PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
-    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
-    FM_CONFIG_OVERRIDE="$home/config" "$TEARDOWN" "$id"
+  env -u TASKS_AXI_FILE -u TASKS_AXI_BACKEND \
+    PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" HOME="$home/user-home" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_DATA_OVERRIDE="$home/data" FM_CONFIG_OVERRIDE="$home/config" "$TEARDOWN" "$id"
 }
 
 # Reproduces the loss exactly with privacy-safe synthetic names: the investigation
@@ -96,13 +144,18 @@ EOF
 tasks_in() {  # <home> <tasks-axi args...>
   local home=$1
   shift
-  (cd "$home" && tasks-axi "$@")
+  (
+    cd "$home" || exit 1
+    env -u TASKS_AXI_FILE -u TASKS_AXI_BACKEND \
+      HOME="$home/user-home" "$TASKS_AXI_BIN" "$@"
+  )
 }
 
 run_decisions() {  # <home> <command args...>
   local home=$1
   shift
-  PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" \
+  env -u TASKS_AXI_FILE -u TASKS_AXI_BACKEND \
+    PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" HOME="$home/user-home" \
     FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_CONFIG_OVERRIDE="$home/config" "$ROOT/bin/fm-decision-hold.sh" "$@"
 }
@@ -212,16 +265,7 @@ EOF
   tasks_in "$home" add sample-route-followup "Check the selected sample route" \
     --kind ship --repo sample --blocked-by "$route_hold" >/dev/null \
     || fail "could not create second dependent work fixture"
-  cat > "$home/fakebin/tasks-axi" <<'EOF'
-#!/usr/bin/env bash
-if [ "${1:-}" = unblock ] && [ "${2:-}" = sample-route-implementation ] \
-  && [ ! -f "$FM_HOME/unblock-failed-once" ]; then
-  : > "$FM_HOME/unblock-failed-once"
-  exit 1
-fi
-exec "$REAL_TASKS_AXI" "$@"
-EOF
-  chmod +x "$home/fakebin/tasks-axi"
+  : > "$home/enable-unblock-failure"
   if run_decisions "$home" resolve "$id" route --decision-file "$home/route-decision.txt" \
     --routed-to sample-route-implementation --routed-to sample-route-followup \
     > "$home/partial-route.out" 2> "$home/partial-route.err"; then
@@ -414,7 +458,7 @@ test_secondmate_hold_stays_in_authoritative_home() {
   local parent mate origin hold json
   parent=$(make_home main-routing)
   mate="$TMP_ROOT/sample-mate-home"
-  mkdir -p "$mate/data" "$mate/state" "$mate/config" "$mate/projects" "$mate/bin"
+  mkdir -p "$mate/data" "$mate/state" "$mate/config" "$mate/projects" "$mate/bin" "$mate/user-home"
   cp "$ROOT/.tasks.toml" "$mate/.tasks.toml"
   printf '# Synthetic secondmate home\n' > "$mate/AGENTS.md"
   printf 'sample-mate\n' > "$mate/.fm-secondmate-home"
@@ -427,6 +471,7 @@ test_secondmate_hold_stays_in_authoritative_home() {
 EOF
   fakebin=$(fm_fakebin "$mate")
   fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
+  write_active_archive_lookup_shim "$fakebin"
   origin=sample-mate-review
   mkdir -p "$mate/data/$origin"
   tasks_in "$mate" add "$origin" "Investigate secondmate sample" --kind scout --repo sample --start >/dev/null


### PR DESCRIPTION
## Intent

Implement the minimal Firstmate-side integration for archive-aware resolved captain-decision lookup using the audited tasks-axi PR 21 pin. Durable decision identity reads must use explicit read-only tasks-axi show <id> --include-archive --full with active-first canonical first-match behavior, while every mutation remains active-only. True absence must require the exact canonical NOT_FOUND envelope and stay distinct from missing or malformed archive-aware tool capability. Preserve active decisions, malformed records, duplicate semantics, privacy-safe output, other backends, and unrelated lifecycle behavior. Add Bash 3.2-compatible focused coverage for active hits, archive fallback, active shadowing, true misses, configured and default archive paths, capability absence, malformed output, archived mutation refusal, and a privacy-safe integration probe of the active local pin. Isolate all real-binary tests from ambient tasks-axi configuration. Keep exact mechanics in the script help/header and tests without changing tasks-axi, pin records, AGENTS.md, or policy unless semantics genuinely require it.

## What Changed

- Make durable captain-decision identity reads archive-aware with active-first lookup, strict output validation, and exact canonical `NOT_FOUND` handling.
- Keep mutations active-only by rejecting archived hold changes while allowing resolved decisions to be verified and retried without archive mutation.
- Add Bash 3.2-compatible regression coverage and documentation for archive fallback, shadowing, true misses, malformed capability output, duplicate fields, and the privacy-safe local integration probe.

## Risk Assessment

✅ Low: Captain, the narrow validator fix correctly prevents malformed duplicate-title output from reaching mutation; only its recorded verification output is stale.

## Testing

After inspecting the base-to-target delta and confirming Bash 3.2.57/tasks-axi 0.2.3, all focused, lifecycle, cleanup, projection, and brief suites passed; lifecycle and cleanup were rerun to definitive completion after an initial parallel yield, while a synthetic real-CLI transcript demonstrated archive fallback, active shadowing, exact miss handling, mutation refusal, and unchanged persisted files.

<details>
<summary>Evidence: Archive-aware lookup end-to-end CLI transcript</summary>

```text
Archive-aware captain-decision lookup: end-to-end CLI evidence
Synthetic identifiers and content only; ambient tasks-axi HOME/overrides are unset.
bash: GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
tasks-axi: 0.2.3

1) Archived record returned by the real active-first lookup:
task:
  id: demo-review-decision-route
  source: archive
  title: Synthetic resolved decision
  state: done
  blocked: no
  blocked_by: none
  held: no
  hold_reason: "-"
  hold_kind: "-"
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: "-"
  closed: 2026-07-23
  deps: none
  links: none
  body: "Resolution recorded by fm-decision-hold.\nDecision digest: synthetic-digest\nRouted identities: synthetic-route\n\nCaptain decision:\nUse the synthetic route.\n\nRouted work:\n- synthetic-route"

2) Firstmate durable verification succeeds from the default Done archive:
verified: demo-review unresolved-decision inventory

3) Attempting to mutate the archived identity is refused:
exit=1
fm-decision-hold: captain decision demo-review-decision-route is archived and cannot be mutated; use a new decision key for a new decision
active backlog unchanged: yes
Done archive unchanged: yes

4) A same-id active record becomes canonical and shadows archive history:
task:
  id: demo-review-decision-route
  source: active
  title: Synthetic active shadow
  state: queued
  blocked: no
  blocked_by: none
  held: no
  hold_reason: "-"
  hold_kind: "-"
  hold_until: "-"
  kind: captain
  repo: sample
  priority: "-"
  created: 2026-07-23
  closed: "-"
  deps: none
  links: none
  body: ""
verification exit=1
fm-decision-hold: captain decision demo-review-decision-route is neither actively held nor durably resolved

5) True absence preserves the exact canonical envelope:
exit=1
error: "Task \"absent-synthetic-decision\" not found in this backlog"
code: NOT_FOUND
help[1]: Run `tasks-axi list` to see existing tasks

RESULT: archive fallback, active-first shadowing, exact miss handling, and active-only mutation behavior all demonstrated.
```
</details>

## Dependency

- [tasks-axi PR 21](https://github.com/kunchenguid/tasks-axi/pull/21) at unchanged audited head `a2fff7a94f8bad1269e12c47b9866246d8376317` supplies `show --include-archive --full` plus active/archive provenance.
- Firstmate refuses durable lookup when that capability is absent or incompatible.
- The current local pin is temporary; an official release should replace it after parity verification.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `bin/fm-decision-hold.sh:149` - Intent requires malformed archive-aware capability to remain distinct from absence. The new exact-one-field check omits `title`, although `command_hold` later consumes it. A malformed successful response containing duplicate `title:` rows can therefore pass validation and trigger `tasks-axi hold`; add `title` to the validated fields and cover this case before merging.

🔧 Fix: Reject duplicate titles before captain hold mutation
1 info still open:
- ℹ️ `docs/decision-hold-lifecycle.md:79` - This block claims to contain the test&#39;s exact summarized output, but the newly added regression prints `ok - duplicate title output refuses active hold mutation` and that line is missing here. Add it after the malformed-output case so the verification record remains accurate.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-status 6db3b09b34dc23787969416bc4dde37adb02ac94 5e941fdbe9c3695ae4b2d984c41e0a94fabc5ccc` plus implementation/test/help inspection</code>
- <code>`bash --version` → GNU Bash 3.2.57; `tasks-axi --version` → 0.2.3</code>
- `bash tests/fm-decision-hold-archive.test.sh`
- `bash tests/fm-decision-hold-lifecycle.test.sh`
- `bash tests/fm-teardown.test.sh`
- `bash tests/fm-fleet-snapshot-view.test.sh`
- `bash tests/fm-bearings-snapshot.test.sh`
- `bash tests/fm-brief.test.sh`
- <code>Isolated synthetic CLI probe using real `tasks-axi`: archived lookup and verification, archived mutation refusal with before/after SHA-256 checks, active-first shadowing, and exact canonical `NOT_FOUND` output</code>
- <code>`bash bin/fm-decision-hold.sh --help` contract checks</code>
- `git status --short --branch`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
