### PR TITLE
fix(spawn): repair the crewmate merge-block permission rules

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -30,6 +30,7 @@ Inheritance also copies the literal `config/crew-dispatch.json` file, so secondm
 
 Each adapter splits into mechanics and knowledge.
 The per-task mechanics, including launch command, autonomy flag, and any enabled crewmate turn-end hook, live in `bin/fm-spawn.sh`.
+The claude crewmate's generated `.claude/settings.local.json`, which carries the semantic busy-state hooks, the turn-end touch, and the merge block in one document, is owned by `bin/fm-crew-settings-lib.sh`.
 Agent lifecycle mechanics - which key interrupts a turn, how many times it must be sent, whether the composer needs clearing afterwards, which command exits the agent, and which task kinds the adapter can run - are owned by the executable control plane in `bin/fm-control-lib.sh` and delivered by `bin/fm-control.sh <task-id> interrupt|exit|relaunch`.
 Never hand-type an interrupt key or exit command through `fm-send`: a routing-marked lifecycle command becomes chat the agent reasons about instead of executing, which is the defect the control plane exists to remove ([`docs/agent-control.md`](../../../docs/agent-control.md)).
 The per-adapter `Exit command` and `Interrupt` rows below remain the verification record for those values; the executable owner is what firstmate actually runs, so a newly verified adapter is not reachable by the control plane until its rows land in that owner.
@@ -191,6 +192,9 @@ The shared symptom is a healthy-looking pane with no work in progress, so each a
 First launch in a fresh worktree, or first ever on a machine, may show a trust or bypass-permissions confirmation.
 After every spawn, peek the pane within about 20 seconds.
 If such a dialog is showing, accept it from an active firstmate session using `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Enter`, or the choice the dialog requires, unless `FM_HOME` is already set to the active firstmate home; verify the brief started processing.
+That accept-it guidance covers launch-time trust and bypass-permissions confirmations only.
+A claude crewmate can also be stopped mid-task by the merge block its own `.claude/settings.local.json` carries, and approving that one would land work without the captain's explicit word (`AGENTS.md` section 1), so never clear it the same reflexive way.
+`bin/fm-crew-settings-lib.sh` owns that block, and `docs/verification/crew-merge-block.md` owns what is actually verified about how the stop surfaces.
 
 Claude renders a predicted-next-prompt suggestion as dim/faint text inside an otherwise-empty composer after a turn completes.
 A plain `tmux capture-pane` cannot tell that ghost text apart from typed text.
@@ -202,7 +206,7 @@ That styled capture is internal to the boolean detector only.
 `fm-peek` and every other human or LLM-facing capture path stays plain `tmux capture-pane` with no escape codes.
 
 **Primary-session guard fact (verified 2026-07-04, Claude Code 2.1.201; preserved 2026-07-08, Claude Code 2.1.204; Stop-owned auto-arm revalidated 2026-07-24, Claude Code 2.1.219).**
