### PR TITLE
feat: add agy Antigravity worker adapter

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -119,6 +119,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-13 on Pi 0.80.6. `pi --help` advertises `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; `pi --print --model openai-codex/gpt-5.6-sol --thinking max 'Reply with exactly OK.'` completed successfully. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| agy | `--model <model>` | `--effort <low\|medium\|high>` | Verified on Antigravity CLI 1.1.5. `agy models` lists names that bake effort into the suffix (e.g. `gemini-3.6-flash-high`), but a separate `--effort` flag drives the reasoning axis and is firstmate's profile knob; pass the bare catalog model name via `--model`. The ceiling is `high`; `xhigh` and `max` are omitted rather than passing an unsupported value. |
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
@@ -132,6 +133,7 @@ Natural language is acceptable if uncertain.
 - codex: `$<skill>`, for example `$no-mistakes`; `/<skill>` is claude-only and codex rejects it as "Unrecognized command".
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
+- agy: no separate verified skill invocation; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) already handles this correctly by reading the cursor row; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 
 ## claude (VERIFIED)
@@ -316,3 +318,38 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## agy (VERIFIED 2026-07-23, Antigravity CLI 1.1.5)
+
+Antigravity CLI (`agy`), Google's Gemini-backed coding agent. It exposes both a one-shot `-p`/`--print` mode and an interactive session; firstmate launches the INTERACTIVE session so the pane stays alive and steerable like every other adapter.
+Launch with the brief as the initial prompt: `agy --dangerously-skip-permissions -i "$(cat <brief>)"`.
+For agy's supported reasoning-effort values and omission behavior, see the [launch-profile-axes table](#launch-profile-axes).
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `esc to cancel` (shown in the footer while a turn runs; the idle footer instead reads `? for shortcuts`). The ASCII `esc to cancel` is the busy regex, added to `FM_TMUX_BUSY_REGEX_DEFAULT`. |
+| Exit command | `/quit` typed into the composer. |
+| Interrupt | single Escape (`esc to cancel` mid-turn). |
+| Skill invocation | none verified; use natural language. |
+| Autonomy | `--dangerously-skip-permissions` auto-approves BOTH file edits and shell commands (both verified empirically). `--mode=accept-edits` is NOT sufficient: it auto-approves file edits only and still gates every shell command behind a `Do you want to proceed?` permission prompt, which would wedge an unattended crewmate. |
+| Env marker | `ANTIGRAVITY_AGENT=1`, set for child/tool processes (alongside `ANTIGRAVITY_AGENTAPI_EXE` and `ANTIGRAVITY_LS_VERSION=cli-<v>`). agy does not set any other harness's marker, so it is unambiguous. |
+| Resume | `agy --continue` (most recent conversation) or `agy --conversation <id>`. |
+
+**Working directory (verified 2026-07-23).**
+The interactive `-i` session inherits the pane's cwd as its workspace, so `fm-spawn` needs no `--add-dir` (it launches inside the treehouse worktree).
+This differs from `-p`/`--print`, which ignores the shell cwd entirely and defaults to `~/.gemini/antigravity-cli/scratch` - print mode would need an explicit `--add-dir <worktree>` to read or write task files, which is why the interactive launch is the correct crewmate shape.
+
+**Directory-trust dialog on first launch per repo root.**
+A fresh worktree shows "Do you trust the contents of this project?" with `> Yes, I trust this folder` / `No, exit`, navigated with arrows and confirmed with Enter.
+It can appear a few seconds AFTER launch (observed ~6s), so peek the pane within about 20 seconds and, if the dialog is showing, accept it with `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Enter` (default selection is already "Yes"), then verify the brief started processing.
+
+**Headless permission auto-deny (verified 2026-07-23).**
+In `-p`/`--print` (headless) mode without `--dangerously-skip-permissions`, any tool that needs a permission decision is auto-denied because headless mode cannot prompt, and the run produces no useful output.
+This is why the autonomy flag is mandatory for a firstmate crewmate rather than optional.
+
+**Turn-end signal.**
+No launch-command turn-end hook is wired yet, so the busy-footer (`esc to cancel` -> idle) stale-pane detection is the only wake signal today; the template is identical for ship/scout/secondmate.
+A dedicated Stop-style hook and a primary-session guard are NOT yet verified for agy and remain open items before agy is used for the firstmate PRIMARY session (as opposed to crewmates).
+
+**Stability caveat.**
+Antigravity is young (CLI first published mid-2026, still on the 1.1.x line; SDK at 0.1.x preview) and community reports flag frequent regressions across releases. Flags may shift between versions, so re-verify `agy --help` when bumping the installed CLI.

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -35,6 +35,10 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # agy (Antigravity CLI) sets ANTIGRAVITY_AGENT=1 in every tool/child process
+  # (verified, cli-1.1.5, alongside ANTIGRAVITY_AGENTAPI_EXE and
+  # ANTIGRAVITY_LS_VERSION=cli-<v>). Unambiguous when firstmate runs on agy.
+  [ "${ANTIGRAVITY_AGENT:-}" = "1" ] && { echo agy; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -44,6 +48,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      agy) echo agy; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -53,6 +58,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *agy*|*antigravity*) echo agy; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -4,7 +4,8 @@
 # Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
-#   positional harness arg still works for back-compat.
+#   positional harness arg still works for back-compat. agy is verified for
+#   worker launches only and is rejected for --secondmate launches.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
@@ -56,7 +57,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|agy)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -444,6 +445,10 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # agy starts an interactive, steerable session in the pane cwd. Keep this
+    # literal command substitution child-side: the pane shell reads the brief
+    # after launch, so no parent expansion can leak or alter its contents.
+    agy) printf '%s' 'agy --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__-i "$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -455,6 +460,10 @@ case "$ARG3" in
     for word in $LAUNCH; do
       case "$word" in [A-Za-z_]*=*) continue ;; *) HARNESS=$(basename "$word"); break ;; esac
     done
+    if [ "$KIND" = secondmate ] && [ "$HARNESS" = agy ]; then
+      echo "error: harness 'agy' is verified for workers only and cannot launch a secondmate" >&2
+      exit 1
+    fi
     ;;
   '')
     # No explicit harness: resolve from config. A secondmate AGENT launches on the
@@ -467,6 +476,10 @@ case "$ARG3" in
     # kinds: a harness with no template aborts the spawn.
     if [ "$KIND" = secondmate ]; then
       HARNESS=$("$FM_ROOT/bin/fm-harness.sh" secondmate)
+      if [ "$HARNESS" = agy ]; then
+        echo "error: harness 'agy' is verified for workers only and cannot launch a secondmate" >&2
+        exit 1
+      fi
       harness_src='config/secondmate-harness (falling back to config/crew-harness)'
     else
       if [ -f "$CONFIG/crew-dispatch.json" ]; then
@@ -480,6 +493,10 @@ case "$ARG3" in
     ;;
   *)
     HARNESS=$ARG3
+    if [ "$KIND" = secondmate ] && [ "$HARNESS" = agy ]; then
+      echo "error: harness 'agy' is verified for workers only and cannot launch a secondmate" >&2
+      exit 1
+    fi
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
 esac
@@ -531,7 +548,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|grok)
+    claude|codex|opencode|pi|grok|agy)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -568,6 +585,16 @@ effort_flag_for_harness() {
       # its --thinking flag.
       case "$effort" in
         low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
+      esac
+      ;;
+    agy)
+      # Antigravity CLI (agy 1.1.5) exposes --effort low|medium|high (verified
+      # `agy --help`). Its model catalog also bakes an effort suffix into some
+      # model names (e.g. gemini-3.6-flash-high); firstmate keeps --model as the
+      # bare catalog name and drives the reasoning axis through --effort. The
+      # ceiling is high, so omit xhigh|max rather than passing a known-bad value.
+      case "$effort" in
+        low|medium|high) printf -- '--effort %s ' "$(shell_quote "$effort")" ;;
       esac
       ;;
     # opencode's interactive `opencode --prompt` launch has a verified --model

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -384,7 +384,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|agy)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -448,7 +448,7 @@ launch_template() {
     # agy starts an interactive, steerable session in the pane cwd. Keep this
     # literal command substitution child-side: the pane shell reads the brief
     # after launch, so no parent expansion can leak or alter its contents.
-    agy) printf '%s' 'agy --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__-i "$(cat __BRIEF__)"' ;;
+    agy) printf '%s' 'agy --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__-i "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -4,8 +4,7 @@
 # Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
-#   positional harness arg still works for back-compat. agy is verified for
-#   worker launches only and is rejected for --secondmate launches.
+#   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
@@ -460,10 +459,6 @@ case "$ARG3" in
     for word in $LAUNCH; do
       case "$word" in [A-Za-z_]*=*) continue ;; *) HARNESS=$(basename "$word"); break ;; esac
     done
-    if [ "$KIND" = secondmate ] && [ "$HARNESS" = agy ]; then
-      echo "error: harness 'agy' is verified for workers only and cannot launch a secondmate" >&2
-      exit 1
-    fi
     ;;
   '')
     # No explicit harness: resolve from config. A secondmate AGENT launches on the
@@ -476,10 +471,6 @@ case "$ARG3" in
     # kinds: a harness with no template aborts the spawn.
     if [ "$KIND" = secondmate ]; then
       HARNESS=$("$FM_ROOT/bin/fm-harness.sh" secondmate)
-      if [ "$HARNESS" = agy ]; then
-        echo "error: harness 'agy' is verified for workers only and cannot launch a secondmate" >&2
-        exit 1
-      fi
       harness_src='config/secondmate-harness (falling back to config/crew-harness)'
     else
       if [ -f "$CONFIG/crew-dispatch.json" ]; then
@@ -493,10 +484,6 @@ case "$ARG3" in
     ;;
   *)
     HARNESS=$ARG3
-    if [ "$KIND" = secondmate ] && [ "$HARNESS" = agy ]; then
-      echo "error: harness 'agy' is verified for workers only and cannot launch a secondmate" >&2
-      exit 1
-    fi
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
 esac

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -62,8 +62,10 @@
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
-# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73);
+# agy (Antigravity CLI): "esc to cancel" (busy footer, shown iff a turn is
+# running - verified agy 1.1.6; the idle footer is "? for shortcuts").
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|esc to cancel|Working\.\.\.|Ctrl\+c:cancel'
 
 # fm_tmux_strip_ghost: thin adapter over the shared, fleet-wide ghost extractor
 # fm_composer_strip_ghost (bin/fm-composer-lib.sh). It drops de-emphasised

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -104,8 +104,10 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
-# locale fragility of matching grok's braille spinner glyph directly).
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+# locale fragility of matching grok's braille spinner glyph directly);
+# agy: "esc to cancel" (Antigravity CLI's mid-turn footer, shown iff a turn is
+# running; the idle footer reads "? for shortcuts" - verified agy 1.1.5).
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|esc to cancel|Working\.\.\.|Ctrl\+c:cancel'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -405,13 +405,14 @@ SH
 # run_session_start <home> <root> <path>
 # Drop every harness env marker from bin/fm-harness.sh detect_own so the
 # surrounding interactive shell cannot leak past the suite's fake ps harness.
-# Markers today: CLAUDECODE (claude), PI_CODING_AGENT (pi), GROK_AGENT (grok).
+# Markers today: CLAUDECODE (claude), PI_CODING_AGENT (pi), GROK_AGENT (grok),
+# ANTIGRAVITY_AGENT (agy).
 # codex and opencode have no env markers (ancestry only). Without this, a local
-# claude/pi/grok session fails cases that pin a different fake harness while CI
+# claude/pi/grok/agy session fails cases that pin a different fake harness while CI
 # (no ambient markers) still passes.
 run_session_start() {
   local home=$1 root=$2 path=$3
-  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u ANTIGRAVITY_AGENT \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
     "$SESSION_START"
 }


### PR DESCRIPTION
Adds the reconciled agy worker adapter and preserves canonical child-side launch-brief encoding.

Validation:
- `tests/fm-session-start.test.sh`
- `tests/fm-operational-input.test.sh`
- `tests/fm-tmux-submit-busy.test.sh`
- shell syntax checks and `git diff --check`

Local `bin/fm-lint.sh` could not run because ShellCheck 0.11.0 is absent; CI is authoritative.