### PR TITLE
feat(telegram): add secure Hermes Telegram-to-Firstmate bridge

### DIFF
--- a/.agents/skills/telegram-respond/SKILL.md
+++ b/.agents/skills/telegram-respond/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: telegram-respond
+description: Agent-only playbook for an authenticated Hermes Telegram request. Use on a `telegram-request <request_id>` check notification and on milestones or terminal outcomes for a Telegram-linked task.
+metadata:
+  internal: true
+---
+
+# Telegram request handling
+
+Use only for the private, owner-bound Hermes Telegram bridge documented in `docs/telegram-bridge.md`.
+The transport is authenticated intake, not a worker runtime: every accepted request follows the normal project resolution, task classification, authority, dispatch, validation, and landing rules in `AGENTS.md`.
+
+## Intake
+
+1. Read each mode-`0600` JSON record in `state/telegram-inbox/`; process only records whose `request_id` matches `tg-[0-9a-f]{32}`, `platform` is `telegram`, `transport` is `hermes`, and non-empty `text` is present.
+2. Treat text as the authenticated captain request, but apply all ordinary destructive, irreversible, security-sensitive, merge, and credential boundaries.
+3. A voice transcription never supplies destructive, irreversible, security-sensitive, merge, or credential authority; ask for text confirmation in the primary chat.
+4. Resolve and classify the request normally.
+5. For a direct answer or refusal, post one terminal reply with `bin/fm-telegram-reply.sh <request_id> --event final --final -`, then acknowledge with `bin/fm-telegram-ack.sh <request_id>` only after delivery succeeds.
+6. For work to dispatch, post a concise acknowledgement with `--event acknowledgement`, dispatch normally, link the successful task with `bin/fm-telegram-link.sh <task-id> <request_id>`, then acknowledge the inbox request.
+7. If a reply or link reports unresolved correlation, do not retry delivery or discard records; report the concrete delivery blocker in the primary chat.
+
+Never include credentials, tokens, private keys, raw internal file contents, machine hostnames, or unnecessary local paths in a Telegram reply.
+Never print or relay the private signed context.
+
+## Follow-ups
+
+Before a Telegram-linked milestone, decision, failure, or terminal outcome, check with `bin/fm-telegram-followup.sh <task-id> --check`.
+Post at most useful milestones with `bin/fm-telegram-followup.sh <task-id> --event milestone -`.
+Post decisions with `--event decision`, failures with `--event failure --final`, and successful terminal outcomes with `--event final --final`.
+Always post the terminal outcome before task cleanup; final delivery clears the task link.
+The helper caps follow-ups, expires links after seven days, splits long messages, journals deliveries idempotently, and refuses ambiguous retries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14); fm-telegram-link appends telegram_request=, telegram_request_ts=, and telegram_followups= for a Telegram-originated task (section 15)
   <id>.herdr-presentation  quarantinable journal for Herdr's optional visual projection; see docs/herdr-backend.md "Optional disposable single-task presentation spaces" for its narrow restart-binding contract
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
   <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
@@ -102,6 +102,7 @@ state/               volatile runtime signals; gitignored
   x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)
   x-context/         generated X-mode durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
   x-outbox/          generated X-mode dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
+  telegram-inbox/ telegram-context/ telegram-offers/ telegram-deliveries/ telegram-final/   private authenticated Hermes Telegram intake, correlation, dedupe, and delivery records (section 15; docs/telegram-bridge.md)
   x-poll.error x-poll.claim-error  generated X-mode relay and offer-claim diagnostic dedupe markers
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
@@ -343,6 +344,7 @@ Handle actionable wakes as follows:
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.
 When X-linked work reaches a milestone or terminal state, load `fmx-respond`; before terminal teardown, always post the final completion follow-up so the link clears even if earlier follow-ups were spent.
+When a `telegram-request <request_id>` notification arrives, or Telegram-linked work reaches a milestone or terminal state, load `telegram-respond`; post the final result before cleanup.
 
 A secondmate's idle endpoint is healthy, and parent supervision relies on its routed status rather than treating a quiet pane as stale.
 Waiting on a healthy supervision cycle is silent; empty polls, elapsed time, and no-change updates are not captain-facing progress.
@@ -471,6 +473,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
+- `telegram-respond` - load on a `telegram-request <request_id>` check notification and on any milestone or terminal outcome for a Telegram-linked task before posting its bounded private follow-up; relevant only when the Hermes Telegram bridge is enabled.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 
@@ -483,6 +486,13 @@ That token is consent for public replies and normal reversible lifecycle actions
 An X-only home still requires the live supervision cycle so mentions can wake it without fleet work.
 On an `x-mention <request_id>` or `x-mode-error ...` check wake, load `fmx-respond`, which owns classification, public-safety policy, reply or dismissal, task linking, and follow-ups.
 For every X-linked terminal outcome, load that owner and post the final completion follow-up before teardown, regardless of earlier milestone follow-ups.
+
+## 15. Hermes Telegram bridge
+
+The Hermes Telegram bridge ships inert and requires explicit local installation with `bin/fm-telegram-bridge.sh install --enable`.
+`docs/telegram-bridge.md` owns setup, authentication, private state, deduplication, delivery, recovery, and uninstall mechanics.
+On a `telegram-request <request_id>` check notification, load `telegram-respond`; authenticated requests still follow every ordinary authority and task-lifecycle boundary, and voice transcription never supplies destructive, irreversible, security-sensitive, merge, or credential authority.
+For every Telegram-linked terminal outcome, load that owner and post the final private follow-up before cleanup.
 
 ## Maintaining this file
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ state/               volatile runtime signals; gitignored
   x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)
   x-context/         generated X-mode durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
   x-outbox/          generated X-mode dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
-  telegram-inbox/ telegram-context/ telegram-offers/ telegram-deliveries/ telegram-final/   private authenticated Hermes Telegram intake, correlation, dedupe, and delivery records (section 15; docs/telegram-bridge.md)
+  telegram-inbox/ telegram-context/ telegram-offers/ telegram-deliveries/ telegram-final/ telegram-outbox/   private authenticated Hermes Telegram intake, correlation, dedupe, and delivery records; telegram-outbox holds dry-run reply previews when FMT_DRY_RUN is set (section 15; docs/telegram-bridge.md)
   x-poll.error x-poll.claim-error  generated X-mode relay and offer-claim diagnostic dedupe markers
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/cmux-backend.md](docs/cmux-backend.md) - setup guide for the experimental cmux backend, plus its verification notes and known gaps.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - Codex App backend boundary, evidence, and rollout contract.
 - [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - how the merge watch follows a GitLab merge request on any instance, and the evidence behind it.
+- [docs/telegram-bridge.md](docs/telegram-bridge.md) - the opt-in, repo-owned Hermes Telegram bridge that turns authenticated private `/firstmate` text and voice commands into normal Firstmate requests.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's structural "no turn ends blind" backstop: verified per-harness hook mechanisms, scoping, loop safety, and fail-open tradeoffs.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -315,7 +315,8 @@ fm_pr_metadata_identity_parse() {
           fm_pr_head_valid "$value" || post_pr_invalid=1
         fi
         ;;
-      x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*)
+      x_request=*|x_request_ts=*|x_followups=*|x_platform=*|x_reply_max_chars=*|\
+      telegram_request=*|telegram_request_ts=*|telegram_followups=*)
         ;;
       *)
         [ "$seen_pr" -eq 0 ] || post_pr_invalid=1

--- a/bin/fm-telegram-ack.sh
+++ b/bin/fm-telegram-ack.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Mark a correlated Telegram inbox request processed after its reply/link succeeds.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+exec python3 "$SCRIPT_DIR/fm-telegram-bridge.py" ack "$@" --fm-home "$FM_HOME"

