### PR TITLE
feat: add graph engineering skill

### DIFF
--- a/.agents/skills/graph-engineering/SKILL.md
+++ b/.agents/skills/graph-engineering/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: graph-engineering
+description: >-
+  Agent-only method for designing and evaluating bounded autonomous improvement loops and deciding whether measured needs justify chains, planning, parallel workers, experiment DAGs, or knowledge graphs.
+  Load before proposing or materially expanding an agent loop, multi-agent workflow, experiment-lineage system, or cross-session graph memory.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Graph engineering
+
+Use this procedure to select the smallest architecture that makes improvement, memory, and evidence explicit.
+Firstmate uses it to brief delegated project work and to evaluate the resulting design rather than taking over project-specific implementation.
+This skill is the single owner of Firstmate's measured loop-to-graph design procedure.
+
+## Declare the inputs
+
+Require these inputs before selecting an architecture.
+
+- State one bounded objective and the acceptance condition that ends the work.
+- Identify mutable surfaces, protected surfaces, permissions, and any decision that still belongs to the captain.
+- Name the current retained artifact or state, its version, and the controlled command or process that evaluates a candidate.
+- Define the primary metric or rubric, its direction, tie or noise treatment, and guardrails for correctness, security, cost, latency, and resource use.
+- Set limits for iterations, retries, tool calls, workers, concurrency, tokens, cost, wall-clock time, and writes as applicable.
+- Define how every candidate is checkpointed, restored, and compared with the retained baseline.
+- Define the trial record, required sources, final evidence, and escalation boundary.
+- Define success, plateau, idea-exhaustion, and budget-exhaustion stopping criteria before the first trial.
+
+Do not authorize an unattended improvement loop when success cannot be checked or candidate changes cannot be reversed safely.
+Use a human-reviewed path until both conditions exist.
+
+## Run one measured ratchet
+
+Start with one loop and keep each trial narrow enough to attribute its result.
+
+1. Inspect the retained artifact, recent trials, current baseline, constraints, and unresolved failures.
+2. Propose one motivated change with a hypothesis, expected metric effect, and observation that would disconfirm it.
+3. Save the candidate as an addressable child of the retained version before evaluation.
+4. Run the bounded evaluator in the declared environment and capture the primary result, every guardrail, resource use, and raw evidence location.
+5. Correct a mechanical execution failure only when the correction does not alter the hypothesis and remains inside the retry budget.
+6. Revert any other failed run and preserve its evidence as a failed trial.
+7. Keep the candidate only when it beats the retained baseline under the declared comparison rule and passes every guardrail.
+8. Restore the retained baseline when the candidate loses, ties without an explicit tie rule, or produces an unreliable comparison.
+9. Append the complete trial record and begin the next trial from the retained state rather than the most recent candidate.
+
+A retained result becomes the next baseline, but a rejected result remains useful evidence.
+Never hide a crash, rejection, or partial result behind a fluent summary.
+
+## Preserve the evidence contract
+
+Each trial must make these facts recoverable without replaying a conversation.
+
+- Record the objective, parent version, candidate version, hypothesis, and exact change.
+- Record the evaluator and rubric version, environment, inputs, command or procedure, and relevant seed or nondeterminism controls.
+- Record baseline and candidate values for the primary measure and every guardrail.
+- Record elapsed time, resource or financial cost, outputs, source links, and the worker or run that produced them.
+- Record whether the candidate was retained, reverted, crashed, or left unresolved, with the comparison reason.
+- Mark every material claim with a source, or label it explicitly as inference or unresolved uncertainty.
+
+Keep artifacts immutable and addressable after they are superseded.
+Return task-specific evidence rather than worker transcripts as the handoff surface.
+
+## Add architecture only for a measured failure
+
+Climb this ladder only when the current rung has exposed the named limitation and the next rung has a measurable exit criterion.
+
+1. Add one tool when a repeated error comes from a missing capability, and give the tool typed inputs, minimum permissions, and result confirmation.
+2. Add a chain when the stages and handoff order are stable.
+3. Add planning only when valid task paths vary, and require explicit dependencies and success conditions before execution.
+4. Add parallel workers only for independent units, after defining isolation, artifact contracts, a reducer, deduplication, concurrency limits, and a final evaluation.
+5. Add a distinct critic or evaluator when its rubric and evidence can catch a demonstrated generator failure rather than merely repeat the generator's opinion.
+6. Add a commit or artifact DAG when alternative lineages, parentage, or discarded experiments must remain traversable.
+7. Add persistent graph memory only when connected facts, provenance, conflicts, or cross-session queries cannot be served adequately by versioned files or relational tables.
+8. Add dynamic swarms only when the workload is safely parallel and measurements show a wall-clock benefit without unacceptable quality or cost loss.
+
+Keep experiment lineage and domain knowledge as separate models even when links connect them.
+Retrieve a bounded, task-relevant subgraph with provenance and conflicts rather than dumping shared memory into every worker's context.
+Use reversible, evidence-backed entity resolution because one false merge can contaminate many later queries.
+Drop back to the simpler rung when the promised exit criterion is not met.
+
+## Stop and return
+
+Stop the loop at the first applicable condition.
+
+- Stop when the acceptance threshold or evaluator approval is reached.
+- Stop when any declared budget is exhausted.
+- Stop at the declared plateau or idea-exhaustion condition.
+- Stop when crashes, evaluator instability, or irreproducible results make comparison unreliable.
+- Stop and escalate before destructive, irreversible, security-sensitive, protected-surface, or contract-expanding action.
+- Stop and escalate when contradictory evidence or unresolved uncertainty can materially change what should be built.
+
+Return the best retained artifact rather than the last candidate.
+Include the stopping reason, trial ledger, consumed budget, discarded but relevant evidence, and unresolved questions.
+
+## Reject these anti-patterns
+
+- Do not optimize activity, worker count, or a single visible metric while ignoring guardrails.
+- Do not combine unrelated changes in one trial when attribution matters.
+- Do not fan out work before defining the reducer and final evaluation.
+- Do not parallelize coupled writes merely because more workers are available.
+- Do not treat conversations as the artifact store, experiment history, or durable world model.
+- Do not introduce a graph merely because agents are involved when files or tables answer the required queries.
+- Do not collapse experiment lineage into the knowledge graph or mistake either graph for verified truth.
+- Do not use an evaluator that shares the same unsupported assumptions, evidence, and prompt as the generator.
+- Do not let retries, branches, graph writes, or stored history grow without declared limits and retention policy.
+
+## Source provenance
+
+This procedure is an original operational synthesis of *Graph Engineering: The Karpathy Loop, Improved 1000x by Itself - The Anthropic Playbook*, an independently compiled July 2026 paper supplied for this task.
+The paper attributes the measured autonomous loop and experiment-DAG direction to Andrej Karpathy's autoresearch and AgentHub work, and it attributes workflow and knowledge-graph patterns to Anthropic materials.
+Consult those primary sources before relying on historical, performance, or product-specific claims because this skill retains only the reusable method.

