### PR TITLE
fix(pi): clear watcher shutdown latch on session_start (/new)

### DIFF
--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -407,7 +407,19 @@ export default function (pi: ExtensionAPI) {
   }
 
   pi.on?.("session_start", () => {
+    // /new keeps this module loaded; clear the shutdown latch so arm works again.
+    stopping = false;
+    retryFailures = 0;
+    if (retryTimer) clearTimeout(retryTimer);
+    retryTimer = null;
+    // session_shutdown removes the exit fallback; put it back for the new session.
+    process.off("exit", cleanupOnProcessExit);
+    process.once("exit", cleanupOnProcessExit);
     markLoaded();
+    // Quiet re-own when this session already holds the lock and nothing is armed.
+    if (lockOwnership() === "owned" && !child && !retryTimer) {
+      startArm();
+    }
   });
   pi.on?.("session_shutdown", () => {
     stopArm();

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -79,6 +79,7 @@ let retryFailures = 0;
 let stopping = false;
 let seq = 0;
 let restoring = false;
+let sessionGeneration = 0;
 const armReadiness = new WeakMap<ChildProcess, Promise<boolean>>();
 const armClose = new WeakMap<ChildProcess, Promise<void>>();
 
@@ -245,13 +246,15 @@ export default function (pi: ExtensionAPI) {
     });
   }
 
