### PR TITLE
fix: refine scout intake and parallel dispatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,17 +226,19 @@ Keep `local-only` work in the main home.
 Send in-scope work to the fitting secondmate unless it is blocked or the captain explicitly redirects it; do not read the secondmate's chat because marked routed replies return through its status or referenced document.
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
 
+Before commissioning an investigation, consult existing reports and established evidence.
 Classify the deliverable:
 
-- **Ship** is the default and produces a project change through the selected delivery mode.
-- **Scout** produces knowledge in `data/<id>/report.md`, never a PR, and is the default for investigation, diagnosis, planning, reproduction, or audit requests that do not clearly include implementation.
+- **Ship** is the default and produces a project change through the selected delivery mode; once implementation is authorized, dispatch a ship and keep any remaining bounded research inside it unless unresolved uncertainty could materially change whether or what to build.
+- **Scout** produces knowledge in `data/<id>/report.md`, never a PR, and is appropriate for investigation, diagnosis, planning, reproduction, or audit work when the captain explicitly requests a separate knowledge or design deliverable or unresolved uncertainty could materially change whether or what to build.
 
+If established evidence already answers an informational question, relay it without a design-only scout; when implementation intent is unclear, answer and ask one concise implementation question when useful rather than dispatching speculative design work.
+Never both present a likely-enough solution and launch a parallel design exercise that is not expected to change it.
 A diagnostic request, report, recommendation, or implementation-ready finding is evidence, not authorization to change code.
-Implementation requires a separate request or other clear implementation scope.
 Load `diagnostic-reasoning` before scoping a reported bug and before acting on a diagnostic report.
 
-Classify work as dispatchable when it does not overlap work under way, or queued and blocked when it touches the same project subsystem or depends on unlanded work.
-Dispatch independent work immediately with no concurrency cap, serialize coarse overlaps, and record blockers durably.
+Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts.
+Serialize only for a true semantic dependency, shared mutable external state, incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, and genuine blockers remain durable.
 Write the task-specific brief under section 11 before spawning.
 
 ### Dispatch and supervision handoff
@@ -305,13 +307,11 @@ Retire one only on an explicit captain or main-firstmate decision, after loading
 
 ### Scout outcome and promotion
 
-A completed scout must leave a self-contained report before its scratch worktree can be discarded.
-Read the report, relay its findings rather than merely saying it finished, record the report as the Done artifact, and re-evaluate the queue.
+A completed scout must leave a self-contained report before its scratch worktree can be discarded; read and relay its findings, record the report as the Done artifact, and re-evaluate the queue.
 A report may recommend implementation but does not authorize it.
 Before treating the investigation or any visual review as complete, load `decision-hold-lifecycle`; teardown enforces that shared completion gate.
 When implementation is separately authorized, promote the existing scout through `bin/fm-promote.sh` rather than creating a duplicate task.
-The promoted worker must inventory scratch state, return to a clean default-branch base, carry over only intended fix changes, create the ship branch, and follow the project's selected delivery path.
-Scratch commits and debug edits never ride along, and a reproduced bug becomes the regression test.
+The promoted worker must inventory scratch state, return to a clean default-branch base, carry over only intended fix changes, create the ship branch, and follow the project's selected delivery path while leaving scratch commits and debug edits behind and turning a reproduced bug into the regression test.
 
 ## 8. Supervision protocol
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 - **One liaison** - you talk only to the first mate; it dispatches, supervises, escalates only real decisions, and reports plain outcomes.
 - **A visible crew** - every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.
 - **Disposable worktrees** - each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides.
-- **Two task shapes** - ship tasks deliver a change; scout tasks investigate, plan, reproduce, or audit and leave a report.
+- **Two task shapes** - ship tasks deliver authorized changes; scout tasks leave standalone investigation reports when the intake contract warrants separate research.
 - **Explicit project modes** - each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.
 - **Optional secondmates** - opt in to persistent second mates that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, supervising project clones or a project-less firstmate-repo domain, kept on the primary firstmate version by guarded local fast-forwards and checked for live agent processes at session start.
 - **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -173,13 +173,13 @@ STATE=${FM_STATE_OVERRIDE:-$FM_HOME/state}
 . "$SCRIPT_DIR/fm-primary-scope-lib.sh"
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
-# Investigation has a dedicated entry point when this home carries it; degrade
+# Name the dedicated scout entry point only when this home carries it; degrade
 # to the two-step brief-then-spawn path when it does not, rather than naming a
 # script that is not there.
 if [ -f "$FM_ROOT/bin/fm-scout.sh" ]; then
