### PR TITLE
fix(pi): remove Calm hidden-block gaps

### DIFF
--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -32,6 +32,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Box, Container, getKeybindings, type Component } from "@earendil-works/pi-tui";
 import type { TSchema } from "typebox";
+import { installCalmAssistantLayout } from "./lib/fm-calm-assistant-layout.ts";
 import {
   calmPresentationHides,
   calmPresentationIsActive,
@@ -72,6 +73,8 @@ const extensionDir = dirname(extensionFile);
 const root = resolve(extensionDir, "../..");
 
 export default function (pi: ExtensionAPI) {
+  installCalmAssistantLayout();
+
   let exportRendering = false;
   let removeTerminalInputHandler: (() => void) | undefined;
 

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -1,0 +1,57 @@
+import { AssistantMessageComponent } from "@earendil-works/pi-coding-agent";
+import { calmPresentationHides } from "./fm-calm-visibility.ts";
+
+type AssistantMessage = Parameters<AssistantMessageComponent["updateContent"]>[0];
+
+type AssistantMessagePresentationState = {
+  hiddenThinkingLabel: string;
+  hideThinkingBlock: boolean;
+  lastMessage?: AssistantMessage;
+};
+
+type CalmAssistantLayoutPatch = {
+  hidesThinking: () => boolean;
+};
+
+const CALM_ASSISTANT_LAYOUT_PATCH = Symbol.for(
+  "firstmate:calm-assistant-layout:pi-0.81.1",
+);
+
+export function installCalmAssistantLayout(): void {
+  const registry = globalThis as typeof globalThis & {
+    [key: symbol]: CalmAssistantLayoutPatch | undefined;
+  };
+  const hidesThinking = (): boolean => calmPresentationHides("assistant-thinking");
+  const installed = registry[CALM_ASSISTANT_LAYOUT_PATCH];
+  if (installed) {
+    installed.hidesThinking = hidesThinking;
+    return;
+  }
+
+  const patch: CalmAssistantLayoutPatch = { hidesThinking };
+  const originalUpdateContent = AssistantMessageComponent.prototype.updateContent;
+  if (typeof originalUpdateContent !== "function") {
+    throw new Error("Firstmate Calm requires Pi AssistantMessageComponent.updateContent");
+  }
+
+  AssistantMessageComponent.prototype.updateContent = function (
+    message: AssistantMessage,
+  ): void {
+    const state = this as unknown as AssistantMessagePresentationState;
+    const hideThinking =
+      state.hiddenThinkingLabel === "" &&
+      state.hideThinkingBlock &&
+      patch.hidesThinking();
+    const presentationMessage = hideThinking
+      ? {
+          ...message,
+          content: message.content.filter((block) => block.type !== "thinking"),
+        }
+      : message;
+
+    originalUpdateContent.call(this, presentationMessage);
+    if (presentationMessage !== message) state.lastMessage = message;
+  };
+
+  registry[CALM_ASSISTANT_LAYOUT_PATCH] = patch;
+}

--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ pi
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
 `/calm` is a conversation-focused transcript toggle whose last choice persists for the effective Firstmate home across Pi session starts and resumes.
-While active, it keeps Pi's built-in `Working...` activity visible and uses Pi's supported presentation APIs to hide collapsed thinking labels, all seven built-in tool shells, the Firstmate watcher tool shell, and compatible presentation entries stored by earlier Calm versions.
+While active, it keeps Pi's built-in `Working...` activity visible and uses Pi's presentation surface to hide collapsed thinking blocks, all seven built-in tool shells, the Firstmate watcher tool shell, and compatible presentation entries stored by earlier Calm versions.
 Calm adds no persistent status row, and controllable hidden rows are removed without reserving vertical space.
 Canonically typed Firstmate operational input remains an ordinary user-role message with its exact origin, ordering, model authority, and session persistence unchanged.
 Pi 0.81.1 exposes no supported renderer for ordinary user rows, so those operational rows remain visible rather than being semantically rerouted or risking a duplicate or lost turn; the session-start nudge remains on its existing non-displayed custom-message path.
 Toggling off restores ordinary rendering, and `Ctrl+O` expansion behavior stays unchanged.
 Tool execution, model context, session storage, diagnostics, and `/export` and `/share` operation remain unchanged.
 Exports and shares remain complete session artifacts, including visible current operational user messages and any legacy hidden custom messages retained in serialized session data and Pi 0.81.1's sidebar tree.
-Pi 0.81.1 still exposes no global transcript filter, so expanded reasoning, its reserved spacing, built-in tool images, user-bash rows, skill and summary rows, status notices, and arbitrary custom-tool or extension rows remain supported-API boundaries.
+Pi 0.81.1 still exposes no global transcript filter, so expanded reasoning, built-in tool images, user-bash rows, skill and summary rows, status notices, and arbitrary custom-tool or extension rows remain supported-API boundaries.
 The version-scoped feasibility evidence and complete render taxonomy are recorded in [docs/calm-mode-feasibility.md](docs/calm-mode-feasibility.md).
 
 ### Talk to it

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -18,44 +18,53 @@ $ pi --version
 0.81.1
 ```
 
+### Original transcript cleanup
+
 The pre-cleanup reproduction used a real isolated Pi TUI at 180 columns by 44 rows with the tracked Calm and watcher extensions, an isolated `FM_HOME`, and a live home-owned watcher cycle.
 The model called `fm_watch_arm_pi`, the real tool returned `watcher: started Pi extension arm child 1`, and a `done:` status write caused the watcher extension to inject `FIRSTMATE WATCHER WAKE: signal: ...` followed by the stable drain instruction.
 With Calm off, the captured transcript contained the genuine user prompt, the full watcher tool shell, the synthetic user-role wake, four collapsed `Thinking...` labels, built-in tool rows from wake handling, and the final assistant response.
 With the pre-cleanup implementation's Calm mode on, the existing seven built-in tool rows disappeared, but the watcher tool shell, synthetic wake, and all four `Thinking...` labels remained.
 The final screenshot-scale regression reproduced the same transcript after the cleanup and verified that Calm removed those remaining controlled rows while retaining the genuine prompt, a watcher-shaped genuine near-miss prompt, and the genuine assistant responses.
 
-The observed causal separation was:
+The original proven comparison path was a built-in text tool.
+Calm owned both of that tool's supported renderer slots and switched its shell to `renderShell: "self"`, so returning empty components removed the complete row and `setToolsExpanded` redrew existing tool components.
+Adding supported empty renderer slots to a scratch copy of `fm_watch_arm_pi` likewise removed its row while the real watcher still started and the model still returned `PROBE_COMPLETE`.
+Legacy synthetic presentation entries use `CustomEntryComponent`, whose host adds spacing only when its renderer returns content, so an undefined Calm renderer result removes the complete row and can later restore it through the ordinary expansion redraw.
+The later duplicate-turn evidence below supersedes custom-message rerouting as an acceptable implementation for current operational input.
 
-| Row | Initiating trigger | Masking condition | Visible symptom |
-| --- | --- | --- | --- |
-| Collapsed thinking | A model assistant turn contained non-empty `thinking` content. | Pi's thinking setting was collapsed, so `AssistantMessageComponent` rendered its configured hidden-thinking label instead of full reasoning; Calm previously touched only tool definitions. | One italic `Thinking...` row remained for each reasoning-bearing assistant turn. |
-| Firstmate watcher tool | The model called the tracked `fm_watch_arm_pi` custom tool. | Calm overrode only Pi's seven built-ins, while this tool followed Pi's custom-tool fallback renderer. | The full custom call and result shell remained. |
-| Synthetic watcher input | The live watcher closed on an actionable signal and `fm-primary-pi-watch.ts` called `sendUserMessage`. | Pi stored and rendered the injected content as an ordinary `user` role with no origin renderer hook. | The wake prefix and stable drain instruction looked like a captain-authored prompt. |
+### Hidden-block height regression
 
-The proven comparison path was a built-in text tool.
-Calm already owned both of that tool's supported renderer slots and switched its shell to `renderShell: "self"`, so returning empty components removed the complete row and `setToolsExpanded` redrew existing tool components.
-The earliest divergence for the watcher was its separate custom fallback definition, and the earliest divergence for thinking and user-role injections was Pi's built-in message component path rather than `ToolExecutionComponent`.
+The 2026-07-23 end-user-aligned reproduction used the installed Pi 0.81.1 TUI at 100 columns by 44 rows, an isolated project and `FM_HOME`, the real `/skill:ahoy` command path, and a deterministic provider that produced five thinking-bearing read calls, five tool results, final hidden thinking, and a visible final response.
+With Calm on and Pi's thinking display collapsed, the completed turn left 14 empty rows between the visible collapsed `[skill] ahoy` content row and the first final assistant row.
+With Calm off, the same sequence rendered all six `Thinking...` labels and all five read rows instead of an empty field.
+A controlled baseline containing only the skill row and final response had two standard visible-row separators.
+Adding one final thinking block increased that gap from two rows to four, while adding a tool call without a result or a completed tool call and result left it at two.
+Removing only all six thinking blocks from the failing persisted session left all five tool calls and results intact and reduced the gap from 14 rows to the two-row baseline.
+Enabling Pi's `terminal.clearOnShrink` on the unchanged failing session left the gap at 14 rows, which rules out stale terminal allocation as the cause.
 
-The original presentation-feasibility counterfactuals produced these results.
-The later duplicate-turn evidence below supersedes custom-message rerouting as an acceptable implementation even where these rendering observations remain true.
+The initiating trigger was a non-empty thinking block in an assistant message that Pi rendered through `AssistantMessageComponent`.
+The masking condition was the combination of Calm being active and Pi's thinking display being collapsed, because Calm replaced the visible label with an empty string while Calm off or explicit thinking expansion filled those rows with visible content.
+The visible symptom was the large empty vertical field between the intentionally visible collapsed skill row and final assistant response.
 
-- Calling `setWorkingVisible(false)` removed the live working row without reserving space.
-- Calling `setHiddenThinkingLabel("")` removed every collapsed `Thinking...` label, but Pi's `AssistantMessageComponent` retained one leading spacer for each reasoning-bearing message.
-- Expanding thinking still rendered full reasoning because Pi exposes no supported getter or setter for the transcript-wide thinking expansion state.
-- Adding supported empty renderer slots to a scratch copy of `fm_watch_arm_pi` removed its row while the real watcher still started and the model still returned `PROBE_COMPLETE`.
-- Delivering a scratch custom message with `display: false` still produced the model response `SYNTHETIC_DELIVERED` and persisted the full custom message in session JSONL.
-- Pairing that hidden context message with a TUI-only custom entry allowed Calm to hide and restore the synthetic user presentation with no content loss.
-- Pi's `CustomMessageComponent` unconditionally adds a leading spacer before invoking a registered message renderer, so returning an empty component cannot hide the whole row.
-- Pi's `CustomEntryComponent` adds spacing only when its renderer returns content, so an undefined Calm renderer result removes the complete live row without a residual gap.
-- Pi does not add a `CustomEntryComponent` whose initial renderer result is undefined, while a component already added to the chat remains mounted after a later expansion rebuild clears all of its children.
-- Synthetic delivery therefore mounts its presentation synchronously before Pi's `entry_appended` event returns, then immediately cycles the supported expansion state so Calm removes the host spacer and content while retaining the zero-height parent for later restoration.
-- Pi coalesces those synchronous render requests, so the genuine interactive fixture shows neither the temporary presentation nor a blank gap.
-- Whole-transcript reconstruction was rejected because it drops non-persisted diagnostics and adds an unrelated navigation status row.
-- Pi's HTML exporter omits plain custom entries and `display: false` custom messages from the main message transcript and does not invoke TUI renderers, but the complete artifact retains legacy hidden operational text in serialized session data and the sidebar tree.
+The earliest divergent layout path was `AssistantMessageComponent.updateContent`, before terminal differential rendering or tool-result composition.
+Pi computed `hasVisibleContent` from the original thinking data and added a leading `Spacer` before applying the hidden-thinking presentation.
+Pi then styled the empty label before constructing `Text`, so the resulting ANSI-only string occupied one rendered row, and a thinking block followed by assistant text also added its ordinary inter-block spacer.
+Each thinking-only tool turn therefore retained two empty rows, while the final thinking-plus-text turn retained two extra rows beyond the final response's normal leading separator.
+The proven tool path diverged through `ToolExecutionComponent`, where the Calm self-render shell returned zero lines for both call and result slots and contributed no residual height.
 
-The disconfirming checks deliberately retained contradictory evidence.
+The smallest counterfactual was the thinking-only removal from the same persisted session, which preserved the skill, tools, results, final response, session ordering, and terminal settings while eliminating every unwanted row.
+The single-thinking, tool-call-only, tool-result, Calm-off, and `clearOnShrink` controls deliberately sought disconfirming evidence and isolated collapsed thinking layout from skill, tool, result, and terminal-cache candidates.
+PR 927 made Calm persistent and described controlled rows as gapless while retaining a documented unsupported boundary for collapsed-thinking spacing.
+PR 936 removed the unsafe operational-input reroute and preserved legacy zero-height entries but did not change assistant-message layout.
+
+The fix installs one idempotent Pi 0.81.1 presentation adapter on the exported `AssistantMessageComponent.updateContent` method.
+Only while Calm is active and Pi has collapsed thinking does the adapter pass a shallow thinking-free presentation copy into Pi's ordinary layout calculation, then retain the original message on the component for invalidation and thinking expansion.
+The persisted assistant message, provider context, tool execution, export data, and expansion history remain unchanged.
+Collapsed thinking-only assistant messages now render zero rows, thinking before visible assistant text adds no spacing beyond the text-only baseline, and expanding thinking still renders the original reasoning.
+
+The disconfirming checks deliberately retain supported boundaries.
 An arbitrary third-party custom tool and a built-in read image remain visible because Pi exposes neither a global tool renderer nor image-row control.
-An expanded thinking fixture remains visible, and an empty collapsed-thinking label leaves blank spacing, so this implementation does not claim complete reasoning-row removal.
+Expanded thinking remains visible by design, while re-collapsing it returns to zero-height Calm presentation.
 Every ordinary user-role message remains visible, including a genuine captain prompt that quotes watcher, guard, startup, or supervisor wording and a structurally valid operational envelope.
 
 ## Duplicate-turn regression and semantic boundary
@@ -112,7 +121,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible. |
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
-| `assistant-thinking` | Thinking content in `AssistantMessageComponent` | Collapsed labels hidden; expanded reasoning and reserved collapsed spacing remain unsupported boundaries. |
+| `assistant-thinking` | Thinking content in `AssistantMessageComponent` | Collapsed reasoning is removed from the shallow presentation copy before layout and occupies zero rows; explicit expansion renders the original reasoning. |
 | `assistant-tool-call` | `ToolExecutionComponent` | Seven built-ins and `fm_watch_arm_pi` hidden; arbitrary custom tools remain an unsupported boundary. |
 | `tool-result` | `ToolExecutionComponent` | Text results for the controlled tools hidden; arbitrary custom results remain an unsupported boundary. |
 | `tool-image` | Image children appended outside tool renderer slots | Unsupported boundary; remains visible. |
@@ -132,7 +141,8 @@ The test fixture enumerates every class below through the centralized policy, an
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
 The installed extension API has no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container access, or generic custom-tool wrapper.
-Runtime prototype replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching were rejected as unsupported or preservation-breaking workarounds.
+Pi 0.81.1 does export `AssistantMessageComponent`, so Calm uses one exact-version, idempotent method adapter only for the component's thinking-layout input while leaving all message data and non-Calm behavior unchanged.
+General component replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching remain rejected as unsupported or preservation-breaking workarounds.
 
 ## Cross-harness verification record
 
@@ -156,7 +166,7 @@ grok 0.2.106 (bde89716f679)
 | Claude Code 2.1.218 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or transcript-wide redraw API. |
 | Codex CLI 0.144.6 | Not feasible through the inspected supported project surface. | The tracked hooks expose session, pre-tool, and stop handling, while the plugin and feature inventories expose no TUI tool-row renderer or transcript redraw control. |
 | OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer; same-name tool replacement changes execution rather than presentation alone. |
-| Pi 0.81.1 | Partially feasible and implemented to the supported boundary. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws, but not built-in message containers or generic tool and status rows. |
+| Pi 0.81.1 | Partially feasible with one exact-version exported-component adapter. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws, while the exported assistant component provides the version-pinned layout boundary and generic user, tool, and status rows remain unavailable. |
 | Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract; `--minimal` changes the whole screen mode rather than selected transcript rows. |
 
 These conclusions are deliberately limited to the named versions and supported surfaces.
@@ -167,7 +177,8 @@ Only Pi's obsolete Calm launch binding and semantic input interceptor were remov
 
 ## Regression coverage
 
-`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool and legacy synthetic rows, checks zero-height hidden legacy entries, covers every policy class, covers persisted preference restoration across session-start reasons and a real restart/resume, proves Pi's native `Working...` row through a delayed deterministic provider, asserts no Calm status row, verifies current operational rows remain ordinary user messages in the TUI and complete exports, and drives a genuine 180 by 44 interactive terminal fixture.
+`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool and legacy synthetic rows, checks zero-height hidden legacy entries and thinking components, covers every policy class, covers persisted preference restoration across session-start reasons and a real restart/resume, proves Pi's native `Working...` row through a delayed deterministic provider, asserts no Calm status row, verifies current operational rows remain ordinary user messages in the TUI and complete exports, and drives genuine 100 by 44 plus 180 by 44 interactive terminal fixtures.
+A native deterministic `/skill:ahoy` turn separately produces thinking, tool-call, and tool-result blocks, asserts that the collapsed skill-to-final gap equals the two-row visible-only baseline, expands and re-collapses original thinking, restores Calm-off rendering, verifies persisted hidden history, and repeats the geometry assertion after restart with `terminal.clearOnShrink` explicitly off.
 The same test runs a native deterministic Pi provider path that fails on landed PR 927 and covers Calm loaded on, loaded off, extension absent, restart with persisted state, a genuine captain prompt, and adjacent notifications coalesced into one intended processing turn.
 It asserts one persisted and rendered captain answer, exact user-role operational envelopes in order, no replacement custom messages, and one processing result.
 `tests/fm-pi-primary-live-e2e.test.sh` also proves the unchanged built-in `Working...` row while Calm is active on the credentialed provider path before continuing its ordinary watcher lifecycle.

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -997,7 +997,7 @@ JS
 
 test_hidden_block_geometry_e2e() {
   local project home config sessions session_file snapshot expanded_snapshot calm_off_snapshot restarted_snapshot
-  local version pane skill_line final_line gap i
+  local version skill_line final_line gap i
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi Calm hidden-block geometry E2E"
     return 0
@@ -1102,6 +1102,22 @@ TS
       "cd '$project' && env FM_HOME='$home' PI_CODING_AGENT_DIR='$config' PI_OFFLINE=1 pi --approve --no-context-files --no-prompt-templates --no-extensions -e ./.pi/extensions/fm-calm.ts -e ./geometry-provider.ts $session_arg; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 20"
   }
 
+  capture_geometry_viewport() {
+    local file=$1
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$file" 2>/dev/null
+  }
+
+  wait_for_geometry_text() {
+    local file=$1 text=$2 attempt=0
+    while [ "$attempt" -lt 120 ]; do
+      capture_geometry_viewport "$file" || true
+      grep -Fq "$text" "$file" 2>/dev/null && return 0
+      sleep 0.05
+      attempt=$((attempt + 1))
+    done
+    return 1
+  }
+
   assert_geometry_gap() {
     local file=$1 label=$2
     skill_line=$(grep -n -m1 '\[skill\] ahoy' "$file" | cut -d: -f1)
@@ -1114,18 +1130,18 @@ TS
   }
 
   start_geometry_pi "--session-dir '$sessions'"
-  wait_for_text "$snapshot" "geometry-provider.ts" \
+  wait_for_geometry_text "$snapshot" "geometry-provider.ts" \
     || fail "Pi Calm hidden-block geometry E2E did not reach the ready composer"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/calm-geometry-e2e'
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   sleep 0.1
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/skill:ahoy'
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
-  wait_for_text "$snapshot" "visible row two" \
+  wait_for_geometry_text "$snapshot" "visible row two" \
     || fail "Pi Calm hidden-block geometry E2E did not complete the /skill:ahoy turn"
   i=0
   while [ "$i" -lt 120 ]; do
-    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - >"$snapshot"
+    capture_geometry_viewport "$snapshot"
     tail -12 "$snapshot" | grep -Fq "Working..." || break
     sleep 0.05
     i=$((i + 1))
@@ -1147,17 +1163,17 @@ TS
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/reload'
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   sleep 0.3
-  tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - >"$snapshot"
+  capture_geometry_viewport "$snapshot"
   assert_geometry_gap "$snapshot" "reloaded native Calm transcript"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-t
-  wait_for_text "$expanded_snapshot" "CALM_GEOMETRY_THINKING_ONE" \
+  wait_for_geometry_text "$expanded_snapshot" "CALM_GEOMETRY_THINKING_ONE" \
     || fail "thinking expansion did not restore Calm-hidden reasoning"
   assert_not_contains "$(cat "$expanded_snapshot")" "probe-one.txt" "thinking expansion restored Calm-hidden tool rows"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-t
   i=0
   while [ "$i" -lt 120 ]; do
-    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - >"$snapshot"
+    capture_geometry_viewport "$snapshot"
     grep -Fq "CALM_GEOMETRY_THINKING_ONE" "$snapshot" || break
     sleep 0.05
     i=$((i + 1))
@@ -1167,14 +1183,14 @@ TS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/calm'
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
-  wait_for_text "$calm_off_snapshot" "probe-one.txt" \
+  wait_for_geometry_text "$calm_off_snapshot" "probe-one.txt" \
     || fail "turning Calm off did not restore the tool-call row"
   assert_contains "$(cat "$calm_off_snapshot")" "Thinking..." "turning Calm off did not restore collapsed thinking labels"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/calm'
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   i=0
   while [ "$i" -lt 120 ]; do
-    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - >"$snapshot"
+    capture_geometry_viewport "$snapshot"
     if ! grep -Fq "probe-one.txt" "$snapshot" && ! grep -Fq "Thinking..." "$snapshot"; then
       break
     fi
@@ -1188,7 +1204,7 @@ TS
   sleep 0.2
   tmux -L "$TMUX_SOCKET" kill-session -t "$TMUX_SESSION" 2>/dev/null || true
   start_geometry_pi "--session '$session_file'"
-  wait_for_text "$restarted_snapshot" "visible row two" \
+  wait_for_geometry_text "$restarted_snapshot" "visible row two" \
     || fail "Pi did not restore the Calm hidden-block geometry session"
   assert_not_contains "$(cat "$restarted_snapshot")" "Thinking..." "restart restored a collapsed thinking label under Calm"
   assert_not_contains "$(cat "$restarted_snapshot")" "probe-one.txt" "restart restored a tool-call row under Calm"

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -7,6 +7,7 @@ set -u
 
 TMP_ROOT=$(fm_test_tmproot fm-calm-pi-extension)
 EXT="$ROOT/.pi/extensions/fm-calm.ts"
+ASSISTANT_LAYOUT="$ROOT/.pi/extensions/lib/fm-calm-assistant-layout.ts"
 VISIBILITY="$ROOT/.pi/extensions/lib/fm-calm-visibility.ts"
 WATCH_EXT="$ROOT/.pi/extensions/fm-primary-pi-watch.ts"
 OPERATIONAL_INPUT="$ROOT/bin/fm-operational-input.sh"
@@ -56,10 +57,12 @@ find_chrome() {
 }
 
 test_static_contract() {
-  local text visibility watch operational
+  local text assistant_layout visibility watch operational
   assert_present "$EXT" "tracked Pi calm extension is missing"
+  assert_present "$ASSISTANT_LAYOUT" "tracked Pi Calm assistant-layout adapter is missing"
   assert_present "$VISIBILITY" "tracked Pi calm visibility policy is missing"
   text=$(cat "$EXT")
+  assistant_layout=$(cat "$ASSISTANT_LAYOUT")
   visibility=$(cat "$VISIBILITY")
   watch=$(cat "$WATCH_EXT")
   operational=$(cat "$PI_OPERATIONAL_INPUT")
@@ -76,6 +79,9 @@ test_static_contract() {
   assert_contains "$text" 'ctx.ui.setWorkingVisible(true)' "Pi calm extension does not preserve Pi's live working row"
   assert_not_contains "$text" 'ctx.ui.setWorkingVisible(!active)' "Pi calm extension still hides Pi's live working row"
   assert_contains "$text" 'ctx.ui.setHiddenThinkingLabel(active ? "" : undefined)' "Pi calm extension does not hide collapsed thinking labels"
+  assert_contains "$text" 'installCalmAssistantLayout()' "Pi Calm extension does not install its zero-height assistant layout"
+  assert_contains "$assistant_layout" 'AssistantMessageComponent.prototype.updateContent' "Pi Calm assistant layout does not control the exported component presentation path"
+  assert_contains "$assistant_layout" 'block.type !== "thinking"' "Pi Calm assistant layout does not remove thinking from its presentation copy"
   assert_not_contains "$text" 'calm transcript' "Pi calm extension still adds a persistent Calm status row"
   assert_not_contains "$text" 'pi.on("input"' "Pi calm extension still intercepts semantic input"
   assert_not_contains "$text" 'sendMessage' "Pi calm extension still replaces user-role input with custom context"
@@ -119,6 +125,7 @@ test_home_resolution() {
     "$fixture/override" \
     "$fixture/launch-cwd"
   cp "$EXT" "$fixture/project/.pi/extensions/fm-calm.ts"
+  cp "$ASSISTANT_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-assistant-layout.ts"
   cp "$VISIBILITY" "$fixture/project/.pi/extensions/lib/fm-calm-visibility.ts"
   cp "$PI_OPERATIONAL_INPUT" "$fixture/project/.pi/extensions/lib/fm-operational-input.ts"
   ln -s "$PI_PACKAGE_DIR" "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
@@ -222,6 +229,7 @@ test_rendering_and_session_lifecycle() {
   fixture="$TMP_ROOT/renderer"
   mkdir -p "$fixture/home" "$fixture/lib" "$fixture/node_modules/@earendil-works"
   cp "$EXT" "$fixture/fm-calm.ts"
+  cp "$ASSISTANT_LAYOUT" "$fixture/lib/fm-calm-assistant-layout.ts"
   cp "$VISIBILITY" "$fixture/lib/fm-calm-visibility.ts"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$fixture/lib/fm-operational-input.ts"
   cp "$WATCH_EXT" "$fixture/fm-primary-pi-watch.ts"
@@ -235,7 +243,8 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const packageRoot = process.env.PI_PACKAGE_DIR;
-const [{ CustomEntryComponent }, { ToolExecutionComponent }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }] = await Promise.all([
+const [{ AssistantMessageComponent }, { CustomEntryComponent }, { ToolExecutionComponent }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }] = await Promise.all([
+  import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/assistant-message.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/custom-entry.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/tool-execution.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/theme/theme.js`).href),
@@ -456,6 +465,46 @@ if (!imageVisibleBefore.join("\n").includes("\x1b]1337;File=")) {
   throw new Error("image-capable Pi fixture did not render the built-in read image boundary");
 }
 
