### PR TITLE
docs(intake): fix delivery lane at dispatch, forbid mid-run downgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,7 @@ Load `diagnostic-reasoning` before scoping a reported bug and before acting on a
 
 Classify work as dispatchable when it does not overlap work under way, or queued and blocked when it touches the same project subsystem or depends on unlanded work.
 Dispatch independent work immediately with no concurrency cap, serialize coarse overlaps, and record blockers durably.
+Choosing or skipping the no-mistakes validation pipeline is a delivery-lane routing decision made here at dispatch time, never a mid-run bypass, and a worker never downgrades its own delivery mode mid-run without a new captain or firstmate decision.
 Write the task-specific brief under section 11 before spawning.
 
 ### Dispatch and supervision handoff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)
   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
+  <id>/promotion-handoff.md  persisted mode-specific ship contract for a promoted scout
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; READ-ONLY for you
 state/               volatile runtime signals; gitignored
@@ -310,7 +311,7 @@ Read the report, relay its findings rather than merely saying it finished, recor
 A report may recommend implementation but does not authorize it.
 Before treating the investigation or any visual review as complete, load `decision-hold-lifecycle`; teardown enforces that shared completion gate.
 When implementation is separately authorized, promote the existing scout through `bin/fm-promote.sh` rather than creating a duplicate task.
-The promoted worker must inventory scratch state, return to a clean default-branch base, carry over only intended fix changes, create the ship branch, and follow the project's selected delivery path.
+The promoted worker must inventory scratch state, return to a clean default-branch base, carry over only intended fix changes, create the ship branch, and follow the task's recorded delivery path from its persisted promotion handoff.
 Scratch commits and debug edits never ride along, and a reproduced bug becomes the regression test.
 
 ## 8. Supervision protocol

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -277,6 +277,11 @@ read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
 
+# Delivery lane is assigned at dispatch and fixed for the task; a worker never
+# downgrades to a faster path mid-run on its own. Shared across every mode DOD so
+# the sentence has a single owner (AGENTS.md section 7 states the same contract).
+LANE_LOCK="Your delivery lane is assigned at dispatch and fixed for this task: never switch lanes or downgrade to a faster path mid-run without a new captain or firstmate decision."
+
 case "$MODE" in
   direct-PR)
     SETUP2=""
