### PR TITLE
perf(bin): shrink the ShellCheck source graph

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -9,14 +9,11 @@
 # HEAD-continuity guard; see docs/architecture.md "No-mistakes gate authority boundary."
 disable_project_settings: true
 
-# Pin lint to the same deterministic command CI runs, instead of leaving it to
-# no-mistakes' default handling. Without a configured commands.lint, the gate's
-# lint step never ran the deterministic
-# `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` that CI runs, so info-level
-# ShellCheck findings (e.g. SC2015) were not surfaced locally before CI rejected
-# them. commands.lint delegates to bin/fm-lint.sh, the single owner of the lint
-# definition that .github/workflows/ci.yml also invokes, so local can never
-# diverge from CI again (parity asserted by tests/fm-lint.test.sh).
+# Pin lint to the same owner CI runs instead of leaving it to no-mistakes'
+# default handling, which does not invoke the repository's canonical lint gate.
+# `bin/fm-lint.sh` owns the complete lint definition and
+# `.github/workflows/ci.yml` invokes it directly, with parity asserted by
+# `tests/fm-lint.test.sh`.
 #
 # Do not set commands.test to a complete tests/*.test.sh walk. Local no-mistakes
 # Test is intent-targeted validation of whether the change meets its brief;

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -77,9 +77,10 @@ fm_afk_launch_lock_owned() {
 }
 
 fm_afk_launch_lock_acquire() {
-  local i incomplete=0 identity
+  local attempt=0 incomplete=0 identity
   mkdir -p "$FM_AFK_LAUNCH_STATE" || return 1
-  for i in $(seq 1 200); do
+  while [ "$attempt" -lt 200 ]; do
+    attempt=$((attempt + 1))
     if mkdir "$FM_AFK_LAUNCH_LOCK" 2>/dev/null; then
       if ! printf '%s' "$$" > "$FM_AFK_LAUNCH_LOCK/pid"; then
         rm -rf "$FM_AFK_LAUNCH_LOCK"
@@ -257,12 +258,13 @@ fm_afk_launch_terminal_alive() {  # <backend> <target>
 }
 
 fm_afk_launch_wait_ready() {  # <backend> <target>
-  local backend=$1 target=$2 i
+  local backend=$1 target=$2 attempt=0
   if [ -n "${FM_AFK_LAUNCH_ENTRY:-}" ]; then
     fm_afk_launch_terminal_alive "$backend" "$target"
     return
   fi
-  for i in $(seq 1 100); do
+  while [ "$attempt" -lt 100 ]; do
+    attempt=$((attempt + 1))
     daemon_lock_held_by_live_daemon && return 0
     fm_afk_launch_terminal_alive "$backend" "$target" || return 1
     sleep 0.05
@@ -287,8 +289,9 @@ fm_afk_launch_commit_terminal() {  # <backend> <target> <extra> [already-recorde
 }
 
 fm_afk_launch_herdr_recover_created() {  # <session> <label>
-  local session=$1 label=$2 workspaces ws_count wsid panes pane_count pane i
-  for i in $(seq 1 20); do
+  local session=$1 label=$2 workspaces ws_count wsid panes pane_count pane attempt=0
+  while [ "$attempt" -lt 20 ]; do
+    attempt=$((attempt + 1))
     workspaces=$(fm_backend_herdr_cli "$session" workspace list 2>/dev/null) || { sleep 0.05; continue; }
     ws_count=$(printf '%s' "$workspaces" | jq --arg want "$label" \
       '[.result.workspaces[]? | select(.label == $want)] | length' 2>/dev/null) || { sleep 0.05; continue; }

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -418,41 +418,44 @@ fm_backend_expected_label_of_selector() {  # <raw-target> <state-dir>
 }
 
 # fm_backend_source: source the named backend's adapter file, once per shell.
+# Each adapter is an independently linted canonical root. The /dev/null source
+# boundaries keep runtime dispatch from importing all five adapter ASTs into
+# every dispatcher consumer while preserving the runtime source operations.
 fm_backend_source() {  # <name>
   local name=$1
   fm_backend_validate "$name" || return 1
   case "$name" in
     tmux)
       if [ -z "${_FM_BACKEND_TMUX_SOURCED:-}" ]; then
-        # shellcheck source=bin/backends/tmux.sh
+        # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
         _FM_BACKEND_TMUX_SOURCED=1
       fi
       ;;
     herdr)
       if [ -z "${_FM_BACKEND_HERDR_SOURCED:-}" ]; then
-        # shellcheck source=bin/backends/herdr.sh
+        # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
         _FM_BACKEND_HERDR_SOURCED=1
       fi
       ;;
     zellij)
       if [ -z "${_FM_BACKEND_ZELLIJ_SOURCED:-}" ]; then
-        # shellcheck source=bin/backends/zellij.sh
+        # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
         _FM_BACKEND_ZELLIJ_SOURCED=1
       fi
       ;;
     orca)
       if [ -z "${_FM_BACKEND_ORCA_SOURCED:-}" ]; then
-        # shellcheck source=bin/backends/orca.sh
+        # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
         _FM_BACKEND_ORCA_SOURCED=1
       fi
       ;;
     cmux)
       if [ -z "${_FM_BACKEND_CMUX_SOURCED:-}" ]; then
-        # shellcheck source=bin/backends/cmux.sh
+        # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
         _FM_BACKEND_CMUX_SOURCED=1
       fi

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -1,65 +1,140 @@
 #!/usr/bin/env bash
 # fm-lint.sh - the single owner of firstmate's shell-lint definition.
 #
-# Runs ShellCheck over firstmate's tracked shell scripts at ShellCheck's default
-# severity (which reports info, warning, and error - the levels CI fails on).
-# The lint command, the file set, the config, AND the pinned ShellCheck version
-# live here and ONLY here, so the gates cannot drift apart: both invoke this
-# script with no arguments.
-#   - CI:       .github/workflows/ci.yml installs the version this script prints
-#               via `--required-version`, then runs `bin/fm-lint.sh`.
-#   - Pre-push: .no-mistakes.yaml `commands.lint` runs `bin/fm-lint.sh`, so the
-#               no-mistakes gate runs the SAME shellcheck as CI. Without a
-#               configured commands.lint, that gate step never ran this
-#               deterministic shellcheck, so info-level findings were not
-#               surfaced locally before CI rejected them.
+# Runs every canonical shell root with ShellCheck's default severity, extended
+# analysis, ambient configuration disabled, and one exact ShellCheck version.
+# CI and no-mistakes both invoke this script with no arguments, so the file set,
+# rule set, version, bounded execution, and diagnostics ordering cannot drift.
+# Tests stop source analysis at imported production modules because every
+# production shell is already a canonical, source-aware root of this same run.
 #
-# Version parity: CI's ShellCheck used to float with the runner image, and
-# ShellCheck retired SC2015 in 0.11.0, so an older CI ShellCheck rejected an
-# SC2015 that a newer local one no longer emits. This script pins one exact
-# version (REQUIRED_SHELLCHECK) and asserts the resolved `shellcheck` matches it,
-# so CI and local run the identical rule set. This is not a CI relaxation: it
-# adopts one upstream release consistently; the only difference from the old
-# floating CI is dropping the upstream-retired, false-positive-prone SC2015.
-# No severity downgrade and no blanket exclude of checks - every still-supported
-# finding at default severity is enforced.
-# The local == CI parity contract is asserted by tests/fm-lint.test.sh.
+# Canonical lint defaults to two bounded workers over two stable logical shards.
+# Each shard writes separate diagnostics, and the parent replays those outputs in
+# deterministic shard and root order after every worker finishes. FM_LINT_JOBS=1
+# runs the same shards serially with byte-identical diagnostics and exit selection.
+#
+# Optional telemetry is quiet and bounded. FM_LINT_TELEMETRY=<path> writes one
+# TSV snapshot with root and source-boundary counts, content identity, timing,
+# CPU, maximum worker RSS, shard weights, load, and competing ShellCheck counts.
+# Routine lint output is unchanged when telemetry is not requested.
 #
 # Usage:
-#   fm-lint.sh                    lint the canonical file set (what both gates run)
-#   fm-lint.sh <path>...          lint only the given paths with the same config
-#                                  (developer convenience; the gates never pass args)
-#   fm-lint.sh --required-version print the pinned ShellCheck version and exit
-#                                  (CI reads this to install the exact same one)
-#
-# Exit status is ShellCheck's own on a lint run, so a caller (CI or the gate)
-# fails exactly when ShellCheck reports a finding; a version mismatch or a
-# missing ShellCheck fails before linting with a distinct message.
-set -eu
+#   fm-lint.sh                         lint the canonical file set
+#   fm-lint.sh <path>...               lint explicit roots with the same config
+#   fm-lint.sh --jobs <1|2> [path]...  override bounded worker count
+#   fm-lint.sh --telemetry <path> ...  write a quiet metrics snapshot
+#   fm-lint.sh --required-version      print the ShellCheck pin
+#   fm-lint.sh --help                  print this usage
+set -u
 
-# The single source of the pinned ShellCheck version. Bump here and CI follows
-# automatically via `--required-version`; the test suite reads it the same way.
 REQUIRED_SHELLCHECK=0.11.0
-
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELF="$SELF_DIR/fm-lint.sh"
+ROOT="$(cd "$SELF_DIR/.." && pwd)"
 cd "$ROOT" || exit 1
 
-# Expose the pinned version without needing ShellCheck installed, so CI can read
-# it to install the exact same build before any lint runs.
+FM_LINT_WORKER_SHELLCHECK_PID=
+# shellcheck disable=SC2329 # Registered by the private worker's signal traps.
+fm_lint_worker_stop() {
+  [ -n "$FM_LINT_WORKER_SHELLCHECK_PID" ] || return 0
+  kill "$FM_LINT_WORKER_SHELLCHECK_PID" 2>/dev/null || true
+  wait "$FM_LINT_WORKER_SHELLCHECK_PID" 2>/dev/null || true
+  FM_LINT_WORKER_SHELLCHECK_PID=
+}
+
+fm_lint_worker() {  # <manifest> <output-dir> <shard-index>
+  local manifest=$1 output_dir=$2 shard_index=$3 tab index path output rc=0
+  local -a roots
+  roots=()
+  tab=$(printf '\t')
+  while IFS="$tab" read -r index path || [ -n "${index:-}${path:-}" ]; do
+    [ -n "${index:-}" ] || continue
+    roots+=("$path")
+  done < "$manifest"
+  output="$output_dir/shard.$shard_index"
+  if [ "${#roots[@]}" -gt 0 ]; then
+    trap 'fm_lint_worker_stop; exit 129' HUP
+    trap 'fm_lint_worker_stop; exit 130' INT
+    trap 'fm_lint_worker_stop; exit 143' TERM
+    "$FM_LINT_SHELLCHECK" --norc --external-sources -- "${roots[@]}" > "$output.out" 2>&1 &
+    FM_LINT_WORKER_SHELLCHECK_PID=$!
+    wait "$FM_LINT_WORKER_SHELLCHECK_PID" || rc=$?
+    FM_LINT_WORKER_SHELLCHECK_PID=
+    trap - HUP INT TERM
+  else
+    : > "$output.out"
+  fi
+  printf '%s\n' "$rc" > "$output.rc"
+  return "$rc"
+}
+
+# Private subprocess mode used only by the bounded parent above.
+if [ "${1:-}" = "--internal-worker" ]; then
+  [ "${FM_LINT_INTERNAL:-}" = 1 ] || {
+    printf 'fm-lint.sh: --internal-worker is private to the lint owner.\n' >&2
+    exit 2
+  }
+  [ "$#" -eq 4 ] && [ -n "${FM_LINT_SHELLCHECK:-}" ] || exit 2
+  fm_lint_worker "$2" "$3" "$4"
+  exit $?
+fi
+
 if [ "${1:-}" = "--required-version" ]; then
   printf '%s\n' "$REQUIRED_SHELLCHECK"
   exit 0
 fi
 
