### PR TITLE
fix(herdr): stop the events capability probe spewing Broken pipe

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1941,8 +1941,13 @@ fm_backend_herdr_socket_path() {  # <session>
 # and both `events.subscribe` and `pane.agent_status_changed` present in `herdr
 # api schema`. FM_BACKEND_HERDR_EVENTS_FORCE overrides the whole verdict for
 # tests (1 = capable, 0 = incapable) without touching the real binary. The
-# `api schema` read is ~220KB, so callers (the watcher) memoize this per session
-# for a process lifetime rather than probing every poll.
+# `api schema` read is large (248KB at herdr 0.7.5), so callers (the watcher)
+# memoize this per session for a process lifetime rather than probing every
+# poll. That payload also dwarfs the 64KB pipe buffer, so the two token checks
+# match it in-shell with `case`: piping it into a short-circuiting reader like
+# `grep -Fq` leaves the writer blocked mid-payload when the reader exits on the
+# match, and every probe then prints `printf: write error: Broken pipe` to
+# stderr wherever SIGPIPE is ignored (the watcher's inherited disposition).
 fm_backend_herdr_events_capable() {  # <session>
   local session=$1 protocol schema
   case "${FM_BACKEND_HERDR_EVENTS_FORCE:-}" in
@@ -1957,8 +1962,8 @@ fm_backend_herdr_events_capable() {  # <session>
   case "$protocol" in ''|*[!0-9]*) return 1 ;; esac
   [ "$protocol" -ge "$FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL" ] || return 1
   schema=$(herdr api schema --json 2>/dev/null) || return 1
-  printf '%s' "$schema" | grep -Fq 'events.subscribe' || return 1
-  printf '%s' "$schema" | grep -Fq 'pane.agent_status_changed' || return 1
+  case "$schema" in *'events.subscribe'*) ;; *) return 1 ;; esac
+  case "$schema" in *'pane.agent_status_changed'*) ;; *) return 1 ;; esac
   return 0
 }
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -156,8 +156,10 @@ TRIAGE_LOG_MAX_BYTES=${FM_WATCH_TRIAGE_LOG_MAX_BYTES:-262144}
 # capability, so a transient herdr hiccup self-heals on the next cycle chain.
 EVENT_CAP_FAIL_MAX=${FM_EVENT_CAP_FAIL_MAX:-3}
 # Per-process memo for the push-capability probe (fm_backend_events_capable runs
-# a ~220KB `herdr api schema` read, too heavy to repeat every poll). Keyed by
-# "<backend>:<session>"; re-probed only when that key changes.
+# a large `herdr api schema` read, too heavy to repeat every poll - see
+# fm_backend_herdr_events_capable in bin/backends/herdr.sh for the payload and
+# its constraints). Keyed by "<backend>:<session>"; re-probed only when that key
+# changes.
 _event_cap_key=""
 _event_cap_ok=0
 _event_cap_fails=0

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2515,6 +2515,79 @@ set_fake_agent() {  # <agent-dir> <window-or-pane> <status>
   printf '%s' "$status" > "$dir/$key.status"
 }
 