--- a/.agents/skills/graph-engineering/SKILL.md
+++ b/.agents/skills/graph-engineering/SKILL.md
@@ -24,6 +24,7 @@ Require these inputs before selecting an architecture.
 - Define the primary metric or rubric, its direction, tie or noise treatment, and guardrails for correctness, security, cost, latency, and resource use.
 - Set limits for iterations, retries, tool calls, workers, concurrency, tokens, cost, wall-clock time, and writes as applicable.
 - Define how every candidate is checkpointed, restored, and compared with the retained baseline.
+- Checkpoint at durable boundaries, and make retried or resumed side effects idempotent or protect them with an idempotency key or compensation.
 - Define the trial record, required sources, final evidence, and escalation boundary.
 - Define success, plateau, idea-exhaustion, and budget-exhaustion stopping criteria before the first trial.
 
@@ -63,12 +64,13 @@ Return task-specific evidence rather than worker transcripts as the handoff surf
 
 ## Add architecture only for a measured failure
 
+Distinguish acyclic execution or lineage DAGs, cyclic state graphs, runtime-generated task graphs, and domain knowledge graphs; multi-agent coordination is orthogonal to all four.
 Climb this ladder only when the current rung has exposed the named limitation and the next rung has a measurable exit criterion.
 
 1. Add one tool when a repeated error comes from a missing capability, and give the tool typed inputs, minimum permissions, and result confirmation.
 2. Add a chain when the stages and handoff order are stable.
 3. Add planning only when valid task paths vary, and require explicit dependencies and success conditions before execution.
-4. Add parallel workers only for independent units, after defining isolation, artifact contracts, a reducer, deduplication, concurrency limits, and a final evaluation.
+4. Add parallel workers only after ruling out dependencies through required data, shared mutable resources, exclusive tools, rate limits, or coupled writes and defining isolation, artifact contracts, a reducer, deduplication, concurrency limits, and a final evaluation.
 5. Add a distinct critic or evaluator when its rubric and evidence can catch a demonstrated generator failure rather than merely repeat the generator's opinion.
 6. Add a commit or artifact DAG when alternative lineages, parentage, or discarded experiments must remain traversable.
 7. Add persistent graph memory only when connected facts, provenance, conflicts, or cross-session queries cannot be served adequately by versioned files or relational tables.
