### PR TITLE
feat(harness): verify Copilot CLI as dispatch + foreground-checkpoint primary

### DIFF
--- a/.agents/skills/firstmate-orca/SKILL.md
+++ b/.agents/skills/firstmate-orca/SKILL.md
@@ -13,7 +13,7 @@ It does not replace `AGENTS.md`, `docs/orca-backend.md`, or `harness-adapters`.
 
 Orca is a runtime backend, not an agent harness.
 The runtime backend owns the task endpoint and, for Orca, the task worktree.
-The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, or `grok`.
+The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, `grok`, or `copilot`.
 Load `harness-adapters` for harness-specific launch, interrupt, resume, trust-dialog, and skill-invocation facts.
 
 Implementation details, metadata fields, teardown guarantees, limitations, and smoke evidence live in `docs/orca-backend.md`.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and copilot (crew/secondmate dispatch plus foreground-checkpoint primary).
 user-invocable: false
 metadata:
   internal: true
@@ -50,15 +50,16 @@ Use that value for interrupt, exit, resume, and skill-invocation facts.
 
 ## Primary turn-end guard
 
-Every verified primary harness has an empirically validated hook path for the "no turn ends blind" guard.
+Every hook-integrated primary harness (`claude`, `codex`, `opencode`, `pi`, `grok`) has an empirically validated hook path for the "no turn ends blind" guard.
 `claude` and `codex` block directly through Stop hooks that preserve exit status 2 and stderr from `bin/fm-turnend-guard.sh`.
 `opencode`, `pi`, and `grok` expose passive lifecycle callbacks for this purpose, so their tracked primary adapters force one bounded follow-up or resume when the shared predicate blocks.
+`copilot` is the exception: its hooks cannot block a stop or force a continued turn (only `preToolUse` can approve/deny, and that fires before a tool call), so it has no turn-end guard and relies solely on its foreground checkpoint loop - see `docs/turnend-guard.md`.
 The exact hook files, commands, validation transcripts, scoping rules, and fail-open tradeoffs are owned by `docs/turnend-guard.md`.
 When changing any primary turn-end hook, validate the real harness behavior in a scratch project or throwaway home before trusting it, then update that doc and the relevant concise fact below.
 
 ## Primary pre-arm (PreToolUse) seatbelt
 
-Every verified primary harness also has a wired PreToolUse-equivalent hook that denies a watcher-arm anti-pattern (shell `&`, truncating pipe, bundling, broad `pkill -f fm-watch`) before it runs.
+Every hook-integrated primary harness (`claude`, `codex`, `opencode`, `pi`, `grok`) also has a wired PreToolUse-equivalent hook that denies a watcher-arm anti-pattern (shell `&`, truncating pipe, bundling, broad `pkill -f fm-watch`) before it runs.
 `claude` and `codex` block directly through PreToolUse hooks; `grok` blocks the same way but requires every `$VAR` reference in its hook `command` string to carry an inline `:-default` or it fails to launch the hook entirely.
 `opencode` and `pi` block by throwing from `tool.execute.before` / returning `{block: true}` from `tool_call`.
 The exact hook files, commands, output-shaping quirks (Claude Code only honors the deny when stdout is empty), and validation transcripts are owned by `docs/arm-pretool-check.md`.
