### PR TITLE
feat(bin): add verified local Markdown previews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,8 @@ Never add an agent name as a commit co-author.
 
 ### Workflow Rules
 
-- Whenever you generate or finish updating a Markdown file (e.g., reports or specs), preview it before delivery.
-- Use only a verified, sanitized local-only Markdown renderer that sends no document content to external APIs, disables raw HTML, and blocks remote subresources before opening the preview.
-- Prefer a one-shot renderer; if a preview server is required, bind it explicitly to `127.0.0.1` on a collision-free port, track the workflow-owned process, verify it serves the current file before opening it, and guarantee its termination after verification and opening and on every failure path so no preview server remains running or serves stale content.
+- Whenever you generate or finish updating a Markdown file, preview it before delivery with `bin/fm-markdown-preview.py FILE`.
+- That helper is the single executable owner of local-only sanitization, remote-resource blocking, current-file verification, collision-safe bounded serving, and cleanup; do not reimplement its lifecycle in a harness.
 
 ## 2. Layout and state
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,9 @@ Ship shared tracked changes through this repo's no-mistakes pipeline and PR path
 Never add an agent name as a commit co-author.
 
 ### Workflow Rules
-- Whenever you generate or finish updating a Markdown file (e.g., reports or specs), automatically open it for preview:
-  - On macOS: `open filename.md`
-  - On Linux/Windows with Grip: `grip filename.md --browser &`
+- Whenever you generate or finish updating a Markdown file (e.g., reports or specs), preview it before delivery.
+- Use only a verified local-only Markdown renderer that sends no document content to external APIs.
+- Manage preview servers collision-safely by stopping the previous server or allocating a fresh port, then verify the current file is served before opening it so later previews cannot show stale content.
 
 ## 2. Layout and state
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Never add an agent name as a commit co-author.
 ### Workflow Rules
 - Whenever you generate or finish updating a Markdown file (e.g., reports or specs), preview it before delivery.
 - Use only a verified local-only Markdown renderer that sends no document content to external APIs.
-- Manage preview servers collision-safely by stopping the previous server or allocating a fresh port, then verify the current file is served before opening it so later previews cannot show stale content.
+- Prefer a one-shot renderer; if a preview server is required, track it explicitly, stop the workflow-owned server before starting any later preview, choose a collision-free port, and verify the current file is served before opening it so repeated previews cannot accumulate processes or show stale content.
 
 ## 2. Layout and state
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Never add an agent name as a commit co-author.
 ### Workflow Rules
 - Whenever you generate or finish updating a Markdown file (e.g., reports or specs), preview it before delivery.
 - Use only a verified local-only Markdown renderer that sends no document content to external APIs.
-- Prefer a one-shot renderer; if a preview server is required, track it explicitly, stop the workflow-owned server before starting any later preview, choose a collision-free port, and verify the current file is served before opening it so repeated previews cannot accumulate processes or show stale content.
+- Prefer a one-shot renderer; if a preview server is required, bind it explicitly to `127.0.0.1` on a collision-free port, track the workflow-owned process, verify it serves the current file before opening it, and guarantee its termination after verification and opening and on every failure path so no preview server remains running or serves stale content.
 
 ## 2. Layout and state
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,11 @@ This repo is a shared template, while `.env`, `data/`, `state/`, `config/`, `pro
 Ship shared tracked changes through this repo's no-mistakes pipeline and PR path, with the same merge authority as any other project.
 Never add an agent name as a commit co-author.
 
+### Workflow Rules
+- Whenever you generate or finish updating a Markdown file (e.g., reports or specs), automatically open it for preview:
+  - On macOS: `open filename.md`
+  - On Linux/Windows with Grip: `grip filename.md --browser &`
+
 ## 2. Layout and state
 
 `docs/configuration.md` is the single owner of the top-level operational-home layout and configuration schemas; each producing script's header and help own exact child fields and mutation mechanics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,9 @@ Ship shared tracked changes through this repo's no-mistakes pipeline and PR path
 Never add an agent name as a commit co-author.
 
 ### Workflow Rules
+
 - Whenever you generate or finish updating a Markdown file (e.g., reports or specs), preview it before delivery.
-- Use only a verified local-only Markdown renderer that sends no document content to external APIs.
+- Use only a verified, sanitized local-only Markdown renderer that sends no document content to external APIs, disables raw HTML, and blocks remote subresources before opening the preview.
 - Prefer a one-shot renderer; if a preview server is required, bind it explicitly to `127.0.0.1` on a collision-free port, track the workflow-owned process, verify it serves the current file before opening it, and guarantee its termination after verification and opening and on every failure path so no preview server remains running or serves stale content.
 
 ## 2. Layout and state

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
   A local `config/backlog-backend=manual` opt-out forces firstmate's routine backlog updates to hand-editing and stays gitignored; validated secondmate handoffs still delegate through `tasks-axi mv`.
   A local `config/backend` file explicitly overrides runtime auto-detection for new task endpoints and stays gitignored; spawn-supported values are `tmux` plus experimental `herdr`, `zellij`, `orca`, and `cmux`, while `codex-app` is documented only in `docs/codex-app-backend.md`.
   It does not make `data/` tracked.
-- Helper scripts in `bin/` are plain bash.
-  Each starts with a usage header comment; keep it accurate when you change behavior.
+- Most helper scripts in `bin/` are plain bash; Python and Node helpers use explicit `.py` and `.mjs` suffixes.
+  Each documents its behavior and invocation in a leading comment or docstring; keep it accurate when you change behavior.
   Test scripts and helpers in `tests/` are plain bash too.
   `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, and pinned shellcheck version), and both CI and the no-mistakes pre-push gate run it, so local and CI can never diverge.
   It pins one exact shellcheck version and refuses to run under any other; print it with `bin/fm-lint.sh --required-version` and install that build locally.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 
 - A verified agent harness: Claude Code, Grok, Pi, Codex, or OpenCode.
 - Git and the GitHub CLI, authenticated through `gh auth login`.
+- Python 3, for local Markdown previews.
 - The CLI and dependencies for your selected runtime backend; tmux is the reference default.
 
 The first mate detects and offers to install supported missing tools after you approve.

--- a/bin/fm-markdown-preview.py
+++ b/bin/fm-markdown-preview.py
@@ -33,6 +33,7 @@ Exit status:
 import argparse
 import hashlib
 import html
+import http.client
 import os
 import re
 import secrets
@@ -42,8 +43,6 @@ import subprocess
 import sys
 import threading
 import time
-import urllib.error
-import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -52,6 +51,9 @@ from urllib.parse import urlsplit
 MAX_SOURCE_BYTES = 8 * 1024 * 1024
 MAX_RENDERED_BYTES = 64 * 1024 * 1024
 INLINE_SCAN_FACTOR = 4
+MAX_BLOCKQUOTE_DEPTH = 64
+MAX_TABLE_COLUMNS = 1024
+MAX_TABLE_CELLS = 100000
 DEFAULT_TIMEOUT = 12.0
 MIN_TIMEOUT = 0.1
 MAX_TIMEOUT = 30.0
@@ -70,7 +72,7 @@ CSP = (
     "style-src 'unsafe-inline'"
 )
 
-FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})\s*([^`]*)$")
+FENCE_PREFIX_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})(.*)$")
 HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$")
 UNORDERED_RE = re.compile(r"^\s{0,3}[-+*]\s+(.+)$")
 ORDERED_RE = re.compile(r"^\s{0,3}\d+[.)]\s+(.+)$")
@@ -81,6 +83,32 @@ TABLE_DIVIDER_RE = re.compile(r"^:?-{3,}:?$")
 
 class PreviewError(Exception):
     pass
+
+
+class RenderBuffer:
+    def __init__(self):
+        self.parts = []
+        self.size = 0
+        self.table_cells = 0
+
+    def append(self, value):
+        size = len(value.encode("utf-8"))
+        if self.size + size > MAX_RENDERED_BYTES:
+            raise PreviewError(
+                f"rendered preview exceeds {MAX_RENDERED_BYTES} bytes"
+            )
+        self.parts.append(value)
+        self.size += size
+
+    def add_table_cells(self, count):
+        if self.table_cells + count > MAX_TABLE_CELLS:
+            raise PreviewError(
+                f"Markdown table exceeds {MAX_TABLE_CELLS} rendered cells"
+            )
+        self.table_cells += count
+
+    def finish(self):
+        return "".join(self.parts)
 
 
 def read_source(path):
@@ -185,6 +213,9 @@ def render_inline(source, depth=0):
                 rendered.append(f"<code>{html.escape(code, quote=True)}</code>")
                 index = close + len(marker)
                 continue
+            plain.append(marker)
+            index = marker_end
+            continue
 
         image_start = source.startswith("![", index)
         link_start = source[index] == "["
@@ -251,8 +282,25 @@ def render_inline(source, depth=0):
     return "".join(rendered)
 
 
+def parse_fence(line):
+    match = FENCE_PREFIX_RE.match(line)
+    if not match:
+        return None
+    marker, tail = match.groups()
+    if "`" in tail:
+        return None
+    return marker, tail.strip()
+
+
 def split_table_row(line):
     stripped = line.strip().strip("|")
+    if not stripped:
+        return []
+    columns = stripped.count("|") + 1
+    if columns > MAX_TABLE_COLUMNS:
+        raise PreviewError(
+            f"Markdown table exceeds {MAX_TABLE_COLUMNS} columns"
+        )
     return [cell.strip() for cell in stripped.split("|")]
 
 
@@ -268,7 +316,7 @@ def is_table(lines, index):
 def starts_block(lines, index):
     line = lines[index]
     return (
-        FENCE_RE.match(line)
+        parse_fence(line) is not None
         or HEADING_RE.match(line)
         or UNORDERED_RE.match(line)
         or ORDERED_RE.match(line)
@@ -279,8 +327,10 @@ def starts_block(lines, index):
     )
 
 
-def render_blocks(lines):
-    output = []
+def render_blocks(lines, quote_depth=0, output=None):
+    root = output is None
+    if root:
+        output = RenderBuffer()
     index = 0
     while index < len(lines):
         line = lines[index]
@@ -288,10 +338,10 @@ def render_blocks(lines):
             index += 1
             continue
 
-        fence = FENCE_RE.match(line)
+        fence = parse_fence(line)
         if fence:
-            marker = fence.group(1)
-            info = fence.group(2).strip().split(None, 1)
+            marker, tail = fence
+            info = tail.split(None, 1)
             language = info[0] if info else ""
             index += 1
             code_lines = []
@@ -328,25 +378,34 @@ def render_blocks(lines):
         if is_table(lines, index):
             headings = split_table_row(line)
             divider_count = len(split_table_row(lines[index + 1]))
+            output.add_table_cells(divider_count)
             index += 2
             rows = []
             while index < len(lines) and lines[index].strip() and "|" in lines[index]:
-                rows.append(split_table_row(lines[index]))
+                row = split_table_row(lines[index])
+                output.add_table_cells(divider_count)
+                rows.append(row)
                 index += 1
             headings = (headings + [""] * divider_count)[:divider_count]
             output.append("<table><thead><tr>")
-            output.extend(f"<th>{render_inline(cell)}</th>" for cell in headings)
+            for cell in headings:
+                output.append(f"<th>{render_inline(cell)}</th>")
             output.append("</tr></thead><tbody>")
             for row in rows:
                 row = (row + [""] * divider_count)[:divider_count]
                 output.append("<tr>")
-                output.extend(f"<td>{render_inline(cell)}</td>" for cell in row)
+                for cell in row:
+                    output.append(f"<td>{render_inline(cell)}</td>")
                 output.append("</tr>")
             output.append("</tbody></table>")
             continue
 
         quote = QUOTE_RE.match(line)
         if quote:
+            if quote_depth >= MAX_BLOCKQUOTE_DEPTH:
+                raise PreviewError(
+                    f"blockquote nesting exceeds {MAX_BLOCKQUOTE_DEPTH} levels"
+                )
             quoted = []
             while index < len(lines):
                 match = QUOTE_RE.match(lines[index])
@@ -354,7 +413,9 @@ def render_blocks(lines):
                     break
                 quoted.append(match.group(1))
                 index += 1
-            output.append(f"<blockquote>{render_blocks(quoted)}</blockquote>")
+            output.append("<blockquote>")
+            render_blocks(quoted, quote_depth + 1, output)
+            output.append("</blockquote>")
             continue
 
         unordered = UNORDERED_RE.match(line)
@@ -403,7 +464,9 @@ def render_blocks(lines):
             index += 1
         output.append(f"<p>{render_inline(' '.join(paragraph))}</p>")
 
-    return "".join(output)
+    if root:
+        return output.finish()
+    return None
 
 
 def render_document(source, title):
@@ -526,24 +589,29 @@ def resolve_opener(explicit):
     raise PreviewError("no supported local desktop opener was found")
 
 
-def verify_server(url, state):
-    request = urllib.request.Request(
-        url,
-        headers={
-            VERIFY_HEADER: state.token,
-            "User-Agent": "firstmate-markdown-preview-verifier",
-        },
-    )
+def verify_server(port, state):
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
     try:
-        with urllib.request.urlopen(request, timeout=2) as response:
-            body = response.read(len(state.body) + 1)
-            digest = response.headers.get("X-Firstmate-Source-SHA256")
-    except urllib.error.HTTPError as error:
-        if error.code == 409:
-            raise PreviewError("source changed before preview verification") from error
-        raise PreviewError(f"local preview verification returned HTTP {error.code}") from error
-    except OSError as error:
+        connection.request(
+            "GET",
+            state.path,
+            headers={
+                VERIFY_HEADER: state.token,
+                "User-Agent": "firstmate-markdown-preview-verifier",
+            },
+        )
+        response = connection.getresponse()
+        status = response.status
+        body = response.read(len(state.body) + 1)
+        digest = response.getheader("X-Firstmate-Source-SHA256")
+    except (OSError, http.client.HTTPException) as error:
         raise PreviewError(f"local preview verification failed: {error}") from error
+    finally:
+        connection.close()
+    if status == 409:
+        raise PreviewError("source changed before preview verification")
+    if status != 200:
+        raise PreviewError(f"local preview verification returned HTTP {status}")
     if body != state.body or digest != state.digest:
         raise PreviewError("local preview verification did not match the current rendering")
 
@@ -624,6 +692,7 @@ def run(args):
     opener = resolve_opener(args.opener)
     server = None
     thread = None
+    thread_started = False
     try:
         server = PreviewServer(state)
         thread = threading.Thread(
@@ -631,18 +700,25 @@ def run(args):
             name="fm-markdown-preview",
             daemon=True,
         )
-        thread.start()
+        try:
+            thread.start()
+        except RuntimeError as error:
+            raise PreviewError(
+                "local preview server thread could not start"
+            ) from error
+        thread_started = True
         port = server.server_address[1]
         url = f"http://127.0.0.1:{port}{state.path}"
-        verify_server(url, state)
+        verify_server(port, state)
         if not state.is_current():
             raise PreviewError("source changed before preview opening")
         open_and_wait(opener, url, state, args.timeout)
     finally:
         if server is not None:
-            server.shutdown()
+            if thread_started:
+                server.shutdown()
             server.server_close()
-        if thread is not None:
+        if thread_started and thread is not None:
             thread.join(timeout=2)
             if thread.is_alive():
                 raise PreviewError("local preview server did not stop")

--- a/bin/fm-markdown-preview.py
+++ b/bin/fm-markdown-preview.py
@@ -52,6 +52,9 @@ MAX_SOURCE_BYTES = 8 * 1024 * 1024
 MAX_RENDERED_BYTES = 64 * 1024 * 1024
 INLINE_SCAN_FACTOR = 4
 MAX_BLOCKQUOTE_DEPTH = 64
+MAX_SOURCE_LINES = 100000
+MAX_RENDER_PARTS = 150000
+MAX_RETAINED_QUOTE_CHARS = MAX_SOURCE_BYTES
 MAX_TABLE_COLUMNS = 1024
 MAX_TABLE_CELLS = 100000
 DEFAULT_TIMEOUT = 12.0
@@ -73,7 +76,7 @@ CSP = (
 )
 
 FENCE_PREFIX_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})(.*)$")
-HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$")
+HEADING_PREFIX_RE = re.compile(r"^[ \t]{0,3}(#{1,6})[ \t](.*)$")
 UNORDERED_RE = re.compile(r"^\s{0,3}[-+*]\s+(.+)$")
 ORDERED_RE = re.compile(r"^\s{0,3}\d+[.)]\s+(.+)$")
 QUOTE_RE = re.compile(r"^\s{0,3}>\s?(.*)$")
@@ -89,9 +92,14 @@ class RenderBuffer:
     def __init__(self):
         self.parts = []
         self.size = 0
+        self.retained_quote_chars = 0
         self.table_cells = 0
 
     def append(self, value):
+        if len(self.parts) >= MAX_RENDER_PARTS:
+            raise PreviewError(
+                f"rendered preview exceeds {MAX_RENDER_PARTS} parts"
+            )
         size = len(value.encode("utf-8"))
         if self.size + size > MAX_RENDERED_BYTES:
             raise PreviewError(
@@ -99,6 +107,14 @@ class RenderBuffer:
             )
         self.parts.append(value)
         self.size += size
+
+    def add_quote_copy(self, count):
+        if self.retained_quote_chars + count > MAX_RETAINED_QUOTE_CHARS:
+            raise PreviewError(
+                "blockquote input exceeds "
+                f"{MAX_RETAINED_QUOTE_CHARS} retained characters"
+            )
+        self.retained_quote_chars += count
 
     def add_table_cells(self, count):
         if self.table_cells + count > MAX_TABLE_CELLS:
@@ -163,7 +179,10 @@ def safe_href(target):
         return None
     if value.startswith("#"):
         return value
-    parsed = urlsplit(value)
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return None
     if parsed.scheme.lower() not in {"http", "https", "mailto"}:
         return None
     return value
@@ -292,38 +311,77 @@ def parse_fence(line):
     return marker, tail.strip()
 
 
-def split_table_row(line):
+def parse_heading(line):
+    match = HEADING_PREFIX_RE.match(line)
+    if not match:
+        return None
+    marker, raw_body = match.groups()
+    if not raw_body:
+        return None
+    body = raw_body.rstrip()
+    without_hashes = body.rstrip("#")
+    if without_hashes:
+        body = without_hashes.rstrip()
+    elif body:
+        body = "#"
+    else:
+        body = " "
+    return marker, body
+
+
+def iter_table_cells(line):
     stripped = line.strip().strip("|")
     if not stripped:
-        return []
-    columns = stripped.count("|") + 1
-    if columns > MAX_TABLE_COLUMNS:
+        return
+    start = 0
+    while True:
+        end = stripped.find("|", start)
+        if end == -1:
+            yield stripped[start:].strip()
+            return
+        yield stripped[start:end].strip()
+        start = end + 1
+
+
+def split_table_row(line):
+    cells = []
+    for cell in iter_table_cells(line):
+        cells.append(cell)
+        if len(cells) > MAX_TABLE_COLUMNS:
+            raise PreviewError(
+                f"Markdown table exceeds {MAX_TABLE_COLUMNS} columns"
+            )
+    return cells
+
+
+def table_column_count(lines, index):
+    if index + 1 >= len(lines) or "|" not in lines[index]:
+        return None
+    count = 0
+    for cell in iter_table_cells(lines[index + 1]):
+        if not TABLE_DIVIDER_RE.fullmatch(cell):
+            return None
+        count += 1
+    if count == 0:
+        return None
+    if count > MAX_TABLE_COLUMNS:
         raise PreviewError(
             f"Markdown table exceeds {MAX_TABLE_COLUMNS} columns"
         )
-    return [cell.strip() for cell in stripped.split("|")]
-
-
-def is_table(lines, index):
-    if index + 1 >= len(lines) or "|" not in lines[index]:
-        return False
-    dividers = split_table_row(lines[index + 1])
-    return bool(dividers) and all(
-        TABLE_DIVIDER_RE.fullmatch(cell) for cell in dividers
-    )
+    return count
 
 
 def starts_block(lines, index):
     line = lines[index]
     return (
         parse_fence(line) is not None
-        or HEADING_RE.match(line)
+        or parse_heading(line) is not None
         or UNORDERED_RE.match(line)
         or ORDERED_RE.match(line)
         or QUOTE_RE.match(line)
         or THEMATIC_RE.match(line)
         or line.startswith("    ")
-        or is_table(lines, index)
+        or table_column_count(lines, index) is not None
     )
 
 
@@ -347,7 +405,7 @@ def render_blocks(lines, quote_depth=0, output=None):
             code_lines = []
             while index < len(lines):
                 candidate = lines[index].lstrip()
-                if candidate.startswith(marker[0] * len(marker)):
+                if candidate.startswith(marker):
                     index += 1
                     break
                 code_lines.append(lines[index])
@@ -361,11 +419,12 @@ def render_blocks(lines, quote_depth=0, output=None):
             output.append(f"<pre><code{language_attr}>{code}</code></pre>")
             continue
 
-        heading = HEADING_RE.match(line)
+        heading = parse_heading(line)
         if heading:
-            level = len(heading.group(1))
+            marker, body = heading
+            level = len(marker)
             output.append(
-                f"<h{level}>{render_inline(heading.group(2))}</h{level}>"
+                f"<h{level}>{render_inline(body)}</h{level}>"
             )
             index += 1
             continue
@@ -375,28 +434,25 @@ def render_blocks(lines, quote_depth=0, output=None):
             index += 1
             continue
 
-        if is_table(lines, index):
+        divider_count = table_column_count(lines, index)
+        if divider_count is not None:
             headings = split_table_row(line)
-            divider_count = len(split_table_row(lines[index + 1]))
             output.add_table_cells(divider_count)
             index += 2
-            rows = []
-            while index < len(lines) and lines[index].strip() and "|" in lines[index]:
-                row = split_table_row(lines[index])
-                output.add_table_cells(divider_count)
-                rows.append(row)
-                index += 1
             headings = (headings + [""] * divider_count)[:divider_count]
             output.append("<table><thead><tr>")
             for cell in headings:
                 output.append(f"<th>{render_inline(cell)}</th>")
             output.append("</tr></thead><tbody>")
-            for row in rows:
+            while index < len(lines) and lines[index].strip() and "|" in lines[index]:
+                row = split_table_row(lines[index])
+                output.add_table_cells(divider_count)
                 row = (row + [""] * divider_count)[:divider_count]
                 output.append("<tr>")
                 for cell in row:
                     output.append(f"<td>{render_inline(cell)}</td>")
                 output.append("</tr>")
+                index += 1
             output.append("</tbody></table>")
             continue
 
@@ -411,7 +467,9 @@ def render_blocks(lines, quote_depth=0, output=None):
                 match = QUOTE_RE.match(lines[index])
                 if not match:
                     break
-                quoted.append(match.group(1))
+                start, end = match.span(1)
+                output.add_quote_copy(end - start)
+                quoted.append(lines[index][start:end])
                 index += 1
             output.append("<blockquote>")
             render_blocks(quoted, quote_depth + 1, output)
@@ -470,7 +528,12 @@ def render_blocks(lines, quote_depth=0, output=None):
 
 
 def render_document(source, title):
-    lines = source.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    normalized = source.replace("\r\n", "\n").replace("\r", "\n")
+    lines = normalized.split("\n", MAX_SOURCE_LINES)
+    if len(lines) > MAX_SOURCE_LINES:
+        raise PreviewError(
+            f"Markdown source exceeds {MAX_SOURCE_LINES} lines"
+        )
     body = render_blocks(lines)
     safe_title = html.escape(title, quote=True)
     rendered = (

--- a/bin/fm-markdown-preview.py
+++ b/bin/fm-markdown-preview.py
@@ -54,6 +54,9 @@ INLINE_SCAN_FACTOR = 4
 MAX_BLOCKQUOTE_DEPTH = 64
 MAX_SOURCE_LINES = 100000
 MAX_RENDER_PARTS = 150000
+MAX_INLINE_FRAGMENTS = 150000
+INLINE_CHUNK_BYTES = 64 * 1024
+INLINE_CHUNK_FRAGMENTS = 1024
 MAX_RETAINED_QUOTE_CHARS = MAX_SOURCE_BYTES
 MAX_TABLE_COLUMNS = 1024
 MAX_TABLE_CELLS = 100000
@@ -127,9 +130,50 @@ class RenderBuffer:
         return "".join(self.parts)
 
 
+class InlineBuffer:
+    def __init__(self):
+        self.chunks = []
+        self.pending = []
+        self.pending_bytes = 0
+        self.size = 0
+        self.fragments = 0
+
+    def append(self, value):
+        if not value:
+            return
+        if self.fragments >= MAX_INLINE_FRAGMENTS:
+            raise PreviewError(
+                f"inline rendering exceeds {MAX_INLINE_FRAGMENTS} fragments"
+            )
+        size = len(value.encode("utf-8"))
+        if self.size + size > MAX_RENDERED_BYTES:
+            raise PreviewError(
+                f"inline rendering exceeds {MAX_RENDERED_BYTES} bytes"
+            )
+        self.pending.append(value)
+        self.pending_bytes += size
+        self.size += size
+        self.fragments += 1
+        if (
+            self.pending_bytes >= INLINE_CHUNK_BYTES
+            or len(self.pending) >= INLINE_CHUNK_FRAGMENTS
+        ):
+            self.flush()
+
+    def flush(self):
+        if self.pending:
+            self.chunks.append("".join(self.pending))
+            self.pending.clear()
+            self.pending_bytes = 0
+
+    def finish(self):
+        self.flush()
+        return "".join(self.chunks)
+
+
 def read_source(path):
     try:
-        fd = os.open(path, os.O_RDONLY)
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NONBLOCK", 0))
     except OSError as error:
         raise PreviewError(f"cannot read Markdown source: {error}") from error
     try:
@@ -188,19 +232,21 @@ def safe_href(target):
     return value
 
 
-def render_inline(source, depth=0):
+def render_inline(source, depth=0, output=None):
+    root = output is None
+    if root:
+        output = InlineBuffer()
     if depth > 4:
-        return html.escape(source, quote=True)
-    rendered = []
-    plain = []
+        output.append(html.escape(source, quote=True))
+        return output.finish() if root else None
     length = len(source)
     index = 0
+    plain_start = 0
     remaining_scan = length * INLINE_SCAN_FACTOR
 
-    def flush_plain():
-        if plain:
-            rendered.append(html.escape("".join(plain), quote=True))
-            plain.clear()
+    def flush_plain(end):
+        if end > plain_start:
+            output.append(html.escape(source[plain_start:end], quote=True))
 
     def find_delimiter(marker, start):
         nonlocal remaining_scan
@@ -216,8 +262,10 @@ def render_inline(source, depth=0):
 
     while index < length:
         if source[index] == "\\" and index + 1 < length:
-            plain.append(source[index + 1])
+            flush_plain(index)
+            output.append(html.escape(source[index + 1], quote=True))
             index += 2
+            plain_start = index
             continue
 
         if source[index] == "`":
@@ -227,12 +275,14 @@ def render_inline(source, depth=0):
             marker = source[index:marker_end]
             close = find_delimiter(marker, marker_end)
             if close != -1:
-                flush_plain()
+                flush_plain(index)
                 code = source[marker_end:close].strip(" ")
-                rendered.append(f"<code>{html.escape(code, quote=True)}</code>")
+                output.append("<code>")
+                output.append(html.escape(code, quote=True))
+                output.append("</code>")
                 index = close + len(marker)
+                plain_start = index
                 continue
-            plain.append(marker)
             index = marker_end
             continue
 
@@ -245,26 +295,25 @@ def render_inline(source, depth=0):
                 find_delimiter(")", label_end + 2) if label_end != -1 else -1
             )
             if label_end != -1 and target_end != -1:
