### PR TITLE
fix: preserve apostrophes in fm-brief no-mistakes and secondmate scaffolds

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -311,25 +311,27 @@ EOF
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
+    render_no_mistakes_dod() {
+      cat <<'EOF'
 # Definition of done
 The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+When you believe it is complete, append `done: {summary}` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
-  Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
-  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
+  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
+- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
 EOF
-)
+    }
+    DOD=$(render_no_mistakes_dod)
     ;;
 esac
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # Behavior tests for bin/fm-brief.sh.
 #
-# Regression coverage for the heredoc-in-command-substitution parse bug (issue
-# #166): each ship-mode branch builds its Definition-of-done text with
-# `VAR=$(cat <<EOF ... EOF)`. Bash's lexer tracks quote state through the
-# heredoc body while it scans for the matching `)` of the command
-# substitution, so a single unescaped apostrophe anywhere in that body breaks
-# parsing of the *entire rest of the script* - `bash -n` fails, not just the
-# generated brief. A plain `cat > file <<EOF ... EOF` (not wrapped in `$(...)`)
-# is unaffected, so the secondmate charter block does not need this guard.
+# Regression coverage for the heredoc-in-command-substitution parse bug (issues
+# #166 and #958): Bash's lexer tracks quote state through an unquoted heredoc
+# body while it scans for the matching `)` of the command substitution, so a
+# single apostrophe in that body can break parsing of the entire script.
+# The no-mistakes Definition-of-done body uses a quoted heredoc delimiter
+# outside the command substitution so apostrophes and backticks remain literal.
+# The secondmate charter is also exercised with apostrophes to guard its
+# scaffold behavior.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -18,9 +18,8 @@ TMP_ROOT=$(fm_test_tmproot fm-brief)
 BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
 
