### PR TITLE
feat(bin): add secure Gitea forge lifecycle support

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -44,16 +44,18 @@ Confirm the source URL, local project name, delivery mode, and autonomy posture.
 Clone into `projects/<name>` and add the registry entry only after the destination is known to be unused.
 A `no-mistakes` project must have an `origin` remote and must complete the initialization procedure below.
 A `direct-PR` project needs an `origin` remote but skips no-mistakes initialization.
+For a Gitea origin, validate the private host/account/token configuration through `bin/fm-forge.sh provider <clone>` before registration; `bin/fm-forge.sh --help` and `docs/configuration.md` own the exact files and custody rules.
 A `local-only` project may have no remote and skips no-mistakes initialization.
 
 ## Create a project
 
-Creating a GitHub repository is outward-facing.
-Before making that remote change, propose the repository name, owner or organization, visibility, and delivery mode, defaulting visibility to private and delivery mode to `no-mistakes`, then obtain the captain's explicit consent for those values.
-Use `gh-axi` for the approved GitHub operation and consult its current help rather than relying on remembered flags.
+Creating any remote repository is outward-facing.
+Before making that remote change, propose the forge, repository name, owner or organization, visibility, and delivery mode, defaulting visibility to private and delivery mode to `no-mistakes`, then obtain the captain's explicit consent for those values.
+Use `gh-axi` for an approved GitHub operation and consult its current help rather than relying on remembered flags.
+FirstMate does not yet expose Gitea repository creation; for Gitea, require the approved repository to exist and add it through the existing-project path instead of improvising a raw authenticated API call.
 After remote creation succeeds, clone it locally, add the registry entry, and initialize it according to its delivery mode.
 
-For a purely `local-only` project, create a local Git repository under its unused `projects/<name>` path, add the registry entry, and make no GitHub call.
+For a purely `local-only` project, create a local Git repository under its unused `projects/<name>` path, add the registry entry, and make no forge call.
 The captain's request to create that local project authorizes this local initialization, but it does not authorize an unmentioned remote repository.
 
 ## Initialize

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub and Gitea pull requests and GitLab merge requests; docs/gitea-forge.md and docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
   <id>.herdr-presentation  quarantinable attempt journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional disposable single-task presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
   <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
@@ -148,7 +148,7 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
 
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
-Use `gh-axi` for GitHub, `chrome-devtools-axi` for browser work, and `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
+Use `gh-axi` for GitHub, `bin/fm-forge.sh` for configured Gitea PR operations, `chrome-devtools-axi` for browser work, and `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
 A silent bootstrap section needs no action; for any printed actionable diagnostic line, load `bootstrap-diagnostics` and follow its owner procedure.
 `BOOTSTRAP_INFO:` lines are completed no-action facts and do not require loading a skill.
 `secondmate-provisioning` owns startup secondmate sync, liveness, and inherited local-material convergence.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/cmux-backend.md](docs/cmux-backend.md) - setup guide for the experimental cmux backend, plus its verification notes and known gaps.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - Codex App backend boundary, evidence, and rollout contract.
 - [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - how the merge watch follows a GitLab merge request on any instance, and the evidence behind it.
+- [docs/gitea-forge.md](docs/gitea-forge.md) - the mocked verification boundary for Gitea pull-request lifecycle support and the separately authorized live-verification path.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's structural "no turn ends blind" backstop: verified per-harness hook mechanisms, scoping, loop safety, and fail-open tradeoffs.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -30,7 +30,7 @@
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):
 #   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge (default)
