### PR TITLE
fix(bin): restore no-mistakes brief scaffolding

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -325,7 +325,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass the authority check applied by firstmate and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -120,18 +120,21 @@ test_captain_escalation_is_decision_ready() {
 }
 
 test_primary_and_secondmate_instruction_generation() {
-  local home ship charter
+  local home ship charter status=0
   home="$TMP_ROOT/home"
   mkdir -p "$home/data"
+  printf '%s\n' '- sample [no-mistakes] - authority fixture (added 2026-07-24)' > "$home/data/projects.md"
 
   FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
-    "$BRIEF" authority-worker sample >/dev/null 2>&1
+    "$BRIEF" authority-worker sample >/dev/null 2>&1 || status=$?
+  expect_code 0 "$status" "no-mistakes implementation brief must scaffold successfully"
   ship="$home/data/authority-worker/brief.md"
+  assert_present "$ship" "no-mistakes implementation brief was not generated"
   assert_grep 'ask-user findings are never yours to answer' "$ship" \
     "generated implementation brief lets the worker own an ask-user decision"
   assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$ship" \
     "generated implementation brief bypasses the primary authority owner"
-  assert_grep "silently bypass firstmate's authority check and any required captain escalation" "$ship" \
+  assert_grep "silently bypass the authority check applied by firstmate and any required captain escalation" "$ship" \
     "generated implementation brief permits silent ask-user auto-resolution"
   assert_no_grep 'the captain, not you, owns the ask-user decisions' "$ship" \
     "generated implementation brief retained conflicting captain-only wording"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -96,14 +96,15 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
-# Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
-# reference must render as plain prose with no dangling apostrophe artifact.
+# Exercise the default no-mistakes ship path and pin the authority and pipeline
+# ownership language that has twice exposed Bash 3.2's heredoc lexer bug.
 test_no_mistakes_dod_wording() {
-  local home id brief
+  local home id brief status=0
   home="$TMP_ROOT/wording-home"
   mkdir -p "$home/data"
   id="brief-wording-b1"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1 || status=$?
+  expect_code 0 "$status" "default no-mistakes ship brief must scaffold successfully"
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
   assert_grep "no-mistakes itself provides for the mechanics" "$brief" \
@@ -114,9 +115,13 @@ test_no_mistakes_dod_wording() {
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
   assert_grep '`help`' "$brief" \
     "no-mistakes DOD must render literal backticks around help"
+  assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$brief" \
+    "no-mistakes DOD lost firstmate authority ownership"
+  assert_grep "silently bypass the authority check applied by firstmate and any required captain escalation" "$brief" \
+    "no-mistakes DOD lost the ask-user auto-resolution warning"
   assert_no_grep "no-mistakes' own guidance" "$brief" \
     "no-mistakes DOD regressed to the apostrophe form that breaks bash -n"
-  pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
+  pass "fm-brief.sh: no-mistakes DOD scaffolds with pipeline and authority ownership"
 }
 
 test_ship_project_memory_wording() {


### PR DESCRIPTION
## Intent

Fix the current upstream Firstmate regression in bin/fm-brief.sh on live main b05eb24 where bin/fm-brief.sh <id> firstmate cannot scaffold a no-mistakes ship task and Bash 3.2 reports an unmatched parenthesis around the definition-of-done command-substitution heredoc. Diagnose the exact apostrophe regression introduced by the ask-user authority wording and inspect relevant history before fixing it. Make the smallest syntax-safe correction while preserving the current authority boundary and no-mistakes pipeline ownership language. Add regression coverage that executes real no-mistakes ship scaffolding rather than relying only on textual assertions, and confirm the existing ask-user-authority generated-instructions failure is resolved. Validate bash syntax, the focused brief and authority tests, repository lint, and directly affected documentation checks. This correction is independent of PR https://github.com/kunchenguid/firstmate/pull/995 and must not modify that PR or its active validation run.

## What Changed

- Reword the no-mistakes authority warning to avoid the apostrophe that broke `fm-brief.sh` parsing and ship-brief scaffolding under Bash 3.2 while preserving Firstmate’s authority boundary.
- Strengthen brief and ask-user-authority regression coverage by executing real no-mistakes scaffolding and verifying the generated pipeline and authority instructions.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, preserves the authority and pipeline-ownership language, and adds real no-mistakes scaffolding regression coverage with explicit failure detection.

## Testing

<code>Apple Bash 3.2 reproduced the base failure and accepted the target; focused brief, ask-user authority, instruction-owner, and documentation checks passed, and a real `fm-brief.sh &lt;id&gt; firstmate` invocation generated a no-mistakes ship brief preserving both the authority boundary and pipeline ownership language. Repository lint was not run because this testing task explicitly forbids linters and static analysis.</code>

<details>
<summary>Evidence: Apple Bash 3.2 baseline failure and successful end-to-end ship scaffold transcript</summary>

```text
User path: bin/fm-brief.sh <id> firstmate
Shell: GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

Baseline syntax reproduction at b05eb244:
/bin/bash: line 314: unexpected EOF while looking for matching `)'
/bin/bash: line 388: syntax error: unexpected end of file
baseline exit: 2

Target syntax check at da7eca0:
target syntax exit: 0

End-user scaffold command:
FM_HOME=/var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYB9CWFW57KNATDVZZE11T9D/fm-home bin/fm-brief.sh brief-upstream-regression-e2e firstmate
scaffolded: /var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYB9CWFW57KNATDVZZE11T9D/fm-home/data/brief-upstream-regression-e2e/brief.md (ship, mode=no-mistakes; replace {TASK})

Generated brief: /var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYB9CWFW57KNATDVZZE11T9D/fm-home/data/brief-upstream-regression-e2e/brief.md

Rendered no-mistakes authority and pipeline section:
You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass the authority check applied by firstmate and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

Acceptance markers:
brief exists: yes
authority owner preserved: yes
pipeline ownership preserved: yes
syntax-breaking wording absent: yes
end-to-end exit: 0
```
</details>
<details>
<summary>Evidence: Generated no-mistakes ship brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/brief-upstream-regression-e2e`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYB9CWFW57KNATDVZZE11T9D/fm-home/state/brief-upstream-regression-e2e.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/gavin/.no-mistakes/worktrees/f04eccabf018/01KYB9CWFW57KNATDVZZE11T9D/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/gavin/.no-mistakes/worktrees/f04eccabf018/01KYB9CWFW57KNATDVZZE11T9D/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass the authority check applied by firstmate and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git show b05eb244ce10f83192a95457b5e2b15c49b4e763:bin/fm-brief.sh | /bin/bash -n` — reproduced the unmatched-parenthesis regression</code>
- <code>Base-script counterfactual replacing `firstmate&#39;s authority check` with `the authority check applied by firstmate`, piped to `/bin/bash -n` — exited successfully</code>
- <code>`git show ec09871 -- bin/fm-brief.sh` and `git log -S&#34;firstmate&#39;s authority check&#34; -- bin/fm-brief.sh` — traced the regression to #945</code>
- <code>`/bin/bash -n bin/fm-brief.sh` using Apple Bash 3.2</code>
- `bin/fm-test-run.sh tests/fm-brief.test.sh tests/fm-ask-user-authority.test.sh`
- `bin/fm-test-run.sh tests/fm-instruction-owners.test.sh tests/fm-documentation-audiences.test.sh`
- <code>`FM_HOME=&lt;evidence-home&gt; bin/fm-brief.sh brief-upstream-regression-e2e firstmate` — generated and inspected a real no-mistakes ship brief</code>
- <code>`git status --short` and transient-output directory inspection — confirmed testing left the worktree clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
