### PR TITLE
fix(bin): make fm-brief.sh parse under stock macOS Bash 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,20 @@ jobs:
           esac
           /bin/bash --version | head -1
           command -v jq >/dev/null || { echo "::error::jq is required"; exit 1; }
-          /bin/bash -n bin/fm-fleet-snapshot.sh
+          # Every tracked firstmate shell script must parse under stock macOS
+          # Bash 3.2 - this is the runtime /bin/bash firstmate crews inherit on
+          # macOS, so a bash-3.2-only syntax regression (e.g. issue #958) must
+          # fail here before merge. shopt nullglob keeps the loop a no-op if a
+          # dir is empty rather than literal-expanding the glob.
+          shopt -s nullglob
+          fail=0
+          for f in bin/*.sh bin/backends/*.sh; do
+            if ! /bin/bash -n "$f"; then
+              echo "::error::$f fails /bin/bash -n (bash 3.2 parse regression)"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || exit 1
 
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ That is firstmate-specific; do not commit `.no-mistakes/evidence/` here even whe
 Check and test the toolbelt before pushing:
 
 ```sh
-for script in bin/*.sh bin/backends/*.sh; do bash -n "$script"; done   # syntax-check the toolbelt (use /bin/bash on macOS: crews run under stock Bash 3.2, so /bin/bash -n is the real compatibility check)
+for script in bin/*.sh bin/backends/*.sh; do /bin/bash -n "$script"; done   # syntax-check the toolbelt; /bin/bash pins macOS to stock Bash 3.2 (the real compatibility check) and is harmless on Linux
 bin/fm-lint.sh   # lint the toolbelt and behavior tests; the single owner CI and the no-mistakes gate both run
 bin/fm-test-run.sh tests/<subject>.test.sh   # one script (primary local focus path, timed)
 bin/fm-test-run.sh --family pure-contract-unit   # ordinary family-scoped local path (serial, timed)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ That is firstmate-specific; do not commit `.no-mistakes/evidence/` here even whe
 Check and test the toolbelt before pushing:
 
 ```sh
-for script in bin/*.sh bin/backends/*.sh; do bash -n "$script"; done   # syntax-check the toolbelt
+for script in bin/*.sh bin/backends/*.sh; do bash -n "$script"; done   # syntax-check the toolbelt (use /bin/bash on macOS: crews run under stock Bash 3.2, so /bin/bash -n is the real compatibility check)
 bin/fm-lint.sh   # lint the toolbelt and behavior tests; the single owner CI and the no-mistakes gate both run
 bin/fm-test-run.sh tests/<subject>.test.sh   # one script (primary local focus path, timed)
 bin/fm-test-run.sh --family pure-contract-unit   # ordinary family-scoped local path (serial, timed)

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -285,19 +285,20 @@ case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
+    # ponytail: read-heredoc, not $(cat <<EOF) — bash 3.2 loses quote state across heredoc-in-$(...) inside case.
+    IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
-)
+    DOD=${DOD%$'\n'}
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
+    IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
@@ -305,13 +306,13 @@ Keep your branch a clean fast-forward onto the current default branch - if \`mai
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
-)
+    DOD=${DOD%$'\n'}
     ;;
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
+    IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
@@ -329,7 +330,7 @@ Two firstmate-specific rules layer on top of that guidance:
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
-)
+    DOD=${DOD%$'\n'}
     ;;
 esac
 


### PR DESCRIPTION
## What Changed
- Replaced the `DOD=$(cat <<EOF ... EOF)` heredoc-in-`$(...)` construction in all three ship-mode branches of `bin/fm-brief.sh` with `IFS= read -r -d '' DOD <<EOF || true`, which is immune to the parse regression stock macOS Bash 3.2 hit on the prior form.
- Broadened the CI Bash 3.2 syntax check from just `bin/fm-fleet-snapshot.sh` to every tracked `bin/*.sh` and `bin/backends/*.sh` script, so this regression class fails before merge.
- Pinned the CONTRIBUTING.md syntax-check example to `/bin/bash -n` so the documented local check matches the macOS Bash 3.2 runtime CI exercises.

## Risk Assessment

✅ Low: Targeted structural swap from `DOD=$(cat <<EOF ... EOF)` to `IFS= read -r -d '' DOD <<EOF || true; DOD=${DOD%$'\n'}` produces byte-identical brief output (heredoc bodies unchanged) while correctly handling the apostrophe at line 329 that triggered bash 3.2's heredoc-in-$(...) inside-case parse failure; CI is extended to verify every tracked shell script parses under stock macOS Bash 3.2, and the CONTRIBUTING.md example is properly pinned to /bin/bash.

## Testing

Verified the fix end-to-end: pre-fix bin/fm-brief.sh provably fails /bin/bash -n on macOS Bash 3.2 with rc=2 and "unexpected EOF while looking for matching `)`", while post-fix parses cleanly (rc=0). The full CI /bin/bash -n loop across all 87 bin/*.sh + 5 bin/backends/*.sh scripts passes. All 15 fm-brief behavior tests pass, including test_script_parses, test_ship_modes_generate_clean_briefs, and test_no_mistakes_dod_wording (the regression guards for this exact bug class). End-to-end brief generation under stock /bin/bash produces correct DOD text for all three ship modes with literal backticks (`gh-axi`, `no-mistakes axi run --help`, etc.) preserved byte-for-byte — captured as three per-mode evidence files. CONTRIBUTING.md line 74 confirms the /bin/bash -n local check pin. No regressions found.

<details>
<summary>Evidence: DOD section: direct-PR (rendered under /bin/bash 3.2)</summary>

```text
# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: DOD section: local-only (rendered under /bin/bash 3.2)</summary>

```text
# Definition of done
This project ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/brief-localonly-x`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/brief-localonly-x` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: DOD section: no-mistakes (rendered under /bin/bash 3.2)</summary>

```text
# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Pre-fix file fails Bash 3.2 parse</summary>

```text
$ git show a5fe1bcc:bin/fm-brief.sh | /bin/bash -n /dev/stdin
/dev/stdin: line 314: unexpected EOF while looking for matching `)'
/dev/stdin: line 388: syntax error: unexpected end of file
rc=2 (under stock macOS Bash 3.2.57(1)-release)

Post-fix: rc=0, no output.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/fm-brief.test.sh:4` - The header comment claims each ship-mode branch builds its DOD text with `VAR=$(cat &lt;&lt;EOF ... EOF)` and that a stray apostrophe breaks `bash -n`. This fix replaced that pattern with `IFS= read -r -d &#39;&#39; DOD &lt;&lt;EOF || true`, which is immune to the apostrophe-in-body bug class, so the comment and the failure message at line 118 (&#34;breaks bash -n&#34;) no longer describe the current code. The tests themselves remain valid behavior guards; only the explanatory text is historical.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `/bin/bash -n bin/fm-brief.sh (Bash 3.2 parse on the post-fix file: rc=0)`
- <code>/bin/bash -n &lt;(git show a5fe1bcc:bin/fm-brief.sh) (proves pre-fix file failed under Bash 3.2: rc=2, &#39;unexpected EOF while looking for matching `)&#39;`)</code>
- `/bin/bash -c 'shopt -s nullglob; for f in bin/*.sh bin/backends/*.sh; do /bin/bash -n "$f" || exit 1; done' (the exact CI workflow snippet across all 92 tracked scripts: pass)`
- `/bin/bash tests/fm-brief.test.sh (all 15 behavior tests pass)`
- `End-to-end brief generation under /bin/bash for all three ship modes (direct-PR, local-only, no-mistakes) with DOD sections captured to dod-{mode}.md evidence files`
- `grep CONTRIBUTING.md line 74 confirms /bin/bash -n pin`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