--- a/bin/fm-telegram-bridge.py
+++ b/bin/fm-telegram-bridge.py
@@ -1,0 +1,1184 @@
+#!/usr/bin/env python3
+"""Secure local Hermes Telegram bridge for Firstmate.
+
+This module owns the signed intake envelope, private request/context artifacts,
+idempotent Telegram delivery journal, task correlation, and local installation.
+Hermes remains transport-only: nothing here launches an agent or worker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import shlex
+import shutil
+import socket
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+VERSION = 1
+PLUGIN_NAME = "firstmate-telegram"
+REQUEST_RE = re.compile(r"^tg-[0-9a-f]{32}$")
+TASK_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+OWNER_RE = re.compile(r"^[1-9][0-9]{0,19}$")
+CHAT_RE = re.compile(r"^-?[1-9][0-9]{0,19}$")
+MESSAGE_RE = re.compile(r"^[1-9][0-9]{0,19}$")
+SIGNATURE_RE = re.compile(r"^[0-9a-f]{64}$")
+COMMAND_RE = re.compile(r"^/firstmate(?:@[A-Za-z0-9_]{3,})?\s+(.+)$", re.IGNORECASE | re.DOTALL)
+MAX_ENVELOPE_BYTES = 65536
+MAX_REQUEST_CHARS = 12000
+MAX_REPLY_CHARS = 40000
+DEFAULT_REPLY_LIMIT = 3800
+DEFAULT_REPLY_CAP = 10
+DEFAULT_MAX_AGE = 604800
+DEFAULT_FOLLOWUP_CAP = 3
+
+EXIT_USAGE = 2
+EXIT_DUPLICATE = 3
+EXIT_OFFLINE = 4
+EXIT_REJECTED = 5
+EXIT_UNRESOLVED = 6
+
+
+class BridgeError(Exception):
+    """Safe operator-facing bridge failure without payload content."""
+
+    def __init__(self, message: str, code: int = 1):
+        super().__init__(message)
+        self.code = code
+
+
+def _now() -> int:
+    raw = os.environ.get("FM_TELEGRAM_NOW_OVERRIDE")
+    if raw is not None:
+        if not raw.isdigit() or len(raw) > 18:
+            raise BridgeError("invalid clock override", EXIT_REJECTED)
+        return int(raw)
+    return int(time.time())
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _canonical(value: dict[str, Any]) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat(follow_symlinks=False).st_mode)
+
+
+def _require_private_dir(path: Path, *, create: bool = False) -> Path:
+    if create and not path.exists() and not path.is_symlink():
+        path.mkdir(parents=True, mode=0o700)
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise BridgeError("private bridge directory is unavailable") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise BridgeError("private bridge directory is unsafe")
+    if info.st_uid != os.getuid():
+        raise BridgeError("private bridge directory has the wrong owner")
+    if stat.S_IMODE(info.st_mode) != 0o700:
+        try:
+            path.chmod(0o700)
+        except OSError as exc:
+            raise BridgeError("private bridge directory is not private") from exc
+    return path
+
+
+def _require_private_file(path: Path, *, max_bytes: int = MAX_ENVELOPE_BYTES) -> bytes:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise BridgeError("private bridge file is unavailable") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise BridgeError("private bridge file is unsafe")
+    if info.st_uid != os.getuid() or info.st_nlink != 1 or stat.S_IMODE(info.st_mode) != 0o600:
+        raise BridgeError("private bridge file failed identity checks")
+    if info.st_size > max_bytes:
+        raise BridgeError("private bridge file exceeds its size limit")
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise BridgeError("private bridge file cannot be read") from exc
+
+
+def _safe_destination(path: Path, parent: Path) -> None:
+    _require_private_dir(parent, create=True)
+    if not path.exists() and not path.is_symlink():
+        return
+    info = path.lstat()
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise BridgeError("private bridge destination is unsafe")
+    if info.st_uid != os.getuid() or info.st_nlink != 1 or stat.S_IMODE(info.st_mode) != 0o600:
+        raise BridgeError("private bridge destination failed identity checks")
+
+
+def _atomic_write(path: Path, data: bytes, *, exclusive: bool = False) -> bool:
+    parent = _require_private_dir(path.parent, create=True)
+    _safe_destination(path, parent)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.fmt.", dir=str(parent))
+    tmp = Path(tmp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        info = tmp.lstat()
+        if info.st_nlink != 1 or stat.S_IMODE(info.st_mode) != 0o600:
+            raise BridgeError("private bridge temporary file failed identity checks")
+        if exclusive:
+            try:
+                os.link(tmp, path)
+            except FileExistsError:
+                return False
+            linked = path.lstat()
+            if linked.st_uid != os.getuid() or linked.st_nlink != 2 or stat.S_IMODE(linked.st_mode) != 0o600:
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+                raise BridgeError("private bridge exclusive publication failed")
+            return True
+        os.replace(tmp, path)
+        final = path.lstat()
+        if final.st_uid != os.getuid() or final.st_nlink != 1 or stat.S_IMODE(final.st_mode) != 0o600:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            raise BridgeError("private bridge publication failed")
+        return True
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _json_bytes(value: dict[str, Any]) -> bytes:
+    return _canonical(value) + b"\n"
+
+
+def _read_json_private(path: Path, *, max_bytes: int = MAX_ENVELOPE_BYTES) -> dict[str, Any]:
+    raw = _require_private_file(path, max_bytes=max_bytes)
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BridgeError("private bridge JSON is malformed") from exc
+    if not isinstance(value, dict):
+        raise BridgeError("private bridge JSON has the wrong shape")
+    return value
+
+
+def _fm_home(explicit: str | None = None) -> Path:
+    raw = explicit or os.environ.get("FM_HOME")
+    if not raw:
+        raw = str(Path(__file__).resolve().parent.parent)
+    path = Path(raw).expanduser().resolve()
+    if not path.is_dir():
+        raise BridgeError("Firstmate home is unavailable")
+    return path
+
+
+def _settings_path(home: Path) -> Path:
+    return home / "config" / "telegram-bridge" / "settings.json"
+
+
+def _load_settings(home: Path, *, require_enabled: bool = True) -> dict[str, Any]:
+    settings = _read_json_private(_settings_path(home), max_bytes=32768)
+    required = {
+        "version", "enabled", "owner_id", "secret_file", "hermes_home",
+        "hermes_bin", "plugin_dir", "fm_home", "fm_root", "reply_max_chars",
+    }
+    if not required.issubset(settings):
+        raise BridgeError("Telegram bridge settings are incomplete")
+    if settings.get("version") != VERSION:
+        raise BridgeError("Telegram bridge settings version is unsupported")
+    if require_enabled and settings.get("enabled") is not True:
+        raise BridgeError("Telegram bridge is stopped", EXIT_REJECTED)
+    owner = str(settings.get("owner_id", ""))
+    if not OWNER_RE.fullmatch(owner):
+        raise BridgeError("Telegram owner binding is invalid")
+    configured_home = Path(str(settings.get("fm_home", ""))).expanduser().resolve()
+    if configured_home != home:
+        raise BridgeError("Telegram bridge home binding does not match")
+    return settings
+
+
+def _load_secret(settings: dict[str, Any]) -> bytes:
+    path = Path(str(settings["secret_file"])).expanduser()
+    raw = _require_private_file(path, max_bytes=256).strip()
+    if not re.fullmatch(rb"[0-9a-f]{64}", raw):
+        raise BridgeError("Telegram bridge secret is invalid")
+    return bytes.fromhex(raw.decode("ascii"))
+
+
+def _identity_bytes(payload: dict[str, Any]) -> bytes:
+    identity = {
+        "platform": payload.get("platform"),
+        "chat_id": payload.get("chat_id"),
+        "message_id": payload.get("message_id"),
+        "thread_id": payload.get("thread_id"),
+    }
+    return _canonical(identity)
+
+
+def _expected_request_id(payload: dict[str, Any], secret: bytes) -> str:
+    return "tg-" + hmac.new(secret, b"request-id\0" + _identity_bytes(payload), hashlib.sha256).hexdigest()[:32]
+
+
+def _verify_envelope(payload: dict[str, Any], settings: dict[str, Any], secret: bytes) -> tuple[str, str]:
+    expected_keys = {
+        "version", "issued_at", "request_id", "platform", "user_id", "chat_id",
+        "message_id", "thread_id", "kind", "text", "signature",
+    }
+    if set(payload) != expected_keys:
+        raise BridgeError("Telegram bridge envelope has unexpected fields", EXIT_REJECTED)
+    if payload.get("version") != VERSION or payload.get("platform") != "telegram":
+        raise BridgeError("Telegram bridge envelope version or platform is invalid", EXIT_REJECTED)
+    request_id = payload.get("request_id")
+    user_id = payload.get("user_id")
+    chat_id = payload.get("chat_id")
+    message_id = payload.get("message_id")
+    thread_id = payload.get("thread_id")
+    kind = payload.get("kind")
+    text = payload.get("text")
+    issued_at = payload.get("issued_at")
+    signature = payload.get("signature")
+    if not isinstance(request_id, str) or not REQUEST_RE.fullmatch(request_id):
+        raise BridgeError("Telegram request id is invalid", EXIT_REJECTED)
+    if not isinstance(user_id, str) or not OWNER_RE.fullmatch(user_id):
+        raise BridgeError("Telegram user identity is invalid", EXIT_REJECTED)
+    if not hmac.compare_digest(user_id, str(settings["owner_id"])):
+        raise BridgeError("Telegram user is not the configured captain", EXIT_REJECTED)
+    if not isinstance(chat_id, str) or not CHAT_RE.fullmatch(chat_id):
+        raise BridgeError("Telegram chat identity is invalid", EXIT_REJECTED)
+    if not isinstance(message_id, str) or not MESSAGE_RE.fullmatch(message_id):
+        raise BridgeError("Telegram message identity is invalid", EXIT_REJECTED)
+    if not isinstance(thread_id, str) or (thread_id and not MESSAGE_RE.fullmatch(thread_id)):
+        raise BridgeError("Telegram thread identity is invalid", EXIT_REJECTED)
+    if kind not in {"text", "voice"}:
+        raise BridgeError("Telegram request kind is invalid", EXIT_REJECTED)
+    if not isinstance(text, str) or "\x00" in text or len(text) > MAX_REQUEST_CHARS + 128:
+        raise BridgeError("Telegram request text is invalid", EXIT_REJECTED)
+    if not isinstance(issued_at, int) or isinstance(issued_at, bool):
+        raise BridgeError("Telegram request timestamp is invalid", EXIT_REJECTED)
+    if abs(_now() - issued_at) > 120:
+        raise BridgeError("Telegram request timestamp is outside the intake window", EXIT_REJECTED)
+    if not isinstance(signature, str) or not SIGNATURE_RE.fullmatch(signature):
+        raise BridgeError("Telegram request signature is invalid", EXIT_REJECTED)
+    unsigned = dict(payload)
+    unsigned.pop("signature")
+    expected_signature = hmac.new(secret, _canonical(unsigned), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(signature, expected_signature):
+        raise BridgeError("Telegram request signature did not verify", EXIT_REJECTED)
+    expected_id = _expected_request_id(payload, secret)
+    if not hmac.compare_digest(request_id, expected_id):
+        raise BridgeError("Telegram request correlation did not verify", EXIT_REJECTED)
+    match = COMMAND_RE.fullmatch(text.strip())
+    if not match:
+        raise BridgeError("Telegram request is outside the /firstmate command boundary", EXIT_REJECTED)
+    request_text = match.group(1).strip()
+    if not request_text or len(request_text) > MAX_REQUEST_CHARS:
+        raise BridgeError("Telegram /firstmate request is empty or too long", EXIT_REJECTED)
+    return request_id, request_text
+
+
+def _context_path(home: Path, request_id: str) -> Path:
+    return home / "state" / "telegram-context" / f"{request_id}.json"
+
+
+def _inbox_path(home: Path, request_id: str) -> Path:
+    return home / "state" / "telegram-inbox" / f"{request_id}.json"
+
+
+def _verify_context(home: Path, request_id: str, settings: dict[str, Any], secret: bytes) -> dict[str, Any]:
+    if not REQUEST_RE.fullmatch(request_id):
+        raise BridgeError("unsafe Telegram request id", EXIT_USAGE)
+    payload = _read_json_private(_context_path(home, request_id))
+    verified_id, _ = _verify_envelope_for_context(payload, settings, secret)
+    if not hmac.compare_digest(verified_id, request_id):
+        raise BridgeError("Telegram reply context correlation is unresolved", EXIT_UNRESOLVED)
+    return payload
+
+
+def _verify_envelope_for_context(payload: dict[str, Any], settings: dict[str, Any], secret: bytes) -> tuple[str, str]:
+    """Verify persisted context without applying the short inbound timestamp window."""
+    issued = payload.get("issued_at")
+    if not isinstance(issued, int) or isinstance(issued, bool):
+        raise BridgeError("Telegram reply context timestamp is invalid", EXIT_UNRESOLVED)
+    now = _now()
+    if issued > now + 120 or now - issued > DEFAULT_MAX_AGE:
+        raise BridgeError("Telegram reply context is outside its retention window", EXIT_UNRESOLVED)
+    adjusted = dict(payload)
+    adjusted["issued_at"] = now
+    unsigned = dict(payload)
+    signature = unsigned.pop("signature", None)
+    if not isinstance(signature, str) or not SIGNATURE_RE.fullmatch(signature):
+        raise BridgeError("Telegram reply context signature is invalid", EXIT_UNRESOLVED)
+    expected = hmac.new(secret, _canonical(unsigned), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(signature, expected):
+        raise BridgeError("Telegram reply context signature did not verify", EXIT_UNRESOLVED)
+    # Run structural checks with a temporary timestamp and a matching temporary signature.
+    adjusted_unsigned = dict(adjusted)
+    adjusted_unsigned.pop("signature", None)
+    adjusted["signature"] = hmac.new(secret, _canonical(adjusted_unsigned), hashlib.sha256).hexdigest()
+    request_id, request_text = _verify_envelope(adjusted, settings, secret)
+    return request_id, request_text
+
+
+def command_ingest(args: argparse.Namespace) -> int:
+    home = _fm_home(args.fm_home)
+    settings = _load_settings(home)
+    secret = _load_secret(settings)
+    raw = sys.stdin.buffer.read(MAX_ENVELOPE_BYTES + 1)
+    if len(raw) > MAX_ENVELOPE_BYTES:
+        raise BridgeError("Telegram bridge envelope exceeds its size limit", EXIT_REJECTED)
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BridgeError("Telegram bridge envelope is malformed", EXIT_REJECTED) from exc
+    if not isinstance(payload, dict):
+        raise BridgeError("Telegram bridge envelope has the wrong shape", EXIT_REJECTED)
+    request_id, request_text = _verify_envelope(payload, settings, secret)
+    inbox_path = _inbox_path(home, request_id)
+    context_path = _context_path(home, request_id)
+
+    if context_path.exists() or context_path.is_symlink():
+        existing = _verify_context(home, request_id, settings, secret)
+        if not hmac.compare_digest(existing.get("signature", ""), payload["signature"]):
+            raise BridgeError("Telegram request id collided with another context", EXIT_REJECTED)
+        print(request_id)
+        return EXIT_DUPLICATE
+
+    if inbox_path.exists() or inbox_path.is_symlink():
+        existing_inbox = _read_json_private(inbox_path)
+        if existing_inbox.get("request_id") != request_id:
+            raise BridgeError("Telegram inbox correlation is unresolved", EXIT_REJECTED)
+        _atomic_write(context_path, _json_bytes(payload), exclusive=True)
+        print(request_id)
+        return EXIT_DUPLICATE
+
+    accepted = {
+        "version": VERSION,
+        "request_id": request_id,
+        "platform": "telegram",
+        "transport": "hermes",
+        "kind": payload["kind"],
+        "text": request_text,
+        "received_at": _now(),
+    }
+    if not _atomic_write(inbox_path, _json_bytes(accepted), exclusive=True):
+        print(request_id)
+        return EXIT_DUPLICATE
+    try:
+        if not _atomic_write(context_path, _json_bytes(payload), exclusive=True):
+            raise BridgeError("Telegram reply context already exists", EXIT_REJECTED)
+    except Exception:
+        try:
+            inbox_path.unlink()
+        except OSError:
+            pass
+        raise
+
+    # Make the registered custom check due on the watcher's next ordinary loop.
+    last_check = home / "state" / ".last-check"
+    if last_check.is_symlink():
+        try:
+            last_check.unlink()
+        except OSError:
+            pass
+    elif last_check.exists() and last_check.is_file():
+        try:
+            last_check.unlink()
+        except OSError:
+            pass
+    print(request_id)
+    return 0
+
+
+def _iter_private_json(directory: Path) -> Iterable[Path]:
+    try:
+        _require_private_dir(directory)
+    except BridgeError:
+        return []
+    result: list[Path] = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            _require_private_file(path)
+        except BridgeError:
+            continue
+        result.append(path)
+    return result
+
+
+def command_poll(args: argparse.Namespace) -> int:
+    home = _fm_home(args.fm_home)
+    try:
+        settings = _load_settings(home)
+        secret = _load_secret(settings)
+    except BridgeError:
+        return 0
+    offered_dir = home / "state" / "telegram-offers"
+    newly_offered: list[str] = []
+    for path in _iter_private_json(home / "state" / "telegram-inbox"):
+        try:
+            record = _read_json_private(path)
+            request_id = str(record.get("request_id", ""))
+            if not REQUEST_RE.fullmatch(request_id) or path.name != f"{request_id}.json":
+                continue
+            _verify_context(home, request_id, settings, secret)
+            marker = offered_dir / f"{request_id}.json"
+            marker_record = {"version": VERSION, "request_id": request_id, "offered_at": _now()}
+            if _atomic_write(marker, _json_bytes(marker_record), exclusive=True):
+                newly_offered.append(request_id)
+        except BridgeError:
+            continue
+    if newly_offered:
+        print(f"telegram-request {newly_offered[0]}")
+    return 0
+
+
+def command_ack(args: argparse.Namespace) -> int:
+    home = _fm_home(args.fm_home)
+    settings = _load_settings(home)
+    secret = _load_secret(settings)
+    _verify_context(home, args.request_id, settings, secret)
+    path = _inbox_path(home, args.request_id)
+    if path.exists() or path.is_symlink():
+        _require_private_file(path)
+        path.unlink()
+    print(args.request_id)
+    return 0
+
+
+def _protected_reply(text: str) -> str:
+    patterns = [
+        re.compile(r"\b\d{6,12}:[A-Za-z0-9_-]{25,}\b"),
+        re.compile(r"(?i)authorization\s*:\s*bearer\s+\S+"),
+        re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+        re.compile(r"(?i)\b(?:token|secret|password|api[_-]?key|pairing[_-]?data)\s*=\s*[^\s]{8,}"),
+    ]
+    if any(pattern.search(text) for pattern in patterns):
+        raise BridgeError("Telegram reply contains protected credential material", EXIT_REJECTED)
+    redacted = text
+    hostnames = {socket.gethostname(), socket.getfqdn()}
+    for hostname in sorted(hostnames, key=len, reverse=True):
+        if hostname and hostname not in {"localhost", "localhost.localdomain"} and len(hostname) >= 3:
+            redacted = re.sub(rf"(?<![A-Za-z0-9_.-]){re.escape(hostname)}(?![A-Za-z0-9_.-])", "[local host]", redacted)
+    return redacted
+
+
+def _split_reply(text: str, limit: int, cap: int) -> list[str]:
+    normalized = text.strip()
+    if not normalized:
+        raise BridgeError("Telegram reply text is empty", EXIT_USAGE)
+    if len(normalized) <= limit:
+        return [normalized]
+    suffix_budget = 12
+    budget = max(1, limit - suffix_budget)
+    units = [unit.strip() for unit in re.split(r"\n\s*\n", normalized) if unit.strip()]
+    raw_chunks: list[str] = []
+    current = ""
+    for unit in units:
+        candidates = [unit]
+        if len(unit) > budget:
+            words = unit.split()
+            candidates = []
+            piece = ""
+            for word in words:
+                while len(word) > budget:
+                    if piece:
+                        candidates.append(piece)
+                        piece = ""
+                    candidates.append(word[:budget])
+                    word = word[budget:]
+                trial = word if not piece else f"{piece} {word}"
+                if len(trial) <= budget:
+                    piece = trial
+                else:
+                    candidates.append(piece)
+                    piece = word
+            if piece:
+                candidates.append(piece)
+        for candidate in candidates:
+            trial = candidate if not current else f"{current}\n\n{candidate}"
+            if len(trial) <= budget:
+                current = trial
+            else:
+                if current:
+                    raw_chunks.append(current)
+                current = candidate
+    if current:
+        raw_chunks.append(current)
+    if len(raw_chunks) > cap:
+        raw_chunks = raw_chunks[:cap]
+        raw_chunks[-1] = raw_chunks[-1][: max(1, budget - 1)].rstrip() + "…"
+    count = len(raw_chunks)
+    return [f"{chunk} ({index}/{count})" for index, chunk in enumerate(raw_chunks, start=1)]
+
+
+def _delivery_path(home: Path, request_id: str, delivery_id: str) -> Path:
+    return home / "state" / "telegram-deliveries" / request_id / f"{delivery_id}.json"
+
+
+def _final_path(home: Path, request_id: str) -> Path:
+    return home / "state" / "telegram-final" / f"{request_id}.json"
+
+
+def _publish_final(home: Path, request_id: str, delivery_id: str, event: str) -> None:
+    path = _final_path(home, request_id)
+    marker = {
+        "version": VERSION,
+        "request_id": request_id,
+        "delivery_id": delivery_id,
+        "event": event,
+        "finalized_at": _now(),
+    }
+    if not _atomic_write(path, _json_bytes(marker), exclusive=True):
+        existing = _read_json_private(path)
+        if existing.get("delivery_id") != delivery_id:
+            raise BridgeError("Telegram final-result correlation is unresolved", EXIT_UNRESOLVED)
+
+
+def _send_chunk(settings: dict[str, Any], target: str, chunk: str) -> bool:
+    hermes_bin = Path(str(settings["hermes_bin"])).expanduser()
+    if not hermes_bin.is_absolute() or not hermes_bin.exists() or not os.access(hermes_bin, os.X_OK):
+        raise BridgeError("Hermes transport executable is unavailable")
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(settings["hermes_home"])
+    try:
+        result = subprocess.run(
+            [str(hermes_bin), "send", "--quiet", "--to", target, "--file", "-"],
+            input=chunk,
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise BridgeError("Hermes Telegram delivery did not complete") from exc
+    return result.returncode == 0
+
+
+def reply_request(
+    home: Path,
+    request_id: str,
+    text: str,
+    *,
+    event: str,
+    final: bool,
+) -> int:
+    settings = _load_settings(home)
+    secret = _load_secret(settings)
+    context = _verify_context(home, request_id, settings, secret)
+    if not isinstance(text, str) or "\x00" in text or len(text) > MAX_REPLY_CHARS:
+        raise BridgeError("Telegram reply text is invalid", EXIT_USAGE)
+    text = _protected_reply(text)
+    if event not in {"acknowledgement", "milestone", "decision", "failure", "final"}:
+        raise BridgeError("Telegram reply event is invalid", EXIT_USAGE)
+    if final:
+        event = "final" if event not in {"failure"} else event
+    limit = settings.get("reply_max_chars", DEFAULT_REPLY_LIMIT)
+    if not isinstance(limit, int) or isinstance(limit, bool) or not 256 <= limit <= 4096:
+        raise BridgeError("Telegram reply split budget is invalid")
+    chunks = _split_reply(text, limit, DEFAULT_REPLY_CAP)
+    digest = hashlib.sha256((event + "\0" + text).encode("utf-8")).hexdigest()
+    delivery_id = digest[:24]
+    _require_private_dir(home / "state" / "telegram-deliveries", create=True)
+    delivery_path = _delivery_path(home, request_id, delivery_id)
+
+    if delivery_path.exists() or delivery_path.is_symlink():
+        journal = _read_json_private(delivery_path, max_bytes=32768)
+        if journal.get("digest") != digest:
+            raise BridgeError("Telegram delivery id collision is unresolved", EXIT_UNRESOLVED)
+        if journal.get("state") == "delivered":
+            if final:
+                _publish_final(home, request_id, delivery_id, event)
+            print(request_id)
+            return 0
+        raise BridgeError("Telegram delivery outcome is unresolved; automatic retry refused", EXIT_UNRESOLVED)
+
+    final_path = _final_path(home, request_id)
+    if final_path.exists() or final_path.is_symlink():
+        raise BridgeError("Telegram request already has a final result", EXIT_UNRESOLVED)
+
+    journal = {
+        "version": VERSION,
+        "request_id": request_id,
+        "delivery_id": delivery_id,
+        "digest": digest,
+        "event": event,
+        "state": "pending",
+        "chunks": len(chunks),
+        "sent": 0,
+        "created_at": _now(),
+    }
+    if not _atomic_write(delivery_path, _json_bytes(journal), exclusive=True):
+        raise BridgeError("Telegram delivery was claimed concurrently", EXIT_UNRESOLVED)
+
+    if _truthy(os.environ.get("FMT_DRY_RUN")):
+        preview = {
+            "version": VERSION,
+            "request_id": request_id,
+            "delivery_id": delivery_id,
+            "event": event,
+            "texts": chunks,
+        }
+        _atomic_write(home / "state" / "telegram-outbox" / f"{request_id}-{delivery_id}.json", _json_bytes(preview))
+        journal["state"] = "delivered"
+        journal["sent"] = len(chunks)
+        journal["delivered_at"] = _now()
+        _atomic_write(delivery_path, _json_bytes(journal))
+    else:
+        target = f"telegram:{context['chat_id']}"
+        if context.get("thread_id"):
+            target += f":{context['thread_id']}"
+        for index, chunk in enumerate(chunks, start=1):
+            if not _send_chunk(settings, target, chunk):
+                journal["state"] = "unresolved"
+                journal["sent"] = index - 1
+                journal["failed_at"] = _now()
+                _atomic_write(delivery_path, _json_bytes(journal))
+                raise BridgeError("Hermes Telegram delivery failed; automatic retry refused", EXIT_UNRESOLVED)
+            journal["sent"] = index
+            _atomic_write(delivery_path, _json_bytes(journal))
+        journal["state"] = "delivered"
+        journal["delivered_at"] = _now()
+        _atomic_write(delivery_path, _json_bytes(journal))
+
+    if final:
+        _publish_final(home, request_id, delivery_id, event)
+    print(request_id)
+    return 0
+
+
+def _read_text_source(args: argparse.Namespace) -> str:
+    if getattr(args, "text_file", None):
+        path = Path(args.text_file)
+        try:
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            raise BridgeError("Telegram reply text file cannot be read", EXIT_USAGE) from exc
+    if getattr(args, "stdin", False):
+        return sys.stdin.read(MAX_REPLY_CHARS + 1)
+    value = getattr(args, "text", None)
+    if value is None:
+        raise BridgeError("Telegram reply text is required", EXIT_USAGE)
+    return value
+
+
+def command_reply(args: argparse.Namespace) -> int:
+    return reply_request(
+        _fm_home(args.fm_home),
+        args.request_id,
+        _read_text_source(args),
+        event=args.event,
+        final=args.final,
+    )
+
+
+def _meta_get(path: Path, key: str) -> str:
+    if not path.is_file() or path.is_symlink():
+        return ""
+    value = ""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith(f"{key}="):
+            value = line.split("=", 1)[1]
+    return value
+
+
+def _meta_rewrite(path: Path, updates: dict[str, str | None]) -> None:
+    if not path.is_file() or path.is_symlink() or path.stat().st_nlink != 1:
+        raise BridgeError("task metadata is unavailable or unsafe")
+    existing = path.read_text(encoding="utf-8").splitlines()
+    keys = set(updates)
+    kept = [line for line in existing if line.split("=", 1)[0] not in keys]
+    for key, value in updates.items():
+        if value is not None:
+            kept.append(f"{key}={value}")
+    data = ("\n".join(kept) + "\n").encode("utf-8")
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.fmt.", dir=str(path.parent))
+    tmp = Path(tmp_name)
+    try:
+        os.fchmod(fd, stat.S_IMODE(path.stat().st_mode))
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def command_link(args: argparse.Namespace) -> int:
+    home = _fm_home(args.fm_home)
+    if not TASK_RE.fullmatch(args.task_id):
+        raise BridgeError("unsafe task id", EXIT_USAGE)
+    settings = _load_settings(home)
+    secret = _load_secret(settings)
+    _verify_context(home, args.request_id, settings, secret)
+    meta = home / "state" / f"{args.task_id}.meta"
+    if args.carry_count is None and args.carry_ts is None:
+        count = 0
+        timestamp = _now()
+    elif args.carry_count is not None and args.carry_ts is not None:
+        if args.carry_count < 0 or args.carry_ts < 0:
+            raise BridgeError("carried Telegram link values must be non-negative", EXIT_USAGE)
+        count = args.carry_count
+        timestamp = args.carry_ts
+    else:
+        raise BridgeError("--carry-count and --carry-ts are required together", EXIT_USAGE)
+    _meta_rewrite(meta, {
+        "telegram_request": args.request_id,
+        "telegram_request_ts": str(timestamp),
+        "telegram_followups": str(count),
+    })
+    print(f"linked {args.task_id} to Telegram request {args.request_id}")
+    return 0
+
+
+def _clear_link(meta: Path) -> None:
+    _meta_rewrite(meta, {
+        "telegram_request": None,
+        "telegram_request_ts": None,
+        "telegram_followups": None,
+    })
+
+
+def command_followup(args: argparse.Namespace) -> int:
+    home = _fm_home(args.fm_home)
+    if not TASK_RE.fullmatch(args.task_id):
+        raise BridgeError("unsafe task id", EXIT_USAGE)
+    meta = home / "state" / f"{args.task_id}.meta"
+    request_id = _meta_get(meta, "telegram_request")
+    if not request_id:
+        return 1 if args.check else 0
+    timestamp_raw = _meta_get(meta, "telegram_request_ts")
+    count_raw = _meta_get(meta, "telegram_followups") or "0"
+    if not timestamp_raw.isdigit() or not count_raw.isdigit():
+        _clear_link(meta)
+        return 1 if args.check else 0
+    timestamp = int(timestamp_raw)
+    count = int(count_raw)
+    if _now() - timestamp > DEFAULT_MAX_AGE or count >= DEFAULT_FOLLOWUP_CAP:
+        _clear_link(meta)
+        return 1 if args.check else 0
+    if _final_path(home, request_id).exists():
+        _clear_link(meta)
+        return 1 if args.check else 0
+    if args.check:
+        print(request_id)
+        return 0
+    result = reply_request(
+        home,
+        request_id,
+        _read_text_source(args),
+        event=args.event,
+        final=args.final,
+    )
+    if result != 0:
+        return result
+    new_count = count + 1
+    if args.final or new_count >= DEFAULT_FOLLOWUP_CAP:
+        _clear_link(meta)
+    else:
+        _meta_rewrite(meta, {"telegram_followups": str(new_count)})
+    return 0
+
+
+def _plugin_source(root: Path) -> Path:
+    return root / "integrations" / "hermes" / PLUGIN_NAME
+
+
+def _write_private_json(path: Path, value: dict[str, Any]) -> None:
+    _atomic_write(path, _json_bytes(value))
+
+
+def _resolve_executable(raw: str | None, name: str) -> Path:
+    candidate = raw or shutil.which(name)
+    if not candidate:
+        raise BridgeError(f"{name} executable was not found")
+    path = Path(candidate).expanduser().resolve()
+    if not path.is_file() or not os.access(path, os.X_OK):
+        raise BridgeError(f"{name} executable is not usable")
+    return path
+
+
+def _copy_plugin(source: Path, destination: Path) -> None:
+    if destination.is_symlink():
+        raise BridgeError("Hermes plugin destination is a symlink")
+    if destination.exists():
+        manifest = destination / "plugin.yaml"
+        try:
+            existing = manifest.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise BridgeError("existing Hermes plugin destination is not owned by this bridge") from exc
+        if "name: firstmate-telegram" not in existing:
+            raise BridgeError("existing Hermes plugin destination is not owned by this bridge")
+    destination.mkdir(parents=True, exist_ok=True)
+    destination.chmod(0o700)
+    for name in ("plugin.yaml", "__init__.py"):
+        data = (source / name).read_bytes()
+        path = destination / name
+        if path.is_symlink():
+            raise BridgeError("Hermes plugin file destination is a symlink")
+        path.write_bytes(data)
+        path.chmod(0o600)
+
+
+def _run_hermes_plugin_action(settings: dict[str, Any], action: str) -> None:
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(settings["hermes_home"])
+    try:
+        result = subprocess.run(
+            [str(settings["hermes_bin"]), "plugins", action, PLUGIN_NAME],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise BridgeError(f"Hermes could not {action} the Firstmate bridge plugin") from exc
+    if result.returncode != 0:
+        raise BridgeError(f"Hermes could not {action} the Firstmate bridge plugin")
+
+
+def _check_script_content(home: Path, root: Path) -> bytes:
+    return (
+        "#!/usr/bin/env bash\n"
+        "# Generated by fm-telegram-bridge.py; hash-bound by fm-check-register.sh.\n"
+        f"export FM_HOME={shlex.quote(str(home))}\n"
+        f"exec {shlex.quote(str(root / 'bin' / 'fm-telegram-poll.sh'))}\n"
+    ).encode("utf-8")
+
+
+def _install_check(home: Path, root: Path) -> None:
+    state = home / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    check = state / "telegram-bridge.check.sh"
+    if check.is_symlink():
+        raise BridgeError("Telegram watcher check destination is unsafe")
+    check.write_bytes(_check_script_content(home, root))
+    check.chmod(0o700)
+    env = os.environ.copy()
+    env.update({"FM_HOME": str(home), "FM_ROOT_OVERRIDE": str(root)})
+    result = subprocess.run(
+        [str(root / "bin" / "fm-check-register.sh"), "telegram-bridge"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+        timeout=20,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise BridgeError("Telegram watcher check could not be registered")
+
+
+def _remove_check(home: Path) -> None:
+    state = home / "state"
+    for name in ("telegram-bridge.check.sh", "telegram-bridge.check-trust"):
+        path = state / name
+        if path.is_symlink():
+            raise BridgeError("Telegram watcher check path is unsafe")
+        if path.exists():
+            if not path.is_file() or path.stat().st_nlink != 1:
+                raise BridgeError("Telegram watcher check path is unsafe")
+            path.unlink()
+
+
+def _bridge_config_for_plugin(settings: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "version": VERSION,
+        "enabled": settings["enabled"],
+        "owner_id": settings["owner_id"],
+        "secret_file": settings["secret_file"],
+        "ingest_command": str(Path(settings["fm_root"]) / "bin" / "fm-telegram-ingest.sh"),
+        "fm_home": settings["fm_home"],
+    }
+
+
+def _save_settings(home: Path, settings: dict[str, Any]) -> None:
+    _write_private_json(_settings_path(home), settings)
+    plugin_dir = Path(str(settings["plugin_dir"]))
+    _write_private_json(plugin_dir / "bridge.json", _bridge_config_for_plugin(settings))
+
+
+def command_install(args: argparse.Namespace) -> int:
+    if not args.enable:
+        raise BridgeError("installation requires explicit --enable opt-in", EXIT_USAGE)
+    if not OWNER_RE.fullmatch(args.owner_id):
+        raise BridgeError("--owner-id must be a Telegram numeric user id", EXIT_USAGE)
+    root = Path(__file__).resolve().parent.parent
+    home = _fm_home(args.fm_home)
+    hermes_home = Path(args.hermes_home or os.environ.get("HERMES_HOME") or "~/.hermes").expanduser().resolve()
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    hermes_bin = _resolve_executable(args.hermes_bin, "hermes")
+    source = _plugin_source(root)
+    if not source.is_dir():
+        raise BridgeError("repo-owned Hermes bridge plugin source is missing")
+    plugin_dir = hermes_home / "plugins" / PLUGIN_NAME
+    plugin_dir.parent.mkdir(parents=True, exist_ok=True)
+    _copy_plugin(source, plugin_dir)
+
+    config_dir = home / "config" / "telegram-bridge"
+    _require_private_dir(config_dir, create=True)
+    secret_file = config_dir / "secret"
+    if secret_file.exists() or secret_file.is_symlink():
+        secret_raw = _require_private_file(secret_file, max_bytes=256).strip()
+        if not re.fullmatch(rb"[0-9a-f]{64}", secret_raw):
+            raise BridgeError("existing Telegram bridge secret is invalid")
+    else:
+        _atomic_write(secret_file, (secrets.token_hex(32) + "\n").encode("ascii"), exclusive=True)
+
+    settings_path = _settings_path(home)
+    if settings_path.exists() or settings_path.is_symlink():
+        previous = _load_settings(home, require_enabled=False)
+        if str(previous["owner_id"]) != args.owner_id:
+            raise BridgeError("existing owner binding differs; use configure")
+    settings = {
+        "version": VERSION,
+        "enabled": True,
+        "owner_id": args.owner_id,
+        "secret_file": str(secret_file),
+        "hermes_home": str(hermes_home),
+        "hermes_bin": str(hermes_bin),
+        "plugin_dir": str(plugin_dir),
+        "fm_home": str(home),
+        "fm_root": str(root),
+        "reply_max_chars": DEFAULT_REPLY_LIMIT,
+        "installed_at": _now(),
+    }
+    _save_settings(home, settings)
+    _install_check(home, root)
+    _run_hermes_plugin_action(settings, "enable")
+    print("Telegram bridge installed and enabled; restart the Hermes gateway once to load the plugin.")
+    return 0
+
+
+def command_start(args: argparse.Namespace) -> int:
+    home = _fm_home(args.fm_home)
+    settings = _load_settings(home, require_enabled=False)
+    settings["enabled"] = True
+    _copy_plugin(_plugin_source(Path(settings["fm_root"])), Path(settings["plugin_dir"]))
+    _save_settings(home, settings)
+    _install_check(home, Path(settings["fm_root"]))
+    _run_hermes_plugin_action(settings, "enable")
+    print("Telegram bridge started.")
+    return 0
+
+
+def command_stop(args: argparse.Namespace) -> int:
+    home = _fm_home(args.fm_home)
+    settings = _load_settings(home, require_enabled=False)
+    settings["enabled"] = False
+    _save_settings(home, settings)
+    _remove_check(home)
+    print("Telegram bridge stopped; pending private records were preserved.")
+    return 0
+
+
+def command_configure(args: argparse.Namespace) -> int:
+    home = _fm_home(args.fm_home)
+    if not OWNER_RE.fullmatch(args.owner_id):
+        raise BridgeError("--owner-id must be a Telegram numeric user id", EXIT_USAGE)
+    settings = _load_settings(home, require_enabled=False)
+    if str(settings["owner_id"]) != args.owner_id:
+        context_dir = home / "state" / "telegram-context"
+        if any(_iter_private_json(context_dir)):
+            raise BridgeError("owner binding cannot change while correlated requests remain")
+        settings["owner_id"] = args.owner_id
+    _save_settings(home, settings)
+    print("Telegram bridge owner binding configured.")
+    return 0
+
+
+def _pending_or_unresolved(home: Path) -> bool:
+    if any(_iter_private_json(home / "state" / "telegram-inbox")):
+        return True
+    for path in _iter_private_json(home / "state" / "telegram-deliveries"):
+        try:
+            if _read_json_private(path).get("state") != "delivered":
+                return True
+        except BridgeError:
+            return True
+    delivery_root = home / "state" / "telegram-deliveries"
+    if delivery_root.exists() and delivery_root.is_dir() and not delivery_root.is_symlink():
+        for child in delivery_root.iterdir():
+            if child.is_dir() and not child.is_symlink():
+                for record in _iter_private_json(child):
+                    try:
+                        if _read_json_private(record).get("state") != "delivered":
+                            return True
+                    except BridgeError:
+                        return True
+    return False
+
+
+def _safe_rmtree(path: Path, parent: Path) -> None:
+    if not path.exists() and not path.is_symlink():
+        return
+    if path.is_symlink() or not path.is_dir() or path.parent.resolve() != parent.resolve():
+        raise BridgeError("Telegram bridge cleanup path is unsafe")
+    shutil.rmtree(path)
+
+
+def command_uninstall(args: argparse.Namespace) -> int:
+    home = _fm_home(args.fm_home)
+    if not _settings_path(home).exists() and not _settings_path(home).is_symlink():
+        print("Telegram bridge is already uninstalled.")
+        return 0
+    settings = _load_settings(home, require_enabled=False)
+    if _pending_or_unresolved(home) and not args.purge:
+        raise BridgeError("pending or unresolved Telegram records remain; inspect them or pass --purge")
+    settings["enabled"] = False
+    _save_settings(home, settings)
+    _remove_check(home)
+    _run_hermes_plugin_action(settings, "disable")
+    plugin_dir = Path(settings["plugin_dir"])
+    _safe_rmtree(plugin_dir, plugin_dir.parent)
+    for name in (
+        "telegram-inbox", "telegram-context", "telegram-offers", "telegram-deliveries",
+        "telegram-final", "telegram-outbox",
+    ):
+        _safe_rmtree(home / "state" / name, home / "state")
+    _safe_rmtree(home / "config" / "telegram-bridge", home / "config")
+    print("Telegram bridge uninstalled; restart the Hermes gateway once to unload the plugin.")
+    return 0
+
+
+def command_status(args: argparse.Namespace) -> int:
+    home = _fm_home(args.fm_home)
+    try:
+        settings = _load_settings(home, require_enabled=False)
+        secret_ok = bool(_load_secret(settings))
+        plugin_ok = Path(settings["plugin_dir"]).joinpath("plugin.yaml").is_file()
+        check_ok = (home / "state" / "telegram-bridge.check.sh").is_file()
+        enabled = settings.get("enabled") is True
+        pending = len(list(_iter_private_json(home / "state" / "telegram-inbox")))
+        print(f"installed: yes\nenabled: {'yes' if enabled else 'no'}\nplugin: {'ready' if plugin_ok else 'missing'}")
+        print(f"private-auth: {'ready' if secret_ok else 'invalid'}\nwatch-intake: {'ready' if check_ok else 'stopped'}\npending: {pending}")
+        return 0 if plugin_ok and secret_ok else 1
+    except BridgeError:
+        print("installed: no\nenabled: no\nplugin: missing\nprivate-auth: unavailable\nwatch-intake: stopped\npending: 0")
+        return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="fm-telegram-bridge.py")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    ingest = sub.add_parser("ingest")
+    ingest.add_argument("--fm-home")
+    ingest.set_defaults(func=command_ingest)
+
+    poll = sub.add_parser("poll")
+    poll.add_argument("--fm-home")
+    poll.set_defaults(func=command_poll)
+
+    ack = sub.add_parser("ack")
+    ack.add_argument("request_id")
+    ack.add_argument("--fm-home")
+    ack.set_defaults(func=command_ack)
+
+    reply = sub.add_parser("reply")
+    reply.add_argument("request_id")
+    reply.add_argument("text", nargs="?")
+    reply.add_argument("--text-file")
+    reply.add_argument("--stdin", action="store_true")
+    reply.add_argument("--event", default="milestone", choices=["acknowledgement", "milestone", "decision", "failure", "final"])
+    reply.add_argument("--final", action="store_true")
+    reply.add_argument("--fm-home")
+    reply.set_defaults(func=command_reply)
+
+    link = sub.add_parser("link")
+    link.add_argument("task_id")
+    link.add_argument("request_id")
+    link.add_argument("--carry-count", type=int)
+    link.add_argument("--carry-ts", type=int)
+    link.add_argument("--fm-home")
+    link.set_defaults(func=command_link)
+
+    followup = sub.add_parser("followup")
+    followup.add_argument("task_id")
+    followup.add_argument("text", nargs="?")
+    followup.add_argument("--text-file")
+    followup.add_argument("--stdin", action="store_true")
+    followup.add_argument("--check", action="store_true")
+    followup.add_argument("--event", default="milestone", choices=["milestone", "decision", "failure", "final"])
+    followup.add_argument("--final", action="store_true")
+    followup.add_argument("--fm-home")
+    followup.set_defaults(func=command_followup)
+
+    install = sub.add_parser("install")
+    install.add_argument("--enable", action="store_true")
+    install.add_argument("--owner-id", required=True)
+    install.add_argument("--fm-home")
+    install.add_argument("--hermes-home")
+    install.add_argument("--hermes-bin")
+    install.set_defaults(func=command_install)
+
+    start = sub.add_parser("start")
+    start.add_argument("--fm-home")
+    start.set_defaults(func=command_start)
+
+    stop = sub.add_parser("stop")
+    stop.add_argument("--fm-home")
+    stop.set_defaults(func=command_stop)
+
+    configure = sub.add_parser("configure")
+    configure.add_argument("--owner-id", required=True)
+    configure.add_argument("--fm-home")
+    configure.set_defaults(func=command_configure)
+
+    uninstall = sub.add_parser("uninstall")
+    uninstall.add_argument("--purge", action="store_true")
+    uninstall.add_argument("--fm-home")
+    uninstall.set_defaults(func=command_uninstall)
+
+    status_cmd = sub.add_parser("status")
+    status_cmd.add_argument("--fm-home")
+    status_cmd.set_defaults(func=command_status)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if getattr(args, "check", False) and any(
+        [getattr(args, "text", None), getattr(args, "text_file", None), getattr(args, "stdin", False), getattr(args, "final", False)]
+    ):
+        raise BridgeError("--check does not accept reply text or --final", EXIT_USAGE)
+    if getattr(args, "text_file", None) and (getattr(args, "stdin", False) or getattr(args, "text", None) is not None):
+        raise BridgeError("choose exactly one Telegram reply text source", EXIT_USAGE)
+    if getattr(args, "stdin", False) and getattr(args, "text", None) is not None:
+        raise BridgeError("choose exactly one Telegram reply text source", EXIT_USAGE)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except BridgeError as exc:
+        print(f"fm-telegram-bridge: {exc}", file=sys.stderr)
+        raise SystemExit(exc.code)

--- a/bin/fm-telegram-bridge.py
+++ b/bin/fm-telegram-bridge.py
@@ -241,6 +241,11 @@ def _expected_request_id(payload: dict[str, Any], secret: bytes) -> str:
     return "tg-" + hmac.new(secret, b"request-id\0" + _identity_bytes(payload), hashlib.sha256).hexdigest()[:32]
 
 
+def _replay_material(payload: dict[str, Any]) -> bytes:
+    material = {k: v for k, v in payload.items() if k not in ("issued_at", "signature")}
+    return _canonical(material)
+
+
 def _verify_envelope(payload: dict[str, Any], settings: dict[str, Any], secret: bytes) -> tuple[str, str]:
     expected_keys = {
         "version", "issued_at", "request_id", "platform", "user_id", "chat_id",
@@ -360,7 +365,7 @@ def command_ingest(args: argparse.Namespace) -> int:
 
     if context_path.exists() or context_path.is_symlink():
         existing = _verify_context(home, request_id, settings, secret)
-        if not hmac.compare_digest(existing.get("signature", ""), payload["signature"]):
+        if not hmac.compare_digest(_replay_material(existing), _replay_material(payload)):
             raise BridgeError("Telegram request id collided with another context", EXIT_REJECTED)
         print(request_id)
         return EXIT_DUPLICATE

--- a/bin/fm-telegram-bridge.py
+++ b/bin/fm-telegram-bridge.py
@@ -391,14 +391,23 @@ def command_ingest(args: argparse.Namespace) -> int:
         print(request_id)
         return EXIT_DUPLICATE
     try:
-        if not _atomic_write(context_path, _json_bytes(payload), exclusive=True):
-            raise BridgeError("Telegram reply context already exists", EXIT_REJECTED)
+        published = _atomic_write(context_path, _json_bytes(payload), exclusive=True)
     except Exception:
         try:
             inbox_path.unlink()
         except OSError:
             pass
         raise
+    if not published:
+        existing = _verify_context(home, request_id, settings, secret)
+        if not hmac.compare_digest(_replay_material(existing), _replay_material(payload)):
+            try:
+                inbox_path.unlink()
+            except OSError:
+                pass
+            raise BridgeError("Telegram request id collided with another context", EXIT_REJECTED)
+        print(request_id)
+        return EXIT_DUPLICATE
 
     # Make the registered custom check due on the watcher's next ordinary loop.
     last_check = home / "state" / ".last-check"

--- a/bin/fm-telegram-bridge.sh
+++ b/bin/fm-telegram-bridge.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Install, configure, start, stop, inspect, or uninstall the Hermes Telegram bridge.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/fm-telegram-bridge.py" "$@"

--- a/bin/fm-telegram-followup.sh
+++ b/bin/fm-telegram-followup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Check or post a bounded task milestone/final reply to its Telegram origin.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+args=()
+for arg in "$@"; do
+  if [ "$arg" = - ]; then
+    args+=(--stdin)
+  else
+    args+=("$arg")
+  fi
+done
+exec python3 "$SCRIPT_DIR/fm-telegram-bridge.py" followup "${args[@]}" --fm-home "$FM_HOME"

--- a/bin/fm-telegram-ingest.sh
+++ b/bin/fm-telegram-ingest.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Accept one HMAC-signed Hermes Telegram envelope on stdin.
+# Refuses intake unless this Firstmate home has live supervision.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+if ! fm_watcher_healthy "$STATE" "$SCRIPT_DIR/fm-watch.sh" "${FM_TELEGRAM_WATCHER_GRACE:-90}" "$FM_HOME"; then
+  echo "fm-telegram-ingest: Firstmate supervision is offline; request not accepted" >&2
+  exit 4
+fi
+
+exec python3 "$SCRIPT_DIR/fm-telegram-bridge.py" ingest --fm-home "$FM_HOME"

--- a/bin/fm-telegram-link.sh
+++ b/bin/fm-telegram-link.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Link normal Firstmate task metadata to its originating Telegram request.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+exec python3 "$SCRIPT_DIR/fm-telegram-bridge.py" link "$@" --fm-home "$FM_HOME"

--- a/bin/fm-telegram-poll.sh
+++ b/bin/fm-telegram-poll.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Trusted watcher check: emit one compact wake when signed Telegram inbox work exists.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+exec python3 "$SCRIPT_DIR/fm-telegram-bridge.py" poll --fm-home "$FM_HOME"

--- a/bin/fm-telegram-reply.sh
+++ b/bin/fm-telegram-reply.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Send one idempotent, request-correlated private Telegram reply through Hermes.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+args=()
+for arg in "$@"; do
+  if [ "$arg" = - ]; then
+    args+=(--stdin)
+  else
+    args+=("$arg")
+  fi
+done
+exec python3 "$SCRIPT_DIR/fm-telegram-bridge.py" reply "${args[@]}" --fm-home "$FM_HOME"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -140,7 +140,8 @@ family_for_basename() {
     fm-afk-inject-herdr-e2e.test.sh|fm-afk-launch.test.sh|fm-backend-autodetect-smoke.test.sh|\
     fm-backend-herdr-eventwait-smoke.test.sh|fm-backend-herdr-presentation-e2e.test.sh|\
     fm-backend-herdr-prune-safety-e2e.test.sh|fm-backend-herdr-respawn-idem-e2e.test.sh|\
-    fm-backend-herdr-smoke.test.sh|fm-backend-herdr-workspace-per-home-e2e.test.sh)
+    fm-backend-herdr-smoke.test.sh|fm-backend-herdr-workspace-per-home-e2e.test.sh|\
+    fm-telegram-herdr-e2e.test.sh)
       printf '%s\n' real-herdr-gated
       ;;
     fm-backlog-handoff.test.sh|fm-secondmate-harness.test.sh|fm-secondmate-lifecycle-e2e.test.sh|\
@@ -165,7 +166,7 @@ family_for_basename() {
       printf '%s\n' backend-dispatch
       ;;
     fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
-    fm-teardown.test.sh|fm-x-mode.test.sh)
+    fm-teardown.test.sh|fm-x-mode.test.sh|fm-telegram-bridge.test.sh)
       printf '%s\n' pr-forge
       ;;
     fm-afk-inject-e2e.test.sh|fm-afk-return.test.sh)
@@ -663,6 +664,11 @@ families_for_changed_path() {
     bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
     bin/fm-x-*|bin/fm-check*)
       printf '%s\n' pr-forge
+      ;;
+    bin/fm-telegram-*|integrations/hermes/firstmate-telegram/*|docs/telegram-bridge.md|\
+    .agents/skills/telegram-respond/SKILL.md)
+      printf '%s\n' pr-forge
+      printf '%s\n' real-herdr-gated
       ;;
     bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-dispatch-select.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ The tracked code root contains the shared instruction, skill, documentation, wor
 `bin/fm-spawn.sh` owns the base task-metadata fields it emits, while the runtime-backend section below owns backend-specific fields and selector interpretation.
 The producing PR and X helpers own the fields they append, `bin/fm-classify-lib.sh` owns status-event vocabulary, and `bin/fm-crew-state.sh` owns current-state reconciliation.
 Wake, watcher, away-mode, and X-specific state mechanics remain with their named scripts and reference sections rather than being duplicated into one exhaustive state tree here.
+The opt-in Hermes Telegram bridge keeps its gitignored settings and HMAC key under `config/telegram-bridge/` and its private inbox, context, offer, delivery, and final records under `state/telegram-*/`; [`docs/telegram-bridge.md`](telegram-bridge.md) owns their lifecycle and security contract.
 
 `bin/fm-session-start.sh`'s header is the single owner of session-start ordering, composed commands, digest contents, and the digest's startup mechanism.
 `docs/sessionstart-nudge.md` owns the native session-open adapter mechanics that nudge the digest command.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -93,3 +93,11 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-x-dismiss.sh`        | Dismiss a skipped X-mode mention at the relay without replying                       |
 | `fm-x-link.sh`           | Link a spawned task to its originating X-mode mention in task meta                   |
 | `fm-x-followup.sh`       | Detect, post, and cap completion follow-ups for an X-mode-linked task                |
+| `fm-telegram-bridge.sh`  | Install, configure, start, stop, inspect, or uninstall the Hermes Telegram bridge (docs/telegram-bridge.md) |
+| `fm-telegram-bridge.py`  | Semantic owner of the Hermes Telegram bridge: signed intake, correlation, dedupe, idempotent delivery, and lifecycle (docs/telegram-bridge.md) |
+| `fm-telegram-ingest.sh`  | Accept one HMAC-signed Hermes Telegram envelope on stdin, refusing intake without live supervision |
+| `fm-telegram-poll.sh`    | Trusted watcher check: emit one compact wake when signed Telegram inbox work exists  |
+| `fm-telegram-link.sh`    | Link a normal Firstmate task's metadata to its originating Telegram request          |
+| `fm-telegram-reply.sh`   | Send one idempotent, request-correlated private Telegram reply through Hermes        |
+| `fm-telegram-followup.sh`| Check or post a bounded task milestone/final reply to its Telegram origin            |
+| `fm-telegram-ack.sh`     | Mark a correlated Telegram inbox request processed after its reply or link succeeds  |

--- a/docs/telegram-bridge.md
+++ b/docs/telegram-bridge.md
@@ -1,0 +1,95 @@
+# Hermes Telegram bridge
+
+Firstmate includes an opt-in, repo-owned Hermes plugin that turns explicit private Telegram `/firstmate` text or voice commands into normal Firstmate requests.
+Hermes remains the Telegram transport and authorization owner; the bridge never modifies Hermes core, launches Pi, or bypasses Firstmate's ordinary project, worker, validation, merge, and supervision lifecycle.
+
+## Security boundary
+
+The plugin intercepts only `/firstmate <request>` (including a bot username suffix) and spoken `firstmate <request>` or `first mate <request>` after Hermes voice transcription.
+All other messages continue through Hermes unchanged.
+Before intake, the plugin requires both Hermes' current Telegram authorization decision and an exact configured numeric owner ID.
+It then sends a versioned envelope over a local subprocess pipe, authenticated with a private mode-`0600` HMAC key.
+The envelope binds platform, owner, chat, thread, message, timestamp, command kind, normalized text, and a deterministic opaque request ID.
+Firstmate independently verifies the HMAC, owner, shape, two-minute timestamp window, and `/firstmate` boundary before atomically publishing mode-`0600` inbox and reply-context records in mode-`0700` directories.
+Raw Telegram IDs remain only in the private signed context and never enter worker instructions, task metadata, notifications, or logs.
+
+Replay of the same Telegram message resolves to the same request ID and cannot publish or run a second request.
+A registered byte-bound watcher check emits only that opaque ID; Firstmate processes the request through `.agents/skills/telegram-respond/SKILL.md`.
+Intake refuses requests while Firstmate supervision is offline, so Hermes can tell the sender to retry instead of silently losing work.
+
+Replies use `hermes send` with the signed context's numeric chat and optional thread target.
+Each delivery is journaled before sending; identical completed delivery retries are no-ops, while interrupted or failed delivery is marked unresolved and is never retried automatically.
+Replies are split below Telegram limits, capped at ten messages, bounded to three task follow-ups over seven days, and rejected if they contain common credential forms.
+Machine hostnames are replaced with `[local host]`.
+
+Authentication protects the local spool and correlation, but does not make voice transcription authoritative for destructive, irreversible, security-sensitive, merge, or credential actions.
+Those voice requests require confirmation in the primary chat.
+All existing Firstmate approval boundaries continue to apply to text requests.
+
+## Install
+
+Prerequisites:
+
+- Hermes is installed and its Telegram gateway is already configured.
+- The captain's Telegram account is authorized through Hermes pairing or its configured allowlist.
+- Firstmate supervision is active.
+- The numeric Telegram user ID is known; do not use a username.
+
+Install is explicit and inert until `--enable` is supplied:
+
+```bash
+bin/fm-telegram-bridge.sh install \
+  --enable \
+  --owner-id 123456789 \
+  --hermes-home "$HOME/.hermes"
+```
+
+Use `--hermes-bin /absolute/path/to/hermes` when `hermes` is not on `PATH`, and `--fm-home /absolute/path` for another Firstmate home.
+The installer copies only `integrations/hermes/firstmate-telegram/` into that Hermes home's plugin directory, creates private local config and HMAC material, enables the plugin through Hermes' plugin command, and registers the Firstmate watcher check.
+It never reads or changes the Telegram bot token.
+Restart the Hermes gateway once after install or uninstall so Hermes reloads its plugin set.
+Do not restart it merely for `start`, `stop`, status, or owner-preserving reinstall.
+
+Verify without exposing secrets:
+
+```bash
+bin/fm-telegram-bridge.sh status
+```
+
+Then send a private Telegram message such as:
+
+```text
+/firstmate summarize what is currently in flight
+```
+
+A healthy bridge replies `Firstmate accepted your request.` and later returns the correlated result in the same chat and topic.
+Unprefixed text remains ordinary Hermes input.
+Unauthorized senders receive no Firstmate acknowledgement and cannot create spool records.
+
+## Lifecycle commands
+
+```bash
+bin/fm-telegram-bridge.sh stop
+bin/fm-telegram-bridge.sh start
+bin/fm-telegram-bridge.sh configure --owner-id 123456789
+bin/fm-telegram-bridge.sh uninstall
+```
+
+`stop` disables intake and removes its watcher check without deleting private records.
+`start` is idempotent and restores both.
+`configure` refuses an owner change while correlated contexts remain.
+`uninstall` refuses while pending or unresolved records remain; after inspection, `--purge` explicitly authorizes removal.
+Repeated install, start, stop, status, reply, and uninstall calls are safe: completed operations are reused or reported, and ambiguous transport outcomes stop for inspection instead of duplicating messages.
+
+## Operations and recovery
+
+Private state is under `state/telegram-{inbox,context,offers,deliveries,final,outbox}/`; local configuration is under `config/telegram-bridge/`.
+Never copy these files into a task, report, log, or chat.
+A signed context expires after seven days.
+If status reports a missing plugin, invalid private authentication, or stopped intake, run `stop`, inspect ownership and modes without printing contents, then run `start`.
+If a reply reports an unresolved delivery, inspect only its private journal metadata and Telegram delivery externally; do not delete the journal or retry until duplicate risk is resolved.
+Rotate the Telegram bot token only through Hermes' existing setup, then restart Hermes; the bridge stores no bot token and needs no reconfiguration.
+To change captain accounts, finish or explicitly purge existing correlated requests before `configure --owner-id`.
+
+Tests use a fake Hermes transport and never send real Telegram messages.
+The real lifecycle test uses only `bin/fm-herdr-lab.sh` with a generated `fm-lab-*` session and a trapped teardown; it never addresses Herdr's `default` session.

--- a/integrations/hermes/firstmate-telegram/__init__.py
+++ b/integrations/hermes/firstmate-telegram/__init__.py
@@ -1,0 +1,250 @@
+"""Authenticated Hermes Telegram transport for explicit Firstmate commands."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import os
+import re
+import stat
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+VERSION = 1
+CONFIG = Path(__file__).with_name("bridge.json")
+TEXT_COMMAND = re.compile(r"^/firstmate(?:@[A-Za-z0-9_]{3,})?\s+(.+)$", re.I | re.S)
+VOICE_COMMAND = re.compile(r"^(?:/firstmate|first\s*mate|firstmate)\s*[,.:;-]?\s+(.+)$", re.I | re.S)
+ID = re.compile(r"^[1-9][0-9]{0,19}$")
+MESSAGE_ID = re.compile(r"^[1-9][0-9]{0,19}$")
+
+
+def _private(path: Path, limit: int) -> bytes:
+    info = path.lstat()
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise ValueError("unsafe file")
+    if info.st_uid != os.getuid() or info.st_nlink != 1 or stat.S_IMODE(info.st_mode) != 0o600:
+        raise ValueError("unsafe file identity")
+    if info.st_size > limit:
+        raise ValueError("file too large")
+    return path.read_bytes()
+
+
+def _load() -> tuple[dict[str, Any], bytes]:
+    value = json.loads(_private(CONFIG, 32768).decode("utf-8"))
+    required = {"version", "enabled", "owner_id", "secret_file", "ingest_command", "fm_home"}
+    if not isinstance(value, dict) or not required.issubset(value) or value["version"] != VERSION:
+        raise ValueError("invalid config")
+    owner = str(value["owner_id"])
+    if not ID.fullmatch(owner):
+        raise ValueError("invalid owner")
+    secret = _private(Path(str(value["secret_file"])), 256).strip()
+    if not re.fullmatch(rb"[0-9a-f]{64}", secret):
+        raise ValueError("invalid secret")
+    command = Path(str(value["ingest_command"]))
+    if not command.is_absolute() or not command.is_file() or not os.access(command, os.X_OK):
+        raise ValueError("invalid intake")
+    return value, bytes.fromhex(secret.decode("ascii"))
+
+
+def _field(event: Any, name: str, default: Any = None) -> Any:
+    value = getattr(event, name, default)
+    if value is not None:
+        return value
+    raw = getattr(event, "raw_message", None)
+    if isinstance(raw, dict):
+        return raw.get(name, default)
+    return default
+
+
+def _platform(event: Any) -> str:
+    value = _field(getattr(event, "source", None), "platform", "")
+    return str(getattr(value, "value", value)).lower()
+
+
+def _kind(event: Any) -> str:
+    value = _field(event, "message_type", "")
+    return str(getattr(value, "value", value)).lower()
+
+
+def _text_request(text: str) -> str | None:
+    match = TEXT_COMMAND.fullmatch(text.strip())
+    return match.group(1).strip() if match and match.group(1).strip() else None
+
+
+def _voice_request(text: str) -> str | None:
+    match = VOICE_COMMAND.fullmatch(text.strip())
+    return match.group(1).strip() if match and match.group(1).strip() else None
+
+
+def _authorized(gateway: Any, event: Any) -> bool:
+    checker = getattr(gateway, "_is_user_authorized", None)
+    source = getattr(event, "source", None)
+    if not callable(checker) or source is None:
+        return False
+    try:
+        return bool(checker(source))
+    except Exception:
+        return False
+
+
+def _voice_path(event: Any) -> str | None:
+    media_urls = _field(event, "media_urls", [])
+    if isinstance(media_urls, list) and media_urls and isinstance(media_urls[0], str):
+        return media_urls[0]
+    return None
+
+
+def _transcribe(event: Any) -> str | None:
+    existing = _field(event, "text", "")
+    if isinstance(existing, str) and existing.strip():
+        return existing
+    path = _voice_path(event)
+    if not path:
+        return None
+    try:
+        from tools.transcription_tools import transcribe_audio
+        result = transcribe_audio(path)
+        if isinstance(result, dict) and result.get("success") and isinstance(result.get("transcript"), str):
+            return result["transcript"]
+    except Exception:
+        return None
+    return None
+
+
+def _signed(config: dict[str, Any], secret: bytes, event: Any, kind: str, text: str) -> dict[str, Any]:
+    source = getattr(event, "source", None)
+    user_id = str(_field(source, "user_id", ""))
+    chat_id = str(_field(source, "chat_id", ""))
+    message_id = str(_field(event, "message_id", "") or _field(source, "message_id", ""))
+    thread_raw = _field(source, "thread_id", "")
+    thread_id = "" if thread_raw in (None, "") else str(thread_raw)
+    if not ID.fullmatch(user_id) or not re.fullmatch(r"^-?[1-9][0-9]{0,19}$", chat_id):
+        raise ValueError("invalid sender identity")
+    if not MESSAGE_ID.fullmatch(message_id) or (thread_id and not MESSAGE_ID.fullmatch(thread_id)):
+        raise ValueError("invalid message identity")
+    identity = {"platform": "telegram", "chat_id": chat_id, "message_id": message_id, "thread_id": thread_id}
+    request_id = "tg-" + hmac.new(
+        secret,
+        b"request-id\0" + json.dumps(identity, sort_keys=True, separators=(",", ":")).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()[:32]
+    unsigned = {
+        "version": VERSION,
+        "issued_at": int(time.time()),
+        "request_id": request_id,
+        "platform": "telegram",
+        "user_id": user_id,
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "thread_id": thread_id,
+        "kind": kind,
+        "text": f"/firstmate {text}",
+    }
+    unsigned["signature"] = hmac.new(
+        secret,
+        json.dumps(unsigned, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return unsigned
+
+
+async def _notice(gateway: Any, event: Any, text: str) -> None:
+    source = getattr(event, "source", None)
+    adapters = getattr(gateway, "adapters", {})
+    adapter = adapters.get(getattr(source, "platform", None)) if isinstance(adapters, dict) else None
+    sender = getattr(adapter, "send", None)
+    if not callable(sender):
+        return
+    try:
+        await sender(
+            str(source.chat_id),
+            text,
+            reply_to=getattr(event, "message_id", None),
+            metadata={"thread_id": getattr(source, "thread_id", None)},
+        )
+    except Exception:
+        return
+
+
+def _submit(config: dict[str, Any], envelope: dict[str, Any]) -> int:
+    env = os.environ.copy()
+    env["FM_HOME"] = str(config["fm_home"])
+    try:
+        result = subprocess.run(
+            [str(config["ingest_command"])],
+            input=json.dumps(envelope, separators=(",", ":")),
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 4
+    return result.returncode
+
+
+def _schedule(gateway: Any, event: Any, text: str) -> None:
+    try:
+        asyncio.get_running_loop().create_task(_notice(gateway, event, text))
+    except RuntimeError:
+        return
+
+
+def pre_gateway_dispatch(event: Any, gateway: Any, **_kwargs: Any) -> dict[str, Any] | None:
+    """Intercept authenticated Telegram /firstmate text or voice requests."""
+    if _platform(event) != "telegram":
+        return None
+    kind = _kind(event)
+    raw_text = _field(event, "text", "")
+    request = _text_request(raw_text) if isinstance(raw_text, str) else None
+    is_voice = kind in {"voice", "audio"}
+    if request is None and not is_voice:
+        return None
+    try:
+        config, secret = _load()
+    except Exception:
+        _schedule(gateway, event, "Firstmate bridge is unavailable. No request was accepted.")
+        return {"action": "skip", "reason": "firstmate-unavailable"}
+    source = getattr(event, "source", None)
+    user_id = str(_field(source, "user_id", ""))
+    if config.get("enabled") is not True:
+        _schedule(gateway, event, "Firstmate bridge is stopped. No request was accepted.")
+        return {"action": "skip", "reason": "firstmate-stopped"}
+    authorized = hmac.compare_digest(user_id, str(config["owner_id"])) and _authorized(gateway, event)
+    if not authorized:
+        if is_voice:
+            return None
+        return {"action": "skip", "reason": "firstmate-unauthorized"}
+    if is_voice:
+        request = _voice_request(_transcribe(event) or "")
+        kind = "voice"
+        if request is None:
+            return None
+    else:
+        kind = "text"
+    try:
+        envelope = _signed(config, secret, event, kind, request)
+    except Exception:
+        _schedule(gateway, event, "Firstmate could not authenticate this request. Nothing was queued.")
+        return {"action": "skip", "reason": "firstmate-auth-failed"}
+    code = _submit(config, envelope)
+    if code == 0:
+        _schedule(gateway, event, "Firstmate accepted your request.")
+    elif code == 4:
+        _schedule(gateway, event, "Firstmate is offline. No request was accepted; retry when supervision is active.")
+    elif code != 3:
+        _schedule(gateway, event, "Firstmate rejected this request. Nothing was queued.")
+    return {"action": "skip", "reason": "firstmate-handled"}
+
+
+def register(context: Any) -> None:
+    """Register hook for Hermes plugin loaders that use explicit callbacks."""
+    hook = getattr(context, "register_hook", None)
+    if callable(hook):
+        hook("pre_gateway_dispatch", pre_gateway_dispatch)

--- a/integrations/hermes/firstmate-telegram/plugin.yaml
+++ b/integrations/hermes/firstmate-telegram/plugin.yaml
@@ -1,0 +1,7 @@
+name: firstmate-telegram
+version: 1.0.0
+kind: standalone
+description: "Authenticated /firstmate Telegram transport into a local Firstmate primary. Hermes remains transport-only."
+author: Firstmate
+hooks:
+  - pre_gateway_dispatch

--- a/tests/fm-telegram-bridge.test.sh
+++ b/tests/fm-telegram-bridge.test.sh
@@ -247,6 +247,77 @@ set -e
 [ ! -e "$HERMES_HOME_TEST/plugins/firstmate-telegram" ] || fail "plugin remained after uninstall"
 pass "uninstall is guarded and status-safe"
 
+CONC_HOME="$TMP/conc-home"
+mkdir -p "$CONC_HOME/config/telegram-bridge" "$CONC_HOME/state"
+chmod 700 "$CONC_HOME/config/telegram-bridge"
+cp "$HOME1/config/telegram-bridge/secret" "$CONC_HOME/config/telegram-bridge/secret"
+chmod 600 "$CONC_HOME/config/telegram-bridge/secret"
+cat >"$CONC_HOME/config/telegram-bridge/settings.json" <<EOF
+{"version":1,"enabled":true,"owner_id":"12345","secret_file":"$CONC_HOME/config/telegram-bridge/secret","hermes_home":"$TMP/hermes","hermes_bin":"$FAKEBIN/hermes","plugin_dir":"$TMP/hermes/plugins/firstmate-telegram","fm_home":"$CONC_HOME","fm_root":"$ROOT","reply_max_chars":256}
+EOF
+chmod 600 "$CONC_HOME/config/telegram-bridge/settings.json"
+RACE_REQUEST=$(make_envelope 106 '/firstmate race the inbox')
+NATURAL_REQUEST=$(make_envelope 107 '/firstmate natural race')
+python3 - "$BRIDGE" "$CONC_HOME" "$RACE_REQUEST" "$NATURAL_REQUEST" <<'PY' || fail "concurrent duplicate intake regressed"
+import importlib.util, io, json, sys, types
+from contextlib import redirect_stdout
+from pathlib import Path
+
+bridge_path, home, race_raw, natural_raw = sys.argv[1:5]
+spec = importlib.util.spec_from_file_location("fmt_bridge_conc", bridge_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+inbox_dir = Path(home) / "state" / "telegram-inbox"
+context_dir = Path(home) / "state" / "telegram-context"
+
+def run_ingest(raw):
+    args = types.SimpleNamespace(fm_home=home)
+    old_stdin = sys.stdin
+    sys.stdin = types.SimpleNamespace(buffer=io.BytesIO(raw.encode()))
+    buf = io.StringIO()
+    try:
+        with redirect_stdout(buf):
+            code = mod.command_ingest(args)
+    except mod.BridgeError as exc:
+        code = exc.code
+    finally:
+        sys.stdin = old_stdin
+    return code, buf.getvalue().strip()
+
+def count(directory):
+    return len(list(directory.glob("*.json"))) if directory.exists() else 0
+
+# Force the reported losing interleaving: caller A wins the inbox write, then a
+# concurrent duplicate publishes the identical verified context a hair before
+# A's own exclusive context link, so A's link reports the context already exists.
+real_atomic_write = mod._atomic_write
+raced = {"fired": False}
+def racing_atomic_write(path, data, *, exclusive=False):
+    if exclusive and path.parent.name == "telegram-context" and not raced["fired"]:
+        raced["fired"] = True
+        assert real_atomic_write(path, data, exclusive=True) is True
+        return False
+    return real_atomic_write(path, data, exclusive=exclusive)
+
+mod._atomic_write = racing_atomic_write
+code, rid = run_ingest(race_raw)
+mod._atomic_write = real_atomic_write
+
+assert raced["fired"], "concurrency injection never triggered"
+assert code == mod.EXIT_DUPLICATE, f"racing caller must resolve as duplicate, got {code}"
+assert count(inbox_dir) == 1 and count(context_dir) == 1, "race did not leave exactly one inbox and one context"
+assert json.loads((inbox_dir / f"{rid}.json").read_text())["request_id"] == rid, "valid inbox correlation was deleted by the loser"
+
+# Two identical signed ingests still resolve as one accepted plus one duplicate.
+c1, o1 = run_ingest(natural_raw)
+c2, o2 = run_ingest(natural_raw)
+assert {c1, c2} == {0, mod.EXIT_DUPLICATE}, f"identical ingests must be one accept + one duplicate, got {c1} and {c2}"
+assert o1 == o2, "identical ingests returned different correlation ids"
+assert count(inbox_dir) == 2 and count(context_dir) == 2, "natural duplicate created a second inbox or context"
+PY
+pass "concurrent duplicate intake keeps exactly one inbox and one context"
+
 ! grep -R -F "$(cat "$HOME1/config/telegram-bridge/secret")" "$TMP" --exclude=secret --exclude=settings.json --exclude=bridge.json >/dev/null 2>&1 \
   || fail "bridge secret leaked outside private config"
 pass "diagnostics and fake transport logs contain no bridge secret"

--- a/tests/fm-telegram-bridge.test.sh
+++ b/tests/fm-telegram-bridge.test.sh
@@ -66,6 +66,26 @@ set -e
 [ "$(find "$HOME1/state/telegram-inbox" -type f | wc -l | tr -d ' ')" = 1 ] || fail "replay duplicated inbox work"
 pass "same Telegram message is replay-safe"
 
+RESIGNED=$(python3 - "$HOME1/config/telegram-bridge/secret" "$REQUEST" <<'PY'
+import hashlib,hmac,json,sys
+secret=bytes.fromhex(open(sys.argv[1],encoding="ascii").read().strip())
+value=json.loads(sys.argv[2])
+value["issued_at"]=int(value["issued_at"])+30
+unsigned={k:v for k,v in value.items() if k!="signature"}
+value["signature"]=hmac.new(secret,json.dumps(unsigned,sort_keys=True,separators=(",",":"),ensure_ascii=False).encode(),hashlib.sha256).hexdigest()
+print(json.dumps(value,separators=(",",":")))
+PY
+)
+[ "$RESIGNED" != "$REQUEST" ] || fail "re-signed envelope was byte-identical to the original"
+set +e
+RESIGNED_OUT=$(printf '%s' "$RESIGNED" | python3 "$BRIDGE" ingest --fm-home "$HOME1")
+RC=$?
+set -e
+[ "$RC" = 3 ] || fail "re-signed replay should return duplicate exit 3, got $RC"
+[ "$RESIGNED_OUT" = "$RID" ] || fail "re-signed replay returned an unexpected correlation id"
+[ "$(find "$HOME1/state/telegram-inbox" -type f | wc -l | tr -d ' ')" = 1 ] || fail "re-signed replay duplicated inbox work"
+pass "same Telegram message re-signed with a later timestamp is replay-safe"
+
 forged=$(printf '%s' "$REQUEST" | python3 -c 'import json,sys; v=json.load(sys.stdin); v["text"]="/firstmate forged"; print(json.dumps(v))')
 set +e
 printf '%s' "$forged" | python3 "$BRIDGE" ingest --fm-home "$HOME1" >/dev/null 2>"$TMP/forged.err"

--- a/tests/fm-telegram-bridge.test.sh
+++ b/tests/fm-telegram-bridge.test.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Focused fake-transport tests for authenticated Hermes Telegram intake/replies.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BRIDGE="$ROOT/bin/fm-telegram-bridge.py"
+TMP=$(fm_test_tmproot fm-telegram)
+HOME1="$TMP/home"
+FAKEBIN=$(fm_fakebin "$TMP")
+LOG="$TMP/hermes.log"
+mkdir -p "$HOME1/config/telegram-bridge" "$HOME1/state"
+chmod 700 "$HOME1/config/telegram-bridge"
+printf '%064d\n' 7 >"$HOME1/config/telegram-bridge/secret"
+chmod 600 "$HOME1/config/telegram-bridge/secret"
+
+cat >"$FAKEBIN/hermes" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = plugins ]; then
+  printf 'PLUGIN %s %s\n' "${2:-}" "${3:-}" >>"$FAKE_HERMES_LOG"
+  exit 0
+fi
+[ "${1:-}" = send ] || exit 2
+printf 'SEND %s\n' "$*" >>"$FAKE_HERMES_LOG"
+cat >>"$FAKE_HERMES_LOG"
+printf '\nEND\n' >>"$FAKE_HERMES_LOG"
+[ ! -e "${FAKE_HERMES_FAIL_FILE:-/nonexistent}" ]
+SH
+chmod +x "$FAKEBIN/hermes"
+export FAKE_HERMES_LOG="$LOG"
+
+cat >"$HOME1/config/telegram-bridge/settings.json" <<EOF
+{"version":1,"enabled":true,"owner_id":"12345","secret_file":"$HOME1/config/telegram-bridge/secret","hermes_home":"$TMP/hermes","hermes_bin":"$FAKEBIN/hermes","plugin_dir":"$TMP/hermes/plugins/firstmate-telegram","fm_home":"$HOME1","fm_root":"$ROOT","reply_max_chars":256}
+EOF
+chmod 600 "$HOME1/config/telegram-bridge/settings.json"
+
+make_envelope() { # message-id text [owner] [kind]
+  python3 - "$HOME1/config/telegram-bridge/secret" "$1" "$2" "${3:-12345}" "${4:-text}" <<'PY'
+import hashlib,hmac,json,sys,time
+secret=bytes.fromhex(open(sys.argv[1],encoding="ascii").read().strip())
+message,text,owner,kind=sys.argv[2:]
+identity={"platform":"telegram","chat_id":"-9988","message_id":message,"thread_id":"77"}
+request_id="tg-"+hmac.new(secret,b"request-id\0"+json.dumps(identity,sort_keys=True,separators=(",",":")).encode(),hashlib.sha256).hexdigest()[:32]
+value={"version":1,"issued_at":int(time.time()),"request_id":request_id,"platform":"telegram","user_id":owner,"chat_id":"-9988","message_id":message,"thread_id":"77","kind":kind,"text":text}
+value["signature"]=hmac.new(secret,json.dumps(value,sort_keys=True,separators=(",",":"),ensure_ascii=False).encode(),hashlib.sha256).hexdigest()
+print(json.dumps(value,separators=(",",":")))
+PY
+}
+
+REQUEST=$(make_envelope 101 '/firstmate inspect the queue')
+RID=$(printf '%s' "$REQUEST" | python3 -c 'import json,sys; print(json.load(sys.stdin)["request_id"])')
+OUT=$(printf '%s' "$REQUEST" | python3 "$BRIDGE" ingest --fm-home "$HOME1") || fail "valid signed request was rejected"
+[ "$OUT" = "$RID" ] || fail "accepted request did not return opaque correlation id"
+[ "$(stat -c %a "$HOME1/state/telegram-inbox/$RID.json")" = 600 ] || fail "inbox record is not private"
+[ "$(stat -c %a "$HOME1/state/telegram-context/$RID.json")" = 600 ] || fail "context record is not private"
+! grep -R -F -- '-9988' "$HOME1/state/telegram-inbox" >/dev/null || fail "raw chat id leaked into worker-facing inbox"
+pass "signed owner-bound request publishes private opaque inbox and context"
+
+set +e
+printf '%s' "$REQUEST" | python3 "$BRIDGE" ingest --fm-home "$HOME1" >"$TMP/replay.out" 2>"$TMP/replay.err"
+RC=$?
+set -e
+[ "$RC" = 3 ] || fail "replay should return duplicate exit 3, got $RC"
+[ "$(find "$HOME1/state/telegram-inbox" -type f | wc -l | tr -d ' ')" = 1 ] || fail "replay duplicated inbox work"
+pass "same Telegram message is replay-safe"
+
+forged=$(printf '%s' "$REQUEST" | python3 -c 'import json,sys; v=json.load(sys.stdin); v["text"]="/firstmate forged"; print(json.dumps(v))')
+set +e
+printf '%s' "$forged" | python3 "$BRIDGE" ingest --fm-home "$HOME1" >/dev/null 2>"$TMP/forged.err"
+RC=$?
+set -e
+[ "$RC" = 5 ] || fail "forged HMAC was not rejected"
+unauthorized=$(make_envelope 102 '/firstmate forbidden' 22222)
+set +e
+printf '%s' "$unauthorized" | python3 "$BRIDGE" ingest --fm-home "$HOME1" >/dev/null 2>"$TMP/owner.err"
+RC=$?
+set -e
+[ "$RC" = 5 ] || fail "wrong owner was not rejected"
+unprefixed=$(make_envelope 103 'ordinary Hermes prompt')
+set +e
+printf '%s' "$unprefixed" | python3 "$BRIDGE" ingest --fm-home "$HOME1" >/dev/null 2>"$TMP/prefix.err"
+RC=$?
+set -e
+[ "$RC" = 5 ] || fail "unprefixed signed text crossed the command boundary"
+pass "forged, wrong-owner, and unprefixed requests fail closed"
+
+POLL1=$(python3 "$BRIDGE" poll --fm-home "$HOME1") || fail "poll failed"
+[ "$POLL1" = "telegram-request $RID" ] || fail "poll emitted unexpected notification: $POLL1"
+POLL2=$(python3 "$BRIDGE" poll --fm-home "$HOME1") || fail "second poll failed"
+[ -z "$POLL2" ] || fail "poll offered the same request twice"
+pass "watch intake offers each durable request once"
+
+python3 "$BRIDGE" reply "$RID" 'Acknowledged safely.' --event acknowledgement --fm-home "$HOME1" >/dev/null || fail "reply failed"
+SEND_COUNT=$(grep -c '^SEND ' "$LOG")
+python3 "$BRIDGE" reply "$RID" 'Acknowledged safely.' --event acknowledgement --fm-home "$HOME1" >/dev/null || fail "idempotent reply retry failed"
+[ "$(grep -c '^SEND ' "$LOG")" = "$SEND_COUNT" ] || fail "completed reply was sent twice"
+grep -Fq -- '--to telegram:-9988:77 --file -' "$LOG" || fail "reply did not use correlated private chat/thread target"
+pass "correlated Hermes reply is delivered once"
+
+set +e
+python3 "$BRIDGE" reply "$RID" 'api_key=abcdefghijk' --fm-home "$HOME1" >"$TMP/secret.out" 2>"$TMP/secret.err"
+RC=$?
+set -e
+[ "$RC" = 5 ] || fail "credential-shaped reply was not rejected"
+! grep -Fq 'abcdefghijk' "$TMP/secret.err" || fail "rejected credential leaked into diagnostics"
+pass "credential-shaped outbound content is rejected without echo"
+
+LONG=$(python3 -c 'print("word "*180)')
+python3 "$BRIDGE" reply "$RID" "$LONG" --event milestone --fm-home "$HOME1" >/dev/null || fail "split reply failed"
+CHUNKS=$(( $(grep -c '^SEND ' "$LOG") - SEND_COUNT ))
+[ "$CHUNKS" -ge 2 ] && [ "$CHUNKS" -le 10 ] || fail "long reply split count is unsafe: $CHUNKS"
+pass "long replies split within bounded Telegram delivery count"
+
+FAIL_REQUEST=$(make_envelope 104 '/firstmate fail safely')
+FAIL_RID=$(printf '%s' "$FAIL_REQUEST" | python3 -c 'import json,sys; print(json.load(sys.stdin)["request_id"])')
+printf '%s' "$FAIL_REQUEST" | python3 "$BRIDGE" ingest --fm-home "$HOME1" >/dev/null || fail "failure fixture intake failed"
+FAIL_FLAG="$TMP/fail-send"
+touch "$FAIL_FLAG"
+export FAKE_HERMES_FAIL_FILE="$FAIL_FLAG"
+set +e
+python3 "$BRIDGE" reply "$FAIL_RID" 'One attempt only.' --fm-home "$HOME1" >/dev/null 2>"$TMP/send-fail.err"
+RC1=$?
+rm -f "$FAIL_FLAG"
+BEFORE=$(grep -c '^SEND ' "$LOG")
+python3 "$BRIDGE" reply "$FAIL_RID" 'One attempt only.' --fm-home "$HOME1" >/dev/null 2>"$TMP/retry.err"
+RC2=$?
+set -e
+[ "$RC1" = 6 ] && [ "$RC2" = 6 ] || fail "ambiguous delivery did not remain unresolved"
+[ "$(grep -c '^SEND ' "$LOG")" = "$BEFORE" ] || fail "unresolved delivery was retried automatically"
+pass "failed delivery refuses duplicate-risk retry"
+
+cat >"$HOME1/state/task.meta" <<'EOF'
+window=fm-task
+worktree=/tmp/example
+project=example
+harness=pi
+kind=ship
+mode=direct-pr
+yolo=0
+EOF
+python3 "$BRIDGE" link task "$RID" --fm-home "$HOME1" >/dev/null || fail "task correlation failed"
+python3 "$BRIDGE" followup task 'Finished.' --event final --final --fm-home "$HOME1" >/dev/null || fail "final follow-up failed"
+! grep -q '^telegram_request=' "$HOME1/state/task.meta" || fail "final follow-up did not clear task correlation"
+python3 "$BRIDGE" ack "$RID" --fm-home "$HOME1" >/dev/null || fail "inbox acknowledgement failed"
+[ ! -e "$HOME1/state/telegram-inbox/$RID.json" ] || fail "acknowledged inbox remained"
+pass "task link, terminal follow-up, and inbox acknowledgement complete lifecycle"
+
+SYMLINK_REQUEST=$(make_envelope 105 '/firstmate symlink attack')
+SYMLINK_RID=$(printf '%s' "$SYMLINK_REQUEST" | python3 -c 'import json,sys; print(json.load(sys.stdin)["request_id"])')
+printf x >"$TMP/victim"
+ln -s "$TMP/victim" "$HOME1/state/telegram-inbox/$SYMLINK_RID.json"
+set +e
+printf '%s' "$SYMLINK_REQUEST" | python3 "$BRIDGE" ingest --fm-home "$HOME1" >/dev/null 2>"$TMP/symlink.err"
+RC=$?
+set -e
+[ "$RC" != 0 ] || fail "symlink destination was accepted"
+[ "$(cat "$TMP/victim")" = x ] || fail "symlink target was modified"
+pass "private spool refuses symlink destinations"
+
+mkdir -p "$TMP/offline/state"
+touch -d '10 minutes ago' "$TMP/offline/state/.last-watcher-beat"
+set +e
+FM_HOME="$TMP/offline" "$ROOT/bin/fm-telegram-ingest.sh" </dev/null >"$TMP/offline.out" 2>"$TMP/offline.err"
+RC=$?
+set -e
+[ "$RC" = 4 ] || fail "offline intake did not return retryable exit 4"
+[ ! -s "$TMP/offline.out" ] || fail "offline intake printed payload data"
+pass "offline Firstmate refuses intake before reading a request"
+
+INSTALL_HOME="$TMP/install-home"
+HERMES_HOME_TEST="$TMP/hermes-home"
+mkdir -p "$INSTALL_HOME/state" "$INSTALL_HOME/config" "$HERMES_HOME_TEST"
+FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" install --enable --owner-id 12345 --hermes-home "$HERMES_HOME_TEST" --hermes-bin "$FAKEBIN/hermes" >/dev/null || fail "installer failed"
+FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" install --enable --owner-id 12345 --hermes-home "$HERMES_HOME_TEST" --hermes-bin "$FAKEBIN/hermes" >/dev/null || fail "idempotent reinstall failed"
+STATUS=$(FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" status) || fail "installed status failed"
+assert_contains "$STATUS" 'enabled: yes' "status did not report enabled"
+[ "$(stat -c %a "$INSTALL_HOME/config/telegram-bridge/secret")" = 600 ] || fail "installer secret mode is not 0600"
+[ -f "$INSTALL_HOME/state/telegram-bridge.check-trust" ] || fail "watcher check was not trust-registered"
+FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" stop >/dev/null || fail "stop failed"
+FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" stop >/dev/null || fail "idempotent stop failed"
+FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" start >/dev/null || fail "start failed"
+pass "install, status, stop, and start are idempotent"
+
+python3 - "$HERMES_HOME_TEST/plugins/firstmate-telegram/__init__.py" <<'PY'
+import importlib.util,sys
+path=sys.argv[1]
+spec=importlib.util.spec_from_file_location("fmt_plugin",path)
+mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+seen=[]; mod._submit=lambda config,envelope: seen.append(envelope) or 0
+class Source:
+    platform="telegram"; chat_id="-9988"; thread_id="77"
+    def __init__(self,user): self.user_id=user
+class Event:
+    def __init__(self,user,text,mid,kind="text"):
+        self.source=Source(user); self.text=text; self.message_id=mid; self.message_type=kind; self.media_urls=[]
+class Gateway:
+    adapters={}
+    def _is_user_authorized(self,source): return source.user_id=="12345"
+g=Gateway()
+assert mod.pre_gateway_dispatch(Event("12345","ordinary Hermes message","201"),g) is None
+assert seen==[]
+assert mod.pre_gateway_dispatch(Event("22222","/firstmate forbidden","202"),g)["action"]=="skip"
+assert seen==[]
+assert mod.pre_gateway_dispatch(Event("12345","/firstmate status","203"),g)["action"]=="skip"
+assert len(seen)==1 and seen[0]["kind"]=="text" and seen[0]["text"]=="/firstmate status"
+mod._transcribe=lambda event: "First mate, inspect queue"
+assert mod.pre_gateway_dispatch(Event("12345","","204","voice"),g,session_store=object())["action"]=="skip"
+assert len(seen)==2 and seen[1]["kind"]=="voice" and seen[1]["text"]=="/firstmate inspect queue"
+assert mod.pre_gateway_dispatch(Event("22222","","205","voice"),g) is None
+class Context:
+    callback=None
+    def register_hook(self,name,callback):
+        assert name=="pre_gateway_dispatch"; self.callback=callback
+ctx=Context(); mod.register(ctx); assert ctx.callback is mod.pre_gateway_dispatch
+PY
+[ "$?" = 0 ] || fail "Hermes hook command/auth/voice contract failed"
+pass "Hermes hook gates prefix and authorization and normalizes voice"
+
+FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" uninstall >/dev/null || fail "uninstall failed"
+FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" uninstall >/dev/null || fail "idempotent uninstall failed"
+set +e
+FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" status >"$TMP/uninstalled.status"
+RC=$?
+set -e
+[ "$RC" = 1 ] || fail "uninstalled status should be nonzero"
+[ ! -e "$HERMES_HOME_TEST/plugins/firstmate-telegram" ] || fail "plugin remained after uninstall"
+pass "uninstall is guarded and status-safe"
+
+! grep -R -F "$(cat "$HOME1/config/telegram-bridge/secret")" "$TMP" --exclude=secret --exclude=settings.json --exclude=bridge.json >/dev/null 2>&1 \
+  || fail "bridge secret leaked outside private config"
+pass "diagnostics and fake transport logs contain no bridge secret"

--- a/tests/fm-telegram-bridge.test.sh
+++ b/tests/fm-telegram-bridge.test.sh
@@ -203,7 +203,7 @@ FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" stop >/dev/null || fai
 FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" start >/dev/null || fail "start failed"
 pass "install, status, stop, and start are idempotent"
 
-python3 - "$HERMES_HOME_TEST/plugins/firstmate-telegram/__init__.py" <<'PY'
+python3 - "$HERMES_HOME_TEST/plugins/firstmate-telegram/__init__.py" <<'PY' || fail "Hermes hook command/auth/voice contract failed"
 import importlib.util,sys
 path=sys.argv[1]
 spec=importlib.util.spec_from_file_location("fmt_plugin",path)
@@ -235,7 +235,6 @@ class Context:
         assert name=="pre_gateway_dispatch"; self.callback=callback
 ctx=Context(); mod.register(ctx); assert ctx.callback is mod.pre_gateway_dispatch
 PY
-[ "$?" = 0 ] || fail "Hermes hook command/auth/voice contract failed"
 pass "Hermes hook gates prefix and authorization and normalizes voice"
 
 FM_HOME="$INSTALL_HOME" "$ROOT/bin/fm-telegram-bridge.sh" uninstall >/dev/null || fail "uninstall failed"

--- a/tests/fm-telegram-herdr-e2e.test.sh
+++ b/tests/fm-telegram-herdr-e2e.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Real lifecycle smoke for Telegram intake -> Herdr task -> correlated final reply.
+# Every direct Herdr operation uses fm-herdr-lab.sh and a generated non-default session.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found"; exit 0; }
+HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+[ -x "$HERDR_LAB_HELPER" ] || { echo "skip: Herdr lab helper not executable"; exit 0; }
+
+TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-telegram-herdr.XXXXXX")
+HERDR_LAB_SESSION=$(
+  "$HERDR_LAB_HELPER" name fm-telegram-bridge-e2e
+) || { rm -rf "$TMP_ROOT"; fail "could not name isolated Herdr lab"; }
+case "$HERDR_LAB_SESSION" in
+  fm-lab-*) ;;
+  *) rm -rf "$TMP_ROOT"; fail "lab helper returned unsafe session name" ;;
+esac
+[ "$HERDR_LAB_SESSION" != default ] || { rm -rf "$TMP_ROOT"; fail "lab helper selected default session"; }
+export HERDR_SESSION="$HERDR_LAB_SESSION"
+LAB_READY=0
+WT=
+cleanup_all() {
+  local status=0
+  if [ -n "$WT" ] && [ -d "$WT" ]; then
+    treehouse return --force "$WT" >/dev/null 2>&1 || true
+  fi
+  if [ "$LAB_READY" -eq 1 ]; then
+    "$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION" >/dev/null 2>&1 || status=$?
+  fi
+  rm -rf "$TMP_ROOT"
+  return "$status"
+}
+on_exit() {
+  local status=$?
+  cleanup_all || status=$?
+  trap - EXIT
+  exit "$status"
+}
+trap on_exit EXIT
+"$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" || fail "could not provision isolated Herdr lab"
+LAB_READY=1
+
+STATE="$TMP_ROOT/state"
+DATA="$TMP_ROOT/data"
+CONFIG="$TMP_ROOT/config"
+mkdir -p "$STATE" "$DATA/tgwork" "$CONFIG/telegram-bridge"
+chmod 700 "$CONFIG/telegram-bridge"
+printf 'herdr\n' >"$CONFIG/backend"
+printf 'lifecycle smoke only\n' >"$DATA/tgwork/brief.md"
+printf '%064d\n' 9 >"$CONFIG/telegram-bridge/secret"
+chmod 600 "$CONFIG/telegram-bridge/secret"
+
+FAKE_HERMES="$TMP_ROOT/hermes"
+SEND_LOG="$TMP_ROOT/send.log"
+cat >"$FAKE_HERMES" <<'SH'
+#!/usr/bin/env bash
+[ "${1:-}" = send ] || exit 2
+printf '%s\n' "$*" >>"$SEND_LOG"
+cat >>"$SEND_LOG"
+SH
+chmod +x "$FAKE_HERMES"
+export SEND_LOG
+cat >"$CONFIG/telegram-bridge/settings.json" <<EOF
+{"version":1,"enabled":true,"owner_id":"12345","secret_file":"$CONFIG/telegram-bridge/secret","hermes_home":"$TMP_ROOT/hermes-home","hermes_bin":"$FAKE_HERMES","plugin_dir":"$TMP_ROOT/plugin","fm_home":"$TMP_ROOT","fm_root":"$ROOT","reply_max_chars":3800}
+EOF
+chmod 600 "$CONFIG/telegram-bridge/settings.json"
+
+PROJECT="$TMP_ROOT/project"
+mkdir -p "$PROJECT"
+git -C "$PROJECT" init -q
+git -C "$PROJECT" config user.name 'Firstmate Tests'
+git -C "$PROJECT" config user.email tests@example.invalid
+printf '# telegram lifecycle fixture\n' >"$PROJECT/README.md"
+git -C "$PROJECT" add README.md
+git -C "$PROJECT" commit -qm initial
+
+ENVELOPE=$(python3 - "$CONFIG/telegram-bridge/secret" <<'PY'
+import hashlib,hmac,json,sys,time
+secret=bytes.fromhex(open(sys.argv[1],encoding="ascii").read().strip())
+identity={"platform":"telegram","chat_id":"-12345","message_id":"501","thread_id":""}
+rid="tg-"+hmac.new(secret,b"request-id\0"+json.dumps(identity,sort_keys=True,separators=(",",":")).encode(),hashlib.sha256).hexdigest()[:32]
+v={"version":1,"issued_at":int(time.time()),"request_id":rid,"platform":"telegram","user_id":"12345","chat_id":"-12345","message_id":"501","thread_id":"","kind":"text","text":"/firstmate run lifecycle smoke"}
+v["signature"]=hmac.new(secret,json.dumps(v,sort_keys=True,separators=(",",":")).encode(),hashlib.sha256).hexdigest()
+print(json.dumps(v,separators=(",",":")))
+PY
+) || fail "could not build signed lifecycle fixture"
+RID=$(printf '%s' "$ENVELOPE" | python3 -c 'import json,sys; print(json.load(sys.stdin)["request_id"])')
+printf '%s' "$ENVELOPE" | FM_HOME="$TMP_ROOT" python3 "$ROOT/bin/fm-telegram-bridge.py" ingest >/dev/null \
+  || fail "signed Telegram lifecycle intake failed"
+NOTICE=$(FM_HOME="$TMP_ROOT" "$ROOT/bin/fm-telegram-poll.sh") || fail "Telegram watcher check failed"
+[ "$NOTICE" = "telegram-request $RID" ] || fail "watcher check did not surface opaque request id"
+pass "real lifecycle: authenticated Telegram request reached Firstmate watcher intake"
+
+OUT="$TMP_ROOT/spawn.out"
+ERR="$TMP_ROOT/spawn.err"
+env -u TMUX HERDR_ENV=1 FM_BACKEND=herdr FM_HOME="$TMP_ROOT" \
+  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+  FM_CONFIG_OVERRIDE="$CONFIG" FM_PROJECTS_OVERRIDE="$TMP_ROOT/projects" \
+  FM_SPAWN_NO_GUARD=1 \
+  "$ROOT/bin/fm-spawn.sh" tgwork "$PROJECT" "sh -c 'echo telegram-herdr-lifecycle-ok; sleep 3'" \
+  >"$OUT" 2>"$ERR" || fail "normal Firstmate spawn failed in isolated Herdr lab: $(cat "$ERR")"
+META="$STATE/tgwork.meta"
+[ -f "$META" ] || fail "spawn did not create task metadata"
+grep -Fq "backend=herdr" "$META" || fail "spawn did not use Herdr"
+grep -Fq "herdr_session=$HERDR_LAB_SESSION" "$META" || fail "spawn escaped named lab session"
+PANE=$(grep '^herdr_pane_id=' "$META" | cut -d= -f2-)
+WT=$(grep '^worktree=' "$META" | cut -d= -f2-)
+[ -n "$PANE" ] && [ -n "$WT" ] || fail "spawn lacked pane or isolated copy"
+sleep 1
+CAPTURED=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane read "$PANE" --source recent --lines 80) \
+  || fail "lab helper could not inspect spawned task"
+case "$CAPTURED" in
+  *telegram-herdr-lifecycle-ok*) ;;
+  *) fail "spawned task did not run in named Herdr lab" ;;
+esac
+pass "real lifecycle: normal Firstmate task ran only in generated Herdr lab session"
+
+FM_HOME="$TMP_ROOT" "$ROOT/bin/fm-telegram-link.sh" tgwork "$RID" >/dev/null || fail "task correlation failed"
+printf 'Lifecycle validation completed in isolated session.\n' | FM_HOME="$TMP_ROOT" \
+  "$ROOT/bin/fm-telegram-followup.sh" tgwork --event final --final - >/dev/null \
+  || fail "correlated final Telegram delivery failed"
+FM_HOME="$TMP_ROOT" "$ROOT/bin/fm-telegram-ack.sh" "$RID" >/dev/null || fail "request acknowledgement failed"
+grep -Fq -- '--to telegram:-12345 --file -' "$SEND_LOG" || fail "final reply missed signed Telegram target"
+! grep -q '^telegram_request=' "$META" || fail "final reply did not clear Telegram task link"
+pass "real lifecycle: task result returned once to correlated Telegram chat"
+
+FM_HOME="$TMP_ROOT" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$STATE" \
+  FM_DATA_OVERRIDE="$DATA" FM_CONFIG_OVERRIDE="$CONFIG" \
+  "$ROOT/bin/fm-teardown.sh" tgwork >"$TMP_ROOT/teardown.out" 2>&1 \
+  || fail "normal task cleanup failed: $(cat "$TMP_ROOT/teardown.out")"
+WT=
+[ ! -e "$META" ] || fail "task metadata remained after cleanup"
+"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION" >/dev/null \
+  || fail "guarded lab teardown or default-session tripwire failed"
+LAB_READY=0
+pass "real lifecycle: guarded helper teardown preserved default Herdr session"


