### PR TITLE
feat(bin): add direct-PR Codex review gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,7 @@ If fast-path risk needs more rigor, escalate whether to use no-mistakes instead 
 The path's worker, automated gates, and captain approval remain authoritative:
 
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
-- **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
+- **direct-PR** has the worker run a single pre-push codex review as the path's own built-in rigor (owned by the delivery contract in bin/fm-brief.sh, not an added independent reviewer or manual gate), then push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
 
 Delivery mode and `yolo` are orthogonal.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -289,7 +289,8 @@ The task is complete only when committed on your branch.
 
 When it is implemented and committed, run the pre-push review gate on your own diff before you push:
 \`\`\`bash
-BASE=\$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD || echo origin/main)
+git remote set-head origin --auto >/dev/null
+BASE=\$(git symbolic-ref --short refs/remotes/origin/HEAD)
 git fetch origin "\${BASE#origin/}"
 codex review -c model_reasoning_effort="xhigh" \\
   "Review this branch against \$BASE. Intent: <what this task set out to accomplish>. Acceptance criteria: <the acceptance criteria from the task above>"
@@ -297,7 +298,11 @@ codex review -c model_reasoning_effort="xhigh" \\
 Name the base inside the prompt rather than with \`--base\`, which codex refuses to combine with a prompt, and fetch first because a pooled clone keeps a stale local default branch.
 The prompt is what buys the spec review axis on top of the coding-standards one, so fill it from the Task section.
 Fix every P0 and P1 finding it reports, commit the fixes, and rerun the same review until it comes back clean; note any P2 or P3 you are leaving in the PR body.
-If the codex account is out of credits or its weekly window is exhausted, do not skip the gate: run the review on \`opencode run --model "opencode/grok-4.5"\` instead, driving it with the \`code-review\` skill or a plain review-this-diff prompt, because opencode has no \`review\` subcommand.
+If the codex account is out of credits or its weekly window is exhausted, do not skip the gate: opencode has no \`review\` subcommand, so drive the same review through a prompt instead.
+\`\`\`bash
+opencode run --model "opencode/grok-4.5" \\
+  "Use the code-review skill on this branch against \$BASE. Intent: <the same intent>. Acceptance criteria: <the same criteria>. Report findings by severity, P0 to P3."
+\`\`\`
 That model string takes a dot - \`opencode/grok-4.5\`, never \`grok-4-5\`, which fails with an opaque server error.
 
 With the gate findings addressed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -289,10 +289,10 @@ The task is complete only when committed on your branch.
 
 When it is implemented and committed, run the pre-push review gate on your own diff before you push:
 \`\`\`bash
-BASE=main   # the default branch of this project
-git fetch origin "\$BASE"
+BASE=\$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD || echo origin/main)
+git fetch origin "\${BASE#origin/}"
 codex review -c model_reasoning_effort="xhigh" \\
-  "Review this branch against origin/\$BASE. Intent: <what this task set out to accomplish>. Acceptance criteria: <the acceptance criteria from the task above>"
+  "Review this branch against \$BASE. Intent: <what this task set out to accomplish>. Acceptance criteria: <the acceptance criteria from the task above>"
 \`\`\`
 Name the base inside the prompt rather than with \`--base\`, which codex refuses to combine with a prompt, and fetch first because a pooled clone keeps a stale local default branch.
 The prompt is what buys the spec review axis on top of the coding-standards one, so fill it from the Task section.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -30,7 +30,8 @@
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):
 #   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge (default)
-#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
+#   direct-PR    implement -> codex review gate -> push + open PR via gh-axi
+#                (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
@@ -285,7 +286,18 @@ case "$MODE" in
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+
+When it is implemented and committed, run the pre-push review gate on your own diff before you push:
+\`\`\`bash
+codex review --base <default-branch> -c model_reasoning_effort="xhigh" \\
+  "Intent: <what this task set out to accomplish>. Acceptance criteria: <the acceptance criteria from the task above>"
+\`\`\`
+Replace \`<default-branch>\` with the default branch of this project, and fill the prompt from the Task section so the review covers the spec as well as the coding standards.
+Fix every P0 and P1 finding it reports, and note any P2 or P3 you are leaving in the PR body.
+If the codex account is out of credits or its weekly window is exhausted, do not skip the gate: run the review on \`opencode run --model "opencode/grok-4.5"\` instead, driving it with the \`code-review\` skill or a plain review-this-diff prompt, because opencode has no \`review\` subcommand.
+That model string takes a dot - \`opencode/grok-4.5\`, never \`grok-4-5\`, which fails with an opaque server error.
+
+With the gate findings addressed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
 )

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -289,9 +289,9 @@ The task is complete only when committed on your branch.
 
 When it is implemented and committed, run the pre-push review gate on your own diff before you push:
 \`\`\`bash
-git remote set-head origin --auto >/dev/null
-BASE=\$(git symbolic-ref --short refs/remotes/origin/HEAD)
-git fetch origin "\${BASE#origin/}"
+git remote set-head origin --auto >/dev/null &&
+BASE=\$(git symbolic-ref --short refs/remotes/origin/HEAD) &&
+git fetch origin "\${BASE#origin/}" &&
 codex review -c model_reasoning_effort="xhigh" \\
   "Review this branch against \$BASE. Intent: <what this task set out to accomplish>. Acceptance criteria: <the acceptance criteria from the task above>"
 \`\`\`
@@ -300,6 +300,7 @@ The prompt is what buys the spec review axis on top of the coding-standards one,
 Fix every P0 and P1 finding it reports, commit the fixes, and rerun the same review until it comes back clean; note any P2 or P3 you are leaving in the PR body.
 If the codex account is out of credits or its weekly window is exhausted, do not skip the gate: opencode has no \`review\` subcommand, so drive the same review through a prompt instead.
 \`\`\`bash
+BASE=\$(git symbolic-ref --short refs/remotes/origin/HEAD) &&
 opencode run --model "opencode/grok-4.5" \\
   "Use the code-review skill on this branch against \$BASE. Intent: <the same intent>. Acceptance criteria: <the same criteria>. Report findings by severity, P0 to P3."
 \`\`\`

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -289,9 +289,10 @@ The task is complete only when committed on your branch.
 
 When it is implemented and committed, run the pre-push review gate on your own diff before you push:
 \`\`\`bash
-git fetch origin <default-branch>
+BASE=main   # the default branch of this project
+git fetch origin "\$BASE"
 codex review -c model_reasoning_effort="xhigh" \\
-  "Review this branch against origin/<default-branch>. Intent: <what this task set out to accomplish>. Acceptance criteria: <the acceptance criteria from the task above>"
+  "Review this branch against origin/\$BASE. Intent: <what this task set out to accomplish>. Acceptance criteria: <the acceptance criteria from the task above>"
 \`\`\`
 Name the base inside the prompt rather than with \`--base\`, which codex refuses to combine with a prompt, and fetch first because a pooled clone keeps a stale local default branch.
 The prompt is what buys the spec review axis on top of the coding-standards one, so fill it from the Task section.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -300,7 +300,9 @@ The prompt is what buys the spec review axis on top of the coding-standards one,
 Fix every P0 and P1 finding it reports, commit the fixes, and rerun the same review until it comes back clean; note any P2 or P3 you are leaving in the PR body.
 If the codex account is out of credits or its weekly window is exhausted, do not skip the gate: opencode has no \`review\` subcommand, so drive the same review through a prompt instead.
 \`\`\`bash
+git remote set-head origin --auto >/dev/null &&
 BASE=\$(git symbolic-ref --short refs/remotes/origin/HEAD) &&
+git fetch origin "\${BASE#origin/}" &&
 opencode run --model "opencode/grok-4.5" \\
   "Use the code-review skill on this branch against \$BASE. Intent: <the same intent>. Acceptance criteria: <the same criteria>. Report findings by severity, P0 to P3."
 \`\`\`

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -303,7 +303,7 @@ If the codex account is out of credits or its weekly window is exhausted, do not
 git remote set-head origin --auto >/dev/null &&
 BASE=\$(git symbolic-ref --short refs/remotes/origin/HEAD) &&
 git fetch origin "\${BASE#origin/}" &&
-opencode run --model "opencode/grok-4.5" \\
+OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode run --model "opencode/grok-4.5" \\
   "Use the code-review skill on this branch against \$BASE. Intent: <the same intent>. Acceptance criteria: <the same criteria>. Report findings by severity, P0 to P3."
 \`\`\`
 That model string takes a dot - \`opencode/grok-4.5\`, never \`grok-4-5\`, which fails with an opaque server error.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -289,11 +289,13 @@ The task is complete only when committed on your branch.
 
 When it is implemented and committed, run the pre-push review gate on your own diff before you push:
 \`\`\`bash
-codex review --base <default-branch> -c model_reasoning_effort="xhigh" \\
-  "Intent: <what this task set out to accomplish>. Acceptance criteria: <the acceptance criteria from the task above>"
+git fetch origin <default-branch>
+codex review -c model_reasoning_effort="xhigh" \\
+  "Review this branch against origin/<default-branch>. Intent: <what this task set out to accomplish>. Acceptance criteria: <the acceptance criteria from the task above>"
 \`\`\`
-Replace \`<default-branch>\` with the default branch of this project, and fill the prompt from the Task section so the review covers the spec as well as the coding standards.
-Fix every P0 and P1 finding it reports, and note any P2 or P3 you are leaving in the PR body.
+Name the base inside the prompt rather than with \`--base\`, which codex refuses to combine with a prompt, and fetch first because a pooled clone keeps a stale local default branch.
+The prompt is what buys the spec review axis on top of the coding-standards one, so fill it from the Task section.
+Fix every P0 and P1 finding it reports, commit the fixes, and rerun the same review until it comes back clean; note any P2 or P3 you are leaving in the PR body.
 If the codex account is out of credits or its weekly window is exhausted, do not skip the gate: run the review on \`opencode run --model "opencode/grok-4.5"\` instead, driving it with the \`code-review\` skill or a plain review-this-diff prompt, because opencode has no \`review\` subcommand.
 That model string takes a dot - \`opencode/grok-4.5\`, never \`grok-4-5\`, which fails with an opaque server error.
 

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -10,7 +10,8 @@
 #
 # mode = how a finished change reaches main:
 #   no-mistakes  full pipeline -> PR -> captain merge (default)
-#   direct-PR    push + PR via gh-axi, no pipeline -> captain merge
+#   direct-PR    pre-push codex review -> push + PR via gh-axi, no pipeline
+#                -> captain merge
 #   local-only   local branch, no remote/PR -> captain approve -> guarded local merge
 # yolo (orthogonal) = when on, firstmate makes approval decisions itself (PR merges,
 #   ask-user findings, local-only merge approval) without checking the captain - except

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -179,7 +179,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 ## Project modes are explicit
 
 `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
