### PR TITLE
fix(herdr): admit agy plain-ASCII '> ' composer via native identity

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1836,6 +1836,15 @@ FM_BACKEND_HERDR_BARE_PROMPT_RE=${FM_BACKEND_HERDR_BARE_PROMPT_RE:-'^[❯›]'}
 # structural candidate so two unrelated transcript rules with an arbitrarily
 # large region between them can never be promoted into a composer.
 FM_BACKEND_HERDR_PI_COMPOSER_MAX_LINES=${FM_BACKEND_HERDR_PI_COMPOSER_MAX_LINES:-8}
+# agy's interactive composer draws a PLAIN ASCII "> " prompt with no side
+# border and no agent-specific glyph, so its empty-composer row is byte-for-byte
+# a bare shell ">" prompt - exactly the dead-shell glyph the shared classifier
+# deliberately refuses as `unknown` (never `empty`). This regex locates that agy
+# prompt row structurally; it is admitted as a real composer ONLY after native
+# `agent get` corroborates the target is agy (see the agy block in
+# fm_backend_herdr_composer_state), the same identity + structure conjunction
+# that makes a blank Pi separator row safe. A bare "> " (or lone ">") only.
+FM_BACKEND_HERDR_AGY_PROMPT_RE=${FM_BACKEND_HERDR_AGY_PROMPT_RE:-'^>( |$)'}
 
 fm_backend_herdr_pi_separator_row() {  # <plain-row>
   local row=$1
@@ -1892,6 +1901,33 @@ $cap
 EOF
 }
 