-This is separate from the per-task crewmate turn-end hook above (that one just `touch`es a marker file in a task's own `.claude/settings.local.json`).
+This is separate from the per-task crewmate turn-end hook above (that one `touch`es a marker file, and shares a task's own `.claude/settings.local.json` with the crewmate merge block).
 The firstmate PRIMARY's own `.claude/settings.json` registers two Stop hooks: `bin/fm-turnend-guard.sh --claude` and the Stop-owned auto-arm `bin/fm-claude-stop-autoarm.sh` (`asyncRewake: true`, `timeout: 28800`), and exiting the guard with status 2 plus stderr reliably forces the model to continue.
 Claude Code's stdin payload to a Stop hook carries a `stop_hook_active` boolean that is `true` when the current stop attempt follows ANY stop-hook-driven continuation, including `asyncRewake` rewakes; the primary guard therefore ignores it in `--claude` mode and uses the cooperative claim/epoch check plus a bounded re-block budget instead, while the codex-mode default still treats it as a one-block loop guard.
 A project-level `.claude/settings.json` only takes effect when Claude Code's project root is that exact directory - it does not walk up from a subdirectory looking for one, so firstmate launches the primary from the repo root.

--- a/bin/fm-crew-settings-lib.sh
+++ b/bin/fm-crew-settings-lib.sh
@@ -36,11 +36,24 @@
 # narrow on purpose: they name the merge ENDPOINTS rather than gating "gh api"
 # wholesale, which would break the ordinary reads a crewmate needs to do its
 # job. See tests/fm-crew-settings.test.sh for the enforced invariants.
+#
+# Rules are per-executable, because a rule is a prefix match on the literal
+# argv[0] token: "Bash(gh pr merge:*)" cannot match "gh-axi pr merge". gh-axi is
+# the GitHub tool the briefs hand a crewmate (AGENTS.md, bin/fm-brief.sh) and the
+# one bin/fm-pr-merge.sh lands PRs with, so it needs its own rule or the most
+# likely merge command is the one left open.
+#
+# Known residual: the REST endpoints and the inline GraphQL mergePullRequest
+# mutation are covered, but a GraphQL merge whose query text never reaches the
+# command line - read from a file or piped in on stdin - matches no pattern here.
+# Command-line rules cannot see that, so it is out of scope by construction
+# rather than by oversight; AGENTS.md section 1's captain-only landing boundary
+# is what covers it.
 
 # Print the merge-block permission rules as a JSON array.
 # Kept as one canonical list so the rules and their regression test cannot drift.
 fm_crew_merge_block_rules() {
-  printf '%s' '["Bash(gh pr merge:*)","Bash(gh api *pulls/*/merge*)","Bash(gh api *repos/*/merges*)","Bash(tk-feature land:*)","Bash(tk-feature-land:*)"]'
+  printf '%s' '["Bash(gh pr merge:*)","Bash(gh-axi pr merge:*)","Bash(gh api *pulls/*/merge*)","Bash(gh api *repos/*/merges*)","Bash(gh api graphql*mergePullRequest*)","Bash(tk-feature land:*)","Bash(tk-feature-land:*)"]'
 }
 
 # Quote a string as one literal POSIX shell word.

--- a/bin/fm-crew-settings-lib.sh
+++ b/bin/fm-crew-settings-lib.sh
@@ -43,12 +43,18 @@
 # one bin/fm-pr-merge.sh lands PRs with, so it needs its own rule or the most
 # likely merge command is the one left open.
 #
-# Known residual: the REST endpoints and the inline GraphQL mergePullRequest
-# mutation are covered, but a GraphQL merge whose query text never reaches the
-# command line - read from a file or piped in on stdin - matches no pattern here.
-# Command-line rules cannot see that, so it is out of scope by construction
-# rather than by oversight; AGENTS.md section 1's captain-only landing boundary
-# is what covers it.
+# Known residual: every rule is matched against the top-level command string, so
+# the block covers DIRECT forge merge invocations and nothing else. Three shapes
+# fall outside it. A wrapper that reaches a merge verb in a subprocess matches no
+# pattern - including bin/fm-pr-merge.sh, the entrypoint AGENTS.md section 7 names
+# for every task PR merge, and equally any bash -c, script, or make target. So
+# does a GraphQL merge whose query text never reaches the command line, read from
+# a file or piped in on stdin. Local landing carries no rule at all, because the
+# list gates forge merge verbs rather than git: bin/fm-merge-local.sh and a bare
+# git merge --ff-only are ungated. Command-line rules cannot see any of that, so
+# this is a boundary by construction rather than an oversight, and the rule list
+# must not be read as full coverage; AGENTS.md section 1's captain-only landing
+# boundary is what covers the rest.
 
 # Print the merge-block permission rules as a JSON array.
 # Kept as one canonical list so the rules and their regression test cannot drift.

--- a/bin/fm-crew-settings-lib.sh
+++ b/bin/fm-crew-settings-lib.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# fm-crew-settings-lib.sh - the single owner of the .claude/settings.local.json
+# firstmate writes into a claude crewmate's worktree.
+#
+# The file carries two independent guarantees that MUST ride in the same JSON
+# document, because it is written once by a single redirect: a second writer
+# would truncate whatever the first one put there.
+#
+#   1. The semantic busy-state hooks and the turn-end notification, under the
+#      contract owned by bin/fm-busy-lib.sh. UserPromptSubmit opens a turn;
+#      Stop (normal completion), StopFailure (API-error turn end), and
+#      SessionEnd (process shutdown) all close it, so an abnormal end can never
+#      leave a stale busy record. Claude fires no hook for a manual interrupt:
+#      fm-control preserves the adapter-owned state, while the legacy fm-send
+#      --key Escape path records idle/fm-interrupt. Stop also touches the
+#      turn-end file, which is how a claude crewmate tells the watcher its turn
+#      ended; losing it blinds supervision. Every hook command tolerates a
+#      refused event (|| true) so a stale-gen writer can never break Claude's
+#      own lifecycle.
+#   2. The merge block. A crewmate launches with --dangerously-skip-permissions,
+#      so allow/deny rules it could simply bypass are not the control here;
+#      permissions.ask is, because an unattended crewmate has no approver and an
+#      "ask" it cannot answer is a stop. The crewmate can still push its branch
+#      and open a PR - those verbs are deliberately not gated. Landing is the
+#      captain's, per AGENTS.md section 1's never-merge-without-explicit-word
+#      boundary.
+#
+# Rule syntax is Claude Code's, and it is strict: ":*" means prefix match and is
+# only legal at the very END of the pattern. Anywhere else the rule is not a
+# soft warning - Claude Code reports it as invalid and SKIPS it, so a malformed
+# rule silently removes the very protection it was written to add while also
+# stopping every fresh spawn on a blocking settings dialog. Use a bare "*" for
+# wildcard matching in the middle of a pattern.
+#
+# The gh api rules are matched against the whole command line, so they stay
+# narrow on purpose: they name the merge ENDPOINTS rather than gating "gh api"
+# wholesale, which would break the ordinary reads a crewmate needs to do its
+# job. See tests/fm-crew-settings.test.sh for the enforced invariants.
+
+# Print the merge-block permission rules as a JSON array.
+# Kept as one canonical list so the rules and their regression test cannot drift.
+fm_crew_merge_block_rules() {
+  printf '%s' '["Bash(gh pr merge:*)","Bash(gh api *pulls/*/merge*)","Bash(gh api *repos/*/merges*)","Bash(tk-feature land:*)","Bash(tk-feature-land:*)"]'
+}
+
+# Quote a string as one literal POSIX shell word.
+# Every value below is interpolated into a command line the hook shell runs, and
+# none is guaranteed benign: the turn-end path and the state directory come from
+# FM_HOME/FM_STATE_OVERRIDE, and the task id is caller-supplied.
+fm_crew_shell_quote() {
+  local s=$1 q="'" esc="'\\''"
+  printf "'%s'" "${s//$q/$esc}"
+}
+
+# Escape a string for use inside a JSON double-quoted scalar.
+# An unescaped quote or backslash makes the whole document invalid, and Claude
+# Code then rejects the file - losing the busy-state hooks AND the merge block at
+# once, which is the failure this library exists to prevent.
+fm_crew_json_escape() {
+  local s=$1
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
+# Print the complete settings.local.json for a claude crewmate worktree.
+#   $1 - absolute path to the task's turn-end file
+#   $2 - absolute path to bin/fm-busy-event.sh
+#   $3 - absolute path to the home's state directory
+#   $4 - task id
+#   $5 - busy-state generation token
+fm_crew_settings_local_json() {
+  local turnend=$1 busy_event=$2 state=$3 id=$4 gen=$5
+  local prefix suffix j_submit j_stop j_stopfail j_sessionend
+  prefix="$(fm_crew_shell_quote "$busy_event") apply $(fm_crew_shell_quote "$state") $(fm_crew_shell_quote "$id")"
+  suffix="--gen $(fm_crew_shell_quote "$gen") --source claude-hook"
+  j_submit=$(fm_crew_json_escape "$prefix busy $suffix --event user-prompt-submit 2>/dev/null || true")
+  j_stop=$(fm_crew_json_escape "touch $(fm_crew_shell_quote "$turnend"); $prefix idle $suffix --event stop 2>/dev/null || true")
+  j_stopfail=$(fm_crew_json_escape "$prefix idle $suffix --event stop-failure 2>/dev/null || true")
+  j_sessionend=$(fm_crew_json_escape "$prefix idle $suffix --event session-end 2>/dev/null || true")
+  printf '%s\n' "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"$j_submit\"}]}],\"Stop\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"$j_stop\"}]}],\"StopFailure\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"$j_stopfail\"}]}],\"SessionEnd\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"$j_sessionend\"}]}]},\"permissions\":{\"ask\":$(fm_crew_merge_block_rules)}}"
+}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -259,6 +259,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-trace-context-lib.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh
 . "$SCRIPT_DIR/fm-remote-readiness-lib.sh"
+# shellcheck source=bin/fm-crew-settings-lib.sh
+. "$SCRIPT_DIR/fm-crew-settings-lib.sh"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
 # a direct report (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
@@ -2363,15 +2365,11 @@ if [ "$KIND" != secondmate ]; then
       # hook command tolerates a refused event (|| true) so a stale-gen writer
       # can never break Claude's own lifecycle.
       mkdir -p "$WT/.claude"
-      busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
-      busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
-      j_submit=$(json_escape "$busy_cmd_prefix busy $busy_suffix --event user-prompt-submit 2>/dev/null || true")
-      j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
-      j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
-      j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
-      cat > "$WT/.claude/settings.local.json" <<EOF
-{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
-EOF
+      # The busy-state hooks and the merge block share one document on purpose;
+      # fm-crew-settings-lib.sh owns why, and the rule syntax that keeps both live.
+      fm_crew_settings_local_json "$TURNEND" \
+        "$FM_ROOT/bin/fm-busy-event.sh" "$STATE_REAL" "$ID" "$BUSY_GEN" \
+        > "$WT/.claude/settings.local.json"
       exclude_path '.claude/settings.local.json'
       ;;
     opencode*)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -137,7 +137,7 @@ family_for_basename() {
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
     fm-classify-decision-key.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
-    fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
+    fm-crew-settings.test.sh|fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -329,6 +329,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/verification/crew-merge-block.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/verification/dispatch-auth.md",
       "audience": "maintainer-verification"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -50,6 +50,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
+| `fm-crew-settings-lib.sh` | Own the claude crewmate's generated `.claude/settings.local.json`: busy-state hooks, turn-end touch, plus merge block |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer shapes, capability-aware screen classification, and verdicts |

--- a/docs/verification/crew-merge-block.md
+++ b/docs/verification/crew-merge-block.md
@@ -53,8 +53,8 @@ The negative control was re-run in the same session: a directory carrying the ma
 
 ## `permissions.ask` stops a crewmate that runs under `--dangerously-skip-permissions`
 
-This is the load-bearing premise of the whole guard, so it was exercised in the crewmate's own shape rather than argued from documentation.
-A session was launched non-interactively with exactly the flag `bin/fm-spawn.sh` uses, in a directory holding the generated file above, and asked to run each command and report whether the tool call executed:
+This is the load-bearing premise of the whole guard, so it was exercised against the live permission engine rather than argued from documentation.
+A session was launched with exactly the flag `bin/fm-spawn.sh` uses, in a directory holding the generated file above, and asked to run each command and report whether the tool call executed:
 
 ```sh
 claude -p --dangerously-skip-permissions '...run each command and report whether it executed...'
@@ -73,6 +73,16 @@ Each block surfaced as `Claude requested permissions to use Bash, but you haven'
 That message is the mechanism in one line: bypass mode skips the *prompt*, not the *rule*, and an unattended crewmate has no approver, so an ask it cannot answer is a stop.
 `ask` rather than `deny` is therefore a proven control here, not an assumption.
 The gated commands were chosen to be inert - `--help`, and a GraphQL mutation carrying a deliberately invalid node id - so a hypothetical non-match could only have printed help text or returned a GraphQL error, never landed a PR.
+
+### What this transcript does and does not prove
+
+The flag matches production; the mode does not.
+`bin/fm-spawn.sh` launches a crewmate interactively (`claude --dangerously-skip-permissions "$(... launch-brief ...)"`, no `-p`), while the run above used `-p`.
+What carries across is the part that matters here: the rule is evaluated, and the merge verb does not execute, under `--dangerously-skip-permissions`.
+What does not carry across is the *shape of the stop*.
+With no TTY, `-p` returns the unanswerable ask to the model as an immediate tool-call refusal, which is why the transcript shows the session continuing to the next command.
+In the interactive TUI a crewmate actually runs in, the same rule can instead surface as a pane-blocking prompt: the merge is stopped just as effectively, but the turn never ends, so the Stop hook never fires and the watcher sees a wedged crewmate rather than a refused one.
+Either outcome satisfies the guard - the crewmate does not land its own work - but they reach the watcher differently, so do not read this transcript as evidence about the interactive surface.
 
 ## The rules match the merge verbs and nothing else
 

--- a/docs/verification/crew-merge-block.md
+++ b/docs/verification/crew-merge-block.md
@@ -10,7 +10,7 @@ Those tests are hermetic and never invoke `claude`, so this record holds the liv
 
 Verified on 2026-07-25 with Claude Code 2.1.220 (native, commit `4073f59596e2`, darwin-arm64) and `gh` authenticated.
 The two `claude doctor` sections below were re-run on 2026-08-13 with Claude Code 2.1.231 (native, commit `bbff368ec698`, darwin-arm64) after the settings document grew the semantic busy-state hooks, so the loads-clean evidence matches the document the library emits today.
-The endpoint-matching table was not re-run; it exercises the rule patterns, which are unchanged.
+The `--dangerously-skip-permissions` session table was not re-run: it exercises the rule patterns, and those are byte-for-byte unchanged by the hook addition.
 
 ## Rule syntax is validated, and an invalid rule is skipped
 
@@ -46,23 +46,43 @@ claude doctor
   "Stop":[{"hooks":[{"type":"command","command":"touch '/tmp/fmtest/state/demo.turn-ended'; '/opt/firstmate/bin/fm-busy-event.sh' apply '/tmp/fmtest/state' 'demo' idle --gen '7-1' --source claude-hook --event stop 2>/dev/null || true"}]}],
   "StopFailure":[{"hooks":[{"type":"command","command":"'/opt/firstmate/bin/fm-busy-event.sh' apply '/tmp/fmtest/state' 'demo' idle --gen '7-1' --source claude-hook --event stop-failure 2>/dev/null || true"}]}],
   "SessionEnd":[{"hooks":[{"type":"command","command":"'/opt/firstmate/bin/fm-busy-event.sh' apply '/tmp/fmtest/state' 'demo' idle --gen '7-1' --source claude-hook --event session-end 2>/dev/null || true"}]}]},
-  "permissions":{"ask":["Bash(gh pr merge:*)","Bash(gh api *pulls/*/merge*)","Bash(gh api *repos/*/merges*)","Bash(tk-feature land:*)","Bash(tk-feature-land:*)"]}}
+  "permissions":{"ask":["Bash(gh pr merge:*)","Bash(gh-axi pr merge:*)","Bash(gh api *pulls/*/merge*)","Bash(gh api *repos/*/merges*)","Bash(gh api graphql*mergePullRequest*)","Bash(tk-feature land:*)","Bash(tk-feature-land:*)"]}}
 ```
 
 The negative control was re-run in the same session: a directory carrying the malformed `Bash(gh api:*/merge*)` rules still produced the `Invalid settings` block quoted above, so the clean result here is a real pass rather than a version that stopped reporting.
 
-## The rules match the merge endpoints and nothing else
+## `permissions.ask` stops a crewmate that runs under `--dangerously-skip-permissions`
 
-Matching was exercised against the live permission engine with the same patterns placed under `permissions.deny`, so a non-match would execute and return an HTTP error instead of being refused.
-Commands targeted a nonexistent repository, so a permitted call could only reach a 404.
+This is the load-bearing premise of the whole guard, so it was exercised in the crewmate's own shape rather than argued from documentation.
+A session was launched non-interactively with exactly the flag `bin/fm-spawn.sh` uses, in a directory holding the generated file above, and asked to run each command and report whether the tool call executed:
 
-| Command | Result |
+```sh
+claude -p --dangerously-skip-permissions '...run each command and report whether it executed...'
+```
+
+| Command | Result under `--dangerously-skip-permissions` |
 |---|---|
-| `gh api --method PUT repos/<none>/nope/pulls/1/merge` | refused by the permission engine |
-| `gh api --method POST repos/<none>/nope/merges` | refused by the permission engine |
-| `gh api repos/<none>/nope/pulls/1/files` | permitted, reached the API and returned 404 |
+| `gh --version` | executed, returned `gh version 2.95.0 (2026-06-17)` |
+| `gh pr merge --help` | blocked, the tool call never reached the shell |
+| `gh-axi pr merge --help` | blocked, the tool call never reached the shell |
+| `gh api graphql -f query='mutation { mergePullRequest(input:{pullRequestId:"PR_kwINVALID"}) { clientMutationId } }'` | blocked, nothing was sent to GitHub |
+| `gh api repos/cli/cli/pulls/1/files` | executed, returned the file list from the API |
 
-The refusal surfaced as `Permission to use Bash with command gh api --method PUT repos/<none>/nope/pulls/1/merge has been denied.`
+Each block surfaced as `Claude requested permissions to use Bash, but you haven't granted it yet.`
 
-This is the intended shape: both merge endpoints are covered, while the ordinary `gh api` reads a crewmate needs remain ungated.
-`permissions.ask` is used in production rather than `deny` because a crewmate launches with `--dangerously-skip-permissions` and has no approver behind it, so an unanswerable ask is the stop.
+That message is the mechanism in one line: bypass mode skips the *prompt*, not the *rule*, and an unattended crewmate has no approver, so an ask it cannot answer is a stop.
+`ask` rather than `deny` is therefore a proven control here, not an assumption.
+The gated commands were chosen to be inert - `--help`, and a GraphQL mutation carrying a deliberately invalid node id - so a hypothetical non-match could only have printed help text or returned a GraphQL error, never landed a PR.
+
+## The rules match the merge verbs and nothing else
+
+The same run is the negative evidence too: `gh --version` and `gh api repos/cli/cli/pulls/1/files` both executed without a prompt.
+Ordinary `gh api` reads a crewmate needs stay ungated, while `gh`, `gh-axi`, the two REST merge endpoints, and the inline GraphQL merge mutation are all covered.
+
+Per-executable rules are required, not redundant: a rule is a prefix match on the literal `argv[0]` token, so `Bash(gh pr merge:*)` does not match `gh-axi pr merge` - the command the briefs hand a crewmate and the one `bin/fm-pr-merge.sh` lands PRs with.
+The separate blocks for `gh pr merge --help` and `gh-axi pr merge --help` in the table above are what demonstrate that.
+
+### Known residual
+
+A GraphQL merge whose query text never appears on the command line - read from a file or piped in on stdin - matches no pattern here, because command-line rules cannot see it.
+That path is out of scope by construction; the captain-only landing boundary in AGENTS.md section 1 is what covers it.

--- a/docs/verification/crew-merge-block.md
+++ b/docs/verification/crew-merge-block.md
@@ -2,7 +2,7 @@
 
 Audience: maintainer verification.
 
-This record supports the current guarantee that a claude crewmate's generated `.claude/settings.local.json` loads without a settings dialog and actually blocks the merge verbs.
+This record supports the current guarantee that a claude crewmate's generated `.claude/settings.local.json` loads without a settings dialog and actually blocks the merge verbs it names when they are run directly.
 The rules themselves and the reasoning behind them live in `bin/fm-crew-settings-lib.sh`; the enforced invariants live in `tests/fm-crew-settings.test.sh`.
 Those tests are hermetic and never invoke `claude`, so this record holds the live-binary evidence they cannot carry.
 
@@ -120,5 +120,5 @@ The refusal surfaced as `Permission to use Bash with command gh api --method PUT
 
 ### Known residual
 
-A GraphQL merge whose query text never appears on the command line - read from a file or piped in on stdin - matches no pattern here, because command-line rules cannot see it.
-That path is out of scope by construction; the captain-only landing boundary in AGENTS.md section 1 is what covers it.
+Every command exercised above was invoked directly, so no run here is evidence about a merge reached through a wrapper, a subprocess, or stdin.
+`bin/fm-crew-settings-lib.sh` owns the residual and what covers it.

--- a/docs/verification/crew-merge-block.md
+++ b/docs/verification/crew-merge-block.md
@@ -8,9 +8,11 @@ Those tests are hermetic and never invoke `claude`, so this record holds the liv
 
 ## Conditions
 
-Verified on 2026-07-25 with Claude Code 2.1.220 (native, commit `4073f59596e2`, darwin-arm64) and `gh` authenticated.
-The two `claude doctor` sections below were re-run on 2026-08-13 with Claude Code 2.1.231 (native, commit `bbff368ec698`, darwin-arm64) after the settings document grew the semantic busy-state hooks, so the loads-clean evidence matches the document the library emits today.
-The `--dangerously-skip-permissions` session table was not re-run: it exercises the rule patterns, and those are byte-for-byte unchanged by the hook addition.
+First verified on 2026-07-25 with Claude Code 2.1.220 (native, commit `4073f59596e2`, darwin-arm64) and `gh` authenticated.
+The evidence below was not all captured in that one session, so each section names the run it came from and no claim here rests on a run other than the one printed beside it.
+
+The two `claude doctor` sections were re-run on 2026-08-13 with Claude Code 2.1.231 (native, commit `bbff368ec698`, darwin-arm64) after the settings document grew the semantic busy-state hooks, so the loads-clean evidence matches the document the library emits today.
+The `--dangerously-skip-permissions` session table was itself re-run when `Bash(gh-axi pr merge:*)` and `Bash(gh api graphql*mergePullRequest*)` were added to the rule list, because neither rule existed in the first session; its commands and its refusal wording therefore differ from the `permissions.deny` matching run that preceded it, and both runs are kept because neither covers the other's patterns.
 
 ## Rule syntax is validated, and an invalid rule is skipped
 
@@ -53,6 +55,8 @@ The negative control was re-run in the same session: a directory carrying the ma
 
 ## `permissions.ask` stops a crewmate that runs under `--dangerously-skip-permissions`
 
+Captured after `Bash(gh-axi pr merge:*)` and `Bash(gh api graphql*mergePullRequest*)` joined the rule list, against the seven-rule document quoted above.
+
 This is the load-bearing premise of the whole guard, so it was exercised against the live permission engine rather than argued from documentation.
 A session was launched with exactly the flag `bin/fm-spawn.sh` uses, in a directory holding the generated file above, and asked to run each command and report whether the tool call executed:
 
@@ -87,10 +91,28 @@ Either outcome satisfies the guard - the crewmate does not land its own work - b
 ## The rules match the merge verbs and nothing else
 
 The same run is the negative evidence too: `gh --version` and `gh api repos/cli/cli/pulls/1/files` both executed without a prompt.
-Ordinary `gh api` reads a crewmate needs stay ungated, while `gh`, `gh-axi`, the two REST merge endpoints, and the inline GraphQL merge mutation are all covered.
+Ordinary `gh api` reads a crewmate needs stay ungated, while `gh pr merge`, `gh-axi pr merge`, and the inline GraphQL merge mutation are blocked.
+That table carries no `gh api ... /merge` row, so it is not evidence for `Bash(gh api *pulls/*/merge*)` or `Bash(gh api *repos/*/merges*)`; those two patterns are covered by the separate matching run below.
 
 Per-executable rules are required, not redundant: a rule is a prefix match on the literal `argv[0]` token, so `Bash(gh pr merge:*)` does not match `gh-axi pr merge` - the command the briefs hand a crewmate and the one `bin/fm-pr-merge.sh` lands PRs with.
 The separate blocks for `gh pr merge --help` and `gh-axi pr merge --help` in the table above are what demonstrate that.
+
+### The two REST merge endpoint patterns match
+
+Captured in the first 2026-07-25 session, before the `gh-axi` and GraphQL rules existed; the two `gh api` patterns it exercises are byte-for-byte the ones the library emits today.
+
+Matching was exercised against the live permission engine with the same patterns placed under `permissions.deny`, so a non-match would execute and return an HTTP error instead of being refused.
+Commands targeted a nonexistent repository, so a permitted call could only reach a 404.
+
+| Command | Result |
+|---|---|
+| `gh api --method PUT repos/<none>/nope/pulls/1/merge` | refused by the permission engine |
+| `gh api --method POST repos/<none>/nope/merges` | refused by the permission engine |
+| `gh api repos/<none>/nope/pulls/1/files` | permitted, reached the API and returned 404 |
+
+The refusal surfaced as `Permission to use Bash with command gh api --method PUT repos/<none>/nope/pulls/1/merge has been denied.`
+
+`deny` is what this run measured; production ships `ask`. What transfers is the pattern match, which is the same rule engine either way - the section above is what establishes that an unanswerable `ask` is a stop under `--dangerously-skip-permissions`, and the wording difference between the two refusal messages is exactly that difference in mode, not a disagreement between the runs.
 
 ### Known residual
 

--- a/docs/verification/crew-merge-block.md
+++ b/docs/verification/crew-merge-block.md
@@ -12,7 +12,8 @@ First verified on 2026-07-25 with Claude Code 2.1.220 (native, commit `4073f5959
 The evidence below was not all captured in that one session, so each section names the run it came from and no claim here rests on a run other than the one printed beside it.
 
 The two `claude doctor` sections were re-run on 2026-08-13 with Claude Code 2.1.231 (native, commit `bbff368ec698`, darwin-arm64) after the settings document grew the semantic busy-state hooks, so the loads-clean evidence matches the document the library emits today.
-The `--dangerously-skip-permissions` session table was itself re-run when `Bash(gh-axi pr merge:*)` and `Bash(gh api graphql*mergePullRequest*)` were added to the rule list, because neither rule existed in the first session; its commands and its refusal wording therefore differ from the `permissions.deny` matching run that preceded it, and both runs are kept because neither covers the other's patterns.
+The `--dangerously-skip-permissions` session table was itself re-run later on 2026-07-25, when `Bash(gh-axi pr merge:*)` and `Bash(gh api graphql*mergePullRequest*)` were added to the rule list, because neither rule existed earlier that day; its commands and its refusal wording therefore differ from the `permissions.deny` matching run that preceded it, and both runs are kept because neither covers the other's patterns.
+That later run is the one section here whose Claude Code build is not pinned - the reason is recorded with the table itself rather than summarized away here.
 
 ## Rule syntax is validated, and an invalid rule is skipped
 
@@ -55,7 +56,10 @@ The negative control was re-run in the same session: a directory carrying the ma
 
 ## `permissions.ask` stops a crewmate that runs under `--dangerously-skip-permissions`
 
-Captured after `Bash(gh-axi pr merge:*)` and `Bash(gh api graphql*mergePullRequest*)` joined the rule list, against the seven-rule document quoted above.
+Captured on 2026-07-25, after `Bash(gh-axi pr merge:*)` and `Bash(gh api graphql*mergePullRequest*)` joined the rule list, against the seven-rule document quoted above.
+The Claude Code build for this run was not captured when it was taken, and nothing in the repository records it, so it is left unstated rather than guessed.
+The date is the only pin this table has: it is the same day as the 2.1.220 session named in Conditions, which makes 2.1.220 the likeliest build, but that is read off the date rather than observed.
+Since the `was skipped` behavior above shows this engine's rule handling is version-sensitive, treat this table as evidence for the mechanism and not for any particular release, and re-run it if a specific build ever has to be established.
 
 This is the load-bearing premise of the whole guard, so it was exercised against the live permission engine rather than argued from documentation.
 A session was launched with exactly the flag `bin/fm-spawn.sh` uses, in a directory holding the generated file above, and asked to run each command and report whether the tool call executed:

--- a/docs/verification/crew-merge-block.md
+++ b/docs/verification/crew-merge-block.md
@@ -1,0 +1,68 @@
+# Crewmate merge-block verification
+
+Audience: maintainer verification.
+
+This record supports the current guarantee that a claude crewmate's generated `.claude/settings.local.json` loads without a settings dialog and actually blocks the merge verbs.
+The rules themselves and the reasoning behind them live in `bin/fm-crew-settings-lib.sh`; the enforced invariants live in `tests/fm-crew-settings.test.sh`.
+Those tests are hermetic and never invoke `claude`, so this record holds the live-binary evidence they cannot carry.
+
+## Conditions
+
+Verified on 2026-07-25 with Claude Code 2.1.220 (native, commit `4073f59596e2`, darwin-arm64) and `gh` authenticated.
+The two `claude doctor` sections below were re-run on 2026-08-13 with Claude Code 2.1.231 (native, commit `bbff368ec698`, darwin-arm64) after the settings document grew the semantic busy-state hooks, so the loads-clean evidence matches the document the library emits today.
+The endpoint-matching table was not re-run; it exercises the rule patterns, which are unchanged.
+
+## Rule syntax is validated, and an invalid rule is skipped
+
+Claude Code treats `:*` as prefix-match syntax that is legal only at the end of a pattern.
+A malformed rule is not a warning that degrades gracefully; it is dropped.
+
+Running `claude doctor` in a directory whose `.claude/settings.local.json` carried `Bash(gh api:*/merge*)` and `Bash(gh api:*/merges*)`:
+
+```
+Invalid settings
+- .../settings.local.json › permissions.ask: Invalid permission rule "Bash(gh api:*/merge*)" was skipped: The :* pattern must be at the end. Move :* to the end for prefix matching, or use * for wildcard matching
+- .../settings.local.json › permissions.ask: Invalid permission rule "Bash(gh api:*/merges*)" was skipped: The :* pattern must be at the end. Move :* to the end for prefix matching, or use * for wildcard matching
+```
+
+`was skipped` is the load-bearing detail: such a rule blocks nothing while a fresh spawn also stops on a blocking settings dialog.
+
+## The generated file loads with zero warnings
+
+Generating the real file from the library and running `claude doctor` beside it:
+
+```sh
+( . bin/fm-crew-settings-lib.sh
+  fm_crew_settings_local_json /tmp/fmtest/state/demo.turn-ended \
+    /opt/firstmate/bin/fm-busy-event.sh /tmp/fmtest/state demo 7-1 ) > .claude/settings.local.json
+claude doctor
+```
+
+`claude doctor` printed no `Invalid settings` section, and the file retained every busy-state hook and the turn-end touch alongside `permissions.ask` (line-wrapped here for reading; the real file is one line):
+
+```json
+{"hooks":{
+  "UserPromptSubmit":[{"hooks":[{"type":"command","command":"'/opt/firstmate/bin/fm-busy-event.sh' apply '/tmp/fmtest/state' 'demo' busy --gen '7-1' --source claude-hook --event user-prompt-submit 2>/dev/null || true"}]}],
+  "Stop":[{"hooks":[{"type":"command","command":"touch '/tmp/fmtest/state/demo.turn-ended'; '/opt/firstmate/bin/fm-busy-event.sh' apply '/tmp/fmtest/state' 'demo' idle --gen '7-1' --source claude-hook --event stop 2>/dev/null || true"}]}],
+  "StopFailure":[{"hooks":[{"type":"command","command":"'/opt/firstmate/bin/fm-busy-event.sh' apply '/tmp/fmtest/state' 'demo' idle --gen '7-1' --source claude-hook --event stop-failure 2>/dev/null || true"}]}],
+  "SessionEnd":[{"hooks":[{"type":"command","command":"'/opt/firstmate/bin/fm-busy-event.sh' apply '/tmp/fmtest/state' 'demo' idle --gen '7-1' --source claude-hook --event session-end 2>/dev/null || true"}]}]},
+  "permissions":{"ask":["Bash(gh pr merge:*)","Bash(gh api *pulls/*/merge*)","Bash(gh api *repos/*/merges*)","Bash(tk-feature land:*)","Bash(tk-feature-land:*)"]}}
+```
+
+The negative control was re-run in the same session: a directory carrying the malformed `Bash(gh api:*/merge*)` rules still produced the `Invalid settings` block quoted above, so the clean result here is a real pass rather than a version that stopped reporting.
+
+## The rules match the merge endpoints and nothing else
+
+Matching was exercised against the live permission engine with the same patterns placed under `permissions.deny`, so a non-match would execute and return an HTTP error instead of being refused.
+Commands targeted a nonexistent repository, so a permitted call could only reach a 404.
+
+| Command | Result |
+|---|---|
+| `gh api --method PUT repos/<none>/nope/pulls/1/merge` | refused by the permission engine |
+| `gh api --method POST repos/<none>/nope/merges` | refused by the permission engine |
+| `gh api repos/<none>/nope/pulls/1/files` | permitted, reached the API and returned 404 |
+
+The refusal surfaced as `Permission to use Bash with command gh api --method PUT repos/<none>/nope/pulls/1/merge has been denied.`
+
+This is the intended shape: both merge endpoints are covered, while the ordinary `gh api` reads a crewmate needs remain ungated.
+`permissions.ask` is used in production rather than `deny` because a crewmate launches with `--dangerously-skip-permissions` and has no approver behind it, so an unanswerable ask is the stop.

--- a/tests/fm-crew-settings.test.sh
+++ b/tests/fm-crew-settings.test.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Behavior tests for the crewmate .claude/settings.local.json contract
+# (bin/fm-crew-settings-lib.sh).
+#
+# Two guarantees ride in one document because fm-spawn writes it with a single
+# redirect, so these tests assert BOTH survive together: losing the busy-state
+# hooks or the turn-end touch blinds supervision, and losing the merge block lets
+# an unattended crewmate land its own work.
+#
+# The rule-syntax case is the load-bearing regression. Claude Code treats ":*"
+# as prefix-match syntax that is legal only at the very end of a pattern, and it
+# does not merely warn about a malformed rule - it SKIPS it. A rule like
+# "Bash(gh api:*/merge*)" therefore fails twice over: it stops every fresh spawn
+# on a blocking settings dialog AND silently removes the merge protection it
+# looks like it is providing. These tests are hermetic and never invoke claude;
+# docs/verification/crew-merge-block.md holds the live-binary evidence.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# The library is its own canonical lint root, so source analysis stops here.
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-crew-settings-lib.sh"
+
+TURNEND=/tmp/fm-crew-settings-test/state/some-task.turn-ended
+BUSY_EVENT=/tmp/fm-crew-settings-test/bin/fm-busy-event.sh
+STATE_DIR=/tmp/fm-crew-settings-test/state
+TASK_ID=some-task
+BUSY_GEN=17-1
+
+settings_json() {
+  fm_crew_settings_local_json "$TURNEND" "$BUSY_EVENT" "$STATE_DIR" "$TASK_ID" "$BUSY_GEN"
+}
+
+rules() {
+  settings_json | jq -r '.permissions.ask[]'
+}
+
+# The document must parse. A crewmate whose settings file is malformed JSON gets
+# neither guarantee, so this is asserted before anything reads fields out of it.
+test_settings_are_valid_json() {
+  settings_json | jq -e . >/dev/null 2>&1 \
+    || fail "generated settings.local.json is not valid JSON"
+  pass "generated settings.local.json parses as JSON"
+}
+
+# Guarantee 1: the turn-end Stop hook, carrying the exact task turn-end path.
+test_stop_hook_survives() {
+  local cmd
+  cmd=$(settings_json | jq -r '.hooks.Stop[0].hooks[0].command')
+  case "$cmd" in
+    *"$TURNEND"*) : ;;
+    *) fail "Stop hook lost the turn-end path (got: $cmd)" ;;
+  esac
+  settings_json | jq -e '.hooks.Stop[0].hooks[0].type == "command"' >/dev/null \
+    || fail "Stop hook must be a command hook"
+  pass "Stop hook is present and carries the turn-end path"
+}
+
+# Guarantee 1, the other half: the semantic busy-state lifecycle (bin/fm-busy-lib.sh).
+# The turn-end touch is only a NOTIFICATION; these four events are what keep the
+# busy record honest, and an abnormal end must still close the turn. They live in
+# this document too, so adding the merge block must not cost any of them.
+test_busy_state_hooks_survive() {
+  local ev cmd doc
+  doc=$(settings_json)
+  for ev in UserPromptSubmit Stop StopFailure SessionEnd; do
+    cmd=$(printf '%s' "$doc" | jq -r ".hooks[\"$ev\"][0].hooks[0].command")
+    [ -n "$cmd" ] && [ "$cmd" != null ] \
+      || fail "settings document lost the $ev busy-state hook"
+    case "$cmd" in
+      *"$BUSY_EVENT"*) : ;;
+      *) fail "$ev hook does not invoke the busy-event script (got: $cmd)" ;;
+    esac
+    case "$cmd" in
+      *"--gen '$BUSY_GEN'"*) : ;;
+      *) fail "$ev hook lost its busy generation token (got: $cmd)" ;;
+    esac
+    # A refused (stale-gen) event must never break Claude's own lifecycle.
+    case "$cmd" in
+      *"|| true") : ;;
+      *) fail "$ev hook must tolerate a refused event (got: $cmd)" ;;
+    esac
+  done
+  pass "busy-state hooks (open on UserPromptSubmit, close on Stop/StopFailure/SessionEnd) all survive"
+}
+
+# Guarantee 2: the merge block rides in the SAME document as the hooks.
+# This is the co-residency invariant a second writer would have truncated.
+test_merge_block_rides_with_stop_hook() {
+  settings_json | jq -e '(.hooks.Stop | length) > 0 and (.permissions.ask | length) > 0' >/dev/null \
+    || fail "Stop hook and permissions.ask must both be present in one document"
+  settings_json | jq -e '(.hooks | keys | length) == 4 and (.permissions.ask | length) > 0' >/dev/null \
+    || fail "all four busy-state hooks and the merge block must share one document"
+  pass "busy-state hooks and merge block share one settings document"
+}
+
+# Every rule must be syntactically valid Claude Code permission syntax: ":*" is
+# prefix-match and is legal ONLY at the very end of the pattern. This is the
+# exact defect that made the gh api rules silently non-functional.
+test_every_rule_is_valid_syntax() {
+  local rule inner rest
+  while IFS= read -r rule; do
+    [ -n "$rule" ] || continue
+    case "$rule" in
+      "Bash("*")") : ;;
+      *) fail "rule is not a well-formed Bash(...) rule: $rule" ;;
+    esac
+    inner=${rule#Bash(}
+    inner=${inner%)}
+    # Strip one legal trailing ":*", then no ":*" may remain anywhere.
+    rest=${inner%:\*}
+    case "$rest" in
+      *:\**) fail "invalid rule '$rule': ':*' must be at the end, use '*' for wildcard matching" ;;
+    esac
+  done <<< "$(rules)"
+  pass "every permission rule uses valid ':*'-at-the-end syntax"
+}
+
+# The verbs that must be blocked. Landing is the captain's call, so both the
+# gh porcelain and the gh api merge endpoints have to be covered - blocking only
+# `gh pr merge` leaves `gh api --method PUT .../pulls/N/merge` wide open.
+test_blocks_every_merge_verb() {
+  local all row label pattern
+  all=$(rules)
+  while IFS='|' read -r label pattern; do
+    [ -n "$label" ] || continue
+    printf '%s\n' "$all" | grep -qF "$pattern" \
+      || fail "merge block is missing the $label rule ($pattern)"
+  done <<'ROWS'
+gh porcelain merge|Bash(gh pr merge:*)
+gh api pull-request merge endpoint|Bash(gh api *pulls/*/merge*)
+gh api branch merges endpoint|Bash(gh api *repos/*/merges*)
+tk-feature land|Bash(tk-feature land:*)
+tk-feature-land|Bash(tk-feature-land:*)
+ROWS
+  # Guard the count so a future edit cannot quietly drop one.
+  row=$(printf '%s\n' "$all" | grep -c .)
+  [ "$row" -eq 5 ] || fail "expected 5 merge-block rules, found $row"
+  pass "every merge verb is blocked (gh porcelain, gh api endpoints, tk-feature)"
+}
+
+# The block must stay narrow. A crewmate needs ordinary `gh api` reads and must
+# be able to push its branch and open a PR; gating those would break delivery
+# rather than protect it.
+test_does_not_overblock_delivery_verbs() {
+  local rule inner
+  while IFS= read -r rule; do
+    [ -n "$rule" ] || continue
+    inner=${rule#Bash(}
+    inner=${inner%)}
+    # A wholesale `gh api` or `gh` prefix gate would swallow legitimate reads.
+    case "$inner" in
+      'gh api:*'|'gh:*'|'gh api *'|'git push'*|'gh pr create'*)
+        fail "rule '$rule' over-blocks a verb the crewmate needs" ;;
+    esac
+  done <<< "$(rules)"
+  pass "delivery verbs (gh api reads, git push, gh pr create) stay ungated"
+}
+
+# permissions.ask, not deny/allow: a crewmate launches with
+# --dangerously-skip-permissions, and ask is the control that still stops an
+# agent with no approver behind it.
+test_uses_ask_not_allow_or_deny() {
+  settings_json | jq -e 'has("permissions") and (.permissions | has("ask"))' >/dev/null \
+    || fail "merge block must be expressed under permissions.ask"
+  pass "merge block uses permissions.ask"
+}
+
+# fm-spawn must actually use the library rather than re-rolling the JSON inline,
+# which is how the two guarantees drifted apart before.
+test_spawn_delegates_to_the_library() {
+  # shellcheck disable=SC2016  # single quotes are deliberate: this is source text to match, not an expansion
+  grep -qF 'fm_crew_settings_local_json "$TURNEND"' "$ROOT/bin/fm-spawn.sh" \
+    || fail "fm-spawn.sh must write settings.local.json via fm_crew_settings_local_json"
+  grep -q 'fm-crew-settings-lib.sh' "$ROOT/bin/fm-spawn.sh" \
+    || fail "fm-spawn.sh must source fm-crew-settings-lib.sh"
+  # The inline heredoc is the shape the two guarantees drifted apart in: a second
+  # writer here would truncate whatever the library just wrote.
+  # shellcheck disable=SC2016  # source text to match, not an expansion
+  grep -qF 'cat > "$WT/.claude/settings.local.json"' "$ROOT/bin/fm-spawn.sh" \
+    && fail "fm-spawn.sh must not re-roll settings.local.json inline alongside the library"
+  pass "fm-spawn.sh delegates settings generation to the library"
+}
+
+test_settings_are_valid_json
+test_stop_hook_survives
+test_busy_state_hooks_survive
+test_merge_block_rides_with_stop_hook
+test_every_rule_is_valid_syntax
+test_blocks_every_merge_verb
+test_does_not_overblock_delivery_verbs
+test_uses_ask_not_allow_or_deny
+test_spawn_delegates_to_the_library

