### PR TITLE
fix(bin): drop the U+2063 mark from the launch-brief envelope

### DIFF
--- a/.agents/skills/ahoy/SKILL.md
+++ b/.agents/skills/ahoy/SKILL.md
@@ -14,12 +14,13 @@ Give the captain a concise session-only recap without gathering fresh state.
 2. Find the most recent real captain-authored message before the current `/ahoy` invocation.
    A captain boundary is an ordinary user-role message unless it matches one of the narrow operational exclusions below.
    Exclude messages that begin with the current U+2063 `FIRSTMATE_OP:` injection prefix.
+   Exclude messages that begin with the unmarked `FIRSTMATE_OP: v1 launch-brief: ` header, the one operational kind that carries no U+2063 because it is an argv launch prompt rather than an injection; `bin/fm-operational-input.sh` owns that form.
    Exclude legacy bare-marker away-mode injections only when U+2063 is immediately followed by `Supervisor escalate (`.
    Exclude the exact legacy unmarked session-start payload ``Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.``
    Custom-role messages such as Pi's `firstmate-sessionstart-nudge` are not captain messages.
    System, developer, tool, watcher, guard, away-mode, and other injected operational messages are not captain messages.
    Never infer captain authorship merely because a synthetic message appears in the user-role transcript.
-   Do not exclude an ordinary captain message merely because it begins with U+2063 followed by other text, contains ASCII `FIRSTMATE_OP:` without a leading U+2063, quotes or embeds a current operational message after ordinary captain text, quotes or mentions the legacy session-start payload, or adds any text to that payload.
+   Do not exclude an ordinary captain message merely because it begins with U+2063 followed by other text, contains ASCII `FIRSTMATE_OP:` without a leading U+2063 in any form other than the unmarked launch-brief header above, quotes or embeds a current operational message after ordinary captain text, quotes or mentions the legacy session-start payload, or adds any text to that payload.
    Apply the current exclusion only when U+2063 `FIRSTMATE_OP:` begins at the first character of the whole message: `Captain quote: ` followed by that current prefix is a captain boundary.
    Apply the legacy startup exclusion as a literal whole-message match: ``Captain quote: Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.`` is a captain boundary.
 3. If no prior real captain message exists, load [`../bearings/SKILL.md`](../bearings/SKILL.md) and follow it exactly.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ pi
 
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
-Pi's `/calm` toggle hides supported transcript chrome, including canonically classified Firstmate operational user rows, while retaining native working activity and all model context and session data.
+Pi's `/calm` toggle hides supported transcript chrome, including the canonically classified Firstmate operational user rows injected into a running agent, while retaining native working activity and all model context and session data.
 The hidden operational inputs remain ordinary user-role messages with unchanged delivery, ordering, authority, persistence, and exports.
 The preference persists for the effective Firstmate home, and toggling it off restores ordinary rendering.
 [Calm's current behavior and supported limits](docs/calm.md) are separate from its [version-scoped maintainer evidence](docs/calm-mode-feasibility.md).

--- a/bin/fm-operational-input.sh
+++ b/bin/fm-operational-input.sh
@@ -5,8 +5,16 @@
 # by JavaScript and TypeScript integrations. It is the single owner of current
 # construction, current parsing, and narrow pre-protocol transcript parsing.
 #
-# Current generic wire form:
+# Current generic wire form, for every kind INJECTED into a running agent:
 #   U+2063 FIRSTMATE_OP: v1 <kind>: <body>
+#
+# Current generic wire form, for a kind listed in FM_OPERATIONAL_UNMARKED_KINDS:
+#   FIRSTMATE_OP: v1 <kind>: <body>
+#
+# The unmarked form is the marked form minus its leading U+2063, and is accepted
+# on parse ONLY for a declared unmarked kind, so no injected kind can be forged
+# without the mark. See FM_OPERATIONAL_UNMARKED_KINDS below for why launch-brief
+# is the one kind that carries it.
 #
 # The landed U+2063 + "FIRSTMATE_OP: " prefix is permanent compatibility.
 # The version and kind header make current inputs structurally typed without
@@ -30,6 +38,37 @@ FM_OPERATIONAL_VERSION=v1
 FM_OPERATIONAL_HEADER_PREFIX="${FM_OPERATIONAL_PREFIX}${FM_OPERATIONAL_VERSION} "
 FM_OPERATIONAL_KINDS='session-start watcher turn-end-guard away-supervisor launch-brief'
 
+# launch-brief is the one kind that is never INJECTED into a running agent: it is
+# passed as the agent's argv launch prompt by bin/fm-spawn.sh. The leading U+2063
+# mark exists to make injected input unforgeable by a human typing at a composer,
+# a property an argv launch prompt cannot need, so launch-brief carries the same
+# versioned envelope without the zero-width mark. Every injected kind keeps the
+# marked envelope and its anti-forgery guarantee unchanged.
+#
+# This is load-bearing, not cosmetic: agents set their terminal pane title from
+# their own launch prompt, and tmux 3.7b aborts the ENTIRE server on a title
+# containing U+2063 ("utf8proc_wcwidth(02063) returned 0" ->
+# "fatal: xreallocarray: zero size"), killing every window at once.
+FM_OPERATIONAL_UNMARKED_KINDS='launch-brief'
+# Derived, never re-typed: the unmarked header is exactly the marked header with
+# its leading U+2063 removed, so the two forms cannot drift apart.
+FM_OPERATIONAL_UNMARKED_HEADER_PREFIX="${FM_OPERATIONAL_HEADER_PREFIX#"$FM_OPERATIONAL_MARK"}"
+
+fm_operational_kind_is_unmarked() {  # <kind>
+  case " $FM_OPERATIONAL_UNMARKED_KINDS " in
+    *" $1 "*) return 0 ;;
+  esac
+  return 1
+}
+
+fm_operational_header_for_kind() {  # <kind>
+  if fm_operational_kind_is_unmarked "$1"; then
+    printf '%s' "$FM_OPERATIONAL_UNMARKED_HEADER_PREFIX"
+  else
+    printf '%s' "$FM_OPERATIONAL_HEADER_PREFIX"
+  fi
+}
+
 # Compatibility name retained for the away-mode owner and its tests.
 # shellcheck disable=SC2034 # Public source-library variable used by callers.
 FM_INJECT_MARK=$FM_OPERATIONAL_MARK
@@ -52,7 +91,7 @@ fm_operational_input_encode() {  # <generic-kind> <body> <result-var>
   [ -n "$result_var" ] || return 2
   fm_operational_kind_is_current "$kind" || return 2
   [ -n "$body" ] || return 2
-  printf -v "$result_var" '%s%s: %s' "$FM_OPERATIONAL_HEADER_PREFIX" "$kind" "$body"
+  printf -v "$result_var" '%s%s: %s' "$(fm_operational_header_for_kind "$kind")" "$kind" "$body"
 }
 
 fm_operational_input_construct() {  # <kind> <body> <result-var>
@@ -65,18 +104,40 @@ fm_operational_input_construct() {  # <kind> <body> <result-var>
   fm_operational_input_encode "$kind" "$body" "$result_var"
 }
 
-fm_operational_generic_kind() {  # <message> <result-var>
-  local message=${1-} result_var=${2-} remainder parsed_kind body
-  [ -n "$result_var" ] || return 2
-  case "$message" in
-    "$FM_OPERATIONAL_HEADER_PREFIX"*': '?*) ;;
+# Single owner of current-envelope splitting for both the marked and the
+# unmarked header. An unmarked header is accepted only for a kind declared in
+# FM_OPERATIONAL_UNMARKED_KINDS, so no injected kind can be forged without the
+# zero-width mark.
+fm_operational_generic_split() {  # <message> <kind-result-var> <body-result-var>
+  # EVERY local here is split_-prefixed, with no exception for the parameters:
+  # under bash dynamic scoping an unprefixed local silently shadows a caller's
+  # own result-variable name, so the write lands on the local and the caller
+  # reads an empty value instead of an error. tests/fm-operational-input.test.sh
+  # locks this by round-tripping through every plausible caller-side name.
+  local split_message=${1-} split_kind_var=${2-} split_body_var=${3-}
+  local split_header split_remainder split_kind split_body
+  [ -n "$split_kind_var" ] && [ -n "$split_body_var" ] || return 2
+  case "$split_message" in
+    "$FM_OPERATIONAL_HEADER_PREFIX"*': '?*) split_header=$FM_OPERATIONAL_HEADER_PREFIX ;;
+    "$FM_OPERATIONAL_UNMARKED_HEADER_PREFIX"*': '?*) split_header=$FM_OPERATIONAL_UNMARKED_HEADER_PREFIX ;;
     *) return 1 ;;
   esac