+# --- events_capable: verdict + a silent probe (no EPIPE noise) ---------------
+#
+# `herdr api schema --json` is a large multi-line payload (248KB at 0.7.5).
+# Feeding it into a short-circuiting reader (`printf '%s' "$schema" | grep -Fq`)
+# left the writer blocked mid-payload when the reader exited on its match, so
+# the probe printed `printf: write error: Broken pipe` to stderr on nearly
+# every watcher arm and buried real diagnostics. `trap '' PIPE` in the driver
+# below is what makes that regression OBSERVABLE: it is the disposition the
+# watcher inherits, and under the default disposition the writer dies silently
+# and stderr stays clean even with the bug present.
+
+# make_herdr_schema_fake: a `herdr` stub answering just the two calls the
+# capability probe makes - `status --json` (protocol FM_FAKE_PROTOCOL) and
+# `api schema --json` (the fixture at FM_FAKE_SCHEMA).
+make_herdr_schema_fake() {  # <dir> -> echoes fakebin dir
+  local fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  "status --json") printf '{"client":{"version":"0.7.5","protocol":%s},"server":{"running":true}}\n' "${FM_FAKE_PROTOCOL:?}" ;;
+  "api schema") cat "${FM_FAKE_SCHEMA:?}" ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/herdr"
+  printf '%s\n' "$fb"
+}
+
+# write_fake_schemas: a ~250KB multi-line schema fixture carrying both required
+# tokens, plus one variant per missing token and an empty one. Both tokens sit
+# past the 64KB pipe buffer with well over a buffer's worth of payload behind
+# them, which is what a short-circuiting reader needs to strand the writer.
+write_fake_schemas() {  # <dir>
+  local dir=$1
+  {
+    awk 'BEGIN{for(i=0;i<1600;i++) printf "              \"description\": \"filler filler filler filler %d\",\n", i}'
+    printf '                  "const": "pane.agent_status_changed",\n'
+    awk 'BEGIN{for(i=0;i<800;i++) printf "              \"description\": \"filler filler filler filler %d\",\n", i}'
+    printf '                  "const": "events.subscribe",\n'
+    awk 'BEGIN{for(i=0;i<1600;i++) printf "              \"description\": \"filler filler filler filler %d\",\n", i}'
+  } > "$dir/both.json"
+  grep -vF 'events.subscribe' "$dir/both.json" > "$dir/no-subscribe.json"
+  grep -vF 'pane.agent_status_changed' "$dir/both.json" > "$dir/no-status.json"
+  : > "$dir/empty.json"
+}
+
+test_events_capable_verdict_and_silent_probe() {
+  local dir fb min schema err rc verdict size
+  dir="$TMP_ROOT/events-capable"; mkdir -p "$dir"
+  write_fake_schemas "$dir"
+  fb=$(make_herdr_schema_fake "$dir")
+  min=$(bash -c '. "$0/bin/backends/herdr.sh"; printf %s "$FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL"' "$ROOT")
+  size=$(wc -c < "$dir/both.json")
+  [ "$size" -gt 200000 ] || fail "the schema fixture must dwarf the 64KB pipe buffer, got $size bytes"
+
+  for schema in both:0 no-subscribe:1 no-status:1 empty:1; do
+    err="$dir/${schema%%:*}.err"
+    PATH="$fb:$PATH" FM_FAKE_SCHEMA="$dir/${schema%%:*}.json" FM_FAKE_PROTOCOL="$min" \
+      FM_BACKEND_HERDR_EVENT_READER="fake-reader" \
+      bash -c 'trap "" PIPE; . "$0/bin/backends/herdr.sh"; fm_backend_herdr_events_capable fmtest' \
+      "$ROOT" >/dev/null 2>"$err"
+    rc=$?
+    verdict=${schema##*:}
+    expect_code "$verdict" "$rc" "events_capable verdict wrong for the ${schema%%:*} schema"
+    if [ -s "$err" ]; then
+      fail "events_capable must probe silently for the ${schema%%:*} schema, got stderr: $(cat "$err")"
+    fi
+  done
+  pass "fm_backend_herdr_events_capable: correct verdict on every schema, and probes a large schema without stderr noise"
+}
+
 test_normalize_event_leaves_from_empty() {
   local rec
   rec=$(bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_normalize_event wG:pQ wG blocked claude' "$ROOT")
@@ -2855,6 +2928,7 @@ test_dispatch_routes_herdr_backend
 test_dispatch_busy_state_unknown_for_tmux
 test_dispatch_composer_state_routes_by_backend
 test_scripts_route_explicit_target_through_meta_backend
+test_events_capable_verdict_and_silent_probe
 test_normalize_event_leaves_from_empty
 test_escalation_marker_keys_like_watcher
 test_apply_transition_blocked_requires_commit_to_dedupe


### PR DESCRIPTION
## Intent

The developer wanted to eliminate spurious `Broken pipe` stderr noise from firstmate's herdr capability probe in `bin/backends/herdr.sh`, where `fm_backend_herdr_events_capable` piped a ~220KB `herdr api schema --json` payload into short-circuiting `grep -Fq` calls, causing `printf` to take EPIPE and bury real watcher diagnostics (it fired in 28 of 33 recent watcher arms). They required a subprocess-free, pipe-free replacement (e.g. shell `case` matching) preserving the exact verdict for all inputs including empty and malformed schemas, staying portable to the script's `/bin/sh`-compatible target without new bashisms, and updating the block comment if the change made its size/memoization description stale. Scope was explicitly bounded to that one function: the other 17 `printf ... | grep -q` sites under `bin/` were to be left untouched with no sweep or shared helper, and any genuinely large-payload site found elsewhere was to be reported in the `done:` line rather than fixed silently. Verification had to go beyond a green suite — reproduce the stderr noise before the change, show it clean after, exercise both the capable and incapable branches, and put before/after evidence in the commit body, adding a regression test only if the repo had a natural home for one. Hard constraints: load the `firstmate-coding-guidelines` skill first, work only in the disposable worktree on branch `fm/fm-herdr-pipe-noise`, disturb no live watchers or `state/` files belonging to running tasks, and issue no herdr lifecycle commands (read-only introspection only). The developer then invoked `/no-mistakes` to validate the change and ship it as a PR.

## What Changed

- Replaced the two `printf '%s' "$schema" | grep -Fq ...` token checks in `fm_backend_herdr_events_capable` (`bin/backends/herdr.sh`) with in-shell `case` glob matches, so probing the large `herdr api schema --json` payload no longer strands the `printf` writer mid-payload when the short-circuiting reader exits — which had been printing `printf: write error: Broken pipe` to stderr wherever SIGPIPE is ignored (the watcher's inherited disposition) and burying real diagnostics.
- Refreshed the stale block comments in `bin/backends/herdr.sh` and `bin/fm-watch.sh` to describe the payload as large (248KB at herdr 0.7.5) instead of the superseded "~220KB", and to document why the checks now match in-shell rather than through a pipe.
- Added `test_events_capable_verdict_and_silent_probe` to `tests/fm-backend-herdr.test.sh`, which drives the probe against a ~250KB fixture (both tokens, each token missing, and empty) under a `trap '' PIPE` disposition to assert both the correct verdict and a clean stderr on every schema.

## Risk Assessment

✅ Low: A two-line, verdict-identical substitution of `case` substring matching for short-circuiting `grep -Fq` pipes in a single function, with no new bashisms, matching an idiom already used three lines above, plus a targeted regression test that pins both the four-schema verdict table and the silent-probe property; the only defect found is a stale payload-size number in a sibling comment.

## Testing

Ran the herdr adapter unit file and the watcher event-splice unit file (both green under a UTF-8 locale), then went past the suite to reproduce the actual defect: with a fake herdr serving the real 248KB `herdr api schema --json` payload, the base adapter prints `printf: write error: Broken pipe` under the watcher's SIGPIPE-ignored disposition while the fixed adapter is silent, and both return identical verdicts across ten payloads (real, each token missing, empty, truncated-malformed, malformed-with-tokens, glob/backslash, split-token, EOF-without-newline, single 200KB line). Driving the real `fm-watch.sh` event splice through the real backend dispatcher over an isolated scratch state dir yields 6 broken-pipe stderr lines across 3 arms before the change and completely clean stderr after — no live watcher, real herdr server, or task-owned `state/` was touched, and only read-only herdr introspection was used. I also confirmed the new regression test genuinely bites (red against the base adapter, green against the fix) and that the `case` construct is portable to /bin/sh, dash, and bash --posix. This change has no UI surface — the reviewer-visible artifact is the CLI/stderr transcript, which is exactly how an operator experiences the noise — so no screenshot applies. The one failure seen, a C-locale prompt-glyph test in the same file, reproduces identically on the base commit and is tracked as issue #883.

<details>
<summary>Evidence: Watcher arm stderr: 3 arms of the real fm-watch.sh event splice, base adapter vs fixed</summary>

<code>===== watcher arm x3, adapter=before =====&#10;$WORK/before/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe&#10;$WORK/before/bin/backends/herdr.sh: line 1961: printf: write error: Broken pipe&#10;$WORK/before/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe&#10;$WORK/before/bin/backends/herdr.sh: line 1961: printf: write error: Broken pipe&#10;$WORK/before/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe&#10;$WORK/before/bin/backends/herdr.sh: line 1961: printf: write error: Broken pipe&#10;-- 6 stderr line(s)&#10;&#10;===== watcher arm x3, adapter=after =====&#10;(watcher stderr: empty - clean arm)</code>

```text
===== watcher arm x3, adapter=before =====
$WORK/before/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe
$WORK/before/bin/backends/herdr.sh: line 1961: printf: write error: Broken pipe
$WORK/before/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe
$WORK/before/bin/backends/herdr.sh: line 1961: printf: write error: Broken pipe
$WORK/before/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe
$WORK/before/bin/backends/herdr.sh: line 1961: printf: write error: Broken pipe
-- 6 stderr line(s)

===== watcher arm x3, adapter=after =====
(watcher stderr: empty - clean arm)
```
</details>
<details>
<summary>Evidence: Before/after probe: noise + verdict parity over the real 248KB schema and 9 variants</summary>

<code>herdr 0.7.5 | real `herdr api schema --json`: 248358 bytes | pipe buffer: 64KB | min events protocol: 16&#10;&#10;PROBE UNDER SIGPIPE-IGNORED (the disposition fm-watch.sh inherits)&#10;schema payload BEFORE AFTER probe stderr&#10;--------------------------------------------------------------------------------------------------&#10;capable capable capable BEFORE ...herdr.sh: line 1960: printf: write error: Broken pipe (x2)&#10;AFTER clean&#10;no-subscribe incapable incapable BEFORE clean / AFTER clean&#10;no-status incapable incapable BEFORE ...line 1960: printf: write error: Broken pipe (x1)&#10;AFTER clean&#10;empty incapable incapable BEFORE clean / AFTER clean&#10;malformed-truncated incapable incapable BEFORE clean / AFTER clean&#10;malformed-with-tokens capable capable BEFORE ...Broken pipe (x2) / AFTER clean&#10;glob-and-backslashes capable capable BEFORE ...Broken pipe (x2) / AFTER clean&#10;tokens-split-across-lines incapable incapable BEFORE clean / AFTER clean&#10;tokens-at-eof-no-newline capable capable BEFORE ...Broken pipe (x2) / AFTER clean&#10;single-huge-line capable capable BEFORE clean / AFTER clean&#10;--------------------------------------------------------------------------------------------------&#10;verdict parity: IDENTICAL on all 10 payloads; stderr: BEFORE noisy, AFTER clean everywhere&#10;&#10;THE TOKEN CHECKS THEMSELVES&#10;BEFORE 1960: printf &#39;%s&#39; &#34;$schema&#34; | grep -Fq &#39;events.subscribe&#39; || return 1&#10;1961: printf &#39;%s&#39; &#34;$schema&#34; | grep -Fq &#39;pane.agent_status_changed&#39; || return 1&#10;AFTER 1965: case &#34;$schema&#34; in *&#39;events.subscribe&#39;*) ;; *) return 1 ;; esac&#10;1966: case &#34;$schema&#34; in *&#39;pane.agent_status_changed&#39;*) ;; *) return 1 ;; esac&#10;subprocesses forked per probe for the token checks: BEFORE 4 (2 printf subshells + 2 greps), AFTER 0</code>

```text
herdr 0.7.5 | real `herdr api schema --json`: 248358 bytes | pipe buffer: 64KB | min events protocol: 16

PROBE UNDER SIGPIPE-IGNORED (the disposition fm-watch.sh inherits)
schema payload             BEFORE     AFTER      probe stderr
--------------------------------------------------------------------------------------------------
capable                    capable    capable    BEFORE  $WORK/before/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe (x2)
                                                 AFTER   clean
no-subscribe               incapable  incapable  BEFORE  clean
                                                 AFTER   clean
no-status                  incapable  incapable  BEFORE  $WORK/before/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe (x1)
                                                 AFTER   clean
empty                      incapable  incapable  BEFORE  clean
                                                 AFTER   clean
malformed-truncated        incapable  incapable  BEFORE  clean
                                                 AFTER   clean
malformed-with-tokens      capable    capable    BEFORE  $WORK/before/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe (x2)
                                                 AFTER   clean
glob-and-backslashes       capable    capable    BEFORE  $WORK/before/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe (x2)
                                                 AFTER   clean
tokens-split-across-lines  incapable  incapable  BEFORE  clean
                                                 AFTER   clean
tokens-at-eof-no-newline   capable    capable    BEFORE  $WORK/before/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe (x2)
                                                 AFTER   clean
single-huge-line           capable    capable    BEFORE  clean
                                                 AFTER   clean
--------------------------------------------------------------------------------------------------
verdict parity: IDENTICAL on all 10 payloads; stderr: BEFORE noisy, AFTER clean everywhere

PROBE UNDER DEFAULT SIGPIPE (writer dies silently - the bug is invisible here)
--------------------------------------------------------------------------------------------------
capable                    BEFORE capable    clean    | AFTER capable    clean
empty                      BEFORE incapable  clean    | AFTER incapable  clean

THE TOKEN CHECKS THEMSELVES
--------------------------------------------------------------------------------------------------
BEFORE  1960:  printf '%s' "$schema" | grep -Fq 'events.subscribe' || return 1
1961:  printf '%s' "$schema" | grep -Fq 'pane.agent_status_changed' || return 1
AFTER   1965:  case "$schema" in *'events.subscribe'*) ;; *) return 1 ;; esac
1966:  case "$schema" in *'pane.agent_status_changed'*) ;; *) return 1 ;; esac
subprocesses forked per probe for the token checks: BEFORE 4 (2 printf subshells + 2 greps), AFTER 0
```
</details>
<details>
<summary>Evidence: Mutation check: the new regression test fails on the base adapter, passes on the fix</summary>

<code>===== the new regression test vs the BASE adapter (printf | grep -Fq) =====&#10;not ok - events_capable must probe silently for the both schema, got stderr: .../before-root/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe&#10;.../before-root/bin/backends/herdr.sh: line 1961: printf: write error: Broken pipe&#10;(exit 1)&#10;&#10;===== the new regression test vs the FIXED adapter (case) =====&#10;ok - fm_backend_herdr_events_capable: correct verdict on every schema, and probes a large schema without stderr noise&#10;(exit 0)</code>

```text
===== the new regression test vs the BASE adapter (printf | grep -Fq) =====
not ok - events_capable must probe silently for the both schema, got stderr: /var/folders/my/h69rp4v528d6qq1tks3kb7_r0000gn/T/no-mistakes-evidence/01KY7XQKJ4Y7J9M1RRK6BGGV42/before-root/bin/backends/herdr.sh: line 1960: printf: write error: Broken pipe
/var/folders/my/h69rp4v528d6qq1tks3kb7_r0000gn/T/no-mistakes-evidence/01KY7XQKJ4Y7J9M1RRK6BGGV42/before-root/bin/backends/herdr.sh: line 1961: printf: write error: Broken pipe
(exit 1)

===== the new regression test vs the FIXED adapter (case) =====
ok - fm_backend_herdr_events_capable: correct verdict on every schema, and probes a large schema without stderr noise
(exit 0)
```
</details>
<details>
<summary>Evidence: Reproducer script: before/after probe + verdict-parity sweep (re-runnable)</summary>

```text
#!/usr/bin/env bash
# Reproduce the herdr events-capability probe's `Broken pipe` stderr noise
# BEFORE the fix (68ed7ed, `printf | grep -Fq`) and show it clean AFTER the fix
# (9d5783c, in-shell `case`), against the REAL `herdr api schema --json`
# payload from the installed herdr 0.7.5 (248KB) plus degraded and adversarial
# variants, asserting the two implementations agree on every verdict.
#
# The driver runs the probe under `trap '' PIPE` - the SIGPIPE-ignored
# disposition the watcher inherits, and the only disposition under which the
# writer's EPIPE surfaces as a message instead of a silent death - and also
# under the default disposition for contrast.
set -u

ROOT=${1:?usage: repro-broken-pipe.sh <repo-root>}
EVID=$(cd "$(dirname "$0")" && pwd)
WORK="$EVID/repro"
BASE=68ed7ed2355619749c6ee2bb91b7298dee420df8
SUB=events.subscribe
STAT=pane.agent_status_changed

rm -rf "$WORK"
mkdir -p "$WORK/fixtures" "$WORK/fakebin" "$WORK/before/bin/backends" "$WORK/out"
F="$WORK/fixtures"

# --- fixtures: the real schema, degraded variants, adversarial payloads -------
herdr api schema --json > "$F/capable.json" 2>/dev/null
grep -vF "$SUB"  "$F/capable.json" > "$F/no-subscribe.json"
grep -vF "$STAT" "$F/capable.json" > "$F/no-status.json"
: > "$F/empty.json"
head -c 120000 "$F/capable.json" > "$F/malformed-truncated.json"
{ head -c 90000 "$F/capable.json"
  printf '\n<<<not json>>> "%s" "%s" \x01\x02 no closing brace\n' "$SUB" "$STAT"
  head -c 90000 "$F/capable.json"
} > "$F/malformed-with-tokens.json"
# glob metacharacters and backslashes around both tokens (a `case` pattern is
# quoted, so the subject must stay literal - this is the parity trap).
{ printf '%s\n' '*' '?' '[a-z]' '\\\\' '\x01' 'a*b?c[d]e\f'
  head -c 60000 "$F/capable.json"
  printf '\n  "const": "%s", *?[  \\ \n  "const": "%s", \n' "$STAT" "$SUB"
  head -c 60000 "$F/capable.json"
} > "$F/glob-and-backslashes.json"
# tokens split across a newline: neither a line-oriented grep nor a whole-string
# `case` may accept these.
{ head -c 60000 "$F/capable.json"
  printf '\nevents.sub\nscribe\npane.agent_status\n_changed\n'
  head -c 60000 "$F/capable.json"
} > "$F/tokens-split-across-lines.json"
# both tokens in the final bytes, with NO trailing newline.
{ head -c 200000 "$F/capable.json"; printf '"%s" "%s"' "$SUB" "$STAT"; } > "$F/tokens-at-eof-no-newline.json"
# one enormous single line (no newline until the very end).
{ head -c 200000 "$F/capable.json" | tr -d '\n'; printf '%s %s\n' "$SUB" "$STAT"; } > "$F/single-huge-line.json"

# --- fake herdr: only the two calls the probe makes --------------------------
cat > "$WORK/fakebin/herdr" <<'SH'
#!/usr/bin/env bash
set -u
case "${1:-} ${2:-}" in
  "status --json") printf '{"client":{"version":"0.7.5","protocol":%s},"server":{"running":true}}\n' "${FM_FAKE_PROTOCOL:?}" ;;
  "api schema")    cat "${FM_FAKE_SCHEMA:?}" ;;
esac
exit 0
SH
chmod +x "$WORK/fakebin/herdr"

# --- BEFORE tree: the base commit's herdr.sh, with its unchanged siblings ----
git -C "$ROOT" show "$BASE:bin/backends/herdr.sh" > "$WORK/before/bin/backends/herdr.sh"
cp "$ROOT/bin/fm-composer-lib.sh" "$ROOT/bin/fm-transition-lib.sh" "$WORK/before/bin/"
BEFORE="$WORK/before/bin/backends/herdr.sh"
AFTER="$ROOT/bin/backends/herdr.sh"

MIN=$(bash -c '. "$0/bin/backends/herdr.sh"; printf %s "$FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL"' "$ROOT")

probe() {  # <adapter-path> <fixture> <ignored|default> -> sets RC, ERR
  local adapter=$1 fixture=$2 disp=$3 pre=""
  [ "$disp" = ignored ] && pre='trap "" PIPE; '
  PATH="$WORK/fakebin:$PATH" \
  FM_FAKE_SCHEMA="$F/$fixture.json" FM_FAKE_PROTOCOL="$MIN" \
  FM_BACKEND_HERDR_EVENT_READER=fake-reader \
    bash -c "${pre}. \"\$0\"; fm_backend_herdr_events_capable fmtest" "$adapter" \
    >/dev/null 2>"$WORK/out/err"
  RC=$?
  ERR=$(cat "$WORK/out/err")
}

verdict() { [ "$1" -eq 0 ] && echo capable || echo incapable; }
noise() {
  if [ -z "$1" ]; then echo 'clean'
  else printf '%s (x%s)' "$(printf '%s' "$1" | sed "s|$WORK|\$WORK|" | head -1)" "$(printf '%s\n' "$1" | grep -c .)"
  fi
}

printf 'herdr %s | real `herdr api schema --json`: %s bytes | pipe buffer: 64KB | min events protocol: %s\n\n' \
  "$(herdr --version 2>&1 | awk '{print $2}')" "$(wc -c < "$F/capable.json" | tr -d ' ')" "$MIN"

printf 'PROBE UNDER SIGPIPE-IGNORED (the disposition fm-watch.sh inherits)\n'
printf '%-26s %-10s %-10s %s\n' 'schema payload' 'BEFORE' 'AFTER' 'probe stderr'
printf -- '%s\n' '--------------------------------------------------------------------------------------------------'
drift=0
for f in capable no-subscribe no-status empty malformed-truncated malformed-with-tokens \
         glob-and-backslashes tokens-split-across-lines tokens-at-eof-no-newline single-huge-line; do
  probe "$BEFORE" "$f" ignored; b_rc=$RC; b_err=$ERR
  probe "$AFTER"  "$f" ignored; a_rc=$RC; a_err=$ERR
  printf '%-26s %-10s %-10s BEFORE  %s\n' "$f" "$(verdict $b_rc)" "$(verdict $a_rc)" "$(noise "$b_err")"
  printf '%-26s %-10s %-10s AFTER   %s\n' '' '' '' "$(noise "$a_err")"
  if [ "$b_rc" != "$a_rc" ]; then printf '  !! VERDICT DRIFT on %s: before=%s after=%s\n' "$f" "$b_rc" "$a_rc"; drift=1; fi
done
printf -- '%s\n' '--------------------------------------------------------------------------------------------------'
[ "$drift" -eq 0 ] && printf 'verdict parity: IDENTICAL on all 10 payloads; stderr: BEFORE noisy, AFTER clean everywhere\n' \
                   || printf 'verdict parity: BROKEN\n'

printf '\nPROBE UNDER DEFAULT SIGPIPE (writer dies silently - the bug is invisible here)\n'
printf -- '%s\n' '--------------------------------------------------------------------------------------------------'
for f in capable empty; do
  probe "$BEFORE" "$f" default; b_rc=$RC; b_err=$ERR
  probe "$AFTER"  "$f" default; a_rc=$RC; a_err=$ERR
  printf '%-26s BEFORE %-10s %-8s | AFTER %-10s %s\n' "$f" "$(verdict $b_rc)" "$(noise "$b_err")" "$(verdict $a_rc)" "$(noise "$a_err")"
done

printf '\nTHE TOKEN CHECKS THEMSELVES\n'
printf -- '%s\n' '--------------------------------------------------------------------------------------------------'
printf 'BEFORE  %s\n' "$(grep -n "grep -Fq '$SUB'\|grep -Fq '$STAT'" "$BEFORE" | sed 's/^ *//')"
printf 'AFTER   %s\n' "$(grep -n "case \"\$schema\" in" "$AFTER" | sed 's/^ *//')"
printf 'subprocesses forked per probe for the token checks: BEFORE %s (2 printf subshells + 2 greps), AFTER 0\n' 4
rm -rf "$WORK/out"
```
</details>
<details>
<summary>Evidence: Reproducer script: real fm-watch.sh event-splice arm, base vs fixed adapter</summary>

```text
#!/usr/bin/env bash
# Drive the REAL watcher splice (bin/fm-watch.sh's event_wait_or_sleep -> the
# real bin/fm-backend.sh dispatcher -> fm_backend_herdr_events_capable) over an
# isolated state dir and a fake `herdr` serving the real 248KB
# `herdr api schema --json` payload, and print the watcher's raw stderr for
# three arms - once with the BASE adapter (68ed7ed) and once with the fixed one.
#
# Nothing here touches a live watcher, a real herdr server, or any real state/:
# FM_STATE_OVERRIDE points at a scratch dir under the evidence directory,
# `herdr` is a stub on PATH, sleep and fm_backend_wait_transition are stubbed,
# and fm-watch.sh's source guard means no singleton lock and no blocking loop.
set -u

ROOT=${1:?usage: watcher-arm.sh <repo-root>}
EVID=$(cd "$(dirname "$0")" && pwd)
WORK="$EVID/repro"          # fixtures + before-tree built by repro-broken-pipe.sh
STATE="$WORK/watch-state"

arm() {  # <before|after>
  local variant=$1 pre=""
  rm -rf "$STATE"; mkdir -p "$STATE"
  [ "$variant" = before ] && pre='. "$WORK_DIR/before/bin/backends/herdr.sh"; _FM_BACKEND_HERDR_SOURCED=1;'
  WORK_DIR="$WORK" \
  PATH="$WORK/fakebin:$PATH" \
  FM_FAKE_SCHEMA="$WORK/fixtures/capable.json" FM_FAKE_PROTOCOL=16 \
  FM_BACKEND_HERDR_EVENT_READER=fake-reader \
  FM_STATE_OVERRIDE="$STATE" FM_ROOT_OVERRIDE="$ROOT" \
    bash -c '
      trap "" PIPE                       # the SIGPIPE disposition the watcher inherits
      . "$0/bin/fm-watch.sh"             # source guard: functions only, no lock, no loop
      '"$pre"'
      sleep() { :; }                     # POLL is 15s; not waiting for it here
      fm_backend_wait_transition() { return 1; }   # clean full-budget wait, no actionable edge
      printf "window=default:wG:pQ\nbackend=herdr\nkind=ship\n" > "$1/tk1.meta"
      for arm in 1 2 3; do
        _event_cap_key=""                # a fresh session key -> the probe re-runs, as on watcher restart
        event_wait_or_sleep
      done
    ' "$ROOT" "$STATE"
}

for variant in before after; do
  printf '===== watcher arm x3, adapter=%s =====\n' "$variant"
  err=$(arm "$variant" 2>&1 >/dev/null)
  if [ -z "$err" ]; then
    printf '(watcher stderr: empty - clean arm)\n\n'
  else
    printf '%s\n' "$err" | sed 's|'"$WORK"'|$WORK|g'
    printf -- '-- %s stderr line(s)\n\n' "$(printf '%s\n' "$err" | grep -c .)"
  fi
done
rm -rf "$STATE"
```
</details>
<details>
<summary>Evidence: Reproducer script: regression-test mutation check against the base adapter</summary>

```text
#!/usr/bin/env bash
# Mutation check: run the NEW regression test
# (tests/fm-backend-herdr.test.sh::test_events_capable_verdict_and_silent_probe)
# unchanged against BOTH adapters - the base commit's `printf | grep -Fq` probe
# and the fixed `case` probe - to show the test actually bites.
#
# A mirror root is assembled under the evidence dir: every bin/ entry symlinked
# to the real worktree, with ONLY bin/backends/herdr.sh replaced by the base
# commit's copy. The worktree itself is never modified.
set -u

ROOT=${1:?usage: regression-test-bites.sh <repo-root>}
EVID=$(cd "$(dirname "$0")" && pwd)
MIRROR="$EVID/before-root"
BASE=68ed7ed2355619749c6ee2bb91b7298dee420df8

rm -rf "$MIRROR"
mkdir -p "$MIRROR/bin/backends" "$MIRROR/tests"
for f in "$ROOT"/bin/*; do
  [ "$(basename "$f")" = backends ] && continue
  ln -s "$f" "$MIRROR/bin/$(basename "$f")"
done
for f in "$ROOT"/bin/backends/*; do
  [ "$(basename "$f")" = herdr.sh ] && continue
  ln -s "$f" "$MIRROR/bin/backends/$(basename "$f")"
done
git -C "$ROOT" show "$BASE:bin/backends/herdr.sh" > "$MIRROR/bin/backends/herdr.sh"
ln -s "$ROOT/tests/lib.sh" "$MIRROR/tests/lib.sh"

# Extract the new test (its two fixture helpers + the test function) verbatim.
sed -n '/^# make_herdr_schema_fake:/,/^}$/p;/^# write_fake_schemas:/,$p' \
  "$ROOT/tests/fm-backend-herdr.test.sh" \
  | sed -n '1,/^test_normalize_event_leaves_from_empty/p' | sed '$d' > "$EVID/.extracted-test.sh"

run_against() {  # <root-with-lib.sh> <label>
  printf '===== %s =====\n' "$2"
  ( set +e
    bash -c '
      . "$0/tests/lib.sh"
      TMP_ROOT=$(fm_test_tmproot fm-events-capable-mutation)
      . "$1"
      test_events_capable_verdict_and_silent_probe
    ' "$1" "$EVID/.extracted-test.sh" 2>&1
    printf '(exit %s)\n\n' "$?"
  )
}

run_against "$MIRROR" "the new regression test vs the BASE adapter (printf | grep -Fq)"
run_against "$ROOT"   "the new regression test vs the FIXED adapter (case)"
rm -f "$EVID/.extracted-test.sh"
```
</details>
- Outcome: ⚠️ 1 info across 1 run (9m56s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-watch.sh:159` - This change corrects the `api schema` payload measurement from &#34;~220KB&#34; to &#34;248KB&#34; in bin/backends/herdr.sh:1944, but the sibling comment in bin/fm-watch.sh:159 — which documents the memoization of this very same probe (&#34;fm_backend_events_capable runs a ~220KB `herdr api schema` read, too heavy to repeat every poll&#34;) — still carries the superseded number. The exact figure the commit set out to correct now survives in the other place it was recorded, so a reader of the watcher&#39;s memo rationale gets the stale measurement. Update the fm-watch.sh comment to 248KB to match.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-backend-herdr.test.sh:1526` - tests/fm-backend-herdr.test.sh fails under a C/POSIX locale on test_composer_state_bare_prompt_is_empty (&#39;a bare prompt glyph should read as empty, got pending&#39;). This predates the change: I ran the same test against the base commit&#39;s bin/backends/herdr.sh via a mirror root and it fails identically. It is open issue #883 (prompt-glyph matching operates on bytes under LC_ALL=C) and is untouched by this diff. Under LC_ALL=en_US.UTF-8 the whole file passes, including the new probe test.
- <code>`LC_ALL=en_US.UTF-8 bash bin/fm-test-run.sh tests/fm-backend-herdr.test.sh` — full herdr adapter unit file including the new `test_events_capable_verdict_and_silent_probe`, all green</code>
- <code>`LC_ALL=en_US.UTF-8 bash bin/fm-test-run.sh tests/fm-supervision-events.test.sh` — the watcher splice that consumes the probe (event_wait_or_sleep capability memo, fail-closed disable), all green</code>
- <code>`bash /var/folders/my/h69rp4v528d6qq1tks3kb7_r0000gn/T/no-mistakes-evidence/01KY7XQKJ4Y7J9M1RRK6BGGV42/repro-broken-pipe.sh &lt;root&gt;` — before/after probe against the real 248KB `herdr api schema --json` payload plus 9 degraded/adversarial variants, under both SIGPIPE-ignored and default dispositions, asserting verdict parity</code>
- <code>`bash /var/folders/my/h69rp4v528d6qq1tks3kb7_r0000gn/T/no-mistakes-evidence/01KY7XQKJ4Y7J9M1RRK6BGGV42/watcher-arm.sh &lt;root&gt;` — real `bin/fm-watch.sh` `event_wait_or_sleep` x3 arms through the real `fm_backend_events_capable` dispatcher over an isolated scratch state dir, base adapter vs fixed adapter</code>
- <code>`bash .../regression-test-bites.sh &lt;root&gt;` — mutation check: the new regression test run unchanged against the base commit&#39;s adapter (fails on the stderr assertion) and against the fixed adapter (passes)</code>
- <code>POSIX portability spot check of the new construct under `/bin/sh`, `/bin/dash`, and `bash --posix` (capable and empty-schema cases both correct); suite itself ran on system bash 3.2.57</code>
- <code>`LC_ALL=C` run of `test_composer_state_bare_prompt_is_empty` against both the base and fixed adapters via a symlink mirror root, confirming the only failure is pre-existing (issue #883)</code>
- <code>Read-only `herdr --version` and `herdr api schema --json | wc -c` (herdr 0.7.5, 248358 bytes) confirming the size claim in the updated block comment; no herdr lifecycle command was issued</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/herdr-backend.md:985` - Judgment call, left as-is: docs/herdr-backend.md&#39;s &#34;Polling is the permanent fail-closed backstop&#34; section credits the three fail-closed fallbacks to the wait_transition/apply_transition cases in tests/fm-backend-herdr.test.sh, and does not name the new test_events_capable_verdict_and_silent_probe. I did not add it, because that sentence is still accurate and the durable invariant the new test pins (the probe must not pipe the schema into a short-circuiting reader) is already owned by the block comment above fm_backend_herdr_events_capable. Naming every test there would turn a prose pointer into a coverage inventory that has to be synchronized on each new test.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