--- a/tests/fm-crew-settings.test.sh
+++ b/tests/fm-crew-settings.test.sh
@@ -121,6 +121,9 @@ test_every_rule_is_valid_syntax() {
 # The verbs that must be blocked. Landing is the captain's call, so both the
 # gh porcelain and the gh api merge endpoints have to be covered - blocking only
 # `gh pr merge` leaves `gh api --method PUT .../pulls/N/merge` wide open.
+# gh-axi needs its own row: a rule is a prefix match on the literal argv[0]
+# token, so `Bash(gh pr merge:*)` never matches `gh-axi pr merge` - the exact
+# command the briefs hand a crewmate and bin/fm-pr-merge.sh lands PRs with.
 test_blocks_every_merge_verb() {
   local all row label pattern
   all=$(rules)
@@ -130,15 +133,30 @@ test_blocks_every_merge_verb() {
       || fail "merge block is missing the $label rule ($pattern)"
   done <<'ROWS'
 gh porcelain merge|Bash(gh pr merge:*)
+gh-axi porcelain merge|Bash(gh-axi pr merge:*)
 gh api pull-request merge endpoint|Bash(gh api *pulls/*/merge*)
 gh api branch merges endpoint|Bash(gh api *repos/*/merges*)
+gh api graphql merge mutation|Bash(gh api graphql*mergePullRequest*)
 tk-feature land|Bash(tk-feature land:*)
 tk-feature-land|Bash(tk-feature-land:*)
 ROWS
   # Guard the count so a future edit cannot quietly drop one.
   row=$(printf '%s\n' "$all" | grep -c .)
-  [ "$row" -eq 5 ] || fail "expected 5 merge-block rules, found $row"
-  pass "every merge verb is blocked (gh porcelain, gh api endpoints, tk-feature)"
+  [ "$row" -eq 7 ] || fail "expected 7 merge-block rules, found $row"
+  pass "every merge verb is blocked (gh, gh-axi, gh api endpoints, tk-feature)"
+}
+
+# A rule that names one executable must not be assumed to cover a differently
+# named one. This is the gh/gh-axi gap stated as an invariant rather than as a
+# single table row, so a future rewrite cannot lose it by editing the table.
+test_each_merge_executable_has_its_own_rule() {
+  local all exe
+  all=$(rules)
+  for exe in 'gh pr merge' 'gh-axi pr merge'; do
+    printf '%s\n' "$all" | grep -qF "Bash($exe:" \
+      || fail "no rule starts with the '$exe' executable+verb; a rule for a differently named executable does not cover it"
+  done
+  pass "each merge executable (gh, gh-axi) carries its own rule"
 }
 
 # The block must stay narrow. A crewmate needs ordinary `gh api` reads and must
@@ -168,6 +186,43 @@ test_uses_ask_not_allow_or_deny() {
   pass "merge block uses permissions.ask"
 }
 
+# The turn-end path is derived from FM_HOME/FM_STATE_OVERRIDE, so it is not
+# guaranteed to be free of quotes or backslashes. An unescaped one makes the
+# document invalid JSON, and a rejected file loses BOTH guarantees at once while
+# stopping the spawn on a settings dialog - the exact failure mode this library
+# exists to prevent. The hook command must also survive the shell that runs it.
+test_hostile_turnend_path_stays_valid() {
+  local path doc cmd tmproot canary name
+  tmproot=$(fm_test_tmproot fm-crew-settings)
+  mkdir -p "$tmproot"
+  canary="$tmproot/substitution-ran"
+  # The Stop command is "touch <path>; <busy-event ...>", so this asserts by
+  # RUNNING it rather than by parsing it apart: the busy half is harmless here
+  # (the script does not exist, and every hook command ends "2>/dev/null || true"),
+  # and executing is the only check that proves the shell reconstructs exactly
+  # the intended path. A substitution that survived quoting would fire the canary.
+  # shellcheck disable=SC2016  # single quotes are deliberate: these are hostile literal paths, not expansions
+  for name in \
+    "fm crew/it's a \"quoted\" \\path/x.turn-ended" \
+    'fm-$(touch '"$canary"')/y.turn-ended' \
+    'fm-`touch '"$canary"'`/z.turn-ended'
+  do
+    path="$tmproot/$name"
+    doc=$(fm_crew_settings_local_json "$path" "$tmproot/no-such-busy-event.sh" \
+      "$tmproot/state" some-task 1-1)
+    printf '%s' "$doc" | jq -e . >/dev/null 2>&1 \
+      || fail "hostile turn-end path produced invalid JSON: $path"
+    cmd=$(printf '%s' "$doc" | jq -r '.hooks.Stop[0].hooks[0].command')
+    mkdir -p "$(dirname "$path")"
+    sh -c "$cmd" || fail "hook command failed for turn-end path: $path"
+    [ -f "$path" ] \
+      || fail "hook command did not touch the turn-end path: $path (cmd: $cmd)"
+  done
+  [ ! -e "$canary" ] \
+    || fail "hook command let a substitution in the turn-end path execute"
+  pass "turn-end paths with quotes, backslashes, and shell metacharacters stay safe"
+}
+
 # fm-spawn must actually use the library rather than re-rolling the JSON inline,
 # which is how the two guarantees drifted apart before.
 test_spawn_delegates_to_the_library() {
@@ -190,6 +245,8 @@ test_busy_state_hooks_survive
 test_merge_block_rides_with_stop_hook
 test_every_rule_is_valid_syntax
 test_blocks_every_merge_verb
+test_each_merge_executable_has_its_own_rule
 test_does_not_overblock_delivery_verbs
 test_uses_ask_not_allow_or_deny
+test_hostile_turnend_path_stays_valid
 test_spawn_delegates_to_the_library

--- a/tests/fm-crew-settings.test.sh
+++ b/tests/fm-crew-settings.test.sh
@@ -192,34 +192,45 @@ test_uses_ask_not_allow_or_deny() {
 # stopping the spawn on a settings dialog - the exact failure mode this library
 # exists to prevent. The hook command must also survive the shell that runs it.
 test_hostile_turnend_path_stays_valid() {
-  local path doc cmd tmproot canary name
+  local path doc cmd tmproot canary
+  # Per-run canary under the suite's own temp root: a fixed /tmp name would
+  # survive a genuine regression and wedge every later run on a stale file, and
+  # would collide with another user's file on a shared runner. The canary name
+  # stays relative and is resolved by running the hook from inside the temp root,
+  # so the payload carries no quotes or spaces of its own to blunt it.
   tmproot=$(fm_test_tmproot fm-crew-settings)
   mkdir -p "$tmproot"
-  canary="$tmproot/substitution-ran"
-  # The Stop command is "touch <path>; <busy-event ...>", so this asserts by
-  # RUNNING it rather than by parsing it apart: the busy half is harmless here
-  # (the script does not exist, and every hook command ends "2>/dev/null || true"),
-  # and executing is the only check that proves the shell reconstructs exactly
-  # the intended path. A substitution that survived quoting would fire the canary.
-  # shellcheck disable=SC2016  # single quotes are deliberate: these are hostile literal paths, not expansions
-  for name in \
-    "fm crew/it's a \"quoted\" \\path/x.turn-ended" \
-    'fm-$(touch '"$canary"')/y.turn-ended' \
-    'fm-`touch '"$canary"'`/z.turn-ended'
+  canary=substitution-ran
+  # A substitution only escapes a naive '...' wrapper if single quotes close it
+  # around the substitution and reopen after it, so the payloads are built that
+  # way: $( ) alone stays inert inside the wrapper, and a lone unbalanced quote
+  # makes the whole line a parse error before anything can run.
+  for path in \
+    "$tmproot/fm crew/it's a \"quoted\" \\path/x.turn-ended" \
+    "$tmproot/quote'\$(touch $canary)'end/y.turn-ended" \
+    "$tmproot/quote'\`touch $canary\`'end/z.turn-ended"
   do
-    path="$tmproot/$name"
     doc=$(fm_crew_settings_local_json "$path" "$tmproot/no-such-busy-event.sh" \
       "$tmproot/state" some-task 1-1)
     printf '%s' "$doc" | jq -e . >/dev/null 2>&1 \
       || fail "hostile turn-end path produced invalid JSON: $path"
     cmd=$(printf '%s' "$doc" | jq -r '.hooks.Stop[0].hooks[0].command')
+    # The Stop command is "touch <path>; <busy-event ...>", so the turn-end
+    # argument can no longer be isolated by stripping a "touch " prefix. Assert
+    # by RUNNING the command instead, which is the stronger check anyway: the
+    # busy half is inert here (the script does not exist, and every hook command
+    # ends "2>/dev/null || true"), and only execution proves the shell
+    # reconstructs exactly the intended path. Run it from inside the temp root so
+    # a substitution that survived quoting drops the canary where it is checked.
     mkdir -p "$(dirname "$path")"
-    sh -c "$cmd" || fail "hook command failed for turn-end path: $path"
+    ( cd "$tmproot" && sh -c "$cmd" ) \
+      || fail "hook command failed for turn-end path: $path (cmd: $cmd)"
     [ -f "$path" ] \
       || fail "hook command did not touch the turn-end path: $path (cmd: $cmd)"
   done
-  [ ! -e "$canary" ] \
+  [ ! -e "$tmproot/$canary" ] \
     || fail "hook command let a substitution in the turn-end path execute"
+  rm -rf "$tmproot"
   pass "turn-end paths with quotes, backslashes, and shell metacharacters stay safe"
 }
 


### PR DESCRIPTION
## What Changed

- Fixed the two `gh api` merge rules that used `:*` mid-pattern — syntax Claude Code rejects and skips, so the merge guard never bit while every fresh spawn also stopped on a blocking Settings Warning dialog. The rule list is now per-executable and adds `gh-axi pr merge` plus the GraphQL `mergePullRequest` shape, and it rides under `permissions.ask` because a crewmate launched with `--dangerously-skip-permissions` can bypass allow/deny but not an "ask" it has no approver for.
- Moved the generated `.claude/settings.local.json` out of `bin/fm-spawn.sh` into the new `bin/fm-crew-settings-lib.sh`, so the busy-state hooks, the turn-end touch, and the merge block provably ride in one document (a single redirect writes the file, so a second writer would truncate the first). The library also carries its own shell-quoting and JSON escaping, which fixes hostile turn-end/state paths corrupting the document.
- Added `tests/fm-crew-settings.test.sh` (11 invariants, wired into `fm-test-run.sh`) and `docs/verification/crew-merge-block.md` holding the live-binary evidence the hermetic tests cannot carry; documented the coverage boundary in the library, `docs/scripts.md`, and the harness-adapters skill — rules match only the top-level command string, so wrapper indirection (`bin/fm-pr-merge.sh`, `bash -c`), stdin-fed GraphQL, and local landing stay ungated (open issue #2319), and a merge-block stop must not be cleared the same reflexive way as a launch-time trust dialog.

## Risk Assessment

⚠️ Medium: Every verification-record defect raised across the three rounds is now resolved and no code changed since round 1, but the branch still introduces a new blocking `permissions.ask` control on every claude crewmate whose wrapper-script bypass surface and interactive-wedge failure mode were consciously accepted rather than mitigated.

## Testing

Ran the new `tests/fm-crew-settings.test.sh` plus the full changed-file selection (45 scripts, 0 failures, 2 unrelated environment gate skips), then went past unit level: I spawned a real claude crewmate through `bin/fm-spawn.sh` and captured the `.claude/settings.local.json` it actually wrote, confirmed with the live Claude Code 2.1.231 binary that it loads with no `Invalid settings` section while the pre-fix `Bash(gh api:*/merge*)` control still reproduces the `was skipped` rejection, and finally launched a `--dangerously-skip-permissions` session in that directory which blocked all six merge verbs (gh, gh-axi, both REST endpoints, the GraphQL mutation, tk-feature land) while ordinary `gh` reads ran — the exact end-user behavior the fix exists to restore. This is a CLI/config surface with no rendered UI, so the evidence is command transcripts and the generated settings file rather than screenshots.

<details>
<summary>Evidence: Consolidated evidence write-up (spawn output, doctor comparison, bypass-mode block table)</summary>

```text
# Crewmate merge-block: end-to-end evidence

Change under test: `fix(spawn): repair the crewmate merge-block permission rules`
(`bin/fm-crew-settings-lib.sh` now owns the crewmate `.claude/settings.local.json`;
the `gh api` rules no longer use `:*` mid-pattern).

## 1. The real spawn writes both guarantees in one document

`bin/fm-spawn.sh` run for real (fake tmux pane + isolated git worktree, harness=claude):

`` `
spawned evidence-task harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-task worktree=<TMP>/claude/wt
spawn exit: 0
`` `

The file it wrote into the crewmate worktree (`spawned-settings.local.json`):

`` `json
{"hooks":["SessionEnd","Stop","StopFailure","UserPromptSubmit"],
 "ask":["Bash(gh pr merge:*)","Bash(gh-axi pr merge:*)","Bash(gh api *pulls/*/merge*)",
        "Bash(gh api *repos/*/merges*)","Bash(gh api graphql*mergePullRequest*)",
        "Bash(tk-feature land:*)","Bash(tk-feature-land:*)"]}
`` `

## 2. It loads clean in the real Claude Code binary (2.1.231), with a negative control

`claude doctor`, same binary, three directories (full output: `claude-doctor.txt`):

| Directory                                   | `Invalid settings` section |
|---------------------------------------------|----------------------------|
| pre-fix rules `Bash(gh api:*/merge*)`       | present - both rules `was skipped` |
| library output `fm_crew_settings_local_json`| absent |
| file written by the real `fm-spawn.sh`      | absent |

Negative-control text, verbatim:

`` `
Invalid permission rule "Bash(gh api:*/merge*)" was skipped: The :* pattern must be at
the end. Move :* to the end for prefix matching, or use * for wildcard matching
`` `

## 3. The rules actually stop the merge verbs under `--dangerously-skip-permissions`

`claude -p --dangerously-skip-permissions` launched inside the generated file's
directory and asked to run eight inert commands (full transcript:
`crewmate-merge-block-session.txt`):

| Command                                         | Result  |
|-------------------------------------------------|---------|
| `gh --version`                                  | executed |
| `gh pr merge --help`                            | blocked |
| `gh-axi pr merge --help`                        | blocked |
| `gh api --method PUT .../pulls/1/merge`         | blocked |
| `gh api --method POST .../merges`               | blocked |
| `gh api graphql -f query='mutation { mergePullRequest ... }'` | blocked |
| `gh api repos/cli/cli/pulls/1/files`            | executed |
| `tk-feature land --help`                        | blocked |

Every block surfaced as `Claude requested permissions to use Bash, but you haven't
granted it yet.` - bypass mode skips the prompt, not the rule, and an unattended
crewmate has no approver. Ordinary `gh api` reads stay ungated.

This run covers the two REST endpoint patterns under `permissions.ask` directly,
which `docs/verification/crew-merge-block.md` had only under `permissions.deny`.
```
</details>
<details>
<summary>Evidence: settings.local.json written by a real fm-spawn.sh crewmate spawn</summary>

`{"hooks":["SessionEnd","Stop","StopFailure","UserPromptSubmit"],"ask":["Bash(gh pr merge:*)","Bash(gh-axi pr merge:*)","Bash(gh api *pulls/*/merge*)","Bash(gh api *repos/*/merges*)","Bash(gh api graphql*mergePullRequest*)","Bash(tk-feature land:*)","Bash(tk-feature-land:*)"]}`

```text
{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"'/Users/khon/.no-mistakes/worktrees/23ff1d3581ba/01KZXEVPHAF5FW5X45WYSYS171/bin/fm-busy-event.sh' apply '/private/var/folders/vz/lz9zp19s2k71kbwjk73xtz5m0000gn/T/fm-spawn-evidence.xmf6Ua/claude/home/state' 'evidence-task' busy --gen 'g1786626277.94535.10911' --source claude-hook --event user-prompt-submit 2>/dev/null || true"}]}],"Stop":[{"hooks":[{"type":"command","command":"touch '/private/var/folders/vz/lz9zp19s2k71kbwjk73xtz5m0000gn/T/fm-spawn-evidence.xmf6Ua/claude/home/state/evidence-task.turn-ended'; '/Users/khon/.no-mistakes/worktrees/23ff1d3581ba/01KZXEVPHAF5FW5X45WYSYS171/bin/fm-busy-event.sh' apply '/private/var/folders/vz/lz9zp19s2k71kbwjk73xtz5m0000gn/T/fm-spawn-evidence.xmf6Ua/claude/home/state' 'evidence-task' idle --gen 'g1786626277.94535.10911' --source claude-hook --event stop 2>/dev/null || true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"'/Users/khon/.no-mistakes/worktrees/23ff1d3581ba/01KZXEVPHAF5FW5X45WYSYS171/bin/fm-busy-event.sh' apply '/private/var/folders/vz/lz9zp19s2k71kbwjk73xtz5m0000gn/T/fm-spawn-evidence.xmf6Ua/claude/home/state' 'evidence-task' idle --gen 'g1786626277.94535.10911' --source claude-hook --event stop-failure 2>/dev/null || true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"'/Users/khon/.no-mistakes/worktrees/23ff1d3581ba/01KZXEVPHAF5FW5X45WYSYS171/bin/fm-busy-event.sh' apply '/private/var/folders/vz/lz9zp19s2k71kbwjk73xtz5m0000gn/T/fm-spawn-evidence.xmf6Ua/claude/home/state' 'evidence-task' idle --gen 'g1786626277.94535.10911' --source claude-hook --event session-end 2>/dev/null || true"}]}]},"permissions":{"ask":["Bash(gh pr merge:*)","Bash(gh-axi pr merge:*)","Bash(gh api *pulls/*/merge*)","Bash(gh api *repos/*/merges*)","Bash(gh api graphql*mergePullRequest*)","Bash(tk-feature land:*)","Bash(tk-feature-land:*)"]}}
```
</details>
<details>
<summary>Evidence: claude doctor 2.1.231 — malformed control vs library output vs real spawned file</summary>

<code>=== negative control (pre-fix rules, &#39;:*&#39; mid-pattern) ===&#10;Invalid settings&#10;- .../live/bad/.claude/settings.local.json &gt; permissions.ask: Invalid permission rule &#34;Bash(gh api:*/merge*)&#34; was skipped: The :* pattern must be at the end. Move :* to the end for prefix matching, or use * for wildcard matching&#10;- .../live/bad/.claude/settings.local.json &gt; permissions.ask: Invalid permission rule &#34;Bash(gh api:*/merges*)&#34; was skipped: ...&#10;&#10;=== fixed rules, file as generated by fm_crew_settings_local_json ===&#10;(no Invalid settings section)&#10;&#10;=== real fm-spawn-generated crewmate worktree file ===&#10;(no Invalid settings section)</code>

```text
=== negative control (pre-fix rules, ':*' mid-pattern) ===
Claude Code doctor

Running: native (2.1.231)
Commit: bbff368ec698
Platform: darwin-arm64
Path: /Users/khon/.local/share/claude/versions/2.1.231
Config install method: native
Search: OK (bundled)
Auto-updates: enabled
Auto-update channel: latest
Last update attempt: none recorded

Invalid settings
- /private/var/folders/vz/lz9zp19s2k71kbwjk73xtz5m0000gn/T/no-mistakes-evidence/01KZXEVPHAF5FW5X45WYSYS171/live/bad/.claude/settings.local.json › permissions.ask: Invalid permission rule "Bash(gh api:*/merge*)" was skipped: The :* pattern must be at the end. Move :* to the end for prefix matching, or use * for wildcard matching
- /private/var/folders/vz/lz9zp19s2k71kbwjk73xtz5m0000gn/T/no-mistakes-evidence/01KZXEVPHAF5FW5X45WYSYS171/live/bad/.claude/settings.local.json › permissions.ask: Invalid permission rule "Bash(gh api:*/merges*)" was skipped: The :* pattern must be at the end. Move :* to the end for prefix matching, or use * for wildcard matching

Remote Control
Remote Control requires feature-flag evaluation, which is disabled because DISABLE_TELEMETRY is set. Unset it (or run in a shell without it) to use Remote Control.
- Feature-flag evaluation disabled (disabled by DISABLE_TELEMETRY)
- Remote Control rollout could not be verified for this account (no server response this session)

No installation issues found.

For a full setup checkup that can also fix issues, run /doctor in a Claude Code session.

=== fixed rules, file as generated by fm_crew_settings_local_json ===
Claude Code doctor

Running: native (2.1.231)
Commit: bbff368ec698
Platform: darwin-arm64
Path: /Users/khon/.local/share/claude/versions/2.1.231
Config install method: native
Search: OK (bundled)
Auto-updates: enabled
Auto-update channel: latest
Last update attempt: none recorded

Remote Control
Remote Control requires feature-flag evaluation, which is disabled because DISABLE_TELEMETRY is set. Unset it (or run in a shell without it) to use Remote Control.
- Feature-flag evaluation disabled (disabled by DISABLE_TELEMETRY)
- Remote Control rollout could not be verified for this account (no server response this session)

No installation issues found.

For a full setup checkup that can also fix issues, run /doctor in a Claude Code session.

=== real fm-spawn-generated crewmate worktree file ===
Claude Code doctor

Running: native (2.1.231)
Commit: bbff368ec698
Platform: darwin-arm64
Path: /Users/khon/.local/share/claude/versions/2.1.231
Config install method: native
Search: OK (bundled)
Auto-updates: enabled
Auto-update channel: latest
Last update attempt: none recorded

Remote Control
Remote Control requires feature-flag evaluation, which is disabled because DISABLE_TELEMETRY is set. Unset it (or run in a shell without it) to use Remote Control.
- Feature-flag evaluation disabled (disabled by DISABLE_TELEMETRY)
- Remote Control rollout could not be verified for this account (no server response this session)

No installation issues found.

For a full setup checkup that can also fix issues, run /doctor in a Claude Code session.
```
</details>
<details>
<summary>Evidence: Live --dangerously-skip-permissions session: merge verbs blocked, reads executed</summary>

<code>| Command | Executed or Blocked |&#10;|---|---|&#10;| gh --version | Executed (gh version 2.95.0) |&#10;| gh pr merge --help | Blocked |&#10;| gh-axi pr merge --help | Blocked |&#10;| gh api --method PUT repos/tkt028/no-such-repo-zzz9/pulls/1/merge | Blocked |&#10;| gh api --method POST repos/tkt028/no-such-repo-zzz9/merges | Blocked |&#10;| gh api graphql -f query=&#34;mutation { mergePullRequest(...) }&#34; | Blocked |&#10;| gh api repos/cli/cli/pulls/1/files | Executed (returned file list) |&#10;| tk-feature land --help | Blocked |&#10;&#10;Every block surfaced as: Claude requested permissions to use Bash, but you haven&#39;t granted it yet.</code>

```text
All 8 attempted. 6 were blocked by the permission system (denied Bash approval), not by me — no refusal text was generated by me or by `gh`; the commands never executed.

| Command | Executed or Blocked | First line of output (or refusal text) |
|---|---|---|
| `gh --version` | Executed | `gh version 2.95.0 (2026-06-17)` |
| `gh pr merge --help` | Blocked | `Claude requested permissions to use Bash, but you haven't granted it yet.` |
| `gh-axi pr merge --help` | Blocked | `Claude requested permissions to use Bash, but you haven't granted it yet.` |
| `gh api --method PUT repos/tkt028/no-such-repo-zzz9/pulls/1/merge` | Blocked | `Claude requested permissions to use Bash, but you haven't granted it yet.` |
| `gh api --method POST repos/tkt028/no-such-repo-zzz9/merges` | Blocked | `Claude requested permissions to use Bash, but you haven't granted it yet.` |
| `gh api graphql -f query="mutation { mergePullRequest(…PR_kwINVALID…) }"` | Blocked | `Claude requested permissions to use Bash, but you haven't granted it yet.` |
| `gh api repos/cli/cli/pulls/1/files` | Executed | `[{"sha":"16b31e3a0487aea4a16c34476513c0d164a59da2","filename":"command/pr.go","status":"modified",…}]` |
| `tk-feature land --help` | Blocked | `Claude requested permissions to use Bash, but you haven't granted it yet.` |

Two notes on reading this result:

- The block is **not** a judgment about the commands. `gh --version` and a read-only `gh api` GET went through; everything else — including the two pure `--help` invocations, which are as inert as `--version` — hit the same generic permission gate. The pattern is the permission ruleset's allowlist, not merge-safety triage.
- Because nothing ran for rows 2–6 and 8, I have no evidence about what those commands *would* have printed. In particular I can't tell you whether the two `gh api` merge calls would have returned `404 Not Found` (repo doesn't exist) or been refused earlier, and I can't confirm `tk-feature land --help` is even on PATH here.

I did not render the mandated `HUMAN_ACTION` footer: it must come from `shared/human-action`'s `ha_emit`, which needs a Bash call that would hit the same gate, and the rules forbid hand-typing the marker. Flagging its absence rather than faking one.
```
</details>
<details>
<summary>Evidence: Harness used to run the real spawn and capture its settings file</summary>

```text
#!/usr/bin/env bash
# Evidence harness: run the REAL bin/fm-spawn.sh for a claude crewmate against a
# fake tmux pane + isolated git worktree, then copy out the settings.local.json
# it actually wrote. Mirrors tests/fm-busy-adapter-wiring.test.sh's run_spawn.
set -u
REPO=$1
OUT=$2
cd "$REPO" || exit 1
. "$REPO/tests/lib.sh"
TMP_ROOT=$(fm_test_tmproot fm-spawn-evidence)
id=evidence-task
case_dir="$TMP_ROOT/claude"; home="$case_dir/home"; proj="$case_dir/project"; wt="$case_dir/wt"
fakebin=$(fm_fakebin "$case_dir/fake")
cat > "$fakebin/tmux" <<'T'
#!/usr/bin/env bash
set -u
case "$*" in *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
case "${1:-}" in
  display-message) printf 'firstmate\n'; exit 0 ;;
  list-windows) exit 0 ;;
  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
esac
exit 0
T
chmod +x "$fakebin/tmux"
fm_fake_exit0 "$fakebin" treehouse pi opencode claude codex
mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
printf 'claude\n' > "$home/config/crew-harness"
fm_git_worktree "$proj" "$wt" "wt-evidence"
touch "$home/state/.last-watcher-beat"
mkdir -p "$home/data/$id"
printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
FM_ROOT_OVERRIDE='' FM_HOME="$home" \
  FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
  FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
  FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
  GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
  "$REPO/bin/fm-spawn.sh" "$id" "$proj" --mode no-mistakes --yolo off 2>&1 | sed "s#$TMP_ROOT#<TMP>#g"
echo "spawn exit: ${PIPESTATUS[0]}"
cp "$wt/.claude/settings.local.json" "$OUT" && echo "copied real spawned settings -> $OUT"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-crew-settings-lib.sh:56` - The merge block only matches top-level Bash command strings, so any indirection defeats it — most importantly the repo&#39;s own sanctioned merge entrypoints. AGENTS.md:323 says &#34;Use `bin/fm-pr-merge.sh` for every task PR merge ... and `bin/fm-merge-local.sh` for approved local-only landing&#34;, and neither has a rule. A claude crewmate working in a firstmate worktree (this branch was produced exactly that way) can run `bin/fm-pr-merge.sh &lt;id&gt; &lt;pr-url&gt;`, which shells out to `gh-axi pr merge` in a subprocess that no `permissions.ask` rule ever sees, and the PR lands. Same for `bash -c &#39;gh pr merge ...&#39;`. The library&#39;s &#34;Known residual&#34; block (lines 46-51) documents only the GraphQL-from-stdin case, which understates the gap and reads as if wrapper scripts were considered and covered. Either add rules for the two `bin/fm-*merge*.sh` entrypoints or state the indirection class explicitly in the residual. Separately, `Bash(tk-feature land:*)` / `Bash(tk-feature-land:*)` hardcode an operator-specific external toolchain into every crewmate&#39;s settings while the product&#39;s own merge scripts are ungated — worth a second look at what the list is scoped to.
- ⚠️ `docs/verification/crew-merge-block.md:90` - The prose asserts &#34;the two REST merge endpoints ... are all covered&#34;, but the live evidence that supported that claim was deleted in b7a7ac7. The original table proved `gh api --method PUT repos/.../pulls/1/merge` and `gh api --method POST repos/.../merges` were refused; the replacement table tests only `gh --version`, `gh pr merge --help`, `gh-axi pr merge --help`, a GraphQL mutation, and a `pulls/N/files` read. So `Bash(gh api *pulls/*/merge*)` and `Bash(gh api *repos/*/merges*)` — the two patterns whose `:*`-mid-pattern syntax bug is the entire reason this branch exists — now have zero live matching evidence anywhere, in a record whose stated job (line 7) is to &#34;hold the live-binary evidence&#34; the hermetic tests cannot carry. The hermetic tests only assert the strings are present, not that Claude Code matches them.
- ⚠️ `docs/verification/crew-merge-block.md:13` - The Conditions note says the `--dangerously-skip-permissions` session table &#34;was not re-run: it exercises the rule patterns, and those are byte-for-byte unchanged by the hook addition&#34; — but the same commit (b7a7ac7) added two new rules (`Bash(gh-axi pr merge:*)`, `Bash(gh api graphql*mergePullRequest*)`) and replaced the table with a demonstrably different live run: different commands, a different refusal message (`Claude requested permissions to use Bash...` vs the previous `Permission to use Bash with command ... has been denied.`), and rows for rules that did not exist before. The patterns were therefore not unchanged and the table was re-run, so the header&#39;s &#34;Verified on 2026-07-25 with Claude Code 2.1.220&#34; and this scoping sentence no longer describe the record&#39;s own contents.
- ⚠️ `docs/verification/crew-merge-block.md:84` - This branch introduces `permissions.ask` into every claude crewmate&#39;s settings for the first time, which creates a new wedge mode the fleet has no detector for. The doc states it: in the interactive TUI a crewmate actually runs in, a matched rule surfaces as a pane-blocking prompt, so the turn never ends, Stop/StopFailure/SessionEnd never fire, the turn-end file is never touched, and the busy record stays `busy` forever. I found nothing that classifies a permission dialog — `bin/fm-composer-lib.sh` has no such screen class, and `bin/fm-inactive-reconcile.sh` only acts on `done`/`failed` state and explicitly leaves `working` to &#34;existing supervision semantics&#34;. The only mitigation shipped is prose in `.agents/skills/harness-adapters/SKILL.md:196` telling a human not to reflexively clear it, which requires a human to peek in the first place. Worth deciding whether a wedged-on-permission-prompt detector is a prerequisite or a follow-up.
- ℹ️ `bin/fm-crew-settings-lib.sh:20` - The merge block exists only for the `claude*` harness — `bin/fm-spawn.sh` writes `.claude/settings.local.json` in that case arm alone, and grok/codex/opencode/pi/cursor/kimi/muse crewmates get no equivalent (grok explicitly cannot, since it needs a hook-trust grant firstmate will not make). That is inherent to the mechanism, but neither the new verification record nor the SKILL.md addition says so, and both are titled generically enough (&#34;Crewmate merge-block verification&#34;) to read as fleet-wide protection. One sentence naming the harness scope would keep a reader from over-trusting it.
- ℹ️ `bin/fm-crew-settings-lib.sh:40` - `fm_crew_shell_quote` and `fm_crew_json_escape` are a third and fourth copy of logic `bin/fm-spawn.sh` already carries as `shell_quote` (line 1078) and `json_escape` (line 1476), now both sourced into the same process. The new copies are strictly better — the sed-based `json_escape` escapes only `\` and `&#34;` and would emit a raw newline/tab into a JSON scalar — yet fm-spawn&#39;s weaker one is still what writes the grok hook command at line 2515, which interpolates a filesystem path the same way. Consolidating both pairs into one shared owner would remove the duplication and close the weaker escaper&#39;s gap in the same move.

🔧 Fix: restore REST endpoint evidence, fix verification run provenance
1 info still open:
- ℹ️ `docs/verification/crew-merge-block.md:58` - The new Conditions rule at line 12 states &#34;each section names the run it came from,&#34; and the other two runs are pinned precisely (2026-07-25 / Claude Code 2.1.220 / commit `4073f59596e2`, and 2026-08-13 / 2.1.231 / commit `bbff368ec698`). The `permissions.ask`-under-bypass section names its run only relationally — &#34;Captured after `Bash(gh-axi pr merge:*)` and `Bash(gh api graphql*mergePullRequest*)` joined the rule list&#34; — with no date and no Claude Code version. That is the record&#39;s single most load-bearing run (it is what establishes that an unanswerable `ask` stops a bypass-mode crewmate at all), and the whole `was skipped` finding above it demonstrates that this engine&#39;s behavior is version-dependent, so a future reader cannot tell whether the evidence predates a version bump. Adding the date + version + commit for that session would close the gap the rest of this commit just closed everywhere else.

🔧 Fix: pin bypass-table run date, state uncaptured build
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-crew-settings.test.sh` — all 11 invariants pass (JSON validity, four busy hooks, turn-end path, co-residency with the merge block, `:*`-at-the-end syntax, 7 merge verbs, per-executable rules, no over-blocking, hostile-path quoting, fm-spawn delegation)</code>
- <code>`bash bin/fm-test-run.sh --changed --base 96876db31009d011694a0174a460d2c587f2c6c8` — 45 scripts, `FM_TEST_SUMMARY total=45 failed=0 skipped_gate=2` (skips are `pi` package / `tsc` absent in this environment)</code>
- <code>Manual: ran the real `bin/fm-spawn.sh evidence-task &lt;proj&gt; --mode no-mistakes --yolo off` with a fake tmux pane and isolated git worktree, then inspected the `.claude/settings.local.json` it wrote (`/var/folders/.../no-mistakes-evidence/01KZXEVPHAF5FW5X45WYSYS171/spawn-evidence.sh`)</code>
- <code>Manual: `claude doctor` (Claude Code 2.1.231) in three directories — pre-fix malformed-rule control, library output, and the real spawned file</code>
- <code>Manual: `claude -p --dangerously-skip-permissions &#39;...run each command and report whether it executed...&#39;` inside the generated settings directory, exercising `gh pr merge`, `gh-axi pr merge`, `gh api --method PUT .../pulls/1/merge`, `gh api --method POST .../merges`, `gh api graphql` mergePullRequest, `tk-feature land --help`, plus `gh --version` and a read-only `gh api` GET as negative controls</code>

</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `bin/fm-crew-settings-lib.sh:46` - The merge block&#39;s coverage boundary is now documented (rules match only the top-level command string, so wrapper indirection and local landing are ungated), but the mechanism itself is unchanged and open issue #2319 leaves the resolution undecided between adding rules for the sanctioned entrypoints, accepting the documented boundary, or moving enforcement below the command string. I chose documentation only, since changing the rule list would be a behaviour and threat-model change outside this documentation pass.
- ℹ️ `docs/scripts.md:53` - bin/fm-spawn.sh writes this settings document for scout tasks as well as ship crewmates (the write is gated only on KIND != secondmate), while every doc surface calls it &#34;the claude crewmate&#39;s&#34; file. Harmless today (a scout never lands work, and the dialog-handling guidance applies identically), so I left the wording alone rather than churn four surfaces for a nuance the change did not introduce.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
