### PR TITLE
fix(teardown): retry worktree return on transient treehouse failure

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -71,7 +71,8 @@
 #      attempts. Retries key off the error text, not whether the lock file still
 #      exists after the failed attempt - a lock that self-clears mid-check still
 #      deserves a retry of the return.
-#   2. Other treehouse return failures still abort immediately and loudly (no retry).
+#   2. Other treehouse return failures still abort immediately and loudly (no retry
+#      inside teardown_treehouse_return itself).
 #   3. If every retry still hits the lock signature and the lock remains, it is removed
 #      and the return tried once more ONLY when the lock is provably stale per
 #      bin/fm-lock-lib.sh's fm_lock_is_provably_stale, passing the worktree dir as the
@@ -86,6 +87,18 @@
 # is present; teardown clears only a provably stale lock, then re-runs the safety
 # checks before any destructive return. Teardown output notes every wait, retry, and
 # removal so the operator can see what happened.
+#
+# Separately, and only for the worktree return call site (the ship/scout worktree
+# path, not the secondmate-home or child-worktree return calls): treehouse has also
+# been observed to fail the return outright on a freshly-reused pool worktree, citing
+# a signature distinct from the index.lock race - the benign stderr of what looks like
+# a successful `git checkout --detach --force` (e.g. "Previous HEAD position was
+# <sha> ..." / "HEAD is now at <sha> ...") - and then succeed unmodified on an
+# immediate retry with no other change. Rather than chase that signature, the worktree
+# return call is wrapped in one generic outer retry (FM_WORKTREE_RETURN_RETRIES,
+# default 1; FM_WORKTREE_RETURN_RETRY_WAIT_SECS, default 0s) on top of
+# teardown_treehouse_return's own index.lock handling, so this class of flake no
+# longer requires firstmate to notice the failure and manually re-run teardown.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -518,6 +531,24 @@ fi
 STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=$TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS
 TEARDOWN_TREEHOUSE_LOCK_REFUSED=2
 TEARDOWN_WORKTREE_SAFETY_LOCK_BLOCKED=3
+
+# Outer retry for the worktree return call only (see script header): treehouse
+# has been observed to fail the first `treehouse return --force` against a
+# freshly-reused pool worktree with a signature distinct from the index.lock
+# race above - it reports failure but attaches the benign stderr of a
+# successful-looking `git checkout --detach --force`, e.g. "Previous HEAD
+# position was <sha> ..." / "HEAD is now at <sha> ..." - then succeeds
+# unmodified on an immediate retry with no other change. This retry is
+# intentionally generic (any non-zero exit from the worktree return, after
+# teardown_treehouse_return's own index.lock retries are exhausted) rather
+# than signature-matched, and applies to the worktree return call site only.
+WORKTREE_RETURN_RETRIES=${FM_WORKTREE_RETURN_RETRIES:-1}
+case "$WORKTREE_RETURN_RETRIES" in ''|*[!0-9]*) WORKTREE_RETURN_RETRIES=1 ;; esac
+WORKTREE_RETURN_RETRY_WAIT_SECS=${FM_WORKTREE_RETURN_RETRY_WAIT_SECS:-0}
+if ! retry_wait_secs_is_valid "$WORKTREE_RETURN_RETRY_WAIT_SECS"; then
+  echo "teardown: invalid worktree return retry wait '$WORKTREE_RETURN_RETRY_WAIT_SECS'; using 0s" >&2
+  WORKTREE_RETURN_RETRY_WAIT_SECS=0
+fi
 
 # True when treehouse/git stderr shows the transient index.lock "File exists" race.
 # Other return failures must not enter the retry path.
@@ -1135,10 +1166,24 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   if [ "$FORCE" != "--force" ] && [ "$KIND" != scout ] && [ "$KIND" != secondmate ]; then
     post_lock_cleanup_check=validate_worktree_teardown_safety
   fi