### PR DESCRIPTION
## Intent

Implement, test, document, and commit a secure repo-owned Hermes Telegram-to-Firstmate bridge using explicit /firstmate text and voice commands, authenticated private intake, durable correlation and deduplication, normal Firstmate wake, spawn, and follow-up lifecycle, safe Telegram replies, idempotent lifecycle commands, and real lifecycle validation exclusively through the named-session fm-herdr-lab.sh helper without touching Herdr's default session. Push and open a PR, but do not merge.

## What Changed

- Add a repo-owned Hermes Telegram bridge (`bin/fm-telegram-bridge.py` plus `fm-telegram-*` wrapper scripts and the `integrations/hermes/firstmate-telegram` plugin) that authenticates private `/firstmate` text and voice intake, enforces the command boundary and a 120s timestamp window, durably records inbox/context state under `telegram-inbox`/`telegram-outbox`, and drives the normal Firstmate wake/spawn/follow-up lifecycle with idempotent lifecycle commands and credential-shaped reply guarding.
- Harden concurrent intake so a benign duplicate `ingest` of the same signed `request_id` no longer unlinks the inbox record when the reply context already exists, preventing silent loss of an authenticated request; also fix dedup to allow re-signed replays and resolve the SC2181 lint in the test.
- Add contract tests (`tests/fm-telegram-bridge.test.sh`) and a named-session Herdr end-to-end test (`tests/fm-telegram-herdr-e2e.test.sh`), plus the `telegram-respond` skill and docs (`docs/telegram-bridge.md`, scripts/configuration references, README index, and the AGENTS.md state inventory).

