### PR TITLE
feat(certification): add durable Firstmate final-certification coordinator

### DIFF
--- a/.agents/skills/certification-coordinator/SKILL.md
+++ b/.agents/skills/certification-coordinator/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: certification-coordinator
+description: >-
+  Agent-only final-certification admission procedure.
+  Load before requesting, retrying, or reconciling a heavy No Mistakes certification, and when a certification coordinator notification is surfaced.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# certification-coordinator
+
+Load this before requesting, retrying, or reconciling a final heavy No Mistakes certification, and whenever monitoring surfaces a coordinator refusal.
+`bin/fm-certification.sh` is the state-machine and command-contract owner.
+[`docs/certification-coordinator.md`](../../../docs/certification-coordinator.md) owns the design rationale, safety invariants, recovery model, and authority boundary.
+Do not reproduce either contract from memory.
+
+## Request final certification
+
+Confirm implementation and focused tests are committed before requesting capacity.
+Write the accepted captain intent to a private task-local file, preserving the objective and material decisions rather than summarizing the diff.
+Resolve the exact full expected commit from the worker's isolated branch.
+Run `bin/fm-certification.sh enqueue <task-id> <expected-head> --intent-file <path>` with the active `FM_HOME` explicit when it is not already exported.
+Treat a blocked result as the concrete safety refusal it names.
+Do not bypass the coordinator by sending a harness-specific No Mistakes invocation directly.
+
+The coordinator may admit immediately or retain durable FIFO position.
+On admission it sends the worker a token-bound `fm-certification.sh start` command.
+That command repeats preflight and execs No Mistakes inside the worker's process, so the worker continues to own all synchronous returns and every gate response.
+Firstmate never runs `no-mistakes axi respond` for that worker.
+
+## Reconcile and retry
+
+Session start and ordinary monitoring invoke `reconcile --notify` automatically.
+A terminal result advances the next eligible request without a manual nudge.
+Use `status` for a read-only queue view.
+Use `retry <task-id>` only after correcting the recorded refusal or inspecting an ambiguous notification delivery.
+Retry never changes the bound branch or expected head.
+A changed expected head needs a new explicit certification request and must not be silently substituted.
+
+Never answer a coordinator refusal by resetting, rebasing, stashing, discarding, cancelling, restarting the shared daemon, retiring unpublished commits, or invoking custody recovery.
+Use the authority those actions already require under the ordinary Firstmate and No Mistakes contracts.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -127,6 +127,9 @@ This preserves launch success instead of passing a known-bad value.
 
 ## no-mistakes skill invocation
 
+Final heavy Firstmate certifications do not use these harness-specific forms.
+Load `certification-coordinator` and enqueue the exact committed head so its backend-neutral token-bound shell command admits and steers the worker.
+The forms below remain reference for non-coordinated skill verification and other non-final use.
 Send the validation skill using the target harness's skill invocation form.
 Natural language is acceptable if uncertain.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,7 +281,9 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
+Load `certification-coordinator` before requesting, retrying, or reconciling a final heavy No Mistakes certification, and on any coordinator refusal.
+Final heavy certifications must enter through `bin/fm-certification.sh`; implementation and focused testing remain parallel, while the coordinator deterministically owns shared-capacity admission and leaves worker-owned No Mistakes execution unchanged.
+For a no-mistakes ship, enqueue the committed expected head so the coordinator admits and steers the same worker through its token-bound start command.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 
@@ -464,6 +466,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
+- `certification-coordinator` - load before requesting, retrying, or reconciling a final heavy No Mistakes certification, and when monitoring surfaces a coordinator refusal.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
 - `project-management` - load before adding, creating, removing, or initializing a project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ It has the knowledge-placement rules that keep `AGENTS.md` from regrowing after 
 There is no reliable way for `bin/fm-brief.sh`'s scaffold to detect that a task's repo is firstmate itself, so firstmate adds this skill's load line to firstmate-repo briefs by hand.
 A crewmate picking up such a brief should load the skill even if the brief predates this instruction.
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
-Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
+Final heavy crewmate validation is admitted through `bin/fm-certification.sh`, while the admitted worker follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: crewmates route every `ask-user` finding to firstmate, which applies the authority contract in `AGENTS.md`, and crewmates avoid `--yes` because it would bypass that check and any required captain escalation.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory and pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job.
 Local no-mistakes Test is intent-targeted and must not re-run every `tests/*.test.sh`; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -315,10 +315,12 @@ EOF
 # Definition of done
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+Firstmate will enqueue your exact committed head for shared certification capacity.
+Do not invoke /no-mistakes directly.
+Wait for the coordinator's token-bound \`fm-certification.sh start\` command, then run that exact command to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Follow the guidance no-mistakes itself provides for the mechanics: the admitted start command runs \`no-mistakes axi run\`, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
@@ -327,7 +329,7 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+After the admitted No Mistakes run reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
 )
     ;;

--- a/bin/fm-certification.sh
+++ b/bin/fm-certification.sh
@@ -39,7 +39,10 @@
 #   FM_CERTIFICATION_CAPACITY positive configured capacity (default 1). The first
 #                           mutation records it durably; later mismatches refuse.
 #   FM_CERTIFICATION_RETAIN positive count of newest terminal records to retain
-#                           (default 100). Older terminal records and their intent are pruned.
+#                           (default 100). Also bounds the quarantine and withdrawn
+#                           archives. Older records and their intent are pruned.
+#   FM_CERTIFICATION_LAUNCH_GRACE positive seconds a launching record may show no
+#                           matching run before reconcile surfaces a stall (default 120).
 #   FM_CERT_NM_BIN          no-mistakes executable (default no-mistakes)
 #   FM_CERT_SEND_BIN        fm-send executable (default tracked fm-send.sh)
 #   FM_CERT_TIMEOUT         read-only CLI timeout seconds (default 15)
@@ -61,6 +64,7 @@ QUARANTINE="$CERT_ROOT/quarantine"
 WITHDRAWN="$CERT_ROOT/withdrawn"
 CAPACITY_REQUESTED="${FM_CERTIFICATION_CAPACITY:-1}"
 RETAIN_REQUESTED="${FM_CERTIFICATION_RETAIN:-100}"
+LAUNCH_GRACE="${FM_CERTIFICATION_LAUNCH_GRACE:-120}"
 NM_BIN="${FM_CERT_NM_BIN:-no-mistakes}"
 SEND_BIN="${FM_CERT_SEND_BIN:-$SCRIPT_DIR/fm-send.sh}"
 NM_TIMEOUT="${FM_CERT_TIMEOUT:-15}"
@@ -68,12 +72,13 @@ NM_TIMEOUT="${FM_CERT_TIMEOUT:-15}"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
-usage() { sed -n '2,46p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,49p' "$0" | sed 's/^# \{0,1\}//'; }
 die() { echo "error: $*" >&2; exit 1; }
 usage_die() { echo "error: $*" >&2; usage >&2; exit 2; }
 
 case "$CAPACITY_REQUESTED" in ''|*[!0-9]*|0) die "FM_CERTIFICATION_CAPACITY must be a positive integer" ;; esac
 case "$RETAIN_REQUESTED" in ''|*[!0-9]*|0) die "FM_CERTIFICATION_RETAIN must be a positive integer" ;; esac
+case "$LAUNCH_GRACE" in ''|*[!0-9]*|0) die "FM_CERTIFICATION_LAUNCH_GRACE must be a positive integer" ;; esac
 case "$NM_TIMEOUT" in ''|*[!0-9]*|0) die "FM_CERT_TIMEOUT must be a positive integer" ;; esac
 
 mkdir_private() {
@@ -110,6 +115,14 @@ capacity_ensure() {
 
 valid_task_id() { case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; *) return 0 ;; esac; }
 valid_head() { printf '%s' "$1" | grep -Eq '^[0-9a-fA-F]{40}$'; }
+is_uint() { case "$1" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+now_epoch() { printf '%s\n' "${FM_CERT_NOW:-$(date +%s)}"; }
+within_launch_grace() { # <launched-at>
+  local launched=$1 now
+  now=$(now_epoch)
+  is_uint "$launched" && is_uint "$now" || return 1
+  [ "$now" -ge "$launched" ] && [ "$((now - launched))" -lt "$LAUNCH_GRACE" ]
+}
 single_line_value() { case "$1" in *$'\n'*|*$'\r'*) return 1 ;; *) return 0 ;; esac; }
 shell_quote() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
 record_field() { grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2- || true; }
@@ -154,27 +167,37 @@ quarantine_sweep() { # sets QUARANTINED=1 and returns 1 if any record was quaran
   return "$rc"
 }
 