@@ -119,6 +120,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-13 on Pi 0.80.6. `pi --help` advertises `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; `pi --print --model openai-codex/gpt-5.6-sol --thinking max 'Reply with exactly OK.'` completed successfully. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| copilot | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-21 on copilot 1.0.73. `--effort` (alias `--reasoning-effort`) advertises `none\|minimal\|low\|medium\|high\|xhigh\|max`, a superset of firstmate's vocabulary, and `--effort low` launched and ran a turn unattended live. The model catalog includes `claude-*`, `gpt-5.6-*`, `gemini-*`, `kimi-*`, and `auto`; `--model claude-haiku-4.5` verified live (the footer showed the selected model). |
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
@@ -132,6 +134,7 @@ Natural language is acceptable if uncertain.
 - codex: `$<skill>`, for example `$no-mistakes`; `/<skill>` is claude-only and codex rejects it as "Unrecognized command".
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
+- copilot: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified live on 1.0.73: copilot discovers `no-mistakes` from `~/.agents/skills/` (its "Personal" source; project skills load from `.github/skills/`, `.agents/skills/`, or `.claude/skills/`), typing `/no-mistakes` opens a slash-autocomplete popup listing the skill with its description, and one Enter submits it - the model then invokes its `skill(no-mistakes)` tool. Unlike grok/codex, the popup did NOT swallow the first Enter for exact-typed command text on the tmux backend (fm-send's 1.2s `/`-settle was in effect; its retried Enter remains the safety net).
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) already handles this correctly by reading the cursor row; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 
 ## claude (VERIFIED)
@@ -316,3 +319,40 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## copilot (VERIFIED 2026-07-21, GitHub Copilot CLI 1.0.73 - crew/secondmate dispatch and foreground-checkpoint primary; no turn-end guard)
+
+GitHub Copilot CLI (`copilot`), an interactive TUI harness.
+Launch with the prompt as the `-i` flag's VALUE, the brief encoded through the shared operational-input encoder like every other harness: `copilot --allow-all --no-ask-user -i "$(<opinput> encode launch-brief < <brief>)"` - `-i/--interactive` starts the supervised interactive session and auto-executes the prompt, while `-p/--prompt` exits after one turn and is unsuitable for a steerable crewmate.
+For copilot's supported model and effort flags, see the [launch-profile-axes table](#launch-profile-axes).
+Every fact below was verified live in throwaway sessions on the tmux backend (private `tmux -L` server, scratch git repos, 2026-07-21).
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `<spinner> Working · <bytes> esc interrupt` (e.g. `◎ Working · 916 B esc interrupt`), shown iff a turn is running; matched by the existing `esc (to )?interrupt` busy-regex alternative, so no copilot-specific regex entry exists. Idle footer is `/ commands · ? help · tab next tab`. |
+| Exit command | `/exit` typed into the composer (give the slash popup a settle before Enter; `fm-send`'s 1.2s `/`-settle suffices). On exit copilot prints session stats plus `Resume  copilot --resume=<session-id>`. |
+| Interrupt | `Ctrl+C` mid-turn (prints `Operation aborted by user` / `Operation cancelled by user`). The busy footer advertises `esc interrupt`, but Esc pressed twice did NOT cancel a running sync shell tool in live testing - use Ctrl+C. On an IDLE composer Ctrl+C instead arms exit (footer shows `ctrl+c again to exit`), so never send it to an idle pane. |
+| Skill invocation | `/<skill>` (e.g. `/no-mistakes`), same form as claude - see the no-mistakes skill invocation list above for the popup and discovery details. |
+| Autonomy | `--allow-all` (equivalent to `--allow-all-tools --allow-all-paths --allow-all-urls`; `--yolo` is its documented alias, also verified live) plus `--no-ask-user` so the `ask_user` tool never stalls the crew. Verified: a shell-touching turn ran fully unattended with no permission prompt after folder trust. |
+| Composer | A bare `❯` glyph row between two horizontal rules, no box border. The glyph is truecolor `38;2;134;134;134` (luminance 134, at/above the ghost-strip threshold) and real typed text renders in the default foreground, so the shared classifier reads idle as `empty` and typed-unsubmitted as `pending` with no `FM_COMPOSER_IDLE_RE` override (verified through `fm_tmux_composer_state` live). |
+| Submit | One Enter submits plain text AND an exact-typed `/<skill>` command on tmux (composer clears immediately; no popup Enter-swallow reproduced there). The herdr adapter's structural bare-prompt scan (`^[❯›]`) matches copilot's composer row, so its settle-plus-retried-Enter submit path applies; live end-to-end herdr steer verification is still pending (see the herdr note below). |
+| Env / detection | `ps -o comm=` reports `MainThread` (the bundled ELF renames its main thread) while `ps -o args=` is exactly `copilot ...`; tmux's `#{pane_current_command}` is cmdline-derived and reports `copilot`. Detection and the session lock ride the anchored args path (`bin/fm-harness.sh`, `bin/fm-lock.sh`). |
+| Resume | `copilot --resume=<session-id>` (printed on exit), `--continue` (most recent), `-r/--resume[=id|name]`, or `--session-id <id>`. |
+
+Folder trust dialog: "Confirm folder trust" appears on EVERY launch in a not-yet-remembered folder, including every fresh task worktree, with `❯ 1. Yes` preselected (option 2 remembers the folder; firstmate does not use it so no durable trust is accumulated for disposable worktrees).
+Accept with Enter from an active firstmate session using `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Enter`, the same post-spawn peek-within-20-seconds handling as claude.
+The `-i` prompt auto-executes immediately after the dialog is accepted (verified: the brief turn started and its shell command ran with no further keystroke).
+
+Turn-end hook: copilot loads repo-level hooks from `<git-root>/.github/hooks/*.json` with no gate beyond the same folder-trust dialog, and fires `agentStop` at every COMPLETED turn boundary (payload includes `stopReason: "end_turn"` and a `stop_hook_active` field; verified with a probe hook - two completed turns fired exactly two `agentStop` events).
+`fm-spawn` therefore writes `<worktree>/.github/hooks/fm-turn-end.json` (an `agentStop` hook touching `state/<id>.turn-ended`), git-excluded via info/exclude and removed by `fm-teardown` before a pooled worktree is returned, exactly the claude `.claude/settings.local.json` shape.
+A user-CANCELLED turn fires no `agentStop` (verified: a Ctrl+C-aborted turn left the count unchanged), which the watcher's pane-staleness backstop covers.
+`sessionStart` (with `initialPrompt`), `preToolUse`/`postToolUse` (with `toolName`/`toolArgs`), and `sessionEnd` (on `/exit`) also fired in the same probe; `userPromptSubmit` and other guessed event names never fired.
+Secondmate spawns skip the hook file (idle panes are healthy, no stale-pane detection for them).
+
+Herdr backend note: the original dispatch-parity observation (a brief typed into copilot's composer via herdr needed a separate Enter) is the shape `fm_backend_herdr_send_text_submit` already handles - it types, settles, then retries Enter until herdr's native agent state or the composer read confirms the submit.
+Copilot's composer rows classify correctly through the shared herdr path (regression-fixtured in `tests/fm-backend-herdr.test.sh` with real captured ANSI rows), but a live herdr end-to-end steer to a copilot crew has not been run yet; treat the first herdr-backed copilot dispatch as a supervised verification of that last step.
+
+Primary supervision: copilot runs a firstmate primary through the codex-style foreground checkpoint (`docs/supervision-protocols/copilot.md`, rendered by `bin/fm-supervision-instructions.sh`), because it cannot reason while a foreground tool call runs, exactly like codex.
+It has NO turn-end guard: copilot hooks cannot block a stop or force a continued turn (only `preToolUse` approves/denies, before a tool call), so the active checkpoint loop is its only supervision backstop - see `docs/turnend-guard.md`.
+Still unbuilt for copilot primary: the PreToolUse watcher-arm seatbelt and the session-start nudge (copilot's `preToolUse` and `sessionStart` hooks exist and could carry them, but the adapters are not written or validated yet).
+A copilot-driven home gets the session lock, own-harness detection, crew/secondmate dispatch, and foreground-checkpoint supervision.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
 The verified harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; never dispatch on an unverified adapter.
+GitHub Copilot CLI (`copilot`) is additionally verified for crewmate and secondmate dispatch, is recognized for session-lock and own-harness detection, and supervises as a primary through the codex-style foreground checkpoint; it has no blocking turn-end guard backstop, so its active checkpoint loop is the only supervision safety net.
 If configured harness data names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-dispatch-select.sh` owns selector mechanics, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -181,7 +181,10 @@ fm_backend_tmux_agent_state() {  # <target>
   }
   comm=${comm#-}
   case "$comm" in
-    *claude*|*codex*|*opencode*|*grok*) printf 'alive' ;;
+    # copilot's ELF renames its main thread (ps comm "MainThread"), but tmux's
+    # #{pane_current_command} is cmdline-derived and reports "copilot" (verified
+    # live, copilot 1.0.73 with tmux 3.x, 2026-07-21).
+    *claude*|*codex*|*opencode*|*grok*|*copilot*) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     '') printf 'unreadable' ;;
     *) printf 'ambiguous' ;;

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -438,7 +438,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
     case "$harness" in
-      claude|codex|opencode|pi|grok) ;;
+      claude|codex|opencode|pi|grok|copilot) ;;
       *)
         case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
         ;;
@@ -715,7 +715,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","copilot"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -723,6 +723,7 @@ crew_dispatch_validate() {
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "copilot" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" then false
       else true
       end;

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -19,8 +19,11 @@
 # container - a bordered composer box, where the harness draws its own prompt
 # glyph (e.g. claude's older `| > ... |`). On a bare, unstructured row it is a
 # dead-shell prompt and is NEVER "empty"; it classifies as `unknown` (not a safe
-# injection target). The AGENT prompt glyphs `❯` (claude) and `›` (codex) are a
-# genuine empty agent composer either way, bordered or bare.
+# injection target). The AGENT prompt glyphs `❯` (claude, and copilot's own
+# composer glyph - verified copilot 1.0.73, 2026-07-21: a bare `❯` styled
+# truecolor 38;2;134;134;134 between two horizontal rules, no box border, real
+# typed text in the default foreground) and `›` (codex) are a genuine empty
+# agent composer either way, bordered or bare.
 #
 # GHOST/PLACEHOLDER TEXT is the other half of this owner (task
 # afk-herdr-false-pending): a harness fills an otherwise-empty composer with

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|copilot|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -45,9 +45,21 @@ detect_own() {
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       pi) echo pi; return ;;
-      node*|python*)
+      copilot) echo copilot; return ;;
+      node*|python*|MainThread)
         # Bare interpreter: match the harness name in its script path.
+        # MainThread is GitHub Copilot CLI's comm (verified 2026-07-21, copilot
+        # 1.0.73: the bundled ELF renames its main thread and its args are
+        # exactly "copilot"). copilot's glob is anchored to a standalone word
+        # or a path-prefixed argv[0] so argv like
+        # ".../extensions/copilot --locale" never matches.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
+        case "$args" in
+          copilot|"copilot "*) echo copilot; return ;;
+        esac
+        case "${args%% *}" in
+          */copilot) echo copilot; return ;;
+        esac
         case "$args" in
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,7 +15,16 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+# copilot (GitHub Copilot CLI) is recognized for the session lock and
+# own-harness detection, and is a verified dispatchable crew/secondmate harness
+# (still not a verified primary). Verified 2026-07-21 on copilot 1.0.73:
+# its bundled ELF renames the main thread, so `ps -o comm=` reports "MainThread"
+# while `ps -o args=` is exactly "copilot"; recognition therefore rides the args
+# path. The copilot alternatives are anchored to a standalone word or a
+# path-prefixed argv[0] (e.g. "/home/x/.local/bin/copilot --allow-all") so
+# unrelated argv such as ".../extensions/copilot --locale" or
+# "@vscode/copilot-typescript-server-plugin" never matches.
+HARNESS_RE='claude|codex|opencode|grok|^pi$|(^| )copilot( |$)|^[^ ]*/copilot( |$)'
 
 harness_pid() {
   local pid=$$ comm args
@@ -26,8 +35,9 @@ harness_pid() {
       echo "$pid"; return 0
     fi
     # Bare interpreter (e.g. node): match the harness name in its script path.
+    # MainThread is copilot's comm (see HARNESS_RE note); its args carry the name.
     case "$comm" in
-      *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
+      *node*|*python*|MainThread) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
@@ -39,7 +49,17 @@ holder_alive() {  # true if $1 is a live process that looks like a harness
   local pid=$1 comm
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
+    return 0
+  fi
+  # Only trust args when comm is a bare interpreter or copilot's MainThread,
+  # mirroring harness_pid; otherwise a recycled pid whose argv merely mentions
+  # a harness name (e.g. "gh copilot suggest") would look like a live holder.
+  case "$comm" in
+    *node*|*python*|MainThread)
+      printf '%s' "$(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE" ;;
+    *) return 1 ;;
+  esac
 }
 
 if [ "${1:-}" = "status" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -59,7 +59,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|copilot)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -386,7 +386,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|copilot)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -447,6 +447,19 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # copilot (GitHub Copilot CLI): -i/--interactive takes the prompt as its VALUE
+    # (verified 1.0.73: it starts the supervised interactive session and
+    # auto-executes the prompt; -p/--prompt would exit after one turn, unsuitable
+    # for a steerable crewmate). --allow-all enables every permission
+    # (tools+paths+URLs; --yolo is its documented alias), and --no-ask-user
+    # disables the ask_user tool so the crew never stalls on a question - both
+    # verified to run a shell-touching turn fully unattended after the folder
+    # trust dialog is accepted (see harness-adapters for the dialog handling).
+    # The brief rides the shared operational-input encoder like every other
+    # harness so steering and marked returns stay consistent. copilot's turn-end
+    # signal does not ride the launch command - it is a repo-level agentStop hook
+    # installed below, so the template is identical for ship/scout/secondmate.
+    copilot) printf '%s' 'copilot --allow-all --no-ask-user __MODELFLAG____EFFORTFLAG__-i "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -534,7 +547,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|grok)
+    claude|codex|opencode|pi|grok|copilot)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -571,6 +584,15 @@ effort_flag_for_harness() {
       # its --thinking flag.
       case "$effort" in
         low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
+      esac
+      ;;
+    copilot)
+      # copilot 1.0.73's --effort (alias --reasoning-effort) advertises
+      # none|minimal|low|medium|high|xhigh|max - a superset of firstmate's
+      # shared effort vocabulary, so every firstmate value passes through
+      # (verified live: --effort low launched and ran a turn unattended).
+      case "$effort" in
+        low|medium|high|xhigh|max) printf -- '--effort %s ' "$(shell_quote "$effort")" ;;
       esac
       ;;
     # opencode's interactive `opencode --prompt` launch has a verified --model
@@ -1233,6 +1255,20 @@ EOF
       ;;
     codex*)
       # codex: turn-end rides the launch command via -c notify=[...] and __TURNEND__.
+      ;;
+    copilot*)
+      # copilot loads repo-level hooks from <git-root>/.github/hooks/*.json with
+      # no trust gate beyond the standard folder-trust dialog the launch already
+      # passes through, and fires agentStop at every COMPLETED turn boundary
+      # (verified 1.0.73: two turns fired two agentStop events with
+      # stopReason=end_turn; a user-cancelled turn fires none, which the
+      # watcher's staleness backstop covers). The "bash" command runs on Unix;
+      # "powershell" would be the Windows key, not needed for this fleet.
+      mkdir -p "$WT/.github/hooks"
+      cat > "$WT/.github/hooks/fm-turn-end.json" <<EOF
+{"version":1,"hooks":{"agentStop":[{"type":"command","bash":"touch '$TURNEND'","timeoutSec":10}]}}
+EOF
+      exclude_path '.github/hooks/fm-turn-end.json'
       ;;
     grok*)
       # grok fires a Stop hook at every turn boundary (verified, grok 0.2.73), the

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -81,7 +81,7 @@ if [ -z "$HARNESS" ]; then
 fi
 
 case "$HARNESS" in
-  claude|codex|opencode|pi|grok) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
+  claude|codex|opencode|pi|grok|copilot) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
   *) HARNESS=unknown; SNIPPET="$DOC_DIR/unknown.md" ;;
 esac
 [ -f "$SNIPPET" ] || SNIPPET="$DOC_DIR/unknown.md"
@@ -136,7 +136,7 @@ repair_line() {
     claude)
       printf '%s%s\n' "$prefix" 'repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task, never shell &.'
       ;;
-    codex)
+    codex|copilot)
       printf '%s%s%s%s\n' "$prefix" 'repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds ' "$checkpoint_seconds" '.'
       ;;
     pi)
@@ -159,7 +159,7 @@ ordinary_wake_line() {
     claude)
       printf '%s\n' '- Ordinary wake: re-arm exactly one bin/fm-watch-arm.sh Claude Code background task as directed below.'
       ;;
-    codex)
+    codex|copilot)
       printf '%s\n' '- Ordinary wake: take the next foreground bin/fm-watch-checkpoint.sh checkpoint as directed below.'
       ;;
     pi)
@@ -203,6 +203,9 @@ else
   printf '%s\n' '- X mode: inactive; use the default watcher cadence.'
 fi
 ordinary_wake_line
+if [ "$HARNESS" = copilot ]; then
+  printf '%s\n' '- Harness note: copilot supervises through the same foreground checkpoint as codex, but it has no blocking turn-end guard backstop (copilot hooks cannot force a continued turn), so the active checkpoint loop is the only supervision safety net; if it ever stops, resume it promptly per the protocol below.'
+fi
 printf '\n'
 render_snippet
 printf '\n'

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -672,7 +672,7 @@ validate_worktree_teardown_safety() {
     echo "Restore the git index state, or get the captain's explicit OK to discard, then --force." >&2
     return 1
   fi
-  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$)' | head -1 || true)
+  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$|\.github/hooks/fm-turn-end\.json$)' | head -1 || true)
 
   if ! unpushed_raw=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null); then
     if worktree_safety_blocked_by_lock "commits not on a remote"; then
@@ -1002,12 +1002,12 @@ cleanup_firstmate_home_children() {
     elif [ "$child_backend" = orca ]; then
       if [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
         validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend" "$child_wt/.github/hooks/fm-turn-end.json"
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend" "$child_wt/.github/hooks/fm-turn-end.json"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
         if teardown_treehouse_return "$child_wt" "$child_proj" "child worktree"; then
           :
@@ -1114,7 +1114,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
         git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
       fi
     fi
-    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend" "$WT/.github/hooks/fm-turn-end.json"
   fi
   [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
   fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
@@ -1126,7 +1126,7 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend" "$WT/.github/hooks/fm-turn-end.json"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
   # the project. teardown_treehouse_return tolerates transient and stale git locks

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -62,7 +62,11 @@
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
-# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
+# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73);
+# copilot: "<spinner> Working · <bytes> esc interrupt" (shown iff a turn is
+# running; idle footer is "/ commands · ? help · tab next tab" - verified
+# copilot 1.0.73, 2026-07-21), already matched by the "esc (to )?interrupt"
+# alternative, so the regex needs no copilot-specific entry.
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
 
 # fm_tmux_strip_ghost: thin adapter over the shared, fleet-wide ghost extractor

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -104,7 +104,10 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
-# locale fragility of matching grok's braille spinner glyph directly).
+# locale fragility of matching grok's braille spinner glyph directly);
+# copilot: "<spinner> Working · <bytes> esc interrupt" iff a turn is running
+# (verified copilot 1.0.73, 2026-07-21), covered by the existing
+# "esc (to )?interrupt" alternative with no copilot-specific entry.
 BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,7 +144,7 @@ The session-start bootstrap step keeps valid dispatch configuration silent unles
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and copilot while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,6 +175,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 ## Harness support
 
 claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+GitHub Copilot CLI (`copilot`) is additionally recognized for the session lock and own-harness detection, so a copilot-driven home can hold its own lock, and is a verified crewmate/secondmate dispatch harness whose empirical facts live in the `harness-adapters` skill; as a primary it supervises through the codex-style foreground checkpoint (`docs/supervision-protocols/copilot.md`), but has no blocking turn-end guard backstop because Copilot hooks cannot force a continued turn (see `docs/turnend-guard.md`).
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -534,7 +534,7 @@ The tmux backend was NOT affected by this incident: `fm_tmux_composer_state` rea
 **Fix:** `fm_backend_herdr_composer_state` replaced the delta-based check with a structural read of the composer's OWN row, mirroring what the cursor-row read gives tmux.
 Herdr's CLI exposes no cursor-row primitive, so the composer row is located by shape instead of position.
 For bordered composers, the row is the only line in a generous tail capture whose trimmed content both starts and ends with the same border glyph (`│`, `┃`, or a plain `|`) - the box's own top/bottom rows use rounded corners and never match, popup item rows and separator rows carry no border glyph at all, and the footer help line uses `│` only as an interior separator (never as the first/last character), so none of those can be mistaken for the composer.
-For unbordered live composers, added after the 2026-07-07 incident below, the row is a bottom-most trimmed line starting with a verified agent prompt glyph (`❯` for claude or `›` for codex); decorative bordered boxes above it lose to that bottom-most match.
+For unbordered live composers, added after the 2026-07-07 incident below, the row is a bottom-most trimmed line starting with a verified agent prompt glyph (`❯` for claude and copilot, or `›` for codex); decorative bordered boxes above it lose to that bottom-most match.
 For Pi, added after the 2026-07-14 incident above, the candidate is the content between the bottom-most complete separator pair, admitted only when native Herdr identity reports exactly `pi` with status `idle`, `done`, or `blocked` and the bounded structure is unambiguous.
 A popup-close-with-placeholder-fill still reads as real content on that row, so composer fallback correctly classifies it as pending; on the normal idle-baseline path, the same first Enter also fails to start a turn, so native agent-state confirmation likewise retries instead of stopping early.
 Known ghost/placeholder composer text (`Type a message...`, verified grok 0.2.82's empty-composer hint) is recognized and still reads as empty.
@@ -879,7 +879,7 @@ Each adapter still owns its own capture and structural row-finding (genuinely di
 
 **The safety rule.** A bare shell prompt glyph is a genuine empty agent composer ONLY inside a bordered composer container (where the harness draws its own prompt glyph, e.g. claude's older `| > ... |`).
 On a bare, unstructured row it is a dead-shell prompt and reads `unknown` (not a safe injection target), never `empty`.
-The agent prompt glyphs `❯` (claude) and `›` (codex) read `empty` either way.
+The agent prompt glyphs `❯` (claude, and copilot's composer glyph - see `bin/fm-composer-lib.sh` for the verified styling) and `›` (codex) read `empty` either way.
 `inject_msg` was hardened to match: its composer-guard now reads `fm_backend_composer_state` directly and defers on anything that is not affirmatively `empty` (`pending` real text, or `unknown` for a dead shell or an unreadable pane), instead of only deferring on `pending`.
 
 **Regression coverage.** `tests/fm-composer-lib.test.sh` pins the shared owner directly (bare shell glyph -> `unknown`, the same glyph bordered -> `empty`, agent glyphs -> `empty` bordered or bare, idle placeholder, real text -> `pending`).

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -1,7 +1,7 @@
 # Orca Backend
 
 Orca is an experimental runtime backend for firstmate.
-It is distinct from the crewmate harness: the harness is the agent process firstmate launches (`claude`, `codex`, `opencode`, `pi`, or `grok`), while Orca owns the task worktree and terminal endpoint underneath that process.
+It is distinct from the crewmate harness: the harness is the agent process firstmate launches (`claude`, `codex`, `opencode`, `pi`, `grok`, or `copilot`), while Orca owns the task worktree and terminal endpoint underneath that process.
 Firstmate agents operating this backend should load the agent-only [`firstmate-orca`](../.agents/skills/firstmate-orca/SKILL.md) checklist before switching to Orca, spawning or supervising Orca-backed work, smoke-testing, debugging task state, or reconciling Orca metadata.
 
 ## Setup

--- a/docs/supervision-protocols/copilot.md
+++ b/docs/supervision-protocols/copilot.md
@@ -1,0 +1,17 @@
+Mode: Copilot foreground checkpoint.
+
+When this session owns supervision and away mode is not active:
+1. Drain first with `bin/fm-wake-drain.sh`.
+2. Source `__FM_X_MODE_ENV__` first when X mode is active.
+3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
+4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
+5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Copilot, then start the next checkpoint.
+6. Never use shell `&` or Copilot background tasks for firstmate watcher supervision.
+7. Do not run `bin/fm-watch-arm.sh` as Copilot's normal supervision command.
+8. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
+
+Copilot cannot reason while a foreground tool call is running.
+The bounded checkpoint returns control regularly so user messages and queued wakes can be handled without relying on background-task wake semantics.
+
+Copilot has no blocking turn-end guard: its hooks cannot force a continued turn the way codex's and claude's Stop hooks can, so the active checkpoint loop above is the only supervision backstop.
+Keep the loop running while any work is in flight, and if a turn ever ends with the loop stopped, resume the checkpoint immediately on the next turn.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -111,6 +111,8 @@ Verified the same session: a persisting parent process running a child command (
 
 The recovery classifier (`fm_backend_tmux_agent_state`) maps the observation to the shared detailed state owned by `fm_backend_agent_state` in `bin/fm-backend.sh`.
 A recognized harness is `alive`, a bare shell is `dead`, and an unrecognized foreground process is `ambiguous`.
+The recognized set is `claude`, `codex`, `opencode`, `grok`, and `copilot`.
+`copilot` matches even though its bundled ELF renames its main thread (`ps -o comm=` reports `MainThread`) because `#{pane_current_command}` is derived from the process cmdline, which is exactly `copilot` (verified live, copilot 1.0.73 with tmux 3.x, 2026-07-21).
 The classifier checks exact window-name membership in a readable session inventory before trusting `display-message`, because tmux silently redirects a missing named target to the active window.
 It returns `missing` when `tmux list-windows` successfully reads the recorded session and omits the exact recorded window, or when tmux definitively reports that the recorded session or server is absent.
 Any other failed inventory or pane read is `unreadable` and never authorizes recovery.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -38,7 +38,7 @@ If `jq` is missing or hook stdin is empty, the guard fails open and exits 0 beca
 
 ## Harness Integrations
 
-All verified primary harnesses have a tracked integration:
+All five hook-integrated primary harnesses have a tracked integration:
 
 - `claude`: `.claude/settings.json` registers a `Stop` hook command anchored through `"$CLAUDE_PROJECT_DIR"/bin/fm-turnend-guard.sh`.
 - `codex`: `.codex/hooks.json` registers a `Stop` hook that reads the hook payload once, anchors the executable to the hook command process working directory, verifies that root is firstmate-shaped and hook-bearing, and pipes the original payload to that checkout's `bin/fm-turnend-guard.sh`.
@@ -59,6 +59,11 @@ Each adapter carries its own in-process or environment loop guard so the forced 
 Pi keeps that latch active across every internal tool turn and clears it only when the generated guard follow-up reaches `agent_settled`, or immediately when follow-up delivery fails.
 If a passive adapter cannot call its SDK method, cannot find `grok`, or cannot recover the Grok session id, it fails open and relies on the pull-based `fm-guard.sh` warning at the next fleet command.
 That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it points back to the active harness protocol instead of hardcoding one background-arm command.
+
+Copilot is a supervised primary without a turn-end guard integration.
+GitHub Copilot CLI hooks cannot block a stop or force a continued turn: only its `preToolUse` hook can approve or deny, and that fires before a tool call, not at turn end (verified against the GitHub Copilot hooks reference, copilot 1.0.74, 2026-07-24).
+So copilot has no entry above and no `bin/fm-turnend-guard.sh` hook.
+Its only supervision backstop is the active foreground checkpoint loop in `docs/supervision-protocols/copilot.md`; when a copilot turn ends with that loop stopped, the pull-based `fm-guard.sh` warning at the next fleet command is what points it back to resuming the checkpoint.
 
 ## Empirical Validation
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2017,6 +2017,39 @@ test_composer_state_grok_bright_truecolor_real_text_is_pending() {
   pass "fm_backend_herdr_composer_state: grok's real bright typed input still reads pending"
 }
 
+# copilot's idle composer (verified live, copilot 1.0.73, 2026-07-21, real tmux
+# capture-pane -e bytes): a bare `❯ ` styled truecolor 38;2;134;134;134
+# (luminance 134, at/above the ghost threshold so the glyph survives the strip)
+# sitting BETWEEN two full-width horizontal rules - the same separated shape as
+# Pi, so this also proves the Pi separator-pair override does not suppress the
+# generic bare-glyph verdict when the glyph row sits INSIDE the pair.
+test_composer_state_copilot_bare_glyph_between_rules_is_empty() {
+  local dir log resp fb out rule
+  dir="$TMP_ROOT/composer-copilot-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  rule=$(printf '\xe2\x94\x80%.0s' 1 2 3 4 5 6 7 8 9 10 11 12)
+  printf ' \xe2\x9d\xaf Reply with exactly: SECOND TURN OK\n %s\n\x1b[38;2;134;134;134m\xe2\x9d\xaf \x1b[39m\n %s\n / commands \xc2\xb7 ? help \xc2\xb7 tab next tab\n' "$rule" "$rule" > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = empty ] || fail "copilot's idle bare-glyph composer between horizontal rules must read empty, got '$out'"
+  pass "fm_backend_herdr_composer_state: copilot's idle bare ❯ between rules reads empty"
+}
+
+# Same shape with REAL typed-but-unsubmitted text (default foreground after the
+# gray glyph run, as captured live) must read pending - the state fm-send's
+# retried Enter relies on when a copilot submit needs a second Enter on herdr.
+test_composer_state_copilot_typed_text_is_pending() {
+  local dir log resp fb out rule
+  dir="$TMP_ROOT/composer-copilot-typed"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  rule=$(printf '\xe2\x94\x80%.0s' 1 2 3 4 5 6 7 8 9 10 11 12)
+  printf ' %s\n\x1b[38;2;134;134;134m\xe2\x9d\xaf \x1b[39mRun the shell command: sleep 60\n %s\n' "$rule" "$rule" > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = pending ] || fail "real typed text in copilot's composer must read pending, got '$out'"
+  pass "fm_backend_herdr_composer_state: copilot's typed-unsubmitted text reads pending"
+}
+
 test_composer_state_codex_bare_prompt_glyph_is_empty() {
   local dir log resp fb out
   dir="$TMP_ROOT/composer-codex-bare"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -3064,6 +3097,8 @@ test_composer_state_claude_dim_prompt_suggestion_ghost_is_empty
 test_composer_state_claude_dim_ghost_row_with_real_text_is_pending
 test_composer_state_grok_dark_truecolor_placeholder_is_empty
 test_composer_state_grok_bright_truecolor_real_text_is_pending
+test_composer_state_copilot_bare_glyph_between_rules_is_empty
+test_composer_state_copilot_typed_text_is_pending
 test_composer_state_codex_bare_prompt_glyph_is_empty
 test_composer_state_codex_faint_suggestion_is_empty
 test_composer_state_codex_non_faint_same_text_is_pending

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -775,6 +775,7 @@ unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
+copilot max effort is accepted^{"rules":[{"when":"github work","use":{"harness":"copilot","effort":"max"}}]}^empty^
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
 array use with quota-balanced is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}],"select":"quota-balanced"}]}^empty^
 array use without select is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}]}]}^empty^

