### PR TITLE
Formalize proportional model routing and direct delivery

### DIFF
--- a/.agents/skills/delivery-quality/SKILL.md
+++ b/.agents/skills/delivery-quality/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: delivery-quality
+description: >-
+  Agent-only procedure for choosing a task's configured model route and proportional delivery evidence.
+  Load before writing any ship or scout brief and before treating a PR as ready, to apply exact-model discovery and fallback, right-size validation, browser and media evidence, reconcile CI and automated review, and report the result concisely without creating another review layer.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# delivery-quality
+
+Load this before writing any ship or scout brief and again before treating a PR as ready.
+This skill owns the conditional decision procedure for model routing, validation depth, browser verification, review evidence, and PR-ready reconciliation.
+The selected delivery path remains authoritative, and this procedure must not create a second orchestration or quality pipeline.
+
+## Choose and record the route
+
+Apply dispatch precedence exactly once: an explicit per-task captain instruction, then the best-fit `config/crew-dispatch.json` rule, then its configured default, then the static crew harness.
+A per-task instruction always wins, including its requested harness or interface, model, and effort axes, unless the requested harness or exact model cannot be established as supported in the current authenticated environment.
+Use the current discovery surface in `harness-adapters` before passing a configured exact model to `fm-spawn`.
+Do not infer an alias, silently substitute a similarly named model, or claim that an unavailable route ran.
+
+A rule's optional `fallback` is a concrete unavailable-model fallback, not a quota candidate or a lower-precedence default.
+Use it only when the rule's single preferred `use` profile names an exact model whose current availability cannot be verified or whose launch reports that it is unavailable.
+Verify the fallback's harness and exact model through the same current discovery surface before dispatching it.
+If both preferred and fallback routes are unavailable or unverified, stop and report the two concrete failures.
+A configured fallback never overrides an explicit per-task captain model instruction unless the captain also authorized that fallback.
+Record the actual selected harness, model, and effort in the spawn flags, and mention a fallback in the eventual outcome because it materially differs from the standing route.
+
+The copyable standing routes and their currently verified exact identifiers live in `docs/examples/crew-dispatch.json`.
+`docs/verification/model-routing.md` records the current local empirical evidence for those identifiers.
+Reverify volatile model availability before applying that private config after a later client, account, or catalog change.
+
+## Write a proportional quality plan
+
+Put a short task-specific validation and evidence plan in the task text before spawning.
+Name the existing checks to run, whether browser verification is material, and whether a screenshot or video belongs in the PR.
+Do not leave the worker to infer an expensive ceremony from the fact that a file is frontend code.
+
+Use this scale:
+
+- A trivial, mechanical, or nonvisual fix uses one cheapest capable worker, low effort, the repository's existing hooks, and only the focused checks already appropriate to the edit.
+  It gets no extra worker, broad review, browser pass, screenshot, or video unless the changed behavior itself makes one materially useful.
+- Quick, well-understood backend work uses one worker on the standing GPT-5.5 route when available, low effort, focused tests, and existing quality gates.
+- Medium engineering work uses one worker on the standing GPT-5.6 route, medium effort, and focused plus affected-subsystem checks.
+- Complex, ambiguous, high-blast-radius, or design-heavy work uses the same strongest appropriate route with high or xhigh effort and broader relevant checks.
+  Add another worker only for an independently valuable investigation or a genuinely distinct validation question that cannot be answered well by the implementation worker or existing repository gates.
+- Substantive frontend implementation uses the standing Claude Opus 5 route when available and gives browser behavior, visual regressions, accessibility, responsive states, and interaction paths the depth their user impact warrants.
+  It does not automatically require video, a second worker, or a second broad code review.
+
+Preserve every repository's installed pre-commit hooks and configured quality gates.
+Run them through the repository's normal commit and delivery flow.
+Do not reinstall, replace, or bypass them merely because a setup skill or local setup note is absent.
+
+## Cross-model validation
+
+For substantive frontend work implemented with Pi and `anthropic/claude-opus-5`, use one focused validation scout on Pi and `openai/gpt-5.6-sol` when it can answer a distinct correctness, browser-behavior, accessibility, responsive-state, or interaction question.
+Validate the exact implementation commit before the PR is opened, and record the validator's model and named question in its instructions.
+When a separate validation scout is required, tell the implementation worker in its original instructions to commit, append one keyed `blocked:` validation-ready event naming the commit, and stop before push so firstmate can act.
+After the scout reports, steer the implementation worker with the findings or clearance and require it to append the matching `resolved:` event when it resumes.
+Keep the scout knowledge-only and route material findings back to the implementation worker for focused fixes and affected-check reruns.
+Do not turn it into a second generic code reviewer, repeat checks already answered by the implementation worker, or add another review after it.
+Skip the extra worker when the change is trivial, nonvisual, or already fully established by focused checks and browser evidence.
+If the exact validation model is unavailable, verify and report the configured fallback rather than claiming cross-model validation occurred.
+
+## Browser and visual evidence
+
+Require browser verification with `chrome-devtools-axi` for user-facing behavior when a real browser can materially validate the changed result.
+Select task-relevant states and viewport sizes rather than performing a generic tour.
+A browser pass is optional for nonvisual changes, generated output, documentation-only edits, and trivial changes whose behavior is fully proven by focused non-browser checks.
+
+Require a screenshot in a frontend PR when it materially improves review of appearance, layout, responsive behavior, or a visible state.
+Require video only when motion, interaction, responsiveness over time, or a state transition is materially clearer in motion than in still images and prose.
+Do not require either medium for nonvisual or trivial changes.
+Use the repository's existing PR upload or evidence mechanism.
+Do not commit disposable screenshots or recordings unless that existing owner requires committed evidence.
+If no existing mechanism can place the useful artifact in the PR without changing repository policy, state that limitation and include the browser result in the PR summary instead of inventing an evidence store.
+
+## Discoveries and scope
+
+A worker must surface a discovery that could materially change correctness, accepted scope, risk, security, migration behavior, or product behavior.
+Route an actual product or engineering-contract choice through the normal decision authority.
+Continue independently only when the correction is clearly required by accepted intent.
+Do not use a discovery as permission for drive-by cleanup, adjacent feature work, or a broader redesign.
+
+## Direct delivery and PR-ready reconciliation
+
+After implementation and any proportionate cross-model validation, run the repository's existing focused tests, hooks, and quality gates.
+Push only the task branch and open its PR through `gh-axi`; never push the default branch and never merge.
+Verify all configured required CI checks are green before reporting the PR ready.
+Inspect current automated review feedback through `gh-axi`, including CodeRabbit when the repository configures it or it has posted on the PR.
+Route every actionable finding that could affect correctness, scope, risk, or product behavior back to the implementation worker, then rerun affected checks and push the focused fix on the same task branch.
+Do not wait forever for an optional service that is absent or silent.
+If no required check or posted review establishes that service as active, make one final refresh after required CI turns green and then treat its absence as non-blocking.
+A pending required check, an already-posted actionable finding, or a repository-documented bot requirement remains blocking until it resolves or reports a concrete failure.
+
+Report readiness to the captain in one concise outcome: what changed, the actual implementation and validation models when useful or when fallback occurred, checks and browser or media evidence, material residual risk, and the full PR URL.
+Do not relay delivery mechanics or a checklist dump.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -137,6 +137,7 @@ Use the discovery surface in the current authenticated environment because suppo
 
 For an unfamiliar harness or model namespace, establish support and provider identity from that harness's authoritative CLI help, model listing, or current documentation rather than guessing from a name or prefix.
 If those sources do not establish the relationship needed for dispatch, fail loudly and report the unresolved candidate.