-  async function restoreAfterActionableClose(predecessorArmPid: string): Promise<string> {
+  async function restoreAfterActionableClose(predecessorArmPid: string, generation: number): Promise<string> {
     let failure = "";
     for (let attempt = 0; attempt <= retryLimit; attempt += 1) {
-      if (stopping) return "";
+      if (stopping || generation !== sessionGeneration) return "";
       const replacement = startArm(predecessorArmPid);
       const successorChild = child;
-      if (replacement.ok && successorChild && await waitForReadiness(successorChild)) return "";
+      const ready = replacement.ok && successorChild && await waitForReadiness(successorChild);
+      if (generation !== sessionGeneration) return "";
+      if (ready) return "";
       if (replacement.ok) {
         failure = "watcher: FAILED - Pi extension could not verify a ready successor watcher";
         if (!(await retireArm(successorChild))) {
@@ -265,6 +268,7 @@ export default function (pi: ExtensionAPI) {
       }
       if (attempt === retryLimit) break;
       await waitForRetry(attempt + 1);
+      if (generation !== sessionGeneration) return "";
     }
     return `${failure}\nwatcher: FAILED - Pi extension could not restore watcher continuity after ${retryLimit} retries`;
   }
@@ -376,9 +380,11 @@ export default function (pi: ExtensionAPI) {
       const predecessor = String(armChild.pid ?? "");
       if (classification.kind === "actionable") {
         retryFailures = 0;
+        const generation = sessionGeneration;
         restoring = true;
         void (async () => {
-          const failure = await restoreAfterActionableClose(predecessor);
+          const failure = await restoreAfterActionableClose(predecessor, generation);
+          if (generation !== sessionGeneration) return;
           restoring = false;
           if (stopping) return;
           const message = failure ? `${classification.message}\n\n${failure}` : classification.message;
@@ -408,6 +414,8 @@ export default function (pi: ExtensionAPI) {
 
   pi.on?.("session_start", () => {
     // /new keeps this module loaded; clear the shutdown latch so arm works again.
+    sessionGeneration += 1;
+    restoring = false;
     stopping = false;
     retryFailures = 0;
     if (retryTimer) clearTimeout(retryTimer);

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -320,6 +320,7 @@ export default function (pi: ExtensionAPI) {
       };
     }
     const id = ++seq;
+    const generation = sessionGeneration;
     const env = {
       ...process.env,
       FM_HOME: fmHome,
@@ -375,12 +376,12 @@ export default function (pi: ExtensionAPI) {
       resolveClosed();
       settleReadiness(false);
       releaseChild();
+      if (generation !== sessionGeneration) return;
       if (stopping) return;
       const classification = classifyClose(stdout, stderr, code, signal);
       const predecessor = String(armChild.pid ?? "");
       if (classification.kind === "actionable") {
         retryFailures = 0;
-        const generation = sessionGeneration;
         restoring = true;
         void (async () => {
           const failure = await restoreAfterActionableClose(predecessor, generation);
@@ -402,6 +403,7 @@ export default function (pi: ExtensionAPI) {
       resolveClosed();
       settleReadiness(false);
       releaseChild();
+      if (generation !== sessionGeneration) return;
       if (stopping) return;
       if (restoring) return;
       scheduleRetry(`watcher: FAILED - Pi extension arm child ${id} failed: ${error.message}`, String(armChild.pid ?? ""));

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -8,6 +8,7 @@ Must-work continuity now lives above that process boundary instead of depending 
 Pi's `.pi/extensions/fm-primary-pi-watch.ts` and OpenCode's `.opencode/plugins/fm-primary-watch-arm.js` own continuous re-arm after an actionable child close.
 Each adapter starts the next arm before delivering the wake prompt, checks current session-lock ownership at launch, preserves one child or scheduled retry at a time, and applies bounded exponential retry after an unexpected or failed close.
 A failed follow-up never cancels continuity restoration.
+Pi `session_start` also clears the process-local shutdown latch and quietly re-owns the arm when this session holds the lock, so `/new` in the same Pi process does not stick on "session is shutting down".
 
 ## Actionable wake ordering
 

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -965,12 +965,103 @@ await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, {});
 if (process.listenerCount("exit") !== before) {
   throw new Error("session_shutdown did not remove the process-exit fallback");
 }
+await handlers.get("session_start")?.({ type: "session_start" }, {});
+if (process.listenerCount("exit") !== before + 1) {
+  throw new Error("session_start did not restore exactly one process-exit fallback");
+}
 EOF
 )
   status=$?
   expect_code 0 "$status" "Pi cleanup fallback listener must install once and unregister on session shutdown"
   [ -z "$out" ] || fail "Pi listener-lifecycle test printed output: $out"
   pass "Pi process-exit cleanup listener has a bounded lifecycle"
+}
+
+test_pi_session_start_clears_shutdown_latch_and_quiet_rearms() {
+  local repo home plugin log stop out status
+  repo="$TMP_ROOT/pi-session-restart-root"
+  home="$TMP_ROOT/pi-session-restart-home"
+  log="$TMP_ROOT/pi-session-restart.log"
+  stop="$TMP_ROOT/pi-session-restart.stop"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_STOP_FILE="$stop" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let tool = null;
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand() {},
+  registerTool(candidate) {
+    if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+  },
+  sendUserMessage: async () => {},
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+if (!tool) throw new Error("Pi watch tool was not registered");
+if (!handlers.has("session_start") || !handlers.has("session_shutdown")) {
+  throw new Error("Pi extension did not register session lifecycle handlers");
+}
+
+// Arm once, then simulate /new: session_shutdown sticks stopping=true in the loaded module.
+await tool.execute("tool-call-before-new", {}, undefined, undefined, {});
+for (let i = 0; i < 100 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (!existsSync(process.env.FM_ARM_LOG)) throw new Error("initial arm child did not start");
+await handlers.get("session_shutdown")({ type: "session_shutdown" }, {});
+const sticky = await tool.execute("tool-call-while-stuck", {}, undefined, undefined, {});
+if (!sticky.content[0]?.text.includes("session is shutting down")) {
+  throw new Error(`expected sticky shutdown refusal, got: ${sticky.content[0]?.text}`);
+}
+
+// session_start must clear the latch and quiet-rearm when the lock is owned.
+await handlers.get("session_start")({ type: "session_start" }, {});
+for (let i = 0; i < 250; i += 1) {
+  const rows = existsSync(process.env.FM_ARM_LOG)
+    ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
+    : [];
+  if (rows.length >= 2) break;
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+const afterStart = existsSync(process.env.FM_ARM_LOG)
+  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
+  : [];
+if (afterStart.length !== 2) {
+  throw new Error(`owned session_start did not quiet-rearm (rows=${afterStart.length}): ${afterStart.join(" | ")}`);
+}
+
+// Explicit arm after session_start must not stick on the shutdown refusal.
+const after = await tool.execute("tool-call-after-new", {}, undefined, undefined, {});
+if (after.content[0]?.text.includes("session is shutting down")) {
+  throw new Error(`sticky shutdown latch survived session_start: ${after.content[0]?.text}`);
+}
+if (!after.content[0]?.text.includes("already owns an arm child")) {
+  throw new Error(`expected ownership no-op after quiet re-arm, got: ${after.content[0]?.text}`);
+}
+writeFileSync(process.env.FM_STOP_FILE, "stop\n");
+await new Promise((resolve) => setTimeout(resolve, 40));
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi session_start must clear the shutdown latch and quiet-rearm when lock-owned"
+  [ -z "$out" ] || fail "Pi session-restart test printed output: $out"
+  pass "Pi session_start clears shutdown latch and quiet-rearms when lock-owned"
 }
 
 test_pi_process_exit_cleanup_stops_arm_child() {
@@ -2013,6 +2104,7 @@ test_pi_established_empty_close_honors_retry_limit
 test_pi_actionable_close_rechecks_session_lock
 test_pi_arm_distinguishes_session_lock_ownership
 test_pi_process_exit_cleanup_listener_lifecycle
+test_pi_session_start_clears_shutdown_latch_and_quiet_rearms
 test_pi_process_exit_cleanup_stops_arm_child
 test_opencode_primary_watch_plugin_static_wiring
 test_opencode_plugin_package_boundary_is_explicit_esm

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -1064,6 +1064,74 @@ EOF
   pass "Pi session_start clears shutdown latch and quiet-rearms when lock-owned"
 }
 
+test_pi_session_start_cancels_prior_restoration() {
+  local repo home plugin log stop out status
+  repo="$TMP_ROOT/pi-session-restoration-root"
+  home="$TMP_ROOT/pi-session-restoration-home"
+  log="$TMP_ROOT/pi-session-restoration.log"
+  stop="$TMP_ROOT/pi-session-restoration.stop"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+count=$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')
+if [ "$count" -eq 1 ]; then
+  printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+  printf 'signal: prior session wake\n'
+  exit 0
+fi
+if [ "$count" -eq 2 ]; then
+  trap 'exit 0' TERM INT
+  while :; do sleep 0.02; done
+fi
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_STOP_FILE="$stop" FM_PI_ARM_READY_TIMEOUT_MS=100 FM_WATCH_REARM_RETRY_BASE_MS=5 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+const prompts = [];
+let tool = null;
+const pi = {
+  on(event, handler) { handlers.set(event, handler); },
+  registerCommand() {},
+  registerTool(candidate) { if (candidate.name === "fm_watch_arm_pi") tool = candidate; },
+  sendUserMessage: async (message) => { prompts.push(message); },
+};
+const rows = () => existsSync(process.env.FM_ARM_LOG)
+  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
+  : [];
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await tool.execute("initial-arm", {}, undefined, undefined, {});
+for (let i = 0; i < 100 && rows().length < 2; i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (rows().length !== 2) throw new Error(`prior restoration did not start: ${rows().join(" | ")}`);
+await handlers.get("session_shutdown")({ type: "session_shutdown" }, {});
+await handlers.get("session_start")({ type: "session_start" }, {});
+for (let i = 0; i < 100 && rows().length < 3; i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+await new Promise((resolve) => setTimeout(resolve, 180));
+if (rows().length !== 3) throw new Error(`prior restoration launched into the new session: ${rows().join(" | ")}`);
+if (prompts.length !== 0) throw new Error(`prior session wake reached the new session: ${prompts.join(" | ")}`);
+writeFileSync(process.env.FM_STOP_FILE, "stop\n");
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi session_start must cancel prior-session actionable restoration"
+  [ -z "$out" ] || fail "Pi session-restoration test printed output: $out"
+  pass "Pi session_start cancels prior-session actionable restoration"
+}
+
 test_pi_process_exit_cleanup_stops_arm_child() {
   local repo home plugin cleanup_log pid_file out status pid i
   repo="$TMP_ROOT/pi-process-exit-root"
@@ -2105,6 +2173,7 @@ test_pi_actionable_close_rechecks_session_lock
 test_pi_arm_distinguishes_session_lock_ownership
 test_pi_process_exit_cleanup_listener_lifecycle
 test_pi_session_start_clears_shutdown_latch_and_quiet_rearms
+test_pi_session_start_cancels_prior_restoration
 test_pi_process_exit_cleanup_stops_arm_child
 test_opencode_primary_watch_plugin_static_wiring
 test_opencode_plugin_package_boundary_is_explicit_esm

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -1132,6 +1132,69 @@ EOF
   pass "Pi session_start cancels prior-session actionable restoration"
 }
 
+test_pi_session_start_ignores_delayed_prior_child_close() {
+  local repo home plugin log stop out status
+  repo="$TMP_ROOT/pi-delayed-close-root"
+  home="$TMP_ROOT/pi-delayed-close-home"
+  log="$TMP_ROOT/pi-delayed-close.log"
+  stop="$TMP_ROOT/pi-delayed-close.stop"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "${FM_ARM_LOG:?}"
+count=$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+if [ "$count" -eq 1 ]; then
+  printf 'signal: delayed prior session wake\n'
+  trap 'sleep 0.15; exit 0' TERM INT
+  while :; do sleep 0.02; done
+fi
+trap 'exit 0' TERM INT
+while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_STOP_FILE="$stop" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+const prompts = [];
+let tool = null;
+const pi = {
+  on(event, handler) { handlers.set(event, handler); },
+  registerCommand() {},
+  registerTool(candidate) { if (candidate.name === "fm_watch_arm_pi") tool = candidate; },
+  sendUserMessage: async (message) => { prompts.push(message); },
+};
+const rows = () => existsSync(process.env.FM_ARM_LOG)
+  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
+  : [];
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await tool.execute("initial-arm", {}, undefined, undefined, {});
+for (let i = 0; i < 100 && rows().length < 1; i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+await handlers.get("session_shutdown")({ type: "session_shutdown" }, {});
+await handlers.get("session_start")({ type: "session_start" }, {});
+for (let i = 0; i < 100 && rows().length < 2; i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+await new Promise((resolve) => setTimeout(resolve, 220));
+if (rows().length !== 2) throw new Error(`delayed prior child launched a successor: ${rows().join(" | ")}`);
+if (prompts.length !== 0) throw new Error(`delayed prior child delivered a stale wake: ${prompts.join(" | ")}`);
+writeFileSync(process.env.FM_STOP_FILE, "stop\n");
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi session_start must ignore a delayed prior-session child close"
+  [ -z "$out" ] || fail "Pi delayed-prior-close test printed output: $out"
+  pass "Pi session_start ignores delayed prior-session child close"
+}
+
 test_pi_process_exit_cleanup_stops_arm_child() {
   local repo home plugin cleanup_log pid_file out status pid i
   repo="$TMP_ROOT/pi-process-exit-root"
@@ -2174,6 +2237,7 @@ test_pi_arm_distinguishes_session_lock_ownership
 test_pi_process_exit_cleanup_listener_lifecycle
 test_pi_session_start_clears_shutdown_latch_and_quiet_rearms
 test_pi_session_start_cancels_prior_restoration
+test_pi_session_start_ignores_delayed_prior_child_close
 test_pi_process_exit_cleanup_stops_arm_child
 test_opencode_primary_watch_plugin_static_wiring
 test_opencode_plugin_package_boundary_is_explicit_esm


### PR DESCRIPTION
## Summary

Fixes Pi `/new` leaving the primary watcher stuck on `watcher: not armed - Pi session is shutting down`.

## Root cause

`.pi/extensions/fm-primary-pi-watch.ts` sets a module-scope `stopping` latch in `stopArm()` on `session_shutdown` / process exit. `/new` keeps the same Pi process and loaded extension module, so the old `session_start` path (only `markLoaded()`) never cleared that latch. Every later arm refused with the shutdown message.

## Fix

On `session_start`:

1. Clear `stopping = false`
2. Reset `retryFailures` / `retryTimer`
3. Re-attach the process-exit cleanup listener
4. `markLoaded()` as before
5. Quiet `startArm()` when this session already owns the lock and nothing is armed

Review follow-ups on the same branch also:

- Cancel / generation-scope pending `restoreAfterActionableClose` work across session boundaries before reopening the latch
- Tag arm children with `sessionGeneration` and ignore delayed close events from a pre-`/new` child

## Scope

Pure upstream fix only (extension + docs note + tests). No ADO forge-adaptation commits.

## Test plan

- [x] `tests/fm-pi-watch-extension.test.sh` — session_start clears shutdown latch and quiet-rearms
- [x] Restoration-cancellation and stale-child-close regressions added by review fixes
- [x] no-mistakes local pipeline: intent/rebase/review/test/document/lint/push passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)