### PR TITLE
feat: add guarded project relocation helper

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -2,8 +2,8 @@
 name: project-management
 description: >-
   Agent-only procedure for Firstmate project management.
-  Use before adding, creating, removing, or initializing a project.
-  Owns project add, create, clone, remove, initialization, registry, delivery-mode, autonomy, and outward-consent decisions.
+  Use before adding, creating, relocating, removing, or initializing a project.
+  Owns project add, create, clone, relocation, removal, initialization, registry, delivery-mode, autonomy, and outward-consent decisions.
 user-invocable: false
 metadata:
   internal: true
@@ -11,7 +11,7 @@ metadata:
 
 # project-management
 
-Use this procedure before adding, creating, removing, or initializing a project.
+Use this procedure before adding, creating, relocating, removing, or initializing a project.
 This skill is the single owner of Firstmate's project-management procedure.
 It does not replace `secondmate-provisioning`, which owns project clones inside persistent secondmate homes.
 
@@ -68,7 +68,7 @@ Initialization configures the local gate and does not vendor a no-mistakes skill
 Do not create a commit merely because initialization ran.
 If doctor reports an environment, authentication, or daemon problem, resolve that blocker before dispatching work and never restart the shared daemon from a project operation.
 
-## Remove
+## Remove or relocate
 
 Project removal is destructive and is not a general direct-write exception under `projects/`.
 Never issue a raw removal command from Firstmate.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -70,9 +70,10 @@ If doctor reports an environment, authentication, or daemon problem, resolve tha
 
 ## Remove
 
-Project removal is destructive and is not one of Firstmate's current direct-write exceptions under `projects/`.
+Project removal is destructive and is not a general direct-write exception under `projects/`.
 Never issue a raw removal command from Firstmate.
-First obtain the captain's explicit removal decision, then inspect the current digest and authoritative repositories for in-flight or queued work, registered secondmate clones, linked worktrees, dirty files, unpushed commits, and any other unlanded work.
+First obtain the captain's explicit decision, then inspect the current digest and authoritative repositories for in-flight or queued work, registered secondmate clones, linked worktrees, dirty files, unpushed commits, and any other unlanded work.
+For a captain-authorized relocation, use only `bin/fm-project-relocate.sh <project-name> <destination-root>`.
+Its header and help own the exact path, clone, landed-work, reference, rename, rollback, and primary-registry guards.
 If any dependency or unlanded work exists, stop and report it before changing the registry.
-Until a guarded removal helper and corresponding prime-directive exception exist, report that implementation gap instead of bypassing the project-write boundary.
-When a clone has already been removed through an approved guarded path, or the registry is provably stale because no clone exists, remove its registry line so navigation matches reality.
+When a clone has already been relocated through the guarded helper, or the registry is provably stale because no clone exists, remove its registry line so navigation matches reality.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ A restart must be a non-event because durable state and live backend inventory, 
 
 ## 6. Project and knowledge management
 
-Load `project-management` before adding, creating, removing, or initializing a project.
+Load `project-management` before adding, creating, relocating, removing, or initializing a project.
 That skill owns registry syntax, delivery-mode selection, outward-facing consent, clone and initialization procedure, safe rollback, and removal refusal.
 Project creation never authorizes an unmentioned remote, and captain-authorized project relocation never bypasses the guarded helper or unlanded-work checks.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Hard rules, in priority order:
 
 1. **Never write to a project.**
    Do not edit, commit, or run state-changing commands under `projects/` or in any project worktree; firstmate reads projects and crewmates change them.
-   The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths owned by their referenced skills and scripts.
+   The only exceptions are guarded project initialization, captain-authorized `bin/fm-project-relocate.sh` moves, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths owned by their referenced skills and scripts.
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
 2. **Never merge a PR without the captain's explicit word.**
    A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns its exceptions and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
@@ -188,7 +188,7 @@ A restart must be a non-event because durable state and live backend inventory, 
 
 Load `project-management` before adding, creating, removing, or initializing a project.
 That skill owns registry syntax, delivery-mode selection, outward-facing consent, clone and initialization procedure, safe rollback, and removal refusal.
-Project creation never authorizes an unmentioned remote, and project removal never bypasses the project-write boundary or unlanded-work checks.
+Project creation never authorizes an unmentioned remote, and captain-authorized project relocation never bypasses the guarded helper or unlanded-work checks.
 
 Load `secondmate-provisioning` before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 Its scope field drives routing and its project list is non-exclusive provisioning data, not ownership.

--- a/bin/fm-gate-refuse-lib.sh
+++ b/bin/fm-gate-refuse-lib.sh
@@ -54,6 +54,7 @@
 # tests/fm-gate-refuse.test.sh strips the bypass so it still verifies real refusal.
 #
 # Sourced by bin/fm-spawn.sh, bin/fm-send.sh, bin/fm-teardown.sh,
+# bin/fm-project-relocate.sh,
 # bin/fm-sessionstart-nudge.sh, and the tests.
 # No side effects on source. set -u / set -e safe. The refusal is a hard exit,
 # not a return, because there is no safe way to continue a fleet mutation from a

--- a/bin/fm-project-relocate.sh
+++ b/bin/fm-project-relocate.sh
@@ -13,13 +13,12 @@
 # This is the sole sanctioned project-relocation path after captain approval.
 # It refuses before moving anything unless the source and destination root are
 # ordinary directories, the source is a standalone Git clone with no linked
-# worktrees, its working tree is clean, every local branch and HEAD are landed
-# on origin's default branch, and no primary task metadata or registered
+# worktrees, its working tree is clean, every local branch, local tag, stash,
+# and HEAD are landed on origin's default branch, and no primary task metadata or registered
 # secondmate lists the project. It also refuses path traversal, source-to-
 # destination nesting, cross-device moves, registry ambiguity, and unsafe
-# registry/state files. The project move uses `mv -T` only after those guards;
-# `-T` prevents a raced destination directory from changing the operation into
-# a recursive move. A registry entry is removed only after that rename succeeds.
+# registry/state files. The project move uses an atomic no-replace rename only
+# after those guards. A registry entry is removed only after that rename succeeds.
 # If registry publication fails, the helper attempts the inverse rename before
 # reporting failure, preserving the source whenever the filesystem permits it.
 # No recursive deletion is used.
