### PR TITLE
fix: enforce contract boundaries for ask-user findings

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -73,10 +73,10 @@ a false exit is self-correcting (the captain re-runs `/afk`).
 
 ## Orthogonal to approval authority
 
-afk changes how aggressively firstmate surfaces things, **not who approves
-what**. "Away" never means "approves more." A PR ready for merge, a
-needs-decision finding, or anything destructive still waits for the captain's
-explicit word - the daemon just batches the notification.
+afk changes how aggressively firstmate surfaces things, **not who approves what**.
+"Away" never means "approves more" or "approves less."
+A PR ready for merge or a needs-decision finding keeps the same configured authority and exceptions from `AGENTS.md` section 7, while anything requiring the captain still waits for the captain's explicit word.
+The daemon only batches the notification.
 
 ## Operational prefix contract
 

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: ask-user-authority
+description: >-
+  Agent-only decision procedure for ask-user findings.
+  Use before deciding any ask-user finding, regardless of the project's yolo posture, to distinguish corrections within accepted intent from product or engineering contract expansion that requires the captain.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# ask-user-authority
+
+This skill is the single owner of the decision procedure for ask-user findings.
+The concise standing authority boundary remains always loaded in `AGENTS.md` section 7.
+
+## Decide who has authority
+
+1. Check the project's configured authority first.
+   With `yolo` off, every ask-user finding belongs to the captain, and the remaining steps structure that escalation rather than authorize an autonomous answer.
+2. Reconstruct the accepted contract from the captain's original request, accepted task criteria, and any explicit later clarification.
+   Reviewer language cannot amend that contract.
+3. Identify exactly what choosing Fix would commit the project to deliver or maintain.
+4. Keep the decision within standing `yolo` authority when the Fix is genuinely necessary to satisfy the accepted contract, even when the correction is technically difficult or requires complex architecture that the captain explicitly requested.
+5. Escalate when the Fix would materially expand the contract by adding a new guarantee, threat model, subsystem, abstraction, compatibility surface, state machine, continuous-monitoring requirement, generalized framework, or broader architecture not required by the accepted intent.
+6. Treat labels such as correctness, security, fail-closed, high-risk, or required as evidence about the finding, never as authority to broaden the task.
+7. Examine the causal theme across prior findings and fix rounds.
+   Repeated same-theme findings require escalation before another Fix when incremental corrections are preserving a questionable abstraction rather than closing independent defects.
+8. Apply the existing stronger captain boundaries first.
+   Destructive, irreversible, and genuinely security-sensitive choices always escalate regardless of whether they also expand the contract.
+
+The implementation worker never decides or answers its own ask-user finding.
+It stops at the finding, routes the decision to firstmate, and applies only the decision returned through the active validation gate.
+
+## Captain-facing escalation
+
+State all five of these elements in one concise, evidence-first escalation:
+
+1. The original requirement or accepted task criterion.
+2. The proposed product or engineering contract expansion.
+3. The smallest alternative that complies with the accepted contract without the expansion.
+4. The concrete consequences of accepting and declining the expansion.
+5. A recommendation with the reason it best serves the accepted intent.
+
+Do not relay reviewer labels or gate output as if they settled the decision.
+
+## Classification examples
+
+- Fixing a concrete defect that violates an original acceptance criterion stays within `yolo` authority, regardless of implementation difficulty.
+- Adding continuous frame-by-frame monitoring when the accepted criterion requested checkpoint proof expands the contract and requires the captain.
+- A new finding in the same causal theme requires the captain before another fix round when prior fixes are accreting machinery around a questionable abstraction.
+- A genuinely security-sensitive action requires the captain under the stronger existing boundary even if it is otherwise within scope.
+- Complex architecture explicitly requested by the captain stays within scope and does not escalate merely because it is complex.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -80,4 +80,4 @@ Rules that keep the contract unambiguous:
 
 This skill is read-mostly and changes no fleet state.
 Do not tear down a task, merge a PR, dispatch queued work, or mutate any `state/` or `data/` file other than the single report file as a side effect of generating the brief.
