### PR TITLE
feat: strengthen crewmate run contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,8 +289,8 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
-The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
+For a no-mistakes ship, the generated brief requires the same worker to invoke the no-mistakes skill immediately after its implementation commit without waiting for a firstmate steer.
+That worker drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome; `harness-adapters` owns invocation syntax if recovery ever requires a steer.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 
 An ask-user finding returns as `needs-decision`; firstmate decides only when the configured authority permits, otherwise escalates to the captain.
@@ -446,7 +446,7 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 ## 11. Crewmate briefs
 
 `bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, and exact safety mechanics.
-Use its scaffold as the contract, then replace every `{TASK}` placeholder with a clear task description, acceptance criteria, constraints, and necessary context before dispatch or seeding.
+Use its scaffold as the contract, then resolve every generated task-contract and unattended-envelope placeholder before dispatch or seeding; the generated field labels define the required content.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -837,8 +837,11 @@ fm_backend_herdr_workspace_find() {  # <session>
   # compile error that `2>/dev/null` would silently swallow, making this find
   # ALWAYS return empty and every spawn mint a fresh "firstmate" workspace
   # (the workspace leak).
+  # Select inside jq rather than piping all matches through head. Early head
+  # closure made the upstream pipeline emit cosmetic broken-pipe noise while
+  # watcher arming even though the first workspace was resolved correctly.
   printf '%s' "$list" | jq -r --arg want "$label" \
-    '.result.workspaces[]? | select(.label == $want) | .workspace_id' 2>/dev/null | head -1
+    '[.result.workspaces[]? | select(.label == $want) | .workspace_id][0] // empty' 2>/dev/null
 }
 
 # fm_backend_herdr_workspace_prune_seeded_default_tab: close EXACTLY

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -2,10 +2,9 @@
 # Scaffold a crewmate brief or persistent secondmate charter at
 # data/<task-id>/brief.md under the active firstmate home.
 # For ordinary tasks, the standard Setup/Rules/Definition-of-done contract is
-# filled in. Firstmate then replaces the {TASK} placeholder with the task
-# description, acceptance criteria, and context, and may adjust other sections
-# when the task genuinely deviates (e.g. working an existing external PR instead
-# of shipping a new one).
+# filled in. Firstmate then fills every task-contract and unattended-envelope
+# placeholder, and may adjust other sections when the task genuinely deviates
+# (e.g. working an existing external PR instead of shipping a new one).
 # Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
@@ -106,6 +105,47 @@ shell_quote() {
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
+SESSION_STATE_TOOL=$(shell_quote "$FM_ROOT/bin/fm-session-state.sh")
+SESSION_STATE_CANDIDATE=$(shell_quote "$DATA/$ID/session-state.candidate.json")
+SESSION_STATE_FILE=$(shell_quote "$DATA/$ID/session-state.json")
+
+emit_crewmate_contracts() {  # <one-line authority class>
+  local authority_class=$1
+  cat <<EOF
+# Task contract
+## Objective and scope
+{TASK}
+
+Source set: {SOURCE_SET}
+Acceptance criteria: {ACCEPTANCE_CRITERIA}
+Authority class: $authority_class
+Load-bearing assumptions: {LOAD_BEARING_ASSUMPTIONS}
+Commissioning remains valid only while these fields match the approved task-class template; a material change returns the brief to the configured approval authority before work continues.
+
+# Unattended-run envelope
+Every autonomous run uses this envelope, and every placeholder must be resolved before dispatch.
+Success predicate: {SUCCESS_PREDICATE}
+Named evaluator: {EVALUATOR}
+Iteration cap: {ITERATION_CAP}
+Wall-clock deadline: {WALL_CLOCK_DEADLINE}
+Token budget: {TOKEN_BUDGET}
+Allowed side effects: {ALLOWED_SIDE_EFFECTS}
+Terminal outcomes: \`done | needs-decision | blocked | failed\`.
+Prefer a deterministic success predicate; when judgment is unavoidable, name \`host-worker\` as evaluator and preserve the evidence it judged.
+Stop at the first reached cap or deadline and report \`blocked\` with the bound and remaining work rather than extending the run implicitly.
+At run end, use exactly one terminal outcome as the final status state and preserve its evidence.
+
+# Session state and phase handoff
+Contract: \`firstmate.session-state/v1\`.
+Schema and validator owner: \`$SESSION_STATE_TOOL\`; its \`schema\`, \`validate\`, and \`compile\` interfaces are authoritative, and \`--help\` owns mechanics.
+Phase candidate: \`$SESSION_STATE_CANDIDATE\`.
+Canonical state: \`$SESSION_STATE_FILE\`.
+At every phase boundary, compile one candidate containing the completed checklist, deviations, decisions, evidence pointers, budget position, next acceptance criteria, and exact resume action.
+The compiler validates before atomically replacing canonical state, so readers see only a complete boundary.
+Do not start the next phase or resume in a fresh session unless canonical state validates; validate and read it before continuation.
+Use a fresh-session handoff at about 200K working or 250K hard-stop context tokens on Claude, and about 140K working or 180K hard-stop context tokens on Codex and Pi.
+EOF
+}
 
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""
@@ -227,11 +267,14 @@ EOF
 fi
 
 if [ "$KIND" = scout ]; then
-cat > "$BRIEF" <<EOF
+SCOUT_AUTHORITY="worker investigates accepted scope, reads and writes only authorized sources and paths, and spends only the envelope budget; firstmate decides routine execution questions above the worker within configured authority; captain decides scope expansion, broader read or write access, sending or publishing outside the brief, overspending, and destructive, irreversible, or security-sensitive actions; no landing is authorized"
+{
+cat <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
-# Task
-{TASK}
+EOF
+emit_crewmate_contracts "$SCOUT_AUTHORITY"
+cat <<EOF
 
 $HERDR_SECTION
 
@@ -243,7 +286,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 
 # Rules
 1. Never push to any remote and never open a PR.
-2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
+2. Stay inside this worktree; the only files you may write outside it are the report, session-state files in the task workspace, and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -270,7 +313,8 @@ Before reporting done, read and follow \`$FM_ROOT/.agents/skills/decision-hold-l
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
 EOF
-echo "scaffolded: $BRIEF (scout; replace {TASK})"
+} > "$BRIEF"
+echo "scaffolded: $BRIEF (scout; fill task contract)"
 exit 0
 fi
 
@@ -313,31 +357,35 @@ EOF
     RULE1='1. Never push to the default branch. Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+The task is complete only after implementation is committed, the no-mistakes pipeline reaches CI green, and the PR URL is available.
+Immediately after your implementation commit, invoke the no-mistakes skill yourself and drive it through the CI-ready return point without waiting for a firstmate steer.
+Do not append \`done:\` after the implementation commit or stop between implementation and pipeline start.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke the no-mistakes skill, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Process every synchronous return until completion or a genuinely new escalation.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass the authority check by firstmate and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+After no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
 )
     ;;
 esac
 
-cat > "$BRIEF" <<EOF
+SHIP_AUTHORITY="worker implements accepted scope, reads and writes only authorized sources and paths, drives the selected delivery path, and spends only the envelope budget; firstmate decides routine execution questions and ask-user findings within configured authority; captain decides scope expansion, broader read or write access, sending or publishing outside the selected delivery path, overspending, and destructive, irreversible, or security-sensitive actions; configured merge authority decides landing"
+{
+cat <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
-# Task
-{TASK}
+EOF
+emit_crewmate_contracts "$SHIP_AUTHORITY"
+cat <<EOF
 
 $HERDR_SECTION
 
@@ -352,7 +400,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 
 # Rules
 $RULE1
-2. Stay inside this worktree; modify nothing outside it.
+2. Stay inside this worktree; the only files you may write outside it are session-state files in the task workspace and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -384,4 +432,5 @@ Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced 
 
 $DOD
 EOF
-echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"
+} > "$BRIEF"
+echo "scaffolded: $BRIEF (ship, mode=$MODE; fill task contract)"

--- a/bin/fm-session-state.sh
+++ b/bin/fm-session-state.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Validate and atomically compile the fleet-wide phase-boundary session state.
+#
+# Session state is task execution state, not project memory. The schema emitted
+# here is its sole versioned contract. A phase-boundary candidate is validated,
+# copied to a temporary file beside the canonical state, validated again, and
+# atomically renamed so readers see either the previous valid state or the new
+# valid state. The next phase must not start unless compile succeeds.
+#
+# Usage:
+#   fm-session-state.sh schema
+#   fm-session-state.sh validate <state.json>
+#   fm-session-state.sh compile <candidate.json> <canonical-state.json>
+set -eu
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+die() {
+  printf 'fm-session-state.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+emit_schema() {
+  cat <<'EOF'
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:firstmate:session-state:v1",
+  "title": "Firstmate phase-boundary session state v1",
+  "x-firstmate-invariants": [
+    "budget.iterations_used must not exceed budget.iteration_cap",
+    "budget.tokens_used must be null when unavailable or must not exceed budget.token_budget"
+  ],
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "compiled_at",
+    "completed_phase",
+    "deviations",
+    "decisions",
+    "evidence_pointers",
+    "budget",
+    "next_phase"
+  ],
+  "properties": {
+    "schema_version": { "const": "firstmate.session-state/v1" },
+    "task_id": { "type": "string", "minLength": 1 },
+    "compiled_at": { "type": "string", "minLength": 1 },
+    "completed_phase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "checklist"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "checklist": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["item", "status"],
+            "properties": {
+              "item": { "type": "string", "minLength": 1 },
+              "status": { "enum": ["done", "skipped"] }
+            }
+          }
+        }
+      }
+    },
+    "deviations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["summary", "disposition"],
+        "properties": {
+          "summary": { "type": "string", "minLength": 1 },
+          "disposition": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "decisions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["summary", "authority"],
+        "properties": {
+          "summary": { "type": "string", "minLength": 1 },
+          "authority": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "evidence_pointers": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "iteration_cap",
+        "iterations_used",
+        "wall_clock_deadline",
+        "token_budget",
+        "tokens_used"
+      ],
+      "properties": {
+        "iteration_cap": { "type": "integer", "minimum": 1 },
+        "iterations_used": { "type": "integer", "minimum": 0 },
+        "wall_clock_deadline": { "type": "string", "minLength": 1 },
+        "token_budget": { "type": "integer", "minimum": 1 },
+        "tokens_used": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "next_phase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "acceptance_criteria", "resume_action"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "acceptance_criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "resume_action": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}
+EOF
+}
+
+validate_state() {
+  local state=$1
+  [ -f "$state" ] || die "state file not found: $state"
+  command -v jq >/dev/null 2>&1 || die "jq is required"
+
+  jq -e '
+    def nonempty: type == "string" and length > 0;
+    def exact_keys($allowed): ((keys_unsorted - $allowed) | length) == 0;
+    def checklist_item:
+      type == "object"
+      and exact_keys(["item", "status"])
+      and (.item | nonempty)
+      and (.status == "done" or .status == "skipped");
+    def deviation:
+      type == "object"
+      and exact_keys(["summary", "disposition"])
+      and (.summary | nonempty)
+      and (.disposition | nonempty);
+    def decision:
+      type == "object"
+      and exact_keys(["summary", "authority"])
+      and (.summary | nonempty)
+      and (.authority | nonempty);
+
+    type == "object"
+    and exact_keys([
+      "schema_version",
+      "task_id",
+      "compiled_at",
+      "completed_phase",
+      "deviations",
+      "decisions",
+      "evidence_pointers",
+      "budget",
+      "next_phase"
+    ])
+    and .schema_version == "firstmate.session-state/v1"
+    and (.task_id | nonempty)
+    and (.compiled_at | nonempty)
+    and (.completed_phase | type == "object")
+    and (.completed_phase | exact_keys(["name", "checklist"]))
+    and (.completed_phase.name | nonempty)
+    and (.completed_phase.checklist | type == "array" and length > 0)
+    and (.completed_phase.checklist | all(.[]; checklist_item))
+    and (.deviations | type == "array" and all(.[]; deviation))
+    and (.decisions | type == "array" and all(.[]; decision))
+    and (.evidence_pointers | type == "array" and length > 0)
+    and (.evidence_pointers | all(.[]; nonempty))
+    and (.budget | type == "object")
+    and (.budget | exact_keys([
+      "iteration_cap",
+      "iterations_used",
+      "wall_clock_deadline",
+      "token_budget",
+      "tokens_used"
+    ]))
+    and (.budget.iteration_cap | type == "number" and floor == . and . >= 1)
+    and (.budget.iterations_used | type == "number" and floor == . and . >= 0)
+    and (.budget.iterations_used <= .budget.iteration_cap)
+    and (.budget.wall_clock_deadline | nonempty)
+    and (.budget.token_budget | type == "number" and floor == . and . >= 1)
+    and (
+      .budget.tokens_used == null
+      or (.budget.tokens_used | type == "number" and floor == . and . >= 0)
+    )
+    and (
+      .budget.tokens_used == null
+      or .budget.tokens_used <= .budget.token_budget
+    )
+    and (.next_phase | type == "object")
+    and (.next_phase | exact_keys(["name", "acceptance_criteria", "resume_action"]))
+    and (.next_phase.name | nonempty)
+    and (.next_phase.acceptance_criteria | type == "array" and length > 0)
+    and (.next_phase.acceptance_criteria | all(.[]; nonempty))
+    and (.next_phase.resume_action | nonempty)
+  ' "$state" >/dev/null || die "state does not match firstmate.session-state/v1: $state"
+}
+
+compile_state() {
+  local candidate=$1 target=$2 target_dir tmp=""
+  validate_state "$candidate"
+  target_dir=$(dirname "$target")
+  [ -d "$target_dir" ] || die "canonical state directory not found: $target_dir"
+  tmp=$(mktemp "$target_dir/.session-state.compile.XXXXXX") \
+    || die "could not create phase-boundary temporary file"
+  trap 'rm -f "${tmp:-}"' EXIT HUP INT TERM
+  cp "$candidate" "$tmp" || die "could not stage phase-boundary state"
+  chmod 0600 "$tmp" || die "could not protect phase-boundary state"
+  validate_state "$tmp"
+  mv -f "$tmp" "$target" || die "could not atomically publish phase-boundary state"
+  tmp=""
+  trap - EXIT HUP INT TERM
+  printf 'compiled: %s\n' "$target"
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    ;;
+  schema)
+    [ "$#" -eq 1 ] || die "schema takes no arguments"
+    emit_schema
+    ;;
+  validate)
+    [ "$#" -eq 2 ] || die "validate requires <state.json>"
+    validate_state "$2"
+    printf 'valid: %s\n' "$2"
+    ;;
+  compile)
+    [ "$#" -eq 3 ] || die "compile requires <candidate.json> <canonical-state.json>"
+    compile_state "$2" "$3"
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -19,6 +19,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
+| `fm-session-state.sh`    | Validate and atomically compile versioned phase-boundary session state               |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1567,6 +1567,21 @@ test_workspace_find_matches_only_this_homes_own_label() {
   pass "fm_backend_herdr_workspace_find: matches only THIS home's own label among several coexisting workspaces"
 }
 
+test_workspace_find_selects_first_match_without_head_pipe() {
+  local dir log resp fb out err source
+  dir="$TMP_ROOT/find-duplicate"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; err="$dir/stderr"; : > "$log"
+  printf '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"},{"workspace_id":"w2","label":"firstmate"}]}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_find fmtest' "$ROOT" 2>"$err" )
+  [ "$out" = "w1" ] || fail "workspace_find should select the first duplicate match, got '$out'"
+  [ ! -s "$err" ] || fail "workspace_find emitted cosmetic stderr: $(cat "$err")"
+  source=$(awk '/^fm_backend_herdr_workspace_find\(\)/,/^}/' "$ROOT/bin/backends/herdr.sh")
+  assert_not_contains "$source" '| head -1' \
+    "workspace_find retained the early-closing head pipe that causes broken-pipe noise"
+  pass "fm_backend_herdr_workspace_find: first-match selection emits no broken-pipe stderr"
+}
+
 # --- list_live: scoped to this home's own workspace only ---------------------
 
 test_list_live_scoped_to_this_homes_workspace_only() {
@@ -3035,6 +3050,7 @@ test_projection_reclaim_refusal_matrix_is_non_mutating
 test_projection_reclaim_replaces_only_exact_husk_and_advances_binding
 test_projection_recovery_is_read_only_and_refuses_live_duplicate_risk
 test_workspace_find_matches_only_this_homes_own_label
+test_workspace_find_selects_first_match_without_head_pipe
 test_list_live_scoped_to_this_homes_workspace_only
 test_parse_target
 test_normalize_key

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -116,7 +116,91 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must render literal backticks around help"
   assert_no_grep "no-mistakes' own guidance" "$brief" \
     "no-mistakes DOD regressed to the apostrophe form that breaks bash -n"
-  pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
+  assert_grep "Immediately after your implementation commit, invoke the no-mistakes skill yourself" "$brief" \
+    "no-mistakes DOD did not make the worker start validation unaided"
+  assert_grep "without waiting for a firstmate steer" "$brief" \
+    "no-mistakes DOD retained the stop-short handoff"
+  assert_grep "Process every synchronous return until completion or a genuinely new escalation." "$brief" \
+    "no-mistakes DOD did not make the worker drive the active run"
+  assert_no_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+    "no-mistakes DOD still requires a firstmate steer after implementation"
+  assert_no_grep "When you believe it is complete, append \`done: {summary}\`" "$brief" \
+    "no-mistakes DOD still permits done before validation"
+  pass "fm-brief.sh: no-mistakes DOD parses and makes the worker drive validation"
+}
+
+test_crewmate_contracts_are_structured_and_bounded() {
+  local home kind id brief authority_count
+  home="$TMP_ROOT/crewmate-contract-home"
+  mkdir -p "$home/data"
+
+  for kind in ship scout; do
+    id="brief-contract-$kind"
+    if [ "$kind" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" sample --scout >/dev/null 2>&1
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" sample >/dev/null 2>&1
+    fi
+    brief="$home/data/$id/brief.md"
+
+    assert_grep "# Task contract" "$brief" "$kind brief omitted the structured task contract"
+    for field in "Source set: {SOURCE_SET}" "Acceptance criteria: {ACCEPTANCE_CRITERIA}" \
+      "Load-bearing assumptions: {LOAD_BEARING_ASSUMPTIONS}"; do
+      assert_grep "$field" "$brief" "$kind brief omitted task-contract field $field"
+    done
+    authority_count=$(grep -c '^Authority class:' "$brief")
+    [ "$authority_count" -eq 1 ] || fail "$kind brief must carry exactly one authority class"
+    assert_grep "firstmate decides" "$brief" "$kind authority class did not name firstmate decisions"
+    assert_grep "captain decides" "$brief" "$kind authority class did not name captain decisions"
+    assert_grep "a material change returns the brief to the configured approval authority" "$brief" \
+      "$kind brief did not re-gate material task-contract changes"
+
+    assert_grep "# Unattended-run envelope" "$brief" "$kind brief omitted the unattended envelope"
+    for field in "Success predicate: {SUCCESS_PREDICATE}" "Named evaluator: {EVALUATOR}" \
+      "Iteration cap: {ITERATION_CAP}" "Wall-clock deadline: {WALL_CLOCK_DEADLINE}" \
+      "Token budget: {TOKEN_BUDGET}" "Allowed side effects: {ALLOWED_SIDE_EFFECTS}"; do
+      assert_grep "$field" "$brief" "$kind brief omitted unattended field $field"
+    done
+    # shellcheck disable=SC2016  # Literal backticks and terminal names must remain unchanged.
+    assert_grep 'Terminal outcomes: `done | needs-decision | blocked | failed`.' "$brief" \
+      "$kind brief omitted the fixed terminal-outcome set"
+    # shellcheck disable=SC2016  # Literal status name must remain unchanged.
+    assert_grep 'report `blocked` with the bound and remaining work' "$brief" \
+      "$kind brief did not map exhausted bounds to the existing status protocol"
+    assert_grep "name \`host-worker\` as evaluator" "$brief" \
+      "$kind brief omitted the judgment-evaluator fallback"
+
+    assert_grep "# Session state and phase handoff" "$brief" "$kind brief omitted session state"
+    assert_grep "Contract: \`firstmate.session-state/v1\`." "$brief" \
+      "$kind brief omitted the versioned state contract"
+    assert_grep "$ROOT/bin/fm-session-state.sh" "$brief" \
+      "$kind brief omitted the schema and validator owner"
+    assert_grep "$home/data/$id/session-state.candidate.json" "$brief" \
+      "$kind brief omitted the task-workspace phase candidate"
+    assert_grep "validates before atomically replacing canonical state" "$brief" \
+      "$kind brief omitted atomic phase-boundary compilation"
+    assert_grep "Do not start the next phase" "$brief" \
+      "$kind brief did not refuse an unvalidated next phase"
+    assert_grep "200K working or 250K hard-stop" "$brief" \
+      "$kind brief omitted Claude handoff thresholds"
+    assert_grep "140K working or 180K hard-stop" "$brief" \
+      "$kind brief omitted Codex and Pi handoff thresholds"
+  done
+  pass "fm-brief.sh: ship and scout briefs carry structured authority, run, and state contracts"
+}
+
+test_secondmate_omits_crewmate_run_contracts() {
+  local home brief
+  home="$TMP_ROOT/secondmate-contract-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='route domain work' \
+    "$ROOT/bin/fm-brief.sh" contract-mate --secondmate --no-projects >/dev/null 2>&1
+  brief="$home/data/contract-mate/brief.md"
+  assert_no_grep "# Unattended-run envelope" "$brief" \
+    "persistent secondmate charter inherited a per-task unattended envelope"
+  assert_no_grep "# Session state and phase handoff" "$brief" \
+    "persistent secondmate charter inherited per-task phase state"
+  pass "fm-brief.sh: persistent secondmate charters omit per-task run contracts"
 }
 
 test_ship_project_memory_wording() {
@@ -387,6 +471,8 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_crewmate_contracts_are_structured_and_bounded
+test_secondmate_omits_crewmate_run_contracts
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path

--- a/tests/fm-session-state.test.sh
+++ b/tests/fm-session-state.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Behavior tests for the versioned phase-boundary session-state compiler.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-session-state)
+mkdir -p "$TMP_ROOT"
+TOOL="$ROOT/bin/fm-session-state.sh"
+CANDIDATE="$TMP_ROOT/candidate.json"
+TARGET="$TMP_ROOT/session-state.json"
+
+write_valid_candidate() {
+  local path=$1
+  cat > "$path" <<'JSON'
+{
+  "schema_version": "firstmate.session-state/v1",
+  "task_id": "sample-task",
+  "compiled_at": "2026-07-26T12:00:00Z",
+  "completed_phase": {
+    "name": "implementation",
+    "checklist": [
+      {"item": "feature implemented", "status": "done"},
+      {"item": "focused tests passed", "status": "done"}
+    ]
+  },
+  "deviations": [
+    {"summary": "fixture deviation", "disposition": "accepted within scope"}
+  ],
+  "decisions": [
+    {"summary": "use the existing interface", "authority": "worker"}
+  ],
+  "evidence_pointers": ["tests/fm-session-state.test.sh"],
+  "budget": {
+    "iteration_cap": 8,
+    "iterations_used": 3,
+    "wall_clock_deadline": "2026-07-26T18:00:00Z",
+    "token_budget": 50000,
+    "tokens_used": 12000
+  },
+  "next_phase": {
+    "name": "validation",
+    "acceptance_criteria": ["all required checks pass"],
+    "resume_action": "run the focused validation suite"
+  }
+}
+JSON
+}
+
+test_schema_is_versioned_and_complete() {
+  local schema
+  schema=$($TOOL schema) || fail "schema command failed"
+  # shellcheck disable=SC2016  # JSON Schema uses a literal $id property.
+  assert_contains "$schema" '"$id": "urn:firstmate:session-state:v1"' \
+    "schema lost its versioned identifier"
+  for field in completed_phase deviations decisions evidence_pointers budget acceptance_criteria resume_action; do
+    assert_contains "$schema" "\"$field\"" "schema omitted required field $field"
+  done
+  assert_contains "$schema" 'budget.iterations_used must not exceed budget.iteration_cap' \
+    "schema omitted the iteration-cap invariant enforced by the validator"
+  assert_contains "$schema" 'budget.tokens_used must be null when unavailable or must not exceed budget.token_budget' \
+    "schema omitted the token-budget invariant enforced by the validator"
+  printf '%s\n' "$schema" | jq -e . >/dev/null || fail "schema command emitted invalid JSON"
+  pass "fm-session-state: schema is versioned and carries the phase-boundary contract"
+}
+
+test_validate_accepts_complete_state() {
+  write_valid_candidate "$CANDIDATE"
+  "$TOOL" validate "$CANDIDATE" >/dev/null 2>&1 \
+    || fail "validator rejected a complete v1 state"
+  pass "fm-session-state: validator accepts complete v1 state"
+}
+
+test_compile_replaces_atomically_after_validation() {
+  local before after status=0
+  write_valid_candidate "$CANDIDATE"
+  printf 'old valid state placeholder\n' > "$TARGET"
+  "$TOOL" compile "$CANDIDATE" "$TARGET" >/dev/null 2>&1 \
+    || fail "compiler rejected a complete candidate"
+  "$TOOL" validate "$TARGET" >/dev/null 2>&1 \
+    || fail "compiled canonical state is invalid"
+  assert_contains "$(cat "$TARGET")" '"name": "validation"' \
+    "compiled state lost the exact resume phase"
+  if find "$TMP_ROOT" -maxdepth 1 -name '.session-state.compile.*' | grep . >/dev/null; then
+    fail "compiler left a phase-boundary temporary file behind"
+  fi
+
+  before=$(shasum -a 256 "$TARGET" | awk '{print $1}')
+  jq '.budget.iterations_used = 9' "$CANDIDATE" > "$TMP_ROOT/invalid.json"
+  "$TOOL" compile "$TMP_ROOT/invalid.json" "$TARGET" >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "compiler accepted iterations beyond the declared cap"
+  after=$(shasum -a 256 "$TARGET" | awk '{print $1}')
+  [ "$before" = "$after" ] || fail "failed iteration-cap compile changed the previous canonical state"
+
+  status=0
+  jq '.budget.tokens_used = 50001' "$CANDIDATE" > "$TMP_ROOT/invalid-token-budget.json"
+  "$TOOL" compile "$TMP_ROOT/invalid-token-budget.json" "$TARGET" >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "compiler accepted tokens beyond the declared budget"
+  after=$(shasum -a 256 "$TARGET" | awk '{print $1}')
+  [ "$before" = "$after" ] || fail "failed token-budget compile changed the previous canonical state"
+  pass "fm-session-state: compile publishes valid state atomically and preserves prior state on failure"
+}
+
+test_validate_rejects_incomplete_boundary() {
+  local status=0
+  write_valid_candidate "$CANDIDATE"
+  jq 'del(.next_phase.resume_action)' "$CANDIDATE" > "$TMP_ROOT/incomplete.json"
+  "$TOOL" validate "$TMP_ROOT/incomplete.json" >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "validator accepted a boundary without an exact resume action"
+  pass "fm-session-state: validator rejects an incomplete phase boundary"
+}
+
+test_schema_is_versioned_and_complete
+test_validate_accepts_complete_state
+test_compile_replaces_atomically_after_validation
+test_validate_rejects_incomplete_boundary


### PR DESCRIPTION
## Intent

Strengthen generated crewmate briefs so unattended work starts with an explicit task contract, authority boundary, bounded run envelope, and durable phase handoff.

## What changed

- Ship and scout briefs now carry structured objective, source-set, acceptance, authority, and load-bearing-assumption fields, with material changes returning to the configured approval authority.
- Every ship and scout brief now carries a mandatory unattended-run envelope with a success predicate, named evaluator, iteration cap, wall-clock deadline, token budget, allowed side effects, and terminal outcome from the existing fixed status set.
- Add `bin/fm-session-state.sh` as the single owner of `firstmate.session-state/v1`, including schema output, validation, and validate-before-rename atomic phase-boundary compilation.
- Phase state captures the completed checklist, deviations, decisions, evidence pointers, budget position, next acceptance criteria, and exact resume action, and the brief refuses continuation from invalid state.
- No-mistakes briefs now require the implementation worker to invoke the no-mistakes skill immediately after its implementation commit and drive every synchronous return through CI green without waiting for a firstmate steer.
- Herdr workspace selection now chooses the first matching workspace inside `jq`, removing the early-closing `head` pipeline that emitted cosmetic broken-pipe stderr while watcher arming.

The brief keeps detail progressively disclosed behind the versioned schema and `--help` interface, uses constrained fields instead of worked tool examples, and leaves each contract with one authoritative owner.

## Composition with prior PRs

PR #423 is closed and unmerged.
This change does not revive its `--budget` option or generic no-progress/action caps.
The only overlap is the amendment-required unattended envelope, whose explicit iteration, deadline, and token fields should be the destination for any future task-specific budget input rather than a second stop-conditions section.

PR #469 is closed and unmerged.
This change adds no parallelism policy or harness-specific fan-out guidance, so a future parallelism contribution can remain an independent section without duplication.

## Proved slice

A real no-mistakes ship brief was generated from the upgraded scaffold, every placeholder was filled, and a matching phase-boundary state was compiled and revalidated.

```text
scaffolded: <proof-home>/data/proved-slice/brief.md (ship, mode=no-mistakes; fill task contract)

