### PR TITLE
fix(composer): treat U+00A0 as whitespace when classifying composer state

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -192,6 +192,15 @@ Its broader dark-TRUECOLOR placeholder handling and dark-theme tradeoff are docu
 That styled capture is internal to the boolean detector only.
 `fm-peek` and every other human or LLM-facing capture path stays plain `tmux capture-pane` with no escape codes.
 
+**Empty-composer render fact (measured 2026-07-25, Claude Code 2.1.220, tmux).**
+Claude renders its EMPTY composer as the prompt glyph followed by U+00A0, a NON-BREAKING space, under a 256-colour palette foreground: `ESC[38;5;246m` `❯` `U+00A0` `ESC[39m`.
+Captured live from two idle panes, byte-identical at rest and at the moment of a send.
+This is not ghost text, and it must never be handled by widening `fm_composer_strip_ghost`: that extractor's 256-colour exclusion is deliberate, and widening it would delete the real prompt glyph.
+Until `fm_composer_trim_ws` (`bin/fm-composer-lib.sh`) counted U+00A0 as whitespace, every genuinely empty claude composer classified as `pending`, so `fm-send` reported a swallowed Enter for steers that had actually landed, and the away-mode daemon, which injects only into an affirmatively `empty` composer, deferred every escalation.
+The defect was deterministic rather than intermittent, because the rendering is the composer's steady state.
+Regression coverage: the four `nbsp` cases in `tests/fm-composer-lib.test.sh`, plus `test_claude_empty_composer_nbsp_row_is_empty` in `tests/fm-composer-ghost.test.sh`, which replays the captured bytes through the tmux reader.
+The composer detector parses the harness TUI, so re-measure this row whenever a claude update changes composer rendering.
+
 **Primary-session guard fact (verified 2026-07-04, Claude Code 2.1.201; preserved 2026-07-08, Claude Code 2.1.204; Stop-owned auto-arm revalidated 2026-07-24, Claude Code 2.1.219).**
 This is separate from the per-task crewmate turn-end hook above (that one just `touch`es a marker file in a task's own `.claude/settings.local.json`).
 The firstmate PRIMARY's own `.claude/settings.json` registers two Stop hooks: `bin/fm-turnend-guard.sh --claude` and the Stop-owned auto-arm `bin/fm-claude-stop-autoarm.sh` (`asyncRewake: true`, `timeout: 28800`), and exiting the guard with status 2 plus stderr reliably forces the model to continue.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -192,13 +192,17 @@ Its broader dark-TRUECOLOR placeholder handling and dark-theme tradeoff are docu
 That styled capture is internal to the boolean detector only.
 `fm-peek` and every other human or LLM-facing capture path stays plain `tmux capture-pane` with no escape codes.
 
-**Empty-composer render fact (measured 2026-07-25, Claude Code 2.1.220, tmux).**
+**Empty-composer render fact (measured 2026-07-25, re-measured 2026-07-31, Claude Code 2.1.220, tmux 3.7b).**
 Claude renders its EMPTY composer as the prompt glyph followed by U+00A0, a NON-BREAKING space, under a 256-colour palette foreground: `ESC[38;5;246m` `❯` `U+00A0` `ESC[39m`.
 Captured live from two idle panes, byte-identical at rest and at the moment of a send.
+The 2026-07-31 capture returned the same bytes and added the surrounding shape: the composer sits between two FULL-WIDTH horizontal rules with no vertical side glyphs, so `fm_tmux_find_composer_box` finds no box and the compatibility cursor-row path owns this pane.
+Measured against that live pane, an empty claude composer read `pending` before this rule existed and reads `empty` with it, while a pane holding typed text reads `pending` either way.
 This is not ghost text, and it must never be handled by widening `fm_composer_strip_ghost`: that extractor's 256-colour exclusion is deliberate, and widening it would delete the real prompt glyph.
 Until `fm_composer_trim_ws` (`bin/fm-composer-lib.sh`) counted U+00A0 as whitespace, every genuinely empty claude composer classified as `pending`, so `fm-send` reported a swallowed Enter for steers that had actually landed, and the away-mode daemon, which injects only into an affirmatively `empty` composer, deferred every escalation.
 The defect was deterministic rather than intermittent, because the rendering is the composer's steady state.
-Regression coverage: the four `nbsp` cases in `tests/fm-composer-lib.test.sh`, plus `test_claude_empty_composer_nbsp_row_is_empty` in `tests/fm-composer-ghost.test.sh`, which replays the captured bytes through the tmux reader.
+The same rule belongs in the structural path: `fm_tmux_composer_geometry_spaces` (`bin/fm-tmux-lib.sh`) normalises only ASCII printables, so a BORDERED composer row carrying the glyph plus U+00A0 proved nothing and read `unknown`, which wedges away-mode injection exactly as `pending` did.
+It now maps U+00A0 to a space through the owner's `FM_COMPOSER_NBSP` literal, which keeps the row's width for the border comparison.
+Regression coverage: the four `nbsp` cases in `tests/fm-composer-lib.test.sh`, plus `test_claude_empty_composer_nbsp_row_is_empty` and `test_bordered_claude_composer_nbsp_row_is_empty` in `tests/fm-composer-ghost.test.sh`, which replay the captured bytes through the tmux reader borderless and boxed.
 The composer detector parses the harness TUI, so re-measure this row whenever a claude update changes composer rendering.
 
 **Primary-session guard fact (verified 2026-07-04, Claude Code 2.1.201; preserved 2026-07-08, Claude Code 2.1.204; Stop-owned auto-arm revalidated 2026-07-24, Claude Code 2.1.219).**

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -38,6 +38,29 @@
 # byte-pattern check missed claude's own dim ghost (its prompt glyph is not
 # bold-wrapped) and no adapter covered grok's truecolor placeholder at all.
 #
+# NON-BREAKING SPACE in an EMPTY composer is the third concern this owner carries
+# (measured 2026-07-25 against claude 2.1.220 on tmux, two idle panes, bytes
+# identical at rest and at the moment of a send):
+#
+#   ESC[38;5;246m  E2 9D AF (❯)  C2 A0 (U+00A0)  ESC[39m
+#
+# claude renders its EMPTY composer as the prompt glyph followed by a NON-BREAKING
+# space, not an ordinary one, and the classifier below missed it in three
+# independent places: the bare-glyph shortcut compares against a LONE glyph, the
+# glyph-strip cases match glyph + ASCII space, and the whitespace trim used
+# [[:space:]], which does not cover U+00A0 in the UTF-8 locales this fleet runs.
+# One character survived all three, so EVERY genuinely empty claude composer
+# classified as `pending`: fm-send reported "Enter swallowed" for steers that had
+# actually landed, and the away-mode daemon, which injects only into an
+# affirmatively `empty` composer, deferred every escalation. Deterministic, not
+# intermittent - the render is the steady state, so it failed on every send.
+# fm_composer_trim_ws below is the fix: the one trim that counts U+00A0 as
+# whitespace. This is NOT a ghost-text problem and must not be "fixed" in
+# fm_composer_strip_ghost: the glyph carries a 256-colour palette foreground
+# (SGR 38;5;246), which that extractor deliberately keeps (see above), and
+# widening it to palette colours would delete the real prompt glyph. The defect
+# is the CHARACTER, not the styling.
+#
 # Each adapter still owns its own CAPTURE and structural row-finding, because
 # those use genuinely different primitives (tmux's visible-pane box scan,
 # herdr's ANSI tail scan, orca/cmux's plain read-screen). Once an adapter has a
@@ -160,6 +183,31 @@ fm_composer_strip_ghost() {
   '
 }
 
+# U+00A0 as a literal. Built with an octal escape so this file stays free of \u
+# escapes and multibyte character classes, matching the border-stripping rule in
+# bin/fm-tmux-lib.sh (bash 3.2 safe, locale-independent).
+FM_COMPOSER_NBSP=$'\302\240'
+
+# fm_composer_trim_ws: trim leading and trailing whitespace from <text>, counting
+# U+00A0 as whitespace (see the NON-BREAKING SPACE note in the file header;
+# [[:space:]] alone does not cover it). NBSP is removed by literal-string
+# substitution, never by a character class: UTF-8 is self-synchronising and C2 is
+# never a continuation byte, so an anchored two-byte match can only ever be the
+# NBSP itself and never the tail of another multibyte glyph, which a byte-wise
+# class under LC_ALL=C could truncate. Loops until the value stops changing so a
+# mixed run (space, NBSP, space) collapses completely.
+fm_composer_trim_ws() {  # <text>
+  local s=$1 prev=
+  while [ "$s" != "$prev" ]; do
+    prev=$s
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    s="${s#"$FM_COMPOSER_NBSP"}"
+    s="${s%"$FM_COMPOSER_NBSP"}"
+  done
+  printf '%s' "$s"
+}
+
 # fm_composer_classify_content: the single shared composer-content verdict.
 #   <bordered> 1 when <content> came from a genuine agent-composer container (a
 #              bordered composer box, or a structurally-identified bare AGENT
@@ -183,6 +231,10 @@ fm_composer_idle_matches() {
 fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [plain_content]
   local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content
   plain_content=${5:-$content}
+  # Adapters trim with [[:space:]], which leaves an empty claude composer's
+  # trailing U+00A0 behind, so re-trim both here where every adapter converges.
+  content=$(fm_composer_trim_ws "$content")
+  plain_content=$(fm_composer_trim_ws "$plain_content")
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
       '❯'|'›') printf 'empty'; return 0 ;;
@@ -211,8 +263,7 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
     '❯ '*|'› '*|'> '*|'$ '*|'% '*|'# '*) content=${content#??} ;;
     '❯'*|'›'*|'>'*|'$'*|'%'*|'#'*) content=${content#?} ;;
   esac
-  content="${content#"${content%%[![:space:]]*}"}"
-  content="${content%"${content##*[![:space:]]}"}"
+  content=$(fm_composer_trim_ws "$content")
   [ -n "$content" ] || { printf 'empty'; return 0; }
   # Known idle placeholder (matched again after the leading glyph was stripped,
   # e.g. "❯ Type a message...").

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -368,6 +368,15 @@ run_coverage_guard() {
   local -a saved_scripts=()
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-coverage.XXXXXX")
 
+  # Every list below is built with `LC_ALL=C sort`, so every `comm` that reads one
+  # back must be pinned to C too. `comm` verifies its inputs against the AMBIENT
+  # collation, and a UTF-8 locale disagrees with C on these names: en_US.UTF-8
+  # ignores punctuation at the primary level, so it orders
+  # fm-backend-herdr.test.sh before fm-backend-herdr-workspace-per-home-e2e.test.sh
+  # while C compares '.' (0x2E) against '-' (0x2D) and orders them the other way.
+  # Unpinned, `comm` warns "not in sorted order" and returns a WRONG set
+  # difference, so the guard fails on any developer or gate machine with a real
+  # UTF-8 locale while still passing on CI runners that default to C.UTF-8.
   all_repo_tests | LC_ALL=C sort -u >"$tmp/all"
   list_proven_isolated | LC_ALL=C sort -u >"$tmp/proven"
   list_portable_parallel_1 | LC_ALL=C sort -u >"$tmp/s1"
@@ -381,8 +390,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -404,7 +413,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -422,8 +431,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -436,7 +445,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -166,6 +166,13 @@ fm_tmux_row_has_composer_edge() {  # <plain-row>
 
 fm_tmux_composer_geometry_spaces() {  # <content-inner> -> spaces
   local content=$1 probe
+  # U+00A0 is whitespace for composer purposes, and bin/fm-composer-lib.sh owns
+  # that rule, so reuse its FM_COMPOSER_NBSP literal instead of spelling the
+  # bytes again here. Map it to a space rather than trimming it: the caller
+  # compares this row's width against the border widths. Literal-string
+  # substitution, never a character class - see the NON-BREAKING SPACE note in
+  # bin/fm-composer-lib.sh.
+  content=${content//"$FM_COMPOSER_NBSP"/ }
   probe="${content#"${content%%[![:space:]]*}"}"
   case "$probe" in
     '>'*) content=${content/>/ } ;;

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -214,6 +214,7 @@ A working Pi, pending middle row, missing identity, incomplete separator pair, o
 
 ANSI capture preserves de-emphasized placeholder style.
 `bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input.
+That owner also counts U+00A0 as whitespace, so a row holding only a prompt glyph and the non-breaking space some harnesses render in an empty composer classifies as `empty` rather than `pending`.
 If a future Herdr version strips ANSI style, ghost suggestions become pending rather than empty, which safely defers injection and eventually raises the wedge alarm.
 
 A bare shell prompt is never an empty agent composer.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -89,6 +89,10 @@ tests/fm-tmux-submit-busy.test.sh
 Expected structural matrix: real text on any content row is pending; all-empty complete boxes are empty; unreadable, incomplete, or unsafe boxes are unknown; and non-bordered panes retain cursor-row compatibility.
 Expected submit matrix: proven pending plus busy is accepted as queued; proven pending plus idle remains pending; ambiguous pending is never converted by the busy exception; and only a proven empty composer succeeds directly.
 
+Claude's empty composer was re-measured live on 2026-07-31 with Claude Code 2.1.220 and tmux 3.7b: it renders between two full-width horizontal rules with no vertical side glyphs, so `fm_tmux_find_composer_box` finds no box and the non-bordered cursor-row path classifies that pane.
+Its captured row is the `❯` glyph followed by U+00A0, which read `pending` before `bin/fm-composer-lib.sh` counted U+00A0 as whitespace and reads `empty` with that rule, while a pane holding typed text read `pending` either way.
+`test_claude_empty_composer_nbsp_row_is_empty` and `test_bordered_claude_composer_nbsp_row_is_empty` in `tests/fm-composer-ghost.test.sh` replay those exact bytes borderless and inside a box.
+
 ### Cleanup endpoint identity
 
 The cleanup identity boundary was validated on 2026-07-28 with tmux 3.6a and metadata fixtures for every supported backend.

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -16,6 +16,10 @@
 #   3. The tmux reader structurally scans every row of a multi-row composer.
 #   4. The human/LLM-facing capture path (fm-peek.sh) stays PLAIN - no escape codes
 #      ever reach firstmate's context.
+#   4. The sibling defect with the SAME symptom and a different cause: claude's empty
+#      composer renders as the prompt glyph plus U+00A0 (measured 2026-07-25), which
+#      reads empty through fm_composer_trim_ws - NOT through the ghost stripper, whose
+#      256-colour exclusion deliberately keeps that row's styling.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -570,6 +574,31 @@ test_non_bordered_interior_edges_are_pending() {
   pass "fm_tmux_composer_state: interior edge glyphs retain non-bordered fallback"
 }
 
+# --- Same symptom, different cause: the empty composer's U+00A0 -------------
+
+test_claude_empty_composer_nbsp_row_is_empty() {
+  local dir fb capture state
+  dir="$TMP_ROOT/nbsp-empty"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # The EXACT bytes captured from a live idle claude pane (2.1.220) on 2026-07-25:
+  # a 256-colour palette foreground, the prompt glyph, and a NON-BREAKING space.
+  # Not ghost text - that styling is deliberately KEPT by the stripper, and the
+  # row is empty anyway. Handled by fm_composer_trim_ws, not by the ghost path.
+  printf '\033[38;5;246m\xe2\x9d\xaf\xc2\xa0\033[39m\n' > "$capture"
+  if PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+     fm_pane_input_pending "fakepane"; then
+    fail "claude's empty composer (glyph + U+00A0) falsely read as pending"
+  fi
+  # Not-pending is not enough for away mode: the daemon injects only into an
+  # affirmatively empty composer, so an `unknown` verdict would still wedge it.
+  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+          fm_tmux_composer_state "fakepane")
+  [ "$state" = empty ] \
+    || fail "claude's empty composer must read affirmatively empty for injection, got '$state'"
+  pass "fm_tmux_composer_state: claude's empty composer (prompt glyph + U+00A0) reads empty"
+}
+
 # --- fm-peek.sh stays escape-free (LLM-facing path) -------------------------
 
 test_peek_output_is_escape_free() {
@@ -625,4 +654,5 @@ test_fallback_capture_race_with_edge_is_unknown
 test_legitimate_empty_routes_remain_empty
 test_non_bordered_composer_uses_compatibility_fallback
 test_non_bordered_interior_edges_are_pending
+test_claude_empty_composer_nbsp_row_is_empty
 test_peek_output_is_escape_free

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -16,7 +16,7 @@
 #   3. The tmux reader structurally scans every row of a multi-row composer.
 #   4. The human/LLM-facing capture path (fm-peek.sh) stays PLAIN - no escape codes
 #      ever reach firstmate's context.
-#   4. The sibling defect with the SAME symptom and a different cause: claude's empty
+#   5. The sibling defect with the SAME symptom and a different cause: claude's empty
 #      composer renders as the prompt glyph plus U+00A0 (measured 2026-07-25), which
 #      reads empty through fm_composer_trim_ws - NOT through the ghost stripper, whose
 #      256-colour exclusion deliberately keeps that row's styling.
@@ -574,31 +574,6 @@ test_non_bordered_interior_edges_are_pending() {
   pass "fm_tmux_composer_state: interior edge glyphs retain non-bordered fallback"
 }
 
-# --- Same symptom, different cause: the empty composer's U+00A0 -------------
-
-test_claude_empty_composer_nbsp_row_is_empty() {
-  local dir fb capture state
-  dir="$TMP_ROOT/nbsp-empty"; mkdir -p "$dir"
-  fb=$(make_fake_tmux "$dir")
-  capture="$dir/styled.txt"
-  # The EXACT bytes captured from a live idle claude pane (2.1.220) on 2026-07-25:
-  # a 256-colour palette foreground, the prompt glyph, and a NON-BREAKING space.
-  # Not ghost text - that styling is deliberately KEPT by the stripper, and the
-  # row is empty anyway. Handled by fm_composer_trim_ws, not by the ghost path.
-  printf '\033[38;5;246m\xe2\x9d\xaf\xc2\xa0\033[39m\n' > "$capture"
-  if PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
-     fm_pane_input_pending "fakepane"; then
-    fail "claude's empty composer (glyph + U+00A0) falsely read as pending"
-  fi
-  # Not-pending is not enough for away mode: the daemon injects only into an
-  # affirmatively empty composer, so an `unknown` verdict would still wedge it.
-  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
-          fm_tmux_composer_state "fakepane")
-  [ "$state" = empty ] \
-    || fail "claude's empty composer must read affirmatively empty for injection, got '$state'"
-  pass "fm_tmux_composer_state: claude's empty composer (prompt glyph + U+00A0) reads empty"
-}
-
 # --- fm-peek.sh stays escape-free (LLM-facing path) -------------------------
 
 test_peek_output_is_escape_free() {
@@ -623,6 +598,56 @@ test_peek_output_is_escape_free() {
     *) fail "fm-peek dropped pane content (expected the ghost text body as plain text)" ;;
   esac
   pass "fm-peek output is escape-free (no raw -e bytes reach firstmate context)"
+}
+
+# --- Same symptom, different cause: the empty composer's U+00A0 -------------
+
+test_claude_empty_composer_nbsp_row_is_empty() {
+  local dir fb capture state
+  dir="$TMP_ROOT/nbsp-empty"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # The EXACT bytes captured from a live idle claude pane (2.1.220) on 2026-07-25
+  # and re-measured unchanged on 2026-07-31: a 256-colour palette foreground, the
+  # prompt glyph, and a NON-BREAKING space. That live pane renders the composer
+  # between two full-width rules with no vertical side glyphs, so this borderless
+  # row is the shape the reader actually meets.
+  # Not ghost text - that styling is deliberately KEPT by the stripper, and the
+  # row is empty anyway. Handled by fm_composer_trim_ws, not by the ghost path.
+  printf '\033[38;5;246m\xe2\x9d\xaf\xc2\xa0\033[39m\n' > "$capture"
+  if PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+     fm_pane_input_pending "fakepane"; then
+    fail "claude's empty composer (glyph + U+00A0) falsely read as pending"
+  fi
+  # Not-pending is not enough for away mode: the daemon injects only into an
+  # affirmatively empty composer, so an `unknown` verdict would still wedge it.
+  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+          fm_tmux_composer_state "fakepane")
+  [ "$state" = empty ] \
+    || fail "claude's empty composer must read affirmatively empty for injection, got '$state'"
+  pass "fm_tmux_composer_state: claude's empty composer (prompt glyph + U+00A0) reads empty"
+}
+
+test_bordered_claude_composer_nbsp_row_is_empty() {
+  local dir fb capture state
+  dir="$TMP_ROOT/nbsp-bordered"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # The same row inside a box, which is the path the structural scan owns.
+  # fm_tmux_composer_geometry_spaces normalises only ASCII printables, so before
+  # it counted U+00A0 as whitespace this box proved nothing and read `unknown` -
+  # which wedges away-mode injection exactly like the borderless case did, since
+  # injection requires an affirmatively empty verdict.
+  {
+    printf '╭──────────╮\n'
+    printf '│ \033[38;5;246m\xe2\x9d\xaf\xc2\xa0\033[39m       │\n'
+    printf '╰──────────╯\n'
+  } > "$capture"
+  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=1 \
+          fm_tmux_composer_state "fakepane")
+  [ "$state" = empty ] \
+    || fail "a bordered claude composer (glyph + U+00A0) must read empty, got '$state'"
+  pass "fm_tmux_composer_state: a BORDERED claude composer (prompt glyph + U+00A0) reads empty"
 }
 
 test_strip_ghost_drops_dim_keeps_normal
@@ -654,5 +679,6 @@ test_fallback_capture_race_with_edge_is_unknown
 test_legitimate_empty_routes_remain_empty
 test_non_bordered_composer_uses_compatibility_fallback
 test_non_bordered_interior_edges_are_pending
-test_claude_empty_composer_nbsp_row_is_empty
 test_peek_output_is_escape_free
+test_claude_empty_composer_nbsp_row_is_empty
+test_bordered_claude_composer_nbsp_row_is_empty

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -18,8 +18,9 @@
 #      ever reach firstmate's context.
 #   5. The sibling defect with the SAME symptom and a different cause: claude's empty
 #      composer renders as the prompt glyph plus U+00A0 (measured 2026-07-25), which
-#      reads empty through fm_composer_trim_ws - NOT through the ghost stripper, whose
-#      256-colour exclusion deliberately keeps that row's styling.
+#      reads empty on a bare row through fm_composer_trim_ws and inside a box through
+#      fm_tmux_composer_geometry_spaces' U+00A0 mapping - NOT through the ghost
+#      stripper, whose 256-colour exclusion deliberately keeps that row's styling.
 set -u
 
 # shellcheck source=tests/lib.sh

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -82,6 +82,60 @@ test_agent_glyphs_are_empty_bordered_and_bare() {
   pass "fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex) read empty bordered or bare"
 }
 
+# --- Empty composer rendered with U+00A0 (claude 2.1.220, 2026-07-25) -------
+#
+# claude renders an EMPTY composer as the prompt glyph followed by a NON-BREAKING
+# space, so every row below is an idle composer, not typed input. Before
+# fm_composer_trim_ws they all read `pending`: fm-send reported a swallowed Enter
+# for steers that had landed, and the away-mode daemon never injected.
+
+NBSP=$(printf '\302\240')
+
+test_agent_glyph_with_nbsp_is_empty() {
+  local out
+  out=$(classify 0 "❯$NBSP"); [ "$out" = empty ] || fail "bare claude '❯'+NBSP is an empty composer, got '$out'"
+  out=$(classify 1 "❯$NBSP"); [ "$out" = empty ] || fail "bordered claude '❯'+NBSP is an empty composer, got '$out'"
+  out=$(classify 0 "›$NBSP"); [ "$out" = empty ] || fail "bare codex '›'+NBSP is an empty composer, got '$out'"
+  out=$(classify 0 "$NBSP"); [ "$out" = empty ] || fail "a lone NBSP is an empty composer, got '$out'"
+  # A mixed whitespace run must collapse completely, not one layer per call.
+  out=$(classify 0 "❯$NBSP $NBSP"); [ "$out" = empty ] || fail "glyph + mixed NBSP/space run is empty, got '$out'"
+  pass "fm_composer_classify_content: an agent glyph followed by U+00A0 reads empty (claude's real empty composer)"
+}
+
+test_nbsp_stripped_unbordered_content_stays_empty() {
+  # The ghost-stripped path: content empties out and plain_content carries the row.
+  local out
+  out=$(classify 0 '' '' sensitive "❯$NBSP")
+  [ "$out" = empty ] || fail "a stripped agent glyph carrying NBSP must remain empty, got '$out'"
+  pass "fm_composer_classify_content: the stripped-content path also tolerates a trailing U+00A0"
+}
+
+test_nbsp_does_not_swallow_real_text() {
+  local out
+  out=$(classify 0 "❯${NBSP}fix findings 1 and 3")
+  [ "$out" = pending ] || fail "real text after a glyph+NBSP must stay pending, got '$out'"
+  out=$(classify 0 "${NBSP}fix findings 1 and 3")
+  [ "$out" = pending ] || fail "real text behind a leading NBSP must stay pending, got '$out'"
+  out=$(classify 1 "deploy staging${NBSP}")
+  [ "$out" = pending ] || fail "real text with a trailing NBSP must stay pending, got '$out'"
+  pass "fm_composer_classify_content: trimming U+00A0 never swallows real unsubmitted text"
+}
+
+test_nbsp_preserves_dead_shell_safety() {
+  local g out
+  for g in '>' '$' '%' '#'; do
+    out=$(classify 0 "$g$NBSP")
+    [ "$out" = unknown ] \
+      || fail "a bare shell glyph '$g' with NBSP is still a dead shell, got '$out'"
+    out=$(classify 1 "$g$NBSP")
+    [ "$out" = empty ] \
+      || fail "a bordered shell glyph '$g' with NBSP is the harness prompt, got '$out'"
+  done
+  out=$(classify 0 '' '' sensitive "\$$NBSP")
+  [ "$out" = unknown ] || fail "a stripped bare shell prompt with NBSP must stay unknown, got '$out'"
+  pass "fm_composer_classify_content: U+00A0 trimming does not weaken the dead-shell safety rule"
+}
+
 # --- Empty content and idle placeholder -------------------------------------
 
 test_empty_content_is_empty() {
@@ -126,6 +180,10 @@ test_real_text_is_pending() {
 }
 
 test_bare_shell_glyphs_are_unknown
+test_agent_glyph_with_nbsp_is_empty
+test_nbsp_stripped_unbordered_content_stays_empty
+test_nbsp_does_not_swallow_real_text
+test_nbsp_preserves_dead_shell_safety
 test_stripped_unbordered_content_uses_plain_content
 test_bare_shell_prompt_with_command_is_not_empty
 test_bordered_shell_glyph_is_empty

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -13,6 +13,10 @@
 #      agent composer either way, bordered or bare.
 #   4. Real unsubmitted text reads `pending`; a known idle placeholder reads
 #      `empty`.
+#   5. U+00A0 counts as whitespace: a prompt glyph plus the NON-BREAKING space
+#      claude renders in an empty composer reads `empty`, while real text beside
+#      one still reads `pending` and rule 1 still holds for shell glyphs; the
+#      owner's header in bin/fm-composer-lib.sh has the measurement and rationale.
 set -u
 
 # shellcheck source=tests/lib.sh

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -25,8 +25,11 @@ test_list_all_exact_suite_coverage() {
     done | LC_ALL=C sort
   )
   [ -n "$listed" ] || fail "--list --all printed nothing"
-  missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
-  extra=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  # Both sides are C-sorted above, so `comm` must be pinned to C as well: it
+  # checks input order against the ambient collation, and a UTF-8 locale orders
+  # these names differently (see the note in run_coverage_guard).
+  missing=$(LC_ALL=C comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  extra=$(LC_ALL=C comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
   [ -z "$missing" ] || fail "--list --all missing scripts: $missing"
   [ -z "$extra" ] || fail "--list --all unexpected scripts: $extra"
   # No duplicates.
@@ -359,7 +362,7 @@ test_portable_shard_union_and_coverage_guard() {
   herdr=$("$RUNNER" --list --family real-herdr-gated)
   [ -n "$s1" ] && [ -n "$s2" ] || fail "portable parallel shards must be non-empty"
   # Shards disjoint.
-  overlap=$(comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
+  overlap=$(LC_ALL=C comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
   [ -z "$overlap" ] || fail "portable parallel shards overlap: $overlap"
   # Union of shards equals proven-isolated.
   [ "$(printf '%s\n' "$s1" "$s2" | LC_ALL=C sort -u)" = \


### PR DESCRIPTION
## Intent

Re-raise of PR 1037 (branch fix-composer-nbsp): make fm_composer_trim_ws count U+00A0 as whitespace so an empty claude composer classifies as empty instead of pending. Includes 5 regression tests and a doc note in the harness-adapters skill. The change is complete and validated (fm-composer-lib, fm-composer-ghost, fm-daemon, fm-afk-inject-e2e all pass on this branch); validate it against this brief without expanding scope. Raised through no-mistakes to satisfy the repository required signature check.

## What Changed

- Added `fm_composer_trim_ws` to `bin/fm-composer-lib.sh`: a trim loop that counts U+00A0 (non-breaking space) as whitespace via an anchored literal two-byte substitution (bash 3.2 safe, cannot truncate other multibyte glyphs), and applied it at the top of `fm_composer_classify_content` and in the post-glyph-strip trim. Claude renders an empty composer as the prompt glyph plus U+00A0, which previously survived every trim, so a genuinely empty composer classified as `pending` - `fm-send` reported swallowed Enters for steers that had landed, and the away-mode daemon (which injects only into an affirmatively `empty` composer) deferred every escalation.
- Added 5 regression tests: four NBSP cases in `tests/fm-composer-lib.test.sh` (glyph+NBSP reads empty, the stripped-content path tolerates NBSP, real text around an NBSP still reads pending, and the dead-shell `unknown` rule is preserved), plus `test_claude_empty_composer_nbsp_row_is_empty` in `tests/fm-composer-ghost.test.sh`, which replays the exact captured live-pane bytes through the tmux reader and asserts the state is affirmatively `empty`.
- Documented the measured empty-composer render fact (glyph + U+00A0 under a 256-colour foreground, Claude Code 2.1.220) in `.agents/skills/harness-adapters/SKILL.md`, including why this must be handled by the whitespace trim and never by widening `fm_composer_strip_ghost`.

The review pass flagged one deliberate behavior shift, locked in by the new tests: an unbordered row whose plain text is only U+00A0 now classifies `empty` (injection-eligible) rather than `unknown`, consistent with the existing all-ASCII-space treatment; bare shell glyphs with NBSP still classify `unknown`. The live-tmux e2e test could not run in this sandbox (Unix socket denial), but the composer, ghost, and daemon suites all pass here and remote CI owns the live e2e.

## Risk Assessment

✅ Low: A well-bounded single-helper fix at the one shared classification convergence point, with five regression tests covering the empty-composer fix, real-text preservation, and the dead-shell safety rule (including a byte-exact tmux replay of the live capture), and no scope beyond the intent's brief.

## Testing

Ran the two composer regression suites and the daemon suite (all pass, including the 5 new NBSP tests), then demonstrated the intent end-to-end by replaying the exact live-captured empty-claude-composer bytes through fm_tmux_composer_state: the base commit misclassifies the row as pending (the reported swallowed-Enter/wedged-injection defect) while this branch reads it as empty. The live-tmux e2e suite could not run because the sandbox denies Unix sockets, and no screenshot exists because the change is a terminal state-classifier with no launchable UI surface in this environment - the byte-level replay transcript is the reviewer-visible artifact (attached inline; the designated evidence directory was write-blocked in this unattended run).

<details>
<summary>Evidence: Before/after replay: captured empty-claude-composer row through fm_tmux_composer_state</summary>

```text
Captured row bytes (tmux capture-pane -e of an idle claude 2.1.220 pane:
256-colour SGR, prompt glyph U+276F, then U+00A0 NON-BREAKING SPACE):
1b 5b 33 38 3b 35 3b 32 34 36 6d e2 9d af c2 a0
033 [ 3 8 ; 5 ; 2 4 6 m 342 235 257 302 240
1b 5b 33 39 6d 0a
033 [ 3 9 m \n

--- BASE (34213e6, before fix) ---
fm_tmux_composer_state verdict: pending

--- FIXED (18eb519, this branch) ---
fm_tmux_composer_state verdict: empty

Effect: 'pending' made fm-send report a swallowed Enter for landed steers and
blocked the away-mode daemon (it injects only into an affirmatively 'empty'
composer). 'empty' is the correct verdict for this idle pane.

(Replay method: the exact captured bytes were served to fm_tmux_composer_state
through the same fake-tmux shim tests/fm-composer-ghost.test.sh uses; the BASE
run sourced bin/fm-tmux-lib.sh + bin/fm-composer-lib.sh extracted from commit
34213e6, the FIXED run sourced the branch worktree copies.)
```
</details>
- Outcome: ⚠️ 1 info across 1 run (4m57s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-composer-lib.sh:236` - Behavior shift: an unbordered row whose plain (ANSI-stripped) text is only U+00A0 now classifies &#39;empty&#39; (injection-eligible) instead of &#39;unknown&#39;, because the new early trim in fm_composer_classify_content empties plain_content before the unbordered stripped-content guard. This is consistent with the pre-existing treatment of an all-ASCII-space row (already &#39;empty&#39;) and is explicitly locked in by the lone-NBSP case in test_agent_glyph_with_nbsp_is_empty, so it reads as deliberate; the dead-shell glyph rule is unaffected (glyph+NBSP still classifies &#39;unknown&#39; when bare, verified by test_nbsp_preserves_dead_shell_safety). Recorded only as an acknowledged tradeoff in an injection-safety classifier.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-afk-inject-e2e.test.sh` - tests/fm-afk-inject-e2e.test.sh (listed in the intent as validated on the branch) cannot run in this sandbox: Unix domain socket operations are denied, so no real tmux server can start (retried with a writable TMUX_TMPDIR; the denial is at the socket syscall, not the path). Not a product failure - the daemon injection contracts are covered by the fake-backed tests/fm-daemon.test.sh, which passes, and remote CI owns the live-tmux e2e.
- <code>`bash tests/fm-composer-lib.test.sh` (13 ok, includes the 4 new NBSP regression tests: glyph+NBSP empty, stripped-path NBSP, real-text-not-swallowed, dead-shell safety)</code>
- <code>`bash tests/fm-composer-ghost.test.sh` (13 ok, includes `test_claude_empty_composer_nbsp_row_is_empty` replaying the captured bytes through the tmux reader)</code>
- <code>`bash tests/fm-daemon.test.sh` (daemon injects only into an affirmatively empty composer; fm-send swallow reporting)</code>
- <code>Manual before/after replay: exact captured idle-claude row bytes (ESC[38;5;246m + U+276F + U+00A0 + ESC[39m) fed to `fm_tmux_composer_state` via the suite&#39;s fake-tmux shim - base-commit libs return `pending` (the bug), branch libs return `empty`</code>
- <code>Attempted `bash tests/fm-afk-inject-e2e.test.sh` - blocked by sandbox denial of Unix domain sockets (real tmux server cannot start); retried with TMUX_TMPDIR workaround, still denied</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