-  teardown_treehouse_return "$WT" "$PROJ" "worktree" "$post_lock_cleanup_check" || {
-    echo "error: treehouse return failed for worktree $WT; teardown aborted" >&2
-    exit 1
-  }
+  # Outer retry for a separate treehouse flake seen only on this call site: see the
+  # "Separately" paragraph in the script header. teardown_treehouse_return's own
+  # index.lock handling still runs on every attempt.
+  worktree_return_attempt=0
+  while :; do
+    if teardown_treehouse_return "$WT" "$PROJ" "worktree" "$post_lock_cleanup_check"; then
+      break
+    fi
+    if [ "$worktree_return_attempt" -ge "$WORKTREE_RETURN_RETRIES" ]; then
+      echo "error: treehouse return failed for worktree $WT; teardown aborted" >&2
+      exit 1
+    fi
+    worktree_return_attempt=$(( worktree_return_attempt + 1 ))
+    echo "teardown: worktree return failed; retrying ($worktree_return_attempt/${WORKTREE_RETURN_RETRIES})" >&2
+    if [ "$WORKTREE_RETURN_RETRY_WAIT_SECS" != 0 ]; then
+      sleep "$WORKTREE_RETURN_RETRY_WAIT_SECS"
+    fi
+  done
 fi
 
 HERDR_PRESENTATION_JOURNAL="$STATE/$ID.herdr-presentation"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -431,6 +431,8 @@ FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh t
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature
 FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=   # legacy alias for FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS when the new variable is unset
+FM_WORKTREE_RETURN_RETRIES=1              # outer retries after fm-teardown.sh's ship/scout worktree treehouse return fails outright, distinct from the index.lock signature above
+FM_WORKTREE_RETURN_RETRY_WAIT_SECS=0      # seconds fm-teardown.sh waits before each of those outer retries
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3        # fetch retries after fm-fleet-sync.sh hits the orphaned .git/packed-refs.lock signature
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=1 # seconds fm-fleet-sync.sh waits before each of those retries
 FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=30       # min mtime age before fm-fleet-sync.sh treats a leftover packed-refs.lock as provably stale
@@ -470,6 +472,10 @@ FM_LOG_KEEP_LINES=2000             # daemon log lines kept when trimming
 When it is unset or blank, `FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS` remains a compatible fallback, and a blank fallback uses the 1-second default.
 An invalid nonblank wait falls back to 1 second rather than interrupting teardown.
 Teardown never removes a lock during the retry window, and after that window it attempts stale-lock cleanup only for a still-present lock that passes the configured age and live-holder checks.
+
+Only for the ship/scout worktree return call (not the secondmate-home or child-worktree return calls), `fm-teardown.sh` layers one generic outer retry, `FM_WORKTREE_RETURN_RETRIES`, on top of that index.lock-specific handling to cover a distinct failure signature: treehouse reporting the return as failed while its attached stderr shows the benign output of a successful `git checkout --detach --force`, then succeeding unmodified on an immediate retry.
+`FM_WORKTREE_RETURN_RETRIES` accepts a nonnegative integer, and an unset, blank, or invalid value uses the default of 1.
+`FM_WORKTREE_RETURN_RETRY_WAIT_SECS` accepts nonnegative whole or fractional seconds between attempts, and an invalid value falls back to the default of 0s.
 
 `fm-fleet-sync.sh` applies the same shape to an orphaned `.git/packed-refs.lock`: it retries only Git's `Unable to create '...packed-refs.lock': File exists` fetch failure up to `FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES` times (nonnegative integer; unset, blank, or invalid uses the default of 3), waiting `FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS` seconds (nonnegative whole or fractional; invalid falls back to 1 second) before each.
 Only after those retries exhaust does it remove the lock, and only when it is provably stale - still present, mtime age at least `FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS` (default 30), and no `lsof` holder of the lock file or of the clone worktree itself (a live `git` keeps that as its cwd even in the window after it closes the lock and before it exits).

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -49,6 +49,8 @@
 #   (w) index.lock mtime read failure                         -> lock kept, REFUSE
 #   (x) transient lock cleared after first failed return      -> retry ALLOW
 #   (y) persistent lock (never clears, not provably stale)    -> REFUSE loudly
