### PR TITLE
fix(fm-teardown): open own-PR vetoes the content-in-default landed check

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -400,14 +400,37 @@ content_in_default() {
   [ "$merged_tree" = "$default_tree" ]
 }
 
+# Is this task's own recorded PR (pr= in meta) still open? An open PR is
+# affirmative proof the task's own work has not landed, even when its content
+# already matches the default branch because a sibling PR carried the same
+# change first. Returns success only when a pr= is recorded and GitHub reports
+# its state as OPEN; returns non-zero for no recorded PR, any other state, or a
+# gh error, so the caller keeps its content fallback for those cases.
+recorded_pr_is_open() {
+  local state
+  [ -n "$PR_URL" ] || return 1
+  state=$(cd "$WT" && gh pr view "$PR_URL" --json state -q '.state' 2>/dev/null) || return 1
+  case "$state" in
+    OPEN|open) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Has the worktree's committed work actually LANDED, though its commits are not
 # reachable from any remote-tracking branch? True when a merged PR proves the
-# current local work is contained in the PR head, OR the content is already in the
-# default branch (fallback, which also covers the no-PR and gh-error paths). False
-# only for genuinely unlanded work.
+# current local work is contained in the PR head. A recorded-but-open PR is
+# positive proof the work is NOT landed, so it refuses without consulting the
+# provenance-blind content check - otherwise a sibling PR's identical content in
+# the default branch would falsely green-light teardown of the still-open task.
+# Otherwise falls back to the content check, which covers the no-PR, gh-error,
+# and squash-merge-then-delete paths. False only for genuinely unlanded work.
 work_is_landed() {
   local branch=$1
   pr_is_merged "$branch" && return 0
+  if recorded_pr_is_open; then
+    WORK_UNLANDED_PR_OPEN=1
+    return 1
+  fi
   content_in_default
 }
 
@@ -715,6 +738,9 @@ validate_worktree_teardown_safety() {
     fi
     if ! work_is_landed "$branch"; then
       echo "REFUSED: worktree $WT has work not on any remote and not landed." >&2
+      if [ -n "${WORK_UNLANDED_PR_OPEN:-}" ]; then
+        echo "PR $PR_URL is still open (not merged); its content may already be in the default branch via a sibling PR, but this task's own PR has not landed." >&2
+      fi
       printf 'unpushed commits:\n%s\n' "$unpushed" >&2
       echo "Push the branch, land its PR, or get the captain's explicit OK to discard, then --force." >&2
       return 1

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -7,7 +7,7 @@
 # and GitHub reports a PR head that contains the current local work, or its content
 # is already in the up-to-date default branch.
 #
-# Covers three fixes:
+# Covers four fixes:
 #   - local-only fork-remote: a fork IS a remote, so fork-pushed upstream-
 #     contribution PRs are teardown-eligible (the pre-fix code false-refused them).
 #   - squash-merge-then-delete-branch: the branch's own commits live nowhere on a
@@ -15,6 +15,10 @@
 #     main. Reachability alone false-refused this common GitHub flow; the check now
 #     recognizes a merged PR head containing the local work (or the content already
 #     in main) as landed.
+#   - open-PR veto: content-in-default is provenance-blind, so a SIBLING PR that
+#     landed the same change makes an unmerged task's content look "landed" and the
+#     old check reaped its still-open PR's state. A recorded-but-open PR now vetoes
+#     the content fallback: the task's own work has not landed until its own PR merges.
 #   - teardown-lock-race: a killed crew process can leave a transient worktree
 #     git index.lock that blocks teardown. The return path retries on the lock
 #     error signature (even if the lock self-clears mid-check), then only removes a
@@ -38,6 +42,8 @@
 #   (o) fm-pr-check rerun after HEAD moved                      -> no stale pr_head
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
+#  (za) no-mistakes + recorded pr= OPEN + sibling content in default -> REFUSE (open-PR veto)
+#  (zb) no-mistakes + recorded pr= MERGED + sibling content in default -> ALLOW (own PR landed)
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -227,6 +233,37 @@ case "\${1:-} \${2:-}" in
     case " \$* " in
       *"state,headRefOid"*) printf '%s\t%s\n' 'MERGED' '$head' ; exit 0 ;;
       *"headRefOid"*) printf '%s\n' '$head' ; exit 0 ;;
+    esac
+    ;;
+esac
+echo "error: pull request not found" >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/gh-axi" "$case_dir/fakebin/gh"
+}
+
+# Override GitHub lookups to report PR 7 as OPEN (not merged). pr_is_merged sees a
+# non-MERGED state and gives up; recorded_pr_is_open sees OPEN and vetoes the content
+# fallback. The head is irrelevant because neither path reaches a containment check.
+add_gh_pr_open() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr list")
+    printf '%s\n' "count: 1 (showing first 1)" "pull_requests[1]{number,state}:" "  7,open" ; exit 0 ;;
+  "pr view")
+    printf '%s\n' "pull_request:" "  number: 7" "  state: open" ; exit 0 ;;
+esac
+exit 0
+SH
+  cat > "$case_dir/fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr view")
+    case " $* " in
+      *"state,headRefOid"*) printf '%s\t%s\n' 'OPEN' '0000000000000000000000000000000000000000' ; exit 0 ;;
+      *"state"*) printf '%s\n' 'OPEN' ; exit 0 ;;
     esac
     ;;
 esac
