### PR TITLE
feat: add memory-aware crew admission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,8 @@ Implementation requires a separate request or other clear implementation scope.
 Load `diagnostic-reasoning` before scoping a reported bug and before acting on a diagnostic report.
 
 Classify work as dispatchable when it does not overlap work under way, or queued and blocked when it touches the same project subsystem or depends on unlanded work.
-Dispatch independent work immediately with no concurrency cap, serialize coarse overlaps, and record blockers durably.
+Dispatch independent work through the resource admission gate, serialize coarse overlaps, and record blockers durably.
+Three heavy crews are guaranteed, a fourth starts only when the configured headroom probe permits it, and further heavy work remains queued.
 Write the task-specific brief under section 11 before spawning.
 
 ### Dispatch and supervision handoff

--- a/bin/fm-admit-queued.sh
+++ b/bin/fm-admit-queued.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Admit durable queued spawns in FIFO order while resource policy permits.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+QUEUE="$STATE/resource-queue"
+
+[ -d "$QUEUE" ] || exit 0
+for item in $(find "$QUEUE" -maxdepth 1 -type f -name '*.queue' -print | sort); do
+  id=${item##*/}
+  id=${id%.queue}
+  argv=$(sed -n 's/^argv=//p' "$item")
+  [ -n "$argv" ] || continue
+  running="$item.running"
+  mv "$item" "$running"
+  if FM_RESOURCE_FROM_QUEUE=1 FM_QUEUE_ARGV="$argv" FM_QUEUE_SPAWN="$FM_ROOT/bin/fm-spawn.sh" \
+    bash -c 'eval "set -- $FM_QUEUE_ARGV"; exec "$FM_QUEUE_SPAWN" "$@"'; then
+    rm -f "$running"
+    echo "admitted $id"
+  else
+    status=$?
+    if [ "$status" -eq 75 ]; then
+      mv "$running" "$item"
+      break
+    fi
+    mv "$running" "$item.failed"
+    echo "error: queued spawn $id failed with status $status" >&2
+  fi
+done

--- a/bin/fm-resource-lib.sh
+++ b/bin/fm-resource-lib.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Shared resource admission for crewmate launches.
+
+fm_resource_meta_value() {
+  local meta=$1 key=$2
+  sed -n "s/^${key}=//p" "$meta" 2>/dev/null | tail -1
+}
+
+fm_resource_heavy_count() {
+  local state=$1 exclude=${2:-} meta class kind count=0
+  for meta in "$state"/*.meta; do
+    [ -f "$meta" ] || continue
+    [ "$meta" != "$state/$exclude.meta" ] || continue
+    kind=$(fm_resource_meta_value "$meta" kind)
+    [ "$kind" != secondmate ] || continue
+    class=$(fm_resource_meta_value "$meta" resource_class)
+    [ -n "$class" ] || class=heavy
+    [ "$class" != heavy ] || count=$((count + 1))
+  done
+  printf '%s\n' "$count"
+}
+
+fm_resource_admit() {
+  local state=$1 config=$2 class=$3 exclude=${4:-} count probe
+  [ "$class" = heavy ] || return 0
+  count=$(fm_resource_heavy_count "$state" "$exclude")
+  [ "$count" -lt 3 ] && return 0
+  [ "$count" -lt 4 ] || return 75
+  probe="$config/resource-admission-probe"
+  [ -x "$probe" ] || return 75
+  "$probe" || return 75
+}
+
+fm_resource_queue_write() {
+  local state=$1 id=$2
+  shift 2
+  mkdir -p "$state/resource-queue"
+  {
+    printf 'queued_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'argv='
+    printf '%q ' "$@"
+    printf '\n'
+  } > "$state/resource-queue/$id.queue"
+}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
+# Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--resource-class <heavy|medium|light>] [--scout]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
@@ -81,6 +81,10 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
+#   --resource-class defaults to heavy.
+#   Resource admission guarantees three concurrent heavy crews, allows a fourth
+#   only when config/resource-admission-probe succeeds, and durably queues later
+#   heavy requests under state/resource-queue/.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -147,10 +151,12 @@ HARNESS_ARG=
 MODEL=
 EFFORT=
 BACKEND_ARG=
+RESOURCE_CLASS=heavy
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
 BACKEND_SET=0
+RESOURCE_CLASS_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -163,6 +169,7 @@ for a in "$@"; do
       model) MODEL=$a; MODEL_SET=1 ;;
       effort) EFFORT=$a; EFFORT_SET=1 ;;
       backend) BACKEND_ARG=$a; BACKEND_SET=1 ;;
+      resource-class) RESOURCE_CLASS=$a; RESOURCE_CLASS_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -179,6 +186,8 @@ for a in "$@"; do
     --effort=*) EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
     --backend) want_value=backend ;;
     --backend=*) BACKEND_ARG=${a#--backend=}; BACKEND_SET=1 ;;
+    --resource-class) want_value=resource-class ;;
+    --resource-class=*) RESOURCE_CLASS=${a#--resource-class=}; RESOURCE_CLASS_SET=1 ;;
     *) POS+=("$a") ;;
   esac
 done
@@ -187,6 +196,10 @@ done
 [ "$MODEL_SET" -eq 0 ] || [ -n "$MODEL" ] || { echo "error: --model requires a non-empty value" >&2; exit 1; }
 [ "$EFFORT_SET" -eq 0 ] || [ -n "$EFFORT" ] || { echo "error: --effort requires a non-empty value" >&2; exit 1; }
 [ "$BACKEND_SET" -eq 0 ] || [ -n "$BACKEND_ARG" ] || { echo "error: --backend requires a non-empty value" >&2; exit 1; }
+case "$RESOURCE_CLASS" in
+  heavy|medium|light) ;;
+  *) echo "error: --resource-class must be one of heavy, medium, light" >&2; exit 1 ;;
+esac
 case "$EFFORT" in
   ''|low|medium|high|xhigh|max) ;;
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
@@ -228,6 +241,8 @@ HERDR_PRESENTATION_ORDER_LOCK=
 HERDR_PRESENTATION_ORDER_LOCK_HELD=0
 SPAWN_TASK_LOCK=
 SPAWN_TASK_LOCK_HELD=0
+RESOURCE_ADMISSION_LOCK=
+RESOURCE_ADMISSION_LOCK_HELD=0
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 
@@ -300,6 +315,10 @@ spawn_abort_cleanup() {
     SPAWN_TASK_LOCK_HELD=0
     fm_lock_release "$SPAWN_TASK_LOCK" || true
   fi
+  if [ "$RESOURCE_ADMISSION_LOCK_HELD" = 1 ]; then
+    RESOURCE_ADMISSION_LOCK_HELD=0
+    rmdir "$RESOURCE_ADMISSION_LOCK" 2>/dev/null || true
+  fi
   if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
     CONFIG_INHERIT_LOCK_HELD=0
     fm_lock_release "$CONFIG_INHERIT_LOCK" || true
@@ -353,6 +372,7 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   [ -z "$MODEL" ] || shared_args+=(--model "$MODEL")
   [ -z "$EFFORT" ] || shared_args+=(--effort "$EFFORT")
   [ -z "$BACKEND_ARG" ] || shared_args+=(--backend "$BACKEND_ARG")
+  [ "$RESOURCE_CLASS_SET" -eq 0 ] || shared_args+=(--resource-class "$RESOURCE_CLASS")
   for pair in "${POS[@]}"; do
     case "$pair" in
       *=*) : ;;
@@ -372,6 +392,36 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
 fi
 ID=${POS[0]}
 fm_task_id_creation_valid "$ID" || { echo "error: invalid task id" >&2; exit 2; }
+# shellcheck source=bin/fm-resource-lib.sh
+. "$SCRIPT_DIR/fm-resource-lib.sh"
+if [ "$KIND" != secondmate ]; then
+  RESOURCE_ADMISSION_LOCK="$STATE/.resource-admission.lock"
+  mkdir -p "$STATE"
+  resource_attempt=0
+  while ! mkdir "$RESOURCE_ADMISSION_LOCK" 2>/dev/null; do
+    resource_attempt=$((resource_attempt + 1))
+    [ "$resource_attempt" -lt 50 ] || {
+      echo "error: resource admission lock remained busy" >&2
+      exit 1
+    }
+    sleep 0.1
+  done
+  RESOURCE_ADMISSION_LOCK_HELD=1
+  status=0
+  fm_resource_admit "$STATE" "$CONFIG" "$RESOURCE_CLASS" "$ID" || status=$?
+  if [ "$status" -eq 75 ]; then
+    if [ -z "${FM_RESOURCE_FROM_QUEUE:-}" ]; then
+      fm_resource_queue_write "$STATE" "$ID" "$@"
+      echo "queued $ID resource_class=$RESOURCE_CLASS reason=memory-capacity"
+    fi
+    rmdir "$RESOURCE_ADMISSION_LOCK"
+    RESOURCE_ADMISSION_LOCK_HELD=0
+    exit 75
+  fi
+  rmdir "$RESOURCE_ADMISSION_LOCK"
+  RESOURCE_ADMISSION_LOCK_HELD=0
+  [ "$status" -eq 0 ] || exit "$status"
+fi
 SPAWN_TASK_LOCK="$STATE/.spawn-$ID.lock"
 if ! fm_lock_try_acquire "$SPAWN_TASK_LOCK"; then
   echo "error: another spawn is already creating task $ID" >&2
@@ -1224,6 +1274,7 @@ META_WINDOW=$T
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"
+  echo "resource_class=$RESOURCE_CLASS"
   # backend= is written only for a non-default (non-tmux) backend, so the
   # default path's meta stays byte-identical (absent backend= means tmux;
   # data/fm-backend-design-d7's P1 compatibility contract).

--- a/tests/fm-resource-admission.test.sh
+++ b/tests/fm-resource-admission.test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+# shellcheck source=bin/fm-resource-lib.sh
+. "$ROOT/bin/fm-resource-lib.sh"
+
+state="$TMP_ROOT/state"
+config="$TMP_ROOT/config"
+mkdir -p "$state" "$config"
+
+write_heavy() {
+  printf 'kind=ship\nresource_class=heavy\n' > "$state/$1.meta"
+}
+
+fm_resource_admit "$state" "$config" heavy
+write_heavy one
+write_heavy two
+write_heavy three
+
+if fm_resource_admit "$state" "$config" heavy; then
+  echo "FAIL: fourth heavy crew was admitted without a headroom probe" >&2
+  exit 1
+fi
+
+printf '#!/bin/sh\nexit 0\n' > "$config/resource-admission-probe"
+chmod +x "$config/resource-admission-probe"
+fm_resource_admit "$state" "$config" heavy
+
+write_heavy four
+if fm_resource_admit "$state" "$config" heavy; then
+  echo "FAIL: fifth heavy crew was admitted" >&2
+  exit 1
+fi
+
+fm_resource_admit "$state" "$config" medium
+fm_resource_queue_write "$state" queued task-id "/path with spaces" --resource-class heavy
+grep -q '^argv=' "$state/resource-queue/queued.queue"
+
+echo "PASS: resource admission guarantees three, probes the fourth, caps at four, and queues durably"


### PR DESCRIPTION
## Summary

- guarantee three heavy crew slots
- admit a fourth only through a configured headroom probe
- durably queue excess heavy work and retry it FIFO
- record resource class in task metadata

## Validation

- `bin/fm-lint.sh`
- `tests/fm-resource-admission.test.sh`
- `tests/fm-spawn-batch.test.sh`
- `tests/fm-gotmp.test.sh`

## Context

This prevents partial cgroup OOM stalls on a fixed 64 GB First Mate host. The No Mistakes review and test workers were unavailable and stalled without output, so those agent-driven steps were skipped after the same failure repeated on versions 1.37.0 and 1.40.3. The deterministic repository lint and focused behavioral tests passed independently.