-#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
+#   direct-PR    implement -> push + open PR via the registered forge (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
@@ -244,7 +244,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 # Rules
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+3. Use gh-axi for GitHub operations, \`$FM_ROOT/bin/fm-forge.sh\` for configured Gitea PR operations, and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -280,16 +280,26 @@ fi
 read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+FORGE_PROVIDER=unknown
+if [ -d "$PROJECTS/$REPO" ]; then
+  FORGE_PROVIDER=$("$FM_ROOT/bin/fm-forge.sh" provider "$PROJECTS/$REPO" 2>/dev/null || echo unknown)
+fi
 
 case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    if [ "$FORGE_PROVIDER" = gitea ]; then
+      DIRECT_PR_OPEN="open the PR through \`$FM_ROOT/bin/fm-forge.sh pr-create\` after consulting its current \`--help\`; do not use GitHub-only PR tooling"
+    else
+      DIRECT_PR_OPEN="open the PR with \`gh-axi\` for GitHub, or the registered forge helper named in \`$FM_ROOT/bin/fm-forge.sh --help\` for another recognized provider"
+    fi
     DOD=$(cat <<EOF
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+When it is implemented and committed, push your branch and $DIRECT_PR_OPEN, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
 )
@@ -353,7 +363,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 # Rules
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+3. Use gh-axi for GitHub operations, \`$FM_ROOT/bin/fm-forge.sh\` for configured Gitea PR operations, and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/bin/fm-forge-lib.sh
+++ b/bin/fm-forge-lib.sh
@@ -328,13 +328,13 @@ fm_forge_gitea_request() {
   if [ "$rc" -eq 0 ]; then
     if [ -n "$body" ]; then
       code=$(printf 'header = "Authorization: token %s"\n' "$FM_GITEA_TOKEN" \
-        | "$curl_bin" --config - --silent --max-time 30 --max-filesize 1048576 \
+        | "$curl_bin" -q --config - --silent --max-time 30 --max-filesize 1048576 \
           --proto '=http,https' --output "$response" --write-out '%{http_code}' \
           --request "$method" --header 'Content-Type: application/json' \
           --data-binary "@$body_file" --url "$FM_GITEA_BASE_URL/api/v1$endpoint" 2>/dev/null) || rc=$?
     else
       code=$(printf 'header = "Authorization: token %s"\n' "$FM_GITEA_TOKEN" \
-        | "$curl_bin" --config - --silent --max-time 30 --max-filesize 1048576 \
+        | "$curl_bin" -q --config - --silent --max-time 30 --max-filesize 1048576 \
           --proto '=http,https' --output "$response" --write-out '%{http_code}' \
           --request "$method" --url "$FM_GITEA_BASE_URL/api/v1$endpoint" 2>/dev/null) || rc=$?
     fi
@@ -466,8 +466,10 @@ fm_forge_gitea_pr_create() {
   local repo_dir=$1 head=$2 base=$3 title=$4 body=$5 payload url path
   fm_forge_repo_from_dir "$repo_dir" || return 1
   [ "$FM_FORGE_REPO_PROVIDER" = gitea ] || { fm_forge_fail "repository is not configured as Gitea"; return 1; }
-  fm_forge_git_branch_valid "$head" && fm_forge_git_branch_valid "$base" \
-    || { fm_forge_fail "Gitea pull request branches are invalid"; return 1; }
+  if ! fm_forge_git_branch_valid "$head" || ! fm_forge_git_branch_valid "$base"; then
+    fm_forge_fail "Gitea pull request branches are invalid"
+    return 1
+  fi
   [ -n "$title" ] && [ "${#title}" -le 4096 ] && [ "${#body}" -le 262144 ] \
     || { fm_forge_fail "Gitea pull request text is invalid"; return 1; }
   path=$FM_FORGE_REPO_PATH

--- a/bin/fm-forge-lib.sh
+++ b/bin/fm-forge-lib.sh
@@ -305,6 +305,7 @@ fm_forge_gitea_identity_bind() {
 # discarded so an untrusted response cannot reflect the credential into logs.
 fm_forge_gitea_request() {
   local method=$1 endpoint=$2 body=${3-} expected=$4 curl_bin response body_file code rc=0 size
+  local response_read_rc=0 token_reflected=false
   local tmp_dir
   FM_GITEA_RESPONSE=
   command -v jq >/dev/null 2>&1 \
@@ -336,10 +337,23 @@ fm_forge_gitea_request() {
           --request "$method" --url "$FM_GITEA_BASE_URL/api/v1$endpoint" 2>/dev/null) || rc=$?
     fi
   fi
+  size=$(wc -c < "$response" 2>/dev/null) || size=1048577
+  if [ "$size" -le 1048576 ]; then
+    FM_GITEA_RESPONSE=$(cat "$response") || response_read_rc=1
+    case "$FM_GITEA_RESPONSE" in
+      *"$FM_GITEA_TOKEN"*) token_reflected=true ;;
+    esac
+  fi
   FM_GITEA_TOKEN=
   if [ "$rc" -ne 0 ]; then
     rm -rf "$tmp_dir"
     fm_forge_fail "Gitea request failed"
+    return 1
+  fi
+  if [ "$token_reflected" = true ]; then
+    FM_GITEA_RESPONSE=
+    rm -rf "$tmp_dir"
+    fm_forge_fail "Gitea response contained private authentication data"
     return 1
   fi
   case "$code" in
@@ -349,10 +363,10 @@ fm_forge_gitea_request() {
     *" $code "*) ;;
     *) rm -rf "$tmp_dir"; fm_forge_fail "Gitea returned an unsupported HTTP response"; return 1 ;;
   esac
-  size=$(wc -c < "$response" 2>/dev/null) || size=1048577
   [ "$size" -le 1048576 ] \
     || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea response exceeded the safety limit"; return 1; }
-  FM_GITEA_RESPONSE=$(cat "$response") || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea response could not be read"; return 1; }
+  [ "$response_read_rc" -eq 0 ] \
+    || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea response could not be read"; return 1; }
   rm -rf "$tmp_dir"
 }
 

--- a/bin/fm-forge-lib.sh
+++ b/bin/fm-forge-lib.sh
@@ -298,6 +298,8 @@ fm_forge_gitea_identity_bind() {
   [ "$FM_PR_URL" = "$FM_GITEA_BASE_URL/$FM_PR_PATH/pulls/$FM_PR_NUMBER" ] \
     && [ "$FM_PR_HOST" = "$FM_GITEA_AUTHORITY" ] \
     || { FM_GITEA_TOKEN=; fm_forge_fail "Gitea pull request host does not match private configuration"; return 1; }
+  fm_forge_gitea_account_bind || return 1
+  fm_forge_gitea_config_load || return 1
 }
 
 # Authenticated Gitea request. The token is delivered through curl's stdin
@@ -368,6 +370,21 @@ fm_forge_gitea_request() {
   [ "$response_read_rc" -eq 0 ] \
     || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea response could not be read"; return 1; }
   rm -rf "$tmp_dir"
+}
+
+fm_forge_gitea_account_bind() {
+  local configured_account=$FM_GITEA_ACCOUNT
+  fm_forge_gitea_request GET '/user' '' '200' || return 1
+  jq -e --arg account "$configured_account" '
+    type == "object" and
+    (.login | type == "string") and
+    .login == $account
+  ' >/dev/null 2>&1 <<< "$FM_GITEA_RESPONSE" \
+    || { fm_forge_fail "Gitea authenticated account does not match private configuration"; return 1; }
+}
+
+fm_forge_git_branch_valid() {
+  [ "$#" -eq 1 ] && git check-ref-format --branch "$1" >/dev/null 2>&1
 }
 
 fm_forge_gitea_pr_json_valid() {
@@ -449,13 +466,15 @@ fm_forge_gitea_pr_create() {
   local repo_dir=$1 head=$2 base=$3 title=$4 body=$5 payload url path
   fm_forge_repo_from_dir "$repo_dir" || return 1
   [ "$FM_FORGE_REPO_PROVIDER" = gitea ] || { fm_forge_fail "repository is not configured as Gitea"; return 1; }
-  [[ "$head" =~ ^[A-Za-z0-9._/-]{1,255}$ ]] && [[ "$base" =~ ^[A-Za-z0-9._/-]{1,255}$ ]] \
+  fm_forge_git_branch_valid "$head" && fm_forge_git_branch_valid "$base" \
     || { fm_forge_fail "Gitea pull request branches are invalid"; return 1; }
   [ -n "$title" ] && [ "${#title}" -le 4096 ] && [ "${#body}" -le 262144 ] \
     || { fm_forge_fail "Gitea pull request text is invalid"; return 1; }
   path=$FM_FORGE_REPO_PATH
   payload=$(jq -cn --arg head "$head" --arg base "$base" --arg title "$title" --arg body "$body" \
     '{head:$head,base:$base,title:$title,body:$body}') || { fm_forge_fail "Gitea request body could not be encoded"; return 1; }
+  fm_forge_gitea_config_load || return 1
+  fm_forge_gitea_account_bind || return 1
   fm_forge_gitea_config_load || return 1
   fm_forge_gitea_request POST "/repos/$path/pulls" "$payload" '201' || return 1
   url=$(jq -er '.html_url | strings' <<< "$FM_GITEA_RESPONSE" 2>/dev/null) \

--- a/bin/fm-forge-lib.sh
+++ b/bin/fm-forge-lib.sh
@@ -487,19 +487,67 @@ fm_forge_gitea_pr_create() {
   printf '%s\n' "$url"
 }
 
+fm_forge_gitea_collection() {
+  local endpoint=$1 kind=$2 page=1 page_size=50 max_pages=20 count
+  local tmp_dir pages_file
+  umask 077
+  tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-gitea-pages.XXXXXX") \
+    || { fm_forge_fail "Gitea pagination workspace could not be created"; return 1; }
+  pages_file="$tmp_dir/pages"
+  : > "$pages_file"
+  while [ "$page" -le "$max_pages" ]; do
+    if [ "$page" -gt 1 ]; then
+      fm_forge_gitea_config_load \
+        || { rm -rf "$tmp_dir"; return 1; }
+    fi
+    fm_forge_gitea_request GET "$endpoint?page=$page&limit=$page_size" '' '200' \
+      || { rm -rf "$tmp_dir"; return 1; }
+    case "$kind" in
+      reviews)
+        jq -ce '
+          type == "array" and all(.[];
+            (.id | type == "number") and (.id >= 1) and
+            (.state == "APPROVED" or .state == "PENDING" or .state == "COMMENT" or
+             .state == "REQUEST_CHANGES" or .state == "REQUEST_REVIEW") and
+            (.user.login | type == "string" and length > 0)
+          )
+        ' >/dev/null 2>&1 <<< "$FM_GITEA_RESPONSE" \
+          || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea returned malformed review data"; return 1; }
+        ;;
+      checks)
+        jq -ce '
+          type == "array" and all(.[];
+            (.id | type == "number") and
+            (.status == "success" or .status == "error" or .status == "failure" or
+             .status == "pending" or .status == "warning") and
+            (.context | type == "string")
+          )
+        ' >/dev/null 2>&1 <<< "$FM_GITEA_RESPONSE" \
+          || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea returned malformed check data"; return 1; }
+        ;;
+      *) rm -rf "$tmp_dir"; fm_forge_fail "Gitea collection type is unsupported"; return 1 ;;
+    esac
+    count=$(jq 'length' <<< "$FM_GITEA_RESPONSE") \
+      || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea collection could not be counted"; return 1; }
+    printf '%s\n' "$FM_GITEA_RESPONSE" >> "$pages_file" \
+      || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea collection could not be recorded"; return 1; }
+    if [ "$count" -lt "$page_size" ]; then
+      FM_GITEA_RESPONSE=$(jq -cs 'add' "$pages_file") \
+        || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea collection could not be aggregated"; return 1; }
+      rm -rf "$tmp_dir"
+      return 0
+    fi
+    page=$((page + 1))
+  done
+  rm -rf "$tmp_dir"
+  fm_forge_fail "Gitea collection exceeded the pagination safety limit"
+  return 1
+}
+
 fm_forge_gitea_pr_reviews() {
   local url=$1
   fm_forge_gitea_identity_bind "$url" || return 1
-  fm_forge_gitea_request GET "/repos/$FM_PR_PATH/pulls/$FM_PR_NUMBER/reviews" '' '200' || return 1
-  jq -ce '
-    type == "array" and all(.[];
-      (.id | type == "number") and (.id >= 1) and
-      (.state == "APPROVED" or .state == "PENDING" or .state == "COMMENT" or
-       .state == "REQUEST_CHANGES" or .state == "REQUEST_REVIEW") and
-      (.user.login | type == "string" and length > 0)
-    )
-  ' >/dev/null 2>&1 <<< "$FM_GITEA_RESPONSE" \
-    || { fm_forge_fail "Gitea returned malformed review data"; return 1; }
+  fm_forge_gitea_collection "/repos/$FM_PR_PATH/pulls/$FM_PR_NUMBER/reviews" reviews || return 1
   jq -c '[.[] | {id,state,user:.user.login,commit_id}]' <<< "$FM_GITEA_RESPONSE"
 }
 
@@ -509,16 +557,7 @@ fm_forge_gitea_pr_checks() {
   head=$(fm_forge_pr_head "$url") || return 1
   # fm_forge_pr_head deliberately clears the token after its request.
   fm_forge_gitea_config_load || return 1
-  fm_forge_gitea_request GET "/repos/$FM_PR_PATH/commits/$head/statuses" '' '200' || return 1
-  jq -ce '
-    type == "array" and all(.[];
-      (.id | type == "number") and
-      (.status == "success" or .status == "error" or .status == "failure" or
-       .status == "pending" or .status == "warning") and
-      (.context | type == "string")
-    )
-  ' >/dev/null 2>&1 <<< "$FM_GITEA_RESPONSE" \
-    || { fm_forge_fail "Gitea returned malformed check data"; return 1; }
+  fm_forge_gitea_collection "/repos/$FM_PR_PATH/commits/$head/statuses" checks || return 1
   jq -c '[.[] | {id,status,context,target_url,description}]' <<< "$FM_GITEA_RESPONSE"
 }
 

--- a/bin/fm-forge-lib.sh
+++ b/bin/fm-forge-lib.sh
@@ -488,7 +488,7 @@ fm_forge_gitea_pr_create() {
 }
 
 fm_forge_gitea_collection() {
-  local endpoint=$1 kind=$2 page=1 page_size=50 max_pages=20 count
+  local endpoint=$1 kind=$2 page=1 page_size=50 max_pages=20 max_records=1000 count total_count=0
   local tmp_dir pages_file
   umask 077
   tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-gitea-pages.XXXXXX") \
@@ -529,14 +529,20 @@ fm_forge_gitea_collection() {
     esac
     count=$(jq 'length' <<< "$FM_GITEA_RESPONSE") \
       || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea collection could not be counted"; return 1; }
-    printf '%s\n' "$FM_GITEA_RESPONSE" >> "$pages_file" \
-      || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea collection could not be recorded"; return 1; }
-    if [ "$count" -lt "$page_size" ]; then
-      FM_GITEA_RESPONSE=$(jq -cs 'add' "$pages_file") \
+    if [ "$count" -eq 0 ]; then
+      FM_GITEA_RESPONSE=$(jq -cs 'add // []' "$pages_file") \
         || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea collection could not be aggregated"; return 1; }
       rm -rf "$tmp_dir"
       return 0
     fi
+    total_count=$((total_count + count))
+    if [ "$total_count" -gt "$max_records" ]; then
+      rm -rf "$tmp_dir"
+      fm_forge_fail "Gitea collection exceeded the record safety limit"
+      return 1
+    fi
+    printf '%s\n' "$FM_GITEA_RESPONSE" >> "$pages_file" \
+      || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea collection could not be recorded"; return 1; }
     page=$((page + 1))
   done
   rm -rf "$tmp_dir"

--- a/bin/fm-forge-lib.sh
+++ b/bin/fm-forge-lib.sh
@@ -1,0 +1,512 @@
+#!/usr/bin/env bash
+# Common forge operations for Firstmate.
+#
+# bin/fm-pr-lib.sh owns canonical pull-request identity and provenance.
+# This file owns provider dispatch plus all Gitea configuration, authentication,
+# HTTP, and response-validation mechanics. Callers must never implement their
+# own Gitea request or token handling.
+
+FM_FORGE_ERROR=
+FM_FORGE_REPO_PROVIDER=
+FM_FORGE_REPO_URL=
+FM_FORGE_REPO_HOST=
+FM_FORGE_REPO_PATH=
+FM_FORGE_REPO_OWNER=
+FM_FORGE_REPO_NAME=
+FM_GITEA_BASE_URL=
+FM_GITEA_AUTHORITY=
+FM_GITEA_WEB_HOST=
+FM_GITEA_ACCOUNT=
+FM_GITEA_SSH_PORT=
+FM_GITEA_SSH_ALIASES=
+FM_GITEA_TOKEN=
+# A caller may have exported a same-named ambient variable. Strip that export
+# attribute before any private token is loaded so curl cannot inherit it.
+export -n FM_GITEA_TOKEN 2>/dev/null || true
+FM_GITEA_RESPONSE=
+
+fm_forge_fail() {
+  # shellcheck disable=SC2034  # Public error result consumed by sourcing callers.
+  FM_FORGE_ERROR=$1
+  return 1
+}
+
+fm_forge_port_valid() {
+  local port=${1-}
+  [[ "$port" =~ ^[1-9][0-9]{0,4}$ ]] || return 1
+  [ "$port" -le 65535 ]
+}
+
+fm_forge_dns_or_ipv4_valid() {
+  local host=${1-} label
+  local -a labels
+  [ "${#host}" -ge 1 ] && [ "${#host}" -le 253 ] || return 1
+  case "$host" in
+    .*|*.|*..*|*[!a-z0-9.-]*) return 1 ;;
+  esac
+  IFS=. read -ra labels <<< "$host"
+  for label in "${labels[@]}"; do
+    [ "${#label}" -ge 1 ] && [ "${#label}" -le 63 ] || return 1
+    case "$label" in -*|*-) return 1 ;; esac
+  done
+}
+
+fm_forge_authority_parse() {
+  local authority=$1 host port=
+  case "$authority" in
+    *:*)
+      host=${authority%:*}
+      port=${authority##*:}
+      [ -n "$host" ] && fm_forge_port_valid "$port" || return 1
+      ;;
+    *) host=$authority ;;
+  esac
+  fm_forge_dns_or_ipv4_valid "$host" || return 1
+  FM_GITEA_AUTHORITY=$authority
+  FM_GITEA_WEB_HOST=$host
+}
+
+fm_forge_config_file_valid() {
+  local file=$1
+  [ -f "$file" ] && [ ! -L "$file" ] || return 1
+  [ "$(fm_pr_file_link_count "$file")" = 1 ] || return 1
+  [ "$(fm_pr_file_mode "$file")" = 600 ]
+}
+
+# Load the single private Gitea account configured for this FirstMate home.
+# docs/configuration.md owns the file schema and permission contract.
+fm_forge_gitea_config_load() {
+  # Never let an inherited xtrace setting print the later auth-config printf.
+  set +x
+  local config_dir=${FM_CONFIG_OVERRIDE:-${FM_HOME:-${FM_ROOT_OVERRIDE:-.}}/config}
+  local config_file="$config_dir/gitea" token_file="$config_dir/gitea-token"
+  local line key value base_count=0 account_count=0 port_count=0 token _extra
+  FM_GITEA_BASE_URL=
+  FM_GITEA_AUTHORITY=
+  FM_GITEA_WEB_HOST=
+  FM_GITEA_ACCOUNT=
+  FM_GITEA_SSH_PORT=
+  FM_GITEA_SSH_ALIASES=
+  FM_GITEA_TOKEN=
+  fm_forge_config_file_valid "$config_file" \
+    || fm_forge_fail "Gitea configuration is unavailable or not mode 0600" || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in ''|'#'*) continue ;; esac
+    case "$line" in *=*) ;; *) fm_forge_fail "Gitea configuration is malformed"; return 1 ;; esac
+    key=${line%%=*}
+    value=${line#*=}
+    [ -n "$value" ] || { fm_forge_fail "Gitea configuration is malformed"; return 1; }
+    case "$key" in
+      base_url)
+        base_count=$((base_count + 1))
+        [ "$base_count" -eq 1 ] || { fm_forge_fail "Gitea configuration is ambiguous"; return 1; }
+        if [[ "$value" =~ ^(https?)://([^/]+)$ ]]; then
+          fm_forge_authority_parse "${BASH_REMATCH[2]}" \
+            || { fm_forge_fail "Gitea base URL is not canonical"; return 1; }
+          FM_GITEA_BASE_URL=$value
+        else
+          fm_forge_fail "Gitea base URL is not canonical"
+          return 1
+        fi
+        ;;
+      account)
+        account_count=$((account_count + 1))
+        [ "$account_count" -eq 1 ] || { fm_forge_fail "Gitea configuration is ambiguous"; return 1; }
+        [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$ ]] \
+          || { fm_forge_fail "Gitea account is invalid"; return 1; }
+        # shellcheck disable=SC2034  # Validated account identity is public client state.
+        FM_GITEA_ACCOUNT=$value
+        ;;
+      ssh_alias)
+        fm_forge_dns_or_ipv4_valid "$value" \
+          || { fm_forge_fail "Gitea SSH alias is invalid"; return 1; }
+        case $'\n'"$FM_GITEA_SSH_ALIASES"$'\n' in
+          *$'\n'"$value"$'\n'*) fm_forge_fail "Gitea SSH alias is duplicated"; return 1 ;;
+        esac
+        FM_GITEA_SSH_ALIASES="${FM_GITEA_SSH_ALIASES}${FM_GITEA_SSH_ALIASES:+$'\n'}$value"
+        ;;
+      ssh_port)
+        port_count=$((port_count + 1))
+        if [ "$port_count" -ne 1 ] || ! fm_forge_port_valid "$value"; then
+          fm_forge_fail "Gitea SSH port is invalid or duplicated"
+          return 1
+        fi
+        FM_GITEA_SSH_PORT=$value
+        ;;
+      *) fm_forge_fail "Gitea configuration contains an unknown key"; return 1 ;;
+    esac
+  done < "$config_file"
+  [ "$base_count" -eq 1 ] && [ "$account_count" -eq 1 ] \
+    || { fm_forge_fail "Gitea configuration is incomplete"; return 1; }
+  case $'\n'"$FM_GITEA_SSH_ALIASES"$'\n' in
+    *$'\n'"$FM_GITEA_WEB_HOST"$'\n'*) ;;
+    *) FM_GITEA_SSH_ALIASES="${FM_GITEA_SSH_ALIASES}${FM_GITEA_SSH_ALIASES:+$'\n'}$FM_GITEA_WEB_HOST" ;;
+  esac
+  fm_forge_config_file_valid "$token_file" \
+    || { fm_forge_fail "Gitea token is unavailable or not mode 0600"; return 1; }
+  exec 7< "$token_file" || { fm_forge_fail "Gitea token cannot be read"; return 1; }
+  IFS= read -r token <&7 || { exec 7<&-; fm_forge_fail "Gitea token is empty"; return 1; }
+  if IFS= read -r _extra <&7; then
+    exec 7<&-
+    fm_forge_fail "Gitea token file must contain exactly one line"
+    return 1
+  fi
+  exec 7<&-
+  [ "${#token}" -ge 1 ] && [ "${#token}" -le 4096 ] \
+    && [[ "$token" =~ ^[A-Za-z0-9._~+-]+$ ]] \
+    || { fm_forge_fail "Gitea token format is invalid"; return 1; }
+  FM_GITEA_TOKEN=$token
+}
+
+fm_forge_repo_parts_valid() {
+  local owner=$1 repo=$2
+  [[ "$owner" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$ ]] || return 1
+  [[ "$repo" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$ ]] || return 1
+  [ "$owner" != . ] && [ "$owner" != .. ] && [ "$repo" != . ] && [ "$repo" != .. ]
+}
+
+fm_forge_gitea_ssh_alias_matches() {
+  local wanted=$1 alias
+  while IFS= read -r alias; do
+    [ "$alias" = "$wanted" ] && return 0
+  done <<< "$FM_GITEA_SSH_ALIASES"
+  return 1
+}
+
+fm_forge_set_repo_identity() {
+  local provider=$1 url=$2 host=$3 owner=$4 repo=$5
+  FM_FORGE_REPO_PROVIDER=$provider
+  FM_FORGE_REPO_URL=$url
+  FM_FORGE_REPO_HOST=$host
+  FM_FORGE_REPO_PATH="$owner/$repo"
+  FM_FORGE_REPO_OWNER=$owner
+  FM_FORGE_REPO_NAME=$repo
+}
+
+fm_forge_set_repo_path_identity() {
+  local provider=$1 url=$2 host=$3 path=$4
+  FM_FORGE_REPO_PROVIDER=$provider
+  FM_FORGE_REPO_URL=$url
+  FM_FORGE_REPO_HOST=$host
+  FM_FORGE_REPO_PATH=$path
+  FM_FORGE_REPO_OWNER=
+  FM_FORGE_REPO_NAME=${path##*/}
+}
+
+# Parse a git origin into a provider-tagged repository identity.
+# Gitea HTTPS/HTTP origins bind to base_url, and SSH origins bind only to the
+# canonical host or configured ssh_alias/ssh_port values.
+fm_forge_repo_url_parse() {
+  local raw=$1 scheme authority owner repo path ssh_host ssh_port=
+  FM_FORGE_REPO_PROVIDER=
+  # shellcheck disable=SC2034  # Repository identity outputs consumed by sourcing callers.
+  FM_FORGE_REPO_URL=
+  # shellcheck disable=SC2034
+  FM_FORGE_REPO_HOST=
+  FM_FORGE_REPO_PATH=
+  # shellcheck disable=SC2034
+  FM_FORGE_REPO_OWNER=
+  # shellcheck disable=SC2034
+  FM_FORGE_REPO_NAME=
+
+  if [[ "$raw" =~ ^https://github\.com/([^/]+)/([^/]+)$ ]]; then
+    owner=${BASH_REMATCH[1]}; repo=${BASH_REMATCH[2]}; repo=${repo%.git}
+    fm_forge_repo_parts_valid "$owner" "$repo" || return 1
+    fm_forge_set_repo_identity github "https://github.com/$owner/$repo" github.com "$owner" "$repo"
+    return 0
+  fi
+  if [[ "$raw" =~ ^(git@)?github\.com:([^/]+)/([^/]+)$ ]] \
+    || [[ "$raw" =~ ^ssh://(git@)?github\.com/([^/]+)/([^/]+)$ ]]; then
+    owner=${BASH_REMATCH[2]}; repo=${BASH_REMATCH[3]}; repo=${repo%.git}
+    fm_forge_repo_parts_valid "$owner" "$repo" || return 1
+    fm_forge_set_repo_identity github "https://github.com/$owner/$repo" github.com "$owner" "$repo"
+    return 0
+  fi
+
+  # A missing Gitea config means this origin may still be GitLab or unknown.
+  if fm_forge_gitea_config_load; then
+    if [[ "$raw" =~ ^(https?)://([^/]+)/([^/]+)/([^/]+)$ ]]; then
+      scheme=${BASH_REMATCH[1]}; authority=${BASH_REMATCH[2]}
+      owner=${BASH_REMATCH[3]}; repo=${BASH_REMATCH[4]}; repo=${repo%.git}
+      if [ "$scheme://$authority" = "$FM_GITEA_BASE_URL" ] \
+        && fm_forge_repo_parts_valid "$owner" "$repo"; then
+        fm_forge_set_repo_identity gitea "$FM_GITEA_BASE_URL/$owner/$repo" "$FM_GITEA_AUTHORITY" "$owner" "$repo"
+        FM_GITEA_TOKEN=
+        return 0
+      fi
+    fi
+    if [[ "$raw" =~ ^ssh://([^@/]+@)?([^/:]+)(:([0-9]+))?/([^/]+)/([^/]+)$ ]]; then
+      ssh_host=${BASH_REMATCH[2]}; ssh_port=${BASH_REMATCH[4]}
+      owner=${BASH_REMATCH[5]}; repo=${BASH_REMATCH[6]}; repo=${repo%.git}
+      if fm_forge_gitea_ssh_alias_matches "$ssh_host" \
+        && fm_forge_repo_parts_valid "$owner" "$repo"; then
+        if [ -n "$ssh_port" ]; then
+          fm_forge_port_valid "$ssh_port" || { FM_GITEA_TOKEN=; return 1; }
+          [ "$ssh_port" = "${FM_GITEA_SSH_PORT:-22}" ] || { FM_GITEA_TOKEN=; return 1; }
+        fi
+        fm_forge_set_repo_identity gitea "$FM_GITEA_BASE_URL/$owner/$repo" "$FM_GITEA_AUTHORITY" "$owner" "$repo"
+        FM_GITEA_TOKEN=
+        return 0
+      fi
+    elif [[ "$raw" =~ ^([^@/:]+@)?([^/:]+):([^/]+)/([^/]+)$ ]]; then
+      ssh_host=${BASH_REMATCH[2]}
+      owner=${BASH_REMATCH[3]}; repo=${BASH_REMATCH[4]}; repo=${repo%.git}
+      if fm_forge_gitea_ssh_alias_matches "$ssh_host" \
+        && fm_forge_repo_parts_valid "$owner" "$repo"; then
+        fm_forge_set_repo_identity gitea "$FM_GITEA_BASE_URL/$owner/$repo" "$FM_GITEA_AUTHORITY" "$owner" "$repo"
+        FM_GITEA_TOKEN=
+        return 0
+      fi
+    fi
+    FM_GITEA_TOKEN=
+  fi
+
+  if [[ "$raw" =~ ^https://gitlab\.com/(.+)$ ]]; then
+    path=${BASH_REMATCH[1]}; path=${path%.git}
+    fm_pr_gitlab_path_valid "$path" || return 1
+    fm_forge_set_repo_path_identity gitlab "https://gitlab.com/$path" gitlab.com "$path"
+    return 0
+  fi
+  if [[ "$raw" =~ ^(git@)?gitlab\.com:(.+)$ ]]; then
+    path=${BASH_REMATCH[2]}; path=${path%.git}
+    fm_pr_gitlab_path_valid "$path" || return 1
+    fm_forge_set_repo_path_identity gitlab "https://gitlab.com/$path" gitlab.com "$path"
+    return 0
+  fi
+  if [[ "$raw" =~ ^ssh://(git@)?gitlab\.com/(.+)$ ]]; then
+    path=${BASH_REMATCH[2]}; path=${path%.git}
+    fm_pr_gitlab_path_valid "$path" || return 1
+    fm_forge_set_repo_path_identity gitlab "https://gitlab.com/$path" gitlab.com "$path"
+    return 0
+  fi
+  return 1
+}
+
+fm_forge_repo_from_dir() {
+  local dir=$1 origin
+  origin=$(git -C "$dir" remote get-url origin 2>/dev/null) \
+    || { fm_forge_fail "repository has no readable origin"; return 1; }
+  fm_forge_repo_url_parse "$origin" \
+    || { fm_forge_fail "repository origin is not a configured forge identity"; return 1; }
+}
+
+fm_forge_gitea_identity_bind() {
+  local url=$1
+  fm_pr_url_parse "$url" && [ "$FM_PR_PROVIDER" = gitea ] \
+    || { fm_forge_fail "pull request is not a canonical Gitea identity"; return 1; }
+  fm_forge_gitea_config_load || return 1
+  [ "$FM_PR_URL" = "$FM_GITEA_BASE_URL/$FM_PR_PATH/pulls/$FM_PR_NUMBER" ] \
+    && [ "$FM_PR_HOST" = "$FM_GITEA_AUTHORITY" ] \
+    || { FM_GITEA_TOKEN=; fm_forge_fail "Gitea pull request host does not match private configuration"; return 1; }
+}
+
+# Authenticated Gitea request. The token is delivered through curl's stdin
+# config, never argv or environment. Raw curl/server errors are intentionally
+# discarded so an untrusted response cannot reflect the credential into logs.
+fm_forge_gitea_request() {
+  local method=$1 endpoint=$2 body=${3-} expected=$4 curl_bin response body_file code rc=0 size
+  local tmp_dir
+  FM_GITEA_RESPONSE=
+  command -v jq >/dev/null 2>&1 \
+    || { FM_GITEA_TOKEN=; fm_forge_fail "Gitea operations require jq"; return 1; }
+  curl_bin=${FM_FORGE_CURL_BIN:-curl}
+  command -v "$curl_bin" >/dev/null 2>&1 \
+    || { FM_GITEA_TOKEN=; fm_forge_fail "Gitea operations require curl"; return 1; }
+  umask 077
+  tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-gitea.XXXXXX") \
+    || { FM_GITEA_TOKEN=; fm_forge_fail "Gitea request workspace could not be created"; return 1; }
+  response="$tmp_dir/response"
+  body_file="$tmp_dir/body"
+  : > "$response"
+  if [ -n "$body" ]; then
+    printf '%s' "$body" > "$body_file" || rc=1
+    chmod 0600 "$body_file" || rc=1
+  fi
+  if [ "$rc" -eq 0 ]; then
+    if [ -n "$body" ]; then
+      code=$(printf 'header = "Authorization: token %s"\n' "$FM_GITEA_TOKEN" \
+        | "$curl_bin" --config - --silent --max-time 30 --max-filesize 1048576 \
+          --proto '=http,https' --output "$response" --write-out '%{http_code}' \
+          --request "$method" --header 'Content-Type: application/json' \
+          --data-binary "@$body_file" --url "$FM_GITEA_BASE_URL/api/v1$endpoint" 2>/dev/null) || rc=$?
+    else
+      code=$(printf 'header = "Authorization: token %s"\n' "$FM_GITEA_TOKEN" \
+        | "$curl_bin" --config - --silent --max-time 30 --max-filesize 1048576 \
+          --proto '=http,https' --output "$response" --write-out '%{http_code}' \
+          --request "$method" --url "$FM_GITEA_BASE_URL/api/v1$endpoint" 2>/dev/null) || rc=$?
+    fi
+  fi
+  FM_GITEA_TOKEN=
+  if [ "$rc" -ne 0 ]; then
+    rm -rf "$tmp_dir"
+    fm_forge_fail "Gitea request failed"
+    return 1
+  fi
+  case "$code" in
+    401|403) rm -rf "$tmp_dir"; fm_forge_fail "Gitea authentication or authorization failed"; return 1 ;;
+  esac
+  case " $expected " in
+    *" $code "*) ;;
+    *) rm -rf "$tmp_dir"; fm_forge_fail "Gitea returned an unsupported HTTP response"; return 1 ;;
+  esac
+  size=$(wc -c < "$response" 2>/dev/null) || size=1048577
+  [ "$size" -le 1048576 ] \
+    || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea response exceeded the safety limit"; return 1; }
+  FM_GITEA_RESPONSE=$(cat "$response") || { rm -rf "$tmp_dir"; fm_forge_fail "Gitea response could not be read"; return 1; }
+  rm -rf "$tmp_dir"
+}
+
+fm_forge_gitea_pr_json_valid() {
+  local url=$1 number path=$2
+  fm_pr_url_parse "$url" || return 1
+  number=$FM_PR_NUMBER
+  jq -e --arg url "$url" --arg path "$path" --argjson number "$number" '
+    type == "object" and
+    .number == $number and
+    .html_url == $url and
+    .base.repo.full_name == $path and
+    (.state == "open" or .state == "closed") and
+    (.merged | type == "boolean") and
+    (.head.sha | type == "string") and
+    (.head.sha | test("^[0-9a-f]{40}$|^[0-9a-f]{64}$"))
+  ' >/dev/null 2>&1 <<< "$FM_GITEA_RESPONSE"
+}
+
+fm_forge_pr_head() {
+  local url=$1 raw
+  fm_pr_url_parse "$url" || { fm_forge_fail "pull request URL is invalid"; return 1; }
+  case "$FM_PR_PROVIDER" in
+    github)
+      raw=$(gh pr view "$FM_PR_URL" --json headRefOid -q .headRefOid 2>/dev/null) \
+        || { fm_forge_fail "GitHub pull request head lookup failed"; return 1; }
+      fm_pr_head_valid "$raw" || { fm_forge_fail "GitHub returned a malformed pull request head"; return 1; }
+      printf '%s\n' "$raw"
+      ;;
+    gitlab)
+      fm_forge_fail "GitLab pull request head lookup is not available"
+      return 1
+      ;;
+    gitea)
+      fm_forge_gitea_identity_bind "$FM_PR_URL" || return 1
+      fm_forge_gitea_request GET "/repos/$FM_PR_PATH/pulls/$FM_PR_NUMBER" '' '200' || return 1
+      fm_forge_gitea_pr_json_valid "$FM_PR_URL" "$FM_PR_PATH" \
+        || { fm_forge_fail "Gitea returned a malformed or cross-project pull request"; return 1; }
+      jq -r '.head.sha' <<< "$FM_GITEA_RESPONSE"
+      ;;
+  esac
+}
+
+fm_forge_pr_state() {
+  local url=$1 raw state
+  fm_pr_url_parse "$url" || { fm_forge_fail "pull request URL is invalid"; return 1; }
+  case "$FM_PR_PROVIDER" in
+    github)
+      raw=$(gh pr view "$FM_PR_URL" --json state -q .state 2>/dev/null) \
+        || { fm_forge_fail "GitHub pull request lookup failed"; return 1; }
+      case "$raw" in OPEN) state=open ;; CLOSED) state=closed ;; MERGED) state=merged ;; *) fm_forge_fail "GitHub returned an unsupported pull request state"; return 1 ;; esac
+      ;;
+    gitlab)
+      raw=$(glab mr view "$FM_PR_NUMBER" -R "https://$FM_PR_HOST/$FM_PR_PATH" 2>/dev/null) \
+        || { fm_forge_fail "GitLab merge request lookup failed"; return 1; }
+      state=$(printf '%s\n' "$raw" | sed -n 's/^state:[[:space:]]*//p')
+      [ "$(printf '%s\n' "$state" | awk 'END { print NR + 0 }')" -eq 1 ] \
+        || { fm_forge_fail "GitLab returned an ambiguous merge request state"; return 1; }
+      case "$state" in opened|open) state=open ;; closed) state=closed ;; merged) ;; *) fm_forge_fail "GitLab returned an unsupported merge request state"; return 1 ;; esac
+      ;;
+    gitea)
+      fm_forge_gitea_identity_bind "$FM_PR_URL" || return 1
+      fm_forge_gitea_request GET "/repos/$FM_PR_PATH/pulls/$FM_PR_NUMBER" '' '200' || return 1
+      fm_forge_gitea_pr_json_valid "$FM_PR_URL" "$FM_PR_PATH" \
+        || { fm_forge_fail "Gitea returned a malformed or cross-project pull request"; return 1; }
+      if [ "$(jq -r '.merged' <<< "$FM_GITEA_RESPONSE")" = true ]; then state=merged; else state=$(jq -r '.state' <<< "$FM_GITEA_RESPONSE"); fi
+      ;;
+  esac
+  printf '%s\n' "$state"
+}
+
+fm_forge_pr_merged() {
+  local state
+  state=$(fm_forge_pr_state "$1") || return 1
+  [ "$state" = merged ] && printf '%s\n' merged
+  return 0
+}
+
+fm_forge_gitea_pr_create() {
+  local repo_dir=$1 head=$2 base=$3 title=$4 body=$5 payload url path
+  fm_forge_repo_from_dir "$repo_dir" || return 1
+  [ "$FM_FORGE_REPO_PROVIDER" = gitea ] || { fm_forge_fail "repository is not configured as Gitea"; return 1; }
+  [[ "$head" =~ ^[A-Za-z0-9._/-]{1,255}$ ]] && [[ "$base" =~ ^[A-Za-z0-9._/-]{1,255}$ ]] \
+    || { fm_forge_fail "Gitea pull request branches are invalid"; return 1; }
+  [ -n "$title" ] && [ "${#title}" -le 4096 ] && [ "${#body}" -le 262144 ] \
+    || { fm_forge_fail "Gitea pull request text is invalid"; return 1; }
+  path=$FM_FORGE_REPO_PATH
+  payload=$(jq -cn --arg head "$head" --arg base "$base" --arg title "$title" --arg body "$body" \
+    '{head:$head,base:$base,title:$title,body:$body}') || { fm_forge_fail "Gitea request body could not be encoded"; return 1; }
+  fm_forge_gitea_config_load || return 1
+  fm_forge_gitea_request POST "/repos/$path/pulls" "$payload" '201' || return 1
+  url=$(jq -er '.html_url | strings' <<< "$FM_GITEA_RESPONSE" 2>/dev/null) \
+    || { fm_forge_fail "Gitea returned a malformed pull request creation response"; return 1; }
+  fm_pr_url_parse "$url" && [ "$FM_PR_PROVIDER" = gitea ] \
+    && [ "$FM_PR_HOST" = "$FM_GITEA_AUTHORITY" ] && [ "$FM_PR_PATH" = "$path" ] \
+    || { fm_forge_fail "Gitea returned a cross-host pull request identity"; return 1; }
+  fm_forge_gitea_pr_json_valid "$url" "$path" \
+    || { fm_forge_fail "Gitea returned a malformed pull request creation response"; return 1; }
+  printf '%s\n' "$url"
+}
+
+fm_forge_gitea_pr_reviews() {
+  local url=$1
+  fm_forge_gitea_identity_bind "$url" || return 1
+  fm_forge_gitea_request GET "/repos/$FM_PR_PATH/pulls/$FM_PR_NUMBER/reviews" '' '200' || return 1
+  jq -ce '
+    type == "array" and all(.[];
+      (.id | type == "number") and (.id >= 1) and
+      (.state == "APPROVED" or .state == "PENDING" or .state == "COMMENT" or
+       .state == "REQUEST_CHANGES" or .state == "REQUEST_REVIEW") and
+      (.user.login | type == "string" and length > 0)
+    )
+  ' >/dev/null 2>&1 <<< "$FM_GITEA_RESPONSE" \
+    || { fm_forge_fail "Gitea returned malformed review data"; return 1; }
+  jq -c '[.[] | {id,state,user:.user.login,commit_id}]' <<< "$FM_GITEA_RESPONSE"
+}
+
+fm_forge_gitea_pr_checks() {
+  local url=$1 head
+  fm_forge_gitea_identity_bind "$url" || return 1
+  head=$(fm_forge_pr_head "$url") || return 1
+  # fm_forge_pr_head deliberately clears the token after its request.
+  fm_forge_gitea_config_load || return 1
+  fm_forge_gitea_request GET "/repos/$FM_PR_PATH/commits/$head/statuses" '' '200' || return 1
+  jq -ce '
+    type == "array" and all(.[];
+      (.id | type == "number") and
+      (.status == "success" or .status == "error" or .status == "failure" or
+       .status == "pending" or .status == "warning") and
+      (.context | type == "string")
+    )
+  ' >/dev/null 2>&1 <<< "$FM_GITEA_RESPONSE" \
+    || { fm_forge_fail "Gitea returned malformed check data"; return 1; }
+  jq -c '[.[] | {id,status,context,target_url,description}]' <<< "$FM_GITEA_RESPONSE"
+}
+
+fm_forge_pr_merge() {
+  local url=$1 method=$2 delete_branch=${3:-false} payload state
+  fm_pr_url_parse "$url" || { fm_forge_fail "pull request URL is invalid"; return 1; }
+  case "$FM_PR_PROVIDER" in
+    github) fm_forge_fail "GitHub merge dispatch remains owned by gh-axi"; return 1 ;;
+    gitlab) fm_forge_fail "GitLab merge is not supported"; return 1 ;;
+    gitea)
+      case "$method" in squash|merge|rebase|rebase-merge) ;; *) fm_forge_fail "Gitea merge method is unsupported"; return 1 ;; esac
+      case "$delete_branch" in true|false) ;; *) fm_forge_fail "Gitea delete-branch choice is invalid"; return 1 ;; esac
+      fm_forge_gitea_identity_bind "$FM_PR_URL" || return 1
+      payload=$(jq -cn --arg method "$method" --argjson delete "$delete_branch" \
+        '{Do:$method,delete_branch_after_merge:$delete}') \
+        || { fm_forge_fail "Gitea merge body could not be encoded"; return 1; }
+      fm_forge_gitea_request POST "/repos/$FM_PR_PATH/pulls/$FM_PR_NUMBER/merge" "$payload" '200' || return 1
+      # A 200 with an empty or version-specific body is not enough. Re-read the
+      # canonical PR and require exact merged state before reporting success.
+      state=$(fm_forge_pr_state "$FM_PR_URL") || return 1
+      [ "$state" = merged ] || { fm_forge_fail "Gitea did not confirm the pull request as merged"; return 1; }
+      ;;
+  esac
+}

--- a/bin/fm-forge.sh
+++ b/bin/fm-forge.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Provider-neutral forge helper for repository detection and PR operations.
+# Canonical identity is owned by bin/fm-pr-lib.sh; provider dispatch and all
+# Gitea HTTP/auth mechanics are owned by bin/fm-forge-lib.sh.
+#
+# Gitea uses private config/gitea and config/gitea-token files under the
+# effective FirstMate config directory. docs/configuration.md owns their exact
+# schema, permission checks, origin binding, and token-custody contract.
+#
+# Usage:
+#   fm-forge.sh provider <repository-dir>
+#   fm-forge.sh canonical-repo <repository-dir>
+#   fm-forge.sh pr-create <repository-dir> --head <branch> --base <branch>
+#     --title <title> [--body <text> | --body-file <path>]
+#   fm-forge.sh pr-state <canonical-pr-url>
+#   fm-forge.sh pr-head <canonical-pr-url>
+#   fm-forge.sh pr-merged <canonical-pr-url>
+#   fm-forge.sh pr-reviews <canonical-gitea-pr-url>
+#   fm-forge.sh pr-checks <canonical-gitea-pr-url>
+#
+# pr-create uses gh-axi for GitHub, glab for GitLab, and the authenticated API
+# client for configured Gitea repositories. It prints the forge's canonical PR
+# URL on success and stops on an unsupported or ambiguous response.
+# Merge is intentionally absent: all task PR merges must go through
+# bin/fm-pr-merge.sh's approval-recording path.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-forge-lib.sh
+. "$SCRIPT_DIR/fm-forge-lib.sh"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+fail() {
+  echo "error: ${FM_FORGE_ERROR:-forge operation failed}" >&2
+  exit 1
+}
+
+command_name=${1:-}
+case "$command_name" in
+  -h|--help) usage; exit 0 ;;
+  provider|canonical-repo)
+    [ "$#" -eq 2 ] || { usage >&2; exit 2; }
+    fm_forge_repo_from_dir "$2" || fail
+    if [ "$command_name" = provider ]; then
+      printf '%s\n' "$FM_FORGE_REPO_PROVIDER"
+    else
+      printf '%s\n' "$FM_FORGE_REPO_URL"
+    fi
+    ;;
+  pr-state|pr-head|pr-merged|pr-reviews|pr-checks)
+    [ "$#" -eq 2 ] || { usage >&2; exit 2; }
+    case "$command_name" in
+      pr-state) fm_forge_pr_state "$2" || fail ;;
+      pr-head) fm_forge_pr_head "$2" || fail ;;
+      pr-merged) fm_forge_pr_merged "$2" || fail ;;
+      pr-reviews) fm_forge_gitea_pr_reviews "$2" || fail ;;
+      pr-checks) fm_forge_gitea_pr_checks "$2" || fail ;;
+    esac
+    ;;
+  pr-create)
+    [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+    repo_dir=$2
+    shift 2
+    head=''
+    base=''
+    title=''
+    body=''
+    body_file=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --head|--base|--title|--body|--body-file)
+          [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+          case "$1" in
+            --head) head=$2 ;;
+            --base) base=$2 ;;
+            --title) title=$2 ;;
+            --body) body=$2 ;;
+            --body-file) body_file=$2 ;;
+          esac
+          shift 2
+          ;;
+        *) usage >&2; exit 2 ;;
+      esac
+    done
+    [ -n "$head" ] && [ -n "$base" ] && [ -n "$title" ] \
+      || { usage >&2; exit 2; }
+    [ -z "$body" ] || [ -z "$body_file" ] \
+      || { echo "error: --body and --body-file are mutually exclusive" >&2; exit 2; }
+    if [ -n "$body_file" ]; then
+      [ -f "$body_file" ] && [ ! -L "$body_file" ] \
+        || { echo "error: PR body file is unavailable" >&2; exit 1; }
+      body=$(cat "$body_file") || { echo "error: PR body file cannot be read" >&2; exit 1; }
+    fi
+    fm_forge_repo_from_dir "$repo_dir" || fail
+    case "$FM_FORGE_REPO_PROVIDER" in
+      github)
+        (cd "$repo_dir" && gh-axi pr create --head "$head" --base "$base" --title "$title" --body "$body")
+        ;;
+      gitlab)
+        command -v glab >/dev/null 2>&1 || { FM_FORGE_ERROR="GitLab PR creation requires glab"; fail; }
+        glab mr create -R "$FM_FORGE_REPO_URL" --source-branch "$head" \
+          --target-branch "$base" --title "$title" --description "$body" --yes
+        ;;
+      gitea) fm_forge_gitea_pr_create "$repo_dir" "$head" "$base" "$title" "$body" || fail ;;
+      *) FM_FORGE_ERROR="repository provider is unsupported"; fail ;;
+    esac
+    ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -3,8 +3,8 @@
 # exact pr_head=<sha> when available, then atomically arm a static merge poll.
 # The watcher check source is byte-for-byte bin/fm-pr-poll.sh; task and PR data
 # live only in a private sidecar and are never interpolated into shell source.
-# A GitHub pull request URL and a GitLab merge request URL are both accepted,
-# including a merge request on a self-hosted GitLab instance.
+# Canonical GitHub, GitLab, and configured Gitea pull-request URLs are accepted,
+# including self-hosted GitLab and private-network Gitea instances.
 # Usage: fm-pr-check.sh <task-id> <pr-url>
 set -eu
 
@@ -15,6 +15,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-forge-lib.sh
+. "$SCRIPT_DIR/fm-forge-lib.sh"
 
 if [ "$#" -ne 2 ]; then
   echo "error: invalid PR check request" >&2
@@ -55,6 +57,18 @@ if [ "$PROVIDER" = gitlab ] && ! command -v glab >/dev/null 2>&1; then
   echo "error: watching a GitLab merge request requires glab on PATH" >&2
   exit 1
 fi
+if [ "$PROVIDER" = gitea ]; then
+  if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    echo "error: watching a Gitea pull request requires curl and jq" >&2
+    exit 1
+  fi
+  if ! fm_forge_gitea_identity_bind "$URL"; then
+    FM_GITEA_TOKEN=
+    echo "error: Gitea pull request does not match valid private configuration" >&2
+    exit 1
+  fi
+  FM_GITEA_TOKEN=
+fi
 
 # Neutralize any pre-fix poll before recording or arming this task. The
 # migration never executes legacy artifacts and holds watcher exclusion while
@@ -62,17 +76,20 @@ fi
 "$SCRIPT_DIR/fm-pr-check-migrate.sh" --checks-safe || exit 1
 "$FM_ROOT/bin/fm-guard.sh" || true
 
-# pr_head is recorded only when the forge's CLI can supply it. gh exposes the
-# head commit as a selectable field; plain glab exposes it only inside its JSON
-# output, which would need a JSON processor firstmate does not require, so a
-# GitLab task records no pr_head. Both consumers already treat it as optional:
-# bin/fm-teardown.sh reads the head from the forge at teardown rather than from
-# metadata and falls back to its provider-agnostic content check, and
-# bin/fm-review-diff.sh resolves the head from the remote when none is recorded.
+# Record an exact head when the provider abstraction can validate one. GitLab
+# keeps its established optional-head behavior; GitHub still uses gh, while
+# Gitea uses the private API client without exposing its token.
 WT=$(grep '^worktree=' "$META" | tail -1 | cut -d= -f2- || true)
 PR_HEAD=
-if [ "$PROVIDER" = github ] && [ -n "$WT" ] && [ -d "$WT" ] && command -v gh >/dev/null 2>&1; then
-  if REMOTE_HEAD=$(cd "$WT" && gh pr view "$URL" --json headRefOid -q .headRefOid 2>/dev/null) \
+if [ "$PROVIDER" = gitea ]; then
+  if REMOTE_HEAD=$(fm_forge_pr_head "$URL" 2>/dev/null) && fm_pr_head_valid "$REMOTE_HEAD"; then
+    PR_HEAD=$REMOTE_HEAD
+  else
+    echo "error: Gitea pull request head could not be validated" >&2
+    exit 1
+  fi
+elif [ -n "$WT" ] && [ -d "$WT" ]; then
+  if REMOTE_HEAD=$(cd "$WT" && fm_forge_pr_head "$URL" 2>/dev/null) \
     && fm_pr_head_valid "$REMOTE_HEAD"; then
     PR_HEAD=$REMOTE_HEAD
   fi

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -4,13 +4,13 @@
 # constructing task paths or performing any side effect.
 #
 # The stored identity is provider-tagged: provider, url, host, path, number.
-# "path" is the full project path, which is owner/repository on GitHub and an
-# arbitrarily nested group/subgroup/project namespace on GitLab. A GitLab
-# project can sit at any depth, so no owner/repository pair can address one and
-# the sidecar carries the whole path instead. GitLab also runs on self-hosted
-# instances, so the host is part of that identity rather than a constant. Every
-# consumer re-derives the identity from the stored URL and refuses any record
-# whose parts do not reconstruct that exact URL.
+# "path" is the full project path, which is owner/repository on GitHub and
+# Gitea, and an arbitrarily nested group/subgroup/project namespace on GitLab.
+# A GitLab project can sit at any depth, so no owner/repository pair can address
+# one and the sidecar carries the whole path instead. Self-hosted GitLab and
+# Gitea identities include their canonical host (and Gitea web port, when
+# explicit). Every consumer re-derives the identity from the stored URL and
+# refuses any record whose parts do not reconstruct that exact URL.
 #
 # A validated exact merged result is retired through a private receipt only
 # after its durable wake is appended.
@@ -156,17 +156,52 @@ fm_pr_gitlab_path_valid() {
   done
 }
 
+# Gitea commonly serves private-network HTTP and non-default web ports.
+# Keep one canonical authority spelling: lowercase DNS/IPv4 host, optional
+# non-zero decimal port with no leading zero, and no userinfo or trailing dot.
+fm_pr_gitea_authority_valid() {
+  local authority=${1-} host label
+  local port=''
+  local LC_ALL=C
+  local -a labels
+  case "$authority" in
+    *:*)
+      host=${authority%:*}
+      port=${authority##*:}
+      [[ "$port" =~ ^[1-9][0-9]{0,4}$ ]] && [ "$port" -le 65535 ] || return 1
+      ;;
+    *) host=$authority ;;
+  esac
+  [ "${#host}" -ge 1 ] && [ "${#host}" -le 253 ] || return 1
+  [ "$host" != github.com ] || return 1
+  case "$host" in
+    .*|*.|*..*|*[!a-z0-9.-]*) return 1 ;;
+  esac
+  IFS=. read -ra labels <<< "$host"
+  for label in "${labels[@]}"; do
+    [ "${#label}" -ge 1 ] && [ "${#label}" -le 63 ] || return 1
+    case "$label" in -*|*-) return 1 ;; esac
+  done
+}
+
+fm_pr_gitea_repo_part_valid() {
+  local value=${1-}
+  [ "${#value}" -ge 1 ] && [ "${#value}" -le 255 ] || return 1
+  case "$value" in
+    .|..|*.git|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+}
+
 # Parse a canonical PR or MR URL into the provider-tagged identity. Validation
 # is strict and per provider: the GitHub username and repository rules are
-# unchanged, and GitLab gets its own host and namespace rules rather than a
-# loosened GitHub rule.
+# unchanged, GitLab keeps its host and nested-namespace rules, and Gitea gets
+# an exact HTTP(S) authority plus owner/repository path.
 #
-# FM_PR_OWNER and FM_PR_REPO are additionally set for github because
-# bin/fm-pr-merge.sh addresses GitHub by owner/repository. A gitlab URL leaves
-# them empty; teaching the merge path about GitLab is a separate change, and
-# until then it refuses a GitLab URL rather than merging anything.
+# FM_PR_OWNER and FM_PR_REPO are additionally set for GitHub and Gitea because
+# both providers use a two-segment repository identity. GitLab leaves them
+# empty because its project namespace has no fixed depth.
 fm_pr_url_parse() {
-  local raw=${1-} pattern host path
+  local raw=${1-} pattern host path scheme owner repo number
   local LC_ALL=C
   FM_PR_PROVIDER=
   FM_PR_URL=
@@ -189,6 +224,28 @@ fm_pr_url_parse() {
     # shellcheck disable=SC2034
     FM_PR_REPO=${BASH_REMATCH[2]}
     FM_PR_NUMBER=${BASH_REMATCH[3]}
+    return 0
+  fi
+  pattern='^(https?)://([a-z0-9.-]+(:[1-9][0-9]{0,4})?)/([A-Za-z0-9._-]{1,255})/([A-Za-z0-9._-]{1,255})/pulls/([1-9][0-9]*)$'
+  if [[ "$raw" =~ $pattern ]]; then
+    scheme=${BASH_REMATCH[1]}
+    host=${BASH_REMATCH[2]}
+    owner=${BASH_REMATCH[4]}
+    repo=${BASH_REMATCH[5]}
+    number=${BASH_REMATCH[6]}
+    fm_pr_gitea_authority_valid "$host" || return 1
+    fm_pr_gitea_repo_part_valid "$owner" || return 1
+    fm_pr_gitea_repo_part_valid "$repo" || return 1
+    FM_PR_PROVIDER=gitea
+    FM_PR_URL="$scheme://$host/$owner/$repo/pulls/$number"
+    [ "$FM_PR_URL" = "$raw" ] || return 1
+    FM_PR_HOST=$host
+    FM_PR_PATH="$owner/$repo"
+    # shellcheck disable=SC2034  # Provider-specific outputs consumed by callers.
+    FM_PR_OWNER=$owner
+    # shellcheck disable=SC2034
+    FM_PR_REPO=$repo
+    FM_PR_NUMBER=$number
     return 0
   fi
   # The path class contains "/" and "-", so this match is greedy to the last

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -218,7 +218,7 @@ fm_pr_url_parse() {
     FM_PR_URL=$raw
     FM_PR_HOST=github.com
     FM_PR_PATH="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
-    # Consumed by bin/fm-pr-merge.sh, which addresses GitHub by owner/repository.
+    # Consumed by bin/fm-pr-merge.sh for GitHub's owner/repository dispatch.
     # shellcheck disable=SC2034
     FM_PR_OWNER=${BASH_REMATCH[1]}
     # shellcheck disable=SC2034

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 # Merge a task's PR after recording pr= and any available pr_head= through
 # bin/fm-pr-check.sh, so teardown can verify landed work after squash merges.
-# The full canonical GitHub PR URL is parsed by bin/fm-pr-lib.sh and the derived
-# owner/repository and PR number are passed to gh-axi as separate arguments.
+# The full canonical PR URL is parsed by bin/fm-pr-lib.sh. GitHub keeps its
+# existing gh-axi number plus owner/repository dispatch. Configured Gitea uses
+# the common private forge client and confirms merged state after the request.
+# GitLab merge remains unsupported and is refused.
 #
 # Merge method defaults to --squash when the caller passes none of --squash,
 # --merge, --rebase, or --method after the optional -- separator. Extra args
 # must not include --repo or -R because the repository comes only from the URL.
-# Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
+# Gitea accepts only method flags plus --delete-branch; unknown provider flags
+# are refused instead of being translated ambiguously.
+# Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <provider merge args>]
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,6 +21,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-forge-lib.sh
+. "$SCRIPT_DIR/fm-forge-lib.sh"
 
 if [ "$#" -lt 2 ]; then
   echo "error: invalid PR merge request" >&2
@@ -24,11 +30,11 @@ if [ "$#" -lt 2 ]; then
 fi
 ID=$1
 RAW_URL=$2
-# bin/fm-pr-lib.sh parses GitLab merge request URLs so the watcher can follow
-# them, but this path still addresses only GitHub by owner/repository. The
-# provider check holds that refusal exactly as it was until merge parity lands.
-if ! fm_pr_task_id_valid "$ID" || ! fm_pr_url_parse "$RAW_URL" \
-  || [ "$FM_PR_PROVIDER" != github ]; then
+if ! fm_pr_task_id_valid "$ID" || ! fm_pr_url_parse "$RAW_URL"; then
+  echo "error: invalid PR merge request" >&2
+  exit 2
+fi
+if [ "$FM_PR_PROVIDER" != github ] && [ "$FM_PR_PROVIDER" != gitea ]; then
   echo "error: invalid PR merge request" >&2
   exit 2
 fi
@@ -81,4 +87,32 @@ if ! caller_has_merge_method "$@"; then
   merge_args=(--squash)
 fi
 
-gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${merge_args[@]}"}" "$@"
+if [ "$FM_PR_PROVIDER" = github ]; then
+  gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${merge_args[@]}"}" "$@"
+  exit $?
+fi
+
+gitea_method=
+gitea_delete=false
+set -- "${merge_args[@]+"${merge_args[@]}"}" "$@"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --squash) gitea_method=squash ;;
+    --merge) gitea_method=merge ;;
+    --rebase) gitea_method=rebase ;;
+    --method)
+      [ "$#" -ge 2 ] || { echo "error: incomplete Gitea merge method" >&2; exit 1; }
+      gitea_method=$2
+      shift
+      ;;
+    --method=*) gitea_method=${1#--method=} ;;
+    --delete-branch) gitea_delete=true ;;
+    *) echo "error: unsupported Gitea merge argument" >&2; exit 1 ;;
+  esac
+  shift
+done
+case "$gitea_method" in squash|merge|rebase|rebase-merge) ;; *) echo "error: unsupported Gitea merge method" >&2; exit 1 ;; esac
+if ! fm_forge_pr_merge "$URL" "$gitea_method" "$gitea_delete"; then
+  echo "error: ${FM_FORGE_ERROR:-Gitea merge failed}" >&2
+  exit 1
+fi

--- a/bin/fm-pr-poll.sh
+++ b/bin/fm-pr-poll.sh
@@ -4,8 +4,10 @@
 # otherwise, including on every error, so a failed lookup can never be read as
 # a merge. The provider-tagged identity is data in the sidecar and is never
 # interpolated into this source: these bytes are identical for every task.
-# Each provider is read through its own standard CLI, gh for GitHub and glab
-# for GitLab, so an upstream checkout needs no extra tooling to follow either.
+# The tracked watcher invocation delegates provider access to fm-forge.sh,
+# keeping Gitea authentication in one private client. The legacy inline
+# GitHub/GitLab cases remain only for direct execution of an older copied poll;
+# no copied poll can perform a Gitea request on its own.
 set -u
 LC_ALL=C
 export LC_ALL
@@ -45,6 +47,20 @@ case "$number" in
   *[!0-9]*) exit 0 ;;
 esac
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd) || exit 0
+if [ -x "$SCRIPT_DIR/fm-forge.sh" ] && [ -f "$SCRIPT_DIR/fm-pr-lib.sh" ] && [ ! -L "$SCRIPT_DIR/fm-pr-lib.sh" ]; then
+  # shellcheck source=bin/fm-pr-lib.sh
+  . "$SCRIPT_DIR/fm-pr-lib.sh"
+  fm_pr_url_parse "$url" || exit 0
+  [ "$FM_PR_PROVIDER" = "$provider" ] && [ "$FM_PR_HOST" = "$host" ] \
+    && [ "$FM_PR_PATH" = "$path" ] && [ "$FM_PR_NUMBER" = "$number" ] || exit 0
+  result=$("$SCRIPT_DIR/fm-forge.sh" pr-merged "$url" 2>/dev/null) || exit 0
+  [ -z "$result" ] || [ "$result" = merged ] || exit 0
+  [ "$result" = merged ] && printf '%s\n' merged
+  exit 0
+fi
+[ "$provider" != gitea ] || exit 0
+
 # Every component is revalidated here rather than trusted from the sidecar, and
 # the stored URL must then be exactly reconstructible from those components, so
 # a doctored sidecar cannot redirect this poll at another host or project.
@@ -78,20 +94,20 @@ case "$provider" in
     # A GitLab project sits under at least one group at no fixed depth, and
     # GitLab reserves the "-" segment as its route separator.
     rest=$path
-    segments=0
+    segment_count=0
     while [ -n "$rest" ]; do
       case "$rest" in
         */*) segment=${rest%%/*}; rest=${rest#*/} ;;
         *) segment=$rest; rest= ;;
       esac
-      segments=$((segments + 1))
-      [ "$segments" -le 20 ] || exit 0
+      segment_count=$((segment_count + 1))
+      [ "$segment_count" -le 20 ] || exit 0
       [ "${#segment}" -ge 1 ] && [ "${#segment}" -le 255 ] || exit 0
       case "$segment" in
         .|..|-*|*.git|*.atom|*[!A-Za-z0-9._-]*) exit 0 ;;
       esac
     done
-    [ "$segments" -ge 2 ] || exit 0
+    [ "$segment_count" -ge 2 ] || exit 0
     [ "$url" = "https://$host/$path/-/merge_requests/$number" ] || exit 0
     # glab resolves the instance from the project URL passed to -R, so the host
     # comes from the validated record rather than glab's configured default.

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -10,7 +10,7 @@
 #
 # mode = how a finished change reaches main:
 #   no-mistakes  full pipeline -> PR -> captain merge (default)
-#   direct-PR    push + PR via gh-axi, no pipeline -> captain merge
+#   direct-PR    push + PR via the registered forge, no pipeline -> captain merge
 #   local-only   local branch, no remote/PR -> captain approve -> guarded local merge
 # yolo (orthogonal) = when on, firstmate may make routine approval decisions itself.
 #   AGENTS.md section 7 is the single owner of authority exceptions, including

--- a/bin/fm-review-diff.sh
+++ b/bin/fm-review-diff.sh
@@ -82,6 +82,10 @@ pr_number_from_target() {
       n=${target##*/pull/}
       n=${n%%[!0-9]*}
       ;;
+    *"/pulls/"*)
+      n=${target##*/pulls/}
+      n=${n%%[!0-9]*}
+      ;;
     [0-9]*)
       n=${target%%[!0-9]*}
       ;;

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -9,7 +9,7 @@
 # reachable from any remote-tracking branch (a fork counts as a remote, so
 # upstream-contribution PRs pushed to a fork satisfy this in any mode), OR - for a
 # normal ship task whose commits are not so reachable - when its PR is merged and
-# GitHub reports a PR head that contains the current local work, or its content is
+# its forge reports a PR head that contains the current local work, or its content is
 # already present in the up-to-date default branch. This recognizes the common
 # squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
 # on a remote yet the change is fully in main.
@@ -106,6 +106,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-forge-lib.sh
+. "$SCRIPT_DIR/fm-forge-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   echo "error: invalid teardown request" >&2
   exit 2
@@ -297,6 +299,10 @@ pr_number_from_target() {
       n=${target##*/pull/}
       n=${n%%[!0-9]*}
       ;;
+    *"/pulls/"*)
+      n=${target##*/pulls/}
+      n=${n%%[!0-9]*}
+      ;;
     [0-9]*)
       n=${target%%[!0-9]*}
       ;;
@@ -348,26 +354,36 @@ EOF
 }
 
 # Is the worktree's PR merged for local work contained in that PR? Resolves the
-# PR from the recorded pr= URL first, then from the branch name, and asks GitHub
-# for both the PR state and head. Returns non-zero when the PR is not merged, the
-# current work is not contained in the PR head, no PR is found, or any gh error
-# occurs - the caller then falls back to the content check.
+# PR from the recorded pr= URL first, then from the branch name. GitHub keeps its
+# established gh query; configured Gitea goes through the common private forge
+# client. Returns non-zero on any absent, unmerged, malformed, or failed lookup,
+# so the caller falls back to the provider-agnostic content check.
 pr_is_merged() {
-  local branch=$1 target view state head current
+  local branch=$1 target view state head current provider
   if [ -n "$PR_URL" ]; then
     target=$PR_URL
   else
     target=$(pr_number_from_branch "$branch") || return 1
   fi
   [ -n "$target" ] || return 1
-  view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid -q '.state + "\t" + .headRefOid' 2>/dev/null) || return 1
-  state=${view%%$'\t'*}
-  head=${view#*$'\t'}
-  [ "$state" != "$view" ] || return 1
-  case "$state" in
-    MERGED|merged) ;;
-    *) return 1 ;;
-  esac
+  provider=github
+  if fm_pr_url_parse "$target"; then
+    provider=$FM_PR_PROVIDER
+  fi
+  if [ "$provider" = gitea ]; then
+    state=$(fm_forge_pr_state "$target" 2>/dev/null) || return 1
+    [ "$state" = merged ] || return 1
+    head=$(fm_forge_pr_head "$target" 2>/dev/null) || return 1
+  else
+    view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid -q '.state + "\t" + .headRefOid' 2>/dev/null) || return 1
+    state=${view%%$'\t'*}
+    head=${view#*$'\t'}
+    [ "$state" != "$view" ] || return 1
+    case "$state" in
+      MERGED|merged) ;;
+      *) return 1 ;;
+    esac
+  fi
   [ -n "$head" ] || return 1
   ensure_commit_object "$target" "$head" || return 1
   current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -164,7 +164,7 @@ family_for_basename() {
     fm-spawn-worktree-settle.test.sh)
       printf '%s\n' backend-dispatch
       ;;
-    fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
+    fm-forge-gitea.test.sh|fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
     fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge
       ;;
@@ -660,8 +660,8 @@ families_for_changed_path() {
     bin/fm-gate-refuse*|bin/fm-lock*)
       printf '%s\n' session-bootstrap
       ;;
-    bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
-    bin/fm-x-*|bin/fm-check*)
+    bin/fm-forge*|bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
+    bin/fm-x-*|bin/fm-check*|docs/gitea-forge.md)
       printf '%s\n' pr-forge
       ;;
     bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-dispatch-select.sh|bin/fm-harness.sh|\

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,11 +185,12 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 
 `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
 `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
-When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
+When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records a GitHub or Gitea `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.
-PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
-The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state; a well-formed GitLab merge request URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) is refused too, explicitly, rather than sent to the wrong forge.
+PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before dispatching the guarded merge to GitHub or the configured Gitea account.
+The helper requires a canonical full GitHub or configured Gitea pull-request URL, defaults to squash, preserves GitHub's supported merge arguments, accepts only the documented merge method and delete-branch choices for Gitea, and rejects malformed URLs, repository overrides, unsupported arguments, and GitLab merge-request URLs before merge dispatch.
+GitHub merges use `gh-axi`, while Gitea merges use the private authenticated client and succeed only after a follow-up state query confirms the pull request is merged.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,39 @@ Wake, watcher, away-mode, and X-specific state mechanics remain with their named
 `AGENTS.md` retains the run-once and read-once operator rules, lock-refusal safety, installation consent, and direct-report recovery boundaries because those facts apply at every session start.
 Ordinary dead-direct-report recovery is owned by `stuck-crewmate-recovery`, while persistent-secondmate recovery is owned by `secondmate-provisioning`.
 
