### PR TITLE
fix: support Grok 0.2.111 busy-state signals

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -296,7 +296,7 @@ For Grok's supported reasoning-effort values and omission behavior, see the [lau
 
 | Fact | Value |
 |---|---|
-| Busy-pane signature | `Esc:cancel` (the mid-turn cancel hint in grok's keybind bar, shown iff a turn is running; the spinner line remains a braille glyph + `<status>… N.Ns` + `[stop]`). Idle keybind bar shows only `Shift+Tab:mode │ Ctrl+x:shortcuts`. The ASCII `Esc:cancel` is the busy regex (avoids locale fragility of matching braille). |
+| Busy-pane signature | `Esc:cancel` (the mid-turn cancel hint in grok's keybind bar, shown iff a turn is running; the spinner line remains a braille glyph + `<status>… N.Ns` + `[stop]`). Idle keybind bar shows only `Shift+Tab:mode │ Ctrl+x:shortcuts`. Firstmate's Grok-scoped ASCII busy regex accepts both 0.2.111's `Esc:cancel` and the legacy 0.2.73 `Ctrl+c:cancel` footer, avoiding locale-fragile matching of the braille spinner. |
 | Exit command | `/exit` typed into the composer exits the TUI cleanly and prints `Resume this session with: grok --resume <session-id>`; `Ctrl+Q` double-press within 1000ms remains a fallback; `Ctrl+D` is the quit key in VS Code family terminals; Escape is the interrupt, not the exit. |
 | Interrupt | single Escape cancels the current turn; the footer shows `Esc:cancel` mid-turn and the pane reports `Turn cancelled by user`. |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`), same as claude. Opens a slash-autocomplete popup. On 0.2.111 one Enter submitted the selected no-argument `/no-mistakes` entry, which discovered the user-level skill and began its repository checks. An argument-hint placeholder left in the composer remains pending and receives the adapter's retry Enter. |

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -153,7 +153,7 @@ Natural language is acceptable if uncertain.
 - codex: `$<skill>`, for example `$no-mistakes`; `/<skill>` is claude-only and codex rejects it as "Unrecognized command".
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
-- grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles this through the structural composer reader; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
+- grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Typing `/<skill>` opens grok's slash-autocomplete. Grok 0.2.111 submits the selected no-argument `/no-mistakes` entry with one Enter; commands whose autocomplete selection expands to an argument-hint placeholder still require a second Enter. `fm_tmux_submit_core`'s composer-state retry (used by `fm-send` on the tmux backend) safely handles both shapes; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on popup-close content changes.
 - kimi: `/<skill>`, for example `/no-mistakes`.
 
 ## Submission acknowledgement hazards
@@ -288,7 +288,7 @@ The model arms through `fm_watch_arm_pi`, never a foreground bash arm; the watch
 `bin/fm-session-start.sh` reports when the live Pi session has not loaded both the turn-end guard and watcher extensions, and points at plain `pi` after project trust as the fix, with `-e` as a trust-free fallback.
 When a secondmate is launched on Pi, `fm-spawn.sh --secondmate` launches Pi with both `-e .pi/extensions/fm-primary-turnend-guard.ts` and `-e .pi/extensions/fm-primary-pi-watch.ts`, both already present in the secondmate home's git worktree.
 
-## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99; exit paths re-verified 2026-07-19 on grok 0.2.103)
+## grok (VERIFIED 2026-07-24, grok 0.2.111)
 
 Grok Build TUI (`grok`), a Claude-Code-compatible CLI from xAI.
 Launch with a positional prompt: `grok --always-approve "$(cat <brief>)"`.
@@ -296,13 +296,20 @@ For Grok's supported reasoning-effort values and omission behavior, see the [lau
 
 | Fact | Value |
 |---|---|
-| Busy-pane signature | `Ctrl+c:cancel` (the mid-turn cancel hint in grok's keybind bar, shown iff a turn is running; the spinner line is a braille glyph + `<status>… N.Ns` + `[stop]`, e.g. `⠹ Thinking… 1.1s … [stop]`). Idle keybind bar shows only `Shift+Tab:mode │ Ctrl+.:shortcuts`. The ASCII `Ctrl+c:cancel` is the busy regex (avoids locale fragility of matching braille). |
-| Exit command | `/exit` typed into the composer exits the TUI cleanly and prints `Resume this session with: grok --resume <session-id>`; `Ctrl+Q` double-press within 1000ms remains a fallback; `Ctrl+D` is the quit key in VS Code family terminals; `Ctrl+C` is the interrupt, not the exit. |
-| Interrupt | single `Ctrl+C` (cancels the current turn; the footer shows `Ctrl+c:cancel` mid-turn). `Esc` only moves focus to the scrollback, it does NOT interrupt. |
-| Skill invocation | `/<skill>` (e.g. `/no-mistakes`), same as claude. Opens a slash-autocomplete popup, so a too-fast Enter selects the popup entry instead of sending. For an argument-taking command that first Enter does not submit at all - it expands the selection into an argument-hint placeholder in the composer (e.g. `/compact` -> `/compact compaction instructions`, live-verified), leaving real text still sitting there unsubmitted; a genuine second Enter is required. `fm-send`'s retried Enter lands it on BOTH backends, but only because each backend's own submit-verification correctly recognizes that placeholder-filled text as still-pending - see the incident below. |
+| Busy-pane signature | `Esc:cancel` (the mid-turn cancel hint in grok's keybind bar, shown iff a turn is running; the spinner line remains a braille glyph + `<status>… N.Ns` + `[stop]`). Idle keybind bar shows only `Shift+Tab:mode │ Ctrl+x:shortcuts`. The ASCII `Esc:cancel` is the busy regex (avoids locale fragility of matching braille). |
+| Exit command | `/exit` typed into the composer exits the TUI cleanly and prints `Resume this session with: grok --resume <session-id>`; `Ctrl+Q` double-press within 1000ms remains a fallback; `Ctrl+D` is the quit key in VS Code family terminals; Escape is the interrupt, not the exit. |
+| Interrupt | single Escape cancels the current turn; the footer shows `Esc:cancel` mid-turn and the pane reports `Turn cancelled by user`. |
+| Skill invocation | `/<skill>` (e.g. `/no-mistakes`), same as claude. Opens a slash-autocomplete popup. On 0.2.111 one Enter submitted the selected no-argument `/no-mistakes` entry, which discovered the user-level skill and began its repository checks. An argument-hint placeholder left in the composer remains pending and receives the adapter's retry Enter. |
 | Autonomy | `--always-approve` (footer shows `· always-approve`); auto-approves every tool execution, verified to run fully unattended. `--permission-mode bypassPermissions` is the stronger equivalent. |
 | Env marker | `GROK_AGENT=1`, set for child/tool processes. grok does NOT set `CLAUDECODE` despite Claude compatibility, so the marker is unambiguous. |
 | Resume | `grok --resume <session-id>` (id printed on exit) or `grok -c` / `--continue` (most recent for the cwd); `--fork-session` branches a new session id. |
+
+**2026-07-24 terminal re-verification (grok 0.2.111).**
+In a disposable git directory inside an isolated firstmate worktree, `grok --always-approve '<prompt>'` immediately submitted the positional prompt, displayed `Grok 4.5 (high) · always-approve`, and ran an unattended shell tool whose child recorded `GROK_AGENT=1` and the disposable working directory.
+During both thinking and a 30-second shell tool the footer displayed `Esc:cancel`; one Escape produced `Turn cancelled by user`, after which the idle footer no longer contained the cancel hint.
+`/exit` cleanly ended the TUI, and `grok --continue --always-approve` in the same directory restored the prior conversation.
+The project was a git repository and displayed no trust, login, update, or permission dialog.
+Typing `/no-mistakes` displayed the discovered skill in slash autocomplete; one Enter submitted it and Grok began the skill's repository checks.
 
 **Incident (2026-07-03, herdr backend only, grok 0.2.82):** two grok/herdr crewmates were sent `/no-mistakes` via `fm-send`; both left it fully typed but unsubmitted in the composer for minutes (footer still `Enter:send`), and `fm-send` exited 0 with no error.
 Reproduced live: the herdr adapter's submit-verification at the time treated ANY pane-content change after Enter as "submitted", and the popup-close-with-placeholder-fill described above IS a visible content change even though nothing was actually sent.

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -37,7 +37,7 @@ detect_own() {
   # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
-  # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
+  # grok sets GROK_AGENT=1 for its child/tool processes (re-verified, grok 0.2.111).
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -61,7 +61,9 @@
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh"
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
-# interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel".
+# interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Esc:cancel".
+# Grok's mid-turn cancel hint is shown iff a turn is running (verified grok
+# 0.2.111).
 # Claude's current spinner has a rotating glyph and word, but every active-turn
 # line has an ellipsis followed by a parenthesized elapsed duration. Keep this
 # signature separate from the shared default because that shape is not generic
@@ -76,12 +78,12 @@
 # busy signals on their own.
 # The full moon-phase set remains locale- and emoji-font-sensitive because Kimi
 # exposes no stable ASCII busy token.
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Esc:cancel'
 FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
-FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
+FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Esc:cancel'
 FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
 
 fm_busy_lines_match() {  # [harness]

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -61,9 +61,9 @@
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh"
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
-# interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Esc:cancel".
-# Grok's mid-turn cancel hint is shown iff a turn is running (verified grok
-# 0.2.111).
+# interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok:
+# "Ctrl+c:cancel" or "Esc:cancel" (mid-turn cancel hints, shown iff a turn is
+# running - verified grok 0.2.73 and 0.2.111).
 # Claude's current spinner has a rotating glyph and word, but every active-turn
 # line has an ellipsis followed by a parenthesized elapsed duration. Keep this
 # signature separate from the shared default because that shape is not generic
@@ -78,12 +78,12 @@
 # busy signals on their own.
 # The full moon-phase set remains locale- and emoji-font-sensitive because Kimi
 # exposes no stable ASCII busy token.
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Esc:cancel'
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|(Ctrl\+c|Esc):cancel'
 FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
-FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Esc:cancel'
+FM_TMUX_GROK_BUSY_REGEX_DEFAULT='(Ctrl\+c|Esc):cancel'
 FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
 
 fm_busy_lines_match() {  # [harness]

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -103,14 +103,15 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # Busy signatures are selected by recorded harness unless FM_BUSY_REGEX globally
 # overrides them.
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
-# grok: "Esc:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
-# turn is running; absent when idle - verified grok 0.2.111, ASCII to avoid the
-# locale fragility of matching grok's braille spinner glyph directly).
+# grok: "Ctrl+c:cancel" or "Esc:cancel" (mid-turn cancel hints in grok's keybind
+# bar, shown iff a turn is running; absent when idle - verified grok 0.2.73 and
+# 0.2.111, ASCII to avoid the locale fragility of matching grok's braille spinner
+# glyph directly).
 # Claude's current spinner signature is matched only for
 # a recorded Claude task because an ellipsis followed by elapsed time is not a
 # safe shared signature for arbitrary harness output. Kimi's moon-plus-middot
 # spinner signature is likewise matched only for a recorded Kimi task.
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Esc:cancel'}
+BUSY_REGEX=${FM_BUSY_REGEX:-$FM_TMUX_BUSY_REGEX_DEFAULT}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -103,11 +103,14 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # Busy signatures are selected by recorded harness unless FM_BUSY_REGEX globally
 # overrides them.
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
-# grok: "Ctrl+c:cancel". Claude's current spinner signature is matched only for
+# grok: "Esc:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
+# turn is running; absent when idle - verified grok 0.2.111, ASCII to avoid the
+# locale fragility of matching grok's braille spinner glyph directly).
+# Claude's current spinner signature is matched only for
 # a recorded Claude task because an ellipsis followed by elapsed time is not a
 # safe shared signature for arbitrary harness output. Kimi's moon-plus-middot
 # spinner signature is likewise matched only for a recorded Kimi task.
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Esc:cancel'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -9,19 +9,27 @@ SPAWN="$ROOT/bin/fm-spawn.sh"
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 TMP_ROOT=$(fm_test_tmproot fm-grok-harness)
 
-test_grok_busy_signature_matches_current_footer() {
+test_grok_busy_signatures_match_verified_footers() {
   local regex
   # shellcheck source=bin/fm-tmux-lib.sh
   . "$ROOT/bin/fm-tmux-lib.sh"
   regex=$FM_TMUX_BUSY_REGEX_DEFAULT
+  printf '%s\n' 'Shift+Tab:mode  │  Ctrl+c:cancel  │  Ctrl+x:shortcuts' \
+    | grep -qiE "$regex" \
+    || fail "grok 0.2.73 busy footer did not match the shared busy regex"
   printf '%s\n' 'Shift+Tab:mode  │  Esc:cancel  │  Ctrl+x:shortcuts' \
     | grep -qiE "$regex" \
     || fail "grok 0.2.111 busy footer did not match the shared busy regex"
   if printf '%s\n' 'Shift+Tab:mode  │  Ctrl+x:shortcuts' | grep -qiE "$regex"; then
     fail "grok 0.2.111 idle footer matched the shared busy regex"
   fi
-  assert_grep "Esc:cancel" "$ROOT/bin/fm-watch.sh" \
-    "watcher busy regex drifted from the shared grok footer signature"
+  assert_grep "BUSY_REGEX=\${FM_BUSY_REGEX:-\$FM_TMUX_BUSY_REGEX_DEFAULT}" \
+    "$ROOT/bin/fm-watch.sh" \
+    "watcher busy regex drifted from the shared busy regex"
+  (
+    tmux() { printf '%s\n' 'Shift+Tab:mode  │  Ctrl+c:cancel  │  Ctrl+x:shortcuts'; }
+    fm_pane_is_busy grok-pane
+  ) || fail "shared tmux pane classifier did not recognize grok 0.2.73 as busy"
   (
     tmux() { printf '%s\n' 'Shift+Tab:mode  │  Esc:cancel  │  Ctrl+x:shortcuts'; }
     fm_pane_is_busy grok-pane
@@ -32,7 +40,7 @@ test_grok_busy_signature_matches_current_footer() {
   ); then
     fail "shared tmux pane classifier treated grok 0.2.111 idle footer as busy"
   fi
-  pass "grok 0.2.111 Esc:cancel footer distinguishes busy from idle"
+  pass "verified grok busy footers distinguish busy from idle"
 }
 
 make_spawn_fakebin() {
@@ -163,7 +171,7 @@ SH
   pass "fm-lock recognizes grok harness processes"
 }
 
-test_grok_busy_signature_matches_current_footer
+test_grok_busy_signatures_match_verified_footers
 test_grok_hook_requires_registered_token
 test_grok_teardown_removes_pointer_and_token
 test_fm_lock_recognizes_grok_holder

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Behavior tests for Grok-harness hook authentication, teardown cleanup, and session-lock holder detection.
+# Behavior tests for Grok-harness busy detection, hook authentication, teardown cleanup, and session-lock holder detection.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -8,6 +8,32 @@ set -u
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 TMP_ROOT=$(fm_test_tmproot fm-grok-harness)
+
+test_grok_busy_signature_matches_current_footer() {
+  local regex
+  # shellcheck source=bin/fm-tmux-lib.sh
+  . "$ROOT/bin/fm-tmux-lib.sh"
+  regex=$FM_TMUX_BUSY_REGEX_DEFAULT
+  printf '%s\n' 'Shift+Tab:mode  │  Esc:cancel  │  Ctrl+x:shortcuts' \
+    | grep -qiE "$regex" \
+    || fail "grok 0.2.111 busy footer did not match the shared busy regex"
+  if printf '%s\n' 'Shift+Tab:mode  │  Ctrl+x:shortcuts' | grep -qiE "$regex"; then
+    fail "grok 0.2.111 idle footer matched the shared busy regex"
+  fi
+  assert_grep "Esc:cancel" "$ROOT/bin/fm-watch.sh" \
+    "watcher busy regex drifted from the shared grok footer signature"
+  (
+    tmux() { printf '%s\n' 'Shift+Tab:mode  │  Esc:cancel  │  Ctrl+x:shortcuts'; }
+    fm_pane_is_busy grok-pane
+  ) || fail "shared tmux pane classifier did not recognize grok 0.2.111 as busy"
+  if (
+    tmux() { printf '%s\n' 'Shift+Tab:mode  │  Ctrl+x:shortcuts'; }
+    fm_pane_is_busy grok-pane
+  ); then
+    fail "shared tmux pane classifier treated grok 0.2.111 idle footer as busy"
+  fi
+  pass "grok 0.2.111 Esc:cancel footer distinguishes busy from idle"
+}
 
 make_spawn_fakebin() {
   local dir=$1 fakebin
@@ -137,6 +163,7 @@ SH
   pass "fm-lock recognizes grok harness processes"
 }
 
+test_grok_busy_signature_matches_current_footer
 test_grok_hook_requires_registered_token
 test_grok_teardown_removes_pointer_and_token
 test_fm_lock_recognizes_grok_holder

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -253,7 +253,7 @@ test_source_graph_boundaries_keep_every_owner() {
     grep -q '^[[:space:]]*# shellcheck source=bin/' "$file" || continue
     production_context_tests="${production_context_tests}$(basename "$file")|"
   done
-  [ "$production_context_tests" = 'fm-backend-herdr.test.sh|fm-daemon.test.sh|fm-pending-reply.test.sh|fm-secondmate-sync.test.sh|' ] \
+  [ "$production_context_tests" = 'fm-backend-herdr.test.sh|fm-daemon.test.sh|fm-grok-harness.test.sh|fm-pending-reply.test.sh|fm-secondmate-sync.test.sh|' ] \
     || fail "only callback/variable interop tests may retain production source context: $production_context_tests"
   pass "dispatcher, adapters, production owner, and tests have explicit lint boundaries"
 }


### PR DESCRIPTION
## Intent

Add Grok CLI as a fully verified firstmate harness adapter so project tasks can be launched, supervised, resumed, validated, and stopped through the normal lifecycle. Start from the existing smoke evidence but empirically verify terminal mechanics in a disposable worktree directory, including autonomous launch and permission flags, positional prompt submission, busy and idle signatures, interrupt and clean exit, resume, dialogs, and no-mistakes skill invocation. Implement Grok anywhere the supported harness set is enumerated, including launch, detection, session locking, supervision busy signatures, turn-end handling, adapter documentation with date and CLI version, and focused tests, without changing unrelated adapters. On the current main baseline most Grok enumeration and lifecycle support already existed; live Grok 0.2.111 verification exposed a changed busy footer and interrupt key, so this branch updates the shared tmux and watcher busy signature from Ctrl+c:cancel to Esc:cancel, refreshes verified adapter facts, and adds focused regression coverage while preserving the existing launch and hook mechanics.

## What Changed

- Recognize Grok 0.2.111’s `Esc:cancel` busy marker while preserving support for the legacy `Ctrl+c:cancel` footer across tmux, watcher, crew-state, and supervision paths.
- Centralize watcher busy detection on the shared tmux regex and update Grok adapter and configuration documentation for the verified 0.2.111 terminal behavior.
- Add regression coverage for current and legacy Grok busy footers, idle-state rejection, and shared pane classification.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, preserves both verified Grok busy markers, centralizes runtime detection, and introduces no substantiated regression.

## Testing

Startup, runtime version, target identity, focused Grok lifecycle tests, adjacent supervision/state regressions, private-tmux evidence, and a credentialed live Grok 0.2.111 busy/interrupt/idle flow all passed; an extra unchanged-path `/exit` setup did not reach a fresh idle composer within its bounded window and was excluded from acceptance evidence, all test-owned temporary files were removed, and the worktree finished clean.

<details>
<summary>Evidence: Live Grok 0.2.111 TUI busy/interrupt evidence</summary>

```text
Installed runtime: grok 0.2.111 (94172f2aa4e5) [stable]
Live busy footer:   Shift+Tab:mode  │  Esc:cancel  │  Ctrl+x:shortcuts
Production classification while active: BUSY
Interrupt result: Escape cleared the cancel footer in 0.00s
Live idle footer:   Enter:send  │  Shift+Tab:mode  │  Ctrl+x:shortcuts
Production classification after interrupt: IDLE
LIVE_TUI_RESULT: Grok 0.2.111 busy detection, Escape interrupt, and idle detection verified.
```
</details>
<details>
<summary>Evidence: Base-versus-target classification comparison</summary>

```text
Observed Grok 0.2.111 footer: Shift+Tab:mode  │  Esc:cancel  │  Ctrl+x:shortcuts

Base commit regex:   esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel
Base classification: IDLE (misses the active Grok turn)

Target commit regex:   esc (to )?interrupt|Working\.\.\.|(Ctrl\+c|Esc):cancel
Target classification: BUSY (active turn remains supervised)

Idle Grok footer:      Shift+Tab:mode  │  Ctrl+x:shortcuts
Idle classification:   IDLE (no false busy state)
```
</details>
<details>
<summary>Evidence: Production tmux classification transcript</summary>

```text
Installed runtime: grok 0.2.111 (94172f2aa4e5) [stable]
Production regex: esc (to )?interrupt|Working\.\.\.|(Ctrl\+c|Esc):cancel

Pane grok-new
  rendered footer: Shift+Tab:mode  │  Esc:cancel  │  Ctrl+x:shortcuts
  supervisor classification: BUSY (expected BUSY)

Pane grok-old
  rendered footer: Shift+Tab:mode  │  Ctrl+c:cancel  │  Ctrl+x:shortcuts
  supervisor classification: BUSY (expected BUSY)

Pane grok-idle
  rendered footer: Shift+Tab:mode  │  Ctrl+x:shortcuts
  supervisor classification: IDLE (expected IDLE)

RESULT: Grok 0.2.111 busy panes remain supervised; idle panes are not falsely marked busy.
```
</details>
<details>
<summary>Evidence: Focused Grok harness test transcript</summary>

```text
FM_TEST_BEGIN 2026-07-24T14:59:25Z tests/fm-grok-harness.test.sh family=pure-contract-unit expected_gate_skip=none
ok - verified grok busy footers distinguish busy from idle
ok - grok global hook requires a firstmate registry token
ok - grok teardown removes pointer and token state
ok - fm-lock recognizes grok harness processes
FM_TEST_END 2026-07-24T14:59:38Z tests/fm-grok-harness.test.sh exit=0 duration_ms=12605 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=13060
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=12605 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-grok-harness.test.sh duration_ms=12605
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-tmux-lib.sh:66` - Replacing the old signature drops compatibility with previously verified Grok versions, while no spawn/bootstrap path requires Grok &gt;=0.2.111. Older installations still launch, but active turns using `Ctrl+c:cancel` appear idle to watcher, crew-state, and away-mode fallbacks. Decide whether to preserve both signatures or enforce a minimum Grok version.
- ⚠️ `docs/configuration.md:435` - The documented `FM_BUSY_REGEX` override still contains only `Ctrl\+c:cancel`. Because this override replaces the new default everywhere, users following the configuration reference will break busy detection on Grok 0.2.111. Update it to the selected current or dual-version pattern.
- ℹ️ `bin/fm-watch.sh:108` - Use the already-loaded shared default (`FM_TMUX_BUSY_REGEX_DEFAULT`) here instead of duplicating the regex literal. This non-functional simplification prevents watcher detection from drifting from crew-state and daemon consumers.

🔧 Fix: Captain, preserve Grok busy markers across versions
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-session-start.sh`
- `grok --version`
- `bin/fm-test-run.sh tests/fm-grok-harness.test.sh`
- `bin/fm-test-run.sh tests/fm-tmux-submit-busy.test.sh tests/fm-crew-state.test.sh tests/fm-watch-triage.test.sh`
- `bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh tests/fm-supervision-instructions.test.sh`
- <code>Private-socket tmux verification using production `fm_pane_is_busy` against Grok 0.2.111, legacy, and idle footers</code>
- <code>Base-versus-target classification using `git show 10ee7797e50c88c9865d8fb382cdfee5c2b8bcd1:bin/fm-tmux-lib.sh` and target `bin/fm-tmux-lib.sh`</code>
- `Credentialed, isolated Grok 0.2.111 TUI verification of positional launch, live busy footer, production classification, Escape interrupt, and post-interrupt idle classification`
- `git diff --check 10ee7797e50c88c9865d8fb382cdfee5c2b8bcd1..c539c29fb553363c24f8cd81c2dd6b0b2a7acbd0`
- <code>Final `git status --short --untracked-files=all` and `git rev-parse HEAD` cleanup/identity audit</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