@@ -76,6 +78,7 @@ Climb this ladder only when the current rung has exposed the named limitation an
 
 Keep experiment lineage and domain knowledge as separate models even when links connect them.
 Retrieve a bounded, task-relevant subgraph with provenance and conflicts rather than dumping shared memory into every worker's context.
+Keep execution flow separate from context flow: an execution edge does not pass a whole transcript; hand off only the required versioned artifacts and evidence.
 Use reversible, evidence-backed entity resolution because one false merge can contaminate many later queries.
 Drop back to the simpler rung when the promised exit criterion is not met.
 
@@ -107,6 +110,6 @@ Include the stopping reason, trial ledger, consumed budget, discarded but releva
 
 ## Source provenance
 
-This procedure is an original operational synthesis of *Graph Engineering: The Karpathy Loop, Improved 1000x by Itself - The Anthropic Playbook*, an independently compiled July 2026 paper supplied for this task.
+This procedure is an original operational synthesis of an independently compiled July 2026 *Graph Engineering* paper supplied for this task.
 The paper attributes the measured autonomous loop and experiment-DAG direction to Andrej Karpathy's autoresearch and AgentHub work, and it attributes workflow and knowledge-graph patterns to Anthropic materials.
 Consult those primary sources before relying on historical, performance, or product-specific claims because this skill retains only the reusable method.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,6 +478,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
+- `graph-engineering` - load before proposing or materially expanding an agent loop, multi-agent workflow, experiment-lineage system, or cross-session graph memory.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -148,6 +148,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/graph-engineering/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/harness-adapters/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

Create a concise reusable internal Firstmate skill from the user-supplied Graph Engineering PDF, with a precise agent-only trigger before proposing or materially expanding agent loops, multi-agent workflows, experiment lineage, or cross-session graph memory. The skill must be an original operational workflow defining inputs, a measured retain-or-revert loop, stopping criteria, evidence expectations, and failure guidance without substantial copyrighted reproduction, scripts, dependencies, assets, parallel documentation, or speculative architecture. Preserve concise provenance and the minimal AGENTS.md trigger plus required documentation inventory. Incorporate only the bounded scout-backed revision: distinguish graph forms while keeping multi-agent coordination orthogonal, test parallel independence against shared resources and limits, require replay-safe durable checkpoints and side effects, separate execution from context flow, and remove unsupported marketing-scale claims without bloating the skill. Validate the branch and open a review-ready PR; do not merge it.

## What Changed
- Adds an internal `graph-engineering` agent skill for evaluating when bounded agent loops, multi-agent workflows, experiment lineage, or graph memory are justified.
- Defines the skill workflow around explicit inputs, measured retain-or-revert trials, stopping criteria, evidence expectations, failure guidance, and replay-safe durable side effects.
- Registers the skill in `AGENTS.md` and updates the documentation audience inventory for the new agent-only guidance.

## Risk Assessment

✅ Low: The branch is limited to an internal agent skill plus the minimal AGENTS.md trigger and documentation-audience inventory entry, and I did not find source-verifiable intent contradictions or material regressions.

## Testing

Exercised the focused documentation-audience regression test, directly checked the inventory/link validator, verified the agent-facing trigger and required workflow content in the new skill, confirmed the skill ships as a single markdown file without extra payloads, and recorded evidence under `/tmp/no-mistakes-evidence/01KYD2HE0GE6E7KX96HNQQ0DYB`; local validation passed, but the required open PR is missing.

<details>
<summary>Evidence: Graph engineering skill validation evidence</summary>