+## Gitea forge account (config/gitea / config/gitea-token)
+
+`bin/fm-forge-lib.sh` is the single implementation owner for forge provider dispatch and every Gitea configuration, authentication, HTTP, and response-validation mechanic.
+`bin/fm-pr-lib.sh` remains the owner of canonical PR identity and private poll provenance for GitHub, GitLab, and Gitea.
+A FirstMate home configures at most one Gitea account through `config/gitea` and `config/gitea-token` under the effective config directory selected by `FM_CONFIG_OVERRIDE`, then `FM_HOME/config`.
+Both files must be ordinary, non-symlink, single-link files with exact mode `0600`.
+`config/gitea` uses one `key=value` record per line, permits blank lines and comments beginning with `#`, requires exactly one `base_url` and one `account`, permits repeated `ssh_alias` records, and permits at most one `ssh_port`.
+Unknown keys, duplicate singleton keys, duplicate aliases, extra path text in the base URL, uppercase or noncanonical hosts, invalid ports, and malformed account values are refused.
+
+```text
+base_url=http://gitea.internal:3000
+account=brad
+ssh_alias=gitea
+ssh_alias=gitea-vpn.internal
+ssh_port=2222
+```
+
+`base_url` must be exactly `http://<lowercase-host>[:port]` or `https://<lowercase-host>[:port]` with no trailing slash or path.
+It is the canonical web and API identity, including an explicit web port when configured.
+`account` names the authenticating Gitea login and does not restrict repositories owned by organizations that account can access.
+Every `ssh_alias` is a lowercase DNS name or IPv4 spelling that may identify the same configured server in a git origin.
+The canonical web host is always accepted as an SSH host even when it is not repeated as an alias.
+An explicit `ssh://` origin port must match `ssh_port`, which defaults to 22 when absent; SCP-shaped origins such as `git@gitea:owner/repo.git` rely on SSH configuration for their port and bind through the alias.
+HTTPS, HTTP, `ssh://`, and SCP-shaped origin recognition all reconstruct the same canonical repository URL before any PR operation.
+
+`config/gitea-token` contains exactly one non-empty token line made only of the client's accepted token characters, with no second line or surrounding prose.
+The token is read only by the private client and is sent to curl through stdin configuration rather than process arguments or environment variables.
+The client discards raw curl and server errors, clears its in-memory shell variable after each request, allows only HTTP(S), limits every request to 30 seconds and 1 MiB, and never writes the token to generated checks, task metadata, reports, or diagnostics.
+Authentication failures, cross-host or cross-project identities, unexpected HTTP codes, malformed JSON, and unknown enum values stop the operation rather than being interpreted as success.
+`bin/fm-forge.sh --help` owns the exact operator commands and points back here for this schema.
+`docs/gitea-forge.md` records mocked verification and the intentionally pending live-verification boundary.
+This foundation does not authorize access to a live Gitea server; live repository verification is a separate captain-approved task.
+
 ## Pi Calm preference (config/calm)
 
 The Pi Calm extension stores the captain's home-local presentation choice in gitignored `config/calm` under the effective Firstmate home, resolved from `FM_HOME`, then `FM_ROOT_OVERRIDE`, then the tracked code root derived from the extension path, or under `FM_CONFIG_OVERRIDE` when that test and specialized-setup override is present.