-# The script itself must always parse. This is the direct regression test for
-# issue #166: a stray apostrophe in any of the three DOD heredoc bodies
-# (no-mistakes/direct-PR/local-only) breaks `bash -n` on the whole file.
+# The script itself must always parse.
+# This directly guards the nested heredoc quote regression.
 test_script_parses() {
   local out rc
   out=$(bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
@@ -114,9 +113,35 @@ test_no_mistakes_dod_wording() {
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
   assert_grep '`help`' "$brief" \
     "no-mistakes DOD must render literal backticks around help"
-  assert_no_grep "no-mistakes' own guidance" "$brief" \
-    "no-mistakes DOD regressed to the apostrophe form that breaks bash -n"
-  pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
+  assert_grep "firstmate's authority check" "$brief" \
+    "no-mistakes DOD lost its literal apostrophe"
+  pass "fm-brief.sh: no-mistakes DOD renders literal apostrophes"
+}
+
+test_apostrophes_render_in_ship_and_secondmate_scaffolds() {
+  local home ship_id ship_brief mate_id mate_brief status
+  home="$TMP_ROOT/apostrophe-home"
+  mkdir -p "$home/data"
+
+  ship_id="brief-apostrophe-c1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$ship_id" some-proj >/dev/null 2>&1; status=$?
+  expect_code 0 "$status" "ship brief with instructional apostrophe should exit 0"
+  ship_brief="$home/data/$ship_id/brief.md"
+  assert_grep "firstmate's authority check" "$ship_brief" \
+    "ship brief did not preserve the instructional apostrophe"
+
+  mate_id="secondmate-apostrophe-c2"
+  FM_HOME="$home" \
+    FM_SECONDMATE_CHARTER="Supervise the owner's domain." \
+    FM_SECONDMATE_SCOPE="Handle the advisor's requests." \
+    "$ROOT/bin/fm-brief.sh" "$mate_id" --secondmate --no-projects >/dev/null 2>&1; status=$?
+  expect_code 0 "$status" "secondmate charter with apostrophes should exit 0"
+  mate_brief="$home/data/$mate_id/brief.md"
+  assert_grep "Supervise the owner's domain." "$mate_brief" \
+    "secondmate charter did not preserve the owner's apostrophe"
+  assert_grep "Handle the advisor's requests." "$mate_brief" \
+    "secondmate scope did not preserve the advisor's apostrophe"
+  pass "fm-brief.sh: ship and secondmate scaffolds preserve apostrophes"
 }
 
 test_ship_project_memory_wording() {
@@ -387,6 +412,7 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_apostrophes_render_in_ship_and_secondmate_scaffolds
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Fix the macOS system Bash 3.2 parse failure in firstmate's own bin/fm-brief.sh on current upstream origin/main. Preserve the brief and secondmate charter text and behavior exactly while making apostrophes such as firstmate's, owner's, and advisor's literal and safe in the scaffold. Use the minimal correct quoted-heredoc or equivalent restructuring, extend tests/fm-brief.test.sh with regression coverage that scaffolds both a ship brief and a --secondmate charter containing apostrophes, and require bash -n, the fm-brief tests, and bin/fm-lint.sh to pass. Ship the contribution as a PR targeting kunchenguid/firstmate origin/main; do not merge it because it awaits the upstream maintainer.

## What Changed

- Extracted the no-mistakes Definition-of-done heredoc in `bin/fm-brief.sh` into a `render_no_mistakes_dod` function using a quoted (`<<'EOF'`) delimiter outside the command substitution, so apostrophes and backticks stay literal instead of tripping macOS system Bash 3.2's lexer (issue #958) — the previous `DOD=$(cat <<EOF ... EOF)` form broke `bash -n` on the entire script when the body contained an apostrophe.
- Restored literal apostrophes in the DOD text (e.g. `firstmate's authority check`, `no-mistakes' own guidance` reworded) now that the quoted heredoc no longer requires escaping.
- Added `tests/fm-brief.test.sh` regression coverage that scaffolds both a ship brief and a `--secondmate` charter/scope containing apostrophes (`owner's`, `advisor's`) and asserts they render verbatim, and refreshed the surrounding comments and `test_no_mistakes_dod_wording` assertions.

## Risk Assessment

✅ Low: Minimal, well-bounded fix that moves one heredoc out of a command substitution with byte-identical output and adds correct regression tests; the only note is a pre-existing latent pattern in untouched sibling branches.

## Testing

Confirmed the bug and its fix under the actual macOS system Bash 3.2.57: `bash -n` fails on the base with the exact issue #958 error and passes clean on the target. The full fm-brief test suite (16 tests) passes, including the new regression test that scaffolds both a ship brief and a --secondmate charter with apostrophes. bin/fm-lint.sh passes at exit 0 after fetching the pinned ShellCheck 0.11.0 native binary into a temp dir (no system install; cleaned up afterward). Captured product-level evidence as the rendered brief.md files showing "firstmate's authority check", literal backticks, and the "owner's"/"advisor's" charter lines preserved. Temp downloads removed; worktree is clean.

<details>
<summary>Evidence: Ship brief — Definition-of-done section (apostrophes + literal backticks preserved)</summary>

<code># Definition of done&#10;...&#10;Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative...&#10;Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.&#10;- Avoid `--yes`: it would silently bypass firstmate&#39;s authority check and any required captain escalation.&#10;After /no-mistakes reports CI green ... append `done: PR {url} checks green` and stop.</code>

```text
# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Secondmate charter — apostrophe lines preserved</summary>

<code>4:Supervise the owner&#39;s domain.&#10;7:Handle the advisor&#39;s requests.</code>

```text
4:Supervise the owner's domain.
7:Handle the advisor's requests.
```
</details>
<details>
<summary>Evidence: Full rendered ship brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/ship-demo-apos`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fmbrief-evid.2eaH9v/state/ship-demo-apos.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/agwerschky/.no-mistakes/worktrees/e661563b090a/01KYA0FKT54X4MYXFMGT5ZZ5B2/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/agwerschky/.no-mistakes/worktrees/e661563b090a/01KYA0FKT54X4MYXFMGT5ZZ5B2/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Full rendered secondmate brief</summary>

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
Supervise the owner's domain.

# Routing scope
Handle the advisor's requests.

# Project clones
None. This is a project-less domain: its subject is the firstmate repo this home lives in, so it needs no separate clones under `projects/`; its crews take pooled worktrees of that firstmate repo.

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fmbrief-evid.2eaH9v/state/mate-demo-apos.status'`
States: working, needs-decision, blocked, paused, done, failed.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
When a decision you escalated is answered or a blocker clears and your domain resumes, append `resolved: {how it was decided or unblocked}` (keyed with `[key=<slug>]` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>
<details>
<summary>Evidence: Base-vs-target bash -n parse (issue #958 repro + fix)</summary>

```text
BASE (10ee779): /bin/bash -n → line 314: unexpected EOF while looking for matching `)' (exit=2)
TARGET (3aa5c25): /bin/bash -n bin/fm-brief.sh → exit=0
System bash: GNU bash 3.2.57(1)-release arm64-apple-darwin25
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-brief.sh:288` - The direct-PR (line 288) and local-only (line 300) branches still build their DOD via the fragile `DOD=$(cat &lt;&lt;EOF ... EOF)` command-substitution + unquoted-heredoc pattern that caused issue #958. They parse today only because their bodies happen to contain no apostrophes; any future apostrophe added to either body would reintroduce the exact bash 3.2 parse failure across the whole script. The fix is correctly minimal for the reported bug, but converting these two siblings to the same quoted-heredoc-function form would eliminate the trap. The added test_script_parses/test_ship_modes_generate_clean_briefs tests only catch such a regression after an apostrophe is introduced, not the structural fragility.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`/bin/bash -n` on base commit fm-brief.sh (10ee779) → reproduces issue #958 parse failure (exit 2, &#39;line 314: unexpected EOF while looking for matching `)&#39;&#39;)</code>
- <code>`/bin/bash -n bin/fm-brief.sh` on target commit → exit 0 (clean parse under system Bash 3.2.57)</code>
- <code>`/bin/bash tests/fm-brief.test.sh` → all 16 tests ok, including new `test_apostrophes_render_in_ship_and_secondmate_scaffolds`</code>
- <code>`bin/fm-lint.sh` with pinned ShellCheck 0.11.0 (native darwin.aarch64 release) on PATH → exit 0</code>
- <code>Manual scaffold: `FM_HOME=... bin/fm-brief.sh ship-demo-apos some-proj` → DOD renders literal apostrophes and backticks</code>
- <code>Manual scaffold: `FM_SECONDMATE_CHARTER=&#34;...owner&#39;s...&#34; FM_SECONDMATE_SCOPE=&#34;...advisor&#39;s...&#34; bin/fm-brief.sh mate-demo-apos --secondmate --no-projects` → charter/scope apostrophes preserved</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
