### PR TITLE
fix(bin): detect PATH-shadowed provisioned gh before gh-axi state-changing commands fail

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, GH_PATH_SHADOW, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -24,6 +24,9 @@ When any diagnostic needs captain attention, report the plain consequence and re
 - `MISSING_MANUAL: <tool> (instructions: <url>)` - tell the captain why the tool is required and give them the printed instructions URL, but do not pass the tool to `bin/fm-bootstrap.sh install`; wait for the captain to complete the manual installation, then rerun session start to confirm the dependency is present.
 - `BACKEND_INVALID: <name> (known: <names>)` - the resolved runtime backend has no verified dependency or lifecycle contract, so do not dispatch work until the invalid `FM_BACKEND` or `config/backend` value is corrected to one of the listed backends.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
+- `GH_PATH_SHADOW: <resolved gh> shadows the provisioned gh at <provisioned path>; gh-axi state-changing commands will fail until PATH is fixed` - a Homebrew or other non-provisioned `gh` sits earlier on `PATH` than DoorDash's version-pinned install, so `gh-axi` state-changing commands (e.g. `pr merge`) will refuse with a version-mismatch error even though read-only commands work fine.
+  This is advisory: bootstrap never reorders `PATH` itself.
+  Tell the captain their `gh` PATH order needs fixing (reorder `PATH` or remove the shadowing install) and, until they do, route any state-changing GitHub operation through the printed provisioned path prefixed onto `PATH` for that one command only.
 - `TANGLE: <remediation>` - the primary checkout is stranded on a feature branch instead of its default branch; `AGENTS.md` section 8 explains why this guard exists and what it protects.
   The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree.
   This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,7 +469,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `GH_PATH_SHADOW:`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -7,6 +7,9 @@
 #          Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)",
 #                 "MISSING_MANUAL: <tool> (instructions: <url>)", "NEEDS_GH_AUTH",
+#                 "GH_PATH_SHADOW: <resolved gh> shadows the provisioned gh at
+#                 <provisioned path>; gh-axi state-changing commands will fail
+#                 until PATH is fixed",
 #                 "BACKEND_INVALID: <name> (known: <names>)",
 #                 "CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>",
 #                 "FLEET_SYNC: <repo>: skipped|recovered|STUCK: <detail>",
@@ -54,6 +57,17 @@
 #          incompatible build reports MISSING like no-mistakes. A compatible
 #          tasks-axi default backend is silent. quota-axi is required for the
 #          agent-owned dispatch-profile array procedure in AGENTS.md section 4.
+#          A GH_PATH_SHADOW line means DoorDash's ai-helpers toolchain provisions
+#          a version-pinned gh at $HOME/doordash-ai-helpers/<os>-<arch>/gh (or
+#          FM_GH_PROVISIONED_ROOT_OVERRIDE/<os>-<arch>/gh when that override is
+#          set) but a different gh resolves earlier on PATH - typically a
+#          Homebrew install at /usr/local/bin/gh. gh-axi resolves gh via the
+#          ambient PATH and refuses every state-changing command (pr merge,
+#          etc.) once the resolved binary's version differs from the pin;
+#          read-only gh-axi commands are unaffected. Detection is presence-only
+#          (a provisioned gh exists elsewhere but is shadowed), not a version
+#          diff, so it can still fire even when the shadowing gh currently
+#          happens to match; bootstrap never reorders PATH itself.
 #          X mode is OPTIONAL and inert unless FM_HOME/.env has a non-empty
 #          FMX_PAIRING_TOKEN. When opted in, bootstrap requires curl+jq, writes
 #          the relay poll shim and 30s cadence config, and prints an FMX line.
@@ -508,6 +522,45 @@ missing_tool_diagnostic() {
   echo "MISSING: $tool (install: $(install_cmd "$tool"))"
 }
 