@@ -364,7 +397,8 @@ FM_ROOT_OVERRIDE=        # override firstmate repo root, tangle-guard target, an
 FM_STATE_OVERRIDE=       # alternate state dir, mainly for tests
 FM_DATA_OVERRIDE=        # alternate data dir, mainly for tests
 FM_PROJECTS_OVERRIDE=    # alternate projects dir, mainly for tests
-FM_CONFIG_OVERRIDE=      # alternate config dir, mainly for tests
+FM_CONFIG_OVERRIDE=      # alternate config dir, mainly for tests; also relocates config/gitea and config/gitea-token together
+FM_FORGE_CURL_BIN=curl   # test-only Gitea HTTP fixture seam; production leaves this unset
 FM_PROC_ROOT_OVERRIDE=   # alternate /proc root for the Linux process-identity read in fm-wake-lib.sh, mainly for tests
 FM_BACKEND=             # optional runtime backend override for new spawns; tmux/herdr/zellij/orca/cmux support ship/scout spawns, codex-app is not accepted
 HERDR_SESSION=default  # herdr-only: named session for normal backend ops; not enough for destructive cleanup (docs/herdr-backend.md)

--- a/docs/gitea-forge.md
+++ b/docs/gitea-forge.md
@@ -1,0 +1,65 @@
+# Gitea forge verification
+
+## Scope and current evidence
+
+The Gitea foundation is verified only with deterministic mocked HTTP and git fixtures as of 2026-07-23.
+No live Gitea server, repository, account, credential, or captain-private token was accessed while producing this evidence.
+`bin/fm-forge-lib.sh` owns provider dispatch and all Gitea configuration, token custody, HTTP, and response validation.
+`bin/fm-pr-lib.sh` owns canonical pull-request identity and poll provenance across GitHub, GitLab, and Gitea.
+The private configuration schema and operator commands live in [`configuration.md`](configuration.md) and `bin/fm-forge.sh --help`.
+
+The mocked suite covers canonical HTTP and HTTPS identities, explicit web ports, SSH aliases and ports, token-file permissions, token absence from argv and diagnostics, authentication failures, malformed and cross-host responses, PR creation, head/state/review/check queries, poll binding, guarded merge confirmation, and landed-work cleanup evidence.
+It also runs the existing GitHub and GitLab PR regressions unchanged.
+
+The implementation run used the repository-pinned ShellCheck 0.11.0 and produced the following exact command summaries.
+
+```text
+$ PATH="<worktree-local-shellcheck-0.11.0>:$PATH" bin/fm-lint.sh
+fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
+
+$ bin/fm-test-run.sh tests/fm-forge-gitea.test.sh
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=6770
+FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=6720 failed=0
+
+$ bin/fm-test-run.sh tests/fm-pr-merge.test.sh
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=5629
+FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=5564 failed=0
+
+$ bin/fm-test-run.sh tests/fm-brief.test.sh
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=1216
+FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=1148 failed=0
+
+$ bin/fm-test-run.sh tests/fm-instruction-owners.test.sh
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=331
+FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=250 failed=0
+
+$ bin/fm-test-run.sh tests/fm-review-diff.test.sh
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=1169
+FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=1103 failed=0
+
+$ bin/fm-test-run.sh tests/fm-teardown.test.sh
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=32908
+FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=32838 failed=0
+
+$ bin/fm-test-run.sh tests/fm-pr-check-security.test.sh
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=373514
+FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=373460 failed=0
+
+$ PATH="<worktree-local-shellcheck-0.11.0>:$PATH" bin/fm-test-run.sh --changed --base HEAD
+FM_TEST_SUMMARY total=36 failed=1 skipped_gate=1 duration_ms=734058
+FM_TEST_SUMMARY_FAMILY family=pr-forge count=6 duration_ms=484975 failed=0
+FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=30 duration_ms=247770 failed=1
+```
+
+The changed-file suite's complete PR/forge family passed.
+Its unrelated `fm-calm-pi-extension.test.sh` failed because the installed Node 22 runtime rejected a direct `.ts` import with `ERR_UNKNOWN_FILE_EXTENSION`, and the optional Pi typecheck reported its normal missing-`tsc` skip.
+No Gitea or PR/forge test failed in that run.
+
+## Live verification boundary
+
+Live behavior remains unverified and must not be inferred from mocked evidence.
+A later separately authorized verification task may exercise only the captain-approved `Brad/Test-Repo` repository and must record the server version, exact commands, redacted outputs, and cleanup outcome here.
+Until that evidence exists, do not describe Gitea support as empirically verified against a production server.
+
+The reusable authenticated request function is the extension point for later issue and milestone operations.
+This slice deliberately exposes no raw arbitrary-API command and no repository-creation command, so future operations must add typed validation rather than bypass token custody through ad hoc curl calls.