@@ -132,7 +131,7 @@ source_has_clean_worktree() {
 }
 
 source_has_only_landed_commits() {
-  local remote_head default_branch default_ref unpushed_head unpushed_branches branches branch
+  local remote_head default_branch default_ref unpushed_head unpushed_branches unpushed_tags unpushed_stash branches branch
   remote_head=$(git -C "$SOURCE" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
   case "$remote_head" in
     origin/*) default_branch=${remote_head#origin/} ;;
@@ -145,7 +144,14 @@ source_has_only_landed_commits() {
     || die "cannot inspect HEAD for commits absent from remotes"
   unpushed_branches=$(git -C "$SOURCE" log --format=%H --branches --not --remotes 2>/dev/null) \
     || die "cannot inspect local branches for commits absent from remotes"
-  if [ -n "$unpushed_head" ] || [ -n "$unpushed_branches" ]; then
+  unpushed_tags=$(git -C "$SOURCE" log --format=%H --tags --not --remotes 2>/dev/null) \
+    || die "cannot inspect local tags and stash for commits absent from remotes"
+  unpushed_stash=
+  if git -C "$SOURCE" rev-parse --verify --quiet refs/stash >/dev/null 2>&1; then
+    unpushed_stash=$(git -C "$SOURCE" log --format=%H refs/stash --not --remotes 2>/dev/null) \
+      || die "cannot inspect local tags and stash for commits absent from remotes"
+  fi
+  if [ -n "$unpushed_head" ] || [ -n "$unpushed_branches" ] || [ -n "$unpushed_tags" ] || [ -n "$unpushed_stash" ]; then
     die "source project has commits absent from every remote"
   fi
   if ! git -C "$SOURCE" merge-base --is-ancestor HEAD "$default_ref"; then
@@ -241,8 +247,10 @@ registered_secondmate_references_project() {
 
 REGISTRY_ACTION=none
 REGISTRY_TMP=
+REGISTRY_ORIGINAL=
 cleanup_registry_tmp() {
   [ -n "${REGISTRY_TMP:-}" ] && rm -f "$REGISTRY_TMP"
+  [ -n "${REGISTRY_ORIGINAL:-}" ] && rm -f "$REGISTRY_ORIGINAL"
   return 0
 }
 trap cleanup_registry_tmp EXIT HUP INT TERM
@@ -264,6 +272,10 @@ prepare_registry_update() {
   esac
   REGISTRY_TMP=$(mktemp "$DATA_ABS/.fm-project-relocate.XXXXXX") \
     || die "cannot prepare project-registry update in $DATA_ABS"
+  REGISTRY_ORIGINAL=$(mktemp "$DATA_ABS/.fm-project-relocate-original.XXXXXX") \
+    || die "cannot prepare project-registry comparison snapshot in $DATA_ABS"
+  cp "$REGISTRY" "$REGISTRY_ORIGINAL" \
+    || die "cannot prepare project-registry comparison snapshot for $NAME"
   awk -v project="$NAME" '!($1 == "-" && $2 == project) { print }' "$REGISTRY" > "$REGISTRY_TMP" \
     || die "cannot prepare project-registry update for $NAME"
   REGISTRY_ACTION=remove
@@ -271,8 +283,48 @@ prepare_registry_update() {
 
 publish_registry_update() {
   [ "$REGISTRY_ACTION" = remove ] || return 0
+  cmp -s "$REGISTRY" "$REGISTRY_ORIGINAL" || return 1
   mv -f "$REGISTRY_TMP" "$REGISTRY" || return 1
   REGISTRY_TMP=
+  rm -f "$REGISTRY_ORIGINAL"
+  REGISTRY_ORIGINAL=
+}
+
+atomic_rename_no_replace() {
+  command -v python3 >/dev/null 2>&1 || return 4
+  python3 - "$1" "$2" <<'PY'
+import ctypes
+import errno
+import os
+import sys
+
+source, destination = map(os.fsencode, sys.argv[1:])
+libc = ctypes.CDLL(None, use_errno=True)
+if sys.platform.startswith("linux"):
+    rename = getattr(libc, "renameat2", None)
+    if rename is None:
+        sys.exit(4)
+    rename.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+    rename.restype = ctypes.c_int
+    result = rename(-100, source, -100, destination, 1)
+elif sys.platform == "darwin":
+    rename = getattr(libc, "renamex_np", None)
+    if rename is None:
+        sys.exit(4)
+    rename.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint]
+    rename.restype = ctypes.c_int
+    result = rename(source, destination, 4)
+else:
+    sys.exit(4)
+if result == 0:
+    sys.exit(0)
+error = ctypes.get_errno()
+if error == errno.EEXIST:
+    sys.exit(3)
+if error in (errno.ENOSYS, errno.EOPNOTSUPP):
+    sys.exit(4)
+sys.exit(1)
+PY
 }
 
 rollback_relocation() {
@@ -280,7 +332,7 @@ rollback_relocation() {
     printf 'ERROR: registry update failed and source path was recreated; clone remains at %s\n' "$DESTINATION" >&2
     return 1
   fi
-  if mv -T "$DESTINATION" "$SOURCE"; then
+  if atomic_rename_no_replace "$DESTINATION" "$SOURCE"; then
     return 0
   fi
   printf 'ERROR: registry update failed and inverse rename also failed; clone remains at %s\n' "$DESTINATION" >&2
@@ -357,11 +409,14 @@ if [ "$secondmate_rc" -ne 1 ]; then
 fi
 prepare_registry_update
 
-# `-T` keeps this a rename to the exact guarded destination rather than allowing
-# a late-created directory to turn it into a nested move.
-if ! mv -T "$SOURCE" "$DESTINATION"; then
-  fail_after_move "rename failed; source remains at $SOURCE"
-fi
+rename_rc=0
+atomic_rename_no_replace "$SOURCE" "$DESTINATION" || rename_rc=$?
+case "$rename_rc" in
+  0) ;;
+  3) fail_after_move "destination project path appeared before rename; source remains at $SOURCE" ;;
+  4) fail_after_move "atomic no-replace rename is unavailable; source remains at $SOURCE" ;;
+  *) fail_after_move "rename failed; source remains at $SOURCE" ;;
+esac
 if ! publish_registry_update; then
   if rollback_relocation; then
     fail_after_move "project registry update failed; relocation was rolled back and source was preserved"

--- a/bin/fm-project-relocate.sh
+++ b/bin/fm-project-relocate.sh
@@ -88,6 +88,13 @@ device_for_path() {
   esac
 }
 
+directory_identity() {
+  case "$(uname -s)" in
+    Darwin) stat -f '%d:%i' "$1" ;;
+    *) stat -c '%d:%i' "$1" ;;
+  esac
+}
+
 optional_operational_dir() {
   local path=$1 label=$2
   if [ -L "$path" ]; then
@@ -248,9 +255,11 @@ registered_secondmate_references_project() {
 REGISTRY_ACTION=none
 REGISTRY_TMP=
 REGISTRY_ORIGINAL=
+REGISTRY_LOCK=
 cleanup_registry_tmp() {
   [ -n "${REGISTRY_TMP:-}" ] && rm -f "$REGISTRY_TMP"
   [ -n "${REGISTRY_ORIGINAL:-}" ] && rm -f "$REGISTRY_ORIGINAL"
+  [ -n "${REGISTRY_LOCK:-}" ] && rmdir "$REGISTRY_LOCK" 2>/dev/null || true
   return 0
 }
 trap cleanup_registry_tmp EXIT HUP INT TERM
@@ -259,6 +268,13 @@ prepare_registry_update() {
   local count
   [ -n "${DATA_ABS:-}" ] || return 0
   [ -e "$REGISTRY" ] || [ -L "$REGISTRY" ] || return 0
+  [ ! -L "$REGISTRY" ] \
+    || die "project registry must not be a symlink: $REGISTRY"
+  [ -f "$REGISTRY" ] \
+    || die "project registry is not a regular file: $REGISTRY"
+  REGISTRY_LOCK="$DATA_ABS/.fm-project-relocate.projects.lock"
+  mkdir "$REGISTRY_LOCK" 2>/dev/null \
+    || die "project registry is busy: $REGISTRY"
   [ ! -L "$REGISTRY" ] \
     || die "project registry must not be a symlink: $REGISTRY"
   [ -f "$REGISTRY" ] \
@@ -292,38 +308,63 @@ publish_registry_update() {
 
 atomic_rename_no_replace() {
   command -v python3 >/dev/null 2>&1 || return 4
-  python3 - "$1" "$2" <<'PY'
+  python3 - "$1" "$2" "$3" "$4" "$5" "$6" <<'PY'
 import ctypes
 import errno
 import os
+import stat
 import sys
 
-source, destination = map(os.fsencode, sys.argv[1:])
-libc = ctypes.CDLL(None, use_errno=True)
-if sys.platform.startswith("linux"):
-    rename = getattr(libc, "renameat2", None)
-    if rename is None:
-        sys.exit(4)
-    rename.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
-    rename.restype = ctypes.c_int
-    result = rename(-100, source, -100, destination, 1)
-elif sys.platform == "darwin":
-    rename = getattr(libc, "renamex_np", None)
-    if rename is None:
-        sys.exit(4)
-    rename.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint]
-    rename.restype = ctypes.c_int
-    result = rename(source, destination, 4)
-else:
+source_root, source_identity, source_name, destination_root, destination_identity, destination_name = sys.argv[1:]
+if not hasattr(os, "O_DIRECTORY") or not hasattr(os, "O_NOFOLLOW"):
     sys.exit(4)
-if result == 0:
-    sys.exit(0)
-error = ctypes.get_errno()
-if error == errno.EEXIST:
-    sys.exit(3)
-if error in (errno.ENOSYS, errno.EOPNOTSUPP):
-    sys.exit(4)
-sys.exit(1)
+flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+if hasattr(os, "O_CLOEXEC"):
+    flags |= os.O_CLOEXEC
+try:
+    source_fd = os.open(source_root, flags)
+    destination_fd = os.open(destination_root, flags)
+except OSError:
+    sys.exit(5)
+try:
+    source_stat = os.fstat(source_fd)
+    destination_stat = os.fstat(destination_fd)
+    if not stat.S_ISDIR(source_stat.st_mode) or not stat.S_ISDIR(destination_stat.st_mode):
+        sys.exit(5)
+    if f"{source_stat.st_dev}:{source_stat.st_ino}" != source_identity:
+        sys.exit(5)
+    if f"{destination_stat.st_dev}:{destination_stat.st_ino}" != destination_identity:
+        sys.exit(5)
+    source = os.fsencode(source_name)
+    destination = os.fsencode(destination_name)
+    libc = ctypes.CDLL(None, use_errno=True)
+    if sys.platform.startswith("linux"):
+        rename = getattr(libc, "renameat2", None)
+        if rename is None:
+            sys.exit(4)
+        rename.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+        rename.restype = ctypes.c_int
+        result = rename(source_fd, source, destination_fd, destination, 1)
+    elif sys.platform == "darwin":
+        rename = getattr(libc, "renameatx_np", None)
+        if rename is None:
+            sys.exit(4)
+        rename.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+        rename.restype = ctypes.c_int
+        result = rename(source_fd, source, destination_fd, destination, 4)
+    else:
+        sys.exit(4)
+    if result == 0:
+        sys.exit(0)
+    error = ctypes.get_errno()
+    if error == errno.EEXIST:
+        sys.exit(3)
+    if error in (errno.ENOSYS, errno.EOPNOTSUPP):
+        sys.exit(4)
+    sys.exit(1)
+finally:
+    os.close(source_fd)
+    os.close(destination_fd)
 PY
 }
 
@@ -332,7 +373,9 @@ rollback_relocation() {
     printf 'ERROR: registry update failed and source path was recreated; clone remains at %s\n' "$DESTINATION" >&2
     return 1
   fi
-  if atomic_rename_no_replace "$DESTINATION" "$SOURCE"; then
+  if atomic_rename_no_replace \
+    "$DESTINATION_ROOT" "$DESTINATION_ROOT_ID" "$NAME" \
+    "$PROJECTS_ABS" "$PROJECTS_ID" "$NAME"; then
     return 0
   fi
   printf 'ERROR: registry update failed and inverse rename also failed; clone remains at %s\n' "$DESTINATION" >&2
@@ -358,12 +401,16 @@ esac
 fm_refuse_if_gate_agent "$FM_ROOT"
 
 PROJECTS_ABS=$(canonical_ordinary_dir "$PROJECTS" "source projects root") || exit 1
+PROJECTS_ID=$(directory_identity "$PROJECTS_ABS") \
+  || die "cannot determine source projects root identity"
 SOURCE="$PROJECTS_ABS/$NAME"
 SOURCE=$(canonical_ordinary_dir "$SOURCE" "source project") || exit 1
 path_is_direct_child "$PROJECTS_ABS" "$SOURCE" \
   || die "source project escapes the declared projects root"
 
 DESTINATION_ROOT=$(canonical_ordinary_dir "$DESTINATION_ROOT_RAW" "destination root") || exit 1
+DESTINATION_ROOT_ID=$(directory_identity "$DESTINATION_ROOT") \
+  || die "cannot determine destination root identity"
 DESTINATION="$DESTINATION_ROOT/$NAME"
 path_is_direct_child "$DESTINATION_ROOT" "$DESTINATION" \
   || die "destination project escapes the declared destination root"
@@ -410,11 +457,14 @@ fi
 prepare_registry_update
 
 rename_rc=0
-atomic_rename_no_replace "$SOURCE" "$DESTINATION" || rename_rc=$?
+atomic_rename_no_replace \
+  "$PROJECTS_ABS" "$PROJECTS_ID" "$NAME" \
+  "$DESTINATION_ROOT" "$DESTINATION_ROOT_ID" "$NAME" || rename_rc=$?
 case "$rename_rc" in
   0) ;;
   3) fail_after_move "destination project path appeared before rename; source remains at $SOURCE" ;;
   4) fail_after_move "atomic no-replace rename is unavailable; source remains at $SOURCE" ;;
+  5) fail_after_move "source or destination root changed before rename; source remains at $SOURCE" ;;
   *) fail_after_move "rename failed; source remains at $SOURCE" ;;
 esac
 if ! publish_registry_update; then

--- a/bin/fm-project-relocate.sh
+++ b/bin/fm-project-relocate.sh
@@ -177,7 +177,7 @@ EOF
 }
 
 metadata_references_source() {
-  local meta line recorded recorded_abs
+  local meta line recorded recorded_abs contents
   [ -n "${STATE_ABS:-}" ] || return 1
   local -a metas=("$STATE_ABS"/*.meta "$STATE_ABS"/.*.meta)
   for meta in "${metas[@]}"; do
@@ -190,7 +190,11 @@ metadata_references_source() {
       printf 'REFUSED: task metadata is not a regular file: %s\n' "$meta" >&2
       return 2
     fi
-    while IFS= read -r line; do
+    contents=$(cat -- "$meta") || {
+      printf 'REFUSED: cannot read task metadata: %s\n' "$meta" >&2
+      return 2
+    }
+    while IFS= read -r line || [ -n "$line" ]; do
       case "$line" in
         project=*)
           recorded=${line#project=}
@@ -212,13 +216,13 @@ metadata_references_source() {
           fi
           ;;
       esac
-    done < "$meta"
+    done <<< "$contents"
   done
   return 1
 }
 
 registered_secondmate_references_project() {
-  local ref
+  local ref contents status
   [ -n "${DATA_ABS:-}" ] || return 1
   [ -e "$SECONDMATES" ] || [ -L "$SECONDMATES" ] || return 1
   if [ -L "$SECONDMATES" ]; then
@@ -229,7 +233,12 @@ registered_secondmate_references_project() {
     printf 'REFUSED: secondmate registry is not a regular file: %s\n' "$SECONDMATES" >&2
     return 2
   fi
-  ref=$(awk -v project="$NAME" '
+  contents=$(cat -- "$SECONDMATES") || {
+    printf 'REFUSED: cannot read secondmate registry: %s\n' "$SECONDMATES" >&2
+    return 2
+  }
+  status=0
+  ref=$(printf '%s\n' "$contents" | awk -v project="$NAME" '
     $1 == "-" {
       line = $0
       if (match(line, /projects:[[:space:]]*[^;)]*/)) {
@@ -248,7 +257,15 @@ registered_secondmate_references_project() {
       }
     }
     END { exit found ? 0 : 1 }