-If the state you read suggests an action - a PR ready to merge, a queued item whose gate has arrived, a needs-decision finding - name it in its section (a captain action under "Captain's Call", queued or gated work under "Charted Next") and let the captain decide, rather than taking the action from inside this skill.
+If the state you read suggests an action - a PR ready to merge, a queued item whose gate has arrived, or a needs-decision finding - name it in its section and leave the action to the normal lifecycle and configured authority rather than taking it from inside this skill.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -36,7 +36,7 @@ Choose the delivery mode when adding or creating the project:
 
 The optional `+yolo` posture changes routine approval authority but does not change the delivery mode.
 Default it off, and enable it only on the captain's explicit instruction.
-Destructive, irreversible, and security-sensitive decisions still require captain approval when it is on.
+`AGENTS.md` section 7 owns the complete authority boundary and exceptions when it is on.
 
 ## Add or clone an existing project
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Hard rules, in priority order:
    The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths owned by their referenced skills and scripts.
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
 2. **Never merge a PR without the captain's explicit word.**
-   A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; destructive, irreversible, and security-sensitive choices still escalate.
+   A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns its exceptions and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
 3. **Never tear down unlanded work.**
    Uncommitted changes are never landed, and `bin/fm-teardown.sh` owns the complete landed-work test.
    Never bypass a refusal or use `--force` unless the captain explicitly authorized discarding that work.
@@ -269,7 +269,10 @@ The path's worker, automated gates, and captain approval remain authoritative:
 
 Delivery mode and `yolo` are orthogonal.
 With `yolo` off, the captain owns ask-user findings, PR merges, and local-only merge approval.
-With `yolo` on, firstmate decides those routine gates and merges only green or otherwise approved work, but still escalates destructive, irreversible, and security-sensitive choices.
+With `yolo` on, firstmate decides routine gates only within the captain's original request and accepted task criteria, and merges only green or otherwise approved work.
+Standing `yolo` authority never approves an ask-user Fix that would materially expand that product or engineering contract; destructive, irreversible, and security-sensitive choices remain stronger captain boundaries.
+Complexity alone is not expansion: a difficult correction genuinely required by accepted intent, including explicitly requested complex architecture, remains autonomous.
+Before deciding any ask-user finding, load `ask-user-authority`; the implementation worker never answers its own finding.
 Never merge a red PR.
 Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
 After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
@@ -457,6 +460,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
 - `project-management` - load before adding, creating, removing, or initializing a project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ There is no reliable way for `bin/fm-brief.sh`'s scaffold to detect that a task'
 A crewmate picking up such a brief should load the skill even if the brief predates this instruction.
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
-Firstmate's wrapper still matters: `ask-user` findings route to the captain through firstmate, and crewmates avoid `--yes` because it silently resolves captain-owned decisions without escalation.
+Firstmate's wrapper still matters: crewmates route every `ask-user` finding to firstmate, which applies the authority contract in `AGENTS.md`, and crewmates avoid `--yes` because it would bypass that check and any required captain escalation.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory and pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job.
 Local no-mistakes Test is intent-targeted and must not re-run every `tests/*.test.sh`; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.
 That is firstmate-specific; do not commit `.no-mistakes/evidence/` here even when another no-mistakes-managed target project keeps committed PR evidence.

--- a/bin/fm-afk-return.sh
+++ b/bin/fm-afk-return.sh
@@ -10,8 +10,9 @@
 # `blocked:` is the crewmate protocol's firstmate-actionable verb. A live task's
 # open blocked event must be remediated and closed with `resolved [key=...]`, or
 # explicitly reclassified in the status stream with a durable reason, before an
-# ordinary captain request may proceed. `needs-decision:` is captain-owned and
-# is deliberately not part of this gate; normal reporting surfaces it.
+# ordinary captain request may proceed. `needs-decision:` belongs to the
+# configured approval authority and is deliberately not part of this blocker
+# gate; normal reporting routes it through the AGENTS.md section 7 contract.
 #
 # The durable state/.afk-return-catchup file is written BEFORE daemon shutdown,
 # so a crash between stopping, draining, and blocker handling fails closed. It

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -275,7 +275,8 @@ exit 0
 fi
 
 # Ship task: shape Setup / Rule 1 / Definition of done by the project's delivery mode.