+# Path of the DoorDash-provisioned gh for this host's os-arch, if present.
+# FM_GH_PROVISIONED_ROOT_OVERRIDE lets tests point this at an empty directory
+# instead of the real $HOME/doordash-ai-helpers, so fixture gh binaries on a
+# fake PATH never trip GH_PATH_SHADOW against a developer machine's real
+# provisioned install.
+gh_provisioned_path() {
+  local root os arch candidate
+  root="${FM_GH_PROVISIONED_ROOT_OVERRIDE:-${HOME:-}/doordash-ai-helpers}"
+  [ -n "$root" ] || return 1
+  os=$(uname -s 2>/dev/null) || return 1
+  arch=$(uname -m 2>/dev/null) || return 1
+  case "$os" in
+    Darwin) os=darwin ;;
+    Linux) os=linux ;;
+    *) return 1 ;;
+  esac
+  case "$arch" in
+    arm64|aarch64) arch=arm64 ;;
+    x86_64|amd64) arch=x64 ;;
+    *) return 1 ;;
+  esac
+  candidate="$root/${os}-${arch}/gh"
+  [ -x "$candidate" ] || return 1
+  printf '%s\n' "$candidate"
+}
+
+# Detects the PATH-shadow shape that trips gh-axi's version-pin refusal on
+# state-changing commands (see the GH_PATH_SHADOW header note above).
+# Presence-only: a provisioned gh existing elsewhere but shadowed is reported
+# even if the shadowing gh's version currently happens to match, since drift
+# can silently reintroduce the failure later.
+gh_path_shadow_diagnostic() {
+  local resolved provisioned
+  resolved=$(command -v gh 2>/dev/null) || return 0
+  provisioned=$(gh_provisioned_path) || return 0
+  [ "$resolved" = "$provisioned" ] && return 0
+  echo "GH_PATH_SHADOW: $resolved shadows the provisioned gh at $provisioned; gh-axi state-changing commands will fail until PATH is fixed"
+}
+
 # Required-tool detection follows the RESOLVED backend, not a one-size default:
 # a universal toolchain every home needs plus the backend-specific delta owned by
 # fm_backend_required_tools (bin/fm-backend.sh). So a herdr/zellij/cmux home is
@@ -845,6 +898,7 @@ if command -v tasks-axi >/dev/null 2>&1 && ! fm_tasks_axi_compatible; then
   echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
 fi
 gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