-retention_sweep() { # prune terminal records beyond the newest RETAIN_REQUESTED
-  local rec base n=0 sorted
-  sorted=$(for rec in "$QUEUE"/*.record; do
+prune_dir_records() { # <dir> <keep> [state-filter]
+  local dir=$1 keep=$2 filter=${3:-} rec base n=0 sorted
+  sorted=$(for rec in "$dir"/*.record; do
     [ -f "$rec" ] || continue
-    [ "$(record_field "$rec" state)" = terminal ] || continue
+    [ -z "$filter" ] || [ "$(record_field "$rec" state)" = "$filter" ] || continue
     printf '%s\n' "$rec"
   done | sort -r)
   [ -n "$sorted" ] || return 0
   while IFS= read -r rec; do
     [ -n "$rec" ] || continue
     n=$((n + 1))
-    [ "$n" -gt "$RETAIN_REQUESTED" ] || continue
+    [ "$n" -gt "$keep" ] || continue
     base=$(basename "$rec" .record)
-    rm -f "$rec" "$QUEUE/$base.intent" 2>/dev/null || true
+    rm -f "$rec" "$(dirname "$rec")/$base.intent" 2>/dev/null || true
   done <<EOF
 $sorted
 EOF
 }
 
-record_write() { # <record> <state> <notification> <run-id> <outcome> <reason>
-  local rec=$1 new_state=$2 notification=$3 run_id=$4 outcome=$5 reason=$6 tmp
+retention_sweep() {
+  # Keep the newest RETAIN_REQUESTED terminal records in the live queue and the
+  # newest RETAIN_REQUESTED entries of each archive so compact recent audit
+  # evidence is preserved while steady-state storage stays flat.
+  prune_dir_records "$QUEUE" "$RETAIN_REQUESTED" terminal
+  prune_dir_records "$QUARANTINE" "$RETAIN_REQUESTED"
+  prune_dir_records "$WITHDRAWN" "$RETAIN_REQUESTED"
+}
+
+record_write() { # <record> <state> <notification> <run-id> <outcome> <reason> [launched-at]
+  local rec=$1 new_state=$2 notification=$3 run_id=$4 outcome=$5 reason=$6 tmp launched
+  if [ "$#" -ge 7 ]; then launched=$7; else launched=$(record_field "$rec" launched_at); fi
   tmp=$(mktemp "$QUEUE/.record.XXXXXX") || die "cannot create certification record"
   {
     printf 'version=1\n'
@@ -191,6 +214,7 @@ record_write() { # <record> <state> <notification> <run-id> <outcome> <reason>
     printf 'run_id=%s\n' "$run_id"
     printf 'outcome=%s\n' "$outcome"
     printf 'reason=%s\n' "$reason"
+    printf 'launched_at=%s\n' "$launched"
   } > "$tmp"
   chmod 0600 "$tmp"
   mv "$tmp" "$rec"
@@ -409,13 +433,19 @@ reconcile_locked() { # <notify 0|1>
           rc=1
           ;;
         none)
-          # Launch custody was recorded but no matching run is visible: a worker
-          # likely crashed between claiming the slot and no-mistakes starting.
-          # Retain the slot (never auto-relaunch) but surface the stall so
-          # session-start/watch reconciliation prompts an explicit retry or withdraw.
-          record_write "$rec" "$st" "$(record_field "$rec" notification)" "$(record_field "$rec" run_id)" "" "launch custody holds a slot but no matching no-mistakes run is visible; inspect then retry or withdraw"
-          echo "certification launch stalled: $(record_field "$rec" task): no matching run visible; inspect then retry or withdraw" >&2
-          rc=1
+          # Launch custody was recorded but no matching run is visible. Within the
+          # bounded launch grace this is an ordinary run still registering, so the
+          # slot is retained silently. Past the grace a worker likely crashed
+          # between claiming the slot and no-mistakes starting: retain the slot
+          # (never auto-relaunch) but surface the stall so session-start/watch
+          # reconciliation prompts an explicit retry or withdraw.
+          if within_launch_grace "$(record_field "$rec" launched_at)"; then
+            :
+          else
+            record_write "$rec" "$st" "$(record_field "$rec" notification)" "$(record_field "$rec" run_id)" "" "launch custody holds a slot but no matching no-mistakes run is visible after the launch grace; inspect then retry or withdraw"
+            echo "certification launch stalled: $(record_field "$rec" task): no matching run visible after ${LAUNCH_GRACE}s grace; inspect then retry or withdraw" >&2
+            rc=1
+          fi
           ;;
       esac
       ;;
@@ -495,7 +525,7 @@ command_enqueue() {
   mv "$tmp" "$intent_dst"
   tmp=$(mktemp "$QUEUE/.record.XXXXXX") || die "cannot create certification record"
   {
-    printf 'version=1\nsequence=%s\ntask=%s\nhome=%s\nproject=%s\nworktree=%s\nbranch=%s\nexpected_head=%s\ntoken=%s\nstate=queued\nnotification=none\nrun_id=\noutcome=\nreason=\n' \
+    printf 'version=1\nsequence=%s\ntask=%s\nhome=%s\nproject=%s\nworktree=%s\nbranch=%s\nexpected_head=%s\ntoken=%s\nstate=queued\nnotification=none\nrun_id=\noutcome=\nreason=\nlaunched_at=\n' \
       "$seq" "$task" "$FM_HOME" "$project" "$wt" "$branch" "$expected" "$token"
   } > "$tmp"
   chmod 0600 "$tmp"
@@ -554,7 +584,7 @@ command_start() {
       fi
       ;;
   esac
-  record_write "$rec" launching sent "$RUN_ID" "" ""
+  record_write "$rec" launching sent "$RUN_ID" "" "" "$(now_epoch)"
   wt=$(record_field "$rec" worktree)
   expected=$(record_field "$rec" expected_head)
   intent_file="${rec%.record}.intent"
@@ -614,13 +644,20 @@ command_withdraw() {
   state=$(record_field "$rec" state)
   # Withdrawal abandons a request and frees its slot. It never cancels an
   # in-flight No Mistakes run: a matching active or terminal run stays under the
-  # worker's gate authority, so those are refused.
+  # worker's gate authority, so those are refused. A launch inside its grace
+  # window may still be registering its run, so withdrawal waits rather than
+  # freeing the slot into an uncoordinated double run.
   case "$state" in launching|running)
     inspect_record_run "$rec"
     case "$RUN_KIND" in
       active) die "task $task has a matching active no-mistakes run; withdrawal cannot cancel it — the worker owns that gate" ;;
       terminal) die "task $task already has authoritative terminal outcome $RUN_OUTCOME; reconcile instead of withdrawing" ;;
       ambiguous) die "$RUN_REASON" ;;
+      none)
+        if within_launch_grace "$(record_field "$rec" launched_at)"; then
+          die "task $task launched within the last ${LAUNCH_GRACE}s and its run may still be registering; wait for the launch grace to elapse before withdrawing to avoid an uncoordinated double run"
+        fi
+        ;;
     esac
     ;;
   esac

--- a/bin/fm-certification.sh
+++ b/bin/fm-certification.sh
@@ -26,7 +26,8 @@
 #   fm-certification.sh retry <task-id>
 #     Requeues a blocked request without changing its expected branch or head,
 #     or explicitly retries a failed/ambiguous notification or unbound launch
-#     after inspection proves no matching active run exists.
+#     after inspection proves no matching active run exists and the launch grace
+#     has elapsed, so retry never re-drives a still-registering launch.
 #   fm-certification.sh withdraw <task-id>
 #     Abandons a request and frees its slot so a corrected head can be
 #     re-enqueued. Refuses to cancel a matching active or terminal run; the
@@ -72,7 +73,7 @@ NM_TIMEOUT="${FM_CERT_TIMEOUT:-15}"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
-usage() { sed -n '2,49p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,50p' "$0" | sed 's/^# \{0,1\}//'; }
 die() { echo "error: $*" >&2; exit 1; }
 usage_die() { echo "error: $*" >&2; usage >&2; exit 2; }
 
@@ -620,7 +621,12 @@ command_retry() {
   launching|running)
     inspect_record_run "$rec"
     case "$RUN_KIND" in
-      none) record_write "$rec" admitted pending "" "" "" ;;
+      none)
+        if within_launch_grace "$(record_field "$rec" launched_at)"; then
+          die "task $task launched within the last ${LAUNCH_GRACE}s and its run may still be registering; wait for the launch grace to elapse before retrying to avoid an uncoordinated double run"
+        fi
+        record_write "$rec" admitted pending "" "" ""
+        ;;
       active) die "task $task already has a matching active run; use its token-bound start command only to reattach" ;;
       terminal) die "task $task already has authoritative terminal outcome $RUN_OUTCOME; reconcile instead" ;;
       ambiguous) die "$RUN_REASON" ;;

--- a/bin/fm-certification.sh
+++ b/bin/fm-certification.sh
@@ -1,0 +1,552 @@
+#!/usr/bin/env bash
+# Durable admission coordinator for final heavy no-mistakes certifications.
+#
+# This script is the single executable owner of the certification state machine.
+# It serializes every mutation through one machine-global coordinator lock, stores
+# its FIFO ledger outside individual Firstmate homes, and never runs a gate
+# response, custody recovery, cancellation, branch rewrite, or daemon lifecycle
+# command.
+#
+# Commands:
+#   fm-certification.sh enqueue <task-id> <expected-head> --intent-file <path>
+#     Records one final certification request for the task in the active FM_HOME.
+#     The task must already have state/<id>.meta. The expected head must be a full
+#     commit id. A successful call reconciles the queue and admits/notifies the
+#     next eligible request when capacity is available.
+#   fm-certification.sh reconcile [--notify]
+#     Reconciles admitted work against read-only no-mistakes state, releases slots
+#     only for an authoritative terminal result, and admits queued eligible work.
+#     --notify submits one idempotently recorded start instruction to each newly
+#     admitted worker through fm-send. This command never drives no-mistakes.
+#   fm-certification.sh start <task-id> <admission-token>
+#     Worker-side entry point. Repeats the full preflight under the coordinator
+#     lock, records launch custody, then execs `no-mistakes axi run` in that
+#     worker's own process with the stored intent. Repeating it reattaches to a
+#     matching active run; it never starts a second mismatched run.
+#   fm-certification.sh retry <task-id>
+#     Requeues a blocked request without changing its expected branch or head,
+#     or explicitly retries a failed/ambiguous notification or unbound launch
+#     after inspection proves no matching active run exists.
+#   fm-certification.sh status
+#     Prints the durable queue in sequence order without mutation.
+#
+# Configuration and test overrides:
+#   FM_CERTIFICATION_ROOT   shared durable root (default ~/.no-mistakes/firstmate-certification)
+#   FM_CERTIFICATION_CAPACITY positive configured capacity (default 1). The first
+#                           mutation records it durably; later mismatches refuse.
+#   FM_CERT_NM_BIN          no-mistakes executable (default no-mistakes)
+#   FM_CERT_SEND_BIN        fm-send executable (default tracked fm-send.sh)
+#   FM_CERT_TIMEOUT         read-only CLI timeout seconds (default 15)
+#   FM_CERT_NO_EXEC=1       test-only: print the worker command instead of exec
+#
+# Exit 0 means the requested operation converged. Exit 1 is an actionable safety
+# refusal or failed notification. Exit 2 is bad usage. Exact state, transition,
+# recovery, and authority rationale lives in docs/certification-coordinator.md.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CERT_ROOT="${FM_CERTIFICATION_ROOT:-${NO_MISTAKES_HOME:-$HOME/.no-mistakes}/firstmate-certification}"
+QUEUE="$CERT_ROOT/queue"
+LOCK="$CERT_ROOT/.lock"
+CAPACITY_REQUESTED="${FM_CERTIFICATION_CAPACITY:-1}"
+NM_BIN="${FM_CERT_NM_BIN:-no-mistakes}"
+SEND_BIN="${FM_CERT_SEND_BIN:-$SCRIPT_DIR/fm-send.sh}"
+NM_TIMEOUT="${FM_CERT_TIMEOUT:-15}"
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+usage() { sed -n '2,39p' "$0" | sed 's/^# \{0,1\}//'; }
+die() { echo "error: $*" >&2; exit 1; }
+usage_die() { echo "error: $*" >&2; usage >&2; exit 2; }
+
+case "$CAPACITY_REQUESTED" in ''|*[!0-9]*|0) die "FM_CERTIFICATION_CAPACITY must be a positive integer" ;; esac
+case "$NM_TIMEOUT" in ''|*[!0-9]*|0) die "FM_CERT_TIMEOUT must be a positive integer" ;; esac
+
+mkdir_private() {
+  umask 077
+  mkdir -p "$CERT_ROOT" "$QUEUE"
+  [ ! -L "$CERT_ROOT" ] && [ ! -L "$QUEUE" ] || die "certification state paths must not be symlinks: $CERT_ROOT"
+  chmod 0700 "$CERT_ROOT" "$QUEUE" 2>/dev/null || true
+}
+
+lock_acquire() {
+  mkdir_private
+  fm_lock_acquire_wait "$LOCK"
+  trap 'fm_lock_release "$LOCK" 2>/dev/null || true' EXIT HUP INT TERM
+}
+lock_release() {
+  fm_lock_release "$LOCK"
+  trap - EXIT HUP INT TERM
+}
+
+capacity_ensure() {
+  local file="$CERT_ROOT/capacity" tmp current
+  if [ -e "$file" ]; then
+    [ -f "$file" ] && [ ! -L "$file" ] || die "coordinator capacity is not a regular file: $file"
+    current=$(cat "$file" 2>/dev/null || true)
+    [ "$current" = "$CAPACITY_REQUESTED" ] || die "configured capacity $CAPACITY_REQUESTED conflicts with durable shared capacity ${current:-unknown} at $file"
+    return
+  fi
+  tmp=$(mktemp "$CERT_ROOT/.capacity.XXXXXX") || die "cannot create coordinator capacity"
+  printf '%s\n' "$CAPACITY_REQUESTED" > "$tmp"
+  chmod 0600 "$tmp"
+  mv "$tmp" "$file"
+}
+
+valid_task_id() { case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; *) return 0 ;; esac; }
+valid_head() { printf '%s' "$1" | grep -Eq '^[0-9a-fA-F]{40}$'; }
+single_line_value() { case "$1" in *$'\n'*|*$'\r'*) return 1 ;; *) return 0 ;; esac; }
+shell_quote() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
+record_field() { grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2- || true; }
+record_for_task() {
+  local task=$1 home=$2 rec
+  for rec in "$QUEUE"/*.record; do
+    [ -f "$rec" ] || continue
+    [ "$(record_field "$rec" task)" = "$task" ] || continue
+    [ "$(record_field "$rec" home)" = "$home" ] || continue
+    printf '%s\n' "$rec"
+    return 0
+  done
+  return 1
+}
+
+record_write() { # <record> <state> <notification> <run-id> <outcome> <reason>
+  local rec=$1 new_state=$2 notification=$3 run_id=$4 outcome=$5 reason=$6 tmp
+  tmp=$(mktemp "$QUEUE/.record.XXXXXX") || die "cannot create certification record"
+  {
+    printf 'version=1\n'
+    printf 'sequence=%s\n' "$(record_field "$rec" sequence)"
+    printf 'task=%s\n' "$(record_field "$rec" task)"
+    printf 'home=%s\n' "$(record_field "$rec" home)"
+    printf 'project=%s\n' "$(record_field "$rec" project)"
+    printf 'worktree=%s\n' "$(record_field "$rec" worktree)"
+    printf 'branch=%s\n' "$(record_field "$rec" branch)"
+    printf 'expected_head=%s\n' "$(record_field "$rec" expected_head)"
+    printf 'token=%s\n' "$(record_field "$rec" token)"
+    printf 'state=%s\n' "$new_state"
+    printf 'notification=%s\n' "$notification"
+    printf 'run_id=%s\n' "$run_id"
+    printf 'outcome=%s\n' "$outcome"
+    printf 'reason=%s\n' "$reason"
+  } > "$tmp"
+  chmod 0600 "$tmp"
+  mv "$tmp" "$rec"
+}
+
+next_sequence() {
+  local file="$CERT_ROOT/next-sequence" n tmp
+  n=$(cat "$file" 2>/dev/null || printf '1')
+  case "$n" in ''|*[!0-9]*) die "invalid coordinator sequence in $file" ;; esac
+  tmp=$(mktemp "$CERT_ROOT/.sequence.XXXXXX") || die "cannot create coordinator sequence"
+  printf '%s\n' "$((n + 1))" > "$tmp"
+  chmod 0600 "$tmp"
+  mv "$tmp" "$file"
+  printf '%012d' "$n"
+}
+
+physical_dir() { (cd "$1" 2>/dev/null && pwd -P); }
+meta_value() { grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2- || true; }
+
+run_bounded() { # <worktree> <args...>
+  local wt=$1
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    (cd "$wt" && timeout "$NM_TIMEOUT" "$NM_BIN" "$@") 2>/dev/null
+  elif command -v gtimeout >/dev/null 2>&1; then
+    (cd "$wt" && gtimeout "$NM_TIMEOUT" "$NM_BIN" "$@") 2>/dev/null
+  else
+    (cd "$wt" && "$NM_BIN" "$@") 2>/dev/null
+  fi
+}
+
+toon_field() { printf '%s\n' "$1" | sed -n "s/^[[:space:]]*$2:[[:space:]]*\"\{0,1\}\([^\"]*\)\"\{0,1\}[[:space:]]*$/\1/p" | head -1; }
+active_run_rows() { printf '%s\n' "$1" | awk '$1 == "running" { print $2 "\t" $3 }'; }
+
+record_is_live() {
+  case "$(record_field "$1" state)" in admitted|launching|running) return 0 ;; *) return 1 ;; esac
+}
+
+coordinated_active_run() { # <project> <branch> <head-prefix>
+  local project=$1 branch=$2 head=$3 rec expected
+  for rec in "$QUEUE"/*.record; do
+    if [ ! -f "$rec" ] || ! record_is_live "$rec"; then
+      continue
+    fi
+    [ "$(record_field "$rec" project)" = "$project" ] || continue
+    [ "$(record_field "$rec" branch)" = "$branch" ] || continue
+    expected=$(record_field "$rec" expected_head)
+    case "$expected" in "$head"*|"$head") return 0 ;; esac
+  done
+  return 1
+}
+
+PREFLIGHT_REASON=
+preflight() { # <record> [allow-self-active]
+  local rec=$1 allow_self=${2:-0} task home project wt branch expected meta top wt_real project_real actual_branch actual_head porcelain home_out runs_out rbranch rhead
+  PREFLIGHT_REASON=
+  task=$(record_field "$rec" task)
+  home=$(record_field "$rec" home)
+  project=$(record_field "$rec" project)
+  wt=$(record_field "$rec" worktree)
+  branch=$(record_field "$rec" branch)
+  expected=$(record_field "$rec" expected_head)
+  meta="$home/state/$task.meta"
+  [ -f "$meta" ] && [ ! -L "$meta" ] || { PREFLIGHT_REASON="task metadata is missing or ambiguous at $meta"; return 1; }
+  [ "$(meta_value "$meta" kind)" = ship ] || { PREFLIGHT_REASON="task $task is not a ship task"; return 1; }
+  [ "$(meta_value "$meta" worktree)" = "$wt" ] || { PREFLIGHT_REASON="task $task metadata no longer names intended isolated copy $wt"; return 1; }
+  [ "$(meta_value "$meta" project)" = "$project" ] || { PREFLIGHT_REASON="task $task metadata no longer names intended project $project"; return 1; }
+  wt_real=$(physical_dir "$wt" 2>/dev/null) || { PREFLIGHT_REASON="isolated copy is unavailable: $wt"; return 1; }
+  project_real=$(physical_dir "$project" 2>/dev/null) || { PREFLIGHT_REASON="project local copy is unavailable: $project"; return 1; }
+  top=$(git -C "$wt" rev-parse --show-toplevel 2>/dev/null || true)
+  top=$(physical_dir "$top" 2>/dev/null || true)
+  [ -n "$top" ] && [ "$top" = "$wt_real" ] && [ "$wt_real" != "$project_real" ] || { PREFLIGHT_REASON="task $task is not in a clean isolated git copy distinct from $project"; return 1; }
+  actual_branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  [ -n "$actual_branch" ] || { PREFLIGHT_REASON="detached HEAD in $wt; attach the intended task branch before certification"; return 1; }
+  [ "$actual_branch" = "$branch" ] || { PREFLIGHT_REASON="wrong branch in $wt: expected $branch, found $actual_branch"; return 1; }
+  actual_head=$(git -C "$wt" rev-parse HEAD 2>/dev/null || true)
+  [ "$actual_head" = "$expected" ] || { PREFLIGHT_REASON="changed head for $task: expected $expected, found ${actual_head:-unknown}; request a new explicit expected head"; return 1; }
+  porcelain=$(git -C "$wt" status --porcelain=v1 --untracked-files=all 2>/dev/null || printf '__git_status_failed__')
+  [ -z "$porcelain" ] || { PREFLIGHT_REASON="isolated copy $wt is not clean; preserve and resolve every unpublished change before certification"; return 1; }
+  if ! home_out=$(run_bounded "$wt" axi); then
+    PREFLIGHT_REASON="no-mistakes state could not be read for $task; leave daemon and custody untouched and inspect the reported tool failure"
+    return 1
+  fi
+  case "$home_out" in
+    *recover_custody*|*"recover custody"*|*"sync --recover"*)
+      PREFLIGHT_REASON="obsolete no-mistakes custody blocks $task; use only the separately authorized custody recovery choice"
+      return 1
+      ;;
+    *"error:"*) PREFLIGHT_REASON="no-mistakes preflight reported an error for $task"; return 1 ;;
+  esac
+  if ! runs_out=$(run_bounded "$wt" runs --limit 200); then
+    PREFLIGHT_REASON="active no-mistakes runs could not be inspected for $task"
+    return 1
+  fi
+  while IFS=$(printf '\t') read -r rbranch rhead; do
+    [ -n "$rbranch" ] || continue
+    if [ "$allow_self" = 1 ] && [ "$rbranch" = "$branch" ]; then
+      case "$expected" in "$rhead"*|"$rhead") continue ;; esac
+    fi
+    if coordinated_active_run "$project" "$rbranch" "$rhead"; then
+      continue
+    fi
+    PREFLIGHT_REASON="uncoordinated active validation on branch $rbranch blocks safe admission for project $project"
+    return 1
+  done < <(active_run_rows "$runs_out")
+  return 0
+}
+
+live_count() {
+  local rec n=0
+  for rec in "$QUEUE"/*.record; do
+    [ -f "$rec" ] && record_is_live "$rec" && n=$((n + 1))
+  done
+  printf '%s\n' "$n"
+}
+
+RUN_KIND=none
+RUN_ID=""
+RUN_OUTCOME=""
+RUN_REASON=""
+inspect_record_run() {
+  local rec=$1 wt branch expected out run_branch run_head status outcome run_full expected_full
+  RUN_KIND=none
+  RUN_ID=""
+  RUN_OUTCOME=""
+  RUN_REASON=""
+  wt=$(record_field "$rec" worktree)
+  branch=$(record_field "$rec" branch)
+  expected=$(record_field "$rec" expected_head)
+  if ! out=$(run_bounded "$wt" axi status); then
+    RUN_KIND=ambiguous; RUN_REASON="no-mistakes status read failed"; return
+  fi
+  case "$out" in *"error:"*) RUN_KIND=none; return ;; esac
+  run_branch=$(toon_field "$out" branch)
+  [ -n "$run_branch" ] || { RUN_KIND=none; return; }
+  [ "$run_branch" = "$branch" ] || { RUN_KIND=none; return; }
+  run_head=$(toon_field "$out" head)
+  [ -n "$run_head" ] || { RUN_KIND=ambiguous; RUN_REASON="matching run has no head identity"; return; }
+  outcome=$(toon_field "$out" outcome)
+  status=$(toon_field "$out" status)
+  expected_full=$(git -C "$wt" rev-parse --verify "${expected}^{commit}" 2>/dev/null || true)
+  run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null || true)
+  if [ -z "$expected_full" ] || [ -z "$run_full" ] || ! git -C "$wt" merge-base --is-ancestor "$expected_full" "$run_full" 2>/dev/null; then
+    case "$outcome:$status" in
+      checks-passed:*|passed:*|failed:*|cancelled:*|*:completed|*:failed|*:cancelled)
+        # A historical terminal result on an older tip of the reused branch is
+        # not this request's run and does not own current certification custody.
+        RUN_KIND=none
+        ;;
+      *)
+        RUN_KIND=ambiguous
+        RUN_REASON="matching active branch run does not descend from expected head $expected"
+        ;;
+    esac
+    return
+  fi
+  RUN_ID=$(toon_field "$out" id)
+  case "$outcome" in checks-passed|passed|failed|cancelled)
+    RUN_KIND=terminal; RUN_OUTCOME=$outcome; return ;;
+  esac
+  case "$status" in completed) RUN_KIND=terminal; RUN_OUTCOME=passed; return ;; failed|cancelled) RUN_KIND=terminal; RUN_OUTCOME=$status; return ;; esac
+  RUN_KIND=active
+}
+
+notify_record() {
+  local rec=$1 home task token fm_root message qhome qroot qtask qtoken
+  [ "$(record_field "$rec" notification)" = pending ] || return 0
+  home=$(record_field "$rec" home)
+  task=$(record_field "$rec" task)
+  token=$(record_field "$rec" token)
+  # Mark before delivery. A crash can lose a notification, but can never submit a
+  # duplicate start instruction. retry is an explicit recovery for failed/unknown delivery.
+  record_write "$rec" "$(record_field "$rec" state)" sending "$(record_field "$rec" run_id)" "$(record_field "$rec" outcome)" "notification delivery in progress"
+  fm_root="$home"
+  [ -x "$fm_root/bin/fm-certification.sh" ] || fm_root="$FM_ROOT"
+  qhome=$(shell_quote "$home")
+  qroot=$(shell_quote "$fm_root/bin/fm-certification.sh")
+  qtask=$(shell_quote "$task")
+  qtoken=$(shell_quote "$token")
+  message="Certification slot admitted for $task. Run exactly: FM_HOME=$qhome $qroot start $qtask $qtoken"
+  if FM_HOME="$home" "$SEND_BIN" "$task" "$message"; then
+    record_write "$rec" "$(record_field "$rec" state)" sent "$(record_field "$rec" run_id)" "$(record_field "$rec" outcome)" ""
+    echo "certification admitted: $task at $(record_field "$rec" expected_head)"
+    return 0
+  fi
+  record_write "$rec" "$(record_field "$rec" state)" failed "$(record_field "$rec" run_id)" "$(record_field "$rec" outcome)" "worker notification failed; inspect delivery before retrying"
+  echo "certification notification failed: $task; inspect delivery before 'fm-certification.sh retry $task'" >&2
+  return 1
+}
+
+reconcile_locked() { # <notify 0|1>
+  local do_notify=$1 rec st notification live rc=0
+  # Terminal reconciliation is authoritative only for records that reached the
+  # worker-side start command. Merely admitted work holds its slot until then.
+  for rec in "$QUEUE"/*.record; do
+    [ -f "$rec" ] || continue
+    st=$(record_field "$rec" state)
+    case "$st" in launching|running)
+      inspect_record_run "$rec"
+      case "$RUN_KIND" in
+        terminal)
+          record_write "$rec" terminal "$(record_field "$rec" notification)" "$RUN_ID" "$RUN_OUTCOME" ""
+          echo "certification terminal: $(record_field "$rec" task) outcome=$RUN_OUTCOME"
+          ;;
+        active)
+          record_write "$rec" running "$(record_field "$rec" notification)" "$RUN_ID" "" ""
+          ;;
+        ambiguous)
+          record_write "$rec" "$st" "$(record_field "$rec" notification)" "$(record_field "$rec" run_id)" "" "$RUN_REASON"
+          echo "certification ownership ambiguous: $(record_field "$rec" task): $RUN_REASON" >&2
+          rc=1
+          ;;
+      esac
+      ;;
+  esac
+  done
+
+  live=$(live_count)
+  for rec in "$QUEUE"/*.record; do
+    [ -f "$rec" ] || continue
+    [ "$live" -lt "$CAPACITY_REQUESTED" ] || break
+    [ "$(record_field "$rec" state)" = queued ] || continue
+    if preflight "$rec" 0; then
+      record_write "$rec" admitted pending "" "" ""
+      live=$((live + 1))
+    else
+      record_write "$rec" blocked none "" "" "$PREFLIGHT_REASON"
+      echo "certification blocked: $(record_field "$rec" task): $PREFLIGHT_REASON" >&2
+      rc=1
+    fi
+  done
+
+  if [ "$do_notify" = 1 ]; then
+    for rec in "$QUEUE"/*.record; do
+      [ -f "$rec" ] || continue
+      [ "$(record_field "$rec" state)" = admitted ] || continue
+      notification=$(record_field "$rec" notification)
+      [ "$notification" = pending ] || continue
+      notify_record "$rec" || rc=1
+    done
+  fi
+  return "$rc"
+}
+
+command_enqueue() {
+  local task=${1:-} expected=${2:-} intent_file="" meta project wt branch actual seq token rec tmp intent_dst existing
+  shift 2 || true
+  [ "${1:-}" = --intent-file ] && [ -n "${2:-}" ] && [ $# -eq 2 ] || usage_die "enqueue requires --intent-file <path>"
+  intent_file=$2
+  valid_task_id "$task" || usage_die "invalid task id '$task'"
+  valid_head "$expected" || usage_die "expected head must be a full 40-character commit id"
+  [ -f "$intent_file" ] && [ ! -L "$intent_file" ] && [ -s "$intent_file" ] || die "intent file must be a non-empty regular file: $intent_file"
+  meta="$STATE/$task.meta"
+  [ -f "$meta" ] && [ ! -L "$meta" ] || die "task metadata missing or ambiguous: $meta"
+  project=$(meta_value "$meta" project)
+  wt=$(meta_value "$meta" worktree)
+  [ -n "$project" ] && [ -n "$wt" ] || die "task metadata lacks project/worktree for $task"
+  branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  [ -n "$branch" ] || die "detached HEAD in $wt; attach the intended task branch before enqueueing certification"
+  if ! { single_line_value "$FM_HOME" && single_line_value "$project" \
+    && single_line_value "$wt" && single_line_value "$branch"; }; then
+    die "certification identity paths and branch must be single-line values"
+  fi
+  actual=$(git -C "$wt" rev-parse HEAD 2>/dev/null || true)
+  [ "$actual" = "$expected" ] || die "expected head $expected does not match task head ${actual:-unknown}"
+  lock_acquire
+  capacity_ensure
+  existing=$(record_for_task "$task" "$FM_HOME" || true)
+  if [ -n "$existing" ]; then
+    [ "$(record_field "$existing" expected_head)" = "$expected" ] || die "task $task already has a certification request for a different expected head"
+    echo "certification already recorded: $task state=$(record_field "$existing" state)"
+    reconcile_locked 1
+    lock_release
+    return
+  fi
+  seq=$(next_sequence)
+  token=$( (command -v sha256sum >/dev/null 2>&1 && printf '%s:%s:%s:%s' "$FM_HOME" "$task" "$expected" "$(date +%s%N)" | sha256sum | cut -c1-24) || (printf '%s%s' "$(date +%s)" "$$") )
+  rec="$QUEUE/$seq-$task.record"
+  intent_dst="$QUEUE/$seq-$task.intent"
+  tmp=$(mktemp "$QUEUE/.intent.XXXXXX") || die "cannot create certification intent"
+  cp "$intent_file" "$tmp"
+  chmod 0600 "$tmp"
+  mv "$tmp" "$intent_dst"
+  tmp=$(mktemp "$QUEUE/.record.XXXXXX") || die "cannot create certification record"
+  {
+    printf 'version=1\nsequence=%s\ntask=%s\nhome=%s\nproject=%s\nworktree=%s\nbranch=%s\nexpected_head=%s\ntoken=%s\nstate=queued\nnotification=none\nrun_id=\noutcome=\nreason=\n' \
+      "$seq" "$task" "$FM_HOME" "$project" "$wt" "$branch" "$expected" "$token"
+  } > "$tmp"
+  chmod 0600 "$tmp"
+  mv "$tmp" "$rec"
+  reconcile_locked 1
+  lock_release
+}
+
+command_reconcile() {
+  local notify=0
+  case "${1:-}" in '') ;; --notify) notify=1 ;; *) usage_die "reconcile accepts only --notify" ;; esac
+  [ $# -le 1 ] || usage_die "reconcile accepts only --notify"
+  # A home with no certification ledger stays byte-for-byte inert. This keeps
+  # ordinary watcher and session-start reconciliation from creating feature state.
+  [ -d "$QUEUE" ] || return 0
+  lock_acquire
+  capacity_ensure
+  reconcile_locked "$notify"
+  lock_release
+}
+
+command_start() {
+  local task=${1:-} token=${2:-} rec state wt expected intent_file expected_branch actual_branch active=0
+  [ $# -eq 2 ] || usage_die "start requires <task-id> <admission-token>"
+  valid_task_id "$task" || usage_die "invalid task id '$task'"
+  lock_acquire
+  capacity_ensure
+  rec=$(record_for_task "$task" "$FM_HOME" || true)
+  [ -n "$rec" ] || die "no certification request for task $task in FM_HOME $FM_HOME"
+  [ "$(record_field "$rec" token)" = "$token" ] || die "admission token does not match task $task"
+  state=$(record_field "$rec" state)
+  case "$state" in admitted|launching|running) ;; *) die "task $task is not admitted (state=$state)" ;; esac
+  if [ "$state" = admitted ]; then
+    if ! preflight "$rec" 1; then
+      record_write "$rec" blocked "$(record_field "$rec" notification)" "$(record_field "$rec" run_id)" "" "$PREFLIGHT_REASON"
+      die "$PREFLIGHT_REASON"
+    fi
+  else
+    # Reattachment may follow pipeline fix commits, so exact-head and clean-copy
+    # checks no longer apply. The attached admitted branch still does.
+    wt=$(record_field "$rec" worktree)
+    expected_branch=$(record_field "$rec" branch)
+    actual_branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+    [ -n "$actual_branch" ] || die "detached HEAD in $wt; refusing certification reattachment"
+    [ "$actual_branch" = "$expected_branch" ] || die "wrong branch in $wt: expected $expected_branch, found $actual_branch"
+  fi
+  inspect_record_run "$rec"
+  case "$RUN_KIND" in
+    terminal) die "task $task already has authoritative terminal outcome $RUN_OUTCOME" ;;
+    ambiguous) die "$RUN_REASON" ;;
+    active) active=1 ;;
+    none)
+      if [ "$state" != admitted ]; then
+        die "task $task launch was already claimed but no matching run is visible; inspect before an explicit retry"
+      fi
+      ;;
+  esac
+  record_write "$rec" launching sent "$RUN_ID" "" ""
+  wt=$(record_field "$rec" worktree)
+  expected=$(record_field "$rec" expected_head)
+  intent_file="${rec%.record}.intent"
+  [ -s "$intent_file" ] || die "stored certification intent is missing for $task"
+  lock_release
+  if [ "${FM_CERT_NO_EXEC:-0}" = 1 ]; then
+    printf 'would exec in %s at %s: %s axi run --intent <stored-intent> (reattach=%s)\n' "$wt" "$expected" "$NM_BIN" "$active"
+    return
+  fi
+  cd "$wt"
+  exec "$NM_BIN" axi run --intent "$(cat "$intent_file")"
+}
+
+command_retry() {
+  local task=${1:-} rec state
+  [ $# -eq 1 ] || usage_die "retry requires <task-id>"
+  lock_acquire
+  capacity_ensure
+  rec=$(record_for_task "$task" "$FM_HOME" || true)
+  [ -n "$rec" ] || die "no certification request for task $task"
+  state=$(record_field "$rec" state)
+  case "$state" in blocked)
+    record_write "$rec" queued none "" "" ""
+    ;;
+  admitted)
+    case "$(record_field "$rec" notification)" in failed|sending)
+      record_write "$rec" admitted pending "$(record_field "$rec" run_id)" "" ""
+      ;;
+    *) die "task $task has no retryable notification" ;;
+    esac
+    ;;
+  launching|running)
+    inspect_record_run "$rec"
+    case "$RUN_KIND" in
+      none) record_write "$rec" admitted pending "" "" "" ;;
+      active) die "task $task already has a matching active run; use its token-bound start command only to reattach" ;;
+      terminal) die "task $task already has authoritative terminal outcome $RUN_OUTCOME; reconcile instead" ;;
+      ambiguous) die "$RUN_REASON" ;;
+    esac
+    ;;
+  *) die "task $task is not retryable (state=$state)" ;;
+  esac
+  reconcile_locked 1
+  lock_release
+}
+
+command_status() {
+  local rec
+  if [ ! -d "$QUEUE" ]; then
+    printf 'capacity=uninitialized\n(no certification requests)\n'
+    return
+  fi
+  printf 'capacity=%s\n' "$(cat "$CERT_ROOT/capacity" 2>/dev/null || printf 'uninitialized')"
+  for rec in "$QUEUE"/*.record; do
+    [ -f "$rec" ] || continue
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$(record_field "$rec" sequence)" "$(record_field "$rec" state)" \
+      "$(record_field "$rec" task)" "$(record_field "$rec" branch)" \
+      "$(record_field "$rec" expected_head)" "$(record_field "$rec" reason)"
+  done
+}
+
+cmd=${1:-}
+[ -n "$cmd" ] || usage_die "missing command"
+shift
+case "$cmd" in
+  -h|--help|help) usage ;;
+  enqueue) command_enqueue "$@" ;;
+  reconcile) command_reconcile "$@" ;;
+  start) command_start "$@" ;;
+  retry) command_retry "$@" ;;
+  status) command_status "$@" ;;
+  *) usage_die "unknown command '$cmd'" ;;
+esac

--- a/bin/fm-certification.sh
+++ b/bin/fm-certification.sh
@@ -27,6 +27,10 @@
 #     Requeues a blocked request without changing its expected branch or head,
 #     or explicitly retries a failed/ambiguous notification or unbound launch
 #     after inspection proves no matching active run exists.
+#   fm-certification.sh withdraw <task-id>
+#     Abandons a request and frees its slot so a corrected head can be
+#     re-enqueued. Refuses to cancel a matching active or terminal run; the
+#     record and its intent are archived under the shared root for evidence.
 #   fm-certification.sh status
 #     Prints the durable queue in sequence order without mutation.
 #
@@ -34,6 +38,8 @@
 #   FM_CERTIFICATION_ROOT   shared durable root (default ~/.no-mistakes/firstmate-certification)
 #   FM_CERTIFICATION_CAPACITY positive configured capacity (default 1). The first
 #                           mutation records it durably; later mismatches refuse.
+#   FM_CERTIFICATION_RETAIN positive count of newest terminal records to retain
+#                           (default 100). Older terminal records and their intent are pruned.
 #   FM_CERT_NM_BIN          no-mistakes executable (default no-mistakes)
 #   FM_CERT_SEND_BIN        fm-send executable (default tracked fm-send.sh)
 #   FM_CERT_TIMEOUT         read-only CLI timeout seconds (default 15)
@@ -51,7 +57,10 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 CERT_ROOT="${FM_CERTIFICATION_ROOT:-${NO_MISTAKES_HOME:-$HOME/.no-mistakes}/firstmate-certification}"
 QUEUE="$CERT_ROOT/queue"
 LOCK="$CERT_ROOT/.lock"
+QUARANTINE="$CERT_ROOT/quarantine"
+WITHDRAWN="$CERT_ROOT/withdrawn"
 CAPACITY_REQUESTED="${FM_CERTIFICATION_CAPACITY:-1}"
+RETAIN_REQUESTED="${FM_CERTIFICATION_RETAIN:-100}"
 NM_BIN="${FM_CERT_NM_BIN:-no-mistakes}"
 SEND_BIN="${FM_CERT_SEND_BIN:-$SCRIPT_DIR/fm-send.sh}"
 NM_TIMEOUT="${FM_CERT_TIMEOUT:-15}"
@@ -59,18 +68,20 @@ NM_TIMEOUT="${FM_CERT_TIMEOUT:-15}"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
-usage() { sed -n '2,39p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,46p' "$0" | sed 's/^# \{0,1\}//'; }
 die() { echo "error: $*" >&2; exit 1; }
 usage_die() { echo "error: $*" >&2; usage >&2; exit 2; }
 
 case "$CAPACITY_REQUESTED" in ''|*[!0-9]*|0) die "FM_CERTIFICATION_CAPACITY must be a positive integer" ;; esac
+case "$RETAIN_REQUESTED" in ''|*[!0-9]*|0) die "FM_CERTIFICATION_RETAIN must be a positive integer" ;; esac
 case "$NM_TIMEOUT" in ''|*[!0-9]*|0) die "FM_CERT_TIMEOUT must be a positive integer" ;; esac
 
 mkdir_private() {
   umask 077
-  mkdir -p "$CERT_ROOT" "$QUEUE"
+  mkdir -p "$CERT_ROOT" "$QUEUE" "$QUARANTINE" "$WITHDRAWN"
   [ ! -L "$CERT_ROOT" ] && [ ! -L "$QUEUE" ] || die "certification state paths must not be symlinks: $CERT_ROOT"
-  chmod 0700 "$CERT_ROOT" "$QUEUE" 2>/dev/null || true
+  [ ! -L "$QUARANTINE" ] && [ ! -L "$WITHDRAWN" ] || die "certification state paths must not be symlinks: $CERT_ROOT"
+  chmod 0700 "$CERT_ROOT" "$QUEUE" "$QUARANTINE" "$WITHDRAWN" 2>/dev/null || true
 }
 
 lock_acquire() {
@@ -112,6 +123,54 @@ record_for_task() {
     return 0
   done
   return 1
+}
+
+RECORD_STATES="queued admitted launching running blocked terminal"
+record_schema_ok() { # <record>
+  local rec=$1 field state seq
+  [ "$(record_field "$rec" version)" = 1 ] || return 1
+  for field in sequence task home project worktree branch expected_head token state; do
+    [ -n "$(record_field "$rec" "$field")" ] || return 1
+  done
+  seq=$(record_field "$rec" sequence)
+  case "$seq" in ''|*[!0-9]*) return 1 ;; esac
+  valid_task_id "$(record_field "$rec" task)" || return 1
+  valid_head "$(record_field "$rec" expected_head)" || return 1
+  state=$(record_field "$rec" state)
+  case " $RECORD_STATES " in *" $state "*) return 0 ;; *) return 1 ;; esac
+}
+
+quarantine_sweep() { # sets QUARANTINED=1 and returns 1 if any record was quarantined
+  local rec base rc=0
+  for rec in "$QUEUE"/*.record; do
+    [ -f "$rec" ] || continue
+    record_schema_ok "$rec" && continue
+    base=$(basename "$rec" .record)
+    mv "$rec" "$QUARANTINE/$base.record" 2>/dev/null || true
+    [ ! -f "$QUEUE/$base.intent" ] || mv "$QUEUE/$base.intent" "$QUARANTINE/$base.intent" 2>/dev/null || true
+    echo "certification record quarantined (unsupported version or malformed schema): $base" >&2
+    rc=1
+  done
+  return "$rc"
+}
+
+retention_sweep() { # prune terminal records beyond the newest RETAIN_REQUESTED
+  local rec base n=0 sorted
+  sorted=$(for rec in "$QUEUE"/*.record; do
+    [ -f "$rec" ] || continue
+    [ "$(record_field "$rec" state)" = terminal ] || continue
+    printf '%s\n' "$rec"
+  done | sort -r)
+  [ -n "$sorted" ] || return 0
+  while IFS= read -r rec; do
+    [ -n "$rec" ] || continue
+    n=$((n + 1))
+    [ "$n" -gt "$RETAIN_REQUESTED" ] || continue
+    base=$(basename "$rec" .record)
+    rm -f "$rec" "$QUEUE/$base.intent" 2>/dev/null || true
+  done <<EOF
+$sorted
+EOF
 }
 
 record_write() { # <record> <state> <notification> <run-id> <outcome> <reason>
@@ -197,6 +256,7 @@ preflight() { # <record> [allow-self-active]
   meta="$home/state/$task.meta"
   [ -f "$meta" ] && [ ! -L "$meta" ] || { PREFLIGHT_REASON="task metadata is missing or ambiguous at $meta"; return 1; }
   [ "$(meta_value "$meta" kind)" = ship ] || { PREFLIGHT_REASON="task $task is not a ship task"; return 1; }
+  [ "$(meta_value "$meta" mode)" = no-mistakes ] || { PREFLIGHT_REASON="task $task delivery mode is $(meta_value "$meta" mode); final certification admits only no-mistakes delivery, never direct-PR or local-only"; return 1; }
   [ "$(meta_value "$meta" worktree)" = "$wt" ] || { PREFLIGHT_REASON="task $task metadata no longer names intended isolated copy $wt"; return 1; }
   [ "$(meta_value "$meta" project)" = "$project" ] || { PREFLIGHT_REASON="task $task metadata no longer names intended project $project"; return 1; }
   wt_real=$(physical_dir "$wt" 2>/dev/null) || { PREFLIGHT_REASON="isolated copy is unavailable: $wt"; return 1; }
@@ -324,6 +384,9 @@ notify_record() {
 
 reconcile_locked() { # <notify 0|1>
   local do_notify=$1 rec st notification live rc=0
+  # Records with an unsupported version or malformed schema never establish
+  # capacity or ownership: quarantine them before any accounting loop runs.
+  quarantine_sweep || rc=1
   # Terminal reconciliation is authoritative only for records that reached the
   # worker-side start command. Merely admitted work holds its slot until then.
   for rec in "$QUEUE"/*.record; do
@@ -334,6 +397,7 @@ reconcile_locked() { # <notify 0|1>
       case "$RUN_KIND" in
         terminal)
           record_write "$rec" terminal "$(record_field "$rec" notification)" "$RUN_ID" "$RUN_OUTCOME" ""
+          rm -f "${rec%.record}.intent" 2>/dev/null || true
           echo "certification terminal: $(record_field "$rec" task) outcome=$RUN_OUTCOME"
           ;;
         active)
@@ -342,6 +406,15 @@ reconcile_locked() { # <notify 0|1>
         ambiguous)
           record_write "$rec" "$st" "$(record_field "$rec" notification)" "$(record_field "$rec" run_id)" "" "$RUN_REASON"
           echo "certification ownership ambiguous: $(record_field "$rec" task): $RUN_REASON" >&2
+          rc=1
+          ;;
+        none)
+          # Launch custody was recorded but no matching run is visible: a worker
+          # likely crashed between claiming the slot and no-mistakes starting.
+          # Retain the slot (never auto-relaunch) but surface the stall so
+          # session-start/watch reconciliation prompts an explicit retry or withdraw.
+          record_write "$rec" "$st" "$(record_field "$rec" notification)" "$(record_field "$rec" run_id)" "" "launch custody holds a slot but no matching no-mistakes run is visible; inspect then retry or withdraw"
+          echo "certification launch stalled: $(record_field "$rec" task): no matching run visible; inspect then retry or withdraw" >&2
           rc=1
           ;;
       esac
@@ -373,6 +446,8 @@ reconcile_locked() { # <notify 0|1>
       notify_record "$rec" || rc=1
     done
   fi
+
+  retention_sweep
   return "$rc"
 }
 
@@ -389,6 +464,8 @@ command_enqueue() {
   project=$(meta_value "$meta" project)
   wt=$(meta_value "$meta" worktree)
   [ -n "$project" ] && [ -n "$wt" ] || die "task metadata lacks project/worktree for $task"
+  [ "$(meta_value "$meta" kind)" = ship ] || die "task $task is not a ship task; final certification admits only ship tasks"
+  [ "$(meta_value "$meta" mode)" = no-mistakes ] || die "task $task delivery mode is $(meta_value "$meta" mode); final certification admits only no-mistakes delivery, never direct-PR or local-only"
   branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
   [ -n "$branch" ] || die "detached HEAD in $wt; attach the intended task branch before enqueueing certification"
   if ! { single_line_value "$FM_HOME" && single_line_value "$project" \
@@ -399,6 +476,7 @@ command_enqueue() {
   [ "$actual" = "$expected" ] || die "expected head $expected does not match task head ${actual:-unknown}"
   lock_acquire
   capacity_ensure
+  quarantine_sweep || true
   existing=$(record_for_task "$task" "$FM_HOME" || true)
   if [ -n "$existing" ]; then
     [ "$(record_field "$existing" expected_head)" = "$expected" ] || die "task $task already has a certification request for a different expected head"
@@ -445,6 +523,7 @@ command_start() {
   valid_task_id "$task" || usage_die "invalid task id '$task'"
   lock_acquire
   capacity_ensure
+  quarantine_sweep || true
   rec=$(record_for_task "$task" "$FM_HOME" || true)
   [ -n "$rec" ] || die "no certification request for task $task in FM_HOME $FM_HOME"
   [ "$(record_field "$rec" token)" = "$token" ] || die "admission token does not match task $task"
@@ -494,6 +573,7 @@ command_retry() {
   [ $# -eq 1 ] || usage_die "retry requires <task-id>"
   lock_acquire
   capacity_ensure
+  quarantine_sweep || true
   rec=$(record_for_task "$task" "$FM_HOME" || true)
   [ -n "$rec" ] || die "no certification request for task $task"
   state=$(record_field "$rec" state)
@@ -518,6 +598,36 @@ command_retry() {
     ;;
   *) die "task $task is not retryable (state=$state)" ;;
   esac
+  reconcile_locked 1
+  lock_release
+}
+
+command_withdraw() {
+  local task=${1:-} rec state base
+  [ $# -eq 1 ] || usage_die "withdraw requires <task-id>"
+  valid_task_id "$task" || usage_die "invalid task id '$task'"
+  lock_acquire
+  capacity_ensure
+  quarantine_sweep || true
+  rec=$(record_for_task "$task" "$FM_HOME" || true)
+  [ -n "$rec" ] || die "no certification request for task $task"
+  state=$(record_field "$rec" state)
+  # Withdrawal abandons a request and frees its slot. It never cancels an
+  # in-flight No Mistakes run: a matching active or terminal run stays under the
+  # worker's gate authority, so those are refused.
+  case "$state" in launching|running)
+    inspect_record_run "$rec"
+    case "$RUN_KIND" in
+      active) die "task $task has a matching active no-mistakes run; withdrawal cannot cancel it — the worker owns that gate" ;;
+      terminal) die "task $task already has authoritative terminal outcome $RUN_OUTCOME; reconcile instead of withdrawing" ;;
+      ambiguous) die "$RUN_REASON" ;;
+    esac
+    ;;
+  esac
+  base=$(basename "$rec" .record)
+  mv "$rec" "$WITHDRAWN/$base.record" 2>/dev/null || die "cannot archive withdrawn record for $task"
+  [ ! -f "$QUEUE/$base.intent" ] || mv "$QUEUE/$base.intent" "$WITHDRAWN/$base.intent" 2>/dev/null || true
+  echo "certification withdrawn: $task (was $state); re-enqueue with a fresh expected head to resubmit"
   reconcile_locked 1
   lock_release
 }
@@ -547,6 +657,7 @@ case "$cmd" in
   reconcile) command_reconcile "$@" ;;
   start) command_start "$@" ;;
   retry) command_retry "$@" ;;
+  withdraw) command_withdraw "$@" ;;
   status) command_status "$@" ;;
   *) usage_die "unknown command '$cmd'" ;;
 esac

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -33,14 +33,17 @@
 #                       when this session actually holds the lock.
 #   3. wake-drain     - mutates the durable wake queue, so it also only runs
 #                       when locked.
-#   4. context digest - data/projects.md, data/secondmates.md, data/captain.md,
+#   4. certification - when locked, reconciles the optional machine-global
+#                       final-certification queue and notifies newly admitted
+#                       workers. It is inert when no queue exists.
+#   5. context digest - data/projects.md, data/secondmates.md, data/captain.md,
 #                       data/captain-shared.md, data/learnings.md: read-only,
 #                       always safe, always runs.
-#   5. fleet digest   - a compact data/backlog.md identity/metadata listing,
+#   6. fleet digest   - a compact data/backlog.md identity/metadata listing,
 #                       every state/*.meta, a bounded state/*.status tail,
 #                       state/.afk, and a cheap per-task endpoint-liveness read:
 #                       read-only, always runs.
-#   6. closing reminder - prints the context-specific watcher next step; this
+#   7. closing reminder - prints the context-specific watcher next step; this
 #                       script points back to the emitted harness supervision
 #                       block and deliberately never arms the watcher itself.
 #
@@ -299,7 +302,26 @@ else
   fi
 fi
 
-# --- 4. supervision operating instructions ----------------------------------
+# --- 4. durable final-certification recovery -------------------------------
+# Reconciliation is a mutation because it can release an authoritative terminal
+# slot and submit the next worker instruction. A lock-refused session must not do
+# either. The owner is inert and silent until its shared queue has been created.
+subsection "FINAL CERTIFICATION"
+if [ "$READ_ONLY" -eq 1 ]; then
+  printf 'skipped (read-only session)\n'
+else
+  CERT_OUT=$(FM_HOME="$FM_HOME" "$SCRIPT_DIR/fm-certification.sh" reconcile --notify 2>&1)
+  CERT_RC=$?
+  if [ -n "$CERT_OUT" ]; then
+    printf '%s\n' "$CERT_OUT"
+  elif [ "$CERT_RC" -eq 0 ]; then
+    printf '(no certification transition)\n'
+  else
+    printf 'certification reconciliation failed without a diagnostic\n'
+  fi
+fi
+
+# --- 5. supervision operating instructions ----------------------------------
 AFK_PRESENT=0
 [ -e "$STATE/.afk" ] && AFK_PRESENT=1
 X_MODE_PRESENT=0

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -120,7 +120,7 @@ family_for_basename() {
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|fm-brief.test.sh|\
     fm-calm-pi-extension.test.sh|fm-captain-translation-contract.test.sh|fm-cd-pretool-check.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
-    fm-continuity-pretool-check.test.sh|fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
+    fm-continuity-pretool-check.test.sh|fm-certification.test.sh|fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-dispatch-select.test.sh|fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
@@ -390,8 +390,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -413,7 +413,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -431,8 +431,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -445,7 +445,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi
@@ -615,6 +615,10 @@ families_for_changed_path() {
       ;;
     bin/fm-test-run.sh|bin/fm-test-isolation-proof.sh)
       printf '%s\n' pure-contract-unit
+      ;;
+    bin/fm-certification.sh|docs/certification-coordinator.md|\
+    .agents/skills/certification-coordinator/SKILL.md)
+      printf '%s\n' "__script__:fm-certification.test.sh"
       ;;
     bin/backends/herdr*|bin/fm-herdr-lab.sh|tests/herdr-test-safety.sh)
       printf '%s\n' real-herdr-gated

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -679,6 +679,20 @@ while :; do
   # alive. Supervision scripts warn when this goes stale with tasks in flight.
   touch "$STATE/.last-watcher-beat"
 
+  # Durable final-certification reconciliation is backend- and harness-neutral.
+  # It is inert until a shared queue exists, releases capacity only from an
+  # authoritative terminal no-mistakes result, and submits each newly admitted
+  # worker instruction at most once. Successful admission/advancement is routine;
+  # only a safety refusal needs to wake firstmate.
+  CERT_OUT=$(FM_HOME="$FM_HOME" "$SCRIPT_DIR/fm-certification.sh" reconcile --notify 2>&1)
+  CERT_RC=$?
+  if [ "$CERT_RC" -ne 0 ] && [ -n "$CERT_OUT" ]; then
+    CERT_REASON=$(printf '%s' "$CERT_OUT" | tr '\n' ';' | sed 's/;*$//')
+    reason="check: certification coordinator: $CERT_REASON"
+    fm_wake_append check certification-coordinator "$reason" || exit 1
+    wake "$reason"
+  fi
+
   # Parent-owned secondmate pending-reply reconciliation: resolve correlated
   # parent reports, observe backend busy/idle turn completion, send one recovery
   # repost after grace, and escalate once if the recovery turn is also missed.

--- a/docs/certification-coordinator.md
+++ b/docs/certification-coordinator.md
@@ -39,10 +39,12 @@ Reconciliation moves `launching` to `running` once a matching active run is auth
 A matching authoritative final result moves `launching` or `running` to `terminal`, releases capacity, and immediately considers the next queued request.
 An ambiguous run identity retains the live state and capacity instead of guessing ownership.
 `retry` may move a corrected `blocked` request back to `queued`, or explicitly retry a failed or ambiguous notification, without changing its bound branch or expected head.
-A `launching` or `running` record whose worker left no matching No Mistakes run keeps its slot but reconciliation reports the stall with a nonzero result so session-start and watch prompt an explicit `retry` or `withdraw` instead of stranding every queued request silently.
+A `launching` or `running` record whose worker left no matching No Mistakes run keeps its slot; within a durable bounded launch grace this is treated as an ordinary run still registering and is not surfaced, but once the grace elapses reconciliation reports the stall with a nonzero result so session-start and watch prompt an explicit `retry` or `withdraw` instead of stranding every queued request silently.
+The launch timestamp is recorded durably on the record when the worker claims the slot, so the grace survives restarts and cannot be reset by reconciliation.
 A changed expected head requires a new explicit request rather than silent rebinding.
-`withdraw` abandons a request and frees its slot so a corrected head can be re-enqueued, but it refuses to cancel a matching active or terminal run because that gate stays under worker authority; the withdrawn record and its intent are archived under the shared root for evidence.
+`withdraw` abandons a request and frees its slot so a corrected head can be re-enqueued, but it refuses to cancel a matching active or terminal run because that gate stays under worker authority, and it refuses a launch still inside its grace window whose run may only be registering, so it never frees a slot into an uncoordinated double run; the withdrawn record and its intent are archived under the shared root for evidence.
 Reaching `terminal` deletes the record's full intent text, and terminal records beyond the newest configured retention count are pruned with their intent so monitoring and storage cost stay bounded.
+The quarantine and withdrawn archives are bounded by the same retention count, keeping recent compact audit evidence while steady-state storage stays flat.
 
 ## Crash and restart recovery
 
@@ -77,4 +79,4 @@ Worker-owned synchronous No Mistakes execution remains unchanged across all five
 ## Evidence
 
 Focused behavior coverage lives in `tests/fm-certification.test.sh`.
-The suite covers concurrent admission, restart reconciliation, detached and wrong branches, changed expected heads, obsolete custody, preserved unpublished work, uncoordinated active runs, terminal advancement, duplicate-notification suppression, command failure paths, non-`no-mistakes` delivery-mode refusal, malformed and version-skewed record quarantine, crashed-launch stall escalation, withdrawal that frees a slot and refuses to cancel an active run, and bounded terminal retention.
+The suite covers concurrent admission, restart reconciliation, detached and wrong branches, changed expected heads, obsolete custody, preserved unpublished work, uncoordinated active runs, terminal advancement, duplicate-notification suppression, command failure paths, non-`no-mistakes` delivery-mode refusal, malformed and version-skewed record quarantine, crashed-launch stall escalation only after the launch grace, grace-window suppression of spurious stalls and withdrawals, withdrawal that frees a slot and refuses to cancel an active run, and bounded terminal, quarantine, and withdrawn retention.

--- a/docs/certification-coordinator.md
+++ b/docs/certification-coordinator.md
@@ -58,6 +58,7 @@ A crash before notification leaves a pending notification that reconciliation ca
 A crash during notification leaves an ambiguous delivery that requires explicit inspection and retry rather than a possible duplicate.
 A crash after worker-side launch custody but before No Mistakes starts retains the slot and refuses an automatic second launch.
 After inspection proves no matching run exists, explicit `retry` republishes one token-bound worker instruction; when a matching run does exist, the original start command reattaches to it.
+Like withdrawal, `retry` refuses a `launching` or `running` record still inside its launch grace whose run may only be registering, so a manual retry cannot re-drive a launch into an uncoordinated double run before the grace elapses.
 No recovery path changes Git history or invokes No Mistakes custody recovery.
 
 ## Authority boundary
@@ -79,4 +80,4 @@ Worker-owned synchronous No Mistakes execution remains unchanged across all five
 ## Evidence
 
 Focused behavior coverage lives in `tests/fm-certification.test.sh`.
-The suite covers concurrent admission, restart reconciliation, detached and wrong branches, changed expected heads, obsolete custody, preserved unpublished work, uncoordinated active runs, terminal advancement, duplicate-notification suppression, command failure paths, non-`no-mistakes` delivery-mode refusal, malformed and version-skewed record quarantine, crashed-launch stall escalation only after the launch grace, grace-window suppression of spurious stalls and withdrawals, withdrawal that frees a slot and refuses to cancel an active run, and bounded terminal, quarantine, and withdrawn retention.
+The suite covers concurrent admission, restart reconciliation, detached and wrong branches, changed expected heads, obsolete custody, preserved unpublished work, uncoordinated active runs, terminal advancement, duplicate-notification suppression, command failure paths, non-`no-mistakes` delivery-mode refusal, malformed and version-skewed record quarantine, crashed-launch stall escalation only after the launch grace, grace-window suppression of spurious stalls and refusal of in-grace withdrawal and retry, withdrawal that frees a slot and refuses to cancel an active run, and bounded terminal, quarantine, and withdrawn retention.

--- a/docs/certification-coordinator.md
+++ b/docs/certification-coordinator.md
@@ -1,0 +1,73 @@
+# Final certification coordinator
+
+`bin/fm-certification.sh` is the one authoritative owner of the final-certification state machine, ledger format, admission lock, preflight, terminal reconciliation, and worker notification.
+This document records the design and safety rationale without duplicating the script's command mechanics.
+
+## Scope
+
+The coordinator governs final heavy No Mistakes certifications only.
+Implementation, focused tests, ordinary worker activity, direct-PR delivery, and local-only delivery remain outside its capacity accounting and continue in parallel.
+The ordinary backlog remains the owner of task lifecycle and dependencies, while the certification ledger records only final-validation admission and never moves or duplicates backlog items.
+The default shared capacity is one.
+The first mutation records the configured positive capacity in the machine-global coordinator root, and a caller presenting a different value is refused rather than creating inconsistent limits.
+The ledger defaults to `~/.no-mistakes/firstmate-certification`, so primary and secondmate homes on the same machine contend through one owner instead of independent per-home slots.
+
+## Safety invariants
+
+- Every state mutation holds the single machine-global coordinator lock.
+- FIFO sequence is durable, and blocked ineligible work does not strand the next eligible request.
+- Live records never exceed the durable configured capacity.
+- Admission binds one Firstmate home, task identity, ship metadata record, project local copy, isolated copy, attached branch, and exact expected commit.
+- Both admission and worker start repeat preflight against current facts.
+- Detached HEAD, wrong branch, changed head, dirty isolated copy, non-isolated location, missing or changed task metadata, uncoordinated active validation, obsolete custody, or ambiguous tool output refuses certification.
+- A slot is released only by a matching run whose branch and commit ancestry bind it to the admitted expected head and whose authoritative outcome is `checks-passed`, `passed`, `failed`, or `cancelled`.
+- Notification moves to an in-progress durable state before submission, so crash ambiguity can lose a steer but cannot automatically duplicate it.
+- Explicit retry is required after ambiguous or failed delivery.
+- The worker invokes the admitted `start` command in its own process and remains the sole driver of every No Mistakes gate and response.
+- The coordinator never invokes `no-mistakes axi respond`, `abort`, `rerun`, `sync`, custody recovery, branch mutation, work disposal, task cleanup, or daemon lifecycle commands.
+
+## States and transitions
+
+`queued` means the request has durable FIFO position but no capacity.
+A successful current preflight moves the oldest eligible `queued` request to `admitted` and reserves capacity.
+A failed preflight moves only that request to `blocked` with an actionable reason, then admission continues with the next eligible request.
+Successful worker-side preflight moves `admitted` to `launching`, after which the worker process starts or reattaches to the matching run.
+Reconciliation moves `launching` to `running` once a matching active run is authoritative.
+A matching authoritative final result moves `launching` or `running` to `terminal`, releases capacity, and immediately considers the next queued request.
+An ambiguous run identity retains the live state and capacity instead of guessing ownership.
+`retry` may move a corrected `blocked` request back to `queued`, or explicitly retry a failed or ambiguous notification, without changing its bound branch or expected head.
+A changed expected head requires a new explicit request rather than silent rebinding.
+
+## Crash and restart recovery
+
+The queue, sequence, capacity, intent, admission token, notification state, run identity, and final outcome are regular owner-only files under the shared durable root.
+Atomic replacement publishes every record transition.
+A stale coordinator process lock is reclaimed only through Firstmate's process-identity-aware shared lock owner.
+Session start reconciles the queue after the per-home session lock is acquired.
+The ordinary watcher also reconciles before status-signal handling, which advances the queue after a worker's terminal result without a repeated manual nudge.
+Repeated reconciliation is idempotent.
+A crash before notification leaves a pending notification that reconciliation can send.
+A crash during notification leaves an ambiguous delivery that requires explicit inspection and retry rather than a possible duplicate.
+A crash after worker-side launch custody but before No Mistakes starts retains the slot and refuses an automatic second launch.
+After inspection proves no matching run exists, explicit `retry` republishes one token-bound worker instruction; when a matching run does exist, the original start command reattaches to it.
+No recovery path changes Git history or invokes No Mistakes custody recovery.
+
+## Authority boundary
+
+Admission, read-only reconciliation, one worker steer, retry after a proven failed delivery, and advancement after an authoritative terminal result are automatic reversible actions.
+Changing shared capacity, discarding or rewriting work, cancelling a run, selecting keep-local custody recovery, restarting the shared daemon, and any existing destructive, irreversible, security-sensitive, merge, delivery-mode, or product decision retain their existing captain authority.
+The coordinator does not reinterpret project `yolo` posture and never grants merge or gate-decision authority.
+
+## Runtime and worker compatibility
+
+The coordinator reads the backend-neutral `state/<id>.meta` worktree and project fields and delegates delivery through `fm-send`'s recorded endpoint abstraction.
+It neither creates, captures, interrupts, resumes, nor destroys an endpoint, so tmux, Herdr, Zellij, Orca, and cmux need no coordinator-specific lifecycle operation.
+Orca's worktree provider difference is non-applicable after metadata publication because the same isolated-copy Git preflight applies.
+Codex App remains non-applicable because it is not a supported task runtime backend.
+The worker instruction names the same shell entry point for Claude, Codex, OpenCode, Pi, and Grok, so slash-command syntax, popup behavior, model flags, effort flags, and busy signatures are non-applicable.
+Worker-owned synchronous No Mistakes execution remains unchanged across all five adapters because `start` execs the command inside the worker's own process and returns every gate result to that worker.
+
+## Evidence
+
+Focused behavior coverage lives in `tests/fm-certification.test.sh`.
+The suite covers concurrent admission, restart reconciliation, detached and wrong branches, changed expected heads, obsolete custody, preserved unpublished work, uncoordinated active runs, terminal advancement, duplicate-notification suppression, and command failure paths.

--- a/docs/certification-coordinator.md
+++ b/docs/certification-coordinator.md
@@ -6,6 +6,7 @@ This document records the design and safety rationale without duplicating the sc
 ## Scope
 
 The coordinator governs final heavy No Mistakes certifications only.
+Admission deterministically requires a `ship` task whose delivery mode is `no-mistakes`; direct-PR and local-only work is refused at enqueue and again at every preflight so it can never be injected into No Mistakes by coordinator error.
 Implementation, focused tests, ordinary worker activity, direct-PR delivery, and local-only delivery remain outside its capacity accounting and continue in parallel.
 The ordinary backlog remains the owner of task lifecycle and dependencies, while the certification ledger records only final-validation admission and never moves or duplicates backlog items.
 The default shared capacity is one.
@@ -15,8 +16,10 @@ The ledger defaults to `~/.no-mistakes/firstmate-certification`, so primary and 
 ## Safety invariants
 
 - Every state mutation holds the single machine-global coordinator lock.
+- Before any capacity or ownership accounting, every record is validated for the exact supported schema version, required fields, canonical task and head identity, and a known state; a record that fails is quarantined under the shared root and never establishes capacity, ownership, or admission.
 - FIFO sequence is durable, and blocked ineligible work does not strand the next eligible request.
 - Live records never exceed the durable configured capacity.
+- Admission and every preflight require a `ship` task whose delivery mode is `no-mistakes`.
 - Admission binds one Firstmate home, task identity, ship metadata record, project local copy, isolated copy, attached branch, and exact expected commit.
 - Both admission and worker start repeat preflight against current facts.
 - Detached HEAD, wrong branch, changed head, dirty isolated copy, non-isolated location, missing or changed task metadata, uncoordinated active validation, obsolete custody, or ambiguous tool output refuses certification.
@@ -36,7 +39,10 @@ Reconciliation moves `launching` to `running` once a matching active run is auth
 A matching authoritative final result moves `launching` or `running` to `terminal`, releases capacity, and immediately considers the next queued request.
 An ambiguous run identity retains the live state and capacity instead of guessing ownership.
 `retry` may move a corrected `blocked` request back to `queued`, or explicitly retry a failed or ambiguous notification, without changing its bound branch or expected head.
+A `launching` or `running` record whose worker left no matching No Mistakes run keeps its slot but reconciliation reports the stall with a nonzero result so session-start and watch prompt an explicit `retry` or `withdraw` instead of stranding every queued request silently.
 A changed expected head requires a new explicit request rather than silent rebinding.
+`withdraw` abandons a request and frees its slot so a corrected head can be re-enqueued, but it refuses to cancel a matching active or terminal run because that gate stays under worker authority; the withdrawn record and its intent are archived under the shared root for evidence.
+Reaching `terminal` deletes the record's full intent text, and terminal records beyond the newest configured retention count are pruned with their intent so monitoring and storage cost stay bounded.
 
 ## Crash and restart recovery
 
@@ -55,6 +61,7 @@ No recovery path changes Git history or invokes No Mistakes custody recovery.
 ## Authority boundary
 
 Admission, read-only reconciliation, one worker steer, retry after a proven failed delivery, and advancement after an authoritative terminal result are automatic reversible actions.
+Withdrawing a request frees its coordinator slot and archives evidence, but it never cancels an in-flight or terminal No Mistakes run, so it grants no discarded-work or cancellation authority.
 Changing shared capacity, discarding or rewriting work, cancelling a run, selecting keep-local custody recovery, restarting the shared daemon, and any existing destructive, irreversible, security-sensitive, merge, delivery-mode, or product decision retain their existing captain authority.
 The coordinator does not reinterpret project `yolo` posture and never grants merge or gate-decision authority.
 
@@ -70,4 +77,4 @@ Worker-owned synchronous No Mistakes execution remains unchanged across all five
 ## Evidence
 
 Focused behavior coverage lives in `tests/fm-certification.test.sh`.
-The suite covers concurrent admission, restart reconciliation, detached and wrong branches, changed expected heads, obsolete custody, preserved unpublished work, uncoordinated active runs, terminal advancement, duplicate-notification suppression, and command failure paths.
+The suite covers concurrent admission, restart reconciliation, detached and wrong branches, changed expected heads, obsolete custody, preserved unpublished work, uncoordinated active runs, terminal advancement, duplicate-notification suppression, command failure paths, non-`no-mistakes` delivery-mode refusal, malformed and version-skewed record quarantine, crashed-launch stall escalation, withdrawal that frees a slot and refuses to cancel an active run, and bounded terminal retention.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ The tracked code root contains the shared instruction, skill, documentation, wor
 `bin/fm-spawn.sh` owns the base task-metadata fields it emits, while the runtime-backend section below owns backend-specific fields and selector interpretation.
 The producing PR and X helpers own the fields they append, `bin/fm-classify-lib.sh` owns status-event vocabulary, and `bin/fm-crew-state.sh` owns current-state reconciliation.
 Wake, watcher, away-mode, and X-specific state mechanics remain with their named scripts and reference sections rather than being duplicated into one exhaustive state tree here.
+Final heavy certification coordination is intentionally machine-global rather than home-local, so its durable root defaults to `~/.no-mistakes/firstmate-certification`; [`docs/certification-coordinator.md`](certification-coordinator.md) owns that state model and authority boundary.
 
 `bin/fm-session-start.sh`'s header is the single owner of session-start ordering, composed commands, digest contents, and the digest's startup mechanism.
 `docs/sessionstart-nudge.md` owns the native session-open adapter mechanics that nudge the digest command.
@@ -112,6 +113,14 @@ Directives are `off` (a position-independent kill switch that disables every act
 An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisely so a wedged away-mode primary is never silent, and it fires at most once per max-defer window after a genuine wedge.
 A missing or failing channel logs and falls through to the next, never crashing the daemon.
 See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
+
+## Final certification capacity
+
+`bin/fm-certification.sh` admits final heavy No Mistakes certifications through one machine-global durable queue while implementation and focused tests continue independently.
+Capacity defaults to one and can be supplied as a positive `FM_CERTIFICATION_CAPACITY` when the shared ledger is first created.
+The durable capacity file then wins: a different caller value is refused rather than allowing homes to disagree.
+Changing shared capacity is a captain decision and must be made only while accounting for every live admission.
+Command mechanics live in the script header and help, while [`docs/certification-coordinator.md`](certification-coordinator.md) is the design owner.
 
 ## Gate defaults (.no-mistakes.yaml)
 
@@ -366,6 +375,8 @@ FM_STATE_OVERRIDE=       # alternate state dir, mainly for tests
 FM_DATA_OVERRIDE=        # alternate data dir, mainly for tests
 FM_PROJECTS_OVERRIDE=    # alternate projects dir, mainly for tests
 FM_CONFIG_OVERRIDE=      # alternate config dir, mainly for tests
+FM_CERTIFICATION_ROOT=   # optional machine-global final-certification ledger root; default ~/.no-mistakes/firstmate-certification
+FM_CERTIFICATION_CAPACITY=1  # positive shared final-certification capacity; must match the durable initialized value
 FM_PROC_ROOT_OVERRIDE=   # alternate /proc root for the Linux process-identity read in fm-wake-lib.sh, mainly for tests
 FM_BACKEND=             # optional runtime backend override for new spawns; tmux/herdr/zellij/orca/cmux support ship/scout spawns, codex-app is not accepted
 HERDR_SESSION=default  # herdr-only: named session for normal backend ops; not enough for destructive cleanup (docs/herdr-backend.md)

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -124,6 +124,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/certification-coordinator/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/decision-hold-lifecycle/SKILL.md",
       "audience": "agent-runtime"
     },
@@ -205,6 +209,10 @@
     },
     {
       "path": "docs/cd-guard.md",
+      "audience": "maintainer-architecture"
+    },
+    {
+      "path": "docs/certification-coordinator.md",
       "audience": "maintainer-architecture"
     },
     {

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -51,6 +51,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
+| `fm-certification.sh`    | Durably admit final heavy no-mistakes certifications through one machine-global capacity queue (docs/certification-coordinator.md) |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and one-shot escalation |
 | `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -96,8 +96,7 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
-# Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
-# reference must render as plain prose with no dangling apostrophe artifact.
+# Pin the final-certification wording and the literal no-mistakes help commands.
 test_no_mistakes_dod_wording() {
   local home id brief
   home="$TMP_ROOT/wording-home"
@@ -106,8 +105,10 @@ test_no_mistakes_dod_wording() {
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
-  assert_grep "no-mistakes itself provides for the mechanics" "$brief" \
-    "no-mistakes DOD lost its guidance-reference sentence"
+  assert_grep "Do not invoke /no-mistakes directly." "$brief" \
+    "no-mistakes DOD does not require coordinated admission"
+  assert_grep "fm-certification.sh start" "$brief" \
+    "no-mistakes DOD lost the token-bound worker start command"
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
   assert_grep '`no-mistakes axi run --help`' "$brief" \
     "no-mistakes DOD must render literal backticks around the help command"

--- a/tests/fm-certification.test.sh
+++ b/tests/fm-certification.test.sh
@@ -8,6 +8,7 @@ set -u
 SCRIPT="$ROOT/bin/fm-certification.sh"
 
 new_fixture() {
+  unset FM_CERT_NOW 2>/dev/null || true
   FIX=$(fm_test_tmproot fm-certification)
   HOME_DIR="$FIX/home"
   CERT="$FIX/cert"
@@ -295,14 +296,75 @@ test_crashed_launch_stall_is_surfaced() {
   wt=$(add_task crashed crashed); h=$(head_of "$wt")
   run_cert enqueue crashed "$h" --intent-file "$HOME_DIR/data/crashed/intent" >/dev/null
   rec=$(record_for crashed); token=$(field "$rec" token)
+  export FM_CERT_NOW=1000
   run_cert start crashed "$token" >/dev/null
   assert_state crashed launching
-  if out=$(run_cert reconcile --notify 2>&1); then fail "a stalled launch reconciled as success"; fi
+  [ "$(field "$(record_for crashed)" launched_at)" = 1000 ] || fail "launch timestamp was not durably recorded"
+  # Inside the launch grace, a still-registering run must not be escalated.
+  FM_CERT_NOW=1050
+  run_cert reconcile --notify >/dev/null 2>&1 || fail "a still-launching run inside grace was falsely stalled"
+  assert_state crashed launching
+  # Past the grace window with no visible run, the stall is surfaced with rc=1.
+  FM_CERT_NOW=99999
+  if out=$(run_cert reconcile --notify 2>&1); then fail "a stalled launch past grace reconciled as success"; fi
   assert_contains "$out" "launch stalled" "crashed launch was not surfaced"
   assert_state crashed launching
   run_cert withdraw crashed >/dev/null
-  [ -z "$(record_for crashed 2>/dev/null)" ] || fail "stalled launch could not be withdrawn"
-  pass "a crashed launch retains its slot, is surfaced, and can be withdrawn"
+  [ -z "$(record_for crashed 2>/dev/null)" ] || fail "stalled launch could not be withdrawn past grace"
+  unset FM_CERT_NOW
+  pass "a launch is graced while registering, surfaced past grace, and then withdrawable"
+}
+
+test_withdraw_refused_inside_launch_grace() {
+  new_fixture
+  local wt1 wt2 h1 h2 rec token out
+  wt1=$(add_task fresh fresh); wt2=$(add_task behind behind)
+  h1=$(head_of "$wt1"); h2=$(head_of "$wt2")
+  run_cert enqueue fresh "$h1" --intent-file "$HOME_DIR/data/fresh/intent" >/dev/null
+  run_cert enqueue behind "$h2" --intent-file "$HOME_DIR/data/behind/intent" >/dev/null
+  rec=$(record_for fresh); token=$(field "$rec" token)
+  export FM_CERT_NOW=1000
+  run_cert start fresh "$token" >/dev/null
+  assert_state fresh launching
+  # A launch still inside its grace window is not withdrawable: freeing the slot
+  # now could admit behind while fresh's run is still registering (double run).
+  FM_CERT_NOW=1050
+  if out=$(run_cert withdraw fresh 2>&1); then fail "a launch inside its grace was withdrawn"; fi
+  assert_contains "$out" "double run" "in-grace withdrawal refusal was not actionable"
+  assert_state fresh launching
+  assert_state behind queued
+  # Once the grace elapses with no visible run, withdrawal is allowed and advances behind.
+  FM_CERT_NOW=99999
+  run_cert withdraw fresh >/dev/null
+  [ -z "$(record_for fresh 2>/dev/null)" ] || fail "past-grace withdrawal did not remove the record"
+  assert_state behind admitted
+  unset FM_CERT_NOW
+  pass "withdrawal waits out the launch grace before freeing a slot"
+}
+
+test_archive_retention_bounds_quarantine_and_withdrawn() {
+  new_fixture
+  export FM_CERTIFICATION_RETAIN=2
+  local wt h i seq dir remaining
+  wt=$(add_task anchor anchor); h=$(head_of "$wt")
+  run_cert enqueue anchor "$h" --intent-file "$HOME_DIR/data/anchor/intent" >/dev/null
+  for dir in "$CERT/quarantine" "$CERT/withdrawn"; do
+    for i in 1 2 3 4; do
+      seq=$(printf '00000000000%s' "$i")
+      printf 'version=1\nsequence=%s\ntask=arch%s\nstate=terminal\n' "$seq" "$i" > "$dir/$seq-arch$i.record"
+      printf 'intent %s\n' "$i" > "$dir/$seq-arch$i.intent"
+    done
+  done
+  run_cert reconcile --notify >/dev/null 2>&1 || true
+  for dir in "$CERT/quarantine" "$CERT/withdrawn"; do
+    remaining=$(find "$dir" -name '*.record' 2>/dev/null | wc -l | tr -d ' ')
+    [ "$remaining" -eq 2 ] || fail "expected 2 retained records in $dir, found $remaining"
+    [ -f "$dir/000000000004-arch4.record" ] || fail "newest archive record was pruned in $dir"
+    [ ! -f "$dir/000000000001-arch1.record" ] || fail "oldest archive record survived the bound in $dir"
+    [ ! -f "$dir/000000000001-arch1.intent" ] || fail "pruned archive intent was retained in $dir"
+  done
+  unset FM_CERTIFICATION_RETAIN
+  pass "quarantine and withdrawn archives are bounded by the retention count"
 }
 
 test_malformed_and_version_skew_records_are_quarantined() {
@@ -386,5 +448,7 @@ test_non_no_mistakes_delivery_is_refused
 test_withdraw_frees_slot_and_allows_new_head
 test_withdraw_refuses_to_cancel_active_run
 test_crashed_launch_stall_is_surfaced
+test_withdraw_refused_inside_launch_grace
 test_malformed_and_version_skew_records_are_quarantined
 test_bounded_terminal_retention_prunes_old_records
+test_archive_retention_bounds_quarantine_and_withdrawn

--- a/tests/fm-certification.test.sh
+++ b/tests/fm-certification.test.sh
@@ -234,6 +234,145 @@ test_notification_and_state_read_failures_stop_safely() {
   pass "notification ambiguity and no-mistakes read failures stop safely"
 }
 
+test_non_no_mistakes_delivery_is_refused() {
+  new_fixture
+  local wt h out
+  wt=$(add_task pronly pronly); h=$(head_of "$wt")
+  fm_write_meta "$HOME_DIR/state/pronly.meta" \
+    "window=fm-pronly" "worktree=$wt" "project=$FIX/pronly-primary" "harness=pi" \
+    "kind=ship" "mode=direct-PR" "yolo=off"
+  if out=$(run_cert enqueue pronly "$h" --intent-file "$HOME_DIR/data/pronly/intent" 2>&1); then fail "non-no-mistakes delivery was admitted"; fi
+  assert_contains "$out" "delivery mode" "delivery-mode refusal was not actionable"
+  [ -z "$(record_for pronly 2>/dev/null)" ] || fail "a non-no-mistakes request entered the ledger"
+  pass "final certification refuses non-no-mistakes delivery modes"
+}
+
+test_withdraw_frees_slot_and_allows_new_head() {
+  new_fixture
+  local wt1 wt2 h1 h2 h1b
+  wt1=$(add_task hold hold); wt2=$(add_task waiting waiting)
+  h1=$(head_of "$wt1"); h2=$(head_of "$wt2")
+  run_cert enqueue hold "$h1" --intent-file "$HOME_DIR/data/hold/intent" >/dev/null
+  run_cert enqueue waiting "$h2" --intent-file "$HOME_DIR/data/waiting/intent" >/dev/null
+  assert_state hold admitted
+  assert_state waiting queued
+  printf change >> "$wt1/README.md"
+  git -C "$wt1" add README.md && git -C "$wt1" -c user.name=test -c user.email=test@example.invalid commit -qm advanced
+  h1b=$(head_of "$wt1")
+  run_cert withdraw hold >/dev/null
+  [ -z "$(record_for hold 2>/dev/null)" ] || fail "withdrawn record still present in queue"
+  [ -n "$(find "$CERT/withdrawn" -name '*-hold.record' -print 2>/dev/null | head -1)" ] || fail "withdrawn record was not archived for evidence"
+  assert_state waiting admitted
+  run_cert enqueue hold "$h1b" --intent-file "$HOME_DIR/data/hold/intent" >/dev/null
+  assert_state hold queued
+  pass "withdraw frees the slot, advances the queue, and permits a corrected head"
+}
+
+test_withdraw_refuses_to_cancel_active_run() {
+  new_fixture
+  local wt h rec token out
+  wt=$(add_task busy busy); h=$(head_of "$wt")
+  run_cert enqueue busy "$h" --intent-file "$HOME_DIR/data/busy/intent" >/dev/null
+  rec=$(record_for busy); token=$(field "$rec" token)
+  run_cert start busy "$token" >/dev/null
+  cat > "$wt/.nm-status" <<EOF
+id: run-busy
+branch: fm/busy
+head: $h
+status: running
+outcome:
+EOF
+  git -C "$wt" add -N .nm-status >/dev/null 2>&1 || true
+  if out=$(run_cert withdraw busy 2>&1); then fail "withdrawal cancelled an active no-mistakes run"; fi
+  assert_contains "$out" "cannot cancel" "active-run withdrawal refusal was not actionable"
+  assert_no_grep "abort" "$FIX/nm-calls.log" "withdrawal cancelled a run"
+  pass "withdrawal never cancels a matching active run"
+}
+
+test_crashed_launch_stall_is_surfaced() {
+  new_fixture
+  local wt h rec token out
+  wt=$(add_task crashed crashed); h=$(head_of "$wt")
+  run_cert enqueue crashed "$h" --intent-file "$HOME_DIR/data/crashed/intent" >/dev/null
+  rec=$(record_for crashed); token=$(field "$rec" token)
+  run_cert start crashed "$token" >/dev/null
+  assert_state crashed launching
+  if out=$(run_cert reconcile --notify 2>&1); then fail "a stalled launch reconciled as success"; fi
+  assert_contains "$out" "launch stalled" "crashed launch was not surfaced"
+  assert_state crashed launching
+  run_cert withdraw crashed >/dev/null
+  [ -z "$(record_for crashed 2>/dev/null)" ] || fail "stalled launch could not be withdrawn"
+  pass "a crashed launch retains its slot, is surfaced, and can be withdrawn"
+}
+
+test_malformed_and_version_skew_records_are_quarantined() {
+  new_fixture
+  local wt h out
+  wt=$(add_task good good); h=$(head_of "$wt")
+  run_cert enqueue good "$h" --intent-file "$HOME_DIR/data/good/intent" >/dev/null
+  assert_state good admitted
+  cat > "$CERT/queue/000000009999-skew.record" <<EOF
+version=2
+sequence=000000009999
+task=skew
+home=$HOME_DIR
+project=$FIX/good-primary
+worktree=$wt
+branch=fm/skew
+expected_head=$h
+token=deadbeef
+state=admitted
+notification=none
+run_id=
+outcome=
+reason=
+EOF
+  printf 'version=1\nstate=admitted\n' > "$CERT/queue/000000009998-broken.record"
+  if out=$(run_cert reconcile --notify 2>&1); then fail "reconcile ignored the quarantine outcome"; fi
+  assert_contains "$out" "quarantined" "malformed/version-skew record was not surfaced"
+  [ -f "$CERT/quarantine/000000009999-skew.record" ] || fail "version-skew record was not quarantined"
+  [ -f "$CERT/quarantine/000000009998-broken.record" ] || fail "malformed record was not quarantined"
+  [ ! -f "$CERT/queue/000000009999-skew.record" ] || fail "version-skew record still affects the live queue"
+  assert_state good admitted
+  pass "unsupported-version and malformed records are quarantined before accounting"
+}
+
+test_bounded_terminal_retention_prunes_old_records() {
+  new_fixture
+  export FM_CERTIFICATION_RETAIN=2
+  local wt h i seq remaining
+  wt=$(add_task keeper keeper); h=$(head_of "$wt")
+  run_cert enqueue keeper "$h" --intent-file "$HOME_DIR/data/keeper/intent" >/dev/null
+  for i in 1 2 3 4; do
+    seq=$(printf '00000000000%s' "$i")
+    cat > "$CERT/queue/$seq-old$i.record" <<EOF
+version=1
+sequence=$seq
+task=old$i
+home=$HOME_DIR
+project=$FIX/keeper-primary
+worktree=$wt
+branch=fm/old$i
+expected_head=$h
+token=tok$i
+state=terminal
+notification=sent
+run_id=run-$i
+outcome=passed
+reason=
+EOF
+    printf 'intent %s\n' "$i" > "$CERT/queue/$seq-old$i.intent"
+  done
+  run_cert reconcile --notify >/dev/null 2>&1 || true
+  remaining=$(find "$CERT/queue" -name '*.record' -exec grep -l '^state=terminal' {} + 2>/dev/null | wc -l | tr -d ' ')
+  [ "$remaining" -eq 2 ] || fail "expected 2 retained terminal records, found $remaining"
+  [ -f "$CERT/queue/000000000004-old4.record" ] || fail "newest terminal record was pruned"
+  [ ! -f "$CERT/queue/000000000001-old1.record" ] || fail "oldest terminal record was retained past the bound"
+  [ ! -f "$CERT/queue/000000000001-old1.intent" ] || fail "pruned terminal intent was retained"
+  unset FM_CERTIFICATION_RETAIN
+  pass "terminal retention keeps the newest records and prunes older intent"
+}
+
 test_concurrent_admission_and_duplicate_notification
 test_duplicate_start_claim_is_refused
 test_restart_terminal_advances_queue
@@ -243,3 +382,9 @@ test_unpublished_dirty_work_is_preserved
 test_active_uncoordinated_run_blocks
 test_restart_hooks_own_automatic_reconciliation
 test_notification_and_state_read_failures_stop_safely
+test_non_no_mistakes_delivery_is_refused
+test_withdraw_frees_slot_and_allows_new_head
+test_withdraw_refuses_to_cancel_active_run
+test_crashed_launch_stall_is_surfaced
+test_malformed_and_version_skew_records_are_quarantined
+test_bounded_terminal_retention_prunes_old_records

--- a/tests/fm-certification.test.sh
+++ b/tests/fm-certification.test.sh
@@ -342,6 +342,32 @@ test_withdraw_refused_inside_launch_grace() {
   pass "withdrawal waits out the launch grace before freeing a slot"
 }
 
+test_retry_refused_inside_launch_grace() {
+  new_fixture
+  local wt h rec token out
+  wt=$(add_task rezero rezero); h=$(head_of "$wt")
+  run_cert enqueue rezero "$h" --intent-file "$HOME_DIR/data/rezero/intent" >/dev/null
+  rec=$(record_for rezero); token=$(field "$rec" token)
+  export FM_CERT_NOW=1000
+  run_cert start rezero "$token" >/dev/null
+  assert_state rezero launching
+  [ "$(wc -l < "$SEND_LOG")" -eq 1 ] || fail "launch did not notify exactly once"
+  # Retrying inside the grace window would reset to admitted+pending and re-notify
+  # the worker to start a second run while the first is still registering.
+  FM_CERT_NOW=1050
+  if out=$(run_cert retry rezero 2>&1); then fail "retry inside the launch grace re-drove a still-registering launch"; fi
+  assert_contains "$out" "double run" "in-grace retry refusal was not actionable"
+  assert_state rezero launching
+  [ "$(wc -l < "$SEND_LOG")" -eq 1 ] || fail "in-grace retry duplicated the start notification"
+  # Once the grace elapses with no visible run, retry re-admits and re-notifies once.
+  FM_CERT_NOW=99999
+  run_cert retry rezero >/dev/null
+  assert_state rezero admitted
+  [ "$(wc -l < "$SEND_LOG")" -eq 2 ] || fail "past-grace retry did not redeliver exactly once"
+  unset FM_CERT_NOW
+  pass "retry waits out the launch grace before re-driving a launch"
+}
+
 test_archive_retention_bounds_quarantine_and_withdrawn() {
   new_fixture
   export FM_CERTIFICATION_RETAIN=2
@@ -449,6 +475,7 @@ test_withdraw_frees_slot_and_allows_new_head
 test_withdraw_refuses_to_cancel_active_run
 test_crashed_launch_stall_is_surfaced
 test_withdraw_refused_inside_launch_grace
+test_retry_refused_inside_launch_grace
 test_malformed_and_version_skew_records_are_quarantined
 test_bounded_terminal_retention_prunes_old_records
 test_archive_retention_bounds_quarantine_and_withdrawn

--- a/tests/fm-certification.test.sh
+++ b/tests/fm-certification.test.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Focused regression tests for the durable final-certification coordinator.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SCRIPT="$ROOT/bin/fm-certification.sh"
+
+new_fixture() {
+  FIX=$(fm_test_tmproot fm-certification)
+  HOME_DIR="$FIX/home"
+  CERT="$FIX/cert"
+  SEND_LOG="$FIX/send.log"
+  mkdir -p "$HOME_DIR/state" "$HOME_DIR/data" "$FIX/bin"
+  cat > "$FIX/bin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_CERT_TEST_NM_CALL_LOG:?}"
+case "$*" in
+  axi)
+    if [ -f .nm-home-fail ]; then exit 1; fi
+    if [ -f .nm-home ]; then cat .nm-home; else printf 'current_branch: %s\nruns: 0 runs yet in this repository\n' "$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"; fi
+    ;;
+  "runs --limit 200") [ ! -f .nm-runs-fail ] || exit 1; [ ! -f .nm-runs ] || cat .nm-runs ;;
+  "axi status") [ ! -f .nm-status-fail ] || exit 1; if [ -f .nm-status ]; then cat .nm-status; else printf 'error: no runs yet\n'; fi ;;
+  "axi run --intent "*) printf 'run\n' >> "${FM_CERT_TEST_RUN_LOG:?}" ;;
+  *) printf 'unexpected no-mistakes args: %s\n' "$*" >&2; exit 2 ;;
+esac
+SH
+  cat > "$FIX/bin/fm-send" <<'SH'
+#!/usr/bin/env bash
+printf '%s\t%s\n' "$1" "$2" >> "${FM_CERT_TEST_SEND_LOG:?}"
+[ ! -f "${FM_CERT_TEST_SEND_FAIL:-/nonexistent}" ]
+SH
+  chmod +x "$FIX/bin/no-mistakes" "$FIX/bin/fm-send"
+  export FM_CERTIFICATION_ROOT="$CERT"
+  export FM_CERTIFICATION_CAPACITY=1
+  export FM_CERT_NM_BIN="$FIX/bin/no-mistakes"
+  export FM_CERT_SEND_BIN="$FIX/bin/fm-send"
+  export FM_CERT_TEST_SEND_LOG="$SEND_LOG"
+  export FM_CERT_TEST_RUN_LOG="$FIX/run.log"
+  export FM_CERT_TEST_NM_CALL_LOG="$FIX/nm-calls.log"
+  export FM_CERT_NO_EXEC=1
+}
+
+add_task() { # <id> <project-name>
+  local id=$1 name=$2 primary wt
+  primary="$FIX/$name-primary"
+  wt="$FIX/$name-wt"
+  fm_git_worktree "$primary" "$wt" "fm/$id"
+  mkdir -p "$HOME_DIR/data/$id"
+  fm_write_meta "$HOME_DIR/state/$id.meta" \
+    "window=fm-$id" "worktree=$wt" "project=$primary" "harness=pi" \
+    "kind=ship" "mode=no-mistakes" "yolo=off"
+  printf 'Validate task %s safely.\n' "$id" > "$HOME_DIR/data/$id/intent"
+  printf '%s\n' "$wt"
+}
+
+head_of() { git -C "$1" rev-parse HEAD; }
+run_cert() { FM_HOME="$HOME_DIR" "$SCRIPT" "$@"; }
+record_for() { find "$CERT/queue" -name "*-$1.record" -print | head -1; }
+field() { grep "^$2=" "$1" | cut -d= -f2-; }
+
+assert_state() {
+  local id=$1 expected=$2 rec
+  rec=$(record_for "$id")
+  [ "$(field "$rec" state)" = "$expected" ] || fail "$id expected state $expected, got $(field "$rec" state)"
+}
+
+test_concurrent_admission_and_duplicate_notification() {
+  new_fixture
+  local wt1 wt2 h1 h2
+  wt1=$(add_task alpha alpha); wt2=$(add_task beta beta)
+  h1=$(head_of "$wt1"); h2=$(head_of "$wt2")
+  run_cert enqueue alpha "$h1" --intent-file "$HOME_DIR/data/alpha/intent" >"$FIX/alpha.out" 2>&1 &
+  local p1=$!
+  run_cert enqueue beta "$h2" --intent-file "$HOME_DIR/data/beta/intent" >"$FIX/beta.out" 2>&1 &
+  local p2=$!
+  wait "$p1" || fail "first concurrent enqueue failed"
+  wait "$p2" || fail "second concurrent enqueue failed"
+  local alpha_state beta_state
+  alpha_state=$(field "$(record_for alpha)" state)
+  beta_state=$(field "$(record_for beta)" state)
+  case "$alpha_state:$beta_state" in admitted:queued|queued:admitted) ;; *) fail "concurrent admission states were $alpha_state/$beta_state" ;; esac
+  [ "$(wc -l < "$SEND_LOG")" -eq 1 ] || fail "capacity one sent more than one admission"
+  run_cert reconcile --notify >/dev/null
+  [ "$(wc -l < "$SEND_LOG")" -eq 1 ] || fail "reconcile duplicated an admission notification"
+  pass "capacity serializes concurrent requests and notification replay is idempotent"
+}
+
+test_duplicate_start_claim_is_refused() {
+  new_fixture
+  local wt h rec token out
+  wt=$(add_task once once); h=$(head_of "$wt")
+  run_cert enqueue once "$h" --intent-file "$HOME_DIR/data/once/intent" >/dev/null
+  rec=$(record_for once); token=$(field "$rec" token)
+  run_cert start once "$token" >/dev/null
+  if out=$(run_cert start once "$token" 2>&1); then fail "a second unbound launch claim was allowed"; fi
+  assert_contains "$out" "already claimed" "duplicate-start refusal was not actionable"
+  [ ! -e "$FIX/run.log" ] || [ "$(wc -l < "$FIX/run.log")" -eq 0 ] || fail "duplicate start invoked a second run"
+  pass "a launch claim cannot create a duplicate certification run"
+}
+
+test_restart_terminal_advances_queue() {
+  new_fixture
+  local wt1 wt2 h1 h2 rec token
+  wt1=$(add_task first first); wt2=$(add_task next next)
+  h1=$(head_of "$wt1"); h2=$(head_of "$wt2")
+  run_cert enqueue first "$h1" --intent-file "$HOME_DIR/data/first/intent" >/dev/null
+  run_cert enqueue next "$h2" --intent-file "$HOME_DIR/data/next/intent" >/dev/null
+  rec=$(record_for first); token=$(field "$rec" token)
+  run_cert start first "$token" >/dev/null
+  cat > "$wt1/.nm-status" <<EOF
+id: run-first
+branch: fm/first
+head: $h1
+status: completed
+outcome: checks-passed
+EOF
+  git -C "$wt1" add -N .nm-status >/dev/null 2>&1 || true
+  # The status stub is test instrumentation. Hide it from git cleanliness because
+  # reconciliation of a launched run intentionally does not rerun clean preflight.
+  run_cert reconcile --notify >/dev/null
+  assert_state first terminal
+  assert_state next admitted
+  [ "$(wc -l < "$SEND_LOG")" -eq 2 ] || fail "terminal result did not notify the next queued task exactly once"
+  run_cert reconcile --notify >/dev/null
+  [ "$(wc -l < "$SEND_LOG")" -eq 2 ] || fail "restart reconciliation duplicated the next notification"
+  pass "authoritative terminal reconciliation survives restart and advances FIFO"
+}
+
+test_detached_wrong_branch_and_changed_head_stop() {
+  new_fixture
+  local wt h rec token old
+  wt=$(add_task branchy branchy); h=$(head_of "$wt")
+  run_cert enqueue branchy "$h" --intent-file "$HOME_DIR/data/branchy/intent" >/dev/null
+  rec=$(record_for branchy); token=$(field "$rec" token)
+  git -C "$wt" checkout --detach -q
+  if out=$(run_cert start branchy "$token" 2>&1); then fail "detached HEAD was admitted"; fi
+  assert_contains "$out" "detached HEAD" "detached HEAD refusal was not actionable"
+  git -C "$wt" checkout -q -b wrong
+  if out=$(run_cert retry branchy 2>&1); then fail "wrong branch should remain blocked after retry"; fi
+  assert_state branchy blocked
+  assert_contains "$(field "$(record_for branchy)" reason)" "wrong branch" "wrong branch was not recorded"
+  git -C "$wt" checkout -q fm/branchy
+  run_cert retry branchy >/dev/null
+  assert_state branchy admitted
+  old=$h
+  printf change >> "$wt/README.md"
+  git -C "$wt" add README.md && git -C "$wt" -c user.name=test -c user.email=test@example.invalid commit -qm changed
+  if out=$(run_cert start branchy "$token" 2>&1); then fail "changed expected head was admitted"; fi
+  assert_contains "$out" "changed head" "changed-head refusal was not actionable"
+  [ "$(git -C "$wt" rev-parse HEAD)" != "$old" ] || fail "changed-head refusal rewrote the branch"
+  pass "detached, wrong, and changed branch identities stop without rewriting work"
+}
+
+test_stale_custody_skips_to_next() {
+  new_fixture
+  local wt1 wt2 h1 h2 out
+  wt1=$(add_task stale stale); wt2=$(add_task eligible eligible)
+  h1=$(head_of "$wt1"); h2=$(head_of "$wt2")
+  printf 'branch_sync:\n  next_action:\n    code: recover_custody\nhelp: no-mistakes axi sync --recover\n' > "$wt1/.nm-home"
+  git -C "$wt1" add .nm-home && git -C "$wt1" -c user.name=test -c user.email=test@example.invalid commit -qm fixture
+  # Record the committed fixture head so stale custody, rather than changed head, is the refusal.
+  h1=$(head_of "$wt1")
+  if out=$(run_cert enqueue stale "$h1" --intent-file "$HOME_DIR/data/stale/intent" 2>&1); then fail "obsolete custody request should report a blocked item"; fi
+  assert_state stale blocked
+  assert_contains "$out" "obsolete no-mistakes custody" "custody refusal was not actionable"
+  run_cert enqueue eligible "$h2" --intent-file "$HOME_DIR/data/eligible/intent" >/dev/null
+  assert_state eligible admitted
+  assert_no_grep "sync" "$FIX/nm-calls.log" "coordinator invoked custody recovery"
+  assert_no_grep "abort" "$FIX/nm-calls.log" "coordinator cancelled a run"
+  assert_no_grep "daemon" "$FIX/nm-calls.log" "coordinator touched the shared daemon"
+  pass "obsolete custody blocks only that item and never performs recovery"
+}
+
+test_unpublished_dirty_work_is_preserved() {
+  new_fixture
+  local wt h out
+  wt=$(add_task dirty dirty); h=$(head_of "$wt")
+  printf 'do not discard\n' > "$wt/unpublished.txt"
+  if out=$(run_cert enqueue dirty "$h" --intent-file "$HOME_DIR/data/dirty/intent" 2>&1); then fail "dirty worktree should block admission"; fi
+  assert_state dirty blocked
+  assert_contains "$out" "not clean" "dirty-copy refusal was not actionable"
+  assert_grep "do not discard" "$wt/unpublished.txt" "dirty work was modified or discarded"
+  [ "$(git -C "$wt" rev-parse HEAD)" = "$h" ] || fail "dirty refusal changed HEAD"
+  pass "dirty unpublished work is preserved byte-for-byte"
+}
+
+test_active_uncoordinated_run_blocks() {
+  new_fixture
+  local wt h out
+  wt=$(add_task active active); h=$(head_of "$wt")
+  printf 'running other/branch %s 2026-01-01\n' "${h:0:7}" > "$wt/.nm-runs"
+  git -C "$wt" add .nm-runs && git -C "$wt" -c user.name=test -c user.email=test@example.invalid commit -qm fixture
+  h=$(head_of "$wt")
+  if out=$(run_cert enqueue active "$h" --intent-file "$HOME_DIR/data/active/intent" 2>&1); then fail "uncoordinated active run should block"; fi
+  assert_state active blocked
+  assert_contains "$out" "uncoordinated active validation" "active-run refusal was not actionable"
+  pass "an active validation outside coordinator ownership stops admission"
+}
+
+test_restart_hooks_own_automatic_reconciliation() {
+  assert_grep 'fm-certification.sh" reconcile --notify' "$ROOT/bin/fm-session-start.sh" \
+    "session restart does not reconcile durable certification state"
+  assert_grep 'fm-certification.sh" reconcile --notify' "$ROOT/bin/fm-watch.sh" \
+    "ordinary monitoring does not advance terminal certification results"
+  pass "session restart and ordinary monitoring both invoke the state-machine owner"
+}
+
+test_notification_and_state_read_failures_stop_safely() {
+  new_fixture
+  local wt h out marker="$FIX/send-fail"
+  wt=$(add_task failures failures); h=$(head_of "$wt")
+  touch "$marker"
+  export FM_CERT_TEST_SEND_FAIL="$marker"
+  if out=$(run_cert enqueue failures "$h" --intent-file "$HOME_DIR/data/failures/intent" 2>&1); then fail "send failure should be actionable"; fi
+  assert_state failures admitted
+  [ "$(field "$(record_for failures)" notification)" = failed ] || fail "send failure was not durably recorded"
+  rm -f "$marker"
+  run_cert reconcile --notify >/dev/null
+  [ "$(wc -l < "$SEND_LOG")" -eq 1 ] || fail "ambiguous send failure was automatically duplicated"
+  run_cert retry failures >/dev/null
+  [ "$(wc -l < "$SEND_LOG")" -eq 2 ] || fail "explicit retry did not redeliver once"
+
+  new_fixture
+  wt=$(add_task unreadable unreadable); h=$(head_of "$wt")
+  touch "$wt/.nm-home-fail"
+  git -C "$wt" add .nm-home-fail && git -C "$wt" -c user.name=test -c user.email=test@example.invalid commit -qm fixture
+  h=$(head_of "$wt")
+  if out=$(run_cert enqueue unreadable "$h" --intent-file "$HOME_DIR/data/unreadable/intent" 2>&1); then fail "no-mistakes read failure should block"; fi
+  assert_state unreadable blocked
+  assert_contains "$out" "could not be read" "state-read failure was not actionable"
+  pass "notification ambiguity and no-mistakes read failures stop safely"
+}
+
+test_concurrent_admission_and_duplicate_notification
+test_duplicate_start_claim_is_refused
+test_restart_terminal_advances_queue
+test_detached_wrong_branch_and_changed_head_stop
+test_stale_custody_skips_to_next
+test_unpublished_dirty_work_is_preserved
+test_active_uncoordinated_run_blocks
+test_restart_hooks_own_automatic_reconciliation
+test_notification_and_state_read_failures_stop_safely


### PR DESCRIPTION
## Intent

Implement and publish a safe, durable Firstmate final-certification coordinator that serializes heavy No Mistakes validations, performs strict identity and delivery-mode preflight checks, survives restarts, automatically advances queued work, preserves worker ownership of No Mistakes gates, handles obsolete requests, crashed launches, malformed or version-skewed records, and bounded retention safely, remains backend- and adapter-neutral, and includes tracked design, documentation, skills, AGENTS updates, lint, and focused regression coverage. Push the feature branch to the authorized ChrisGutierrezNet fork and open an upstream PR against kunchenguid/firstmate main; do not merge.

## What Changed

- Adds `bin/fm-certification.sh`, a restart-durable coordinator that serializes heavy No Mistakes validations behind a machine-global lock, enforces strict identity and delivery-mode preflight checks (detached HEAD, wrong branch, changed HEAD, dirty work, non-no-mistakes delivery refusal), and auto-advances queued work in FIFO order while preserving worker ownership of the No Mistakes gates.
- Handles the failure surface: obsolete/withdrawn requests, crashed launches via a launch grace window, malformed and version-skewed records through quarantine, stall escalation, and bounded retention for terminal/quarantined/withdrawn records.
- Wires the feature into the surrounding harness — new `certification-coordinator` skill and `harness-adapters` note, `AGENTS.md`/`CONTRIBUTING.md`/config/scripts docs, a design doc (`docs/certification-coordinator.md`), touch-ups to `fm-brief.sh`, `fm-session-start.sh`, `fm-test-run.sh`, and `fm-watch.sh`, plus 18 focused regression tests in `tests/fm-certification.test.sh` (all passing).

## Risk Assessment

✅ Low: The change is a well-bounded, single-owner shell coordinator that matches its documented invariants and ships comprehensive regression coverage for every state path; the only findings are minor, non-blocking hardening/simplification notes.

## Testing

Baseline: the focused suite `tests/fm-certification.test.sh` passes all 18 cases covering the coordinator's safety invariants. To show the intent working the way an operator experiences it, I built and ran a CLI transcript that drives the real script against real git worktrees through the complete lifecycle — capacity-1 serialized admission, a single token-bound worker steer, worker-owned `start`, authoritative terminal reconciliation, and automatic FIFO advancement — and demonstrates the safety boundaries (direct-PR delivery refused, dirty unpublished work preserved with HEAD unchanged, and a call log proving the coordinator issued only read-only no-mistakes inspections and never a respond/abort/rerun/sync/recover/daemon/run command). Adjacent suites touched by the diff (fm-watch-triage, fm-watch-checkpoint, fm-brief, fm-test-run) pass. One fm-session-start assertion fails, but it reproduces identically on the base commit (a tmux window-relaunch liveness check in this sandbox) and the test file is unchanged by the diff, so it is pre-existing and unrelated. The only unmet part of the intent is the publish step: no upstream PR exists on kunchenguid/firstmate and origin is the upstream rather than the ChrisGutierrezNet fork — surfaced as an ask-user finding since performing the push/PR is outside testing scope. No visual/UI surface is involved (this is a shell CLI), so the reviewer-visible evidence is the captured CLI transcript rather than a screenshot. The working tree was left clean.

<details>
<summary>Evidence: Operator CLI transcript: full certification lifecycle + safety invariants</summary>

```text

========================================================================
1. Two ship tasks enqueue for final certification (shared capacity = 1)
========================================================================
$ fm-certification.sh enqueue alpha <head> --intent-file .../alpha/intent
certification admitted: alpha at 8e23897d4ed408f54ab66124164c8b527b23ce27
$ fm-certification.sh enqueue beta  <head> --intent-file .../beta/intent

========================================================================
2. status: one admitted, one held queued behind the single slot
========================================================================
$ fm-certification.sh status   (cols: seq  state  task  branch  head  reason)
capacity=1
000000000001	admitted	alpha	fm/alpha	8e23897d4ed408f54ab66124164c8b527b23ce27	
000000000002	queued	beta	fm/beta	d2641696c599b64ad1489c647c6060d4907ac238	

========================================================================
3. The admitted worker received exactly one token-bound start steer
========================================================================
$ cat send.log
alpha	Certification slot admitted for alpha. Run exactly: FM_HOME='/tmp/cert-demo.7TmrqL/home' '/home/exedev/.no-mistakes/worktrees/579deb6a33c1/01KYA7YMYR2CYGGRT4C4MGRK6Y/bin/fm-certification.sh' start 'alpha' '2e2b1c2380ed1ec61c8a0a06'

========================================================================
4. Worker runs its own token-bound start (worker owns the No Mistakes gate)
========================================================================
$ FM_HOME=... fm-certification.sh start alpha <token>
would exec in /tmp/cert-demo.7TmrqL/alpha-wt at 8e23897d4ed408f54ab66124164c8b527b23ce27: /tmp/cert-demo.7TmrqL/bin/no-mistakes axi run --intent <stored-intent> (reattach=0)
-> record advanced to:
000000000001	launching	alpha	fm/alpha	8e23897d4ed408f54ab66124164c8b527b23ce27	
000000000002	queued	beta	fm/beta	d2641696c599b64ad1489c647c6060d4907ac238	

========================================================================
5. No Mistakes reports an authoritative terminal pass for alpha's run
========================================================================
$ fm-certification.sh reconcile --notify   (session-start / watch calls this)
certification terminal: alpha outcome=checks-passed
certification admitted: beta at d2641696c599b64ad1489c647c6060d4907ac238
-> queue after terminal advancement:
capacity=1
000000000001	terminal	alpha	fm/alpha	8e23897d4ed408f54ab66124164c8b527b23ce27	
000000000002	admitted	beta	fm/beta	d2641696c599b64ad1489c647c6060d4907ac238	

========================================================================
6. beta is now admitted and steered automatically — FIFO advanced, no manual nudge
========================================================================
$ cat send.log   (second line = beta's start steer)
alpha	Certification slot admitted for alpha. Run exactly: FM_HOME='/tmp/cert-demo.7TmrqL/home' '/home/exedev/.no-mistakes/worktrees/579deb6a33c1/01KYA7YMYR2CYGGRT4C4MGRK6Y/bin/fm-certification.sh' start 'alpha' '2e2b1c2380ed1ec61c8a0a06'
beta	Certification slot admitted for beta. Run exactly: FM_HOME='/tmp/cert-demo.7TmrqL/home' '/home/exedev/.no-mistakes/worktrees/579deb6a33c1/01KYA7YMYR2CYGGRT4C4MGRK6Y/bin/fm-certification.sh' start 'beta' '1105084bf310f1e1f53c5124'

========================================================================
7. SAFETY: a non-no-mistakes (direct-PR) task is refused at the boundary
========================================================================
$ fm-certification.sh enqueue pronly <head> ...   (delivery mode = direct-PR)
error: task pronly delivery mode is direct-PR; final certification admits only no-mistakes delivery, never direct-PR or local-only
(refused with exit 1, as required)

========================================================================
8. SAFETY: unpublished dirty work is preserved, never discarded
========================================================================
$ fm-certification.sh enqueue guarded <head> ...   (worktree is dirty)
certification blocked: guarded: isolated copy /tmp/cert-demo.7TmrqL/guarded-wt is not clean; preserve and resolve every unpublished change before certification
(refused, as required)
-> blocked reason:
000000000001	blocked	guarded	fm/guarded	2beb1eae4583b87fee2e20e5ef5748f406b57417	isolated copy /tmp/cert-demo.7TmrqL/guarded-wt is not clean; preserve and resolve every unpublished change before certification
-> dirty file still present & untouched:
precious unpublished change
-> HEAD unchanged: 2beb1eae4583b87fee2e20e5ef5748f406b57417

========================================================================
9. The coordinator never drove a No Mistakes gate/recovery/cancel command
========================================================================
$ cat nm-calls.log   (only read-only axi / status / runs inspections)
axi
runs --limit 200
axi
runs --limit 200
axi status
axi status
axi
runs --limit 200

CONFIRMED: no respond/abort/rerun/sync/recover/daemon/run command was issued

demo complete.
```
</details>
<details>
<summary>Evidence: Reproducible demo harness driving the real coordinator</summary>

```text
#!/usr/bin/env bash
# End-to-end operator transcript for the durable certification coordinator.
# Drives the REAL bin/fm-certification.sh against real git worktrees, stubbing
# only the external no-mistakes and fm-send endpoints, and narrates each step the
# way an operator/watcher would experience it.
set -eu

ROOT=/home/exedev/.no-mistakes/worktrees/579deb6a33c1/01KYA7YMYR2CYGGRT4C4MGRK6Y
SCRIPT="$ROOT/bin/fm-certification.sh"
FIX=$(mktemp -d "${TMPDIR:-/tmp}/cert-demo.XXXXXX")
HOME_DIR="$FIX/home"
CERT="$FIX/cert"
SEND_LOG="$FIX/send.log"
mkdir -p "$HOME_DIR/state" "$HOME_DIR/data" "$FIX/bin"

# --- stub external endpoints (no-mistakes CLI + fm-send steer delivery) -------
cat > "$FIX/bin/no-mistakes" <<'SH'
#!/usr/bin/env bash
printf '%s\n' "$*" >> "${FM_CERT_TEST_NM_CALL_LOG:?}"
case "$*" in
  axi) printf 'current_branch: %s\nruns: 0 runs yet in this repository\n' "$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)" ;;
  "runs --limit 200") [ ! -f .nm-runs ] || cat .nm-runs ;;
  "axi status") if [ -f .nm-status ]; then cat .nm-status; else printf 'error: no runs yet\n'; fi ;;
  *) printf 'unexpected no-mistakes args: %s\n' "$*" >&2; exit 2 ;;
esac
SH
cat > "$FIX/bin/fm-send" <<'SH'
#!/usr/bin/env bash
printf '%s\t%s\n' "$1" "$2" >> "${FM_CERT_TEST_SEND_LOG:?}"
SH
chmod +x "$FIX/bin/no-mistakes" "$FIX/bin/fm-send"

export FM_CERTIFICATION_ROOT="$CERT"
export FM_CERTIFICATION_CAPACITY=1
export FM_CERT_NM_BIN="$FIX/bin/no-mistakes"
export FM_CERT_SEND_BIN="$FIX/bin/fm-send"
export FM_CERT_TEST_SEND_LOG="$SEND_LOG"
export FM_CERT_TEST_NM_CALL_LOG="$FIX/nm-calls.log"
export FM_CERT_NO_EXEC=1
: > "$SEND_LOG"; : > "$FIX/nm-calls.log"

gitc() { git -C "$1" -c user.name=demo -c user.email=demo@example.invalid "${@:2}"; }
mktask() { # <id>
  local id=$1
  local primary="$FIX/$id-primary"
  local wt="$FIX/$id-wt"
  mkdir -p "$primary"; git -C "$primary" init -q
  printf '# %s\n' "$id" > "$primary/README.md"
  gitc "$primary" add README.md; gitc "$primary" commit -qm initial
  git -C "$primary" worktree add --quiet -b "fm/$id" "$wt"
  mkdir -p "$HOME_DIR/data/$id"
  { printf 'window=fm-%s\nworktree=%s\nproject=%s\nharness=pi\nkind=ship\nmode=no-mistakes\nyolo=off\n' "$id" "$wt" "$primary"; } > "$HOME_DIR/state/$id.meta"
  printf 'Run the heavy No Mistakes final certification for %s safely.\n' "$id" > "$HOME_DIR/data/$id/intent"
  printf '%s\n' "$wt"
}
cert() { FM_HOME="$HOME_DIR" "$SCRIPT" "$@"; }
rule() { printf '\n========================================================================\n%s\n========================================================================\n' "$1"; }

wt_alpha=$(mktask alpha); h_alpha=$(git -C "$wt_alpha" rev-parse HEAD)
wt_beta=$(mktask beta);   h_beta=$(git -C "$wt_beta" rev-parse HEAD)

rule "1. Two ship tasks enqueue for final certification (shared capacity = 1)"
echo "\$ fm-certification.sh enqueue alpha <head> --intent-file .../alpha/intent"
cert enqueue alpha "$h_alpha" --intent-file "$HOME_DIR/data/alpha/intent"
echo "\$ fm-certification.sh enqueue beta  <head> --intent-file .../beta/intent"
cert enqueue beta "$h_beta" --intent-file "$HOME_DIR/data/beta/intent"

rule "2. status: one admitted, one held queued behind the single slot"
echo "\$ fm-certification.sh status   (cols: seq  state  task  branch  head  reason)"
cert status

rule "3. The admitted worker received exactly one token-bound start steer"
echo "\$ cat send.log"
cat "$SEND_LOG"

rule "4. Worker runs its own token-bound start (worker owns the No Mistakes gate)"
token=$(grep '^token=' "$(find "$CERT/queue" -name '*-alpha.record')" | cut -d= -f2-)
echo "\$ FM_HOME=... fm-certification.sh start alpha <token>"
cert start alpha "$token"
echo "-> record advanced to:"; cert status | grep -E 'alpha|beta' || true

rule "5. No Mistakes reports an authoritative terminal pass for alpha's run"
cat > "$wt_alpha/.nm-status" <<EOF
id: run-alpha
branch: fm/alpha
head: $h_alpha
status: completed
outcome: checks-passed
EOF
echo "\$ fm-certification.sh reconcile --notify   (session-start / watch calls this)"
cert reconcile --notify
echo "-> queue after terminal advancement:"; cert status

rule "6. beta is now admitted and steered automatically — FIFO advanced, no manual nudge"
echo "\$ cat send.log   (second line = beta's start steer)"
cat "$SEND_LOG"

rule "7. SAFETY: a non-no-mistakes (direct-PR) task is refused at the boundary"
wt_pr=$(mktask pronly)
{ printf 'window=fm-pronly\nworktree=%s\nproject=%s\nharness=pi\nkind=ship\nmode=direct-PR\nyolo=off\n' "$wt_pr" "$FIX/pronly-primary"; } > "$HOME_DIR/state/pronly.meta"
echo "\$ fm-certification.sh enqueue pronly <head> ...   (delivery mode = direct-PR)"
if cert enqueue pronly "$(git -C "$wt_pr" rev-parse HEAD)" --intent-file "$HOME_DIR/data/pronly/intent"; then
  echo "UNEXPECTED: direct-PR admitted"; else echo "(refused with exit $?, as required)"; fi

rule "8. SAFETY: unpublished dirty work is preserved, never discarded"
# Use a fresh coordinator root so this task has a free slot and preflight runs.
wt_g=$(mktask guarded); h_g=$(git -C "$wt_g" rev-parse HEAD)
printf 'precious unpublished change\n' > "$wt_g/unpublished.txt"
echo "\$ fm-certification.sh enqueue guarded <head> ...   (worktree is dirty)"
FM_CERTIFICATION_ROOT="$FIX/cert-b" cert enqueue guarded "$h_g" --intent-file "$HOME_DIR/data/guarded/intent" || echo "(refused, as required)"
echo "-> blocked reason:"; FM_CERTIFICATION_ROOT="$FIX/cert-b" cert status | grep guarded
echo "-> dirty file still present & untouched:"; cat "$wt_g/unpublished.txt"
[ "$(git -C "$wt_g" rev-parse HEAD)" = "$h_g" ] && echo "-> HEAD unchanged: $h_g"

rule "9. The coordinator never drove a No Mistakes gate/recovery/cancel command"
echo "\$ cat nm-calls.log   (only read-only axi / status / runs inspections)"
cat "$FIX/nm-calls.log"
echo
if grep -Eq 'respond|abort|rerun|sync|recover|--recover|daemon|axi run' "$FIX/nm-calls.log"; then
  echo "UNEXPECTED: coordinator invoked a gate-driving command"
else
  echo "CONFIRMED: no respond/abort/rerun/sync/recover/daemon/run command was issued"
fi

rm -rf "$FIX"
echo
echo "demo complete."
```
</details>
<details>
<summary>Evidence: fm-certification.test.sh — 18/18 focused regression tests pass</summary>

```text
ok - capacity serializes concurrent requests and notification replay is idempotent
ok - a launch claim cannot create a duplicate certification run
ok - authoritative terminal reconciliation survives restart and advances FIFO
ok - detached, wrong, and changed branch identities stop without rewriting work
ok - obsolete custody blocks only that item and never performs recovery
ok - dirty unpublished work is preserved byte-for-byte
ok - an active validation outside coordinator ownership stops admission
ok - session restart and ordinary monitoring both invoke the state-machine owner
ok - notification ambiguity and no-mistakes read failures stop safely
ok - final certification refuses non-no-mistakes delivery modes
ok - withdraw frees the slot, advances the queue, and permits a corrected head
ok - withdrawal never cancels a matching active run
ok - a launch is graced while registering, surfaced past grace, and then withdrawable
ok - withdrawal waits out the launch grace before freeing a slot
ok - retry waits out the launch grace before re-driving a launch
ok - unsupported-version and malformed records are quarantined before accounting
ok - terminal retention keeps the newest records and prunes older intent
ok - quarantine and withdrawn archives are bounded by the retention count
```
</details>
- Outcome: ⚠️ 2 issues (1 warning, 1 info) across 1 run (6m59s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-certification.sh:297` - no-mistakes CLI reads are deliberately time-bounded via run_bounded()/timeout because they can hang, but the surrounding git commands in preflight and inspect_record_run are not — notably `git status --porcelain=v1 --untracked-files=all` (line 297) and the rev-parse/merge-base calls (lines 289-296, 360-362). All of these execute while holding the single machine-global coordinator lock ($CERT_ROOT/.lock) that serializes every FM_HOME&#39;s certification work. A slow or wedged git in one worktree (huge untracked tree, stuck index/fs) therefore stalls the coordinator for all homes, undercutting the same availability property the timeout wrapping was added to protect. Consider running the git identity/cleanliness probes through the same bounded helper.
- ℹ️ `bin/fm-certification.sh:236` - record_field() (line 129) and meta_value() (line 236) are byte-for-byte identical grep|tail|cut helpers. They can be collapsed to a single helper (or one aliased to the other) to remove the duplication; the two names can be kept as thin wrappers if the call-site semantics are worth preserving.

</details>

<details>
<summary>⚠️ **Test** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `docs/certification-coordinator.md:1` - The intent&#39;s publish requirement — push the feature branch to the authorized ChrisGutierrezNet fork and open an upstream PR against kunchenguid/firstmate main — is not verifiably satisfied from the test environment. `gh-axi search prs` for a certification-coordinator PR and for author:ChrisGutierrezNet on kunchenguid/firstmate both return 0, and the worktree&#39;s `origin` points at kunchenguid/firstmate (the upstream), not a ChrisGutierrezNet fork. The target commit is not on any remote branch. Opening/pushing a PR is an outward-facing, hard-to-reverse action outside testing scope, so I did not perform it. The user needs to confirm the branch was pushed to the fork and the upstream PR opened (and left unmerged).
- ℹ️ `tests/fm-session-start.test.sh:1` - tests/fm-session-start.test.sh has one failing assertion (&#39;the later fleet read did not confirm the relaunched window&#39; — a tmux window-relaunch liveness check). It reproduces identically on the base commit 10ee779 (the test file is unchanged by this diff), so it is a pre-existing environmental/tmux-sandbox failure, not a regression from the certification change. No action needed for this change.
- <code>`bash tests/fm-certification.test.sh` — all 18 focused regression tests pass (concurrent admission, restart/FIFO advance, detached/wrong-branch/changed-head preflight, obsolete custody, dirty-work preservation, uncoordinated-run block, non-no-mistakes delivery refusal, malformed/version-skew quarantine, launch-grace stall/withdraw/retry, bounded terminal/quarantine/withdrawn retention)</code>
- <code>Ran a custom operator CLI transcript (`/tmp/no-mistakes-evidence/01KYA7YMYR2CYGGRT4C4MGRK6Y/demo-lifecycle.sh`) driving the real `bin/fm-certification.sh` through enqueue → status → notify → start → reconcile terminal → FIFO advance, plus direct-PR refusal and dirty-work preservation, verifying only read-only no-mistakes inspections were issued</code>
- <code>`bash tests/fm-watch-triage.test.sh`, `bash tests/fm-watch-checkpoint.test.sh`, `bash tests/fm-brief.test.sh`, `bash tests/fm-test-run.test.sh` — all pass (affected/adjacent scripts touched by the diff)</code>
- <code>`bash tests/fm-session-start.test.sh` — 1 pre-existing tmux-liveness failure; confirmed identical failure on base commit 10ee779 via `git checkout &lt;base&gt; -- bin/fm-session-start.sh tests/fm-session-start.test.sh` (then restored), establishing it is environmental, not a regression</code>
- <code>`gh-axi search prs &#34;certification coordinator repo:kunchenguid/firstmate&#34;` and `author:ChrisGutierrezNet` — 0 results; `git remote -v` and `git branch -r --contains &lt;target&gt;` confirm no upstream PR/push yet</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
