### PR TITLE
fix: reconcile unreported PRs at Codex checkpoints

### DIFF
--- a/bin/fm-pr-arrival-reconcile.sh
+++ b/bin/fm-pr-arrival-reconcile.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Discover an open non-draft GitHub PR that belongs to an in-flight PR-based
+# ship task but has not reached Firstmate through the task's status channel.
+#
+# This is the single owner of the unreported-PR reconciliation contract.
+# A candidate is eligible only when all of these independently-derived facts
+# agree:
+#   - state/<id>.meta is a regular single-link task record with kind=ship,
+#     mode=no-mistakes or direct-PR, and no recorded pr= identity;
+#   - its worktree is a real Git top-level on the exact generated fm/<id> branch;
+#   - that worktree's origin is a supported canonical GitHub remote;
+#   - gh-axi, run inside that worktree and filtered to the exact branch, reports
+#     an open non-draft PR whose canonical URL names the same origin repository.
+# Drafts, local-only tasks, scouts, secondmates, detached or renamed branches,
+# already-recorded PRs, unrelated repositories, and unrelated branches are
+# silent skips.
+#
+# On the first exact match, append a durable check wake before printing the same
+# actionable reason and exiting 0.
+# A clean scan with no match exits 1 silently.
+# The outer scan is foreground-only and bounded by --timeout, including every
+# gh-axi lookup; it never creates a shell background process.
+# A timeout or an inability to inspect any otherwise-eligible task exits 3 with
+# a diagnostic so the checkpoint treats the scan as failed instead of claiming
+# a quiet interval.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+TIMEOUT_SECONDS=${FM_PR_ARRIVAL_RECONCILE_TIMEOUT:-10}
+INTERNAL_SCAN=${FM_PR_ARRIVAL_RECONCILE_INTERNAL:-0}
+
+usage() {
+  cat <<'EOF'
+Usage: fm-pr-arrival-reconcile.sh [--timeout <seconds>]
+
+Scan this home's in-flight PR-based ship tasks for an unreported open non-draft
+GitHub PR on the task's exact fm/<task-id> branch.
+
+On a match, queue and print:
+  check: unreported PR for task <id>: <url> (open non-draft PR matches <branch>; run bin/fm-pr-check.sh <id> <url>)
+
+Exit 0 when a reconciliation wake was queued, 1 when no PR matched, 2 for
+invalid arguments, and 3 when the bounded scan could not inspect eligible work.
+The timeout defaults to FM_PR_ARRIVAL_RECONCILE_TIMEOUT, then 10 seconds.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --timeout)
+      [ "$#" -gt 1 ] || { echo "error: --timeout requires a value" >&2; exit 2; }
+      TIMEOUT_SECONDS=$2
+      shift 2
+      ;;
+    --timeout=*)
+      TIMEOUT_SECONDS=${1#--timeout=}
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$TIMEOUT_SECONDS" in
+  ''|*[!0-9]*) echo "error: --timeout must be a positive integer" >&2; exit 2 ;;
+  0) echo "error: --timeout must be greater than zero" >&2; exit 2 ;;
+esac
+
+run_with_perl_timeout() {
+  perl -e '
+    my $seconds = shift;
+    my $pid = fork;
+    die "fork failed\n" unless defined $pid;
+    if (!$pid) {
+      setpgrp(0, 0);
+      exec @ARGV;
+      die "exec failed: $!\n";
+    }
+    local $SIG{ALRM} = sub {
+      kill "TERM", -$pid;
+      select undef, undef, undef, 0.2;
+      kill "KILL", -$pid;
+      exit 124;
+    };
+    alarm $seconds;
+    waitpid $pid, 0;
+    exit($? >> 8);
+  ' "$TIMEOUT_SECONDS" "$0"
+}
+
+if [ "$INTERNAL_SCAN" != 1 ]; then
+  scan_status=0
+  if command -v timeout >/dev/null 2>&1; then
+    FM_PR_ARRIVAL_RECONCILE_INTERNAL=1 \
+      timeout "$TIMEOUT_SECONDS" "$0" || scan_status=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    FM_PR_ARRIVAL_RECONCILE_INTERNAL=1 \
+      gtimeout "$TIMEOUT_SECONDS" "$0" || scan_status=$?
+  else
+    FM_PR_ARRIVAL_RECONCILE_INTERNAL=1 \
+      run_with_perl_timeout || scan_status=$?
+  fi
+  case "$scan_status" in
+    0|1|2|3) exit "$scan_status" ;;
+    124|137|143)
+      echo "error: PR arrival reconciliation timed out after ${TIMEOUT_SECONDS}s" >&2
+      exit 3
+      ;;
+    *)
+      echo "error: PR arrival reconciliation failed with exit $scan_status" >&2
+      exit 3
+      ;;
+  esac
+fi
+
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+meta_value_once() {
+  local meta=$1 key=$2 count
+  count=$(grep -c "^${key}=" "$meta" 2>/dev/null || true)
+  [ "$count" = 1 ] || return 1
+  sed -n "s/^${key}=//p" "$meta"
+}
+
+github_remote_path() {
+  local remote=$1 path
+  case "$remote" in
+    https://github.com/*)
+      path=${remote#https://github.com/}
+      ;;
+    git@github.com:*)
+      path=${remote#git@github.com:}
+      ;;
+    ssh://git@github.com/*)
+      path=${remote#ssh://git@github.com/}
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  path=${path%.git}
+  fm_pr_url_parse "https://github.com/$path/pull/1" || return 1
+  [ "$FM_PR_PROVIDER" = github ] || return 1
+  printf '%s\n' "$FM_PR_PATH"
+}
+
+command -v gh-axi >/dev/null 2>&1 || {
+  echo "error: PR arrival reconciliation requires gh-axi" >&2
+  exit 3
+}
+
+eligible=0
+inspected=0
+failed_ids=
+row_pattern='^[[:space:]]*([0-9]+),.*,open,[^,]+,(yes|no),[^,]+,"(https://github\.com/[^"[:space:]]+/pull/[0-9]+)"[[:space:]]*$'
+for meta in "$STATE"/*.meta; do
+  [ -f "$meta" ] && [ ! -L "$meta" ] || continue
+  [ "$(fm_pr_file_link_count "$meta")" = 1 ] || continue
+  id=$(basename "$meta" .meta)
+  fm_pr_task_id_valid "$id" || continue
+  kind=$(meta_value_once "$meta" kind) || continue
+  [ "$kind" = ship ] || continue
+  mode=$(meta_value_once "$meta" mode) || continue
+  case "$mode" in
+    no-mistakes|direct-PR) ;;
+    *) continue ;;
+  esac
+  grep -q '^pr=' "$meta" 2>/dev/null && continue
+  wt=$(meta_value_once "$meta" worktree) || continue
+  wt_real=$(cd "$wt" 2>/dev/null && pwd -P) || continue
+  top=$(git -C "$wt_real" rev-parse --show-toplevel 2>/dev/null) || continue
+  top_real=$(cd "$top" 2>/dev/null && pwd -P) || continue
+  [ "$wt_real" = "$top_real" ] || continue
+  branch=$(git -C "$wt_real" symbolic-ref --quiet --short HEAD 2>/dev/null) || continue
+  [ "$branch" = "fm/$id" ] || continue
+  remote=$(git -C "$wt_real" remote get-url origin 2>/dev/null) || continue
+  remote_path=$(github_remote_path "$remote") || continue
+  eligible=$((eligible + 1))
+
+  if ! out=$(cd "$wt_real" && gh-axi pr list --state open --head "$branch" --limit 10 --fields url 2>/dev/null); then
+    failed_ids="$failed_ids $id"
+    continue
+  fi
+  inspected=$((inspected + 1))
+  lookup_rows=0
+  while IFS= read -r row; do
+    if [[ "$row" =~ $row_pattern ]]; then
+      lookup_rows=$((lookup_rows + 1))
+      number=${BASH_REMATCH[1]}
+      draft=${BASH_REMATCH[2]}
+      url=${BASH_REMATCH[3]}
+      [ "$draft" = no ] || continue
+      fm_pr_url_parse "$url" || continue
+      [ "$FM_PR_PROVIDER" = github ] || continue
+      [ "$FM_PR_NUMBER" = "$number" ] || continue
+      remote_path_lower=$(printf '%s' "$remote_path" | tr '[:upper:]' '[:lower:]')
+      pr_path_lower=$(printf '%s' "$FM_PR_PATH" | tr '[:upper:]' '[:lower:]')
+      [ "$remote_path_lower" = "$pr_path_lower" ] || continue
+      reason="check: unreported PR for task $id: $url (open non-draft PR matches $branch; run bin/fm-pr-check.sh $id $url)"
+      fm_wake_append check "pr-arrival:$id" "$reason" || {
+        echo "error: could not queue PR arrival reconciliation for task $id" >&2
+        exit 3
+      }
+      printf '%s\n' "$reason"
+      exit 0
+    fi
+  done <<EOF
+$out
+EOF
+  if [ "$lookup_rows" -eq 0 ] \
+    && ! printf '%s\n' "$out" | grep -qE '^count:[[:space:]]*0($|[[:space:]])'; then
+    failed_ids="$failed_ids $id"
+  fi
+done
+
+if [ -n "$failed_ids" ]; then
+  echo "error: PR arrival reconciliation could not inspect task(s):${failed_ids}" >&2
+  exit 3
+fi
+if [ "$eligible" -gt 0 ] && [ "$inspected" -eq 0 ]; then
+  echo "error: PR arrival reconciliation could not inspect eligible work" >&2
+  exit 3
+fi
+exit 1

--- a/bin/fm-watch-checkpoint.sh
+++ b/bin/fm-watch-checkpoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Run one bounded foreground watcher checkpoint for harnesses that should not
 # rely on background-task completion to wake the model.
+# On a quiet watcher expiry, invoke the bounded owner in
+# bin/fm-pr-arrival-reconcile.sh before declaring the interval quiet.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,7 +14,10 @@ Usage: fm-watch-checkpoint.sh [--seconds <n>]
 
 Run bin/fm-watch.sh in the foreground for a bounded checkpoint.
 On an actionable watcher wake, pass through the watcher output and exit 0.
+On a quiet watcher expiry, run the bounded task-correlated unreported-PR scan.
+When that scan queues a reconciliation wake, print its "check:" reason and exit 0.
 On a quiet checkpoint, print "checkpoint: no actionable wake within <n>s" and exit 124.
+When the reconciliation scan itself fails, print its diagnostic and exit 1.
 EOF
 }
 
@@ -49,7 +54,11 @@ ERR=$(mktemp "${TMPDIR:-/tmp}/fm-watch-checkpoint.err.XXXXXX") || {
   rm -f "$OUT"
   exit 1
 }
-trap 'rm -f "$OUT" "$ERR"' EXIT
+RECON_ERR=$(mktemp "${TMPDIR:-/tmp}/fm-watch-checkpoint.reconcile.err.XXXXXX") || {
+  rm -f "$OUT" "$ERR"
+  exit 1
+}
+trap 'rm -f "$OUT" "$ERR" "$RECON_ERR"' EXIT
 
 run_with_perl_timeout() {
   perl -e '
@@ -100,8 +109,25 @@ if grep -E '^watcher: already running' "$OUT" "$ERR" >/dev/null 2>&1; then
 fi
 
 if [ "$RC" -eq 124 ]; then
-  printf 'checkpoint: no actionable wake within %ss\n' "$SECONDS_ARG"
-  exit 124
+  RECON_OUT=
+  RECON_RC=0
+  RECON_OUT=$("$SCRIPT_DIR/fm-pr-arrival-reconcile.sh" 2>"$RECON_ERR") || RECON_RC=$?
+  case "$RECON_RC" in
+    0)
+      printf '%s\n' "$RECON_OUT"
+      [ ! -s "$RECON_ERR" ] || cat "$RECON_ERR" >&2
+      exit 0
+      ;;
+    1)
+      printf 'checkpoint: no actionable wake within %ss\n' "$SECONDS_ARG"
+      exit 124
+      ;;
+    *)
+      [ ! -s "$RECON_ERR" ] || cat "$RECON_ERR" >&2
+      echo "checkpoint: unreported-PR reconciliation failed after quiet watcher interval" >&2
+      exit 1
+      ;;
+  esac
 fi
 
 [ ! -s "$OUT" ] || cat "$OUT"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,7 @@ Optional X mode integrates with the watcher only after explicit opt-in; [configu
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
 That block owns the live wait shape for the running primary harness: Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
+After a quiet Codex watcher expiry, `bin/fm-watch-checkpoint.sh` invokes `bin/fm-pr-arrival-reconcile.sh`, whose header and help own the bounded task-correlated GitHub PR discovery contract and durable reconciliation wake.
 `bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints an honest `started`, `attached`, or nonzero `FAILED` status.
 On `attached` it stays live across identity-matched successors, and an unexplained clean child close either attaches to a verified healthy successor or becomes the typed nonzero `watcher: FAILED - cycle ended without an actionable reason` result.
 The arm layer records one bounded lifecycle row per observed cycle in `state/.watch-cycle-exits.log`; `state/.watch-triage.log` remains exclusively the absorbed-wake debug log.

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -5,11 +5,12 @@ When this session owns supervision and away mode is not active:
 2. Source `__FM_X_MODE_ENV__` first when X mode is active.
 3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
 4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
-5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
-6. Never use shell `&` or Codex background tasks for firstmate watcher supervision.
-7. Do not run `bin/fm-watch-arm.sh` as Codex's normal supervision command.
+5. A quiet watcher expiry runs `bin/fm-pr-arrival-reconcile.sh` before it can print `checkpoint:`; handle any resulting `check:` output like an ordinary wake.
+6. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
+7. Never use shell `&` or Codex background tasks for firstmate watcher supervision.
+8. Do not run `bin/fm-watch-arm.sh` as Codex's normal supervision command.
    If it is ever shelled anyway, a backgrounded, piped, or bundled anti-pattern is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`) registered in `.codex/hooks.json`.
-8. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
+9. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
 
 Codex cannot reason while a foreground tool call is running.
 The bounded checkpoint returns control regularly so user messages and queued wakes can be handled without relying on background-task wake semantics.

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -6,6 +6,8 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 CHECKPOINT="$ROOT/bin/fm-watch-checkpoint.sh"
+PR_RECONCILE="$ROOT/bin/fm-pr-arrival-reconcile.sh"
+TURNEND_GUARD="$ROOT/bin/fm-turnend-guard.sh"
 TMP_ROOT=$(fm_test_tmproot fm-watch-checkpoint)
 
 make_home() {
@@ -87,7 +89,189 @@ test_existing_singleton_watcher_is_not_success() {
   pass "checkpoint rejects an existing watcher singleton as unowned"
 }
 
+# Regression for the 2026-07-23 agents.house incident: PR 60 was open without a
+# matching status event, the Codex foreground checkpoint expired, and the
+# loop-guarded Stop was allowed to end blind.
+test_unreported_task_pr_is_actionable_before_turn_end() {
+  local home wt fakebin checkpoint_out checkpoint_err checkpoint_status
+  local guard_out guard_status combined
+  home=$(make_home unreported-pr)
+  wt="$home/task-worktree"
+  fakebin="$home/fakebin"
+  mkdir -p "$home/bin" "$wt" "$fakebin"
+  : > "$home/AGENTS.md"
+  git init -q "$home"
+  git -C "$home" -c user.name=fmtest -c user.email=fmtest@example.invalid \
+    commit -q --allow-empty -m "primary fixture"
+  git init -q "$wt"
+  git -C "$wt" -c user.name=fmtest -c user.email=fmtest@example.invalid \
+    commit -q --allow-empty -m "task fixture"
+  git -C "$wt" switch -q -c fm/agents-house-delivery
+  git -C "$wt" remote add origin https://github.com/example/agents.house.git
+cat > "$fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_TEST_GH_AXI_LOG"
+case "${1:-} ${2:-}" in
+  "pr list")
+    sleep "${FM_TEST_GH_AXI_SLEEP:-0}"
+    [ "${FM_TEST_GH_AXI_FAIL:-0}" = 0 ] || exit 1
+    if [ "${FM_TEST_GH_AXI_MALFORMED:-0}" = 1 ]; then
+      printf '%s\n' "count: 1 of 1 total" "pull_requests: changed schema"
+      exit 0
+    fi
+    requested_head=
+    shift 2
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --head)
+          requested_head=${2:-}
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    if [ "$requested_head" = "${FM_TEST_PR_HEAD:-fm/agents-house-delivery}" ]; then
+      printf '%s\n' \
+        "count: 1 of 1 total" \
+        "pull_requests[1]{number,title,state,author,draft,review,url}:" \
+        "  60,\"agents.house delivery\",open,example,${FM_TEST_PR_DRAFT:-no},none,\"${FM_TEST_PR_URL:-https://github.com/example/agents.house/pull/60}\""
+      exit 0
+    fi
+    printf '%s\n' "count: 0" "pull_requests: []"
+    exit 0
+    ;;
+esac
+echo "unexpected gh-axi call: $*" >&2
+exit 1
+SH
+  chmod +x "$fakebin/gh-axi"
+  printf '%s\n' \
+    'window=fm-agents-house-delivery' \
+    "worktree=$wt" \
+    "project=$home/agents.house" \
+    'harness=codex' \
+    'kind=ship' \
+    'mode=no-mistakes' \
+    'yolo=off' > "$home/state/agents-house-delivery.meta"
+  chmod 0600 "$home/state/agents-house-delivery.meta"
+  : > "$home/gh-axi.log"
+
+  checkpoint_out="$home/checkpoint.out"
+  checkpoint_err="$home/checkpoint.err"
+  checkpoint_status=0
+  PATH="$fakebin:$PATH" FM_TEST_GH_AXI_LOG="$home/gh-axi.log" \
+    FM_ROOT_OVERRIDE="$home" FM_HOME="$home" FM_POLL=1 \
+    FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    "$CHECKPOINT" --seconds 1 >"$checkpoint_out" 2>"$checkpoint_err" \
+    || checkpoint_status=$?
+
+  guard_status=0
+  guard_out=$(printf '{"stop_hook_active":true}' \
+    | PATH="$fakebin:$PATH" FM_TEST_GH_AXI_LOG="$home/gh-axi.log" \
+      FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+      bash "$TURNEND_GUARD" 2>&1) || guard_status=$?
+  combined="$(cat "$checkpoint_out")"$'\n'"$(cat "$checkpoint_err")"$'\n'"$guard_out"
+
+  if { [ "$checkpoint_status" -eq 0 ] || [ "$guard_status" -eq 2 ]; } \
+    && printf '%s\n' "$combined" | grep -qF 'agents-house-delivery' \
+    && printf '%s\n' "$combined" | grep -qF 'https://github.com/example/agents.house/pull/60'; then
+    assert_contains "$(cat "$home/state/.wake-queue")" \
+      "https://github.com/example/agents.house/pull/60" \
+      "unreported PR was printed without a durable reconciliation wake"
+    assert_no_grep '^pr checks' "$home/gh-axi.log" \
+      "PR arrival reconciliation depended on GitHub CI"
+  else
+    fail "unreported task PR stayed invisible: checkpoint rc=$checkpoint_status; guard rc=$guard_status; output=$combined"
+  fi
+
+  : > "$home/state/.wake-queue"
+  : > "$home/gh-axi.log"
+  checkpoint_status=0
+  checkpoint_out=$(
+    PATH="$fakebin:$PATH" FM_TEST_GH_AXI_LOG="$home/gh-axi.log" FM_TEST_PR_DRAFT=yes \
+      FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+      "$PR_RECONCILE" --timeout 2 2>&1
+  ) || checkpoint_status=$?
+  expect_code 1 "$checkpoint_status" "draft task PR reconciliation exit"
+  [ -z "$checkpoint_out" ] || fail "draft task PR produced reconciliation output: $checkpoint_out"
+  [ ! -s "$home/state/.wake-queue" ] || fail "draft task PR produced a durable wake"
+
+  : > "$home/gh-axi.log"
+  checkpoint_status=0
+  checkpoint_out=$(
+    PATH="$fakebin:$PATH" FM_TEST_GH_AXI_LOG="$home/gh-axi.log" \
+      FM_TEST_PR_HEAD=fm/unrelated-delivery \
+      FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+      "$PR_RECONCILE" --timeout 2 2>&1
+  ) || checkpoint_status=$?
+  expect_code 1 "$checkpoint_status" "unrelated task PR reconciliation exit"
+  [ -z "$checkpoint_out" ] || fail "unrelated task PR produced reconciliation output: $checkpoint_out"
+  [ ! -s "$home/state/.wake-queue" ] || fail "unrelated task PR produced a durable wake"
+
+  checkpoint_status=0
+  checkpoint_out=$(
+    PATH="$fakebin:$PATH" FM_TEST_GH_AXI_LOG="$home/gh-axi.log" \
+      FM_TEST_PR_URL=https://github.com/example/unrelated/pull/60 \
+      FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+      "$PR_RECONCILE" --timeout 2 2>&1
+  ) || checkpoint_status=$?
+  expect_code 1 "$checkpoint_status" "other-repository PR reconciliation exit"
+  [ -z "$checkpoint_out" ] || fail "other-repository PR produced reconciliation output: $checkpoint_out"
+  [ ! -s "$home/state/.wake-queue" ] || fail "other-repository PR produced a durable wake"
+
+  checkpoint_status=0
+  checkpoint_out=$(
+    PATH="$fakebin:$PATH" FM_TEST_GH_AXI_LOG="$home/gh-axi.log" \
+      FM_TEST_GH_AXI_SLEEP=5 \
+      FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+      "$PR_RECONCILE" --timeout 1 2>&1
+  ) || checkpoint_status=$?
+  expect_code 3 "$checkpoint_status" "bounded task PR reconciliation timeout exit"
+  assert_contains "$checkpoint_out" "timed out after 1s" \
+    "bounded task PR reconciliation timeout diagnostic"
+  [ ! -s "$home/state/.wake-queue" ] || fail "timed-out task PR scan produced a durable wake"
+
+  checkpoint_status=0
+  checkpoint_out=$(
+    PATH="$fakebin:$PATH" FM_TEST_GH_AXI_LOG="$home/gh-axi.log" \
+      FM_TEST_GH_AXI_FAIL=1 \
+      FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+      "$PR_RECONCILE" --timeout 2 2>&1
+  ) || checkpoint_status=$?
+  expect_code 3 "$checkpoint_status" "failed task PR lookup exit"
+  assert_contains "$checkpoint_out" "could not inspect task(s): agents-house-delivery" \
+    "failed task PR lookup diagnostic"
+
+  checkpoint_status=0
+  checkpoint_out=$(
+    PATH="$fakebin:$PATH" FM_TEST_GH_AXI_LOG="$home/gh-axi.log" \
+      FM_TEST_GH_AXI_MALFORMED=1 \
+      FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+      "$PR_RECONCILE" --timeout 2 2>&1
+  ) || checkpoint_status=$?
+  expect_code 3 "$checkpoint_status" "unrecognized task PR response exit"
+  assert_contains "$checkpoint_out" "could not inspect task(s): agents-house-delivery" \
+    "unrecognized task PR response diagnostic"
+
+  printf '%s\n' 'pr=https://github.com/example/agents.house/pull/60' \
+    >> "$home/state/agents-house-delivery.meta"
+  : > "$home/gh-axi.log"
+  checkpoint_status=0
+  checkpoint_out=$(
+    PATH="$fakebin:$PATH" FM_TEST_GH_AXI_LOG="$home/gh-axi.log" \
+      FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+      "$PR_RECONCILE" --timeout 2 2>&1
+  ) || checkpoint_status=$?
+  expect_code 1 "$checkpoint_status" "recorded task PR reconciliation exit"
+  [ -z "$checkpoint_out" ] || fail "recorded task PR produced reconciliation output: $checkpoint_out"
+  [ ! -s "$home/gh-axi.log" ] || fail "recorded task PR was looked up again"
+  pass "unreported task PR is surfaced before turn end without waking on drafts, unrelated PRs, or GitHub CI"
+}
+
 test_quiet_checkpoint_exits_124_cleanly
 test_signal_passes_through_and_exits_zero
 test_registered_check_uses_preserved_watcher_environment
 test_existing_singleton_watcher_is_not_success
+test_unreported_task_pr_is_actionable_before_turn_end


### PR DESCRIPTION
## Summary

Fix the 2026-07-23 supervision failure where a delivery PR became open without a matching status wake and the Codex foreground checkpoint later expired quietly.

After an otherwise quiet bounded checkpoint, reconcile only this home’s exact in-flight PR-based ship tasks against open non-draft PRs for their validated repository and `fm/<task-id>` branch.

Publish a durable actionable `check` wake before returning control, preserve the foreground-checkpoint contract, use no shell background process, and avoid draft, unrelated, already-recorded, scout, secondmate, and local-only PR wakes.

The mechanism does not depend on GitHub CI and therefore covers repositories using the local no-mistakes gate.

## Regression evidence

Red before behavior change:

```text
$ tests/fm-watch-checkpoint.test.sh
not ok - unreported task PR stayed invisible: checkpoint rc=124; guard rc=0; output=checkpoint: no actionable wake within 1s
```

Green on commit `68d3355a0ac43b99137ff6d5f82040f303839eef`:

```text
$ bin/fm-test-run.sh tests/fm-watch-checkpoint.test.sh
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0
ok - unreported task PR is surfaced before turn end without waking on drafts, unrelated PRs, or GitHub CI

$ bin/fm-test-run.sh tests/fm-supervision-instructions.test.sh
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0

$ bin/fm-test-run.sh tests/fm-turnend-guard.test.sh
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0

$ bin/fm-test-run.sh tests/fm-arm-pretool-check.test.sh
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0

$ bin/fm-doc-audience-check.sh
fm-doc-audience-check: ok surfaces=55 local_links=145

$ shellcheck --version && bin/fm-lint.sh
ShellCheck 0.11.0
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
```

`bash -n` on the changed shell files, `git diff --check origin/main...HEAD`, and temporary-tool cleanup also passed.