+gh_path_shadow_diagnostic
 # Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its
 # default branch, not a feature branch (see fm-tangle-lib.sh). Scoped to the
 # primary only; detached-HEAD worktrees and secondmate homes never trip it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,6 +259,8 @@ When X mode is opted in, bootstrap also requires `curl` and `jq` before arming t
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.
 An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
 An absent `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; firstmate cannot resolve a profile array until current quota output is available for every candidate.
+Bootstrap also reports a `GH_PATH_SHADOW:` line when a DoorDash-provisioned `gh` exists at `$HOME/doordash-ai-helpers/<os>-<arch>/gh` (or `FM_GH_PROVISIONED_ROOT_OVERRIDE/<os>-<arch>/gh` when that test override is set) but a different `gh` resolves earlier on `PATH`.
+That shape makes `gh-axi` refuse state-changing commands like `pr merge` on a version-pin mismatch even though read-only commands keep working; detection is presence-only and bootstrap never reorders `PATH` itself.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.
@@ -366,6 +368,7 @@ FM_DATA_OVERRIDE=        # alternate data dir, mainly for tests
 FM_PROJECTS_OVERRIDE=    # alternate projects dir, mainly for tests
 FM_CONFIG_OVERRIDE=      # alternate config dir, mainly for tests
 FM_PROC_ROOT_OVERRIDE=   # alternate /proc root for the Linux process-identity read in fm-wake-lib.sh, mainly for tests
+FM_GH_PROVISIONED_ROOT_OVERRIDE=   # alternate root for the DoorDash-provisioned gh lookup (default $HOME/doordash-ai-helpers), mainly for tests
 FM_BACKEND=             # optional runtime backend override for new spawns; tmux/herdr/zellij/orca/cmux support ship/scout spawns, codex-app is not accepted
 HERDR_SESSION=default  # herdr-only: named session for normal backend ops; not enough for destructive cleanup (docs/herdr-backend.md)
 FM_BACKEND_HERDR_COMPOSER_LINES=20  # herdr-only: tail lines scanned by composer-state guard/fallback paths; idle-baseline submit confirmation uses agent-state

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -23,6 +23,11 @@ set -u
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 TMP_ROOT=$(fm_test_tmproot fm-bootstrap-tests)
 export FM_BACKEND_CMUX_BUNDLE_BIN="$TMP_ROOT/no-bundled-cmux"
+# Every fixture gh below is a trivial fake, not a real provisioned binary, so
+# point GH_PATH_SHADOW detection at an empty directory - otherwise it would
+# leak a real $HOME/doordash-ai-helpers install on a dev machine into cases
+# that expect silence.
+export FM_GH_PROVISIONED_ROOT_OVERRIDE="$TMP_ROOT/no-provisioned-gh"
 
 # Hermetic runtime-backend detection. These cases pin the backend per-home via
 # config/backend; the dev shell's ambient runtime markers ($TMUX inside tmux,
@@ -72,6 +77,26 @@ SH
   add_tasks_axi "$fakebin" "0.1.1"
   add_quota_axi "$fakebin"
   printf '%s\n' "$fakebin"
+}
+
+# Mirrors fm-bootstrap.sh's gh_provisioned_path os/arch mapping so GH_PATH_SHADOW
+# fixtures land in the exact subdirectory name the script under test computes
+# for the real host running the suite, whatever that host is.
+gh_shadow_test_platform() {
+  local os arch
+  os=$(uname -s)
+  arch=$(uname -m)
+  case "$os" in
+    Darwin) os=darwin ;;
+    Linux) os=linux ;;
+    *) os=unsupported ;;
+  esac
+  case "$arch" in
+    arm64|aarch64) arch=arm64 ;;
+    x86_64|amd64) arch=x64 ;;
+    *) arch=unsupported ;;
+  esac
+  printf '%s\n' "${os}-${arch}"
 }
 
 add_quota_axi() {
@@ -346,6 +371,53 @@ SH
   expected="MISSING: git (install: brew install git  # or the platform's package manager)"
   [ "$out" = "$expected" ] || fail "missing git should report the supported install instruction, got: $out"
   pass "bootstrap requires git with an install instruction"
+}
+
+test_gh_path_shadow_flags_shadowed_provisioned_gh() {
+  local case_dir fakebin provisioned_root platform out expected
+  case_dir="$TMP_ROOT/gh-path-shadow"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  provisioned_root="$case_dir/provisioned"
+  platform=$(gh_shadow_test_platform)
+  mkdir -p "$provisioned_root/$platform"
+  cat > "$provisioned_root/$platform/gh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$provisioned_root/$platform/gh"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_GH_PROVISIONED_ROOT_OVERRIDE="$provisioned_root" \
+    "$ROOT/bin/fm-bootstrap.sh")
+  expected="GH_PATH_SHADOW: $fakebin/gh shadows the provisioned gh at $provisioned_root/$platform/gh; gh-axi state-changing commands will fail until PATH is fixed"
+  assert_contains "$out" "$expected" "a PATH-earlier gh shadowing a provisioned install must report GH_PATH_SHADOW"
+  pass "bootstrap flags a PATH-shadowed provisioned gh"
+}
+
+test_gh_path_shadow_silent_when_resolved_gh_is_the_provisioned_one() {
+  local case_dir fakebin provisioned_root platform out
+  case_dir="$TMP_ROOT/gh-path-shadow-match"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  rm -f "$fakebin/gh"
+  provisioned_root="$case_dir/provisioned"
+  platform=$(gh_shadow_test_platform)
+  mkdir -p "$provisioned_root/$platform"
+  cat > "$provisioned_root/$platform/gh" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = auth ] && [ "${2:-}" = status ]; then
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$provisioned_root/$platform/gh"
+  out=$(PATH="$provisioned_root/$platform:$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_GH_PROVISIONED_ROOT_OVERRIDE="$provisioned_root" \
+    "$ROOT/bin/fm-bootstrap.sh")
+  assert_not_contains "$out" "GH_PATH_SHADOW" "a resolved gh that is itself the provisioned binary must not report a shadow"
+  pass "bootstrap stays silent when the resolved gh is the provisioned one"
 }
 
 test_orca_backend_gates_orca_tool_only_when_selected() {
@@ -797,6 +869,8 @@ ROWS
 test_bootstrap_reporting
 test_no_mistakes_min_version
 test_git_is_required_with_supported_install_instruction
+test_gh_path_shadow_flags_shadowed_provisioned_gh
+test_gh_path_shadow_silent_when_resolved_gh_is_the_provisioned_one
 test_orca_backend_gates_orca_tool_only_when_selected
 test_session_provider_backends_do_not_require_tmux
 test_session_provider_backends_gate_own_cli_not_tmux


### PR DESCRIPTION
## What Changed

- `bin/fm-bootstrap.sh` adds `gh_provisioned_path`/`gh_path_shadow_diagnostic`, which resolve the DoorDash-provisioned `gh` for the host's os-arch (respecting `FM_GH_PROVISIONED_ROOT_OVERRIDE` for tests) and emit a new `GH_PATH_SHADOW: <resolved gh> shadows the provisioned gh at <provisioned path>; gh-axi state-changing commands will fail until PATH is fixed` diagnostic when a different `gh` resolves earlier on `PATH`; detection is presence-only and bootstrap never reorders `PATH` itself.
- `.agents/skills/bootstrap-diagnostics/SKILL.md` and `AGENTS.md` add `GH_PATH_SHADOW` to the list of actionable bootstrap diagnostics and give the agent handling guidance (route state-changing GitHub operations through the printed provisioned path for that one command).
- `docs/configuration.md` documents the `GH_PATH_SHADOW:` line and the new `FM_GH_PROVISIONED_ROOT_OVERRIDE` test override variable; `tests/fm-bootstrap.test.sh` adds coverage for the shadowed and non-shadowed cases.

## Risk Assessment

✅ Low: Small, additive, presence-only detection with symmetric positive/negative tests and matching documentation updates across SKILL.md, AGENTS.md, and docs/configuration.md; no existing code paths are modified and the new diagnostic is silent by default off DoorDash-provisioned machines.

## Testing

Ran the full fm-bootstrap.test.sh suite (23/23 passing, no regressions) and additionally reproduced the GH_PATH_SHADOW scenario directly against bin/fm-bootstrap.sh to capture the exact diagnostic line a user/agent would see at session start, confirming the new PATH-shadow detection fires correctly and stays silent when gh resolves to the provisioned binary; no issues found.

<details>
<summary>Evidence: Captured GH_PATH_SHADOW diagnostic line from a live bootstrap run against a fixture PATH-shadowed gh</summary>

`GH_PATH_SHADOW: .../fakebin/gh shadows the provisioned gh at .../provisioned/darwin-arm64/gh; gh-axi state-changing commands will fail until PATH is fixed`

```text
GH_PATH_SHADOW: /var/folders/sx/5y5xkxcn1hxgf_xtt5mzg0lr0000gn/T//fm-bootstrap-tests.wSQQ8k/gh-path-shadow/fakebin/gh shadows the provisioned gh at /var/folders/sx/5y5xkxcn1hxgf_xtt5mzg0lr0000gn/T//fm-bootstrap-tests.wSQQ8k/gh-path-shadow/provisioned/darwin-arm64/gh; gh-axi state-changing commands will fail until PATH is fixed
```
</details>
<details>
<summary>Evidence: Full fm-bootstrap.test.sh suite run (23/23 ok, no regressions)</summary>

```text
ok - bootstrap reports treehouse lease + tasks-axi/quota-axi bootstrap contracts
ok - bootstrap enforces no-mistakes minimum version
ok - bootstrap requires git with an install instruction
ok - bootstrap flags a PATH-shadowed provisioned gh
ok - bootstrap stays silent when the resolved gh is the provisioned one
ok - bootstrap: backend=orca gates the Orca CLI without requiring it on the default backend
ok - bootstrap: session-provider backends require their own CLI + jq + treehouse, never tmux
ok - bootstrap: a session-provider backend gates its own CLI, never a false tmux requirement
ok - bootstrap: Herdr manual-install guidance is never executed as a shell command
ok - bootstrap: the bundled cmux CLI satisfies the active backend dependency
ok - bootstrap: unknown resolved backends fail closed with an actionable diagnostic
ok - bootstrap: JSON-emitting backends require jq (their genuine dep), never tmux
ok - bootstrap: the treehouse lease check follows the resolved backend's worktree provider
ok - bootstrap computes a fleet-size-aware default timeout and preserves partial fleet-sync output
ok - bootstrap keeps the quick 20s default for small fleets
ok - bootstrap preserves FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT as an explicit override
ok - bootstrap treats a blank timeout override as unset
ok - bootstrap computes the timeout before launching fleet sync
ok - bootstrap keeps routine tasks-axi, harness, dispatch, and already-live liveness confirmations silent
ok - bootstrap routine contract runs under system /bin/bash
ok - bootstrap diagnostics trigger excludes benign lines and keeps actionable prefixes
ok - bootstrap surfaces active crew-dispatch rules only as verbose BOOTSTRAP_INFO
ok - bootstrap validates crew-dispatch.json and reports malformed or unverified configs
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-bootstrap.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-bootstrap.test.sh` (full suite, 23/23 ok, no regressions)</code>
- `test_gh_path_shadow_flags_shadowed_provisioned_gh (isolated run) — confirms bootstrap emits GH_PATH_SHADOW when a fake shadowing gh precedes a fixture provisioned gh on PATH`
- `test_gh_path_shadow_silent_when_resolved_gh_is_the_provisioned_one (isolated run) — confirms silence when the resolved gh is itself the provisioned binary`
- `Manual capture: ran bin/fm-bootstrap.sh directly against the shadow fixture (FM_GH_PROVISIONED_ROOT_OVERRIDE pointed at a temp provisioned gh, PATH pointed at a temp shadowing gh) and captured the exact printed GH_PATH_SHADOW line as end-user-visible CLI output`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
