### PR TITLE
docs(bin): add bilingual delivery-language policy and brief pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,15 @@ A secondmate's routed reply returns through status or a document pointer, not by
 For the parent-owned correlation, recovery, and escalation contract on marked secondmate requests, see `bin/fm-pending-reply-lib.sh`.
 Supervise all live work under section 8.
 
+### Delivery language
+
+This section is the sole owner of Firstmate's prospective delivery-language policy.
+Use concise English for commit subjects and pull-request titles, and concise Brazilian Portuguese for authored commit bodies and pull-request bodies.
+Do not rewrite existing commit history or edit existing open pull requests to apply this policy.
+For no-mistakes runs, include this language directive in the run intent so its prompt-generated pull-request copy and prose reports use Brazilian Portuguese while the pull-request title stays in English.
+Give captain-facing validation summaries in Brazilian Portuguese without dropping evidence, risks, decisions, fixes, or lifecycle content.
+The installed no-mistakes tool exposes no locale or language setting for its fixed AXI labels, findings, and help text, so those tool-owned surfaces remain English; never claim that they were localized.
+
 ### Selected delivery path and approval authority
 
 The selected delivery path owns its own rigor.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,7 +397,7 @@ When evidence uses an internal label, rewrite it before sending:
 - fail-open, fails open, passive fail-open, or degraded-open -> steps aside and lets work continue when the check cannot complete, or continues without that optional protection.
 
 Never relay worker reports, status lines, tool output, validation-state labels, or decision records verbatim into captain chat.
-Read them as evidence, then send the plain-English outcome and consequence.
+Read them as evidence, then send the plain-language outcome and consequence in the delivery language set by section 7.
 Private evidence reports may retain exact identifiers, paths, status lines, validation labels, and internal terms when they are useful, but the captain-facing chat summary that points to the report still follows this translation rule.
 
 Every escalation must stand alone and remain concise.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -44,6 +44,8 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
+# Every ship brief points workers to AGENTS.md section 7's authoritative
+# delivery-language policy before they commit, open a PR, or start no-mistakes.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -372,6 +374,7 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Before committing, opening a PR, or starting no-mistakes, read and follow the authoritative Delivery language policy in \`$FM_ROOT/AGENTS.md\` section 7, including its no-mistakes intent requirement.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -136,6 +136,31 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+test_ship_brief_points_to_delivery_language_owner() {
+  local home id brief
+  home="$TMP_ROOT/delivery-language-home"
+  write_registry "$home"
+  assert_grep "### Delivery language" "$ROOT/AGENTS.md" \
+    "AGENTS.md lost the authoritative delivery-language section"
+  assert_grep "Use concise English for commit subjects and pull-request titles, and concise Brazilian Portuguese for authored commit bodies and pull-request bodies." "$ROOT/AGENTS.md" \
+    "delivery-language owner lost the bilingual copy contract"
+  assert_grep "include this language directive in the run intent" "$ROOT/AGENTS.md" \
+    "delivery-language owner lost the no-mistakes prompt-surface requirement"
+  assert_grep "exposes no locale or language setting" "$ROOT/AGENTS.md" \
+    "delivery-language owner no longer documents the no-mistakes localization limit"
+
+  for id_proj in "language-nomistakes:no-registry-proj" "language-direct:direct-proj" "language-local:local-proj"; do
+    id=${id_proj%%:*}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "${id_proj##*:}" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_grep "authoritative Delivery language policy in \`$ROOT/AGENTS.md\` section 7" "$brief" \
+      "$id: ship brief lost its delivery-language owner reference"
+    assert_grep "including its no-mistakes intent requirement" "$brief" \
+      "$id: ship brief lost the no-mistakes language-intent requirement"
+  done
+  pass "fm-brief.sh: every ship mode references the authoritative delivery-language policy"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -388,6 +413,7 @@ test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_ship_brief_points_to_delivery_language_owner
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout


### PR DESCRIPTION
## Intent

Implement the existing bilingual-delivery-copy backlog item prospectively across Firstmate projects. Future Firstmate-authored commit subjects and pull-request titles must be concise English; authored commit and pull-request bodies must be concise Brazilian Portuguese. No-mistakes prompt-generated pull-request copy and prose reports, plus captain-facing validation summaries, must use Brazilian Portuguese wherever supported without weakening evidence, risks, decisions, fixes, or lifecycle content; keep the pull-request title in concise English. Preserve existing history and open pull requests. Use one authoritative policy owner, short references elsewhere, existing no-mistakes intent/prompt surfaces instead of translation machinery, no language-detection CI, document unsupported fixed tool surfaces honestly, and add the smallest focused check.

