### PR TITLE
feat(skills): add RunLit lab repair skill

### DIFF
--- a/.agents/skills/runlit-lab-fix/SKILL.md
+++ b/.agents/skills/runlit-lab-fix/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: runlit-lab-fix
+description: >-
+  Repair the non-production RunLit Kubernetes lab when the captain invokes /runlit-lab-fix, asks to fix, restore, or reset the RunLit Kubernetes lab, or asks to return the k8s lab to a healthy baseline.
+  The invocation authorizes a bounded read-only health assessment and the one documented recommendationservice rollback when its crash-loop and low-memory signature is present, but no other infrastructure mutation.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# runlit-lab-fix
+
+Restore the non-production RunLit Kubernetes lab to its documented healthy baseline.
+This skill is the single owner of the RunLit lab repair procedure and its narrow mutation whitelist.
+
+## Authority and routing
+
+The captain's explicit invocation is approval for all read-only checks in this skill, a local evidence note, and the exact `recommendationservice` rollback described below when its full precondition is proven.
+Do not ask again before that whitelisted rollback.
+The invocation does not authorize a general reset, arbitrary Kubernetes mutation, or changes outside the RunLit lab.
+
+Follow Firstmate's normal delegation boundary.
+If a registered RunLit second mate fits the request, route it there through the normal marked request and reply path.
+Within the RunLit home, dispatch one isolated worker to perform this checklist and return the evidence.
+The RunLit second mate that receives the routed request owns dispatching the worker and must not route the request back to the primary home.
+Keep the task operational and evidence-producing only, with no project-code edits or pull request.
+
+## Read-only assessment
+
+Perform the checks in this order and retain only the minimum output needed for diagnosis.
+
+1. Read the RunLit lab's documented topology and identify the expected non-production kube context, namespaces, monitoring services, storefront route, backend route, and healthy resource baseline.
+   Treat the documented context mapping as authority rather than guessing from a context name.
+2. Run `kubectl config current-context` without printing kubeconfig contents.
+   If the current context is not proven to be the documented RunLit lab context, stop before any cluster request and report the mismatch.
+3. Verify read access with non-mutating `kubectl auth can-i` checks for the resources needed below.
+   A failed access check is a blocker, not permission to change credentials or kubeconfig.
+4. Inspect nodes with `kubectl get nodes -o wide` and summarize Ready state, scheduling state, and pressure conditions.
+5. Inspect pods and deployments across the documented lab namespaces with `kubectl get pods -A -o wide` and `kubectl get deployments -A`.
+   Record unhealthy, unready, pending, terminating, or restart-heavy workloads without deleting them.
+6. Inspect recent warning events with `kubectl get events -A --field-selector type=Warning --sort-by=.lastTimestamp`.
+   Separate current repeated warnings from stale events that predate the present workload revision.
+7. Inspect `recommendationservice` with `kubectl get deployment recommendationservice -n online-boutique`, `kubectl rollout history deployment/recommendationservice -n online-boutique`, its ReplicaSets, and pods selected by `app=recommendationservice`.
+   Capture the deployment revision, desired and available replicas, pod names and UIDs, restart counts, last termination reasons, and container image.
+8. Read only the service's memory request and limit with a narrow JSONPath query such as `kubectl get deployment recommendationservice -n online-boutique -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{" request="}{.resources.requests.memory}{" limit="}{.resources.limits.memory}{"\n"}{end}'`.
+   Use pod status, termination reasons, warning events, and only a bounded tail of service logs when needed to distinguish an OOM or low-memory crash loop from an unrelated failure.
+9. Inspect the documented Prometheus and Alertmanager workloads, readiness, targets, and active alerts through their read-only Kubernetes or HTTP APIs.
+   Record alert names, states, and relevant labels without copying secret-bearing configuration or full payloads.
+10. Check the documented storefront and backend deployment readiness, Service endpoints, and health URLs with read-only GET requests.
+    Record status codes and health conclusions rather than response bodies that may contain customer data or credentials.
+
+Do not proceed from a partial assessment when the evidence cannot distinguish the known artifact from another failure.
+
+## Whitelisted remediation
+
+The only infrastructure-changing command approved by this invocation is:
+
+```sh
+kubectl rollout undo deployment/recommendationservice -n online-boutique
+```
+
+Run it only when all of these facts are true:
+
+- The active context is proven to be the documented non-production RunLit lab context.
+- The current `recommendationservice` revision has a crash-loop or unavailable pod.
+- Pod termination state, repeated warning events, or bounded logs identify an OOM or low-memory failure.
+- The current deployment memory request or limit matches the known low-memory artifact rather than the documented healthy baseline.
+- Rollout history contains the immediately previous healthy revision with the documented memory request and limit.
+
+Capture the current revision and crash-loop pod UIDs before the command.
+Run the undo at most once for one observed broken revision.
+If another operator has already changed the revision, reassess from the beginning and do not undo blindly.
+Do not use this rollback for an image, configuration, dependency, scheduling, storage, network, or unknown failure.
+
+## Verification
+
+After the rollback, complete every verification step before calling the lab healthy.
+
+1. Run `kubectl rollout status deployment/recommendationservice -n online-boutique --timeout=60s` and verify desired, updated, available, and ready replicas converge.
+   If it times out while the rollout is still progressing, report progress and repeat the bounded check rather than starting one long blocking wait.
+2. Re-read the deployment revision and memory JSONPath and verify both the request and limit equal the documented healthy baseline or the captured previous healthy revision.
+3. Verify the pre-rollback crash-loop pod UIDs are gone, the replacement pod is Ready, and the new pod is not accumulating restarts.
+4. Recheck warning events and confirm the low-memory or OOM warning has stopped recurring on the new revision.
+5. Recheck Prometheus and Alertmanager and confirm the related workload or availability alerts recover.
+6. Recheck the storefront and backend readiness, endpoints, and documented health URLs.
+7. Observe the repaired state for a bounded period long enough to catch an immediate repeat crash and alert reevaluation.
+
+Do not delete the old pod to manufacture a passing result.
+The Deployment controller must replace it as part of the rollback.
+If the rollout, memory baseline, pod replacement, health checks, or relevant alerts do not recover, report that the lab is not yet healthy.
+
+## Hard boundaries
+
+- Do not touch production.
+- Do not touch Coolify.
+- Do not read, print, rotate, or change database secrets.
+- Do not touch the private Postgres rollout.
+- Do not stop, restart, reconfigure, or profile the Mac mini worker runtime.
+- Do not touch Proxmox, the NAS, DNS, network configuration, provider accounts, or project code.
+- Do not delete pods as the primary fix for a Deployment-managed fault.
+- Do not scale, patch, apply, restart, or roll back any other Kubernetes resource.
+- Do not suppress, inhibit, or silence alerts unless the captain separately asks for that action.
+- Never print kubeconfig contents, Kubernetes Secret objects, credential environment variables, tokens, passwords, or connection strings.
+
+Any remediation outside the one whitelisted rollback requires a new captain decision.
+Stop before running it and provide the exact proposed command, target resources, expected effect, rollback plan, and blast radius.
+
+## Evidence and captain handoff
+
+When the active RunLit home is known and writable, write a concise local note to `$FM_HOME/data/runlit-lab-fix-<UTC timestamp>.md`.
+If the request arrived through the primary home, the RunLit second mate or its worker writes the note in the RunLit home rather than the primary home.
+Do not guess a home path or write the note into project code.
+
+The note records:
+
+- UTC start and finish times.
+- The context name and topology sources used to prove it is the lab.
+- Precheck and postcheck summaries for nodes, workloads, warning events, monitoring, storefront, and backend.
+- The `recommendationservice` revisions, pod UIDs, restart evidence, and memory request and limit before and after.
+- Whether the whitelisted command ran and its result.
+- Relevant alert names and recovery state.
+- Any unresolved symptom or required captain decision.
+
+Keep raw secrets, kubeconfig content, Secret objects, credentials, full logs, and sensitive response bodies out of the note.
+
+Report the outcome concisely using `AGENTS.md` section 9's captain-facing translation contract.
+State whether the lab was already healthy, was restored by the approved rollback, or remains unhealthy.
+Name the verified storefront, backend, recommendation service, and alert state, then link the local evidence note when one was written.
+If more mutation is needed, end with the exact decision-ready proposal and do not imply that the original invocation approved it.

--- a/.agents/skills/runlit-lab-fix/SKILL.md
+++ b/.agents/skills/runlit-lab-fix/SKILL.md
@@ -33,10 +33,11 @@ Perform the checks in this order and retain only the minimum output needed for d
    The checkout is the RunLit clone under the active home's `projects/` directory that the home's `data/projects.md` registry names, or the isolated task worktree the worker already runs in when that worktree is a RunLit checkout; when both resolve, they must be the same repository.
    Confirm the resolved path is the expected RunLit repository and that its sources are current.
    A dispatched worker runs on a task branch in an isolated worktree, so require only that the worktree's base is the project's default branch; never require the branch it is on to be the default branch itself.
-   Prove currency with a non-mutating `git ls-remote` read of the remote default branch and compare what it reports against what the checkout contains.
+   Prove currency by comparing the checkout's base against the live remote default-branch commit that a non-mutating `git ls-remote` read of the remote default branch reports.
+   The base is the worktree's merge-base with the default branch, or the base commit the task recorded; never compare the task-branch HEAD, which differs from the remote tip by construction and would block a sound checkout.
    An already-present remote-tracking ref is only as fresh as the last fetch, which this skill never performs, so agreeing with it proves nothing on its own; treat that comparison as corroboration after `git ls-remote` has answered, never as the proof itself.
    Never run `git fetch`, or any other state-changing git command, under `projects/` or in any project worktree; the read-only project boundary in `AGENTS.md` section 1 outranks this check.
-   If no checkout resolves, more than one candidate resolves, the checkout is not the expected RunLit repository, `git ls-remote` cannot reach the remote, currency cannot be proven, or any of the four sources below is missing, treat it as a blocker: stop before any cluster access or mutation, never use these sources as mutation guidance, and escalate to the captain.
+   If no checkout resolves, more than one candidate resolves, the checkout is not the expected RunLit repository, `git ls-remote` cannot reach the remote, the base does not match the remote default-branch commit, that base match cannot be proven, or any of the four sources below is missing, treat it as a blocker: stop before any cluster access or mutation, never use these sources as mutation guidance, and escalate to the captain.
    Read the RunLit lab's documented topology from `scripts/k3s/CLUSTER-STATE.md` and `scripts/k3s/README.md` in that checkout, and identify the expected non-production kube context, namespaces, monitoring services, storefront route, backend route, and healthy resource baseline.
    Read the documented `recommendationservice` healthy memory request and limit, its expected container image, and its documented restore path from `docs/dogfood/oom-crashloop-validation.md` and `scripts/k3s/demo-chaos.sh` in that same checkout.
    These four files are the authoritative topology and baseline sources for this skill.
@@ -119,13 +120,16 @@ A step whose documented access path does not exist or cannot be reached is unava
 5. Recheck Prometheus and Alertmanager over the external URLs `scripts/k3s/CLUSTER-STATE.md` documents and confirm the related workload or availability alerts recover.
    Judge the two services separately as step 9 does, and when one service's documented URL is missing or unreachable, record its alert recovery as unavailable and do not call monitoring or alerting healthy on that evidence.
 6. Recheck the storefront and backend readiness, endpoints, and documented health URLs, recording any missing or unreachable documented URL as unavailable rather than as a passed or failed check.
+   When a documented storefront or backend health URL is missing or unreachable, record app-health verification as unavailable, keep that label distinct from a monitoring gap, and do not call the application healthy on that evidence.
 7. Observe the repaired state for a bounded period long enough to catch an immediate repeat crash and alert reevaluation.
 
 Do not delete the old pod to manufacture a passing result.
 The Deployment controller must replace it as part of the rollback.
 If the rollout, memory baseline, pod replacement, health checks, or relevant alerts do not recover, report that the lab is not yet healthy.
-When every check that could run passed but a monitoring or health check was unavailable, report only the narrower conclusion the evidence supports: the application-level repair is verified, monitoring or alerting verification was unavailable, and the missing URL or access path is named.
-Never widen that into a claim that the lab, its monitoring, or its alerting is healthy, and never downgrade it into a claim that a check failed.
+When every check that could run passed but some check was unavailable, report only the narrower conclusion the evidence supports: name the checks that actually ran and passed, name each unavailable check for what it was, and name its missing URL or access path.
+Label the two gaps separately, because they support different claims: an unavailable Prometheus or Alertmanager URL means monitoring verification was unavailable and monitoring must not be called healthy, while an unavailable storefront or backend health URL means app-health verification was unavailable and the application must not be called healthy.
+So a rollback that converged behind an unreachable storefront health URL is reported as the `recommendationservice` rollback and Kubernetes-level readiness verified with app-health verification unavailable, never as an application-level repair verified with a monitoring gap.
+Never widen any of it into a claim that the lab is healthy, and never downgrade an unavailable check into a claim that a check failed.
 
 ## Hard boundaries
 
@@ -140,8 +144,9 @@ Never widen that into a claim that the lab, its monitoring, or its alerting is h
 - Do not dump a full revision or ReplicaSet template, or any container environment, when choosing the rollback revision; read only the narrow fields step 7 names.
 - Do not run a cluster-wide `-A` read; scope every namespaced read to the documented `online-boutique` or `monitoring` namespace.
 - Do not open a `kubectl port-forward` or `kubectl proxy` tunnel, exec or attach into a pod, or copy files out of one; reach an in-cluster HTTP API only over the read-only URLs `scripts/k3s/CLUSTER-STATE.md` documents, and report that service's check as unavailable when no documented URL is reachable.
-- Do not call monitoring or alerting healthy on an unavailable check, and do not report an unavailable check as a failure; name the missing URL or access path instead.
-- Do not run `git fetch` or any other state-changing command in the RunLit checkout; prove source currency with a non-mutating `git ls-remote` read, never with a remote-tracking ref alone.
+- Do not call monitoring or alerting healthy on an unavailable check, do not call the application healthy on an unavailable app health check, and do not report an unavailable check as a failure; name each unavailable check and its missing URL or access path instead.
+- Do not label an unavailable storefront or backend health URL as a monitoring gap, or the reverse; the two carry different claims and are reported separately.
+- Do not run `git fetch` or any other state-changing command in the RunLit checkout; prove source currency by comparing the checkout's base against a non-mutating `git ls-remote` read, never against the task-branch HEAD and never with a remote-tracking ref alone.
 - Do not delete pods as the primary fix for a Deployment-managed fault.
 - Do not scale, patch, apply, restart, or roll back any other Kubernetes resource.
 - Do not suppress, inhibit, or silence alerts unless the captain separately asks for that action.
@@ -164,7 +169,8 @@ The note records:
 - The `recommendationservice` revisions, pod UIDs, restart evidence, and memory request and limit before and after.
 - Whether the whitelisted command ran and its result.
 - Relevant alert names and recovery state, each recorded as recovered, not recovered, or unavailable with its missing URL or access path named.
-- The source currency proof, recorded as the `git ls-remote` comparison result rather than as a bare assertion that the checkout was current.
+- The storefront and backend health-URL outcomes, recorded separately from the monitoring outcome, each as verified, failed, or unavailable with its own missing URL or access path named.
+- The source currency proof, recorded as the comparison of the checkout's base against the `git ls-remote` default-branch commit rather than as a bare assertion that the checkout was current.
 - Any unresolved symptom or required captain decision.
 
 Keep raw secrets, kubeconfig content, Secret objects, credentials, full logs, and sensitive response bodies out of the note.
@@ -172,5 +178,6 @@ Keep raw secrets, kubeconfig content, Secret objects, credentials, full logs, an
 Report the outcome concisely using `AGENTS.md` section 9's captain-facing translation contract.
 State whether the lab was already healthy, was restored by the approved rollback, or remains unhealthy.
 Name the verified storefront, backend, recommendation service, and alert state, then link the local evidence note when one was written.
-When a monitoring or health check was unavailable, say so in that same summary, name the missing URL or access path, and scope the claim to the application-level repair instead of to the lab as a whole.
+When a check was unavailable, say so in that same summary, name which check it was and its missing URL or access path, and keep a monitoring gap and an app-health gap separately labelled.
+Scope every positive claim to the checks that actually ran, never to the lab as a whole.
 If more mutation is needed, end with the exact decision-ready proposal and do not imply that the original invocation approved it.

--- a/.agents/skills/runlit-lab-fix/SKILL.md
+++ b/.agents/skills/runlit-lab-fix/SKILL.md
@@ -29,24 +29,29 @@ Keep the task operational and evidence-producing only, with no project-code edit
 
 Perform the checks in this order and retain only the minimum output needed for diagnosis.
 
-1. Read the RunLit lab's documented topology and identify the expected non-production kube context, namespaces, monitoring services, storefront route, backend route, and healthy resource baseline.
+1. Read the RunLit lab's documented topology from `scripts/k3s/CLUSTER-STATE.md` and `scripts/k3s/README.md` in the RunLit project, and identify the expected non-production kube context, namespaces, monitoring services, storefront route, backend route, and healthy resource baseline.
+   Read the documented `recommendationservice` healthy memory request and limit and its documented restore path from `docs/dogfood/oom-crashloop-validation.md` and `scripts/k3s/demo-chaos.sh` in the same project.
+   These four files are the authoritative topology and baseline sources for this skill.
    Treat the documented context mapping as authority rather than guessing from a context name.
-2. Run `kubectl config current-context` without printing kubeconfig contents.
-   If the current context is not proven to be the documented RunLit lab context, stop before any cluster request and report the mismatch.
-3. Verify read access with non-mutating `kubectl auth can-i` checks for the resources needed below.
+   `scripts/k3s/CLUSTER-STATE.md` maps the lab cluster to the local kubeconfig `default` context, and the documented lab namespaces are `online-boutique` and `monitoring`.
+   If any of those sources is absent, stale, or disagrees with the observed cluster identity, stop before any cluster access or mutation and escalate to the captain.
+2. Run `kubectl config current-context` without printing kubeconfig contents, and compare the documented lab context and its documented API server against what the local kubeconfig defines for `default`.
+   Every kubectl command below pins `--context=default` so a later context switch, another agent, a different shell environment, or a changed `KUBECONFIG` cannot redirect a read or the rollback at another cluster.
+   If the `default` context is missing, or is not proven to be the documented RunLit lab cluster, stop before any cluster request and report the mismatch.
+3. Verify read access with non-mutating `kubectl --context=default auth can-i` checks for the resources needed below.
    A failed access check is a blocker, not permission to change credentials or kubeconfig.
-4. Inspect nodes with `kubectl get nodes -o wide` and summarize Ready state, scheduling state, and pressure conditions.
-5. Inspect pods and deployments across the documented lab namespaces with `kubectl get pods -A -o wide` and `kubectl get deployments -A`.
+4. Inspect nodes with `kubectl --context=default get nodes -o wide` and summarize Ready state, scheduling state, and pressure conditions.
+5. Inspect pods and deployments in the documented lab namespaces only, with `kubectl --context=default get pods -n online-boutique -o wide` and `kubectl --context=default get deployments -n online-boutique`, then the same two reads with `-n monitoring`.
    Record unhealthy, unready, pending, terminating, or restart-heavy workloads without deleting them.
-6. Inspect recent warning events with `kubectl get events -A --field-selector type=Warning --sort-by=.lastTimestamp`.
+6. Inspect recent warning events in the same two namespaces with `kubectl --context=default get events -n online-boutique --field-selector type=Warning --sort-by=.lastTimestamp`, then the same read with `-n monitoring`.
    Separate current repeated warnings from stale events that predate the present workload revision.
-7. Inspect `recommendationservice` with `kubectl get deployment recommendationservice -n online-boutique`, `kubectl rollout history deployment/recommendationservice -n online-boutique`, its ReplicaSets, and pods selected by `app=recommendationservice`.
+7. Inspect `recommendationservice` with `kubectl --context=default get deployment recommendationservice -n online-boutique`, `kubectl --context=default rollout history deployment/recommendationservice -n online-boutique`, its ReplicaSets, and pods selected by `app=recommendationservice`.
    Capture the deployment revision, desired and available replicas, pod names and UIDs, restart counts, last termination reasons, and container image.
-8. Read only the service's memory request and limit with a narrow JSONPath query such as `kubectl get deployment recommendationservice -n online-boutique -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{" request="}{.resources.requests.memory}{" limit="}{.resources.limits.memory}{"\n"}{end}'`.
+8. Read only the service's memory request and limit with a narrow JSONPath query such as `kubectl --context=default get deployment recommendationservice -n online-boutique -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{" request="}{.resources.requests.memory}{" limit="}{.resources.limits.memory}{"\n"}{end}'`.
    Use pod status, termination reasons, warning events, and only a bounded tail of service logs when needed to distinguish an OOM or low-memory crash loop from an unrelated failure.
-9. Inspect the documented Prometheus and Alertmanager workloads, readiness, targets, and active alerts through their read-only Kubernetes or HTTP APIs.
+9. Inspect the documented Prometheus and Alertmanager workloads, readiness, targets, and active alerts through their read-only Kubernetes or HTTP APIs, pinning `--context=default` and `-n monitoring` on every kubectl read.
    Record alert names, states, and relevant labels without copying secret-bearing configuration or full payloads.
-10. Check the documented storefront and backend deployment readiness, Service endpoints, and health URLs with read-only GET requests.
+10. Check the documented storefront and backend deployment readiness, Service endpoints, and health URLs with read-only GET requests, pinning `--context=default` and `-n online-boutique` on every kubectl read.
     Record status codes and health conclusions rather than response bodies that may contain customer data or credentials.
 
 Do not proceed from a partial assessment when the evidence cannot distinguish the known artifact from another failure.
@@ -56,18 +61,23 @@ Do not proceed from a partial assessment when the evidence cannot distinguish th
 The only infrastructure-changing command approved by this invocation is:
 
 ```sh