+const assistantBase = {
+  role: "assistant",
+  api: "calm-render-test",
+  provider: "calm-render-test",
+  model: "deterministic",
+  usage: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  },
+  stopReason: "stop",
+  timestamp: 1,
+};
+const assistantTextOnly = new AssistantMessageComponent({
+  ...assistantBase,
+  content: [{ type: "text", text: "VISIBLE_ASSISTANT_TEXT" }],
+}, true);
+const assistantThinkingText = new AssistantMessageComponent({
+  ...assistantBase,
+  content: [
+    { type: "thinking", thinking: "HIDDEN_FINAL_THINKING" },
+    { type: "text", text: "VISIBLE_ASSISTANT_TEXT" },
+  ],
+}, true);
+const assistantThinkingTool = new AssistantMessageComponent({
+  ...assistantBase,
+  content: [
+    { type: "thinking", thinking: "HIDDEN_TOOL_THINKING" },
+    { type: "toolCall", id: "assistant-layout-tool", name: "read", arguments: { path: "sample.txt" } },
+  ],
+  stopReason: "toolUse",
+}, true);
+if (!assistantThinkingText.render(100).join("\n").includes("Thinking...")) {
+  throw new Error("stock collapsed-thinking fixture did not render before Calm was active");
+}
+
+const assistantComponents = [assistantTextOnly, assistantThinkingText, assistantThinkingTool];
 let expanded = true;
 let editorText = "";
 let terminalInputHandler;