+#   (z) worktree return fails once with a non-lock signature  -> outer retry ALLOW
+#   (aa) worktree return always fails with a non-lock signature -> outer retry exhausts, REFUSE loudly
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -391,6 +393,53 @@ if [ "${1:-}" = return ]; then
   fi
   echo "fatal: Unable to create '$lock': File exists." >&2
   exit 128
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+}
+
+# treehouse return fails once with a signature distinct from the index.lock
+# race - the benign-looking stderr of what looks like a successful
+# `git checkout --detach --force` - then succeeds on the next attempt with no
+# other change. This drives the outer worktree-return-only retry added for that
+# flake (see the "Separately" paragraph in bin/fm-teardown.sh's header).
+add_generic_failure_once_treehouse() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = return ]; then
+  shift
+  count_file="${TREEHOUSE_ATTEMPT_FILE:?}"
+  count=0
+  if [ -f "$count_file" ]; then
+    count=$(cat "$count_file")
+  fi
+  count=$(( count + 1 ))
+  printf '%s\n' "$count" > "$count_file"
+  if [ "$count" -eq 1 ]; then
+    echo "failed to return worktree: git checkout --detach --force refs/remotes/origin/main: Previous HEAD position was abc1234 origin baseline" >&2
+    echo "HEAD is now at def5678 origin baseline" >&2
+    exit 1
+  fi
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+}
+
+# treehouse return always fails with the same non-lock signature; used to assert
+# the outer worktree-return retry still exhausts and refuses loudly.
+add_generic_failure_always_treehouse() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = return ]; then
+  shift
+  echo "failed to return worktree: git checkout --detach --force refs/remotes/origin/main: Previous HEAD position was abc1234 origin baseline" >&2
+  echo "HEAD is now at def5678 origin baseline" >&2
+  exit 1
 fi
 exit 0
 SH
@@ -1226,6 +1275,64 @@ test_fractional_legacy_retry_wait_refuses_without_arithmetic_error() {
   pass "fractional legacy retry wait remains supported without arithmetic"
 }
 
