### PR TITLE
fix: inherit harness credential config on spawn

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -97,6 +97,21 @@ OpenCode uses `.opencode/plugins/fm-primary-watch-arm.js`, which coordinates wit
 Pi uses the tracked `.pi/extensions/fm-primary-turnend-guard.ts` plus the tracked `.pi/extensions/fm-primary-pi-watch.ts`, both project-local extensions Pi auto-discovers once trusted.
 When changing any primary watcher adapter, update `docs/supervision-protocols/`, `docs/turnend-guard.md` if a shared idle or turn-end hook changed, and the relevant concise fact below.
 
+## Spawned credential-config directories
+
+`bin/fm-spawn.sh` prefixes the final interactive launch command with the primary session's config-directory selection, so a fresh backend shell cannot silently fall back to another identity.
+For `pi`, it passes `PI_CODING_AGENT_DIR` from the spawning environment or Pi's verified 0.81.1 default of `$HOME/.pi/agent`.
+For `claude`, it passes `CLAUDE_CONFIG_DIR` from the spawning environment or the standard `$HOME/.claude` default.
+The assignment is inline on the command submitted after every backend creates its pane or terminal, so it applies equally to crewmates, scouts, and secondmates on tmux, herdr, zellij, Orca, and cmux.
+It does not copy config files or credential bytes, change `$HOME`, or select a provider or model.
+Codex, OpenCode, and Grok were reviewed at their launch-template integration surface and have no corresponding Claude or Pi config-directory variable to forward.
+
+**Verification (2026-07-23).**
+On this host, the primary Pi process had no `PI_CODING_AGENT_DIR` export and Pi 0.81.1 reported `PI_CODING_AGENT_DIR - Config directory (default: ~/.pi/agent)` from `pi --help`, resolving the active store to `/Users/jfmcoronel/.pi/agent`.
+A disposable real tmux spawn using the Pi launch template printed `PI_CODING_AGENT_DIR=</Users/jfmcoronel/.pi/agent>` inside the spawned pane, matching the primary selection.
+A matching disposable tmux Claude launch printed `CLAUDE_CONFIG_DIR=</Users/jfmcoronel/.claude>` inside its spawned pane, matching the primary selection.
+The probes used harness stand-ins that printed only directory paths and `$HOME`, never credential contents, and the disposable sessions were removed afterward.
+
 ## Launch profile axes
 
 `bin/fm-spawn.sh` accepts concrete `--harness`, `--model`, and `--effort` values chosen by firstmate at intake.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -528,6 +528,23 @@ shell_quote() {
   printf "'"
 }
 
+credential_config_prefix() {  # <verified-harness> -> shell assignments for the launched agent only
+  local harness=$1 dir
+  case "$harness" in
+    pi)
+      # Pi 0.81.1 documents ~/.pi/agent as its default config directory.
+      # An inline assignment reaches a shell created by every backend even when
+      # that shell did not inherit the primary process's exported environment.
+      dir=${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}
+      printf 'PI_CODING_AGENT_DIR=%s ' "$(shell_quote "$dir")"
+      ;;
+    claude)
+      dir=${CLAUDE_CONFIG_DIR:-$HOME/.claude}
+      printf 'CLAUDE_CONFIG_DIR=%s ' "$(shell_quote "$dir")"
+      ;;
+  esac
+}
+
 model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
@@ -1262,6 +1279,7 @@ sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 PIBRIEFENV=
 [ "$HARNESS" != pi ] || PIBRIEFENV="FM_FIRSTMATE_PI_LAUNCH_BRIEF=$sq_brief"
+CREDENTIAL_CONFIG_PREFIX=$(credential_config_prefix "$HARNESS")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
@@ -1273,6 +1291,7 @@ LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 LAUNCH=${LAUNCH//__PIBRIEFENV__/$PIBRIEFENV}
+LAUNCH="$CREDENTIAL_CONFIG_PREFIX$LAUNCH"
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,6 +186,7 @@ Those inherited values are defaults and rules only; `fm-spawn` still permits a c
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
+For pi and claude, `fm-spawn.sh` also prefixes the final launch command with an inline `PI_CODING_AGENT_DIR` or `CLAUDE_CONFIG_DIR` assignment carrying the spawning session's config-directory selection, so crewmates and secondmates authenticate against the primary's config directory instead of a fresh one; see [`harness-adapters`](../.agents/skills/harness-adapters/SKILL.md) "Spawned credential-config directories" for the full contract.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)
 
@@ -427,6 +428,8 @@ FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'   # busy-pane s
 FM_COMPOSER_IDLE_RE=    # optional empty-composer regex, applied after ghost and border stripping
 FM_COMPOSER_GHOST_LUMA_MAX=128   # fleet-wide: max perceived luminance (0.299R+0.587G+0.114B, 0-255) for a TRUECOLOR foreground to count as de-emphasised ghost/placeholder text and be stripped; dim/faint (SGR 2) is stripped regardless. Assumes a dark terminal theme (bin/fm-composer-lib.sh's fm_composer_strip_ghost, shared by the tmux and herdr composer readers)
 GROK_HOME=              # optional Grok config home for firstmate's global grok turn-end hook; defaults to ~/.grok
+PI_CODING_AGENT_DIR=    # pi-only: config directory forwarded inline to spawned pi launches so crew inherit the primary's authenticated config; defaults to ~/.pi/agent
+CLAUDE_CONFIG_DIR=      # claude-only: config directory forwarded inline to spawned claude launches so crew inherit the primary's authenticated config; defaults to ~/.claude
 FM_SEND_RETRIES=3       # fm-send Enter-retry attempts after typing the line once
 FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
 FM_SEND_SETTLE=1        # seconds fm-send waits after a successful text submit; 0 disables