-  ' "$SECONDMATES") || return 1
+  ') || status=$?
+  case "$status" in
+    0) ;;
+    1) return 1 ;;
+    *)
+      printf 'REFUSED: cannot inspect secondmate registry: %s\n' "$SECONDMATES" >&2
+      return 2
+      ;;
+  esac
   printf '%s\n' "$ref"
 }
 

--- a/bin/fm-project-relocate.sh
+++ b/bin/fm-project-relocate.sh
@@ -265,16 +265,17 @@ cleanup_registry_tmp() {
 trap cleanup_registry_tmp EXIT HUP INT TERM
 
 prepare_registry_update() {
-  local count
+  local count registry_lock
   [ -n "${DATA_ABS:-}" ] || return 0
   [ -e "$REGISTRY" ] || [ -L "$REGISTRY" ] || return 0
   [ ! -L "$REGISTRY" ] \
     || die "project registry must not be a symlink: $REGISTRY"
   [ -f "$REGISTRY" ] \
     || die "project registry is not a regular file: $REGISTRY"
-  REGISTRY_LOCK="$DATA_ABS/.fm-project-relocate.projects.lock"
-  mkdir "$REGISTRY_LOCK" 2>/dev/null \
+  registry_lock="$DATA_ABS/.fm-project-relocate.projects.lock"
+  mkdir "$registry_lock" 2>/dev/null \
     || die "project registry is busy: $REGISTRY"
+  REGISTRY_LOCK=$registry_lock
   [ ! -L "$REGISTRY" ] \
     || die "project registry must not be a symlink: $REGISTRY"
   [ -f "$REGISTRY" ] \

--- a/bin/fm-project-relocate.sh
+++ b/bin/fm-project-relocate.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# Relocate one captain-authorized project clone out of the active firstmate
+# home's projects/ directory with a same-filesystem rename only.
+#
+# Usage:
+#   fm-project-relocate.sh <project-name> <destination-root>
+#
+# <project-name> must be one plain projects/ entry name.
+# <destination-root> must be an explicit absolute, ordinary, non-symlink
+# directory on the same filesystem as <FM_HOME>/projects/<project-name>.
+# The destination is <destination-root>/<project-name> and must not exist.
+#
+# This is the sole sanctioned project-relocation path after captain approval.
+# It refuses before moving anything unless the source and destination root are
+# ordinary directories, the source is a standalone Git clone with no linked
+# worktrees, its working tree is clean, every local branch and HEAD are landed
+# on origin's default branch, and no primary task metadata or registered
+# secondmate lists the project. It also refuses path traversal, source-to-
+# destination nesting, cross-device moves, registry ambiguity, and unsafe
+# registry/state files. The project move uses `mv -T` only after those guards;
+# `-T` prevents a raced destination directory from changing the operation into
+# a recursive move. A registry entry is removed only after that rename succeeds.
+# If registry publication fails, the helper attempts the inverse rename before
+# reporting failure, preserving the source whenever the filesystem permits it.
+# No recursive deletion is used.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+PROJECTS="$FM_HOME/projects"
+DATA="$FM_HOME/data"
+STATE="$FM_HOME/state"
+
+# shellcheck source=bin/fm-gate-refuse-lib.sh disable=SC1091
+. "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+
+usage() {
+  sed -n '2,19{s/^# \{0,1\}//;p;}' "$0" >&2
+}
+
+die() {
+  printf 'REFUSED: %s\n' "$*" >&2
+  exit 1
+}
+
+fail_after_move() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+path_is_direct_child() {
+  local root=$1 path=$2 tail
+  case "$path" in
+    "$root"/*)
+      tail=${path#"$root"/}
+      [ -n "$tail" ] || return 1
+      case "$tail" in */*) return 1 ;; esac
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+path_is_within_or_equal() {
+  local root=$1 path=$2
+  [ "$root" = "$path" ] && return 0
+  case "$path" in "$root"/*) return 0 ;; esac
+  return 1
+}
+
+canonical_ordinary_dir() {
+  local path=$1 label=$2
+  if [ -L "$path" ]; then
+    printf 'REFUSED: %s must not be a symlink: %s\n' "$label" "$path" >&2
+    return 1
+  fi
+  if [ ! -d "$path" ]; then
+    printf 'REFUSED: %s is not a directory: %s\n' "$label" "$path" >&2
+    return 1
+  fi
+  cd "$path" && pwd -P
+}
+
+device_for_path() {
+  case "$(uname -s)" in
+    Darwin) stat -f %d "$1" ;;
+    *) stat -c %d "$1" ;;
+  esac
+}
+
+optional_operational_dir() {
+  local path=$1 label=$2
+  if [ -L "$path" ]; then
+    printf 'REFUSED: %s must not be a symlink: %s\n' "$label" "$path" >&2
+    return 1
+  fi
+  if [ ! -e "$path" ]; then
+    return 0
+  fi
+  canonical_ordinary_dir "$path" "$label"
+}
+
+source_is_standalone_clone() {
+  local top git_dir worktrees count listed
+  top=$(git -C "$SOURCE" rev-parse --show-toplevel 2>/dev/null) \
+    || die "source project is not an inspectable Git repository: $SOURCE"
+  top=$(canonical_ordinary_dir "$top" "source Git top-level") || exit 1
+  [ "$top" = "$SOURCE" ] \
+    || die "source project is not the Git top-level: $SOURCE"
+  [ -d "$SOURCE/.git" ] && [ ! -L "$SOURCE/.git" ] \
+    || die "source project is not a standalone Git clone: $SOURCE"
+  git_dir=$(git -C "$SOURCE" rev-parse --git-dir 2>/dev/null) \
+    || die "cannot inspect source Git directory: $SOURCE"
+  [ "$git_dir" = .git ] \
+    || die "source project has a linked Git directory: $SOURCE"
+  worktrees=$(git -C "$SOURCE" -c core.quotePath=false worktree list --porcelain 2>/dev/null) \
+    || die "cannot inspect linked worktrees for $SOURCE"
+  count=$(printf '%s\n' "$worktrees" | awk '$1 == "worktree" { count++ } END { print count + 0 }')
+  [ "$count" -eq 1 ] \
+    || die "source project has $count registered worktrees; expected exactly one"
+  listed=$(printf '%s\n' "$worktrees" | awk '$1 == "worktree" { sub(/^worktree /, ""); print; exit }')
+  [ "$listed" = "$SOURCE" ] \
+    || die "source project's registered worktree does not match its declared path"
+}
+
+source_has_clean_worktree() {
+  local dirty
+  dirty=$(git -C "$SOURCE" status --porcelain=v1 --untracked-files=all 2>/dev/null) \
+    || die "cannot inspect working tree for $SOURCE"
+  [ -z "$dirty" ] || die "source project has uncommitted or untracked changes"
+}
+
+source_has_only_landed_commits() {
+  local remote_head default_branch default_ref unpushed_head unpushed_branches branches branch
+  remote_head=$(git -C "$SOURCE" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  case "$remote_head" in
+    origin/*) default_branch=${remote_head#origin/} ;;
+    *) die "cannot determine origin's default branch for $SOURCE" ;;
+  esac
+  default_ref="refs/remotes/origin/$default_branch"
+  git -C "$SOURCE" show-ref --verify --quiet "$default_ref" \
+    || die "origin's default branch is unavailable locally: origin/$default_branch"
+  unpushed_head=$(git -C "$SOURCE" log --format=%H HEAD --not --remotes 2>/dev/null) \
+    || die "cannot inspect HEAD for commits absent from remotes"
+  unpushed_branches=$(git -C "$SOURCE" log --format=%H --branches --not --remotes 2>/dev/null) \
+    || die "cannot inspect local branches for commits absent from remotes"
+  if [ -n "$unpushed_head" ] || [ -n "$unpushed_branches" ]; then
+    die "source project has commits absent from every remote"
+  fi
+  if ! git -C "$SOURCE" merge-base --is-ancestor HEAD "$default_ref"; then
+    die "source HEAD is not landed on origin/$default_branch"
+  fi
+  branches=$(git -C "$SOURCE" for-each-ref --format='%(refname:short)' refs/heads 2>/dev/null) \
+    || die "cannot inspect local branches for landed status"
+  while IFS= read -r branch; do
+    [ -n "$branch" ] || continue
+    if ! git -C "$SOURCE" merge-base --is-ancestor "refs/heads/$branch" "$default_ref"; then
+      die "local branch $branch is not landed on origin/$default_branch"
+    fi
+  done <<EOF
+$branches
+EOF
+}
+
+metadata_references_source() {
+  local meta line recorded recorded_abs
+  [ -n "${STATE_ABS:-}" ] || return 1
+  local -a metas=("$STATE_ABS"/*.meta "$STATE_ABS"/.*.meta)
+  for meta in "${metas[@]}"; do
+    [ -e "$meta" ] || [ -L "$meta" ] || continue
+    if [ -L "$meta" ]; then
+      printf 'REFUSED: task metadata must not be a symlink: %s\n' "$meta" >&2
+      return 2
+    fi
+    if [ ! -f "$meta" ]; then
+      printf 'REFUSED: task metadata is not a regular file: %s\n' "$meta" >&2
+      return 2
+    fi
+    while IFS= read -r line; do
+      case "$line" in
+        project=*)
+          recorded=${line#project=}
+          case "$recorded" in
+            "$SOURCE"|"$SOURCE"/)
+              printf '%s\n' "$meta"
+              return 0
+              ;;
+          esac
+          if [ -d "$recorded" ]; then
+            recorded_abs=$(cd "$recorded" && pwd -P) || {
+              printf 'REFUSED: cannot resolve project path in task metadata: %s\n' "$meta" >&2
+              return 2
+            }
+            if [ "$recorded_abs" = "$SOURCE" ]; then
+              printf '%s\n' "$meta"
+              return 0
+            fi
+          fi
+          ;;
+      esac
+    done < "$meta"
+  done
+  return 1
+}
+
+registered_secondmate_references_project() {
+  local ref
+  [ -n "${DATA_ABS:-}" ] || return 1
+  [ -e "$SECONDMATES" ] || [ -L "$SECONDMATES" ] || return 1
+  if [ -L "$SECONDMATES" ]; then
+    printf 'REFUSED: secondmate registry must not be a symlink: %s\n' "$SECONDMATES" >&2
+    return 2
+  fi
+  if [ ! -f "$SECONDMATES" ]; then
+    printf 'REFUSED: secondmate registry is not a regular file: %s\n' "$SECONDMATES" >&2
+    return 2
+  fi
+  ref=$(awk -v project="$NAME" '
+    $1 == "-" {
+      line = $0
+      if (match(line, /projects:[[:space:]]*[^;)]*/)) {
+        listed = substr(line, RSTART + 9, RLENGTH - 9)
+        count = split(listed, entries, ",")
+        for (i = 1; i <= count; i++) {
+          entry = entries[i]
+          sub(/^[[:space:]]+/, "", entry)
+          sub(/[[:space:]]+$/, "", entry)
+          if (entry == project) {
+            print $2
+            found = 1
+            exit
+          }
+        }
+      }
+    }
+    END { exit found ? 0 : 1 }
+  ' "$SECONDMATES") || return 1
+  printf '%s\n' "$ref"
+}
+
+REGISTRY_ACTION=none
+REGISTRY_TMP=
+cleanup_registry_tmp() {
+  [ -n "${REGISTRY_TMP:-}" ] && rm -f "$REGISTRY_TMP"
+  return 0
+}
+trap cleanup_registry_tmp EXIT HUP INT TERM
+
+prepare_registry_update() {
+  local count
+  [ -n "${DATA_ABS:-}" ] || return 0
+  [ -e "$REGISTRY" ] || [ -L "$REGISTRY" ] || return 0
+  [ ! -L "$REGISTRY" ] \
+    || die "project registry must not be a symlink: $REGISTRY"
+  [ -f "$REGISTRY" ] \
+    || die "project registry is not a regular file: $REGISTRY"
+  count=$(awk -v project="$NAME" '$1 == "-" && $2 == project { count++ } END { print count + 0 }' "$REGISTRY") \
+    || die "cannot inspect project registry: $REGISTRY"
+  case "$count" in
+    0) return 0 ;;
+    1) ;;
+    *) die "project registry has $count entries for $NAME; resolve the ambiguity first" ;;
+  esac
+  REGISTRY_TMP=$(mktemp "$DATA_ABS/.fm-project-relocate.XXXXXX") \
+    || die "cannot prepare project-registry update in $DATA_ABS"
+  awk -v project="$NAME" '!($1 == "-" && $2 == project) { print }' "$REGISTRY" > "$REGISTRY_TMP" \
+    || die "cannot prepare project-registry update for $NAME"
+  REGISTRY_ACTION=remove
+}
+
+publish_registry_update() {
+  [ "$REGISTRY_ACTION" = remove ] || return 0
+  mv -f "$REGISTRY_TMP" "$REGISTRY" || return 1
+  REGISTRY_TMP=
+}
+
+rollback_relocation() {
+  if [ -e "$SOURCE" ] || [ -L "$SOURCE" ]; then
+    printf 'ERROR: registry update failed and source path was recreated; clone remains at %s\n' "$DESTINATION" >&2
+    return 1
+  fi
+  if mv -T "$DESTINATION" "$SOURCE"; then
+    return 0
+  fi
+  printf 'ERROR: registry update failed and inverse rename also failed; clone remains at %s\n' "$DESTINATION" >&2
+  return 1
+}
+
+if [ "${1:-}" = --help ] || [ "${1:-}" = -h ]; then
+  usage
+  exit 0
+fi
+[ "$#" -eq 2 ] || { usage; exit 2; }
+NAME=$1
+DESTINATION_ROOT_RAW=$2
+case "$NAME" in
+  ''|.|..|*/*|*';'*|*'('*|*')'*|*[[:space:]]*) die "project name must be one plain projects/ entry" ;;
+esac
+case "$DESTINATION_ROOT_RAW" in
+  /*) ;;
+  *) die "destination root must be an explicit absolute path" ;;
+esac
+
+# This mutation must never be driven by a no-mistakes gate agent.
+fm_refuse_if_gate_agent "$FM_ROOT"
+
+PROJECTS_ABS=$(canonical_ordinary_dir "$PROJECTS" "source projects root") || exit 1
+SOURCE="$PROJECTS_ABS/$NAME"
+SOURCE=$(canonical_ordinary_dir "$SOURCE" "source project") || exit 1
+path_is_direct_child "$PROJECTS_ABS" "$SOURCE" \
+  || die "source project escapes the declared projects root"
+
+DESTINATION_ROOT=$(canonical_ordinary_dir "$DESTINATION_ROOT_RAW" "destination root") || exit 1
+DESTINATION="$DESTINATION_ROOT/$NAME"
+path_is_direct_child "$DESTINATION_ROOT" "$DESTINATION" \
+  || die "destination project escapes the declared destination root"
+if [ -e "$DESTINATION" ] || [ -L "$DESTINATION" ]; then
+  die "destination project path already exists: $DESTINATION"
+fi
+if path_is_within_or_equal "$SOURCE" "$DESTINATION"; then
+  die "destination project path is inside the source project"
+fi
+
+SOURCE_DEVICE=$(device_for_path "$SOURCE") \
+  || die "cannot determine source filesystem device"
+DESTINATION_DEVICE=$(device_for_path "$DESTINATION_ROOT") \
+  || die "cannot determine destination filesystem device"
+[ "$SOURCE_DEVICE" = "$DESTINATION_DEVICE" ] \
+  || die "source and destination are on different filesystems; rename-only relocation is impossible"
+
+DATA_ABS=$(optional_operational_dir "$DATA" "data directory") || exit 1
+STATE_ABS=$(optional_operational_dir "$STATE" "state directory") || exit 1
+REGISTRY=${DATA_ABS:+$DATA_ABS/projects.md}
+SECONDMATES=${DATA_ABS:+$DATA_ABS/secondmates.md}
+
+source_is_standalone_clone
+source_has_clean_worktree
+source_has_only_landed_commits
+task_meta=
+metadata_rc=0
+task_meta=$(metadata_references_source) || metadata_rc=$?
+if [ "$metadata_rc" -eq 0 ]; then
+  die "task metadata references this project: $task_meta"
+fi
+if [ "$metadata_rc" -ne 1 ]; then
+  exit "$metadata_rc"
+fi
+secondmate=
+secondmate_rc=0
+secondmate=$(registered_secondmate_references_project) || secondmate_rc=$?
+if [ "$secondmate_rc" -eq 0 ]; then
+  die "registered secondmate $secondmate references project $NAME"
+fi
+if [ "$secondmate_rc" -ne 1 ]; then
+  exit "$secondmate_rc"
+fi
+prepare_registry_update
+
+# `-T` keeps this a rename to the exact guarded destination rather than allowing
+# a late-created directory to turn it into a nested move.
+if ! mv -T "$SOURCE" "$DESTINATION"; then
+  fail_after_move "rename failed; source remains at $SOURCE"
+fi
+if ! publish_registry_update; then
+  if rollback_relocation; then
+    fail_after_move "project registry update failed; relocation was rolled back and source was preserved"
+  fi
+  fail_after_move "project registry update failed after relocation"
+fi
+
+if [ "$REGISTRY_ACTION" = remove ]; then
+  printf 'relocated %s from %s to %s; removed its primary project-registry entry\n' \
+    "$NAME" "$SOURCE" "$DESTINATION"
+else
+  printf 'relocated %s from %s to %s; no primary project-registry entry existed\n' \
+    "$NAME" "$SOURCE" "$DESTINATION"
+fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -124,7 +124,7 @@ family_for_basename() {
     fm-dispatch-select.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
-    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
+    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|fm-project-relocate.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-tmux-submit-busy.test.sh|fm-transition-lib.test.sh|\
@@ -682,7 +682,7 @@ families_for_changed_path() {
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
-    bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
+    bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-project-relocate.sh|bin/fm-promote.sh|\
     bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
       printf '%s\n' pure-contract-unit
       ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,7 +126,7 @@ Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-
 
 Firstmate's own no-mistakes gate runs agents inside a checkout that also contains the fleet-captain identity in `AGENTS.md`, so gate execution needs an authority boundary separate from ordinary crewmate worktree isolation.
 The tracked `.no-mistakes.yaml` sets `disable_project_settings: true`; no-mistakes honors that setting only from the trusted default-branch copy, so a pushed branch cannot enable its own project instructions during validation.
-Independently, `fm-spawn.sh`, `fm-send.sh`, and `fm-teardown.sh` source `bin/fm-gate-refuse-lib.sh` and exit with status 3 before fleet mutation when the gate environment marker is present or the current checkout matches the default no-mistakes gate-repository topology.
+Independently, `fm-spawn.sh`, `fm-send.sh`, `fm-teardown.sh`, and `fm-project-relocate.sh` source `bin/fm-gate-refuse-lib.sh` and exit with status 3 before fleet mutation when the gate environment marker is present or the current checkout matches the default no-mistakes gate-repository topology.
 A normal primary checkout or crewmate worktree has neither signal and remains unaffected.
 The helper's header owns the exact signal detection, relocated-home limitation, test-harness bypass, and relationship to no-mistakes' HEAD-continuity guard.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -49,6 +49,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live secondmates mid-session and send a pointer to the literal-content config reread when config changed |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
+| `fm-project-relocate.sh` | Rename-only captain-authorized relocation of one clean, landed, unreferenced project clone |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |

--- a/tests/fm-project-relocate.test.sh
+++ b/tests/fm-project-relocate.test.sh
@@ -265,6 +265,32 @@ test_refuses_root_replacement_and_busy_registry() {
   pass "root replacement and a busy project registry refuse relocation"
 }
 
+test_refuses_unreadable_reference_data() {
+  local pair home destination
+  pair=$(make_case alpha)
+  home=${pair%%$'\t'*}
+  destination="$TMP_ROOT/destination-unreadable-metadata"
+  mkdir -p "$destination"
+  printf 'project=other\n' > "$home/state/unreadable.meta"
+  chmod 000 "$home/state/unreadable.meta"
+
+  assert_refused_unchanged "$home" "$destination" alpha "cannot read task metadata" \
+    "unreadable task metadata"
+
+  pair=$(make_case beta)
+  home=${pair%%$'\t'*}
+  destination="$TMP_ROOT/destination-unreadable-secondmates"
+  mkdir -p "$destination"
+  printf '%s\n' \
+    '- design - design work (home: /tmp/design; scope: design; projects: other; added 2026-07-24)' \
+    > "$home/data/secondmates.md"
+  chmod 000 "$home/data/secondmates.md"
+
+  assert_refused_unchanged "$home" "$destination" beta "cannot read secondmate registry" \
+    "unreadable secondmate registry"
+  pass "unreadable task metadata and secondmate registry refuse relocation"
+}
+
 test_refuses_task_and_secondmate_references() {
   local pair home clone destination source_abs
   pair=$(make_case alpha)
@@ -329,5 +355,6 @@ test_refuses_linked_worktree_and_dirty_worktree
 test_refuses_unpushed_and_pushed_unlanded_branches
 test_refuses_unlanded_tags_and_stashes
 test_refuses_root_replacement_and_busy_registry
+test_refuses_unreadable_reference_data
 test_refuses_task_and_secondmate_references
 test_refuses_traversal_duplicate_registry_and_gate_agent

--- a/tests/fm-project-relocate.test.sh
+++ b/tests/fm-project-relocate.test.sh
@@ -223,6 +223,46 @@ test_refuses_unlanded_tags_and_stashes() {
   pass "unlanded local tags and stashes both refuse relocation"
 }
 
+test_refuses_root_replacement_and_busy_registry() {
+  local pair home destination fakebin real_python replacement out rc
+  pair=$(make_case alpha)
+  home=${pair%%$'\t'*}
+  destination="$TMP_ROOT/destination-root-race"
+  fakebin="$TMP_ROOT/fake-python"
+  replacement="$TMP_ROOT/replacement-projects"
+  real_python=$(command -v python3)
+  mkdir -p "$destination" "$fakebin" "$replacement"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'mv "$RELOCATE_RACE_ROOT" "$RELOCATE_RACE_ROOT.original"' \
+    'ln -s "$RELOCATE_RACE_REPLACEMENT" "$RELOCATE_RACE_ROOT"' \
+    'exec "$RELOCATE_REAL_PYTHON" "$@"' \
+    > "$fakebin/python3"
+  chmod +x "$fakebin/python3"
+
+  rc=0
+  out=$(PATH="$fakebin:$PATH" \
+    RELOCATE_RACE_ROOT="$home/projects" \
+    RELOCATE_RACE_REPLACEMENT="$replacement" \
+    RELOCATE_REAL_PYTHON="$real_python" \
+    run_relocate "$home" alpha "$destination" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "root replacement unexpectedly succeeded"
+  assert_contains "$out" "source or destination root changed before rename" \
+    "root replacement did not explain its refusal"
+  assert_present "$home/projects.original/alpha" "root replacement moved the source clone"
+  assert_absent "$destination/alpha" "root replacement created a destination clone"
+  assert_grep "- alpha " "$home/data/projects.md" "root replacement changed the primary registry"
+
+  pair=$(make_case beta)
+  home=${pair%%$'\t'*}
+  destination="$TMP_ROOT/destination-registry-lock"
+  mkdir -p "$destination" "$home/data/.fm-project-relocate.projects.lock"
+
+  assert_refused_unchanged "$home" "$destination" beta "project registry is busy" \
+    "busy project registry"
+  pass "root replacement and a busy project registry refuse relocation"
+}
+
 test_refuses_task_and_secondmate_references() {
   local pair home clone destination source_abs
   pair=$(make_case alpha)
@@ -286,5 +326,6 @@ test_refuses_symlink_source_and_destination_root
 test_refuses_linked_worktree_and_dirty_worktree
 test_refuses_unpushed_and_pushed_unlanded_branches
 test_refuses_unlanded_tags_and_stashes
+test_refuses_root_replacement_and_busy_registry
 test_refuses_task_and_secondmate_references
 test_refuses_traversal_duplicate_registry_and_gate_agent

--- a/tests/fm-project-relocate.test.sh
+++ b/tests/fm-project-relocate.test.sh
@@ -234,9 +234,9 @@ test_refuses_root_replacement_and_busy_registry() {
   mkdir -p "$destination" "$fakebin" "$replacement"
   printf '%s\n' \
     '#!/usr/bin/env bash' \
-    'mv "$RELOCATE_RACE_ROOT" "$RELOCATE_RACE_ROOT.original"' \
-    'ln -s "$RELOCATE_RACE_REPLACEMENT" "$RELOCATE_RACE_ROOT"' \
-    'exec "$RELOCATE_REAL_PYTHON" "$@"' \
+    "mv \"\$RELOCATE_RACE_ROOT\" \"\$RELOCATE_RACE_ROOT.original\"" \
+    "ln -s \"\$RELOCATE_RACE_REPLACEMENT\" \"\$RELOCATE_RACE_ROOT\"" \
+    "exec \"\$RELOCATE_REAL_PYTHON\" \"\$@\"" \
     > "$fakebin/python3"
   chmod +x "$fakebin/python3"
 

--- a/tests/fm-project-relocate.test.sh
+++ b/tests/fm-project-relocate.test.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Focused behavior tests for the guarded, rename-only project relocation helper.
+#
+# Every fixture is a private FM_HOME below a temporary directory.
+# The successful case proves the clone changes roots and only then loses its
+# primary registry entry, while each refusal proves the source clone and its
+# registry entry remain intact.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SCRIPT="$ROOT/bin/fm-project-relocate.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-project-relocate.XXXXXX")
+FM_TEST_CLEANUP_DIRS+=("$TMP_ROOT")
+trap fm_test_cleanup EXIT
+fm_git_identity fmtest fmtest@example.invalid
+
+new_home() {
+  local home
+  home=$(mktemp -d "$TMP_ROOT/home.XXXXXX")
+  mkdir -p "$home/projects" "$home/data" "$home/state"
+  printf '%s\n' "$home"
+}
+
+make_landed_clone() {
+  local home=$1 name=$2 seed remote remote_abs clone
+  seed="$home/seed-$name"
+  remote="$home/remotes/$name.git"
+  clone="$home/projects/$name"
+  mkdir -p "$home/remotes"
+  git init -q "$seed"
+  git -C "$seed" symbolic-ref HEAD refs/heads/main
+  printf 'initial\n' > "$seed/README.md"
+  git -C "$seed" add README.md
+  git -C "$seed" commit -qm initial
+  git clone --quiet --bare "$seed" "$remote"
+  git -C "$remote" symbolic-ref HEAD refs/heads/main
+  remote_abs=$(cd "$remote" && pwd -P)
+  git -C "$seed" remote add origin "file://$remote_abs"
+  git -C "$seed" push -q -u origin main
+  git clone --quiet "file://$remote_abs" "$clone"
+  git -C "$clone" remote set-head origin main >/dev/null 2>&1 || true
+  printf '%s\n' "$clone"
+}
+
+write_project_registry() {
+  local home=$1 name=$2
+  {
+    printf -- '- %s [no-mistakes] - relocation fixture (added 2026-07-24)\n' "$name"
+    printf '%s\n' '- keep [local-only] - unaffected registry entry (added 2026-07-24)'
+  } > "$home/data/projects.md"
+}
+
+make_case() {
+  local name=${1:-alpha} home clone
+  home=$(new_home)
+  clone=$(make_landed_clone "$home" "$name")
+  write_project_registry "$home" "$name"
+  printf '%s\t%s\n' "$home" "$clone"
+}
+
+run_relocate() {
+  local home=$1
+  shift
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$SCRIPT" "$@"
+}
+
+assert_refused_unchanged() {
+  local home=$1 destination_root=$2 name=$3 expected=$4 label=$5 out rc
+  rc=0
+  out=$(run_relocate "$home" "$name" "$destination_root" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "$label unexpectedly succeeded: $out"
+  assert_contains "$out" "$expected" "$label did not explain its refusal"
+  [ -e "$home/projects/$name" ] || [ -L "$home/projects/$name" ] \
+    || fail "$label moved or removed the source clone"
+  [ ! -e "$destination_root/$name" ] && [ ! -L "$destination_root/$name" ] \
+    || fail "$label created the destination project path"
+  assert_grep "- $name " "$home/data/projects.md" "$label changed the primary registry"
+}
+
+test_success_renames_and_removes_registry_afterward() {
+  local pair home clone destination out
+  pair=$(make_case alpha)
+  home=${pair%%$'\t'*}
+  clone=${pair#*$'\t'}
+  destination="$TMP_ROOT/destination-success"
+  mkdir -p "$destination"
+
+  out=$(run_relocate "$home" alpha "$destination") \
+    || fail "clean landed project did not relocate"
+
+  assert_contains "$out" "relocated alpha" "success did not report relocation"
+  assert_absent "$clone" "success left the source clone behind"
+  assert_present "$destination/alpha" "success did not create the destination clone"
+  assert_no_grep "- alpha " "$home/data/projects.md" "success did not remove the relocated registry entry"
+  assert_grep "- keep " "$home/data/projects.md" "success changed an unrelated registry entry"
+  [ "$(git -C "$destination/alpha" rev-parse --show-toplevel)" = "$destination/alpha" ] \
+    || fail "success did not preserve an inspectable Git clone at the destination"
+  pass "clean landed project relocates by rename and then updates the primary registry"
+}
+
+test_refuses_existing_destination() {
+  local pair home destination out rc
+  pair=$(make_case alpha)
+  home=${pair%%$'\t'*}
+  destination="$TMP_ROOT/destination-existing"
+  mkdir -p "$destination/alpha"
+
+  rc=0
+  out=$(run_relocate "$home" alpha "$destination" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "existing destination unexpectedly succeeded"
+  assert_contains "$out" "destination project path already exists" \
+    "existing destination did not explain its refusal"
+  assert_present "$home/projects/alpha" "existing destination moved or removed the source clone"
+  assert_present "$destination/alpha" "existing destination was changed"
+  assert_grep "- alpha " "$home/data/projects.md" "existing destination changed the primary registry"
+  pass "existing destination refuses without moving the source clone"
+}
+
+test_refuses_symlink_source_and_destination_root() {
+  local pair home clone real_source destination actual_destination
+  pair=$(make_case alpha)
+  home=${pair%%$'\t'*}
+  clone=${pair#*$'\t'}
+  real_source="$home/real-alpha"
+  mv "$clone" "$real_source"
+  ln -s "$real_source" "$clone"
+  destination="$TMP_ROOT/destination-source-symlink"
+  mkdir -p "$destination"
+
+  assert_refused_unchanged "$home" "$destination" alpha "source project must not be a symlink" \
+    "symlink source"
+
+  pair=$(make_case beta)
+  home=${pair%%$'\t'*}
+  actual_destination="$TMP_ROOT/destination-real"
+  destination="$TMP_ROOT/destination-root-symlink"
+  mkdir -p "$actual_destination"
+  ln -s "$actual_destination" "$destination"
+
+  assert_refused_unchanged "$home" "$destination" beta "destination root must not be a symlink" \
+    "symlink destination root"
+  pass "symlink source or destination root refuses before relocation"
+}
+
+test_refuses_linked_worktree_and_dirty_worktree() {
+  local pair home clone destination linked
+  pair=$(make_case alpha)
+  home=${pair%%$'\t'*}
+  clone=${pair#*$'\t'}
+  destination="$TMP_ROOT/destination-linked"
+  linked="$TMP_ROOT/linked-alpha"
+  mkdir -p "$destination"
+  git -C "$clone" worktree add --quiet -b linked-alpha "$linked"
+
+  assert_refused_unchanged "$home" "$destination" alpha "registered worktrees" \
+    "linked worktree"
+
+  pair=$(make_case beta)
+  home=${pair%%$'\t'*}
+  clone=${pair#*$'\t'}
+  destination="$TMP_ROOT/destination-dirty"
+  mkdir -p "$destination"
+  printf 'untracked\n' > "$clone/dirty.txt"
+
+  assert_refused_unchanged "$home" "$destination" beta "uncommitted or untracked changes" \
+    "dirty worktree"
+  pass "linked or dirty project clone refuses before relocation"
+}
+
+test_refuses_unpushed_and_pushed_unlanded_branches() {
+  local pair home clone destination
+  pair=$(make_case alpha)
+  home=${pair%%$'\t'*}
+  clone=${pair#*$'\t'}
+  destination="$TMP_ROOT/destination-unpushed"
+  mkdir -p "$destination"
+  git -C "$clone" commit --quiet --allow-empty -m unpushed
+
+  assert_refused_unchanged "$home" "$destination" alpha "commits absent from every remote" \
+    "unpushed commit"
+
+  pair=$(make_case beta)
+  home=${pair%%$'\t'*}
+  clone=${pair#*$'\t'}
+  destination="$TMP_ROOT/destination-unlanded"
+  mkdir -p "$destination"
+  git -C "$clone" checkout --quiet -b feature
+  git -C "$clone" commit --quiet --allow-empty -m pushed-but-unlanded
+  git -C "$clone" push --quiet -u origin feature
+  git -C "$clone" checkout --quiet main
+
+  assert_refused_unchanged "$home" "$destination" beta "local branch feature is not landed on origin/main" \
+    "pushed unlanded branch"
+  pass "unpushed and pushed-but-unlanded commits both refuse relocation"
+}
+
+test_refuses_task_and_secondmate_references() {
+  local pair home clone destination source_abs
+  pair=$(make_case alpha)
+  home=${pair%%$'\t'*}
+  clone=${pair#*$'\t'}
+  destination="$TMP_ROOT/destination-task-reference"
+  mkdir -p "$destination"
+  source_abs=$(cd "$clone" && pwd -P)
+  printf 'project=%s\n' "$source_abs" > "$home/state/inflight.meta"
+
+  assert_refused_unchanged "$home" "$destination" alpha "task metadata references this project" \
+    "task metadata reference"
+
+  pair=$(make_case beta)
+  home=${pair%%$'\t'*}
+  destination="$TMP_ROOT/destination-secondmate-reference"
+  mkdir -p "$destination"
+  printf '%s\n' \
+    '- design - design work (home: /tmp/design; scope: design; projects: other, beta; added 2026-07-24)' \
+    > "$home/data/secondmates.md"
+
+  assert_refused_unchanged "$home" "$destination" beta "registered secondmate design references project beta" \
+    "registered secondmate reference"
+  pass "task metadata and registered secondmate references both block relocation"
+}
+
+test_refuses_traversal_duplicate_registry_and_gate_agent() {
+  local pair home destination out rc
+  pair=$(make_case alpha)
+  home=${pair%%$'\t'*}
+  destination="$TMP_ROOT/destination-traversal"
+  mkdir -p "$destination"
+  rc=0
+  out=$(run_relocate "$home" ../alpha "$destination" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "project-name traversal unexpectedly succeeded"
+  assert_contains "$out" "project name must be one plain projects/ entry" \
+    "project-name traversal did not refuse clearly"
+  assert_present "$home/projects/alpha" "project-name traversal changed the source clone"
+
+  {
+    printf '%s\n' '- alpha - duplicate one (added 2026-07-24)'
+    printf '%s\n' '- alpha - duplicate two (added 2026-07-24)'
+  } > "$home/data/projects.md"
+  assert_refused_unchanged "$home" "$destination" alpha "project registry has 2 entries" \
+    "duplicate project registry"
+
+  write_project_registry "$home" alpha
+  rc=0
+  out=$(env -u FM_GATE_REFUSE_BYPASS NO_MISTAKES_GATE=1 \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$SCRIPT" alpha "$destination" 2>&1) || rc=$?
+  [ "$rc" -eq 3 ] || fail "no-mistakes gate agent was not refused with exit 3: $out"
+  assert_contains "$out" "NO_MISTAKES_GATE set" "gate-agent refusal did not explain the boundary"
+  assert_present "$home/projects/alpha" "gate-agent refusal changed the source clone"
+  assert_absent "$destination/alpha" "gate-agent refusal created a destination clone"
+  pass "traversal, registry ambiguity, and no-mistakes gate context refuse without relocation"
+}
+
+test_success_renames_and_removes_registry_afterward
+test_refuses_existing_destination
+test_refuses_symlink_source_and_destination_root
+test_refuses_linked_worktree_and_dirty_worktree
+test_refuses_unpushed_and_pushed_unlanded_branches
+test_refuses_task_and_secondmate_references
+test_refuses_traversal_duplicate_registry_and_gate_agent

--- a/tests/fm-project-relocate.test.sh
+++ b/tests/fm-project-relocate.test.sh
@@ -260,6 +260,8 @@ test_refuses_root_replacement_and_busy_registry() {
 
   assert_refused_unchanged "$home" "$destination" beta "project registry is busy" \
     "busy project registry"
+  assert_present "$home/data/.fm-project-relocate.projects.lock" \
+    "busy project registry lock was removed by the refused contender"
   pass "root replacement and a busy project registry refuse relocation"
 }
 

--- a/tests/fm-project-relocate.test.sh
+++ b/tests/fm-project-relocate.test.sh
@@ -196,6 +196,33 @@ test_refuses_unpushed_and_pushed_unlanded_branches() {
   pass "unpushed and pushed-but-unlanded commits both refuse relocation"
 }
 
+test_refuses_unlanded_tags_and_stashes() {
+  local pair home clone destination
+  pair=$(make_case alpha)
+  home=${pair%%$'\t'*}
+  clone=${pair#*$'\t'}
+  destination="$TMP_ROOT/destination-tag"
+  mkdir -p "$destination"
+  git -C "$clone" commit --quiet --allow-empty -m tag-retained
+  git -C "$clone" tag local-retained
+  git -C "$clone" reset --quiet --hard origin/main
+
+  assert_refused_unchanged "$home" "$destination" alpha "commits absent from every remote" \
+    "unlanded local tag"
+
+  pair=$(make_case beta)
+  home=${pair%%$'\t'*}
+  clone=${pair#*$'\t'}
+  destination="$TMP_ROOT/destination-stash"
+  mkdir -p "$destination"
+  printf 'stashed\n' > "$clone/stashed.txt"
+  git -C "$clone" stash push --quiet --include-untracked -m local-retained
+
+  assert_refused_unchanged "$home" "$destination" beta "commits absent from every remote" \
+    "unlanded stash"
+  pass "unlanded local tags and stashes both refuse relocation"
+}
+
 test_refuses_task_and_secondmate_references() {
   local pair home clone destination source_abs
   pair=$(make_case alpha)
@@ -258,5 +285,6 @@ test_refuses_existing_destination
 test_refuses_symlink_source_and_destination_root
 test_refuses_linked_worktree_and_dirty_worktree
 test_refuses_unpushed_and_pushed_unlanded_branches
+test_refuses_unlanded_tags_and_stashes
 test_refuses_task_and_secondmate_references
 test_refuses_traversal_duplicate_registry_and_gate_agent


### PR DESCRIPTION
## Intent

Implement a captain-authorized cleanup helper that relocates exactly one explicitly named Firstmate project clone from FM_HOME/projects to an explicit destination root without raw recursive deletion. It must fail closed unless both declared roots are ordinary non-symlink directories; the destination project path is absent; the clone is a standalone clean Git checkout with no linked worktrees and no unpushed or otherwise unlanded commits; no primary task metadata or registered secondmate references it; and the source and destination cannot escape their roots. Perform a same-filesystem rename only after every guard passes, preserve the source on refusal or failure, and remove the primary projects registry entry only after successful relocation. Do not relocate a real captain clone or touch captain data/state outside this task progress/status. Add focused shell tests, help and documentation, and keep the helper unavailable to no-mistakes gate agents.

## What Changed

- Added a captain-authorized, rename-only helper to relocate one clean, landed, unreferenced project clone with fail-closed path, Git, reference, registry, and gate-agent guards.
- Serialized primary registry updates, removed the relocated entry only after a successful move, and attempted rollback when registry publication fails.
- Added focused relocation coverage and documented the guarded workflow and no-mistakes gate boundary.

## Risk Assessment

⚠️ Medium: Captain, the change now appears source-clean, but its safety-critical relocation path relies on platform-specific atomic rename behavior and a dense set of guards.

## Testing

Reviewed the target change and help surface, ran the focused relocation shell tests covering success plus guarded refusals, and exercised a disposable end-user CLI flow. The transcript demonstrates a clean landed clone relocating by identity-preserving rename, post-rename registry removal, and refusal that leaves an existing destination, source clone, and registry untouched. No UI artifact applies because this is a CLI-only helper.

<details>
<summary>Evidence: End-to-end CLI relocation transcript</summary>

`Clean clone relocated by same-directory identity-preserving rename; source disappeared, Git clone remained inspectable at destination, registry entry was removed; existing destination refusal preserved source, registry, and destination.`

```text
End-user CLI evidence: captain-authorized clean clone relocation
Note: FM_GATE_REFUSE_BYPASS=1 is required only because this validation runs inside the no-mistakes gate worktree; production gate-agent refusal is covered by the focused test.
source before: /tmp/no-mistakes-evidence/01KYAHJQDSR4B3HVDY0KPSRKFY/relocation-fixture.VedrDD/fm-home/projects/alpha (identity 48:103990)
registry before:
  - alpha [no-mistakes] - evidence fixture (added 2026-07-24)
  - keep [local-only] - unaffected entry (added 2026-07-24)
command output:
relocated alpha from /tmp/no-mistakes-evidence/01KYAHJQDSR4B3HVDY0KPSRKFY/relocation-fixture.VedrDD/fm-home/projects/alpha to /tmp/no-mistakes-evidence/01KYAHJQDSR4B3HVDY0KPSRKFY/relocation-fixture.VedrDD/retired-projects/alpha; removed its primary project-registry entry
source absent after: yes
destination Git top-level: /tmp/no-mistakes-evidence/01KYAHJQDSR4B3HVDY0KPSRKFY/relocation-fixture.VedrDD/retired-projects/alpha
same directory identity after rename: yes
registry after:
  - keep [local-only] - unaffected entry (added 2026-07-24)
refusal check (destination project path already exists):
REFUSED: destination project path already exists: /tmp/no-mistakes-evidence/01KYAHJQDSR4B3HVDY0KPSRKFY/relocation-fixture.VedrDD/retired-projects/beta
refusal exit: 1; source preserved: yes; registry preserved: yes; existing destination preserved: yes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-project-relocate.sh:144` - Required criterion: “no unpushed or otherwise unlanded commits.” The checks at lines 144-159 inspect only HEAD and refs under `refs/heads`; an unpushed commit retained only by `refs/tags/*` or `refs/stash` is ignored, so the clone can relocate despite retaining unlanded work.
- 🚨 `bin/fm-project-relocate.sh:362` - The destination absence check is not preserved through the rename. If a regular file or symlink appears at the destination after line 318, `mv -T` replaces it rather than refusing, violating the fail-closed absent-destination guard and potentially destroying destination data. Use an atomic no-replace rename mechanism or fail closed when unavailable.
- 🚨 `bin/fm-project-relocate.sh:362` - `mv -T` is a GNU extension and is unsupported by macOS/BSD `mv`; this helper explicitly contains Darwin support in `device_for_path`, but relocation will fail at the final move on that platform. Use a portable guarded rename implementation or explicitly provide a supported Darwin path.
- ⚠️ `bin/fm-project-relocate.sh:274` - The registry is rendered into a temporary snapshot before the move, then line 274 blindly replaces `projects.md`. A concurrent registry update between lines 265-268 and publication is silently lost, including unrelated project entries. Serialize registry publication or verify the original file is unchanged before replacing it.

🔧 Fix: Harden guarded project relocation
2 issues (1 error, 1 warning) still open:
- 🚨 `bin/fm-project-relocate.sh:413` - Required criterion: “both declared roots are ordinary non-symlink directories” and “the source and destination cannot escape their roots.” The roots are canonicalized early, but the later `atomic_rename_no_replace &#34;$SOURCE&#34; &#34;$DESTINATION&#34;` passes absolute pathnames to the kernel. A concurrent replacement of either root with a symlink between those checks and this call can redirect the rename outside the approved root. Pin and operate through verified directory FDs (or otherwise serialize root identity) before relocating.
- ⚠️ `bin/fm-project-relocate.sh:287` - The comparison snapshot reduces registry races but does not close them: an update that lands after `cmp -s` succeeds and before `mv -f` still gets overwritten, dropping unrelated registry changes. Serialize publication with the registry’s writers or use an atomic compare-and-swap protocol.

🔧 Fix: Pin relocation roots and serialize registry updates
1 error still open:
- 🚨 `bin/fm-project-relocate.sh:275` - `REGISTRY_LOCK` is assigned before lock acquisition. When a second relocation finds an existing empty lock directory, `mkdir` fails and `die` triggers the EXIT trap, whose `rmdir` removes the first relocation’s lock. That permits another publisher to enter during the first operation and reintroduces the registry overwrite race. Record lock ownership only after a successful `mkdir` (or use a separate ownership flag).

🔧 Fix: Preserve registry lock ownership on refusal
2 errors still open:
- 🚨 `bin/fm-project-relocate.sh:215` - Required criterion: “It must fail closed unless … no primary task metadata … references it.” If opening a metadata file fails after the `-f` check, this redirection’s nonzero status is ignored and the function reaches `return 1`, which the caller interprets as “no reference.” Preserve and propagate read failures so relocation refuses.
- 🚨 `bin/fm-project-relocate.sh:251` - Required criterion: “It must fail closed unless … no … registered secondmate references it.” This collapses every nonzero `awk` status—including an unreadable registry or an `awk` execution/read error—into `return 1`; the caller treats that as a clean no-reference result and can relocate. Distinguish the intentional no-match status from inspection failures.

🔧 Fix: Fail closed on unreadable reference data
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-project-relocate.sh --help`
- `bash tests/fm-project-relocate.test.sh`
- <code>Manual disposable-FM_HOME CLI relocation and existing-destination refusal, captured in `/tmp/no-mistakes-evidence/01KYAHJQDSR4B3HVDY0KPSRKFY/relocation-cli-transcript-clean.txt`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fix literal helper command ShellCheck warnings
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