--- a/docs/gitlab-merge-watch.md
+++ b/docs/gitlab-merge-watch.md
@@ -192,8 +192,8 @@ No armed watch is lost by upgrading.
 
 ## What this change does not cover
 
-`bin/fm-pr-merge.sh` still addresses GitHub only, by owner and repository.
-It refuses a GitLab merge request URL rather than sending it to the wrong forge, so merging a merge request stays a deliberate manual step until merge parity lands separately.
+`bin/fm-pr-merge.sh` supports canonical GitHub and configured Gitea pull-request URLs.
+It still refuses a GitLab merge request URL rather than sending it to the wrong forge, so merging a merge request stays a deliberate manual step until GitLab merge parity lands separately.
 
 A GitLab task records no `pr_head=`.
 `gh` exposes the head commit as a selectable field, while plain `glab` exposes it only inside its JSON output, which would need a JSON processor firstmate does not require.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -79,10 +79,12 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |
 | `fm-check-lib.sh`        | Validate custom-check registrations and prepare private execution snapshots          |
 | `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll publication and identity-bound retirement |
+| `fm-forge-lib.sh`        | Dispatch forge operations and own private Gitea configuration, HTTP, and response validation |
+| `fm-forge.sh`            | Detect repositories and perform provider-neutral PR create, state, head, review, and check operations |
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
-| `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
+| `fm-pr-merge.sh`         | Record PR metadata, then guardedly merge a canonical GitHub or configured Gitea PR   |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/tests/fm-forge-gitea.test.sh
+++ b/tests/fm-forge-gitea.test.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+# Mocked security and lifecycle tests for the Gitea forge foundation.
+# No live server, repository, credential, or captain-private config is read.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-pr-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-forge-lib.sh"
+
+FORGE="$ROOT/bin/fm-forge.sh"
+PR_CHECK="$ROOT/bin/fm-pr-check.sh"
+PR_MERGE="$ROOT/bin/fm-pr-merge.sh"
+POLL="$ROOT/bin/fm-pr-poll.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=$(fm_test_tmproot fm-forge-gitea)
+TOKEN='fixture-secret-token-ABC123'
+PR_URL='http://gitea.lan:3000/Brad/Test-Repo/pulls/7'
+HEAD='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+file_mode() {
+  if [ "$(uname)" = Darwin ]; then stat -f %Lp "$1"; else stat -c %a "$1"; fi
+}
+
+write_config() {
+  local dir=$1
+  mkdir -p "$dir/config"
+  cat > "$dir/config/gitea" <<'EOF'
+base_url=http://gitea.lan:3000
+account=brad
+ssh_alias=forge
+ssh_alias=gitea-vpn.lan
+ssh_port=2222
+EOF
+  printf '%s\n' "$TOKEN" > "$dir/config/gitea-token"
+  chmod 0600 "$dir/config/gitea" "$dir/config/gitea-token"
+}
+
+make_fake_curl() {
+  local dir=$1
+  mkdir -p "$dir/fakebin"
+  cat > "$dir/fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+set -u
+method=GET
+url=
+output=
+data=
+auth=$(cat)
+printf 'call' >> "$FM_TEST_CURL_ARGV"
+while [ "$#" -gt 0 ]; do
+  printf ' <%s>' "$1" >> "$FM_TEST_CURL_ARGV"
+  case "$1" in
+    --request) method=$2; shift 2 ;;
+    --url) url=$2; shift 2 ;;
+    --output) output=$2; shift 2 ;;
+    --data-binary) data=${2#@}; shift 2 ;;
+    --config|--write-out|--header|--max-time|--max-filesize|--proto) shift 2 ;;
+    --silent) shift ;;
+    *) exit 91 ;;
+  esac
+done
+printf '\n' >> "$FM_TEST_CURL_ARGV"
+[ "$auth" = 'header = "Authorization: token fixture-secret-token-ABC123"' ] || exit 92
+[ -z "${FM_GITEA_TOKEN+x}" ] || exit 95
+printf 'auth-ok\n' >> "$FM_TEST_CURL_AUTH"
+scenario=${FM_TEST_GITEA_SCENARIO:-normal}
+fixture_head=${FM_TEST_GITEA_HEAD:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+code=200
+body=
+case "$scenario" in
+  auth-fail) code=401; body='{"error":"fixture-secret-token-ABC123 rejected"}' ;;
+  malformed) body='{"number":7,"html_url":"http://gitea.lan:3000/Brad/Test-Repo/pulls/7"}' ;;
+  cross-host) body='{"number":7,"html_url":"http://evil.lan:3000/Brad/Test-Repo/pulls/7","base":{"repo":{"full_name":"Brad/Test-Repo"}},"head":{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"state":"open","merged":false}' ;;
+  *)
+    case "$url" in
+      */pulls/7/reviews)
+        if [ "$scenario" = malformed-reviews ]; then
+          body='[{"id":1,"state":"UNRECOGNIZED","user":{"login":"reviewer"}}]'
+        else
+          body='[{"id":1,"state":"APPROVED","user":{"login":"reviewer"},"commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]'
+        fi
+        ;;
+      */commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/statuses)
+        if [ "$scenario" = malformed-checks ]; then
+          body='[{"id":2,"status":"unknown","context":"ci/test"}]'
+        else
+          body='[{"id":2,"status":"success","context":"ci/test","target_url":"http://ci.invalid/2","description":"passed"}]'
+        fi
+        ;;
+      */pulls/7/merge)
+        [ "$method" = POST ] || exit 93
+        [ -n "$data" ] && cp "$data" "$FM_TEST_CURL_MERGE_BODY"
+        [ "$scenario" = no-confirm ] || : > "$FM_TEST_CURL_MERGED"
+        body='{}'
+        ;;
+      */pulls)
+        [ "$method" = POST ] || exit 94
+        code=201
+        [ -n "$data" ] && cp "$data" "$FM_TEST_CURL_CREATE_BODY"
+        body=$(printf '{"number":7,"html_url":"http://gitea.lan:3000/Brad/Test-Repo/pulls/7","base":{"repo":{"full_name":"Brad/Test-Repo"}},"head":{"sha":"%s"},"state":"open","merged":false}' "$fixture_head")
+        ;;
+      */pulls/7)
+        state=open; merged=false
+        [ "$scenario" = closed ] && state=closed
+        if [ "$scenario" = merged ] || [ -e "$FM_TEST_CURL_MERGED" ]; then state=closed; merged=true; fi
+        body=$(printf '{"number":7,"html_url":"http://gitea.lan:3000/Brad/Test-Repo/pulls/7","base":{"repo":{"full_name":"Brad/Test-Repo"}},"head":{"sha":"%s"},"state":"%s","merged":%s}' "$fixture_head" "$state" "$merged")
+        ;;
+      *) code=404; body='{"message":"not found"}' ;;
+    esac
+    ;;
+esac
+printf '%s' "$body" > "$output"
+printf '%s' "$code"
+SH
+  chmod 0755 "$dir/fakebin/curl"
+  : > "$dir/curl.argv"
+  : > "$dir/curl.auth"
+}
+
+make_repo() {
+  local dir=$1 origin=${2:-git@forge:Brad/Test-Repo.git}
+  mkdir -p "$dir/repo"
+  git -C "$dir/repo" init -q
+  git -C "$dir/repo" remote add origin "$origin"
+}
+
+run_forge() {
+  local dir=$1; shift
+  FM_CONFIG_OVERRIDE="$dir/config" \
+  FM_FORGE_CURL_BIN="$dir/fakebin/curl" \
+  FM_TEST_CURL_ARGV="$dir/curl.argv" \
+  FM_TEST_CURL_AUTH="$dir/curl.auth" \
+  FM_TEST_CURL_CREATE_BODY="$dir/create.body" \
+  FM_TEST_CURL_MERGE_BODY="$dir/merge.body" \
+  FM_TEST_CURL_MERGED="$dir/merged.marker" \
+  "$FORGE" "$@"
+}
+
+assert_token_absent_tree() {
+  local dir=$1
+  if grep -R -F "$TOKEN" "$dir" \
+      --exclude=gitea-token --exclude=curl --exclude='*.test.sh' >/dev/null 2>&1; then
+    fail "token escaped its private fixture file"
+  fi
+}
+
+test_canonical_pr_parser() {
+  local url
+  while IFS= read -r url; do
+    fm_pr_url_parse "$url" || fail "Gitea parser rejected $url"
+    [ "$FM_PR_PROVIDER" = gitea ] || fail "Gitea parser returned wrong provider"
+    [ "$FM_PR_PATH" = Brad/Test-Repo ] || fail "Gitea parser returned wrong path"
+  done <<'EOF'
+http://gitea.lan:3000/Brad/Test-Repo/pulls/7
+https://10.0.0.8:8443/Brad/Test-Repo/pulls/7
+https://code.internal/Brad/Test-Repo/pulls/7
+EOF
+  for url in \
+    'HTTP://gitea.lan:3000/Brad/Test-Repo/pulls/7' \
+    'http://Gitea.lan:3000/Brad/Test-Repo/pulls/7' \
+    'http://gitea.lan:03000/Brad/Test-Repo/pulls/7' \
+    'http://gitea.lan:65536/Brad/Test-Repo/pulls/7' \
+    'http://user@gitea.lan:3000/Brad/Test-Repo/pulls/7' \
+    'http://gitea.lan:3000/Brad/Test-Repo.git/pulls/7' \
+    'http://gitea.lan:3000/Brad/Test-Repo/pulls/07' \
+    'http://gitea.lan:3000/Brad/Test-Repo/pulls/7?x=1' \
+    'https://github.com/Brad/Test-Repo/pulls/7'; do
+    ! fm_pr_url_parse "$url" || fail "Gitea parser accepted noncanonical $url"
+  done
+  fm_pr_url_parse https://github.com/o/r/pull/1 || fail "GitHub canonical URL regressed"
+  [ "$FM_PR_PROVIDER" = github ] || fail "GitHub provider regressed"
+  fm_pr_url_parse https://gitlab.com/g/p/-/merge_requests/1 || fail "GitLab canonical URL regressed"
+  [ "$FM_PR_PROVIDER" = gitlab ] || fail "GitLab provider regressed"
+  pass "Gitea PR identities support private HTTP ports without loosening GitHub or GitLab"
+}
+
+test_origin_alias_and_port_binding() {
+  local dir origin
+  dir="$TMP_ROOT/origins"
+  write_config "$dir"
+  for origin in \
+    'http://gitea.lan:3000/Brad/Test-Repo.git' \
+    'ssh://git@forge:2222/Brad/Test-Repo.git' \
+    'ssh://git@gitea.lan:2222/Brad/Test-Repo.git' \
+    'git@forge:Brad/Test-Repo.git' \
+    'git@gitea-vpn.lan:Brad/Test-Repo.git'; do
+    FM_CONFIG_OVERRIDE="$dir/config" fm_forge_repo_url_parse "$origin" \
+      || fail "configured Gitea origin was rejected: $origin"
+    [ "$FM_FORGE_REPO_PROVIDER" = gitea ] || fail "origin returned wrong provider"
+    [ "$FM_FORGE_REPO_URL" = 'http://gitea.lan:3000/Brad/Test-Repo' ] \
+      || fail "origin did not reconstruct canonical repo URL"
+  done
+  for origin in \
+    'http://other.lan:3000/Brad/Test-Repo.git' \
+    'ssh://git@forge:22/Brad/Test-Repo.git' \
+    'ssh://git@other:2222/Brad/Test-Repo.git' \
+    'git@other:Brad/Test-Repo.git'; do
+    ! FM_CONFIG_OVERRIDE="$dir/config" fm_forge_repo_url_parse "$origin" \
+      || fail "cross-host Gitea origin was accepted: $origin"
+  done
+  FM_CONFIG_OVERRIDE="$dir/config" fm_forge_repo_url_parse git@github.com:owner/repo.git \
+    || fail "GitHub repository identity regressed"
+  [ "$FM_FORGE_REPO_PROVIDER:$FM_FORGE_REPO_PATH" = github:owner/repo ] \
+    || fail "GitHub repository identity changed"
+  FM_CONFIG_OVERRIDE="$dir/config" fm_forge_repo_url_parse https://gitlab.com/group/subgroup/repo.git \
+    || fail "nested GitLab repository identity was not recognized"
+  [ "$FM_FORGE_REPO_PROVIDER:$FM_FORGE_REPO_PATH" = gitlab:group/subgroup/repo ] \
+    || fail "GitLab repository identity changed"
+  pass "forge repository identities bind Gitea aliases while preserving GitHub and nested GitLab"
+}
+
+test_private_configuration_and_token_custody() {
+  local dir out rc
+  dir="$TMP_ROOT/custody"
+  write_config "$dir"
+  make_fake_curl "$dir"
+  make_repo "$dir"
+
+  chmod 0644 "$dir/config/gitea-token"
+  set +e
+  out=$(run_forge "$dir" pr-state "$PR_URL" 2>&1); rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "world-readable token was accepted"
+  assert_contains "$out" 'not mode 0600' "unsafe token mode refusal was unclear"
+  chmod 0600 "$dir/config/gitea-token"
+
+  chmod 0644 "$dir/config/gitea"
+  set +e
+  out=$(run_forge "$dir" provider "$dir/repo" 2>&1); rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "world-readable Gitea config was accepted"
+  chmod 0600 "$dir/config/gitea"
+
+  printf '%s\n%s\n' "$TOKEN" extra > "$dir/config/gitea-token"
+  chmod 0600 "$dir/config/gitea-token"
+  set +e
+  out=$(run_forge "$dir" pr-state "$PR_URL" 2>&1); rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "multiline token file was accepted"
+  printf '%s\n' "$TOKEN" > "$dir/config/token-target"
+  chmod 0600 "$dir/config/token-target"
+  rm -f "$dir/config/gitea-token"
+  ln -s "$dir/config/token-target" "$dir/config/gitea-token"
+  set +e
+  out=$(run_forge "$dir" pr-state "$PR_URL" 2>&1); rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "symlinked token file was accepted"
+  rm -f "$dir/config/gitea-token" "$dir/config/token-target"
+  printf '%s\n' "$TOKEN" > "$dir/config/gitea-token"
+  chmod 0600 "$dir/config/gitea-token"
+
+  printf '%s\n' 'base_url=http://gitea.lan:3000' 'base_url=http://gitea.lan:4000' \
+    'account=brad' > "$dir/config/gitea"
+  chmod 0600 "$dir/config/gitea"
+  set +e
+  out=$(run_forge "$dir" provider "$dir/repo" 2>&1); rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "duplicate Gitea base URL was accepted"
+  write_config "$dir"
+
+  out=$(run_forge "$dir" pr-state "$PR_URL" 2> "$dir/stderr") \
+    || fail "valid private Gitea state lookup failed"
+  [ "$out" = open ] || fail "valid state lookup returned $out"
+  grep -qxF auth-ok "$dir/curl.auth" || fail "curl did not receive auth over stdin config"
+  assert_no_grep "$TOKEN" "$dir/curl.argv" "token appeared in curl argv"
+  assert_no_grep "$TOKEN" "$dir/stderr" "token appeared in successful diagnostics"
+
+  set +e
+  out=$(FM_TEST_GITEA_SCENARIO=auth-fail run_forge "$dir" pr-state "$PR_URL" 2>&1); rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "Gitea auth failure was accepted"
+  assert_contains "$out" 'authentication or authorization failed' "auth failure was not fixed and safe"
+  case "$out" in *"$TOKEN"*) fail "reflected auth error exposed the token" ;; esac
+  assert_token_absent_tree "$dir"
+  pass "Gitea config permissions and stdin-only token custody fail safely"
+}
+
+test_pr_operations_and_malformed_responses() {
+  local dir out rc scenario_command scenario command_name
+  dir="$TMP_ROOT/operations"
+  write_config "$dir"
+  make_fake_curl "$dir"
+  make_repo "$dir"
+  printf 'Body fixture.\n' > "$dir/body.md"
+
+  out=$(run_forge "$dir" pr-create "$dir/repo" --head fm/topic --base main \
+    --title 'Fixture PR' --body-file "$dir/body.md") || fail "Gitea PR create failed"
+  [ "$out" = "$PR_URL" ] || fail "Gitea PR create did not return canonical URL"
+  jq -e '.head == "fm/topic" and .base == "main" and .title == "Fixture PR" and .body == "Body fixture."' \
+    "$dir/create.body" >/dev/null || fail "Gitea PR create body was malformed"
+  [ "$(run_forge "$dir" pr-head "$PR_URL")" = "$HEAD" ] || fail "Gitea PR head failed"
+  [ "$(FM_TEST_GITEA_SCENARIO=closed run_forge "$dir" pr-state "$PR_URL")" = closed ] \
+    || fail "Gitea closed-unmerged state was misread"
+  [ -z "$(FM_TEST_GITEA_SCENARIO=closed run_forge "$dir" pr-merged "$PR_URL")" ] \
+    || fail "closed-unmerged Gitea PR reported merged"
+  assert_contains "$(run_forge "$dir" pr-reviews "$PR_URL")" '"state":"APPROVED"' \
+    "Gitea reviews were not validated"
+  assert_contains "$(run_forge "$dir" pr-checks "$PR_URL")" '"status":"success"' \
+    "Gitea checks were not validated"
+
+  for scenario_command in malformed:pr-head cross-host:pr-head malformed-reviews:pr-reviews malformed-checks:pr-checks; do
+    scenario=${scenario_command%%:*}
+    command_name=${scenario_command##*:}
+    set +e
+    out=$(FM_TEST_GITEA_SCENARIO=$scenario run_forge "$dir" "$command_name" "$PR_URL" 2>&1); rc=$?
+    set -e
+    [ "$rc" -ne 0 ] || fail "$scenario Gitea response was accepted"
+    case "$out" in *"$TOKEN"*) fail "$scenario response exposed token" ;; esac
+  done
+  set +e
+  out=$(run_forge "$dir" pr-state 'http://other.lan:3000/Brad/Test-Repo/pulls/7' 2>&1); rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "cross-host PR request was sent"
+  assert_contains "$out" 'does not match private configuration' "cross-host refusal was unclear"
+  pass "Gitea create, head, state, reviews, and checks validate exact response identities"
+}
+
+make_lifecycle_case() {
+  local dir=$1
+  write_config "$dir"
+  make_fake_curl "$dir"
+  mkdir -p "$dir/home/state" "$dir/fake-root/bin" "$dir/wt"
+  cat > "$dir/fake-root/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod 0755 "$dir/fake-root/bin/fm-guard.sh"
+  fm_write_meta "$dir/home/state/task-g.meta" \
+    'window=fm-task-g' \
+    "worktree=$dir/wt" \
+    "project=$dir/project" \
+    'kind=ship' \
+    'mode=direct-PR'
+}
+
+run_check() {
+  local dir=$1
+  FM_ROOT_OVERRIDE="$dir/fake-root" FM_HOME="$dir/home" FM_CONFIG_OVERRIDE="$dir/config" \
+  FM_FORGE_CURL_BIN="$dir/fakebin/curl" FM_TEST_CURL_ARGV="$dir/curl.argv" \
+  FM_TEST_CURL_AUTH="$dir/curl.auth" FM_TEST_CURL_CREATE_BODY="$dir/create.body" \
+  FM_TEST_CURL_MERGE_BODY="$dir/merge.body" FM_TEST_CURL_MERGED="$dir/merged.marker" \
+    "$PR_CHECK" task-g "$PR_URL"
+}
+
+run_merge() {
+  local dir=$1; shift
+  FM_ROOT_OVERRIDE="$dir/fake-root" FM_HOME="$dir/home" FM_CONFIG_OVERRIDE="$dir/config" \
+  FM_FORGE_CURL_BIN="$dir/fakebin/curl" FM_TEST_CURL_ARGV="$dir/curl.argv" \
+  FM_TEST_CURL_AUTH="$dir/curl.auth" FM_TEST_CURL_CREATE_BODY="$dir/create.body" \
+  FM_TEST_CURL_MERGE_BODY="$dir/merge.body" FM_TEST_CURL_MERGED="$dir/merged.marker" \
+    "$PR_MERGE" task-g "$PR_URL" "$@"
+}
+
+test_check_poll_and_guarded_merge() {
+  local dir out rc
+  dir="$TMP_ROOT/lifecycle"
+  make_lifecycle_case "$dir"
+  set +e
+  FM_TEST_GITEA_SCENARIO=auth-fail run_check "$dir" > "$dir/auth-check.out" 2> "$dir/auth-check.err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "fm-pr-check armed after a Gitea auth failure"
+  assert_absent "$dir/home/state/task-g.check.sh" "auth failure published a Gitea poll"
+  assert_no_grep '^pr=' "$dir/home/state/task-g.meta" "auth failure recorded a Gitea PR"
+  assert_no_grep "$TOKEN" "$dir/auth-check.err" "auth failure exposed token through fm-pr-check"
+
+  run_check "$dir" > "$dir/check.out" 2> "$dir/check.err" || fail "Gitea PR check failed"
+  grep -qxF "pr=$PR_URL" "$dir/home/state/task-g.meta" || fail "Gitea canonical PR was not recorded"
+  grep -qxF "pr_head=$HEAD" "$dir/home/state/task-g.meta" || fail "Gitea PR head was not recorded"
+  [ "$(cat "$dir/home/state/task-g.pr-poll")" = $'gitea\nhttp://gitea.lan:3000/Brad/Test-Repo/pulls/7\ngitea.lan:3000\nBrad/Test-Repo\n7' ] \
+    || fail "Gitea poll sidecar was not canonical"
+  cmp -s "$POLL" "$dir/home/state/task-g.check.sh" || fail "Gitea poll was not static"
+  assert_no_grep "$TOKEN" "$dir/home/state/task-g.meta" "token reached metadata"
+  assert_no_grep "$TOKEN" "$dir/home/state/task-g.check.sh" "token reached generated check"
+  assert_no_grep "$TOKEN" "$dir/home/state/task-g.pr-poll" "token reached poll data"
+
+  out=$(FM_HOME="$dir/home" FM_CONFIG_OVERRIDE="$dir/config" FM_FORGE_CURL_BIN="$dir/fakebin/curl" \
+    FM_TEST_CURL_ARGV="$dir/curl.argv" FM_TEST_CURL_AUTH="$dir/curl.auth" \
+    FM_TEST_CURL_CREATE_BODY="$dir/create.body" FM_TEST_CURL_MERGE_BODY="$dir/merge.body" \
+    FM_TEST_CURL_MERGED="$dir/merged.marker" FM_TEST_GITEA_SCENARIO=closed \
+    "$POLL" --validated gitea "$PR_URL" gitea.lan:3000 Brad/Test-Repo 7)
+  [ -z "$out" ] || fail "closed-unmerged Gitea poll emitted output"
+  out=$(FM_HOME="$dir/home" FM_CONFIG_OVERRIDE="$dir/config" FM_FORGE_CURL_BIN="$dir/fakebin/curl" \
+    FM_TEST_CURL_ARGV="$dir/curl.argv" FM_TEST_CURL_AUTH="$dir/curl.auth" \
+    FM_TEST_CURL_CREATE_BODY="$dir/create.body" FM_TEST_CURL_MERGE_BODY="$dir/merge.body" \
+    FM_TEST_CURL_MERGED="$dir/merged.marker" FM_TEST_GITEA_SCENARIO=auth-fail \
+    "$POLL" --validated gitea "$PR_URL" gitea.lan:3000 Brad/Test-Repo 7)
+  [ -z "$out" ] || fail "auth-failed Gitea poll emitted output"
+  assert_present "$dir/home/state/task-g.check.sh" "auth-failed poll retired its evidence"
+  out=$(FM_HOME="$dir/home" FM_CONFIG_OVERRIDE="$dir/config" FM_FORGE_CURL_BIN="$dir/fakebin/curl" \
+    FM_TEST_CURL_ARGV="$dir/curl.argv" FM_TEST_CURL_AUTH="$dir/curl.auth" \
+    FM_TEST_CURL_CREATE_BODY="$dir/create.body" FM_TEST_CURL_MERGE_BODY="$dir/merge.body" \
+    FM_TEST_CURL_MERGED="$dir/merged.marker" FM_TEST_GITEA_SCENARIO=merged \
+    "$POLL" --validated gitea "$PR_URL" gitea.lan:3000 Brad/Test-Repo 7)
+  [ "$out" = merged ] || fail "merged Gitea poll did not emit exactly merged"
+
+  rm -f "$dir/merged.marker"
+  run_merge "$dir" -- --squash --delete-branch > "$dir/merge.out" 2> "$dir/merge.err" \
+    || fail "guarded Gitea merge failed: $(cat "$dir/merge.err")"
+  jq -e '.Do == "squash" and .delete_branch_after_merge == true' "$dir/merge.body" >/dev/null \
+    || fail "Gitea merge payload did not preserve method and delete choice"
+
+  rm -f "$dir/merged.marker"
+  set +e
+  FM_TEST_GITEA_SCENARIO=no-confirm run_merge "$dir" -- --merge > "$dir/unconfirmed.out" 2> "$dir/unconfirmed.err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "unconfirmed Gitea merge reported success"
+  assert_token_absent_tree "$dir"
+  pass "fm-pr-check, static polling, and approval-path merge support canonical Gitea PRs"
+}
+
+test_gitea_teardown_landed_check() {
+  local dir head
+  dir="$TMP_ROOT/teardown"
+  write_config "$dir"
+  make_fake_curl "$dir"
+  mkdir -p "$dir/home/state" "$dir/data" "$dir/fake-root/bin" "$dir/fakebin"
+  cat > "$dir/fake-root/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$dir/fake-root/bin/fm-fleet-sync.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$dir/fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod 0755 "$dir/fake-root/bin/fm-guard.sh" "$dir/fake-root/bin/fm-fleet-sync.sh" \
+    "$dir/fakebin/treehouse" "$dir/fakebin/tmux"
+
+  git init -q --bare "$dir/origin.git"
+  git -C "$dir/origin.git" symbolic-ref HEAD refs/heads/main
+  git clone -q "$dir/origin.git" "$dir/seed" 2>/dev/null
+  git -C "$dir/seed" -c user.name=fixture -c user.email=fixture@example.invalid \
+    commit -q --allow-empty -m baseline
+  git -C "$dir/seed" push -q origin main
+  git clone -q "$dir/origin.git" "$dir/project"
+  git -C "$dir/project" worktree add -q -b fm/task-g-teardown "$dir/wt" main
+  git -C "$dir/wt" -c user.name=fixture -c user.email=fixture@example.invalid \
+    commit -q --allow-empty -m feature
+  head=$(git -C "$dir/wt" rev-parse HEAD)
+  fm_write_meta "$dir/home/state/task-g-teardown.meta" \
+    'window=fm-task-g-teardown' \
+    "worktree=$dir/wt" \
+    "project=$dir/project" \
+    'kind=ship' \
+    'mode=direct-PR' \
+    "pr=$PR_URL" \
+    "pr_head=$head"
+  touch "$dir/home/state/.last-watcher-beat"
+
+  FM_ROOT_OVERRIDE="$dir/fake-root" FM_HOME="$dir/home" \
+  FM_STATE_OVERRIDE="$dir/home/state" FM_DATA_OVERRIDE="$dir/data" \
+  FM_CONFIG_OVERRIDE="$dir/config" FM_FORGE_CURL_BIN="$dir/fakebin/curl" \
+  FM_TEST_CURL_ARGV="$dir/curl.argv" FM_TEST_CURL_AUTH="$dir/curl.auth" \
+  FM_TEST_CURL_CREATE_BODY="$dir/create.body" FM_TEST_CURL_MERGE_BODY="$dir/merge.body" \
+  FM_TEST_CURL_MERGED="$dir/merged.marker" FM_TEST_GITEA_SCENARIO=merged \
+  FM_TEST_GITEA_HEAD="$head" PATH="$dir/fakebin:$PATH" \
+    "$TEARDOWN" task-g-teardown > "$dir/teardown.out" 2> "$dir/teardown.err" \
+    || fail "Gitea merged-PR teardown refused: $(cat "$dir/teardown.err")"
+  assert_absent "$dir/home/state/task-g-teardown.meta" "Gitea landed cleanup retained task metadata"
+  assert_no_grep "$TOKEN" "$dir/teardown.err" "Gitea landed cleanup exposed token"
+  pass "Gitea merged-state and head evidence satisfy the existing guarded cleanup check"
+}
+
+test_gitea_direct_pr_brief() {
+  local dir brief
+  dir="$TMP_ROOT/brief"
+  write_config "$dir"
+  mkdir -p "$dir/data" "$dir/projects/gitea-project"
+  git -C "$dir/projects/gitea-project" init -q
+  git -C "$dir/projects/gitea-project" remote add origin git@forge:Brad/Test-Repo.git
+  printf '%s\n' '- gitea-project [direct-PR] - Gitea fixture (added 2026-07-21)' > "$dir/data/projects.md"
+  FM_HOME="$dir" "$ROOT/bin/fm-brief.sh" task-gitea gitea-project >/dev/null \
+    || fail "Gitea direct-PR brief generation failed"
+  brief="$dir/data/task-gitea/brief.md"
+  assert_grep 'fm-forge.sh pr-create' "$brief" "Gitea brief omitted common PR creation helper"
+  assert_grep 'do not use GitHub-only PR tooling' "$brief" "Gitea brief retained GitHub-only PR instruction"
+  # shellcheck disable=SC2016  # Backticks are literal generated brief text.
+  assert_no_grep 'open a PR with `gh-axi`' "$brief" "Gitea brief told worker to use gh-axi"
+  pass "registered Gitea direct-PR projects receive provider-correct worker instructions"
+}
+
+test_canonical_pr_parser
+test_origin_alias_and_port_binding
+test_private_configuration_and_token_custody
+test_pr_operations_and_malformed_responses
+test_check_poll_and_guarded_merge
+test_gitea_teardown_landed_check
+test_gitea_direct_pr_brief