## Risk Assessment

✅ Low: The only change since the prior review is a surgical, well-targeted fix for the previously-flagged concurrent-duplicate intake race, backed by a deterministic regression test that proves exactly one inbox and one context survive; no new issues were introduced and the rest of the additive, opt-in subsystem is unchanged.

## Testing

Ran both bridge test suites and a manual end-user demonstration. The focused fake-transport suite (17 checks covering authenticated intake, dedup, fail-closed rejection, idempotent replies/lifecycle, and secret non-leakage) and the real Herdr lifecycle e2e (intake→normal spawn in a generated fm-lab-* session→correlated single final reply→guarded teardown that preserved the default session) both pass against real herdr/treehouse binaries. I additionally captured a reviewer-visible CLI transcript exercising the real bridge code that shows the actual Telegram chat experience: an authorized captain's /firstmate command returns "Firstmate accepted your request." and a correlated final result to the same chat/topic, while unauthorized and credential-shaped traffic fail closed with nothing delivered. No screenshot applies — this is a Telegram-transport/CLI feature with no rendered UI surface, so the delivered-message transcript is the end-user artifact. Working tree left clean with no leaked sessions or state.

<details>
<summary>Evidence: End-user Telegram chat experience (authorized ack+result, unauthorized fail-closed, credential refusal)</summary>