-kubectl rollout undo deployment/recommendationservice -n online-boutique
+kubectl --context=default rollout undo deployment/recommendationservice -n online-boutique --to-revision=<verified revision>
 ```
+
+`<verified revision>` is the integer revision already read from rollout history and proven to carry the documented healthy memory request and limit.
+Never run an unqualified undo, because an undo without `--to-revision` targets whatever the previous revision happens to be at execution time rather than the revision this assessment proved healthy.
 
 Run it only when all of these facts are true:
 
-- The active context is proven to be the documented non-production RunLit lab context.
+- The `default` context is proven to be the documented non-production RunLit lab cluster.
 - The current `recommendationservice` revision has a crash-loop or unavailable pod.
 - Pod termination state, repeated warning events, or bounded logs identify an OOM or low-memory failure.
 - The current deployment memory request or limit matches the known low-memory artifact rather than the documented healthy baseline.
-- Rollout history contains the immediately previous healthy revision with the documented memory request and limit.
+- Rollout history contains an earlier healthy revision whose memory request and limit equal the documented baseline, and that revision's integer number is recorded.
 
 Capture the current revision and crash-loop pod UIDs before the command.
+Immediately before running it, re-prove both facts that the command depends on: re-run `kubectl config current-context` and the `default` context identity check, and re-read `kubectl --context=default rollout history deployment/recommendationservice -n online-boutique` to confirm the current revision is still the broken one and `<verified revision>` still names the inspected healthy revision.
+If either recheck disagrees with the assessment, stop and reassess from the beginning rather than running the command.
 Run the undo at most once for one observed broken revision.
 If another operator has already changed the revision, reassess from the beginning and do not undo blindly.
 Do not use this rollback for an image, configuration, dependency, scheduling, storage, network, or unknown failure.
@@ -76,7 +86,7 @@ Do not use this rollback for an image, configuration, dependency, scheduling, st
 
 After the rollback, complete every verification step before calling the lab healthy.
 
-1. Run `kubectl rollout status deployment/recommendationservice -n online-boutique --timeout=60s` and verify desired, updated, available, and ready replicas converge.
+1. Run `kubectl --context=default rollout status deployment/recommendationservice -n online-boutique --timeout=60s` and verify desired, updated, available, and ready replicas converge.
    If it times out while the rollout is still progressing, report progress and repeat the bounded check rather than starting one long blocking wait.
 2. Re-read the deployment revision and memory JSONPath and verify both the request and limit equal the documented healthy baseline or the captured previous healthy revision.
 3. Verify the pre-rollback crash-loop pod UIDs are gone, the replacement pod is Ready, and the new pod is not accumulating restarts.
@@ -97,6 +107,8 @@ If the rollout, memory baseline, pod replacement, health checks, or relevant ale
 - Do not touch the private Postgres rollout.
 - Do not stop, restart, reconfigure, or profile the Mac mini worker runtime.
 - Do not touch Proxmox, the NAS, DNS, network configuration, provider accounts, or project code.
+- Do not send any cluster request, read or mutation, without an explicit `--context=default`, and never let the ambient current context decide which cluster a command reaches; the `kubectl config current-context` identity check is the only local kubeconfig read exempt from the flag.
+- Do not run a cluster-wide `-A` read; scope every namespaced read to the documented `online-boutique` or `monitoring` namespace.
 - Do not delete pods as the primary fix for a Deployment-managed fault.
 - Do not scale, patch, apply, restart, or roll back any other Kubernetes resource.
 - Do not suppress, inhibit, or silence alerts unless the captain separately asks for that action.
@@ -107,7 +119,7 @@ Stop before running it and provide the exact proposed command, target resources,
 
 ## Evidence and captain handoff
 
-When the active RunLit home is known and writable, write a concise local note to `$FM_HOME/data/runlit-lab-fix-<UTC timestamp>.md`.
+When the active RunLit home is known and writable, resolve the effective home the way `docs/configuration.md` describes and write a concise local note to `data/runlit-lab-fix-<UTC timestamp>.md` under it.
 If the request arrived through the primary home, the RunLit second mate or its worker writes the note in the RunLit home rather than the primary home.
 Do not guess a home path or write the note into project code.
 

--- a/.agents/skills/runlit-lab-fix/SKILL.md
+++ b/.agents/skills/runlit-lab-fix/SKILL.md
@@ -29,17 +29,23 @@ Keep the task operational and evidence-producing only, with no project-code edit
 
 Perform the checks in this order and retain only the minimum output needed for diagnosis.
 
-1. Read the RunLit lab's documented topology from `scripts/k3s/CLUSTER-STATE.md` and `scripts/k3s/README.md` in the RunLit project, and identify the expected non-production kube context, namespaces, monitoring services, storefront route, backend route, and healthy resource baseline.
-   Read the documented `recommendationservice` healthy memory request and limit and its documented restore path from `docs/dogfood/oom-crashloop-validation.md` and `scripts/k3s/demo-chaos.sh` in the same project.
+1. Resolve one unambiguous RunLit project checkout first, and read every source below from that same checkout.
+   The checkout is the RunLit clone under the active home's `projects/` directory that the home's `data/projects.md` registry names, or the worker's own checkout when it already runs inside the RunLit repository; when both resolve, they must be the same repository.
+   Confirm the resolved path is the expected RunLit repository, is on its default branch, and is current with its remote rather than a detached, diverged, or long-stale copy.
+   If no checkout resolves, more than one candidate resolves, the checkout is not the expected current RunLit repository, or any of the four sources below is missing, stop before any cluster access or mutation and escalate to the captain.
+   Read the RunLit lab's documented topology from `scripts/k3s/CLUSTER-STATE.md` and `scripts/k3s/README.md` in that checkout, and identify the expected non-production kube context, namespaces, monitoring services, storefront route, backend route, and healthy resource baseline.
+   Read the documented `recommendationservice` healthy memory request and limit, its expected container image, and its documented restore path from `docs/dogfood/oom-crashloop-validation.md` and `scripts/k3s/demo-chaos.sh` in that same checkout.
    These four files are the authoritative topology and baseline sources for this skill.
    Treat the documented context mapping as authority rather than guessing from a context name.
    `scripts/k3s/CLUSTER-STATE.md` maps the lab cluster to the local kubeconfig `default` context, and the documented lab namespaces are `online-boutique` and `monitoring`.
    If any of those sources is absent, stale, or disagrees with the observed cluster identity, stop before any cluster access or mutation and escalate to the captain.
-2. Prove the `default` context is the lab cluster before any cluster request, using the API server it points at rather than its name, because `default` is a generic name that any kubeconfig can define.
+2. Prove the `default` context is the lab cluster immediately before the first Kubernetes API request, using the API server it points at rather than its name, because `default` is a generic name that any kubeconfig can define.
    Run `kubectl config view --minify --context=default -o jsonpath="{.clusters[0].cluster.server}"` and compare the exact result against the lab API server documented in `scripts/k3s/CLUSTER-STATE.md`.
    That read returns one server URL and no credentials, so it satisfies the boundary against printing kubeconfig contents.
    Also run `kubectl config current-context` to record which context was ambient at the start, and treat that name as evidence for the note rather than as proof of identity.
-   Every kubectl command below pins `--context=default` so a later context switch, another agent, a different shell environment, or a changed `KUBECONFIG` cannot redirect a read or the rollback at another cluster.
+   Every kubectl command below pins `--context=default` so ambient current-context drift, whether from a later context switch or from another agent, cannot redirect a read or the rollback at another cluster.
+   The pin selects a context by name inside whichever kubeconfig is active, so it is no defense against a changed `KUBECONFIG` that defines its own `default` context; only this API server comparison proves cluster identity.
+   Because of that, repeat this exact comparison immediately before the rollback, and re-run it before resuming reads whenever the assessment is interrupted, resumed later, or shares the environment with another agent.
    If the `default` context is missing, the server URL is empty, or it differs from the documented lab API server by any character, stop before any cluster request and report the mismatch.
 3. Verify read access with non-mutating `kubectl --context=default auth can-i` checks for the resources needed below.
    A failed access check is a blocker, not permission to change credentials or kubeconfig.
@@ -48,8 +54,13 @@ Perform the checks in this order and retain only the minimum output needed for d
    Record unhealthy, unready, pending, terminating, or restart-heavy workloads without deleting them.
 6. Inspect recent warning events in the same two namespaces with `kubectl --context=default get events -n online-boutique --field-selector type=Warning --sort-by=.lastTimestamp`, then the same read with `-n monitoring`.
    Separate current repeated warnings from stale events that predate the present workload revision.
-7. Inspect `recommendationservice` with `kubectl --context=default get deployment recommendationservice -n online-boutique`, `kubectl --context=default rollout history deployment/recommendationservice -n online-boutique`, its ReplicaSets, and pods selected by `app=recommendationservice`.
+7. Inspect `recommendationservice` with `kubectl --context=default get deployment recommendationservice -n online-boutique`, `kubectl --context=default rollout history deployment/recommendationservice -n online-boutique`, and pods selected by `app=recommendationservice`.
    Capture the deployment revision, desired and available replicas, pod names and UIDs, restart counts, last termination reasons, and container image.
+   Rollout history prints only revision numbers and change causes, so read each revision's own settings from its ReplicaSet before choosing a rollback target, with one narrow non-secret query that outputs nothing else:
+   `kubectl --context=default get replicasets -n online-boutique -l app=recommendationservice -o jsonpath='{range .items[*]}{.metadata.name}{" revision="}{.metadata.annotations.deployment\.kubernetes\.io/revision}{" image="}{.spec.template.spec.containers[?(@.name=="server")].image}{" request="}{.spec.template.spec.containers[?(@.name=="server")].resources.requests.memory}{" limit="}{.spec.template.spec.containers[?(@.name=="server")].resources.limits.memory}{"\n"}{end}'`
+   Use the container name the documented baseline records; the documented deployment names it `server`.
+   That row gives the ReplicaSet name, its deployment revision annotation, the server image, and the memory request and limit, which is everything the rollback precondition needs.
+   Never widen it into a full revision or ReplicaSet template dump, including `rollout history --revision=<n>`, because those echo container environment variables this skill must not print.
 8. Read only the service's memory request and limit with a narrow JSONPath query such as `kubectl --context=default get deployment recommendationservice -n online-boutique -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{" request="}{.resources.requests.memory}{" limit="}{.resources.limits.memory}{"\n"}{end}'`.
    Use pod status, termination reasons, warning events, and only a bounded tail of service logs when needed to distinguish an OOM or low-memory crash loop from an unrelated failure.
 9. Inspect the documented Prometheus and Alertmanager workloads, readiness, targets, and active alerts through their read-only Kubernetes or HTTP APIs, pinning `--context=default` and `-n monitoring` on every kubectl read.