-  ROUTE='investigation or diagnosis goes to bin/fm-scout.sh "<question>" [project], and ship work goes to bin/fm-brief.sh then bin/fm-spawn.sh'
+  ROUTE='first classify the work under the AGENTS.md intake contract: work already classified as a scout goes to bin/fm-scout.sh "<question>" [project], while authorized ship work and its bounded research go to bin/fm-brief.sh then bin/fm-spawn.sh'
 else
-  ROUTE='investigation and ship work both go to bin/fm-brief.sh then bin/fm-spawn.sh'
+  ROUTE='first classify the work under the AGENTS.md intake contract, then use bin/fm-brief.sh followed by bin/fm-spawn.sh for dispatched work'
 fi
 
 REASON="[subagent-dispatch] the firstmate primary dispatches through the fleet, not the harness's own delegation tools: work started that way has no durable fleet record, leaves every firstmate guard inert, and dies with this session. Instead, $ROUTE (blocked tool: $TOOL, delegation-shaped on \"$MATCHED\"). Launch the session with FM_ALLOW_SUBAGENT=1 for a deliberate exception."

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,7 +128,8 @@ The helper's header owns the exact signal detection, relocated-home limitation, 
 
 ## Two task shapes
 
-Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
+Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks leave standalone investigation reports at `data/<id>/report.md` and never push.
+The intake and authority contract in `AGENTS.md` owns when separate scout research is warranted.
 
 ## Dispatch profiles
 

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -161,8 +161,8 @@ A tool removed from the schema stays removed, so a genuinely intended use of a l
 - Malformed or empty stdin, invalid JSON, a payload with no tool name, and missing `jq` for stdin transport all fail open with exit 0 and no output.
 
 The deny message names the real dispatch path.
-When `bin/fm-scout.sh` exists in the home it routes investigation and diagnosis there and ship work to `bin/fm-brief.sh` then `bin/fm-spawn.sh`.
-When that script is absent the message degrades to naming `bin/fm-brief.sh` then `bin/fm-spawn.sh` for both, rather than pointing at a script that is not there.
+When `bin/fm-scout.sh` exists in the home the message first defers to the `AGENTS.md` intake classification, then routes work already classified as a scout there and authorized ship work with its bounded research to `bin/fm-brief.sh` then `bin/fm-spawn.sh`.
+When that script is absent the message still defers to intake classification and degrades to naming `bin/fm-brief.sh` then `bin/fm-spawn.sh` for dispatched work, rather than pointing at a script that is not there.
 
 ## Harness wiring
 

--- a/tests/fm-instruction-owners.test.sh
+++ b/tests/fm-instruction-owners.test.sh
@@ -192,6 +192,33 @@ test_compressed_agents_owner_map() {
   pass "compressed AGENTS.md records the approved one-owner map"
 }
 