## What Changed

- Added a `### Delivery language` section to `AGENTS.md` as the sole owner of the prospective policy: concise English commit subjects/PR titles, concise Brazilian Portuguese commit/PR bodies, Portuguese no-mistakes prompt copy and captain-facing summaries (via run intent, without dropping evidence/risks/decisions/fixes/lifecycle), and an honest note that no-mistakes' fixed tool surfaces stay English; also retargeted the section-9 captain-outcome wording to reference this owner.
- Extended `bin/fm-brief.sh` so every generated ship brief points workers to the authoritative section 7 delivery-language policy (including its no-mistakes intent requirement) before they commit, open a PR, or start no-mistakes.
- Added `test_ship_brief_points_to_delivery_language_owner` in `tests/fm-brief.test.sh` to assert the AGENTS.md owner copy and the brief pointer across all ship modes.

## Risk Assessment

✅ Low: A mudança é puramente documental (política em AGENTS.md, uma referência curta no brief e um teste focado), conforma-se a todos os critérios de intenção e não altera comportamento executável.

## Testing

Rodei a suíte `tests/fm-brief.test.sh` (16 testes, todos passam, incluindo o novo teste da política de idioma) e, como o intent é sobre copy/política visível ao worker, gerei um ship brief real para capturar o texto exatamente como o crewmate o vê: a regra 8 aponta para a "authoritative Delivery language policy in AGENTS.md section 7, including its no-mistakes intent requirement". Confirmei que a subseção autoritativa realmente vive na seção 7 e capturei o texto completo da política como artefato. Esta é uma mudança de docs/shell sem superfície de UI renderizada, então a evidência revisável é o markdown do brief gerado e a seção de AGENTS.md — não há screenshot aplicável. Resultado geral: verde, intent satisfeito de ponta a ponta.

<details>
<summary>Evidence: Ship brief gerado — regra 8 de delivery-language visível ao worker</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-ticket`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.BxIfl19wdZ/state/demo-ticket.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
8. Before committing, opening a PR, or starting no-mistakes, read and follow the authoritative Delivery language policy in `/home/lucas/.no-mistakes/worktrees/2e94237bfec0/01KY8CGJE97D848GZFMNWZ6J2J/AGENTS.md` section 7, including its no-mistakes intent requirement.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/lucas/.no-mistakes/worktrees/2e94237bfec0/01KY8CGJE97D848GZFMNWZ6J2J/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/lucas/.no-mistakes/worktrees/2e94237bfec0/01KY8CGJE97D848GZFMNWZ6J2J/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Seção autoritativa da política em AGENTS.md (seção 7)</summary>

```text
### Delivery language

This section is the sole owner of Firstmate's prospective delivery-language policy.
Use concise English for commit subjects and pull-request titles, and concise Brazilian Portuguese for authored commit bodies and pull-request bodies.
Do not rewrite existing commit history or edit existing open pull requests to apply this policy.
For no-mistakes runs, include this language directive in the run intent so its prompt-generated pull-request copy and prose reports use Brazilian Portuguese while the pull-request title stays in English.
Give captain-facing validation summaries in Brazilian Portuguese without dropping evidence, risks, decisions, fixes, or lifecycle content.
The installed no-mistakes tool exposes no locale or language setting for its fixed AXI labels, findings, and help text, so those tool-owned surfaces remain English; never claim that they were localized.
```
</details>
<details>
<summary>Evidence: Regra 8 renderizada no brief</summary>

```text
8. Before committing, opening a PR, or starting no-mistakes, read and follow the authoritative Delivery language policy in `.../AGENTS.md` section 7, including its no-mistakes intent requirement.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` — suíte completa, incluindo o novo `test_ship_brief_points_to_delivery_language_owner` (todos passam)</code>
- <code>Renderização manual de um ship brief real via `FM_HOME=... bin/fm-brief.sh demo-ticket demo-project` e extração da regra 8 (referência à Delivery language policy)</code>
- <code>Verificação de que a subseção `### Delivery language` reside sob `## 7. Task lifecycle`, confirmando que o ponteiro &#34;section 7&#34; do brief é preciso</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