@@ -67,7 +78,7 @@ The only infrastructure-changing command approved by this invocation is:
 kubectl --context=default rollout undo deployment/recommendationservice -n online-boutique --to-revision=<verified revision>
 ```
 
-`<verified revision>` is the integer revision already read from rollout history and proven to carry the documented healthy memory request and limit.
+`<verified revision>` is the integer revision already read from rollout history and proven by step 7's ReplicaSet query to carry the documented healthy memory request and limit and the expected server image.
 Never run an unqualified undo, because an undo without `--to-revision` targets whatever the previous revision happens to be at execution time rather than the revision this assessment proved healthy.
 
 Run it only when all of these facts are true:
@@ -76,7 +87,7 @@ Run it only when all of these facts are true:
 - The current `recommendationservice` revision has a crash-loop or unavailable pod.
 - Pod termination state, repeated warning events, or bounded logs identify an OOM or low-memory failure.
 - The current deployment memory request or limit matches the known low-memory artifact rather than the documented healthy baseline.
-- Rollout history contains an earlier healthy revision whose memory request and limit equal the documented baseline, and that revision's integer number is recorded.
+- An earlier revision's own ReplicaSet row, read with step 7's narrow query rather than inferred from a revision number, shows a memory request and limit equal to the documented baseline and a server image equal to the expected image, and that revision's integer number is recorded.
 
 Capture the current revision and crash-loop pod UIDs before the command.
 Immediately before running it, re-prove both facts that the command depends on.
@@ -113,7 +124,8 @@ If the rollout, memory baseline, pod replacement, health checks, or relevant ale
 - Do not stop, restart, reconfigure, or profile the Mac mini worker runtime.
 - Do not touch Proxmox, the NAS, DNS, network configuration, provider accounts, or project code.
 - Do not send any cluster request, read or mutation, without an explicit `--context=default`, and never let the ambient current context decide which cluster a command reaches; the local `kubectl config current-context` read is the only command exempt from the flag.
-- Do not accept a context name as proof of cluster identity; only the documented API server URL comparison proves it.
+- Do not accept a context name as proof of cluster identity, and do not treat the `--context=default` pin as protection against a changed `KUBECONFIG`; only the documented API server URL comparison proves it.
+- Do not dump a full revision or ReplicaSet template, or any container environment, when choosing the rollback revision; read only the narrow fields step 7 names.
 - Do not run a cluster-wide `-A` read; scope every namespaced read to the documented `online-boutique` or `monitoring` namespace.
 - Do not delete pods as the primary fix for a Deployment-managed fault.
 - Do not scale, patch, apply, restart, or roll back any other Kubernetes resource.

--- a/.agents/skills/runlit-lab-fix/SKILL.md
+++ b/.agents/skills/runlit-lab-fix/SKILL.md
@@ -33,9 +33,10 @@ Perform the checks in this order and retain only the minimum output needed for d
    The checkout is the RunLit clone under the active home's `projects/` directory that the home's `data/projects.md` registry names, or the isolated task worktree the worker already runs in when that worktree is a RunLit checkout; when both resolve, they must be the same repository.
    Confirm the resolved path is the expected RunLit repository and that its sources are current.
    A dispatched worker runs on a task branch in an isolated worktree, so require only that the worktree's base is the project's default branch; never require the branch it is on to be the default branch itself.
-   Establish currency with read-only git commands only, such as comparing the checkout against its already-present remote-tracking ref or against `git ls-remote`.
+   Prove currency with a non-mutating `git ls-remote` read of the remote default branch and compare what it reports against what the checkout contains.
+   An already-present remote-tracking ref is only as fresh as the last fetch, which this skill never performs, so agreeing with it proves nothing on its own; treat that comparison as corroboration after `git ls-remote` has answered, never as the proof itself.
    Never run `git fetch`, or any other state-changing git command, under `projects/` or in any project worktree; the read-only project boundary in `AGENTS.md` section 1 outranks this check.
-   If no checkout resolves, more than one candidate resolves, the checkout is not the expected RunLit repository, currency cannot be established read-only, or any of the four sources below is missing, stop before any cluster access or mutation and escalate to the captain.
+   If no checkout resolves, more than one candidate resolves, the checkout is not the expected RunLit repository, `git ls-remote` cannot reach the remote, currency cannot be proven, or any of the four sources below is missing, treat it as a blocker: stop before any cluster access or mutation, never use these sources as mutation guidance, and escalate to the captain.
    Read the RunLit lab's documented topology from `scripts/k3s/CLUSTER-STATE.md` and `scripts/k3s/README.md` in that checkout, and identify the expected non-production kube context, namespaces, monitoring services, storefront route, backend route, and healthy resource baseline.
    Read the documented `recommendationservice` healthy memory request and limit, its expected container image, and its documented restore path from `docs/dogfood/oom-crashloop-validation.md` and `scripts/k3s/demo-chaos.sh` in that same checkout.
    These four files are the authoritative topology and baseline sources for this skill.
@@ -69,7 +70,8 @@ Perform the checks in this order and retain only the minimum output needed for d
 9. Inspect the documented Prometheus and Alertmanager workload readiness through the Kubernetes API, pinning `--context=default` and `-n monitoring` on every kubectl read.
    Read their targets and active alerts only over the external read-only URLs that `scripts/k3s/CLUSTER-STATE.md` documents for those two services, with plain GET requests.
    Those documented URLs are the single approved path to the monitoring HTTP APIs, and the hard boundaries below forbid tunnelling into the cluster to reach them by any other route.
-   If `scripts/k3s/CLUSTER-STATE.md` documents no reachable URL for either service, record its alert state as unverified and say so in the report rather than improvising an access path.
+   Judge the two services separately: whenever `scripts/k3s/CLUSTER-STATE.md` documents no URL for one of them, or the URL it documents cannot be reached, record that one service's target and alert state as unavailable and name the missing URL or access path, rather than improvising a path or letting the other service stand in for it.
+   Unavailable is a third outcome, not a health verdict: never report an unavailable check as healthy, and never report it as a failed check either.
    Record alert names, states, and relevant labels without copying secret-bearing configuration or full payloads.
 10. Check the documented storefront and backend deployment readiness and Service endpoints through the Kubernetes API, pinning `--context=default` and `-n online-boutique` on every kubectl read, then request the health URLs `scripts/k3s/CLUSTER-STATE.md` documents for them with read-only GETs under the same single-approved-path rule as step 9.
     Record status codes and health conclusions rather than response bodies that may contain customer data or credentials.
@@ -107,19 +109,23 @@ Do not use this rollback for an image, configuration, dependency, scheduling, st
 ## Verification
 
 After the rollback, complete every verification step before calling the lab healthy.
+A step whose documented access path does not exist or cannot be reached is unavailable, which is neither passed nor failed; carry that distinction from the assessment into the verdict below instead of forcing it into either.
 
 1. Run `kubectl --context=default rollout status deployment/recommendationservice -n online-boutique --timeout=60s` and verify desired, updated, available, and ready replicas converge.
    If it times out while the rollout is still progressing, report progress and repeat the bounded check rather than starting one long blocking wait.
 2. Re-read the deployment revision and memory JSONPath and verify both the request and limit equal the documented healthy baseline or the captured previous healthy revision.
 3. Verify the pre-rollback crash-loop pod UIDs are gone, the replacement pod is Ready, and the new pod is not accumulating restarts.
 4. Recheck warning events and confirm the low-memory or OOM warning has stopped recurring on the new revision.
-5. Recheck Prometheus and Alertmanager and confirm the related workload or availability alerts recover.
-6. Recheck the storefront and backend readiness, endpoints, and documented health URLs.
+5. Recheck Prometheus and Alertmanager over the external URLs `scripts/k3s/CLUSTER-STATE.md` documents and confirm the related workload or availability alerts recover.
+   Judge the two services separately as step 9 does, and when one service's documented URL is missing or unreachable, record its alert recovery as unavailable and do not call monitoring or alerting healthy on that evidence.
+6. Recheck the storefront and backend readiness, endpoints, and documented health URLs, recording any missing or unreachable documented URL as unavailable rather than as a passed or failed check.
 7. Observe the repaired state for a bounded period long enough to catch an immediate repeat crash and alert reevaluation.
 
 Do not delete the old pod to manufacture a passing result.
 The Deployment controller must replace it as part of the rollback.
 If the rollout, memory baseline, pod replacement, health checks, or relevant alerts do not recover, report that the lab is not yet healthy.
+When every check that could run passed but a monitoring or health check was unavailable, report only the narrower conclusion the evidence supports: the application-level repair is verified, monitoring or alerting verification was unavailable, and the missing URL or access path is named.
+Never widen that into a claim that the lab, its monitoring, or its alerting is healthy, and never downgrade it into a claim that a check failed.
 
 ## Hard boundaries
 
@@ -133,8 +139,9 @@ If the rollout, memory baseline, pod replacement, health checks, or relevant ale
 - Do not accept a context name as proof of cluster identity, and do not treat the `--context=default` pin as protection against a changed `KUBECONFIG`; only the documented API server URL comparison proves it.
 - Do not dump a full revision or ReplicaSet template, or any container environment, when choosing the rollback revision; read only the narrow fields step 7 names.
 - Do not run a cluster-wide `-A` read; scope every namespaced read to the documented `online-boutique` or `monitoring` namespace.
-- Do not open a `kubectl port-forward` or `kubectl proxy` tunnel, exec or attach into a pod, or copy files out of one; reach an in-cluster HTTP API only over the read-only URLs `scripts/k3s/CLUSTER-STATE.md` documents, and report the check as unverified when no documented URL is reachable.
-- Do not run `git fetch` or any other state-changing command in the RunLit checkout; prove source currency with read-only git reads only.
+- Do not open a `kubectl port-forward` or `kubectl proxy` tunnel, exec or attach into a pod, or copy files out of one; reach an in-cluster HTTP API only over the read-only URLs `scripts/k3s/CLUSTER-STATE.md` documents, and report that service's check as unavailable when no documented URL is reachable.
+- Do not call monitoring or alerting healthy on an unavailable check, and do not report an unavailable check as a failure; name the missing URL or access path instead.
+- Do not run `git fetch` or any other state-changing command in the RunLit checkout; prove source currency with a non-mutating `git ls-remote` read, never with a remote-tracking ref alone.
 - Do not delete pods as the primary fix for a Deployment-managed fault.
 - Do not scale, patch, apply, restart, or roll back any other Kubernetes resource.
 - Do not suppress, inhibit, or silence alerts unless the captain separately asks for that action.
@@ -156,7 +163,8 @@ The note records:
 - Precheck and postcheck summaries for nodes, workloads, warning events, monitoring, storefront, and backend.
 - The `recommendationservice` revisions, pod UIDs, restart evidence, and memory request and limit before and after.
 - Whether the whitelisted command ran and its result.
-- Relevant alert names and recovery state.
+- Relevant alert names and recovery state, each recorded as recovered, not recovered, or unavailable with its missing URL or access path named.
+- The source currency proof, recorded as the `git ls-remote` comparison result rather than as a bare assertion that the checkout was current.
 - Any unresolved symptom or required captain decision.
 
 Keep raw secrets, kubeconfig content, Secret objects, credentials, full logs, and sensitive response bodies out of the note.
@@ -164,4 +172,5 @@ Keep raw secrets, kubeconfig content, Secret objects, credentials, full logs, an
 Report the outcome concisely using `AGENTS.md` section 9's captain-facing translation contract.
 State whether the lab was already healthy, was restored by the approved rollback, or remains unhealthy.
 Name the verified storefront, backend, recommendation service, and alert state, then link the local evidence note when one was written.
+When a monitoring or health check was unavailable, say so in that same summary, name the missing URL or access path, and scope the claim to the application-level repair instead of to the lab as a whole.
 If more mutation is needed, end with the exact decision-ready proposal and do not imply that the original invocation approved it.

--- a/.agents/skills/runlit-lab-fix/SKILL.md
+++ b/.agents/skills/runlit-lab-fix/SKILL.md
@@ -35,9 +35,12 @@ Perform the checks in this order and retain only the minimum output needed for d
    Treat the documented context mapping as authority rather than guessing from a context name.
    `scripts/k3s/CLUSTER-STATE.md` maps the lab cluster to the local kubeconfig `default` context, and the documented lab namespaces are `online-boutique` and `monitoring`.
    If any of those sources is absent, stale, or disagrees with the observed cluster identity, stop before any cluster access or mutation and escalate to the captain.
-2. Run `kubectl config current-context` without printing kubeconfig contents, and compare the documented lab context and its documented API server against what the local kubeconfig defines for `default`.
+2. Prove the `default` context is the lab cluster before any cluster request, using the API server it points at rather than its name, because `default` is a generic name that any kubeconfig can define.
+   Run `kubectl config view --minify --context=default -o jsonpath="{.clusters[0].cluster.server}"` and compare the exact result against the lab API server documented in `scripts/k3s/CLUSTER-STATE.md`.
+   That read returns one server URL and no credentials, so it satisfies the boundary against printing kubeconfig contents.
+   Also run `kubectl config current-context` to record which context was ambient at the start, and treat that name as evidence for the note rather than as proof of identity.
    Every kubectl command below pins `--context=default` so a later context switch, another agent, a different shell environment, or a changed `KUBECONFIG` cannot redirect a read or the rollback at another cluster.
-   If the `default` context is missing, or is not proven to be the documented RunLit lab cluster, stop before any cluster request and report the mismatch.
+   If the `default` context is missing, the server URL is empty, or it differs from the documented lab API server by any character, stop before any cluster request and report the mismatch.
 3. Verify read access with non-mutating `kubectl --context=default auth can-i` checks for the resources needed below.
    A failed access check is a blocker, not permission to change credentials or kubeconfig.
 4. Inspect nodes with `kubectl --context=default get nodes -o wide` and summarize Ready state, scheduling state, and pressure conditions.
@@ -69,14 +72,16 @@ Never run an unqualified undo, because an undo without `--to-revision` targets w
 
 Run it only when all of these facts are true:
 
-- The `default` context is proven to be the documented non-production RunLit lab cluster.
+- The `default` context's API server exactly matches the lab API server documented in `scripts/k3s/CLUSTER-STATE.md`.
 - The current `recommendationservice` revision has a crash-loop or unavailable pod.
 - Pod termination state, repeated warning events, or bounded logs identify an OOM or low-memory failure.
 - The current deployment memory request or limit matches the known low-memory artifact rather than the documented healthy baseline.
 - Rollout history contains an earlier healthy revision whose memory request and limit equal the documented baseline, and that revision's integer number is recorded.
 
 Capture the current revision and crash-loop pod UIDs before the command.
-Immediately before running it, re-prove both facts that the command depends on: re-run `kubectl config current-context` and the `default` context identity check, and re-read `kubectl --context=default rollout history deployment/recommendationservice -n online-boutique` to confirm the current revision is still the broken one and `<verified revision>` still names the inspected healthy revision.
+Immediately before running it, re-prove both facts that the command depends on.
+Re-run `kubectl config view --minify --context=default -o jsonpath="{.clusters[0].cluster.server}"` and confirm it still equals the documented lab API server exactly, because a kubeconfig edit between assessment and mutation can repoint `default` at another cluster.
+Re-read `kubectl --context=default rollout history deployment/recommendationservice -n online-boutique` and confirm the current revision is still the broken one and `<verified revision>` still names the inspected healthy revision.
 If either recheck disagrees with the assessment, stop and reassess from the beginning rather than running the command.
 Run the undo at most once for one observed broken revision.
 If another operator has already changed the revision, reassess from the beginning and do not undo blindly.
@@ -107,7 +112,8 @@ If the rollout, memory baseline, pod replacement, health checks, or relevant ale
 - Do not touch the private Postgres rollout.
 - Do not stop, restart, reconfigure, or profile the Mac mini worker runtime.
 - Do not touch Proxmox, the NAS, DNS, network configuration, provider accounts, or project code.
-- Do not send any cluster request, read or mutation, without an explicit `--context=default`, and never let the ambient current context decide which cluster a command reaches; the `kubectl config current-context` identity check is the only local kubeconfig read exempt from the flag.
+- Do not send any cluster request, read or mutation, without an explicit `--context=default`, and never let the ambient current context decide which cluster a command reaches; the local `kubectl config current-context` read is the only command exempt from the flag.
+- Do not accept a context name as proof of cluster identity; only the documented API server URL comparison proves it.
 - Do not run a cluster-wide `-A` read; scope every namespaced read to the documented `online-boutique` or `monitoring` namespace.
 - Do not delete pods as the primary fix for a Deployment-managed fault.
 - Do not scale, patch, apply, restart, or roll back any other Kubernetes resource.
@@ -126,7 +132,7 @@ Do not guess a home path or write the note into project code.
 The note records:
 
 - UTC start and finish times.
-- The context name and topology sources used to prove it is the lab.
+- The context name, the API server URL comparison result, and the topology sources used to prove it is the lab, recorded as matched or mismatched rather than by pasting the URL.
 - Precheck and postcheck summaries for nodes, workloads, warning events, monitoring, storefront, and backend.
 - The `recommendationservice` revisions, pod UIDs, restart evidence, and memory request and limit before and after.
 - Whether the whitelisted command ran and its result.

--- a/.agents/skills/runlit-lab-fix/SKILL.md
+++ b/.agents/skills/runlit-lab-fix/SKILL.md
@@ -30,9 +30,12 @@ Keep the task operational and evidence-producing only, with no project-code edit
 Perform the checks in this order and retain only the minimum output needed for diagnosis.
 
 1. Resolve one unambiguous RunLit project checkout first, and read every source below from that same checkout.
-   The checkout is the RunLit clone under the active home's `projects/` directory that the home's `data/projects.md` registry names, or the worker's own checkout when it already runs inside the RunLit repository; when both resolve, they must be the same repository.
-   Confirm the resolved path is the expected RunLit repository, is on its default branch, and is current with its remote rather than a detached, diverged, or long-stale copy.
-   If no checkout resolves, more than one candidate resolves, the checkout is not the expected current RunLit repository, or any of the four sources below is missing, stop before any cluster access or mutation and escalate to the captain.
+   The checkout is the RunLit clone under the active home's `projects/` directory that the home's `data/projects.md` registry names, or the isolated task worktree the worker already runs in when that worktree is a RunLit checkout; when both resolve, they must be the same repository.
+   Confirm the resolved path is the expected RunLit repository and that its sources are current.
+   A dispatched worker runs on a task branch in an isolated worktree, so require only that the worktree's base is the project's default branch; never require the branch it is on to be the default branch itself.
+   Establish currency with read-only git commands only, such as comparing the checkout against its already-present remote-tracking ref or against `git ls-remote`.
+   Never run `git fetch`, or any other state-changing git command, under `projects/` or in any project worktree; the read-only project boundary in `AGENTS.md` section 1 outranks this check.
+   If no checkout resolves, more than one candidate resolves, the checkout is not the expected RunLit repository, currency cannot be established read-only, or any of the four sources below is missing, stop before any cluster access or mutation and escalate to the captain.
    Read the RunLit lab's documented topology from `scripts/k3s/CLUSTER-STATE.md` and `scripts/k3s/README.md` in that checkout, and identify the expected non-production kube context, namespaces, monitoring services, storefront route, backend route, and healthy resource baseline.
    Read the documented `recommendationservice` healthy memory request and limit, its expected container image, and its documented restore path from `docs/dogfood/oom-crashloop-validation.md` and `scripts/k3s/demo-chaos.sh` in that same checkout.
    These four files are the authoritative topology and baseline sources for this skill.
@@ -63,9 +66,12 @@ Perform the checks in this order and retain only the minimum output needed for d
    Never widen it into a full revision or ReplicaSet template dump, including `rollout history --revision=<n>`, because those echo container environment variables this skill must not print.
 8. Read only the service's memory request and limit with a narrow JSONPath query such as `kubectl --context=default get deployment recommendationservice -n online-boutique -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{" request="}{.resources.requests.memory}{" limit="}{.resources.limits.memory}{"\n"}{end}'`.
    Use pod status, termination reasons, warning events, and only a bounded tail of service logs when needed to distinguish an OOM or low-memory crash loop from an unrelated failure.
