### PR TITLE
test(watcher): de-flake and leak-proof the watcher-lock suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,8 @@ Use `bin/fm-test-run.sh --list-lanes` for exact lane names and `--help` for `--j
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.
 The [Herdr backend guide](docs/herdr-backend.md#destructive-lab-safety) owns the lane's isolation boundary, while [runtime backend verification](docs/verification/runtime-backends.md#herdr) owns active empirical evidence; live harness credential tests remain opt-in.
+A test that starts a background process must register it with `fm_test_track_pid` so it is reaped on every exit path, including the abort that `fail` performs mid-case.
+A leaked child keeps the suite's inherited output pipe open, which hangs whatever is reading that pipe to EOF, and it keeps holding its temp home's watcher lock; `tests/lib.sh` owns the registry and reaping rules, including why nothing is ever reaped by process-name pattern.
 
 ## Questions
 

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -501,22 +501,24 @@ owned_child_finished() {
   fi
 
   if [ "$rc" -eq 0 ]; then
+    # Surface the child's own words the moment it closes, BEFORE spending the
+    # bounded successor-confirmation window on it. The child explains itself
+    # here ("already running pid N" when it stood down behind a peer), and
+    # whoever is reading this arm's output should not have to wait out that poll
+    # to learn why. The relative order of what this arm prints is unchanged: the
+    # child's output has always preceded the attached/FAILED line that follows.
+    print_watch_output "$child_out"
+    rm -f "$child_out" 2>/dev/null || true
+    child=
+    child_out=
     if wait_for_healthy_successor; then
       cycle_log_append "$rc" "$signal" unexpected-clean-exit "attached:$HEALTHY_PID"
-      print_watch_output "$child_out"
-      rm -f "$child_out" 2>/dev/null || true
-      child=
-      child_out=
       cycle_mark_predecessor_successor "attached:$HEALTHY_PID"
       report_attached
       cycle_begin "$HEALTHY_PID" attached "$HEALTHY_IDENTITY"
       attach_and_wait "$HEALTHY_PID"
       return $?
     fi
-    print_watch_output "$child_out"
-    rm -f "$child_out" 2>/dev/null || true
-    child=
-    child_out=
     if close_unobserved_cycle; then
       cycle_log_append "$rc" "$signal" clean-exit-delivered-wake none
       return 0

--- a/tests/fm-afk-pi-herdr-return-e2e.test.sh
+++ b/tests/fm-afk-pi-herdr-return-e2e.test.sh
@@ -57,6 +57,7 @@ cleanup() {
     rc=1
   fi
   rm -rf "$TMP_ROOT"
+  fm_test_cleanup
   exit "$rc"
 }
 trap cleanup EXIT

--- a/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
+++ b/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
@@ -51,6 +51,7 @@ cleanup() {
     rc=1
   fi
   rm -rf "$TMP_ROOT"
+  fm_test_cleanup
   exit "$rc"
 }
 trap cleanup EXIT

--- a/tests/fm-tmux-submit-busy.test.sh
+++ b/tests/fm-tmux-submit-busy.test.sh
@@ -10,7 +10,7 @@ set -u
 . "$ROOT/bin/fm-tmux-lib.sh"
 
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-tmux-submit-busy.XXXXXX")
-trap 'rm -rf "$TMP_ROOT"' EXIT
+trap 'rm -rf "$TMP_ROOT"; fm_test_cleanup' EXIT
 
 # Override fm_pane_is_busy for testing: FM_FAKE_PANE_BUSY=1 means busy.
 fm_pane_is_busy() {

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -15,6 +15,21 @@ LIB="$ROOT/bin/fm-wake-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-watcher-lock-tests)
 
+# Every case here starts real watchers and real arms, and fail() exits the file
+# on the spot. Without this, an aborted case left its arm and the watcher that
+# arm had forked running forever: reparented to init, still holding the temp
+# home's singleton lock, and - because they inherited the suite's stdout and
+# stderr - still holding that pipe open, which hangs any caller reading the
+# suite's output to EOF. Reap on EVERY exit path: registered pids first (that
+# lets each arm run its own TERM teardown), then any watcher grandchild still
+# identified by a temp home's lock, then the temp dirs.
+watcher_lock_cleanup() {
+  fm_test_reap_tracked_pids
+  fm_wake_reap_temp_watchers "$TMP_ROOT"
+  fm_test_cleanup
+}
+trap watcher_lock_cleanup EXIT
+
 mark_pr_check_migration_complete() {
   local state=$1
   printf '%s\n' fm-pr-check-migration-scan-v1 > "$state/.pr-check-migration-scan-v1"
@@ -44,8 +59,10 @@ test_singleton_start() {
   mark_pr_check_migration_complete "$state"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out1" &
   pid1=$!
+  fm_test_track_pid "$pid1"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out2" &
   pid2=$!
+  fm_test_track_pid "$pid2"
   i=0
   while [ "$i" -lt 50 ]; do
     live=0
@@ -82,6 +99,7 @@ test_stale_watch_lock_reclaimed() {
   printf '%s\n' "$dead_pid" > "$state/.watch.lock/pid"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
+  fm_test_track_pid "$pid"
   i=0
   live=0
   lock_pid=
@@ -210,6 +228,7 @@ test_lock_single_winner_under_concurrency() {
       fi
     ' _ "$LIB" "$lockdir" "$marker" &
     pids="$pids $!"
+    fm_test_track_pid "$!"
     i=$((i + 1))
   done
   for pid in $pids; do
@@ -260,6 +279,7 @@ test_lock_stale_steal_single_winner_under_concurrency() {
       fi
     ' _ "$LIB" "$lockdir" "$marker" &
     pids="$pids $!"
+    fm_test_track_pid "$!"
     i=$((i + 1))
   done
   for pid in $pids; do
@@ -287,6 +307,7 @@ test_lock_live_steal_mutex_is_not_reclaimed() {
     fm_lock_release "$2.steal"
   ' _ "$LIB" "$lockdir" "$holder_file" &
   holder=$!
+  fm_test_track_pid "$holder"
   i=0
   while [ "$i" -lt 50 ] && [ ! -s "$holder_file" ]; do
     sleep 0.1
@@ -317,6 +338,7 @@ test_lock_does_not_steal_live_lock() {
   lockdir="$state/.contend.lock"
   sleep 300 &
   live=$!
+  fm_test_track_pid "$live"
   mkdir "$lockdir"
   printf '%s\n' "$live" > "$lockdir/pid"
   out=$(FM_STATE_OVERRIDE="$state" bash -c '
@@ -429,6 +451,7 @@ test_watch_restart_rejects_reused_pid() {
   mark_pr_check_migration_complete "$state"
   sleep 300 &
   live=$!
+  fm_test_track_pid "$live"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$live" > "$state/.watch.lock/pid"
   printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
@@ -436,6 +459,12 @@ test_watch_restart_rejects_reused_pid() {
   printf '%s\n' "stale watcher identity" > "$state/.watch.lock/pid-identity"
   PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" --restart > "$out" &
   pid=$!
+  fm_test_track_pid "$pid"
+  # The honest arm forks the fresh watcher as a tracked child and waits on it, so
+  # the lock now names that child, not the arm invocation. The property is the
+  # same: the stale reused-pid lock is replaced by a genuinely live watcher, which
+  # the arm confirms before reporting it. Wait for that confirmation, not just for
+  # the lock pid to appear (identity and beacon land a beat later).
   i=0
   while [ "$i" -lt 80 ] && is_live_non_zombie "$pid"; do
     sleep 0.1
@@ -460,18 +489,16 @@ test_watch_restart_attaches_to_healthy_peer() {
   out="$dir/restart.out"
   peer_ready="$dir/peer.ready"
   mark_pr_check_migration_complete "$state"
-  node -e 'const fs = require("node:fs"); process.on("SIGTERM", () => {}); fs.writeFileSync(process.argv[1], "ready\n"); setTimeout(() => {}, 300000)' "$peer_ready" &
-  peer=$!
-  i=0
-  while [ "$i" -lt 50 ] && [ ! -s "$peer_ready" ]; do
-    sleep 0.1
-    i=$((i + 1))
-  done
-  if [ ! -s "$peer_ready" ]; then
-    kill -KILL "$peer" 2>/dev/null || true
-    wait "$peer" 2>/dev/null || true
-    fail "TERM-resistant peer did not become ready"
-  fi
+  # --restart TERMs the pid this home's lock records before it forks anything, so
+  # the stand-in peer must already be ignoring TERM when its pid is published.
+  # Backgrounding a program and publishing its pid straight away does NOT
+  # guarantee that: the process is still starting up, and the arm's TERM lands
+  # first, killing the "TERM-resistant" peer. The arm then legitimately starts
+  # its own watcher, this case's attach assertion misses, and the case aborts -
+  # leaving that arm and its watcher running. fm_wake_start_peer hands the pid
+  # back only once the disposition is installed and the identity is settled.
+  fm_wake_start_peer "$dir/peer.ready" --ignore-term
+  peer=$FM_WAKE_PEER_PID
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"
@@ -481,15 +508,19 @@ test_watch_restart_attaches_to_healthy_peer() {
   touch "$state/.last-watcher-beat"
   PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_ATTACH_POLL=0.1 FM_ARM_CONFIRM_TIMEOUT=1 "$WATCH_ARM" --restart > "$out" &
   armpid=$!
+  fm_test_track_pid "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF "watcher: attached pid=$peer" "$out" 2>/dev/null && break
     sleep 0.1
     i=$((i + 1))
   done
+  # Check the premise before the conclusion: if the peer is gone, the arm was
+  # right to start its own watcher and the interesting failure is the fixture,
+  # not the arm.
+  is_live_non_zombie "$peer" || fail "restart killed a TERM-resistant peer unexpectedly"
   grep -qF "watcher: attached pid=$peer" "$out" || fail "restart did not attach to the verified healthy peer: $(cat "$out")"
   is_live_non_zombie "$armpid" || fail "restart arm exited instead of following the healthy peer"
-  is_live_non_zombie "$peer" || fail "restart killed a TERM-resistant peer unexpectedly"
   kill -KILL "$peer" 2>/dev/null || true
   wait "$peer" 2>/dev/null || true
   wait_for_exit "$armpid" 80
@@ -507,6 +538,7 @@ test_watcher_self_evicts_on_lock_takeover() {
   out="$dir/watch.out"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
+  fm_test_track_pid "$pid"
   i=0
   while [ "$i" -lt 80 ]; do
     [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] \
@@ -538,6 +570,7 @@ test_arm_self_eviction_is_loud_without_successor() {
   mark_pr_check_migration_complete "$state"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=1 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_track_pid "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
@@ -569,6 +602,7 @@ test_arm_attaches_and_waits_for_live_fresh_watcher() {
   # A genuinely live watcher with a fresh beacon already holds the singleton.
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   wpid=$!
+  fm_test_track_pid "$wpid"
   i=0
   while [ "$i" -lt 60 ]; do
     [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] && [ -e "$state/.last-watcher-beat" ] && break
@@ -580,6 +614,7 @@ test_arm_attaches_and_waits_for_live_fresh_watcher() {
   # exit while the seed still holds the healthy lock.
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_ARM_ATTACH_POLL=0.1 FM_ARM_CONFIRM_TIMEOUT=1 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_track_pid "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF "watcher: attached pid=$wpid" "$armout" 2>/dev/null && break
@@ -610,6 +645,7 @@ test_attached_arm_signal_is_recorded_in_cycle_ledger() {
   armout="$dir/arm.out"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   wpid=$!
+  fm_test_track_pid "$wpid"
   i=0
   while [ "$i" -lt 60 ]; do
     [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] && [ -e "$state/.last-watcher-beat" ] && break
@@ -619,6 +655,7 @@ test_attached_arm_signal_is_recorded_in_cycle_ledger() {
   [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] || fail "seed watcher did not take the lock"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_ARM_ATTACH_POLL=0.1 FM_ARM_CONFIRM_TIMEOUT=1 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_track_pid "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF "watcher: attached pid=$wpid" "$armout" 2>/dev/null && break
@@ -662,6 +699,7 @@ test_arm_starts_and_self_heals() {
     fi
     PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
     armpid=$!
+    fm_test_track_pid "$armpid"
     i=0
     while [ "$i" -lt 80 ]; do
       if [ "$row" = dead-pid ]; then
@@ -701,6 +739,7 @@ test_arm_hup_cleans_child_and_temp_output() {
   armout="$dir/arm.out"
   PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_track_pid "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
@@ -758,31 +797,42 @@ test_arm_waits_for_peer_beacon_after_child_stands_down() {
   fakebin="$dir/fakebin"
   armout="$dir/arm.out"
   mark_pr_check_migration_complete "$state"
-  sleep 300 &
-  peer=$!
+  fm_wake_start_peer "$dir/peer.ready"
+  peer=$FM_WAKE_PEER_PID
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"
   printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
   printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
   printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
-  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=1 FM_ARM_ATTACH_POLL=0.1 "$WATCH_ARM" > "$armout" &
+  # FM_ARM_CONFIRM_TIMEOUT bounds two waits this case has to fit inside: how long
+  # the arm waits for its own child to resolve, and how long it then waits for
+  # the peer to publish a beacon. One second is below this case's own irreducible
+  # setup cost, which is what made it fail under load - so give the bound real
+  # headroom. It cannot mask a regression: the assertions below require the arm
+  # to still be waiting, and to NOT have attached, at the moment the beacon
+  # appears.
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=5 FM_ARM_ATTACH_POLL=0.1 "$WATCH_ARM" > "$armout" &
   armpid=$!
-  # Synchronize on the owned child declining the live peer lock before making
-  # the peer healthy. Sleeping for the same one-second budget as the arm made
-  # this regression fixture race the confirmation deadline under full-suite
-  # load, rather than testing the intended successor-handshake boundary.
+  fm_test_track_pid "$armpid"
+  # Synchronize on the owned child declining the live peer lock before making the
+  # peer healthy - and do it on the arm's OWN output, which is this case's file
+  # and lives as long as the case does. The arm's internal per-child temp file
+  # carries the same line but the arm deletes it moments later, so an observer
+  # that arrives late concludes the child never stood down at all. That is the
+  # exact failure that turned CI red.
   i=0
-  while [ "$i" -lt 80 ]; do
-    grep -qF "watcher: already running pid $peer" "$state"/.watch-arm-output.* 2>/dev/null && break
+  while [ "$i" -lt 100 ]; do
+    grep -qF "watcher: already running pid $peer" "$armout" 2>/dev/null && break
     sleep 0.1
     i=$((i + 1))
   done
-  grep -qF "watcher: already running pid $peer" "$state"/.watch-arm-output.* 2>/dev/null \
-    || fail "arm child did not stand down behind the peer watcher"
+  grep -qF "watcher: already running pid $peer" "$armout" \
+    || fail "arm child did not stand down behind the peer watcher: $(cat "$armout")"
+  ! grep -qF 'watcher: attached' "$armout" || fail "arm attached before the peer published a beacon: $(cat "$armout")"
   touch "$state/.last-watcher-beat"
   i=0
-  while [ "$i" -lt 80 ]; do
+  while [ "$i" -lt 100 ]; do
     grep -qF "watcher: attached pid=$peer" "$armout" 2>/dev/null && break
     sleep 0.1
     i=$((i + 1))
@@ -793,7 +843,9 @@ test_arm_waits_for_peer_beacon_after_child_stands_down() {
   # After the peer dies without a successor, the attached arm must fail loudly.
   kill "$peer" 2>/dev/null || true
   wait "$peer" 2>/dev/null || true
-  wait_for_exit "$armpid" 80
+  # The arm spends its whole confirmation window looking for a successor before
+  # it gives up, so this budget has to clear that window comfortably.
+  wait_for_exit "$armpid" 200
   status=$?
   [ "$status" -ne 0 ] && [ "$status" -ne 124 ] || fail "attached arm did not fail after peer died (status $status): $(cat "$armout")"
   grep -qF 'watcher: FAILED - cycle ended without an actionable reason' "$armout" || fail "peer-attached arm did not emit the typed cycle-end failure"
@@ -809,6 +861,7 @@ test_arm_fails_loud_when_no_fresh_watcher_confirmable() {
   mark_pr_check_migration_complete "$state"
   sleep 300 &
   live=$!
+  fm_test_track_pid "$live"
   # A live process holds the lock but is NOT a confirmable watcher (no identity),
   # and the beacon is stale. The fresh child cannot steal a LIVE lock, so no
   # watcher can ever be confirmed - the honest answer is FAILED, not healthy.
@@ -817,6 +870,7 @@ test_arm_fails_loud_when_no_fresh_watcher_confirmable() {
   touch -t 200001010000 "$state/.last-watcher-beat"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=3 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_track_pid "$armpid"
   wait_for_exit "$armpid" 120
   status=$?
   [ "$status" -ne 124 ] || fail "arm never returned for an unconfirmable watcher"
@@ -848,6 +902,7 @@ SH
 
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=0 FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
   first_arm=$!
+  fm_test_track_pid "$first_arm"
   wait "$first_arm" || fail "first ledger cycle did not surface its actionable wake"
   grep -q "arm_pid=$first_arm.*reason=actionable-check.*successor=none" "$state/.watch-cycle-exits.log" \
     || fail "first ledger record omitted its actionable classification"
@@ -857,6 +912,7 @@ SH
   armout="$dir/successor-arm.out"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_WATCH_PREDECESSOR_ARM_PID="$first_arm" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
   successor_arm=$!
+  fm_test_track_pid "$successor_arm"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
@@ -882,6 +938,7 @@ SH
     armout="$dir/bounded-$iteration.out"
     PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_WATCH_CYCLE_LOG_MAX_BYTES=1400 FM_WATCH_CYCLE_LOG_KEEP_LINES=2 FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
     successor_arm=$!
+    fm_test_track_pid "$successor_arm"
     i=0
     while [ "$i" -lt 80 ]; do
       grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
@@ -911,6 +968,7 @@ test_stopped_watcher_is_live_but_stale_then_exit_is_classified() {
   mark_pr_check_migration_complete "$state"
   PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_track_pid "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
@@ -948,8 +1006,12 @@ test_pid_identity_is_locale_invariant() {
   # locale like ko_KR.UTF-8 is not installed (the equality then holds trivially).
   local live no_proc fakebin locale_log baseline via_lc_all via_lc_time
   local real_first real_second observed
-  sleep 300 &
-  live=$!
+  # The three reads are only comparable once the stand-in has exec'd its final
+  # program: a read that lands in the fork-before-exec window records the
+  # launcher's command line instead, and the comparison fails for a reason that
+  # has nothing to do with locale.
+  fm_wake_start_peer "$TMP_ROOT/locale-peer.ready"
+  live=$FM_WAKE_PEER_PID
   no_proc="$TMP_ROOT/no-proc"
   fakebin="$TMP_ROOT/locale-ps"
   locale_log="$TMP_ROOT/locale-ps.observed"
@@ -1098,6 +1160,25 @@ test_msys_pid_identity_uses_proc() {
   pass "MSYS process identity uses compatible /proc fields"
 }
 
+test_cases_leave_nothing_running() {
+  # Runs last, and deliberately BEFORE the EXIT reaper, so it measures what the
+  # cases themselves left behind rather than what cleanup rescued.
+  #
+  # This suite used to end every run with a detached arm and the watcher that arm
+  # had forked still alive, reparented to init and still holding a temp home's
+  # singleton lock. They also still held the stdout/stderr pipe they inherited
+  # from the suite, so anything reading the suite's output to EOF - a CI step
+  # collecting the log, a local `... | tail` - hung long after the last test
+  # printed. Both halves are checked here: registered pids, and watcher
+  # grandchildren the pid registry cannot see but a temp home's lock still names.
+  local strays watchers
+  strays=$(fm_test_live_tracked_pids | tr '\n' ' ')
+  watchers=$(fm_wake_temp_watcher_pids "$TMP_ROOT" | tr '\n' ' ')
+  [ -z "${strays// /}" ] || fail "cases left background processes running: $strays"
+  [ -z "${watchers// /}" ] || fail "cases left watchers holding a temp home's lock: $watchers"
+  pass "every case leaves no background process and no watcher holding a temp home lock"
+}
+
 test_singleton_start
 test_pid_identity_is_locale_invariant
 test_proc_pid_identity_ignores_wall_clock_and_detects_pid_reuse
@@ -1127,3 +1208,5 @@ test_arm_waits_for_peer_beacon_after_child_stands_down
 test_arm_fails_loud_when_no_fresh_watcher_confirmable
 test_cycle_exit_ledger_links_successor_and_stays_bounded
 test_stopped_watcher_is_live_but_stale_then_exit_is_classified
+# Keep last: it audits what every case above left behind.
+test_cases_leave_nothing_running

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -482,12 +482,11 @@ test_watch_restart_rejects_reused_pid() {
 }
 
 test_watch_restart_attaches_to_healthy_peer() {
-  local dir state fakebin out peer_ready peer identity armpid status i
+  local dir state fakebin out peer identity armpid status i
   dir=$(make_case restart-healthy-peer)
   state="$dir/state"
   fakebin="$dir/fakebin"
   out="$dir/restart.out"
-  peer_ready="$dir/peer.ready"
   mark_pr_check_migration_complete "$state"
   # --restart TERMs the pid this home's lock records before it forks anything, so
   # the stand-in peer must already be ignoring TERM when its pid is published.

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -50,12 +50,14 @@ pass() {
   printf 'ok - %s\n' "$1"
 }
 
-# --- self-cleaning temp root ------------------------------------------------
+# --- self-cleaning temp root and background-process reaping ------------------
 #
 # fm_test_tmproot <prefix> echoes a fresh temp dir and registers it for removal
-# on EXIT/INT/TERM. A test file that needs extra teardown (e.g. killing a
-# daemon) should define its own EXIT trap and call fm_test_cleanup from inside
-# it so registered dirs are still removed.
+# on EXIT/INT/TERM. fm_test_track_pid <pid> registers a background process for
+# reaping on the same EXIT, on the success path AND on every fail() path. A test
+# file that needs extra teardown (e.g. killing a daemon) should define its own
+# EXIT trap and call fm_test_cleanup from inside it so both registries are still
+# drained.
 #
 # The call site is almost always `TMP_ROOT=$(fm_test_tmproot prefix)`, which
 # forks a subshell to capture stdout. Anything that function does to the
@@ -66,10 +68,25 @@ pass() {
 # subshell's - see `man bash` on `$$`), so fm_test_tmproot records the
 # directory in a `$$`-keyed registry file instead, and the trap that reaps
 # that file is armed once, here, at source time - which always runs in the
-# real caller, never a subshell.
+# real caller, never a subshell. The pid registry is the same shape for the
+# same reason: fm_test_track_pid is often called from a subshell too.
+#
+# Both registries are mktemp'd here in the sourcing shell rather than opened at
+# a predictable $$-derived name in a shared /tmp, where another user could
+# pre-create or symlink one and steer the rm -rf in fm_test_cleanup. Every read
+# is existence-guarded so an absent file reads as empty.
+#
+# Reaping is BY REGISTERED PID ONLY, and only while that pid is still a child of
+# this shell. Never reap by process-name pattern: a pattern like the watcher's
+# script path matches every firstmate home on the machine, including a sibling
+# home's real watcher.
 
 FM_TEST_CLEANUP_DIRS=()
 FM_TEST_CLEANUP_REGISTRY=$(mktemp "${TMPDIR:-/tmp}/.fm-test-cleanup.$$.XXXXXX") || return 1
+FM_TEST_PID_LOG=$(mktemp "${TMPDIR:-/tmp}/.fm-test-pids.$$.XXXXXX") || {
+  rm -f "$FM_TEST_CLEANUP_REGISTRY"
+  return 1
+}
 
 fm_test_pid_identity() {
   local pid=$1
@@ -78,12 +95,66 @@ fm_test_pid_identity() {
 }
 
 FM_TEST_OWNER_IDENTITY=$(fm_test_pid_identity "$$") || {
-  rm -f "$FM_TEST_CLEANUP_REGISTRY"
+  rm -f "$FM_TEST_CLEANUP_REGISTRY" "$FM_TEST_PID_LOG"
   return 1
+}
+
+# fm_test_pid_is_own_child <pid>: true while <pid> is still a direct child of
+# this shell. This guards every signal the reaper sends: once a pid has been
+# waited on the kernel is free to hand that number to an unrelated process, and
+# a test harness must never signal a process it does not own.
+fm_test_pid_is_own_child() {
+  local pid=$1 parent
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  parent=$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d '[:space:]')
+  [ -n "$parent" ] && [ "$parent" = "$$" ]
+}
+
+fm_test_track_pid() {
+  local pid=$1
+  case "$pid" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  printf '%s\n' "$pid" >> "$FM_TEST_PID_LOG"
+}
+
+# fm_test_live_tracked_pids: print every registered pid still running as a child
+# of this shell. Used both by the reaper and by suites that assert they left
+# nothing behind.
+fm_test_live_tracked_pids() {
+  local pid
+  [ -n "${FM_TEST_PID_LOG:-}" ] && [ -s "$FM_TEST_PID_LOG" ] || return 0
+  while read -r pid; do
+    fm_test_pid_is_own_child "$pid" || continue
+    printf '%s\n' "$pid"
+  done < "$FM_TEST_PID_LOG"
+}
+
+fm_test_reap_tracked_pids() {
+  local pid i
+  for pid in $(fm_test_live_tracked_pids); do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  # Give a TERM-handling child its own teardown (fm-watch-arm.sh tears down the
+  # watcher it forked) a bounded moment before escalating.
+  i=0
+  while [ "$i" -lt 20 ] && [ -n "$(fm_test_live_tracked_pids)" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  for pid in $(fm_test_live_tracked_pids); do
+    kill -KILL "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+  [ -f "$FM_TEST_PID_LOG" ] && : > "$FM_TEST_PID_LOG"
+  return 0
 }
 
 fm_test_cleanup() {
   local d
+  fm_test_reap_tracked_pids
   for d in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
     [ -n "$d" ] && rm -rf "$d"
   done
@@ -93,6 +164,8 @@ fm_test_cleanup() {
     done < "$FM_TEST_CLEANUP_REGISTRY"
     rm -f "$FM_TEST_CLEANUP_REGISTRY"
   fi
+  [ -n "${FM_TEST_PID_LOG:-}" ] && rm -f "$FM_TEST_PID_LOG"
+  return 0
 }
 
 fm_test_tmproot() {

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -274,6 +274,99 @@ SH
   printf '%s\n' "$dir"
 }
 
+# fm_wake_start_peer <ready-file> [--ignore-term]: start a long-lived stand-in
+# for a peer watcher process and hand its pid back in FM_WAKE_PEER_PID only once
+# the process is genuinely READY. Readiness matters twice, and both used to be
+# raced:
+#   - the stand-in has exec'd its final program, so bin/fm-wake-lib.sh's
+#     fm_pid_identity records the identity the process will keep, not the
+#     pre-exec fork it happened to catch;
+#   - with --ignore-term the SIGTERM ignore disposition is already installed, so
+#     a restart arm's TERM cannot kill the fixture in its startup window and turn
+#     a "peer survives, arm attaches" case into a confusing "did not attach".
+# It is a plain function, not a command substitution, so $! stays a child of the
+# caller's shell and the caller can still wait on it.
+FM_WAKE_PEER_PID=
+fm_wake_start_peer() {
+  local ready=$1 policy=${2:-} i
+  rm -f "$ready"
+  bash -c '
+    [ "$2" = --ignore-term ] && trap "" TERM
+    : > "$1"
+    # Short sleeps, so a fixture that has to be force-killed cannot orphan a
+    # long-lived grandchild.
+    while :; do sleep 1; done
+  ' _ "$ready" "$policy" &
+  FM_WAKE_PEER_PID=$!
+  fm_test_track_pid "$FM_WAKE_PEER_PID"
+  i=0
+  while [ "$i" -lt 100 ] && [ ! -e "$ready" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$ready" ] || fail "peer fixture never signalled ready"
+  [ "$policy" = --ignore-term ] || return 0
+  # Fixture self-check: prove the ignore disposition really took, so a broken
+  # peer fails here by name instead of downstream as a flaky assertion.
+  kill -TERM "$FM_WAKE_PEER_PID" 2>/dev/null || true
+  i=0
+  while [ "$i" -lt 5 ]; do
+    is_live_non_zombie "$FM_WAKE_PEER_PID" || fail "term-resistant peer fixture died on SIGTERM"
+    sleep 0.1
+    i=$((i + 1))
+  done
+}
+
+# fm_wake_temp_watcher_pids <root>: print the pid of every watcher still recorded
+# as the live owner of a temp home's singleton lock under <root>. Scoped by path
+# and identity so it can never name a sibling firstmate home's real watcher: only
+# locks reached through the suite's own mktemp glob "$root"/*/state/.watch.lock are
+# considered - no real home occupies that path - and the pid is confirmed through
+# bin/fm-wake-lib.sh's identity check, so a recycled pid is skipped. The fm-home
+# read from each lock is passed straight back to fm_watcher_lock_matches_pid, so
+# that home argument is no longer load-bearing; the identity comparison is.
+fm_wake_temp_watcher_pids() {
+  local root=$1 lock state home pid lib="$ROOT/bin/fm-wake-lib.sh"
+  for lock in "$root"/*/state/.watch.lock; do
+    [ -d "$lock" ] || continue
+    state=$(dirname "$lock")
+    pid=$(cat "$lock/pid" 2>/dev/null || true)
+    home=$(cat "$lock/fm-home" 2>/dev/null || true)
+    case "$pid" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    kill -0 "$pid" 2>/dev/null || continue
+    FM_STATE_OVERRIDE="$state" bash -c '
+      # shellcheck disable=SC1090,SC1091
+      . "$1"
+      fm_watcher_lock_matches_pid "$2" "$3" "$4" "$5"
+    ' _ "$lib" "$state" "$ROOT/bin/fm-watch.sh" "$pid" "$home" || continue
+    printf '%s\n' "$pid"
+  done
+}
+
+# fm_wake_reap_temp_watchers <root>: end the watchers fm_wake_temp_watcher_pids
+# names. These are grandchildren (an arm forks its watcher), so the pid registry
+# in tests/lib.sh cannot reach them; the identity-verified temp-home lock can.
+fm_wake_reap_temp_watchers() {
+  local root=$1 pid i
+  for pid in $(fm_wake_temp_watcher_pids "$root"); do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  i=0
+  while [ "$i" -lt 20 ] && [ -n "$(fm_wake_temp_watcher_pids "$root")" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  # Re-derive the list rather than reusing the first one: a pid only stays
+  # eligible for the harder signal while the temp home's lock still identifies it
+  # as that home's watcher.
+  for pid in $(fm_wake_temp_watcher_pids "$root"); do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+  return 0
+}
+
 wait_for_exit() {
   local pid=$1 limit=${2:-50} i=0
   while [ "$i" -lt "$limit" ]; do


### PR DESCRIPTION
## Intent

Upstream contribution from the mattwwatson/firstmate fork: de-flake and leak-proof the watcher-lock test suite at the root. Peer watcher starts are now exec-confirmed with durable-file synchronization instead of sleeps, a self-checking bash peer, and an injectable FM_ARM_CONFIRM_TIMEOUT; tests/lib.sh gains file-backed pid and temp registries with a home-scoped reaper (fm_test_track_pid) so no failure path leaks background processes or holds a temp home's watcher lock, and CONTRIBUTING.md documents the convention (nothing reaped by process-name pattern). The CONTRIBUTING.md paragraph was hand-merged onto the current upstream testing-docs rewrite, keeping upstream's fm-test-run.sh section intact and appending only the two new convention sentences. Suite passes 28/28 locally on the upstream base.

## What Changed

- Replaced sleep-based peer-watcher startup in the watcher-lock suite with exec-confirmed durable-file synchronization: a self-checking bash peer, an injectable `FM_ARM_CONFIRM_TIMEOUT`, and an `fm-watch-arm.sh` tweak that surfaces the finished child's stand-down output before the successor-confirmation wait so tests can synchronize on it.
- Added file-backed pid and temp-dir registries to `tests/lib.sh` (stored in a private `mktemp -d` directory) with a home-scoped reaper via `fm_test_track_pid`, so failing test paths no longer leak background processes or hold a temp home's watcher lock — nothing is reaped by process-name pattern. Suites that install custom EXIT traps now drain these registries in their own cleanup.
- Documented the process-tracking convention in CONTRIBUTING.md, appending two sentences to the existing `fm-test-run.sh` testing section. Suite verified 28/28 across three consecutive runs in the pipeline, including its built-in no-leaked-process/no-held-lock audit.

## Risk Assessment

✅ Low: The final commit cleanly closes the round-2 registry-dir leak by adding idempotent, exit-status-preserving fm_test_cleanup calls to the exact three non-conforming suites, and the full branch now satisfies every stated intent criterion with no outstanding source findings.

## Testing

Ran the watcher-lock suite three times through the canonical runner (28/28 each, no flakes), ran the three other touched suites (pass/clean self-skip), and demonstrated the leak-proofing end-to-end with a fail()-aborted real-arm demo (children reaped, lock released, 5s pipe EOF) against a pre-change contrast that hung the pipe 76s; before/after audits show zero leaked processes or temp dirs and the user's real watcher untouched. No UI surface — this is CLI/test infrastructure, so transcripts are the reviewer-visible evidence.

<details>
<summary>Evidence: watcher-lock suite run 1 transcript (28/28 ok)</summary>

```text
FM_TEST_BEGIN 2026-07-23T09:11:05Z tests/fm-watcher-lock.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - Linux process identity clock-step regression skipped on non-Linux host
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when fresh
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart refuses to signal a reused pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts+confirms a fresh watcher on a clean lock and self-heals a dead-pid lock (never healthy off a dead pid)
ok - arm cleans child watcher and temp output on HUP
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 46486 but heartbeat is stale for 838152738s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
ok - every case leaves no background process and no watcher holding a temp home lock
FM_TEST_END 2026-07-23T09:13:06Z tests/fm-watcher-lock.test.sh exit=0 duration_ms=121237 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=121336
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=121237 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-watcher-lock.test.sh duration_ms=121237
```
</details>
<details>
<summary>Evidence: watcher-lock suite run 2 transcript (28/28 ok)</summary>

```text
FM_TEST_BEGIN 2026-07-23T09:13:50Z tests/fm-watcher-lock.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - Linux process identity clock-step regression skipped on non-Linux host
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when fresh
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart refuses to signal a reused pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts+confirms a fresh watcher on a clean lock and self-heals a dead-pid lock (never healthy off a dead pid)
ok - arm cleans child watcher and temp output on HUP
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 65710 but heartbeat is stale for 838152901s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
ok - every case leaves no background process and no watcher holding a temp home lock
FM_TEST_END 2026-07-23T09:15:49Z tests/fm-watcher-lock.test.sh exit=0 duration_ms=119233 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=119426
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=119233 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-watcher-lock.test.sh duration_ms=119233
```
</details>
<details>
<summary>Evidence: watcher-lock suite run 3 transcript (28/28 ok)</summary>

```text
FM_TEST_BEGIN 2026-07-23T09:15:50Z tests/fm-watcher-lock.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - Linux process identity clock-step regression skipped on non-Linux host
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when fresh
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart refuses to signal a reused pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts+confirms a fresh watcher on a clean lock and self-heals a dead-pid lock (never healthy off a dead pid)
ok - arm cleans child watcher and temp output on HUP
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 95414 but heartbeat is stale for 838153023s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
ok - every case leaves no background process and no watcher holding a temp home lock
FM_TEST_END 2026-07-23T09:17:52Z tests/fm-watcher-lock.test.sh exit=0 duration_ms=121856 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=121931
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=121856 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-watcher-lock.test.sh duration_ms=121856
```
</details>
<details>
<summary>Evidence: Fail-path leak demo transcript — tracked arm+watcher reaped after mid-case fail(), lock released, 5s pipe EOF</summary>

<code>demo exit=1 (expected nonzero: fail() aborted the case)&#10;seconds-to-EOF=5 (a leaked child would hold the pipe open and hang this read)&#10;arm pid 65278: gone (reaped)&#10;watcher grandchild pid 65293: gone (reaped)&#10;temp root .../fm-leak-demo.lDnZPj: removed (watcher lock released with it)</code>

```text
== driver: run fail-path demo, reading its output to EOF (the hang symptom) ==
demo exit=1 (expected nonzero: fail() aborted the case)
seconds-to-EOF=5 (a leaked child would hold the pipe open and hang this read)
demo output: not ok - simulated mid-case assertion failure (arm=65278 watcher=65293 still live)

