### PR TITLE
fix(tmux): re-anchor composer state off the agent input row so the away-mode daemon delivers escalations

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -294,11 +294,11 @@ Verified live against grok 0.2.93: real input is the bright `38;2;224;222;244` (
 This assumes a dark terminal theme, the fleet reality; the SGR-2 signal stays theme-independent.
 Regression coverage: `tests/fm-composer-ghost.test.sh` (`test_strip_ghost_drops_dark_truecolor_ghost`, `test_dark_truecolor_ghost_only_composer_is_not_pending`) and `tests/fm-backend-herdr.test.sh` (`test_composer_state_grok_dark_truecolor_placeholder_is_empty`, `test_composer_state_grok_bright_truecolor_real_text_is_pending`).
 
-**Residual gap, tmux-only (unfixed):**
-in that same pristine placeholder-only state, tmux's own `#{cursor_y}` points at the composer box's BOTTOM BORDER row, one row below the actual text row (the box appears to render one row lower before any real typing starts); once real text is typed the cursor correctly aligns with the text row again.
+**Cursor-row off-by-one, tmux-only (FIXED 2026-07-24, incident afk-daemon-composer-wedge-fix):**
+in a pristine, never-typed-into rule-bordered composer box, tmux's own `#{cursor_y}` points at the composer box's BOTTOM RULE row, one row below the actual input row (the box appears to render one row lower before any real typing starts); once real text is typed the cursor correctly aligns with the input row again.
 This is a row-SELECTION quirk, orthogonal to the styling fix above, and affects only the tmux path (herdr uses a structural composer-row scan, not `cursor_y`, so it is unaffected).
-A correct fix needs a row-window read near `cursor_y` rather than the single `cursor_y` row.
-In practice `fm-spawn` launches grok with the brief as its initial prompt, so a live task's composer is never observed in this pristine pre-typing state - but this is unverified for every path (e.g. a steer sent before grok's first real turn settles) and needs dedicated investigation before relying on it.
+It is not grok-only: it bit firstmate's OWN idle claude composer, whose rule-bordered box read as pending input, wedging the away-mode escalation injector into deferring every escalation for ~15h.
+`fm_tmux_composer_state` (`bin/fm-tmux-lib.sh`) now re-anchors from a pure rule cursor row onto the adjacent `❯`/`›` agent-composer input row via a small row-window read; see [tmux-backend.md](../../../docs/tmux-backend.md) "Composer cursor_y off-by-one re-anchor" for the full account and regression coverage.
 
 Turn-end hook: grok fires a `Stop` hook at every turn boundary, giving firstmate a precise per-turn wake instead of only stale-pane detection.
 grok loads PROJECT hooks (`<worktree>/.grok/hooks/`, `<worktree>/.claude/settings.local.json`) only after the folder is granted hook-trust in `~/.grok/trusted_folders.toml`, which is not automatic and which firstmate will not establish by editing grok's own managed trust store.

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -167,7 +167,7 @@ fm_tmux_classify_raw_row() {  # <raw-styled-row> -> empty|pending|unknown
 # composer structurally, not by cursor_y (bin/backends/herdr.sh), so this is
 # tmux-path-scoped; see docs/tmux-backend.md.
 fm_tmux_composer_state() {  # <target> -> empty|pending|unknown
-  local target=$1 cy raw plain win row rp anchored=""
+  local target=$1 cy raw plain win start row rp anchored=""
   cy=$(tmux display-message -p -t "$target" '#{cursor_y}' 2>/dev/null) || { printf 'unknown'; return 0; }
   case "$cy" in ''|*[!0-9]*) printf 'unknown'; return 0 ;; esac
   raw=$(tmux capture-pane -e -p -t "$target" -S "$cy" -E "$cy" 2>/dev/null) || { printf 'unknown'; return 0; }
@@ -177,10 +177,11 @@ fm_tmux_composer_state() {  # <target> -> empty|pending|unknown
   plain="${plain#"${plain%%[![:space:]]*}"}"
   plain="${plain%"${plain##*[![:space:]]}"}"
   if fm_tmux_row_is_rule "$plain"; then
-    win=$(tmux capture-pane -e -p -t "$target" -S "$((cy - 2))" -E "$((cy + 2))" 2>/dev/null) || win=""
+    start=$((cy - 2)); [ "$start" -ge 0 ] || start=0
+    win=$(tmux capture-pane -e -p -t "$target" -S "$start" -E "$((cy + 2))" 2>/dev/null) || win=""
     if [ -n "$win" ]; then
       while IFS= read -r row; do
-        rp=$(printf '%s\n' "$row" | fm_composer_strip_ghost)
+        rp=$(printf '%s\n' "$row" | fm_composer_strip_ansi)
         rp="${rp#"${rp%%[![:space:]]*}"}"
         rp="${rp%"${rp##*[![:space:]]}"}"
         # Strip an agent box's side borders before testing the glyph (defensive:

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -74,36 +74,40 @@ FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
 # so the tmux and herdr adapters cannot drift apart on what counts as ghost text.
 fm_tmux_strip_ghost() { fm_composer_strip_ghost; }
 
-# fm_tmux_composer_state: classify the cursor/composer line of <target> as
-#   empty   - no pending input (blank, a busy footer, an empty agent composer, or
-#             only de-emphasised ghost/placeholder text). Safe to inject; also the positive
-#             acknowledgement that a submit landed.
-#   pending - real, unsubmitted text on the cursor line (a human mid-typing, or a
-#             previous injection whose Enter was swallowed). Defer / retry.
-#   unknown - the pane could not be read (tmux error), OR the cursor line is a
-#             bare shell prompt (`$`/`%`/`#`/`>`) - a dead shell, not an agent
-#             composer, so NOT a safe injection target. The caller decides.
-#
-# The cursor line is captured WITH ANSI styling (capture-pane -e) and bounded to
-# the single composer row (-S/-E). The bordered flag (a genuine composer box) is
-# read from the PLAIN row (fm_composer_strip_ansi keeps ghost text so the box
-# border is still visible), while the real-typed CONTENT is extracted with the
-# shared fm_composer_strip_ghost so dim/faint AND dark-truecolor ghost text drops
-# out before classification (grok's dark box border drops with the ghost, which
-# is why the bordered flag is read from the plain row, not the ghost-stripped
-# one). Both are internal only, never surfaced. The detector strips the harness's
-# box-drawing composer borders ("│ … │", heavy "┃", or a plain ASCII "|") using
-# literal-string substitution (bash 3.2 safe, locale-independent - no \u escapes,
-# no multibyte character classes), and delegates the empty/pending/unknown
-# decision to the shared owner fm_composer_classify_content
-# (bin/fm-composer-lib.sh). The bordered flag is what lets a bordered `│ > │`
-# (claude's own idle composer) read empty while a bare, unbordered `$ ` dead-shell
-# prompt reads unknown.
-fm_tmux_composer_state() {  # <target> -> empty|pending|unknown
-  local target=$1 cy raw plain stripped bordered=0
-  cy=$(tmux display-message -p -t "$target" '#{cursor_y}' 2>/dev/null) || { printf 'unknown'; return 0; }
-  case "$cy" in ''|*[!0-9]*) printf 'unknown'; return 0 ;; esac
-  raw=$(tmux capture-pane -e -p -t "$target" -S "$cy" -E "$cy" 2>/dev/null) || { printf 'unknown'; return 0; }
+# fm_tmux_row_is_rule: 0 (true) when a TRIMMED plain row consists solely of the
+# composer box's horizontal rule glyphs - light ─ (U+2500) or heavy ━ (U+2501),
+# the top/bottom border of claude's and codex's rule-bordered composer. Such a
+# row is box DECORATION, never composer content. Detected here so the tmux
+# cursor_y off-by-one (see fm_tmux_composer_state) can re-anchor. Non-empty rows
+# only; a blank row is not a rule. bash 3.2 safe: literal multibyte substitution,
+# no \u escapes or multibyte character classes (matches herdr's Pi-separator
+# check, bin/backends/herdr.sh).
+fm_tmux_row_is_rule() {  # <trimmed-plain-row>
+  local r=$1 stripped
+  [ -n "$r" ] || return 1
+  stripped=${r//─/}
+  stripped=${stripped//━/}
+  [ -z "$stripped" ]
+}
+
+# fm_tmux_classify_raw_row: given the RAW (ANSI-styled) bytes of a single chosen
+# composer row, produce the empty|pending|unknown verdict. Split out of
+# fm_tmux_composer_state so the row-window re-anchoring there can hand it whatever
+# row it settled on. The bordered flag (a genuine composer box) is read from the
+# PLAIN row (fm_composer_strip_ansi keeps ghost text so the box border survives an
+# all-ANSI strip), while the real-typed CONTENT is extracted with the shared
+# fm_composer_strip_ghost so dim/faint AND dark-truecolor ghost text drops out
+# before classification (grok's dark box border drops with the ghost, which is why
+# the bordered flag is read from the plain row, not the ghost-stripped one). The
+# detector strips the harness's box-drawing composer borders ("│ … │", heavy "┃",
+# or a plain ASCII "|") using literal-string substitution (bash 3.2 safe,
+# locale-independent - no \u escapes, no multibyte character classes), and
+# delegates the empty/pending/unknown decision to the shared owner
+# fm_composer_classify_content (bin/fm-composer-lib.sh). The bordered flag is what
+# lets a bordered `│ > │` (a harness's own idle composer) read empty while a bare,
+# unbordered `$ ` dead-shell prompt reads unknown.
+fm_tmux_classify_raw_row() {  # <raw-styled-row> -> empty|pending|unknown
+  local raw=$1 plain stripped bordered=0
   # bordered: from the plain row (borders survive an all-ANSI strip).
   plain=$(printf '%s\n' "$raw" | fm_composer_strip_ansi)
   plain="${plain#"${plain%%[![:space:]]*}"}"
@@ -129,6 +133,75 @@ fm_tmux_composer_state() {  # <target> -> empty|pending|unknown
     printf 'empty'; return 0
   fi
   fm_composer_classify_content "$bordered" "$stripped" "${FM_COMPOSER_IDLE_RE:-}" insensitive "$plain"
+}
+
+# fm_tmux_composer_state: classify the cursor/composer line of <target> as
+#   empty   - no pending input (blank, a busy footer, an empty agent composer, or
+#             only de-emphasised ghost/placeholder text). Safe to inject; also the positive
+#             acknowledgement that a submit landed.
+#   pending - real, unsubmitted text on the cursor line (a human mid-typing, or a
+#             previous injection whose Enter was swallowed). Defer / retry.
+#   unknown - the pane could not be read (tmux error), OR the cursor line is a
+#             bare shell prompt (`$`/`%`/`#`/`>`) - a dead shell, not an agent
+#             composer, so NOT a safe injection target. The caller decides.
+#
+# The cursor line is captured WITH ANSI styling (capture-pane -e) and bounded to
+# the single composer row (-S/-E), then classified by fm_tmux_classify_raw_row.
+#
+# Cursor-row off-by-one re-anchor (incident afk-daemon-composer-wedge-fix):
+# a pristine, never-typed-into claude/codex composer renders its input row inside
+# a rule-bordered box (─────/❯/─────), and tmux's own #{cursor_y} points one row
+# BELOW the ❯ input row, at the box's bottom rule (the box appears to render one
+# row lower before any real typing starts; documented as the "Residual gap,
+# tmux-only" quirk in the harness-adapters skill). Reading only that single row,
+# the rule glyphs classify as pending, so the away-mode escalation injector
+# (bin/fm-supervise-daemon.sh) read firstmate's OWN idle composer as pending input
+# and deferred 100% of escalations for ~15 hours with no delivery. When the cursor
+# row is a pure rule, this widens to a small row window around cursor_y and
+# re-anchors on the adjacent genuine agent-composer input row (a row whose trimmed
+# content starts with the agent prompt glyph ❯ or ›, which appears ONLY on the
+# live composer input row, never in transcript). If no such row is found the
+# cursor row is kept, so the verdict defers safely and injection is never forced;
+# the fix only ever turns a rule-masked EMPTY composer back into empty, and a
+# rule-row that carries real ❯ text still reads pending. herdr locates its
+# composer structurally, not by cursor_y (bin/backends/herdr.sh), so this is
+# tmux-path-scoped; see docs/tmux-backend.md.
+fm_tmux_composer_state() {  # <target> -> empty|pending|unknown
+  local target=$1 cy raw plain win row rp anchored=""
+  cy=$(tmux display-message -p -t "$target" '#{cursor_y}' 2>/dev/null) || { printf 'unknown'; return 0; }
+  case "$cy" in ''|*[!0-9]*) printf 'unknown'; return 0 ;; esac
+  raw=$(tmux capture-pane -e -p -t "$target" -S "$cy" -E "$cy" 2>/dev/null) || { printf 'unknown'; return 0; }
+  # If cursor_y landed on the composer box's horizontal rule (the off-by-one
+  # above), re-anchor on the neighbouring ❯/› input row.
+  plain=$(printf '%s\n' "$raw" | fm_composer_strip_ansi)
+  plain="${plain#"${plain%%[![:space:]]*}"}"
+  plain="${plain%"${plain##*[![:space:]]}"}"
+  if fm_tmux_row_is_rule "$plain"; then
+    win=$(tmux capture-pane -e -p -t "$target" -S "$((cy - 2))" -E "$((cy + 2))" 2>/dev/null) || win=""
+    if [ -n "$win" ]; then
+      while IFS= read -r row; do
+        rp=$(printf '%s\n' "$row" | fm_composer_strip_ghost)
+        rp="${rp#"${rp%%[![:space:]]*}"}"
+        rp="${rp%"${rp##*[![:space:]]}"}"
+        # Strip an agent box's side borders before testing the glyph (defensive:
+        # claude's rule box has no side borders, but a boxed harness may).
+        case "$rp" in
+          '│'*'│') rp=${rp#│}; rp=${rp%│} ;;
+          '┃'*'┃') rp=${rp#┃}; rp=${rp%┃} ;;
+          '|'*'|') rp=${rp#|}; rp=${rp%|} ;;
+        esac
+        rp="${rp#"${rp%%[![:space:]]*}"}"
+        rp="${rp%"${rp##*[![:space:]]}"}"
+        case "$rp" in
+          '❯'*|'›'*) anchored=$row ;;
+        esac
+      done <<EOF
+$win
+EOF
+      if [ -n "$anchored" ]; then raw=$anchored; fi
+    fi
+  fi
+  fm_tmux_classify_raw_row "$raw"
 }
 
 # fm_pane_input_pending: 0 (pending) if the cursor line holds real unsubmitted

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -57,6 +57,15 @@ Agent liveness and composer safety are separate checks.
 The shared classifier in `bin/fm-composer-lib.sh` accepts a shell glyph as an empty agent composer only inside a verified bordered composer.
 A bare shell prompt is `unknown`, so away-mode escalation is never injected into a dead shell.
 
+### Composer cursor_y off-by-one re-anchor
+
+A pristine, never-typed-into claude or codex composer renders its input row inside a rule-bordered box, and tmux's `#{cursor_y}` points one row below that input row, at the box's bottom rule.
+Reading only that single cursor row classified the rule glyphs as pending input, which read firstmate's own idle composer as pending.
+`fm_tmux_composer_state` (`bin/fm-tmux-lib.sh`) now detects a pure horizontal-rule cursor row and re-anchors on the adjacent agent-composer input row within a small window around `#{cursor_y}`.
+Re-anchoring only ever matches an `❯` (claude) or `›` (codex) agent prompt glyph, never a bare shell prompt, so a rule-masked empty composer reads `empty` again while real unsubmitted text still reads `pending` and a dead or unreadable pane still reads `unknown`.
+tmux is the only backend that keys composer detection off `#{cursor_y}`; herdr scans for its composer structurally, and orca, cmux, and zellij have no cursor-row composer primitive.
+[`verification/runtime-backends.md`](verification/runtime-backends.md#tmux) records the dated incident, live reproduction, and regression coverage.
+
 `bin/fm-tmux-lib.sh` owns exact type-and-submit mechanics.
 It types a message once and retries Enter only until the composer clears.
 A cleared composer is the positive delivery acknowledgement; text left in the composer remains `pending`, and `fm-send.sh` reports the failure instead of retyping.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -39,6 +39,39 @@ tests/fm-tmux-submit-busy.test.sh
 
 Expected matrix: pending plus busy is accepted as queued; pending plus idle remains pending; a cleared composer succeeds in either state.
 
+### Composer cursor_y off-by-one re-anchor
+
+The re-anchor guarantee for the `bin/fm-tmux-lib.sh` composer classifier follows the incident afk-daemon-composer-wedge-fix, where an away-mode escalation daemon read firstmate's own idle claude composer as pending input and deferred every escalation for roughly fifteen hours.
+
+The row-selection mechanism was reproduced live on 2026-07-24 with tmux 3.6a on macOS (Darwin 25.5.0) by classifying each row of a live idle claude composer box (a rule-bordered `❯` box on absolute rows 17-19) as if `#{cursor_y}` pointed there:
+
+```sh
+. bin/fm-tmux-lib.sh
+for r in 17 18 19; do
+  raw=$(tmux capture-pane -e -p -t firstmate:1 -S "$r" -E "$r")
+  printf 'row %s -> %s\n' "$r" "$(fm_tmux_classify_raw_row "$raw")"
+done
+```
+
+Observed output:
+
+```text
+row 17 -> pending  (top rule)
+row 18 -> empty    (input row)
+row 19 -> pending  (bottom rule, where cursor_y lands in the pristine box)
+```
+
+A single-row read landing on row 17 or 19 yields `pending`; only row 18 yields `empty`, which is why the re-anchor widens to a small window around `#{cursor_y}`.
+
+Regression coverage is pinned by `tests/fm-composer-ghost.test.sh`:
+
+```sh
+tests/fm-composer-ghost.test.sh
+```
+
+Cases: `test_row_is_rule_recognizes_only_pure_rule_rows`, `test_pristine_composer_box_cursor_on_bottom_rule_is_empty`, `test_pristine_composer_box_cursor_on_input_row_is_empty`, `test_composer_box_with_real_text_stays_pending`, and `test_rule_cursor_never_reanchors_onto_a_shell_prompt`.
+The wedge case `test_pristine_composer_box_cursor_on_bottom_rule_is_empty` fails against the pre-fix single-row classifier (`got 'pending'`) and passes after.
+
 ## Herdr
 
 The compatibility floor is protocol 14.

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -65,6 +65,73 @@ SH
   printf '%s\n' "$fb"
 }
 
+# A fake tmux that serves a MULTI-ROW composer box, addressable by row, so the
+# cursor_y row-window re-anchor (incident afk-daemon-composer-wedge-fix) can be
+# exercised. Rows are 1-indexed from a FM_FAKE_ROWS file (one styled row per
+# line); cursor_y comes from FM_FAKE_CY. capture-pane honours -S/-E as absolute
+# row bounds (mirroring how fm_tmux_composer_state addresses rows by cursor_y),
+# returns the styled rows verbatim WITH -e, and SGR-stripped WITHOUT -e. A row
+# index outside the file yields a blank line, as a real pane's empty rows do.
+make_fake_tmux_box() {  # <dir>
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+rows_file="${FM_FAKE_ROWS:-/dev/null}"
+row_at() {  # <1-indexed row> -> that row's styled bytes, or blank
+  local want=$1 n=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    n=$((n + 1))
+    if [ "$n" = "$want" ]; then printf '%s\n' "$line"; return 0; fi
+  done < "$rows_file"
+  printf '\n'
+}
+case "${1:-}" in
+  display-message)
+    for a in "$@"; do case "$a" in *cursor_y*) printf '%s\n' "${FM_FAKE_CY:-0}"; exit 0 ;; esac; done
+    printf 'fakepane\n'; exit 0 ;;
+  capture-pane)
+    has_e=0; S=""; E=""; prev=""
+    for a in "$@"; do
+      [ "$a" = "-e" ] && has_e=1
+      case "$prev" in -S) S=$a ;; -E) E=$a ;; esac
+      prev=$a
+    done
+    [ -n "$S" ] || S="${FM_FAKE_CY:-0}"; [ -n "$E" ] || E=$S
+    r=$S
+    while [ "$r" -le "$E" ]; do
+      if [ "$r" -ge 1 ]; then styled=$(row_at "$r"); else styled=""; fi
+      if [ "$has_e" = 1 ]; then
+        printf '%s\n' "$styled"
+      else
+        printf '%s\n' "$styled" | LC_ALL=C awk '{gsub(/\033\[[0-9;]*m/, ""); print}'
+      fi
+      r=$((r + 1))
+    done
+    exit 0 ;;
+  list-windows) exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fb/tmux"
+  printf '%s\n' "$fb"
+}
+
+# A pristine, rule-bordered agent composer box: a top rule, the bare prompt-glyph
+# input row, and a bottom rule. <glyph> is the agent prompt glyph bytes (❯ or ›);
+# [input_tail] optional real typed text after the glyph. tmux's cursor_y lands on
+# the BOTTOM rule (row 3), one below the input row (row 2) - the off-by-one this
+# fixture exists to exercise.
+write_composer_box() {  # <file> <glyph-bytes> [input_tail]
+  local file=$1 glyph=$2 tail=${3:-}
+  {
+    printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n'
+    printf '%s %s\n' "$glyph" "$tail"
+    printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n'
+  } > "$file"
+}
+
 # --- fm_tmux_strip_ghost (pure) ---------------------------------------------
 
 test_strip_ghost_drops_dim_keeps_normal() {
@@ -250,6 +317,102 @@ test_real_text_with_trailing_ghost_is_pending() {
   pass "fm_pane_input_pending: real text plus a trailing ghost run is still pending"
 }
 
+# --- cursor_y row-window re-anchor (incident afk-daemon-composer-wedge-fix) --
+#
+# A pristine, never-typed-into claude/codex composer renders its input row inside
+# a rule-bordered box (─────/❯/─────), and tmux's #{cursor_y} points one row BELOW
+# the ❯ input row, at the box's bottom rule. Reading only that single cursor row,
+# the rule glyphs classify as pending, so the away-mode injector read firstmate's
+# OWN idle composer as pending input and deferred 100% of escalations for ~15h.
+# fm_tmux_composer_state now re-anchors from a pure rule row onto the neighbouring
+# ❯/› input row. These pin the fix AND its safety envelope: it only ever turns a
+# rule-masked empty composer back into empty, never forces a busy/half-typed pane.
+
+test_row_is_rule_recognizes_only_pure_rule_rows() {
+  # Pure light and heavy rules (any length >=1) are rules; anything with other
+  # glyphs, or a blank row, is not.
+  fm_tmux_row_is_rule "$(printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80')" \
+    || fail "light rule ───  not recognized"
+  fm_tmux_row_is_rule "$(printf '\xe2\x94\x81\xe2\x94\x81')" \
+    || fail "heavy rule ━━ not recognized"
+  if fm_tmux_row_is_rule "$(printf '\xe2\x9d\xaf ')"; then fail "❯ prompt row misread as a rule"; fi
+  if fm_tmux_row_is_rule ""; then fail "blank row misread as a rule"; fi
+  if fm_tmux_row_is_rule "$(printf '\xe2\x94\x80\xe2\x94\x80 typed')"; then
+    fail "rule with trailing text misread as a pure rule"
+  fi
+  pass "fm_tmux_row_is_rule: only pure ─/━ rows are rules"
+}
+
+test_pristine_composer_box_cursor_on_bottom_rule_is_empty() {
+  local dir fb rows glyph out
+  dir="$TMP_ROOT/box-wedge"; mkdir -p "$dir"
+  fb=$(make_fake_tmux_box "$dir")
+  rows="$dir/rows.txt"
+  # The exact overnight-wedge shape: pristine claude composer box, cursor_y on
+  # the bottom rule (row 3), input row (row 2) is a bare ❯. This is the case that
+  # returned `pending` before the fix; it must now read `empty`.
+  for glyph in '\xe2\x9d\xaf' '\xe2\x80\xba'; do  # ❯ (claude), › (codex)
+    write_composer_box "$rows" "$(printf '%b' "$glyph")"
+    out=$(PATH="$fb:$PATH" FM_FAKE_ROWS="$rows" FM_FAKE_CY=3 \
+      fm_tmux_composer_state "fakepane")
+    [ "$out" = empty ] \
+      || fail "pristine composer box (glyph '$glyph') with cursor_y on the bottom rule must read empty, got '$out'"
+  done
+  pass "fm_tmux_composer_state: pristine composer box, cursor_y on the bottom rule, reads empty (wedge fix)"
+}
+
+test_pristine_composer_box_cursor_on_input_row_is_empty() {
+  local dir fb rows out
+  dir="$TMP_ROOT/box-aligned"; mkdir -p "$dir"
+  fb=$(make_fake_tmux_box "$dir")
+  rows="$dir/rows.txt"
+  # Same box, but cursor_y correctly on the ❯ input row (row 2): unchanged, empty.
+  write_composer_box "$rows" "$(printf '\xe2\x9d\xaf')"
+  out=$(PATH="$fb:$PATH" FM_FAKE_ROWS="$rows" FM_FAKE_CY=2 \
+    fm_tmux_composer_state "fakepane")
+  [ "$out" = empty ] || fail "composer box with cursor_y on the ❯ input row must read empty, got '$out'"
+  pass "fm_tmux_composer_state: composer box, cursor_y on the ❯ input row, reads empty (no regression)"
+}
+
+test_composer_box_with_real_text_stays_pending() {
+  local dir fb rows out cy
+  dir="$TMP_ROOT/box-real"; mkdir -p "$dir"
+  fb=$(make_fake_tmux_box "$dir")
+  rows="$dir/rows.txt"
+  # Real unsubmitted text inside the box. Whether cursor_y sits on the bottom
+  # rule (re-anchor path) or on the input row, the safety guard must hold: real
+  # text reads pending, never forced empty.
+  write_composer_box "$rows" "$(printf '\xe2\x9d\xaf')" 'fix findings 1 and 3, skip 2'
+  for cy in 3 2; do
+    out=$(PATH="$fb:$PATH" FM_FAKE_ROWS="$rows" FM_FAKE_CY=$cy \
+      fm_tmux_composer_state "fakepane")
+    [ "$out" = pending ] \
+      || fail "real text in composer box (cursor_y=$cy) must read pending, got '$out'"
+  done
+  pass "fm_tmux_composer_state: real text in a composer box stays pending (cursor on rule OR input row)"
+}
+
+test_rule_cursor_never_reanchors_onto_a_shell_prompt() {
+  local dir fb rows out
+  dir="$TMP_ROOT/box-shellnear"; mkdir -p "$dir"
+  fb=$(make_fake_tmux_box "$dir")
+  rows="$dir/rows.txt"
+  # A pure rule on the cursor row (row 2) with a BARE shell prompt one row above
+  # (row 1) and nothing agent-composer-shaped. Re-anchor is ❯/›-ONLY, so it must
+  # NOT latch a shell prompt and force empty: the injector must never type into a
+  # dead shell. The rule row itself carries no agent glyph, so the verdict stays
+  # non-empty (the rule text reads pending) - a safe defer, not a forced inject.
+  {
+    printf '$ \n'
+    printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n'
+  } > "$rows"
+  out=$(PATH="$fb:$PATH" FM_FAKE_ROWS="$rows" FM_FAKE_CY=2 \
+    fm_tmux_composer_state "fakepane")
+  [ "$out" != empty ] \
+    || fail "rule cursor row near a bare shell prompt must NOT be forced empty, got '$out'"
+  pass "fm_tmux_composer_state: a rule cursor row never re-anchors onto a bare shell prompt"
+}
+
 # --- fm-peek.sh stays escape-free (LLM-facing path) -------------------------
 
 test_peek_output_is_escape_free() {
@@ -287,4 +450,9 @@ test_colored_text_with_2_payload_still_pending
 test_dark_truecolor_ghost_only_composer_is_not_pending
 test_dark_truecolor_bare_shell_prompt_is_unknown
 test_real_text_with_trailing_ghost_is_pending
+test_row_is_rule_recognizes_only_pure_rule_rows
+test_pristine_composer_box_cursor_on_bottom_rule_is_empty
+test_pristine_composer_box_cursor_on_input_row_is_empty
+test_composer_box_with_real_text_stays_pending
+test_rule_cursor_never_reanchors_onto_a_shell_prompt
 test_peek_output_is_escape_free

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -392,6 +392,31 @@ test_composer_box_with_real_text_stays_pending() {
   pass "fm_tmux_composer_state: real text in a composer box stays pending (cursor on rule OR input row)"
 }
 
+test_pristine_composer_box_dim_glyph_reanchors_empty() {
+  local dir fb rows out styled
+  dir="$TMP_ROOT/box-dimglyph"; mkdir -p "$dir"
+  fb=$(make_fake_tmux_box "$dir")
+  rows="$dir/rows.txt"
+  # A pristine composer box whose ❯/› input row glyph is de-emphasised - dim/faint
+  # (claude) OR a dark/muted truecolor (grok's placeholder shape), with cursor_y on
+  # the bottom rule. The re-anchor must detect the glyph off the ANSI-stripped
+  # (ghost-KEPT) row: ghost-stripping the anchor row would drop the de-emphasised
+  # glyph and miss the input row, keeping the rule verdict (pending) - the latent
+  # gap this pins. It must read empty.
+  for styled in '\033[2m\xe2\x9d\xaf\033[0m' '\033[38;2;50;47;70m\xe2\x80\xba\033[0m'; do
+    {
+      printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n'
+      printf '%b \n' "$styled"
+      printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n'
+    } > "$rows"
+    out=$(PATH="$fb:$PATH" FM_FAKE_ROWS="$rows" FM_FAKE_CY=3 \
+      fm_tmux_composer_state "fakepane")
+    [ "$out" = empty ] \
+      || fail "composer box with a de-emphasised input glyph ('$styled') must re-anchor and read empty, got '$out'"
+  done
+  pass "fm_tmux_composer_state: pristine composer box, de-emphasised input glyph, re-anchors empty"
+}
+
 test_rule_cursor_never_reanchors_onto_a_shell_prompt() {
   local dir fb rows out
   dir="$TMP_ROOT/box-shellnear"; mkdir -p "$dir"
@@ -454,5 +479,6 @@ test_row_is_rule_recognizes_only_pure_rule_rows
 test_pristine_composer_box_cursor_on_bottom_rule_is_empty
 test_pristine_composer_box_cursor_on_input_row_is_empty
 test_composer_box_with_real_text_stays_pending
+test_pristine_composer_box_dim_glyph_reanchors_empty
 test_rule_cursor_never_reanchors_onto_a_shell_prompt
 test_peek_output_is_escape_free


### PR DESCRIPTION
## Intent

Fix an away-mode supervision daemon bug: while the captain was afk ~15h (2026-07-23 19:50 to 2026-07-24 05:41), the daemon buffered every escalation and delivered none (2471 deferred injects, zero deliveries), leaving the captain blind to a review decision. Root cause: fm_tmux_composer_state (bin/fm-tmux-lib.sh) reads composer emptiness off tmux's single #{cursor_y} row. A pristine, never-typed-into claude/codex composer renders its input row inside a rule-bordered box (top rule / bare prompt-glyph row / bottom rule), and tmux's cursor_y points one row BELOW the prompt-glyph input row, at the box's bottom rule. Reading only that single cursor row, the box-drawing rule glyphs classified as pending, so the injector read firstmate's OWN idle composer as pending input and deferred 100% of escalations. This is the 'Residual gap, tmux-only' cursor-row off-by-one previously documented as unfixed in the harness-adapters skill. Fix: when the cursor row is a pure horizontal rule (only light or heavy rule glyphs, detected by new helper fm_tmux_row_is_rule), widen to a small row window around cursor_y and re-anchor on the adjacent genuine agent-composer input row (a row whose trimmed content starts with the agent prompt glyph). Deliberate safety decisions: re-anchoring is agent-prompt-glyph-only and never latches a bare shell prompt, so injection is never forced into a dead shell; if no agent input row is found the cursor row is kept and the verdict defers safely; the fix only ever turns a rule-masked EMPTY composer back into empty while real unsubmitted text still reads pending and a dead shell / unreadable pane still reads unknown. The injection safety guard was deliberately NOT weakened (unknown is never treated as empty) and target auto-discovery was deliberately left unchanged (firstmate:0 fallback was correct; the bug was purely composer misclassification). Refactored the classification body into fm_tmux_classify_raw_row so the re-anchor path can reuse it; the change is in the shared tmux owner so the away-mode injector, fm-send, and the always-on watcher all benefit. The shared content classifier (bin/fm-composer-lib.sh) was intentionally untouched because the bug was row SELECTION, not content classification. Verified tmux-path-scoped: herdr locates its composer structurally (not by cursor_y), orca/cmux/zellij have no cursor-row composer primitive. Added 5 regression cases to tests/fm-composer-ghost.test.sh (a multi-row box fixture), including the wedge repro that fails against the pre-fix single-row classifier and passes after; updated docs/tmux-backend.md with dated repro plus fix evidence; marked the harness-adapters residual-gap note fixed. bin/fm-lint.sh and shellcheck are clean.

## What Changed

- Reworked `fm_tmux_composer_state` in `bin/fm-tmux-lib.sh` so a pristine, rule-bordered claude/codex composer box no longer reads as pending input: the classification body was extracted into `fm_tmux_classify_raw_row`, and when tmux's `cursor_y` row is a pure horizontal rule (detected by the new `fm_tmux_row_is_rule` helper), it widens to a small clamped row window and re-anchors on the adjacent genuine agent-composer input row before classifying. Re-anchoring is agent-prompt-glyph-only (never latches a bare shell), operates on the ANSI-stripped row so de-emphasized glyphs still match, and falls back to the original cursor row when no agent input row is found, keeping the injection safety guard intact (unknown is never treated as empty).
- Added a multi-row box fixture plus 6 re-anchor regression cases to `tests/fm-composer-ghost.test.sh`, including the wedge repro that fails against the pre-fix single-row classifier and passes after (18/18).
- Documented the dated repro and fix evidence in `docs/tmux-backend.md` and marked the previously-unfixed tmux cursor-row residual-gap note as resolved in `.agents/skills/harness-adapters/SKILL.md`.

## Risk Assessment

✅ Low: Well-bounded, tmux-path-scoped composer row-selection fix with a preserved fail-safe (defer/unknown on any doubt), both prior-round findings correctly addressed, and regression tests pinning the fix and its safety envelope.

## Testing

Ran the existing colocated regression suite (18/18 pass, 6 new cases pin the fix and its safety envelope) and built a from-scratch end-to-end reproduction that drives the shared tmux classifier through a fake tmux serving the exact overnight-wedge fixture — a pristine agent composer box with cursor_y landing on the box's bottom rule. Against the base commit the idle composer classifies as `pending` (the injector's defer condition, i.e. the 2471-deferred/0-delivered wedge), and against the fix commit it classifies as `empty` (safe to inject → escalation delivered), while real unsubmitted text still reads `pending` and a bare shell prompt near a rule row is never latched. Traced the injector to confirm delivery is gated on this exact verdict. Working tree left clean; all transient repro copies live only in the dedicated evidence directory.

<details>
<summary>Evidence: End-to-end wedge reproduction transcript (pre-fix vs post-fix + safety scenarios)</summary>

<code>Scenario A cursor_y=3 (overnight-wedge shape):&#10;PRE-FIX base 10ee779: composer_state = pending -&gt; injector reads OWN idle composer as pending -&gt; DEFERS (15h, 0 delivered)&#10;POST-FIX fix af8b591: composer_state = empty -&gt; re-anchors on the input row -&gt; reads empty -&gt; DELIVERS escalation&#10;Scenario B cursor_y=2 (on input row): PRE empty / POST empty (no regression)&#10;Scenario C real unsubmitted text, cursor_y=3: POST pending (never forced empty)&#10;Scenario D rule row above bare shell prompt: POST pending (never latches a dead shell)&#10;VERDICT: bug reproduced on base, cured by fix, safety envelope intact.</code>

```text
==================================================================
 Away-mode supervision wedge: end-to-end reproduction + fix proof
 incident afk-daemon-composer-wedge-fix
==================================================================

Fixture rows served by fake tmux (pristine, never-typed claude composer box):
  row 1: ────────   (top rule)
  row 2: ❯          (bare prompt-glyph INPUT row)
  row 3: ────────   (bottom rule)  <-- tmux #{cursor_y} lands HERE (off-by-one)

--- Scenario A: cursor_y=3 (the real overnight-wedge shape) ---
  PRE-FIX  base 10ee779: composer_state = pending  -> injector reads OWN idle composer as pending -> DEFERS (15h, 0 delivered)
  POST-FIX fix  af8b591: composer_state = empty    -> re-anchors on ❯ input row -> reads empty -> DELIVERS escalation

--- Scenario B: cursor_y=2 (correctly on ❯ input row) — no regression ---
  PRE-FIX : empty
  POST-FIX: empty

--- Scenario C: SAFETY — real unsubmitted text in the box, cursor_y=3 ---
  POST-FIX: composer_state = pending  -> real text still reads pending; fix never forces a busy pane empty

--- Scenario D: SAFETY — rule cursor row above a BARE shell prompt ---
  POST-FIX: composer_state = pending  -> ❯-only re-anchor never latches a dead shell; safe defer, no forced inject

==================================================================
VERDICT: bug reproduced on base, cured by fix, safety envelope intact.
==================================================================
```
</details>
<details>
<summary>Evidence: Regression suite result (fm-composer-ghost.test.sh)</summary>

```text
ok - fm_tmux_row_is_rule: only pure horizontal-rule rows are rules
ok - fm_tmux_composer_state: pristine composer box, cursor_y on the bottom rule, reads empty (wedge fix)
ok - fm_tmux_composer_state: composer box, cursor_y on the input row, reads empty (no regression)
ok - fm_tmux_composer_state: real text in a composer box stays pending (cursor on rule OR input row)
ok - fm_tmux_composer_state: pristine composer box, de-emphasised input glyph, re-anchors empty
ok - fm_tmux_composer_state: a rule cursor row never re-anchors onto a bare shell prompt
(18/18 total ok)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-tmux-lib.sh:183` - Re-anchor detects the composer input row by ghost-stripping (fm_composer_strip_ghost, line 183) then requiring a literal ❯/› (line 196), which is STRICTER than the shared classifier it delegates to. fm_composer_classify_content already has a plain_content fallback that treats a de-emphasized (dim SGR-2 or dark-truecolor) ❯/› glyph — ghost-stripped to empty but visible on the ANSI-stripped row — as empty. If any harness renders the pristine input-row glyph de-emphasized (grok draws borders/placeholder as dark truecolor; incident #429 documents claude dimming composer text), the re-anchor&#39;s glyph test misses it, the pure-rule cursor row is kept, and the injector defers — reproducing exactly the ~15h escalation blindness this change fixes. Latent, not active: claude/codex glyphs are currently bright (fixture and live repro both use a bright glyph). Suggest matching plain/plain_content by detecting the glyph off the ANSI-stripped (ghost-kept) row; classify_raw_row still makes the final empty/pending decision, so no new over-inject risk beyond the existing &#39;the glyph never appears in transcript&#39; assumption already relied on.
- ℹ️ `bin/fm-tmux-lib.sh:180` - The re-anchor window start &#39;-S &#34;$((cy - 2))&#34;&#39; goes negative when cursor_y is 0 or 1, which makes tmux capture-pane read scrollback history rows into the anchor window. Harmless in practice — the re-anchor only fires when the cursor row is a pure horizontal rule, which sits at the composer box near the pane bottom (cursor_y large), so a negative start is effectively unreachable — but the start is unclamped.

🔧 Fix: fix(tmux): re-anchor on ANSI-stripped row, clamp window start
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-composer-ghost.test.sh` — 18/18 pass including 6 new re-anchor regression cases (fm_tmux_row_is_rule, pristine box cursor-on-bottom-rule reads empty, cursor-on-input-row no regression, real text stays pending, dim/dark-truecolor glyph re-anchors, rule-cursor never latches a bare shell)</code>
- `End-to-end wedge repro: fake tmux serving a pristine claude/codex composer box (top rule / bare ❯ input row / bottom rule) with cursor_y=3; classified with pre-fix (10ee779) and post-fix (af8b591) copies of bin/fm-tmux-lib.sh sourcing the unchanged bin/fm-composer-lib.sh`
- <code>Verified `inject_msg` in bin/fm-supervise-daemon.sh gates delivery on `fm_backend_composer_state == empty` (step 3b), confirming the classifier verdict is the actual defer/deliver switch</code>
- `Confirmed bin/fm-composer-lib.sh has no change in the commit range (content classifier intentionally untouched; bug was row selection)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