-                flush_plain()
+                flush_plain(index)
                 label = source[label_start:label_end]
                 target = source[label_end + 2 : target_end]
                 if image_start:
-                    rendered.append(
-                        '<span class="image-alt">Image: '
-                        f"{html.escape(label, quote=True)}</span>"
-                    )
+                    output.append('<span class="image-alt">Image: ')
+                    output.append(html.escape(label, quote=True))
+                    output.append("</span>")
                 else:
                     href = safe_href(target)
-                    label_html = render_inline(label, depth + 1)
-                    if href is None:
-                        rendered.append(label_html)
-                    else:
-                        rendered.append(
+                    if href is not None:
+                        output.append(
                             '<a rel="noreferrer noopener" target="_blank" '
                             f'href="{html.escape(href, quote=True)}">'
-                            f"{label_html}</a>"
                         )
+                    render_inline(label, depth + 1, output)
+                    if href is not None:
+                        output.append("</a>")
                 index = target_end + 1
+                plain_start = index
                 continue
 
         matched_delimiter = False
@@ -272,12 +321,13 @@ def render_inline(source, depth=0):
             if source.startswith(marker, index):
                 close = find_delimiter(marker, index + len(marker))
                 if close > index + len(marker):
-                    flush_plain()
+                    flush_plain(index)
                     inner = source[index + len(marker) : close]
-                    rendered.append(
-                        f"<{tag}>{render_inline(inner, depth + 1)}</{tag}>"
-                    )
+                    output.append(f"<{tag}>")
+                    render_inline(inner, depth + 1, output)
+                    output.append(f"</{tag}>")
                     index = close + len(marker)
+                    plain_start = index
                     matched_delimiter = True
                     break
         if matched_delimiter:
@@ -287,18 +337,20 @@ def render_inline(source, depth=0):
             marker = source[index]
             close = find_delimiter(marker, index + 1)
             if close > index + 1:
-                flush_plain()
-                rendered.append(
-                    f"<em>{render_inline(source[index + 1:close], depth + 1)}</em>"
-                )
+                flush_plain(index)
+                output.append("<em>")
+                render_inline(source[index + 1:close], depth + 1, output)
+                output.append("</em>")
                 index = close + 1
+                plain_start = index
                 continue
 
-        plain.append(source[index])
         index += 1
 
-    flush_plain()
-    return "".join(rendered)
+    flush_plain(length)
+    if root:
+        return output.finish()
+    return None
 
 
 def parse_fence(line):

--- a/bin/fm-markdown-preview.py
+++ b/bin/fm-markdown-preview.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""Render and open one fail-closed local Markdown preview.
+
+This helper is the single executable owner of Firstmate's Markdown preview
+lifecycle.
+It reads one current regular file, renders a conservative Markdown subset with
+raw HTML escaped and image targets omitted, adds a restrictive Content Security
+Policy, serves only that in-memory result on an ephemeral 127.0.0.1 port, and
+opens the tokenized URL through a local desktop opener.
+The source digest is checked during the browser request so a changed file is
+never answered with the older rendering.
+The server exists only for a bounded wait and is shut down on success, failure,
+timeout, or interruption.
+
+Usage:
+  fm-markdown-preview.py [--timeout SECONDS] [--opener PATH] FILE
+
+Options:
+  --timeout SECONDS  Maximum wait for the browser to fetch the page (default 12,
+                     accepted range 0.1 through 30).
+  --opener PATH      Desktop URL opener executable.
+                     Intended for deterministic tests; normal use auto-detects
+                     open, xdg-open, or gio.
+
+Exit status:
+  0  The browser fetched the verified current rendering.
+  1  Rendering, verification, opening, serving, or cleanup failed.
+  2  Arguments were invalid.
+"""
+
+import argparse
+import hashlib
+import html
+import os
+import re
+import secrets
+import shutil
+import stat
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+MAX_SOURCE_BYTES = 8 * 1024 * 1024
+DEFAULT_TIMEOUT = 12.0
+MIN_TIMEOUT = 0.1
+MAX_TIMEOUT = 30.0
+VERIFY_HEADER = "X-Firstmate-Preview-Check"
+CSP = (
+    "default-src 'none'; "
+    "base-uri 'none'; "
+    "connect-src 'none'; "
+    "font-src 'none'; "
+    "form-action 'none'; "
+    "frame-src 'none'; "
+    "img-src data:; "
+    "media-src 'none'; "
+    "object-src 'none'; "
+    "script-src 'none'; "
+    "style-src 'unsafe-inline'"
+)
+
+FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})\s*([^`]*)$")
+HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$")
+UNORDERED_RE = re.compile(r"^\s{0,3}[-+*]\s+(.+)$")
+ORDERED_RE = re.compile(r"^\s{0,3}\d+[.)]\s+(.+)$")
+QUOTE_RE = re.compile(r"^\s{0,3}>\s?(.*)$")
+THEMATIC_RE = re.compile(r"^\s{0,3}((\*\s*){3,}|(-\s*){3,}|(_\s*){3,})$")
+TABLE_DIVIDER_RE = re.compile(r"^:?-{3,}:?$")
+
+
+class PreviewError(Exception):
+    pass
+
+
+def read_source(path):
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError as error:
+        raise PreviewError(f"cannot read Markdown source: {error}") from error
+    try:
+        before = os.fstat(fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise PreviewError("Markdown source is not a regular file")
+        chunks = []
+        total = 0
+        while True:
+            chunk = os.read(fd, min(65536, MAX_SOURCE_BYTES + 1 - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > MAX_SOURCE_BYTES:
+                raise PreviewError(
+                    f"Markdown source exceeds {MAX_SOURCE_BYTES} bytes"
+                )
+        after = os.fstat(fd)
+    finally:
+        os.close(fd)
+    identity_before = (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+    )
+    identity_after = (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+    )
+    if identity_before != identity_after:
+        raise PreviewError("Markdown source changed while it was being read")
+    data = b"".join(chunks)
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise PreviewError("Markdown source is not valid UTF-8") from error
+    return data, text
+
+
+def safe_href(target):
+    value = target.strip()
+    if not value or any(ord(char) < 32 for char in value):
+        return None
+    if value.startswith("#"):
+        return value
+    parsed = urlsplit(value)
+    if parsed.scheme.lower() not in {"http", "https", "mailto"}:
+        return None
+    return value
+
+
+def render_inline(source, depth=0):
+    if depth > 4:
+        return html.escape(source, quote=True)
+    rendered = []
+    plain = []
+    length = len(source)
+    index = 0
+
+    def flush_plain():
+        if plain:
+            rendered.append(html.escape("".join(plain), quote=True))
+            plain.clear()
+
+    while index < length:
+        if source[index] == "\\" and index + 1 < length:
+            plain.append(source[index + 1])
+            index += 2
+            continue
+
+        if source[index] == "`":
+            marker_end = index
+            while marker_end < length and source[marker_end] == "`":
+                marker_end += 1
+            marker = source[index:marker_end]
+            close = source.find(marker, marker_end)
+            if close != -1:
+                flush_plain()
+                code = source[marker_end:close].strip(" ")
+                rendered.append(f"<code>{html.escape(code, quote=True)}</code>")
+                index = close + len(marker)
+                continue
+
+        image_start = source.startswith("![", index)
+        link_start = source[index] == "["
+        label_start = index + 2 if image_start else index + 1
+        if image_start or link_start:
+            label_end = source.find("](", label_start)
+            target_end = source.find(")", label_end + 2) if label_end != -1 else -1
+            if label_end != -1 and target_end != -1:
+                flush_plain()
+                label = source[label_start:label_end]
+                target = source[label_end + 2 : target_end]
+                if image_start:
+                    rendered.append(
+                        '<span class="image-alt">Image: '
+                        f"{html.escape(label, quote=True)}</span>"
+                    )
+                else:
+                    href = safe_href(target)
+                    label_html = render_inline(label, depth + 1)
+                    if href is None:
+                        rendered.append(label_html)
+                    else:
+                        rendered.append(
+                            '<a rel="noreferrer noopener" target="_blank" '
+                            f'href="{html.escape(href, quote=True)}">'
+                            f"{label_html}</a>"
+                        )
+                index = target_end + 1
+                continue
+
+        matched_delimiter = False
+        for marker, tag in (("**", "strong"), ("__", "strong"), ("~~", "del")):
+            if source.startswith(marker, index):
+                close = source.find(marker, index + len(marker))
+                if close > index + len(marker):
+                    flush_plain()
+                    inner = source[index + len(marker) : close]
+                    rendered.append(
+                        f"<{tag}>{render_inline(inner, depth + 1)}</{tag}>"
+                    )
+                    index = close + len(marker)
+                    matched_delimiter = True
+                    break
+        if matched_delimiter:
+            continue
+
+        if source[index] in "*_":
+            marker = source[index]
+            close = source.find(marker, index + 1)
+            if close > index + 1:
+                flush_plain()
+                rendered.append(
+                    f"<em>{render_inline(source[index + 1:close], depth + 1)}</em>"
+                )
+                index = close + 1
+                continue
+
+        plain.append(source[index])
+        index += 1
+
+    flush_plain()
+    return "".join(rendered)
+
+
+def split_table_row(line):
+    stripped = line.strip().strip("|")
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def is_table(lines, index):
+    if index + 1 >= len(lines) or "|" not in lines[index]:
+        return False
+    dividers = split_table_row(lines[index + 1])
+    return bool(dividers) and all(
+        TABLE_DIVIDER_RE.fullmatch(cell) for cell in dividers
+    )
+
+
+def starts_block(lines, index):
+    line = lines[index]
+    return (
+        FENCE_RE.match(line)
+        or HEADING_RE.match(line)
+        or UNORDERED_RE.match(line)
+        or ORDERED_RE.match(line)
+        or QUOTE_RE.match(line)
+        or THEMATIC_RE.match(line)
+        or line.startswith("    ")
+        or is_table(lines, index)
+    )
+
+
+def render_blocks(lines):
+    output = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            index += 1
+            continue
+
+        fence = FENCE_RE.match(line)
+        if fence:
+            marker = fence.group(1)
+            info = fence.group(2).strip().split(None, 1)
+            language = info[0] if info else ""
+            index += 1
+            code_lines = []
+            while index < len(lines):
+                candidate = lines[index].lstrip()
+                if candidate.startswith(marker[0] * len(marker)):
+                    index += 1
+                    break
+                code_lines.append(lines[index])
+                index += 1
+            language_attr = (
+                f' class="language-{html.escape(language, quote=True)}"'
+                if language
+                else ""
+            )
+            code = html.escape("\n".join(code_lines), quote=True)
+            output.append(f"<pre><code{language_attr}>{code}</code></pre>")
+            continue
+
+        heading = HEADING_RE.match(line)
+        if heading:
+            level = len(heading.group(1))
+            output.append(
+                f"<h{level}>{render_inline(heading.group(2))}</h{level}>"
+            )
+            index += 1
+            continue
+
+        if THEMATIC_RE.match(line):
+            output.append("<hr>")
+            index += 1
+            continue
+
+        if is_table(lines, index):
+            headings = split_table_row(line)
+            divider_count = len(split_table_row(lines[index + 1]))
+            index += 2
+            rows = []
+            while index < len(lines) and lines[index].strip() and "|" in lines[index]:
+                rows.append(split_table_row(lines[index]))
+                index += 1
+            headings = (headings + [""] * divider_count)[:divider_count]
+            output.append("<table><thead><tr>")
+            output.extend(f"<th>{render_inline(cell)}</th>" for cell in headings)
+            output.append("</tr></thead><tbody>")
+            for row in rows:
+                row = (row + [""] * divider_count)[:divider_count]
+                output.append("<tr>")
+                output.extend(f"<td>{render_inline(cell)}</td>" for cell in row)
+                output.append("</tr>")
+            output.append("</tbody></table>")
+            continue
+
+        quote = QUOTE_RE.match(line)
+        if quote:
+            quoted = []
+            while index < len(lines):
+                match = QUOTE_RE.match(lines[index])
+                if not match:
+                    break
+                quoted.append(match.group(1))
+                index += 1
+            output.append(f"<blockquote>{render_blocks(quoted)}</blockquote>")
+            continue
+
+        unordered = UNORDERED_RE.match(line)
+        if unordered:
+            output.append("<ul>")
+            while index < len(lines):
+                match = UNORDERED_RE.match(lines[index])
+                if not match:
+                    break
+                output.append(f"<li>{render_inline(match.group(1))}</li>")
+                index += 1
+            output.append("</ul>")
+            continue
+
+        ordered = ORDERED_RE.match(line)
+        if ordered:
+            output.append("<ol>")
+            while index < len(lines):
+                match = ORDERED_RE.match(lines[index])
+                if not match:
+                    break
+                output.append(f"<li>{render_inline(match.group(1))}</li>")
+                index += 1
+            output.append("</ol>")
+            continue
+
+        if line.startswith("    "):
+            code_lines = []
+            while index < len(lines) and (
+                lines[index].startswith("    ") or not lines[index].strip()
+            ):
+                code_lines.append(lines[index][4:] if lines[index] else "")
+                index += 1
+            code = html.escape("\n".join(code_lines), quote=True)
+            output.append(f"<pre><code>{code}</code></pre>")
+            continue
+
+        paragraph = [line.strip()]
+        index += 1
+        while (
+            index < len(lines)
+            and lines[index].strip()
+            and not starts_block(lines, index)
+        ):
+            paragraph.append(lines[index].strip())
+            index += 1
+        output.append(f"<p>{render_inline(' '.join(paragraph))}</p>")
+
+    return "".join(output)
+
+
+def render_document(source, title):
+    lines = source.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    body = render_blocks(lines)
+    safe_title = html.escape(title, quote=True)
+    return (
+        "<!doctype html>\n"
+        '<html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        f'<meta http-equiv="Content-Security-Policy" content="{CSP}">'
+        f"<title>{safe_title}</title>"
+        "<style>"
+        ":root{color-scheme:light dark}"
+        "body{font:16px/1.6 system-ui,sans-serif;max-width:900px;margin:3rem auto;"
+        "padding:0 1.5rem;overflow-wrap:anywhere}"
+        "pre{padding:1rem;overflow:auto;background:color-mix(in srgb,currentColor 8%,transparent)}"
+        "code{font-family:ui-monospace,SFMono-Regular,Consolas,monospace}"
+        "blockquote{border-left:.25rem solid currentColor;margin-left:0;padding-left:1rem;opacity:.85}"
+        "table{border-collapse:collapse;width:100%}"
+        "th,td{border:1px solid;padding:.4rem .6rem;text-align:left}"
+        "a{color:LinkText}.image-alt{font-style:italic;opacity:.75}"
+        "</style></head><body>"
+        f"{body}</body></html>\n"
+    ).encode("utf-8")
+
+
+class PreviewState:
+    def __init__(self, source_path, digest, body, token):
+        self.source_path = source_path
+        self.digest = digest
+        self.body = body
+        self.token = token
+        self.path = f"/{token}/"
+        self.delivered = threading.Event()
+        self.stale = threading.Event()
+
+    def is_current(self):
+        try:
+            data, _text = read_source(self.source_path)
+        except PreviewError:
+            self.stale.set()
+            return False
+        current = hashlib.sha256(data).hexdigest()
+        if not secrets.compare_digest(current, self.digest):
+            self.stale.set()
+            return False
+        return True
+
+
+class PreviewServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = False
+
+    def __init__(self, state):
+        self.state = state
+        super().__init__(("127.0.0.1", 0), PreviewHandler)
+
+
+class PreviewHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, _format, *_args):
+        return
+
+    def send_fixed(self, status, body, content_type):
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Security-Policy", CSP)
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Firstmate-Source-SHA256", self.server.state.digest)
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError):
+            return False
+        return True
+
+    def do_GET(self):
+        state = self.server.state
+        if self.path != state.path:
+            self.send_fixed(404, b"preview unavailable\n", "text/plain; charset=utf-8")
+            return
+        if not state.is_current():
+            self.send_fixed(409, b"preview source changed\n", "text/plain; charset=utf-8")
+            return
+        if self.send_fixed(200, state.body, "text/html; charset=utf-8"):
+            if self.headers.get(VERIFY_HEADER) != state.token:
+                state.delivered.set()
+
+
+def resolve_opener(explicit):
+    if explicit:
+        resolved = shutil.which(explicit)
+        if resolved is None:
+            candidate = Path(explicit)
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                resolved = str(candidate)
+        if resolved is None:
+            raise PreviewError(f"opener is not executable: {explicit}")
+        return [resolved]
+    if sys.platform == "darwin":
+        opener = shutil.which("open")
+        if opener:
+            return [opener]
+    opener = shutil.which("xdg-open")
+    if opener:
+        return [opener]
+    opener = shutil.which("gio")
+    if opener:
+        return [opener, "open"]
+    raise PreviewError("no supported local desktop opener was found")
+
+
+def verify_server(url, state):
+    request = urllib.request.Request(
+        url,
+        headers={
+            VERIFY_HEADER: state.token,
+            "User-Agent": "firstmate-markdown-preview-verifier",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=2) as response:
+            body = response.read(MAX_SOURCE_BYTES + 1)
+            digest = response.headers.get("X-Firstmate-Source-SHA256")
+    except urllib.error.HTTPError as error:
+        if error.code == 409:
+            raise PreviewError("source changed before preview verification") from error
+        raise PreviewError(f"local preview verification returned HTTP {error.code}") from error
+    except OSError as error:
+        raise PreviewError(f"local preview verification failed: {error}") from error
+    if body != state.body or digest != state.digest:
+        raise PreviewError("local preview verification did not match the current rendering")
+
+
+def stop_process(process):
+    if process is None or process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=0.5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=0.5)
+
+
+def open_and_wait(command, url, state, timeout):
+    try:
+        process = subprocess.Popen(
+            [*command, url],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as error:
+        raise PreviewError(f"could not start local desktop opener: {error}") from error
+
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            if state.stale.is_set():
+                raise PreviewError("source changed before preview delivery")
+            if state.delivered.is_set():
+                break
+            return_code = process.poll()
+            if return_code not in (None, 0):
+                error = process.stderr.read().strip()
+                detail = f": {error}" if error else ""
+                raise PreviewError(
+                    f"local desktop opener exited {return_code}{detail}"
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise PreviewError("timed out waiting for the browser to fetch the preview")
+            state.delivered.wait(min(0.05, remaining))
+
+        try:
+            return_code = process.wait(timeout=1)
+        except subprocess.TimeoutExpired as error:
+            raise PreviewError(
+                "local desktop opener did not exit after opening the preview"
+            ) from error
+        if return_code != 0:
+            error = process.stderr.read().strip()
+            detail = f": {error}" if error else ""
+            raise PreviewError(f"local desktop opener exited {return_code}{detail}")
+    finally:
+        stop_process(process)
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Render and open one fail-closed local Markdown preview."
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT,
+        help="maximum browser-fetch wait in seconds (0.1 through 30)",
+    )
+    parser.add_argument(
+        "--opener",
+        help="local desktop URL opener executable (primarily for tests)",
+    )
+    parser.add_argument("file", help="Markdown file to preview")
+    args = parser.parse_args(argv)
+    if not MIN_TIMEOUT <= args.timeout <= MAX_TIMEOUT:
+        parser.error(
+            f"--timeout must be between {MIN_TIMEOUT:g} and {MAX_TIMEOUT:g} seconds"
+        )
+    return args
+
+
+def run(args):
+    source_path = Path(args.file).expanduser().absolute()
+    data, source = read_source(source_path)
+    digest = hashlib.sha256(data).hexdigest()
+    body = render_document(source, source_path.name)
+    state = PreviewState(source_path, digest, body, secrets.token_urlsafe(24))
+    opener = resolve_opener(args.opener)
+    server = None
+    thread = None
+    try:
+        server = PreviewServer(state)
+        thread = threading.Thread(
+            target=server.serve_forever,
+            name="fm-markdown-preview",
+            daemon=True,
+        )
+        thread.start()
+        port = server.server_address[1]
+        url = f"http://127.0.0.1:{port}{state.path}"
+        verify_server(url, state)
+        if not state.is_current():
+            raise PreviewError("source changed before preview opening")
+        open_and_wait(opener, url, state, args.timeout)
+    finally:
+        if server is not None:
+            server.shutdown()
+            server.server_close()
+        if thread is not None:
+            thread.join(timeout=2)
+            if thread.is_alive():
+                raise PreviewError("local preview server did not stop")
+    print(f"ok - previewed {source_path.name}")
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    try:
+        run(args)
+    except PreviewError as error:
+        print(f"fm-markdown-preview: {error}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("fm-markdown-preview: interrupted", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/fm-markdown-preview.py
+++ b/bin/fm-markdown-preview.py
@@ -9,6 +9,8 @@ Policy, serves only that in-memory result on an ephemeral 127.0.0.1 port, and
 opens the tokenized URL through a local desktop opener.
 The source digest is checked during the browser request so a changed file is
 never answered with the older rendering.
+A verified browser fetch is success independently of the opener process
+lifetime.
 The server exists only for a bounded wait and is shut down on success, failure,
 timeout, or interruption.
 
@@ -48,6 +50,8 @@ from urllib.parse import urlsplit
 
 
 MAX_SOURCE_BYTES = 8 * 1024 * 1024
+MAX_RENDERED_BYTES = 64 * 1024 * 1024
+INLINE_SCAN_FACTOR = 4
 DEFAULT_TIMEOUT = 12.0
 MIN_TIMEOUT = 0.1
 MAX_TIMEOUT = 30.0
@@ -144,11 +148,24 @@ def render_inline(source, depth=0):
     plain = []
     length = len(source)
     index = 0
+    remaining_scan = length * INLINE_SCAN_FACTOR
 
     def flush_plain():
         if plain:
             rendered.append(html.escape("".join(plain), quote=True))
             plain.clear()
+
+    def find_delimiter(marker, start):
+        nonlocal remaining_scan
+        if start >= length or remaining_scan <= 0:
+            return -1
+        stop = min(length, start + remaining_scan)
+        found = source.find(marker, start, stop)
+        if found == -1:
+            remaining_scan -= stop - start
+        else:
+            remaining_scan -= found + len(marker) - start
+        return found
 
     while index < length:
         if source[index] == "\\" and index + 1 < length:
@@ -161,7 +178,7 @@ def render_inline(source, depth=0):
             while marker_end < length and source[marker_end] == "`":
                 marker_end += 1
             marker = source[index:marker_end]
-            close = source.find(marker, marker_end)
+            close = find_delimiter(marker, marker_end)
             if close != -1:
                 flush_plain()
                 code = source[marker_end:close].strip(" ")
@@ -173,8 +190,10 @@ def render_inline(source, depth=0):
         link_start = source[index] == "["
         label_start = index + 2 if image_start else index + 1
         if image_start or link_start:
-            label_end = source.find("](", label_start)
-            target_end = source.find(")", label_end + 2) if label_end != -1 else -1
+            label_end = find_delimiter("](", label_start)
+            target_end = (
+                find_delimiter(")", label_end + 2) if label_end != -1 else -1
+            )
             if label_end != -1 and target_end != -1:
                 flush_plain()
                 label = source[label_start:label_end]
@@ -201,7 +220,7 @@ def render_inline(source, depth=0):
         matched_delimiter = False
         for marker, tag in (("**", "strong"), ("__", "strong"), ("~~", "del")):
             if source.startswith(marker, index):
-                close = source.find(marker, index + len(marker))
+                close = find_delimiter(marker, index + len(marker))
                 if close > index + len(marker):
                     flush_plain()
                     inner = source[index + len(marker) : close]
@@ -216,7 +235,7 @@ def render_inline(source, depth=0):
 
         if source[index] in "*_":
             marker = source[index]
-            close = source.find(marker, index + 1)
+            close = find_delimiter(marker, index + 1)
             if close > index + 1:
                 flush_plain()
                 rendered.append(
@@ -391,7 +410,7 @@ def render_document(source, title):
     lines = source.replace("\r\n", "\n").replace("\r", "\n").split("\n")
     body = render_blocks(lines)
     safe_title = html.escape(title, quote=True)
-    return (
+    rendered = (
         "<!doctype html>\n"
         '<html lang="en"><head><meta charset="utf-8">'
         '<meta name="viewport" content="width=device-width, initial-scale=1">'
@@ -410,6 +429,11 @@ def render_document(source, title):
         "</style></head><body>"
         f"{body}</body></html>\n"
     ).encode("utf-8")
+    if len(rendered) > MAX_RENDERED_BYTES:
+        raise PreviewError(
+            f"rendered preview exceeds {MAX_RENDERED_BYTES} bytes"
+        )
+    return rendered
 
 
 class PreviewState:
@@ -512,7 +536,7 @@ def verify_server(url, state):
     )
     try:
         with urllib.request.urlopen(request, timeout=2) as response:
-            body = response.read(MAX_SOURCE_BYTES + 1)
+            body = response.read(len(state.body) + 1)
             digest = response.headers.get("X-Firstmate-Source-SHA256")
     except urllib.error.HTTPError as error:
         if error.code == 409:
@@ -541,43 +565,31 @@ def open_and_wait(command, url, state, timeout):
             [*command, url],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            text=True,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
         )
     except OSError as error:
         raise PreviewError(f"could not start local desktop opener: {error}") from error
 
     deadline = time.monotonic() + timeout
+    delivered = False
     try:
         while True:
             if state.stale.is_set():
                 raise PreviewError("source changed before preview delivery")
             if state.delivered.is_set():
-                break
+                delivered = True
+                return
             return_code = process.poll()
             if return_code not in (None, 0):
-                error = process.stderr.read().strip()
-                detail = f": {error}" if error else ""
-                raise PreviewError(
-                    f"local desktop opener exited {return_code}{detail}"
-                )
+                raise PreviewError(f"local desktop opener exited {return_code}")
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise PreviewError("timed out waiting for the browser to fetch the preview")
             state.delivered.wait(min(0.05, remaining))
-
-        try:
-            return_code = process.wait(timeout=1)
-        except subprocess.TimeoutExpired as error:
-            raise PreviewError(
-                "local desktop opener did not exit after opening the preview"
-            ) from error
-        if return_code != 0:
-            error = process.stderr.read().strip()
-            detail = f": {error}" if error else ""
-            raise PreviewError(f"local desktop opener exited {return_code}{detail}")
     finally:
-        stop_process(process)
+        if not delivered:
+            stop_process(process)
 
 
 def parse_args(argv):

--- a/bin/fm-markdown-preview.py
+++ b/bin/fm-markdown-preview.py
@@ -176,25 +176,40 @@ def read_source(path):
         fd = os.open(path, os.O_RDONLY | getattr(os, "O_NONBLOCK", 0))
     except OSError as error:
         raise PreviewError(f"cannot read Markdown source: {error}") from error
+    operation_failed = False
     try:
-        before = os.fstat(fd)
-        if not stat.S_ISREG(before.st_mode):
-            raise PreviewError("Markdown source is not a regular file")
-        chunks = []
-        total = 0
-        while True:
-            chunk = os.read(fd, min(65536, MAX_SOURCE_BYTES + 1 - total))
-            if not chunk:
-                break
-            chunks.append(chunk)
-            total += len(chunk)
-            if total > MAX_SOURCE_BYTES:
-                raise PreviewError(
-                    f"Markdown source exceeds {MAX_SOURCE_BYTES} bytes"
-                )
-        after = os.fstat(fd)
+        try:
+            before = os.fstat(fd)
+            if not stat.S_ISREG(before.st_mode):
+                raise PreviewError("Markdown source is not a regular file")
+            chunks = []
+            total = 0
+            while True:
+                chunk = os.read(fd, min(65536, MAX_SOURCE_BYTES + 1 - total))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                total += len(chunk)
+                if total > MAX_SOURCE_BYTES:
+                    raise PreviewError(
+                        f"Markdown source exceeds {MAX_SOURCE_BYTES} bytes"
+                    )
+            after = os.fstat(fd)
+        except OSError as error:
+            raise PreviewError(
+                f"cannot read Markdown source: {error}"
+            ) from error
+    except BaseException:
+        operation_failed = True
+        raise
     finally:
-        os.close(fd)
+        try:
+            os.close(fd)
+        except OSError as error:
+            if not operation_failed:
+                raise PreviewError(
+                    f"cannot close Markdown source: {error}"
+                ) from error
     identity_before = (
         before.st_dev,
         before.st_ino,
@@ -809,7 +824,12 @@ def run(args):
     thread = None
     thread_started = False
     try:
-        server = PreviewServer(state)
+        try:
+            server = PreviewServer(state)
+        except OSError as error:
+            raise PreviewError(
+                f"could not start local preview server: {error}"
+            ) from error
         thread = threading.Thread(
             target=server.serve_forever,
             name="fm-markdown-preview",

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -124,7 +124,8 @@ family_for_basename() {
     fm-dispatch-select.test.sh|fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
-    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
+    fm-operational-input.test.sh|fm-markdown-preview.test.sh|\
+    fm-pi-primary-types-order.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-tmux-submit-busy.test.sh|fm-transition-lib.test.sh|\

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -215,7 +215,7 @@ The operational provider path covers Calm loaded on, loaded off, default prefere
 It asserts one persisted and rendered captain answer, exact user-role operational envelopes in order, no replacement custom messages, one processing result, zero operational transcript rows, and the two-row neighboring-assistant geometry for live, adjacent, and restart paths.
 Quoted current markers, ASCII-only labels, ordinary text before a marker, unrelated U+2063 placement, and image-bearing input remain visible in component and native transcript checks.
 `tests/fm-pi-primary-live-e2e.test.sh` also proves the unchanged built-in `Working...` row while Calm is active on the credentialed provider path before continuing its ordinary watcher lifecycle.
-`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi 0.81.1 declarations.
+`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi 0.81.1 declarations when TypeScript 5 or newer is available.
 
 The relevant commands are:
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,7 +1,7 @@
 # The bin/ toolbelt
 
 The first mate drives these; interactive entrypoints work by hand too, while `*-lib.sh` files are sourced helpers.
-Each row is one purpose clause only: the script's own header comment is the authoritative description of its behavior, flags, and contracts, so read the header before first use.
+Each row is one purpose clause only: the script's own leading comment or docstring is the authoritative description of its behavior, flags, and contracts, so read it before first use.
 If you have changed away from the firstmate home in an interactive shell, invoke these scripts by absolute path through the repo's `bin/` directory; the scripts self-locate internally after they start.
 The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarized in [architecture.md](architecture.md#no-mistakes-gate-authority-boundary), while `docs/sessionstart-nudge.md` covers the silent hook-nudge use; `fm-gate-refuse-lib.sh`'s header owns its exact contract.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -14,6 +14,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
+| `fm-markdown-preview.py` | Safely render and open one verified current Markdown file through a bounded loopback server |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -115,7 +115,7 @@ BASE_REF=$(resolve_base_ref) \
 OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-decision-hold.sh fm-backend.sh fm-operational-input.sh"
 # A pull-request merge may add a new main-only dependency that the branch's older baseline does not have yet.
 OLD_BIN_OPTIONAL_SIBLINGS="fm-pending-reply-lib.sh"
-OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh fm-marker-lib.sh"
+OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh fm-marker-lib.sh fm-operational-input.sh"
 
 build_old_bin() {  # <name> -> echoes root dir (root/bin/<script> is the entry point)
   local name=$1 root bin f

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -349,7 +349,7 @@ SH
 }
 
 test_orca_backend_gates_orca_tool_only_when_selected() {
-  local case_dir fakebin out missing_orca
+  local case_dir fakebin bash_env out missing_orca
   missing_orca="MISSING: orca (install: brew install orca  # or the platform's package manager)"
 
   case_dir="$TMP_ROOT/orca-backend-selected"
@@ -357,7 +357,19 @@ test_orca_backend_gates_orca_tool_only_when_selected() {
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   printf '%s\n' orca > "$case_dir/home/config/backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  bash_env="$case_dir/no-orca.bash"
+  cat > "$bash_env" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = orca ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+orca() {
+  return 127
+}
+SH
+  out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   [ "$out" = "$missing_orca" ] || fail "backend=orca should require only the Orca-specific missing tool, got: $out"
 

--- a/tests/fm-markdown-preview.test.sh
+++ b/tests/fm-markdown-preview.test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Behavior tests for the fail-closed Markdown preview helper.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HELPER="$ROOT/bin/fm-markdown-preview.py"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-markdown-preview.XXXXXX")
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+OPENER="$TMP_ROOT/opener.py"
+cat >"$OPENER" <<'PY'
+#!/usr/bin/env python3
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+capture = Path(os.environ["FM_PREVIEW_TEST_CAPTURE"])
+capture.mkdir(parents=True, exist_ok=True)
+url = sys.argv[1]
+(capture / "url").write_text(url, encoding="utf-8")
+
+source = os.environ.get("FM_PREVIEW_TEST_MUTATE")
+if source:
+    Path(source).write_text("# Replaced after launch\n", encoding="utf-8")
+
+if os.environ.get("FM_PREVIEW_TEST_SKIP_FETCH"):
+    raise SystemExit(0)
+
+request = urllib.request.Request(url, headers={"User-Agent": "fm-preview-test"})
+try:
+    with urllib.request.urlopen(request, timeout=2) as response:
+        (capture / "status").write_text(str(response.status), encoding="utf-8")
+        (capture / "headers").write_text(
+            "".join(f"{key}: {value}\n" for key, value in response.headers.items()),
+            encoding="utf-8",
+        )
+        (capture / "body").write_bytes(response.read())
+except urllib.error.HTTPError as error:
+    (capture / "status").write_text(str(error.code), encoding="utf-8")
+    (capture / "body").write_bytes(error.read())
+    raise SystemExit(4)
+PY
+chmod +x "$OPENER"
+
+assert_present "$HELPER" "Markdown preview helper is missing"
+[ -x "$HELPER" ] || fail "Markdown preview helper must be executable"
+
+test_safe_render_and_cleanup() {
+  local source="$TMP_ROOT/safe.md" capture="$TMP_ROOT/safe-capture"
+  cat >"$source" <<'MD'
+# Safety preview
+
+<script>window.bad = true</script>
+<img src="https://raw-image.example.invalid/raw.png" onerror="window.bad = true">
+
+![Remote pixel](https://pixel.example.invalid/pixel.png)
+
+[Safe remote link](https://example.invalid/read)
+[Unsafe link](javascript:alert(1))
+
+```html
+<iframe src="https://frames.example.invalid/"></iframe>
+```
+
+```
+bare fenced code
+```
+MD
+
+  FM_PREVIEW_TEST_CAPTURE="$capture" \
+    "$HELPER" --opener "$OPENER" --timeout 2 "$source" \
+    >"$TMP_ROOT/safe.out" 2>"$TMP_ROOT/safe.err" \
+    || fail "safe Markdown preview failed: $(cat "$TMP_ROOT/safe.err")"
+
+  assert_grep "http://127.0.0.1:" "$capture/url" \
+    "preview did not bind to loopback"
+  [ "$(cat "$capture/status")" = 200 ] \
+    || fail "preview opener did not receive HTTP 200"
+  assert_grep "Content-Security-Policy: default-src 'none'" "$capture/headers" \
+    "preview response is missing its fail-closed CSP"
+  assert_grep "&lt;script&gt;window.bad = true&lt;/script&gt;" "$capture/body" \
+    "raw HTML was not escaped"
+  assert_no_grep "<script>" "$capture/body" \
+    "preview emitted an executable script element"
+  assert_no_grep "pixel.example.invalid" "$capture/body" \
+    "preview retained a remote image subresource"
+  assert_no_grep "<img" "$capture/body" \
+    "preview emitted an image element"
+  assert_no_grep "<iframe" "$capture/body" \
+    "preview emitted a frame element"
+  assert_grep "<pre><code>bare fenced code</code></pre>" "$capture/body" \
+    "preview did not render a bare fenced code block"
+  assert_no_grep 'href="javascript:' "$capture/body" \
+    "preview retained an unsafe link scheme"
+  assert_grep 'href="https://example.invalid/read"' "$capture/body" \
+    "preview dropped an ordinary remote hyperlink"
+
+  if python3 - "$(cat "$capture/url")" >/dev/null 2>&1 <<'PY'
+import sys
+import urllib.request
+
+urllib.request.urlopen(sys.argv[1], timeout=0.5)
+PY
+  then
+    fail "preview server remained reachable after the helper exited"
+  fi
+
+  pass "Markdown preview escapes HTML, blocks subresources, and cleans up"
+}
+
+test_changed_source_fails_closed() {
+  local source="$TMP_ROOT/changed.md" capture="$TMP_ROOT/changed-capture" rc=0
+  printf '# Original snapshot\n' >"$source"
+
+  FM_PREVIEW_TEST_CAPTURE="$capture" \
+    FM_PREVIEW_TEST_MUTATE="$source" \
+    "$HELPER" --opener "$OPENER" --timeout 2 "$source" \
+    >"$TMP_ROOT/changed.out" 2>"$TMP_ROOT/changed.err" || rc=$?
+
+  [ "$rc" -ne 0 ] || fail "preview served a stale snapshot after the source changed"
+  [ "$(cat "$capture/status")" = 409 ] \
+    || fail "changed source did not receive HTTP 409"
+  assert_no_grep "Original snapshot" "$capture/body" \
+    "changed source response leaked stale rendered content"
+  assert_grep "source changed before preview delivery" "$TMP_ROOT/changed.err" \
+    "changed source failure was not explained"
+  pass "Markdown preview refuses stale source snapshots"
+}
+
+test_server_wait_is_bounded() {
+  local source="$TMP_ROOT/bounded.md" capture="$TMP_ROOT/bounded-capture" rc=0
+  printf '# Bounded server\n' >"$source"
+
+  FM_PREVIEW_TEST_CAPTURE="$capture" \
+    FM_PREVIEW_TEST_SKIP_FETCH=1 \
+    "$HELPER" --opener "$OPENER" --timeout 0.2 "$source" \
+    >"$TMP_ROOT/bounded.out" 2>"$TMP_ROOT/bounded.err" || rc=$?
+
+  [ "$rc" -ne 0 ] || fail "preview succeeded without a browser fetch"
+  assert_grep "timed out waiting for the browser" "$TMP_ROOT/bounded.err" \
+    "bounded wait failure was not explained"
+  if python3 - "$(cat "$capture/url")" >/dev/null 2>&1 <<'PY'
+import sys
+import urllib.request
+
+urllib.request.urlopen(sys.argv[1], timeout=0.5)
+PY
+  then
+    fail "timed-out preview server remained reachable"
+  fi
+  pass "Markdown preview bounds serving time and cleans up on timeout"
+}
+
+test_safe_render_and_cleanup
+test_changed_source_fails_closed
+test_server_wait_is_bounded

--- a/tests/fm-markdown-preview.test.sh
+++ b/tests/fm-markdown-preview.test.sh
@@ -86,6 +86,7 @@ test_safe_render_and_cleanup() {
 
 [Safe remote link](https://example.invalid/read)
 [Unsafe link](javascript:alert(1))
+[Malformed link](https://[invalid)
 
 ```html
 <iframe src="https://frames.example.invalid/"></iframe>
@@ -124,6 +125,10 @@ MD
     "preview retained an unsafe link scheme"
   assert_grep 'href="https://example.invalid/read"' "$capture/body" \
     "preview dropped an ordinary remote hyperlink"
+  assert_grep "Malformed link" "$capture/body" \
+    "preview dropped the label for a malformed link"
+  assert_no_grep 'href="https://[invalid"' "$capture/body" \
+    "preview retained a malformed link target"
 
   if python3 - "$(cat "$capture/url")" >/dev/null 2>&1 <<'PY'
 import sys
@@ -324,6 +329,95 @@ PY
   pass "inline delimiter scanning remains bounded"
 }
 
+test_block_parser_scans_are_bounded() {
+  local source="$TMP_ROOT/block-scans.md" capture="$TMP_ROOT/block-scans-capture"
+  python3 - "$source" <<'PY'
+import sys
+from pathlib import Path
+
+marker = b"~" * (2 * 1024 * 1024)
+heading = b"# title" + b" " * (2 * 1024 * 1024) + b"x\n"
+Path(sys.argv[1]).write_bytes(
+    marker + b"\n" + b"body\n" * 512 + marker + b"\n\n" + heading
+)
+PY
+
+  if ! FM_PREVIEW_TEST_CAPTURE="$capture" \
+    python3 - "$HELPER" "$OPENER" "$source" <<'PY'
+import os
+import subprocess
+import sys
+
+try:
+    result = subprocess.run(
+        [sys.argv[1], "--opener", sys.argv[2], "--timeout", "2", sys.argv[3]],
+        capture_output=True,
+        env=os.environ.copy(),
+        text=True,
+        timeout=20,
+    )
+except subprocess.TimeoutExpired:
+    raise SystemExit(124)
+if result.returncode != 0:
+    sys.stderr.write(result.stderr)
+    raise SystemExit(result.returncode)
+PY
+  then
+    fail "block delimiter-heavy Markdown exceeded its bounded render time"
+  fi
+  pass "fence and heading parsing remain bounded"
+}
+
+test_render_object_budgets_fail_before_accumulation() {
+  local lines="$TMP_ROOT/too-many-lines.md" parts="$TMP_ROOT/too-many-parts.md" rc=0
+  python3 - "$lines" "$parts" <<'PY'
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_bytes(b"x\n\n" * 100001)
+Path(sys.argv[2]).write_bytes(
+    b"|a|b|\n|---|---|\n" + b"|x|x|\n" * 40000
+)
+PY
+
+  "$HELPER" --opener "$OPENER" --timeout 2 "$lines" \
+    >"$TMP_ROOT/too-many-lines.out" 2>"$TMP_ROOT/too-many-lines.err" || rc=$?
+  [ "$rc" -ne 0 ] || fail "excessive source lines were accepted"
+  assert_grep "source exceeds" "$TMP_ROOT/too-many-lines.err" \
+    "source line budget failure was not explained"
+
+  rc=0
+  "$HELPER" --opener "$OPENER" --timeout 2 "$parts" \
+    >"$TMP_ROOT/too-many-parts.out" 2>"$TMP_ROOT/too-many-parts.err" || rc=$?
+  [ "$rc" -ne 0 ] || fail "excessive render parts were accepted"
+  assert_grep "rendered preview exceeds" "$TMP_ROOT/too-many-parts.err" \
+    "render part budget failure was not explained"
+  pass "source line and render part budgets fail before accumulation"
+}
+
+test_non_table_delimiters_do_not_trigger_table_limits() {
+  local source="$TMP_ROOT/non-table.md" capture="$TMP_ROOT/non-table-capture"
+  python3 - "$source" <<'PY'
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text(
+    "Ordinary | prose\n" + "value|" * 2048 + "\n",
+    encoding="utf-8",
+)
+PY
+
+  FM_PREVIEW_TEST_CAPTURE="$capture" \
+    "$HELPER" --opener "$OPENER" --timeout 2 "$source" \
+    >"$TMP_ROOT/non-table.out" 2>"$TMP_ROOT/non-table.err" \
+    || fail "non-table delimiters triggered table limits: $(cat "$TMP_ROOT/non-table.err")"
+
+  wait_for_file "$capture/body"
+  assert_grep "Ordinary | prose" "$capture/body" \
+    "non-table prose was not rendered"
+  pass "table limits apply only after divider recognition"
+}
+
 test_blockquote_nesting_is_bounded() {
   local source="$TMP_ROOT/blockquote-depth.md" rc=0
   python3 - "$source" <<'PY'
@@ -340,6 +434,24 @@ PY
   assert_grep "blockquote nesting exceeds" "$TMP_ROOT/blockquote-depth.err" \
     "blockquote depth failure was not explained"
   pass "blockquote nesting fails closed at its configured bound"
+}
+
+test_blockquote_copy_budget_fails_before_amplification() {
+  local source="$TMP_ROOT/blockquote-copy.md" rc=0
+  python3 - "$source" <<'PY'
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_bytes(b"> " * 64 + b"x" * (6 * 1024 * 1024) + b"\n")
+PY
+
+  "$HELPER" --opener "$OPENER" --timeout 2 "$source" \
+    >"$TMP_ROOT/blockquote-copy.out" 2>"$TMP_ROOT/blockquote-copy.err" || rc=$?
+
+  [ "$rc" -ne 0 ] || fail "amplifying blockquote input was accepted"
+  assert_grep "blockquote input exceeds" "$TMP_ROOT/blockquote-copy.err" \
+    "blockquote copy budget failure was not explained"
+  pass "blockquote copies fail before input amplification"
 }
 
 test_table_cell_budget_fails_before_wide_render() {
@@ -392,6 +504,10 @@ test_verified_delivery_detaches_long_lived_opener
 test_verification_bypasses_proxy_environment
 test_unstarted_server_thread_cleans_up_without_deadlock
 test_inline_delimiter_scan_is_bounded
+test_block_parser_scans_are_bounded
+test_render_object_budgets_fail_before_accumulation
+test_non_table_delimiters_do_not_trigger_table_limits
 test_blockquote_nesting_is_bounded
+test_blockquote_copy_budget_fails_before_amplification
 test_table_cell_budget_fails_before_wide_render
 test_expanded_render_verifies_in_full

--- a/tests/fm-markdown-preview.test.sh
+++ b/tests/fm-markdown-preview.test.sh
@@ -7,8 +7,13 @@ set -u
 
 HELPER="$ROOT/bin/fm-markdown-preview.py"
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-markdown-preview.XXXXXX")
+LONG_LIVED_PID=
 
 cleanup() {
+  if [ -n "$LONG_LIVED_PID" ]; then
+    kill "$LONG_LIVED_PID" 2>/dev/null || true
+    kill -9 "$LONG_LIVED_PID" 2>/dev/null || true
+  fi
   rm -rf "$TMP_ROOT"
 }
 trap cleanup EXIT
@@ -18,6 +23,7 @@ cat >"$OPENER" <<'PY'
 #!/usr/bin/env python3
 import os
 import sys
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -47,11 +53,25 @@ except urllib.error.HTTPError as error:
     (capture / "status").write_text(str(error.code), encoding="utf-8")
     (capture / "body").write_bytes(error.read())
     raise SystemExit(4)
+
+if os.environ.get("FM_PREVIEW_TEST_STAY_OPEN"):
+    (capture / "pid").write_text(str(os.getpid()), encoding="utf-8")
+    while True:
+        time.sleep(1)
 PY
 chmod +x "$OPENER"
 
 assert_present "$HELPER" "Markdown preview helper is missing"
 [ -x "$HELPER" ] || fail "Markdown preview helper must be executable"
+
+wait_for_file() {
+  local path=$1 attempt
+  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+    [ -e "$path" ] && return 0
+    sleep 0.05
+  done
+  fail "timed out waiting for test artifact $path"
+}
 
 test_safe_render_and_cleanup() {
   local source="$TMP_ROOT/safe.md" capture="$TMP_ROOT/safe-capture"
@@ -80,6 +100,7 @@ MD
     >"$TMP_ROOT/safe.out" 2>"$TMP_ROOT/safe.err" \
     || fail "safe Markdown preview failed: $(cat "$TMP_ROOT/safe.err")"
 
+  wait_for_file "$capture/body"
   assert_grep "http://127.0.0.1:" "$capture/url" \
     "preview did not bind to loopback"
   [ "$(cat "$capture/status")" = 200 ] \
@@ -159,6 +180,95 @@ PY
   pass "Markdown preview bounds serving time and cleans up on timeout"
 }
 
+test_verified_delivery_detaches_long_lived_opener() {
+  local source="$TMP_ROOT/long-lived.md" capture="$TMP_ROOT/long-lived-capture"
+  local attempt
+  printf '# Foreground browser handler\n' >"$source"
+
+  FM_PREVIEW_TEST_CAPTURE="$capture" \
+    FM_PREVIEW_TEST_STAY_OPEN=1 \
+    "$HELPER" --opener "$OPENER" --timeout 2 "$source" \
+    >"$TMP_ROOT/long-lived.out" 2>"$TMP_ROOT/long-lived.err" \
+    || fail "verified delivery waited for or terminated its opener: $(cat "$TMP_ROOT/long-lived.err")"
+
+  wait_for_file "$capture/pid"
+  assert_present "$capture/pid" "long-lived opener did not record its pid"
+  LONG_LIVED_PID=$(cat "$capture/pid")
+  kill -0 "$LONG_LIVED_PID" 2>/dev/null \
+    || fail "verified delivery terminated the foreground browser handler"
+
+  kill "$LONG_LIVED_PID" 2>/dev/null || true
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    kill -0 "$LONG_LIVED_PID" 2>/dev/null || break
+    sleep 0.05
+  done
+  if kill -0 "$LONG_LIVED_PID" 2>/dev/null; then
+    kill -9 "$LONG_LIVED_PID" 2>/dev/null || true
+  fi
+  LONG_LIVED_PID=
+  pass "verified delivery succeeds independently of opener lifetime"
+}
+
+test_inline_delimiter_scan_is_bounded() {
+  local source="$TMP_ROOT/delimiters.md" capture="$TMP_ROOT/delimiters-capture"
+  python3 - "$source" <<'PY'
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_bytes(b"# Delimiter load\n\n" + b"[" * (2 * 1024 * 1024) + b"\n")
+PY
+
+  if ! FM_PREVIEW_TEST_CAPTURE="$capture" \
+    python3 - "$HELPER" "$OPENER" "$source" <<'PY'
+import os
+import subprocess
+import sys
+
+try:
+    result = subprocess.run(
+        [sys.argv[1], "--opener", sys.argv[2], "--timeout", "2", sys.argv[3]],
+        capture_output=True,
+        env=os.environ.copy(),
+        text=True,
+        timeout=10,
+    )
+except subprocess.TimeoutExpired:
+    raise SystemExit(124)
+if result.returncode != 0:
+    sys.stderr.write(result.stderr)
+    raise SystemExit(result.returncode)
+PY
+  then
+    fail "delimiter-heavy Markdown exceeded its bounded render time"
+  fi
+  pass "inline delimiter scanning remains bounded"
+}
+
+test_expanded_render_verifies_in_full() {
+  local source="$TMP_ROOT/expanded.md" capture="$TMP_ROOT/expanded-capture"
+  local rendered_size
+  python3 - "$source" <<'PY'
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_bytes(b"# Expanded body\n\n" + b"&" * (2 * 1024 * 1024) + b"\n")
+PY
+
+  FM_PREVIEW_TEST_CAPTURE="$capture" \
+    "$HELPER" --opener "$OPENER" --timeout 2 "$source" \
+    >"$TMP_ROOT/expanded.out" 2>"$TMP_ROOT/expanded.err" \
+    || fail "expanded rendered body was not verified in full: $(cat "$TMP_ROOT/expanded.err")"
+
+  wait_for_file "$capture/body"
+  rendered_size=$(wc -c <"$capture/body" | tr -d ' ')
+  [ "$rendered_size" -gt $((8 * 1024 * 1024)) ] \
+    || fail "expanded render fixture did not exceed the source-byte verification bound"
+  pass "expanded rendered bodies verify against their own bounded length"
+}
+
 test_safe_render_and_cleanup
 test_changed_source_fails_closed
 test_server_wait_is_bounded
+test_verified_delivery_detaches_long_lived_opener
+test_inline_delimiter_scan_is_bounded
+test_expanded_render_verifies_in_full

--- a/tests/fm-markdown-preview.test.sh
+++ b/tests/fm-markdown-preview.test.sh
@@ -307,7 +307,7 @@ test_verified_delivery_detaches_long_lived_opener() {
     || fail "verified delivery terminated the foreground browser handler"
 
   kill "$LONG_LIVED_PID" 2>/dev/null || true
-  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  for ((attempt = 0; attempt < 10; attempt += 1)); do
     kill -0 "$LONG_LIVED_PID" 2>/dev/null || break
     sleep 0.05
   done
@@ -327,8 +327,8 @@ test_verification_bypasses_proxy_environment() {
     https_proxy=http://127.0.0.1:9 \
     HTTPS_PROXY=http://127.0.0.1:9 \
     ALL_PROXY=http://127.0.0.1:9 \
-    no_proxy= \
-    NO_PROXY= \
+    no_proxy='' \
+    NO_PROXY='' \
     FM_PREVIEW_TEST_CAPTURE="$capture" \
     "$HELPER" --opener "$OPENER" --timeout 2 "$source" \
     >"$TMP_ROOT/proxy.out" 2>"$TMP_ROOT/proxy.err" \

--- a/tests/fm-markdown-preview.test.sh
+++ b/tests/fm-markdown-preview.test.sh
@@ -172,6 +172,80 @@ PY
   pass "FIFO sources fail without blocking"
 }
 
+test_source_descriptor_errors_are_controlled() {
+  local source="$TMP_ROOT/descriptor-errors.md"
+  printf '# Descriptor errors\n' >"$source"
+
+  if ! python3 - "$HELPER" "$source" "$TMP_ROOT" <<'PY'
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("fm_markdown_preview", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+source = sys.argv[2]
+directory = sys.argv[3]
+
+def expect_preview_error(call, required, forbidden=None):
+    try:
+        call()
+    except module.PreviewError as error:
+        message = str(error)
+        if required not in message:
+            raise SystemExit(f"missing controlled error text: {message}")
+        if forbidden is not None and forbidden in message:
+            raise SystemExit(f"masked original preview error: {message}")
+    else:
+        raise SystemExit("descriptor failure unexpectedly succeeded")
+
+original_fstat = module.os.fstat
+def fail_fstat(_fd):
+    raise OSError("injected fstat failure")
+module.os.fstat = fail_fstat
+try:
+    expect_preview_error(
+        lambda: module.read_source(source),
+        "cannot read Markdown source",
+    )
+finally:
+    module.os.fstat = original_fstat
+
+original_read = module.os.read
+def fail_read(_fd, _count):
+    raise OSError("injected read failure")
+module.os.read = fail_read
+try:
+    expect_preview_error(
+        lambda: module.read_source(source),
+        "cannot read Markdown source",
+    )
+finally:
+    module.os.read = original_read
+
+original_close = module.os.close
+def fail_close(fd):
+    original_close(fd)
+    raise OSError("injected close failure")
+module.os.close = fail_close
+try:
+    expect_preview_error(
+        lambda: module.read_source(source),
+        "cannot close Markdown source",
+    )
+    expect_preview_error(
+        lambda: module.read_source(directory),
+        "not a regular file",
+        "close failure",
+    )
+finally:
+    module.os.close = original_close
+PY
+  then
+    fail "source descriptor errors escaped the controlled failure contract"
+  fi
+  pass "source descriptor errors remain controlled"
+}
+
 test_changed_source_fails_closed() {
   local source="$TMP_ROOT/changed.md" capture="$TMP_ROOT/changed-capture" rc=0
   printf '# Original snapshot\n' >"$source"
@@ -312,6 +386,38 @@ PY
     fail "server cleanup deadlocked when its thread never started"
   fi
   pass "unstarted server thread closes without shutdown deadlock"
+}
+
+test_server_bind_errors_are_controlled() {
+  local source="$TMP_ROOT/server-bind.md"
+  printf '# Server bind failure\n' >"$source"
+
+  if ! python3 - "$HELPER" "$OPENER" "$source" <<'PY'
+import importlib.util
+import sys
+from types import SimpleNamespace
+
+spec = importlib.util.spec_from_file_location("fm_markdown_preview", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+def fail_server(_state):
+    raise OSError("injected bind failure")
+
+module.PreviewServer = fail_server
+args = SimpleNamespace(file=sys.argv[3], opener=sys.argv[2], timeout=0.2)
+try:
+    module.run(args)
+except module.PreviewError as error:
+    if "could not start local preview server" not in str(error):
+        raise
+else:
+    raise SystemExit("server bind failure unexpectedly succeeded")
+PY
+  then
+    fail "server bind error escaped the controlled failure contract"
+  fi
+  pass "server bind errors remain controlled"
 }
 
 test_inline_delimiter_scan_is_bounded() {
@@ -546,11 +652,13 @@ PY
 
 test_safe_render_and_cleanup
 test_fifo_source_is_rejected_without_blocking
+test_source_descriptor_errors_are_controlled
 test_changed_source_fails_closed
 test_server_wait_is_bounded
 test_verified_delivery_detaches_long_lived_opener
 test_verification_bypasses_proxy_environment
 test_unstarted_server_thread_cleans_up_without_deadlock
+test_server_bind_errors_are_controlled
 test_inline_delimiter_scan_is_bounded
 test_inline_fragment_budget_fails_before_accumulation
 test_block_parser_scans_are_bounded

--- a/tests/fm-markdown-preview.test.sh
+++ b/tests/fm-markdown-preview.test.sh
@@ -143,6 +143,35 @@ PY
   pass "Markdown preview escapes HTML, blocks subresources, and cleans up"
 }
 
+test_fifo_source_is_rejected_without_blocking() {
+  local source="$TMP_ROOT/source.fifo"
+  mkfifo "$source"
+
+  if ! python3 - "$HELPER" "$OPENER" "$source" <<'PY'
+import subprocess
+import sys
+
+try:
+    result = subprocess.run(
+        [sys.argv[1], "--opener", sys.argv[2], "--timeout", "2", sys.argv[3]],
+        capture_output=True,
+        text=True,
+        timeout=2,
+    )
+except subprocess.TimeoutExpired:
+    raise SystemExit(124)
+if result.returncode == 0:
+    raise SystemExit("FIFO source unexpectedly succeeded")
+if "not a regular file" not in result.stderr:
+    sys.stderr.write(result.stderr)
+    raise SystemExit("FIFO source failure was not explained")
+PY
+  then
+    fail "FIFO source blocked before regular-file validation"
+  fi
+  pass "FIFO sources fail without blocking"
+}
+
 test_changed_source_fails_closed() {
   local source="$TMP_ROOT/changed.md" capture="$TMP_ROOT/changed-capture" rc=0
   printf '# Original snapshot\n' >"$source"
@@ -329,6 +358,24 @@ PY
   pass "inline delimiter scanning remains bounded"
 }
 
+test_inline_fragment_budget_fails_before_accumulation() {
+  local source="$TMP_ROOT/inline-fragments.md" rc=0
+  python3 - "$source" <<'PY'
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_bytes(b"*x*" * 200000 + b"\n")
+PY
+
+  "$HELPER" --opener "$OPENER" --timeout 2 "$source" \
+    >"$TMP_ROOT/inline-fragments.out" 2>"$TMP_ROOT/inline-fragments.err" || rc=$?
+
+  [ "$rc" -ne 0 ] || fail "excessive inline fragments were accepted"
+  assert_grep "inline rendering exceeds" "$TMP_ROOT/inline-fragments.err" \
+    "inline fragment budget failure was not explained"
+  pass "inline fragment budgets fail before accumulation"
+}
+
 test_block_parser_scans_are_bounded() {
   local source="$TMP_ROOT/block-scans.md" capture="$TMP_ROOT/block-scans-capture"
   python3 - "$source" <<'PY'
@@ -498,12 +545,14 @@ PY
 }
 
 test_safe_render_and_cleanup
+test_fifo_source_is_rejected_without_blocking
 test_changed_source_fails_closed
 test_server_wait_is_bounded
 test_verified_delivery_detaches_long_lived_opener
 test_verification_bypasses_proxy_environment
 test_unstarted_server_thread_cleans_up_without_deadlock
 test_inline_delimiter_scan_is_bounded
+test_inline_fragment_budget_fails_before_accumulation
 test_block_parser_scans_are_bounded
 test_render_object_budgets_fail_before_accumulation
 test_non_table_delimiters_do_not_trigger_table_limits

--- a/tests/fm-markdown-preview.test.sh
+++ b/tests/fm-markdown-preview.test.sh
@@ -41,8 +41,9 @@ if os.environ.get("FM_PREVIEW_TEST_SKIP_FETCH"):
     raise SystemExit(0)
 
 request = urllib.request.Request(url, headers={"User-Agent": "fm-preview-test"})
+opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 try:
-    with urllib.request.urlopen(request, timeout=2) as response:
+    with opener.open(request, timeout=2) as response:
         (capture / "status").write_text(str(response.status), encoding="utf-8")
         (capture / "headers").write_text(
             "".join(f"{key}: {value}\n" for key, value in response.headers.items()),
@@ -209,13 +210,92 @@ test_verified_delivery_detaches_long_lived_opener() {
   pass "verified delivery succeeds independently of opener lifetime"
 }
 
+test_verification_bypasses_proxy_environment() {
+  local source="$TMP_ROOT/proxy.md" capture="$TMP_ROOT/proxy-capture"
+  printf '# Direct loopback verification\n' >"$source"
+
+  http_proxy=http://127.0.0.1:9 \
+    HTTP_PROXY=http://127.0.0.1:9 \
+    https_proxy=http://127.0.0.1:9 \
+    HTTPS_PROXY=http://127.0.0.1:9 \
+    ALL_PROXY=http://127.0.0.1:9 \
+    no_proxy= \
+    NO_PROXY= \
+    FM_PREVIEW_TEST_CAPTURE="$capture" \
+    "$HELPER" --opener "$OPENER" --timeout 2 "$source" \
+    >"$TMP_ROOT/proxy.out" 2>"$TMP_ROOT/proxy.err" \
+    || fail "proxy environment intercepted loopback verification: $(cat "$TMP_ROOT/proxy.err")"
+
+  wait_for_file "$capture/body"
+  pass "loopback verification bypasses proxy configuration"
+}
+
+test_unstarted_server_thread_cleans_up_without_deadlock() {
+  local source="$TMP_ROOT/thread-start.md"
+  printf '# Thread start failure\n' >"$source"
+
+  if ! python3 - "$HELPER" "$OPENER" "$source" <<'PY'
+import subprocess
+import sys
+
+code = r'''
+import importlib.util
+import sys
+from types import SimpleNamespace
+
+spec = importlib.util.spec_from_file_location("fm_markdown_preview", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+def fail_start(_thread):
+    raise RuntimeError("injected start failure")
+
+module.threading.Thread.start = fail_start
+args = SimpleNamespace(file=sys.argv[3], opener=sys.argv[2], timeout=0.2)
+try:
+    module.run(args)
+except module.PreviewError as error:
+    if "server thread" not in str(error):
+        raise
+else:
+    raise SystemExit("thread start failure unexpectedly succeeded")
+'''
+
+try:
+    result = subprocess.run(
+        [sys.executable, "-c", code, *sys.argv[1:]],
+        capture_output=True,
+        text=True,
+        timeout=3,
+    )
+except subprocess.TimeoutExpired:
+    raise SystemExit(124)
+if result.returncode != 0:
+    sys.stderr.write(result.stderr)
+    raise SystemExit(result.returncode)
+PY
+  then
+    fail "server cleanup deadlocked when its thread never started"
+  fi
+  pass "unstarted server thread closes without shutdown deadlock"
+}
+
 test_inline_delimiter_scan_is_bounded() {
   local source="$TMP_ROOT/delimiters.md" capture="$TMP_ROOT/delimiters-capture"
   python3 - "$source" <<'PY'
 import sys
 from pathlib import Path
 
-Path(sys.argv[1]).write_bytes(b"# Delimiter load\n\n" + b"[" * (2 * 1024 * 1024) + b"\n")
+size = 2 * 1024 * 1024
+Path(sys.argv[1]).write_bytes(
+    b"# Delimiter load\n\n"
+    + b"[" * size
+    + b"\n\nx"
+    + b"`" * size
+    + b"\n\n~~~"
+    + b" " * size
+    + b"`\n"
+)
 PY
 
   if ! FM_PREVIEW_TEST_CAPTURE="$capture" \
@@ -230,7 +310,7 @@ try:
         capture_output=True,
         env=os.environ.copy(),
         text=True,
-        timeout=10,
+        timeout=20,
     )
 except subprocess.TimeoutExpired:
     raise SystemExit(124)
@@ -242,6 +322,45 @@ PY
     fail "delimiter-heavy Markdown exceeded its bounded render time"
   fi
   pass "inline delimiter scanning remains bounded"
+}
+
+test_blockquote_nesting_is_bounded() {
+  local source="$TMP_ROOT/blockquote-depth.md" rc=0
+  python3 - "$source" <<'PY'
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text("> " * 128 + "nested\n", encoding="utf-8")
+PY
+
+  "$HELPER" --opener "$OPENER" --timeout 2 "$source" \
+    >"$TMP_ROOT/blockquote-depth.out" 2>"$TMP_ROOT/blockquote-depth.err" || rc=$?
+
+  [ "$rc" -ne 0 ] || fail "excessive blockquote nesting was accepted"
+  assert_grep "blockquote nesting exceeds" "$TMP_ROOT/blockquote-depth.err" \
+    "blockquote depth failure was not explained"
+  pass "blockquote nesting fails closed at its configured bound"
+}
+
+test_table_cell_budget_fails_before_wide_render() {
+  local source="$TMP_ROOT/wide-table.md" rc=0
+  python3 - "$source" <<'PY'
+import sys
+from pathlib import Path
+
+columns = 2048
+header = "|" + "x|" * columns
+divider = "|" + "---|" * columns
+Path(sys.argv[1]).write_text(header + "\n" + divider + "\n", encoding="utf-8")
+PY
+
+  "$HELPER" --opener "$OPENER" --timeout 2 "$source" \
+    >"$TMP_ROOT/wide-table.out" 2>"$TMP_ROOT/wide-table.err" || rc=$?
+
+  [ "$rc" -ne 0 ] || fail "wide table exceeded the render budget without refusal"
+  assert_grep "table exceeds" "$TMP_ROOT/wide-table.err" \
+    "wide table budget failure was not explained"
+  pass "table cell budgets reject wide renders before accumulation"
 }
 
 test_expanded_render_verifies_in_full() {
@@ -270,5 +389,9 @@ test_safe_render_and_cleanup
 test_changed_source_fails_closed
 test_server_wait_is_bounded
 test_verified_delivery_detaches_long_lived_opener
+test_verification_bypasses_proxy_environment
+test_unstarted_server_thread_cleans_up_without_deadlock
 test_inline_delimiter_scan_is_bounded
+test_blockquote_nesting_is_bounded
+test_table_cell_budget_fails_before_wide_render
 test_expanded_render_verifies_in_full

--- a/tests/fm-pi-primary-types-order.test.sh
+++ b/tests/fm-pi-primary-types-order.test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Regression test for package-first Pi typecheck probing.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TARGET="$ROOT/tests/fm-pi-primary-types.test.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-pi-primary-types-order.XXXXXX")
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+FAKEBIN="$TMP_ROOT/fakebin"
+mkdir -p "$FAKEBIN"
+
+cat >"$FAKEBIN/npm" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' '/missing/npm/root'
+SH
+
+cat >"$FAKEBIN/tsc" <<'SH'
+#!/usr/bin/env bash
+printf 'tsc was probed\n' >"$FM_PI_TSC_PROBE_MARKER"
+exit 91
+SH
+
+chmod +x "$FAKEBIN/npm" "$FAKEBIN/tsc"
+
+marker="$TMP_ROOT/tsc-probed"
+missing_package="$TMP_ROOT/missing-pi-package"
+out=$(
+  PATH="$FAKEBIN:$PATH" \
+    FM_PI_PACKAGE_DIR="$missing_package" \
+    FM_PI_TSC_PROBE_MARKER="$marker" \
+    "$TARGET" 2>&1
+) || fail "missing Pi package did not take the skip path: $out"
+
+assert_contains "$out" "skip: Pi package not found at $missing_package" \
+  "missing Pi package skip was not reported"
+assert_absent "$marker" "tsc was probed before the Pi package was validated"
+pass "Pi package detection precedes compiler probing"

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -6,15 +6,16 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 command -v npm >/dev/null 2>&1 || { echo "skip: npm not found for Pi extension typecheck"; exit 0; }
 command -v tsc >/dev/null 2>&1 || { echo "skip: tsc not found for Pi extension typecheck"; exit 0; }
-TSC_VERSION=$(tsc --version 2>/dev/null || true)
-TSC_MAJOR=${TSC_VERSION#Version }
-TSC_MAJOR=${TSC_MAJOR%%.*}
-case "$TSC_MAJOR" in
-  ''|*[!0-9]*)
-    echo "skip: compatible tsc version could not be determined"
-    exit 0
-    ;;
-esac
+if ! TSC_VERSION=$(tsc --version 2>/dev/null); then
+  echo "not ok - tsc version probe failed" >&2
+  exit 1
+fi
+if [[ "$TSC_VERSION" =~ ^Version\ ([0-9]+)\.[0-9]+(\.[0-9]+)?([-+][0-9A-Za-z.-]+)?$ ]]; then
+  TSC_MAJOR=${BASH_REMATCH[1]}
+else
+  echo "not ok - compatible tsc version could not be determined" >&2
+  exit 1
+fi
 if [ "$TSC_MAJOR" -lt 5 ]; then
   echo "skip: TypeScript 5 or newer required for Pi extension typecheck"
   exit 0

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -4,7 +4,17 @@ set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-command -v npm >/dev/null 2>&1 || { echo "skip: npm not found for Pi extension typecheck"; exit 0; }
+if [ -n "${FM_PI_PACKAGE_DIR:-}" ]; then
+  PI_PACKAGE_DIR=$FM_PI_PACKAGE_DIR
+else
+  command -v npm >/dev/null 2>&1 || { echo "skip: npm not found for Pi extension typecheck"; exit 0; }
+  PI_PACKAGE_DIR="$(npm root -g)/@earendil-works/pi-coding-agent"
+fi
+if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+  echo "skip: Pi package not found at $PI_PACKAGE_DIR"
+  exit 0
+fi
+
 command -v tsc >/dev/null 2>&1 || { echo "skip: tsc not found for Pi extension typecheck"; exit 0; }
 if ! TSC_VERSION=$(tsc --version 2>/dev/null); then
   echo "not ok - tsc version probe failed" >&2
@@ -21,11 +31,6 @@ if [ "$TSC_MAJOR" -lt 5 ]; then
   exit 0
 fi
 
-PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g)/@earendil-works/pi-coding-agent"}
-if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
-  echo "skip: installed @earendil-works/pi-coding-agent package not found"
-  exit 0
-fi
 if [ ! -d "$PI_PACKAGE_DIR/node_modules/typebox" ] || \
    [ ! -d "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" ] || \
    [ ! -d "$PI_PACKAGE_DIR/node_modules/@types/node" ]; then

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -6,6 +6,19 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 command -v npm >/dev/null 2>&1 || { echo "skip: npm not found for Pi extension typecheck"; exit 0; }
 command -v tsc >/dev/null 2>&1 || { echo "skip: tsc not found for Pi extension typecheck"; exit 0; }
+TSC_VERSION=$(tsc --version 2>/dev/null || true)
+TSC_MAJOR=${TSC_VERSION#Version }
+TSC_MAJOR=${TSC_MAJOR%%.*}
+case "$TSC_MAJOR" in
+  ''|*[!0-9]*)
+    echo "skip: compatible tsc version could not be determined"
+    exit 0
+    ;;
+esac
+if [ "$TSC_MAJOR" -lt 5 ]; then
+  echo "skip: TypeScript 5 or newer required for Pi extension typecheck"
+  exit 0
+fi
 
 PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g)/@earendil-works/pi-coding-agent"}
 if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then


### PR DESCRIPTION
## What Changed

- Add a fail-closed Markdown preview helper with sanitized rendering, bounded resource use, current-file verification, tokenized loopback serving, and reliable cleanup.
- Require previews for generated or updated Markdown and document the helper, its Python 3 requirement, and test-runner integration.
- Add comprehensive preview regression coverage while hardening Pi TypeScript probing and isolating Orca bootstrap tests from host binaries.

## Risk Assessment

✅ Low: The latest changes correctly preserve existing preview failures while normalizing descriptor I/O, close, and loopback server-construction errors without introducing a material source risk.

## Testing

Baseline diff/status inspection, focused preview and related regression tests, and a live end-user rendering all completed successfully; the screenshot shows formatted Markdown with raw script text escaped and the remote image omitted, the helper reported success, and its loopback server was closed afterward. The in-app browser was unavailable, so the visual evidence was captured with local headless Chrome instead.

- Evidence: Rendered Firstmate Markdown preview (local file: <code>/tmp/no-mistakes-evidence/01KY7DACYHC79Z810G6TNF0G39/markdown-preview.png</code>)
<details>
<summary>Evidence: Successful preview and lifecycle evidence</summary>

<code>ok - previewed preview-fixture.md&#10;preview server closed after delivery (curl exit 7)</code>

```text
ok - previewed preview-fixture.md
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (6) ✅</summary>

- ⚠️ `AGENTS.md:49` - The mandatory security-sensitive preview workflow has no repository-owned renderer or verification helper. Each harness must independently interpret sanitization, remote-resource blocking, current-file verification, and cleanup, producing inconsistent guarantees or making delivery impossible on a clean host. Decide whether to add one pinned, fail-safe preview helper or skill and reference it here.
- ⚠️ `tests/fm-pi-primary-types.test.sh:9` - The `tsc --version` probe runs before checking whether the Pi package exists. A host without Pi but with a broken, wrapped, or unrelated `tsc` now fails instead of taking the documented Pi-not-installed skip path. Resolve and validate `PI_PACKAGE_DIR` before probing the compiler.

🔧 Fix: Captain: Add fail-safe previews and package-first Pi checks
3 issues (1 error, 2 warnings) still open:
- 🚨 `bin/fm-markdown-preview.py:569` - After a verified browser fetch, the helper still requires the opener process to exit within one second and then terminates it. `xdg-open` can run its selected handler in the foreground, so a successfully loaded preview may be reported as failed and its newly launched browser terminated. Decide whether verified delivery should constitute success independently of opener lifetime.
- ⚠️ `bin/fm-markdown-preview.py:176` - Every unmatched `[` scans the remainder of the line for `](`, with similar repeated scans for unmatched emphasis delimiters. Bracket-heavy input is therefore quadratic, while rendering occurs before the timeout and accepts files up to 8 MiB. Use a single-pass or otherwise bounded delimiter scan.
- ⚠️ `bin/fm-markdown-preview.py:515` - Server verification reads at most `MAX_SOURCE_BYTES + 1`, but HTML escaping can expand an accepted source to several times that size. A valid source below the 8 MiB limit can therefore be truncated during verification and falsely rejected as a content mismatch. Read against the bounded rendered-body length or enforce an explicit rendered-output limit before serving.

🔧 Fix: Captain: Harden preview delivery and rendering bounds
6 issues (1 error, 5 warnings) still open:
- 🚨 `bin/fm-markdown-preview.py:538` - `urllib.request.urlopen` honors proxy environment variables, so local verification can send the tokenized loopback URL to an external proxy and falsely fail when loopback is not exempted. Use a proxy-disabled opener or a direct loopback connection for verification.
- ⚠️ `bin/fm-markdown-preview.py:643` - If `thread.start()` raises, cleanup calls `server.shutdown()` even though `serve_forever()` never started; `BaseServer.shutdown()` can then wait indefinitely. Track whether the thread started and call only `server_close()` otherwise.
- ⚠️ `bin/fm-markdown-preview.py:178` - The delimiter budget does not cover counting a backtick run. For a large unmatched run, each successive backtick recounts most of the remaining run, making rendering quadratic before the serving timeout begins. Consume the whole unmatched run at once or include this scan in the budget.
- ⚠️ `bin/fm-markdown-preview.py:73` - The fence regex combines overlapping whitespace-capable groups before an end anchor, causing quadratic backtracking for a tilde fence followed by a long whitespace tail and a final backtick. Parse the fence tail separately or make the groups non-overlapping.
- ⚠️ `bin/fm-markdown-preview.py:357` - Nested blockquotes recursively invoke `render_blocks` without a depth bound, so roughly 1,000 nested markers can raise an uncaught `RecursionError` from a small accepted file. Render iteratively or reject excessive nesting with `PreviewError`.
- ⚠️ `bin/fm-markdown-preview.py:432` - The 64 MiB rendered-output limit is checked only after all block and table output has been accumulated, joined, and encoded. A wide accepted table can therefore allocate hundreds of megabytes before rejection. Enforce an output or cell budget during rendering.

🔧 Fix: Harden preview verification and rendering bounds
6 warnings still open:
- ⚠️ `bin/fm-markdown-preview.py:350` - Each fenced-block line rebuilds a marker-sized closing prefix. An accepted file with a multi-megabyte opening fence and many short body lines therefore performs quadratic allocation and work. Reuse `marker` directly in `startswith` or cache the prefix once.
- ⚠️ `bin/fm-markdown-preview.py:76` - The lazy heading body followed by overlapping `\s*#*\s*` suffixes can backtrack quadratically on a heading containing a long whitespace run before a non-matching suffix. Parse trailing heading markers in one pass or make the groups non-overlapping.
- ⚠️ `bin/fm-markdown-preview.py:100` - `RenderBuffer` limits bytes but not part count. Millions of tiny accepted blocks can remain below 64 MiB of output while `split()` and `parts` retain millions of Python objects, consuming hundreds of megabytes. Add a line/block/part budget or coalesce output incrementally.
- ⚠️ `bin/fm-markdown-preview.py:166` - `urlsplit` raises `ValueError` for malformed targets such as an unmatched IPv6 bracket, so one malformed Markdown link produces an uncaught traceback instead of being rendered without an unsafe href. Catch parser errors and return `None`.
- ⚠️ `bin/fm-markdown-preview.py:310` - Table detection applies the column limit before confirming that the following line is a divider. Ordinary prose containing `|` followed by a non-table line with over 1,024 delimited fields is therefore rejected as an oversized table. Enforce the limit only after recognizing a valid divider row.
- ⚠️ `bin/fm-markdown-preview.py:414` - The 64-level quote bound still copies the nearly complete captured line at every recursive level. A valid 8 MiB line with 64 nested quote markers can retain roughly 512 MiB before output budgeting applies. Strip quote prefixes iteratively or include retained input size in the budget.

🔧 Fix: Bound Markdown parser work and retained memory
2 warnings still open:
- ⚠️ `bin/fm-markdown-preview.py:132` - `read_source()` performs a blocking `os.open(..., O_RDONLY)` before validating that the descriptor is regular. A FIFO, including a path swapped to one, can therefore hang the supposedly bounded helper indefinitely. Open nonblocking and then validate the descriptor type.
- ⚠️ `bin/fm-markdown-preview.py:194` - The new byte and part budgets apply only after `render_inline()` has accumulated and joined its private lists. One accepted 8 MiB line containing dense short markup can retain millions of fragments and substantial object overhead before a single `RenderBuffer.append()` occurs. Apply incremental byte/fragment limits inside inline rendering or coalesce bounded chunks.

🔧 Fix: Bound source opening and inline rendering
2 warnings still open:
- ⚠️ `bin/fm-markdown-preview.py:180` - Only `os.open` is translated to `PreviewError`; failures from `os.fstat`, `os.read`, or `os.close` escape as raw tracebacks instead of the documented controlled preview failure. Normalize descriptor I/O errors while preserving existing `PreviewError` exceptions.
- ⚠️ `bin/fm-markdown-preview.py:812` - Loopback socket creation or binding can raise `OSError` from `PreviewServer(state)`, but `main()` does not catch it, so an expected serving failure produces a traceback. Wrap server construction as `PreviewError` and retain cleanup for partially initialized state.

🔧 Fix: Normalize preview I/O and server failures
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 68ed7ed2355619749c6ee2bb91b7298dee420df8..37b94216fea0b795e92676b45b1c85362c638d98` to establish intent and affected test scope.</code>
- `tests/fm-markdown-preview.test.sh`
- `tests/fm-bootstrap.test.sh`
- `tests/fm-pi-primary-types-order.test.sh`
- <code>`tests/fm-pi-primary-types.test.sh` (expected environment skip because installed TypeScript is older than version 5)</code>
- `bin/fm-markdown-preview.py --timeout 30 --opener /tmp/no-mistakes-evidence/01KY7DACYHC79Z810G6TNF0G39/capture-url-opener.sh /tmp/no-mistakes-evidence/01KY7DACYHC79Z810G6TNF0G39/preview-fixture.md`
- <code>Rendered the live loopback URL using `google-chrome --headless --window-size=1440,1000 --screenshot=...` and visually inspected the resulting PNG.</code>
- <code>Verified the loopback URL was unreachable after delivery using `curl --noproxy &#39;*&#39; --silent --show-error --max-time 1 &#34;$preview_url&#34;`.</code>
- <code>Checked cleanup with `git status --short`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