--- a/tests/fm-spawn-config-inherit.test.sh
+++ b/tests/fm-spawn-config-inherit.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Regression coverage for fm-spawn.sh's inline credential-config assignments.
+# A backend creates a fresh shell or terminal, so the assignment must travel in
+# the final launch command rather than relying on the spawning shell's exports.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+TMP_ROOT=$(fm_test_tmproot fm-spawn-config-inherit)
+SPAWN="$ROOT/bin/fm-spawn.sh"
+
+make_fakebin() {  # <dir> -> fakebin
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "${FM_TMUX_RECORD:?}"
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:?}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n' ;;
+  new-window) printf '@spawn-window\n' ;;
+  list-windows|has-session|new-session|send-keys|set-window-option) : ;;
+esac
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+make_repo() {  # <path> -> git repository path
+  local repo=$1
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  printf 'fixture\n' > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -qm fixture
+  printf '%s\n' "$repo"
+}
+
+make_secondmate_home() {  # <home> <id>
+  local home=$1 id=$2
+  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects" "$home/bin"
+  printf '%s\n' "$id" > "$home/.fm-secondmate-home"
+  printf '# firstmate fixture\n' > "$home/AGENTS.md"
+  printf 'secondmate brief\n' > "$home/data/charter.md"
+}
+
+run_spawn() {  # <home> <id> <project-or-home> <harness> [--secondmate]
+  local home=$1 id=$2 target=$3 harness=$4 kind=${5:-}
+  if [ "$kind" != --secondmate ]; then
+    mkdir -p "$home/data/$id"
+    printf 'crew brief\n' > "$home/data/$id/brief.md"
+  fi
+  PI_CODING_AGENT_DIR="$PI_DIR" CLAUDE_CONFIG_DIR="$CLAUDE_DIR" \
+    FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_DATA_OVERRIDE="$home/data" FM_PROJECTS_OVERRIDE="$home/projects" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_SPAWN_NO_GUARD=1 \
+    FM_FAKE_PANE_PATH="$WORKTREE" FM_TMUX_RECORD="$RECORD" TMUX='fake,1,0' \
+    PATH="$FAKEBIN:$PATH" \
+    "$SPAWN" "$id" "$target" "$harness" --backend tmux ${kind:+"$kind"} >/dev/null
+}
+
+test_credential_config_reaches_crew_and_secondmate() {
+  local home secondmate project
+  home="$TMP_ROOT/home"
+  secondmate="$TMP_ROOT/secondmate"
+  project=$(make_repo "$TMP_ROOT/project")
+  WORKTREE="$TMP_ROOT/worktree"
+  git -C "$project" worktree add -q --detach "$WORKTREE" >/dev/null 2>&1
+  PI_DIR="$TMP_ROOT/captain/pi-agent"
+  CLAUDE_DIR="$TMP_ROOT/captain/claude"
+  mkdir -p "$PI_DIR" "$CLAUDE_DIR" "$home/data"
+  PI_DIR=$(cd "$PI_DIR" && pwd -P)
+  CLAUDE_DIR=$(cd "$CLAUDE_DIR" && pwd -P)
+  make_secondmate_home "$secondmate" pi-secondmate
+  make_secondmate_home "$TMP_ROOT/secondmate-claude" claude-secondmate
+  RECORD="$TMP_ROOT/tmux.log"
+  : > "$RECORD"
+  FAKEBIN=$(make_fakebin "$TMP_ROOT/fake")
+
+  run_spawn "$home" pi-crew "$project" pi
+  run_spawn "$home" claude-crew "$project" claude
+  run_spawn "$home" pi-secondmate "$secondmate" pi --secondmate
+  run_spawn "$home" claude-secondmate "$TMP_ROOT/secondmate-claude" claude --secondmate
+
+  assert_grep "PI_CODING_AGENT_DIR='$PI_DIR'" "$RECORD" \
+    "Pi crew and secondmate launches must carry the primary Pi config directory"
+  assert_grep "CLAUDE_CONFIG_DIR='$CLAUDE_DIR'" "$RECORD" \
+    "Claude crew and secondmate launches must carry the primary Claude config directory"
+  assert_not_contains "$(cat "$RECORD")" 'PI_CODING_AGENT_DIR='"$PI_DIR"' codex' \
+    "unrelated harnesses must not receive Pi config assignments"
+  pass "fm-spawn: Pi and Claude config directories reach crew and secondmate launch shells"
+}
+
+test_credential_config_reaches_crew_and_secondmate
+
+echo "# all fm-spawn-config-inherit tests passed"


### PR DESCRIPTION
## Summary
- Forward the primary Pi or Claude config directory in every spawned launch command.
- Cover crew and secondmate launches with regression tests.
- Document the verified shared-config behavior without exposing credential contents.

## Validation
- `bin/fm-lint.sh`
- `tests/fm-spawn-config-inherit.test.sh`
- `tests/fm-backend.test.sh`
- `tests/fm-tangle-guard.test.sh`
- `tests/fm-spawn-worktree-settle.test.sh`

## Pipeline note
The no-mistakes review, test, documentation, and lint stages completed successfully. Its direct upstream push was denied because the active account lacks write access to `kunchenguid/firstmate`, so this branch was pushed to the captain-approved `jfmcoronel/firstmate` fork and opened as a cross-repository PR.