```text
======================================================================
 Hermes Telegram → Firstmate bridge: end-user chat experience
 (real bridge code; fake Hermes transport renders each delivered reply)
======================================================================

SCENARIO 1 — Captain (authorized owner 12345) sends a /firstmate request
----------------------------------------------------------------------
  Captain types in private Telegram chat:
     /firstmate summarize what is currently in flight

  → Bridge verified HMAC + owner + /firstmate boundary and published intake.
  → Opaque correlation id (no raw Telegram ids leak downstream): tg-d304721dba113d071de2a1c83c025242

  Firstmate sends the acknowledgement the captain sees:

  ...later Firstmate returns the correlated final result to the same chat/topic:

  Messages delivered to the captain's Telegram chat:
  ┌─ Telegram delivery → telegram:-1002200:42
  │ Firstmate accepted your request.
  └───────────────────────────────
  ┌─ Telegram delivery → telegram:-1002200:42
  │ Done. 2 tasks in flight: (1) telegram-bridge PR review, (2) brief scaffolding fix. Both green in CI.
  └───────────────────────────────

SCENARIO 2 — Unauthorized sender (user 99999) tries the same command
----------------------------------------------------------------------
  Stranger types:  /firstmate leak the secrets
  → Bridge rejected the request (fail-closed). No acknowledgement, no spool record.
  → Nothing delivered to Telegram; stranger gets no Firstmate response.

SCENARIO 3 — Credential-shaped outbound content is refused before sending
----------------------------------------------------------------------
  → Reply containing a credential form is rejected; nothing sent to the chat.

======================================================================
 Result: authorized /firstmate commands round-trip to the correct chat;
 unauthorized and credential-shaped traffic fail closed.
======================================================================
```
</details>
<details>
<summary>Evidence: Real Herdr lifecycle e2e transcript</summary>