== recorded live pids at moment of failure ==
arm=65278 watcher=65293 tmp_root=/var/folders/mz/9drvc3ms7w9c8vzk0j1gj2vm0000gp/T//fm-leak-demo.lDnZPj

== after exit: are they reaped? ==
  PID COMMAND
arm pid 65278: gone (reaped)
  PID COMMAND
watcher grandchild pid 65293: gone (reaped)
temp root /var/folders/mz/9drvc3ms7w9c8vzk0j1gj2vm0000gp/T//fm-leak-demo.lDnZPj: removed (watcher lock released with it)
```
</details>
<details>
<summary>Evidence: Pre-change contrast transcript — untracked children held the output pipe 76s past the abort</summary>

```text
== driver: run OLD-STYLE demo (no pid registry), reading output to EOF with a 15s cap ==
driver read returned rc=1 after 76s (142=ALRM: the leaked children held the pipe open past the 15s cap)

== recorded pids at moment of failure ==
arm=71892 watcher=71925

== after the case aborted: still running? ==
  PID 
arm gone
  PID 
watcher gone

== driver cleans up the deliberately leaked fixture pids ==
  PID 
leaked fixtures now cleaned up by driver
```
</details>
<details>
<summary>Evidence: Fail-path demo script (replicates a watcher-lock case with the new registry convention)</summary>

```text
#!/usr/bin/env bash
# Demonstrates the leak-proofing this change adds to tests/lib.sh:
# a watcher-lock-style case starts a REAL fm-watch-arm.sh (which forks a real
# fm-watch.sh grandchild that takes the temp home's singleton lock), registers
# the arm with fm_test_track_pid exactly as the suite does, and then aborts
# mid-case via fail() - the exact path that used to leak the arm + watcher
# forever and hold the suite's stdout pipe open.
#
# Usage: fail-path-leak-demo.sh <worktree> <status-file>
# The status file (outside TMP_ROOT, which the reaper deletes) records the pids
# and temp home so the driver can verify everything was reaped after exit.
set -u
WT=$1
STATUS=$2
# shellcheck source=/dev/null
. "$WT/tests/wake-helpers.sh"
WATCH_ARM="$ROOT/bin/fm-watch-arm.sh"
TMP_ROOT=$(fm_test_tmproot fm-leak-demo)