@@ -822,6 +859,54 @@ test_content_in_default_fallback_allows() {
   pass "worktree whose content already landed in the default branch is torn down (content fallback)"
 }
 
+test_open_pr_with_sibling_content_in_default_refuses() {
+  local case_dir rc
+  case_dir=$(make_case open-pr-sibling-content)
+  write_meta "$case_dir" no-mistakes ship
+  append_pr_meta_url "$case_dir"
+  # The task branch adds feature.txt, and the identical net change has independently
+  # landed on origin/main via a SIBLING PR - so content_in_default alone would call it
+  # "landed". But this task's OWN recorded PR is still open, which is positive proof
+  # the work has not landed for this task. Teardown must refuse rather than reap the
+  # state of a live, unmerged PR.
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  land_on_origin_main "$case_dir" feature.txt hello
+  add_gh_pr_open "$case_dir"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "open-pr-sibling-content: teardown must refuse while the task's own PR is still open"
+  grep -q REFUSED "$case_dir/stderr" || fail "open-pr-sibling-content: no REFUSED line in stderr"
+  grep -q "still open" "$case_dir/stderr" || fail "open-pr-sibling-content: refusal did not tell the operator the PR is still open"
+  pass "open PR whose content is in default via a sibling is refused, not reaped"
+}
+
+test_merged_pr_with_sibling_content_allows() {
+  local case_dir rc pr_head
+  case_dir=$(make_case merged-pr-sibling-content)
+  write_meta "$case_dir" no-mistakes ship
+  append_pr_meta_url "$case_dir"
+  # Same shared-surface shape as the refuse case, but this task's OWN recorded PR is
+  # MERGED with a head that contains the local work. That is genuine landing, so the
+  # open-PR veto must not fire and teardown proceeds.
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  land_on_origin_main "$case_dir" feature.txt hello
+  pr_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "merged-pr-sibling-content: teardown should proceed when the task's own PR is merged"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "merged-pr-sibling-content: teardown printed a REFUSED line"
+  pass "task whose own PR is merged is torn down even when a sibling shares its content"
+}
+
 test_content_fallback_refreshes_stale_origin_ref() {
   local case_dir rc
   case_dir=$(make_case content-stale-ref)
@@ -1390,6 +1475,8 @@ test_merged_pr_with_later_local_commit_refuses
 test_pr_check_does_not_refresh_stale_pr_head
 test_pr_check_records_remote_head_when_local_lags
 test_content_in_default_fallback_allows
+test_open_pr_with_sibling_content_in_default_refuses
+test_merged_pr_with_sibling_content_allows
 test_content_fallback_refreshes_stale_origin_ref
 test_dirty_worktree_refuses
 test_gh_error_and_content_absent_refuses


### PR DESCRIPTION
## Summary

`bin/fm-teardown.sh`'s landed-work safety (`work_is_landed` -> `content_in_default`) can delete a ship task's `state/<id>.meta`, `.status`, `.turn-ended`, and PR-poll/check sidecars **while that task's own PR is still open (green but unmerged)**.

`content_in_default()` (`bin/fm-teardown.sh:385`) only checks whether the branch's *content* is already in the up-to-date default branch, via `git merge-tree --write-tree` tree-equality. That is true both when the task's own PR squash-merged (intended) **and** when a *sibling* PR landed the same/overlapping content first (false positive). Because `work_is_landed` was `pr_is_merged || content_in_default`, an open PR did not stop the fallback, so a normal (no `--force`) teardown proceeded and reaped live work.

## Impact (observed)

Three tasks on 2026-07-22 in one home lost `.meta` + `.status` after reaching done, with no intended teardown, all shared-surface slices:

- `rb-audit-surface-data-2a` (PR #680) - slice A of a shared audit-surfacing contract with slice B, sharing types/RPC/queries.
- `ct-catalog-index-fix-4g` - carried two PRs (#800/#801); the earlier PR's content already in main made the delivered branch's content match the default tree.
- `rb-agent-auth-audit-6a` - an audit scout.

Recovery required hand-rewriting `.meta` and re-running `fm-pr-check` before the still-open PRs could be merged. The watcher's `.seen-*`/`.hb-surfaced-*` markers survived with the same mtimes as the removed files, ruling out an age-based external reaper or `git clean`; the exact removed set matches teardown's own `rm` list. The mechanism was reproduced end to end against the real `bin/fm-teardown.sh` (open, unmerged PR + sibling content in default -> teardown removed `.meta`/`.status`/`.turn-ended`, exit 0, no REFUSED).

## Fix

An open PR is affirmative proof the task's own work has not landed, so `content_in_default` (a fallback for the unknown/absent PR-state case) must not override it.

In `work_is_landed()`: when a `pr=` is recorded and GitHub reports it OPEN, refuse without consulting `content_in_default`. The content fallback is unchanged for tasks with no recorded PR, a gh lookup error, or a merged PR (squash-merge-then-delete still works). The refusal now tells the operator the PR is still open.

## Test coverage

Extends `tests/fm-teardown.test.sh` with the sibling-content scenarios:

- recorded `pr=` reported OPEN + content already in default via a sibling -> **REFUSE** (new open-PR veto).
- recorded `pr=` reported MERGED + content in default -> **ALLOW** (own PR genuinely landed; veto must not over-refuse).
- the existing no-PR + content-in-default case (`test_content_in_default_fallback_allows`) is unchanged.

All teardown cases pass; `bin/fm-lint.sh` is clean (shellcheck 0.11.0, the pinned version).

Fixes #986