--- a/tests/fm-forge-gitea.test.sh
+++ b/tests/fm-forge-gitea.test.sh
@@ -91,15 +91,21 @@ case "$scenario" in
         elif [ "$scenario" = reflected-review ]; then
           body='[{"id":1,"state":"APPROVED","user":{"login":"fixture-secret-token-ABC123"},"commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]'
         elif [ "$scenario" = paginated-reviews ] && [ "$page" -eq 1 ]; then
-          body=$(jq -cn '[range(1; 51) | {id:.,state:"APPROVED",user:{login:"reviewer"},commit_id:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]')
-        elif [ "$scenario" = paginated-reviews ]; then
+          body=$(jq -cn '[range(1; 21) | {id:.,state:"APPROVED",user:{login:"reviewer"},commit_id:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]')
+        elif [ "$scenario" = paginated-reviews ] && [ "$page" -eq 2 ]; then
           body='[{"id":51,"state":"REQUEST_CHANGES","user":{"login":"second-reviewer"},"commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]'
+        elif [ "$scenario" = paginated-reviews ]; then
+          body='[]'
         elif [ "$scenario" = malformed-review-page ] && [ "$page" -eq 1 ]; then
           body=$(jq -cn '[range(1; 51) | {id:.,state:"APPROVED",user:{login:"reviewer"},commit_id:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]')
         elif [ "$scenario" = malformed-review-page ]; then
           body='[{"id":51,"state":"UNRECOGNIZED","user":{"login":"reviewer"}}]'
         elif [ "$scenario" = excessive-reviews ]; then
           body=$(jq -cn --argjson page "$page" '[range(1; 51) | {id:(($page - 1) * 50 + .),state:"APPROVED",user:{login:"reviewer"},commit_id:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]')
