### PR TITLE
ci: bump artifact-action versions to clear Node 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-portable-parallel-1.json"
       - name: Upload shard 1 timing artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fm-test-timing-portable-parallel-1
           path: ${{ runner.temp }}/fm-test/fm-test-timing-portable-parallel-1.json
@@ -96,7 +96,7 @@ jobs:
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-portable-parallel-2.json"
       - name: Upload shard 2 timing artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fm-test-timing-portable-parallel-2
           path: ${{ runner.temp }}/fm-test/fm-test-timing-portable-parallel-2.json
@@ -141,7 +141,7 @@ jobs:
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-portable-serial.json"
       - name: Upload portable serial timing artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fm-test-timing-portable-serial
           path: ${{ runner.temp }}/fm-test/fm-test-timing-portable-serial.json
@@ -256,7 +256,7 @@ jobs:
           }
       - name: Upload Herdr timing and diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fm-test-timing-herdr
           path: |
@@ -278,7 +278,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download lane timing artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: fm-test-timing-*
           path: ${{ runner.temp }}/fm-test-aggregate
@@ -298,7 +298,7 @@ jobs:
             "${inputs[@]}"
       - name: Upload aggregate timing artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fm-test-timing-aggregate
           path: ${{ runner.temp }}/fm-test/fm-test-timing-aggregate.json


### PR DESCRIPTION
## Intent

Clear the Node 20 deprecation warning in CI by bumping actions/upload-artifact from v4 to v7 (5 occurrences) and actions/download-artifact from v4 to v8 (1 occurrence, in the tests-timing-aggregate job). Both v7/v8 declare using: node24 natively. This is a small, standalone version bump with no other logic changes. Prior research (SC1's handoff on the chromium bootstrap CI failure) already confirmed neither bump affects this repo's actual usage pattern of these actions. One known behavior change: download-artifact@v8 makes a digest/hash mismatch a hard failure by default instead of just a warning - if tests-timing-aggregate ever fails on a hash mismatch after this, it's likely a transient GitHub cache/CDN issue, not a real regression from this change.

## What Changed
- Bumped `actions/upload-artifact` from v4 to v7 across all 5 occurrences in `.github/workflows/ci.yml`.
- Bumped `actions/download-artifact` from v4 to v8 in the `tests-timing-aggregate` job.
- No other workflow logic changed; both v7/v8 declare `using: node24` natively, clearing the Node 20 deprecation warning.

## Risk Assessment

✅ Low: Pure version-bump diff (6 lines) in one workflow file, exactly matching the stated intent with no logic changes.

## Testing

This is a standalone CI workflow version bump (no application code changed), so the strongest available evidence was a full diff/grep audit confirming exactly the 6 intended line changes with nothing else touched, YAML-parse validation that the workflow still loads correctly, and upstream verification via GitHub's API that actions/upload-artifact@v7 and actions/download-artifact@v8 both exist and declare using: node24 (clearing the Node 20 deprecation) and that v8's digest-mismatch-as-hard-error default matches the author's stated known behavior change; actually exercising the workflow end-to-end would require pushing this branch to trigger real GitHub Actions runs, which I did not do since it wasn't requested and pushing is a shared-visible action requiring separate confirmation — all checks pass and no issues were found.

<details>
<summary>Evidence: Confirmed action tags exist upstream with node24 runtime + v8 digest-mismatch default</summary>

```text
upload-artifact@v7 action.yml: using: 'node24'
download-artifact@v8 action.yml: using: 'node24'
download-artifact v8 README: "Hash mismatches will now error by default... default value is `error`" — matches stated known behavior change.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff f017572...5b2f807 — confirmed only version strings changed in .github/workflows/ci.yml, no logic changes`
- `grep -rn 'actions/upload-artifact|actions/download-artifact' .github/workflows/ — verified 5 upload-artifact@v7 and 1 download-artifact@v8, no leftover @v4 references anywhere`
- `python3 yaml.safe_load(.github/workflows/ci.yml) — confirmed workflow YAML still parses correctly, all 9 jobs intact, tests-timing-aggregate job correctly shows both bumped uses: lines`
- `gh api repos/actions/upload-artifact/contents/action.yml?ref=v7 and repos/actions/download-artifact/contents/action.yml?ref=v8 — confirmed both tags exist upstream and declare using: node24, matching the PR's Node 20 deprecation rationale`
- `gh api repos/actions/download-artifact/contents/README.md?ref=v8 — confirmed the digest-mismatch-is-a-hard-error-by-default behavior change cited in the intent is accurate for v8`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