# Task contract
Source set: upstream Firstmate branch and focused scaffold tests
Acceptance criteria: all required contract sections render exactly once and focused checks pass
Authority class: worker implements accepted scope ...; firstmate decides routine execution questions and ask-user findings within configured authority; captain decides expanded or sensitive authority; configured merge authority decides landing
Load-bearing assumptions: the proof performs no remote or external side effects

# Unattended-run envelope
Success predicate: required headings and filled fields are present exactly once
Named evaluator: deterministic grep assertions
Iteration cap: 3
Wall-clock deadline: 2026-07-26T18:00:00Z
Token budget: 10000 tokens
Allowed side effects: write only this proof fixture inside the disposable worktree
Terminal outcomes: done | needs-decision | blocked | failed

# Session state and phase handoff
Contract: firstmate.session-state/v1
The compiler validates before atomically replacing canonical state, so readers see only a complete boundary.
Do not start the next phase or resume in a fresh session unless canonical state validates.

# Definition of done
Immediately after your implementation commit, invoke the no-mistakes skill yourself and drive it through the CI-ready return point without waiting for a firstmate steer.

compiled: <proof-home>/data/proved-slice/session-state.json
valid: <proof-home>/data/proved-slice/session-state.json
```

## Validation

- `/bin/bash -n bin/fm-brief.sh`
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-session-state.test.sh`
- `bash tests/fm-backend-herdr.test.sh`
- `bin/fm-doc-audience-check.sh`
- `bin/fm-lint.sh`
- `git diff --check`

All passed on stock macOS Bash 3.2.57 and pinned ShellCheck 0.11.0.