-9. Inspect the documented Prometheus and Alertmanager workloads, readiness, targets, and active alerts through their read-only Kubernetes or HTTP APIs, pinning `--context=default` and `-n monitoring` on every kubectl read.
+9. Inspect the documented Prometheus and Alertmanager workload readiness through the Kubernetes API, pinning `--context=default` and `-n monitoring` on every kubectl read.
+   Read their targets and active alerts only over the external read-only URLs that `scripts/k3s/CLUSTER-STATE.md` documents for those two services, with plain GET requests.
+   Those documented URLs are the single approved path to the monitoring HTTP APIs, and the hard boundaries below forbid tunnelling into the cluster to reach them by any other route.
+   If `scripts/k3s/CLUSTER-STATE.md` documents no reachable URL for either service, record its alert state as unverified and say so in the report rather than improvising an access path.
    Record alert names, states, and relevant labels without copying secret-bearing configuration or full payloads.
-10. Check the documented storefront and backend deployment readiness, Service endpoints, and health URLs with read-only GET requests, pinning `--context=default` and `-n online-boutique` on every kubectl read.
+10. Check the documented storefront and backend deployment readiness and Service endpoints through the Kubernetes API, pinning `--context=default` and `-n online-boutique` on every kubectl read, then request the health URLs `scripts/k3s/CLUSTER-STATE.md` documents for them with read-only GETs under the same single-approved-path rule as step 9.
     Record status codes and health conclusions rather than response bodies that may contain customer data or credentials.
 
 Do not proceed from a partial assessment when the evidence cannot distinguish the known artifact from another failure.
@@ -127,6 +133,8 @@ If the rollout, memory baseline, pod replacement, health checks, or relevant ale
 - Do not accept a context name as proof of cluster identity, and do not treat the `--context=default` pin as protection against a changed `KUBECONFIG`; only the documented API server URL comparison proves it.
 - Do not dump a full revision or ReplicaSet template, or any container environment, when choosing the rollback revision; read only the narrow fields step 7 names.
 - Do not run a cluster-wide `-A` read; scope every namespaced read to the documented `online-boutique` or `monitoring` namespace.
+- Do not open a `kubectl port-forward` or `kubectl proxy` tunnel, exec or attach into a pod, or copy files out of one; reach an in-cluster HTTP API only over the read-only URLs `scripts/k3s/CLUSTER-STATE.md` documents, and report the check as unverified when no documented URL is reachable.
+- Do not run `git fetch` or any other state-changing command in the RunLit checkout; prove source currency with read-only git reads only.
 - Do not delete pods as the primary fix for a Deployment-managed fault.
 - Do not scale, patch, apply, restart, or roll back any other Kubernetes resource.
 - Do not suppress, inhibit, or silence alerts unless the captain separately asks for that action.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,7 @@ Firstmate never writes a project's `AGENTS.md` directly.
 A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.
 Keep fleet delivery posture and captain-private strategy out of project memory.
 When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
+When the captain invokes `/runlit-lab-fix`, asks to fix, restore, or reset the RunLit Kubernetes lab, or asks to return the k8s lab to a healthy baseline, load the `runlit-lab-fix` skill and follow its bounded remediation authority.
 
 ## 7. Task lifecycle
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/afk`               | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
 | `/ahoy`              | Recap only visible session events since the prior real captain message, falling back to Bearings when invoked as the session's first real captain message |
 | `/bearings`          | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
-| `/runlit-lab-fix`    | Assess the non-production RunLit Kubernetes lab and restore its known recommendation service crash-loop and low-memory artifact through one guarded rollback |
+| `/runlit-lab-fix`    | Assess the non-production RunLit Kubernetes lab and repair its known recommendation service crash-loop and low-memory artifact through one guarded rollback |
 | `/updatefirstmate`   | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`              | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
 

--- a/README.md
+++ b/README.md
@@ -171,13 +171,14 @@ Full architecture - the supervision engine, worktree isolation, secondmates, dis
 Firstmate ships these user-invocable built-in skills.
 Claude and grok use the slash form shown here; codex uses the same names with `$`, such as `$afk`.
 