--- a/tests/fm-copilot-harness.test.sh
+++ b/tests/fm-copilot-harness.test.sh
@@ -1,0 +1,441 @@
+#!/usr/bin/env bash
+# Behavior tests for GitHub Copilot CLI recognition and crew/secondmate dispatch:
+# session-lock acquisition and holder detection, own-harness detection, anchored
+# non-matches against unrelated copilot-flavored argv, the verified launch template
+# with model/effort flags, the repo-level agentStop turn-end hook install, and its
+# teardown cleanup.
+# Empirical shape (copilot 1.0.73, 2026-07-21): `ps -o comm=` reports "MainThread"
+# (the bundled ELF renames its main thread) and `ps -o args=` is exactly "copilot".
+# Dispatch facts (same session, harness-adapters "copilot" section): -i takes the
+# prompt as its value and auto-executes, --allow-all + --no-ask-user run a turn
+# fully unattended, --effort accepts firstmate's full low..max vocabulary, and
+# repo-level .github/hooks/*.json fire agentStop at every completed turn end.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LOCK="$ROOT/bin/fm-lock.sh"
+HARNESS="$ROOT/bin/fm-harness.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-copilot-harness)
+
+# Fake ps reproducing the observed copilot process shape for every queried pid.
+make_copilot_ps() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*) printf '%s\n' 'copilot'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
+test_fm_lock_acquires_under_copilot_ancestor() {
+  local home fakebin out status
+  home="$TMP_ROOT/acquire-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/acquire-fake")
+  mkdir -p "$home/state"
+  make_copilot_ps "$fakebin"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK")
+  status=$?
+  expect_code 0 "$status" "copilot-ancestored lock acquisition should succeed"
+  assert_contains "$out" "lock acquired: harness pid" "fm-lock did not acquire under a copilot ancestor"
+  assert_present "$home/state/.lock" "lock file was not written"
+  pass "fm-lock acquires under a copilot ancestor (comm MainThread, args copilot)"
+}
+
+test_fm_lock_overwrites_stale_dead_copilot_holder() {
+  local home fakebin dead out status
+  home="$TMP_ROOT/stale-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/stale-fake")
+  mkdir -p "$home/state"
+  make_copilot_ps "$fakebin"
+  dead=$(bash -c 'echo $$')
+  while kill -0 "$dead" 2>/dev/null; do sleep 0.1; done
+  printf '%s\n' "$dead" > "$home/state/.lock"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK")
+  status=$?
+  expect_code 0 "$status" "stale dead-holder lock should be overwritten"
+  assert_contains "$out" "lock acquired: harness pid" "fm-lock did not overwrite the stale holder"
+  [ "$(cat "$home/state/.lock")" != "$dead" ] || fail "stale holder pid survived in the lock file"
+  pass "fm-lock overwrites a stale dead-holder lock under a copilot ancestor"
+}
+
+test_fm_lock_recognizes_copilot_holder() {
+  local home fakebin out
+  home="$TMP_ROOT/holder-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/holder-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  make_copilot_ps "$fakebin"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: held by live harness pid" "fm-lock did not recognize copilot as a live holder"
+  pass "fm-lock recognizes a copilot holder as live"
+}
+
+test_fm_lock_acquires_under_path_prefixed_copilot() {
+  local home fakebin out status
+  home="$TMP_ROOT/pathargv-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/pathargv-fake")
+  mkdir -p "$home/state"
+  # A copilot primary launched via an absolute path keeps comm MainThread but
+  # carries the full path in argv[0]; it must still read as a harness.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*) printf '%s\n' '/home/x/.local/bin/copilot --allow-all'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK")
+  status=$?
+  expect_code 0 "$status" "path-prefixed copilot argv should acquire the lock"
+  assert_contains "$out" "lock acquired: harness pid" "fm-lock did not accept a path-prefixed copilot argv[0]"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: held by live harness pid" "path-prefixed copilot holder should read as live"
+  pass "fm-lock recognizes a path-prefixed copilot argv[0]"
+}
+
+test_fm_lock_ignores_unrelated_copilot_argv() {
+  local home fakebin out status
+  home="$TMP_ROOT/plugin-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/plugin-fake")
+  mkdir -p "$home/state"
+  # A node process whose argv only mentions copilot inside plugin paths (the
+  # VS Code tsserver shape observed alongside the real copilot CLI) must not
+  # be mistaken for a harness.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'node'; exit 0 ;;
+  *"args="*) printf '%s\n' 'node tsserver.js --globalPlugins @vscode/copilot-typescript-server-plugin --pluginProbeLocations /x/extensions/copilot --locale en'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" 2>&1)
+  status=$?
+  expect_code 1 "$status" "plugin-path argv must not be recognized as a harness"
+  assert_contains "$out" "cannot locate harness process" "fm-lock accepted vscode copilot plugin argv as a harness"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: stale" "holder with only plugin-path copilot argv should read as stale"
+  pass "anchored copilot match ignores vscode plugin paths in unrelated argv"
+}
+
+test_fm_lock_holder_argv_only_matters_for_interpreters() {
+  local home fakebin out
+  home="$TMP_ROOT/recycled-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/recycled-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  # Recycled pid: comm gh, argv merely containing the word copilot must not
+  # read as a live harness holder.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'gh'; exit 0 ;;
+  *"args="*) printf '%s\n' 'gh copilot suggest fix my code'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: stale" "gh-comm holder with copilot argv should read as stale"
+
+  # comm-only path still recognizes a real harness comm.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'claude'; exit 0 ;;
+  *"args="*) printf '%s\n' 'claude'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: held by live harness pid" "claude comm holder should still read as live"
+  pass "holder argv is only trusted for interpreter/MainThread comms"
+}
+
+test_fm_lock_acquires_under_renamed_copilot_wrapper() {
+  local home wrapper out status
+  home="$TMP_ROOT/wrapper-home"
+  mkdir -p "$home/state" "$TMP_ROOT/wrapper-bin"
+  # Real ps, real ancestry: a wrapper process whose comm is "copilot" (a script
+  # named copilot) stands in for the CLI on platforms where comm is the binary name.
+  wrapper="$TMP_ROOT/wrapper-bin/copilot"
+  # Direct shebang: an env shebang would exec bash and reset comm to "bash",
+  # while a direct interpreter keeps comm as the script name "copilot".
+  cat > "$wrapper" <<'SH'
+#!/bin/bash
+"$@"
+SH
+  chmod +x "$wrapper"
+  out=$(FM_HOME="$home" "$wrapper" "$LOCK")
+  status=$?
+  expect_code 0 "$status" "lock acquisition under a copilot-named ancestor should succeed"
+  assert_contains "$out" "lock acquired: harness pid" "fm-lock did not find the copilot-named ancestor with real ps"
+  pass "fm-lock acquires under a real copilot-named ancestor process"
+}
+
+test_fm_harness_reports_copilot() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/detect-fake")
+  make_copilot_ps "$fakebin"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = copilot ] || fail "fm-harness printed '$out' instead of copilot for the MainThread/args shape"
+
+  # comm reported directly as the binary name (non-thread-renaming platforms).
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' '/home/x/.local/bin/copilot'; exit 0 ;;
+  *"args="*) printf '%s\n' 'copilot'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = copilot ] || fail "fm-harness printed '$out' instead of copilot for a copilot comm"
+
+  # MainThread comm with a path-prefixed argv[0] (absolute-path launch).
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*) printf '%s\n' '/home/x/.local/bin/copilot --allow-all'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = copilot ] || fail "fm-harness printed '$out' instead of copilot for a path-prefixed argv[0]"
+  pass "fm-harness reports copilot distinctly for all observed process shapes"
+}
+
+test_fm_harness_copilot_brief_argv_mentions_other_harness() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/brief-fake")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*) printf '%s\n' 'copilot --allow-all --no-ask-user -i Update CLAUDE.md per the brief'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = copilot ] || fail "fm-harness printed '$out' instead of copilot when the -i brief argv mentions claude"
+  pass "copilot detection wins over unanchored harness names in the brief argv"
+}
+
+test_fm_harness_existing_detection_unchanged() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/regress-fake")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'pi'; exit 0 ;;
+  *"args="*) printf '%s\n' 'pi'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = pi ] || fail "fm-harness printed '$out' instead of pi (anchoring regression)"
+  pass "existing pi detection is unchanged by the copilot entry"
+}
+
+# A tmux stub that behaves like the grok test's spawn stub but also captures the
+# literal `send-keys -l <cmd>` launch command into FM_FAKE_LAUNCH_LOG, mirroring
+# tests/fm-secondmate-harness.test.sh's make_launch_capturing_tmux.
+make_copilot_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  printf '%s\n' "$fakebin"
+}
+
+make_copilot_spawn_case() {
+  local name=$1 case_dir home proj wt fakebin id
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_copilot_spawn_fakebin "$case_dir/fake")
+  id="copilot-$name-x1"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$id"
+}
+
+run_copilot_spawn() {
+  local home=$1 proj=$2 wt=$3 fakebin=$4 id=$5 launchlog=$6
+  shift 6
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" FM_FAKE_LAUNCH_LOG="$launchlog" \
+    TMUX="fake,1,0" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" copilot "$@" 2>&1
+}
+
+test_spawn_dispatches_copilot_with_flags_and_turnend_hook() {
+  local rec case_dir home proj wt fakebin id launchlog out status launch hook excl meta
+  rec=$(make_copilot_spawn_case dispatch)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  launchlog="$case_dir/launch.log"
+  : > "$launchlog"
+  out=$(run_copilot_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$launchlog" \
+    --model claude-haiku-4.5 --effort low)
+  status=$?
+  expect_code 0 "$status" "copilot spawn should succeed"
+  assert_contains "$out" "spawned $id harness=copilot" "copilot spawn did not report success"
+
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "copilot --allow-all --no-ask-user " \
+    "launch command lost the verified unattended-autonomy flags"
+  assert_contains "$launch" "--model 'claude-haiku-4.5'" "launch command lost the model flag"
+  assert_contains "$launch" "--effort 'low'" "launch command lost the effort flag"
+# shellcheck disable=SC2016  # single quotes are deliberate: the literal $(...) encoder call must appear in the launch command
+  assert_contains "$launch" '-i "$(' \
+    "launch command must pass the brief as -i's value (auto-executing interactive mode)"
+# shellcheck disable=SC2016  # the brief rides the shared operational-input encoder like every other harness
+  assert_contains "$launch" 'encode launch-brief' \
+    "launch command must encode the brief through the shared operational-input encoder"
+
+  hook="$wt/.github/hooks/fm-turn-end.json"
+  assert_present "$hook" "repo-level agentStop turn-end hook was not installed"
+  assert_grep 'agentStop' "$hook" "turn-end hook is not registered on the agentStop event"
+  assert_grep "$id.turn-ended" "$hook" "turn-end hook does not touch the task's turn-ended file"
+  excl=$(git -C "$wt" rev-parse --git-path info/exclude)
+  assert_grep '.github/hooks/fm-turn-end.json' "$excl" \
+    "turn-end hook file was not git-excluded (would dirty teardown's landed-work check)"
+
+  meta="$home/state/$id.meta"
+  assert_grep 'harness=copilot' "$meta" "meta did not record harness=copilot"
+  pass "copilot dispatch wires the verified launch template, flags, and agentStop hook"
+}
+
+test_spawn_copilot_omits_default_model_effort() {
+  local rec case_dir home proj wt fakebin id launchlog out status launch
+  rec=$(make_copilot_spawn_case defaults)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  launchlog="$case_dir/launch.log"
+  : > "$launchlog"
+  out=$(run_copilot_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$launchlog")
+  status=$?
+  expect_code 0 "$status" "flagless copilot spawn should succeed"
+  launch=$(cat "$launchlog")
+  case "$launch" in
+    *--model*|*--effort*) fail "default model/effort must emit no flag, got: $launch" ;;
+  esac
+  pass "copilot dispatch omits model/effort flags when unset"
+}
+
+# The live-captured busy and idle footers (copilot 1.0.73, 2026-07-21). The busy
+# footer must match the shared default busy regex (via its "esc (to )?interrupt"
+# alternative - no copilot-specific entry exists) and the idle footer must not,
+# so a working copilot crew reads busy and an idle one reads stale-eligible.
+test_copilot_busy_footer_matches_default_busy_regex() {
+  local regex
+  regex=$(bash -c '. "$0/bin/fm-tmux-lib.sh"; printf "%s" "$FM_TMUX_BUSY_REGEX_DEFAULT"' "$ROOT")
+  printf '%s' ' ◎ Working · 916 B esc interrupt' | grep -qiE "$regex" \
+    || fail "copilot's live busy footer did not match the default busy regex"
+  printf '%s' ' ● Working esc interrupt' | grep -qiE "$regex" \
+    || fail "copilot's byte-count-free busy footer did not match the default busy regex"
+  printf '%s' ' / commands · ? help · tab next tab' | grep -qiE "$regex" \
+    && fail "copilot's idle footer must not match the busy regex"
+  grep -qF "BUSY_REGEX=\${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\\.\\.\\.|Ctrl\\+c:cancel'}" "$ROOT/bin/fm-watch.sh" \
+    || fail "fm-watch.sh BUSY_REGEX default drifted from the value these footers were verified against"
+  pass "copilot busy/idle footers classify correctly under the shared busy regex"
+}
+
+test_copilot_teardown_removes_turnend_hook() {
+  local rec case_dir home proj wt fakebin id launchlog out status
+  rec=$(make_copilot_spawn_case teardown)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  launchlog="$case_dir/launch.log"
+  : > "$launchlog"
+  out=$(run_copilot_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$launchlog")
+  status=$?
+  expect_code 0 "$status" "copilot spawn should succeed before teardown"
+  assert_present "$wt/.github/hooks/fm-turn-end.json" "hook missing before teardown"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    PATH="$fakebin:$PATH" \
+    "$ROOT/bin/fm-teardown.sh" "$id" --force >/dev/null 2>&1 \
+    || fail "copilot teardown failed"
+
+  assert_absent "$wt/.github/hooks/fm-turn-end.json" \
+    "agentStop hook survived teardown (a reused pool worktree would fire signals for a dead task)"
+  assert_absent "$home/state/$id.turn-ended" "turn-ended state file survived teardown"
+  pass "copilot teardown removes the repo-level agentStop hook"
+}
+
+test_fm_lock_acquires_under_copilot_ancestor
+test_fm_lock_overwrites_stale_dead_copilot_holder
+test_fm_lock_recognizes_copilot_holder
+test_fm_lock_acquires_under_path_prefixed_copilot
+test_fm_lock_ignores_unrelated_copilot_argv
+test_fm_lock_holder_argv_only_matters_for_interpreters
+test_fm_lock_acquires_under_renamed_copilot_wrapper
+test_fm_harness_reports_copilot
+test_fm_harness_copilot_brief_argv_mentions_other_harness
+test_fm_harness_existing_detection_unchanged
+test_spawn_dispatches_copilot_with_flags_and_turnend_hook
+test_spawn_copilot_omits_default_model_effort
+test_copilot_busy_footer_matches_default_busy_regex
+test_copilot_teardown_removes_turnend_hook

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -97,7 +97,7 @@ SH
 test_tmux_agent_state_classifies() {
   local fb out
 
-  for harness in claude codex opencode grok; do
+  for harness in claude codex opencode grok copilot; do
     fb=$(make_probe_tmux "$TMP_ROOT/tmux-$harness" "$harness")
     out=$(PATH="$fb:$BASE_PATH" bash -c '. "$0/bin/fm-backend.sh"; fm_backend_agent_state tmux sess:win' "$ROOT")
     [ "$out" = alive ] || fail "a live $harness foreground process should classify as alive, got '$out'"

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -27,6 +27,23 @@ test_unknown_fallback() {
   pass "renderer falls back to unknown.md for unverified harness names"
 }
 
+test_copilot_detected_with_checkpoint() {
+  local out ordinary
+  out=$("$RENDER" --harness copilot)
+  assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: copilot" "copilot heading missing or renamed to unknown"
+  assert_contains "$out" "Mode: Copilot foreground checkpoint." "copilot did not get its own foreground-checkpoint snippet"
+  assert_contains "$out" "bin/fm-watch-checkpoint.sh" "copilot checkpoint helper missing"
+  assert_contains "$out" "no blocking turn-end guard" "copilot harness note lost the missing-backstop fact"
+  assert_not_contains "$out" "Mode: Unknown harness fallback." "copilot must not fall back to the manual snippet"
+  out=$("$RENDER" --harness copilot --repair-line)
+  assert_contains "$out" "bin/fm-watch-checkpoint.sh" "copilot repair line should use the foreground checkpoint helper"
+  out=$("$RENDER" --harness copilot)
+  ordinary=$(printf '%s\n' "$out" | grep -F -- '- Ordinary wake:')
+  assert_contains "$ordinary" "next foreground" "copilot ordinary-wake line lost its foreground checkpoint"
+  assert_contains "$ordinary" "bin/fm-watch-checkpoint.sh" "copilot ordinary-wake line lost the checkpoint command"
+  pass "copilot supervises through the codex-style foreground checkpoint with an honest no-backstop note"
+}
+
 test_conditional_stanzas() {
   local home config out
   home="$TMP_ROOT/conditional-home"
@@ -156,6 +173,7 @@ test_pi_snippet_uses_effective_extension_path() {
 
 test_selected_harness_block_only
 test_unknown_fallback
+test_copilot_detected_with_checkpoint
 test_conditional_stanzas
 test_repair_lines
 test_cross_harness_ordinary_continuation_and_repair_matrix


### PR DESCRIPTION
## What this adds

Brings GitHub Copilot CLI (`copilot`) to codex-level parity as far as its hook contract allows, by synthesizing two existing PRs cleanly onto current `main`:

- **#827 (includes #816)** - crew/secondmate **dispatch**: distinct detection + session lock (`fm-harness`, `fm-lock`), spawn launch template with `--model`/`--effort` passthrough and a repo-level `agentStop` turn-end hook (`fm-spawn`, `fm-teardown`), tmux agent liveness (`backends/tmux`, `secondmate-liveness`), busy/composer classification, and crew-dispatch profile validation (`fm-bootstrap`).
- **#420's supervision piece only** - copilot supervises a **primary** through the codex-style foreground checkpoint (`docs/supervision-protocols/copilot.md`, rendered by `fm-supervision-instructions`).

## Why a fresh synthesis instead of merging #827/#420

Both PRs are stale against current `main` (the herdr/liveness subsystems were reworked upstream). A plain `git merge` reverted unrelated main changes. This branch instead applies only each PR's real per-file delta onto current `main`, so the change set is limited to 25 copilot-related files with no spurious reverts.

One adaptation to current `main`: copilot's launch brief now rides the shared operational-input encoder (`__OPINPUT__ encode launch-brief`) like every other harness, replacing #827's raw `cat` (which predated that convention).

## Known limitation: no turn-end guard

Copilot has **no blocking turn-end guard**. Its hooks cannot block a stop or force a continued turn - only `preToolUse` can approve/deny, and that fires before a tool call, not at turn end (verified against the GitHub Copilot hooks reference on copilot 1.0.74, 2026-07-24). So copilot's only supervision backstop is the active foreground checkpoint loop. `docs/turnend-guard.md` and the `harness-adapters` skill document this exception.

Still unbuilt for copilot primary (out of scope here, buildable via copilot's `preToolUse`/`sessionStart` hooks): the PreToolUse watcher-arm seatbelt and the session-start nudge.

## Validation

- `tests/fm-copilot-harness.test.sh`, `fm-supervision-instructions.test.sh`, `fm-secondmate-liveness.test.sh`, `fm-bootstrap.test.sh`, `fm-backend-herdr.test.sh` - green.
- `fm-spawn-dispatch-profile`, `fm-backend`, `fm-dispatch-select`, `fm-secondmate-harness`, `fm-grok-harness`, `fm-spawn-batch` - green.
- `bin/fm-lint.sh` (ShellCheck 0.11.0) - clean.
