### PR TITLE
fix: require event-scoped shipshape acknowledgements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,6 +410,7 @@ Reach the captain immediately for:
 - A needed credential or login.
 
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
+When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.
 Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.
 Whenever a PR is mentioned, include its full `https://...` URL before any shorthand reference.

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -103,6 +103,16 @@ test_verbatim_internal_evidence_is_rejected_from_chat() {
   pass "captain chat rejects verbatim internal evidence while private reports stay precise"
 }
 
+test_routine_no_action_response_is_event_scoped() {
+  local contract
+  contract=$(section_9)
+  assert_contains "$contract" 'reply exactly `Captain, shipshape.` without characterizing the visible session' \
+    "section 9 does not require the exact event-scoped routine no-action response"
+  assert_not_contains "$contract" 'Captain, no decision is needed.' \
+    "section 9 implies the visible session has no unrelated open decisions"
+  pass "routine no-action response is exact and scoped to its event"
+}
+
 test_outward_facing_skill_points_reference_section_9_owner() {
   assert_grep "using \`AGENTS.md\` section 9's captain-facing translation contract" "$BOOTSTRAP" \
     "bootstrap diagnostics do not reference section 9 at captain handoff"
@@ -243,6 +253,7 @@ test_scout_remains_allowed_house_vocabulary
 test_compressed_safety_labels_have_plain_renderings
 test_mapping_list_covers_high_risk_internal_families
 test_verbatim_internal_evidence_is_rejected_from_chat
+test_routine_no_action_response_is_event_scoped
 test_outward_facing_skill_points_reference_section_9_owner
 test_section_9_owner_is_not_duplicated_into_skills
 test_ahoy_is_an_internal_user_invocable_skill


### PR DESCRIPTION
## Intent

Require the smallest authoritative Firstmate captain-facing etiquette correction: when a routine operational update's specific event requires no action but a response must be sent, require the exact response 'Captain, shipshape.' rather than 'Captain, no decision is needed.' The rule must remain scoped to that event and must not imply the visible session has no unrelated open decisions. Preserve only the one-line AGENTS.md owner and the focused existing captain-translation contract-test adjustment. Do not add persistence, a decision inventory, parsing, a ledger, lifecycle machinery, or broader behavior.

## What Changed

- Require routine no-action operational updates to reply exactly `Captain, shipshape.` without implying that the visible session has no unrelated open decisions.
- Extend the captain-translation contract test to enforce the exact event-scoped response and reject `Captain, no decision is needed.`

## Risk Assessment

✅ Low: The change is narrowly scoped to the authoritative etiquette rule and its focused contract test, requires the exact event-scoped response, and avoids implying that unrelated decisions are absent.

## Testing

The focused captain-translation contract test passed, manual evidence confirmed the exact event-scoped response and absence of the forbidden broader response, and commit-scope inspection found only AGENTS.md and the existing focused contract test changed. No screenshot was captured because this is an instruction-only captain-chat contract with no rendered UI surface.

<details>
<summary>Evidence: Captain-facing contract evidence</summary>

<code>Trigger: routine operational update requiring a response but no action&#10;Captain-facing response: Captain, shipshape.&#10;Scope: only that event; unrelated session decisions remain uncharacterized</code>

```text
Trigger: a routine operational update whose specific event requires no action, but a response is required
Captain-facing response: Captain, shipshape.
Scope: only that event; unrelated visible-session decisions are not characterized
Authoritative contract: When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
```
</details>
<details>
<summary>Evidence: Focused contract-test transcript</summary>

```text
ok - section 9 owns the positive captain-facing translation contract
ok - scout remains allowed in private captain chat
ok - compressed safety labels require concrete plain renderings
ok - section 9 maps high-risk internal vocabulary families
ok - captain chat rejects verbatim internal evidence while private reports stay precise
ok - routine no-action response is exact and scoped to its event
ok - outward-facing skill handoffs point to the section 9 owner
ok - skills cross-reference section 9 instead of duplicating the mapping list
ok - ahoy is internal, user-invocable, and absent from public skills
ok - README lists ahoy under the shared cross-harness invocation convention
ok - ahoy delegates first-message fallback and keeps later recaps visible-session-only
ok - ahoy: one canonical owner constructs typed operational input for every Firstmate-controlled user-role producer
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 3eca8ff0129792c97e933616f2d72ec5801679f1..56ccd60a2f99893abd6d6c662cfca5e78043f39b` and full diff inspection</code>
- `./tests/fm-captain-translation-contract.test.sh`
- <code>Manual Section 9 extraction confirming exact `Captain, shipshape.` wording, event-only scope, and absence of `Captain, no decision is needed.`</code>
- `git diff --name-only 3eca8ff0129792c97e933616f2d72ec5801679f1..56ccd60a2f99893abd6d6c662cfca5e78043f39b`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