# Same cleanup convention as tests/fm-watcher-lock.test.sh.
watcher_lock_cleanup() {
  fm_test_reap_tracked_pids
  fm_wake_reap_temp_watchers "$TMP_ROOT"
  fm_test_cleanup
}
trap watcher_lock_cleanup EXIT

dir=$(make_case leak-demo)
state="$dir/state"
fakebin="$dir/fakebin"
armout="$dir/arm.out"
printf '%s\n' fm-pr-check-migration-scan-v1 > "$state/.pr-check-migration-scan-v1"
printf '%s\n' fm-pr-check-migration-v1 > "$state/.pr-check-migration-v1"
chmod 0600 "$state/.pr-check-migration-scan-v1" "$state/.pr-check-migration-v1"

PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_POLL=5 \
  FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
  "$WATCH_ARM" > "$armout" &
armpid=$!
fm_test_track_pid "$armpid"

i=0
while [ "$i" -lt 80 ]; do
  grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
  sleep 0.1
  i=$((i + 1))
done
grep -qF 'watcher: started pid=' "$armout" || fail "demo arm never started a watcher"
watcher_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
printf 'arm=%s watcher=%s tmp_root=%s\n' "$armpid" "$watcher_pid" "$TMP_ROOT" > "$STATUS"

# Abort mid-case with a live arm + live watcher grandchild holding the lock -
# the leak scenario. fail() exits 1; the EXIT trap must reap everything.
fail "simulated mid-case assertion failure (arm=$armpid watcher=$watcher_pid still live)"
```
</details>
<details>
<summary>Evidence: Other touched suites transcript (tmux 4/4 ok; herdr e2e clean opt-in skips)</summary>

```text
FM_TEST_BEGIN 2026-07-23T09:17:59Z tests/fm-tmux-submit-busy.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm_tmux_submit_enter_core: busy pane + pending composer returns empty (message queued)
ok - fm_tmux_submit_enter_core: idle pane + pending composer stays pending (genuine swallow preserved)
ok - fm_tmux_submit_enter_core: busy pane clears composer on first Enter - returns empty
ok - fm_tmux_submit_enter_core: idle pane clears composer on first Enter - returns empty as before
FM_TEST_END 2026-07-23T09:18:01Z tests/fm-tmux-submit-busy.test.sh exit=0 duration_ms=2526 gate_skip=false
FM_TEST_BEGIN 2026-07-23T09:18:01Z tests/fm-afk-pi-herdr-return-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
skip: set FM_AFK_PI_HERDR_E2E=1 to run the real Pi/Herdr away-return regression
FM_TEST_END 2026-07-23T09:18:02Z tests/fm-afk-pi-herdr-return-e2e.test.sh exit=0 duration_ms=107 gate_skip=true
FM_TEST_BEGIN 2026-07-23T09:18:02Z tests/fm-send-secondmate-marker-herdr-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
skip: set FM_SEND_MARKER_HERDR_E2E=1 to run the real Pi/Herdr secondmate-marker regression
FM_TEST_END 2026-07-23T09:18:02Z tests/fm-send-secondmate-marker-herdr-e2e.test.sh exit=0 duration_ms=83 gate_skip=true
FM_TEST_SUMMARY total=3 failed=0 skipped_gate=2 duration_ms=2922
FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=2 duration_ms=190 failed=0
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=2526 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-tmux-submit-busy.test.sh duration_ms=2526
FM_TEST_SLOWEST rank=2 script=tests/fm-afk-pi-herdr-return-e2e.test.sh duration_ms=107
FM_TEST_SLOWEST rank=3 script=tests/fm-send-secondmate-marker-herdr-e2e.test.sh duration_ms=83
```
</details>
<details>
<summary>Evidence: Leak audit: TMPDIR fm-* dirs and watcher processes before/after all runs (zero suite leftovers)</summary>

```text
fm-test-registry.LSGxKZ
fm-wake-tangle-root.HEPx5S
fm-wedge-rec.tJ6Rr5
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `tests/lib.sh:85` - The file-backed registries use predictable world-tmp paths (`${TMPDIR:-/tmp}/fm-test-cleanup.$$` and `fm-test-pids.$$`), and fm_test_cleanup later `rm -rf`s every path read back from the cleanup log (guarded only against empty and `/`). On a multi-user machine another user can pre-create or symlink those names — sticky-bit /tmp even makes the source-time `rm -f` of a foreign-owned planted file fail silently — letting planted content steer the `rm -rf`. The in-code rationale for rejecting mktemp (that an assignment would die inside a command-substitution subshell) does not apply at source time: these variables are assigned when lib.sh is sourced in the main shell, where a mktemp&#39;d path would be equally visible to every subshell; the only real trade-off is the documented lazy-creation/no-stray-file property. Consider a mktemp&#39;d per-process registry directory created at source time (fixed filenames inside, created lazily), which keeps laziness for the files while removing name predictability. Flagged ask-user because the current scheme is explicitly documented as deliberate.
- ℹ️ `bin/fm-watch-arm.sh:418` - A commit scoped `test(watcher):` changes production behavior in bin/fm-watch-arm.sh: the arm now prints its finished child&#39;s output (and deletes the temp file) before spending the successor-confirmation window, so the child&#39;s stand-down explanation surfaces up to FM_ARM_CONFIRM_TIMEOUT seconds earlier. I verified the change is safe (wait_for_healthy_successor/healthy_watcher never read child/child_out; the signal handler behaves identically since the child is already reaped on this path; relative stdout order and cycle-ledger timing are unchanged) and it is load-bearing for the new durable-file synchronization in test_arm_waits_for_peer_beacon_after_child_stands_down, which greps the arm&#39;s own output for the stand-down line before the beacon exists. Only noting that the commit-type label understates a production output-timing change.