-# Enforce the pin so local and CI resolve the identical rule set.
+fm_lint_usage() {
+  sed -n '2,25{s/^# \{0,1\}//;p;}' "$SELF"
+}
+
+JOBS=${FM_LINT_JOBS:-2}
+TELEMETRY=${FM_LINT_TELEMETRY:-}
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --jobs)
+      [ "$#" -ge 2 ] || { printf 'fm-lint.sh: --jobs requires 1 or 2.\n' >&2; exit 2; }
+      JOBS=$2
+      shift 2
+      ;;
+    --jobs=*)
+      JOBS=${1#*=}
+      shift
+      ;;
+    --telemetry)
+      [ "$#" -ge 2 ] || { printf 'fm-lint.sh: --telemetry requires a path.\n' >&2; exit 2; }
+      TELEMETRY=$2
+      shift 2
+      ;;
+    --telemetry=*)
+      TELEMETRY=${1#*=}
+      shift
+      ;;
+    --help|-h)
+      fm_lint_usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *) break ;;
+  esac
+done
+
+case "$JOBS" in
+  1|2) ;;
+  *) printf 'fm-lint.sh: jobs must be 1 or 2, got %s.\n' "$JOBS" >&2; exit 2 ;;
+esac
+
 if ! command -v shellcheck >/dev/null 2>&1; then
   printf 'fm-lint.sh: ShellCheck not found; install ShellCheck %s for CI parity.\n' \
     "$REQUIRED_SHELLCHECK" >&2
   exit 127
 fi
 unset SHELLCHECK_OPTS
-resolved=$(shellcheck --version | awk '/^version:/ {print $2; exit}')
-# Log the resolved version to stderr so both CI and local runs record it.
+SHELLCHECK_BIN=$(command -v shellcheck)
+resolved=$("$SHELLCHECK_BIN" --version | awk '/^version:/ {print $2; exit}')
 printf 'fm-lint.sh: ShellCheck %s (pinned %s)\n' "$resolved" "$REQUIRED_SHELLCHECK" >&2
 if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
   printf 'fm-lint.sh: ShellCheck %s required for CI parity, found %s. Install %s.\n' \
@@ -68,9 +143,288 @@ if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
 fi
 
 if [ "$#" -gt 0 ]; then
