### PR TITLE
fix(fm-brief): close the "committed = delivered" gap in ship contracts

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -288,8 +288,10 @@ case "$MODE" in
     DOD=$(cat <<EOF
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+A committed implementation is not the finish line; the finish line is an opened pull request.
+The moment your change is implemented and committed, immediately push your branch and open a PR with \`gh-axi\`.
+Do not stop or idle at the commit, and never report \`done:\` for a commit with no PR: a committed change with no open PR is \`working:\`, never \`done:\`.
+When the PR is open, append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
 )
@@ -300,9 +302,9 @@ EOF
     DOD=$(cat <<EOF
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+For this mode the finish line is a clean ready branch: the task is complete only when your change is implemented and committed on branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop; a change not yet committed on \`fm/$ID\` is \`working:\`, never \`done:\`.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
 )
@@ -313,9 +315,10 @@ EOF
     RULE1='1. Never push to the default branch. Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+This project ships **no-mistakes**: a committed implementation is not the finish line.
+The finish line is a pushed pull request with green CI checks, produced by the no-mistakes pipeline.
+The moment your change is implemented and committed on your branch, immediately invoke /no-mistakes and drive the pipeline through to green CI.
+Do not stop or idle at the commit, and never report \`done:\` for a commit that has not reached a green PR: a committed change without a green PR is \`working:\`, never \`done:\`.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -363,6 +366,8 @@ $RULE1
    firstmate reads your pane for that.
    A mid-task \`working:\` line (including setup complete) is nonterminal: do not end the
    turn after it; continue the same stage until a defined \`done:\` gate under Definition of done.
+   \`done:\` is reserved for the delivery-mode finish line named in Definition of done; a finished
+   implementation commit that has not reached that finish line is \`working:\`, never \`done:\`.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -73,6 +73,61 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+# The "committed = delivered" trap fix: for every ship mode the generated
+# Definition of done must make the mode's real finish line unmissable at the
+# point of action - committing is never the finish line for no-mistakes or
+# direct-PR - and the shared status protocol must reserve `done:` for that
+# finish line so a finished implementation commit is `working:`, never `done:`.
+test_ship_dod_finish_line_is_not_commit() {
+  local home id brief
+  home="$TMP_ROOT/finish-line-home"
+  write_registry "$home"
+
+  # no-mistakes: an unregistered project defaults to no-mistakes.
+  id="brief-finish-nomistakes-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" no-registry-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "a committed implementation is not the finish line" "$brief" \
+    "no-mistakes DOD did not disclaim commit-as-finish-line"
+  assert_grep "immediately invoke /no-mistakes and drive the pipeline through to green CI" "$brief" \
+    "no-mistakes DOD did not make immediate pipeline invocation the point-of-action step"
+  # shellcheck disable=SC2016  # literal backticks/braces must stay unexpanded
+  assert_grep 'a committed change without a green PR is `working:`, never `done:`' "$brief" \
+    "no-mistakes DOD did not reserve done: for the green-PR finish line"
+
+  # direct-PR
+  id="brief-finish-directpr-e2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "the finish line is an opened pull request" "$brief" \
+    "direct-PR DOD did not name the opened-PR finish line"
+  assert_grep "immediately push your branch and open a PR" "$brief" \
+    "direct-PR DOD did not make push-and-open the point-of-action step"
+  # shellcheck disable=SC2016  # literal backticks/braces must stay unexpanded
+  assert_grep 'a committed change with no open PR is `working:`, never `done:`' "$brief" \
+    "direct-PR DOD did not reserve done: for the opened-PR finish line"
+
+  # local-only: committing IS the finish line, but it must be named as such and
+  # still reserve done: for the committed ready branch.
+  id="brief-finish-localonly-e3"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" local-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "the finish line is a clean ready branch" "$brief" \
+    "local-only DOD did not name the ready-branch finish line"
+  # shellcheck disable=SC2016  # literal backticks must stay unexpanded
+  assert_grep "is \`working:\`, never \`done:\`" "$brief" \
+    "local-only DOD did not reserve done: for the committed ready branch"
+
+  # The shared status protocol reserves done: for the finish line in every mode.
+  for id in brief-finish-nomistakes-e1 brief-finish-directpr-e2 brief-finish-localonly-e3; do
+    brief="$home/data/$id/brief.md"
+    # shellcheck disable=SC2016  # literal backticks must stay unexpanded
+    assert_grep '`done:` is reserved for the delivery-mode finish line named in Definition of done' "$brief" \
+      "$id: shared status protocol did not reserve done: for the finish line"
+  done
+  pass "fm-brief.sh: every ship mode names its finish line and reserves done: for it"
+}
+
 test_faster_paths_use_configured_authority_without_stacked_review() {
   local home id brief
   home="$TMP_ROOT/configured-authority-home"
@@ -385,6 +440,7 @@ test_scout_and_secondmate_scaffold() {
 test_script_parses
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_ship_dod_finish_line_is_not_commit
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording


### PR DESCRIPTION
## Problem: "committed = delivered" trap in the generated ship contract

Ship-task crewmates repeatedly finish their implementation commit, append `done: committed <work>` to the status file, and then idle forever - never invoking the validation pipeline and never opening a PR.

Observed instances:
- 2026-07-20: three codex crewmates in one session stopped at `done: committed` (`sp-create-nav-6d`, `sp-heldout-corpus-4b`, `sp-combat-panel-2k`).
- 2026-07-24: `ct-mcp-profiles-settings-5m` stopped at `done: committed` with 37 passing tests and no pipeline run.

Root cause: the generated ship contract in `bin/fm-brief.sh` under-specifies that committing is **not** the definition of done, and the shared status protocol lets `done:` be appended before the delivery mode's real finish line. Two lines drive it:

- Each ship-mode Definition of done opened with "The task is complete only when committed on your branch" - literally false for `no-mistakes` (finish line: PR with green checks) and `direct-PR` (finish line: PR opened).
- Rule 4's status protocol listed `done:` as a valid state with no constraint that it may only be used at the finish line, so a finished commit reads as `done:`.

## Fix

All changes are confined to `bin/fm-brief.sh`'s generated ship contract plus its colocated tests.

1. **Make the finish line unmissable at the point of action.** Right after the implementation commit, each mode now states its real finish line and requires driving to it:
   - `no-mistakes`: immediately invoke `/no-mistakes` and drive the pipeline through to green CI.
   - `direct-PR`: immediately push the branch and open the PR.
   - `local-only`: the committed ready branch is itself the finish line (now named explicitly).
2. **Constrain the status verb.** The shared status protocol now reserves `done:` for the delivery-mode finish line named in Definition of done; a finished implementation commit that has not reached that finish line is `working:`, never `done:`. Each mode's DOD repeats the constraint at its point of action.
3. **Tests.** `tests/fm-brief.test.sh` gains `test_ship_dod_finish_line_is_not_commit`, asserting the finish-line and `done:`-reservation lines render in generated briefs for all three ship modes.

Wording follows repo style (one sentence per line, plain dashes, literal backticks preserved through the heredocs).

## Design note

For `no-mistakes`, the contract now has the worker drive validation to green immediately after committing rather than stopping at the commit and waiting to be told to run the pipeline. This is what the observed idle-forever failure requires, and it is consistent with the existing "the task worker drives the pipeline" model and with Rule 4 ("a mid-task `working:` line is nonterminal … continue until a defined `done:` gate"). Firstmate triggering validation remains a valid supervisory backstop; maintainers may want to align the `AGENTS.md` "Validate" wording accordingly, which is left out of scope here.

## Verification

```
bin/fm-test-run.sh tests/fm-brief.test.sh   # 16 tests pass, incl. the new one
bin/fm-lint.sh                              # ShellCheck 0.11.0 (pinned) clean
bash -n bin/fm-brief.sh                     # parses cleanly
```