+test_intake_reuses_evidence_and_parallelizes_safe_work() {
+  for phrase in \
+    'consult existing reports and established evidence' \
+    'remaining bounded research inside it' \
+    'unresolved uncertainty could materially change whether or what to build' \
+    'relay it without a design-only scout' \
+    'ask one concise implementation question when useful' \
+    'Never both present a likely-enough solution' \
+    'overlap as a risk signal rather than an automatic reason to wait' \
+    'independently implemented and validated' \
+    'selected delivery path can reconcile ordinary rebases or conflicts' \
+    'Serialize only for a true semantic dependency' \
+    'shared mutable external state' \
+    'incompatible concurrent migration' \
+    'same-file editing alone is insufficient' \
+    'genuine blockers remain durable'; do
+    assert_grep "$phrase" "$AGENTS" "intake contract lost '$phrase'"
+  done
+  assert_grep 'dispatch isolated work immediately with no concurrency cap' "$AGENTS" \
+    "intake contract lost unbounded safe parallel dispatch"
+  assert_grep 'captain explicitly requests a separate knowledge or design deliverable' "$AGENTS" \
+    "intake contract lost captain-requested separate scouts"
+  assert_grep 'When implementation is separately authorized, promote the existing scout' "$AGENTS" \
+    "intake contract lost genuine scout promotion"
+  pass "intake reuses evidence, reserves scouts for uncertainty, and parallelizes safe work"
+}
+
 test_compressed_agents_retains_authority_and_supervision_safety() {
   for phrase in \
     'A lock-refused session must not spawn, steer, merge, drain the wake queue' \
@@ -229,4 +256,5 @@ test_shared_authoring_requirements_are_owned
 test_secondmate_registry_contract_stays_concise
 test_state_startup_and_ordinary_recovery_placement
 test_compressed_agents_owner_map
+test_intake_reuses_evidence_and_parallelizes_safe_work
 test_compressed_agents_retains_authority_and_supervision_safety

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -18,8 +18,8 @@ mkdir -p "$PRIMARY/bin" "$STATE"
 printf '# fixture\n' > "$PRIMARY/AGENTS.md"
 git -C "$PRIMARY" init -q
 
-BRIEF_ONLY_ROUTE='investigation and ship work both go to bin/fm-brief.sh then bin/fm-spawn.sh'
-SCOUT_ROUTE='investigation or diagnosis goes to bin/fm-scout.sh "<question>" [project], and ship work goes to bin/fm-brief.sh then bin/fm-spawn.sh'
+BRIEF_ONLY_ROUTE='first classify the work under the AGENTS.md intake contract, then use bin/fm-brief.sh followed by bin/fm-spawn.sh for dispatched work'
+SCOUT_ROUTE='first classify the work under the AGENTS.md intake contract: work already classified as a scout goes to bin/fm-scout.sh "<question>" [project], while authorized ship work and its bounded research go to bin/fm-brief.sh then bin/fm-spawn.sh'
 
 # Every delegation, scheduling, worktree, and task-tracking tool Claude Code
 # 2.1.217 offered a primary session in the observed baseline.
@@ -118,14 +118,17 @@ test_guard_never_classifies_mcp_tools() {
   pass "MCP tool names are never classified as harness delegation"
 }
 
-test_scout_entry_point_named_when_present() {
+test_deny_message_defers_to_intake_classification() {
   local actual
   printf '#!/usr/bin/env bash\n' > "$PRIMARY/bin/fm-scout.sh"
   run_tool Agent && fail "scout-present case must still deny"
   actual=$(jq -r '.systemMessage' "$ERR")
   case "$actual" in
     *"$SCOUT_ROUTE"*) ;;
-    *) fail "deny must name bin/fm-scout.sh when it exists: $actual" ;;
+    *) fail "deny must reserve bin/fm-scout.sh for classified scout work: $actual" ;;
+  esac
+  case "$actual" in
+    *'investigation or diagnosis goes to bin/fm-scout.sh'*) fail "deny must not classify all investigation or diagnosis as scout work: $actual" ;;
   esac
   rm -f "$PRIMARY/bin/fm-scout.sh"
   run_tool Agent && fail "scout-absent case must still deny"
@@ -134,7 +137,7 @@ test_scout_entry_point_named_when_present() {
     *"$BRIEF_ONLY_ROUTE"*) ;;
     *) fail "deny must degrade to brief-then-spawn when fm-scout.sh is absent: $actual" ;;
   esac