+# Locate the bottom-most agy prompt row (a bare ASCII "> " / ">" with no side
+# border) and record its screen line and RAW styled bytes. This shape is
+# structurally indistinguishable from a dead-shell prompt, so - exactly like the
+# Pi separator finder - it only records position/content here and defers the
+# empty-vs-unknown verdict to an identity check in the caller. A global carries
+# the raw row so empty composer content is not lost through command substitution.
+fm_backend_herdr_agy_composer_find() {  # <ansi-capture>
+  local cap=$1 line plain row=0
+  FM_BACKEND_HERDR_AGY_ROW_FOUND=0
+  FM_BACKEND_HERDR_AGY_ROW_LINE=0
+  FM_BACKEND_HERDR_AGY_ROW_RAW=""
+  while IFS= read -r line; do
+    row=$((row + 1))
+    plain=$(fm_backend_herdr_strip_ansi "$line")
+    plain="${plain#"${plain%%[![:space:]]*}"}"
+    plain="${plain%"${plain##*[![:space:]]}"}"
+    [ -n "$plain" ] || continue
+    if printf '%s' "$plain" | grep -qE "$FM_BACKEND_HERDR_AGY_PROMPT_RE"; then
+      FM_BACKEND_HERDR_AGY_ROW_FOUND=1
+      FM_BACKEND_HERDR_AGY_ROW_LINE=$row
+      FM_BACKEND_HERDR_AGY_ROW_RAW=$line
+    fi
+  done <<EOF
+$cap
+EOF
+}
+
 fm_backend_herdr_agent_identity_raw() {  # <session> <pane> -> <agent>\t<status>
   local out
   out=$(fm_backend_herdr_cli "$1" agent get "$2" 2>/dev/null) || return 1
@@ -1900,7 +1936,7 @@ fm_backend_herdr_agent_identity_raw() {  # <session> <pane> -> <agent>\t<status>
 
 fm_backend_herdr_composer_state() {  # <target> -> empty|pending|unknown
   local target=$1 session pane cap line trimmed found=0 shape="" raw_match="" bordered=0 stripped
-  local identity agent agent_status row=0 generic_line=0
+  local identity agent agent_status row=0 generic_line=0 identity_fetched=0
   fm_backend_herdr_parse_target "$target" || { printf 'unknown'; return 0; }
   session=$FM_BACKEND_HERDR_SESSION
   pane=$FM_BACKEND_HERDR_PANE
@@ -1941,7 +1977,10 @@ fm_backend_herdr_composer_state() {  # <target> -> empty|pending|unknown
   if [ "$FM_BACKEND_HERDR_PI_PAIR_FOUND" -eq 1 ] \
      && [ "$FM_BACKEND_HERDR_PI_PAIR_LINE" -gt "$generic_line" ] \
      && [ "$generic_line" -lt "$FM_BACKEND_HERDR_PI_PAIR_OPEN_LINE" ]; then
-    identity=$(fm_backend_herdr_agent_identity_raw "$session" "$pane" 2>/dev/null || true)
+    if [ "$identity_fetched" -eq 0 ]; then
+      identity=$(fm_backend_herdr_agent_identity_raw "$session" "$pane" 2>/dev/null || true)
+      identity_fetched=1
+    fi
     IFS=$'\t' read -r agent agent_status <<EOF
 $identity
 EOF
@@ -1968,6 +2007,44 @@ EOF
     # not provide the complete Pi composer structure required for injection.
     found=0
   fi
+  # agy has no side border and no agent-specific glyph: its live composer draws
+  # a PLAIN ASCII "> " prompt, byte-for-byte the bare shell prompt the shared
+  # classifier deliberately refuses as `unknown` (the dead-shell safety rule).
+  # So - exactly like the Pi separator shape - an agy prompt row is admitted as
+  # a real, injectable composer ONLY when Herdr's native `agent get` corroborates
+  # the target is agy AND reports it idle, done, or blocked. The agy row must be
+  # the bottom-most composer-like candidate (below any generic bordered/bare
+  # match and below any Pi separator activity) so a stale transcript `>` line can
+  # never outrank the live composer, and identity is consulted only then - which
+  # also keeps the Pi shapes above making exactly one identity call, never two.
+  # A missing/stale/non-agy identity, or a working agy, leaves the row `unknown`,
+  # preserving the dead-shell rule for a bare `>` under a non-agy (or no) agent.
+  fm_backend_herdr_agy_composer_find "$cap"
+  if [ "$FM_BACKEND_HERDR_AGY_ROW_FOUND" -eq 1 ] \
+     && [ "$FM_BACKEND_HERDR_AGY_ROW_LINE" -gt "$generic_line" ] \
+     && [ "$FM_BACKEND_HERDR_AGY_ROW_LINE" -gt "$FM_BACKEND_HERDR_PI_PAIR_LINE" ] \
+     && [ "$FM_BACKEND_HERDR_AGY_ROW_LINE" -gt "$FM_BACKEND_HERDR_PI_LAST_SEPARATOR_LINE" ]; then
+    if [ "$identity_fetched" -eq 0 ]; then
+      identity=$(fm_backend_herdr_agent_identity_raw "$session" "$pane" 2>/dev/null || true)
+      identity_fetched=1
+    fi
+    IFS=$'\t' read -r agent agent_status <<EOF
+$identity
+EOF
+    case "$agent:$agent_status" in
+      agy:idle|agy:done|agy:blocked)
+        shape=agy
+        raw_match=$FM_BACKEND_HERDR_AGY_ROW_RAW
+        found=1
+        ;;
+      agy:*|:*)
+        # A working agy or unreadable/absent identity cannot authorize
+        # injection; the bare "> " prompt stays a dead-shell candidate.
+        found=0
+        ;;
+      *) : ;; # A known non-agy agent keeps its established generic verdict.
+    esac
+  fi
   [ "$found" -eq 1 ] || { printf 'unknown'; return 0; }
   # Content: extract the real typed text from the raw row with the shared,
   # fleet-wide ghost stripper (bin/fm-composer-lib.sh), which drops dim/faint AND
@@ -1991,6 +2068,13 @@ EOF
     # The native Pi identity plus the complete separator pair is the genuine
     # composer container, equivalent to a bordered box for shared content
     # classification. ANSI stripping keeps real text and drops only styling.
+    bordered=1
+  elif [ "$shape" = agy ]; then
+    # The native agy identity plus the "> " prompt row is the genuine composer
+    # container, equivalent to a bordered box for shared content classification.
+    # Marking it bordered is exactly what lets fm_composer_classify_content read
+    # a lone "> " as an empty AGENT composer (the harness's own prompt) rather
+    # than the `unknown` a bare, unstructured shell ">" would get.
     bordered=1
   fi
   # Delegate the empty/pending/unknown decision to the shared owner. The bare

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -182,8 +182,14 @@ A human-blocked permission dialog has no busy banner and still surfaces.
 ## Composer and injection safety
 
 Herdr has no direct cursor-row primitive.
-The adapter locates the bottom-most recognized bordered row, Claude `❯` row, Codex `›` row, or a Pi separator region admitted only when native identity is exactly Pi and state is idle, done, or blocked.
+The adapter locates the bottom-most recognized bordered row, Claude `❯` row, Codex `›` row, a Pi separator region admitted only when native identity is exactly Pi and state is idle, done, or blocked, or an agy `> ` prompt row admitted only when native identity is exactly agy and state is idle, done, or blocked.
 A working Pi, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains pending or unknown.
+
+agy is a known gap in the shared classifier's dead-shell rule.
+agy's interactive composer draws a plain ASCII `> ` prompt with no side border and no agent-specific glyph, so its empty-composer row is byte-for-byte the bare shell `>` prompt the shared classifier deliberately refuses as `unknown` rather than `empty`.
+The herdr adapter closes this gap the same way it admits Pi's borderless separator composer: it locates the bottom-most `> ` prompt row structurally and admits it as a real, injectable composer only when native `agent get` corroborates the target is agy and reports it idle, done, or blocked.
+A working agy, a non-agy or unregistered agent, or an unreadable identity leaves the bare `> ` row `unknown`, so the dead-shell rule still holds for every non-agy prompt.
+This identity plus structure conjunction stays inside the herdr adapter (`FM_BACKEND_HERDR_AGY_PROMPT_RE`, `fm_backend_herdr_agy_composer_find`, and the agy block in `fm_backend_herdr_composer_state`); the shared classifier's bare-glyph safety rule is not weakened.
 
 ANSI capture preserves de-emphasized placeholder style.
 `bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1895,6 +1895,80 @@ test_composer_state_pi_separator_requires_safe_native_identity() {
   pass "fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets"
 }
 
+# --- composer_state: agy plain-ASCII "> " composer (herdr-specific shape) -----
+# agy's interactive composer draws a PLAIN ASCII "> " prompt with no side
+# border and no agent-specific glyph, so its empty-composer row is byte-for-byte
+# the bare shell ">" prompt the shared classifier deliberately refuses as
+# `unknown` (the dead-shell safety rule). Like Pi's separator composer, the agy
+# row is admitted as a real, injectable composer ONLY when native `agent get`
+# corroborates the target is agy AND reports it idle/done/blocked. These assert
+# the identity + structure conjunction, and that the dead-shell rule still holds
+# for a bare ">" under a non-agy (or absent) agent.
+
+test_composer_state_agy_prompt_idle_is_empty() {
+  local dir log resp fb out calls
+  dir="$TMP_ROOT/composer-agy-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '  some transcript line\n  another line\n\n> \n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"agy","agent_status":"idle"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = empty ] || fail "an idle native agy '> ' composer should read empty, got '$out'"
+  calls=$(grep -c $'\x1f''agent'$'\x1f''get' "$log")
+  [ "$calls" -eq 1 ] || fail "agy recognition must corroborate identity exactly once, made $calls agent calls"
+  pass "fm_backend_herdr_composer_state: a native idle agy '> ' composer reads empty"
+}
+
+test_composer_state_agy_prompt_real_text_is_pending() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-agy-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '  transcript\n\n> hello captain this is a draft\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"agy","agent_status":"done"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = pending ] || fail "real unsubmitted text in an agy '> ' composer should read pending, got '$out'"
+  pass "fm_backend_herdr_composer_state: real agy composer text reads pending"
+}
+
+# The core collision this task exists to resolve: a bare "> " row that is NOT a
+# live agy composer (a dead shell, or any non-agy / unregistered agent) must
+# stay `unknown`, never `empty` - the dead-shell safety rule the shared
+# classifier enforces. A working agy also cannot authorize injection.
+test_composer_state_agy_prompt_requires_safe_native_identity() {
+  local dir log resp fb out case_id
+  for case_id in working non-agy unreadable absent; do
+    dir="$TMP_ROOT/composer-agy-$case_id"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+    printf '  transcript\n\n> \n' > "$resp/1.out"
+    case "$case_id" in
+      working) printf '{"result":{"agent":{"agent":"agy","agent_status":"working"}}}\n' > "$resp/2.out" ;;
+      non-agy) printf '{"result":{"agent":{"agent":"shell","agent_status":"idle"}}}\n' > "$resp/2.out" ;;
+      unreadable) printf '1\n' > "$resp/2.exit" ;;
+      absent) printf '{"error":{"code":"agent_not_found","message":"no agent"}}\n' > "$resp/2.out" ;;
+    esac
+    fb=$(make_herdr_fakebin "$dir")
+    out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+    [ "$out" = unknown ] || fail "a bare '> ' row under an unsafe/absent agy identity case '$case_id' must remain unknown (dead-shell rule), got '$out'"
+  done
+  pass "fm_backend_herdr_composer_state: a bare '> ' row stays unknown for working, non-agy, unreadable, or unregistered agents"
+}
+
+# A live bottom-most agy "> " prompt below a stale bordered decorative box must
+# win: the box (identity-free) cannot outrank the identity-corroborated live
+# composer, and a stale transcript ">" above it cannot either.
+test_composer_state_agy_prompt_below_stale_bordered_box_wins() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-agy-below-box"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '\xe2\x95\xad\xe2\x94\x80\xe2\x94\x80\xe2\x95\xae\n\xe2\x94\x82 stale notice \xe2\x94\x82\n\xe2\x95\xb0\xe2\x94\x80\xe2\x94\x80\xe2\x95\xaf\n\n> \n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"agy","agent_status":"idle"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = empty ] || fail "a live idle agy '> ' composer below a stale bordered box must win (empty), got '$out'"
+  pass "fm_backend_herdr_composer_state: a live agy '> ' composer below a stale bordered box wins"
+}
+
 # --- composer_state: unbordered (bare) composer rows -------------------------
 # Regression coverage for the away-mode redelivery-loop incident
 # (docs/herdr-backend.md "Incident (2026-07-07)"): real claude and codex
@@ -3057,6 +3131,10 @@ test_composer_state_pi_separator_idle_is_empty
 test_composer_state_pi_separator_real_text_is_pending
 test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown
 test_composer_state_pi_separator_requires_safe_native_identity
+test_composer_state_agy_prompt_idle_is_empty
+test_composer_state_agy_prompt_real_text_is_pending
+test_composer_state_agy_prompt_requires_safe_native_identity
+test_composer_state_agy_prompt_below_stale_bordered_box_wins
 test_composer_state_claude_unbordered_prompt_is_empty
 test_composer_state_claude_unbordered_prompt_is_pending
 test_composer_state_bare_prompt_below_stale_bordered_banner_wins


### PR DESCRIPTION
## Summary

Adds a herdr-specific composer shape for **agy**, whose interactive composer draws a plain ASCII `> ` prompt. That row is byte-for-byte the bare shell prompt that `bin/fm-composer-lib.sh` deliberately classifies as `unknown` (never `empty`) under the fleet-wide dead-shell safety rule. As a result, agy's empty composer under herdr fell into `unknown` instead of `empty`, unlike bordered or agent-glyph harnesses.

The fix mirrors the existing Pi separated-composer precedent: the agy `> ` row is located structurally and admitted as a real, injectable composer **only when** herdr's native `agent get` corroborates the target is agy **and** reports it idle, done, or blocked. A working agy, a non-agy or unregistered agent, or an unreadable identity leaves the bare `> ` row `unknown`, so the dead-shell rule still holds for every non-agy prompt.

The change stays entirely inside the herdr adapter — the shared classifier's bare-glyph safety rule is untouched.

## Changes

- `bin/backends/herdr.sh`
  - `FM_BACKEND_HERDR_AGY_PROMPT_RE` — matches a bare `> ` / lone `>` prompt row.
  - `fm_backend_herdr_agy_composer_find` — locates the bottom-most agy prompt row, defers the empty/unknown verdict to an identity check (same pattern as the Pi separator finder).
  - agy block in `fm_backend_herdr_composer_state` — admits the shape only on native identity `agy` + idle/done/blocked, requiring the agy row to be the bottom-most candidate (below any generic bordered/bare match and any Pi separator activity). Reuses the existing `<bordered>` content contract so a lone `>` reads `empty` and `> text` reads `pending`.
  - Memoized the `agent get` fetch so the Pi and agy blocks together make at most one identity call.
- `docs/herdr-backend.md` — documents agy as a known-gap, identity-gated shape.
- `tests/fm-backend-herdr.test.sh` — 4 new agy composer tests (idle empty, real-text pending, identity-required unknown cases, live-below-stale-box wins).

## Testing

- All 26 herdr composer unit tests pass, including the 4 new agy tests; no regressions.
- `bash -n` syntax check passes on both modified shell files.

The pre-existing `container_ensure` failure in the full-file run is environmental (resolves a `2ndmate-dms-dev` home label) and unrelated to this change.