+        elif [ "$scenario" = excessive-review-records ]; then
+          body=$(jq -cn '[range(1; 1002) | {id:.,state:"APPROVED",user:{login:"reviewer"},commit_id:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]')
+        elif [ "$page" -gt 1 ]; then
+          body='[]'
         else
           body='[{"id":1,"state":"APPROVED","user":{"login":"reviewer"},"commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]'
         fi
@@ -111,9 +117,13 @@ case "$scenario" in
         elif [ "$scenario" = reflected-check ]; then
           body='[{"id":2,"status":"success","context":"ci/test","target_url":"http://ci.invalid/fixture-secret-token-ABC123","description":"passed"}]'
         elif [ "$scenario" = paginated-checks ] && [ "$page" -eq 1 ]; then
-          body=$(jq -cn '[range(1; 51) | {id:.,status:"success",context:("ci/" + (.|tostring)),target_url:"http://ci.invalid/status",description:"passed"}]')
-        elif [ "$scenario" = paginated-checks ]; then
+          body=$(jq -cn '[range(1; 21) | {id:.,status:"success",context:("ci/" + (.|tostring)),target_url:"http://ci.invalid/status",description:"passed"}]')
+        elif [ "$scenario" = paginated-checks ] && [ "$page" -eq 2 ]; then
           body='[{"id":51,"status":"failure","context":"ci/final","target_url":"http://ci.invalid/51","description":"failed"}]'
+        elif [ "$scenario" = paginated-checks ]; then
+          body='[]'
+        elif [ "$page" -gt 1 ]; then
+          body='[]'
         else
           body='[{"id":2,"status":"success","context":"ci/test","target_url":"http://ci.invalid/2","description":"passed"}]'
         fi
@@ -369,11 +379,11 @@ test_pr_operations_and_malformed_responses() {
   assert_contains "$(run_forge "$dir" pr-checks "$PR_URL")" '"status":"success"' \
     "Gitea checks were not validated"
   reviews=$(FM_TEST_GITEA_SCENARIO=paginated-reviews run_forge "$dir" pr-reviews "$PR_URL")
-  [ "$(jq 'length' <<< "$reviews")" -eq 51 ] || fail "Gitea review pagination omitted records"
+  [ "$(jq 'length' <<< "$reviews")" -eq 21 ] || fail "Gitea review pagination omitted records"
   assert_contains "$reviews" '"state":"REQUEST_CHANGES"' \
     "Gitea review pagination omitted a later change request"
   checks=$(FM_TEST_GITEA_SCENARIO=paginated-checks run_forge "$dir" pr-checks "$PR_URL")
-  [ "$(jq 'length' <<< "$checks")" -eq 51 ] || fail "Gitea check pagination omitted records"
+  [ "$(jq 'length' <<< "$checks")" -eq 21 ] || fail "Gitea check pagination omitted records"
   assert_contains "$checks" '"status":"failure"' \
     "Gitea check pagination omitted a later failure"
 
@@ -390,6 +400,11 @@ test_pr_operations_and_malformed_responses() {
   assert_contains "$out" 'pagination safety limit' "excessive review pagination refusal was unclear"
   [ "$(grep -c 'reviews?page=' "$dir/curl.argv")" -le 20 ] \
     || fail "Gitea review pagination exceeded its request bound"
+  set +e
+  out=$(FM_TEST_GITEA_SCENARIO=excessive-review-records run_forge "$dir" pr-reviews "$PR_URL" 2>&1); rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "excessive Gitea review record count was accepted"
+  assert_contains "$out" 'record safety limit' "excessive review record refusal was unclear"
 
   for scenario_command in malformed:pr-head cross-host:pr-head malformed-reviews:pr-reviews malformed-checks:pr-checks; do
     scenario=${scenario_command%%:*}

--- a/tests/fm-forge-gitea.test.sh
+++ b/tests/fm-forge-gitea.test.sh
@@ -84,20 +84,36 @@ case "$scenario" in
           body='{"login":"brad"}'
         fi
         ;;
-      */pulls/7/reviews)
+      */pulls/7/reviews?page=*)
+        page=${url##*page=}; page=${page%%&*}
         if [ "$scenario" = malformed-reviews ]; then
           body='[{"id":1,"state":"UNRECOGNIZED","user":{"login":"reviewer"}}]'
         elif [ "$scenario" = reflected-review ]; then
           body='[{"id":1,"state":"APPROVED","user":{"login":"fixture-secret-token-ABC123"},"commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]'
+        elif [ "$scenario" = paginated-reviews ] && [ "$page" -eq 1 ]; then
+          body=$(jq -cn '[range(1; 51) | {id:.,state:"APPROVED",user:{login:"reviewer"},commit_id:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]')
+        elif [ "$scenario" = paginated-reviews ]; then
+          body='[{"id":51,"state":"REQUEST_CHANGES","user":{"login":"second-reviewer"},"commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]'
+        elif [ "$scenario" = malformed-review-page ] && [ "$page" -eq 1 ]; then
+          body=$(jq -cn '[range(1; 51) | {id:.,state:"APPROVED",user:{login:"reviewer"},commit_id:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]')
+        elif [ "$scenario" = malformed-review-page ]; then
+          body='[{"id":51,"state":"UNRECOGNIZED","user":{"login":"reviewer"}}]'
+        elif [ "$scenario" = excessive-reviews ]; then
+          body=$(jq -cn --argjson page "$page" '[range(1; 51) | {id:(($page - 1) * 50 + .),state:"APPROVED",user:{login:"reviewer"},commit_id:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]')
         else
           body='[{"id":1,"state":"APPROVED","user":{"login":"reviewer"},"commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]'
         fi
         ;;
-      */commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/statuses)
+      */commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/statuses?page=*)
+        page=${url##*page=}; page=${page%%&*}
         if [ "$scenario" = malformed-checks ]; then
           body='[{"id":2,"status":"unknown","context":"ci/test"}]'
         elif [ "$scenario" = reflected-check ]; then
           body='[{"id":2,"status":"success","context":"ci/test","target_url":"http://ci.invalid/fixture-secret-token-ABC123","description":"passed"}]'
+        elif [ "$scenario" = paginated-checks ] && [ "$page" -eq 1 ]; then
+          body=$(jq -cn '[range(1; 51) | {id:.,status:"success",context:("ci/" + (.|tostring)),target_url:"http://ci.invalid/status",description:"passed"}]')
+        elif [ "$scenario" = paginated-checks ]; then
+          body='[{"id":51,"status":"failure","context":"ci/final","target_url":"http://ci.invalid/51","description":"failed"}]'
         else
           body='[{"id":2,"status":"success","context":"ci/test","target_url":"http://ci.invalid/2","description":"passed"}]'
         fi
@@ -307,7 +323,7 @@ test_private_configuration_and_token_custody() {
 }
 
 test_pr_operations_and_malformed_responses() {
-  local dir out rc scenario_command scenario command_name branch
+  local dir out rc scenario_command scenario command_name branch reviews checks
   dir="$TMP_ROOT/operations"
   write_config "$dir"
   make_fake_curl "$dir"
@@ -352,6 +368,28 @@ test_pr_operations_and_malformed_responses() {
     "Gitea reviews were not validated"
   assert_contains "$(run_forge "$dir" pr-checks "$PR_URL")" '"status":"success"' \
     "Gitea checks were not validated"
+  reviews=$(FM_TEST_GITEA_SCENARIO=paginated-reviews run_forge "$dir" pr-reviews "$PR_URL")
+  [ "$(jq 'length' <<< "$reviews")" -eq 51 ] || fail "Gitea review pagination omitted records"
+  assert_contains "$reviews" '"state":"REQUEST_CHANGES"' \
+    "Gitea review pagination omitted a later change request"
+  checks=$(FM_TEST_GITEA_SCENARIO=paginated-checks run_forge "$dir" pr-checks "$PR_URL")
+  [ "$(jq 'length' <<< "$checks")" -eq 51 ] || fail "Gitea check pagination omitted records"
+  assert_contains "$checks" '"status":"failure"' \
+    "Gitea check pagination omitted a later failure"
+
+  set +e
+  out=$(FM_TEST_GITEA_SCENARIO=malformed-review-page run_forge "$dir" pr-reviews "$PR_URL" 2>&1); rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "malformed later Gitea review page was accepted"
+  assert_contains "$out" 'malformed review data' "malformed later review page refusal was unclear"
+  : > "$dir/curl.argv"
+  set +e
+  out=$(FM_TEST_GITEA_SCENARIO=excessive-reviews run_forge "$dir" pr-reviews "$PR_URL" 2>&1); rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "excessive Gitea review pagination was accepted"
+  assert_contains "$out" 'pagination safety limit' "excessive review pagination refusal was unclear"
+  [ "$(grep -c 'reviews?page=' "$dir/curl.argv")" -le 20 ] \
+    || fail "Gitea review pagination exceeded its request bound"
 
   for scenario_command in malformed:pr-head cross-host:pr-head malformed-reviews:pr-reviews malformed-checks:pr-checks; do
     scenario=${scenario_command%%:*}

--- a/tests/fm-forge-gitea.test.sh
+++ b/tests/fm-forge-gitea.test.sh
@@ -75,6 +75,15 @@ case "$scenario" in
   cross-host) body='{"number":7,"html_url":"http://evil.lan:3000/Brad/Test-Repo/pulls/7","base":{"repo":{"full_name":"Brad/Test-Repo"}},"head":{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"state":"open","merged":false}' ;;
   *)
     case "$url" in
+      */api/v1/user)
+        if [ "$scenario" = malformed-account ]; then
+          body='{"login":7}'
+        elif [ "$scenario" = wrong-account ]; then
+          body='{"login":"mallory"}'
+        else
+          body='{"login":"brad"}'
+        fi
+        ;;
       */pulls/7/reviews)
         if [ "$scenario" = malformed-reviews ]; then
           body='[{"id":1,"state":"UNRECOGNIZED","user":{"login":"reviewer"}}]'
@@ -298,7 +307,7 @@ test_private_configuration_and_token_custody() {
 }
 
 test_pr_operations_and_malformed_responses() {
-  local dir out rc scenario_command scenario command_name
+  local dir out rc scenario_command scenario command_name branch
   dir="$TMP_ROOT/operations"
   write_config "$dir"
   make_fake_curl "$dir"
@@ -310,6 +319,30 @@ test_pr_operations_and_malformed_responses() {
   [ "$out" = "$PR_URL" ] || fail "Gitea PR create did not return canonical URL"
   jq -e '.head == "fm/topic" and .base == "main" and .title == "Fixture PR" and .body == "Body fixture."' \
     "$dir/create.body" >/dev/null || fail "Gitea PR create body was malformed"
+
+  for branch in '.hidden' 'feature..topic' 'feature.lock' 'feature/' 'feature//topic' 'feature@{topic}'; do
+    : > "$dir/curl.argv"
+    set +e
+    out=$(run_forge "$dir" pr-create "$dir/repo" --head "$branch" --base main \
+      --title 'Fixture PR' --body-file "$dir/body.md" 2>&1); rc=$?
+    set -e
+    [ "$rc" -ne 0 ] || fail "Git-invalid Gitea head branch was accepted: $branch"
+    assert_contains "$out" 'branches are invalid' "Git-invalid branch refusal was unclear"
+    [ ! -s "$dir/curl.argv" ] || fail "Git-invalid branch triggered a Gitea request: $branch"
+  done
+
+  for scenario in malformed-account wrong-account; do
+    : > "$dir/curl.argv"
+    set +e
+    out=$(FM_TEST_GITEA_SCENARIO=$scenario run_forge "$dir" pr-state "$PR_URL" 2>&1); rc=$?
+    set -e
+    [ "$rc" -ne 0 ] || fail "$scenario Gitea account response was accepted"
+    assert_contains "$out" 'authenticated account does not match' \
+      "$scenario Gitea account refusal was unclear"
+    assert_no_grep '/repos/' "$dir/curl.argv" \
+      "$scenario Gitea account response allowed a repository request"
+  done
+
   [ "$(run_forge "$dir" pr-head "$PR_URL")" = "$HEAD" ] || fail "Gitea PR head failed"
   [ "$(FM_TEST_GITEA_SCENARIO=closed run_forge "$dir" pr-state "$PR_URL")" = closed ] \
     || fail "Gitea closed-unmerged state was misread"

--- a/tests/fm-forge-gitea.test.sh
+++ b/tests/fm-forge-gitea.test.sh
@@ -78,6 +78,8 @@ case "$scenario" in
       */pulls/7/reviews)
         if [ "$scenario" = malformed-reviews ]; then
           body='[{"id":1,"state":"UNRECOGNIZED","user":{"login":"reviewer"}}]'
+        elif [ "$scenario" = reflected-review ]; then
+          body='[{"id":1,"state":"APPROVED","user":{"login":"fixture-secret-token-ABC123"},"commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]'
         else
           body='[{"id":1,"state":"APPROVED","user":{"login":"reviewer"},"commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]'
         fi
@@ -85,6 +87,8 @@ case "$scenario" in
       */commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/statuses)
         if [ "$scenario" = malformed-checks ]; then
           body='[{"id":2,"status":"unknown","context":"ci/test"}]'
+        elif [ "$scenario" = reflected-check ]; then
+          body='[{"id":2,"status":"success","context":"ci/test","target_url":"http://ci.invalid/fixture-secret-token-ABC123","description":"passed"}]'
         else
           body='[{"id":2,"status":"success","context":"ci/test","target_url":"http://ci.invalid/2","description":"passed"}]'
         fi
@@ -105,7 +109,11 @@ case "$scenario" in
         state=open; merged=false
         [ "$scenario" = closed ] && state=closed
         if [ "$scenario" = merged ] || [ -e "$FM_TEST_CURL_MERGED" ]; then state=closed; merged=true; fi