-`no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
+`no-mistakes` projects run the full validation pipeline, `direct-PR` projects follow the pre-push review and PR contract in [`bin/fm-brief.sh`](../bin/fm-brief.sh) without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -128,8 +128,8 @@ test_direct_pr_review_gate() {
     "direct-PR brief lost the fix, commit, and re-review loop"
   # opencode has no review subcommand, so a promptless `opencode run` reviews
   # nothing; the fallback is only a gate if it carries the review instruction.
-  assert_grep 'opencode run --model "opencode/grok-4.5"' "$brief" \
-    "direct-PR brief lost the out-of-credits review fallback"
+  assert_grep "OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"allow\"}}' opencode run --model \"opencode/grok-4.5\"" "$brief" \
+    "direct-PR brief lost the unattended out-of-credits review fallback"
   assert_grep "Use the code-review skill on this branch against" "$brief" \
     "direct-PR brief left the fallback without a review prompt"
   # Both blocks chain on && so a failed base refresh stops before the review

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -132,6 +132,13 @@ test_direct_pr_review_gate() {
     "direct-PR brief lost the out-of-credits review fallback"
   assert_grep "Use the code-review skill on this branch against" "$brief" \
     "direct-PR brief left the fallback without a review prompt"
+  # Both blocks chain on && so a failed base refresh stops before the review
+  # runs against the wrong ref, and the fallback resolves its own BASE because
+  # it may run in a fresh shell.
+  assert_grep "git fetch origin \"\${BASE#origin/}\" &&" "$brief" \
+    "direct-PR gate stopped chaining the review onto a successful base refresh"
+  [ "$(grep -Fc 'BASE=$(git symbolic-ref --short refs/remotes/origin/HEAD)' "$brief")" = 2 ] \
+    || fail "direct-PR fallback stopped resolving its own review base"
   assert_grep "never \`grok-4-5\`" "$brief" \
     "direct-PR brief lost the warning against the dashed model string"
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -113,13 +113,15 @@ test_direct_pr_review_gate() {
   # crewmate cannot run.
   assert_no_grep "codex review --base" "$brief" \
     "direct-PR brief used the --base form that codex rejects alongside a prompt"
-  # A bare <default-branch> placeholder inside the shell block parses as a
-  # redirection and fails before codex runs, so the base must arrive as a
-  # substitutable variable the crewmate can execute as written.
-  assert_grep "BASE=main" "$brief" \
-    "direct-PR brief lost the runnable default-branch variable"
+  # The base must be runnable as written: a bare <default-branch> placeholder
+  # parses as a redirection, and a hardcoded branch name reviews the wrong ref
+  # on any project whose default branch is not main.
+  assert_grep "refs/remotes/origin/HEAD" "$brief" \
+    "direct-PR brief stopped resolving the default branch of the project"
   assert_no_grep "git fetch origin <" "$brief" \
     "direct-PR brief left a shell-invalid placeholder in the fetch command"
+  assert_no_grep "BASE=main" "$brief" \
+    "direct-PR brief hardcoded main as the review base"
   assert_grep "Fix every P0 and P1 finding it reports, commit the fixes, and rerun the same review" "$brief" \
     "direct-PR brief lost the fix, commit, and re-review loop"
   assert_grep "opencode/grok-4.5" "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -113,6 +113,13 @@ test_direct_pr_review_gate() {
   # crewmate cannot run.
   assert_no_grep "codex review --base" "$brief" \
     "direct-PR brief used the --base form that codex rejects alongside a prompt"
+  # A bare <default-branch> placeholder inside the shell block parses as a
+  # redirection and fails before codex runs, so the base must arrive as a
+  # substitutable variable the crewmate can execute as written.
+  assert_grep "BASE=main" "$brief" \
+    "direct-PR brief lost the runnable default-branch variable"
+  assert_no_grep "git fetch origin <" "$brief" \
+    "direct-PR brief left a shell-invalid placeholder in the fetch command"
   assert_grep "Fix every P0 and P1 finding it reports, commit the fixes, and rerun the same review" "$brief" \
     "direct-PR brief lost the fix, commit, and re-review loop"
   assert_grep "opencode/grok-4.5" "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -137,6 +137,7 @@ test_direct_pr_review_gate() {
   # it may run in a fresh shell.
   assert_grep "git fetch origin \"\${BASE#origin/}\" &&" "$brief" \
     "direct-PR gate stopped chaining the review onto a successful base refresh"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the brief carries this text literally
   [ "$(grep -Fc 'BASE=$(git symbolic-ref --short refs/remotes/origin/HEAD)' "$brief")" = 2 ] \
     || fail "direct-PR fallback stopped resolving its own review base"
   assert_grep "never \`grok-4-5\`" "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -106,10 +106,15 @@ test_direct_pr_review_gate() {
   id="brief-direct-gate-a5"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
-  assert_grep 'codex review --base <default-branch> -c model_reasoning_effort="xhigh"' "$brief" \
+  assert_grep 'codex review -c model_reasoning_effort="xhigh"' "$brief" \
     "direct-PR brief lost the pre-push review gate invocation"
-  assert_grep "Fix every P0 and P1 finding" "$brief" \
-    "direct-PR brief lost the finding-severity contract"
+  # codex 0.145.0 refuses --base together with a prompt, so the base belongs in
+  # the prompt text; a brief that reintroduces the flag generates a command the
+  # crewmate cannot run.
+  assert_no_grep "codex review --base" "$brief" \
+    "direct-PR brief used the --base form that codex rejects alongside a prompt"
+  assert_grep "Fix every P0 and P1 finding it reports, commit the fixes, and rerun the same review" "$brief" \
+    "direct-PR brief lost the fix, commit, and re-review loop"
   assert_grep "opencode/grok-4.5" "$brief" \
     "direct-PR brief lost the out-of-credits review fallback"
   assert_grep "never \`grok-4-5\`" "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -116,6 +116,8 @@ test_direct_pr_review_gate() {
   # The base must be runnable as written: a bare <default-branch> placeholder
   # parses as a redirection, and a hardcoded branch name reviews the wrong ref
   # on any project whose default branch is not main.
+  assert_grep "git remote set-head origin --auto" "$brief" \
+    "direct-PR brief stopped repairing a clone with no recorded remote HEAD"
   assert_grep "refs/remotes/origin/HEAD" "$brief" \
     "direct-PR brief stopped resolving the default branch of the project"
   assert_no_grep "git fetch origin <" "$brief" \
@@ -124,8 +126,12 @@ test_direct_pr_review_gate() {
     "direct-PR brief hardcoded main as the review base"
   assert_grep "Fix every P0 and P1 finding it reports, commit the fixes, and rerun the same review" "$brief" \
     "direct-PR brief lost the fix, commit, and re-review loop"
-  assert_grep "opencode/grok-4.5" "$brief" \
+  # opencode has no review subcommand, so a promptless `opencode run` reviews
+  # nothing; the fallback is only a gate if it carries the review instruction.
+  assert_grep 'opencode run --model "opencode/grok-4.5"' "$brief" \
     "direct-PR brief lost the out-of-credits review fallback"
+  assert_grep "Use the code-review skill on this branch against" "$brief" \
+    "direct-PR brief left the fallback without a review prompt"
   assert_grep "never \`grok-4-5\`" "$brief" \
     "direct-PR brief lost the warning against the dashed model string"
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -96,6 +96,34 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
+# The direct-PR path has no pipeline, so its only pre-push review is the codex
+# review gate. Pin the invocation, the credit fallback, and the fact that the
+# gate belongs to direct-PR alone.
+test_direct_pr_review_gate() {
+  local home id brief
+  home="$TMP_ROOT/review-gate-home"
+  write_registry "$home"
+  id="brief-direct-gate-a5"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep 'codex review --base <default-branch> -c model_reasoning_effort="xhigh"' "$brief" \
+    "direct-PR brief lost the pre-push review gate invocation"
+  assert_grep "Fix every P0 and P1 finding" "$brief" \
+    "direct-PR brief lost the finding-severity contract"
+  assert_grep "opencode/grok-4.5" "$brief" \
+    "direct-PR brief lost the out-of-credits review fallback"
+  assert_grep "never \`grok-4-5\`" "$brief" \
+    "direct-PR brief lost the warning against the dashed model string"
+
+  for id_proj in "brief-nomistakes-gate-a5:no-registry-proj" "brief-localonly-gate-a5:local-proj"; do
+    id=${id_proj%%:*}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "${id_proj##*:}" >/dev/null 2>&1
+    assert_no_grep "codex review" "$home/data/$id/brief.md" \
+      "$id: review gate leaked into a delivery mode that does not own it"
+  done
+  pass "fm-brief.sh: direct-PR briefs carry the codex review gate and its fallback"
+}
+
 # Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
 # reference must render as plain prose with no dangling apostrophe artifact.
 test_no_mistakes_dod_wording() {
@@ -345,6 +373,7 @@ test_script_parses
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
+test_direct_pr_review_gate
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete


### PR DESCRIPTION
## What Changed

- Add a direct-PR-only pre-push Codex review gate with refreshed `origin/HEAD` base resolution, P0/P1 fix-and-rerun requirements, and an unattended OpenCode fallback.
- Update delivery-mode policy and architecture guidance to make the review gate part of the direct-PR contract.
- Add regression coverage for gate rendering, base refresh, fallback prompts and permissions, and isolation from other delivery modes.

## Risk Assessment

✅ Low: Captain, the latest change is a narrow and consistent fix to the fallback invocation; previously accepted residuals are not re-reported.

## Testing

Focused tests and the repository test runner passed. End-to-end CLI generation confirmed the direct-PR brief contains the base-refreshing Codex gate and OpenCode fallback, while other modes do not. Evidence was captured; the worktree remains clean.

<details>
<summary>Evidence: Generated direct-PR brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of direct-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/direct-gate-e2e`

