### PR TITLE
test(pi): stabilize Calm interactive E2E settling

### DIFF
--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -26,10 +26,18 @@ cleanup() {
 trap cleanup EXIT
 
 wait_for_text() {
-  local file=$1 text=$2 i=0
+  local file=$1 text i=0 complete
+  shift
   while [ "$i" -lt 120 ]; do
     tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - >"$file" 2>/dev/null || true
-    grep -Fq "$text" "$file" 2>/dev/null && return 0
+    complete=1
+    for text in "$@"; do
+      if ! grep -Fq "$text" "$file" 2>/dev/null; then
+        complete=0
+        break
+      fi
+    done
+    [ "$complete" -eq 1 ] && return 0
     sleep 0.05
     i=$((i + 1))
   done
@@ -1473,7 +1481,7 @@ TS
 }
 
 test_interactive_terminal_e2e() {
-  local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot export_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait
+  local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot export_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait chrome_stop_wait active_wait active_screen_wait
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi calm interactive E2E"
     return 0
@@ -1673,8 +1681,10 @@ JSON
   assert_not_contains "$(cat "$default_snapshot")" 'Run `bin/fm-session-start.sh` now' \
     "native session-start context unexpectedly rendered while Calm was off"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-o
-  wait_for_text "$expanded_snapshot" "escape to interrupt" \
-    || fail "Ctrl+O did not retain Pi's ordinary startup and tool expansion behavior"
+  # Pi writes the expanded header before the rest of the same TUI frame, so wait for both native regions together.
+  wait_for_text "$expanded_snapshot" "escape to interrupt" "CALM_E2E_OUTPUT" \
+    || fail "Ctrl+O did not settle with Pi's ordinary startup and tool expansion behavior"
+  assert_contains "$(cat "$expanded_snapshot")" "escape to interrupt" "ordinary Ctrl+O expansion did not expand Pi's startup help"
   assert_contains "$(cat "$expanded_snapshot")" "CALM_E2E_OUTPUT" "ordinary Ctrl+O expansion hid tool activity while calm mode was off"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
@@ -1854,6 +1864,14 @@ JS
     chrome_wait=$((chrome_wait + 1))
   done
   kill "$chrome_pid" 2>/dev/null || true
+  chrome_stop_wait=0
+  while kill -0 "$chrome_pid" 2>/dev/null && [ "$chrome_stop_wait" -lt 20 ]; do
+    sleep 0.1
+    chrome_stop_wait=$((chrome_stop_wait + 1))
+  done
+  if kill -0 "$chrome_pid" 2>/dev/null; then
+    kill -KILL "$chrome_pid" 2>/dev/null || true
+  fi
   wait "$chrome_pid" 2>/dev/null || true
   grep -Fq '</html>' "$export_dom" 2>/dev/null \
     || fail "could not render calm-mode HTML export DOM"


### PR DESCRIPTION
## Intent

Reproduce and correct the live-main Pi Calm interactive regression under Pi 0.81.1 where ordinary Ctrl+O can appear to hide CALM_E2E_OUTPUT while Calm is off. Preserve native Calm-off behavior plus Calm-on, restart, tool-expansion, thinking-expansion, export, and persistence semantics. Determine whether the cause is the extension, transcript layout, settling timing, or an upstream contract change using real interactive TUI evidence; retain the behavioral assertions and make the E2E deterministic without weakening or skipping genuine failures. Run the focused Calm suite, strict Pi extension typecheck, lint, and directly affected tests, then ship an independent PR without modifying PR #995.

## What Changed

- Make the Pi Calm interactive E2E wait for both native Ctrl+O expansion and `CALM_E2E_OUTPUT` in the same settled TUI capture.
- Harden export verification cleanup by waiting for headless Chrome to exit and force-stopping it when necessary.

## Risk Assessment

✅ Low: Captain, the change is test-only and narrowly replaces a premature single-marker capture with a bounded settled-frame check while preserving the original behavioral assertions.

## Testing

After commit-delta and Pi-version inspection, two complete focused Calm runs exercised native Ctrl+O, Calm toggling, tool/thinking expansion, Working visibility, export, persistence, and restart; strict Pi extension typechecking and affected watcher tests also passed, and TUI plus rendered-export evidence was retained. Lint was not run because this validation task explicitly prohibited linters.

<details>
<summary>Evidence: Calm-off Ctrl+O expanded TUI</summary>

```text

 pi v0.81.1
 escape to interrupt
 ctrl+c to clear
 ctrl+c twice to exit
 ctrl+d to exit (empty)
 ctrl+z to suspend
 ctrl+k to delete to end
 shift+tab to cycle thinking level
 ctrl+p/shift+ctrl+p to cycle models
 ctrl+l to select model
 ctrl+o to expand tools
 ctrl+t to expand thinking
 ctrl+g for external editor
 / for commands
 ! to run bash
 !! to run bash (no context)
 option+enter to queue follow-up
 option+up to edit all queued messages
 ctrl+v to paste image (with text fallback)
 drop files to attach

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  project
    /var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project/.pi/extensions/fm-calm-e2e-inject.ts
    /var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project/.pi/extensions/fm-calm.ts
    /var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project/.pi/extensions/fm-primary-pi-watch.ts

/var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project/.pi/extensions/fm-primary-turnend-guard.ts


 Show a deterministic tool example.


 Thinking...

 I will run one command.


 $ printf 'CALM_E2E_OUTPUT
 '

 CALM_E2E_OUTPUT


 Thinking...


 grep /CALM_EXPORT_GREP/ in .

 sample.txt:1:CALM_EXPORT_GREP



 find CALM_EXPORT_FIND* in .

 CALM_EXPORT_FIND.txt


 Thinking...


 fm_watch_arm_pi
 watcher: started Pi extension arm child 1



 FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status

 Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.



 FIRSTMATE WATCHER WAKE: can you explain this phrase?



 Captain quote: ⁣FIRSTMATE_OP: v1 watcher: QUOTED_CURRENT_NEAR_MISS



 FIRSTMATE_OP: v1 watcher: ASCII_ONLY_NEAR_MISS



 Ordinary captain text before ⁣FIRSTMATE_OP: v1 watcher: EMBEDDED_CURRENT_NEAR_MISS



 ⁣ordinary captain text after unrelated separator


 The deterministic tool example is complete.

 Warning: Could not restore model anthropic/claude-sonnet-4-5. Using calm-e2e/delayed

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project (master)
↑7 ↓4 0.8%/4.1k (auto)                                                                                                                                                       delayed
```
</details>
<details>
<summary>Evidence: Calm-on hidden transcript</summary>

```text
  project
    /var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project/.pi/extensions/fm-calm-e2e-inject.ts
    /var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project/.pi/extensions/fm-calm.ts
    /var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project/.pi/extensions/fm-primary-pi-watch.ts

/var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project/.pi/extensions/fm-primary-turnend-guard.ts


 Show a deterministic tool example.


 I will run one command.


 FIRSTMATE WATCHER WAKE: can you explain this phrase?



 Captain quote: ⁣FIRSTMATE_OP: v1 watcher: QUOTED_CURRENT_NEAR_MISS



 FIRSTMATE_OP: v1 watcher: ASCII_ONLY_NEAR_MISS



 Ordinary captain text before ⁣FIRSTMATE_OP: v1 watcher: EMBEDDED_CURRENT_NEAR_MISS



 ⁣ordinary captain text after unrelated separator


 The deterministic tool example is complete.

 Warning: Could not restore model anthropic/claude-sonnet-4-5. Using calm-e2e/delayed

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project (master)
↑7 ↓4 0.8%/4.1k (auto)                                                                                                                                                       delayed
```
</details>
<details>
<summary>Evidence: Calm-on Working row</summary>

```text


 FIRSTMATE_OP: v1 watcher: ASCII_ONLY_NEAR_MISS



 Ordinary captain text before ⁣FIRSTMATE_OP: v1 watcher: EMBEDDED_CURRENT_NEAR_MISS



 ⁣ordinary captain text after unrelated separator


 The deterministic tool example is complete.

 Warning: Could not restore model anthropic/claude-sonnet-4-5. Using calm-e2e/delayed

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.

 Warning: CALM_TRANSIENT_DIAGNOSTIC

 Error: CALM_OPERATIONAL_E2E_ERROR

 Error: CALM_OPERATIONAL_E2E_ERROR

 Error: CALM_OPERATIONAL_E2E_ERROR

 Error: CALM_OPERATIONAL_E2E_ERROR

 Error: CALM_OPERATIONAL_E2E_ERROR

 Session exported to: /var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/calm-export.html


 CALM_WORKING_E2E_PROMPT


 ⠹ Working...

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project (master)
↑7 ↓4 2.8%/4.1k (auto)                                                                                                                                                       delayed
```
</details>
<details>
<summary>Evidence: Calm-on after restart</summary>

```text
fd not found. Offline mode enabled, skipping download.

 pi v0.81.1
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  fm-calm-e2e-inject.ts, fm-calm.ts, fm-primary-pi-watch.ts, fm-primary-turnend-guard.ts


 Show a deterministic tool example.


 I will run one command.


 FIRSTMATE WATCHER WAKE: can you explain this phrase?



 Captain quote: ⁣FIRSTMATE_OP: v1 watcher: QUOTED_CURRENT_NEAR_MISS



 FIRSTMATE_OP: v1 watcher: ASCII_ONLY_NEAR_MISS



 Ordinary captain text before ⁣FIRSTMATE_OP: v1 watcher: EMBEDDED_CURRENT_NEAR_MISS



 ⁣ordinary captain text after unrelated separator


 The deterministic tool example is complete.

 Error: CALM_OPERATIONAL_E2E_ERROR

 Error: CALM_OPERATIONAL_E2E_ERROR

 Error: CALM_OPERATIONAL_E2E_ERROR

 Error: CALM_OPERATIONAL_E2E_ERROR

 Error: CALM_OPERATIONAL_E2E_ERROR


 CALM_WORKING_E2E_PROMPT


 CALM_WORKING_E2E_RESPONSE

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project (master)
↑7 ↓4 3.8%/4.1k (auto)                                                                                                                                                       delayed
```
</details>
<details>
<summary>Evidence: Calm-off restoration after restart</summary>

```text

 pi v0.81.1
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  fm-calm-e2e-inject.ts, fm-calm.ts, fm-primary-pi-watch.ts, fm-primary-turnend-guard.ts


 Show a deterministic tool example.


 Thinking...

 I will run one command.


 $ printf 'CALM_E2E_OUTPUT
 '

 CALM_E2E_OUTPUT


 Thinking...


 grep /CALM_EXPORT_GREP/ in .

 sample.txt:1:CALM_EXPORT_GREP



 find CALM_EXPORT_FIND* in .

 CALM_EXPORT_FIND.txt


 Thinking...


 fm_watch_arm_pi
 watcher: started Pi extension arm child 1



 FIRSTMATE WATCHER WAKE: can you explain this phrase?



 Captain quote: ⁣FIRSTMATE_OP: v1 watcher: QUOTED_CURRENT_NEAR_MISS



 FIRSTMATE_OP: v1 watcher: ASCII_ONLY_NEAR_MISS



 Ordinary captain text before ⁣FIRSTMATE_OP: v1 watcher: EMBEDDED_CURRENT_NEAR_MISS



 ⁣ordinary captain text after unrelated separator


 The deterministic tool example is complete.


 ⁣FIRSTMATE_OP: v1 watcher: CURRENT_WATCHER_E2E /tmp/active-probe.status


 Error: CALM_OPERATIONAL_E2E_ERROR


 ⁣FIRSTMATE_OP: v1 turn-end-guard: CURRENT_TURN_END_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR


 ⁣FIRSTMATE_OP: v1 away-supervisor: CURRENT_AWAY_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR


 [fm-from-firstmate]⁣corr=0123456789abcdef CURRENT_FROM_FIRSTMATE_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR


 ⁣FIRSTMATE_OP: v1 launch-brief: CURRENT_LAUNCH_BRIEF_E2E


 Error: CALM_OPERATIONAL_E2E_ERROR


 CALM_WORKING_E2E_PROMPT


 CALM_WORKING_E2E_RESPONSE

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/fm-calm-pi-extension.oGz4wW/e2e-project (master)
↑7 ↓4 3.8%/4.1k (auto)                                                                                                                                                       delayed
```
</details>
- Evidence: Rendered Calm HTML export (local file: <code>/var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYBB98H9T8K4MN9XKFZMGX79/pi-0.81.1-calm-export-rendered.png</code>)
<details>
<summary>Evidence: Rendered Calm HTML export</summary>

```text
<!DOCTYPE html>
<html lang="en"><head>
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Session Export</title>
  <style>
    :root {
      --accent: #8abeb7;
      --border: #5f87ff;
      --borderAccent: #00d7ff;
      --borderMuted: #505050;
      --success: #b5bd68;
      --error: #cc6666;
      --warning: #ffff00;
      --muted: #808080;
      --dim: #666666;
      --text: #d4d4d4;
      --thinkingText: #808080;
      --selectedBg: #3a3a4a;
      --userMessageBg: #343541;
      --userMessageText: #d4d4d4;
      --customMessageBg: #2d2838;
      --customMessageText: #d4d4d4;
      --customMessageLabel: #9575cd;
      --toolPendingBg: #282832;
      --toolSuccessBg: #283228;
      --toolErrorBg: #3c2828;
      --toolTitle: #d4d4d4;
      --toolOutput: #808080;
      --mdHeading: #f0c674;
      --mdLink: #81a2be;
      --mdLinkUrl: #666666;
      --mdCode: #8abeb7;
      --mdCodeBlock: #b5bd68;
      --mdCodeBlockBorder: #808080;
      --mdQuote: #808080;
      --mdQuoteBorder: #808080;
      --mdHr: #808080;
      --mdListBullet: #8abeb7;
      --toolDiffAdded: #b5bd68;
      --toolDiffRemoved: #cc6666;
      --toolDiffContext: #808080;
      --syntaxComment: #6A9955;
      --syntaxKeyword: #569CD6;
      --syntaxFunction: #DCDCAA;
      --syntaxVariable: #9CDCFE;
      --syntaxString: #CE9178;
      --syntaxNumber: #B5CEA8;
      --syntaxType: #4EC9B0;
      --syntaxOperator: #D4D4D4;
      --syntaxPunctuation: #D4D4D4;
      --thinkingOff: #505050;
      --thinkingMinimal: #6e6e6e;
      --thinkingLow: #5f87af;
      --thinkingMedium: #81a2be;
      --thinkingHigh: #b294bb;
      --thinkingXhigh: #d183e8;
      --thinkingMax: #ff5fff;
      --bashMode: #b5bd68;
      --exportPageBg: #18181e;
      --exportCardBg: #1e1e24;
      --exportInfoBg: #3c3728;
      --body-bg: #18181e;
      --container-bg: #1e1e24;
      --info-bg: #3c3728;
    }

    * { margin: 0; padding: 0; box-sizing: border-box; }

    :root {
      --line-height: 18px; /* 12px font * 1.5 */
      --sidebar-width: 400px;
      --sidebar-min-width: 240px;
      --sidebar-max-width: 840px;
      --sidebar-resizer-width: 6px;
    }

    body {
      font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
      font-size: 12px;
      line-height: var(--line-height);
      color: var(--text);
      background: var(--body-bg);
    }

    body.sidebar-resizing {
      cursor: col-resize;
      user-select: none;
    }

    #app {
      display: flex;
      min-height: 100vh;
    }

    /* Sidebar */
    #sidebar {
      width: var(--sidebar-width);
      min-width: var(--sidebar-width);
      max-width: var(--sidebar-width);
      background: var(--container-bg);
      flex-shrink: 0;
      display: flex;
      flex-direction: column;
      position: sticky;
      top: 0;
      height: 100vh;
      border-right: 1px solid var(--dim);
    }

    #sidebar-resizer {
      width: var(--sidebar-resizer-width);
      flex-shrink: 0;
      position: sticky;
      top: 0;
      height: 100vh;
      cursor: col-resize;
      touch-action: none;
      background: transparent;
      border-right: 1px solid transparent;
    }

    #sidebar-resizer:hover,
    body.sidebar-resizing #sidebar-resizer {
      background: var(--selectedBg);
      border-right-color: var(--dim);
    }

    .sidebar-header {
      padding: 8px 12px;
      flex-shrink: 0;
    }

    .sidebar-controls {
      padding: 8px 8px 4px 8px;
    }

    .sidebar-search {
      width: 100%;
      box-sizing: border-box;
      padding: 4px 8px;
      font-size: 11px;
      font-family: inherit;
      background: var(--body-bg);
      color: var(--text);
      border: 1px solid var(--dim);
      border-radius: 3px;
    }

    .sidebar-filters {
      display: flex;
      padding: 4px 8px 8px 8px;
      gap: 4px;
      align-items: center;
      flex-wrap: wrap;
    }

    .sidebar-search:focus {
      outline: none;
      border-color: var(--accent);
    }

    .sidebar-search::placeholder {
      color: var(--muted);
    }

    .filter-btn {
      padding: 3px 8px;
      font-size: 10px;
      font-family: inherit;
      background: transparent;
      color: var(--muted);
      border: 1px solid var(--dim);
      border-radius: 3px;
      cursor: pointer;
    }

    .filter-btn:hover {
      color: var(--text);
      border-color: var(--text);
    }

    .filter-btn.active {
      background: var(--accent);
      color: var(--body-bg);
      border-color: var(--accent);
    }

    .sidebar-close {
      display: none;
      padding: 3px 8px;
      font-size: 12px;
      font-family: inherit;
      background: transparent;
      color: var(--muted);
      border: 1px solid var(--dim);
      border-radius: 3px;
      cursor: pointer;
      margin-left: auto;
    }

    .sidebar-close:hover {
      color: var(--text);
      border-color: var(--text);
    }

    .tree-container {
      flex: 1;
      overflow: auto;
      padding: 4px 0;
    }

    .tree-node {
      padding: 0 8px;
      cursor: pointer;
      display: flex;
      align-items: baseline;
      font-size: 11px;
      line-height: 13px;
      white-space: nowrap;
    }

    .tree-node:hover {
      background: var(--selectedBg);
    }

    .tree-node.active {
      background: var(--selectedBg);
    }

    .tree-node.active .tree-content {
      font-weight: bold;
    }

    .tree-node.in-path {
      background: color-mix(in srgb, var(--accent) 10%, transparent);
    }

    .tree-node:not(.in-path) {
      opacity: 0.5;
    }

    .tree-node:not(.in-path):hover {
      opacity: 1;
    }

    .tree-prefix {
      color: var(--muted);
      flex-shrink: 0;
      font-family: monospace;
      white-space: pre;
    }

    .tree-marker {
      color: var(--accent);
      flex-shrink: 0;
    }

    .tree-content {
      color: var(--text);
    }

    .tree-role-user {
      color: var(--accent);
    }

    .tree-role-skill {
      color: var(--customMessageLabel);
    }

    .tree-role-assistant {
      color: var(--success);
    }

    .tree-role-tool {
      color: var(--muted);
    }

    .tree-muted {
      color: var(--muted);
    }

    .tree-error {
      color: var(--error);
    }

    .tree-compaction {
      color: var(--borderAccent);
    }

    .tree-branch-summary {
      color: var(--warning);
    }

    .tree-custom-message {
      color: var(--customMessageLabel);
    }

    .tree-status {
      padding: 4px 12px;
      font-size: 10px;
      color: var(--muted);
      flex-shrink: 0;
    }

    /* Main content */
    #content {
      flex: 1;
      min-width: 0;
      overflow-y: auto;
      padding: var(--line-height) calc(var(--line-height) * 2);
      display: flex;
      flex-direction: column;
      align-items: center;
    }

    #content > * {
      width: 100%;
      max-width: 800px;
    }

    /* Help bar */
    .help-bar {
      font-size: 11px;
      color: var(--warning);
      margin-bottom: var(--line-height);
      display: flex;
      align-items: center;
      justify-content: space-between;
      flex-wrap: wrap;
      gap: 12px;
    }

    .help-hint {
      flex: 1 1 240px;
    }

    .help-actions {
      display: flex;
      align-items: center;
      flex-wrap: wrap;
      gap: 8px;
    }

    .header-toggle-btn,
    .download-json-btn {
      font-size: 10px;
      padding: 2px 8px;
      background: var(--container-bg);
      border: 1px solid var(--border);
      border-radius: 3px;
      color: var(--text);
      cursor: pointer;
      font-family: inherit;
    }

    .header-toggle-btn:hover,
    .download-json-btn:hover {
      background: var(--hover);
      border-color: var(--borderAccent);
    }

    /* Header */
    .header {
      background: var(--container-bg);
      border-radius: 4px;
      padding: var(--line-height);
      margin-bottom: var(--line-height);
    }

    .header h1 {
      font-size: 12px;
      font-weight: bold;
      color: var(--borderAccent);
      margin-bottom: var(--line-height);
    }

    .header-info {
      display: flex;
      flex-direction: column;
      gap: 0;
      

... [317439 bytes truncated] ...

ne code: escape HTML
          codespan(token) {
            return `<code>${escapeHtml(token.text)}</code>`;
          }
        }
      });

      // Simple marked parse (escaping handled in renderers)
      function safeMarkedParse(text) {
        return marked.parse(text);
      }

      // Search input
      const searchInput = document.getElementById('tree-search');
      searchInput.addEventListener('input', (e) => {
        searchQuery = e.target.value;
        forceTreeRerender();
      });

      // Filter buttons
      document.querySelectorAll('.filter-btn').forEach(btn => {
        btn.addEventListener('click', () => {
          document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
          btn.classList.add('active');
          filterMode = btn.dataset.filter;
          forceTreeRerender();
        });
      });

      // Sidebar toggle
      const sidebar = document.getElementById('sidebar');
      const overlay = document.getElementById('sidebar-overlay');
      const hamburger = document.getElementById('hamburger');
      const sidebarResizer = document.getElementById('sidebar-resizer');
      const SIDEBAR_WIDTH_STORAGE_KEY = 'pi-share:v1:sidebar-width';
      const MIN_CONTENT_WIDTH = 320;

      function isMobileLayout() {
        return window.matchMedia('(max-width: 900px)').matches;
      }

      function getSidebarBounds() {
        const rootStyles = getComputedStyle(document.documentElement);
        const minWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-min-width')) || 240;
        const maxWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-max-width')) || 720;
        const viewportMaxWidth = window.innerWidth - MIN_CONTENT_WIDTH;
        return {
          minWidth,
          maxWidth: Math.max(minWidth, Math.min(maxWidth, viewportMaxWidth))
        };
      }

      function clampSidebarWidth(width) {
        const { minWidth, maxWidth } = getSidebarBounds();
        return Math.max(minWidth, Math.min(maxWidth, width));
      }

      function applySidebarWidth(width) {
        document.documentElement.style.setProperty('--sidebar-width', `${Math.round(clampSidebarWidth(width))}px`);
      }

      function loadSidebarWidth() {
        try {
          const raw = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
          if (raw === null) return null;
          const width = Number(raw);
          return Number.isFinite(width) ? width : null;
        } catch {
          return null;
        }
      }

      function saveSidebarWidth(width) {
        try {
          localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(Math.round(clampSidebarWidth(width))));
        } catch {
          // Ignore storage failures (e.g. private browsing restrictions)
        }
      }

      function setupSidebarResize() {
        const savedWidth = loadSidebarWidth();
        if (savedWidth !== null) {
          applySidebarWidth(savedWidth);
        }

        if (!sidebarResizer) return;

        let cleanupDrag = null;

        const stopDrag = (pointerId) => {
          if (cleanupDrag) {
            cleanupDrag(pointerId);
            cleanupDrag = null;
          }
        };

        sidebarResizer.addEventListener('pointerdown', (e) => {
          if (isMobileLayout()) return;

          e.preventDefault();
          const startX = e.clientX;
          const startWidth = sidebar.getBoundingClientRect().width;
          document.body.classList.add('sidebar-resizing');
          sidebarResizer.setPointerCapture?.(e.pointerId);

          const onPointerMove = (event) => {
            applySidebarWidth(startWidth + (event.clientX - startX));
          };

          cleanupDrag = (pointerIdToRelease) => {
            document.body.classList.remove('sidebar-resizing');
            sidebarResizer.releasePointerCapture?.(pointerIdToRelease);
            window.removeEventListener('pointermove', onPointerMove);
            window.removeEventListener('pointerup', onPointerUp);
            window.removeEventListener('pointercancel', onPointerCancel);
            saveSidebarWidth(sidebar.getBoundingClientRect().width);
          };

          const onPointerUp = (event) => stopDrag(event.pointerId);
          const onPointerCancel = (event) => stopDrag(event.pointerId);

          window.addEventListener('pointermove', onPointerMove);
          window.addEventListener('pointerup', onPointerUp);
          window.addEventListener('pointercancel', onPointerCancel);
        });

        sidebarResizer.addEventListener('dblclick', () => {
          if (isMobileLayout()) return;
          applySidebarWidth(400);
          saveSidebarWidth(400);
        });

        window.addEventListener('resize', () => {
          if (isMobileLayout()) return;
          applySidebarWidth(sidebar.getBoundingClientRect().width);
        });
      }

      setupSidebarResize();

      hamburger.addEventListener('click', () => {
        sidebar.classList.add('open');
        overlay.classList.add('open');
        hamburger.style.display = 'none';
      });

      const closeSidebar = () => {
        sidebar.classList.remove('open');
        overlay.classList.remove('open');
        hamburger.style.display = '';
      };

      overlay.addEventListener('click', closeSidebar);
      document.getElementById('sidebar-close').addEventListener('click', closeSidebar);

      // Toggle states
      let thinkingExpanded = true;
      let toolOutputsExpanded = false;

      const toggleThinking = () => {
        thinkingExpanded = !thinkingExpanded;
        document.querySelectorAll('.thinking-text').forEach(el => {
          el.style.display = thinkingExpanded ? '' : 'none';
        });
        document.querySelectorAll('.thinking-collapsed').forEach(el => {
          el.style.display = thinkingExpanded ? 'none' : 'block';
        });
      };

      const toggleToolOutputs = () => {
        toolOutputsExpanded = !toolOutputsExpanded;
        document.querySelectorAll('.tool-output.expandable').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
        document.querySelectorAll('.compaction').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
        document.querySelectorAll('.skill-invocation').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
      };

      const attachHeaderHandlers = () => {
        document.querySelector('[data-action="toggle-thinking"]')?.addEventListener('click', toggleThinking);
        document.querySelector('[data-action="toggle-tools"]')?.addEventListener('click', toggleToolOutputs);
      };

      const isEditableTarget = (element) => {
        if (!element) return false;
        const tagName = element.tagName;
        if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT' || tagName === 'BUTTON') {
          return true;
        }
        return element.isContentEditable || Boolean(element.closest?.('[contenteditable="true"]'));
      };

      // Keyboard shortcuts
      document.addEventListener('keydown', (e) => {
        if (e.key === 'Escape') {
          searchInput.value = '';
          searchQuery = '';
          navigateTo(leafId, 'bottom');
        }

        if (isEditableTarget(document.activeElement)) {
          return;
        }

        const key = e.key.toLowerCase();
        if (key === 't') {
          e.preventDefault();
          toggleThinking();
        } else if (key === 'o') {
          e.preventDefault();
          toggleToolOutputs();
        }
      });

      // Initial render
      // If URL has targetId, scroll to that specific message; otherwise stay at top
      if (leafId) {
        if (urlTargetId && byId.has(urlTargetId)) {
          // Deep link: navigate to leaf and scroll to target message
          navigateTo(leafId, 'target', urlTargetId);
        } else {
          navigateTo(leafId, 'none');
        }
      } else if (entries.length > 0) {
        // Fallback: use last entry if no leafId
        navigateTo(entries[entries.length - 1].id, 'none');
      }
    })();

  </script>


</body></html>
```
</details>
<details>
<summary>Evidence: End-user evidence checks</summary>

```text
verified: Ctrl+O frame contains expanded help + CALM_E2E_OUTPUT
verified: Calm-on hides CALM_E2E_OUTPUT while Working remains visible
verified: restart preserves Calm-on and toggling off restores CALM_E2E_OUTPUT
verified: HTML export rendered a conversation DOM
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --histogram b05eb244ce10f83192a95457b5e2b15c49b4e763..8eddef70e8e999b70c755de5eeb3e28cf60cb254 -- tests/fm-calm-pi-extension.test.sh`
- <code>`pi --version` (verified 0.81.1)</code>
- `tests/fm-calm-pi-extension.test.sh`
- <code>Second complete `tests/fm-calm-pi-extension.test.sh` run with final capture-directory retention</code>
- `tests/fm-pi-primary-types.test.sh`
- `tests/fm-pi-watch-extension.test.sh`
- `Headless Chrome rendering of the generated Calm export HTML`
- `Manual artifact assertions for Ctrl+O settling, Calm-on hiding, Working visibility, restart persistence, Calm-off restoration, and export DOM`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