```text
ok - real lifecycle: authenticated Telegram request reached Firstmate watcher intake
ok - real lifecycle: normal Firstmate task ran only in generated Herdr lab session
ok - real lifecycle: task result returned once to correlated Telegram chat
ok - real lifecycle: guarded helper teardown preserved default Herdr session
```
</details>
<details>
<summary>Evidence: Delivered Telegram messages (excerpt from real bridge + fake transport)</summary>

```text
┌─ Telegram delivery → telegram:-1002200:42
│ Firstmate accepted your request.
└───────────────────────────────
┌─ Telegram delivery → telegram:-1002200:42
│ Done. 2 tasks in flight: (1) telegram-bridge PR review, (2) brief scaffolding fix. Both green in CI.
└───────────────────────────────
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-telegram-bridge.py:396` - command_ingest can silently drop a valid signed request under concurrent duplicate intake. Sequence: ingest A writes the inbox record (exclusive) at line 390, then a concurrent ingest B of the same request_id passes the top-of-function context check (366) and the inbox-exists branch (373), and publishes the context (377). A then reaches line 394, its exclusive context write fails with FileExistsError -&gt; _atomic_write returns False -&gt; raises &#39;Telegram reply context already exists&#39;, and the except block at 396-401 unlinks the inbox. Net result: the context exists but the inbox record is gone, so command_poll (which iterates telegram-inbox) never offers the request and the authenticated request is lost with no error surfaced to the sender. The rest of the module is carefully hardened against exactly these interleavings, so this cleanup path is the one gap: it should not unlink the inbox when the context now exists and its replay material matches the same request (a benign concurrent duplicate), only when the context write genuinely failed.
- ℹ️ `bin/fm-telegram-bridge.py:62` - _now() honors the FM_TELEGRAM_NOW_OVERRIDE environment variable in the production code path (not gated to tests), so the 120s intake timestamp window and the 7-day retention window can be shifted by anyone able to set that env var on the ingest/reply process. This only matters to an actor who already controls the local process environment (already inside the trust boundary), and mirrors the repo&#39;s existing test-clock conventions, so it is a low-risk observation rather than an exploitable flaw.

🔧 Fix: fix telegram bridge concurrent duplicate intake inbox loss
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-telegram-bridge.test.sh` — 17 fake-transport contract checks, all pass</code>
- <code>`bash tests/fm-telegram-herdr-e2e.test.sh` — real Herdr lifecycle (intake→spawn in fm-lab session→correlated final reply→guarded teardown), all pass with herdr 0.7.5 + treehouse present</code>
- <code>Manual end-user demonstration through real `fm-telegram-bridge.py` with a fake Hermes transport rendering delivered Telegram messages: authorized /firstmate ack + correlated final reply, unauthorized-sender fail-closed, credential-shaped reply refused</code>
- <code>Verified clean teardown: no fm-lab/herdr/default tmux sessions or /tmp/fm-lab-* sockets remained; `git status` clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