@@ -477,6 +526,9 @@ const commandContext = {
     },
     setHiddenThinkingLabel(value) {
       hiddenThinkingLabel = value;
+      for (const component of assistantComponents) {
+        component.setHiddenThinkingLabel(value ?? "Thinking...");
+      }
     },
     setStatus(key, value) {
       statuses.set(key, value);
@@ -592,6 +644,20 @@ if (!customRow.render(100).join("\n").includes("CUSTOM_CALL")) {
 if (watchActual.render(100).length !== 0) {
   throw new Error("Calm left the fm_watch_arm_pi call/result shell visible");
 }
+if (assistantThinkingTool.render(100).length !== 0) {
+  throw new Error("Calm-hidden thinking beside a tool call retained vertical height");
+}
+if (JSON.stringify(assistantThinkingText.render(100)) !== JSON.stringify(assistantTextOnly.render(100))) {
+  throw new Error("Calm-hidden thinking changed final assistant row geometry");
+}
+assistantThinkingTool.setHideThinkingBlock(false);
+if (!assistantThinkingTool.render(100).join("\n").includes("HIDDEN_TOOL_THINKING")) {
+  throw new Error("expanding thinking did not restore the original reasoning content");
+}
+assistantThinkingTool.setHideThinkingBlock(true);
+if (assistantThinkingTool.render(100).length !== 0) {
+  throw new Error("collapsing thinking again restored residual Calm rows");
+}
 if (JSON.stringify(sessionEntries) !== entriesBefore) {
   throw new Error("calm mode changed session entries or model context");
 }
@@ -618,6 +684,9 @@ if (JSON.stringify(watchActual.render(100)) !== JSON.stringify(watchBaseline.ren
 }
 if (workingVisible !== true || hiddenThinkingLabel !== undefined || statuses.get("firstmate-calm") !== undefined) {
   throw new Error("turning Calm off did not restore stock presentation controls");
+}
+if (!assistantThinkingTool.render(100).join("\n").includes("Thinking...")) {
+  throw new Error("turning Calm off did not restore the collapsed thinking label");
 }
 if (readFileSync(`${process.env.FM_HOME}/config/calm`, "utf8") !== "off\n") {
   throw new Error("Calm did not persist the inactive choice in the effective Firstmate home");
@@ -680,6 +749,7 @@ test_operational_followup_turn_e2e() {
   mkdir -p "$project/.pi/extensions/lib" "$home/config" "$config" "$sessions"
   fm_git_init_commit "$project"
   cp "$EXT" "$project/.pi/extensions/fm-calm.ts"
+  cp "$ASSISTANT_LAYOUT" "$project/.pi/extensions/lib/fm-calm-assistant-layout.ts"
   cp "$VISIBILITY" "$project/.pi/extensions/lib/fm-calm-visibility.ts"
   cp "$PI_OPERATIONAL_INPUT" "$project/.pi/extensions/lib/fm-operational-input.ts"
   printf '%s\n' '{"followUpMode":"all"}' >"$config/settings.json"
@@ -925,6 +995,211 @@ JS
   pass "Pi operational follow-up E2E preserves one captain answer, exact user-role monitoring turns, Calm on/off/absent behavior, adjacent coalescing, genuine prompts, and restart persistence"
 }
 
+test_hidden_block_geometry_e2e() {
+  local project home config sessions session_file snapshot expanded_snapshot calm_off_snapshot restarted_snapshot
+  local version pane skill_line final_line gap i
+  if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
+    echo "skip: pi or tmux not found for Pi Calm hidden-block geometry E2E"
+    return 0
+  fi
+  version=$(pi --version 2>/dev/null || true)
+  [ "$version" = "0.81.1" ] || fail "Pi Calm hidden-block geometry E2E requires Pi 0.81.1, found $version"
+
+  project="$TMP_ROOT/geometry-project"
+  home="$TMP_ROOT/geometry-home"
+  config="$TMP_ROOT/geometry-config"
+  sessions="$TMP_ROOT/geometry-sessions"
+  snapshot="$TMP_ROOT/geometry-calm-on.txt"
+  expanded_snapshot="$TMP_ROOT/geometry-expanded.txt"
+  calm_off_snapshot="$TMP_ROOT/geometry-calm-off.txt"
+  restarted_snapshot="$TMP_ROOT/geometry-restarted.txt"
+  mkdir -p \
+    "$project/.agents/skills/ahoy" \
+    "$project/.pi/extensions/lib" \
+    "$home/config" \
+    "$config" \
+    "$sessions"
+  fm_git_init_commit "$project"
+  cp "$EXT" "$project/.pi/extensions/fm-calm.ts"
+  cp "$ASSISTANT_LAYOUT" "$project/.pi/extensions/lib/fm-calm-assistant-layout.ts"
+  cp "$VISIBILITY" "$project/.pi/extensions/lib/fm-calm-visibility.ts"
+  printf '%s\n' on >"$home/config/calm"
+  printf '%s\n' '{"hideThinkingBlock":true,"terminal":{"clearOnShrink":false}}' >"$config/settings.json"
+  printf '%s\n' 'tool result one' >"$project/probe-one.txt"
+  printf '%s\n' 'tool result two' >"$project/probe-two.txt"
+  cat >"$project/.agents/skills/ahoy/SKILL.md" <<'MD'
+---
+name: ahoy
+description: Deterministic Calm hidden-block geometry probe.
+---
+
+# Ahoy
+
+Read both probe files, then return the final response.
+MD
+  cat >"$project/geometry-provider.ts" <<'TS'
+import {
+  createFauxCore,
+  fauxAssistantMessage,
+  fauxThinking,
+  fauxText,
+  fauxToolCall,
+} from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI): void {
+  const faux = createFauxCore({
+    api: "calm-geometry-e2e-api",
+    provider: "calm-geometry-e2e",
+    models: [{
+      id: "deterministic",
+      name: "Calm hidden-block geometry E2E",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 4096,
+      maxTokens: 128,
+    }],
+    tokenSize: { min: 1, max: 1 },
+  });
+  faux.setResponses([
+    fauxAssistantMessage([
+      fauxThinking("CALM_GEOMETRY_THINKING_ONE"),
+      fauxToolCall("read", { path: "probe-one.txt" }, { id: "calm_geometry_read_one" }),
+    ], { stopReason: "toolUse" }),
+    fauxAssistantMessage([
+      fauxThinking("CALM_GEOMETRY_THINKING_TWO"),
+      fauxToolCall("read", { path: "probe-two.txt" }, { id: "calm_geometry_read_two" }),
+    ], { stopReason: "toolUse" }),
+    fauxAssistantMessage([
+      fauxThinking("CALM_GEOMETRY_FINAL_THINKING"),
+      fauxText("CALM_GEOMETRY_FINAL\n\n- visible row one\n- visible row two"),
+    ]),
+  ]);
+  pi.registerProvider("calm-geometry-e2e", {
+    baseUrl: "http://127.0.0.1/unused",
+    apiKey: "test-only",
+    api: faux.api,
+    models: faux.models,
+    streamSimple: faux.streamSimple,
+  });
+  pi.registerCommand("calm-geometry-e2e", {
+    description: "Select the deterministic Calm hidden-block geometry model.",
+    handler: async (_args, ctx) => {
+      const model = ctx.modelRegistry.find("calm-geometry-e2e", "deterministic");
+      if (!model || !(await pi.setModel(model))) {
+        throw new Error("Calm hidden-block geometry model unavailable");
+      }
+    },
+  });
+}
+TS
+
+  start_geometry_pi() {
+    local session_arg=$1
+    tmux -L "$TMUX_SOCKET" kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+    tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 100 -y 44 \
+      "cd '$project' && env FM_HOME='$home' PI_CODING_AGENT_DIR='$config' PI_OFFLINE=1 pi --approve --no-context-files --no-prompt-templates --no-extensions -e ./.pi/extensions/fm-calm.ts -e ./geometry-provider.ts $session_arg; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 20"
+  }
+
+  assert_geometry_gap() {
+    local file=$1 label=$2
+    skill_line=$(grep -n -m1 '\[skill\] ahoy' "$file" | cut -d: -f1)
+    final_line=$(grep -n -m1 'CALM_GEOMETRY_FINAL' "$file" | cut -d: -f1)
+    [ -n "$skill_line" ] && [ -n "$final_line" ] \
+      || fail "$label did not render the collapsed skill row and final assistant response"
+    gap=$((final_line - skill_line - 1))
+    [ "$gap" -eq 2 ] \
+      || fail "$label left $gap rows between the collapsed skill row and final response instead of the two standard visible-row separators"
+  }
+
+  start_geometry_pi "--session-dir '$sessions'"
+  wait_for_text "$snapshot" "geometry-provider.ts" \
+    || fail "Pi Calm hidden-block geometry E2E did not reach the ready composer"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/calm-geometry-e2e'
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  sleep 0.1
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/skill:ahoy'
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  wait_for_text "$snapshot" "visible row two" \
+    || fail "Pi Calm hidden-block geometry E2E did not complete the /skill:ahoy turn"
+  i=0
+  while [ "$i" -lt 120 ]; do
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - >"$snapshot"
+    tail -12 "$snapshot" | grep -Fq "Working..." || break
+    sleep 0.05
+    i=$((i + 1))
+  done
+  assert_contains "$(cat "$snapshot")" "[skill] ahoy" "Calm hid the collapsed skill header"
+  assert_contains "$(cat "$snapshot")" "CALM_GEOMETRY_FINAL" "Calm hid the final assistant response"
+  assert_not_contains "$(cat "$snapshot")" "Thinking..." "Calm left a collapsed thinking label visible"
+  assert_not_contains "$(cat "$snapshot")" "probe-one.txt" "Calm left a tool-call row visible"
+  assert_not_contains "$(cat "$snapshot")" "tool result one" "Calm left a tool-result row visible"
+  assert_geometry_gap "$snapshot" "completed native Calm /skill:ahoy turn"
+
+  session_file=$(find "$sessions" -type f -name '*.jsonl' -exec grep -l 'CALM_GEOMETRY_FINAL' {} + 2>/dev/null | head -1 || true)
+  [ -n "$session_file" ] || fail "Pi Calm hidden-block geometry E2E did not persist its session"
+  grep -Fq 'CALM_GEOMETRY_THINKING_ONE' "$session_file" \
+    || fail "Calm removed hidden thinking from persisted history"
+  grep -Fq 'tool result one' "$session_file" \
+    || fail "Calm removed hidden tool results from persisted history"
+
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/reload'
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  sleep 0.3
+  tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - >"$snapshot"
+  assert_geometry_gap "$snapshot" "reloaded native Calm transcript"
+
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-t
+  wait_for_text "$expanded_snapshot" "CALM_GEOMETRY_THINKING_ONE" \
+    || fail "thinking expansion did not restore Calm-hidden reasoning"
+  assert_not_contains "$(cat "$expanded_snapshot")" "probe-one.txt" "thinking expansion restored Calm-hidden tool rows"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-t
+  i=0
+  while [ "$i" -lt 120 ]; do
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - >"$snapshot"
+    grep -Fq "CALM_GEOMETRY_THINKING_ONE" "$snapshot" || break
+    sleep 0.05
+    i=$((i + 1))
+  done
+  assert_not_contains "$(cat "$snapshot")" "CALM_GEOMETRY_THINKING_ONE" "collapsing thinking restored hidden-row output"
+  assert_geometry_gap "$snapshot" "re-collapsed native Calm transcript"
+
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/calm'
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  wait_for_text "$calm_off_snapshot" "probe-one.txt" \
+    || fail "turning Calm off did not restore the tool-call row"
+  assert_contains "$(cat "$calm_off_snapshot")" "Thinking..." "turning Calm off did not restore collapsed thinking labels"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/calm'
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  i=0
+  while [ "$i" -lt 120 ]; do
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - >"$snapshot"
+    if ! grep -Fq "probe-one.txt" "$snapshot" && ! grep -Fq "Thinking..." "$snapshot"; then
+      break
+    fi
+    sleep 0.05
+    i=$((i + 1))
+  done
+  assert_geometry_gap "$snapshot" "Calm redraw of existing transcript"
+
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/quit'
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  sleep 0.2
+  tmux -L "$TMUX_SOCKET" kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+  start_geometry_pi "--session '$session_file'"
+  wait_for_text "$restarted_snapshot" "visible row two" \
+    || fail "Pi did not restore the Calm hidden-block geometry session"
+  assert_not_contains "$(cat "$restarted_snapshot")" "Thinking..." "restart restored a collapsed thinking label under Calm"
+  assert_not_contains "$(cat "$restarted_snapshot")" "probe-one.txt" "restart restored a tool-call row under Calm"
+  assert_geometry_gap "$restarted_snapshot" "restarted native Calm transcript"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/quit'
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
+  sleep 0.2
+  tmux -L "$TMUX_SOCKET" kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+  pass "Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering"
+}
+
 test_interactive_terminal_e2e() {
   local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot export_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
@@ -955,6 +1230,7 @@ test_interactive_terminal_e2e() {
   fm_git_init_commit "$project"
   : > "$project/AGENTS.md"
   cp "$EXT" "$project/.pi/extensions/fm-calm.ts"
+  cp "$ASSISTANT_LAYOUT" "$project/.pi/extensions/lib/fm-calm-assistant-layout.ts"
   cp "$VISIBILITY" "$project/.pi/extensions/lib/fm-calm-visibility.ts"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$project/.pi/extensions/lib/fm-operational-input.ts"
   cp "$WATCH_EXT" "$project/.pi/extensions/fm-primary-pi-watch.ts"
@@ -1409,4 +1685,5 @@ test_static_contract
 test_home_resolution
 test_rendering_and_session_lifecycle
 test_operational_followup_turn_e2e
+test_hidden_block_geometry_e2e
 test_interactive_terminal_e2e

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1118,6 +1118,21 @@ TS
     return 1
   }
 
+  wait_for_geometry_transition() {
+    local file=$1 transient_text=$2 final_text=$3 attempt=0 saw_transient=0
+    while [ "$attempt" -lt 600 ]; do
+      capture_geometry_viewport "$file" || true
+      if grep -Fq "$transient_text" "$file" 2>/dev/null; then
+        saw_transient=1
+      elif [ "$saw_transient" -eq 1 ] && grep -Fq "$final_text" "$file" 2>/dev/null; then
+        return 0
+      fi
+      sleep 0.01
+      attempt=$((attempt + 1))
+    done
+    return 1
+  }
+
   assert_geometry_gap() {
     local file=$1 label=$2
     skill_line=$(grep -n -m1 '\[skill\] ahoy' "$file" | cut -d: -f1)
@@ -1162,8 +1177,11 @@ TS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/reload'
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
-  sleep 0.3
-  capture_geometry_viewport "$snapshot"
+  wait_for_geometry_transition \
+    "$snapshot" \
+    "Reloading keybindings, extensions, skills, prompts, themes, and context files..." \
+    "CALM_GEOMETRY_FINAL" \
+    || fail "Pi Calm hidden-block geometry E2E did not complete the /reload viewport transition"
   assert_geometry_gap "$snapshot" "reloaded native Calm transcript"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-t

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -251,6 +251,7 @@ run_native_ahoy_regressions
 mkdir -p "$PROJECT/.pi/extensions/lib"
 cp "$ROOT/.pi/extensions/fm-calm.ts" "$PROJECT/.pi/extensions/fm-calm.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$PROJECT/.pi/extensions/fm-primary-pi-watch.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-assistant-layout.ts" "$PROJECT/.pi/extensions/lib/fm-calm-assistant-layout.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$PROJECT/.pi/extensions/lib/fm-calm-visibility.ts"
 cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$PROJECT/.pi/extensions/lib/fm-operational-input.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts"

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -29,6 +29,7 @@ mkdir -p "$TMP_ROOT/lib" "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/nod
 cp "$ROOT/.pi/extensions/fm-calm.ts" "$TMP_ROOT/fm-calm.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-assistant-layout.ts" "$TMP_ROOT/lib/fm-calm-assistant-layout.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$TMP_ROOT/lib/fm-calm-visibility.ts"
 cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$TMP_ROOT/lib/fm-operational-input.ts"
 ln -s "$PI_PACKAGE_DIR" "$TMP_ROOT/node_modules/@earendil-works/pi-coding-agent"


### PR DESCRIPTION
## Intent

Fix the captain-reported Pi Calm blank-space regression on the currently supported Pi version so every Calm-hidden transcript block contributes zero vertical height with no residual rows while preserving the collapsed skill header, final assistant response, Pi's native Working indicator, Calm-off rendering, explicit thinking expansion, persisted transcript/history, and restart behavior. The work must be grounded in a real isolated Pi TUI reproduction of /skill:ahoy with separately controlled thinking, skill, tool-call, and tool-result blocks, must distinguish trigger, masking condition, and symptom, and must preserve the measured native row-geometry and causal evidence in project documentation and the PR. Validation must exercise the actual Pi TUI rendered geometry, cover every implicated hidden block type, strictly review the post-fix viewport, run focused and relevant broader tests on supported Pi 0.81.1, keep tracked Markdown one sentence per physical line, use plain dashes, and keep changed shell scripts ShellCheck-clean. Push the complete validated change to a feature branch, open a PR that faithfully reports the 14-row failing geometry versus 2-row baseline, the thinking-only causal counterfactual and disconfirming tool/cache evidence, and continue until CI is green without merging.

## What Changed

- Remove collapsed thinking blocks from Pi’s assistant layout calculation while Calm is active, eliminating residual blank rows while preserving original reasoning for explicit expansion and history.
- Add Pi 0.81.1 TUI regression coverage for hidden thinking, tool calls, tool results, Calm toggling, reload completion, restart behavior, and current-viewport geometry.
- Document the reproduced 14-row gap, two-row baseline, causal counterfactuals, and updated Calm support boundaries.

## Risk Assessment

✅ Low: The runtime change remains narrowly scoped to Pi 0.81.1, and the geometry validation now measures the current viewport while explicitly observing reload start and completion before asserting layout.

## Testing

On supported Pi 0.81.1, the focused native TUI and interactive checks passed: Calm-hidden thinking, tool calls, and tool results contribute zero residual height, leaving the two-row baseline while preserving the collapsed skill header, final response, Working indicator, explicit expansion and re-collapse, Calm-off rendering, persisted history, reload, restart, export behavior, and Ctrl+O state; a raw viewport plus reviewer-visible HTML and PNG were captured, and testing left no worktree changes.

- Evidence: Rendered post-fix Pi Calm viewport showing the native two-row skill-to-response gap (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY8ECFNMH20KCRQVXEWN0FD4/pi-calm-post-fix-viewport.png</code>)
<details>
<summary>Evidence: Reviewer-visible rendering of the captured Pi viewport</summary>

```text
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <title>Pi Calm post-fix viewport</title>
  <style>
    :root { color-scheme: dark; }
    html, body { margin: 0; min-height: 100%; background: #151515; }
    body { display: grid; place-items: center; padding: 40px; box-sizing: border-box; }
    .terminal {
      width: 100%;
      min-height: 620px;
      box-sizing: border-box;
      padding: 34px 40px;
      border: 1px solid #3b3b3b;
      border-radius: 14px;
      background: #1e1e1e;
      box-shadow: 0 24px 70px rgba(0, 0, 0, .45);
      color: #e8e8e8;
      font: 18px/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
      white-space: pre-wrap;
    }
    .skill { color: #d6a8ff; }
    .answer { color: #f2f2f2; }
    .status { color: #a8a8a8; }
    .composer { color: #d4d4d4; }
  </style>
</head>
<body>
  <main class="terminal" aria-label="Pi 0.81.1 Calm post-fix terminal viewport"><span class="skill"> [skill] ahoy (ctrl+o to expand)</span>


<span class="answer"> CALM_GEOMETRY_FINAL

 - visible row one
 - visible row two</span>

<span class="status"> Thinking blocks: hidden</span>

────────────────────────────────────────────────────────────────────────────────────────────
<span class="composer"> &gt; </span>
────────────────────────────────────────────────────────────────────────────────────────────
<span class="status"> calm-geometry-e2e/deterministic                         thinking collapsed</span></main>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Raw 100x44 Pi TUI viewport and measured geometry</summary>

`skill_line=13 final_line=16 intervening_rows=2`

```text
 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Skills]
  ahoy, animejs, axi, contribute-catalog, create-readme, create-terminal-demo, css-animations, gsap,
hyperframes, hyperframes-cli, hyperframes-media, hyperframes-registry, illo, lavish, no-mistakes,
rovodev-integration, setup-app-update, stripe-best-practices, tailwind, three,
use-kunchenguid-design-system, website-to-hyperframes

[Extensions]
  fm-calm.ts, geometry-provider.ts


 [skill] ahoy (ctrl+o to expand)


 CALM_GEOMETRY_FINAL

 - visible row one
 - visible row two

 Thinking blocks: hidden

────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-calm-pi-extension.Ohzv4L/geometry-pro...
↑7.3k ↓50 R7.3k W7.3k CH59.5% 150.4%/4.1k (auto)                              deterministic • medium
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `tests/fm-calm-pi-extension.test.sh:1128` - The required criterion says validation must &#34;strictly review the post-fix viewport,&#34; but this snapshot uses `capture-pane -S -` to include the entire scrollback, while `assert_geometry_gap` selects the first matching skill and final rows with `grep -m1`. After reload or Calm toggles, the assertion can measure a stale pre-transition transcript and pass even when the current viewport regresses. Capture only the current viewport for geometry assertions, or otherwise isolate the newest rendered transcript before measuring it.

🔧 Fix: Validate Calm geometry against current viewport
1 warning still open:
- ⚠️ `tests/fm-calm-pi-extension.test.sh:1165` - The reload geometry check waits a fixed 300 ms without proving `/reload` started or completed. If tmux has not processed the command, the unchanged pre-reload viewport satisfies the assertion; if reload is still running, the transient overlay causes a false failure. Wait until the reload overlay appears, then disappears with the final transcript visible before measuring the viewport.

🔧 Fix: Synchronize Calm geometry checks with reload completion
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff `d89a1b69115525f9c3b1cef03615afabee186ff7..748bf2c657749494d471e67b5d714e0a705f05e1` and its documented trigger, masking condition, symptom, counterfactual, and supported-version boundary.</code>
- <code>Ran `tests/fm-calm-pi-extension.test.sh` against Pi 0.81.1, including the real 100x44 `/skill:ahoy` TUI geometry fixture and the broader 180x44 interactive lifecycle fixture.</code>
- <code>Reran `tests/fm-calm-pi-extension.test.sh` to preserve the live post-fix viewport before fixture cleanup.</code>
- <code>Measured the captured viewport with `awk`, confirming `[skill] ahoy` at row 13, the final response at row 16, and exactly two intervening native separator rows.</code>
- <code>Rendered `pi-calm-post-fix-viewport.html` with headless Chrome and visually inspected the resulting 1120x760 PNG for residual blank rows or layout overflow.</code>
- <code>Checked `git status --short` after testing to confirm the working tree remained unchanged.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