```text
# Graph Engineering Skill Validation Evidence

## Repository state

`` `text
HEAD: c15e1dfc257298d3f8f6901a47054752a173a21e
merge-base-with-supplied-base: 3f71cddd764a49ab71bcd53a46b84e5e7336557a
changed-files:
.agents/skills/graph-engineering/SKILL.md
AGENTS.md
docs/documentation-audiences.json
`` `

## Documentation inventory check

`` `text
fm-doc-audience-check: ok surfaces=56 local_links=145
`` `

## Agent-facing trigger and inventory lines

`` `text
.agents/skills/graph-engineering/SKILL.md:2:name: graph-engineering
.agents/skills/graph-engineering/SKILL.md:5:  Load before proposing or materially expanding an agent loop, multi-agent workflow, experiment-lineage system, or cross-session graph memory.
.agents/skills/graph-engineering/SKILL.md:6:user-invocable: false
.agents/skills/graph-engineering/SKILL.md:8:  internal: true
AGENTS.md:481:- `graph-engineering` - load before proposing or materially expanding an agent loop, multi-agent workflow, experiment-lineage system, or cross-session graph memory.
docs/documentation-audiences.json:151:      "path": ".agents/skills/graph-engineering/SKILL.md",
`` `

## Required workflow content line evidence

`` `text
17:## Declare the inputs
21:- State one bounded objective and the acceptance condition that ends the work.
24:- Define the primary metric or rubric, its direction, tie or noise treatment, and guardrails for correctness, security, cost, latency, and resource use.
25:- Set limits for iterations, retries, tool calls, workers, concurrency, tokens, cost, wall-clock time, and writes as applicable.
26:- Define how every candidate is checkpointed, restored, and compared with the retained baseline.
27:- Checkpoint at durable boundaries, and make retried or resumed side effects idempotent or protect them with an idempotency key or compensation.
28:- Define the trial record, required sources, final evidence, and escalation boundary.
29:- Define success, plateau, idea-exhaustion, and budget-exhaustion stopping criteria before the first trial.
34:## Run one measured ratchet
44:7. Keep the candidate only when it beats the retained baseline under the declared comparison rule and passes every guardrail.
45:8. Restore the retained baseline when the candidate loses, ties without an explicit tie rule, or produces an unreliable comparison.
46:9. Append the complete trial record and begin the next trial from the retained state rather than the most recent candidate.
51:## Preserve the evidence contract
65:## Add architecture only for a measured failure
67:Distinguish acyclic execution or lineage DAGs, cyclic state graphs, runtime-generated task graphs, and domain knowledge graphs; multi-agent coordination is orthogonal to all four.
73:4. Add parallel workers only after ruling out dependencies through required data, shared mutable resources, exclusive tools, rate limits, or coupled writes and defining isolation, artifact contracts, a reducer, deduplication, concurrency limits, and a final evaluation.
81:Keep execution flow separate from context flow: an execution edge does not pass a whole transcript; hand off only the required versioned artifacts and evidence.
85:## Stop and return
99:## Reject these anti-patterns
101:- Do not optimize activity, worker count, or a single visible metric while ignoring guardrails.
104:- Do not parallelize coupled writes merely because more workers are available.
111:## Source provenance
113:This procedure is an original operational synthesis of an independently compiled July 2026 *Graph Engineering* paper supplied for this task.
`` `

## Extra payload check

`` `text
.agents/skills/graph-engineering/SKILL.md
115 .agents/skills/graph-engineering/SKILL.md
1266 .agents/skills/graph-engineering/SKILL.md
`` `

## Open PR check

`` `text
count: 0
pull_requests: []
help[2]:
  Run `gh-axi pr create --title "..." --body-file <path>` to create a PR
  Run `gh-axi pr list --state closed` to see closed PRs
`` `
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (2m6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ The supplied intent requires the branch to have an open review-ready PR and not be merged, but `gh-axi pr list --head fm/graph-engineering-skill --state open` returned `count: 0`. Local validation evidence is available, but the PR-readiness part of the acceptance criteria is not satisfied until a PR is opened.
- `tests/fm-documentation-audiences.test.sh`
- `bin/fm-doc-audience-check.sh`
- `rg -n 'graph-engineering|Load before proposing|user-invocable: false|internal: true' AGENTS.md docs/documentation-audiences.json .agents/skills/graph-engineering/SKILL.md`
- `rg -n 'Declare the inputs|Run one measured ratchet|Preserve the evidence contract|Add architecture only for a measured failure|Stop and return|Reject these anti-patterns|bounded objective|acceptance condition|guardrails|workers, concurrency|checkpointed|idempotent|stopping criteria|Keep the candidate|Restore the retained baseline|trial record|acyclic execution|cyclic state graphs|runtime-generated task graphs|domain knowledge graphs|multi-agent coordination is orthogonal|shared mutable resources|rate limits|coupled writes|execution flow separate from context flow|Source provenance|original operational synthesis' .agents/skills/graph-engineering/SKILL.md`
- `find .agents/skills/graph-engineering -maxdepth 2 -type f -print | sort`
- `gh-axi pr list --head fm/graph-engineering-skill --state open`

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ The branch intent requires a review-ready PR, but `gh-axi pr list --head fm/graph-engineering-skill --state open` returned no open pull request. This is outside the documentation-only edit scope of this audit.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