-  pass "deny names bin/fm-scout.sh when it exists and degrades gracefully when it does not"
+  pass "deny defers to intake classification and degrades gracefully without fm-scout.sh"
 }
 
 test_escape_hatch_allows_deliberate_use() {
@@ -274,7 +277,7 @@ test_guard_denies_every_currently_known_delegation_tool
 test_guard_denies_hypothetical_future_tools
 test_guard_allows_ordinary_and_observe_only_tools
 test_guard_never_classifies_mcp_tools
-test_scout_entry_point_named_when_present
+test_deny_message_defers_to_intake_classification
 test_escape_hatch_allows_deliberate_use
 test_task_worktree_and_non_firstmate_repo_are_inert
 test_secondmate_home_is_in_scope


### PR DESCRIPTION
## Intent

Clarify Firstmate's existing AGENTS.md intake contract so established reports and evidence answer informational questions without redundant design-only scouts; unclear implementation intent gets a concise implementation question rather than speculative design; authorized implementation keeps bounded research inside the ship unless uncertainty could materially change whether or what to build; genuine separately requested or decision-changing scouts remain valid and are promoted after separate implementation authorization. Also clarify the adjacent concurrency contract so file or subsystem overlap is a risk signal rather than an automatic wait: isolated, independently validatable work runs immediately with no concurrency cap when its selected delivery path can reconcile ordinary rebases or conflicts, while only concrete semantic dependencies, unsafe shared mutable external state, incompatible migrations, or equivalent reconciliation hazards serialize. Preserve information-versus-implementation authority, durable genuine blockers, all delivery paths, the existing section ownership, one sentence per Markdown line, and neutral AGENTS.md line count. Run this in parallel with the other AGENTS.md branch, let no-mistakes own rebasing and conflict handling, open a green PR, and leave it unmerged for captain review.

## What Changed

- Reuse established reports and evidence, keep bounded research within authorized ships, and reserve separate scouts for explicit knowledge requests or decision-changing uncertainty.
- Treat file and subsystem overlap as a risk signal, allowing independently validatable work to proceed concurrently while serializing concrete reconciliation hazards.
- Align delegation-guard guidance and documentation with intake classification, with regression coverage for the updated contracts and denial messages.

## Risk Assessment

✅ Low: The change is well-bounded, preserves the stated intake and concurrency contracts, and the follow-up consistently removes the previously conflicting scout-routing path across source, documentation, and focused regression coverage.

## Testing

Validated the five-file change with focused contract and guard tests, manual review of the intake and concurrency language, Markdown invariants, equal 484-line base and target counts, and an end-user CLI transcript for both scout configurations; all local checks passed, the worktree stayed clean, and PR creation plus remote CI remain for no-mistakes.

<details>
<summary>Evidence: Primary-session intake denial transcript</summary>

<code>The primary-session guard denied a delegation-shaped `Agent` call with exit 2. With `fm-scout.sh` present, it required intake classification first and reserved the scout path for already-classified scout work. Without it, it deferred to intake classification and used brief-then-spawn.</code>

```text
PRIMARY SESSION DENIAL - SCOUT ENTRY POINT PRESENT
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[subagent-dispatch] the firstmate primary dispatches through the fleet, not the harness's own delegation tools: work started that way has no durable fleet record, leaves every firstmate guard inert, and dies with this session. Instead, first classify the work under the AGENTS.md intake contract: work already classified as a scout goes to bin/fm-scout.sh \"<question>\" [project], while authorized ship work and its bounded research go to bin/fm-brief.sh then bin/fm-spawn.sh (blocked tool: Agent, delegation-shaped on \"agent\"). Launch the session with FM_ALLOW_SUBAGENT=1 for a deliberate exception."}
exit_status=2

PRIMARY SESSION DENIAL - SCOUT ENTRY POINT ABSENT
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[subagent-dispatch] the firstmate primary dispatches through the fleet, not the harness's own delegation tools: work started that way has no durable fleet record, leaves every firstmate guard inert, and dies with this session. Instead, first classify the work under the AGENTS.md intake contract, then use bin/fm-brief.sh followed by bin/fm-spawn.sh for dispatched work (blocked tool: Agent, delegation-shaped on \"agent\"). Launch the session with FM_ALLOW_SUBAGENT=1 for a deliberate exception."}
exit_status=2
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `AGENTS.md:232` - The required behavior says “authorized implementation keeps bounded research inside the ship,” but the existing supported correction path in `bin/fm-subagent-pretool-check.sh:179-185` still tells a primary that all “investigation or diagnosis goes to bin/fm-scout.sh” whenever that entry point exists. Thus an authorized fix involving bounded diagnosis can still be redirected into the redundant separate scout this change forbids. Update that corrective route and its tests/docs to defer to the intake classification, reserving `fm-scout.sh` for work already classified as a scout.

🔧 Fix: Align scout guard with intake classification
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `Inspected the complete five-file diff and manually checked changed Markdown for one sentence per physical line.`
- `bash tests/fm-instruction-owners.test.sh`
- `bash tests/fm-subagent-pretool-check.test.sh`
- `git diff --check ca4be1ca7fc4d2dca1614b9336f5080ee7ca5076..4f96a051083b233e4a9633d02b1bcfde650c2066 -- AGENTS.md docs/subagent-guard.md`
- <code>Compared base and target `AGENTS.md` line counts and confirmed 484 lines at both revisions.</code>
- <code>Invoked `./bin/fm-subagent-pretool-check.sh --claude --tool Agent` against isolated primary-home fixtures with and without `bin/fm-scout.sh`, capturing both denial surfaces and exit status 2.</code>
- <code>`gh-axi pr list --state all --head fm/fm-avoid-redundant-design-scouts-r1 --limit 10` confirmed no PR exists yet; PR creation and green remote CI remain owned by the later no-mistakes pipeline stage.</code>
- <code>`git status --short --branch` confirmed testing left the target worktree clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
