### PR TITLE
fix(bin): restore fm-brief.sh parse under macOS bash 3.2 and guard against regressions

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -81,6 +81,9 @@ Keep instructions as the authority and discovery layer, but make repeated execut
 - Plain dash `-`, never an em dash.
 - Never add an agent name as a commit co-author.
 - `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`.
+- Never put an apostrophe or unbalanced quote in a heredoc body that sits inside a `$(...)` command substitution (`VAR=$(cat <<EOF ... EOF)`): bash 3.2 (macOS `/bin/bash`) fails to parse the whole script, while bash 4/5 parses it fine, so Linux CI cannot catch it.
+  Reword to drop the apostrophe or move the heredoc out of the substitution.
+  Top-level heredocs (`cat > file <<EOF`) are unaffected.
 - Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, and pinned shellcheck version) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
 - A backend-verification doc (`docs/*-backend.md`) records empirical facts, not assumptions.

--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -81,8 +81,9 @@ Keep instructions as the authority and discovery layer, but make repeated execut
 - Plain dash `-`, never an em dash.
 - Never add an agent name as a commit co-author.
 - `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`.
-- Never put an apostrophe or unbalanced quote in a heredoc body that sits inside a `$(...)` command substitution (`VAR=$(cat <<EOF ... EOF)`): bash 3.2 (macOS `/bin/bash`) fails to parse the whole script, while bash 4/5 parses it fine, so Linux CI cannot catch it.
-  Reword to drop the apostrophe or move the heredoc out of the substitution.
+- Never let a heredoc body that sits inside a `$(...)` command substitution (`VAR=$(cat <<EOF ... EOF)`) carry an unbalanced (odd) total count of single-quote characters, e.g. one stray apostrophe in prose: bash 3.2 (macOS `/bin/bash`) fails to parse the whole script, while bash 4/5 parses it fine, so Linux CI cannot catch it.
+  Balanced pairs (ANSI-C `$'...'` strings, quoted jq filters, etc.) are fine since the count stays even.
+  Reword to drop the stray apostrophe, balance the quote, or move the heredoc out of the substitution.
   Top-level heredocs (`cat > file <<EOF`) are unaffected.
 - Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, and pinned shellcheck version) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -325,7 +325,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass the firstmate authority check and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -131,7 +131,7 @@ test_primary_and_secondmate_instruction_generation() {
     "generated implementation brief lets the worker own an ask-user decision"
   assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$ship" \
     "generated implementation brief bypasses the primary authority owner"
-  assert_grep "silently bypass firstmate's authority check and any required captain escalation" "$ship" \
+  assert_grep "silently bypass the firstmate authority check and any required captain escalation" "$ship" \
     "generated implementation brief permits silent ask-user auto-resolution"
   assert_no_grep 'the captain, not you, owns the ask-user decisions' "$ship" \
     "generated implementation brief retained conflicting captain-only wording"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -2,13 +2,18 @@
 # Behavior tests for bin/fm-brief.sh.
 #
 # Regression coverage for the heredoc-in-command-substitution parse bug (issue
-# #166): each ship-mode branch builds its Definition-of-done text with
-# `VAR=$(cat <<EOF ... EOF)`. Bash's lexer tracks quote state through the
-# heredoc body while it scans for the matching `)` of the command
-# substitution, so a single unescaped apostrophe anywhere in that body breaks
-# parsing of the *entire rest of the script* - `bash -n` fails, not just the
-# generated brief. A plain `cat > file <<EOF ... EOF` (not wrapped in `$(...)`)
-# is unaffected, so the secondmate charter block does not need this guard.
+# #166, re-broken by PR #945 on 2026-07-24): each ship-mode branch builds its
+# Definition-of-done text with `VAR=$(cat <<EOF ... EOF)`. Bash 3.2's lexer
+# tracks quote state through the heredoc body while it scans for the matching
+# `)` of the command substitution, so a single unescaped apostrophe anywhere
+# in that body breaks parsing of the *entire rest of the script* under macOS
+# /bin/bash 3.2.57 - `bash -n` fails, not just the generated brief. Bash 4/5
+# parses the same construct fine, so `bash -n` alone cannot guard this on a
+# Linux CI host: the durable guard is the version-independent no-apostrophe
+# style check in test_dod_heredocs_carry_no_apostrophes below, backed by the
+# style rule in .agents/skills/firstmate-coding-guidelines/SKILL.md. A plain
+# `cat > file <<EOF ... EOF` (not wrapped in `$(...)`) is unaffected, so the
+# secondmate charter block does not need this guard.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -20,13 +25,39 @@ mkdir -p "$BRIEF_HOME/data"
 
 # The script itself must always parse. This is the direct regression test for
 # issue #166: a stray apostrophe in any of the three DOD heredoc bodies
-# (no-mistakes/direct-PR/local-only) breaks `bash -n` on the whole file.
+# (no-mistakes/direct-PR/local-only) breaks `bash -n` on the whole file under
+# bash 3.2. It only bites when the test host runs bash 3.2 (macOS /bin/bash);
+# on a Linux bash 5 host the apostrophe parses fine and this test cannot catch
+# the regression - test_dod_heredocs_carry_no_apostrophes is the durable,
+# version-independent guard.
 test_script_parses() {
   local out rc
   out=$(bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
   expect_code 0 "$rc" "bash -n bin/fm-brief.sh must parse cleanly (got: $out)"
   [ -z "$out" ] || fail "bash -n bin/fm-brief.sh emitted unexpected output: $out"
   pass "fm-brief.sh: bash -n succeeds"
+}
+
+# Version-independent style guard for the #166/#945 parse quirk: an
+# apostrophe inside a heredoc body that sits in a `$(...)` command
+# substitution breaks `bash -n` under bash 3.2 but parses fine under bash 5,
+# so `test_script_parses` alone cannot catch it on a Linux host. Scan every
+# `VAR=$(cat <<EOF ... EOF)` body in bin/fm-brief.sh and reject apostrophes
+# outright, regardless of the bash version running the test.
+test_dod_heredocs_carry_no_apostrophes() {
+  local hits
+  hits=$(awk '
+    /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=\$\(cat <<[A-Za-z_]+[[:space:]]*$/ {
+      in_heredoc=1
+      next
+    }
+    in_heredoc && /^EOF$/ { in_heredoc=0; next }
+    in_heredoc && /'"'"'/ { print NR ": " $0 }
+  ' "$ROOT/bin/fm-brief.sh")
+  if [ -n "$hits" ]; then
+    fail "apostrophe(s) inside a \$(cat <<EOF ...) heredoc body break bash 3.2 parsing (see firstmate-coding-guidelines style rules):"$'\n'"$hits"
+  fi
+  pass "fm-brief.sh: command-substitution heredoc bodies carry no apostrophes"
 }
 
 test_help_includes_entire_header() {
@@ -116,6 +147,14 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must render literal backticks around help"
   assert_no_grep "no-mistakes' own guidance" "$brief" \
     "no-mistakes DOD regressed to the apostrophe form that breaks bash -n"
+  # PR #945's ask-user authority wording must survive, in the apostrophe-free
+  # form bash 3.2 can parse.
+  assert_grep "the firstmate authority check and any required captain escalation" "$brief" \
+    "no-mistakes DOD lost the #945 firstmate authority wording"
+  assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$brief" \
+    "no-mistakes DOD lost the #945 authority-contract sentence"
+  assert_no_grep "firstmate's authority check" "$brief" \
+    "no-mistakes DOD regressed to the #945 apostrophe form that breaks bash 3.2"
   pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
 }
 
@@ -383,6 +422,7 @@ test_scout_and_secondmate_scaffold() {
 }
 
 test_script_parses
+test_dod_heredocs_carry_no_apostrophes
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -42,12 +42,14 @@ test_script_parses() {
 # apostrophe inside a heredoc body that sits in a `$(...)` command
 # substitution breaks `bash -n` under bash 3.2 but parses fine under bash 5,
 # so `test_script_parses` alone cannot catch it on a Linux host. Scan every
-# `VAR=$(cat <<EOF ... EOF)` body in bin/fm-brief.sh and reject apostrophes
-# outright, regardless of the bash version running the test.
+# `VAR=$(cat <<EOF ... EOF)` and `VAR=$(cat <<'EOF' ... EOF)` body in
+# bin/fm-brief.sh and reject apostrophes outright, regardless of the bash
+# version running the test. Bash 3.2 is equally vulnerable whether the
+# heredoc delimiter is quoted or not, so both forms must be scanned.
 test_dod_heredocs_carry_no_apostrophes() {
   local hits
   hits=$(awk '
-    /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=\$\(cat <<[A-Za-z_]+[[:space:]]*$/ {
+    /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=\$\(cat <<'"'"'?[A-Za-z_]+'"'"'?[[:space:]]*$/ {
       in_heredoc=1
       next
     }

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -10,10 +10,14 @@
 # /bin/bash 3.2.57 - `bash -n` fails, not just the generated brief. Bash 4/5
 # parses the same construct fine, so `bash -n` alone cannot guard this on a
 # Linux CI host: the durable guard is the version-independent no-apostrophe
-# style check in test_dod_heredocs_carry_no_apostrophes below, backed by the
-# style rule in .agents/skills/firstmate-coding-guidelines/SKILL.md. A plain
-# `cat > file <<EOF ... EOF` (not wrapped in `$(...)`) is unaffected, so the
-# secondmate charter block does not need this guard.
+# style check in test_bin_heredocs_carry_no_apostrophes below, backed by the
+# style rule in .agents/skills/firstmate-coding-guidelines/SKILL.md. That
+# guard scans every bin/*.sh script, not just fm-brief.sh - the identical
+# `VAR=$(cat <<EOF ... EOF)` pattern also appears in bin/fm-bootstrap.sh and
+# bin/fm-fleet-snapshot.sh, and is equally vulnerable there even though
+# neither currently carries an apostrophe. A plain `cat > file <<EOF ... EOF`
+# (not wrapped in `$(...)`) is unaffected, so the secondmate charter block
+# does not need this guard.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -28,7 +32,7 @@ mkdir -p "$BRIEF_HOME/data"
 # (no-mistakes/direct-PR/local-only) breaks `bash -n` on the whole file under
 # bash 3.2. It only bites when the test host runs bash 3.2 (macOS /bin/bash);
 # on a Linux bash 5 host the apostrophe parses fine and this test cannot catch
-# the regression - test_dod_heredocs_carry_no_apostrophes is the durable,
+# the regression - test_bin_heredocs_carry_no_apostrophes is the durable,
 # version-independent guard.
 test_script_parses() {
   local out rc
@@ -38,28 +42,65 @@ test_script_parses() {
   pass "fm-brief.sh: bash -n succeeds"
 }
 
-# Version-independent style guard for the #166/#945 parse quirk: an
-# apostrophe inside a heredoc body that sits in a `$(...)` command
-# substitution breaks `bash -n` under bash 3.2 but parses fine under bash 5,
-# so `test_script_parses` alone cannot catch it on a Linux host. Scan every
-# `VAR=$(cat <<EOF ... EOF)` and `VAR=$(cat <<'EOF' ... EOF)` body in
-# bin/fm-brief.sh and reject apostrophes outright, regardless of the bash
-# version running the test. Bash 3.2 is equally vulnerable whether the
+# Version-independent style guard for the #166/#945 parse quirk. Verified
+# directly against real /bin/bash 3.2.57: bash 3.2's command-substitution
+# scanner tracks single-quote state through the heredoc body, so what
+# actually breaks `bash -n` is an UNBALANCED (odd) count of single-quote
+# characters in the body - e.g. one stray apostrophe in prose. A body with
+# an EVEN count (balanced ANSI-C `$'...'` strings, balanced jq `'...'`
+# strings, etc., as seen in bin/fm-fleet-snapshot.sh) parses fine under
+# bash 3.2, so flagging every single-quote character outright would
+# false-positive on those. `test_script_parses` alone cannot catch the odd
+# case on a Linux bash 5 host, since bash 4/5 parses it fine either way.
+# Scan every `VAR=$(cat <<DELIM ... DELIM)` and `VAR=$(cat <<'DELIM' ...
+# DELIM)` body across every bin/*.sh script (not just fm-brief.sh - the
+# same pattern recurs with delimiters other than EOF, e.g. BASH/JQ in
+# fm-fleet-snapshot.sh) and reject any body whose total single-quote count
+# is odd, regardless of the bash version running the test or which
+# delimiter word is used. Bash 3.2 is equally vulnerable whether the
 # heredoc delimiter is quoted or not, so both forms must be scanned.
-test_dod_heredocs_carry_no_apostrophes() {
-  local hits
-  hits=$(awk '
-    /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=\$\(cat <<'"'"'?[A-Za-z_]+'"'"'?[[:space:]]*$/ {
-      in_heredoc=1
-      next
-    }
-    in_heredoc && /^EOF$/ { in_heredoc=0; next }
-    in_heredoc && /'"'"'/ { print NR ": " $0 }
-  ' "$ROOT/bin/fm-brief.sh")
+test_bin_heredocs_carry_no_apostrophes() {
+  local hits file file_hits
+  hits=""
+  for file in "$ROOT"/bin/*.sh; do
+    file_hits=$(awk '
+      /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=\$\(cat <<-?'"'"'?[A-Za-z_][A-Za-z0-9_]*'"'"'?[[:space:]]*$/ {
+        delim = $0
+        sub(/^.*<<-?/, "", delim)
+        gsub(/'"'"'/, "", delim)
+        gsub(/[[:space:]]/, "", delim)
+        in_heredoc = 1
+        quote_count = 0
+        n = 0
+        next
+      }
+      in_heredoc && $0 == delim {
+        if (quote_count % 2 == 1) {
+          for (i = 1; i <= n; i++) print FILENAME ":" line_no[i] ": " line_text[i]
+        }
+        in_heredoc = 0
+        next
+      }
+      in_heredoc {
+        line = $0
+        c = gsub(/'"'"'/, "'"'"'", line)
+        if (c > 0) {
+          quote_count += c
+          n++
+          line_no[n] = FNR
+          line_text[n] = $0
+        }
+        next
+      }
+    ' "$file")
+    if [ -n "$file_hits" ]; then
+      hits="$hits${hits:+$'\n'}$file_hits"
+    fi
+  done
   if [ -n "$hits" ]; then
-    fail "apostrophe(s) inside a \$(cat <<EOF ...) heredoc body break bash 3.2 parsing (see firstmate-coding-guidelines style rules):"$'\n'"$hits"
+    fail "unbalanced (odd) single-quote count inside a \$(cat <<DELIM ...) heredoc body breaks bash 3.2 parsing (see firstmate-coding-guidelines style rules):"$'\n'"$hits"
   fi
-  pass "fm-brief.sh: command-substitution heredoc bodies carry no apostrophes"
+  pass "bin/*.sh: command-substitution heredoc bodies carry no unbalanced single quotes"
 }
 
 test_help_includes_entire_header() {
@@ -424,7 +465,7 @@ test_scout_and_secondmate_scaffold() {
 }
 
 test_script_parses
-test_dod_heredocs_carry_no_apostrophes
+test_bin_heredocs_carry_no_apostrophes
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review


### PR DESCRIPTION
## Intent

Fix bin/fm-brief.sh, which since PR #945 (commit ec09871) fails to parse under macOS /bin/bash 3.2.57 - an apostrophe ('firstmate's authority check') inside an unquoted heredoc body that sits inside a $( ) command substitution in the no-mistakes case branch breaks bash 3.2's parser, so ALL brief generation was broken on every macOS firstmate home (bash 4/5 parse it, which is why Linux CI stayed green). The fix rewords that one line to 'the firstmate authority check' - the #945 ask-user authority wording must survive semantically, only the apostrophe goes. Audited the rest of bin/ (no other occurrences). Added the version-independent regression guard test_dod_heredocs_carry_no_apostrophes in tests/fm-brief.test.sh (bash -n on Linux bash 5 cannot reproduce the 3.2 quirk), pinned the #945 wording apostrophe-free, and documented the style rule in firstmate-coding-guidelines. Captain-approved follow-ups from prior runs' gates are already on the branch: the review gate extended the guard to quoted-delimiter heredocs (HERDR_SECTION site), and the document gate updated the stale assertion in tests/fm-ask-user-authority.test.sh. Per the captain's FORK+PR decision, the gate is configured with fork-url: branches push to the captain-authorized fork localxcrm/firstmate while the PR opens against upstream kunchenguid/firstmate main. Out of scope: no refactoring of fm-brief.sh beyond this fix, no other repos.

## What Changed

- Reworded the apostrophe in `bin/fm-brief.sh`'s no-mistakes case-branch heredoc (`firstmate's authority check` → `the firstmate authority check`), fixing the bash 3.2 command-substitution/heredoc parser failure introduced in PR #945 that broke brief generation on every macOS firstmate home while leaving Linux CI green.
- Added a version-independent regression guard (`test_dod_heredocs_carry_no_apostrophes` / `test_bin_heredocs_carry_no_apostrophes`) in `tests/fm-brief.test.sh`, extended repo-wide across `bin/*.sh` to also cover quoted-delimiter heredocs, using an odd/even single-quote parity check since `bash -n` on Linux bash 5 cannot reproduce the 3.2 quirk.
- Documented the new style rule in `.agents/skills/firstmate-coding-guidelines/SKILL.md`: heredoc bodies inside `$(...)` command substitutions must not carry an unbalanced count of single quotes.
- Updated the stale wording assertion in `tests/fm-ask-user-authority.test.sh` to match the reworded, apostrophe-free string.

## Risk Assessment

✅ Low: The follow-up commit correctly widens the regression guard to scan all bin/*.sh files with a parity-based single-quote check that I empirically verified against real /bin/bash 3.2.57 on this machine (constructed odd/even-quote heredoc test cases and confirmed the parser fails exactly on odd counts and passes on even/balanced counts), confirmed bin/fm-brief.sh, bin/fm-bootstrap.sh, and bin/fm-fleet-snapshot.sh all parse cleanly under that real bash 3.2 binary, and confirmed no stale references to the renamed test function remain — fully resolving the round-1 audit-accuracy gap with no new issues introduced.

## Testing

Directly reproduced and resolved the reported bash 3.2 parse failure using real macOS /bin/bash 3.2.57 (conveniently the default bash on this host): the base commit fails `bash -n` with the exact error class described (unexpected EOF / syntax error from the unbalanced apostrophe inside the command-substitution heredoc), and the target commit parses cleanly. Full fm-brief and fm-ask-user-authority test suites pass under bash 3.2, and a manual fault-injection check confirms the new repo-wide regression guard and DOD-wording assertions are real (not tautological) — reintroducing the apostrophe reproduces the failure and restoring the fix clears it. Worktree is clean; no findings.

<details>
<summary>Evidence: bash 3.2.57 parse repro: base commit fails, target commit passes</summary>

```text
=== bash --version (default on PATH in this environment) ===
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

=== BASE commit 10ee779 bin/fm-brief.sh under real bash 3.2.57: bash -n ===
/tmp/fm-brief-repro/base-fm-brief.sh: line 314: unexpected EOF while looking for matching `)'
/tmp/fm-brief-repro/base-fm-brief.sh: line 388: syntax error: unexpected end of file
exit: 2

=== TARGET commit c913543 bin/fm-brief.sh under real bash 3.2.57: bash -n ===
exit: 0
```
</details>
<details>
<summary>Evidence: tests/fm-brief.test.sh full run output under bash 3.2.57 (target commit)</summary>

```text
ok - fm-brief.sh: bash -n succeeds
ok - bin/*.sh: command-substitution heredoc bodies carry no unbalanced single quotes
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `bin/fm-bootstrap.sh:692` - The commit message for eae0a3d and the intent (&#39;Audited the rest of bin/ (no other occurrences)&#39;) claim fm-brief.sh&#39;s three DOD branches are the only VAR=$(cat &lt;&lt;EOF ... EOF) heredocs in bin/. That&#39;s inaccurate: bin/fm-bootstrap.sh:692 (cadence_body=$(cat &lt;&lt;&#39;EOF&#39; ... EOF)) and bin/fm-fleet-snapshot.sh:787,837,849,885 (script=$(cat &lt;&lt;&#39;BASH&#39; ..., parse_filter=$(cat &lt;&lt;&#39;JQ&#39; ..., etc.) use the identical pattern, which is equally vulnerable to the bash 3.2 command-substitution/heredoc parser bug. None of those bodies currently contain an apostrophe, so nothing is broken today, but the new repo-wide style rule added to firstmate-coding-guidelines/SKILL.md (&#39;a heredoc body that sits inside a $(...) command substitution&#39;) is worded generally, while the only enforcement (test_dod_heredocs_carry_no_apostrophes) scans exclusively bin/fm-brief.sh.

🔧 Fix: Widen bin heredoc apostrophe guard repo-wide with correct odd-quote parity check
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`/bin/bash -n` on bin/fm-brief.sh at base commit 10ee779 (real macOS bash 3.2.57) — reproduces the PR #945 parse failure</code>
- <code>`/bin/bash -n` on bin/fm-brief.sh at target commit c913543 (real macOS bash 3.2.57) — parses cleanly</code>
- <code>`bash tests/fm-brief.test.sh` (16 tests, run under bash 3.2.57 since it&#39;s the default `bash` here) — all pass, including new test_bin_heredocs_carry_no_apostrophes guard and the #945 wording assertions in test_no_mistakes_dod_wording</code>
- <code>`bash tests/fm-ask-user-authority.test.sh` (9 tests) — all pass, including the updated stale-wording assertion</code>
- <code>Manual regression check: reintroduced &#34;firstmate&#39;s authority check&#34; apostrophe into bin/fm-brief.sh, reran tests/fm-brief.test.sh under bash 3.2 — test_script_parses failed immediately with the same bash -n error as the base commit, confirming the guard/fix is load-bearing; restored file via `git checkout`</code>
- <code>`grep` audit of all bin/*.sh files with heredocs for other stray-apostrophe occurrences — none found outside comments (which are unaffected, being outside command-substitution heredoc bodies)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