-  exec shellcheck --norc "$@"
+  ROOTS=("$@")
+else
+  # Canonical file set: the one authoritative definition. Callers never repeat
+  # these globs, and every adapter and test shell remains an independent root.
+  ROOTS=(bin/*.sh bin/backends/*.sh tests/*.sh)
+fi
+ROOT_COUNT=${#ROOTS[@]}
+
+if [ -n "$TELEMETRY" ]; then
+  telemetry_parent=$(dirname "$TELEMETRY")
+  [ -d "$telemetry_parent" ] || {
+    printf 'fm-lint.sh: telemetry directory does not exist: %s\n' "$telemetry_parent" >&2
+    exit 2
+  }
 fi
 
-# Canonical file set: the ONE authoritative definition. Callers reference this
-# script; they never re-spell these globs.
-exec shellcheck --norc bin/*.sh bin/backends/*.sh tests/*.sh
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-lint.XXXXXX") || exit 1
+ACTIVE_PIDS=()
+# shellcheck disable=SC2329 # Registered by the EXIT and signal traps below.
+fm_lint_cleanup() {
+  local pid
+  for pid in "${ACTIVE_PIDS[@]:-}"; do
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+  done
+  for pid in "${ACTIVE_PIDS[@]:-}"; do
+    [ -n "$pid" ] && wait "$pid" 2>/dev/null || true
+  done
+  rm -rf "$TMP_ROOT"
+}
+trap fm_lint_cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+TAB=$(printf '\t')
+WEIGHTS="$TMP_ROOT/weights"
+OUTPUT_DIR="$TMP_ROOT/output"
+mkdir -p "$OUTPUT_DIR"
+SHARD_COUNT=2
+worker=0
+while [ "$worker" -lt "$SHARD_COUNT" ]; do
+  : > "$TMP_ROOT/manifest.$worker"
+  worker=$((worker + 1))
+done
+
+index=1
+: > "$WEIGHTS"
+for path in "${ROOTS[@]}"; do
+  case "$path" in
+    *"$TAB"*|*$'\n'*)
+      printf 'fm-lint.sh: paths containing tabs or newlines are not supported: %s\n' "$path" >&2
+      exit 2
+      ;;
+  esac
+  if [ -f "$path" ]; then
+    weight=$(wc -c < "$path" 2>/dev/null | tr -d '[:space:]')
+  else
+    weight=1
+  fi
+  case "$weight" in ''|*[!0-9]*) weight=1 ;; esac
+  printf '%s\t%s\t%s\n' "$weight" "$index" "$path" >> "$WEIGHTS"
+  index=$((index + 1))
+done
+
+# Largest-first deterministic greedy assignment keeps the two bounded workers
+# balanced without affecting replay order. Direct bytes are a stable portable
+# proxy after the expensive dynamic adapter source fan-out is cut.
+WORKER_LOADS=(0 0)
+LC_ALL=C sort -t "$TAB" -k1,1nr -k2,2n "$WEIGHTS" > "$WEIGHTS.sorted"
+while IFS="$TAB" read -r weight index path; do
+  worker=0
+  if [ "${WORKER_LOADS[1]}" -lt "${WORKER_LOADS[0]}" ]; then
+    worker=1
+  fi
+  printf '%s\t%s\n' "$index" "$path" >> "$TMP_ROOT/manifest.$worker"
+  WORKER_LOADS[worker]=$((WORKER_LOADS[worker] + weight))
+done < "$WEIGHTS.sorted"
+worker=0
+while [ "$worker" -lt "$SHARD_COUNT" ]; do
+  LC_ALL=C sort -t "$TAB" -k1,1n "$TMP_ROOT/manifest.$worker" > "$TMP_ROOT/manifest.$worker.sorted"
+  mv "$TMP_ROOT/manifest.$worker.sorted" "$TMP_ROOT/manifest.$worker"
+  worker=$((worker + 1))
+done
+
+fm_lint_shellcheck_count() {
+  if command -v pgrep >/dev/null 2>&1; then
+    pgrep -x shellcheck 2>/dev/null | wc -l | tr -d '[:space:]'
+  else
+    printf 'unavailable'
+  fi
+}
+
+fm_lint_load_average() {
+  if [ -r /proc/loadavg ]; then
+    awk '{print $1 "/" $2 "/" $3}' /proc/loadavg
+  elif command -v sysctl >/dev/null 2>&1; then
+    sysctl -n vm.loadavg 2>/dev/null | awk '{gsub(/[{}]/, ""); print $1 "/" $2 "/" $3}' || printf 'unavailable'
+  else
+    printf 'unavailable'
+  fi
+}
+
+fm_lint_aggregate_cpu() {
+  ps -A -o %cpu= 2>/dev/null | awk '{sum += $1} END {printf "%.2f", sum + 0}'
+}
+
+TELEMETRY_START_EPOCH=0
+TELEMETRY_SHELLCHECK_START=unavailable
+TELEMETRY_LOAD_START=unavailable
+TELEMETRY_CPU_START=unavailable
+if [ -n "$TELEMETRY" ]; then
+  TELEMETRY_START_EPOCH=$(date +%s)
+  TELEMETRY_SHELLCHECK_START=$(fm_lint_shellcheck_count)
+  TELEMETRY_LOAD_START=$(fm_lint_load_average)
+  TELEMETRY_CPU_START=$(fm_lint_aggregate_cpu)
+fi
+
+fm_lint_run_worker() {  # <worker-index>
+  local worker_index=$1 manifest timing
+  manifest="$TMP_ROOT/manifest.$worker_index"
+  timing="$TMP_ROOT/timing.$worker_index"
+  if [ -n "$TELEMETRY" ] && [ -x /usr/bin/time ]; then
+    if [ "$(uname)" = Darwin ]; then
+      /usr/bin/time -lp -o "$timing" \
+        env FM_LINT_INTERNAL=1 FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+        "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
+    else
+      /usr/bin/time -f 'wall_seconds=%e\nuser_seconds=%U\nsystem_seconds=%S\nmax_rss_kib=%M' -o "$timing" \
+        env FM_LINT_INTERNAL=1 FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+        "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
+    fi
+  else
+    [ -z "$TELEMETRY" ] || printf 'timing_unavailable=1\n' > "$timing"
+    env FM_LINT_INTERNAL=1 FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+      "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
+  fi
+}
+
+if [ "$JOBS" -eq 1 ]; then
+  worker=0
+  while [ "$worker" -lt "$SHARD_COUNT" ]; do
+    fm_lint_run_worker "$worker" || true
+    worker=$((worker + 1))
+  done
+else
+  worker=0
+  while [ "$worker" -lt "$SHARD_COUNT" ]; do
+    fm_lint_run_worker "$worker" &
+    ACTIVE_PIDS+=("$!")
+    worker=$((worker + 1))
+  done
+  for pid in "${ACTIVE_PIDS[@]}"; do
+    wait "$pid" 2>/dev/null || true
+  done
+  ACTIVE_PIDS=()
+fi
+
+# Replay both stable shards in deterministic order and select the first nonzero
+# shard status. ShellCheck processes every root in a shard after earlier findings.
+overall_rc=0
+worker=0
+while [ "$worker" -lt "$SHARD_COUNT" ]; do
+  output="$OUTPUT_DIR/shard.$worker"
+  [ ! -f "$output.out" ] || cat "$output.out"
+  if [ -f "$output.rc" ]; then
+    rc=$(cat "$output.rc" 2>/dev/null || printf '2')
+    case "$rc" in ''|*[!0-9]*) rc=2 ;; esac
+  else
+    printf 'fm-lint.sh: worker produced no result for shard %s.\n' "$worker" >&2
+    rc=2
+  fi
+  if [ "$overall_rc" -eq 0 ] && [ "$rc" -ne 0 ]; then
+    overall_rc=$rc
+  fi
+  worker=$((worker + 1))
+done
+
+if [ -n "$TELEMETRY" ]; then
+  TELEMETRY_END_EPOCH=$(date +%s)
+  TELEMETRY_SHELLCHECK_END=$(fm_lint_shellcheck_count)
+  TELEMETRY_LOAD_END=$(fm_lint_load_average)
+  TELEMETRY_CPU_END=$(fm_lint_aggregate_cpu)
+
+  direct_lines=$(awk 'END {print NR + 0}' "${ROOTS[@]}" 2>/dev/null || printf 'unavailable')
+  direct_bytes=0
+  : > "$TMP_ROOT/content-cksums"
+  : > "$TMP_ROOT/source-targets"
+  source_directives=0
+  source_boundaries=0
+  for path in "${ROOTS[@]}"; do
+    if [ -f "$path" ]; then
+      bytes=$(wc -c < "$path" 2>/dev/null | tr -d '[:space:]')
+      case "$bytes" in ''|*[!0-9]*) bytes=0 ;; esac
+      direct_bytes=$((direct_bytes + bytes))
+      cksum "$path" >> "$TMP_ROOT/content-cksums" 2>/dev/null || true
+      awk '
+        /^[[:space:]]*# shellcheck source=/ {
+          target=$0
+          sub(/^[[:space:]]*# shellcheck source=/, "", target)
+          sub(/[[:space:]].*$/, "", target)
+          print target
+        }
+      ' "$path" >> "$TMP_ROOT/source-targets"
+    fi
+  done
+  source_directives=$(wc -l < "$TMP_ROOT/source-targets" | tr -d '[:space:]')
+  source_boundaries=$(grep -c '^/dev/null$' "$TMP_ROOT/source-targets" 2>/dev/null || true)
+  case "$source_boundaries" in ''|*[!0-9]*) source_boundaries=0 ;; esac
+  source_followed=$((source_directives - source_boundaries))
+  source_targets=$(LC_ALL=C sort -u "$TMP_ROOT/source-targets" | wc -l | tr -d '[:space:]')
+  content_cksum=$(cksum "$TMP_ROOT/content-cksums" | awk '{print $1 "-" $2}')
+  git_head=$(git rev-parse HEAD 2>/dev/null || printf 'unavailable')
+
+  if [ -x /usr/bin/time ]; then
+    if [ "$(uname)" = Darwin ]; then
+      timing_summary=$(awk '
+        /^real / {wall += $2; if ($2 > max_wall) max_wall=$2}
+        /^user / {user += $2}
+        /^sys / {sys_cpu += $2}
+        /maximum resident set size/ {
+          rss=$1 / 1024
+          rss_sum += rss
+          if (rss > max_rss) max_rss=rss
+        }
+        END {printf "%.2f %.2f %.2f %.0f %.0f %.2f", user, sys_cpu, wall, max_rss, rss_sum, max_wall}
+      ' "$TMP_ROOT"/timing.*)
+    else
+      timing_summary=$(awk -F= '
+        $1 == "wall_seconds" {wall += $2; if ($2 > max_wall) max_wall=$2}
+        $1 == "user_seconds" {user += $2}
+        $1 == "system_seconds" {sys_cpu += $2}
+        $1 == "max_rss_kib" {rss_sum += $2; if ($2 > max_rss) max_rss=$2}
+        END {printf "%.2f %.2f %.2f %.0f %.0f %.2f", user, sys_cpu, wall, max_rss, rss_sum, max_wall}
+      ' "$TMP_ROOT"/timing.*)
+    fi
+    read -r timing_user timing_system timing_worker_wall max_worker_rss worker_rss_sum max_worker_wall <<EOF
+$timing_summary
+EOF
+  else
+    timing_user=unavailable
+    timing_system=unavailable
+    timing_worker_wall=unavailable
+    max_worker_rss=unavailable
+    worker_rss_sum=unavailable
+    max_worker_wall=unavailable
+  fi
+
+  telemetry_tmp="$TMP_ROOT/telemetry.tsv"
+  {
+    printf 'format\tfm-lint-telemetry-v1\n'
+    printf 'git_head\t%s\n' "$git_head"
+    printf 'content_cksum\t%s\n' "$content_cksum"
+    printf 'shellcheck_version\t%s\n' "$resolved"
+    printf 'jobs\t%s\n' "$JOBS"
+    printf 'root_count\t%s\n' "$ROOT_COUNT"
+    printf 'direct_lines\t%s\n' "$direct_lines"
+    printf 'direct_bytes\t%s\n' "$direct_bytes"
+    printf 'source_directives\t%s\n' "$source_directives"
+    printf 'source_boundary_directives\t%s\n' "$source_boundaries"
+    printf 'source_followed_directives\t%s\n' "$source_followed"
+    printf 'source_target_count\t%s\n' "$source_targets"
+    printf 'shard_1_weight_bytes\t%s\n' "${WORKER_LOADS[0]}"
+    printf 'shard_2_weight_bytes\t%s\n' "${WORKER_LOADS[1]:-0}"
+    printf 'wall_seconds\t%s\n' "$((TELEMETRY_END_EPOCH - TELEMETRY_START_EPOCH))"
+    printf 'worker_wall_sum_seconds\t%s\n' "$timing_worker_wall"
+    printf 'max_worker_wall_seconds\t%s\n' "$max_worker_wall"
+    printf 'user_seconds\t%s\n' "$timing_user"
+    printf 'system_seconds\t%s\n' "$timing_system"
+    printf 'max_worker_rss_kib\t%s\n' "$max_worker_rss"
+    printf 'worker_rss_sum_kib\t%s\n' "$worker_rss_sum"
+    printf 'shellcheck_processes_start\t%s\n' "$TELEMETRY_SHELLCHECK_START"
+    printf 'shellcheck_processes_end\t%s\n' "$TELEMETRY_SHELLCHECK_END"
+    printf 'load_average_start\t%s\n' "$TELEMETRY_LOAD_START"
+    printf 'load_average_end\t%s\n' "$TELEMETRY_LOAD_END"
+    printf 'aggregate_cpu_percent_start\t%s\n' "$TELEMETRY_CPU_START"
+    printf 'aggregate_cpu_percent_end\t%s\n' "$TELEMETRY_CPU_END"
+    printf 'result_exit\t%s\n' "$overall_rc"
+  } > "$telemetry_tmp"
+  if ! mv -f "$telemetry_tmp" "$TELEMETRY"; then
+    printf 'fm-lint.sh: could not write telemetry to %s.\n' "$TELEMETRY" >&2
+    [ "$overall_rc" -ne 0 ] || overall_rc=2
+  fi
+fi
+
+exit "$overall_rc"

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -13,10 +13,8 @@
 # deterministic shard and root order after every worker finishes. FM_LINT_JOBS=1
 # runs the same shards serially with byte-identical diagnostics and exit selection.
 #
-# Optional telemetry is quiet and bounded. FM_LINT_TELEMETRY=<path> writes one
-# TSV snapshot with root and source-boundary counts, content identity, timing,
-# CPU, maximum worker RSS, shard weights, load, and competing ShellCheck counts.
-# Routine lint output is unchanged when telemetry is not requested.
+# Optional quiet telemetry writes one bounded TSV snapshot of content and source
+# graph identity, wall/CPU/RSS, shard load, and competing ShellCheck processes.
 #
 # Usage:
 #   fm-lint.sh                         lint the canonical file set

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -134,6 +134,10 @@ if ! command -v shellcheck >/dev/null 2>&1; then
 fi
 unset SHELLCHECK_OPTS
 SHELLCHECK_BIN=$(command -v shellcheck)
+if ! PERL_BIN=$(command -v perl); then
+  printf 'fm-lint.sh: perl is required for bounded worker cleanup.\n' >&2
+  exit 127
+fi
 resolved=$("$SHELLCHECK_BIN" --version | awk '/^version:/ {print $2; exit}')
 printf 'fm-lint.sh: ShellCheck %s (pinned %s)\n' "$resolved" "$REQUIRED_SHELLCHECK" >&2
 if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
@@ -165,7 +169,14 @@ ACTIVE_PIDS=()
 fm_lint_cleanup() {
   local pid
   for pid in "${ACTIVE_PIDS[@]:-}"; do
-    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+    [ -n "$pid" ] || continue
+    kill -TERM -- "-$pid" 2>/dev/null || true
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  for pid in "${ACTIVE_PIDS[@]:-}"; do
+    [ -n "$pid" ] || continue
+    kill -KILL -- "-$pid" 2>/dev/null || true
+    kill -KILL "$pid" 2>/dev/null || true
   done
   for pid in "${ACTIVE_PIDS[@]:-}"; do
     [ -n "$pid" ] && wait "$pid" 2>/dev/null || true
@@ -266,38 +277,52 @@ fm_lint_run_worker() {  # <worker-index>
   timing="$TMP_ROOT/timing.$worker_index"
   if [ -n "$TELEMETRY" ] && [ -x /usr/bin/time ]; then
     if [ "$(uname)" = Darwin ]; then
-      /usr/bin/time -lp -o "$timing" \
+      exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
+        /usr/bin/time -lp -o "$timing" \
         env FM_LINT_INTERNAL=1 FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
         "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
     else
-      /usr/bin/time -f 'wall_seconds=%e\nuser_seconds=%U\nsystem_seconds=%S\nmax_rss_kib=%M' -o "$timing" \
+      exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
+        /usr/bin/time -f 'wall_seconds=%e\nuser_seconds=%U\nsystem_seconds=%S\nmax_rss_kib=%M' -o "$timing" \
         env FM_LINT_INTERNAL=1 FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
         "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
     fi
   else
     [ -z "$TELEMETRY" ] || printf 'timing_unavailable=1\n' > "$timing"
-    env FM_LINT_INTERNAL=1 FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+    exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
+      env FM_LINT_INTERNAL=1 FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
       "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
   fi
+}
+
+fm_lint_start_worker() {
+  fm_lint_run_worker "$1" &
+  ACTIVE_PIDS+=("$!")
+}
+
+fm_lint_wait_workers() {
+  local pid
+  while [ "${#ACTIVE_PIDS[@]}" -gt 0 ]; do
+    pid=${ACTIVE_PIDS[0]}
+    wait "$pid" 2>/dev/null || true
+    ACTIVE_PIDS=("${ACTIVE_PIDS[@]:1}")
+  done
 }
 
 if [ "$JOBS" -eq 1 ]; then
   worker=0
   while [ "$worker" -lt "$SHARD_COUNT" ]; do
-    fm_lint_run_worker "$worker" || true
+    fm_lint_start_worker "$worker"
+    fm_lint_wait_workers
     worker=$((worker + 1))
   done
 else
   worker=0
   while [ "$worker" -lt "$SHARD_COUNT" ]; do
-    fm_lint_run_worker "$worker" &
-    ACTIVE_PIDS+=("$!")
+    fm_lint_start_worker "$worker"
     worker=$((worker + 1))
   done
-  for pid in "${ACTIVE_PIDS[@]}"; do
-    wait "$pid" 2>/dev/null || true
-  done
-  ACTIVE_PIDS=()
+  fm_lint_wait_workers
 fi
 
 # Replay both stable shards in deterministic order and select the first nonzero

--- a/bin/fm-push-transition-lib.sh
+++ b/bin/fm-push-transition-lib.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Shared owner of the watcher's native push-transition escalation.
+#
+# The watcher and event-wait smoke tests source this library instead of loading
+# the whole watcher to obtain handle_push_transition. Its source list is limited
+# to the four production boundaries the transition handler actually calls.
+
+FM_PUSH_TRANSITION_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$FM_PUSH_TRANSITION_LIB_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-classify-lib.sh
+. "$FM_PUSH_TRANSITION_LIB_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-backend.sh
+. "$FM_PUSH_TRANSITION_LIB_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-transition-lib.sh
+. "$FM_PUSH_TRANSITION_LIB_DIR/fm-transition-lib.sh"
+
+TRIAGE_LOG="$STATE/.watch-triage.log"
+TRIAGE_LOG_MAX_BYTES=${FM_WATCH_TRIAGE_LOG_MAX_BYTES:-262144}
+
+# Append one bounded best-effort line for an absorbed supervision event.
+triage_log() {
+  local sz
+  printf '[%s] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$1" >> "$TRIAGE_LOG" 2>/dev/null || return 0
+  sz=$(wc -c < "$TRIAGE_LOG" 2>/dev/null | tr -d '[:space:]')
+  case "$sz" in ''|*[!0-9]*) return 0 ;; esac
+  if [ "$sz" -ge "$TRIAGE_LOG_MAX_BYTES" ]; then
+    tail -n 2000 "$TRIAGE_LOG" > "$TRIAGE_LOG.tmp" 2>/dev/null && mv -f "$TRIAGE_LOG.tmp" "$TRIAGE_LOG" 2>/dev/null
+    rm -f "$TRIAGE_LOG.tmp" 2>/dev/null || true
+  fi
+}
+
+# Exit after reporting one actionable wake. Tests override this callback.
+wake() {
+  case "$1" in
+    heartbeat*) echo $(( $(cat "$STATE/.heartbeat-streak" 2>/dev/null || echo 0) + 1 )) > "$STATE/.heartbeat-streak" ;;
+    *) echo 0 > "$STATE/.heartbeat-streak" ;;
+  esac
+  echo "$1"
+  exit 0
+}
+
+_hb_surfaced_path() {
+  printf '%s/.hb-surfaced-%s' "$STATE" "$(printf '%s' "$1" | tr ':/.' '___')"
+}
+
+# Record a captain-relevant status after its durable wake has been enqueued.
+mark_surfaced() {  # <status-file>
+  local f=$1 task last
+  task=$(basename "$f"); task="${task%.status}"
+  last=$(last_status_line "$f")
+  [ -n "$last" ] || return 0
+  status_is_captain_relevant "$last" || return 0
+  printf '%s' "$last" > "$(_hb_surfaced_path "$task")"
+}
+
+# Act on a fresh actionable transition from a push-capable backend.
+handle_push_transition() {  # <backend> <session> <record>
+  local backend=$1 session=$2 record=$3 pane_id to window task reason
+  pane_id=$(fm_transition_pane_id "$record")
+  to=$(fm_transition_to_status "$record")
+  [ -n "$pane_id" ] || { sleep 1; return; }
+  window="$session:$pane_id"
+  task=$(window_to_task "$window" "$STATE")
+  if status_is_paused "$(last_status_line "$STATE/$task.status")"; then
+    triage_log "absorbed push $to (declared pause, awaiting external): $window"
+    fm_backend_commit_transition "$backend" "$STATE" "$session" "$record" || exit 1
+    return
+  fi
+  reason="stale: $window (herdr: agent $to - waiting on human, escalated immediately, not via wedge timer)"
+  fm_wake_append stale "$window" "$reason" || exit 1
+  fm_backend_commit_transition "$backend" "$STATE" "$session" "$record" || exit 1
+  mark_surfaced "$STATE/$task.status"
+  wake "$reason"
+}

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -50,29 +50,11 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 mkdir -p "$STATE"
 
-# shellcheck source=bin/fm-wake-lib.sh
-. "$SCRIPT_DIR/fm-wake-lib.sh"
-# Shared wake classifier (captain-relevant verbs + signal/stale/heartbeat
-# predicates), the SAME library the away-mode daemon uses, so the triage policy
-# has one definition.
-# shellcheck source=bin/fm-classify-lib.sh
-. "$SCRIPT_DIR/fm-classify-lib.sh"
-# The DEFAULT EVENT SOURCE: this watcher's poll loop over the pull primitives
-# (capture, recorded windows, backend busy-state, and the BUSY_REGEX fallback)
-# synthesizes the signal/stale/check/heartbeat wake vocabulary for backends with
-# no native event push. tmux always reports unknown busy-state, preserving the
-# original regex path. A push-capable backend (herdr) additionally replaces this
-# watcher's blind terminal sleep with a bounded wait on its native event stream
-# (event_wait_or_sleep below), so a crew entering `blocked` wakes its supervisor
-# sub-second; the poll loop stays live every cycle as the permanent fail-closed
-# backstop. See bin/fm-backend.sh and docs/herdr-backend.md.
-# shellcheck source=bin/fm-backend.sh
-. "$SCRIPT_DIR/fm-backend.sh"
-# Shared normalized-transition accessors and the single-owner status->action
-# policy table, so the event-wait splice reads transition records the same way
-# the herdr subscriber writes them (bin/fm-transition-lib.sh).
-# shellcheck source=bin/fm-transition-lib.sh
-. "$SCRIPT_DIR/fm-transition-lib.sh"
+# The native event fast-path and only its true dependencies have one narrow
+# production owner. The Herdr event-wait smoke test consumes this same owner
+# without sourcing the entire watcher graph.
+# shellcheck source=bin/fm-push-transition-lib.sh
+. "$SCRIPT_DIR/fm-push-transition-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-x-lib.sh
@@ -150,8 +132,6 @@ STALE_ESCALATE_SECS=${FM_STALE_ESCALATE_SECS:-240}  # idle secs before a provabl
 # These cases re-surface once for a recheck every PAUSE_RESURFACE_SECS - far
 # longer than the wedge threshold, but finite so a forgotten hold cannot rot invisibly.
 PAUSE_RESURFACE_SECS=${FM_PAUSE_RESURFACE_SECS:-$FM_PAUSE_RESURFACE_SECS_DEFAULT}
-TRIAGE_LOG="$STATE/.watch-triage.log"
-TRIAGE_LOG_MAX_BYTES=${FM_WATCH_TRIAGE_LOG_MAX_BYTES:-262144}
 # Consecutive event-path failures (fm_backend_wait_transition returning 2 -
 # connect/subscribe failure) before the push fast-path is disabled for the rest
 # of this watcher process and the loop reverts to pure polling (report section
@@ -170,20 +150,6 @@ _event_cap_fails=0
 # every wake) and let the daemon classify - never absorb here, or the daemon's
 # digest/injection layer would never see the wake.
 afk_present() { [ -e "$STATE/.afk" ]; }
-
-# Append one line to the triage debug log explaining an absorbed (benign) wake,
-# size-capped so a long benign stretch cannot grow it without bound. Best-effort:
-# a logging hiccup never affects supervision.
-triage_log() {
-  local sz
-  printf '[%s] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$1" >> "$TRIAGE_LOG" 2>/dev/null || return 0
-  sz=$(wc -c < "$TRIAGE_LOG" 2>/dev/null | tr -d '[:space:]')
-  case "$sz" in ''|*[!0-9]*) return 0 ;; esac
-  if [ "$sz" -ge "$TRIAGE_LOG_MAX_BYTES" ]; then
-    tail -n 2000 "$TRIAGE_LOG" > "$TRIAGE_LOG.tmp" 2>/dev/null && mv -f "$TRIAGE_LOG.tmp" "$TRIAGE_LOG" 2>/dev/null
-    rm -f "$TRIAGE_LOG.tmp" 2>/dev/null || true
-  fi
-}
 
 hash_pane() {
   if command -v md5 >/dev/null 2>&1; then md5 -q; else md5sum | cut -d' ' -f1; fi
@@ -254,18 +220,6 @@ recorded_windows() {
     seen="$seen|$w|"
     printf '%s\n' "$w"
   done
-}
-
-# Exit reporting a wake. Consecutive heartbeats with no other wake in between
-# mean an idle fleet, so the heartbeat interval backs off exponentially
-# (base * 2^streak, capped at HEARTBEAT_MAX); any real wake resets the cadence.
-wake() {
-  case "$1" in
-    heartbeat*) echo $(( $(cat "$STATE/.heartbeat-streak" 2>/dev/null || echo 0) + 1 )) > "$STATE/.heartbeat-streak" ;;
-    *) echo 0 > "$STATE/.heartbeat-streak" ;;
-  esac
-  echo "$1"
-  exit 0
 }
 
 # Consecutive wedge-escalation count for a window past FM_WEDGE_DEMAND_INSPECT_COUNT
@@ -539,27 +493,8 @@ run_check_capture() {
   fm_check_output_cleanup
 }
 
-# Surfaced-marker bookkeeping for the heartbeat backstop. The watcher records the
-# captain-relevant status line it SURFACED (woke firstmate for) in
-# .hb-surfaced-<task>, the watcher's analogue of the daemon's
-# .subsuper-seen-status. Unlike .seen-* (a size:mtime signature advanced on BOTH
-# surface and absorb), .hb-surfaced is advanced ONLY on surface, so the heartbeat
-# fleet-scan can tell apart a captain-relevant status that already woke firstmate
-# from one that has not - the latter being a per-wake-path miss it must surface.
-_hb_surfaced_path() { printf '%s/.hb-surfaced-%s' "$STATE" "$(printf '%s' "$1" | tr ':/.' '___')"; }
-
-# Record a status file's captain-relevant last line as surfaced (no-op for a
-# non-captain-relevant or empty status). Call AFTER the wake is enqueued, so the
-# enqueue-before-suppress ordering holds for this marker too.
-mark_surfaced() {  # <status-file>
-  local f=$1 task last
-  task=$(basename "$f"); task="${task%.status}"
-  last=$(last_status_line "$f")
-  [ -n "$last" ] || return 0
-  status_is_captain_relevant "$last" || return 0
-  printf '%s' "$last" > "$(_hb_surfaced_path "$task")"
-}
-
+# Surfaced-marker bookkeeping for the heartbeat backstop is owned by
+# fm-push-transition-lib.sh because push and poll paths must write one format.
 # Mark every current captain-relevant status as surfaced. Called after the
 # heartbeat backstop enqueues its wake, so the same statuses are not re-surfaced
 # by the next heartbeat.
@@ -665,34 +600,6 @@ event_wait_or_sleep() {
       _event_cap_fails=0
       ;;
   esac
-}
-
-# handle_push_transition: act on a fresh actionable (blocked) transition record
-# the backend returned. Maps the pane back to its window and task, applies the
-# declared-pause exemption (a crew waiting on a known external dependency is not
-# a surprise block - absorb it on the poll loop's long pause cadence instead),
-# and otherwise enqueues an immediate `stale` wake and wakes the supervisor. The
-# `stale` kind is deliberate: the supervisor's handler for it ("peek the pane to
-# diagnose") is exactly right for a blocked crew, and the drain/dedupe/guard
-# machinery already understands it (queued by key=window, so a later poll-path
-# stale for the same pane collapses on drain).
-handle_push_transition() {  # <backend> <session> <record>
-  local backend=$1 session=$2 record=$3 pane_id to window task reason
-  pane_id=$(fm_transition_pane_id "$record")
-  to=$(fm_transition_to_status "$record")
-  [ -n "$pane_id" ] || { sleep 1; return; }
-  window="$session:$pane_id"
-  task=$(window_to_task "$window" "$STATE")
-  if status_is_paused "$(last_status_line "$STATE/$task.status")"; then
-    triage_log "absorbed push $to (declared pause, awaiting external): $window"
-    fm_backend_commit_transition "$backend" "$STATE" "$session" "$record" || exit 1
-    return
-  fi
-  reason="stale: $window (herdr: agent $to - waiting on human, escalated immediately, not via wedge timer)"
-  fm_wake_append stale "$window" "$reason" || exit 1
-  fm_backend_commit_transition "$backend" "$STATE" "$session" "$record" || exit 1
-  mark_surfaced "$STATE/$task.status"
-  wake "$reason"
 }
 
 # --- Main entry: the runtime below runs only when this file is executed as a

--- a/tests/fm-afk-inject-e2e.test.sh
+++ b/tests/fm-afk-inject-e2e.test.sh
@@ -69,7 +69,7 @@ LOG_FILE="$STATE_DIR/submitted.log"
 : > "$LOG_FILE"
 
 # Source the daemon to get FM_INJECT_MARK, afk_enter, afk_exit.
-# shellcheck source=bin/fm-supervise-daemon.sh
+# shellcheck source=/dev/null
 . "$DAEMON"
 
 # Private tmux server with a supervisor session.

--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -68,7 +68,7 @@ trap cleanup_all EXIT
 fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
 
 # --- source the daemon (for afk_enter/afk_exit/FM_INJECT_MARK) + the backend -
-# shellcheck source=bin/fm-supervise-daemon.sh
+# shellcheck source=/dev/null
 . "$DAEMON"
 fm_backend_source herdr || fail "fm_backend_source herdr failed"
 

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -771,7 +771,7 @@ e2e_herdr() {
   command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (herdr e2e)"; return 0; }
   # shellcheck source=tests/herdr-test-safety.sh
   . "$ROOT/tests/herdr-test-safety.sh"
-  # shellcheck source=bin/fm-backend.sh
+  # shellcheck source=/dev/null
   . "$ROOT/bin/fm-backend.sh"
 
   local SESSION home_tmp cap_ws cap_tab cap_pane target

--- a/tests/fm-afk-pi-herdr-return-e2e.test.sh
+++ b/tests/fm-afk-pi-herdr-return-e2e.test.sh
@@ -15,9 +15,9 @@ set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
-# shellcheck source=bin/fm-supervise-daemon.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-supervise-daemon.sh"
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 
 if [ "${FM_AFK_PI_HERDR_E2E:-0}" != 1 ]; then

--- a/tests/fm-backend-cmux-smoke.test.sh
+++ b/tests/fm-backend-cmux-smoke.test.sh
@@ -24,7 +24,7 @@ pass() { printf 'ok - %s\n' "$1"; }
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the cmux adapter)"; exit 0; }
 
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 fm_backend_source cmux || { echo "skip: could not source the cmux adapter"; exit 0; }
 

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -317,7 +317,7 @@ test_dispatch_routes_cmux_backend() {
 }
 
 test_dispatch_busy_state_unknown_for_cmux() {
-  # shellcheck source=bin/fm-backend.sh
+  # shellcheck source=/dev/null
   . "$ROOT/bin/fm-backend.sh"
   [ "$(fm_backend_busy_state cmux '11111111-1111-1111-1111-111111111111:22222222-2222-2222-2222-222222222222')" = unknown ] \
     || fail "fm_backend_busy_state should report unknown for cmux (no native agent-state primitive)"
@@ -1003,7 +1003,7 @@ test_secondmate_spawn_refuses_cmux_backend() {
   pass "fm-spawn.sh: refuses backend=cmux for --secondmate spawns (mirrors Orca's refusal; no secondmate launch design exists yet)"
 }
 
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 
 test_version_check_accepts_current_version

--- a/tests/fm-backend-herdr-eventwait-smoke.test.sh
+++ b/tests/fm-backend-herdr-eventwait-smoke.test.sh
@@ -35,7 +35,9 @@ cleanup_all() {
 trap cleanup_all EXIT
 fm_herdr_lab_prepare "$SESSION" || fail "could not prepare the isolated Herdr lab session"
 
-# shellcheck source=bin/fm-backend.sh
+# The dispatcher is a separately linted production boundary. Its dynamic
+# adapter source edges stop at each independently linted canonical adapter.
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 fm_backend_source herdr || fail "fm_backend_source herdr failed"
 
@@ -111,12 +113,12 @@ UNDER_ONE=$(python3 -c "print('yes' if (($END)-($START)) < 1.0 else 'no')" 2>/de
 pass "real herdr ($HERDR_VERSION): a driven idle->blocked transition returns the blocked record in ${ELAPSED}s (pane $PANE_ID)"
 
 # --- the watcher's fast-path lands a stale record in the scratch wake queue ---
-# Source the watcher (its guard returns before the lock/loop) and override wake so
-# handle_push_transition enqueues without exiting the test.
+# Load the narrow production owner only after pointing it at scratch state, then
+# override wake so the handler enqueues without exiting the test.
 export FM_STATE_OVERRIDE="$STATE"
 export FM_ROOT_OVERRIDE="$ROOT"
-# shellcheck source=bin/fm-watch.sh
-. "$ROOT/bin/fm-watch.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-push-transition-lib.sh"
 wake() { return 0; }
 handle_push_transition herdr "$SESSION" "$REC"
 [ -e "$STATE/.wake-queue" ] || fail "handle_push_transition did not create the wake queue"

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -902,7 +902,7 @@ if sed -n "$((SECOND_SPAWN_LOG_START + 1)),\$p" "$HERDR_CALL_LOG" \
   | grep -E $'^(workspace\tmove|session\tlist)' >/dev/null 2>&1; then
   fail "secondmate spawn attempted presentation ordering"
 fi
-# shellcheck source=bin/fm-config-inherit-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-config-inherit-lib.sh"
 propagate_inheritable_config "$HOME_DIR/config" "$SECOND_HOME_A/config" \
   || fail "inheritance into secondmate A failed"
@@ -1137,7 +1137,7 @@ teardown_task restart1 "$HOME_DIR" > "$TMP_ROOT/restart-teardown.out" 2> "$TMP_R
 # Missing, renamed, and duplicate tokens are read-only recovery diagnostics.
 # The duplicate case allows flat fallback only when every matching pane is
 # positively agent-free.
-# shellcheck source=bin/backends/herdr.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/backends/herdr.sh"
 
 MISSING_STATE="$TMP_ROOT/missing-state"; mkdir -p "$MISSING_STATE"

--- a/tests/fm-backend-herdr-prune-safety-e2e.test.sh
+++ b/tests/fm-backend-herdr-prune-safety-e2e.test.sh
@@ -43,7 +43,7 @@ cleanup_all() {
 trap cleanup_all EXIT
 fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
 
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 fm_backend_source herdr || fail "fm_backend_source herdr failed"
 

--- a/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
+++ b/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
@@ -55,7 +55,7 @@ cleanup_all() {
 trap cleanup_all EXIT
 fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
 
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 fm_backend_source herdr || fail "fm_backend_source herdr failed"
 

--- a/tests/fm-backend-herdr-smoke.test.sh
+++ b/tests/fm-backend-herdr-smoke.test.sh
@@ -37,7 +37,7 @@ cleanup_all() {
 trap cleanup_all EXIT
 fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
 
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 fm_backend_source herdr || fail "fm_backend_source herdr failed"
 

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -73,7 +73,7 @@ cleanup_all() {
 trap cleanup_all EXIT
 fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
 
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 fm_backend_source herdr || fail "fm_backend_source herdr failed"
 

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -49,7 +49,7 @@ chmod +x "$SHIM_DIR/tmux"
 PATH="$SHIM_DIR:$PATH"
 export PATH
 
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 fm_backend_source tmux || fail "fm_backend_source tmux failed"
 

--- a/tests/fm-backend-zellij-smoke.test.sh
+++ b/tests/fm-backend-zellij-smoke.test.sh
@@ -43,7 +43,7 @@ mkdir -p "$LONG_CWD" || fail "could not create long cwd fixture: $LONG_CWD"
 LONG_CWD=$(cd "$LONG_CWD" && pwd -P) || fail "could not resolve long cwd fixture: $LONG_CWD"
 printf -v LONG_CWD_Q '%q' "$LONG_CWD"
 
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 fm_backend_source zellij || fail "fm_backend_source zellij failed"
 

--- a/tests/fm-backend-zellij.test.sh
+++ b/tests/fm-backend-zellij.test.sh
@@ -437,7 +437,7 @@ test_dispatch_routes_zellij_backend() {
 }
 
 test_dispatch_busy_state_unknown_for_zellij() {
-  # shellcheck source=bin/fm-backend.sh
+  # shellcheck source=/dev/null
   . "$ROOT/bin/fm-backend.sh"
   [ "$(fm_backend_busy_state zellij 'firstmate:5')" = unknown ] \
     || fail "fm_backend_busy_state should report unknown for zellij (no native agent-state primitive; D5: watcher falls back to regex, same as tmux)"
@@ -1010,7 +1010,7 @@ test_scripts_reject_fm_target_label_mismatch() {
   pass "fm-send: fm-id zellij targets reject pane ids whose tab label no longer matches"
 }
 
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 
 test_version_check_accepts_current_version

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -30,7 +30,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 fm_git_identity fmtest fmtest@example.invalid
 
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-backend-tests)

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -23,7 +23,7 @@ set -u
 LIB="$ROOT/bin/fm-tmux-lib.sh"
 PEEK="$ROOT/bin/fm-peek.sh"
 
-# shellcheck source=bin/fm-tmux-lib.sh
+# shellcheck source=/dev/null
 . "$LIB"
 
 TMP_ROOT=$(fm_test_tmproot fm-ghost-tests)

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -18,7 +18,7 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-# shellcheck source=bin/fm-composer-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-composer-lib.sh"
 
 # classify <bordered> <content> [idle_re] -> echoes the verdict.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -29,7 +29,7 @@ set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
-# shellcheck source=bin/fm-classify-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-classify-lib.sh"
 
 CREW_STATE="$ROOT/bin/fm-crew-state.sh"

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -91,7 +91,7 @@ run_guard_lib() {
       empty) export NO_MISTAKES_GATE= ;;
     esac
     set -eu
-    # shellcheck source=bin/fm-gate-refuse-lib.sh
+    # shellcheck source=/dev/null
     . "$GATE_LIB"
     fm_refuse_if_gate_agent
   ) 2>&1

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -71,7 +71,7 @@ esac
 SH
 chmod +x "$FAKEBIN/herdr"
 
-# shellcheck source=bin/fm-herdr-lab.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-herdr-lab.sh"
 
 run_with_fake() {

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -335,6 +335,82 @@ SH
   pass "jobs=1 and jobs=2 preserve deterministic diagnostics, failures, cleanup bounds, and quiet telemetry"
 }
 
+test_worker_trees_stop_on_signal() {
+  local tmp fakebin fixture jobs telemetry lint_tmp pid_file out_file telemetry_file
+  local parent_pid shellcheck_pid i parent_rc survivor
+  tmp=$(fm_test_tmproot fm-lint-signal)
+  mkdir -p "$tmp"
+  fakebin=$(fm_fakebin "$tmp")
+  fixture="$tmp/good.sh"
+  cat > "$fixture" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-ok}"
+SH
+  cat > "$fakebin/shellcheck" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+  printf 'ShellCheck - shell script analysis tool\nversion: 0.11.0\n'
+  exit 0
+fi
+printf '%s\n' "$$" > "$FM_TEST_SHELLCHECK_PID"
+trap 'exit 143' HUP INT TERM
+while :; do
+  sleep 1
+done
+SH
+  chmod +x "$fakebin/shellcheck"
+
+  for jobs in 1 2; do
+    for telemetry in off on; do
+      lint_tmp="$tmp/lint-$jobs-$telemetry"
+      pid_file="$tmp/shellcheck-$jobs-$telemetry.pid"
+      out_file="$tmp/output-$jobs-$telemetry"
+      telemetry_file=
+      mkdir -p "$lint_tmp"
+      if [ "$telemetry" = on ]; then
+        telemetry_file="$tmp/telemetry-$jobs.tsv"
+      fi
+      PATH="$fakebin:$PATH" TMPDIR="$lint_tmp" FM_LINT_JOBS="$jobs" \
+        FM_LINT_TELEMETRY="$telemetry_file" FM_TEST_SHELLCHECK_PID="$pid_file" \
+        "$LINT" "$fixture" > "$out_file" 2>&1 &
+      parent_pid=$!
+      i=0
+      while [ "$i" -lt 500 ] && [ ! -s "$pid_file" ]; do
+        kill -0 "$parent_pid" 2>/dev/null || break
+        sleep 0.01
+        i=$((i + 1))
+      done
+      [ -s "$pid_file" ] || {
+        kill -TERM "$parent_pid" 2>/dev/null || true
+        wait "$parent_pid" 2>/dev/null || true
+        fail "jobs=$jobs telemetry=$telemetry did not start ShellCheck"
+      }
+      shellcheck_pid=$(cat "$pid_file")
+      kill -TERM "$parent_pid" 2>/dev/null \
+        || fail "jobs=$jobs telemetry=$telemetry parent could not be interrupted"
+      parent_rc=0
+      wait "$parent_pid" 2>/dev/null || parent_rc=$?
+      survivor=0
+      i=0
+      while [ "$i" -lt 100 ] && kill -0 "$shellcheck_pid" 2>/dev/null; do
+        sleep 0.01
+        i=$((i + 1))
+      done
+      if kill -0 "$shellcheck_pid" 2>/dev/null; then
+        survivor=1
+        kill -KILL "$shellcheck_pid" 2>/dev/null || true
+      fi
+      [ "$parent_rc" -eq 143 ] \
+        || fail "jobs=$jobs telemetry=$telemetry signal exit was $parent_rc, expected 143"
+      [ "$survivor" -eq 0 ] \
+        || fail "jobs=$jobs telemetry=$telemetry left ShellCheck running"
+      [ -z "$(find "$lint_tmp" -mindepth 1 -maxdepth 1 -name 'fm-lint.*' -print -quit)" ] \
+        || fail "jobs=$jobs telemetry=$telemetry left temporary worker state"
+    done
+  done
+  pass "jobs=1 and jobs=2 stop complete worker trees with and without telemetry"
+}
+
 test_seeded_module_boundary_parity() {
   if ! pinned_ready; then
     pass "SKIP (ShellCheck $REQUIRED not resolved): seeded source-boundary parity check"
@@ -419,4 +495,5 @@ test_ignores_ambient_shellcheck_opts
 test_clean_fixture_passes
 test_source_graph_boundaries_keep_every_owner
 test_jobs_are_deterministic_and_complete
+test_worker_trees_stop_on_signal
 test_seeded_module_boundary_parity

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -22,7 +22,7 @@ CI="$ROOT/.github/workflows/ci.yml"
 NM="$ROOT/.no-mistakes.yaml"
 INSTALLER="$ROOT/bin/fm-install-shellcheck.sh"
 # The authoritative file set the one owner must run.
-CANON='shellcheck --norc bin/*.sh bin/backends/*.sh tests/*.sh'
+CANON='ROOTS=(bin/*.sh bin/backends/*.sh tests/*.sh)'
 # The pinned version, read from the single source (the one owner itself).
 REQUIRED=$("$LINT" --required-version)
 
@@ -45,7 +45,9 @@ test_owner_defines_canonical_set() {
   # that would hide findings CI fails on.
   assert_no_grep '--severity' "$LINT" "fm-lint.sh must not lower severity below the CI default"
   assert_no_grep '--exclude' "$LINT" "fm-lint.sh must not blanket-exclude checks CI enforces"
-  [ "$(grep -Fc 'exec shellcheck --norc' "$LINT")" -eq 2 ] || fail "both lint modes must ignore ambient ShellCheck configuration"
+  assert_grep "\"\$FM_LINT_SHELLCHECK\" --norc --external-sources -- \"\${roots[@]}\"" "$LINT" "every bounded worker must ignore ambient config and preserve annotated production sources"
+  [ "$(grep -Fc -- '--norc --external-sources' "$LINT")" -eq 1 ] || fail "the one worker command must own ShellCheck configuration"
+  assert_grep "JOBS=\${FM_LINT_JOBS:-2}" "$LINT" "canonical lint must default to two bounded workers"
   pass "fm-lint.sh is the sole authoritative definition at CI-default severity"
 }
 
@@ -236,6 +238,174 @@ SH
   pass "fm-lint.sh passes a clean fixture"
 }
 
+test_source_graph_boundaries_keep_every_owner() {
+  local adapter file production_context_tests=""
+  [ "$(grep -Fc '# shellcheck source=/dev/null' "$ROOT/bin/fm-backend.sh")" -eq 5 ] \
+    || fail "the dispatcher must stop static source following at all five dynamic adapters"
+  for adapter in tmux herdr zellij orca cmux; do
+    assert_present "$ROOT/bin/backends/$adapter.sh" "canonical adapter root is missing: $adapter"
+  done
+  assert_present "$ROOT/bin/fm-push-transition-lib.sh" "narrow push-transition owner is missing"
+  assert_grep '# shellcheck source=bin/fm-push-transition-lib.sh' "$ROOT/bin/fm-watch.sh" "the watcher must consume the narrow push-transition owner"
+  assert_grep ". \"\$ROOT/bin/fm-push-transition-lib.sh\"" "$ROOT/tests/fm-backend-herdr-eventwait-smoke.test.sh" "the Herdr event-wait smoke must consume the narrow production owner"
+  assert_no_grep '# shellcheck source=bin/fm-watch.sh' "$ROOT/tests/fm-backend-herdr-eventwait-smoke.test.sh" "the event-wait smoke must not re-import the whole watcher graph"
+  for file in "$ROOT"/tests/*.sh; do
+    grep -q '^[[:space:]]*# shellcheck source=bin/' "$file" || continue
+    production_context_tests="${production_context_tests}$(basename "$file")|"
+  done
+  [ "$production_context_tests" = 'fm-backend-herdr.test.sh|fm-daemon.test.sh|fm-pending-reply.test.sh|fm-secondmate-sync.test.sh|' ] \
+    || fail "only callback/variable interop tests may retain production source context: $production_context_tests"
+  pass "dispatcher, adapters, production owner, and tests have explicit lint boundaries"
+}
+
+test_jobs_are_deterministic_and_complete() {
+  if ! pinned_ready; then
+    pass "SKIP (ShellCheck $REQUIRED not resolved): deterministic bounded jobs check"
+    return
+  fi
+  local tmp good bad_a bad_b out_clean_1 out_clean_2 out_fail_1 out_fail_2 out_fail_2b
+  local telemetry telemetry_out cleanup_tmp cleanup_out rc_clean_1 rc_clean_2 rc_fail_1 rc_fail_2 rc_fail_2b rc_bad_jobs
+  tmp=$(fm_test_tmproot fm-lint-jobs)
+  mkdir -p "$tmp"
+  good="$tmp/good.sh"
+  bad_a="$tmp/bad-a.sh"
+  bad_b="$tmp/bad-b.sh"
+  telemetry="$tmp/telemetry.tsv"
+  cat > "$good" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-ok}"
+SH
+  cat > "$bad_a" <<'SH'
+#!/usr/bin/env bash
+bad_a() {
+  local a= b=
+  printf '%s\n' "$a$b"
+}
+SH
+  cat > "$bad_b" <<'SH'
+#!/usr/bin/env bash
+bad_b() {
+  printf '%s\n' $1
+}
+SH
+
+  rc_clean_1=0
+  out_clean_1=$(FM_LINT_JOBS=1 "$LINT" "$good" 2>&1) || rc_clean_1=$?
+  rc_clean_2=0
+  out_clean_2=$(FM_LINT_JOBS=2 "$LINT" "$good" 2>&1) || rc_clean_2=$?
+  [ "$rc_clean_1" -eq 0 ] && [ "$rc_clean_2" -eq 0 ] || fail "clean jobs=1/jobs=2 paths must both pass"
+  [ "$out_clean_1" = "$out_clean_2" ] || fail "clean jobs=1/jobs=2 output differs"
+
+  rc_fail_1=0
+  out_fail_1=$(FM_LINT_JOBS=1 "$LINT" "$bad_a" "$bad_b" 2>&1) || rc_fail_1=$?
+  rc_fail_2=0
+  out_fail_2=$(FM_LINT_JOBS=2 "$LINT" "$bad_a" "$bad_b" 2>&1) || rc_fail_2=$?
+  rc_fail_2b=0
+  out_fail_2b=$(FM_LINT_JOBS=2 "$LINT" "$bad_a" "$bad_b" 2>&1) || rc_fail_2b=$?
+  [ "$rc_fail_1" -ne 0 ] && [ "$rc_fail_1" -eq "$rc_fail_2" ] && [ "$rc_fail_2" -eq "$rc_fail_2b" ] \
+    || fail "failing jobs=1/jobs=2 exit results differ: $rc_fail_1/$rc_fail_2/$rc_fail_2b"
+  [ "$out_fail_1" = "$out_fail_2" ] && [ "$out_fail_2" = "$out_fail_2b" ] \
+    || fail "failing diagnostics are not byte-identical and deterministic across jobs"
+  assert_contains "$out_fail_1" "SC1007" "the first failing root diagnostic was lost"
+  assert_contains "$out_fail_1" "SC2086" "the later failing root diagnostic was lost"
+  rc_bad_jobs=0
+  FM_LINT_JOBS=3 "$LINT" "$good" >/dev/null 2>&1 || rc_bad_jobs=$?
+  [ "$rc_bad_jobs" -eq 2 ] || fail "the lint owner must reject unbounded worker counts"
+
+  telemetry_out=$(FM_LINT_JOBS=2 FM_LINT_TELEMETRY="$telemetry" "$LINT" "$good" 2>&1) \
+    || fail "telemetry-enabled clean lint failed"
+  [ "$telemetry_out" = "$out_clean_2" ] || fail "quiet telemetry changed routine lint output"
+  assert_grep $'format\tfm-lint-telemetry-v1' "$telemetry" "telemetry format marker is missing"
+  assert_grep $'jobs\t2' "$telemetry" "telemetry did not record bounded jobs"
+  assert_grep $'root_count\t1' "$telemetry" "telemetry did not record root count"
+  assert_grep $'wall_seconds\t' "$telemetry" "telemetry did not record wall time"
+  assert_grep $'user_seconds\t' "$telemetry" "telemetry did not record user CPU"
+  assert_grep $'system_seconds\t' "$telemetry" "telemetry did not record system CPU"
+  assert_grep $'max_worker_rss_kib\t' "$telemetry" "telemetry did not record maximum RSS"
+  assert_grep $'source_boundary_directives\t' "$telemetry" "telemetry did not record source-graph boundaries"
+  assert_grep $'shellcheck_processes_start\t' "$telemetry" "telemetry did not record competing ShellCheck conditions"
+
+  cleanup_tmp="$tmp/lint-tmp"
+  mkdir -p "$cleanup_tmp"
+  cleanup_out=$(TMPDIR="$cleanup_tmp" FM_LINT_JOBS=2 "$LINT" "$good" 2>&1) \
+    || fail "cleanup fixture lint failed"
+  [ "$cleanup_out" = "$out_clean_2" ] || fail "cleanup fixture changed routine diagnostics"
+  [ -z "$(find "$cleanup_tmp" -mindepth 1 -maxdepth 1 -name 'fm-lint.*' -print -quit)" ] \
+    || fail "bounded lint left temporary worker state behind"
+  pass "jobs=1 and jobs=2 preserve deterministic diagnostics, failures, cleanup bounds, and quiet telemetry"
+}
+
+test_seeded_module_boundary_parity() {
+  if ! pinned_ready; then
+    pass "SKIP (ShellCheck $REQUIRED not resolved): seeded source-boundary parity check"
+    return
+  fi
+  local tmp rel adapter dispatcher dep owner test_root out rc
+  tmp=$(mktemp -d "$ROOT/.fm-lint-parity.XXXXXX")
+  if [ "${#FM_TEST_CLEANUP_DIRS[@]}" -eq 0 ]; then
+    trap fm_test_cleanup EXIT
+  fi
+  FM_TEST_CLEANUP_DIRS+=("$tmp")
+  rel=${tmp#"$ROOT/"}
+  adapter="$tmp/adapter.sh"
+  dispatcher="$tmp/dispatcher.sh"
+  dep="$tmp/owner-dep.sh"
+  owner="$tmp/owner.sh"
+  test_root="$tmp/test-local.sh"
+
+  cat > "$adapter" <<'SH'
+#!/usr/bin/env bash
+adapter_bad() {
+  rm $1
+}
+SH
+  cat > "$dispatcher" <<SH
+#!/usr/bin/env bash
+# shellcheck source=/dev/null
+. "$adapter"
+dispatcher_bad() {
+  local a= b=
+  printf '%s\n' "\$a\$b"
+}
+SH
+  cat > "$dep" <<'SH'
+#!/usr/bin/env bash
+owner_dependency_value=ok
+SH
+  cat > "$owner" <<SH
+#!/usr/bin/env bash
+# shellcheck source=$rel/owner-dep.sh
+. "$dep"
+owner_bad() {
+  printf '%s\n' "\$owner_dependency_value"
+  cd "\$1"
+}
+SH
+  cat > "$test_root" <<SH
+#!/usr/bin/env bash
+# shellcheck source=/dev/null
+. "$owner"
+test_local_bad() {
+  local output=\$(printf ok)
+  printf '%s\n' "\$output"
+}
+SH
+
+  rc=0
+  out=$(FM_LINT_JOBS=2 "$LINT" "$dispatcher" "$adapter" "$owner" "$test_root" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "seeded module-boundary defects unexpectedly passed"
+  assert_contains "$out" "SC1007" "representative dispatcher defect was hidden"
+  assert_contains "$out" "SC2086" "representative canonical adapter defect was hidden"
+  assert_contains "$out" "SC2164" "representative production-owner defect was hidden"
+  assert_contains "$out" "SC2155" "representative test-local defect was hidden"
+  assert_not_contains "$out" "SC2154" "the production owner lost source-aware dependency context"
+  [ "$(printf '%s\n' "$out" | grep -Fc 'SC2086 (info)')" -eq 1 ] \
+    || fail "the dispatcher boundary re-imported the adapter diagnostic"
+  [ "$(printf '%s\n' "$out" | grep -Fc 'SC2164 (warning)')" -eq 1 ] \
+    || fail "the test boundary re-imported the production-owner diagnostic"
+  pass "seeded dispatcher, adapter, production-owner, and test-local diagnostics preserve parity"
+}
+
 test_owner_exists_and_executable
 test_owner_defines_canonical_set
 test_ci_invokes_the_owner
@@ -247,3 +417,6 @@ test_rejects_wrong_shellcheck_version
 test_catches_a_real_lint_defect
 test_ignores_ambient_shellcheck_opts
 test_clean_fixture_passes
+test_source_graph_boundaries_keep_every_owner
+test_jobs_are_deterministic_and_complete
+test_seeded_module_boundary_parity

--- a/tests/fm-opencode-primary-live-e2e.test.sh
+++ b/tests/fm-opencode-primary-live-e2e.test.sh
@@ -28,7 +28,7 @@ PROJECT="$LAB/project"
 HOME_DIR="$LAB/fmhome"
 OPENCODE_VERSION=$(opencode --version)
 AHOY_PROJECT="$LAB/ahoy-project"
-# shellcheck source=bin/fm-operational-input.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-operational-input.sh"
 # shellcheck disable=SC2016 # Backticks are literal prompt markup.
 LEGACY_START='Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.'

--- a/tests/fm-operational-input.test.sh
+++ b/tests/fm-operational-input.test.sh
@@ -6,7 +6,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 OWNER="$ROOT/bin/fm-operational-input.sh"
-# shellcheck source=bin/fm-operational-input.sh
+# shellcheck source=/dev/null
 . "$OWNER"
 
 cleanup() {

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -28,7 +28,7 @@ PROJECT="$LAB/project"
 AHOY_PROJECT="$LAB/ahoy-project"
 HOME_DIR="$LAB/fmhome"
 PI_VERSION=$(pi --version)
-# shellcheck source=bin/fm-operational-input.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-operational-input.sh"
 # shellcheck disable=SC2016 # Backticks are literal prompt markup.
 LEGACY_START='Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.'

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -5,11 +5,11 @@ set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
-# shellcheck source=bin/fm-pr-lib.sh disable=SC1091
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-pr-lib.sh"
-# shellcheck source=bin/fm-x-lib.sh disable=SC1091
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-x-lib.sh"
-# shellcheck source=bin/fm-check-lib.sh disable=SC1091
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-check-lib.sh"
 
 PR_CHECK="$ROOT/bin/fm-pr-check.sh"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -38,9 +38,9 @@ set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
-# shellcheck source=bin/fm-ff-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-ff-lib.sh"
-# shellcheck source=bin/fm-config-inherit-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-config-inherit-lib.sh"
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}

--- a/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
+++ b/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
@@ -17,9 +17,9 @@ set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
-# shellcheck source=bin/fm-marker-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-marker-lib.sh"
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
 
 if [ "${FM_SEND_MARKER_HERDR_E2E:-0}" != 1 ]; then

--- a/tests/fm-send-secondmate-marker.test.sh
+++ b/tests/fm-send-secondmate-marker.test.sh
@@ -18,7 +18,7 @@ set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
-# shellcheck source=bin/fm-marker-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-marker-lib.sh"
 
 SEND="$ROOT/bin/fm-send.sh"
@@ -107,7 +107,7 @@ test_secondmate_target_is_marked() {
     *audit\ the\ build) : ;;
     *) fail "secondmate send lost the request body"$'\n'"$got" ;;
   esac
-  # shellcheck source=bin/fm-pending-reply-lib.sh
+  # shellcheck source=/dev/null
   . "$ROOT/bin/fm-pending-reply-lib.sh"
   corr=$(fm_pending_reply_extract_corr "$got")
   [ -f "$(fm_pending_reply_path "$home/state" "$corr")" ] \
@@ -128,7 +128,7 @@ test_exact_secondmate_task_id_is_marked() {
     "$FM_FROMFIRST_MARK"corr=[a-f0-9]*) : ;;
     *) fail "exact secondmate send: literal text should be marker+corr+text"$'\n'"--- bytes ---"$'\n'"$(printf '%s' "$got" | od -An -c)" ;;
   esac
-  # shellcheck source=bin/fm-pending-reply-lib.sh
+  # shellcheck source=/dev/null
   . "$ROOT/bin/fm-pending-reply-lib.sh"
   corr=$(fm_pending_reply_extract_corr "$got")
   # Resend with the same corr already present: embed is idempotent for that corr.
@@ -239,7 +239,7 @@ test_marked_send_preserves_trailing_newlines() {
   payload=$'audit the build\n\n'
   run_send "$fb" "$home" "$log" "domain" "$payload"; rc=$?
   expect_code 0 "$rc" "marked send with trailing newlines should succeed"
-  # shellcheck source=bin/fm-pending-reply-lib.sh
+  # shellcheck source=/dev/null
   . "$ROOT/bin/fm-pending-reply-lib.sh"
   corr=$(fm_pending_reply_extract_corr "$(cat "$log")")
   [ -n "$corr" ] || fail "marked send should embed a corr id"

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -9,7 +9,7 @@ unset NO_MISTAKES_GATE
 
 TMP_ROOT=$(fm_test_tmproot fm-sessionstart-nudge)
 NUDGE="$ROOT/bin/fm-sessionstart-nudge.sh"
-# shellcheck source=bin/fm-operational-input.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-operational-input.sh"
 NUDGE_TEXT="Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions."
 fm_operational_input_encode session-start "$NUDGE_TEXT" NUDGE_LINE \

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -8,7 +8,7 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-# shellcheck source=bin/fm-config-inherit-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-config-inherit-lib.sh"
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}

--- a/tests/fm-supervision-events.test.sh
+++ b/tests/fm-supervision-events.test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # tests/fm-supervision-events.test.sh - unit tests for the watcher's native
-# event-wait splice (event_wait_or_sleep, handle_push_transition in
-# bin/fm-watch.sh). The watcher's source guard lets this file source it to load
+# event-wait splice (event_wait_or_sleep in bin/fm-watch.sh and
+# handle_push_transition in bin/fm-push-transition-lib.sh). The watcher's source
+# guard lets this file source it to load
 # the functions WITHOUT acquiring the singleton lock or entering the blocking
 # loop; wake/sleep and the backend dispatchers are overridden so the exemptions,
 # capability memo, and fail-closed disable are asserted deterministically with no
@@ -19,7 +20,9 @@ mkdir -p "$STATE_DIR"
 # lock/loop, so only the functions load.
 export FM_STATE_OVERRIDE="$STATE_DIR"
 export FM_ROOT_OVERRIDE="$ROOT"
-# shellcheck source=bin/fm-watch.sh
+# Production modules are independently linted canonical roots. Keep this test's
+# ShellCheck context local while preserving its unchanged runtime source path.
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-watch.sh"
 
 # Overrides: capture wake reasons and neutralize real sleeps (POLL is 15s).
@@ -59,6 +62,7 @@ pass "handle_push_transition: a blocked crew enqueues a stale wake naming its wi
 reset_state
 fm_write_meta "$STATE_DIR/tk1.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship"
 (
+  # shellcheck disable=SC2329 # Runtime override called by the isolated production owner.
   fm_wake_append() { return 1; }
   handle_push_transition herdr default "$(mkrec wG:pQ blocked)"
 ) >/dev/null 2>&1 || true
@@ -83,7 +87,9 @@ pass "handle_push_transition: a declared-pause crew is absorbed (no fast wake), 
 reset_state
 fm_write_meta "$STATE_DIR/tk3.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship"
 fm_write_meta "$STATE_DIR/sm1.meta" "window=default:wA:pS" "backend=herdr" "kind=secondmate"
+# shellcheck disable=SC2329 # Runtime overrides called by the isolated watcher.
 fm_backend_events_capable() { return 0; }
+# shellcheck disable=SC2329 # Runtime overrides called by the isolated watcher.
 fm_backend_wait_transition() { shift 4; printf '%s\n' "$*" > "$TMP/panes"; return 1; }
 event_wait_or_sleep
 PANES=$(cat "$TMP/panes" 2>/dev/null || true)
@@ -94,7 +100,9 @@ pass "event_wait_or_sleep: herdr windows go on the event pane list, but kind=sec
 reset_state
 fm_write_meta "$STATE_DIR/tk3.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship"
 CAP_CALLS=0
+# shellcheck disable=SC2329 # Runtime overrides called by the isolated watcher.
 fm_backend_events_capable() { CAP_CALLS=$((CAP_CALLS + 1)); return 0; }
+# shellcheck disable=SC2329 # Runtime overrides called by the isolated watcher.
 fm_backend_wait_transition() {
   [ "${FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED:-0}" = 1 ] || fail "cached capability verdict was not passed to the wait"
   return 1
@@ -108,6 +116,7 @@ pass "event_wait_or_sleep: one cached capability probe owns validation across bo
 
 reset_state
 fm_write_meta "$STATE_DIR/tk4.meta" "window=fmses:fm-tk4" "kind=ship"   # no backend= -> tmux
+# shellcheck disable=SC2329 # Runtime override called by the isolated watcher.
 fm_backend_wait_transition() { printf 'CALLED\n' > "$TMP/wtcalled"; return 1; }
 event_wait_or_sleep
 [ ! -e "$TMP/wtcalled" ] || fail "a tmux-only home must never invoke the event wait path"
@@ -118,8 +127,10 @@ pass "event_wait_or_sleep: a home with no push-capable window is inert (sleeps P
 
 reset_state
 fm_write_meta "$STATE_DIR/tk5.meta" "window=default:wG:pQ" "backend=herdr" "kind=ship"
-EVENT_CAP_FAIL_MAX=2
+export EVENT_CAP_FAIL_MAX=2
+# shellcheck disable=SC2329 # Runtime overrides called by the isolated watcher.
 fm_backend_events_capable() { return 0; }
+# shellcheck disable=SC2329 # Runtime overrides called by the isolated watcher.
 fm_backend_wait_transition() { printf 'WT\n' >> "$TMP/wtcalls"; return 2; }
 : > "$TMP/wtcalls"
 event_wait_or_sleep   # fails=1

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -18,7 +18,7 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-# shellcheck source=bin/fm-tangle-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-tangle-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-tangle-guard)

--- a/tests/fm-tmux-submit-busy.test.sh
+++ b/tests/fm-tmux-submit-busy.test.sh
@@ -6,7 +6,7 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-# shellcheck source=bin/fm-tmux-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-tmux-lib.sh"
 
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-tmux-submit-busy.XXXXXX")

--- a/tests/fm-transition-lib.test.sh
+++ b/tests/fm-transition-lib.test.sh
@@ -7,7 +7,7 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-# shellcheck source=bin/fm-transition-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-transition-lib.sh"
 
 # --- record construction + accessors ----------------------------------------

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -13,7 +13,7 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-# shellcheck source=bin/fm-supervision-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-supervision-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-turnend-guard)

--- a/tests/fm-wake-daemon-lifecycle-e2e.test.sh
+++ b/tests/fm-wake-daemon-lifecycle-e2e.test.sh
@@ -27,7 +27,7 @@ DAEMON="$ROOT/bin/fm-supervise-daemon.sh"
 # Source the daemon's pure functions (its main loop is guarded out under sourcing).
 if [ -z "${FM_TEST_DAEMON_SOURCED:-}" ]; then
   export FM_TEST_DAEMON_SOURCED=1
-  # shellcheck source=bin/fm-supervise-daemon.sh
+  # shellcheck source=/dev/null
   . "$DAEMON"
 fi
 

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -19,7 +19,7 @@ set -u
 
 # shellcheck source=tests/wake-helpers.sh
 . "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
-# shellcheck source=bin/fm-classify-lib.sh
+# shellcheck source=/dev/null
 . "$ROOT/bin/fm-classify-lib.sh"
 
 WATCH="$ROOT/bin/fm-watch.sh"

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -1043,7 +1043,7 @@ test_reply_dry_run_outbox_private_publication_rejects_unsafe_paths() {
 }
 
 test_split_thread_lib() {
-  # shellcheck source=bin/fm-x-lib.sh
+  # shellcheck source=/dev/null
   . "$ROOT/bin/fm-x-lib.sh"
   local out n last rejoin maxlen txt
   # A reply that fits one tweet stays a single, UNNUMBERED chunk.
@@ -1605,7 +1605,7 @@ test_poll_records_context_registry_from_relay_platform() {
 
 test_context_registry_private_publication_rejects_unsafe_paths() {
   local home rc dest hardlink target out
-  # shellcheck source=bin/fm-x-lib.sh
+  # shellcheck source=/dev/null
   . "$ROOT/bin/fm-x-lib.sh"
 
   home="$TMP_ROOT/context-linked-dir"; mkdir -p "$home/state" "$home/external"
@@ -1670,7 +1670,7 @@ test_context_registry_private_publication_rejects_unsafe_paths() {
 
 test_context_registry_rejects_unsafe_reads() {
   local home out target dest hardlink
-  # shellcheck source=bin/fm-x-lib.sh
+  # shellcheck source=/dev/null
   . "$ROOT/bin/fm-x-lib.sh"
 
   home="$TMP_ROOT/context-read-linked-dir"; mkdir -p "$home/state" "$home/external-context"

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -11,7 +11,7 @@ set -u
 export FM_GATE_REFUSE_BYPASS=1
 
 HERDR_TEST_SAFETY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# shellcheck source=bin/fm-herdr-lab.sh
+# shellcheck source=/dev/null
 . "$HERDR_TEST_SAFETY_DIR/bin/fm-herdr-lab.sh"
 
 herdr_refuse_if_default() { # <session>


### PR DESCRIPTION
## Intent

Implement and ship the captain-authorized Firstmate ShellCheck source-graph speedup using the completed measured diagnosis rather than repeating profiling. Preserve every canonical shell file, ShellCheck 0.11.0, default severity, extended analysis, meaningful diagnostics, local/CI parity through bin/fm-lint.sh alone, all tests, and all five backends. Extract handle_push_transition into a narrow shared production owner used by the watcher and Herdr event-wait smoke, make every adapter an independently linted canonical boundary, fix the newly exposed SC2034 warning rather than suppressing it, and isolate imported production modules from test lint roots only where seeded parity proves dispatcher, adapter, production-owner, and test-local findings remain detectable. Add portable deterministic bounded jobs=1 and jobs=2 execution with separate outputs, stable replay, full failure propagation and cleanup, plus quiet optional telemetry for content, source graph, wall/CPU/RSS, and contention. Meet the representative-host targets of roughly <=110 seconds sequential and <=65 seconds with two workers without timing assertions in CI, and report any miss honestly. Keep CI and no-mistakes invoking only bin/fm-lint.sh; do not weaken or fork the manifest.

## What Changed

- Shrink ShellCheck’s source graph while preserving canonical lint roots, source-aware analysis, all backend adapters, and the shared push-transition behavior.
- Add deterministic one- and two-worker lint execution with stable diagnostics, failure propagation, cancellation cleanup, and optional quiet telemetry.
- Expand lint regression coverage for source boundaries, seeded diagnostic parity, worker cleanup, and local/CI ownership through `bin/fm-lint.sh`.

## Risk Assessment

✅ Low: The follow-up now tracks both sequential and parallel workers in isolated process groups, terminates complete worker trees on cancellation, and resolves the prior required-cleanup violation without introducing another material source risk.

## Testing

After baseline diff and cleanliness checks, focused lint-runner, supervision, backend, AFK, seeded CLI, telemetry, and real isolated Herdr checks passed with reviewer-visible CLI evidence; this is a CLI-only change, so no visual screenshot applies, while representative-host canonical timing remains unmeasured.

<details>
<summary>Evidence: Deterministic lint CLI and telemetry transcript</summary>

```text
Command: FM_LINT_JOBS=1 bin/fm-lint.sh fixtures/bad-a.sh fixtures/bad-b.sh
Exit: 1
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)

In fixtures/bad-a.sh line 3:
  local a= b=
          ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).

For more information:
  https://www.shellcheck.net/wiki/SC1007 -- Remove space after = if trying to...

In fixtures/bad-b.sh line 3:
  printf '%s\n' $1
                ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  printf '%s\n' "$1"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

Command: FM_LINT_JOBS=2 bin/fm-lint.sh fixtures/bad-a.sh fixtures/bad-b.sh
Exit: 1
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)

In fixtures/bad-a.sh line 3:
  local a= b=
          ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).

For more information:
  https://www.shellcheck.net/wiki/SC1007 -- Remove space after = if trying to...

In fixtures/bad-b.sh line 3:
  printf '%s\n' $1
                ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  printf '%s\n' "$1"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

Byte-identical diagnostics: yes

Command: FM_LINT_JOBS=2 FM_LINT_TELEMETRY=fixture-telemetry.tsv bin/fm-lint.sh fixtures/good.sh
Exit: 0
CLI output:
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
Telemetry:
format	fm-lint-telemetry-v1
git_head	6d5b90eff58991f705081ef5ff764f079917516f
content_cksum	2996591949-127
shellcheck_version	0.11.0
jobs	2
root_count	1
direct_lines	2
direct_bytes	45
source_directives	0
source_boundary_directives	0
source_followed_directives	0
source_target_count	0
shard_1_weight_bytes	45
shard_2_weight_bytes	0
wall_seconds	0
worker_wall_sum_seconds	0.06
max_worker_wall_seconds	0.05
user_seconds	0.01
system_seconds	0.01
max_worker_rss_kib	24832
worker_rss_sum_kib	32096
shellcheck_processes_start	1
shellcheck_processes_end	1
load_average_start	5.82/5.69/6.29
load_average_end	5.82/5.69/6.29
aggregate_cpu_percent_start	309.20
aggregate_cpu_percent_end	304.00
result_exit	0
```
</details>
<details>
<summary>Evidence: Real isolated Herdr event-wait evidence</summary>

```text
ok - real herdr (herdr 0.7.5): events.subscribe capability gate passes (protocol >= 16, events surface present in api schema)
ok - real herdr (herdr 0.7.5): a driven idle->blocked transition returns the blocked record in 0.103s (pane w1:p2)
ok - real herdr: the watcher fast-path enqueues a stale wake naming the task window from the live blocked transition
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (4m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-lint.sh:287` - Required criterion contradicted: “jobs=1 and jobs=2 execution with ... full failure propagation and cleanup.” The jobs=1 path runs `fm_lint_run_worker` synchronously without adding its process to `ACTIVE_PIDS`, while the signal/EXIT cleanup only terminates `ACTIVE_PIDS`. If the parent receives TERM while the worker is running, it can exit and delete `TMP_ROOT` without terminating the worker or ShellCheck. Telemetry adds another untracked `/usr/bin/time` wrapper layer. Launch and track each worker, including sequential workers, at a shared process-group boundary so cleanup terminates the complete worker tree before removing temporary state.

🔧 Fix: Ensure lint workers terminate fully on cancellation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `bin/fm-lint.sh:14` - The representative-host performance thresholds of roughly 110 seconds sequential and 65 seconds with two workers were not independently measured during this targeted run. Verifying them requires a separately authorized canonical timing run; the supplied instructions prohibited running static analysis broadly and the intent asked not to repeat profiling.
- <code>Inspected `git diff 792174da723a9f03bed1ff13d4d2fb0c96522e75..6d5b90eff58991f705081ef5ff764f079917516f` and `git status --short`</code>
- `bash tests/fm-lint.test.sh`
- `bash tests/fm-supervision-events.test.sh`
- `bash tests/fm-backend-herdr-eventwait-smoke.test.sh`
- <code>`FM_LINT_JOBS=1 bin/fm-lint.sh &lt;two seeded fixtures&gt;` and `FM_LINT_JOBS=2 bin/fm-lint.sh &lt;same fixtures&gt;`, followed by `cmp`</code>
- `FM_LINT_JOBS=2 FM_LINT_TELEMETRY=<evidence>/fixture-telemetry.tsv bin/fm-lint.sh <clean fixture>`
- `bash tests/fm-backend.test.sh`
- `bash tests/fm-afk-launch.test.sh`
- <code>Checked for leftover `fm-lint.*` and `.fm-lint-parity.*` directories and confirmed the worktree remained clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