+`docs/verification/model-routing.md` records dated empirical probes for the exact identifiers in the copyable dispatch example, while `delivery-quality` owns the per-task unavailable-model fallback decision.
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,7 @@ If fast-path risk needs more rigor, escalate whether to use no-mistakes instead 
 The path's worker, automated gates, and captain approval remain authoritative:
 
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
-- **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
+- **direct-PR** has the worker complete the `delivery-quality` direct path, push only the task branch, open a PR, reconcile required CI and configured review feedback, then wait for the configured merge authority.
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
 
 Delivery mode and `yolo` are orthogonal.
@@ -305,7 +305,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 
 ### PR ready, landing, and teardown
 
-For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
+For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url> checks green` only after the task's direct validation, required CI, and configured review feedback are reconciled.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
@@ -471,6 +471,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `delivery-quality` - load before writing any ship or scout brief and before treating a PR as ready; it owns exact-model fallback, proportional validation, browser and media evidence, automated-review reconciliation, and concise readiness reporting.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -731,6 +731,7 @@ crew_dispatch_validate() {
       end;
     def configured_profiles:
       ([(.rules // [])[]? | profiles(.use?)[]?]
+        + [(.rules // [])[]? | .fallback? // empty]
         + (if has("default") then [profiles(.default)[]?] else [] end));
     def malformed_optional_fields($items):
       ($items | any(has("model") and (((.model | type) != "string") or (.model | length) == 0)))
@@ -752,6 +753,11 @@ crew_dispatch_validate() {
     elif [(.rules // [])[]? | profiles(.use?)[]? | select(type != "object")] | length > 0 then "each use profile must be an object"
     elif [(.rules // [])[]? | profiles(.use?)[]? | select((.harness? | type) != "string" or (.harness | length) == 0)] | length > 0 then "each use profile needs harness"
     elif malformed_optional_fields([(.rules // [])[]? | profiles(.use?)[]?]) then "use profile model and effort must be non-empty strings when present"
+    elif [(.rules // [])[]? | select(has("fallback") and (.use | type) == "array")] | length > 0 then "fallback requires a single preferred use profile"
+    elif [(.rules // [])[]? | select(has("fallback") and (.fallback | type) != "object")] | length > 0 then "fallback must be a profile object"
+    elif [(.rules // [])[]? | .fallback? // empty | select((.harness? | type) != "string" or (.harness | length) == 0)] | length > 0 then "each fallback profile needs harness"
+    elif [(.rules // [])[]? | .fallback? // empty | select((.model? | type) != "string" or (.model | length) == 0)] | length > 0 then "each fallback profile needs an exact model"
+    elif malformed_optional_fields([(.rules // [])[]? | .fallback? // empty]) then "fallback profile effort must be a non-empty string when present"
     elif [(.rules // [])[]? | select(has("select") and ((.select? | type) != "string" or (.select | length) == 0))] | length > 0 then "select must be a non-empty string"
     elif [(.rules // [])[]? | .select? // empty | select(. != "quota-balanced")] | length > 0 then
       "unknown select: " + ([ (.rules // [])[]? | .select? // empty | select(. != "quota-balanced") ] | unique | join(", "))
@@ -790,7 +796,8 @@ crew_dispatch_validate() {
       else profile($value)
       end;
     (["BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json"]
-      + [(.rules // [])[]? | "BOOTSTRAP_INFO: crew dispatch rule: " + (.when | tostring) + " -> " + profile_set(.use; .select?)]
+      + [(.rules // [])[]? | "BOOTSTRAP_INFO: crew dispatch rule: " + (.when | tostring) + " -> " + profile_set(.use; .select?)
+        + (if .fallback? != null then " (unavailable fallback: " + profile(.fallback) + ")" else "" end)]
       + (if has("default") then ["BOOTSTRAP_INFO: crew dispatch default: " + profile_set(.default; null)] else [] end))
     | .[]
   ' "$file"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -288,9 +288,9 @@ case "$MODE" in
     DOD=$(cat <<EOF
 # Definition of done
 This project ships through the direct PR path.
-The task is complete only after the task's explicit validation and evidence requirements, the repository's existing hooks and quality gates, required CI, and configured review feedback are reconciled.
+The task is complete only after explicit task validation and evidence requirements, existing repository hooks and quality gates, required CI, and configured review feedback are reconciled.
 Commit on your task branch, push only that branch, and open its PR with \`gh-axi\`; never push the default branch and never merge.
-Address actionable CI or configured review findings on the same task branch, rerun affected checks, and use the task's bounded rule for an optional review service that stays absent.
+Address actionable CI or configured review findings on the same task branch, rerun affected checks, and use the bounded task rule for an optional review service that stays absent.
 Then append \`done: PR {url} checks green\` to the status file and stop.
 The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -30,7 +30,7 @@
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):
 #   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge (default)
-#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
+#   direct-PR    implement -> direct validation/gates -> task-branch PR -> CI/review reconciliation -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
@@ -287,10 +287,12 @@ case "$MODE" in
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done
-This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+This project ships through the direct PR path.
+The task is complete only after the task's explicit validation and evidence requirements, the repository's existing hooks and quality gates, required CI, and configured review feedback are reconciled.
+Commit on your task branch, push only that branch, and open its PR with \`gh-axi\`; never push the default branch and never merge.
+Address actionable CI or configured review findings on the same task branch, rerun affected checks, and use the task's bounded rule for an optional review service that stays absent.
+Then append \`done: PR {url} checks green\` to the status file and stop.
+The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
 )
     ;;
@@ -374,6 +376,11 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+
+# Delivery discipline
+Follow the task's explicit validation, browser, and review-evidence requirements without adding redundant workers or review layers.
+Preserve the repository's existing pre-commit hooks and quality gates; do not reinstall, replace, or bypass them merely because setup guidance is absent.
+Surface discoveries that could materially change correctness, accepted scope, risk, security, migration behavior, or product behavior, but do not make drive-by changes.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -120,7 +120,7 @@ family_for_basename() {
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|fm-brief.test.sh|\
     fm-calm-pi-extension.test.sh|fm-captain-translation-contract.test.sh|fm-cd-pretool-check.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
-    fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
+    fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|fm-delivery-quality.test.sh|\
     fm-dispatch-select.test.sh|fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,7 +141,8 @@ The intake and authority contract in `AGENTS.md` owns when separate scout resear
 
 Crewmate and scout dispatch can stay on the static crewmate harness resolved by `config/crew-harness`, or it can use local dispatch profiles in `config/crew-dispatch.json`.
 The dispatch file is intentionally judgment-based: firstmate reads the natural-language rules at intake, chooses the best matching rule, resolves profile arrays itself from current quota output under `AGENTS.md` section 4, and passes only concrete `--harness`, `--model`, and `--effort` axes to `fm-spawn.sh`.
-The shell scripts validate the JSON shape and verified harness/effort combinations, but they do not parse task intent, match natural-language rules, or own array selection.
+The shell scripts validate the JSON shape and verified harness/effort combinations, but they do not parse task intent, match natural-language rules, discover model availability, or own array selection.
+A single-profile rule may declare one validated concrete `fallback` for an unavailable exact model; `delivery-quality` owns the current-discovery and fallback decision, while the dispatch schema remains in `docs/configuration.md`.
 `fm-dispatch-select.sh` is vestigial and not called during this transition; its separately based removal follows after the replacement instruction lands.
 The session-start bootstrap step keeps valid dispatch configuration silent unless verbose facts are enabled and surfaces a concise invalid-config line when validation fails.
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
@@ -187,7 +188,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 ## Project modes are explicit
 
 `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