🔧 Fix: harden test registries with private mktemp dir
1 info still open:
- ℹ️ `tests/lib.sh:85` - The round-1 hardening makes the registry directory eager: sourcing tests/lib.sh now always runs `mktemp -d` (tests/lib.sh:85), so any suite that sources lib.sh but overrides the EXIT trap without calling fm_test_cleanup leaks one small empty registry dir per run. Exactly three suites do this: tests/fm-tmux-submit-busy.test.sh (trap &#39;rm -rf &#34;$TMP_ROOT&#34;&#39; EXIT), tests/fm-afk-pi-herdr-return-e2e.test.sh (custom cleanup that rm -rfs its own TMP_ROOT but never drains the registries — it already leaked the lazy cleanup-log file under the previous commit since it uses fm_test_tmproot), and tests/fm-send-secondmate-marker-herdr-e2e.test.sh. All three violate the trap convention this branch documents in lib.sh and CONTRIBUTING.md, and the leak is bounded to a tiny OS-reaped tmp dir. Making their traps call fm_test_cleanup is a mechanical follow-up, but it would expand this focused upstream-contribution branch to unrelated suites — asking rather than auto-fixing; deferring entirely is also reasonable.

🔧 Fix: drain test registries in suites with custom EXIT traps
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-watcher-lock.test.sh` ×3 consecutive runs — 28/28 ok each, exit=0, including the suite&#39;s built-in no-leaked-process/no-held-lock audit case</code>
- <code>`bin/fm-test-run.sh tests/fm-tmux-submit-busy.test.sh tests/fm-afk-pi-herdr-return-e2e.test.sh tests/fm-send-secondmate-marker-herdr-e2e.test.sh` — tmux suite 4/4 ok; both herdr e2e suites self-skip cleanly behind their opt-in env gates with the new fm_test_cleanup trap line in place</code>
- `Fail-path leak demo: real fm-watch-arm.sh + watcher grandchild registered via fm_test_track_pid, aborted mid-case with fail() — verified both pids reaped, temp home watcher lock released, and suite output pipe reached EOF in 5s`
- `Pre-change contrast demo (untracked pid, dirs-only EXIT trap) — reproduced the old symptom: output pipe held 76s past the abort by lingering arm/watcher before driver cleanup`
- `Leak audit: diffed TMPDIR fm-* dirs and fm-watch/fm-watch-arm processes before vs after all runs — zero suite leftovers, TMPDIR restored to exact baseline, user's real-home watcher untouched`
- `Reviewed CONTRIBUTING.md diff — two convention sentences appended after upstream's intact fm-test-run.sh testing-docs section`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