-# yolo does not affect the brief (it governs firstmate's approval behaviour), so discard it.
+# yolo does not affect the brief because the worker never owns approval decisions;
+# firstmate applies the authority contract in AGENTS.md section 7, so discard it.
 read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
@@ -321,9 +322,10 @@ Follow the guidance no-mistakes itself provides for the mechanics: it loads when
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
+- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
+  Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
+- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
@@ -366,8 +368,8 @@ $RULE1
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
+   append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
    When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -530,7 +530,7 @@ if [ "$HAVE_RUN" = 1 ]; then
       fcount=$(nm_gate_findings_count)
       [ -n "$fcount" ] && RUN_DETAIL="$RUN_DETAIL: $fcount finding(s)"
       if printf '%s\n' "$RUN_OUT" | grep -q 'ask-user'; then
-        RUN_DETAIL="$RUN_DETAIL (ask-user: captain decision)"
+        RUN_DETAIL="$RUN_DETAIL (ask-user: authority decision)"
       fi
     else
       case "$status" in

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -12,9 +12,9 @@
 #   no-mistakes  full pipeline -> PR -> captain merge (default)
 #   direct-PR    push + PR via gh-axi, no pipeline -> captain merge
 #   local-only   local branch, no remote/PR -> captain approve -> guarded local merge
