### PR TITLE
fix: verify archived captain decisions after retention

### DIFF
--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -186,6 +186,14 @@ valid_date() {  # <YYYY-MM-DD>
   ' "$1"
 }
 
+decision_lines_are_canonical() {  # <text>
+  command -v node >/dev/null 2>&1 || fail "node is required to validate captain decision text"
+  node -e '
+    const lines = process.argv[1].split("\n");
+    if (lines.some(line => line.length > 0 && line.trim().length === 0)) process.exit(1);
+  ' -- "$1"
+}
+
 scan_decision_identity() {  # <mode> <path> <id> [archive-view]
   command -v node >/dev/null 2>&1 || fail "node is required to inspect decision identities"
   node - "$@" <<'NODE'
@@ -304,6 +312,16 @@ verify_archive_unchanged() {  # <archive> <expected-digest>
   archive_is_safe "$archive" || fail "decision archive disappeared during verification: $archive"
   current=$(sha256_file "$archive") || fail "could not fingerprint decision archive: $archive"
   [ "$current" = "$expected" ] || fail "decision archive changed during verification: $archive"
+}
+
+verify_archive_identity_unchanged() {  # <archive> <id> <expected-digest> <expected-counts>
+  local archive=$1 id=$2 expected_digest=$3 expected_counts=$4 current_counts
+  verify_archive_unchanged "$archive" "$expected_digest"
+  current_counts=$(archive_identity_counts "$archive" "$id") \
+    || fail "could not recheck archived decision identity $id"
+  verify_archive_unchanged "$archive" "$expected_digest"
+  [ "$current_counts" = "$expected_counts" ] \
+    || fail "decision archive identity changed during verification: $id"
 }
 
 verify_archive_absent() {  # <archive>
@@ -455,6 +473,7 @@ decision_lookup() {  # <decision-id>
     [ "$current_active" -eq 0 ] \
       || fail "captain decision $id appeared in the active backlog during verification"
     verify_archived_resolution "$id" "$DECISION_SHOW" "$header"
+    verify_archive_identity_unchanged "$archive" "$id" "$archive_digest" "$counts"
     return 0
   fi
   if [ -n "$archive_digest" ]; then
@@ -743,6 +762,8 @@ command_resolve() {
   [ -n "$decision" ] || fail "decision file must not be empty"
   [ "$(printf '%s' "$decision" | LC_ALL=C wc -c | tr -d ' ')" -le 8192 ] \
     || fail "decision file exceeds 8192 bytes"
+  decision_lines_are_canonical "$decision" \
+    || fail "decision file contains a whitespace-only line; remove its whitespace or use an empty line"
   [ -n "$routed" ] || fail "at least one --routed-to task is required"
   routed=$(printf '%s\n' "$routed" | tr ' ' '\n' | sed '/^$/d' | LC_ALL=C sort -u | paste -sd' ' -)
   routed_csv=$(printf '%s\n' "$routed" | tr ' ' ',')

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -15,6 +15,10 @@
 # is idempotent. A different decision key creates a different backlog identity.
 # All backlog mutations run in the active FM_HOME, which keeps main-home and
 # secondmate-home ownership aligned with the work that discovered the decision.
+# Resolved decisions remain verifiable after normal retention moves them from the
+# active backlog to data/done-archive.md. Archive reads reject unsafe files,
+# duplicate identities, concurrent changes, and records that do not exactly match
+# the durable resolution format written by this command.
 #
 # Usage:
 #   fm-decision-hold.sh id <origin-id> <decision-key>
@@ -44,6 +48,7 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+ARCHIVE_VIEW=''
 
 # shellcheck source=bin/fm-classify-lib.sh
 # shellcheck disable=SC1091
@@ -65,6 +70,18 @@ fail() {
   exit 1
 }
 
+cleanup_archive_view() {
+  if [ -n "$ARCHIVE_VIEW" ]; then
+    rm -f -- "$ARCHIVE_VIEW"
+    ARCHIVE_VIEW=''
+  fi
+}
+
+trap cleanup_archive_view EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 validate_slug() {  # <label> <value>
   local label=$1 value=$2
   case "$value" in
@@ -85,6 +102,16 @@ sha256_text() {  # <text>
     printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
   elif command -v sha256sum >/dev/null 2>&1; then
     printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else
+    fail "shasum or sha256sum is required"
+  fi
+}
+
+sha256_file() {  # <path>
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
   else
     fail "shasum or sha256sum is required"
   fi
@@ -113,6 +140,255 @@ task_show() {  # <id>
 show_field() {  # <show-output> <field>
   local output=$1 field=$2
   printf '%s\n' "$output" | sed -n "s/^  $field: //p" | head -1
+}
+
+decode_json_string() {  # <json-string>
+  command -v node >/dev/null 2>&1 || fail "node is required to decode tasks-axi output"
+  printf '%s' "$1" | node -e '
+    let input = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", chunk => { input += chunk; });
+    process.stdin.on("end", () => {
+      try {
+        const value = JSON.parse(input);
+        if (typeof value !== "string" || value.includes("\u0000")) process.exit(1);
+        process.stdout.write(value);
+      } catch (_) {
+        process.exit(1);
+      }
+    });
+  '
+}
+
+valid_date() {  # <YYYY-MM-DD>
+  command -v node >/dev/null 2>&1 || fail "node is required to validate tasks-axi output"
+  node -e '
+    const value = process.argv[1];
+    if (!/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(value)) process.exit(1);
+    const [year, month, day] = value.split("-").map(Number);
+    const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+    const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    if (year < 1 || month < 1 || month > 12 || day < 1 || day > days[month - 1]) process.exit(1);
+  ' "$1"
+}
+
+active_identity_count() {  # <id>
+  local id=$1 backlog="$DATA/backlog.md"
+  [ -f "$backlog" ] || { printf '0\n'; return 0; }
+  awk -v id="$id" '
+    index($0, "- [ ] " id " - ") == 1 || index($0, "- [x] " id " - ") == 1 { count++ }
+    END { print count + 0 }
+  ' "$backlog"
+}
+
+archive_is_safe() {  # <archive>
+  local archive=$1
+  [ ! -L "$archive" ] || fail "decision archive must not be a symlink: $archive"
+  [ -e "$archive" ] || return 1
+  [ -f "$archive" ] || fail "decision archive is not a regular file: $archive"
+  [ -r "$archive" ] || fail "decision archive is not readable: $archive"
+}
+
+archive_identity_counts() {  # <archive> <id>
+  local archive=$1 id=$2
+  awk -v id="$id" '
+    function target(line) {
+      return index(line, "- [ ] " id " - ") == 1 || index(line, "- [x] " id " - ") == 1
+    }
+    /^## / {
+      archived = ($0 ~ /^## Archived [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)
+    }
+    target($0) {
+      total++
+      if (archived) valid++
+    }
+    END { print total + 0, valid + 0 }
+  ' "$archive"
+}
+
+verify_archive_unchanged() {  # <archive> <expected-digest>
+  local archive=$1 expected=$2 current
+  archive_is_safe "$archive" || fail "decision archive disappeared during verification: $archive"
+  current=$(sha256_file "$archive") || fail "could not fingerprint decision archive: $archive"
+  [ "$current" = "$expected" ] || fail "decision archive changed during verification: $archive"
+}
+
+verify_archive_absent() {  # <archive>
+  local archive=$1
+  [ ! -L "$archive" ] || fail "decision archive appeared during verification: $archive"
+  [ ! -e "$archive" ] || fail "decision archive appeared during verification: $archive"
+}
+
+extract_archive_record() {  # <archive> <id>
+  local archive=$1 id=$2
+  cleanup_archive_view
+  ARCHIVE_VIEW=$(
+    umask 077
+    mktemp "$DATA/.fm-decision-hold-archive.XXXXXX"
+  ) || fail "could not create private archive parser view"
+  awk -v id="$id" '
+    BEGIN {
+      print "## Done"
+      print ""
+    }
+    capturing {
+      if ($0 ~ /^- \[[ x]\] / || $0 ~ /^## /) exit
+      if ($0 == "" || substr($0, 1, 2) == "  ") {
+        print
+        next
+      }
+      exit
+    }
+    /^## / {
+      archived = ($0 ~ /^## Archived [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)
+    }
+    archived && (index($0, "- [ ] " id " - ") == 1 || index($0, "- [x] " id " - ") == 1) {
+      found++
+      capturing = 1
+      print
+    }
+    END { if (found != 1) exit 1 }
+  ' "$archive" > "$ARCHIVE_VIEW" || fail "could not extract exact archived decision $id"
+}
+
+verify_archived_resolution() {  # <id> <show-output> <raw-header>
+  local id=$1 show=$2 header=$3 parsed_id state kind hold_kind hold_reason closed body_json body
+  local marker rest digest routes route sorted_routes route_suffix expected_prefix decision
+  case "$header" in
+    "- [x] $id - "*) : ;;
+    *) fail "archived captain decision $id is not an exact terminal record" ;;
+  esac
+  parsed_id=$(show_field "$show" id)
+  state=$(show_field "$show" state)
+  kind=$(show_field "$show" kind)
+  hold_kind=$(show_field "$show" hold_kind)
+  hold_reason=$(show_field "$show" hold_reason)
+  closed=$(show_field "$show" closed)
+  body_json=$(show_field "$show" body)
+  [ "$parsed_id" = "$id" ] || fail "archived captain decision has the wrong identity: $parsed_id"
+  [ "$state" = done ] || fail "archived captain decision $id is not typed done"
+  [ "$kind" = captain ] || fail "archived backlog item $id is not kind captain"
+  [ "$hold_kind" = captain ] || fail "archived backlog item $id is not held for the captain"
+  [ -n "$hold_reason" ] && [ "$hold_reason" != '-' ] \
+    || fail "archived captain decision $id has no hold reason"
+  valid_date "$closed" || fail "archived captain decision $id has an invalid closure date: $closed"
+  body=$(decode_json_string "$body_json" && printf '\034') \
+    || fail "archived captain decision $id has an invalid structured body"
+  body=${body%$'\034'}
+
+  marker=$'Resolution recorded by fm-decision-hold.\nDecision digest: '
+  case "$body" in
+    "$marker"*) rest=${body#"$marker"} ;;
+    *) fail "archived captain decision $id has no exact resolution record" ;;
+  esac
+  case "$rest" in
+    *$'\n'*) digest=${rest%%$'\n'*}; rest=${rest#*$'\n'} ;;
+    *) fail "archived captain decision $id has a truncated decision digest" ;;
+  esac
+  [ "${#digest}" -eq 64 ] || fail "archived captain decision $id has an invalid decision digest"
+  case "$digest" in
+    *[!0-9a-f]*) fail "archived captain decision $id has an invalid decision digest" ;;
+  esac
+  case "$rest" in
+    'Routed identities: '*) rest=${rest#'Routed identities: '} ;;
+    *) fail "archived captain decision $id has no exact routed identity record" ;;
+  esac
+  case "$rest" in
+    *$'\n'*) routes=${rest%%$'\n'*} ;;
+    *) fail "archived captain decision $id has a truncated routed identity record" ;;
+  esac
+  case "$routes" in
+    ''|,*|*,|*,,*) fail "archived captain decision $id has invalid routed identities" ;;
+  esac
+  while IFS= read -r route; do
+    validate_slug routed-identity "$route"
+  done <<EOF
+$(printf '%s\n' "$routes" | tr ',' '\n')
+EOF
+  sorted_routes=$(printf '%s\n' "$routes" | tr ',' '\n' | LC_ALL=C sort -u | paste -sd, -)
+  [ "$routes" = "$sorted_routes" ] \
+    || fail "archived captain decision $id has unsorted or duplicate routed identities"
+
+  route_suffix=$'\n\nRouted work:'
+  while IFS= read -r route; do
+    if [ "$route_suffix" = $'\n\nRouted work:' ]; then
+      route_suffix="${route_suffix}- $route"
+    else
+      route_suffix="${route_suffix}"$'\n'"- $route"
+    fi
+  done <<EOF
+$(printf '%s\n' "$routes" | tr ',' '\n')
+EOF
+  case "$body" in
+    *"$route_suffix") rest=${body%"$route_suffix"} ;;
+    *) fail "archived captain decision $id has invalid or truncated routed work" ;;
+  esac
+  expected_prefix="${marker}${digest}"$'\n'"Routed identities: ${routes}"$'\n\nCaptain decision:\n'
+  case "$rest" in
+    "$expected_prefix"*) decision=${rest#"$expected_prefix"} ;;
+    *) fail "archived captain decision $id has an invalid resolution body" ;;
+  esac
+  [ -n "$decision" ] || fail "archived captain decision $id has an empty captain decision"
+  [ "$(sha256_text "$decision")" = "$digest" ] \
+    || fail "archived captain decision $id does not match its decision digest"
+}
+
+DECISION_SHOW=''
+
+decision_lookup() {  # <decision-id>
+  local id=$1 archive="$DATA/done-archive.md" active_count counts archive_count=0 archive_valid=0
+  local archive_digest='' current_active header
+  validate_slug decision-id "$id"
+  DECISION_SHOW=''
+  active_count=$(active_identity_count "$id") || fail "could not inspect active decision identity $id"
+  [ "$active_count" -le 1 ] || fail "duplicate active captain decision identity: $id"
+  if archive_is_safe "$archive"; then
+    archive_digest=$(sha256_file "$archive") || fail "could not fingerprint decision archive: $archive"
+    counts=$(archive_identity_counts "$archive" "$id") \
+      || fail "could not inspect archived decision identity $id"
+    archive_count=${counts%% *}
+    archive_valid=${counts##* }
+    verify_archive_unchanged "$archive" "$archive_digest"
+    [ "$archive_count" = "$archive_valid" ] \
+      || fail "captain decision $id appears outside a canonical archive section"
+    [ "$archive_count" -le 1 ] || fail "duplicate archived captain decision identity: $id"
+  fi
+  [ "$active_count" -eq 0 ] || [ "$archive_count" -eq 0 ] \
+    || fail "captain decision $id exists in both active backlog and archive"
+
+  if [ "$active_count" -eq 1 ]; then
+    DECISION_SHOW=$(task_show "$id") || fail "active captain decision $id changed during verification"
+    current_active=$(active_identity_count "$id") \
+      || fail "could not recheck active decision identity $id"
+    [ "$current_active" -eq 1 ] || fail "active captain decision $id changed during verification"
+    if [ -n "$archive_digest" ]; then
+      verify_archive_unchanged "$archive" "$archive_digest"
+    else
+      verify_archive_absent "$archive"
+    fi
+    return 0
+  fi
+  if [ "$archive_count" -eq 1 ]; then
+    extract_archive_record "$archive" "$id"
+    verify_archive_unchanged "$archive" "$archive_digest"
+    header=$(sed -n '3p' "$ARCHIVE_VIEW")
+    DECISION_SHOW=$(tasks_axi show "$id" --full --file "$ARCHIVE_VIEW" 2>/dev/null) \
+      || fail "could not parse exact archived captain decision $id"
+    cleanup_archive_view
+    verify_archive_unchanged "$archive" "$archive_digest"
+    current_active=$(active_identity_count "$id") \
+      || fail "could not recheck active decision identity $id"
+    [ "$current_active" -eq 0 ] \
+      || fail "captain decision $id appeared in the active backlog during verification"
+    verify_archived_resolution "$id" "$DECISION_SHOW" "$header"
+    return 0
+  fi
+  if [ -n "$archive_digest" ]; then
+    verify_archive_unchanged "$archive" "$archive_digest"
+  else
+    verify_archive_absent "$archive"
+  fi
+  return 1
 }
 
 origin_exists_here() {  # <origin-id>
@@ -159,7 +435,8 @@ origin_open_decisions() {  # <origin-id>
 
 verify_hold_active() {  # <hold-id>
   local id=$1 show state held kind hold_kind
-  show=$(task_show "$id") || fail "captain hold $id is absent from $FM_HOME/data/backlog.md"
+  decision_lookup "$id" || fail "captain hold $id is absent from the active backlog and decision archive"
+  show=$DECISION_SHOW
   state=$(show_field "$show" state)
   held=$(show_field "$show" held)
   kind=$(show_field "$show" kind)
@@ -172,7 +449,8 @@ verify_hold_active() {  # <hold-id>
 
 verify_hold_resolved() {  # <hold-id>
   local id=$1 show state kind body
-  show=$(task_show "$id") || return 1
+  decision_lookup "$id" || return 1
+  show=$DECISION_SHOW
   state=$(show_field "$show" state)
   kind=$(show_field "$show" kind)
   body=$(show_field "$show" body)
@@ -186,7 +464,9 @@ verify_hold_resolved() {  # <hold-id>
 
 verify_hold_durable() {  # <hold-id>
   local id=$1 show state held kind hold_kind body
-  show=$(task_show "$id") || fail "captain decision $id is absent from $FM_HOME/data/backlog.md"
+  decision_lookup "$id" \
+    || fail "captain decision $id is absent from the active backlog and decision archive"
+  show=$DECISION_SHOW
   state=$(show_field "$show" state)
   held=$(show_field "$show" held)
   kind=$(show_field "$show" kind)
@@ -249,7 +529,8 @@ command_hold() {
   require_tasks_axi
   origin_exists_here "$origin" || fail "origin $origin is not owned by the active home $FM_HOME"
   id=$(hold_id "$origin" "$key")
-  if show=$(task_show "$id"); then
+  if decision_lookup "$id"; then
+    show=$DECISION_SHOW
     state=$(show_field "$show" state)
     kind=$(show_field "$show" kind)
     existing_title=$(show_field "$show" title)
@@ -394,14 +675,14 @@ command_resolve() {
   require_tasks_axi
   id=$(hold_id "$origin" "$key")
   if verify_hold_resolved "$id"; then
-    hold_show=$(task_show "$id")
+    hold_show=$DECISION_SHOW
     hold_body=$(show_field "$hold_show" body)
     verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv"
     printf 'resolved: %s\n' "$id"
     return 0
   fi
   verify_hold_active "$id"
-  hold_show=$(task_show "$id")
+  hold_show=$DECISION_SHOW
   hold_body=$(show_field "$hold_show" body)
   case "$hold_body" in
     *"Resolution recorded by fm-decision-hold."*)

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -231,6 +231,7 @@ scan_decision_identity() {  # <mode> <path> <id> [archive-view]
   command -v node >/dev/null 2>&1 || fail "node is required to inspect decision identities"
   node - "$@" <<'NODE'
 const fs = require("fs");
+const { TextDecoder } = require("util");
 
 const [mode, path, id, view] = process.argv.slice(2);
 if (!["active-count", "archive-count", "archive-extract"].includes(mode) || !path || !id) {
@@ -239,7 +240,7 @@ if (!["active-count", "archive-count", "archive-extract"].includes(mode) || !pat
 
 let source;
 try {
-  source = fs.readFileSync(path, "utf8");
+  source = new TextDecoder("utf-8", { fatal: true }).decode(fs.readFileSync(path));
 } catch (_) {
   process.exit(1);
 }

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -277,7 +277,8 @@ function extractRecord(start) {
     const line = lines[index];
     const semantic = semanticLine(line);
     if (isSectionHeading(line) || taskHeader(line) !== undefined) break;
-    if (semantic.trim().length === 0 || semantic.startsWith("  ")) {
+    if (line.length > 0 && line.trim().length === 0) process.exit(1);
+    if (line.length === 0 || semantic.startsWith("  ")) {
       record.push(line);
       continue;
     }
@@ -322,18 +323,22 @@ try {
 NODE
 }
 
+store_file_is_safe() {  # <label> <path>
+  local label=$1 path=$2
+  [ ! -L "$path" ] || fail "$label must not be a symlink: $path"
+  [ -e "$path" ] || return 1
+  [ -f "$path" ] || fail "$label is not a regular file: $path"
+  [ -r "$path" ] || fail "$label is not readable: $path"
+}
+
 active_identity_count() {  # <id>
   local id=$1 backlog="$DATA/backlog.md"
-  [ -f "$backlog" ] || { printf '0\n'; return 0; }
+  store_file_is_safe "active backlog" "$backlog" || { printf '0\n'; return 0; }
   scan_decision_identity active-count "$backlog" "$id"
 }
 
 archive_is_safe() {  # <archive>
-  local archive=$1
-  [ ! -L "$archive" ] || fail "decision archive must not be a symlink: $archive"
-  [ -e "$archive" ] || return 1
-  [ -f "$archive" ] || fail "decision archive is not a regular file: $archive"
-  [ -r "$archive" ] || fail "decision archive is not readable: $archive"
+  store_file_is_safe "decision archive" "$1"
 }
 
 archive_identity_counts() {  # <archive> <id>
@@ -393,6 +398,13 @@ verify_archived_resolution() {  # <id> <show-output> <raw-header>
   [ "$state" = "done" ] || fail "archived captain decision $id is not typed done"
   [ "$kind" = captain ] || fail "archived backlog item $id is not kind captain"
   [ "$hold_kind" = captain ] || fail "archived backlog item $id is not held for the captain"
+  case "$hold_reason" in
+    \"*)
+      hold_reason=$(decode_json_string "$hold_reason" && printf '\034') \
+        || fail "archived captain decision $id has an invalid hold reason"
+      hold_reason=${hold_reason%$'\034'}
+      ;;
+  esac
   [ -n "$hold_reason" ] && [ "$hold_reason" != '-' ] \
     || fail "archived captain decision $id has no hold reason"
   valid_date "$closed" || fail "archived captain decision $id has an invalid closure date: $closed"
@@ -508,6 +520,10 @@ decision_lookup() {  # <decision-id>
       || fail "captain decision $id appeared in the active backlog during verification"
     verify_archived_resolution "$id" "$DECISION_SHOW" "$header"
     verify_archive_identity_unchanged "$archive" "$id" "$archive_digest" "$counts"
+    current_active=$(active_identity_count "$id") \
+      || fail "could not recheck active decision identity $id"
+    [ "$current_active" -eq 0 ] \
+      || fail "captain decision $id appeared in the active backlog during verification"
     return 0
   fi
   if [ -n "$archive_digest" ]; then

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -210,23 +210,15 @@ const inFlight = new RegExp(`^- \\*\\*(${idChars})\\*\\* - (.*)$`);
 const queued = new RegExp(`^- \\[ \\] (${idChars}) - (.*)$`);
 const done = new RegExp(`^- \\[x\\] (${idChars}) - (.*)$`);
 
-function sectionState(line) {
-  const match = semanticLine(line).match(/^##\s+(.*?)\s*$/);
-  if (!match) return undefined;
-  const text = match[1].toLowerCase();
-  if (text === "in flight") return "in_flight";
-  if (text === "queued") return "queued";
-  if (text.startsWith("done")) return "done";
-  return undefined;
-}
-
-function taskIdentity(line, state) {
+function taskHeader(line) {
   const semantic = semanticLine(line);
-  let match;
-  if (state === "done") match = semantic.match(done);
-  if (state === "queued") match = semantic.match(queued);
-  if (state === "in_flight") match = semantic.match(inFlight) || semantic.match(queued);
-  return match ? match[1] : undefined;
+  let match = semantic.match(inFlight);
+  if (match) return { id: match[1], form: "in_flight" };
+  match = semantic.match(queued);
+  if (match) return { id: match[1], form: "queued" };
+  match = semantic.match(done);
+  if (match) return { id: match[1], form: "done" };
+  return undefined;
 }
 
 function isSectionHeading(line) {
@@ -242,7 +234,7 @@ function extractRecord(start) {
   for (let index = start + 1; index < lines.length; index++) {
     const line = lines[index];
     const semantic = semanticLine(line);
-    if (isSectionHeading(line) || taskIdentity(line, "done") !== undefined) break;
+    if (isSectionHeading(line) || taskHeader(line) !== undefined) break;
     if (semantic.trim().length === 0 || semantic.startsWith("  ")) {
       record.push(line);
       continue;
@@ -252,7 +244,6 @@ function extractRecord(start) {
   return record;
 }
 
-let state;
 let archived = false;
 let total = 0;
 let valid = 0;
@@ -261,12 +252,12 @@ for (let index = 0; index < lines.length; index++) {
   const line = lines[index];
   if (isSectionHeading(line)) {
     archived = isCanonicalArchiveHeading(line);
-    state = archived ? "done" : sectionState(line);
     continue;
   }
-  if (taskIdentity(line, state) !== id) continue;
+  const header = taskHeader(line);
+  if (!header || header.id !== id) continue;
   total++;
-  if (archived) {
+  if (archived && header.form === "done") {
     valid++;
     if (record === undefined) record = extractRecord(index);
   }
@@ -280,7 +271,7 @@ if (mode === "archive-count") {
   process.stdout.write(`${total} ${valid}\n`);
   process.exit(0);
 }
-if (!view || valid !== 1 || record === undefined) process.exit(1);
+if (!view || total !== 1 || valid !== 1 || record === undefined) process.exit(1);
 try {
   fs.writeFileSync(view, ["## Done", "", ...record].join("\n") + "\n", "utf8");
 } catch (_) {

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -49,6 +49,7 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 ARCHIVE_VIEW=''
+TASKS_AXI_SECTION_HEADING_RE='^##[[:space:]]+'
 
 # shellcheck source=bin/fm-classify-lib.sh
 # shellcheck disable=SC1091
@@ -191,11 +192,11 @@ archive_is_safe() {  # <archive>
 
 archive_identity_counts() {  # <archive> <id>
   local archive=$1 id=$2
-  awk -v id="$id" '
+  awk -v id="$id" -v section_heading_re="$TASKS_AXI_SECTION_HEADING_RE" '
     function target(line) {
       return index(line, "- [ ] " id " - ") == 1 || index(line, "- [x] " id " - ") == 1
     }
-    /^## / {
+    $0 ~ section_heading_re {
       archived = ($0 ~ /^## Archived [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)
     }
     target($0) {
@@ -226,20 +227,20 @@ extract_archive_record() {  # <archive> <id>
     umask 077
     mktemp "$DATA/.fm-decision-hold-archive.XXXXXX"
   ) || fail "could not create private archive parser view"
-  awk -v id="$id" '
+  awk -v id="$id" -v section_heading_re="$TASKS_AXI_SECTION_HEADING_RE" '
     BEGIN {
       print "## Done"
       print ""
     }
     capturing {
-      if ($0 ~ /^- \[[ x]\] / || $0 ~ /^## /) exit
+      if ($0 ~ /^- \[[ x]\] / || $0 ~ section_heading_re) exit
       if ($0 == "" || substr($0, 1, 2) == "  ") {
         print
         next
       }
       exit
     }
-    /^## / {
+    $0 ~ section_heading_re {
       archived = ($0 ~ /^## Archived [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)
     }
     archived && (index($0, "- [ ] " id " - ") == 1 || index($0, "- [x] " id " - ") == 1) {
@@ -266,7 +267,7 @@ verify_archived_resolution() {  # <id> <show-output> <raw-header>
   closed=$(show_field "$show" closed)
   body_json=$(show_field "$show" body)
   [ "$parsed_id" = "$id" ] || fail "archived captain decision has the wrong identity: $parsed_id"
-  [ "$state" = done ] || fail "archived captain decision $id is not typed done"
+  [ "$state" = "done" ] || fail "archived captain decision $id is not typed done"
   [ "$kind" = captain ] || fail "archived backlog item $id is not kind captain"
   [ "$hold_kind" = captain ] || fail "archived backlog item $id is not held for the captain"
   [ -n "$hold_reason" ] && [ "$hold_reason" != '-' ] \
@@ -665,6 +666,7 @@ command_resolve() {
   [ -n "$decision_file" ] || fail "--decision-file is required"
   [ -f "$decision_file" ] || fail "decision file does not exist: $decision_file"
   decision=$(cat "$decision_file")
+  case "$decision" in *$'\r'*) fail "decision file must use LF line endings" ;; esac
   [ -n "$decision" ] || fail "decision file must not be empty"
   [ "$(printf '%s' "$decision" | LC_ALL=C wc -c | tr -d ' ')" -le 8192 ] \
     || fail "decision file exceeds 8192 bytes"

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -186,12 +186,45 @@ valid_date() {  # <YYYY-MM-DD>
   ' "$1"
 }
 
-decision_lines_are_canonical() {  # <text>
+read_canonical_decision_file() {  # <path>
+  local path=$1 status
   command -v node >/dev/null 2>&1 || fail "node is required to validate captain decision text"
-  node -e '
-    const lines = process.argv[1].split("\n");
-    if (lines.some(line => line.length > 0 && line.trim().length === 0)) process.exit(1);
-  ' -- "$1"
+  if node -e '
+    const fs = require("fs");
+    const { TextDecoder } = require("util");
+    let bytes;
+    try {
+      bytes = fs.readFileSync(process.argv[1]);
+    } catch (_) {
+      process.exit(2);
+    }
+    if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+      process.exit(3);
+    }
+    if (bytes.includes(0)) process.exit(4);
+    let text;
+    try {
+      text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch (_) {
+      process.exit(1);
+    }
+    if (text.split("\n").some(line => line.length > 0 && line.trim().length === 0)) {
+      process.exit(5);
+    }
+    process.stdout.write(bytes);
+  ' -- "$path"; then
+    return 0
+  else
+    status=$?
+  fi
+  case "$status" in
+    1) fail "decision file must contain valid UTF-8" ;;
+    2) fail "could not read decision file: $path" ;;
+    3) fail "decision file must not start with a UTF-8 BOM" ;;
+    4) fail "decision file must not contain NUL bytes" ;;
+    5) fail "decision file contains a whitespace-only line; remove its whitespace or use an empty line" ;;
+    *) fail "could not validate decision file: $path" ;;
+  esac
 }
 
 scan_decision_identity() {  # <mode> <path> <id> [archive-view]
@@ -757,13 +790,11 @@ command_resolve() {
   validate_slug decision-key "$key"
   [ -n "$decision_file" ] || fail "--decision-file is required"
   [ -f "$decision_file" ] || fail "decision file does not exist: $decision_file"
-  decision=$(cat "$decision_file")
+  decision=$(read_canonical_decision_file "$decision_file") || exit 1
   case "$decision" in *$'\r'*) fail "decision file must use LF line endings" ;; esac
   [ -n "$decision" ] || fail "decision file must not be empty"
   [ "$(printf '%s' "$decision" | LC_ALL=C wc -c | tr -d ' ')" -le 8192 ] \
     || fail "decision file exceeds 8192 bytes"
-  decision_lines_are_canonical "$decision" \
-    || fail "decision file contains a whitespace-only line; remove its whitespace or use an empty line"
   [ -n "$routed" ] || fail "at least one --routed-to task is required"
   routed=$(printf '%s\n' "$routed" | tr ' ' '\n' | sed '/^$/d' | LC_ALL=C sort -u | paste -sd' ' -)
   routed_csv=$(printf '%s\n' "$routed" | tr ' ' ',')

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -398,6 +398,7 @@ verify_archived_resolution() {  # <id> <show-output> <raw-header>
   [ "$state" = "done" ] || fail "archived captain decision $id is not typed done"
   [ "$kind" = captain ] || fail "archived backlog item $id is not kind captain"
   [ "$hold_kind" = captain ] || fail "archived backlog item $id is not held for the captain"
+  [ "$hold_reason" != '-' ] || fail "archived captain decision $id has no hold reason"
   case "$hold_reason" in
     \"*)
       hold_reason=$(decode_json_string "$hold_reason" && printf '\034') \
@@ -405,8 +406,7 @@ verify_archived_resolution() {  # <id> <show-output> <raw-header>
       hold_reason=${hold_reason%$'\034'}
       ;;
   esac
-  [ -n "$hold_reason" ] && [ "$hold_reason" != '-' ] \
-    || fail "archived captain decision $id has no hold reason"
+  [ -n "$hold_reason" ] || fail "archived captain decision $id has no hold reason"
   valid_date "$closed" || fail "archived captain decision $id has an invalid closure date: $closed"
   body=$(decode_json_string "$body_json" && printf '\034') \
     || fail "archived captain decision $id has an invalid structured body"

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -49,7 +49,6 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 ARCHIVE_VIEW=''
-TASKS_AXI_SECTION_HEADING_RE='^##[[:space:]]+'
 
 # shellcheck source=bin/fm-classify-lib.sh
 # shellcheck disable=SC1091
@@ -98,24 +97,38 @@ validate_one_line() {  # <label> <value>
   esac
 }
 
+sha256_digest_from_output() {  # <hash-output>
+  local output=$1 digest
+  digest=${output%%[[:space:]]*}
+  [ "${#digest}" -eq 64 ] || return 1
+  case "$digest" in
+    ''|*[!0-9a-f]*) return 1 ;;
+  esac
+  printf '%s\n' "$digest"
+}
+
 sha256_text() {  # <text>
+  local output
   if command -v shasum >/dev/null 2>&1; then
-    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+    output=$(printf '%s' "$1" | shasum -a 256) || return 1
   elif command -v sha256sum >/dev/null 2>&1; then
-    printf '%s' "$1" | sha256sum | awk '{print $1}'
+    output=$(printf '%s' "$1" | sha256sum) || return 1
   else
     fail "shasum or sha256sum is required"
   fi
+  sha256_digest_from_output "$output"
 }
 
 sha256_file() {  # <path>
+  local output
   if command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "$1" | awk '{print $1}'
+    output=$(shasum -a 256 -- "$1") || return 1
   elif command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$1" | awk '{print $1}'
+    output=$(sha256sum -- "$1") || return 1
   else
     fail "shasum or sha256sum is required"
   fi
+  sha256_digest_from_output "$output"
 }
 
 hold_id() {  # <origin-id> <decision-key>
@@ -173,13 +186,113 @@ valid_date() {  # <YYYY-MM-DD>
   ' "$1"
 }
 
+scan_decision_identity() {  # <mode> <path> <id> [archive-view]
+  command -v node >/dev/null 2>&1 || fail "node is required to inspect decision identities"
+  node - "$@" <<'NODE'
+const fs = require("fs");
+
+const [mode, path, id, view] = process.argv.slice(2);
+if (!["active-count", "archive-count", "archive-extract"].includes(mode) || !path || !id) {
+  process.exit(2);
+}
+
+let source;
+try {
+  source = fs.readFileSync(path, "utf8");
+} catch (_) {
+  process.exit(1);
+}
+const body = source.endsWith("\n") ? source.slice(0, -1) : source;
+const lines = body === "" ? [] : body.split("\n");
+const semanticLine = line => line.endsWith("\r") ? line.slice(0, -1) : line;
+const idChars = "[A-Za-z0-9][A-Za-z0-9._-]*";
+const inFlight = new RegExp(`^- \\*\\*(${idChars})\\*\\* - (.*)$`);
+const queued = new RegExp(`^- \\[ \\] (${idChars}) - (.*)$`);
+const done = new RegExp(`^- \\[x\\] (${idChars}) - (.*)$`);
+
+function sectionState(line) {
+  const match = semanticLine(line).match(/^##\s+(.*?)\s*$/);
+  if (!match) return undefined;
+  const text = match[1].toLowerCase();
+  if (text === "in flight") return "in_flight";
+  if (text === "queued") return "queued";
+  if (text.startsWith("done")) return "done";
+  return undefined;
+}
+
+function taskIdentity(line, state) {
+  const semantic = semanticLine(line);
+  let match;
+  if (state === "done") match = semantic.match(done);
+  if (state === "queued") match = semantic.match(queued);
+  if (state === "in_flight") match = semantic.match(inFlight) || semantic.match(queued);
+  return match ? match[1] : undefined;
+}
+
+function isSectionHeading(line) {
+  return /^##\s+/.test(semanticLine(line));
+}
+
+function isCanonicalArchiveHeading(line) {
+  return /^## Archived [0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(line);
+}
+
+function extractRecord(start) {
+  const record = [lines[start]];
+  for (let index = start + 1; index < lines.length; index++) {
+    const line = lines[index];
+    const semantic = semanticLine(line);
+    if (isSectionHeading(line) || taskIdentity(line, "done") !== undefined) break;
+    if (semantic.trim().length === 0 || semantic.startsWith("  ")) {
+      record.push(line);
+      continue;
+    }
+    break;
+  }
+  return record;
+}
+
+let state;
+let archived = false;
+let total = 0;
+let valid = 0;
+let record;
+for (let index = 0; index < lines.length; index++) {
+  const line = lines[index];
+  if (isSectionHeading(line)) {
+    archived = isCanonicalArchiveHeading(line);
+    state = archived ? "done" : sectionState(line);
+    continue;
+  }
+  if (taskIdentity(line, state) !== id) continue;
+  total++;
+  if (archived) {
+    valid++;
+    if (record === undefined) record = extractRecord(index);
+  }
+}
+
+if (mode === "active-count") {
+  process.stdout.write(`${total}\n`);
+  process.exit(0);
+}
+if (mode === "archive-count") {
+  process.stdout.write(`${total} ${valid}\n`);
+  process.exit(0);
+}
+if (!view || valid !== 1 || record === undefined) process.exit(1);
+try {
+  fs.writeFileSync(view, ["## Done", "", ...record].join("\n") + "\n", "utf8");
+} catch (_) {
+  process.exit(1);
+}
+NODE
+}
+
 active_identity_count() {  # <id>
   local id=$1 backlog="$DATA/backlog.md"
   [ -f "$backlog" ] || { printf '0\n'; return 0; }
-  awk -v id="$id" '
-    index($0, "- [ ] " id " - ") == 1 || index($0, "- [x] " id " - ") == 1 { count++ }
-    END { print count + 0 }
-  ' "$backlog"
+  scan_decision_identity active-count "$backlog" "$id"
 }
 
 archive_is_safe() {  # <archive>
@@ -192,19 +305,7 @@ archive_is_safe() {  # <archive>
 
 archive_identity_counts() {  # <archive> <id>
   local archive=$1 id=$2
-  awk -v id="$id" -v section_heading_re="$TASKS_AXI_SECTION_HEADING_RE" '
-    function target(line) {
-      return index(line, "- [ ] " id " - ") == 1 || index(line, "- [x] " id " - ") == 1
-    }
-    $0 ~ section_heading_re {
-      archived = ($0 ~ /^## Archived [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)
-    }
-    target($0) {
-      total++
-      if (archived) valid++
-    }
-    END { print total + 0, valid + 0 }
-  ' "$archive"
+  scan_decision_identity archive-count "$archive" "$id"
 }
 
 verify_archive_unchanged() {  # <archive> <expected-digest>
@@ -227,34 +328,13 @@ extract_archive_record() {  # <archive> <id>
     umask 077
     mktemp "$DATA/.fm-decision-hold-archive.XXXXXX"
   ) || fail "could not create private archive parser view"
-  awk -v id="$id" -v section_heading_re="$TASKS_AXI_SECTION_HEADING_RE" '
-    BEGIN {
-      print "## Done"
-      print ""
-    }
-    capturing {
-      if ($0 ~ /^- \[[ x]\] / || $0 ~ section_heading_re) exit
-      if ($0 == "" || substr($0, 1, 2) == "  ") {
-        print
-        next
-      }
-      exit
-    }
-    $0 ~ section_heading_re {
-      archived = ($0 ~ /^## Archived [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)
-    }
-    archived && (index($0, "- [ ] " id " - ") == 1 || index($0, "- [x] " id " - ") == 1) {
-      found++
-      capturing = 1
-      print
-    }
-    END { if (found != 1) exit 1 }
-  ' "$archive" > "$ARCHIVE_VIEW" || fail "could not extract exact archived decision $id"
+  scan_decision_identity archive-extract "$archive" "$id" "$ARCHIVE_VIEW" \
+    || fail "could not extract exact archived decision $id"
 }
 
 verify_archived_resolution() {  # <id> <show-output> <raw-header>
   local id=$1 show=$2 header=$3 parsed_id state kind hold_kind hold_reason closed body_json body
-  local marker rest digest routes route sorted_routes route_suffix expected_prefix decision
+  local marker rest digest routes route sorted_routes route_suffix expected_prefix decision recomputed_digest
   case "$header" in
     "- [x] $id - "*) : ;;
     *) fail "archived captain decision $id is not an exact terminal record" ;;
@@ -330,7 +410,9 @@ EOF
     *) fail "archived captain decision $id has an invalid resolution body" ;;
   esac
   [ -n "$decision" ] || fail "archived captain decision $id has an empty captain decision"
-  [ "$(sha256_text "$decision")" = "$digest" ] \
+  recomputed_digest=$(sha256_text "$decision") \
+    || fail "could not recompute archived captain decision digest: $id"
+  [ "$recomputed_digest" = "$digest" ] \
     || fail "archived captain decision $id does not match its decision digest"
 }
 
@@ -673,7 +755,7 @@ command_resolve() {
   [ -n "$routed" ] || fail "at least one --routed-to task is required"
   routed=$(printf '%s\n' "$routed" | tr ' ' '\n' | sed '/^$/d' | LC_ALL=C sort -u | paste -sd' ' -)
   routed_csv=$(printf '%s\n' "$routed" | tr ' ' ',')
-  decision_digest=$(sha256_text "$decision")
+  decision_digest=$(sha256_text "$decision") || fail "could not digest captain decision"
   require_tasks_axi
   id=$(hold_id "$origin" "$key")
   if verify_hold_resolved "$id"; then

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -284,6 +284,7 @@ function extractRecord(start) {
     }
     break;
   }
+  if (record.some(line => line.includes("\r"))) process.exit(1);
   return record;
 }
 

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -13,7 +13,7 @@ The `hold` subcommand maps an originating work id and stable decision key to `<o
 It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold <id> --reason <reason> --kind captain` on every retry.
 It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
 
-Every decision lookup counts the exact identity across the active backlog and canonical `## Archived YYYY-MM-DD` sections in `data/done-archive.md`.
+Every decision lookup resets archive membership at every tasks-axi-recognized level-two heading and counts the exact identity only in canonical `## Archived YYYY-MM-DD` sections in `data/done-archive.md`.
 It rejects duplicate active identities, duplicate archived identities, active/archive collisions, symlink or non-regular archives, unreadable archives, and archive bytes that change during verification.
 For an archived identity, it extracts only that record into a private single-record `## Done` view and parses it through public `tasks-axi show --full --file` output.
 The archived record is accepted only when its terminal checkbox and typed state, captain kind and hold kind, closure date, decision digest, sorted unique routed identities, non-empty decision, and exact routed-work suffix all match the durable bytes written by `resolve`.
@@ -30,6 +30,7 @@ Scout teardown calls the script's read-only `verify` subcommand after checking f
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
 The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
+It rejects carriage-return line endings before any backlog mutation so accepted decision bytes remain recomputable after structured Markdown retention.
 It records the decision digest and routed task identities as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
 An exact retry can finish a partial routing operation, while a changed decision or routed-task set is rejected.
 A failed intermediate step leaves the hold open.
@@ -69,7 +70,7 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
-ok - retained decisions support complete/verify/retry and malformed, forged, wrong-kind, unresolved, arbitrary, duplicate, and unsafe archives fail closed
+ok - retained LF decisions verify after archival while CRLF, tab-heading, malformed, forged, duplicate, and unsafe records are rejected
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -19,7 +19,7 @@ It rejects duplicate active identities, duplicate archived identities, active/ar
 Archive fingerprinting accepts only a successful lowercase SHA-256 digest before any comparison.
 For an archived identity, it extracts only that record into a private single-record `## Done` view and parses it through public `tasks-axi show --full --file` output.
 The extractor rejects non-empty whitespace-only archive lines so the typed parser cannot collapse different stored bytes into the same decision body.
-The archived record is accepted only when its terminal checkbox and typed state, captain kind and hold kind, closure date, decision digest, sorted unique routed identities, non-empty decision, and exact routed-work suffix all match the durable bytes written by `resolve`.
+The archived record is accepted only when its terminal checkbox and typed state, captain kind and hold kind, present hold reason distinct from the raw unquoted missing sentinel, closure date, decision digest, sorted unique routed identities, non-empty decision, and exact routed-work suffix all match the durable bytes written by `resolve`.
 Immediately before acceptance, it rechecks the archive fingerprint and exact identity counts after active-store and structured record validation have both finished, then rechecks the active identity after final archive validation.
 This preserves the historical `Routed work:- <first-id>` writer format without rewriting active or archived records.
 
@@ -75,6 +75,7 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
+ok - retained quoted dash hold reasons survive complete, verify, and idempotent resolve
 ok - canonical Unicode survives retention while malformed bytes, lossy text, late collisions, duplicates, and unsafe stores are rejected
 
 $ bash tests/fm-fleet-snapshot-view.test.sh

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -34,8 +34,8 @@ Scout teardown calls the script's read-only `verify` subcommand after checking f
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
 The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
-It reads one raw decision-file snapshot and rejects invalid UTF-8, a UTF-8 BOM, NUL bytes, carriage-return line endings, and non-empty whitespace-only lines before any backlog mutation.
-Accepted Unicode is neither normalized nor rewritten, so its exact bytes remain recomputable after structured Markdown retention while canonical empty lines remain unchanged.
+It reads one raw decision-file snapshot and rejects invalid UTF-8, a UTF-8 BOM, NUL bytes, any carriage return, and non-empty whitespace-only lines before any backlog mutation.
+Bash command substitution removes all trailing LF bytes before size validation and digesting; accepted Unicode is otherwise not normalized, and internal empty lines remain distinct through structured Markdown retention.
 It records the decision digest and routed task identities as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
 An exact retry can finish a partial routing operation, while a changed decision or routed-task set is rejected.
 A failed intermediate step leaves the hold open.

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -13,6 +13,12 @@ The `hold` subcommand maps an originating work id and stable decision key to `<o
 It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold <id> --reason <reason> --kind captain` on every retry.
 It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
 
+Every decision lookup counts the exact identity across the active backlog and canonical `## Archived YYYY-MM-DD` sections in `data/done-archive.md`.
+It rejects duplicate active identities, duplicate archived identities, active/archive collisions, symlink or non-regular archives, unreadable archives, and archive bytes that change during verification.
+For an archived identity, it extracts only that record into a private single-record `## Done` view and parses it through public `tasks-axi show --full --file` output.
+The archived record is accepted only when its terminal checkbox and typed state, captain kind and hold kind, closure date, decision digest, sorted unique routed identities, non-empty decision, and exact routed-work suffix all match the durable bytes written by `resolve`.
+This preserves the historical `Routed work:- <first-id>` writer format without rewriting active or archived records.
+
 The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
 A post-teardown visual review can complete against the surviving report and durable holds without recreating volatile task metadata.
 It accepts `--none` as an explicit semantic inventory result, not as inferred absence.
@@ -43,6 +49,7 @@ The projection remains read-only and does not inspect historical prose.
 Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Archive-aware retention and adversarial verification date: 2026-07-23.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
@@ -62,6 +69,7 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
+ok - retained decisions support complete/verify/retry and malformed, forged, wrong-kind, unresolved, arbitrary, duplicate, and unsafe archives fail closed
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -13,7 +13,8 @@ The `hold` subcommand maps an originating work id and stable decision key to `<o
 It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold <id> --reason <reason> --kind captain` on every retry.
 It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
 
-One shared scanner mirrors tasks-axi's task-header forms and ECMAScript level-two heading boundary while counting exact identities in the active backlog and canonical `## Archived YYYY-MM-DD` sections in `data/done-archive.md`.
+One shared scanner mirrors tasks-axi's lexical task-header forms and ECMAScript level-two heading boundary while counting every exact identity independently of section validity across the active backlog and archive.
+Only a terminal header under an exact canonical `## Archived YYYY-MM-DD` heading is eligible for structured archive verification.
 It rejects duplicate active identities, duplicate archived identities, active/archive collisions, symlink or non-regular archives, unreadable archives, and archive bytes that change during verification.
 Archive fingerprinting accepts only a successful lowercase SHA-256 digest before any comparison.
 For an archived identity, it extracts only that record into a private single-record `## Done` view and parses it through public `tasks-axi show --full --file` output.
@@ -71,7 +72,7 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
-ok - retained LF decisions verify while CRLF, grammar escapes, bold collisions, hash failures, and unsafe records are rejected
+ok - one canonical retained decision verifies while CRLF, grammar escapes, invalid duplicates, hash failures, and unsafe records are rejected
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -18,7 +18,7 @@ Only a terminal header under an exact canonical `## Archived YYYY-MM-DD` heading
 It rejects duplicate active identities, duplicate archived identities, active/archive collisions, symlink, non-regular, or unreadable active and archive stores, and archive bytes that change during verification.
 Archive fingerprinting accepts only a successful lowercase SHA-256 digest before any comparison.
 For an archived identity, it extracts only that record into a private single-record `## Done` view and parses it through public `tasks-axi show --full --file` output.
-The extractor rejects non-empty whitespace-only archive lines so the typed parser cannot collapse different stored bytes into the same decision body.
+The extractor rejects carriage returns and non-empty whitespace-only archive lines so the typed parser cannot collapse different stored bytes into the same decision body.
 The archived record is accepted only when its terminal checkbox and typed state, captain kind and hold kind, present hold reason distinct from the raw unquoted missing sentinel, closure date, decision digest, sorted unique routed identities, non-empty decision, and exact routed-work suffix all match the durable bytes written by `resolve`.
 Immediately before acceptance, it rechecks the archive fingerprint and exact identity counts after active-store and structured record validation have both finished, then rechecks the active identity after final archive validation.
 This preserves the historical `Routed work:- <first-id>` writer format without rewriting active or archived records.

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -15,11 +15,12 @@ It rejects an identity collision, a changed title, and attempts to reopen an alr
 
 One shared scanner mirrors tasks-axi's lexical task-header forms and ECMAScript level-two heading boundary while counting every exact identity independently of section validity across the active backlog and archive.
 Only a terminal header under an exact canonical `## Archived YYYY-MM-DD` heading is eligible for structured archive verification.
-It rejects duplicate active identities, duplicate archived identities, active/archive collisions, symlink or non-regular archives, unreadable archives, and archive bytes that change during verification.
+It rejects duplicate active identities, duplicate archived identities, active/archive collisions, symlink, non-regular, or unreadable active and archive stores, and archive bytes that change during verification.
 Archive fingerprinting accepts only a successful lowercase SHA-256 digest before any comparison.
 For an archived identity, it extracts only that record into a private single-record `## Done` view and parses it through public `tasks-axi show --full --file` output.
+The extractor rejects non-empty whitespace-only archive lines so the typed parser cannot collapse different stored bytes into the same decision body.
 The archived record is accepted only when its terminal checkbox and typed state, captain kind and hold kind, closure date, decision digest, sorted unique routed identities, non-empty decision, and exact routed-work suffix all match the durable bytes written by `resolve`.
-Immediately before acceptance, it rechecks the archive fingerprint and exact identity counts after active-store and structured record validation have both finished.
+Immediately before acceptance, it rechecks the archive fingerprint and exact identity counts after active-store and structured record validation have both finished, then rechecks the active identity after final archive validation.
 This preserves the historical `Routed work:- <first-id>` writer format without rewriting active or archived records.
 
 The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
@@ -74,7 +75,7 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
-ok - canonical Unicode survives retention while malformed bytes, lossy whitespace, late mutations, duplicates, and unsafe archives are rejected
+ok - canonical Unicode survives retention while malformed bytes, lossy text, late collisions, duplicates, and unsafe stores are rejected
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -33,7 +33,8 @@ Scout teardown calls the script's read-only `verify` subcommand after checking f
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
 The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
-It rejects carriage-return line endings and non-empty whitespace-only lines before any backlog mutation so accepted decision bytes remain recomputable after structured Markdown retention while canonical empty lines remain unchanged.
+It reads one raw decision-file snapshot and rejects invalid UTF-8, a UTF-8 BOM, NUL bytes, carriage-return line endings, and non-empty whitespace-only lines before any backlog mutation.
+Accepted Unicode is neither normalized nor rewritten, so its exact bytes remain recomputable after structured Markdown retention while canonical empty lines remain unchanged.
 It records the decision digest and routed task identities as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
 An exact retry can finish a partial routing operation, while a changed decision or routed-task set is rejected.
 A failed intermediate step leaves the hold open.
@@ -73,7 +74,7 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
-ok - canonical LF decisions survive retention while whitespace-only inputs, late mutations, invalid duplicates, and unsafe archives are rejected
+ok - canonical Unicode survives retention while malformed bytes, lossy whitespace, late mutations, duplicates, and unsafe archives are rejected
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -19,6 +19,7 @@ It rejects duplicate active identities, duplicate archived identities, active/ar
 Archive fingerprinting accepts only a successful lowercase SHA-256 digest before any comparison.
 For an archived identity, it extracts only that record into a private single-record `## Done` view and parses it through public `tasks-axi show --full --file` output.
 The archived record is accepted only when its terminal checkbox and typed state, captain kind and hold kind, closure date, decision digest, sorted unique routed identities, non-empty decision, and exact routed-work suffix all match the durable bytes written by `resolve`.
+Immediately before acceptance, it rechecks the archive fingerprint and exact identity counts after active-store and structured record validation have both finished.
 This preserves the historical `Routed work:- <first-id>` writer format without rewriting active or archived records.
 
 The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
@@ -32,7 +33,7 @@ Scout teardown calls the script's read-only `verify` subcommand after checking f
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
 The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
-It rejects carriage-return line endings before any backlog mutation so accepted decision bytes remain recomputable after structured Markdown retention.
+It rejects carriage-return line endings and non-empty whitespace-only lines before any backlog mutation so accepted decision bytes remain recomputable after structured Markdown retention while canonical empty lines remain unchanged.
 It records the decision digest and routed task identities as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
 An exact retry can finish a partial routing operation, while a changed decision or routed-task set is rejected.
 A failed intermediate step leaves the hold open.
@@ -72,7 +73,7 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
-ok - one canonical retained decision verifies while CRLF, grammar escapes, invalid duplicates, hash failures, and unsafe records are rejected
+ok - canonical LF decisions survive retention while whitespace-only inputs, late mutations, invalid duplicates, and unsafe archives are rejected
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -13,8 +13,9 @@ The `hold` subcommand maps an originating work id and stable decision key to `<o
 It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold <id> --reason <reason> --kind captain` on every retry.
 It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
 
-Every decision lookup resets archive membership at every tasks-axi-recognized level-two heading and counts the exact identity only in canonical `## Archived YYYY-MM-DD` sections in `data/done-archive.md`.
+One shared scanner mirrors tasks-axi's task-header forms and ECMAScript level-two heading boundary while counting exact identities in the active backlog and canonical `## Archived YYYY-MM-DD` sections in `data/done-archive.md`.
 It rejects duplicate active identities, duplicate archived identities, active/archive collisions, symlink or non-regular archives, unreadable archives, and archive bytes that change during verification.
+Archive fingerprinting accepts only a successful lowercase SHA-256 digest before any comparison.
 For an archived identity, it extracts only that record into a private single-record `## Done` view and parses it through public `tasks-axi show --full --file` output.
 The archived record is accepted only when its terminal checkbox and typed state, captain kind and hold kind, closure date, decision digest, sorted unique routed identities, non-empty decision, and exact routed-work suffix all match the durable bytes written by `resolve`.
 This preserves the historical `Routed work:- <first-id>` writer format without rewriting active or archived records.
@@ -70,7 +71,7 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
-ok - retained LF decisions verify after archival while CRLF, tab-heading, malformed, forged, duplicate, and unsafe records are rejected
+ok - retained LF decisions verify while CRLF, grammar escapes, bold collisions, hash failures, and unsafe records are rejected
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -594,7 +594,7 @@ assert_archive_verify_fails() {  # <home> <origin> <case>
 }
 
 test_retained_decisions_are_strictly_archive_aware() {
-  local home origin older_hold newer_hold archive record heading digest closed variant before after show
+  local home origin older_hold newer_hold archive record unresolved_record heading digest closed variant before after show
   local separator_label separator_code separator
   local dependent=sample-retained-dependent
   home=$(make_home retained-decisions)
@@ -708,12 +708,18 @@ EOF
 
   record=$(archive_record "$archive" "$older_hold")
   [ -n "$record" ] || fail "could not extract the retained synthetic record"
+  unresolved_record=${record/"- [x] $older_hold -"/"- [ ] $older_hold -"}
+  [ "$unresolved_record" != "$record" ] || fail "could not build the unresolved duplicate fixture"
   heading=$(sed -n '/^## Archived /{p;q;}' "$archive")
   [ -n "$heading" ] || fail "retained archive has no canonical section heading"
   digest=$(printf '%s\n' "$record" | sed -n 's/^  Decision digest: //p' | head -1)
   [ -n "$digest" ] || fail "retained record has no decision digest"
   closed=$(printf '%s\n' "$record" | sed -n 's/.*(done \([0-9][0-9-]*\)).*/\1/p' | head -1)
   [ -n "$closed" ] || fail "retained record has no closure date"
+
+  variant=$(clone_home "$home" retained-single-canonical)
+  run_decisions "$variant" verify "$origin" >/dev/null \
+    || fail "a single canonical archived decision did not verify"
 
   variant=$(clone_home "$home" retained-truncated)
   rewrite_once "$variant/data/done-archive.md" \
@@ -763,6 +769,28 @@ EOF
   variant=$(clone_home "$home" retained-duplicate)
   printf '\n## Archived 2026-07-24\n%s\n' "$record" >> "$variant/data/done-archive.md"
   assert_archive_verify_fails "$variant" "$origin" duplicate-record
+
+  variant=$(clone_home "$home" retained-canonical-malformed-duplicate)
+  printf '\n%s extra\n%s\n' "$heading" "$record" >> "$variant/data/done-archive.md"
+  assert_archive_verify_fails "$variant" "$origin" canonical-malformed-duplicate
+  assert_grep "appears outside a canonical archive section" \
+    "$variant/canonical-malformed-duplicate.err" \
+    "a malformed duplicate was hidden from exact identity counting"
+
+  variant=$(clone_home "$home" retained-canonical-unresolved-duplicate)
+  printf '\n%s\n%s\n' "$heading" "$unresolved_record" >> "$variant/data/done-archive.md"
+  assert_archive_verify_fails "$variant" "$origin" canonical-unresolved-duplicate
+  assert_grep "appears outside a canonical archive section" \
+    "$variant/canonical-unresolved-duplicate.err" \
+    "an unresolved duplicate was hidden from exact identity counting"
+
+  variant=$(clone_home "$home" retained-duplicate-invalid)
+  rewrite_once "$variant/data/done-archive.md" "$heading" "$heading extra"
+  printf '\n## Unknown\n%s\n' "$record" >> "$variant/data/done-archive.md"
+  assert_archive_verify_fails "$variant" "$origin" duplicate-invalid-records
+  assert_grep "appears outside a canonical archive section" \
+    "$variant/duplicate-invalid-records.err" \
+    "duplicate invalid identities were hidden from exact identity counting"
 
   variant=$(clone_home "$home" retained-malformed-section)
   rewrite_once "$variant/data/done-archive.md" "$heading" "$heading extra"
@@ -891,7 +919,7 @@ EOF
   printf '\n%s\n' "$record" >> "$variant/data/backlog.md"
   assert_archive_verify_fails "$variant" "$origin" active-archive-collision
 
-  pass "retained LF decisions verify while CRLF, grammar escapes, bold collisions, hash failures, and unsafe records are rejected"
+  pass "one canonical retained decision verifies while CRLF, grammar escapes, invalid duplicates, hash failures, and unsafe records are rejected"
 }
 
 test_uninventoried_report_decision_refuses_completion

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -594,7 +594,7 @@ assert_archive_verify_fails() {  # <home> <origin> <case>
 }
 
 test_retained_decisions_are_strictly_archive_aware() {
-  local home origin older_hold newer_hold archive record heading digest closed variant
+  local home origin older_hold newer_hold archive record heading digest closed variant before after
   local dependent=sample-retained-dependent
   home=$(make_home retained-decisions)
   origin=sample-retained-review
@@ -614,6 +614,17 @@ test_retained_decisions_are_strictly_archive_aware() {
     || fail "could not create retained-decision dependent work"
   tasks_in "$home" block "$dependent" --by "$older_hold" >/dev/null \
     || fail "could not block retained-decision dependent work"
+  printf 'Use the retained route.\r\n' > "$home/crlf-retained-decision.txt"
+  before=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+  if run_decisions "$home" resolve "$origin" older \
+    --decision-file "$home/crlf-retained-decision.txt" --routed-to "$dependent" \
+    > "$home/crlf-decision.out" 2> "$home/crlf-decision.err"; then
+    fail "resolve accepted a CRLF captain decision"
+  fi
+  after=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+  [ "$before" = "$after" ] || fail "CRLF rejection mutated the backlog"
+  assert_grep "decision file must use LF line endings" "$home/crlf-decision.err" \
+    "CRLF rejection did not report the canonical decision-file requirement"
   printf 'Use the retained route.\n' > "$home/retained-decision.txt"
   run_decisions "$home" resolve "$origin" older --decision-file "$home/retained-decision.txt" \
     --routed-to "$dependent" >/dev/null \
@@ -756,6 +767,11 @@ EOF
   rewrite_once "$variant/data/done-archive.md" "$heading" "$heading extra"
   assert_archive_verify_fails "$variant" "$origin" malformed-section
 
+  variant=$(clone_home "$home" retained-tab-heading)
+  rewrite_once "$variant/data/done-archive.md" "$heading" \
+    "${heading}"$'\n\n##\tDone'
+  assert_archive_verify_fails "$variant" "$origin" tab-heading-section-escape
+
   variant=$(clone_home "$home" retained-symlink)
   mv "$variant/data/done-archive.md" "$variant/data/archive-target.md"
   ln -s archive-target.md "$variant/data/done-archive.md"
@@ -791,7 +807,7 @@ EOF
   printf '\n%s\n' "$record" >> "$variant/data/backlog.md"
   assert_archive_verify_fails "$variant" "$origin" active-archive-collision
 
-  pass "retained decisions support complete/verify/retry and malformed, forged, wrong-kind, unresolved, arbitrary, duplicate, and unsafe archives fail closed"
+  pass "retained LF decisions verify after archival while CRLF, tab-heading, malformed, forged, duplicate, and unsafe records are rejected"
 }
 
 test_uninventoried_report_decision_refuses_completion

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -675,7 +675,7 @@ test_retained_quoted_dash_hold_reason_survives_lifecycle() {
 test_retained_decisions_are_strictly_archive_aware() {
   local home origin older_hold newer_hold archive record unresolved_record heading digest closed variant before after show
   local separator_label separator_code separator
-  local decision_case decision_bytes decision_path encoding_case
+  local decision_case decision_bytes decision_line decision_path encoding_case
   local dependent=sample-retained-dependent
   home=$(make_home retained-decisions)
   origin=sample-retained-review
@@ -903,6 +903,12 @@ Buffer.from(lossyDigest).copy(archive, digestIndex);
 fs.writeFileSync(archivePath, archive);
 NODE
   assert_archive_verify_fails "$variant" "$origin" invalid-utf8-record
+
+  variant=$(clone_home "$home" retained-crlf-decision-line)
+  decision_line=$(printf '%b' '  Use the retained route. \344\270\255\346\226\207')
+  rewrite_once "$variant/data/done-archive.md" \
+    "$decision_line" "${decision_line}"$'\r'
+  assert_archive_verify_fails "$variant" "$origin" crlf-decision-line
 
   variant=$(clone_home "$home" retained-wrong-kind)
   rewrite_once "$variant/data/done-archive.md" "(kind: captain)" "(kind: ship)"

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -550,6 +550,250 @@ test_resolve_matches_quoted_blocked_by_edges() {
   pass "resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id"
 }
 
+clone_home() {  # <source-home> <name>
+  local source=$1 destination="$TMP_ROOT/$2"
+  cp -R "$source" "$destination"
+  printf '%s\n' "$destination"
+}
+
+rewrite_once() {  # <file> <old> <new>
+  local file=$1 old=$2 new=$3 content
+  content=$(cat "$file")
+  case "$content" in
+    *"$old"*) : ;;
+    *) fail "archive fixture text was not found in $file: $old" ;;
+  esac
+  content=${content/"$old"/"$new"}
+  printf '%s\n' "$content" > "$file"
+}
+
+archive_record() {  # <archive> <id>
+  local archive=$1 id=$2
+  awk -v id="$id" '
+    capturing {
+      if ($0 ~ /^- \[[ x]\] / || $0 ~ /^## /) exit
+      if ($0 == "" || substr($0, 1, 2) == "  ") {
+        print
+        next
+      }
+      exit
+    }
+    index($0, "- [x] " id " - ") == 1 {
+      capturing = 1
+      print
+    }
+  ' "$archive"
+}
+
+assert_archive_verify_fails() {  # <home> <origin> <case>
+  local home=$1 origin=$2 case_name=$3
+  if run_decisions "$home" verify "$origin" \
+    > "$home/$case_name.out" 2> "$home/$case_name.err"; then
+    fail "archive verification accepted $case_name"
+  fi
+}
+
+test_retained_decisions_are_strictly_archive_aware() {
+  local home origin older_hold newer_hold archive record heading digest closed variant
+  local dependent=sample-retained-dependent
+  home=$(make_home retained-decisions)
+  origin=sample-retained-review
+  mkdir -p "$home/data/$origin"
+  tasks_in "$home" add "$origin" "Review retained decisions" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create retained-decision origin"
+  write_origin_meta "$home" "$origin"
+  printf 'done: retained-decision report complete\n' > "$home/state/$origin.status"
+  printf '# Retained decision review\n\nOne historical decision is resolved.\n' > "$home/data/$origin/report.md"
+
+  older_hold=$(run_decisions "$home" hold "$origin" older \
+    --title "Choose the retained route" --reason "captain retained route pending" --repo sample) \
+    || fail "could not create the decision that will be retained"
+  run_decisions "$home" complete "$origin" older >/dev/null \
+    || fail "could not inventory the decision before retention"
+  tasks_in "$home" add "$dependent" "Apply the retained route" --kind ship --repo sample >/dev/null \
+    || fail "could not create retained-decision dependent work"
+  tasks_in "$home" block "$dependent" --by "$older_hold" >/dev/null \
+    || fail "could not block retained-decision dependent work"
+  printf 'Use the retained route.\n' > "$home/retained-decision.txt"
+  run_decisions "$home" resolve "$origin" older --decision-file "$home/retained-decision.txt" \
+    --routed-to "$dependent" >/dev/null \
+    || fail "could not resolve the decision before retention"
+
+  for number in 01 02 03 04 05 06 07 08 09 10 11; do
+    tasks_in "$home" add "sample-retention-$number" "Retention filler $number" \
+      --kind ship --repo sample >/dev/null \
+      || fail "could not create retention filler $number"
+    tasks_in "$home" "done" "sample-retention-$number" >/dev/null \
+      || fail "could not complete retention filler $number"
+  done
+  archive="$home/data/done-archive.md"
+  assert_present "$archive" "done_keep retention did not create an archive"
+  assert_no_grep "- [x] $older_hold -" "$home/data/backlog.md" \
+    "retained decision remained active instead of entering the archive"
+  assert_grep "- [x] $older_hold -" "$archive" \
+    "retained decision was not archived"
+
+  cat > "$home/fakebin/tasks-axi" <<'EOF'
+#!/usr/bin/env bash
+previous=''
+view=''
+for argument in "$@"; do
+  if [ "$previous" = --file ]; then view=$argument; fi
+  previous=$argument
+done
+if [ -n "$view" ]; then
+  if [ "$(uname)" = Darwin ]; then
+    mode=$(stat -f %Lp "$view")
+  else
+    mode=$(stat -c %a "$view")
+  fi
+  [ "$mode" = 600 ] || exit 91
+  grep -F -- '- [x] sample-retained-review-decision-older -' "$view" >/dev/null || exit 92
+  [ "$(grep -c '^- \[' "$view")" = 1 ] || exit 93
+  ! grep -F -- 'sample-retention-01' "$view" >/dev/null || exit 94
+  : > "$FM_HOME/private-parser-view-checked"
+fi
+exec "$REAL_TASKS_AXI" "$@"
+EOF
+  chmod +x "$home/fakebin/tasks-axi"
+
+  newer_hold=$(run_decisions "$home" hold "$origin" newer \
+    --title "Choose the current route" --reason "captain current route pending" --repo sample) \
+    || fail "could not create the current decision after retention"
+  run_decisions "$home" complete "$origin" older newer >/dev/null \
+    || fail "completion could not verify a retained historical decision"
+  run_decisions "$home" complete "$origin" older newer >/dev/null \
+    || fail "repeated completion was not idempotent after retention"
+  run_decisions "$home" verify "$origin" >/dev/null \
+    || fail "verification could not read the retained decision"
+  assert_present "$home/private-parser-view-checked" \
+    "archive verification did not use a private exact-record parser view"
+  run_decisions "$home" resolve "$origin" older --decision-file "$home/retained-decision.txt" \
+    --routed-to "$dependent" >/dev/null \
+    || fail "identical resolution retry could not read the retained decision"
+  printf 'Use a different retained route.\n' > "$home/changed-retained-decision.txt"
+  if run_decisions "$home" resolve "$origin" older \
+    --decision-file "$home/changed-retained-decision.txt" --routed-to "$dependent" \
+    > "$home/archived-changed-decision.out" 2> "$home/archived-changed-decision.err"; then
+    fail "archived resolution retry accepted a different captain decision"
+  fi
+  if run_decisions "$home" resolve "$origin" older \
+    --decision-file "$home/retained-decision.txt" --routed-to sample-retained-other \
+    > "$home/archived-changed-routes.out" 2> "$home/archived-changed-routes.err"; then
+    fail "archived resolution retry accepted different routed work"
+  fi
+  if run_decisions "$home" hold "$origin" older \
+    --title "Choose the retained route" --reason "captain retained route pending" --repo sample \
+    > "$home/archived-hold.out" 2> "$home/archived-hold.err"; then
+    fail "hold reopened a retained resolved identity"
+  fi
+  assert_no_grep "- [ ] $older_hold -" "$home/data/backlog.md" \
+    "hold created an active duplicate of a retained identity"
+  assert_grep "decision_keys=newer,older" "$home/state/$origin.meta" \
+    "retained and current decisions were not unioned deterministically"
+  assert_grep "- [ ] $newer_hold -" "$home/data/backlog.md" \
+    "the current active decision did not survive retained verification"
+
+  record=$(archive_record "$archive" "$older_hold")
+  [ -n "$record" ] || fail "could not extract the retained synthetic record"
+  heading=$(sed -n '/^## Archived /{p;q;}' "$archive")
+  [ -n "$heading" ] || fail "retained archive has no canonical section heading"
+  digest=$(printf '%s\n' "$record" | sed -n 's/^  Decision digest: //p' | head -1)
+  [ -n "$digest" ] || fail "retained record has no decision digest"
+  closed=$(printf '%s\n' "$record" | sed -n 's/.*(done \([0-9][0-9-]*\)).*/\1/p' | head -1)
+  [ -n "$closed" ] || fail "retained record has no closure date"
+
+  variant=$(clone_home "$home" retained-truncated)
+  rewrite_once "$variant/data/done-archive.md" \
+    "  Routed work:- $dependent" "  Routed work:"
+  assert_archive_verify_fails "$variant" "$origin" truncated-record
+
+  variant=$(clone_home "$home" retained-forged)
+  rewrite_once "$variant/data/done-archive.md" \
+    "  Decision digest: $digest" \
+    "  Decision digest: 0000000000000000000000000000000000000000000000000000000000000000"
+  assert_archive_verify_fails "$variant" "$origin" forged-record
+
+  variant=$(clone_home "$home" retained-wrong-kind)
+  rewrite_once "$variant/data/done-archive.md" "(kind: captain)" "(kind: ship)"
+  assert_archive_verify_fails "$variant" "$origin" wrong-kind-record
+
+  variant=$(clone_home "$home" retained-wrong-hold-kind)
+  rewrite_once "$variant/data/done-archive.md" "(hold-kind: captain)" "(hold-kind: ship)"
+  assert_archive_verify_fails "$variant" "$origin" wrong-hold-kind-record
+
+  variant=$(clone_home "$home" retained-invalid-closure)
+  rewrite_once "$variant/data/done-archive.md" "(done $closed)" "(done 2026-02-31)"
+  assert_archive_verify_fails "$variant" "$origin" invalid-closure-record
+
+  variant=$(clone_home "$home" retained-duplicate-routes)
+  rewrite_once "$variant/data/done-archive.md" \
+    "  Routed identities: $dependent" "  Routed identities: $dependent,$dependent"
+  assert_archive_verify_fails "$variant" "$origin" duplicate-routed-identities
+
+  variant=$(clone_home "$home" retained-empty-decision)
+  rewrite_once "$variant/data/done-archive.md" \
+    "  Decision digest: $digest" \
+    "  Decision digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  rewrite_once "$variant/data/done-archive.md" "  Use the retained route." "  "
+  assert_archive_verify_fails "$variant" "$origin" empty-decision-record
+
+  variant=$(clone_home "$home" retained-unresolved)
+  rewrite_once "$variant/data/done-archive.md" \
+    "- [x] $older_hold -" "- [ ] $older_hold -"
+  assert_archive_verify_fails "$variant" "$origin" unresolved-record
+
+  variant=$(clone_home "$home" retained-arbitrary-id)
+  rewrite_once "$variant/data/done-archive.md" \
+    "- [x] $older_hold -" "- [x] $older_hold-unrelated -"
+  assert_archive_verify_fails "$variant" "$origin" arbitrary-id-record
+
+  variant=$(clone_home "$home" retained-duplicate)
+  printf '\n## Archived 2026-07-24\n%s\n' "$record" >> "$variant/data/done-archive.md"
+  assert_archive_verify_fails "$variant" "$origin" duplicate-record
+
+  variant=$(clone_home "$home" retained-malformed-section)
+  rewrite_once "$variant/data/done-archive.md" "$heading" "$heading extra"
+  assert_archive_verify_fails "$variant" "$origin" malformed-section
+
+  variant=$(clone_home "$home" retained-symlink)
+  mv "$variant/data/done-archive.md" "$variant/data/archive-target.md"
+  ln -s archive-target.md "$variant/data/done-archive.md"
+  assert_archive_verify_fails "$variant" "$origin" symlink-archive
+
+  variant=$(clone_home "$home" retained-directory)
+  mv "$variant/data/done-archive.md" "$variant/data/archive-target.md"
+  mkdir "$variant/data/done-archive.md"
+  assert_archive_verify_fails "$variant" "$origin" non-regular-archive
+
+  variant=$(clone_home "$home" retained-unreadable)
+  chmod 000 "$variant/data/done-archive.md"
+  assert_archive_verify_fails "$variant" "$origin" unreadable-archive
+  chmod 600 "$variant/data/done-archive.md"
+
+  variant=$(clone_home "$home" retained-concurrent-change)
+  cat > "$variant/fakebin/tasks-axi" <<'EOF'
+#!/usr/bin/env bash
+case " $* " in
+  *" show "*" --file "*)
+    if [ ! -f "$FM_HOME/archive-changed-once" ]; then
+      : > "$FM_HOME/archive-changed-once"
+      printf '\n# concurrent archive change\n' >> "$FM_HOME/data/done-archive.md"
+    fi
+    ;;
+esac
+exec "$REAL_TASKS_AXI" "$@"
+EOF
+  chmod +x "$variant/fakebin/tasks-axi"
+  assert_archive_verify_fails "$variant" "$origin" concurrent-change
+
+  variant=$(clone_home "$home" retained-active-archive-collision)
+  printf '\n%s\n' "$record" >> "$variant/data/backlog.md"
+  assert_archive_verify_fails "$variant" "$origin" active-archive-collision
+
+  pass "retained decisions support complete/verify/retry and malformed, forged, wrong-kind, unresolved, arbitrary, duplicate, and unsafe archives fail closed"
+}
+
 test_uninventoried_report_decision_refuses_completion
 
 test_scout_teardown_always_requires_inventory_verification
@@ -560,3 +804,4 @@ test_none_inventory_and_resolved_prose_do_not_create_holds
 test_terminal_single_owner_status_decision_does_not_block_empty_inventory
 test_secondmate_hold_stays_in_authoritative_home
 test_resolve_matches_quoted_blocked_by_edges
+test_retained_decisions_are_strictly_archive_aware

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -594,7 +594,8 @@ assert_archive_verify_fails() {  # <home> <origin> <case>
 }
 
 test_retained_decisions_are_strictly_archive_aware() {
-  local home origin older_hold newer_hold archive record heading digest closed variant before after
+  local home origin older_hold newer_hold archive record heading digest closed variant before after show
+  local separator_label separator_code separator
   local dependent=sample-retained-dependent
   home=$(make_home retained-decisions)
   origin=sample-retained-review
@@ -767,10 +768,93 @@ EOF
   rewrite_once "$variant/data/done-archive.md" "$heading" "$heading extra"
   assert_archive_verify_fails "$variant" "$origin" malformed-section
 
-  variant=$(clone_home "$home" retained-tab-heading)
+  while IFS=' ' read -r separator_label separator_code; do
+    separator=$(node -e \
+      'process.stdout.write(String.fromCodePoint(Number.parseInt(process.argv[1], 16)))' \
+      "$separator_code") || fail "could not build $separator_label heading separator"
+    variant=$(clone_home "$home" "retained-heading-$separator_label")
+    rewrite_once "$variant/data/done-archive.md" "$heading" \
+      "${heading}"$'\n\n##'"${separator}Done"
+    assert_archive_verify_fails "$variant" "$origin" "$separator_label-heading-section-escape"
+  done <<'EOF'
+tab 0009
+vertical-tab 000B
+form-feed 000C
+carriage-return 000D
+space 0020
+no-break-space 00A0
+ogham-space 1680
+en-quad 2000
+em-quad 2001
+en-space 2002
+em-space 2003
+three-per-em-space 2004
+four-per-em-space 2005
+six-per-em-space 2006
+figure-space 2007
+punctuation-space 2008
+thin-space 2009
+hair-space 200A
+line-separator 2028
+paragraph-separator 2029
+narrow-no-break-space 202F
+medium-mathematical-space 205F
+ideographic-space 3000
+byte-order-mark FEFF
+EOF
+
+  separator=$(node -e 'process.stdout.write(String.fromCodePoint(0x85))') \
+    || fail "could not build non-ECMAScript whitespace control"
+  variant=$(clone_home "$home" retained-heading-nel-control)
   rewrite_once "$variant/data/done-archive.md" "$heading" \
-    "${heading}"$'\n\n##\tDone'
-  assert_archive_verify_fails "$variant" "$origin" tab-heading-section-escape
+    "${heading}"$'\n\n##'"${separator}Done"
+  run_decisions "$variant" verify "$origin" >/dev/null \
+    || fail "archive verification treated non-ECMAScript whitespace as a heading"
+
+  variant=$(clone_home "$home" retained-bold-neighbor)
+  printf '\n## In flight\n\n- **%s-neighbor** - Nearby active identity (repo: sample) (kind: captain)\n' \
+    "$older_hold" >> "$variant/data/backlog.md"
+  show=$(tasks_in "$variant" show "$older_hold-neighbor" --full) \
+    || fail "bold near-identity positive control was not tasks-axi-readable"
+  assert_contains "$show" "state: in_flight" \
+    "bold near-identity positive control was not in flight"
+  run_decisions "$variant" verify "$origin" >/dev/null \
+    || fail "bold near-identity positive control collided with the archived decision"
+
+  variant=$(clone_home "$home" retained-bold-collision)
+  printf '\n## In flight\n\n- **%s** - Colliding active identity (repo: sample) (kind: captain)\n' \
+    "$older_hold" >> "$variant/data/backlog.md"
+  show=$(tasks_in "$variant" show "$older_hold" --full) \
+    || fail "bold collision fixture was not tasks-axi-readable"
+  assert_contains "$show" "state: in_flight" "bold collision fixture was not in flight"
+  assert_archive_verify_fails "$variant" "$origin" bold-active-archive-collision
+  assert_grep "exists in both active backlog and archive" \
+    "$variant/bold-active-archive-collision.err" \
+    "bold active/archive collision did not report the exact identity conflict"
+
+  variant=$(clone_home "$home" retained-active-hash-failure)
+  rewrite_once "$variant/state/$origin.meta" "decision_keys=newer,older" "decision_keys=newer"
+  cat > "$variant/fakebin/shasum" <<'EOF'
+#!/usr/bin/env bash
+exit 73
+EOF
+  chmod +x "$variant/fakebin/shasum"
+  assert_archive_verify_fails "$variant" "$origin" active-hash-command-failure
+  assert_grep "could not fingerprint decision archive" \
+    "$variant/active-hash-command-failure.err" \
+    "active lookup did not reject a failed archive hash command"
+
+  variant=$(clone_home "$home" retained-archive-hash-malformed)
+  rewrite_once "$variant/state/$origin.meta" "decision_keys=newer,older" "decision_keys=older"
+  cat > "$variant/fakebin/shasum" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'not-a-sha256  archive'
+EOF
+  chmod +x "$variant/fakebin/shasum"
+  assert_archive_verify_fails "$variant" "$origin" archived-hash-malformed
+  assert_grep "could not fingerprint decision archive" \
+    "$variant/archived-hash-malformed.err" \
+    "archived lookup did not reject malformed hash output"
 
   variant=$(clone_home "$home" retained-symlink)
   mv "$variant/data/done-archive.md" "$variant/data/archive-target.md"
@@ -807,7 +891,7 @@ EOF
   printf '\n%s\n' "$record" >> "$variant/data/backlog.md"
   assert_archive_verify_fails "$variant" "$origin" active-archive-collision
 
-  pass "retained LF decisions verify after archival while CRLF, tab-heading, malformed, forged, duplicate, and unsafe records are rejected"
+  pass "retained LF decisions verify while CRLF, grammar escapes, bold collisions, hash failures, and unsafe records are rejected"
 }
 
 test_uninventoried_report_decision_refuses_completion

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -622,6 +622,56 @@ EOF
   chmod +x "$home/fakebin/shasum"
 }
 
+test_retained_quoted_dash_hold_reason_survives_lifecycle() {
+  local home origin hold dependent archive record number
+  home=$(make_home retained-dash-hold-reason)
+  origin=sample-dash-reason-review
+  dependent=sample-dash-reason-dependent
+  mkdir -p "$home/data/$origin"
+  tasks_in "$home" add "$origin" "Review dash reason retention" \
+    --kind scout --repo sample --start >/dev/null \
+    || fail "could not create dash-reason origin"
+  write_origin_meta "$home" "$origin"
+  printf 'done: dash-reason report complete\n' > "$home/state/$origin.status"
+  printf '# Dash reason review\n\nThe retained decision is resolved.\n' > "$home/data/$origin/report.md"
+
+  hold=$(run_decisions "$home" hold "$origin" retained \
+    --title "Choose the dash-reason route" --reason "-" --repo sample) \
+    || fail "could not create a writer-owned dash hold reason"
+  run_decisions "$home" complete "$origin" retained >/dev/null \
+    || fail "could not inventory the dash-reason decision"
+  tasks_in "$home" add "$dependent" "Apply the dash-reason route" \
+    --kind ship --repo sample >/dev/null \
+    || fail "could not create dash-reason dependent work"
+  tasks_in "$home" block "$dependent" --by "$hold" >/dev/null \
+    || fail "could not block dash-reason dependent work"
+  printf 'Use the retained dash-reason route.\n' > "$home/dash-reason-decision.txt"
+  run_decisions "$home" resolve "$origin" retained \
+    --decision-file "$home/dash-reason-decision.txt" --routed-to "$dependent" >/dev/null \
+    || fail "could not resolve the dash-reason decision"
+
+  for number in 01 02 03 04 05 06 07 08 09 10 11; do
+    tasks_in "$home" add "sample-dash-retention-$number" "Dash retention filler $number" \
+      --kind ship --repo sample >/dev/null \
+      || fail "could not create dash retention filler $number"
+    tasks_in "$home" "done" "sample-dash-retention-$number" >/dev/null \
+      || fail "could not complete dash retention filler $number"
+  done
+  archive="$home/data/done-archive.md"
+  record=$(archive_record "$archive" "$hold")
+  assert_contains "$record" "(hold: -) (hold-kind: captain)" \
+    "retention did not preserve the writer-owned dash hold reason"
+  run_decisions "$home" complete "$origin" retained >/dev/null \
+    || fail "retained complete rejected the quoted dash hold reason"
+  run_decisions "$home" verify "$origin" >/dev/null \
+    || fail "retained verify rejected the quoted dash hold reason"
+  run_decisions "$home" resolve "$origin" retained \
+    --decision-file "$home/dash-reason-decision.txt" --routed-to "$dependent" >/dev/null \
+    || fail "idempotent resolve rejected the quoted dash hold reason"
+
+  pass "retained quoted dash hold reasons survive complete, verify, and idempotent resolve"
+}
+
 test_retained_decisions_are_strictly_archive_aware() {
   local home origin older_hold newer_hold archive record unresolved_record heading digest closed variant before after show
   local separator_label separator_code separator
@@ -1127,4 +1177,5 @@ test_none_inventory_and_resolved_prose_do_not_create_holds
 test_terminal_single_owner_status_decision_does_not_block_empty_inventory
 test_secondmate_hold_stays_in_authoritative_home
 test_resolve_matches_quoted_blocked_by_edges
+test_retained_quoted_dash_hold_reason_survives_lifecycle
 test_retained_decisions_are_strictly_archive_aware

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -11,6 +11,7 @@ TEARDOWN="$ROOT/bin/fm-teardown.sh"
 BEARINGS="$ROOT/bin/fm-bearings-snapshot.sh"
 TMP_ROOT=$(fm_test_tmproot fm-decision-hold)
 TASKS_AXI_BIN=$(command -v tasks-axi || true)
+SHASUM_BIN=$(command -v shasum || true)
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
 command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found"; exit 0; }
@@ -102,7 +103,7 @@ tasks_in() {  # <home> <tasks-axi args...>
 run_decisions() {  # <home> <command args...>
   local home=$1
   shift
-  PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" \
+  PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" REAL_SHASUM="$SHASUM_BIN" \
     FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_CONFIG_OVERRIDE="$home/config" "$ROOT/bin/fm-decision-hold.sh" "$@"
 }
@@ -593,9 +594,24 @@ assert_archive_verify_fails() {  # <home> <origin> <case>
   fi
 }
 
+install_late_archive_mutator() {  # <home>
+  local home=$1
+  cat > "$home/fakebin/shasum" <<'EOF'
+#!/usr/bin/env bash
+if [ "$#" -eq 2 ] && [ "$1" = -a ] && [ "$2" = 256 ] \
+  && [ ! -f "$FM_HOME/late-archive-mutated" ]; then
+  : > "$FM_HOME/late-archive-mutated"
+  cat "$FM_HOME/late-archive-append" >> "$FM_HOME/data/done-archive.md"
+fi
+exec "$REAL_SHASUM" "$@"
+EOF
+  chmod +x "$home/fakebin/shasum"
+}
+
 test_retained_decisions_are_strictly_archive_aware() {
   local home origin older_hold newer_hold archive record unresolved_record heading digest closed variant before after show
   local separator_label separator_code separator
+  local decision_case decision_bytes decision_path
   local dependent=sample-retained-dependent
   home=$(make_home retained-decisions)
   origin=sample-retained-review
@@ -626,7 +642,31 @@ test_retained_decisions_are_strictly_archive_aware() {
   [ "$before" = "$after" ] || fail "CRLF rejection mutated the backlog"
   assert_grep "decision file must use LF line endings" "$home/crlf-decision.err" \
     "CRLF rejection did not report the canonical decision-file requirement"
-  printf 'Use the retained route.\n' > "$home/retained-decision.txt"
+
+  for decision_case in internal-space internal-tab internal-mixed all-space all-tab all-mixed; do
+    case "$decision_case" in
+      internal-space) decision_bytes=$'Use the retained route.\n   \nKeep the fallback available.\n' ;;
+      internal-tab) decision_bytes=$'Use the retained route.\n\t\t\nKeep the fallback available.\n' ;;
+      internal-mixed) decision_bytes=$'Use the retained route.\n \t \nKeep the fallback available.\n' ;;
+      all-space) decision_bytes=$'   \n' ;;
+      all-tab) decision_bytes=$'\t\t\n' ;;
+      all-mixed) decision_bytes=$' \t \n' ;;
+    esac
+    decision_path="$home/$decision_case-decision.txt"
+    printf '%s' "$decision_bytes" > "$decision_path"
+    if run_decisions "$home" resolve "$origin" older \
+      --decision-file "$decision_path" --routed-to "$dependent" \
+      > "$home/$decision_case-decision.out" 2> "$home/$decision_case-decision.err"; then
+      fail "resolve accepted the $decision_case whitespace-only decision line fixture"
+    fi
+    after=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+    [ "$before" = "$after" ] || fail "$decision_case rejection mutated the backlog"
+    assert_grep "decision file contains a whitespace-only line" \
+      "$home/$decision_case-decision.err" \
+      "$decision_case rejection did not report how to make the decision canonical"
+  done
+
+  printf 'Use the retained route.\n\nKeep the fallback available.\n' > "$home/retained-decision.txt"
   run_decisions "$home" resolve "$origin" older --decision-file "$home/retained-decision.txt" \
     --routed-to "$dependent" >/dev/null \
     || fail "could not resolve the decision before retention"
@@ -915,11 +955,27 @@ EOF
   chmod +x "$variant/fakebin/tasks-axi"
   assert_archive_verify_fails "$variant" "$origin" concurrent-change
 
+  variant=$(clone_home "$home" retained-late-duplicate-change)
+  printf '\n%s\n%s\n' "$heading" "$record" > "$variant/late-archive-append"
+  install_late_archive_mutator "$variant"
+  assert_archive_verify_fails "$variant" "$origin" late-duplicate-change
+  assert_grep "decision archive changed during verification" \
+    "$variant/late-duplicate-change.err" \
+    "a duplicate appended during structured validation escaped the final archive recheck"
+
+  variant=$(clone_home "$home" retained-late-nonidentity-change)
+  printf '\n# late non-identity archive mutation\n' > "$variant/late-archive-append"
+  install_late_archive_mutator "$variant"
+  assert_archive_verify_fails "$variant" "$origin" late-nonidentity-change
+  assert_grep "decision archive changed during verification" \
+    "$variant/late-nonidentity-change.err" \
+    "a non-identity mutation during structured validation escaped the final archive recheck"
+
   variant=$(clone_home "$home" retained-active-archive-collision)
   printf '\n%s\n' "$record" >> "$variant/data/backlog.md"
   assert_archive_verify_fails "$variant" "$origin" active-archive-collision
 
-  pass "one canonical retained decision verifies while CRLF, grammar escapes, invalid duplicates, hash failures, and unsafe records are rejected"
+  pass "canonical LF decisions survive retention while whitespace-only inputs, late mutations, invalid duplicates, and unsafe archives are rejected"
 }
 
 test_uninventoried_report_decision_refuses_completion

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -608,6 +608,20 @@ EOF
   chmod +x "$home/fakebin/shasum"
 }
 
+install_late_active_mutator() {  # <home>
+  local home=$1
+  cat > "$home/fakebin/shasum" <<'EOF'
+#!/usr/bin/env bash
+if [ "$#" -eq 2 ] && [ "$1" = -a ] && [ "$2" = 256 ] \
+  && [ ! -f "$FM_HOME/late-active-mutated" ]; then
+  : > "$FM_HOME/late-active-mutated"
+  cat "$FM_HOME/late-active-append" >> "$FM_HOME/data/backlog.md"
+fi
+exec "$REAL_SHASUM" "$@"
+EOF
+  chmod +x "$home/fakebin/shasum"
+}
+
 test_retained_decisions_are_strictly_archive_aware() {
   local home origin older_hold newer_hold archive record unresolved_record heading digest closed variant before after show
   local separator_label separator_code separator
@@ -848,6 +862,12 @@ NODE
   rewrite_once "$variant/data/done-archive.md" "(hold-kind: captain)" "(hold-kind: ship)"
   assert_archive_verify_fails "$variant" "$origin" wrong-hold-kind-record
 
+  variant=$(clone_home "$home" retained-empty-hold-reason)
+  rewrite_once "$variant/data/done-archive.md" "(hold: captain retained route pending)" "(hold: )"
+  assert_archive_verify_fails "$variant" "$origin" empty-hold-reason
+  assert_grep "has no hold reason" "$variant/empty-hold-reason.err" \
+    "an encoded empty hold reason passed archived validation"
+
   variant=$(clone_home "$home" retained-invalid-closure)
   rewrite_once "$variant/data/done-archive.md" "(done $closed)" "(done 2026-02-31)"
   assert_archive_verify_fails "$variant" "$origin" invalid-closure-record
@@ -863,6 +883,11 @@ NODE
     "  Decision digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   rewrite_once "$variant/data/done-archive.md" "  Use the retained route." "  "
   assert_archive_verify_fails "$variant" "$origin" empty-decision-record
+
+  variant=$(clone_home "$home" retained-lossy-blank-line)
+  rewrite_once "$variant/data/done-archive.md" \
+    $'\n\n  Combining: ' $'\n \t\n  Combining: '
+  assert_archive_verify_fails "$variant" "$origin" lossy-blank-line
 
   variant=$(clone_home "$home" retained-unresolved)
   rewrite_once "$variant/data/done-archive.md" \
@@ -1007,6 +1032,42 @@ EOF
   assert_archive_verify_fails "$variant" "$origin" unreadable-archive
   chmod 600 "$variant/data/done-archive.md"
 
+  variant=$(clone_home "$home" retained-absent-active-store)
+  rewrite_once "$variant/state/$origin.meta" "decision_keys=newer,older" "decision_keys=older"
+  rm "$variant/data/backlog.md"
+  run_decisions "$variant" verify "$origin" >/dev/null \
+    || fail "an absent active store was not treated as empty"
+
+  variant=$(clone_home "$home" retained-symlink-active-store)
+  rewrite_once "$variant/state/$origin.meta" "decision_keys=newer,older" "decision_keys=older"
+  mv "$variant/data/backlog.md" "$variant/data/backlog-target.md"
+  ln -s backlog-target.md "$variant/data/backlog.md"
+  assert_archive_verify_fails "$variant" "$origin" symlink-active-store
+
+  variant=$(clone_home "$home" retained-broken-symlink-active-store)
+  rewrite_once "$variant/state/$origin.meta" "decision_keys=newer,older" "decision_keys=older"
+  rm "$variant/data/backlog.md"
+  ln -s missing-backlog.md "$variant/data/backlog.md"
+  assert_archive_verify_fails "$variant" "$origin" broken-symlink-active-store
+
+  variant=$(clone_home "$home" retained-directory-active-store)
+  rewrite_once "$variant/state/$origin.meta" "decision_keys=newer,older" "decision_keys=older"
+  mv "$variant/data/backlog.md" "$variant/data/backlog-target.md"
+  mkdir "$variant/data/backlog.md"
+  assert_archive_verify_fails "$variant" "$origin" directory-active-store
+
+  variant=$(clone_home "$home" retained-fifo-active-store)
+  rewrite_once "$variant/state/$origin.meta" "decision_keys=newer,older" "decision_keys=older"
+  mv "$variant/data/backlog.md" "$variant/data/backlog-target.md"
+  mkfifo "$variant/data/backlog.md"
+  assert_archive_verify_fails "$variant" "$origin" fifo-active-store
+
+  variant=$(clone_home "$home" retained-unreadable-active-store)
+  rewrite_once "$variant/state/$origin.meta" "decision_keys=newer,older" "decision_keys=older"
+  chmod 000 "$variant/data/backlog.md"
+  assert_archive_verify_fails "$variant" "$origin" unreadable-active-store
+  chmod 600 "$variant/data/backlog.md"
+
   variant=$(clone_home "$home" retained-concurrent-change)
   cat > "$variant/fakebin/tasks-axi" <<'EOF'
 #!/usr/bin/env bash
@@ -1039,11 +1100,21 @@ EOF
     "$variant/late-nonidentity-change.err" \
     "a non-identity mutation during structured validation escaped the final archive recheck"
 
+  variant=$(clone_home "$home" retained-late-active-collision)
+  rewrite_once "$variant/state/$origin.meta" "decision_keys=newer,older" "decision_keys=older"
+  printf '\n## Queued\n\n- [ ] %s - Late active collision (repo: sample) (kind: captain) (hold: captain collision pending) (hold-kind: captain)\n' \
+    "$older_hold" > "$variant/late-active-append"
+  install_late_active_mutator "$variant"
+  assert_archive_verify_fails "$variant" "$origin" late-active-collision
+  assert_grep "appeared in the active backlog during verification" \
+    "$variant/late-active-collision.err" \
+    "an active identity inserted during structured validation escaped the final recheck"
+
   variant=$(clone_home "$home" retained-active-archive-collision)
   printf '\n%s\n' "$record" >> "$variant/data/backlog.md"
   assert_archive_verify_fails "$variant" "$origin" active-archive-collision
 
-  pass "canonical Unicode survives retention while malformed bytes, lossy whitespace, late mutations, duplicates, and unsafe archives are rejected"
+  pass "canonical Unicode survives retention while malformed bytes, lossy text, late collisions, duplicates, and unsafe stores are rejected"
 }
 
 test_uninventoried_report_decision_refuses_completion

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -611,7 +611,7 @@ EOF
 test_retained_decisions_are_strictly_archive_aware() {
   local home origin older_hold newer_hold archive record unresolved_record heading digest closed variant before after show
   local separator_label separator_code separator
-  local decision_case decision_bytes decision_path
+  local decision_case decision_bytes decision_path encoding_case
   local dependent=sample-retained-dependent
   home=$(make_home retained-decisions)
   origin=sample-retained-review
@@ -643,6 +643,49 @@ test_retained_decisions_are_strictly_archive_aware() {
   assert_grep "decision file must use LF line endings" "$home/crlf-decision.err" \
     "CRLF rejection did not report the canonical decision-file requirement"
 
+  for encoding_case in lone-continuation truncated overlong surrogate out-of-range; do
+    decision_path="$home/$encoding_case-decision.txt"
+    case "$encoding_case" in
+      lone-continuation) printf '%s' $'\x80' > "$decision_path" ;;
+      truncated) printf '%s' $'\xe2\x82' > "$decision_path" ;;
+      overlong) printf '%s' $'\xc0\xaf' > "$decision_path" ;;
+      surrogate) printf '%s' $'\xed\xa0\x80' > "$decision_path" ;;
+      out-of-range) printf '%s' $'\xf4\x90\x80\x80' > "$decision_path" ;;
+    esac
+    if run_decisions "$home" resolve "$origin" older \
+      --decision-file "$decision_path" --routed-to "$dependent" \
+      > "$home/$encoding_case-decision.out" 2> "$home/$encoding_case-decision.err"; then
+      fail "resolve accepted the $encoding_case malformed UTF-8 fixture"
+    fi
+    after=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+    [ "$before" = "$after" ] || fail "$encoding_case rejection mutated the backlog"
+    assert_grep "decision file must contain valid UTF-8" \
+      "$home/$encoding_case-decision.err" \
+      "$encoding_case rejection did not report the strict UTF-8 requirement"
+  done
+
+  printf '%s' $'\xef\xbb\xbfUse the retained route.\n' > "$home/bom-decision.txt"
+  if run_decisions "$home" resolve "$origin" older \
+    --decision-file "$home/bom-decision.txt" --routed-to "$dependent" \
+    > "$home/bom-decision.out" 2> "$home/bom-decision.err"; then
+    fail "resolve accepted a UTF-8 BOM"
+  fi
+  after=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+  [ "$before" = "$after" ] || fail "UTF-8 BOM rejection mutated the backlog"
+  assert_grep "decision file must not start with a UTF-8 BOM" "$home/bom-decision.err" \
+    "UTF-8 BOM rejection did not report the canonical byte requirement"
+
+  printf 'Use the retained route.\0' > "$home/nul-decision.txt"
+  if run_decisions "$home" resolve "$origin" older \
+    --decision-file "$home/nul-decision.txt" --routed-to "$dependent" \
+    > "$home/nul-decision.out" 2> "$home/nul-decision.err"; then
+    fail "resolve accepted a NUL byte"
+  fi
+  after=$(shasum -a 256 "$home/data/backlog.md" | awk '{print $1}')
+  [ "$before" = "$after" ] || fail "NUL-byte rejection mutated the backlog"
+  assert_grep "decision file must not contain NUL bytes" "$home/nul-decision.err" \
+    "NUL-byte rejection did not report the shell-safe byte requirement"
+
   for decision_case in internal-space internal-tab internal-mixed all-space all-tab all-mixed; do
     case "$decision_case" in
       internal-space) decision_bytes=$'Use the retained route.\n   \nKeep the fallback available.\n' ;;
@@ -666,7 +709,7 @@ test_retained_decisions_are_strictly_archive_aware() {
       "$decision_case rejection did not report how to make the decision canonical"
   done
 
-  printf 'Use the retained route.\n\nKeep the fallback available.\n' > "$home/retained-decision.txt"
+  printf '%b' 'Use the retained route. \344\270\255\346\226\207\n\nCombining: e\314\201\nNon-BMP: \360\237\232\200\n' > "$home/retained-decision.txt"
   run_decisions "$home" resolve "$origin" older --decision-file "$home/retained-decision.txt" \
     --routed-to "$dependent" >/dev/null \
     || fail "could not resolve the decision before retention"
@@ -975,7 +1018,7 @@ EOF
   printf '\n%s\n' "$record" >> "$variant/data/backlog.md"
   assert_archive_verify_fails "$variant" "$origin" active-archive-collision
 
-  pass "canonical LF decisions survive retention while whitespace-only inputs, late mutations, invalid duplicates, and unsafe archives are rejected"
+  pass "canonical Unicode survives retention while malformed bytes, lossy whitespace, late mutations, duplicates, and unsafe archives are rejected"
 }
 
 test_uninventoried_report_decision_refuses_completion

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -815,6 +815,31 @@ EOF
     "  Decision digest: 0000000000000000000000000000000000000000000000000000000000000000"
   assert_archive_verify_fails "$variant" "$origin" forged-record
 
+  variant=$(clone_home "$home" retained-invalid-utf8)
+  node - "$variant/data/done-archive.md" "$variant/retained-decision.txt" "$digest" <<'NODE' \
+    || fail "could not build the invalid UTF-8 archive fixture"
+const crypto = require("crypto");
+const fs = require("fs");
+
+const [archivePath, decisionPath, oldDigest] = process.argv.slice(2);
+const archive = fs.readFileSync(archivePath);
+const decision = fs.readFileSync(decisionPath);
+const decisionLine = Buffer.from("  Use the retained route.");
+const decisionIndex = archive.indexOf(decisionLine);
+const digestBytes = Buffer.from(oldDigest);
+const digestIndex = archive.indexOf(digestBytes);
+if (decisionIndex === -1 || digestIndex === -1 || archive.indexOf(digestBytes, digestIndex + 1) !== -1) {
+  process.exit(1);
+}
+archive[decisionIndex + 2] = 0x80;
+decision[0] = 0x80;
+const lossyDecision = decision.toString("utf8").replace(/\n+$/, "");
+const lossyDigest = crypto.createHash("sha256").update(lossyDecision).digest("hex");
+Buffer.from(lossyDigest).copy(archive, digestIndex);
+fs.writeFileSync(archivePath, archive);
+NODE
+  assert_archive_verify_fails "$variant" "$origin" invalid-utf8-record
+
   variant=$(clone_home "$home" retained-wrong-kind)
   rewrite_once "$variant/data/done-archive.md" "(kind: captain)" "(kind: ship)"
   assert_archive_verify_fails "$variant" "$origin" wrong-kind-record


### PR DESCRIPTION
## What Changed

- Make decision lookup archive-aware so `complete`, `verify`, and identical `resolve` retries work after a captain decision is retained, while `hold` cannot recreate an archived resolution.
- Fail closed on duplicate or colliding identities, unsafe or changing stores, malformed archive records, resolution mismatches, and noncanonical decision-file bytes.
- Document the retained-decision byte contract and expand lifecycle coverage for quoted dash reasons and adversarial archive cases.

## Risk Assessment

✅ Low: Captain, the CR rejection now closes the parser-normalization gap without changing writer or lifecycle semantics, and no remaining material source defect was substantiated.

## Testing

已核对目标 SHA，聚焦回归通过；真实 CLI 流程完成 retention 后的三条调用路径，持久化证据与篡改负控符合预期，并用 base commit 在同一状态复现原失败。测试残留已清理；按要求未运行 lint、formatter 或静态分析，此 CLI 变更无 UI 截图适用。

<details>
<summary>Evidence: 目标提交端到端 CLI 记录</summary>

<code>active_lookup_exit=1&#10;complete: sample-archive-review decision inventory reviewed (route)&#10;verified: sample-archive-review unresolved-decision inventory&#10;resolved: sample-archive-review-decision-route&#10;archive SHA-256 unchanged&#10;tampered_verify_exit=1&#10;E2E_RESULT=PASS</code>

```text
Archive-aware decision lifecycle end-to-end evidence
target_commit=c7314195f61e05cbce6fa7cba54df6bd71349aec
tasks_axi_version=0.2.3

$ tasks-axi add sample-archive-review ... --start
ok: added sample-archive-review (scout, repo sample) -> In flight
task:
  id: sample-archive-review
  title: Review archive-aware routing
  state: in_flight
  blocked: no
  blocked_by: none
  held: no
  hold_reason: "-"
  hold_kind: "-"
  hold_until: "-"
  kind: scout
  repo: sample
  priority: "-"
  created: 2026-07-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi done sample-archive-review --pr <url>` when it ships
  - Run `tasks-axi block sample-archive-review --by <other>` to record a dependency

$ fm-decision-hold.sh hold sample-archive-review route ...
sample-archive-review-decision-route

$ fm-decision-hold.sh complete sample-archive-review route
complete: sample-archive-review decision inventory reviewed (route)

$ tasks-axi add/block dependent work
ok: added sample-archive-dependent (ship, repo sample) -> Queued
task:
  id: sample-archive-dependent
  title: Apply the retained route
  state: queued
  blocked: no
  blocked_by: none
  held: no
  hold_reason: "-"
  hold_kind: "-"
  hold_until: "-"
  kind: ship
  repo: sample
  priority: "-"
  created: 2026-07-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start sample-archive-dependent` to move it to in flight
  - Run `tasks-axi block sample-archive-dependent --by <other>` to record a dependency
ok: block sample-archive-dependent -> blocked-by sample-archive-review-decision-route
help[2]:
  - Run `tasks-axi unblock sample-archive-dependent --by <other>` to clear it
  - Run `tasks-axi ready` to see what is still dispatchable

$ fm-decision-hold.sh resolve sample-archive-review route --routed-to sample-archive-dependent
resolved: sample-archive-review-decision-route -> sample-archive-dependent

$ complete 11 later items to trigger done_keep=10 retention
retention_result=decision exists only in data/done-archive.md

$ tasks-axi show sample-archive-review-decision-route --full
error: "Task \"sample-archive-review-decision-route\" not found in this backlog"
code: NOT_FOUND
help[1]: Run `tasks-axi list` to see existing tasks
active_lookup_exit=1

$ fm-decision-hold.sh complete sample-archive-review route  # after retention
complete: sample-archive-review decision inventory reviewed (route)

$ fm-decision-hold.sh verify sample-archive-review         # after retention
verified: sample-archive-review unresolved-decision inventory

$ fm-decision-hold.sh resolve sample-archive-review route ... # identical retry after retention
resolved: sample-archive-review-decision-route
archive_sha256_before=c97e1a4cbf868175ad0a2ee0d804828470a6d7accab54c4903cdb698f71ec1e8
archive_sha256_after=c97e1a4cbf868175ad0a2ee0d804828470a6d7accab54c4903cdb698f71ec1e8

$ tasks-axi show sample-archive-dependent --full
task:
  id: sample-archive-dependent
  title: Apply the retained route
  state: queued
  blocked: no
  blocked_by: none
  held: no
  hold_reason: "-"
  hold_kind: "-"
  hold_until: "-"
  kind: ship
  repo: sample
  priority: "-"
  created: 2026-07-23
  closed: "-"
  deps: none
  links: none
  body: ""

$ archived decision record
- [x] sample-archive-review-decision-route - Choose the retained route (repo: sample) (kind: captain) (done 2026-07-23) (hold: captain retained route pending) (hold-kind: captain)
  Resolution recorded by fm-decision-hold.
  Decision digest: 1a97d3719671e4a3edd2531a973bcdaa6da31c98c1ac6392cfc4d41d8ff786ec
  Routed identities: sample-archive-dependent

  Captain decision:
  Use route north.

  Unicode proof: 中文 and é.

  Routed work:- sample-archive-dependent


private_parser_views_remaining=0

$ fm-decision-hold.sh verify sample-archive-review  # tampered archive negative control
fm-decision-hold: archived captain decision sample-archive-review-decision-route does not match its decision digest
tampered_verify_exit=1

E2E_RESULT=PASS archived complete/verify/resolve succeeded; tampered archive was rejected
```
</details>
<details>
<summary>Evidence: 基线提交反事实</summary>

`Base commit reports the archived decision absent from backlog.md and exits 1 on the same retained state.`

```text
Base commit counterfactual on the same retained state
base_commit=bd43c73fc956af2c7dfddd8ba74bab214a3012c0

$ fm-decision-hold.sh verify sample-archive-review
fm-decision-hold: captain decision sample-archive-review-decision-route is absent from /var/folders/_7/702wv9kj39gcb3_wqvrzq3r40000gn/T/no-mistakes-evidence/01KY6YX41FVCXZKBQ9VMXG6KNH/baseline-counterfactual-home/data/backlog.md
baseline_verify_exit=1
```
</details>
<details>
<summary>Evidence: Retention 后的持久化 archive</summary>

```text

## Archived 2026-07-23
- [x] sample-archive-review-decision-route - Choose the retained route (repo: sample) (kind: captain) (done 2026-07-23) (hold: captain retained route pending) (hold-kind: captain)
  Resolution recorded by fm-decision-hold.
  Decision digest: 1a97d3719671e4a3edd2531a973bcdaa6da31c98c1ac6392cfc4d41d8ff786ec
  Routed identities: sample-archive-dependent

  Captain decision:
  Use route north.

  Unicode proof: 中文 and é.

  Routed work:- sample-archive-dependent

## Archived 2026-07-23
- [x] sample-retention-01 - Retention filler 01 (repo: sample) (kind: ship) (done 2026-07-23)
```
</details>
<details>
<summary>Evidence: Retention 后的 active backlog</summary>

```text
## In flight
- [ ] sample-archive-review - Review archive-aware routing (repo: sample) (kind: scout) (since 2026-07-23)

## Queued
- [ ] sample-archive-dependent - Apply the retained route (repo: sample) (kind: ship) (since 2026-07-23)
## Done
- [x] sample-retention-11 - Retention filler 11 (repo: sample) (kind: ship) (done 2026-07-23)
- [x] sample-retention-10 - Retention filler 10 (repo: sample) (kind: ship) (done 2026-07-23)
- [x] sample-retention-09 - Retention filler 09 (repo: sample) (kind: ship) (done 2026-07-23)
- [x] sample-retention-08 - Retention filler 08 (repo: sample) (kind: ship) (done 2026-07-23)
- [x] sample-retention-07 - Retention filler 07 (repo: sample) (kind: ship) (done 2026-07-23)
- [x] sample-retention-06 - Retention filler 06 (repo: sample) (kind: ship) (done 2026-07-23)
- [x] sample-retention-05 - Retention filler 05 (repo: sample) (kind: ship) (done 2026-07-23)
- [x] sample-retention-04 - Retention filler 04 (repo: sample) (kind: ship) (done 2026-07-23)
- [x] sample-retention-03 - Retention filler 03 (repo: sample) (kind: ship) (done 2026-07-23)
- [x] sample-retention-02 - Retention filler 02 (repo: sample) (kind: ship) (done 2026-07-23)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-decision-hold.sh:327` - `active_identity_count` treats every non-regular backlog path as an empty store because `[ -f ]` is also false for directories, FIFOs, and broken symlinks. Archived verification can therefore succeed and permit scout cleanup while the active backlog is invalid and was never checked for collisions. Return zero only when the path is genuinely absent; reject unsafe or unreadable active-store paths.
- 🚨 `bin/fm-decision-hold.sh:396` - `hold_reason` is still TOON-encoded. A malformed archived header containing `(hold: ) (hold-kind: captain)` yields an empty reason rendered as `&#34;&#34;`; both shell predicates pass, so the record is accepted. Decode the field or explicitly reject the encoded empty value.
- 🚨 `bin/fm-decision-hold.sh:280` - The extractor accepts non-empty whitespace-only raw lines, which tasks-axi normalizes to empty lines before digest validation. Changing a canonical blank decision line to spaces therefore produces a stable archive that still verifies, contradicting the lossless canonical-record contract. Reject whitespace-only raw lines or validate the extracted record before parsing.
- ⚠️ `bin/fm-decision-hold.sh:505` - The active identity is rechecked before `verify_archived_resolution`, but that validation invokes another hash subprocess and the final pass checks only the archive. A concurrent insertion of the same active ID during that window can leave an active/archive collision while lookup returns success. Repeat the active check after final structured/archive validation or use a coherent store lock.

🔧 Fix: Harden archive-aware decision verification
1 error still open:
- 🚨 `bin/fm-decision-hold.sh:403` - The new decode loses the distinction between TOON&#39;s missing sentinel `-` and the valid quoted value `&#34;-&#34;`. Both `command_hold` and tasks-axi accept `--reason -`; after retention, this block decodes `&#34;-&#34;` to `-` and line 408 rejects it, making a writer-created decision unusable by complete, verify, resolve retry, and scout teardown. Check the raw unquoted sentinel before decoding, then reject only a decoded empty string.

🔧 Fix: Preserve quoted dash hold reasons
1 error still open:
- 🚨 `bin/fm-decision-hold.sh:249` - `semanticLine` strips trailing carriage returns while `extractRecord` accepts and copies CR-terminated nonblank lines into the parser view. Because tasks-axi also strips those carriage returns, changing an archived decision line from LF to CRLF leaves the parsed decision and digest unchanged, allowing a byte-corrupted archive to verify. Reject carriage returns anywhere in the extracted record before parsing.

🔧 Fix: Reject carriage returns in archived decisions
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short --branch && git rev-parse HEAD && git branch --show-current`
- `git diff --name-status bd43c73fc956af2c7dfddd8ba74bab214a3012c0 c7314195f61e05cbce6fa7cba54df6bd71349aec`
- `bin/fm-test-run.sh tests/fm-decision-hold-lifecycle.test.sh`
- <code>`bash .tmp-archive-aware-evidence.sh`（临时驱动已删除；使用真实 `tasks-axi 0.2.3` 完成 hold、resolve、retention、归档后重试及篡改负控）</code>
- `FM_HOME=<baseline-counterfactual-home> bash <base-code>/fm-decision-hold.sh verify sample-archive-review`
- <code>证据完整性检查：身份计数、archive SHA-256、关键 transcript 行及最终 `git status --short`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