-  remainder=${message#"$FM_OPERATIONAL_HEADER_PREFIX"}
-  parsed_kind=${remainder%%': '*}
-  fm_operational_kind_is_current "$parsed_kind" || return 1
-  body=${remainder#"${parsed_kind}: "}
-  [ "$body" != "$remainder" ] && [ -n "$body" ] || return 1
+  split_remainder=${split_message#"$split_header"}
+  split_kind=${split_remainder%%': '*}
+  fm_operational_kind_is_current "$split_kind" || return 1
+  if [ "$split_header" = "$FM_OPERATIONAL_UNMARKED_HEADER_PREFIX" ]; then
+    fm_operational_kind_is_unmarked "$split_kind" || return 1
+  fi
+  split_body=${split_remainder#"${split_kind}: "}
+  [ "$split_body" != "$split_remainder" ] && [ -n "$split_body" ] || return 1
+  printf -v "$split_kind_var" '%s' "$split_kind"
+  printf -v "$split_body_var" '%s' "$split_body"
+}
+
+fm_operational_generic_kind() {  # <message> <result-var>
+  local message=${1-} result_var=${2-} parsed_kind parsed_body
+  [ -n "$result_var" ] || return 2
+  fm_operational_generic_split "$message" parsed_kind parsed_body || return 1
   printf -v "$result_var" '%s' "$parsed_kind"
 }
 
@@ -99,8 +160,7 @@ fm_operational_input_kind() {  # <message> <result-var>
 fm_operational_input_body() {  # <current-message> <result-var>
   local message=${1-} result_var=${2-} current_kind parsed_body
   [ -n "$result_var" ] || return 2
-  if fm_operational_generic_kind "$message" current_kind; then
-    parsed_body=${message#"${FM_OPERATIONAL_HEADER_PREFIX}${current_kind}: "}
+  if fm_operational_generic_split "$message" current_kind parsed_body; then
     printf -v "$result_var" '%s' "$parsed_body"
     return 0
   fi

--- a/bin/fm-operational-input.sh
+++ b/bin/fm-operational-input.sh
@@ -48,7 +48,10 @@ FM_OPERATIONAL_KINDS='session-start watcher turn-end-guard away-supervisor launc
 # This is load-bearing, not cosmetic: agents set their terminal pane title from
 # their own launch prompt, and tmux 3.7b aborts the ENTIRE server on a title
 # containing U+2063 ("utf8proc_wcwidth(02063) returned 0" ->
-# "fatal: xreallocarray: zero size"), killing every window at once.
+# "fatal: xreallocarray: zero size"), killing every window at once. The header
+# alone is not enough for that: an unmarked kind's body is captain-supplied
+# text, so fm_operational_input_encode strips U+2063 from it and the whole
+# envelope carries no mark in any position.
 FM_OPERATIONAL_UNMARKED_KINDS='launch-brief'
 # Derived, never re-typed: the unmarked header is exactly the marked header with
 # its leading U+2063 removed, so the two forms cannot drift apart.
@@ -61,11 +64,13 @@ fm_operational_kind_is_unmarked() {  # <kind>
   return 1
 }
 
-fm_operational_header_for_kind() {  # <kind>
-  if fm_operational_kind_is_unmarked "$1"; then
-    printf '%s' "$FM_OPERATIONAL_UNMARKED_HEADER_PREFIX"
+fm_operational_header_for_kind() {  # <kind> <result-var>
+  local header_kind=${1-} header_result_var=${2-}
+  [ -n "$header_result_var" ] || return 2
+  if fm_operational_kind_is_unmarked "$header_kind"; then
+    printf -v "$header_result_var" '%s' "$FM_OPERATIONAL_UNMARKED_HEADER_PREFIX"
   else
-    printf '%s' "$FM_OPERATIONAL_HEADER_PREFIX"
+    printf -v "$header_result_var" '%s' "$FM_OPERATIONAL_HEADER_PREFIX"
   fi
 }
 
@@ -86,22 +91,38 @@ fm_operational_kind_is_current() {  # <kind>
   return 1
 }
 
+# Convention for every <result-var> function below: EVERY local is prefixed with
+# a per-function tag, with no exception for the parameters. This is not
+# stylistic. Under bash dynamic scoping an unprefixed local silently shadows a
+# caller's own result-variable name, so the write lands on the local, the
+# function still returns 0, and the caller reads an empty value instead of an
+# error. tests/fm-operational-input.test.sh locks this by round-tripping the
+# public entry points through every plausible caller-side name.
 fm_operational_input_encode() {  # <generic-kind> <body> <result-var>
-  local kind=${1-} body=${2-} result_var=${3-}
-  [ -n "$result_var" ] || return 2
-  fm_operational_kind_is_current "$kind" || return 2
-  [ -n "$body" ] || return 2
-  printf -v "$result_var" '%s%s: %s' "$(fm_operational_header_for_kind "$kind")" "$kind" "$body"
+  local encode_kind=${1-} encode_body=${2-} encode_result_var=${3-} encode_header
+  [ -n "$encode_result_var" ] || return 2
+  fm_operational_kind_is_current "$encode_kind" || return 2
+  [ -n "$encode_body" ] || return 2
+  fm_operational_header_for_kind "$encode_kind" encode_header || return 2
+  # An unmarked kind guarantees a mark-free envelope in every position, not just
+  # in its header: the body is captain-supplied text and a pane title built from
+  # it aborts the whole tmux server on a single U+2063. A body that is nothing
+  # but marks encodes to no body at all, which is invalid use.
+  if fm_operational_kind_is_unmarked "$encode_kind"; then
+    encode_body=${encode_body//"$FM_OPERATIONAL_MARK"/}
+    [ -n "$encode_body" ] || return 2
+  fi
+  printf -v "$encode_result_var" '%s%s: %s' "$encode_header" "$encode_kind" "$encode_body"
 }
 
 fm_operational_input_construct() {  # <kind> <body> <result-var>
-  local kind=${1-} body=${2-} result_var=${3-}
-  [ -n "$result_var" ] && [ -n "$body" ] || return 2
-  if [ "$kind" = from-firstmate ]; then
-    fm_message_mark_from_firstmate "$body" "$result_var"
+  local construct_kind=${1-} construct_body=${2-} construct_result_var=${3-}
+  [ -n "$construct_result_var" ] && [ -n "$construct_body" ] || return 2
+  if [ "$construct_kind" = from-firstmate ]; then
+    fm_message_mark_from_firstmate "$construct_body" "$construct_result_var"
     return
   fi
-  fm_operational_input_encode "$kind" "$body" "$result_var"
+  fm_operational_input_encode "$construct_kind" "$construct_body" "$construct_result_var"
 }
 
 # Single owner of current-envelope splitting for both the marked and the
@@ -109,11 +130,6 @@ fm_operational_input_construct() {  # <kind> <body> <result-var>
 # FM_OPERATIONAL_UNMARKED_KINDS, so no injected kind can be forged without the
 # zero-width mark.
 fm_operational_generic_split() {  # <message> <kind-result-var> <body-result-var>
-  # EVERY local here is split_-prefixed, with no exception for the parameters:
-  # under bash dynamic scoping an unprefixed local silently shadows a caller's
-  # own result-variable name, so the write lands on the local and the caller
-  # reads an empty value instead of an error. tests/fm-operational-input.test.sh
-  # locks this by round-tripping through every plausible caller-side name.
   local split_message=${1-} split_kind_var=${2-} split_body_var=${3-}
   local split_header split_remainder split_kind split_body
   [ -n "$split_kind_var" ] && [ -n "$split_body_var" ] || return 2
@@ -135,22 +151,23 @@ fm_operational_generic_split() {  # <message> <kind-result-var> <body-result-var
 }
 
 fm_operational_generic_kind() {  # <message> <result-var>
-  local message=${1-} result_var=${2-} parsed_kind parsed_body
-  [ -n "$result_var" ] || return 2
-  fm_operational_generic_split "$message" parsed_kind parsed_body || return 1
-  printf -v "$result_var" '%s' "$parsed_kind"
+  # shellcheck disable=SC2034 # Declared local so the splitter's write stays scoped.
+  local gkind_message=${1-} gkind_result_var=${2-} gkind_parsed_kind gkind_parsed_body
+  [ -n "$gkind_result_var" ] || return 2
+  fm_operational_generic_split "$gkind_message" gkind_parsed_kind gkind_parsed_body || return 1
+  printf -v "$gkind_result_var" '%s' "$gkind_parsed_kind"
 }
 
 fm_operational_input_kind() {  # <message> <result-var>
-  local message=${1-} result_var=${2-} current_kind
-  [ -n "$result_var" ] || return 2
-  if fm_operational_generic_kind "$message" current_kind; then
-    printf -v "$result_var" '%s' "$current_kind"
+  local kind_message=${1-} kind_result_var=${2-} kind_current
+  [ -n "$kind_result_var" ] || return 2
+  if fm_operational_generic_kind "$kind_message" kind_current; then
+    printf -v "$kind_result_var" '%s' "$kind_current"
     return 0
   fi
-  case "$message" in
+  case "$kind_message" in
     "$FM_FROMFIRST_MARK"?*)
-      printf -v "$result_var" '%s' from-firstmate
+      printf -v "$kind_result_var" '%s' from-firstmate
       return 0
       ;;
   esac
@@ -158,16 +175,17 @@ fm_operational_input_kind() {  # <message> <result-var>
 }
 
 fm_operational_input_body() {  # <current-message> <result-var>
-  local message=${1-} result_var=${2-} current_kind parsed_body
-  [ -n "$result_var" ] || return 2
-  if fm_operational_generic_split "$message" current_kind parsed_body; then
-    printf -v "$result_var" '%s' "$parsed_body"
+  # shellcheck disable=SC2034 # Declared local so the splitter's write stays scoped.
+  local body_message=${1-} body_result_var=${2-} body_current_kind body_parsed
+  [ -n "$body_result_var" ] || return 2
+  if fm_operational_generic_split "$body_message" body_current_kind body_parsed; then
+    printf -v "$body_result_var" '%s' "$body_parsed"
     return 0
   fi
-  case "$message" in
+  case "$body_message" in
     "$FM_FROMFIRST_MARK"?*)
-      parsed_body=${message#"$FM_FROMFIRST_MARK"}
-      printf -v "$result_var" '%s' "$parsed_body"
+      body_parsed=${body_message#"$FM_FROMFIRST_MARK"}
+      printf -v "$body_result_var" '%s' "$body_parsed"
       return 0
       ;;
   esac
@@ -185,34 +203,34 @@ FM_LEGACY_TURNEND_PREFIX=$'TURN WOULD END BLIND - supervision is off. The watche
 FM_LEGACY_AWAY_PREFIX="${FM_OPERATIONAL_MARK}Supervisor escalate ("
 
 fm_legacy_operational_input_kind() {  # <message> <result-var>
-  local message=${1-} result_var=${2-}
-  [ -n "$result_var" ] || return 2
+  local legacy_message=${1-} legacy_result_var=${2-}
+  [ -n "$legacy_result_var" ] || return 2
 
   # PR 899 landed an untyped FIRSTMATE_OP prefix. Its subtype cannot be
   # recovered without body prose, so it is explicitly generic.
-  case "$message" in
+  case "$legacy_message" in
     "$FM_OPERATIONAL_PREFIX"?*)
-      printf -v "$result_var" '%s' legacy-operational
+      printf -v "$legacy_result_var" '%s' legacy-operational
       return 0
       ;;
   esac
 
-  if [ "$message" = "$FM_LEGACY_SESSIONSTART" ]; then
-    printf -v "$result_var" '%s' session-start
+  if [ "$legacy_message" = "$FM_LEGACY_SESSIONSTART" ]; then
+    printf -v "$legacy_result_var" '%s' session-start
     return 0
   fi
-  case "$message" in
+  case "$legacy_message" in
     "$FM_LEGACY_AWAY_PREFIX"*)
-      printf -v "$result_var" '%s' away-supervisor
+      printf -v "$legacy_result_var" '%s' away-supervisor
       return 0
       ;;
     "$FM_LEGACY_WATCHER_PREFIX"*"$FM_LEGACY_WATCHER_SUFFIX")
-      [ "${#message}" -gt "$(( ${#FM_LEGACY_WATCHER_PREFIX} + ${#FM_LEGACY_WATCHER_SUFFIX} ))" ] || return 1
-      printf -v "$result_var" '%s' watcher
+      [ "${#legacy_message}" -gt "$(( ${#FM_LEGACY_WATCHER_PREFIX} + ${#FM_LEGACY_WATCHER_SUFFIX} ))" ] || return 1
+      printf -v "$legacy_result_var" '%s' watcher
       return 0
       ;;
     "$FM_LEGACY_TURNEND_PREFIX"?*)
-      printf -v "$result_var" '%s' turn-end-guard
+      printf -v "$legacy_result_var" '%s' turn-end-guard
       return 0
       ;;
   esac
@@ -220,38 +238,38 @@ fm_legacy_operational_input_kind() {  # <message> <result-var>
 }
 
 fm_operational_input_classify() {  # <message> <result-var>
-  local message=${1-} result_var=${2-} classified_kind
-  [ -n "$result_var" ] || return 2
-  if fm_operational_input_kind "$message" classified_kind ||
-     fm_legacy_operational_input_kind "$message" classified_kind; then
-    printf -v "$result_var" '%s' "$classified_kind"
+  local classify_message=${1-} classify_result_var=${2-} classify_kind
+  [ -n "$classify_result_var" ] || return 2
+  if fm_operational_input_kind "$classify_message" classify_kind ||
+     fm_legacy_operational_input_kind "$classify_message" classify_kind; then
+    printf -v "$classify_result_var" '%s' "$classify_kind"
     return 0
   fi
   return 1
 }
 
 fm_message_from_firstmate() {  # <message>
-  local kind
-  fm_operational_input_kind "${1-}" kind && [ "$kind" = from-firstmate ]
+  local fromfirst_kind
+  fm_operational_input_kind "${1-}" fromfirst_kind && [ "$fromfirst_kind" = from-firstmate ]
 }
 
 fm_message_mark_from_firstmate() {  # <message> <result-var>
-  local message=${1-} result_var=${2-} transformed
-  [ -n "$result_var" ] || return 2
-  if fm_message_from_firstmate "$message"; then
-    transformed=$message
+  local mark_message=${1-} mark_result_var=${2-} mark_transformed
+  [ -n "$mark_result_var" ] || return 2
+  if fm_message_from_firstmate "$mark_message"; then
+    mark_transformed=$mark_message
   else
-    transformed="${FM_FROMFIRST_MARK}${message}"
+    mark_transformed="${FM_FROMFIRST_MARK}${mark_message}"
   fi
-  printf -v "$result_var" '%s' "$transformed"
+  printf -v "$mark_result_var" '%s' "$mark_transformed"
 }
 
 fm_operational_read_stdin() {  # <result-var>
-  local result_var=${1-} value
-  [ -n "$result_var" ] || return 2
-  value=$(cat; printf x)
-  value=${value%x}
-  printf -v "$result_var" '%s' "$value"
+  local stdin_result_var=${1-} stdin_value
+  [ -n "$stdin_result_var" ] || return 2
+  stdin_value=$(cat; printf x)
+  stdin_value=${stdin_value%x}
+  printf -v "$stdin_result_var" '%s' "$stdin_value"
 }
 
 fm_operational_usage() {

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -132,7 +132,8 @@ Only `genuine-user-prompt`, `genuine-agent-response`, and `working-status` are p
 Every other audited class is policy-hidden when Pi exposes a supported presentation boundary, but semantic input is never transformed to enforce that preference.
 The home-local persistence schema is owned by [`docs/configuration.md`](configuration.md#pi-calm-preference-configcalm).
 
-Current session-start, watcher, turn-end guard, away supervisor, and launch-brief inputs retain their versioned U+2063 static envelopes.
+Current session-start, watcher, turn-end guard, and away supervisor inputs - every kind injected into a running agent - retain their versioned U+2063 static envelopes.
+Launch-brief is never injected and carries the same versioned envelope without the mark, so Calm's U+2063 gate never classifies it as operational and it stays visible like ordinary captain text; `bin/fm-operational-input.sh` owns both wire forms and the rule that an unmarked header is accepted only for a declared unmarked kind.
 The established leading `[fm-from-firstmate]` plus U+2063 routing carrier remains current so running secondmate charters remain compatible.
 An exact current static envelope remains sufficient provenance without nonce, source-authentication, replay-prevention, secondary-token, blocking, redaction, or private-retrieval machinery.
 Calm classifies only at Pi's transcript-presentation owner through the canonical parser and never replaces, reorders, or weakens those messages.

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -168,7 +168,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | `system-notice` | `showStatus`, `showError`, compaction, retry, and startup warning rows | Unsupported boundary; remains visible. |
 | `cache-notice` | Non-persisted cache-miss `Text` row | Unsupported boundary; remains visible. |
 | `project-trust-warning` | Non-persisted startup `Text` row | Unsupported boundary; remains visible. |
-| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages stay ordinary semantic user messages but render through the zero-height Pi 0.81.1 through 0.82.0 adapter under Calm; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
+| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages carrying the U+2063 mark stay ordinary semantic user messages but render through the zero-height Pi 0.81.1 through 0.82.0 adapter under Calm; the unmarked positional brief never reaches that gate and stays visible; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
 | `synthetic-assistant` | No authoritative Firstmate source found | Policy-hidden, but Pi exposes no generic assistant-role renderer. |
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
@@ -214,7 +214,7 @@ It covers persisted preference restoration across every session-start reason and
 A native deterministic `/skill:ahoy` turn produces thinking, tool-call, and tool-result blocks, asserts that the collapsed skill-to-final gap equals the two-row visible-only baseline, expands and re-collapses original thinking, restores Calm-off rendering, verifies persisted hidden history, and repeats the geometry assertion after restart with `terminal.clearOnShrink` explicitly off.
 The operational provider path covers Calm loaded on, loaded off, default preference, extension absent, exact watcher delivery, narrow bare-marker legacy input, persisted restart replay, a genuine captain prompt, and adjacent notifications coalesced into one intended processing turn.
 It asserts one persisted and rendered captain answer, exact user-role operational envelopes in order, no replacement custom messages, one processing result, zero operational transcript rows, and the two-row neighboring-assistant geometry for live, adjacent, and restart paths.
-Quoted current markers, ASCII-only labels, ordinary text before a marker, unrelated U+2063 placement, and image-bearing input remain visible in component and native transcript checks.
+Quoted current markers, ASCII-only labels, the unmarked `launch-brief` envelope, ordinary text before a marker, unrelated U+2063 placement, and image-bearing input remain visible in component and native transcript checks.
 `tests/fm-pi-primary-live-e2e.test.sh` also proves the unchanged built-in `Working...` row while Calm is active on the credentialed provider path before continuing its ordinary watcher lifecycle.
 `tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi declarations, currently package version 0.81.1.
 

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -4,8 +4,9 @@ Calm is a Pi-only conversation presentation toggle.
 It is off by default, and the last `/calm` choice persists for the effective Firstmate home across Pi session starts and resumes.
 
 While Calm is active, Pi's built-in `Working...` activity remains visible and no separate Calm status row is added.
-Calm hides collapsed thinking labels, the shells for Pi's seven built-in tools, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
+Calm hides collapsed thinking labels, the shells for Pi's seven built-in tools, the `fm_watch_arm_pi` tool shell, and the canonically classified Firstmate operational user rows that carry the U+2063 mark.
 The operational inputs remain ordinary user-role messages, while Pi's transcript layout renders their complete rows at zero height.
+An agent's own `launch-brief` prompt carries the unmarked envelope owned by `bin/fm-operational-input.sh`, so Calm leaves it visible like ordinary captain text.
 The session-start nudge remains on its existing non-displayed custom-message path.
 
 Calm changes presentation only.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -193,7 +193,7 @@ A bare shell prompt is never an empty agent composer.
 Away-mode injection proceeds only on an affirmative `empty` result, never on unknown.
 This prevents a dead agent pane from receiving and possibly executing an escalation as shell input.
 
-The current operational envelope starts with U+2063 and `FIRSTMATE_OP: `.
+Every current operational envelope injected into a running agent starts with U+2063 and `FIRSTMATE_OP: `.
 The separate routed-request carrier uses `[fm-from-firstmate]` plus U+2063.
 U+2063 survives Herdr terminal input as text, unlike the legacy ASCII control separator that could erase the visible routing label.
 `bin/fm-operational-input.sh` owns current operational construction and parsing, and the AFK skill owns legacy away-input compatibility.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -81,6 +81,7 @@ Ambiguous pending text never receives the busy-queue conversion.
 - tmux is the reference path and supports secondmate homes.
 - Existing Pi agent-process liveness is inconclusive, while an authoritatively missing Pi window can trigger recovery.
 - The OpenCode busy-queue exception is tmux-specific; Herdr retains its separately documented gap.
+- tmux 3.7b aborts the whole server on a pane title containing U+2063, and an agent titles its pane from its own launch prompt, so the launch prompt must stay free of that mark; `bin/fm-operational-input.sh` owns the mark-free `launch-brief` envelope.
 
 ```sh
 tests/fm-backend-tmux-smoke.test.sh

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -54,7 +54,7 @@ fatal: xreallocarray: zero size
 
 Agents set their pane title from their own launch prompt, so a launch prompt carrying U+2063 killed every window on the server within seconds of each spawn.
 This defect is upstream and is not worked around in Firstmate.
-The Firstmate-side guarantee it requires - the `launch-brief` envelope contains no U+2063 in any position, while every injected kind keeps its mark - is owned by `bin/fm-operational-input.sh` and pinned by:
+The Firstmate-side guarantee it requires - an encoded `launch-brief` envelope contains no U+2063 in any position, because its header is the marked header minus the mark and the encoder strips the mark from the captain-supplied body, while every injected kind keeps its mark - is owned by `bin/fm-operational-input.sh` and pinned by:
 
 ```sh
 tests/fm-operational-input.test.sh

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -43,6 +43,25 @@ tests/fm-tmux-submit-busy.test.sh
 Expected structural matrix: real text on any content row is pending; all-empty complete boxes are empty; unreadable, incomplete, or unsafe boxes are unknown; and non-bordered panes retain cursor-row compatibility.
 Expected submit matrix: proven pending plus busy is accepted as queued; proven pending plus idle remains pending; ambiguous pending is never converted by the busy exception; and only a proven empty composer succeeds directly.
 
+### Pane titles and U+2063
+
+tmux 3.7b on macOS was observed on 2026-07-25 aborting the entire server, not the offending pane, while handling a pane title containing U+2063:
+
+```text
+utf8proc_wcwidth(02063) returned 0
+fatal: xreallocarray: zero size
+```
+
+Agents set their pane title from their own launch prompt, so a launch prompt carrying U+2063 killed every window on the server within seconds of each spawn.
+This defect is upstream and is not worked around in Firstmate.
+The Firstmate-side guarantee it requires - the `launch-brief` envelope contains no U+2063 in any position, while every injected kind keeps its mark - is owned by `bin/fm-operational-input.sh` and pinned by:
+
+```sh
+tests/fm-operational-input.test.sh
+```
+
+The crash itself is deliberately not scripted as a regression: reproducing it aborts the tmux server running the fleet.
+
 ## Herdr
 
 The compatibility floor is protocol 14.

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1792,9 +1792,13 @@ if (current.length !== expected.size) {
 for (const [needle, kind] of expected) {
   const entry = current.find((candidate) => JSON.stringify(candidate.message.content).includes(needle));
   const text = entry?.message.content?.find((item) => item.type === "text")?.text;
+  // launch-brief is never injected, so its versioned envelope carries no
+  // U+2063: bin/fm-operational-input.sh owns both wire forms.
   const exactEnvelope = kind === "from-firstmate"
     ? text?.startsWith("[fm-from-firstmate]\u2063corr=0123456789abcdef ")
-    : text?.startsWith(`\u2063FIRSTMATE_OP: v1 ${kind}: `);
+    : kind === "launch-brief"
+      ? text?.startsWith(`FIRSTMATE_OP: v1 ${kind}: `) && !text.includes("\u2063")
+      : text?.startsWith(`\u2063FIRSTMATE_OP: v1 ${kind}: `);
   if (!entry || !exactEnvelope) {
     throw new Error(`expected exact user-role ${needle} as ${kind}, found ${JSON.stringify(entry)}`);
   }
@@ -1818,11 +1822,13 @@ JS
     CURRENT_WATCHER_E2E \
     CURRENT_TURN_END_E2E \
     CURRENT_AWAY_E2E \
-    CURRENT_FROM_FIRSTMATE_E2E \
-    CURRENT_LAUNCH_BRIEF_E2E
+    CURRENT_FROM_FIRSTMATE_E2E
   do
     assert_not_contains "$(cat "$active_hidden_snapshot")" "$hidden" "Calm rendered operational input $hidden"
   done
+  # launch-brief is never injected and carries the unmarked envelope, so Calm's
+  # U+2063 gate never classifies it as operational: it stays visible.
+  assert_contains "$(cat "$active_hidden_snapshot")" "CURRENT_LAUNCH_BRIEF_E2E" "Calm hid the unmarked launch-brief envelope"
   assert_contains "$(cat "$active_hidden_snapshot")" "Warning: CALM_TRANSIENT_DIAGNOSTIC" "operational arrival lost its preceding transient diagnostic"
   assert_contains "$(cat "$active_hidden_snapshot")" " Error:" "operational delivery did not produce a transient provider diagnostic"
   hash_before=$(shasum -a 256 "$session_file" | awk '{print $1}')
@@ -1955,11 +1961,11 @@ JS
     CURRENT_WATCHER_E2E \
     CURRENT_TURN_END_E2E \
     CURRENT_AWAY_E2E \
-    CURRENT_FROM_FIRSTMATE_E2E \
-    CURRENT_LAUNCH_BRIEF_E2E
+    CURRENT_FROM_FIRSTMATE_E2E
   do
     assert_not_contains "$(cat "$restarted_snapshot")" "$hidden" "restart/resume rendered operational input $hidden"
   done
+  assert_contains "$(cat "$restarted_snapshot")" "CURRENT_LAUNCH_BRIEF_E2E" "restart/resume hid the unmarked launch-brief envelope"
   assert_not_contains "$(cat "$restarted_snapshot")" "calm transcript" "restart/resume added a persistent Calm status row"
   assert_contains "$(cat "$restarted_snapshot")" "CALM_WORKING_E2E_PROMPT" "restart/resume removed a genuine user prompt"
   assert_contains "$(cat "$restarted_snapshot")" "CALM_WORKING_E2E_RESPONSE" "restart/resume removed a genuine assistant response"

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -178,6 +178,8 @@ test_ahoy_owns_only_the_visible_session_recap() {
     "ahoy lacks an explicit captain-authored boundary rule"
   assert_grep 'Exclude messages that begin with the current U+2063 `FIRSTMATE_OP:` injection prefix.' "$AHOY" \
     "ahoy does not exclude current marked operational injections"
+  assert_grep 'Exclude messages that begin with the unmarked `FIRSTMATE_OP: v1 launch-brief: ` header' "$AHOY" \
+    "ahoy does not exclude the unmarked launch-brief header a secondmate carries in its own transcript"
   assert_grep 'Exclude legacy bare-marker away-mode injections only when U+2063 is immediately followed by `Supervisor escalate (`.' "$AHOY" \
     "ahoy does not narrowly exclude the legacy away-mode injection shape"
   assert_grep 'Exclude the exact legacy unmarked session-start payload ``Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.``' "$AHOY" \

--- a/tests/fm-operational-input.test.sh
+++ b/tests/fm-operational-input.test.sh
@@ -94,6 +94,38 @@ test_launch_brief_carries_no_zero_width_mark() {
   pass "operational input: launch-brief encodes with zero U+2063 bytes in any position"
 }
 
+test_launch_brief_body_cannot_reintroduce_the_mark() {
+  local marked_body encoded cli_encoded injected
+
+  # A launch-brief body is verbatim captain-supplied brief text: a charter or
+  # task description that pastes an operational message would otherwise put
+  # U+2063 back into the agent's pane title and abort the whole tmux server.
+  marked_body="LAUNCH ${FM_OPERATIONAL_MARK}BODY${FM_OPERATIONAL_MARK}"
+  fm_operational_input_encode launch-brief "$marked_body" encoded \
+    || fail "could not encode a launch-brief body carrying U+2063"
+  [ "$encoded" = "FIRSTMATE_OP: v1 launch-brief: LAUNCH BODY" ] \
+    || fail "launch-brief body stripping changed more than U+2063: $encoded"
+  case "$(printf '%s' "$encoded" | od -An -tx1 | tr -d ' \n')" in
+    *e281a3*) fail "a launch-brief body reintroduced U+2063 into the envelope" ;;
+  esac
+
+  cli_encoded=$(printf '%s' "$marked_body" | "$OWNER" encode launch-brief) \
+    || fail "CLI could not encode a launch-brief body carrying U+2063"
+  [ "$cli_encoded" = "$encoded" ] \
+    || fail "CLI launch-brief body stripping diverged from the library"
+
+  # A body that is nothing but marks encodes to no body at all: invalid use.
+  fm_operational_input_encode launch-brief "$FM_OPERATIONAL_MARK" encoded \
+    && fail "an all-U+2063 launch-brief body was accepted as an empty envelope"
+
+  # Injected kinds are untouched: their bodies stay byte-verbatim.
+  fm_operational_input_encode watcher "$marked_body" injected \
+    || fail "could not encode an injected body carrying U+2063"
+  [ "$injected" = "${FM_OPERATIONAL_HEADER_PREFIX}watcher: ${marked_body}" ] \
+    || fail "an injected kind's body was altered by launch-brief mark stripping"
+  pass "operational input: a launch-brief body cannot carry U+2063 while injected bodies stay verbatim"
+}
+
 test_unmarked_header_is_rejected_for_injected_kinds() {
   local kind forged parsed body
   for kind in session-start watcher turn-end-guard away-supervisor; do
@@ -155,6 +187,67 @@ test_generic_split_does_not_shadow_caller_result_variables() {
       || fail "split shadowed a caller body variable named $name (got '$body_probe')"
   done
   pass "operational input: envelope splitting never shadows a caller's result variable"
+}
+
+test_public_entry_points_do_not_shadow_caller_result_variables() {
+  local encoded name probe
+  fm_operational_input_encode watcher 'SHADOW BODY' encoded \
+    || fail "could not encode the public shadowing fixture"
+
+  # The splitter is not the only function with the hazard: every public
+  # <result-var> entry point writes with printf -v into a caller-supplied name.
+  for name in kind body message remainder parsed_kind parsed_body current_kind \
+              header result_var value transformed classified_kind; do
+    unset -v "$name"
+    eval "fm_operational_input_kind \"\$encoded\" $name" \
+      || fail "fm_operational_input_kind failed writing into a caller variable named $name"
+    eval "probe=\${$name-}"
+    [ "$probe" = watcher ] \
+      || fail "fm_operational_input_kind shadowed a caller variable named $name (got '$probe')"
+
+    unset -v "$name"
+    eval "fm_operational_generic_kind \"\$encoded\" $name" \
+      || fail "fm_operational_generic_kind failed writing into a caller variable named $name"
+    eval "probe=\${$name-}"
+    [ "$probe" = watcher ] \
+      || fail "fm_operational_generic_kind shadowed a caller variable named $name (got '$probe')"
+
+    unset -v "$name"
+    eval "fm_operational_input_classify \"\$encoded\" $name" \
+      || fail "fm_operational_input_classify failed writing into a caller variable named $name"
+    eval "probe=\${$name-}"
+    [ "$probe" = watcher ] \
+      || fail "fm_operational_input_classify shadowed a caller variable named $name (got '$probe')"
+
+    unset -v "$name"
+    eval "fm_operational_input_body \"\$encoded\" $name" \
+      || fail "fm_operational_input_body failed writing into a caller variable named $name"
+    eval "probe=\${$name-}"
+    [ "$probe" = 'SHADOW BODY' ] \
+      || fail "fm_operational_input_body shadowed a caller variable named $name (got '$probe')"
+
+    unset -v "$name"
+    eval "fm_operational_input_encode watcher 'SHADOW BODY' $name" \
+      || fail "fm_operational_input_encode failed writing into a caller variable named $name"
+    eval "probe=\${$name-}"
+    [ "$probe" = "$encoded" ] \
+      || fail "fm_operational_input_encode shadowed a caller variable named $name (got '$probe')"
+
+    unset -v "$name"
+    eval "fm_operational_input_construct from-firstmate 'SHADOW BODY' $name" \
+      || fail "fm_operational_input_construct failed writing into a caller variable named $name"
+    eval "probe=\${$name-}"
+    [ "$probe" = "${FM_FROMFIRST_MARK}SHADOW BODY" ] \
+      || fail "fm_operational_input_construct shadowed a caller variable named $name (got '$probe')"
+
+    unset -v "$name"
+    eval "fm_operational_read_stdin $name <<<'SHADOW STDIN'" \
+      || fail "fm_operational_read_stdin failed writing into a caller variable named $name"
+    eval "probe=\${$name-}"
+    [ "$probe" = $'SHADOW STDIN\n' ] \
+      || fail "fm_operational_read_stdin shadowed a caller variable named $name (got '$probe')"
+  done
+  pass "operational input: no public entry point shadows a caller's result variable"
 }
 
 test_current_from_firstmate_carrier() {
@@ -263,8 +356,10 @@ test_invalid_current_encodings_are_rejected() {
 test_current_generic_matrix
 test_injected_kinds_keep_the_leading_mark
 test_launch_brief_carries_no_zero_width_mark
+test_launch_brief_body_cannot_reintroduce_the_mark
 test_unmarked_header_is_rejected_for_injected_kinds
 test_generic_split_does_not_shadow_caller_result_variables
+test_public_entry_points_do_not_shadow_caller_result_variables
 test_current_from_firstmate_carrier
 test_landed_untyped_prefix_is_explicitly_legacy
 test_isolated_legacy_matrix

--- a/tests/fm-operational-input.test.sh
+++ b/tests/fm-operational-input.test.sh
@@ -48,6 +48,115 @@ test_current_generic_matrix() {
   pass "operational input: every current generic envelope retains its exact structured kind"
 }
 
+test_injected_kinds_keep_the_leading_mark() {
+  local kind encoded head_hex
+  [ "$FM_OPERATIONAL_UNMARKED_HEADER_PREFIX" \
+    = "${FM_OPERATIONAL_HEADER_PREFIX#"$FM_OPERATIONAL_MARK"}" ] \
+    || fail "the unmarked header drifted from the marked header minus U+2063"
+
+  for kind in session-start watcher turn-end-guard away-supervisor; do
+    fm_operational_kind_is_unmarked "$kind" \
+      && fail "injected kind $kind was declared unmarked"
+    fm_operational_input_encode "$kind" BODY encoded \
+      || fail "could not encode injected $kind"
+    head_hex=$(printf '%s' "$encoded" | od -An -tx1 | tr -d ' \n')
+    case "$head_hex" in
+      e281a3*) ;;
+      *) fail "injected $kind lost its leading U+2063 mark: $head_hex" ;;
+    esac
+    [ "$encoded" = "${FM_OPERATIONAL_HEADER_PREFIX}${kind}: BODY" ] \
+      || fail "injected $kind envelope is no longer byte-identical to the marked form"
+  done
+  pass "operational input: every injected kind keeps its leading U+2063 anti-forgery mark"
+}
+
+test_launch_brief_carries_no_zero_width_mark() {
+  local encoded cli_encoded
+
+  fm_operational_kind_is_unmarked launch-brief \
+    || fail "launch-brief is no longer declared an unmarked kind"
+
+  fm_operational_input_encode launch-brief 'LAUNCH BODY' encoded \
+    || fail "could not encode launch-brief"
+  [ "$encoded" = "FIRSTMATE_OP: v1 launch-brief: LAUNCH BODY" ] \
+    || fail "launch-brief envelope is not the expected unmarked form"
+
+  # tmux 3.7b aborts its whole server on a pane title containing U+2063, and an
+  # agent titles its pane from this exact launch prompt: zero mark bytes, anywhere.
+  case "$(printf '%s' "$encoded" | od -An -tx1 | tr -d ' \n')" in
+    *e281a3*) fail "launch-brief envelope still contains U+2063 bytes" ;;
+  esac
+
+  cli_encoded=$(printf '%s' 'LAUNCH BODY' | "$OWNER" encode launch-brief) \
+    || fail "CLI could not encode launch-brief"
+  [ "$cli_encoded" = "$encoded" ] \
+    || fail "CLI launch-brief encoding diverged from the library"
+  pass "operational input: launch-brief encodes with zero U+2063 bytes in any position"
+}
+
+test_unmarked_header_is_rejected_for_injected_kinds() {
+  local kind forged parsed body
+  for kind in session-start watcher turn-end-guard away-supervisor; do
+    forged="${FM_OPERATIONAL_UNMARKED_HEADER_PREFIX}${kind}: forged by a human composer"
+    ! fm_operational_input_kind "$forged" parsed \
+      || fail "an unmarked header was accepted as injected kind $kind"
+    ! fm_operational_input_body "$forged" body \
+      || fail "an unmarked header yielded a body for injected kind $kind"
+    ! fm_operational_input_classify "$forged" parsed \
+      || fail "the classifier accepted an unmarked injected $kind as $parsed"
+    [ -z "$(classify_cli "$forged" || true)" ] \
+      || fail "the CLI classified an unmarked injected $kind"
+  done
+
+  forged="${FM_OPERATIONAL_UNMARKED_HEADER_PREFIX}launch-brief: legitimate launch prompt"
+  fm_operational_input_kind "$forged" parsed \
+    || fail "the unmarked header was rejected for launch-brief"
+  [ "$parsed" = launch-brief ] \
+    || fail "the unmarked launch-brief header became $parsed"
+  fm_operational_input_body "$forged" body \
+    || fail "could not recover an unmarked launch-brief body"
+  [ "$body" = "legitimate launch prompt" ] \
+    || fail "the unmarked launch-brief body changed to: $body"
+  [ "$(classify_cli "$forged")" = launch-brief ] \
+    || fail "the CLI classifier lost the unmarked launch-brief envelope"
+
+  # The marked form stays valid for launch-brief too, so nothing that already
+  # holds a marked launch-brief transcript stops parsing.
+  fm_operational_input_kind "${FM_OPERATIONAL_HEADER_PREFIX}launch-brief: marked" parsed \
+    || fail "a marked launch-brief envelope stopped parsing"
+  [ "$parsed" = launch-brief ] \
+    || fail "a marked launch-brief envelope became $parsed"
+  pass "operational input: the unmarked header is accepted only for launch-brief and forgeable for no injected kind"
+}
+
+test_generic_split_does_not_shadow_caller_result_variables() {
+  local encoded
+  fm_operational_input_encode watcher 'SHADOW BODY' encoded \
+    || fail "could not encode the shadowing fixture"
+
+  # Bash dynamic scoping lets the splitter's own locals shadow a caller's result
+  # variable name, which silently returns an empty value instead of failing.
+  # Every plausible caller-side name must survive the round trip.
+  local name kind_probe body_probe
+  for name in kind body message remainder parsed_kind parsed_body current_kind \
+              header result_var; do
+    unset -v "$name"
+    eval "fm_operational_generic_split \"\$encoded\" $name body_probe" \
+      || fail "split failed writing its kind into a caller variable named $name"
+    eval "kind_probe=\${$name-}"
+    [ "$kind_probe" = watcher ] \
+      || fail "split shadowed a caller kind variable named $name (got '$kind_probe')"
+
+    unset -v "$name"
+    eval "fm_operational_generic_split \"\$encoded\" kind_probe $name" \
+      || fail "split failed writing its body into a caller variable named $name"
+    eval "body_probe=\${$name-}"
+    [ "$body_probe" = 'SHADOW BODY' ] \
+      || fail "split shadowed a caller body variable named $name (got '$body_probe')"
+  done
+  pass "operational input: envelope splitting never shadows a caller's result variable"
+}
+
 test_current_from_firstmate_carrier() {
   local encoded parsed separator
   separator=$(printf '\342\201\243')
@@ -152,6 +261,10 @@ test_invalid_current_encodings_are_rejected() {
 }
 
 test_current_generic_matrix
+test_injected_kinds_keep_the_leading_mark
+test_launch_brief_carries_no_zero_width_mark
+test_unmarked_header_is_rejected_for_injected_kinds
+test_generic_split_does_not_shadow_caller_result_variables
 test_current_from_firstmate_carrier
 test_landed_untyped_prefix_is_explicitly_legacy
 test_isolated_legacy_matrix


### PR DESCRIPTION
## Intent

tmux 3.7b aborts the ENTIRE tmux server, not just the offending pane, when it handles a pane title containing U+2063 (utf8proc_wcwidth(02063) returned 0 -> fatal: xreallocarray: zero size). Agents set their tmux pane title from their own launch prompt, and firstmate's launch prompt began with the operational mark U+2063, so every crewmate spawned on this machine killed the whole tmux server within 3-40 seconds, taking every other window with it. This change fixes that blocker; it is load-bearing, not cosmetic.

The goal: make 'launch-brief' - the ONLY operational kind that is never injected into a running agent, because bin/fm-spawn.sh passes it as the agent's argv launch prompt - carry the same versioned envelope WITHOUT the leading U+2063 mark: 'FIRSTMATE_OP: v1 launch-brief: <body>'. The mark exists solely to make injected input unforgeable by a human typing at a composer, a property an argv launch prompt cannot need. Every injected kind (session-start, watcher, turn-end-guard, away-supervisor) deliberately keeps its marked envelope byte-identical - that was an explicit constraint, not an oversight.

The security-relevant property, covered explicitly by new tests: an unmarked 'FIRSTMATE_OP: v1 <kind>: ...' header is REJECTED for every injected kind and accepted ONLY for launch-brief. fm_operational_generic_split is introduced as the single owner of envelope splitting for both header forms, and both fm_operational_generic_kind and fm_operational_input_body route through it.

Deliberate decisions a reviewer reading only the diff would not know:
1. FM_OPERATIONAL_UNMARKED_HEADER_PREFIX is DERIVED from the marked prefix minus the mark rather than re-typing the 'FIRSTMATE_OP: ' literal, so the two wire forms cannot drift apart and the grammar has one owner. A starting patch hardcoded the literal; deriving it was a deliberate improvement.
2. EVERY local in fm_operational_generic_split is split_-prefixed, INCLUDING its parameters. This is not stylistic: under bash dynamic scoping an unprefixed local silently shadows a caller's own result-variable name, so the write lands on the local and the caller reads an empty value instead of an error. A starting patch prefixed only the working locals and left message/kind_var/body_var unprefixed; the new test caught that a caller passing a variable named 'message' got a silent empty result. The test round-trips through nine plausible caller-side names to lock this.
3. The ahoy skill change is a gap this change opened and had to close, not scope creep. A secondmate carries its charter launch prompt in its own user-role transcript, and /ahoy excluded it via the leading-U+2063 rule that the unmarked envelope no longer satisfies - without the fix the charter would read as the captain's own message. The exclusion is deliberately as narrow as its neighbours: it matches only the exact unmarked header at the first character, and ASCII FIRSTMATE_OP: text in any other form remains an ordinary captain message. tests/fm-captain-translation-contract.test.sh pins it.
4. The tmux crash is deliberately NOT scripted as a regression test, and is stated as such in docs/verification/runtime-backends.md: reproducing it aborts the tmux server running the fleet. Fixing or working around tmux itself was explicitly out of scope.
5. Docs follow this repo's one-owner rule: bin/fm-operational-input.sh's header block owns both wire forms, and docs/calm-mode-feasibility.md, docs/tmux-backend.md, and docs/verification/runtime-backends.md cross-reference it rather than restating the grammar.

Compatibility was reviewed rather than assumed: all five supported harnesses (claude, codex, opencode, pi, grok) consume launch-brief identically as a shell-quoted argv positional and none parses the envelope; no runtime backend (tmux, herdr, zellij, orca, cmux) references it at all; the Pi adapter delegates entirely to the shell owner so it classifies the unmarked form correctly, and Calm's U+2063 fast-path means an unmarked launch-brief simply stays visible rather than being hidden - the safe direction, now documented.

Verified: tests/fm-operational-input.test.sh (extended, not a new runner), tests/fm-spawn-dispatch-profile.test.sh, and tests/fm-captain-translation-contract.test.sh all pass, plus 28 more suites in changed scope; bin/fm-lint.sh and bin/fm-doc-audience-check.sh are clean; the full kind matrix was re-verified under macOS system bash 3.2 for compatibility. Two suites (tests/fm-brief.test.sh, tests/fm-ask-user-authority.test.sh) fail on this machine for a PRE-EXISTING reason unrelated to this change: bin/fm-brief.sh does not parse under macOS system bash 3.2, and that file is byte-identical to origin/main on this branch.

## What Changed

- `bin/fm-operational-input.sh` now encodes `launch-brief` — the one operational kind passed as an agent's argv launch prompt rather than injected into a running agent — as `FIRSTMATE_OP: v1 launch-brief: <body>` with no leading U+2063, and strips U+2063 from the captain-supplied body so the whole envelope is mark-free. The unmarked header prefix is derived from the marked one rather than re-typed, and every injected kind (session-start, watcher, turn-end-guard, away-supervisor) keeps its marked envelope byte-identical. This unblocks tmux 3.7b, which aborts the entire server on a pane title containing U+2063.
- A new `fm_operational_generic_split` becomes the single owner of envelope splitting for both wire forms, accepting an unmarked header only for a declared unmarked kind so no injected kind can be forged without the mark; `fm_operational_generic_kind` and `fm_operational_input_body` route through it. Every local in the result-var functions is now per-function prefixed, including parameters, so a caller's result-variable name can no longer be silently shadowed under bash dynamic scoping.
- `.agents/skills/ahoy/SKILL.md` excludes the exact unmarked launch-brief header at the first character so a secondmate's charter prompt is not read as a captain message, pinned by `tests/fm-captain-translation-contract.test.sh`; `tests/fm-operational-input.test.sh` gains envelope and shadowing coverage, `tests/fm-calm-pi-extension.test.sh` now asserts the unmarked brief stays visible under Calm, and the Calm, tmux, and Herdr docs cross-reference the shell owner instead of restating the grammar. The Review stage's four findings were auto-fixed and re-checked clean; all listed suites pass.

## Risk Assessment

✅ Low: The change is a narrowly scoped wire-format adjustment for the one never-injected operational kind, its security-relevant property (unmarked header accepted only for launch-brief, injected kinds byte-identical) is directly pinned by new tests, and every finding from the previous review round is resolved with regression coverage.

## Testing

Ran the three suites the intent names plus nine more envelope-consuming suites — all green — then produced product-level evidence instead of relying on them: driving the real bin/fm-spawn.sh with the repo's fake tmux and a fake harness that records argv shows all five harnesses (claude, codex, opencode, pi, grok) now receive `FIRSTMATE_OP: v1 launch-brief: …` starting at byte 0x46 with no U+2063 anywhere, where the base encoder produced a leading e2 81 a3; a CLI classify matrix confirms the unmarked header is rejected for session-start, watcher, turn-end-guard and away-supervisor and accepted only for launch-brief while all marked envelopes classify unchanged; a real secondmate spawn shows its charter argv no longer matches ahoy's leading-U+2063 rule and does match the new unmarked-launch-brief rule, with quoted and prose `FIRSTMATE_OP:` text still reading as captain messages; and on this machine the live crewmate carrying the unmarked argv has run 45 minutes as a child of a tmux 3.7b server up over an hour. There is no rendered UI surface here — the end-user surfaces are the argv launch prompt and the tmux pane title, captured as byte-level CLI transcripts. I attempted the tmux abort on a throwaway socket (never the fleet's) and could not trigger it externally, consistent with the change deliberately not scripting that repro. The two suites failing on this box (fm-brief, fm-ask-user-authority) fail only under macOS system bash 3.2 in a file md5-identical to origin/main and pass under bash 5.3, so they are pre-existing and unrelated.

<details>
<summary>Evidence: End-to-end launch prompt per harness, before vs after</summary>

<code>### harness: claude&#10;launch command firstmate sends (tmux send-keys -l):&#10;CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions &#34;$(&#39;&lt;repo&gt;/bin/fm-operational-input.sh&#39; encode launch-brief &lt; &#39;&lt;tmp&gt;/.../brief.md&#39;)&#34;&#10;BEFORE argv prompt : ⁣FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an aut&#10;BEFORE first bytes : e281a346495253544d4154455f4f503a20763120&#10;BEFORE U+2063 : PRESENT &lt;- tmux 3.7b aborts the whole server on this pane title&#10;AFTER argv prompt : FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an autono&#10;AFTER first bytes : 46495253544d4154455f4f503a207631206c6175&#10;AFTER U+2063 : absent anywhere in the envelope - safe pane title&#10;&#10;(identical BEFORE/AFTER result for codex, opencode, pi, grok)</code>

```text
== crewmate launch prompt, end to end through bin/fm-spawn.sh ==

### harness: claude
  launch command firstmate sends (tmux send-keys -l):
    CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('<repo>/bin/fm-operational-input.sh' encode launch-brief < '<tmp>//fm-launch-prompt-evidence.jN6NMW/claude/home/data/evidence-claude-z1/brief.md')"
  BEFORE  argv prompt : ⁣FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an aut
  BEFORE  first bytes : e281a346495253544d4154455f4f503a20763120
  BEFORE  U+2063     : PRESENT  <- tmux 3.7b aborts the whole server on this pane title
  AFTER   argv prompt : FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an autono
  AFTER   first bytes : 46495253544d4154455f4f503a207631206c6175
  AFTER   U+2063     : absent anywhere in the envelope - safe pane title

### harness: codex
  launch command firstmate sends (tmux send-keys -l):
    codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private<tmp>/fm-launch-prompt-evidence.jN6NMW/codex/home/state/evidence-codex-z1.turn-ended'\"]" "$('<repo>/bin/fm-operational-input.sh' encode launch-brief < '<tmp>//fm-launch-prompt-evidence.jN6NMW/codex/home/data/evidence-codex-z1/brief.md')"
  BEFORE  argv prompt : ⁣FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an aut
  BEFORE  first bytes : e281a346495253544d4154455f4f503a20763120
  BEFORE  U+2063     : PRESENT  <- tmux 3.7b aborts the whole server on this pane title
  AFTER   argv prompt : FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an autono
  AFTER   first bytes : 46495253544d4154455f4f503a207631206c6175
  AFTER   U+2063     : absent anywhere in the envelope - safe pane title

### harness: opencode
  launch command firstmate sends (tmux send-keys -l):
    OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --prompt "$('<repo>/bin/fm-operational-input.sh' encode launch-brief < '<tmp>//fm-launch-prompt-evidence.jN6NMW/opencode/home/data/evidence-opencode-z1/brief.md')"
  BEFORE  argv prompt : ⁣FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an aut
  BEFORE  first bytes : e281a346495253544d4154455f4f503a20763120
  BEFORE  U+2063     : PRESENT  <- tmux 3.7b aborts the whole server on this pane title
  AFTER   argv prompt : FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an autono
  AFTER   first bytes : 46495253544d4154455f4f503a207631206c6175
  AFTER   U+2063     : absent anywhere in the envelope - safe pane title

### harness: pi
  launch command firstmate sends (tmux send-keys -l):
    pi -e '<tmp>//fm-launch-prompt-evidence.jN6NMW/pi/home/state/evidence-pi-z1.pi-ext.ts' "$('<repo>/bin/fm-operational-input.sh' encode launch-brief < '<tmp>//fm-launch-prompt-evidence.jN6NMW/pi/home/data/evidence-pi-z1/brief.md')"
  BEFORE  argv prompt : ⁣FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an aut
  BEFORE  first bytes : e281a346495253544d4154455f4f503a20763120
  BEFORE  U+2063     : PRESENT  <- tmux 3.7b aborts the whole server on this pane title
  AFTER   argv prompt : FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an autono
  AFTER   first bytes : 46495253544d4154455f4f503a207631206c6175
  AFTER   U+2063     : absent anywhere in the envelope - safe pane title

### harness: grok
  launch command firstmate sends (tmux send-keys -l):
    grok --always-approve "$('<repo>/bin/fm-operational-input.sh' encode launch-brief < '<tmp>//fm-launch-prompt-evidence.jN6NMW/grok/home/data/evidence-grok-z1/brief.md')"
  BEFORE  argv prompt : ⁣FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an aut
  BEFORE  first bytes : e281a346495253544d4154455f4f503a20763120
  BEFORE  U+2063     : PRESENT  <- tmux 3.7b aborts the whole server on this pane title
  AFTER   argv prompt : FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an autono
  AFTER   first bytes : 46495253544d4154455f4f503a207631206c6175
  AFTER   U+2063     : absent anywhere in the envelope - safe pane title
```
</details>
<details>
<summary>Evidence: Wire-contract matrix through the CLI classifier</summary>

<code>== a human at a composer forges an unmarked operational header ==&#10;FIRSTMATE_OP: v1 session-start: ... -&gt; &lt;REJECTED&gt;&#10;FIRSTMATE_OP: v1 watcher: ... -&gt; &lt;REJECTED&gt;&#10;FIRSTMATE_OP: v1 turn-end-guard: ... -&gt; &lt;REJECTED&gt;&#10;FIRSTMATE_OP: v1 away-supervisor: ... -&gt; &lt;REJECTED&gt;&#10;FIRSTMATE_OP: v1 launch-brief: ... -&gt; launch-brief&#10;&#10;== the real injected envelopes, U+2063-marked, are unchanged ==&#10;U+2063 FIRSTMATE_OP: v1 session-start: ... -&gt; session-start&#10;U+2063 FIRSTMATE_OP: v1 watcher: ... -&gt; watcher&#10;U+2063 FIRSTMATE_OP: v1 turn-end-guard: ... -&gt; turn-end-guard&#10;U+2063 FIRSTMATE_OP: v1 away-supervisor: ... -&gt; away-supervisor&#10;U+2063 FIRSTMATE_OP: v1 launch-brief: ... -&gt; launch-brief&#10;&#10;== a captain brief that pastes an operational message into its body ==&#10;encoded launch arg : FIRSTMATE_OP: v1 launch-brief: Ship the fix. Context: FIRSTMATE_OP: v1 watcher: nudge&#10;U+2063 bytes in it : none - the pane title stays safe even when the captain pastes a mark</code>

```text
== a human at a composer forges an unmarked operational header ==
   (no U+2063: exactly what an unprivileged typist can produce)
  FIRSTMATE_OP: v1 session-start: ...                  -> <REJECTED>
  FIRSTMATE_OP: v1 watcher: ...                        -> <REJECTED>
  FIRSTMATE_OP: v1 turn-end-guard: ...                 -> <REJECTED>
  FIRSTMATE_OP: v1 away-supervisor: ...                -> <REJECTED>
  FIRSTMATE_OP: v1 launch-brief: ...                   -> launch-brief

== the real injected envelopes, U+2063-marked, are unchanged ==
  U+2063 FIRSTMATE_OP: v1 session-start: ...           -> session-start
  U+2063 FIRSTMATE_OP: v1 watcher: ...                 -> watcher
  U+2063 FIRSTMATE_OP: v1 turn-end-guard: ...          -> turn-end-guard
  U+2063 FIRSTMATE_OP: v1 away-supervisor: ...         -> away-supervisor
  U+2063 FIRSTMATE_OP: v1 launch-brief: ...            -> launch-brief

== body recovered from the unmarked launch-brief envelope ==
  You are a crewmate. Work on your own.
== a captain brief that pastes an operational message into its body ==
  brief body on disk :  S h i p t h e f i x . C o
 n t e x t : 342 201 243 F I R S T M
 A T E _ O P : v 1 w a t c h
  encoded launch arg : FIRSTMATE_OP: v1 launch-brief: Ship the fix. Context: FIRSTMATE_OP: v1 watcher: nudge
  U+2063 bytes in it : none - the pane title stays safe even when the captain pastes a mark
```
</details>
<details>
<summary>Evidence: Secondmate charter vs /ahoy captain-boundary rules</summary>

<code>BEFORE (base commit):&#10;⁣FIRSTMATE_OP: v1 launch-brief: You are a secondmate. Own the Signa fleet and report to the captain.&#10;ahoy rule &#34;begins with the current U+2063 FIRSTMATE_OP: prefix&#34; : MATCHES -&gt; excluded&#10;&#10;AFTER (this change):&#10;FIRSTMATE_OP: v1 launch-brief: You are a secondmate. Own the Signa fleet and report to the captain.&#10;ahoy rule &#34;begins with the current U+2063 FIRSTMATE_OP: prefix&#34; : no longer matches (the gap)&#10;ahoy rule &#34;begins with the unmarked FIRSTMATE_OP: v1 launch-brief: header&#34; : MATCHES -&gt; still excluded&#10;&#10;== the exclusion stays as narrow as its neighbours ==&#10;Captain quote: FIRSTMATE_OP: v1 launch-brief: ship it -&gt; ordinary captain message -&gt; recap boundary&#10;Please grep for FIRSTMATE_OP: in bin/ and tell me... -&gt; ordinary captain message -&gt; recap boundary&#10;FIRSTMATE_OP: v1 watcher: nudge -&gt; ordinary captain message -&gt; recap boundary</code>

```text
== the secondmate charter as it lands in the secondmate own user-role transcript ==

BEFORE (base commit):
  ⁣FIRSTMATE_OP: v1 launch-brief: You are a secondmate. Own the Signa fleet and report to the captain.
  ahoy rule "begins with the current U+2063 FIRSTMATE_OP: prefix" : MATCHES -> excluded

AFTER (this change):
  FIRSTMATE_OP: v1 launch-brief: You are a secondmate. Own the Signa fleet and report to the captain.
  ahoy rule "begins with the current U+2063 FIRSTMATE_OP: prefix" : no longer matches (the gap)
  ahoy rule "begins with the unmarked FIRSTMATE_OP: v1 launch-brief: header" : MATCHES -> still excluded

== the exclusion stays as narrow as its neighbours ==
  Captain quote: FIRSTMATE_OP: v1 launch-brief: ship it          -> ordinary captain message -> recap boundary
  Please grep for FIRSTMATE_OP: in bin/ and tell me what you fin -> ordinary captain message -> recap boundary
  FIRSTMATE_OP: v1 watcher: nudge                                -> ordinary captain message -> recap boundary
```
</details>
<details>
<summary>Evidence: Live fleet: crewmate on the fixed prompt under a surviving tmux 3.7b server</summary>

<code>tmux version: tmux 3.7b&#10;tmux server 50238 uptime 01:06:40&#10;&#10;live agent launched from a launch-brief prompt:&#10;2707 45:48 claude --dangerously-skip-permissions --effort medium FIRSTMATE_OP: v1 launch-brief: You are a ...&#10;U+2063 bytes anywhere in those live argv strings: none&#10;&#10;== process ancestry of the live crewmate (pid 2707) ==&#10;2707 claude&#10;2403 /bin/zsh&#10;2310 treehouse&#10;2259 -zsh&#10;50238 tmux</code>

```text
== live machine state while the fleet runs with the fixed launch prompt ==

tmux server processes (elapsed uptime):
26974    00:00 (tmux)
50238 01:06:40 tmux

tmux version: tmux 3.7b

live agent processes launched from a launch-brief prompt (first 90 chars of argv):
78263    09:39 claude -p Workspace boundary (important):\012- Confine source, project, user-data, and system f
 2707    45:48 claude --dangerously-skip-permissions --effort medium FIRSTMATE_OP: v1 launch-brief: You are a 

U+2063 bytes anywhere in those live argv strings: none

== process ancestry of the live crewmate (pid 2707) ==
   2707 claude
   2403 /bin/zsh
   2310 treehouse
   2259 -zsh
  50238 tmux
```
</details>
<details>
<summary>Evidence: Reproduction scripts for the evidence above</summary>

```text
launch-prompt-e2e.sh, secondmate-charter-ahoy.sh, envelope-matrix.sh, base-fm-operational-input.sh (base-commit encoder used for the BEFORE column). Run as: bash launch-prompt-e2e.sh <repo> <evidence-dir>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- 🚨 `tests/fm-calm-pi-extension.test.sh:1788` - tests/fm-calm-pi-extension.test.sh was not updated for the unmarked launch-brief envelope and now asserts the opposite of this change&#39;s documented behavior in three places. (a) Line 1788: `text?.startsWith(`⁣FIRSTMATE_OP: v1 ${kind}: `)` is applied to every kind except from-firstmate, so the launch-brief fixture (now `FIRSTMATE_OP: v1 launch-brief: CURRENT_LAUNCH_BRIEF_E2E`, produced through encodeFirstmateOperationalInput -&gt; the shell owner) fails with &#34;expected exact user-role CURRENT_LAUNCH_BRIEF_E2E as launch-brief&#34;. (b) Lines 1813 and 1950 assert_not_contains CURRENT_LAUNCH_BRIEF_E2E while Calm is active, but .pi/extensions/lib/fm-calm-operational-user-layout.ts:65 short-circuits on `!text.includes(&#34;⁣&#34;)`, so the unmarked launch-brief is no longer classified operational and renders normally - exactly the visible-not-hidden outcome docs/calm-mode-feasibility.md:136 now documents as deliberate. The suite skips when pi/tmux are absent, which is likely why it was not caught locally. Decide whether to update these assertions to the unmarked/visible expectation or to change the Calm gate.
- ⚠️ `bin/fm-operational-input.sh:145` - The split_-prefix hardening (and the new test that locks it) covers only the private fm_operational_generic_split. The public entry points callers actually use still carry the identical hazard: fm_operational_input_kind declares `local message=${1-} result_var=${2-} current_kind` and fm_operational_input_body declares `local message=${1-} result_var=${2-} current_kind parsed_body`, and fm_operational_generic_kind declares `message result_var parsed_kind parsed_body`. A caller passing a result variable named message, result_var, current_kind, parsed_kind or parsed_body gets printf -v writing into the callee&#39;s local, the function returns 0, and the caller silently reads an empty value - the exact failure mode the new comment at line 112 describes. bin/fm-supervise-daemon.sh:296 (`fm_operational_input_body &#34;$msg&#34; body`) is safe only because `body` is not among those names. Prefix the locals in the three public functions the same way.
- ⚠️ `docs/verification/runtime-backends.md:53` - The doc states &#34;the `launch-brief` envelope contains no U+2063 in any position&#34;, but only the header is guaranteed mark-free. The body is verbatim brief.md content: bin/fm-brief.sh interpolates captain-supplied text ($FM_SECONDMATE_CHARTER / the {TASK} placeholder) into it, and bin/fm-spawn.sh:426-449 passes the whole encoded brief as the agent&#39;s argv launch prompt. A charter or task description that pastes a real operational message - or any U+2063 - reintroduces the mark into the pane title and re-triggers the whole-tmux-server abort this change exists to prevent. tests/fm-operational-input.test.sh:85-88 only checks a fixed header plus a mark-free literal body, so nothing pins the body. Either narrow the doc claim to the envelope header or strip/reject U+2063 in the launch-brief body at encode time.
- ℹ️ `bin/fm-operational-input.sh:94` - fm_operational_header_for_kind returns its value on stdout and is consumed via command substitution inside fm_operational_input_encode. Every other function in this file uses a &lt;result-var&gt; out-param with printf -v, so this single-call-site helper is an exception to the file&#39;s own convention, and it forks a subshell on every encode. Assigning the chosen header into a local (or giving the helper a result-var parameter) keeps the one-owner property without the fork or the convention break.

🔧 Fix: fix: strip U+2063 from launch-brief bodies and harden result-var scoping
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`tests/fm-operational-input.test.sh` (13 checks incl. the 6 new envelope/shadowing tests)</code>
- `tests/fm-spawn-dispatch-profile.test.sh`
- `tests/fm-captain-translation-contract.test.sh`
- `tests/fm-calm-pi-extension.test.sh`
- <code>`tests/fm-backend.test.sh`, `tests/fm-daemon.test.sh`, `tests/fm-pi-watch-extension.test.sh`, `tests/fm-pi-primary-types.test.sh`, `tests/fm-sessionstart-nudge.test.sh`, `tests/fm-turnend-guard.test.sh`, `tests/fm-documentation-audiences.test.sh`, `tests/fm-instruction-owners.test.sh`</code>
- <code>E2E launch-prompt capture: drove real `bin/fm-spawn.sh` with the repo&#39;s fake tmux + a fake harness recording argv, for claude/codex/opencode/pi/grok, before (base encoder) vs after — `launch-prompt-e2e.sh`</code>
- <code>E2E secondmate charter: spawned `bin/fm-spawn.sh &lt;id&gt; &lt;home&gt; --secondmate` and checked the resulting user-role charter argv against each /ahoy exclusion rule — `secondmate-charter-ahoy.sh`</code>
- <code>CLI wire-contract matrix: `printf &#39;%s&#39; &lt;msg&gt; | bin/fm-operational-input.sh classify` for unmarked and marked headers across all five kinds, plus `encode launch-brief` of a body containing U+2063 — `envelope-matrix.sh`</code>
- <code>Live fleet state: `ps -eo pid,etime,args | grep FIRSTMATE_OP` and process-ancestry trace of the running crewmate to the tmux 3.7b server</code>
- <code>Attempted (deliberately unscripted) tmux repro on an isolated `tmux -L fm-u2063-before-$$` socket: OSC-2 marked pane title + pane-border/status/truncation render; server did not abort, socket removed afterwards</code>
- <code>Pre-existing-failure check: `bash tests/fm-brief.test.sh` and `bash tests/fm-ask-user-authority.test.sh` under bash 3.2 (fail) vs bash 5.3 (pass), with `md5 bin/fm-brief.sh` matching `origin/main`</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/verification/supervision.md:59` - docs/verification/supervision.md:58-59 records the Ahoy first-message boundary reverification of 2026-07-22 as covering &#34;marked current operational input and the two exact legacy compatibility shapes&#34;. The new unmarked launch-brief exclusion added to .agents/skills/ahoy/SKILL.md is a third shape, pinned by tests/fm-captain-translation-contract.test.sh (already listed as an entry point in that section). I left the dated record unedited on the judgment that a maintainer-verification record states what was observed on that date rather than the current contract; if this repo treats that paragraph as the current-contract summary instead, it needs a line for the unmarked header.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