+test_worktree_return_generic_failure_succeeds_on_retry() {
+  local case_dir rc attempt_file
+  case_dir=$(make_case worktree-return-generic-retry)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit "$case_dir" "shippable work"
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+
+  add_generic_failure_once_treehouse "$case_dir"
+
+  attempt_file="$case_dir/treehouse-attempts"
+  : > "$attempt_file"
+
+  set +e
+  TREEHOUSE_ATTEMPT_FILE="$attempt_file" \
+  FM_WORKTREE_RETURN_RETRIES=1 \
+  FM_WORKTREE_RETURN_RETRY_WAIT_SECS=0 \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" \
+    "worktree-return-generic-retry: teardown should succeed on retry after a non-lock treehouse failure"
+  assert_grep "worktree return failed; retrying" "$case_dir/stderr" \
+    "worktree-return-generic-retry: teardown did not report the outer retry"
+  [ "$(cat "$attempt_file")" = 2 ] \
+    || fail "worktree-return-generic-retry: expected exactly 2 treehouse return attempts, got $(cat "$attempt_file")"
+  pass "worktree return failing with a benign-looking checkout message on first attempt succeeds on immediate retry"
+}
+
+test_worktree_return_generic_failure_exhausts_retries_and_refuses() {
+  local case_dir rc
+  case_dir=$(make_case worktree-return-generic-exhausted)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit "$case_dir" "shippable work"
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+
+  add_generic_failure_always_treehouse "$case_dir"
+
+  set +e
+  FM_WORKTREE_RETURN_RETRIES=1 \
+  FM_WORKTREE_RETURN_RETRY_WAIT_SECS=0 \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" \
+    "worktree-return-generic-exhausted: teardown should refuse when treehouse return never succeeds"
+  assert_grep "worktree return failed; retrying" "$case_dir/stderr" \
+    "worktree-return-generic-exhausted: teardown did not report the outer retry"
+  assert_grep "treehouse return failed for worktree" "$case_dir/stderr" \
+    "worktree-return-generic-exhausted: teardown did not report the final failure"
+  [ -f "$case_dir/state/task-x1.meta" ] \
+    || fail "worktree-return-generic-exhausted: teardown completed despite persistent treehouse failure"
+  pass "worktree return that never succeeds still exhausts the outer retry and refuses loudly"
+}
+
 test_local_only_force_overrides_unpushed() {
   local case_dir rc
   case_dir=$(make_case force-override)
@@ -1403,3 +1510,5 @@ test_transient_index_lock_clears_after_first_attempt_and_retry_succeeds
 test_persistent_index_lock_exhausts_retries_and_refuses_loudly
 test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
+test_worktree_return_generic_failure_succeeds_on_retry
+test_worktree_return_generic_failure_exhausts_retries_and_refuses


### PR DESCRIPTION
## Intent

The developer (acting as firstmate, supervising a crewmate agent) asked the crewmate to fix a recurring bug in bin/fm-teardown.sh: the `treehouse return --force "$WT"` call fails on its first attempt (~6+ observed times) with a "Previous HEAD position was..." git checkout error, then succeeds unmodified on immediate retry, forcing firstmate to manually notice and re-run the script. The fix must be a narrowly scoped retry wrapper around only that one call site (around line 645), without patching the external treehouse binary, without adding retries elsewhere in the script, and while preserving the existing landed-work and dirty-worktree safety refusal checks exactly as-is. The crewmate implemented a configurable one-time retry (via FM_WORKTREE_RETURN_RETRIES/FM_WORKTREE_RETURN_RETRY_WAIT_SECS), added tests reproducing the failure-then-success and persistent-failure signatures, verified lint/tests passed, and committed on branch fm/fm-teardown-worktree-retry. The developer then directed running /no-mistakes to validate and ship a PR; during that pipeline run a push was blocked by a permissions/credential issue (403 denied pushing to kunchenguid/firstmate), which the developer resolved by providing a personal fork URL (git@github.com:austinyong/firstmate.git) and instructing the agent to reinitialize with that fork and resume the pipeline to push and open the PR against it.

## What Changed

- Wraps the ship/scout worktree `treehouse return --force` call in `bin/fm-teardown.sh` with a generic outer retry (`FM_WORKTREE_RETURN_RETRIES`, default 1; `FM_WORKTREE_RETURN_RETRY_WAIT_SECS`, default 0s), layered on top of the existing index.lock-specific retry inside `teardown_treehouse_return`, since treehouse has been observed to fail that call outright on a freshly-reused pool worktree with benign `git checkout --detach --force`-shaped stderr, then succeed unmodified on immediate retry.
- Scopes the new retry strictly to the worktree return call site, leaving the secondmate-home and child-worktree return call sites unretried.
- Adds `FM_WORKTREE_RETURN_RETRIES`/`FM_WORKTREE_RETURN_RETRY_WAIT_SECS` documentation in `docs/configuration.md` and new test coverage in `tests/fm-teardown.test.sh` for both the retry-succeeds and retries-exhausted-then-refuses paths.

## Risk Assessment

✅ Low: The change adds a narrowly-scoped, well-documented outer retry only around the ship/scout worktree treehouse-return call site, leaves the index.lock-specific inner retry and all safety-refusal checks (which already run earlier in the script) untouched, and is covered by new tests for both the retry-succeeds and retry-exhausted paths; docs are updated consistently with the implemented defaults.

## Testing

Ran the full existing fm-teardown test suite (all 34 cases pass, including the two new cases reproducing the failure-then-success and persistent-failure signatures) and additionally drove the real bin/fm-teardown.sh end-to-end by hand against a live git worktree fixture with a fake treehouse binary reproducing the exact reported error text, confirming the fix eliminates the manual-rerun step on a transient failure while still failing loudly on a persistent one; no issues found.

<details>
<summary>Evidence: Manual CLI transcripts: transient failure auto-retried to success, and persistent failure still refused loudly</summary>

```text
# Manual end-to-end CLI transcripts: bin/fm-teardown.sh worktree-return retry

Reproduces the exact reported bug (treehouse `return --force` failing once with a
benign-looking "Previous HEAD position was ..." / "HEAD is now at ..." git checkout
message, then succeeding unmodified on retry) against the REAL `bin/fm-teardown.sh`
entrypoint on the target commit (7f9f012), using a fake `treehouse` shim only (real
git worktree, real teardown logic, real safety checks). `FM_GATE_REFUSE_BYPASS=1` is
the same escape hatch firstmate's own test harness uses so the script's no-mistakes
gate-agent refusal doesn't fire for this sandboxed run.

## Case 1: treehouse fails once, then succeeds on immediate retry (the reported bug)

Command:

`` `
FM_WORKTREE_RETURN_RETRIES=1 FM_WORKTREE_RETURN_RETRY_WAIT_SECS=0 FM_GATE_REFUSE_BYPASS=1 \
  bin/fm-teardown.sh task-x1
`` `

Output:

`` `
failed to return worktree: git checkout --detach --force refs/remotes/origin/main: Previous HEAD position was abc1234 origin baseline
HEAD is now at def5678 origin baseline
teardown: worktree return failed; retrying (1/1)
/tmp/fm-teardown-manual-24294/project: already current
teardown task-x1 complete (window fm-task-x1, worktree /tmp/fm-teardown-manual-24294/wt)
Backlog: task-x1 just finished. Update data/backlog.md - move task-x1 to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
EXIT_CODE=0
`` `

Treehouse `return` was invoked exactly twice (attempt count file read back "2").
Before this fix, this same first-attempt failure would have aborted teardown
immediately with exit code 1, requiring a human/firstmate to notice and re-run the
script by hand - that manual-rerun step is what this fix eliminates.

## Case 2: treehouse fails every attempt (retry budget exhausted, safety preserved)

Command:

`` `
FM_WORKTREE_RETURN_RETRIES=1 FM_WORKTREE_RETURN_RETRY_WAIT_SECS=0 FM_GATE_REFUSE_BYPASS=1 \
  bin/fm-teardown.sh task-x1
`` `

Output:

`` `
failed to return worktree: git checkout --detach --force refs/remotes/origin/main: Previous HEAD position was abc1234 origin baseline
HEAD is now at def5678 origin baseline
teardown: worktree return failed; retrying (1/1)
failed to return worktree: git checkout --detach --force refs/remotes/origin/main: Previous HEAD position was abc1234 origin baseline
HEAD is now at def5678 origin baseline
error: treehouse return failed for worktree /tmp/fm-teardown-manual-persist-28353/wt; teardown aborted
EXIT_CODE=1
`` `

Confirms the retry is bounded (not an infinite loop masking a real failure) and
teardown still aborts loudly and non-zero when the underlying problem doesn't
clear.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`./tests/fm-teardown.test.sh` (full suite, 34 cases including the 2 new ones: `test_worktree_return_generic_failure_succeeds_on_retry`, `test_worktree_return_generic_failure_exhausts_retries_and_refuses`) — all passed</code>
- <code>Manual end-to-end run of the real `bin/fm-teardown.sh` against a fresh git worktree fixture with a fake `treehouse` shim that fails the first `return --force` call with the exact reported stderr signature (&#34;Previous HEAD position was ...&#34; / &#34;HEAD is now at ...&#34;) then succeeds — confirmed teardown auto-retries once and completes with exit code 0, no manual re-run needed</code>
- <code>Manual end-to-end run of the same script where `treehouse return` fails every attempt — confirmed the retry is bounded (exactly FM_WORKTREE_RETURN_RETRIES extra attempts) and teardown still aborts with exit code 1 and a clear error, i.e. safety is preserved</code>
- `Read-through of bin/fm-teardown.sh call sites at lines ~954 (secondmate-home return) and ~1043 (child-worktree return) to confirm neither was wrapped in the new outer retry, matching the narrowly-scoped intent`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