-        body=$(printf '{"number":7,"html_url":"http://gitea.lan:3000/Brad/Test-Repo/pulls/7","base":{"repo":{"full_name":"Brad/Test-Repo"}},"head":{"sha":"%s"},"state":"%s","merged":%s}' "$fixture_head" "$state" "$merged")
+        if [ "$scenario" = reflected-pr ]; then
+          body=$(printf '{"number":7,"html_url":"http://gitea.lan:3000/Brad/Test-Repo/pulls/7","base":{"repo":{"full_name":"Brad/Test-Repo"}},"head":{"sha":"%s"},"state":"%s","merged":%s,"title":"fixture-secret-token-ABC123"}' "$fixture_head" "$state" "$merged")
+        else
+          body=$(printf '{"number":7,"html_url":"http://gitea.lan:3000/Brad/Test-Repo/pulls/7","base":{"repo":{"full_name":"Brad/Test-Repo"}},"head":{"sha":"%s"},"state":"%s","merged":%s}' "$fixture_head" "$state" "$merged")
+        fi
         ;;
       *) code=404; body='{"message":"not found"}' ;;
     esac
@@ -212,7 +220,7 @@ test_origin_alias_and_port_binding() {
 }
 
 test_private_configuration_and_token_custody() {
-  local dir out rc
+  local dir out rc scenario_command scenario command_name
   dir="$TMP_ROOT/custody"
   write_config "$dir"
   make_fake_curl "$dir"
@@ -271,8 +279,20 @@ test_private_configuration_and_token_custody() {
   out=$(FM_TEST_GITEA_SCENARIO=auth-fail run_forge "$dir" pr-state "$PR_URL" 2>&1); rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "Gitea auth failure was accepted"
-  assert_contains "$out" 'authentication or authorization failed' "auth failure was not fixed and safe"
+  assert_contains "$out" 'response contained private authentication data' "reflected auth failure was not fixed and safe"
   case "$out" in *"$TOKEN"*) fail "reflected auth error exposed the token" ;; esac
+
+  for scenario_command in reflected-pr:pr-state reflected-review:pr-reviews reflected-check:pr-checks; do
+    scenario=${scenario_command%%:*}
+    command_name=${scenario_command##*:}
+    set +e
+    out=$(FM_TEST_GITEA_SCENARIO=$scenario run_forge "$dir" "$command_name" "$PR_URL" 2>&1); rc=$?
+    set -e
+    [ "$rc" -ne 0 ] || fail "$scenario Gitea response was accepted"
+    assert_contains "$out" 'response contained private authentication data' \
+      "$scenario refusal was unclear"
+    case "$out" in *"$TOKEN"*) fail "$scenario response exposed the token" ;; esac
+  done
   assert_token_absent_tree "$dir"
   pass "Gitea config permissions and stdin-only token custody fail safely"
 }

--- a/tests/fm-forge-gitea.test.sh
+++ b/tests/fm-forge-gitea.test.sh
@@ -49,6 +49,7 @@ output=
 data=
 auth=$(cat)
 printf 'call' >> "$FM_TEST_CURL_ARGV"
+[ "${1:-}" = -q ] || exit 96
 while [ "$#" -gt 0 ]; do
   printf ' <%s>' "$1" >> "$FM_TEST_CURL_ARGV"
   case "$1" in
@@ -57,7 +58,7 @@ while [ "$#" -gt 0 ]; do
     --output) output=$2; shift 2 ;;
     --data-binary) data=${2#@}; shift 2 ;;
     --config|--write-out|--header|--max-time|--max-filesize|--proto) shift 2 ;;
-    --silent) shift ;;
+    -q|--silent) shift ;;
     *) exit 91 ;;
   esac
 done
@@ -307,6 +308,8 @@ test_private_configuration_and_token_custody() {
     || fail "valid private Gitea state lookup failed"
   [ "$out" = open ] || fail "valid state lookup returned $out"
   grep -qxF auth-ok "$dir/curl.auth" || fail "curl did not receive auth over stdin config"
+  grep -q '^call <-q>' "$dir/curl.argv" \
+    || fail "authenticated curl did not disable ambient configuration first"
   assert_no_grep "$TOKEN" "$dir/curl.argv" "token appeared in curl argv"
   assert_no_grep "$TOKEN" "$dir/stderr" "token appeared in successful diagnostics"
 

--- a/tests/fm-instruction-owners.test.sh
+++ b/tests/fm-instruction-owners.test.sh
@@ -68,7 +68,7 @@ test_project_management_owner_covers_guarded_operations() {
     '`direct-PR`' \
     '`local-only`' \
     'Default it off' \
-    'Creating a GitHub repository is outward-facing.' \
+    'Creating any remote repository is outward-facing.' \
     "captain's explicit consent" \
     'Never issue a raw removal command from Firstmate.' \
     'no-mistakes init && no-mistakes doctor'; do


### PR DESCRIPTION
## Intent

Implement the first production-quality Gitea forge foundation for FirstMate while preserving all existing GitHub and GitLab behavior. Introduce one secure provider abstraction for canonical repository and pull-request identities, private-network HTTP ports and SSH aliases/ports, strict private host/account/token configuration, and Gitea PR creation, state, head, review, checks, polling, guarded merge, and landed-work lifecycle integration. Keep tokens out of argv, environment, logs, generated checks, metadata, reports, and errors; stop on malformed, ambiguous, cross-host, auth, or unsupported responses. Update project and brief guidance so Gitea projects do not receive GitHub-only PR instructions, document mocked evidence without claiming live support, expose a typed extension point for later issue/milestone work, and comprehensively test security plus unchanged GitHub/GitLab behavior. Do not access any live Gitea server, repository, credential, or captain-private gitea-token; use deterministic mocked HTTP and git fixtures only, leaving live Brad/Test-Repo verification to a separately authorized task.

## What Changed

- Add a provider-neutral forge interface with canonical Gitea repository and pull-request identities, strict private configuration, and isolated token-authenticated HTTP requests.
- Integrate Gitea PR creation, state, head, reviews, checks, polling, guarded merge, and landed-work teardown while preserving GitHub and GitLab behavior.
- Add Gitea operator guidance and deterministic mocked coverage for security, pagination, private ports and SSH aliases, lifecycle behavior, and existing forge regressions.

## Risk Assessment

✅ Low: The latest fix now paginates independently of server page-size caps, validates every page, aggregates only within explicit page and record bounds, and fails closed when completion cannot be proven.

## Testing

Inspected the target diff, ran the deterministic mocked Gitea lifecycle/security suite and focused existing GitHub/GitLab PR, brief, review, teardown, and poll-security regressions, then generated reviewer-visible CLI help and a real Gitea worker brief; everything passed without live network or credential access, and the worktree stayed clean.

<details>
<summary>Evidence: Mocked Gitea lifecycle transcript</summary>

```text
FM_TEST_BEGIN 2026-07-24T01:16:33Z tests/fm-forge-gitea.test.sh family=pr-forge expected_gate_skip=none
ok - Gitea PR identities support private HTTP ports without loosening GitHub or GitLab
ok - forge repository identities bind Gitea aliases while preserving GitHub and nested GitLab
ok - Gitea config permissions and stdin-only token custody fail safely
ok - Gitea create, head, state, reviews, and checks validate exact response identities
ok - fm-pr-check, static polling, and approval-path merge support canonical Gitea PRs
ok - Gitea merged-state and head evidence satisfy the existing guarded cleanup check
ok - registered Gitea direct-PR projects receive provider-correct worker instructions
FM_TEST_END 2026-07-24T01:16:45Z tests/fm-forge-gitea.test.sh exit=0 duration_ms=12213 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=12274
FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=12213 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-forge-gitea.test.sh duration_ms=12213
fm-test-run: wrote timing artifact: /tmp/no-mistakes-evidence/01KY8TP89A2XW3SMPST870FFTQ/fm-forge-gitea-test.json
```
</details>
<details>
<summary>Evidence: Existing GitHub/GitLab PR regression transcript</summary>

```text
FM_TEST_BEGIN 2026-07-24T01:16:54Z tests/fm-pr-merge.test.sh family=pr-forge expected_gate_skip=none
ok - fm-pr-merge records pr= and pr_head= before invoking gh-axi pr merge
ok - fm-pr-merge propagates a real merge failure without silently succeeding
ok - fm-pr-merge forwards extra flags to gh-axi pr merge after the -- separator
ok - fm-pr-merge refuses before merging when task meta is missing
ok - fm-pr-merge refuses malformed PR URLs before calling gh-axi
ok - fm-pr-merge refuses unsafe PR URL segments before recording state
ok - fm-pr-merge refuses repo override args before recording state
ok - fm-pr-merge does not add default --squash when the caller passes an explicit merge method
ok - fm-pr-merge respects --method=<value> as an explicit merge method
ok - fm-pr-merge parses a GitHub PR URL into gh-axi number and --repo arguments
FM_TEST_END 2026-07-24T01:17:02Z tests/fm-pr-merge.test.sh exit=0 duration_ms=7354 gate_skip=false
FM_TEST_BEGIN 2026-07-24T01:17:02Z tests/fm-brief.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm-brief.sh: bash -n succeeds
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
FM_TEST_END 2026-07-24T01:17:03Z tests/fm-brief.test.sh exit=0 duration_ms=961 gate_skip=false
FM_TEST_BEGIN 2026-07-24T01:17:03Z tests/fm-review-diff.test.sh family=pr-forge expected_gate_skip=none
ok - fm-review-diff falls back to recorded pr_head when pull head cannot be fetched
ok - fm-review-diff fetches refs/pull/<n>/head when pr_head= is absent
ok - fm-review-diff prefers freshly fetched PR head over a stale recorded pr_head=
ok - fm-review-diff without pr= keeps the worktree-branch diff
ok - fm-review-diff falls back to local branch with a warning when PR head is unreachable
FM_TEST_END 2026-07-24T01:17:04Z tests/fm-review-diff.test.sh exit=0 duration_ms=838 gate_skip=false
FM_TEST_BEGIN 2026-07-24T01:17:04Z tests/fm-teardown.test.sh family=pr-forge expected_gate_skip=none
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains the stale journal and attempts no workspace cleanup when exact-pane close is unconfirmed
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
ok - fm-pr-check does not refresh PR head after HEAD moves
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
FM_TEST_END 2026-07-24T01:17:36Z tests/fm-teardown.test.sh exit=0 duration_ms=32763 gate_skip=false
FM_TEST_BEGIN 2026-07-24T01:17:36Z tests/fm-pr-check-security.test.sh family=pr-forge expected_gate_skip=none
ok - raw-byte parser accepts canonical URLs and rejects the complete adversarial matrix
ok - GitLab merge requests are followed on any instance and never wake falsely
ok - validated merged polls notify once and retire before the next watcher cycle
ok - merged poll retirement preserves every persistent secondmate lifecycle artifact
ok - queue, receipt, and every fixed-path removal crash point recover without loss or repeated execution
ok - open/red, closed-unmerged, malformed, and forge errors remain armed until an exact merged transition
ok - replacement, nonterminal, tampered, and custom results receive no deletion authority
ok - queue failure and untrusted receipts preserve canonical poll evidence
ok - GitHub and GitLab exact merged results share one retirement path
ok - PR and teardown entrypoints reject invalid arguments before every side effect
ok - valid direct and merge flows record exact metadata and reject multiline head metadata
ok - rejected metacharacter bytes remain inert at generation and watcher time
ok - static poll is silent except for one merged line and remains watcher-bounded
ok - interrupted atomic preparation cleans private temporaries and publishes nothing
ok - concurrent watchers observe only complete private poll publications
ok - post-rename poll validation faults revoke both names and allow a clean retry
ok - migration creates and validates private state before watcher exclusion
ok - migration pauses older watchers and acquires exclusion before its first scan or marker
ok - poll, marker, diagnostic, and quarantine paths refuse symlinks and directories
ok - marker and diagnostic rename errors and signals fail closed and recover durably on retry
ok - post-rename marker, diagnostic, and obligation faults are revoked and reconstructed on retry
ok - quarantine type and mode faults fail closed and recover only when a retry can validate them
ok - canonical and ambiguous failure obligations block every retry until all task artifacts are repaired
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - ambiguous migration recovery accepts an explicitly validated replacement poll
ok - ambiguous repair rejects copied, metadata- or task-mismatched, forged, and partial poll publications
ok - all live, marker, diagnostic, X, custom-check, obligation, and teardown boundaries require single-link files
ok - canonical publication failure remains incomplete until a later clean retry rebuilds the poll
ok - legacy reserved obligations and delimiter-bearing task IDs retry without ambiguity
ok - migration never executes legacy checks, preserves X mode, quarantines ambiguity, and is idempotent
ok - historical X shims migrate only from the exact single-link mode-0755 identity
ok - direct registration refreshes authenticated v1 X shims across marker states
ok - bootstrap runs the non-executing migration at the locked session boundary
ok - bootstrap isolates incomplete poll migration from unrelated recovery sweeps
ok - watcher signals promptly stop custom checks and clean private state
ok - returned custom check descendants are drained on installed and fallback timeout paths
ok - teardown removes safe poll artifacts and refuses quarantine-directory symlinks without traversal
FM_TEST_END 2026-07-24T01:24:13Z tests/fm-pr-check-security.test.sh exit=0 duration_ms=397035 gate_skip=false
FM_TEST_SUMMARY total=5 failed=0 skipped_gate=0 duration_ms=439149
FM_TEST_SUMMARY_FAMILY family=pr-forge count=4 duration_ms=437990 failed=0
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=961 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-pr-check-security.test.sh duration_ms=397035
FM_TEST_SLOWEST rank=2 script=tests/fm-teardown.test.sh duration_ms=32763
FM_TEST_SLOWEST rank=3 script=tests/fm-pr-merge.test.sh duration_ms=7354
FM_TEST_SLOWEST rank=4 script=tests/fm-brief.test.sh duration_ms=961
FM_TEST_SLOWEST rank=5 script=tests/fm-review-diff.test.sh duration_ms=838
fm-test-run: wrote timing artifact: /tmp/no-mistakes-evidence/01KY8TP89A2XW3SMPST870FFTQ/existing-pr-regressions.json
```
</details>
<details>
<summary>Evidence: Generated provider-correct Gitea worker brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of gitea-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/task-gitea`

# Rules
1. Never push to the default branch (push only your `fm/task-gitea` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations, `/home/brad/.no-mistakes/worktrees/2bd8cc0004cc/01KY8TP89A2XW3SMPST870FFTQ/bin/fm-forge.sh` for configured Gitea PR operations, and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KY8TP89A2XW3SMPST870FFTQ/brief-home/state/task-gitea.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/brad/.no-mistakes/worktrees/2bd8cc0004cc/01KY8TP89A2XW3SMPST870FFTQ/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/brad/.no-mistakes/worktrees/2bd8cc0004cc/01KY8TP89A2XW3SMPST870FFTQ/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open the PR with `gh-axi` for GitHub, or the registered forge helper named in `/home/brad/.no-mistakes/worktrees/2bd8cc0004cc/01KY8TP89A2XW3SMPST870FFTQ/bin/fm-forge.sh --help` for another recognized provider, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Provider-neutral forge CLI help</summary>

```text
Provider-neutral forge helper for repository detection and PR operations.
Canonical identity is owned by bin/fm-pr-lib.sh; provider dispatch and all
Gitea HTTP/auth mechanics are owned by bin/fm-forge-lib.sh.

Gitea uses private config/gitea and config/gitea-token files under the
effective FirstMate config directory. docs/configuration.md owns their exact
schema, permission checks, origin binding, and token-custody contract.

Usage:
  fm-forge.sh provider <repository-dir>
  fm-forge.sh canonical-repo <repository-dir>
  fm-forge.sh pr-create <repository-dir> --head <branch> --base <branch>
    --title <title> [--body <text> | --body-file <path>]
  fm-forge.sh pr-state <canonical-pr-url>
  fm-forge.sh pr-head <canonical-pr-url>
  fm-forge.sh pr-merged <canonical-pr-url>
  fm-forge.sh pr-reviews <canonical-gitea-pr-url>
  fm-forge.sh pr-checks <canonical-gitea-pr-url>

pr-create uses gh-axi for GitHub, glab for GitLab, and the authenticated API
client for configured Gitea repositories. It prints the forge's canonical PR
URL on success and stops on an unsupported or ambiguous response.
Merge is intentionally absent: all task PR merges must go through
bin/fm-pr-merge.sh's approval-recording path.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-forge-lib.sh:331` - The required criterion says “Keep tokens out of argv, environment, logs, generated checks, metadata, reports, and errors,” but curl is invoked without `-q` as its first argument. Curl therefore loads the ambient `.curlrc` even when `--config -` is used; options such as `trace`, `verbose`, or an additional URL can expose the Authorization header/token. Invoke curl with `-q` first to isolate the authenticated request from user configuration.
- ⚠️ `bin/fm-forge-lib.sh:493` - Review and check lookups request only the API&#39;s default page and return it as the complete result. PRs with enough reviews or commit statuses to paginate will silently omit later entries, potentially hiding a change request or failed check. Fetch validated pages until exhaustion (with a bounded page/record limit) before emitting the aggregate.

🔧 Fix: Paginate validated Gitea lifecycle collections
1 error still open:
- 🚨 `bin/fm-forge-lib.sh:531` - Pagination stops whenever a page contains fewer than the requested 50 records. Gitea can configure `MAX_RESPONSE_ITEMS` below 50, so a server capped at 20 would return 20 records for page 1 and this code would incorrectly treat the collection as complete, potentially hiding later change requests or failed checks. Continue until an empty page or validated pagination metadata indicates completion, while retaining the page/record safety bound.

🔧 Fix: Handle server-capped Gitea pagination safely
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --stat` and `git diff --name-only ec0987141aea533684c6a6d8b74d692f8326994e..871394269023432f8d8033e6da77a95b878f3629` plus the relevant implementation, tests, and documentation.</code>
- `bin/fm-test-run.sh tests/fm-forge-gitea.test.sh --json /tmp/no-mistakes-evidence/01KY8TP89A2XW3SMPST870FFTQ/fm-forge-gitea-test.json`
- `bin/fm-test-run.sh tests/fm-pr-merge.test.sh tests/fm-brief.test.sh tests/fm-review-diff.test.sh tests/fm-teardown.test.sh tests/fm-pr-check-security.test.sh --json /tmp/no-mistakes-evidence/01KY8TP89A2XW3SMPST870FFTQ/existing-pr-regressions.json`
- <code>Generated an actual direct-PR Gitea project brief with `FM_HOME=&lt;evidence-fixture&gt; bin/fm-brief.sh task-gitea gitea-project` and inspected its provider-specific instructions.</code>
- <code>Captured and inspected `bin/fm-forge.sh --help` for the exposed provider-neutral PR workflow and guarded-merge boundary.</code>
- <code>Verified cleanup state with `git status --short`; testing introduced no worktree changes.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Fix Gitea curl isolation and branch lint
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