# Rules
1. Never push to the default branch (push only your `fm/direct-gate-e2e` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/xc/x5q7ql9j20jdx40999xg5bfw0000gn/T/no-mistakes-evidence/01KY6DMKR1GFWP99P5XYKKC6YN/direct-pr-e2e/state/direct-gate-e2e.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/juliusretzer/.no-mistakes/worktrees/26eb2811f2ab/01KY6DMKR1GFWP99P5XYKKC6YN/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/juliusretzer/.no-mistakes/worktrees/26eb2811f2ab/01KY6DMKR1GFWP99P5XYKKC6YN/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.

When it is implemented and committed, run the pre-push review gate on your own diff before you push:
`` `bash
git remote set-head origin --auto >/dev/null &&
BASE=$(git symbolic-ref --short refs/remotes/origin/HEAD) &&
git fetch origin "${BASE#origin/}" &&
codex review -c model_reasoning_effort="xhigh" \
  "Review this branch against $BASE. Intent: <what this task set out to accomplish>. Acceptance criteria: <the acceptance criteria from the task above>"
`` `
Name the base inside the prompt rather than with `--base`, which codex refuses to combine with a prompt, and fetch first because a pooled clone keeps a stale local default branch.
The prompt is what buys the spec review axis on top of the coding-standards one, so fill it from the Task section.
Fix every P0 and P1 finding it reports, commit the fixes, and rerun the same review until it comes back clean; note any P2 or P3 you are leaving in the PR body.
If the codex account is out of credits or its weekly window is exhausted, do not skip the gate: opencode has no `review` subcommand, so drive the same review through a prompt instead.
`` `bash
git remote set-head origin --auto >/dev/null &&
BASE=$(git symbolic-ref --short refs/remotes/origin/HEAD) &&
git fetch origin "${BASE#origin/}" &&
OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode run --model "opencode/grok-4.5" \
  "Use the code-review skill on this branch against $BASE. Intent: <the same intent>. Acceptance criteria: <the same criteria>. Report findings by severity, P0 to P3."
`` `
That model string takes a dot - `opencode/grok-4.5`, never `grok-4-5`, which fails with an opaque server error.

With the gate findings addressed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Delivery-mode isolation check</summary>

```text
direct-PR: review gate present; no-mistakes: review gate absent; local-only: review gate absent
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-brief.sh:295` - The gate runs only after the worker has committed, but `codex review` is invoked without `--base`, `--commit`, or `--uncommitted`; `$BASE` appears only as prompt text. This does not reliably select the committed branch diff, so the gate can review nothing. Use a supported explicit diff target while preserving the task prompt.
- 🚨 `bin/fm-brief.sh:303` - The opencode fallback resolves `origin/HEAD` but omits the primary path&#39;s `git remote set-head --auto` and base fetch. In a fresh pooled clone without `refs/remotes/origin/HEAD`, the advertised fallback exits before reviewing. Repeat the same base-refresh chain or share it through a helper.
- 🚨 `bin/fm-brief.sh:290` - The new direct-PR review gate conflicts with `AGENTS.md:256-259`, which forbids adding independent reviewers/manual gates to faster paths, and with the direct-PR lifecycle at `AGENTS.md:263`. Update the governing policy or clarify that this gate is an explicit exception.

🔧 Fix: Fixed direct-PR fallback refresh and policy contract
1 error still open:
- 🚨 `bin/fm-brief.sh:306` - The corrected fallback still launches headless OpenCode without the permission bypass used by the repository&#39;s unattended `opencode run` paths (`OPENCODE_CONFIG_CONTENT` or `--auto`). With `--auto` defaulting to false, the model can stop on a permission prompt or denial instead of completing the review; carry the established permission configuration into this fallback.

🔧 Fix: Add unattended OpenCode permissions to direct-PR fallback
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh`
- `bash -n bin/fm-brief.sh`
- `bash bin/fm-test-run.sh tests/fm-brief.test.sh`
- `Generated direct-PR, no-mistakes, and local-only briefs under the required evidence directory and verified review-gate isolation.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