@@ -284,6 +289,7 @@ case "$MODE" in
     DOD=$(cat <<EOF
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
+$LANE_LOCK
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
@@ -296,6 +302,7 @@ EOF
     DOD=$(cat <<EOF
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
+$LANE_LOCK
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
@@ -309,6 +316,8 @@ EOF
     RULE1='1. Never push to the default branch. Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done
+This project ships **no-mistakes**: the full validation pipeline runs on your committed branch before the PR is raised and merged.
+$LANE_LOCK
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -66,7 +66,11 @@ shape_ship_contract() {
   case "$mode" in
     direct-PR)
       SETUP2=""
-      RULE1='1. Never push to the default branch (push only your `fm/'"$id"'` branch). Never merge a PR.'
+      RULE1=$(cat <<EOF
+1. Never push to the default branch (push only your \`fm/$id\` branch).
+   Never merge a PR.
+EOF
+)
       DOD=$(cat <<EOF
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
@@ -80,7 +84,11 @@ EOF
       ;;
     local-only)
       SETUP2=""
-      RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$id\` branch; firstmate handles the merge into local \`main\`."
+      RULE1=$(cat <<EOF
+1. Never push to any remote and never open a PR.
+   Work only on your \`fm/$id\` branch; firstmate handles the merge into local \`main\`.
+EOF
+)
       DOD=$(cat <<EOF
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
@@ -94,9 +102,12 @@ EOF
 )
       ;;
     no-mistakes)
-      SETUP2="
-2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
-      RULE1='1. Never push to the default branch. Never merge a PR.'
+      SETUP2="2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
+      RULE1=$(cat <<'EOF'
+1. Never push to the default branch.
+   Never merge a PR.
+EOF
+)
       DOD=$(cat <<EOF
 # Definition of done
 This project ships **no-mistakes**: the full validation pipeline runs on your committed branch before the PR is raised and merged.
@@ -126,12 +137,24 @@ EOF
   esac
 }
 
+render_promoted_ship_contract() {
+  shape_ship_contract "$1" "$2"
+
+  cat <<EOF
+# Promoted ship contract
+The mode-specific setup, rules, and definition of done below supersede every conflicting scout-brief instruction, including its blanket rule forbidding pushes and pull requests.
+EOF
+  if [ -n "$SETUP2" ]; then
+    printf '\n# Mode-specific setup\n%s\n' "$SETUP2"
+  fi
+  printf '\n# Mode-specific rules\n%s\n\n%s\n' "$RULE1" "$DOD"
+}
+
 case "${1:-}" in
   -h|--help) usage; exit 0 ;;
   --ship-contract)
     [ "$#" -eq 3 ] || { echo "error: usage: fm-brief.sh --ship-contract <task-id> <mode>" >&2; exit 2; }
-    shape_ship_contract "$3" "$2"
-    printf '%s\n' "$DOD"
+    render_promoted_ship_contract "$3" "$2"
     exit 0
     ;;
 esac
@@ -369,7 +392,8 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+1. First action: create your branch: \`git checkout -b fm/$ID\`
+$SETUP2
 
 # Rules
 $RULE1

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -8,6 +8,7 @@
 # of shipping a new one).
 # Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
+#        fm-brief.sh --ship-contract <task-id> <mode>
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
 #   --secondmate writes a persistent secondmate charter. The project list
@@ -57,8 +58,82 @@ usage() {
   ' "$0"
 }
 
+LANE_LOCK="Your delivery lane is assigned at dispatch and fixed for this task: never switch lanes or downgrade to a faster path mid-run without a new captain or firstmate decision."
+
+shape_ship_contract() {
+  local mode=$1 id=$2
+
+  case "$mode" in
+    direct-PR)
+      SETUP2=""
+      RULE1='1. Never push to the default branch (push only your `fm/'"$id"'` branch). Never merge a PR.'
+      DOD=$(cat <<EOF
+# Definition of done
+This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
+$LANE_LOCK
+The task is complete only when committed on your branch.
+When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+Do NOT run /no-mistakes.
+The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+EOF
+)
+      ;;
+    local-only)
+      SETUP2=""
+      RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$id\` branch; firstmate handles the merge into local \`main\`."
+      DOD=$(cat <<EOF
+# Definition of done
+This project ships **local-only**: no remote, no PR, no pipeline.
+$LANE_LOCK
+The task is complete only when committed on your branch \`fm/$id\`.
+Do NOT push, do NOT open a PR, do NOT merge.
+Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
+When it is implemented and committed, append \`done: ready in branch fm/$id\` to the status file and stop.
+The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
+EOF
+)
+      ;;
+    no-mistakes)
+      SETUP2="
+2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
+      RULE1='1. Never push to the default branch. Never merge a PR.'
+      DOD=$(cat <<EOF
+# Definition of done
+This project ships **no-mistakes**: the full validation pipeline runs on your committed branch before the PR is raised and merged.
+$LANE_LOCK
+The task is complete only when committed on your branch.
+When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+
+You drive no-mistakes by responding to its gates, not by implementing fixes.
+Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+
+Two firstmate-specific rules layer on top of that guidance:
+- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
+  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
+- Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
+
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop.
+You are finished.
+EOF
+)
+      ;;
+    *)
+      echo "error: unsupported delivery mode: $mode" >&2
+      return 2
+      ;;
+  esac
+}
+
 case "${1:-}" in
   -h|--help) usage; exit 0 ;;
+  --ship-contract)
+    [ "$#" -eq 3 ] || { echo "error: usage: fm-brief.sh --ship-contract <task-id> <mode>" >&2; exit 2; }
+    shape_ship_contract "$3" "$2"
+    printf '%s\n' "$DOD"
+    exit 0
+    ;;
 esac
 
 # shellcheck source=bin/fm-marker-lib.sh
@@ -277,65 +352,7 @@ read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
 
-# Delivery lane is assigned at dispatch and fixed for the task; a worker never
-# downgrades to a faster path mid-run on its own. Shared across every mode DOD so
-# the sentence has a single owner (AGENTS.md section 7 states the same contract).
-LANE_LOCK="Your delivery lane is assigned at dispatch and fixed for this task: never switch lanes or downgrade to a faster path mid-run without a new captain or firstmate decision."
-
-case "$MODE" in
-  direct-PR)
-    SETUP2=""
-    RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-$LANE_LOCK
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
-EOF
-)
-    ;;
-  local-only)
-    SETUP2=""
-    RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **local-only**: no remote, no PR, no pipeline.
-$LANE_LOCK
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
-Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
-The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
-EOF
-)
-    ;;
-  *)  # no-mistakes (default)
-    SETUP2="
-2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
-    RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **no-mistakes**: the full validation pipeline runs on your committed branch before the PR is raised and merged.
-$LANE_LOCK
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
-
-You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
-Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
-
-Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
-  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
-
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
-EOF
-)
-    ;;
-esac
+shape_ship_contract "$MODE" "$ID"
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -16,6 +16,8 @@
 #   tells the main firstmate when to route work there; routine churn stays in its own home;
 #   captain-relevant escalations and marked from-firstmate replies append to this
 #   home's status file.
+#   --ship-contract writes only the mode-specific setup, rules, and definition of done to stdout for a promoted scout, including the fixed-lane contract.
+#   Its <mode> must be no-mistakes, direct-PR, or local-only.
 #   --no-projects writes a project-less charter for a domain whose subject is the
 #   firstmate repo itself (its home is a firstmate worktree, its crews take pooled
 #   worktrees of the same repo). It is mutually exclusive with a project list, and

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -5,7 +5,8 @@
 # again. After promoting, send the crewmate its ship instructions via fm-send.sh
 # (inventory scratch state, reset to a clean default-branch base, carry over only
 # intended fix changes, create branch fm/<task-id>, implement, then report done
-# according to the project's delivery mode).
+# according to the recorded delivery mode and fixed-lane contract rendered by
+# fm-brief.sh).
 # Usage: fm-promote.sh <task-id>
 set -eu
 
@@ -19,11 +20,30 @@ META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
 grep -qx 'kind=scout' "$META" || { echo "error: task $ID is not a scout task (kind=scout not in meta)" >&2; exit 1; }
 
+MODE=$(sed -n 's/^mode=//p' "$META")
+case "$MODE" in
+  no-mistakes|direct-PR|local-only) ;;
+  *) echo "error: task $ID has missing, duplicate, or unsupported recorded mode" >&2; exit 1 ;;
+esac
+SHIP_CONTRACT=$("$FM_ROOT/bin/fm-brief.sh" --ship-contract "$ID" "$MODE")
+HANDOFF=$(cat <<EOF
+The scout task is now promoted to a ship task.
+Review scratch state with git status and git log.
+Return to a clean default-branch base.
+Carry over only intended fix changes.
+Create branch fm/$ID and implement the authorized change.
+Follow the recorded delivery contract below.
+
+$SHIP_CONTRACT
+EOF
+)
+
 TMP="$META.tmp"
 grep -v '^kind=' "$META" > "$TMP"
 echo "kind=ship" >> "$TMP"
 mv "$TMP" "$META"
 
 HOME_Q=$(printf '%q' "$FM_HOME")
+HANDOFF_Q=$(printf '%q' "$HANDOFF")
 echo "promoted $ID to ship (teardown protection restored)"
-echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement; report done>'"
+echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID $HANDOFF_Q"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -2,8 +2,8 @@
 # Promote a scout task to a ship task in place: the crewmate keeps its window,
 # worktree, and loaded context; only the contract changes. Flips kind= to ship in
 # state/<task-id>.meta so fm-teardown.sh applies the full ship-task teardown protection
-# again. Before promoting, persist the crewmate's ship instructions under the
-# task data directory, then print a one-line fm-send.sh pointer to that file.
+# again. Before promoting, persist the crewmate's ship instructions at
+# data/<task-id>/promotion-handoff.md, then print a one-line fm-send.sh pointer to that file.
 # The handoff covers inventorying scratch state, resetting to a clean
 # default-branch base, carrying over only intended fix changes, creating branch
 # fm/<task-id>, implementing, and reporting done according to the recorded

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -2,11 +2,12 @@
 # Promote a scout task to a ship task in place: the crewmate keeps its window,
 # worktree, and loaded context; only the contract changes. Flips kind= to ship in
 # state/<task-id>.meta so fm-teardown.sh applies the full ship-task teardown protection
-# again. After promoting, send the crewmate its ship instructions via fm-send.sh
-# (inventory scratch state, reset to a clean default-branch base, carry over only
-# intended fix changes, create branch fm/<task-id>, implement, then report done
-# according to the recorded delivery mode and fixed-lane contract rendered by
-# fm-brief.sh).
+# again. Before promoting, persist the crewmate's ship instructions under the
+# task data directory, then print a one-line fm-send.sh pointer to that file.
+# The handoff covers inventorying scratch state, resetting to a clean
+# default-branch base, carrying over only intended fix changes, creating branch
+# fm/<task-id>, implementing, and reporting done according to the recorded
+# delivery mode and fixed-lane contract rendered by fm-brief.sh.
 # Usage: fm-promote.sh <task-id>
 set -eu
 
@@ -14,6 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1
 META="$STATE/$ID.meta"
@@ -26,7 +28,12 @@ case "$MODE" in
   *) echo "error: task $ID has missing, duplicate, or unsupported recorded mode" >&2; exit 1 ;;
 esac
 SHIP_CONTRACT=$("$FM_ROOT/bin/fm-brief.sh" --ship-contract "$ID" "$MODE")
-HANDOFF=$(cat <<EOF
+HANDOFF_DIR="$DATA/$ID"
+HANDOFF_FILE="$HANDOFF_DIR/promotion-handoff.md"
+HANDOFF_TMP="$HANDOFF_FILE.tmp"
+mkdir -p "$HANDOFF_DIR"
+cat > "$HANDOFF_TMP" <<EOF
+# Scout promotion handoff
 The scout task is now promoted to a ship task.
 Review scratch state with git status and git log.
 Return to a clean default-branch base.
@@ -36,7 +43,7 @@ Follow the recorded delivery contract below.
 
 $SHIP_CONTRACT
 EOF
-)
+mv "$HANDOFF_TMP" "$HANDOFF_FILE"
 
 TMP="$META.tmp"
 grep -v '^kind=' "$META" > "$TMP"
@@ -44,6 +51,7 @@ echo "kind=ship" >> "$TMP"
 mv "$TMP" "$META"
 
 HOME_Q=$(printf '%q' "$FM_HOME")
-HANDOFF_Q=$(printf '%q' "$HANDOFF")
+POINTER="Read the promotion handoff at $HANDOFF_FILE and follow it."
+POINTER_Q=$(printf '%q' "$POINTER")
 echo "promoted $ID to ship (teardown protection restored)"
-echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID $HANDOFF_Q"
+echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID $POINTER_Q"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,6 +180,8 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 
 `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
 `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
+[`AGENTS.md`](../AGENTS.md) section 7 owns the dispatch-time fixed-lane policy; generated ship briefs name the recorded mode explicitly, and scout promotion reuses that same recorded mode.
+Scout promotion validates the mode in task metadata, persists its generated ship contract at `data/<id>/promotion-handoff.md` before changing the task kind, and sends the worker a one-line pointer to that handoff.
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ The shared orchestrator behavior lives in [`AGENTS.md`](../AGENTS.md) - edit it 
 
 This section is the single owner of the top-level operational-home layout; producer script headers and their help own exact child-file fields and mutation contracts.
 The tracked code root contains the shared instruction, skill, documentation, workflow, and `bin/` surfaces, while each effective `FM_HOME` contains private operational directories.
-`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, and scout reports.
+`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, scout reports, and scout-promotion handoffs.
 `state/` holds volatile runtime records such as task metadata, append-only status events, endpoint signals, watcher and wake-queue coordination, away-mode state, generated X-mode artifacts, private secondmate config-reread generations with their retry and quarantine state, and parent-owned secondmate pending-reply records under `state/pending-replies/` (`bin/fm-pending-reply-lib.sh`).
 `config/` holds local gitignored operating choices, and `projects/` holds the local project clones that Firstmate reads but changes only through the guarded exceptions in `AGENTS.md`.
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -84,7 +84,7 @@ test_ship_modes_generate_clean_briefs() {
 }
 
 test_promoted_scouts_reuse_recorded_ship_contract() {
-  local home id meta out status lane
+  local home id meta handoff out status lane next_line next_count
   home="$TMP_ROOT/promote-home"
   mkdir -p "$home/state"
   touch "$home/state/.last-watcher-beat"
@@ -107,9 +107,24 @@ test_promoted_scouts_reuse_recorded_ship_contract() {
       local-only) lane='This project ships **local-only**' ;;
       *) lane='This project ships **no-mistakes**' ;;
     esac
-    assert_contains "$out" "$lane" "$id: promotion handoff must name its recorded delivery lane"
-    assert_contains "$out" "delivery lane is assigned at dispatch and fixed for this task" \
+    handoff="$home/data/$id/promotion-handoff.md"
+    assert_present "$handoff" "$id: promotion handoff file was not persisted"
+    assert_grep "$lane" "$handoff" "$id: promotion handoff must name its recorded delivery lane"
+    assert_grep "delivery lane is assigned at dispatch and fixed for this task" "$handoff" \
       "$id: promotion handoff must carry the fixed-lane contract"
+    next_line=$(printf '%s\n' "$out" | sed -n '/^next: /p')
+    next_count=$(printf '%s\n' "$out" | awk '/^next: / { count++ } END { print count + 0 }')
+    [ "$next_count" -eq 1 ] || fail "$id: promotion must print exactly one fm-send pointer"
+    assert_contains "$next_line" "bin/fm-send.sh fm-$id" \
+      "$id: promotion must target its worker through fm-send"
+    assert_contains "$next_line" 'Read\ the\ promotion\ handoff\ at' \
+      "$id: fm-send pointer must tell the worker to read the handoff"
+    assert_contains "$next_line" "promotion-handoff.md" \
+      "$id: fm-send must point the worker to the persisted handoff"
+    assert_not_contains "$next_line" '\n' \
+      "$id: fm-send pointer must not encode a multi-line payload"
+    assert_not_contains "$out" "$lane" \
+      "$id: promotion must not route the multi-line ship contract through fm-send"
     assert_grep "mode=$mode" "$meta" "$id: promotion must preserve the recorded delivery mode"
     assert_grep "kind=ship" "$meta" "$id: promotion must restore ship teardown protection"
     assert_no_grep "kind=scout" "$meta" "$id: promotion must replace the scout kind"
@@ -139,6 +154,8 @@ test_promotion_refuses_invalid_recorded_mode_before_mutation() {
     "invalid promotion refusal must explain the recorded-mode defect"
   assert_grep "kind=scout" "$meta" "invalid promotion must preserve scout teardown semantics"
   assert_no_grep "kind=ship" "$meta" "invalid promotion mutated kind before validating its handoff"
+  assert_absent "$home/data/$id/promotion-handoff.md" \
+    "invalid promotion wrote a handoff before validating its recorded mode"
   pass "fm-promote.sh: invalid recorded mode refuses before task mutation"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -83,6 +83,65 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+test_promoted_scouts_reuse_recorded_ship_contract() {
+  local home id meta out status lane
+  home="$TMP_ROOT/promote-home"
+  mkdir -p "$home/state"
+  touch "$home/state/.last-watcher-beat"
+
+  for mode in no-mistakes direct-PR local-only; do
+    id="promote-${mode//[^a-zA-Z0-9]/-}"
+    meta="$home/state/$id.meta"
+    fm_write_meta "$meta" \
+      "window=firstmate:fm-$id" \
+      "worktree=$home/worktree-$id" \
+      "project=$home/project-$id" \
+      "harness=codex" \
+      "kind=scout" \
+      "mode=$mode" \
+      "yolo=off"
+    out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-promote.sh" "$id" 2>&1); status=$?
+    expect_code 0 "$status" "fm-promote.sh $id should exit 0"
+    case "$mode" in
+      direct-PR) lane='This project ships **direct-PR**' ;;
+      local-only) lane='This project ships **local-only**' ;;
+      *) lane='This project ships **no-mistakes**' ;;
+    esac
+    assert_contains "$out" "$lane" "$id: promotion handoff must name its recorded delivery lane"
+    assert_contains "$out" "delivery lane is assigned at dispatch and fixed for this task" \
+      "$id: promotion handoff must carry the fixed-lane contract"
+    assert_grep "mode=$mode" "$meta" "$id: promotion must preserve the recorded delivery mode"
+    assert_grep "kind=ship" "$meta" "$id: promotion must restore ship teardown protection"
+    assert_no_grep "kind=scout" "$meta" "$id: promotion must replace the scout kind"
+  done
+  pass "fm-promote.sh: promoted scouts reuse their recorded ship contract"
+}
+
+test_promotion_refuses_invalid_recorded_mode_before_mutation() {
+  local home id meta out status
+  home="$TMP_ROOT/promote-invalid-home"
+  id="promote-invalid-mode"
+  meta="$home/state/$id.meta"
+  mkdir -p "$home/state"
+  touch "$home/state/.last-watcher-beat"
+  fm_write_meta "$meta" \
+    "window=firstmate:fm-$id" \
+    "worktree=$home/worktree-$id" \
+    "project=$home/project-$id" \
+    "harness=codex" \
+    "kind=scout" \
+    "mode=scout" \
+    "yolo=off"
+  status=0
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-promote.sh" "$id" 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "fm-promote.sh accepted an unsupported recorded mode"
+  assert_contains "$out" "missing, duplicate, or unsupported recorded mode" \
+    "invalid promotion refusal must explain the recorded-mode defect"
+  assert_grep "kind=scout" "$meta" "invalid promotion must preserve scout teardown semantics"
+  assert_no_grep "kind=ship" "$meta" "invalid promotion mutated kind before validating its handoff"
+  pass "fm-promote.sh: invalid recorded mode refuses before task mutation"
+}
+
 test_faster_paths_use_configured_authority_without_stacked_review() {
   local home id brief
   home="$TMP_ROOT/configured-authority-home"
@@ -354,6 +413,8 @@ test_scout_and_secondmate_scaffold() {
 test_script_parses
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_promoted_scouts_reuse_recorded_ship_contract
+test_promotion_refuses_invalid_recorded_mode_before_mutation
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -84,7 +84,7 @@ test_ship_modes_generate_clean_briefs() {
 }
 
 test_promoted_scouts_reuse_recorded_ship_contract() {
-  local home id meta handoff out status lane next_line next_count
+  local home id meta handoff out status lane rule rule2 done_line next_line next_count
   home="$TMP_ROOT/promote-home"
   mkdir -p "$home/state"
   touch "$home/state/.last-watcher-beat"
@@ -103,15 +103,46 @@ test_promoted_scouts_reuse_recorded_ship_contract() {
     out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-promote.sh" "$id" 2>&1); status=$?
     expect_code 0 "$status" "fm-promote.sh $id should exit 0"
     case "$mode" in
-      direct-PR) lane='This project ships **direct-PR**' ;;
-      local-only) lane='This project ships **local-only**' ;;
-      *) lane='This project ships **no-mistakes**' ;;
+      direct-PR)
+        lane='This project ships **direct-PR**'
+        rule="Never push to the default branch (push only your \`fm/$id\` branch)."
+        rule2='Never merge a PR.'
+        done_line="append \`done: PR {url}\` to the status file and stop."
+        ;;
+      local-only)
+        lane='This project ships **local-only**'
+        rule='Never push to any remote and never open a PR.'
+        rule2="Work only on your \`fm/$id\` branch; firstmate handles the merge into local \`main\`."
+        done_line="append \`done: ready in branch fm/$id\` to the status file and stop."
+        ;;
+      *)
+        lane='This project ships **no-mistakes**'
+        rule='Never push to the default branch.'
+        rule2='Never merge a PR.'
+        done_line="append \`done: {summary}\` to the status file and stop."
+        ;;
     esac
     handoff="$home/data/$id/promotion-handoff.md"
     assert_present "$handoff" "$id: promotion handoff file was not persisted"
     assert_grep "$lane" "$handoff" "$id: promotion handoff must name its recorded delivery lane"
+    assert_grep "$rule" "$handoff" "$id: promotion handoff must carry its mode-specific Rule 1"
+    assert_grep "$rule2" "$handoff" "$id: promotion handoff must carry all of its mode-specific Rule 1"
+    assert_grep "$done_line" "$handoff" "$id: promotion handoff must carry its mode-specific definition of done"
     assert_grep "delivery lane is assigned at dispatch and fixed for this task" "$handoff" \
       "$id: promotion handoff must carry the fixed-lane contract"
+    assert_grep "supersede every conflicting scout-brief instruction" "$handoff" \
+      "$id: promotion handoff must supersede conflicting scout rules"
+    assert_grep "blanket rule forbidding pushes and pull requests" "$handoff" \
+      "$id: promotion handoff must supersede the scout no-push/no-PR rule"
+    if [ "$mode" = no-mistakes ]; then
+      assert_grep "Run \`no-mistakes doctor\`" "$handoff" \
+        "$id: no-mistakes promotion must carry its mode-specific setup"
+      assert_grep "run \`no-mistakes init\`" "$handoff" \
+        "$id: no-mistakes promotion must carry its initialization setup"
+    else
+      assert_no_grep "Run \`no-mistakes doctor\`" "$handoff" \
+        "$id: faster-path promotion inherited no-mistakes setup"
+    fi
     next_line=$(printf '%s\n' "$out" | sed -n '/^next: /p')
     next_count=$(printf '%s\n' "$out" | awk '/^next: / { count++ } END { print count + 0 }')
     [ "$next_count" -eq 1 ] || fail "$id: promotion must print exactly one fm-send pointer"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -53,7 +53,7 @@ EOF
 # one of these DOD blocks, since a broken heredoc corrupts or empties the
 # generated brief content, not just the script's own syntax.
 test_ship_modes_generate_clean_briefs() {
-  local home id brief status
+  local home id brief status lane
   home="$TMP_ROOT/ship-home"
   write_registry "$home"
 
@@ -68,6 +68,16 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
+    # Every ship brief must state its assigned delivery lane explicitly and
+    # forbid a mid-run lane change without a new captain/firstmate decision.
+    case "$proj" in
+      direct-proj) lane='This project ships **direct-PR**' ;;
+      local-proj)  lane='This project ships **local-only**' ;;
+      *)           lane='This project ships **no-mistakes**' ;;
+    esac
+    assert_grep "$lane" "$brief" "$id: brief must state its assigned delivery lane explicitly"
+    assert_grep "delivery lane is assigned at dispatch and fixed for this task" "$brief" \
+      "$id: brief must forbid a mid-run lane change without a new decision"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"


### PR DESCRIPTION
## Summary

Make the delivery-lane choice a dispatch-time routing decision that a worker cannot skip or downgrade mid-run.

- **AGENTS.md section 7 (intake):** add one line stating that choosing or skipping the no-mistakes validation pipeline is a delivery-lane routing decision made at dispatch time, never a mid-run bypass, and that a worker never downgrades its own delivery mode mid-run without a new captain or firstmate decision.
- **bin/fm-brief.sh:** every generated ship brief now states its assigned delivery lane explicitly and carries a shared fixed-lane contract. The mode-specific setup, rules, and definition of done are refactored into a single `shape_ship_contract` owner reused by both fresh briefs and a new `--ship-contract` renderer.
- **bin/fm-promote.sh:** the scout-promotion path now propagates the same invariant. It persists the complete mode-specific contract (definition of done, mode Rule 1, and any setup steps) to a `data/<task>/promotion-handoff.md` file and sends the promoted worker only a one-line pointer through `fm-send.sh`, respecting its one-line contract. The handoff explicitly supersedes conflicting scout-brief rules, including the blanket no-push/no-PR rule, so a promoted push-based lane is not left forbidden from pushing.
- **Tests:** colocated `tests/fm-brief.test.sh` and `tests/fm-promote.test.sh` assert each mode's brief and promotion handoff name the assigned lane, carry the fixed-lane contract, and (for promotion) carry the correct mode-specific rules with scout rules superseded.

## Validation

Validated through the no-mistakes pipeline: review, test, document, and lint all passed with no outstanding findings. The review step surfaced and drove fixes for the promotion-path propagation gaps listed above. Scripts are shellcheck-clean under the pinned version; tracked Markdown follows the one-sentence-per-line convention.

This changes firstmate's shared tracked material (AGENTS.md and bin/), so it ships through the standard pipeline and PR path.
