### PR TITLE
docs: prefer direct paths for operational work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,8 @@ Route by the nature of the work against each registered secondmate scope, not by
 Keep `local-only` work in the main home.
 Send in-scope work to the fitting secondmate unless it is blocked or the captain explicitly redirects it; do not read the secondmate's chat because marked routed replies return through its status or referenced document.
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
+For one-off or infrequent operational work, start with the simplest direct end-to-end path.
+Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.
 
 Before commissioning an investigation, consult existing reports and established evidence.
 Classify the deliverable:


### PR DESCRIPTION
## Intent

Add exactly two captain-approved sentences to AGENTS.md under section 7 Intake and authority, immediately after secondmate routing and before investigation commissioning. The sentences require one-off or infrequent operational work to begin with the simplest direct end-to-end path and prohibit wrappers, control planes, policy layers, custom verifiers, or automation unless a concrete blocker or repeated need justifies them. Preserve the exact wording, punctuation, plain dashes, and one-sentence-per-physical-line style. The final tracked diff must remain exactly those two added sentences in AGENTS.md and no other file; do not add mechanisms, enforcement, tests, skills, documentation, policy exceptions, abstractions, adjacent cleanup, or alter scope.

## What Changed

- Updated agent intake guidance to start one-off or infrequent operational work with the simplest direct end-to-end path.
- Discouraged additional wrappers, control planes, policy layers, verifiers, and automation unless justified by a concrete blocker or repeated need.

## Risk Assessment

✅ Low: The change is limited to exactly the two required sentences in AGENTS.md, with the specified wording, placement, punctuation, and line style, and introduces no material source risk.

## Testing

Inspected the baseline-to-target diff and commit scope, found no existing focused test for this prose contract, corrected an initially incomplete context fixture, then passed an exact automated content-and-placement check and captured the resulting policy excerpt. The worktree remained clean. No screenshot was appropriate because AGENTS.md is a plaintext agent-policy surface, so the exact textual excerpt is the direct end-user evidence.

<details>
<summary>Evidence: AGENTS.md direct-path validation</summary>

`Exact diff-scope, wording, physical-line, dash-style, and placement validation with the reviewer-visible AGENTS.md excerpt.`

```text
PASS: target commit adds exactly 2 lines and removes 0 lines, all in AGENTS.md.
PASS: both captain-approved sentences match exactly, occupy one physical line each, and contain plain dashes only.
PASS: placement is immediately after secondmate routing and before investigation commissioning.

Reviewer-visible target excerpt:

If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
For one-off or infrequent operational work, start with the simplest direct end-to-end path.
Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.

Before commissioning an investigation, consult existing reports and established evidence.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-status --stat --unified=12 ec0987141aea533684c6a6d8b74d692f8326994e 09d4e08d940c5d8851297ae61197dbba34e1af20 -- AGENTS.md`
- `rg -n "simplest direct end-to-end path|wrappers, control planes|Intake and authority|Before commissioning an investigation" AGENTS.md tests .agents`
- <code>Focused `node -e` assertion comparing the exact two added lines, zero removals, one-sentence-per-line layout, plain-dash requirement, and adjacency to routing and investigation text</code>
- `git diff-tree --no-commit-id --name-status -r 09d4e08d940c5d8851297ae61197dbba34e1af20`
- <code>`git status --short` after evidence generation</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