-| Skill              | What it does                                                                                                                                  |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
-| `/ahoy`            | Recap only visible session events since the prior real captain message, falling back to Bearings when invoked as the session's first real captain message |
-| `/bearings`        | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
-| `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
-| `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
+| Skill                | What it does                                                                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/afk`               | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
+| `/ahoy`              | Recap only visible session events since the prior real captain message, falling back to Bearings when invoked as the session's first real captain message |
+| `/bearings`          | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
+| `/runlit-lab-fix`    | Assess the non-production RunLit Kubernetes lab and restore its known recommendation service crash-loop and low-memory artifact through one guarded rollback |
+| `/updatefirstmate`   | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
+| `/stow`              | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
 
 Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).
 

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -160,12 +160,14 @@ test_runlit_lab_fix_is_bounded_and_user_invocable() {
 
 # The prescriptive body of the skill: everything except the "Hard boundaries"
 # prohibition list, where naming a forbidden command strengthens the contract
-# instead of authorizing it.
+# instead of authorizing it. The mandatory `--context=default` pin is stripped
+# so forbidden-verb guards match the skill's own command style rather than a
+# bare `kubectl <verb>` form the file never uses.
 runlit_prescribed_commands() {
   awk '
     /^## Hard boundaries$/ { skipping = 1; next }
     skipping && /^## / { skipping = 0 }
-    !skipping { print }
+    !skipping { gsub(/--context=default /, ""); print }
   ' "$RUNLIT"
 }
 
@@ -173,6 +175,9 @@ test_runlit_lab_fix_owns_safe_repair_contract() {
   local prescribed
   for phrase in \
     'kubectl config current-context' \
+    'kubectl config view --minify --context=default -o jsonpath="{.clusters[0].cluster.server}"' \
+    'lab API server documented in `scripts/k3s/CLUSTER-STATE.md`' \
+    'Do not accept a context name as proof of cluster identity' \
     'kubectl --context=default get nodes -o wide' \
     'kubectl --context=default get pods -n online-boutique -o wide' \
     'kubectl --context=default get deployments -n online-boutique' \
@@ -201,14 +206,35 @@ test_runlit_lab_fix_owns_safe_repair_contract() {
   done
   assert_no_grep '$FM_HOME/data/' "$RUNLIT" "RunLit lab repair evidence path expands FM_HOME literally instead of resolving the effective home"
   prescribed=$(runlit_prescribed_commands)
+  assert_contains "$prescribed" 'kubectl get nodes -o wide' \
+    "the --context=default pin is no longer stripped, so the forbidden-command guards below are dead"
   assert_not_contains "$prescribed" 'kubectl delete' "RunLit lab repair skill prescribes a pod deletion command"
   assert_not_contains "$prescribed" 'kubectl apply' "RunLit lab repair skill prescribes an apply command"
   assert_not_contains "$prescribed" 'kubectl patch' "RunLit lab repair skill prescribes a patch command"
+  assert_not_contains "$prescribed" 'kubectl set ' "RunLit lab repair skill prescribes a resource-mutating set command"
+  assert_not_contains "$prescribed" 'kubectl scale' "RunLit lab repair skill prescribes a scale command"
   assert_not_contains "$prescribed" 'kubectl rollout restart' "RunLit lab repair skill prescribes a restart command"
   assert_not_contains "$prescribed" 'kubectl get pods -A' "RunLit lab repair skill prescribes a cluster-wide pod read"
   assert_not_contains "$prescribed" 'kubectl get deployments -A' "RunLit lab repair skill prescribes a cluster-wide deployment read"
   assert_not_contains "$prescribed" 'kubectl get events -A' "RunLit lab repair skill prescribes a cluster-wide event read"
+  assert_not_contains "$prescribed" '--all-namespaces' "RunLit lab repair skill prescribes a cluster-wide read"
   pass "RunLit lab repair owns one guarded mutation and the required evidence and safety boundaries"
+}
+
+test_runlit_lab_fix_reproves_cluster_identity_before_mutating() {
+  local remediation
+  remediation=$(awk '
+    /^## Whitelisted remediation$/ { found = 1; next }
+    found && /^## / { exit }
+    found { print }
+  ' "$RUNLIT")
+  assert_contains "$remediation" 'kubectl config view --minify --context=default -o jsonpath="{.clusters[0].cluster.server}"' \
+    "the rollback does not re-prove the lab API server immediately before mutating"
+  assert_contains "$remediation" 'rollout history deployment/recommendationservice -n online-boutique' \
+    "the rollback does not re-read rollout history immediately before mutating"
+  assert_not_contains "$remediation" 'kubectl config current-context' \
+    "the pre-mutation recheck relies on the ambient context name, which proves nothing once every command pins --context"
+  pass "RunLit lab repair re-proves cluster identity and revision immediately before the one mutation"
 }
 
 test_ahoy_is_an_internal_user_invocable_skill() {
@@ -317,6 +343,7 @@ test_outward_facing_skill_points_reference_section_9_owner
 test_section_9_owner_is_not_duplicated_into_skills
 test_runlit_lab_fix_is_bounded_and_user_invocable
 test_runlit_lab_fix_owns_safe_repair_contract
+test_runlit_lab_fix_reproves_cluster_identity_before_mutating
 test_ahoy_is_an_internal_user_invocable_skill
 test_ahoy_readme_uses_cross_harness_convention
 test_ahoy_owns_only_the_visible_session_recap

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -211,11 +211,14 @@ test_runlit_lab_fix_owns_safe_repair_contract() {
     'is no defense against a changed `KUBECONFIG`' \
     "the home's \`data/projects.md\` registry names" \
     'require only that the worktree'"'"'s base is the project'"'"'s default branch' \
-    'or against `git ls-remote`' \
+    'Prove currency with a non-mutating `git ls-remote` read of the remote default branch' \
+    'never as the proof itself' \
     'Never run `git fetch`, or any other state-changing git command, under `projects/`' \
     'Do not open a `kubectl port-forward` or `kubectl proxy` tunnel' \
     'external read-only URLs that `scripts/k3s/CLUSTER-STATE.md` documents' \
-    'record its alert state as unverified' \
+    'record that one service'"'"'s target and alert state as unavailable' \
+    'never report an unavailable check as healthy, and never report it as a failed check either' \
+    'Do not call monitoring or alerting healthy on an unavailable check' \
     'kubectl --context=default get replicasets -n online-boutique -l app=recommendationservice' \
     'Never widen it into a full revision or ReplicaSet template dump' \
     'kubectl --context=default get nodes -o wide' \
@@ -283,6 +286,24 @@ test_runlit_lab_fix_prescribes_no_mutating_or_cluster_wide_kubectl() {
     fail "RunLit lab repair skill writes a kubectl command outside a code span, where the command guards cannot see it"
   fi
   pass "RunLit lab repair prescribes no mutating or cluster-wide kubectl command in any flag order"
+}
+
+test_runlit_lab_fix_carries_unavailable_outcome_into_verification() {
+  local verification
+  verification=$(awk '
+    /^## Verification$/ { found = 1; next }
+    found && /^## / { exit }
+    found { print }
+  ' "$RUNLIT")
+  assert_contains "$verification" 'unavailable, which is neither passed nor failed' \
+    "the Verification section does not carry the assessment's unavailable outcome, so an unreachable check has to be forced into pass or fail"
+  assert_contains "$verification" 'do not call monitoring or alerting healthy on that evidence' \
+    "the Verification section lets a missing or unreachable monitoring URL read as healthy"
+  assert_contains "$verification" 'the application-level repair is verified, monitoring or alerting verification was unavailable, and the missing URL or access path is named' \
+    "the Verification verdict has no narrower app-only conclusion, so an unavailable monitoring check forces a false not-healthy or a silent deviation"
+  assert_no_grep 'unverified' "$RUNLIT" \
+    "RunLit lab repair mixes 'unverified' into the 'unavailable' outcome vocabulary"
+  pass "RunLit lab repair carries the unavailable outcome from assessment into the verification verdict"
 }
 
 test_runlit_lab_fix_reproves_cluster_identity_before_mutating() {
@@ -408,6 +429,7 @@ test_section_9_owner_is_not_duplicated_into_skills
 test_runlit_lab_fix_is_bounded_and_user_invocable
 test_runlit_lab_fix_owns_safe_repair_contract
 test_runlit_lab_fix_prescribes_no_mutating_or_cluster_wide_kubectl
+test_runlit_lab_fix_carries_unavailable_outcome_into_verification
 test_runlit_lab_fix_reproves_cluster_identity_before_mutating
 test_ahoy_is_an_internal_user_invocable_skill
 test_ahoy_readme_uses_cross_harness_convention

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -17,6 +17,7 @@ CODEXAPP="$ROOT/.agents/skills/firstmate-codexapp/SKILL.md"
 FMX="$ROOT/.agents/skills/fmx-respond/SKILL.md"
 UPDATE="$ROOT/.agents/skills/updatefirstmate/SKILL.md"
 AHOY="$ROOT/.agents/skills/ahoy/SKILL.md"
+RUNLIT="$ROOT/.agents/skills/runlit-lab-fix/SKILL.md"
 README="$ROOT/README.md"
 
 section_9() {
@@ -126,19 +127,65 @@ test_outward_facing_skill_points_reference_section_9_owner() {
     "X reply safety does not state that it supplements section 9"
   assert_grep "under \`AGENTS.md\` section 9 without firstmate's internal vocabulary" "$UPDATE" \
     "Firstmate update reporting does not reference section 9"
+  assert_grep "using \`AGENTS.md\` section 9's captain-facing translation contract" "$RUNLIT" \
+    "RunLit lab repair reporting does not reference section 9"
   pass "outward-facing skill handoffs point to the section 9 owner"
 }
 
 test_section_9_owner_is_not_duplicated_into_skills() {
   local duplicate_count file
   duplicate_count=0
-  for file in "$BOOTSTRAP" "$AFK" "$DECISION" "$RECOVERY" "$HARNESS" "$CODEXAPP" "$UPDATE"; do
+  for file in "$BOOTSTRAP" "$AFK" "$DECISION" "$RECOVERY" "$HARNESS" "$CODEXAPP" "$UPDATE" "$RUNLIT"; do
     if grep -Fq "When evidence uses an internal label, rewrite it before sending:" "$file"; then
       duplicate_count=$((duplicate_count + 1))
     fi
   done
   [ "$duplicate_count" -eq 0 ] || fail "skills duplicated section 9's mapping owner"
   pass "skills cross-reference section 9 instead of duplicating the mapping list"
+}
+
+test_runlit_lab_fix_is_bounded_and_user_invocable() {
+  local trigger_count
+
+  assert_present "$RUNLIT" "RunLit lab repair skill is missing"
+  assert_grep 'name: runlit-lab-fix' "$RUNLIT" "RunLit lab repair skill metadata has the wrong name"
+  assert_grep 'user-invocable: true' "$RUNLIT" "RunLit lab repair skill is not user-invocable"
+  assert_grep '  internal: true' "$RUNLIT" "RunLit lab repair skill is not internal"
+  [ ! -e "$ROOT/skills/runlit-lab-fix" ] || fail "RunLit lab repair must not exist in the public installer-facing skills directory"
+  trigger_count=$(grep -Fc 'load the `runlit-lab-fix` skill' "$AGENTS")
+  [ "$trigger_count" -eq 1 ] || fail "runlit-lab-fix must have exactly one AGENTS.md trigger, found $trigger_count"
+  assert_grep '| `/runlit-lab-fix`' "$README" "README built-in skills table does not list /runlit-lab-fix"
+  pass "RunLit lab repair is internal, user-invocable, and precisely triggered"
+}
+
+test_runlit_lab_fix_owns_safe_repair_contract() {
+  for phrase in \
+    'kubectl config current-context' \
+    'kubectl get nodes -o wide' \
+    'kubectl get pods -A -o wide' \
+    'kubectl get deployments -A' \
+    'type=Warning' \
+    'Prometheus and Alertmanager' \
+    'storefront and backend' \
+    'kubectl rollout undo deployment/recommendationservice -n online-boutique' \
+    'kubectl rollout status deployment/recommendationservice -n online-boutique --timeout=60s' \
+    'Do not delete the old pod to manufacture a passing result.' \
+    'Do not touch production.' \
+    'Do not touch Coolify.' \
+    'Do not touch the private Postgres rollout.' \
+    'Mac mini worker runtime' \
+    'Do not touch Proxmox, the NAS, DNS, network configuration, provider accounts, or project code.' \
+    'Do not suppress, inhibit, or silence alerts unless the captain separately asks for that action.' \
+    'Never print kubeconfig contents' \
+    'exact proposed command, target resources, expected effect, rollback plan, and blast radius' \
+    '$FM_HOME/data/runlit-lab-fix-<UTC timestamp>.md'; do
+    assert_grep "$phrase" "$RUNLIT" "RunLit lab repair contract is missing '$phrase'"
+  done
+  assert_no_grep 'kubectl delete' "$RUNLIT" "RunLit lab repair skill includes a pod deletion command"
+  assert_no_grep 'kubectl apply' "$RUNLIT" "RunLit lab repair skill includes an apply command"
+  assert_no_grep 'kubectl patch' "$RUNLIT" "RunLit lab repair skill includes a patch command"
+  assert_no_grep 'kubectl rollout restart' "$RUNLIT" "RunLit lab repair skill includes a restart command"
+  pass "RunLit lab repair owns one guarded mutation and the required evidence and safety boundaries"
 }
 
 test_ahoy_is_an_internal_user_invocable_skill() {
@@ -245,6 +292,8 @@ test_mapping_list_covers_high_risk_internal_families
 test_verbatim_internal_evidence_is_rejected_from_chat
 test_outward_facing_skill_points_reference_section_9_owner
 test_section_9_owner_is_not_duplicated_into_skills
+test_runlit_lab_fix_is_bounded_and_user_invocable
+test_runlit_lab_fix_owns_safe_repair_contract
 test_ahoy_is_an_internal_user_invocable_skill
 test_ahoy_readme_uses_cross_harness_convention
 test_ahoy_owns_only_the_visible_session_recap

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -158,26 +158,60 @@ test_runlit_lab_fix_is_bounded_and_user_invocable() {
   pass "RunLit lab repair is internal, user-invocable, and precisely triggered"
 }
 
-# The prescriptive body of the skill: everything except the "Hard boundaries"
-# prohibition list, where naming a forbidden command strengthens the contract
-# instead of authorizing it. The mandatory `--context=default` pin is stripped
-# so forbidden-verb guards match the skill's own command style rather than a
-# bare `kubectl <verb>` form the file never uses.
-runlit_prescribed_commands() {
+# One line per kubectl command the skill prescribes, taken from its code spans
+# and fenced blocks and excluding the "Hard boundaries" prohibition list, where
+# naming a forbidden verb strengthens the contract instead of authorizing it.
+# Whole commands, not a `kubectl <verb>` prefix: the guards below match a
+# forbidden verb or a cluster-wide selector anywhere in the command, so no flag
+# order and no `--context=default` pin can hide a mutation from them.
+runlit_prescribed_kubectl() {
   awk '
     /^## Hard boundaries$/ { skipping = 1; next }
     skipping && /^## / { skipping = 0 }
-    !skipping { gsub(/--context=default /, ""); print }
+    skipping { next }
+    /^```/ { fence = !fence; next }
+    fence { if ($0 ~ /kubectl/) print; next }
+    {
+      rest = $0
+      while (match(rest, /`[^`]*`/)) {
+        span = substr(rest, RSTART + 1, RLENGTH - 2)
+        if (span ~ /kubectl/) print span
+        rest = substr(rest, RSTART + RLENGTH)
+      }
+    }
   ' "$RUNLIT"
 }
 
+# The same body with every code span and fenced block stripped, so a kubectl
+# command written as bare prose - which the extractor above would never see -
+# still has to answer to a guard.
+runlit_uncoded_prose() {
+  awk '
+    /^## Hard boundaries$/ { skipping = 1; next }
+    skipping && /^## / { skipping = 0 }
+    skipping { next }
+    /^```/ { fence = !fence; next }
+    fence { next }
+    { gsub(/`[^`]*`/, " "); print }
+  ' "$RUNLIT"
+}
+
+# Standalone-word match so `replicasets` never reads as `set` and
+# `--field-selector` never reads as `select`.
+runlit_kubectl_mentions() {
+  printf '%s\n' "$1" | grep -Eq -- "(^|[^[:alnum:]_-])$2([^[:alnum:]_-]|\$)"
+}
+
 test_runlit_lab_fix_owns_safe_repair_contract() {
-  local prescribed
   for phrase in \
     'kubectl config current-context' \
     'kubectl config view --minify --context=default -o jsonpath="{.clusters[0].cluster.server}"' \
     'lab API server documented in `scripts/k3s/CLUSTER-STATE.md`' \
     'Do not accept a context name as proof of cluster identity' \
+    'is no defense against a changed `KUBECONFIG`' \
+    "the home's \`data/projects.md\` registry names" \
+    'kubectl --context=default get replicasets -n online-boutique -l app=recommendationservice' \
+    'Never widen it into a full revision or ReplicaSet template dump' \
     'kubectl --context=default get nodes -o wide' \
     'kubectl --context=default get pods -n online-boutique -o wide' \
     'kubectl --context=default get deployments -n online-boutique' \
@@ -205,20 +239,44 @@ test_runlit_lab_fix_owns_safe_repair_contract() {
     assert_grep "$phrase" "$RUNLIT" "RunLit lab repair contract is missing '$phrase'"
   done
   assert_no_grep '$FM_HOME/data/' "$RUNLIT" "RunLit lab repair evidence path expands FM_HOME literally instead of resolving the effective home"
-  prescribed=$(runlit_prescribed_commands)
-  assert_contains "$prescribed" 'kubectl get nodes -o wide' \
-    "the --context=default pin is no longer stripped, so the forbidden-command guards below are dead"
-  assert_not_contains "$prescribed" 'kubectl delete' "RunLit lab repair skill prescribes a pod deletion command"
-  assert_not_contains "$prescribed" 'kubectl apply' "RunLit lab repair skill prescribes an apply command"
-  assert_not_contains "$prescribed" 'kubectl patch' "RunLit lab repair skill prescribes a patch command"
-  assert_not_contains "$prescribed" 'kubectl set ' "RunLit lab repair skill prescribes a resource-mutating set command"
-  assert_not_contains "$prescribed" 'kubectl scale' "RunLit lab repair skill prescribes a scale command"
-  assert_not_contains "$prescribed" 'kubectl rollout restart' "RunLit lab repair skill prescribes a restart command"
-  assert_not_contains "$prescribed" 'kubectl get pods -A' "RunLit lab repair skill prescribes a cluster-wide pod read"
-  assert_not_contains "$prescribed" 'kubectl get deployments -A' "RunLit lab repair skill prescribes a cluster-wide deployment read"
-  assert_not_contains "$prescribed" 'kubectl get events -A' "RunLit lab repair skill prescribes a cluster-wide event read"
-  assert_not_contains "$prescribed" '--all-namespaces' "RunLit lab repair skill prescribes a cluster-wide read"
   pass "RunLit lab repair owns one guarded mutation and the required evidence and safety boundaries"
+}
+
+test_runlit_lab_fix_prescribes_no_mutating_or_cluster_wide_kubectl() {
+  local prescribed verb line
+  prescribed=$(runlit_prescribed_kubectl)
+  assert_contains "$prescribed" 'kubectl --context=default get nodes -o wide' \
+    "the prescribed kubectl commands could not be extracted, so the guards below are dead"
+  for verb in delete apply patch create replace edit set scale autoscale expose annotate label taint drain cordon uncordon \
+    exec attach cp proxy port-forward debug; do
+    if runlit_kubectl_mentions "$prescribed" "$verb"; then
+      fail "RunLit lab repair skill prescribes a forbidden 'kubectl $verb' command"
+    fi
+  done
+  if printf '%s\n' "$prescribed" | grep -Eq 'rollout[[:space:]]+restart'; then
+    fail "RunLit lab repair skill prescribes a rollout restart"
+  fi
+  if runlit_kubectl_mentions "$prescribed" '-A' || runlit_kubectl_mentions "$prescribed" '--all-namespaces'; then
+    fail "RunLit lab repair skill prescribes a cluster-wide read"
+  fi
+  # Every prescribed request-issuing command must carry the pin; only the local
+  # `kubectl config` reads, which touch no cluster, are exempt.
+  while IFS= read -r line; do
+    case "$line" in
+      *'kubectl config'*) continue ;;
+      *kubectl*) : ;;
+      *) continue ;;
+    esac
+    case "$line" in
+      *'--context=default'*) : ;;
+      *) fail "RunLit lab repair skill prescribes an unpinned cluster command: $line" ;;
+    esac
+  done <<< "$prescribed"
+  # A real command written outside a code span would bypass the extractor above.
+  if printf '%s\n' "$(runlit_uncoded_prose)" | grep -Eq 'kubectl[[:space:]]+(-|/|(get|config|auth|rollout|delete|apply|patch|create|replace|edit|set|scale|exec|cp|drain|cordon|uncordon|label|annotate|taint|port-forward|proxy|attach|debug|top|logs|describe|wait|expose|autoscale)([^[:alnum:]_-]|$))'; then
+    fail "RunLit lab repair skill writes a kubectl command outside a code span, where the command guards cannot see it"
+  fi
+  pass "RunLit lab repair prescribes no mutating or cluster-wide kubectl command in any flag order"
 }
 
 test_runlit_lab_fix_reproves_cluster_identity_before_mutating() {
@@ -343,6 +401,7 @@ test_outward_facing_skill_points_reference_section_9_owner
 test_section_9_owner_is_not_duplicated_into_skills
 test_runlit_lab_fix_is_bounded_and_user_invocable
 test_runlit_lab_fix_owns_safe_repair_contract
+test_runlit_lab_fix_prescribes_no_mutating_or_cluster_wide_kubectl
 test_runlit_lab_fix_reproves_cluster_identity_before_mutating
 test_ahoy_is_an_internal_user_invocable_skill
 test_ahoy_readme_uses_cross_harness_convention

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -211,8 +211,10 @@ test_runlit_lab_fix_owns_safe_repair_contract() {
     'is no defense against a changed `KUBECONFIG`' \
     "the home's \`data/projects.md\` registry names" \
     'require only that the worktree'"'"'s base is the project'"'"'s default branch' \
-    'Prove currency with a non-mutating `git ls-remote` read of the remote default branch' \
+    'Prove currency by comparing the checkout'"'"'s base against the live remote default-branch commit' \
+    'never compare the task-branch HEAD' \
     'never as the proof itself' \
+    'Do not label an unavailable storefront or backend health URL as a monitoring gap' \
     'Never run `git fetch`, or any other state-changing git command, under `projects/`' \
     'Do not open a `kubectl port-forward` or `kubectl proxy` tunnel' \
     'external read-only URLs that `scripts/k3s/CLUSTER-STATE.md` documents' \
@@ -299,8 +301,12 @@ test_runlit_lab_fix_carries_unavailable_outcome_into_verification() {
     "the Verification section does not carry the assessment's unavailable outcome, so an unreachable check has to be forced into pass or fail"
   assert_contains "$verification" 'do not call monitoring or alerting healthy on that evidence' \
     "the Verification section lets a missing or unreachable monitoring URL read as healthy"
-  assert_contains "$verification" 'the application-level repair is verified, monitoring or alerting verification was unavailable, and the missing URL or access path is named' \
-    "the Verification verdict has no narrower app-only conclusion, so an unavailable monitoring check forces a false not-healthy or a silent deviation"
+  assert_contains "$verification" 'name the checks that actually ran and passed, name each unavailable check for what it was' \
+    "the Verification verdict has no narrower conclusion, so an unavailable check forces a false not-healthy or a silent deviation"
+  assert_contains "$verification" 'record app-health verification as unavailable' \
+    "an unreachable storefront or backend health URL has no app-health label of its own"
+  assert_contains "$verification" 'never as an application-level repair verified with a monitoring gap' \
+    "the Verification verdict can still report an unavailable app health check as a monitoring gap"
   assert_no_grep 'unverified' "$RUNLIT" \
     "RunLit lab repair mixes 'unverified' into the 'unavailable' outcome vocabulary"
   pass "RunLit lab repair carries the unavailable outcome from assessment into the verification verdict"

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -210,6 +210,12 @@ test_runlit_lab_fix_owns_safe_repair_contract() {
     'Do not accept a context name as proof of cluster identity' \
     'is no defense against a changed `KUBECONFIG`' \
     "the home's \`data/projects.md\` registry names" \
+    'require only that the worktree'"'"'s base is the project'"'"'s default branch' \
+    'or against `git ls-remote`' \
+    'Never run `git fetch`, or any other state-changing git command, under `projects/`' \
+    'Do not open a `kubectl port-forward` or `kubectl proxy` tunnel' \
+    'external read-only URLs that `scripts/k3s/CLUSTER-STATE.md` documents' \
+    'record its alert state as unverified' \
     'kubectl --context=default get replicasets -n online-boutique -l app=recommendationservice' \
     'Never widen it into a full revision or ReplicaSet template dump' \
     'kubectl --context=default get nodes -o wide' \

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -158,17 +158,35 @@ test_runlit_lab_fix_is_bounded_and_user_invocable() {
   pass "RunLit lab repair is internal, user-invocable, and precisely triggered"
 }
 
+# The prescriptive body of the skill: everything except the "Hard boundaries"
+# prohibition list, where naming a forbidden command strengthens the contract
+# instead of authorizing it.
+runlit_prescribed_commands() {
+  awk '
+    /^## Hard boundaries$/ { skipping = 1; next }
+    skipping && /^## / { skipping = 0 }
+    !skipping { print }
+  ' "$RUNLIT"
+}
+
 test_runlit_lab_fix_owns_safe_repair_contract() {
+  local prescribed
   for phrase in \
     'kubectl config current-context' \
-    'kubectl get nodes -o wide' \
-    'kubectl get pods -A -o wide' \
-    'kubectl get deployments -A' \
-    'type=Warning' \
+    'kubectl --context=default get nodes -o wide' \
+    'kubectl --context=default get pods -n online-boutique -o wide' \
+    'kubectl --context=default get deployments -n online-boutique' \
+    'kubectl --context=default get events -n online-boutique --field-selector type=Warning' \
     'Prometheus and Alertmanager' \
     'storefront and backend' \
-    'kubectl rollout undo deployment/recommendationservice -n online-boutique' \
-    'kubectl rollout status deployment/recommendationservice -n online-boutique --timeout=60s' \
+    'kubectl --context=default rollout undo deployment/recommendationservice -n online-boutique --to-revision=<verified revision>' \
+    'Never run an unqualified undo' \
+    'kubectl --context=default rollout status deployment/recommendationservice -n online-boutique --timeout=60s' \
+    'scripts/k3s/CLUSTER-STATE.md' \
+    'scripts/k3s/README.md' \
+    'docs/dogfood/oom-crashloop-validation.md' \
+    'scripts/k3s/demo-chaos.sh' \
+    'stop before any cluster access or mutation and escalate to the captain' \
     'Do not delete the old pod to manufacture a passing result.' \
     'Do not touch production.' \
     'Do not touch Coolify.' \
@@ -178,13 +196,18 @@ test_runlit_lab_fix_owns_safe_repair_contract() {
     'Do not suppress, inhibit, or silence alerts unless the captain separately asks for that action.' \
     'Never print kubeconfig contents' \
     'exact proposed command, target resources, expected effect, rollback plan, and blast radius' \
-    '$FM_HOME/data/runlit-lab-fix-<UTC timestamp>.md'; do
+    'data/runlit-lab-fix-<UTC timestamp>.md'; do
     assert_grep "$phrase" "$RUNLIT" "RunLit lab repair contract is missing '$phrase'"
   done
-  assert_no_grep 'kubectl delete' "$RUNLIT" "RunLit lab repair skill includes a pod deletion command"
-  assert_no_grep 'kubectl apply' "$RUNLIT" "RunLit lab repair skill includes an apply command"
-  assert_no_grep 'kubectl patch' "$RUNLIT" "RunLit lab repair skill includes a patch command"
-  assert_no_grep 'kubectl rollout restart' "$RUNLIT" "RunLit lab repair skill includes a restart command"
+  assert_no_grep '$FM_HOME/data/' "$RUNLIT" "RunLit lab repair evidence path expands FM_HOME literally instead of resolving the effective home"
+  prescribed=$(runlit_prescribed_commands)
+  assert_not_contains "$prescribed" 'kubectl delete' "RunLit lab repair skill prescribes a pod deletion command"
+  assert_not_contains "$prescribed" 'kubectl apply' "RunLit lab repair skill prescribes an apply command"
+  assert_not_contains "$prescribed" 'kubectl patch' "RunLit lab repair skill prescribes a patch command"
+  assert_not_contains "$prescribed" 'kubectl rollout restart' "RunLit lab repair skill prescribes a restart command"
+  assert_not_contains "$prescribed" 'kubectl get pods -A' "RunLit lab repair skill prescribes a cluster-wide pod read"
+  assert_not_contains "$prescribed" 'kubectl get deployments -A' "RunLit lab repair skill prescribes a cluster-wide deployment read"
+  assert_not_contains "$prescribed" 'kubectl get events -A' "RunLit lab repair skill prescribes a cluster-wide event read"
   pass "RunLit lab repair owns one guarded mutation and the required evidence and safety boundaries"
 }
 


### PR DESCRIPTION
## Intent

The developer was shipping a small RunLit lab repair skill through the firstmate no-mistakes pipeline and wanted the change validated and landed without weakening prior review hardening. They had already absorbed two rounds of review feedback: pinning the runlit-lab-fix skill's context, sources, and rollback behavior, then requiring deterministic proof of API-server identity and reviving command guards. Their constraints were that the pipeline's own gates stay authoritative, that lint be judged against the repository's authoritative pinned ShellCheck 0.11.0 rather than failing because the lane lacked the tool, and that the pipeline's fix commits not be dropped while recovering between runs. When the push step failed because the authenticated GitHub account `shan33k` could not write directly to `kunchenguid/firstmate`, they wanted the already-existing writable fork configured as the push target and the run resumed from the preserved gate branch state rather than rebasing or recreating the branch. They also accepted the documentation gate's no-op finding, declining to move the one-line trigger into AGENTS.md because that would add more always-loaded structure than the minimal pointer they asked for.

## What Changed

- Adds a new user-invocable `runlit-lab-fix` skill (`.agents/skills/runlit-lab-fix/SKILL.md`) that repairs RunLit's k3s lab recommendation-service crash-loop and low-memory artifact, with a pinned `--context=default`, deterministic API-server identity proof, a worktree-aware checkout preflight using a non-mutating `git ls-remote` currency check, a single whitelisted `rollout undo --to-revision` mutation, and a verdict that scopes claims to the checks that actually ran when app-health or monitoring URLs are unavailable.
- Registers the skill's `/runlit-lab-fix` trigger in `AGENTS.md` and documents it in the README built-in skills table.
- Extends `tests/fm-captain-translation-contract.test.sh` with contract checks covering the skill's identity proof, revision read, and forbidden-command guards (pod delete, cluster-wide reads, `port-forward`/`proxy`, and related verbs).

## Risk Assessment

✅ Low: This round is a documentation-and-test-only change that resolves both prior findings exactly as decided, with contract assertions that match the skill verbatim and no new command or reporting ambiguity introduced.

## Testing

Baseline unit tests pass: the full fm-captain-translation-contract suite is green including the 5 new runlit-lab-fix checks, and adjacent contract tests pass. Beyond pass/fail, I demonstrated the skill working the way it would be experienced: a mutation harness confirms the guards actually catch weakened hardening (9/9 rejected), and a real-kubectl walkthrough against a stubbed lab API server exercises the whole documented procedure — cluster-identity-by-API-server proof, OOM low-memory detection, the one whitelisted rollout undo --to-revision, post-rollback verification (crash-loop pod replaced, memory restored to the 220Mi/450Mi baseline), separate unavailable labelling for unreachable monitoring vs app-health URLs, and a KUBECONFIG-swap negative case that halts before any cluster call. The README table change is shown via rendered HTML plus an accessibility snapshot rather than a PNG, because the chrome-devtools-axi screenshot bridge in this session reports a path but does not write an image file.

<details>
<summary>Evidence: Real-kubectl end-to-end walkthrough of the runlit-lab-fix procedure (assessment → whitelisted rollback → verification → KUBECONFIG-swap negative case)</summary>

```text
==============================================================
 /runlit-lab-fix  -  walkthrough against a stubbed RunLit lab
==============================================================

--- Assessment step 2: prove cluster identity by API server ---

$ kubectl config current-context
some-other-cluster
  # recorded as ambient context only, never as identity proof

$ kubectl config view --minify --context=default -o jsonpath="{.clusters[0].cluster.server}"
http://127.0.0.1:18443
  # matches the lab API server documented in scripts/k3s/CLUSTER-STATE.md -> proceed
  # output is one server URL, no credentials (kubeconfig holds a token)

--- Assessment step 3: read access ---

$ kubectl --context=default auth can-i get pods -n online-boutique
yes

$ kubectl --context=default auth can-i get deployments -n monitoring
yes

--- Assessment steps 4-6: nodes, workloads, warning events ---

$ kubectl --context=default get nodes -o wide
NAME            STATUS   ROLES                  AGE   VERSION        INTERNAL-IP   OS-IMAGE              KERNEL-VERSION   CONTAINER-RUNTIME
runlit-lab-cp   Ready    control-plane,master   52d   v1.30.4+k3s1   10.0.0.61     Debian GNU/Linux 12   6.1.0-23-arm64   containerd://1.7.17

$ kubectl --context=default get pods -n online-boutique -o wide
NAME                                     READY   STATUS             RESTARTS   AGE   IP           NODE
frontend-6b9c7d5f47-h2n9c                1/1     Running            0          3d    10.42.0.20   runlit-lab-cp
productcatalogservice-77d4b8c9f5-r8lqz   1/1     Running            0          3d    10.42.0.20   runlit-lab-cp
recommendationservice-7d94c6f8b9-q4x2p   0/1     CrashLoopBackOff   7          3d    10.42.0.37   runlit-lab-cp

$ kubectl --context=default get deployments -n online-boutique
NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
frontend                1/1     1            1           3d
recommendationservice   0/1     1            0           3d

$ kubectl --context=default get pods -n monitoring -o wide
NAME                  READY   STATUS    RESTARTS   AGE   IP           NODE
prometheus-server-0   1/1     Running   0          3d    10.42.0.11   runlit-lab-cp
alertmanager-0        1/1     Running   0          3d    10.42.0.12   runlit-lab-cp

$ kubectl --context=default get events -n online-boutique --field-selector type=Warning --sort-by=.lastTimestamp
LAST SEEN              TYPE      REASON       OBJECT                                       MESSAGE
2026-07-23T09:31:04Z   Warning   OOMKilling   pod/recommendationservice-7d94c6f8b9-q4x2p   Memory cgroup out of memory: Killed process 1 (server) total-vm:722000kB
2026-07-23T09:32:41Z   Warning   BackOff      pod/recommendationservice-7d94c6f8b9-q4x2p   Back-off restarting failed container server

--- Assessment step 7: revision + narrow ReplicaSet read ---

$ kubectl --context=default rollout history deployment/recommendationservice -n online-boutique
deployment.apps/recommendationservice 
REVISION  CHANGE-CAUSE
2         <none>
3         <none>


$ kubectl --context=default get replicasets -n online-boutique -l app=recommendationservice -o jsonpath='<narrow row>'
recommendationservice-5c8f9d7b64 revision=2 image=us-central1-docker.pkg.dev/runlit-lab/boutique/recommendationservice:v0.10.2 request=220Mi limit=450Mi
recommendationservice-7d94c6f8b9 revision=3 image=us-central1-docker.pkg.dev/runlit-lab/boutique/recommendationservice:v0.10.2 request=20Mi limit=24Mi
  # no container environment in the output, though the ReplicaSet carries a DB password env var

$ kubectl --context=default get pods -n online-boutique -l app=recommendationservice -o jsonpath=<uid/restarts/termination>
recommendationservice-7d94c6f8b9-q4x2p uid=8f2c0a11-6b13-4c9e-9f2d-3a71b6e0d551 restarts=7 lastTerminated=OOMKilled

--- Assessment step 8: current memory request and limit ---

$ kubectl --context=default get deployment recommendationservice -n online-boutique -o jsonpath='<memory>'
server request=20Mi limit=24Mi
  # documented healthy baseline is request=220Mi limit=450Mi -> low-memory artifact confirmed

--- Assessment steps 9-10: monitoring and app health over documented URLs ---

$ curl -sS -o /dev/null -w '%{http_code}' --max-time 3 http://127.0.0.1:19998/api/v1/targets
(no response)
  # Prometheus targets documented URL unreachable -> record UNAVAILABLE, not healthy and not failed

$ curl -sS -o /dev/null -w '%{http_code}' --max-time 3 http://127.0.0.1:19999/healthz
(no response)
  # storefront health documented URL unreachable -> record UNAVAILABLE, not healthy and not failed

--- Pre-mutation recheck (identity + revision) ---

$ kubectl config view --minify --context=default -o jsonpath="{.clusters[0].cluster.server}"
http://127.0.0.1:18443
  # still the documented lab API server

$ kubectl --context=default rollout history deployment/recommendationservice -n online-boutique
deployment.apps/recommendationservice 
REVISION  CHANGE-CAUSE
2         <none>
3         <none>

  # current revision is still 3 (broken); revision 2 is the proven-healthy target

--- Whitelisted remediation (the one approved mutation) ---

$ kubectl --context=default rollout undo deployment/recommendationservice -n online-boutique --to-revision=2
deployment.apps/recommendationservice rolled back

--- Verification ---

$ kubectl --context=default rollout status deployment/recommendationservice -n online-boutique --timeout=60s
deployment "recommendationservice" successfully rolled out

$ kubectl --context=default get deployment recommendationservice -n online-boutique -o jsonpath='<revision+memory>'
revision=4
server request=220Mi limit=450Mi
  # request/limit back to the documented 220Mi/450Mi baseline

$ kubectl --context=default get pods -n online-boutique -l app=recommendationservice -o wide
NAME                                     READY   STATUS    RESTARTS   AGE   IP           NODE
recommendationservice-5c8f9d7b64-m7t8k   1/1     Running   0          3d    10.42.0.44   runlit-lab-cp
  # pre-rollback crash-loop pod UID 8f2c0a11-6b13-4c9e-9f2d-3a71b6e0d551 is gone; replacement pod is Ready with 0 restarts
  # the Deployment controller replaced it - no pod was deleted to manufacture this

--- Captain-facing verdict this evidence supports ---
  recommendationservice rollback ran and Kubernetes-level readiness is verified:
  deployment back to the documented 220Mi/450Mi baseline, crash-loop pod replaced,
  new pod Ready with 0 restarts.
  App-health verification: UNAVAILABLE - documented storefront health URL
  http://127.0.0.1:19999/healthz could not be reached.
  Monitoring verification: UNAVAILABLE - documented Prometheus targets URL
  http://127.0.0.1:19998/api/v1/targets could not be reached.
  Those two gaps are reported separately and neither is reported as a failed check,
  so this is NOT reported as "the lab is healthy".

==============================================================
 Negative case: KUBECONFIG swapped so 'default' names another cluster
==============================================================
https://prod-cluster.example.invalid:6443
  # --context=default still resolves, but the API server differs from the documented lab.
  # Skill outcome: stop before any cluster request and report the mismatch. No kubectl read ran.

walkthrough complete
```
</details>
<details>
<summary>Evidence: Mutation-testing report: 9 hardening-weakening edits, all rejected by the contract suite</summary>

```text

### assessment gains a 'kubectl delete pod' step
caught -> not ok - RunLit lab repair skill prescribes a forbidden 'kubectl delete' command

### rollback loses its --to-revision pin
caught -> not ok - RunLit lab repair contract is missing 'kubectl --context=default rollout undo deployment/recommendationservice -n online-boutique --to-revision=<verified revision>'

### pre-mutation API-server recheck removed
caught -> not ok - the rollback does not re-prove the lab API server immediately before mutating (missing: 'kubectl config view --minify --context=default -o jsonpath="{.clusters[0].cluster.server}"')

### verification drops the app-health vs monitoring distinction
caught -> not ok - the Verification verdict can still report an unavailable app health check as a monitoring gap (missing: 'never as an application-level repair verified with a monitoring gap')

### unavailable outcome downgraded to a plain failure
caught -> not ok - RunLit lab repair contract is missing 'never report an unavailable check as healthy, and never report it as a failed check either'

### a kubectl command hidden in bare prose
caught -> not ok - RunLit lab repair skill writes a kubectl command outside a code span, where the command guards cannot see it

### cluster-wide -A read added
caught -> not ok - RunLit lab repair skill prescribes a cluster-wide read

### AGENTS.md trigger line deleted
caught -> not ok - runlit-lab-fix must have exactly one AGENTS.md trigger, found 0

### skill also dropped into the public installer-facing skills dir
caught -> not ok - RunLit lab repair must not exist in the public installer-facing skills directory

---
all mutations rejected by tests/fm-captain-translation-contract.test.sh
```
</details>
<details>
<summary>Evidence: Rendered README &#39;Built-in skills&#39; table showing the /runlit-lab-fix row (GitHub-styled HTML)</summary>

```text
<!doctype html>
<html><head><meta charset="utf-8"><title>firstmate README - Built-in skills</title>
<style>
  body { margin: 0; background: #0d1117; color: #e6edf3;
         font: 16px/1.6 -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
  .wrap { max-width: 1060px; margin: 0 auto; padding: 32px 40px 48px;
           border: 1px solid #30363d; border-radius: 8px; background: #0d1117; }
  h2 { font-size: 24px; padding-bottom: .3em; border-bottom: 1px solid #30363d; margin-top: 0; }
  table { border-collapse: collapse; width: 100%; display: table; }
  th, td { border: 1px solid #30363d; padding: 8px 13px; text-align: left; vertical-align: top; }
  th { background: #161b22; font-weight: 600; }
  tr:nth-child(2n) td { background: #161b22; }
  code { background: #6e768166; border-radius: 6px; padding: .2em .4em;
          font: 85%/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: nowrap; }
  td:first-child { width: 190px; }
  a { color: #4493f8; }
  .badge { display:inline-block; margin-bottom:14px; padding:4px 10px; border-radius:999px;
            background:#1f6feb33; color:#79c0ff; font-size:12px; letter-spacing:.04em; }
</style></head>
<body><div class="wrap"><div class="badge">README.md &middot; branch fm/runlit-lab-fix-skill</div>
<h2>Built-in skills</h2>
<p>Firstmate ships these user-invocable built-in skills.<br>Claude and grok use the slash form shown here; codex uses the same names with <code>$</code>, such as <code>$afk</code>.</p>
<table><thead><tr><th>Skill</th><th>What it does</th></tr></thead><tbody><tr><td><code>/afk</code></td><td>Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away</td></tr><tr><td><code>/ahoy</code></td><td>Recap only visible session events since the prior real captain message, falling back to Bearings when invoked as the session&#x27;s first real captain message</td></tr><tr><td><code>/bearings</code></td><td>Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in <code>data/</code> and surfaced concisely in chat; read-mostly, mutates no task state</td></tr><tr><td><code>/runlit-lab-fix</code></td><td>Assess the non-production RunLit Kubernetes lab and repair its known recommendation service crash-loop and low-memory artifact through one guarded rollback</td></tr><tr><td><code>/updatefirstmate</code></td><td>Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates</td></tr><tr><td><code>/stow</code></td><td>Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset</td></tr></tbody></table>
<p>Agent-only reference skills live under <code>.agents/skills/</code> and are loaded by firstmate at the trigger points named in <a href="AGENTS.md"><code>AGENTS.md</code></a>.</p>
<h3>Two-tier skill layout</h3>
<p>Firstmate&#x27;s skills live in two separate places with different audiences:</p>
<p>- <code>.agents/skills/</code> - agent-loaded skills (this section&#x27;s table, plus firstmate&#x27;s agent-only reference skills). Every one of these assumes a live firstmate home and is meaningless, or actively misleading, installed anywhere else, so each carries <code>metadata.internal: true</code> in its frontmatter. That flag hides them from installer discovery (tools like the <a href="https://skills.sh">skills.sh</a> <code>npx skills add</code> installer) without affecting how firstmate itself loads them - frontmatter metadata is inert to the agent&#x27;s own skill loader.<br>- <code>skills/</code> - public, installer-facing skills meant to be installed standalone into any project, independent of firstmate.<br>  Each one is a self-contained skill with no dependency on firstmate&#x27;s paths, tools, or vocabulary.<br>  Today that is <code>skills/stow</code>, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private <code>.stow-notes.md</code> fallback in the current directory, and closes with a resume pointer for the next session.<br>  It intentionally shares no code with the firstmate-internal <code>.agents/skills/stow</code> it is named after, so the two can evolve independently.</p>
</div></body></html>
```
</details>
<details>
<summary>Evidence: Stub RunLit lab API server used for the walkthrough</summary>

```text
#!/usr/bin/env python3
"""Stub Kubernetes API server standing in for the non-production RunLit lab.

Serves just enough of the API surface for the exact kubectl commands the
runlit-lab-fix skill prescribes: discovery, node/pod/deployment/replicaset/event
reads, SelfSubjectAccessReview, the rollout undo PATCH, and the rollout status
watch. State starts in the documented broken shape (recommendationservice
revision 3 with the low-memory artifact, OOMKilled crash-loop pods) and the
rollback restores the revision 2 baseline.
"""

import copy
import os
import json
import sys
import threading
import time
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
from urllib.parse import urlparse, parse_qs

HEALTHY_IMAGE = "us-central1-docker.pkg.dev/runlit-lab/boutique/recommendationservice:v0.10.2"
HEALTHY_REQUEST = "220Mi"
HEALTHY_LIMIT = "450Mi"
BROKEN_REQUEST = "20Mi"
BROKEN_LIMIT = "24Mi"

LOCK = threading.Lock()


def container(image, req, lim):
    return {
        "name": "server",
        "image": image,
        # Deliberately present so the narrow JSONPath the skill prescribes can be
        # shown NOT to echo it.
        "env": [
            {"name": "PORT", "value": "8080"},
            {"name": "PRODUCT_CATALOG_SERVICE_ADDR", "value": "productcatalogservice:3550"},
            {"name": "RUNLIT_LAB_DB_PASSWORD", "value": "s3cr3t-lab-password"},
        ],
        "resources": {
            "requests": {"memory": req, "cpu": "100m"},
            "limits": {"memory": lim, "cpu": "200m"},
        },
    }


def rs(name, revision, image, req, lim, replicas):
    return {
        "apiVersion": "apps/v1",
        "kind": "ReplicaSet",
        "metadata": {
            "name": name,
            "namespace": "online-boutique",
            "uid": "rs-uid-%s" % revision,
            "creationTimestamp": "2026-07-21T09:%02d:00Z" % (10 * int(revision)),
            "labels": {"app": "recommendationservice", "pod-template-hash": name.split("-")[-1]},
            "annotations": {
                "deployment.kubernetes.io/revision": revision,
                "deployment.kubernetes.io/desired-replicas": "1",
            },
            "ownerReferences": [
                {
                    "apiVersion": "apps/v1",
                    "kind": "Deployment",
                    "name": "recommendationservice",
                    "uid": "dep-uid-recommendationservice",
                    "controller": True,
                }
            ],
        },
        "spec": {
            "replicas": replicas,
            "selector": {"matchLabels": {"app": "recommendationservice"}},
            "template": {
                "metadata": {"labels": {"app": "recommendationservice"}},
                "spec": {"containers": [container(image, req, lim)]},
            },
        },
        "status": {"replicas": replicas, "readyReplicas": 0 if replicas else 0},
    }


STATE = {
    "revision": "3",
    "rollback_patches": [],
    "deployment": {
        "apiVersion": "apps/v1",
        "kind": "Deployment",
        "metadata": {
            "name": "recommendationservice",
            "namespace": "online-boutique",
            "uid": "dep-uid-recommendationservice",
            "generation": 3,
            "creationTimestamp": "2026-07-21T09:10:00Z",
            "labels": {"app": "recommendationservice"},
            "annotations": {"deployment.kubernetes.io/revision": "3"},
        },
        "spec": {
            "replicas": 1,
            "selector": {"matchLabels": {"app": "recommendationservice"}},
            "template": {
                "metadata": {"labels": {"app": "recommendationservice"}},
                "spec": {"containers": [container(HEALTHY_IMAGE, BROKEN_REQUEST, BROKEN_LIMIT)]},
            },
        },
        "status": {
            "replicas": 1,
            "updatedReplicas": 1,
            "readyReplicas": 0,
            "availableReplicas": 0,
            "unavailableReplicas": 1,
            "observedGeneration": 3,
            "conditions": [
                {"type": "Available", "status": "False", "reason": "MinimumReplicasUnavailable"},
                {"type": "Progressing", "status": "True", "reason": "ReplicaSetUpdated"},
            ],
        },
    },
    "replicasets": [
        rs("recommendationservice-5c8f9d7b64", "2", HEALTHY_IMAGE, HEALTHY_REQUEST, HEALTHY_LIMIT, 0),
        rs("recommendationservice-7d94c6f8b9", "3", HEALTHY_IMAGE, BROKEN_REQUEST, BROKEN_LIMIT, 1),
    ],
}


def broken_pod():
    return {
        "apiVersion": "v1",
        "kind": "Pod",
        "metadata": {
            "name": "recommendationservice-7d94c6f8b9-q4x2p",
            "namespace": "online-boutique",
            "uid": "8f2c0a11-6b13-4c9e-9f2d-3a71b6e0d551",
            "labels": {"app": "recommendationservice", "pod-template-hash": "7d94c6f8b9"},
            "creationTimestamp": "2026-07-23T09:12:00Z",
        },
        "spec": {"nodeName": "runlit-lab-cp", "containers": [container(HEALTHY_IMAGE, BROKEN_REQUEST, BROKEN_LIMIT)]},
        "status": {
            "phase": "Running",
            "podIP": "10.42.0.37",
            "containerStatuses": [
                {
                    "name": "server",
                    "ready": False,
                    "restartCount": 7,
                    "image": HEALTHY_IMAGE,
                    "state": {"waiting": {"reason": "CrashLoopBackOff", "message": "back-off 5m0s restarting failed container"}},
                    "lastState": {"terminated": {"reason": "OOMKilled", "exitCode": 137, "finishedAt": "2026-07-23T09:31:04Z"}},
                }
            ],
        },
    }


def healthy_pod():
    return {
        "apiVersion": "v1",
        "kind": "Pod",
        "metadata": {
            "name": "recommendationservice-5c8f9d7b64-m7t8k",
            "namespace": "online-boutique",
            "uid": "c41d77a2-9e05-4b6f-8a10-2d5e9c7f4410",
            "labels": {"app": "recommendationservice", "pod-template-hash": "5c8f9d7b64"},
            "creationTimestamp": "2026-07-23T09:34:00Z",
        },
        "spec": {"nodeName": "runlit-lab-cp", "containers": [container(HEALTHY_IMAGE, HEALTHY_REQUEST, HEALTHY_LIMIT)]},
        "status": {
            "phase": "Running",
            "podIP": "10.42.0.44",
            "containerStatuses": [
                {
                    "name": "server",
                    "ready": True,
                    "restartCount": 0,
                    "image": HEALTHY_IMAGE,
                    "state": {"running": {"startedAt": "2026-07-23T09:34:06Z"}},
                }
            ],
        },
    }


def other_pod(name, app, ready=True):
    return {
        "apiVersion": "v1",
        "kind": "Pod",
        "metadata": {
            "name": name,
            "namespace": "online-boutique",
            "uid": "uid-" + name,
            "labels": {"app": app},
            "creationTimestamp": "2026-07-20T08:00:00Z",
        },
        "spec": {"nodeName": "runlit-lab-cp", "containers": [{"name": "server", "image": "boutique/" + app + ":v0.10.2"}]},
        "status": {
            "phase": "Running",
            "podIP": "10.42.0.20",
            "containerStatuses": [{"name": "server", "ready": ready, "restartCount": 0, "state": {"running": {"startedAt": "2026-07-20T08:00:11Z"}}}],
        },
    }


STATE["pods"] = {
    "online-boutique": [
        other_pod("frontend-6b9c7d5f47-h2n9c", "frontend"),
        other_pod("productcatalogservice-77d4b8c9f5-r8lqz", "productcatalogservice"),
        broken_pod(),
    ],
    "monitoring": [
        {
            "apiVersion": "v1",
            "kind": "Pod",
            "metadata": {"name": "prometheus-server-0", "namespace": "monitoring", "uid": "uid-prom", "labels": {"app": "prometheus"}, "creationTimestamp": "2026-07-18T08:00:00Z"},
            "spec": {"nodeName": "runlit-lab-cp", "containers": [{"name": "prometheus", "image": "prom/prometheus:v2.53.0"}]},
            "status": {"phase": "Running", "podIP": "10.42.0.11", "containerStatuses": [{"name": "prometheus", "ready": True, "restartCount": 0, "state": {"running": {"startedAt": "2026-07-18T08:00:12Z"}}}]},
        },
        {
          

... [10846 bytes truncated] ...

        "resources": [
                    {"name": "deployments", "singularName": "deployment", "namespaced": True, "kind": "Deployment", "verbs": ["get", "list", "watch", "patch", "update"], "shortNames": ["deploy"]},
                    {"name": "replicasets", "singularName": "replicaset", "namespaced": True, "kind": "ReplicaSet", "verbs": ["get", "list", "watch"], "shortNames": ["rs"]},
                ],
            })
        if path == "/apis/authorization.k8s.io/v1":
            return self._send({
                "kind": "APIResourceList",
                "apiVersion": "v1",
                "groupVersion": "authorization.k8s.io/v1",
                "resources": [{"name": "selfsubjectaccessreviews", "singularName": "selfsubjectaccessreview", "namespaced": False, "kind": "SelfSubjectAccessReview", "verbs": ["create"]}],
            })
        if path == "/api/v1/nodes":
            return self._list("nodes", "v1", NODES)
        parts = path.strip("/").split("/")
        # /api/v1/namespaces/<ns>/<resource>[/<name>]
        if parts[:3] == ["api", "v1", "namespaces"] and len(parts) >= 5:
            ns, resource = parts[3], parts[4]
            if resource == "pods":
                items = STATE["pods"].get(ns, [])
                sel = q.get("labelSelector", [""])[0]
                if sel.startswith("app="):
                    want = sel.split("=", 1)[1]
                    items = [p for p in items if p["metadata"]["labels"].get("app") == want]
                return self._list("pods", "v1", items)
            if resource == "events":
                return self._list("events", "v1", warning_events(ns))
        if parts[:3] == ["apis", "apps", "v1"] and len(parts) >= 6 and parts[3] == "namespaces":
            ns, resource = parts[4], parts[5]
            name = parts[6] if len(parts) > 6 else None
            if resource == "deployments":
                if name:
                    with LOCK:
                        dep = copy.deepcopy(STATE["deployment"])
                    if q.get("watch", ["false"])[0] == "true":
                        return self._watch_deployment()
                    if self._wants_table():
                        return self._send(as_table("deployments", [dep]))
                    return self._send(dep)
                if q.get("watch", ["false"])[0] == "true":
                    return self._watch_deployment()
                return self._list("deployments", "apps/v1", deployments(ns))
            if resource == "replicasets":
                with LOCK:
                    items = copy.deepcopy(STATE["replicasets"])
                sel = q.get("labelSelector", [""])[0]
                if sel.startswith("app="):
                    want = sel.split("=", 1)[1]
                    items = [r for r in items if r["metadata"]["labels"].get("app") == want]
                return self._list("replicasets", "apps/v1", items)
        return self._send({"kind": "Status", "status": "Failure", "message": "not found: " + path, "code": 404}, 404)

    def _watch_deployment(self):
        """Serve a list-watch the way client-go expects: initial ADDED events, a
        bookmark marking the end of the initial set, then an idle stream."""
        self.send_response(200)
        self.send_header("Content-Type", "application/json")
        self.send_header("Transfer-Encoding", "chunked")
        self.end_headers()
        with LOCK:
            dep = copy.deepcopy(STATE["deployment"])
        dep["metadata"]["resourceVersion"] = "1000"
        self._chunk(json.dumps({"type": "ADDED", "object": dep}) + "\n")
        self._chunk(json.dumps({
            "type": "BOOKMARK",
            "object": {
                "apiVersion": "apps/v1",
                "kind": "Deployment",
                "metadata": {"resourceVersion": "1000", "annotations": {"k8s.io/initial-events-end": "true"}},
            },
        }) + "\n")
        for _ in range(20):
            time.sleep(0.25)
        try:
            self.wfile.write(b"0\r\n\r\n")
        except Exception:
            pass
        self.close_connection = True

    def _chunk(self, payload):
        data = payload.encode()
        self.wfile.write(b"%x\r\n" % len(data) + data + b"\r\n")
        self.wfile.flush()

    def _read_body(self):
        if (self.headers.get("Transfer-Encoding") or "").lower() == "chunked":
            buf = b""
            while True:
                size_line = self.rfile.readline().strip()
                size = int(size_line.split(b";")[0] or b"0", 16)
                if size == 0:
                    self.rfile.readline()
                    break
                buf += self.rfile.read(size)
                self.rfile.readline()
            return buf
        return self.rfile.read(int(self.headers.get("Content-Length") or 0))

    def do_POST(self):
        u = urlparse(self.path)
        # kubectl sends SelfSubjectAccessReview as protobuf, but its Accept header
        # allows JSON, so answer in JSON without decoding the request body.
        self._read_body()
        if u.path == "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews":
            return self._send({
                "apiVersion": "authorization.k8s.io/v1",
                "kind": "SelfSubjectAccessReview",
                "metadata": {"creationTimestamp": None},
                "spec": {"resourceAttributes": {}},
                "status": {"allowed": True, "reason": "RBAC: allowed by lab read-only role"},
            }, 201)
        return self._send({"kind": "Status", "status": "Failure", "message": "not found", "code": 404}, 404)

    def do_PATCH(self):
        u = urlparse(self.path)
        raw = self._read_body() or b"{}"
        patch = json.loads(raw)
        parts = u.path.strip("/").split("/")
        if parts[:3] == ["apis", "apps", "v1"] and len(parts) >= 7 and parts[5] == "deployments":
            with LOCK:
                dep = STATE["deployment"]
                STATE["rollback_patches"].append(json.loads(raw))
                if isinstance(patch, list):
                    apply_json_patch(dep, patch)
                else:
                    deep_merge(dep, patch)
                # Emulate the Deployment controller reacting to the rolled-back
                # template: revision 4 adopts the revision 2 ReplicaSet, the
                # crash-looping pod is replaced, and the rollout converges.
                STATE["revision"] = "4"
                dep["metadata"]["annotations"]["deployment.kubernetes.io/revision"] = "4"
                dep["metadata"]["generation"] = 4
                dep["status"] = {
                    "replicas": 1,
                    "updatedReplicas": 1,
                    "readyReplicas": 1,
                    "availableReplicas": 1,
                    "observedGeneration": 4,
                    "conditions": [
                        {"type": "Available", "status": "True", "reason": "MinimumReplicasAvailable"},
                        {"type": "Progressing", "status": "True", "reason": "NewReplicaSetAvailable"},
                    ],
                }
                for r in STATE["replicasets"]:
                    if r["metadata"]["annotations"]["deployment.kubernetes.io/revision"] == "2":
                        r["metadata"]["annotations"]["deployment.kubernetes.io/revision"] = "4"
                        r["spec"]["replicas"] = 1
                        r["status"] = {"replicas": 1, "readyReplicas": 1}
                    else:
                        r["spec"]["replicas"] = 0
                        r["status"] = {"replicas": 0, "readyReplicas": 0}
                STATE["pods"]["online-boutique"] = [
                    p for p in STATE["pods"]["online-boutique"] if p["metadata"]["labels"].get("app") != "recommendationservice"
                ] + [healthy_pod()]
                out = copy.deepcopy(dep)
            return self._send(out)
        return self._send({"kind": "Status", "status": "Failure", "message": "not found", "code": 404}, 404)


if __name__ == "__main__":
    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8443
    srv = ThreadingHTTPServer(("127.0.0.1", port), Handler)
    srv.serve_forever()
```
</details>
- Evidence: Walkthrough driver script (prescribed kubectl sequence) (local file: <code>/var/folders/55/2cz1xv1s0yn2k2jjqmg13zhm0000gn/T/no-mistakes-evidence/01KY932J9VEYRYHQ71MMK0DQK3/run_lab_walkthrough.sh</code>)
- Evidence: Mutation-check harness (local file: <code>/var/folders/55/2cz1xv1s0yn2k2jjqmg13zhm0000gn/T/no-mistakes-evidence/01KY932J9VEYRYHQ71MMK0DQK3/mutation_check.sh</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed (4) ✅</summary>

- ⚠️ `.agents/skills/runlit-lab-fix/SKILL.md:42` - The skill states that pinning `--context=default` means &#34;a changed `KUBECONFIG` cannot redirect a read or the rollback at another cluster&#34;. That is not true: `--context` selects a context by name inside whatever kubeconfig is active, so a different `KUBECONFIG` that also defines a `default` context redirects every pinned command. The API-server URL comparison in step 2 is the only real identity proof, and it is re-proven only immediately before the rollback (line 84). Failure scenario: KUBECONFIG changes (another agent, a different shell env, a sourced profile) after step 2; assessment reads 4 through 10 then run against a foreign cluster while the skill&#39;s own text tells the agent the pin made that impossible, and warning events, pod UIDs, and memory readings from the wrong cluster feed the rollback preconditions. Recommend restating the pin as protection against ambient current-context drift within a fixed kubeconfig only, and either re-proving the API server (or pinning `--kubeconfig`) across the read phase too.
- ⚠️ `.agents/skills/runlit-lab-fix/SKILL.md:79` - The rollback precondition requires that &#34;Rollout history contains an earlier healthy revision whose memory request and limit equal the documented baseline&#34;, but no step prescribes a command that reads a historical revision&#39;s memory settings. Step 8&#39;s JSONPath reads the live deployment only, and step 7 mentions &#34;its ReplicaSets&#34; without a read. Failure scenario: the agent picks the highest earlier revision number from `rollout history` output (which shows only REVISION and CHANGE-CAUSE), rolls back to a revision that also carries the low-memory artifact or an unrelated bad image, and the one whitelisted mutation is spent on a revision that was never verified. Prescribe the exact read (for example `kubectl --context=default rollout history deployment/recommendationservice -n online-boutique --revision=&lt;n&gt;`, or the ReplicaSet JSONPath for memory request and limit), and note that a full revision template dump can echo env vars, which the skill&#39;s own secret boundary forbids printing.
- ⚠️ `AGENTS.md:214` - A deployment-specific runbook (RunLit&#39;s k3s lab, Coolify, the Mac mini worker, Proxmox, the NAS, a named private Postgres rollout) is added to this shared firstmate repo: a trigger line in always-loaded `AGENTS.md` and a row in README&#39;s &#34;Firstmate ships these user-invocable built-in skills&#34; table. Section 6 of the same file, four lines above the new trigger, says knowledge general to every firstmate user belongs in the shared tracked surface, which implies non-general knowledge does not. Failure scenario: every other contributor to this repo loads a `/runlit-lab-fix` trigger they can never use and sees it advertised in the public README as a shipped built-in, and the always-loaded instruction surface grows per operator-specific lab. Worth confirming this is intended here rather than in the RunLit home or a home-local skill.
- ⚠️ `tests/fm-captain-translation-contract.test.sh:211` - The forbidden-command guards match a literal `kubectl &lt;verb&gt;` substring after `--context=default ` is stripped, so they only fire when the verb sits immediately after `kubectl`. Failure scenario: a later edit writes `kubectl -n online-boutique --context=default delete pod recommendationservice-xxxx` or `kubectl --context=default get pods -o wide -A`; both strip to strings that contain none of the guarded substrings, so the test passes while the skill prescribes exactly the pod deletion and cluster-wide read these assertions exist to block. Also unguarded: `exec`, `edit`, `replace`, `annotate`, `label`, `drain`, `cordon`, `port-forward`. Match the verb anywhere on a `kubectl` line (grep -E over the prescribed body) instead of by position.
- ℹ️ `README.md:179` - The README row reads &#34;restore its known recommendation service crash-loop and low-memory artifact&#34;, which literally describes re-introducing the fault rather than repairing it. Failure scenario: a reader scanning the built-in skills table concludes `/runlit-lab-fix` injects the chaos artifact (the repo does have `scripts/k3s/demo-chaos.sh` for that) and invokes or avoids it on the wrong assumption. Suggest &#34;repair its known recommendation service crash-loop and low-memory artifact&#34;.
- ℹ️ `.agents/skills/runlit-lab-fix/SKILL.md:32` - The four authoritative topology and baseline sources are given as bare relative paths (`scripts/k3s/CLUSTER-STATE.md`, `scripts/k3s/README.md`, `docs/dogfood/oom-crashloop-validation.md`, `scripts/k3s/demo-chaos.sh`) qualified only by &#34;in the RunLit project&#34;, while the evidence note gets an explicit home-resolution rule via `docs/configuration.md`. Failure scenario: the dispatched worker runs from a firstmate worktree or a stale RunLit checkout, reads a different copy of `CLUSTER-STATE.md`, and the API-server comparison in step 2 is made against the wrong baseline while still reporting &#34;matched&#34;. Naming how to resolve the RunLit project root would close it.

🔧 Fix: tighten runlit-lab-fix identity proof, revision read, guards
2 issues (1 warning, 1 info) still open:
- ⚠️ `.agents/skills/runlit-lab-fix/SKILL.md:34` - The new preflight requires the resolved RunLit checkout to be &#34;on its default branch, and is current with its remote&#34;, but both halves collide with this repo&#39;s own invariants. (a) `AGENTS.md:251` and `AGENTS.md:355` require every dispatched worker to run in an isolated task worktree distinct from the primary checkout, so &#34;the worker&#39;s own checkout&#34; is on a task branch, not the default branch, and step 1 rejects it. (b) The other candidate, the clone under `projects/`, cannot be proven &#34;current with its remote&#34; without a network refresh, and `AGENTS.md:24` forbids running state-changing commands under `projects/` (a `git fetch` writes refs into that clone). Failure scenario: the worker resolves its worktree, fails the default-branch clause, escalates to the captain, and the skill never reaches the assessment; or it runs `git fetch` inside `projects/` and breaks the read-only project rule. Suggest accepting a worktree whose base is the default branch, and naming a read-only currency check (compare against the existing remote-tracking ref, or `git ls-remote`, which mutates nothing) instead of wording that implies a fetch.
- ℹ️ `.agents/skills/runlit-lab-fix/SKILL.md:66` - Steps 9 and 10 require reading Prometheus targets and Alertmanager active alerts &#34;through their read-only Kubernetes or HTTP APIs&#34;, but no access path to an in-cluster HTTP API is prescribed, and the new contract test now forbids the skill from ever prescribing `port-forward` or `proxy` (tests/fm-captain-translation-contract.test.sh:251). Failure scenario: the alert state is only reachable in-cluster, the agent improvises `kubectl --context=default port-forward` (not banned by the skill&#39;s own Hard boundaries, only undocumented) or skips the alert checks, and verification step 5 &#34;confirm the related alerts recover&#34; is silently unmet. Naming the documented external URLs from `scripts/k3s/CLUSTER-STATE.md`, the way the storefront and backend health URLs are handled, would close the gap without adding a forbidden verb.

🔧 Fix: align checkout preflight with worktree rules; pin monitoring access path
2 issues (1 warning, 1 info) still open:
- ⚠️ `.agents/skills/runlit-lab-fix/SKILL.md:116` - Step 9 (line 72) introduces an &#34;unverified&#34; outcome when `scripts/k3s/CLUSTER-STATE.md` documents no reachable monitoring URL, but the Verification section was not updated to match: line 109 says &#34;complete every verification step before calling the lab healthy&#34;, step 5 (line 116) requires confirming alerts recover, step 6 (line 117) requires rechecking the documented health URLs, and line 122 says report the lab not healthy if &#34;relevant alerts do not recover&#34;. Failure scenario: the lab documents no external Prometheus or Alertmanager URL, the rollback succeeds and every pod, memory, and event check passes, yet the alert recheck is structurally impossible, so the skill either reports &#34;not yet healthy&#34; for a lab that is repaired or the agent silently deviates from a section that says every step is mandatory. Mirror the step 9 allowance into verification steps 5 and 6 and into line 122: an unverifiable-by-design check should be reported as unverified, distinct from a check that failed. While there, &#34;no reachable URL for either service&#34; reads ambiguously for the one-of-two case.
- ℹ️ `.agents/skills/runlit-lab-fix/SKILL.md:36` - The rewrite dropped &#34;rather than a detached, diverged, or long-stale copy&#34; and now offers &#34;comparing the checkout against its already-present remote-tracking ref&#34; as a sufficient read-only currency check. A remote-tracking ref is only as fresh as the last fetch, which this skill is now forbidden to perform, so that comparison proves the checkout matches a possibly year-old snapshot rather than the remote. Failure scenario: the `projects/` clone has not been fetched in months, `git rev-parse HEAD` equals `refs/remotes/origin/main`, currency is declared established, and the API-server URL and memory baseline are read from an outdated `CLUSTER-STATE.md` while the note reports &#34;matched&#34;. Suggest treating `git ls-remote` as the proving check and the remote-tracking-ref comparison as inconclusive on its own, with an explicit staleness bound or escalation when the remote cannot be reached.

🔧 Fix: wire unavailable outcome through verification; require ls-remote currency proof
2 issues (1 warning, 1 info) still open:
- ⚠️ `.agents/skills/runlit-lab-fix/SKILL.md:127` - Verification step 6 (line 121) explicitly allows the storefront or backend health URL to be unavailable, but the verdict template that consumes that outcome only models a monitoring gap: line 127 renders any unavailable check as &#34;the application-level repair is verified, monitoring or alerting verification was unavailable&#34;, and line 175 says to &#34;scope the claim to the application-level repair instead of to the lab as a whole&#34;. Failure scenario: `CLUSTER-STATE.md` documents no reachable storefront health URL, the rollback and every kubectl check pass, and the captain is told the application-level repair is verified and that the gap was in monitoring, when the unverified check was the application health probe itself. Have the narrower conclusion name which checks were unavailable and scope the claim to the checks that actually ran (for example, the recommendationservice rollback and Kubernetes-level readiness are verified, and the storefront health URL was unavailable), rather than fixing the label to monitoring or alerting.
- ℹ️ `.agents/skills/runlit-lab-fix/SKILL.md:36` - &#34;Prove currency with a non-mutating `git ls-remote` read of the remote default branch and compare what it reports against what the checkout contains&#34; does not say which object must match, while line 35 establishes that the resolved checkout is normally a task-branch worktree. A task branch&#39;s HEAD can never equal the remote default-branch tip, and a worktree branched a day earlier will not either. Failure scenario: the worker compares HEAD to the `ls-remote` tip, they differ by construction, currency &#34;cannot be proven&#34;, and line 38&#39;s blocker fires on a perfectly good checkout, reproducing the dead-end this preflight was rewritten to avoid. Name the comparison target explicitly, for example that the four source files must match the remote default-branch tip, or that the worktree&#39;s merge-base with the default branch must equal it.

🔧 Fix: separate app-health from monitoring gaps; pin currency base
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-captain-translation-contract.test.sh` — full suite green, including all 5 new runlit-lab-fix checks</code>
- <code>`bash mutation_check.sh` — 9 hardening-weakening mutations, all rejected by the suite</code>
- <code>`bash run_lab_walkthrough.sh` — skill&#39;s prescribed kubectl v1.35.3 sequence run against a stub lab API server, including the whitelisted rollout undo --to-revision and a KUBECONFIG-swap negative case</code>
- <code>`fm-instruction-owners.test.sh`, `fm-stow-contract.test.sh`, `fm-nm-test-contract.test.sh`, `fm-no-mistakes-ownership.test.sh` — pass</code>
- <code>Rendered README `## Built-in skills` to HTML and confirmed the `/runlit-lab-fix` row via browser snapshot</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