-`no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
+`no-mistakes` projects run their configured validation pipeline, `direct-PR` projects follow the proportional validation, repository-gate, task-branch PR, CI, and review-feedback path owned by `delivery-quality`, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,6 +213,7 @@ This section is the single owner of the canonical schema and its per-field seman
       "use": [
         { "harness": "<adapter>", "model": "<optional model>", "effort": "<low|medium|high|xhigh|max, optional>" }
       ],
+      "fallback": { "harness": "<adapter>", "model": "<exact model>", "effort": "<optional effort>" },
       "select": "<optional strategy>",
       "why": "<optional rationale that helps firstmate choose>"
     }
@@ -228,15 +229,20 @@ Both `use` and the optional top-level `default` accept either one profile object
 The single-object form stays fully backward-compatible, and every profile needs `harness`.
 Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
+A rule may also carry one `fallback` profile object only when `use` is a single preferred profile object.
+The fallback requires an explicit harness and exact model, accepts an optional effort, and is used only when current authoritative discovery or launch establishes that the preferred exact model is unavailable or unverified.
+It is not an array candidate, a quota alternative, or permission to replace an explicit per-task captain model instruction.
+Firstmate verifies its exact model through the same current discovery surface before dispatch, records the actual concrete profile in spawn metadata, and stops if neither preferred nor fallback model can be established.
 Every profile array is an implicit quota-aware choice and does not need a selector property.
 `select: "quota-balanced"` remains accepted on rules for configuration compatibility and routes to the same agent-judged array procedure.
 If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before falling back to `config/crew-harness`.
 If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
 `bin/fm-dispatch-select.sh` is vestigial during the instruction transition and must not be called; a separately based follow-up removes it after the replacement operating contract lands.
-See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
+See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for the copyable standing configuration with the currently verified exact model identifiers and concrete unavailable-model fallbacks.
+Apply it to the primary home's private `config/crew-dispatch.json` only after rechecking the current authenticated model discovery surfaces; [`docs/verification/model-routing.md`](verification/model-routing.md) records the dated local evidence behind those identifiers.
 When the file exists, bootstrap validates it with `jq`.
 Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstrap emits `BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json`, one `BOOTSTRAP_INFO:` fact per rule, and one fact for the optional default profile set.
-Malformed JSON, an empty or malformed rule/default array, an unverified harness, an unknown `select`, or an effort value unsupported by that harness is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
+Malformed JSON, an empty or malformed rule/default array, a malformed fallback, an unverified harness, an unknown `select`, or an effort value unsupported by that harness is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
 While the file remains present, no crewmate or scout spawn may proceed without an explicit resolved harness; malformed configuration must be reported and corrected rather than selected around.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -132,6 +132,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/delivery-quality/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/firstmate-codexapp/SKILL.md",
       "audience": "agent-runtime"
     },
@@ -298,6 +302,10 @@
     {
       "path": "docs/turnend-guard.md",
       "audience": "operator-current"
+    },
+    {
+      "path": "docs/verification/model-routing.md",
+      "audience": "maintainer-verification"
     },
     {
       "path": "docs/verification/runtime-backends.md",

--- a/docs/examples/crew-dispatch.json
+++ b/docs/examples/crew-dispatch.json
@@ -1,26 +1,41 @@
 {
   "rules": [
     {
-      "when": "The task depends on fresh news, current events, live public facts, or recent market and product changes.",
-      "use": { "harness": "grok" },
-      "why": "Grok is the preferred dispatch when current web-connected context is central to the work."
+      "when": "The task is a trivial mechanical or nonvisual fix with an explicit bounded path.",
+      "use": { "harness": "pi", "model": "anthropic/claude-haiku-4-5-20251001", "effort": "low" },
+      "fallback": { "harness": "pi", "model": "openai/gpt-5.5", "effort": "low" },
+      "why": "Use the cheapest verified capable route and only the focused existing checks appropriate to the edit."
     },
     {
-      "when": "The task is a trivial mechanical edit such as a rote rename, formatting sweep, targeted typo fix, or simple file gathering.",
-      "use": { "harness": "claude", "model": "haiku", "effort": "low" },
-      "why": "Use the cheapest fast profile when the task is narrow and low ambiguity."
+      "when": "The task is quick, well-understood backend implementation with low ambiguity and a bounded change path.",
+      "use": { "harness": "pi", "model": "openai/gpt-5.5", "effort": "low" },
+      "fallback": { "harness": "pi", "model": "openai/gpt-5.6-sol", "effort": "low" },
+      "why": "Prefer GPT-5.5 for fast bounded backend work and fall back only when its exact model is unavailable."
     },
     {
-      "when": "The task is a big or ambiguous multi-file feature, a risky refactor, or work that requires holding many moving parts in mind.",
-      "use": [
-        { "harness": "claude", "model": "claude-sonnet-5", "effort": "high" },
-        { "harness": "codex", "model": "gpt-5.5", "effort": "high" }
-      ],
-      "why": "Arrays are quota-aware automatically, so use a strong coding profile with the most available relevant quota."
+      "when": "The task is substantive frontend implementation whose user-facing behavior or visual result needs careful engineering.",
+      "use": { "harness": "pi", "model": "anthropic/claude-opus-5", "effort": "high" },
+      "fallback": { "harness": "pi", "model": "openai/gpt-5.6-sol", "effort": "high" },
+      "why": "Prefer Claude Opus 5 through Pi for substantive frontend implementation, with GPT-5.6 as the concrete unavailable-model fallback."
+    },
+    {
+      "when": "The task is a focused cross-model validation scout for substantive frontend implementation authored with Pi and anthropic/claude-opus-5, and it asks one distinct correctness or browser-behavior question not already answered by focused checks.",
+      "use": { "harness": "pi", "model": "openai/gpt-5.6-sol", "effort": "high" },
+      "fallback": { "harness": "pi", "model": "openai/gpt-5.5", "effort": "high" },
+      "why": "Use GPT-5.6 through Pi for one materially useful focused validation, never as a redundant generic reviewer."
+    },
+    {
+      "when": "The task is medium engineering work that is not a better match for the quick-backend or substantive-frontend rules.",
+      "use": { "harness": "pi", "model": "openai/gpt-5.6-sol", "effort": "medium" },
+      "fallback": { "harness": "pi", "model": "openai/gpt-5.5", "effort": "medium" },
+      "why": "Use GPT-5.6 through Pi with proportional reasoning for ordinary multi-step engineering."
+    },
+    {
+      "when": "The task is complex, ambiguous, high-blast-radius, design-heavy, or requires holding many interacting engineering constraints.",
+      "use": { "harness": "pi", "model": "openai/gpt-5.6-sol", "effort": "high" },
+      "fallback": { "harness": "pi", "model": "anthropic/claude-opus-5", "effort": "high" },
+      "why": "Use GPT-5.6 through Pi for complex engineering and preserve a verified strong-model fallback rather than silently downgrading."
     }
   ],
-  "default": [
-    { "harness": "codex", "model": "gpt-5.5", "effort": "medium" },
-    { "harness": "pi", "model": "anthropic/claude-sonnet-5", "effort": "medium" }
-  ]
+  "default": { "harness": "pi", "model": "openai/gpt-5.6-sol", "effort": "medium" }
 }

--- a/docs/verification/model-routing.md
+++ b/docs/verification/model-routing.md
@@ -1,0 +1,51 @@
+# Model routing verification
+
+This record supports the exact Pi model identifiers used by the copyable crew dispatch example.
+The dispatch procedure still rechecks the current authenticated discovery surface at intake because account entitlement and model catalogs are volatile.
+
+## 2026-07-25 local verification
+
+The installed client reported:
+
+```text
+$ pi --version
+0.82.0
+```
+
+Pi listed the exact Anthropic implementation models and their current limits:
+
+```text
+$ pi --list-models anthropic/claude-opus-5 | awk 'NR == 1 || $2 == "claude-opus-5"'
+provider   model                     context  max-out  thinking  images
+anthropic  claude-opus-5             1M       128K     yes       yes
+$ pi --list-models anthropic/claude-haiku-4-5-20251001 | awk 'NR == 1 || $2 == "claude-haiku-4-5-20251001"'
+provider   model                      context  max-out  thinking  images
+anthropic  claude-haiku-4-5-20251001  200K     64K      yes       yes
+```
+
+Pi listed the exact OpenAI backend and validation models:
+
+```text
+$ pi --list-models openai/gpt-5.5 | awk 'NR == 1 || $2 == "gpt-5.5"'
+provider  model        context  max-out  thinking  images
+openai    gpt-5.5      272K     128K     yes       yes
+$ pi --list-models openai/gpt-5.6-sol | awk 'NR == 1 || $2 == "gpt-5.6-sol"'
+provider  model        context  max-out  thinking  images
+openai    gpt-5.6-sol  272K     128K     yes       yes
+```
+
+Each exact route also completed a live low-thinking request through Pi:
+
+```text
+$ pi --print --model anthropic/claude-opus-5 --thinking low 'Reply with exactly MODEL_OK.'
+MODEL_OK
+$ pi --print --model anthropic/claude-haiku-4-5-20251001 --thinking low 'Reply with exactly MODEL_OK.'
+MODEL_OK
+$ pi --print --model openai/gpt-5.5 --thinking low 'Reply with exactly MODEL_OK.'
+Captain, MODEL_OK
+$ pi --print --model openai/gpt-5.6-sol --thinking low 'Reply with exactly MODEL_OK.'
+MODEL_OK
+```
+
+These probes establish the exact Pi provider/model identifiers for this environment on that date.
+They do not authorize silently substituting an alias or a similarly named model after a later availability failure.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -730,7 +730,7 @@ test_crew_dispatch_active_rules_are_verbose_bootstrap_info() {
   case_dir="$TMP_ROOT/dispatch-active"
   mkdir -p "$case_dir/home/config"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
-  printf '%s\n' '{"rules":[{"when":"fresh news","use":{"harness":"grok"},"why":"current context"},{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}]},{"when":"legacy feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"quota-balanced"}],"default":[{"harness":"pi","model":"anthropic/claude-sonnet-5","effort":"high"},{"harness":"grok","model":"grok-4.5","effort":"high"}]}' > "$case_dir/home/config/crew-dispatch.json"
+  printf '%s\n' '{"rules":[{"when":"fresh news","use":{"harness":"grok"},"fallback":{"harness":"codex","model":"gpt-5.6-sol","effort":"high"},"why":"current context"},{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}]},{"when":"legacy feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"quota-balanced"}],"default":[{"harness":"pi","model":"anthropic/claude-sonnet-5","effort":"high"},{"harness":"grok","model":"grok-4.5","effort":"high"}]}' > "$case_dir/home/config/crew-dispatch.json"
   fakebin=$(make_fake_toolchain "$case_dir")
   add_real_jq "$fakebin"
 
@@ -741,7 +741,7 @@ test_crew_dispatch_active_rules_are_verbose_bootstrap_info() {
   out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_BOOTSTRAP_VERBOSE_FACTS=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
 
-  expect=$'BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json\nBOOTSTRAP_INFO: crew dispatch rule: fresh news -> grok\nBOOTSTRAP_INFO: crew dispatch rule: big feature -> quota-balanced[claude/claude-sonnet-5/high, codex/gpt-5.5/high]\nBOOTSTRAP_INFO: crew dispatch rule: legacy feature -> quota-balanced[claude, codex]\nBOOTSTRAP_INFO: crew dispatch default: quota-balanced[pi/anthropic/claude-sonnet-5/high, grok/grok-4.5/high]'
+  expect=$'BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json\nBOOTSTRAP_INFO: crew dispatch rule: fresh news -> grok (unavailable fallback: codex/gpt-5.6-sol/high)\nBOOTSTRAP_INFO: crew dispatch rule: big feature -> quota-balanced[claude/claude-sonnet-5/high, codex/gpt-5.5/high]\nBOOTSTRAP_INFO: crew dispatch rule: legacy feature -> quota-balanced[claude, codex]\nBOOTSTRAP_INFO: crew dispatch default: quota-balanced[pi/anthropic/claude-sonnet-5/high, grok/grok-4.5/high]'
   [ "$out" = "$expect" ] || fail "active dispatch verbose info block mismatch"$'\n'"expected: $expect"$'\n'"actual:   $out"
   pass "bootstrap surfaces active crew-dispatch rules only as verbose BOOTSTRAP_INFO"
 }
@@ -776,6 +776,13 @@ unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","us
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
+concrete unavailable-model fallback is accepted^{"rules":[{"when":"frontend","use":{"harness":"claude","model":"claude-opus-5","effort":"high"},"fallback":{"harness":"codex","model":"gpt-5.6-sol","effort":"high"}}]}^empty^
+array use cannot carry unavailable-model fallback^{"rules":[{"when":"frontend","use":[{"harness":"claude"}],"fallback":{"harness":"codex","model":"gpt-5.6-sol"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - fallback requires a single preferred use profile
+fallback must be an object^{"rules":[{"when":"frontend","use":{"harness":"claude"},"fallback":"codex"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - fallback must be a profile object
+fallback requires harness^{"rules":[{"when":"frontend","use":{"harness":"claude"},"fallback":{"model":"gpt-5.6-sol"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each fallback profile needs harness
+fallback requires exact model^{"rules":[{"when":"frontend","use":{"harness":"claude"},"fallback":{"harness":"codex"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each fallback profile needs an exact model
+fallback unverified harness is flagged^{"rules":[{"when":"frontend","use":{"harness":"claude"},"fallback":{"harness":"spaceship","model":"warp-9"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
+fallback unsupported effort is flagged^{"rules":[{"when":"frontend","use":{"harness":"claude"},"fallback":{"harness":"codex","model":"gpt-5.6-sol","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
 array use with quota-balanced is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}],"select":"quota-balanced"}]}^empty^
 array use without select is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}]}]}^empty^
 one-element array use is accepted^{"rules":[{"when":"focused feature","use":[{"harness":"claude"}]}]}^empty^

--- a/tests/fm-delivery-quality.test.sh
+++ b/tests/fm-delivery-quality.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Deterministic contract tests for model-routing precedence, concrete unavailable-
+# model fallback, proportional validation, and browser/media evidence triggers.
+# Single-quoted assertion needles deliberately retain literal Markdown backticks.
+# shellcheck disable=SC2016
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SKILL="$ROOT/.agents/skills/delivery-quality/SKILL.md"
+EXAMPLE="$ROOT/docs/examples/crew-dispatch.json"
+
+assert_file_contains() {
+  local file=$1 needle=$2 message=$3
+  grep -F "$needle" "$file" >/dev/null || fail "$message"
+}
+
+assert_file_not_contains() {
+  local file=$1 needle=$2 message=$3
+  if grep -F "$needle" "$file" >/dev/null; then
+    fail "$message"
+  fi
+}
+
+test_trigger_and_precedence_contract() {
+  assert_file_contains "$ROOT/AGENTS.md" \
+    'load before writing any ship or scout brief and before treating a PR as ready' \
+    "AGENTS.md lost the delivery-quality load trigger"
+  assert_file_contains "$SKILL" \
+    'an explicit per-task captain instruction, then the best-fit `config/crew-dispatch.json` rule, then its configured default, then the static crew harness' \
+    "dispatch precedence no longer keeps explicit captain instructions first"
+  assert_file_contains "$SKILL" \
+    'including its requested harness or interface, model, and effort axes' \
+    "explicit per-task interface and model requests no longer override standing routes"
+  assert_file_contains "$SKILL" \
+    'A configured fallback never overrides an explicit per-task captain model instruction' \
+    "unavailable-model fallback can override a per-task captain route"
+  assert_file_not_contains "$SKILL" 'fm-dispatch-select.sh' \
+    "delivery-quality reintroduced the vestigial selector"
+  assert_file_not_contains "$SKILL" 'no-mistakes' \
+    "delivery-quality depends on the retiring pipeline"
+  pass "delivery-quality is discoverable and preserves per-task routing precedence"
+}
+
+test_exact_standing_routes_and_fallbacks() {
+  jq -e '
+    def rule($text): [.rules[] | select(.when | test($text; "i"))][0];
+    (rule("trivial") | .use == {harness:"pi",model:"anthropic/claude-haiku-4-5-20251001",effort:"low"}) and
+    (rule("well-understood backend") | .use == {harness:"pi",model:"openai/gpt-5.5",effort:"low"}) and
+    (rule("substantive frontend implementation whose") | .use == {harness:"pi",model:"anthropic/claude-opus-5",effort:"high"}) and
+    (rule("substantive frontend implementation whose") | .fallback == {harness:"pi",model:"openai/gpt-5.6-sol",effort:"high"}) and
+    (rule("focused cross-model validation") | .use == {harness:"pi",model:"openai/gpt-5.6-sol",effort:"high"}) and
+    (rule("medium engineering") | .use == {harness:"pi",model:"openai/gpt-5.6-sol",effort:"medium"}) and
+    (rule("complex") | .use == {harness:"pi",model:"openai/gpt-5.6-sol",effort:"high"}) and
+    (.rules | all((.fallback | type) == "object" and (.fallback.model | type) == "string"))
+  ' "$EXAMPLE" >/dev/null || fail "copyable dispatch config lost an exact preferred route or concrete fallback"
+  assert_file_contains "$ROOT/docs/verification/model-routing.md" 'claude-opus-5' \
+    "verification record lost Claude Opus 5 evidence"
+  assert_file_contains "$ROOT/docs/verification/model-routing.md" 'gpt-5.5' \
+    "verification record lost GPT-5.5 evidence"
+  assert_file_contains "$ROOT/docs/verification/model-routing.md" 'gpt-5.6-sol' \
+    "verification record lost GPT-5.6 evidence"
+  pass "copyable config carries exact locally verified routes and concrete fallbacks"
+}
+
+test_proportional_validation_and_visual_triggers() {
+  assert_file_contains "$SKILL" \
+    'It gets no extra worker, broad review, browser pass, screenshot, or video unless the changed behavior itself makes one materially useful.' \
+    "trivial work no longer has a cheap validation ceiling"
+  assert_file_contains "$SKILL" \
+    'use one focused validation scout on Pi and `openai/gpt-5.6-sol` when it can answer a distinct correctness' \
+    "focused cross-model validation has no exact bounded scout route"
+  assert_file_contains "$SKILL" \
+    'Do not turn it into a second generic code reviewer, repeat checks already answered by the implementation worker, or add another review after it.' \
+    "focused cross-model validation can become redundant ceremony"
+  assert_file_contains "$SKILL" \
+    'Push only the task branch and open its PR through `gh-axi`; never push the default branch and never merge.' \
+    "direct delivery lost its task-branch PR boundary"
+  assert_file_contains "$SKILL" \
+    'Require browser verification with `chrome-devtools-axi` for user-facing behavior when a real browser can materially validate the changed result.' \
+    "browser verification trigger changed"
+  assert_file_contains "$SKILL" \
+    'Require a screenshot in a frontend PR when it materially improves review' \
+    "screenshot trigger changed"
+  assert_file_contains "$SKILL" \
+    'Require video only when motion, interaction, responsiveness over time, or a state transition is materially clearer in motion' \
+    "video trigger changed"
+  assert_file_contains "$SKILL" \
+    'Do not commit disposable screenshots or recordings unless that existing owner requires committed evidence.' \
+    "disposable evidence can be committed without an owner"
+  assert_file_contains "$SKILL" \
+    'including CodeRabbit when the repository configures it or it has posted on the PR' \
+    "automated review reconciliation lost CodeRabbit"
+  assert_file_contains "$SKILL" \
+    'make one final refresh after required CI turns green and then treat its absence as non-blocking' \
+    "optional automated review has no bounded absence behavior"
+  pass "validation depth and visual evidence remain proportional to task-relevant value"
+}
+
+test_ship_brief_preserves_delivery_discipline() {
+  local brief_script="$ROOT/bin/fm-brief.sh"
+  assert_file_contains "$brief_script" '# Delivery discipline' \
+    "ship brief lost its delivery discipline section"
+  assert_file_contains "$brief_script" 'existing pre-commit hooks and quality gates' \
+    "ship brief no longer preserves repository quality hooks"
+  assert_file_contains "$brief_script" 'do not make drive-by changes' \
+    "ship brief no longer forbids discovery-driven scope expansion"
+  assert_file_contains "$brief_script" 'push only that branch' \
+    "direct PR brief lost the task-branch push boundary"
+  assert_file_contains "$brief_script" 'required CI, and configured review feedback are reconciled' \
+    "direct PR brief reports ready before CI and review reconciliation"
+  assert_file_contains "$ROOT/AGENTS.md" '`direct-PR` reports `done: PR <url> checks green` only after' \
+    "always-loaded lifecycle still treats PR creation as review-ready"
+  pass "ship brief scaffolding carries the compact worker-facing delivery invariants"
+}
+
+test_trigger_and_precedence_contract
+test_exact_standing_routes_and_fallbacks
+test_proportional_validation_and_visual_triggers
+test_ship_brief_preserves_delivery_discipline
+
+echo "# all fm-delivery-quality tests passed"


### PR DESCRIPTION
## Summary
- add verified Pi model-routing profiles with concrete fallbacks and captain override precedence
- define proportionate cross-model frontend validation, browser evidence, and direct task-branch delivery through existing Firstmate ownership surfaces
- require direct PRs to reconcile repository gates, required CI, and configured automated review before review readiness
- add deterministic dispatch, policy, documentation-audience, and route-contract coverage

## Validation
- `bin/fm-test-run.sh tests/fm-delivery-quality.test.sh`
- `bin/fm-test-run.sh tests/fm-bootstrap.test.sh`
- `bin/fm-test-run.sh tests/fm-test-run.test.sh`
- `bin/fm-doc-audience-check.sh`
- `bin/fm-lint.sh`
- JSON parsing for both changed JSON documents
- `git diff --check`
- `bin/fm-test-run.sh --changed` ran 40 tests: 36 passed, 1 optional typecheck skipped, and 4 local macOS Bash 3 failures were reproduced unchanged on `origin/main` (`fm-ask-user-authority`, `fm-brief`, `fm-tangle-guard`, and `fm-session-start`)