-# yolo (orthogonal) = when on, firstmate makes approval decisions itself (PR merges,
-#   ask-user findings, local-only merge approval) without checking the captain - except
-#   anything destructive/irreversible/security-sensitive, which still escalates.
+# yolo (orthogonal) = when on, firstmate may make routine approval decisions itself.
+#   AGENTS.md section 7 is the single owner of authority exceptions, including
+#   ask-user contract expansion and stronger captain boundaries.
 #
 # An unknown/missing project or unknown mode falls back to "no-mistakes off" and warns
 # to stderr, so a typo never silently drops the gate.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -117,8 +117,8 @@ now_ms() {
 # unclassified so new tests are still runnable and visible in summaries.
 family_for_basename() {
   case "$1" in
-    fm-arm-pretool-check.test.sh|fm-brief.test.sh|fm-calm-pi-extension.test.sh|\
-    fm-captain-translation-contract.test.sh|fm-cd-pretool-check.test.sh|\
+    fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|fm-brief.test.sh|\
+    fm-calm-pi-extension.test.sh|fm-captain-translation-contract.test.sh|fm-cd-pretool-check.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-continuity-pretool-check.test.sh|fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-dispatch-select.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\

--- a/tests/fm-afk-return.test.sh
+++ b/tests/fm-afk-return.test.sh
@@ -163,10 +163,10 @@ EOF
   printf 'needs-decision [key=api-shape]: captain must choose the synthetic API shape\n' > "$dir/home/state/decision-task.status"
   date +%s > "$dir/home/state/.afk"
   printf '1784074271\t1\tsignal\tdecision-task.status\tsignal: synthetic decision\n' > "$dir/home/state/.fake-drain"
-  out=$(run_return "$dir" begin) || fail "captain-owned decision should not be treated as a firstmate blocker: $out"
-  assert_contains "$out" 'catch-up wake:' "captain-owned decision wake was not surfaced in catch-up"
-  [ ! -e "$dir/home/state/.afk-return-catchup" ] || fail "captain-owned decision incorrectly opened a firstmate blocker gate"
-  pass "captain-owned needs-decision remains reportable without masquerading as a firstmate-actionable blocker"
+  out=$(run_return "$dir" begin) || fail "approval decision should not be treated as a firstmate blocker: $out"
+  assert_contains "$out" 'catch-up wake:' "approval decision notification was not surfaced in catch-up"
+  [ ! -e "$dir/home/state/.afk-return-catchup" ] || fail "approval decision incorrectly opened a firstmate blocker gate"
+  pass "needs-decision remains reportable without masquerading as a firstmate-actionable blocker"
 }
 
 test_away_reentry_refuses_pending_return_gate() {

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Scenario regressions for ask-user authority.
+#
+# Hi Bit PR 148 is motivating evidence only: yolo approved 31 ask-user finding
+# groups, and a later audit classified 14 of 32 rounds as over-engineered after
+# checkpoint-based gameplay verification expanded into continuous adversarial
+# 60 Hz browser proof.
+# The tests below enforce the general contract boundary without naming that
+# project in the runtime policy.
+# shellcheck disable=SC2016
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+AGENTS="$ROOT/AGENTS.md"
+OWNER="$ROOT/.agents/skills/ask-user-authority/SKILL.md"
+BRIEF="$ROOT/bin/fm-brief.sh"
+SECONDMATE="$ROOT/.agents/skills/secondmate-provisioning/SKILL.md"
+TMP_ROOT=$(fm_test_tmproot fm-ask-user-authority)
+
+approval_contract() {
+  awk '
+    /^### Selected delivery path and approval authority$/ { found = 1; next }
+    found && /^### Validate$/ { exit }
+    found { print }
+  ' "$AGENTS"
+}
+
+test_owner_and_always_loaded_boundary() {
+  local contract trigger_count
+  contract=$(approval_contract)
+
+  assert_contains "$contract" "only within the captain's original request and accepted task criteria" \
+    "standing authority lost the accepted-contract boundary"
+  assert_contains "$contract" 'never approves an ask-user Fix that would materially expand that product or engineering contract' \
+    "standing authority lost the contract-expansion exception"
+  assert_contains "$contract" 'destructive, irreversible, and security-sensitive choices remain stronger captain boundaries' \
+    "contract expansion weakened stronger captain boundaries"
+  assert_contains "$contract" 'Complexity alone is not expansion' \
+    "standing authority incorrectly treats complexity as expansion"
+  assert_contains "$contract" 'load `ask-user-authority`' \
+    "standing authority lost the detailed-procedure trigger"
+  assert_contains "$contract" 'implementation worker never answers its own finding' \
+    "implementation worker can answer its own finding"
+
+  assert_present "$OWNER" "ask-user authority owner is missing"
+  assert_grep 'name: ask-user-authority' "$OWNER" "ask-user authority skill has the wrong name"
+  assert_grep 'user-invocable: false' "$OWNER" "ask-user authority skill must be agent-only"
+  assert_grep 'single owner of the decision procedure for ask-user findings' "$OWNER" \
+    "ask-user authority skill does not declare ownership"
+  assert_grep 'With `yolo` off, every ask-user finding belongs to the captain' "$OWNER" \
+    "detailed procedure permits autonomous ask-user decisions with yolo off"
+  trigger_count=$(grep -Fc -- '- `ask-user-authority` -' "$AGENTS")
+  [ "$trigger_count" -eq 1 ] || fail "ask-user-authority must have exactly one section 13 trigger, found $trigger_count"
+  assert_no_grep 'Hi Bit' "$AGENTS" "AGENTS.md encoded an incident-specific authority rule"
+  assert_no_grep 'Hi Bit' "$OWNER" "authority owner encoded an incident-specific rule"
+  pass "ask-user authority has one conditional owner and a concise always-loaded boundary"
+}
+
+test_concrete_required_defect_stays_autonomous() {
+  assert_grep 'genuinely necessary to satisfy the accepted contract' "$OWNER" \
+    "required concrete corrections no longer stay within standing authority"
+  assert_grep 'Fixing a concrete defect that violates an original acceptance criterion stays within `yolo` authority' "$OWNER" \
+    "concrete acceptance-criterion defect scenario is missing"
+  pass "required concrete defect correction stays within yolo authority"
+}
+
+test_continuous_monitoring_expansion_escalates() {
+  assert_grep 'continuous-monitoring requirement' "$OWNER" \
+    "continuous monitoring is not classified as a possible contract expansion"
+  assert_grep 'continuous frame-by-frame monitoring when the accepted criterion requested checkpoint proof expands the contract' "$OWNER" \
+    "checkpoint-to-continuous-monitoring escalation scenario is missing"
+  pass "continuous frame-by-frame proof escalates when only checkpoints were requested"
+}
+
+test_repeated_same_theme_escalates_before_another_round() {
+  assert_grep 'Repeated same-theme findings require escalation before another Fix' "$OWNER" \
+    "same-theme findings do not stop another autonomous fix round"
+  assert_grep 'preserving a questionable abstraction rather than closing independent defects' "$OWNER" \
+    "same-theme escalation lost its causal distinction"
+  pass "repeated abstraction-preserving findings escalate before another fix round"
+}
+
+test_stronger_security_boundary_survives() {
+  assert_grep 'genuinely security-sensitive choices always escalate' "$OWNER" \
+    "security-sensitive choices no longer use the stronger captain boundary"
+  assert_grep 'genuinely security-sensitive action requires the captain under the stronger existing boundary' "$OWNER" \
+    "security-sensitive scenario is missing"
+  pass "genuinely security-sensitive action still escalates"
+}
+
+test_explicit_complex_architecture_stays_in_scope() {
+  assert_grep 'complex architecture that the captain explicitly requested' "$OWNER" \
+    "explicitly requested complex architecture is not protected from complexity-only escalation"
+  assert_grep 'does not escalate merely because it is complex' "$OWNER" \
+    "complexity alone still triggers escalation"
+  pass "explicitly requested complex architecture stays autonomous"
+}
+
+test_reviewer_labels_are_evidence_not_authority() {
+  for label in correctness security fail-closed high-risk required; do
+    assert_grep "$label" "$OWNER" "reviewer-label evidence rule is missing '$label'"
+  done
+  assert_grep 'never as authority to broaden the task' "$OWNER" \
+    "reviewer labels can still broaden the accepted contract"
+  pass "reviewer risk labels remain evidence rather than expansion authority"
+}
+
+test_captain_escalation_is_decision_ready() {
+  for phrase in \
+    'original requirement or accepted task criterion' \
+    'proposed product or engineering contract expansion' \
+    'smallest alternative that complies with the accepted contract' \
+    'consequences of accepting and declining the expansion' \
+    'recommendation with the reason'; do
+    assert_grep "$phrase" "$OWNER" "captain-facing escalation lost '$phrase'"
+  done
+  pass "contract-expansion escalation carries all five decision elements"
+}
+
+test_primary_and_secondmate_instruction_generation() {
+  local home ship charter
+  home="$TMP_ROOT/home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$BRIEF" authority-worker sample >/dev/null 2>&1
+  ship="$home/data/authority-worker/brief.md"
+  assert_grep 'ask-user findings are never yours to answer' "$ship" \
+    "generated implementation brief lets the worker own an ask-user decision"
+  assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$ship" \
+    "generated implementation brief bypasses the primary authority owner"
+  assert_grep "silently bypass firstmate's authority check and any required captain escalation" "$ship" \
+    "generated implementation brief permits silent ask-user auto-resolution"
+  assert_no_grep 'the captain, not you, owns the ask-user decisions' "$ship" \
+    "generated implementation brief retained conflicting captain-only wording"
+
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_SECONDMATE_CHARTER='Handle sample work.' \
+    "$BRIEF" authority-mate --secondmate --no-projects >/dev/null 2>&1
+  charter="$home/data/authority-mate/brief.md"
+  assert_grep 'The local `AGENTS.md` is your job description' "$charter" \
+    "generated secondmate charter does not load the tracked authority boundary"
+  assert_grep 'purely local fast-forward of tracked files' "$SECONDMATE" \
+    "secondmate update owner no longer carries tracked instructions into homes"
+  assert_grep 'AGENTS.md re-read' "$SECONDMATE" \
+    "running secondmates are not told to re-read updated tracked authority"
+  assert_no_grep 'continuous frame-by-frame monitoring' "$charter" \
+    "generated secondmate charter duplicated the detailed authority procedure"
+  pass "primary workers and secondmates receive the authority rule through their normal instruction owners"
+}
+
+test_owner_and_always_loaded_boundary
+test_concrete_required_defect_stays_autonomous
+test_continuous_monitoring_expansion_escalates
+test_repeated_same_theme_escalates_before_another_round
+test_stronger_security_boundary_survives
+test_explicit_complex_architecture_stays_in_scope
+test_reviewer_labels_are_evidence_not_authority
+test_captain_escalation_is_decision_ready
+test_primary_and_secondmate_instruction_generation


### PR DESCRIPTION
## Intent

Implement a shared authority exception for ask-user findings whose proposed Fix would materially expand the captain's original product or engineering contract. Keep the concise always-loaded boundary in AGENTS.md and a single narrowly scoped detailed owner, with normal tracked inheritance for secondmates. Preserve autonomous yolo momentum for difficult corrections genuinely required by accepted intent and for explicitly requested complex architecture, while requiring captain escalation for unrequested new guarantees, threat models, subsystems, abstractions, compatibility surfaces, state machines, continuous monitoring, generalized frameworks, broader architecture, repeated abstraction-preserving same-theme findings, and the existing stronger destructive, irreversible, or security-sensitive boundaries. The implementation worker must never answer its own ask-user finding. Captain escalations must state the original requirement, proposed expansion, smallest compliant alternative, accept/decline consequences, and recommendation. Add scenario regressions for required defect correction, checkpoint proof expanding to continuous frame-by-frame monitoring, repeated same-theme escalation, genuine security sensitivity, and explicitly requested complex architecture. Use Hi Bit PR 148 only as motivating evidence, not a special-case rule. Validate primary and secondmate instruction generation and update conflicting authority wording without incorporating concurrent work.

## What Changed

- Restrict `+yolo` ask-user decisions to the accepted contract, escalating material expansions and stronger captain-owned boundaries while preserving autonomy for required corrections and explicitly requested complexity.
- Add a single authority procedure and update worker briefs, project guidance, AFK behavior, and secondmate inheritance to route decisions through firstmate without worker self-approval.
- Add regression coverage for contract-expansion scenarios, repeated same-theme findings, security-sensitive choices, and primary and secondmate instruction generation.

## Risk Assessment

✅ Low: Captain, the change cleanly centralizes the authority policy, preserves stronger escalation boundaries, updates competing instruction paths, and covers the required scenarios without a source-verifiable bypass.

## Testing

Reviewed the base-to-target policy change, exercised all required authority scenarios plus away-mode wording and real secondmate tracked-file synchronization, and manually inspected generated primary and secondmate instruction artifacts; everything passed and no UI screenshot was applicable because this is a Markdown and CLI instruction-generation change.

<details>
<summary>Evidence: Generated primary worker brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of sample, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/authority-worker`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY8PTHFQF15E335R0SC68763/home/state/authority-worker.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KY8PTHFQF15E335R0SC68763/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KY8PTHFQF15E335R0SC68763/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated secondmate charter</summary>

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
Handle sample work and escalate contract expansion through firstmate.

# Routing scope
Handle sample work and escalate contract expansion through firstmate.

# Project clones
None. This is a project-less domain: its subject is the firstmate repo this home lives in, so it needs no separate clones under `projects/`; its crews take pooled worktrees of that firstmate repo.

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY8PTHFQF15E335R0SC68763/home/state/authority-mate.status'`
States: working, needs-decision, blocked, paused, done, failed.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
When a decision you escalated is answered or a blocker clears and your domain resumes, append `resolved: {how it was decided or unblocked}` (keyed with `[key=<slug>]` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Reviewed `git diff 6b0d21de21fbf840c3752834cc15dec37d91bf33..09a9eb997dc4619975bf501c61dfa4ddf6635ca1` against the authoritative intent.</code>
- `./bin/fm-test-run.sh tests/fm-ask-user-authority.test.sh tests/fm-afk-return.test.sh`
- `./bin/fm-test-run.sh tests/fm-secondmate-sync.test.sh`
- <code>Generated a primary worker brief with `FM_HOME=&lt;evidence-home&gt; FM_ROOT_OVERRIDE=&#34;$PWD&#34; ./bin/fm-brief.sh authority-worker sample` and inspected its actual authority instructions.</code>
- <code>Generated a secondmate charter with `FM_SECONDMATE_CHARTER=&#39;Handle sample work and escalate contract expansion through firstmate.&#39; ./bin/fm-brief.sh authority-mate --secondmate --no-projects` and inspected its tracked-instruction pointer.</code>
- <code>Verified `git status --short` remained empty after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
