### PR TITLE
docs: remove superseded interim quota-window rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ Account for every candidate; if any harness/model/provider relationship, applica
 Preserve malformed profile configuration as an actionable error rather than selecting around it.
 When every candidate is tight, preserve the captain's strongest-reasoning class rather than silently downgrading it solely to conserve quota; stop and report the tight choice if that class cannot proceed.
 Break genuine headroom ties without array-order or harness bias.
-`quota-axi` owns how model or product windows relate to bounding account windows; as an explicitly interim rule until successor `quota-axi-interpretation-hints-h3` lands, use the weakest applicable remaining headroom, then remove this interim rule.
+`quota-axi` owns how model or product windows relate to bounding account windows.
 The generic effort fallback and its precedence are owned by `harness-adapters`: explicit captain and standing configured effort win; otherwise use low for well-understood explicit work, xhigh for ambiguous investigation or design, intermediate levels proportionally, and never max without explicit captain preference.
 Do not add model-specific versions of that policy.
 

--- a/tests/fm-instruction-owners.test.sh
+++ b/tests/fm-instruction-owners.test.sh
@@ -115,8 +115,7 @@ test_agent_owned_quota_array_dispatch_contract() {
     'Preserve malformed profile configuration as an actionable error' \
     "preserve the captain's strongest-reasoning class rather than silently downgrading it" \
     'Break genuine headroom ties without array-order or harness bias' \
-    '`quota-axi` owns how model or product windows relate to bounding account windows' \
-    'explicitly interim rule until successor `quota-axi-interpretation-hints-h3` lands'; do
+    '`quota-axi` owns how model or product windows relate to bounding account windows'; do
     assert_grep "$phrase" "$AGENTS" "array-dispatch contract lost '$phrase'"
   done
 


### PR DESCRIPTION
## Intent

Remove the superseded interim quota-window rule from firstmate's AGENTS.md section 4, plus its matching test assertion.

AGENTS.md section 4 ended its quota paragraph with an explicitly self-terminating interim rule: it said to use the weakest applicable remaining headroom until successor 'quota-axi-interpretation-hints-h3' landed, and then to remove the interim rule itself. That successor has landed and shipped, so the removal condition written into the rule is satisfied. Verified before this work started: installed quota-axi is 0.1.13, 'quota-axi --json' emits schemaVersion 2, every provider carries a quotaSemantics object, and where semantics are known quotaSemantics.effectiveAvailability[] supplies the computed answer directly via effectivePercentRemaining, boundedBy, and limitingWindowIds. Observed live: grok reports effectivePercentRemaining 1 bounded by its shared credits window even though product:grok_build alone shows 88 percent remaining - exactly the model-or-product-versus-account-window relationship the interim rule stood in for.

Deliberate decisions a reviewer reading only the diff would not know:

1. The ownership clause is intentionally kept and only the interim clause is dropped, so line 171 now reads exactly: '`quota-axi` owns how model or product windows relate to bounding account windows.'
2. The emitted field names (quotaSemantics, effectiveAvailability, effectivePercentRemaining, boundedBy, limitingWindowIds) are deliberately NOT restated in AGENTS.md. Under this repo's one-owner rule (see the firstmate-coding-guidelines skill), quota-axi owns that interpretation; naming its fields in AGENTS.md would create a second copy that rots on the next schema change. Do not suggest documenting them there.
3. quota-axi does not always produce a computed answer - cursor and copilot report quotaSemantics.status 'unknown' with an empty effectiveAvailability. No replacement clause was added for that case on purpose: it is already covered by the existing earlier sentence in the same paragraph requiring firstmate to stop and report a candidate whose applicable quota data or interpretation cannot be established. Adding new wording would duplicate an existing contract.
4. tests/fm-instruction-owners.test.sh line 119 dropped only the assertion phrase for the removed interim text; the surrounding loop and the retained '`quota-axi` owns how model or product windows relate to bounding account windows' assertion are intact and still pass.
5. This was scoped as a deliberately small, surgical change. Neighboring sentences were intentionally not reworded and section 4 was intentionally not restructured; anything beyond this scope was out of scope by instruction.

A repo-wide grep for 'quota-axi-interpretation-hints-h3', 'interim rule', and 'weakest' across docs/, .agents/skills/, skills/, README.md, and CONTRIBUTING.md returns no remaining matches. tests/fm-instruction-owners.test.sh and bin/fm-doc-audience-check.sh both pass locally (exit 0). Repo style requires one full sentence per line in tracked Markdown, plain dashes rather than em dashes, and no agent name as a commit co-author. Note CLAUDE.md is a symlink to AGENTS.md, so it reflects the same edit by design.

## What Changed

- Remove the superseded interim quota-window selection rule while retaining `quota-axi` ownership of window relationships.
- Update the instruction-ownership test to stop asserting the removed interim wording.

## Risk Assessment

✅ Low: The change is a surgical removal of a self-terminating interim rule and its matching assertion, while preserving the quota-axi ownership clause and fail-closed handling for unknown interpretations.

## Testing

Independently repeated the author-reported focused ownership and documentation checks, inspected the two-file diff, and captured the real rendered Markdown contract plus exact positive and negative assertions. All checks passed. No screenshot was needed because this changes agent instruction prose, not a rendered UI.

<details>
<summary>Evidence: Quota interim-rule removal evidence</summary>

`Shows the exact retained AGENTS.md contract, CLAUDE.md symlink behavior, removed-text searches, and focused test results.`

```text
Target commit: 939754f046fcf5fd1b4ff7266c4d577b3ac6d2a5
Changed files:
M	AGENTS.md
M	tests/fm-instruction-owners.test.sh

Rendered AGENTS.md section 4 quota contract:
Routing precedence is an explicit per-task captain override, then the best-fit configured rule, then the configured default, then the static crewmate harness.
Firstmate alone resolves a matched profile array: run `quota-axi --json` at that intake, evaluate every configured candidate against that current output, and choose the candidate with the most real headroom.
Account for every candidate; if any harness/model/provider relationship, applicable quota data, or interpretation cannot be established, stop and report that candidate instead of omitting it, guessing, falling back, or calling the result quota-informed.
Preserve malformed profile configuration as an actionable error rather than selecting around it.
When every candidate is tight, preserve the captain's strongest-reasoning class rather than silently downgrading it solely to conserve quota; stop and report the tight choice if that class cannot proceed.
Break genuine headroom ties without array-order or harness bias.
`quota-axi` owns how model or product windows relate to bounding account windows.
The generic effort fallback and its precedence are owned by `harness-adapters`: explicit captain and standing configured effort win; otherwise use low for well-understood explicit work, xhigh for ambiguous investigation or design, intermediate levels proportionally, and never max without explicit captain preference.
Do not add model-specific versions of that policy.

CLAUDE.md link target and matching retained contract:
AGENTS.md
`quota-axi` owns how model or product windows relate to bounding account windows.

Forbidden interim wording search across maintained prose scopes:
No matches found.

Focused instruction-owner regression test:
ok - new internal skills have one precise AGENTS.md trigger each
ok - diagnostic-reasoning owns the approved evidence procedure
ok - project-management owns registry, delivery posture, consent, initialization, and removal safety
ok - generic effort fallback applies only below captain and standing configuration
ok - firstmate directly compares every quota candidate with authoritative model discovery
ok - firstmate-coding-guidelines owns compatibility review and deterministic enforcement
ok - secondmate registry guidance keeps concise routes and points to the charter
ok - state, startup, and ordinary recovery have focused owners and triggers
ok - compressed AGENTS.md records the approved one-owner map
ok - intake reuses evidence, reserves scouts for uncertainty, and parallelizes safe work
ok - compressed AGENTS.md retains authority, supervision, AFK, and X safety

Documentation audience contract check:
fm-doc-audience-check: ok surfaces=55 local_links=145

Exact source and regression-assertion verification:
118:    '`quota-axi` owns how model or product windows relate to bounding account windows'; do
Ownership sentence occurs exactly once in AGENTS.md; its regression assertion remains; removed clause is absent from both files.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-instruction-owners.test.sh`
- `bin/fm-doc-audience-check.sh`
- `Rendered AGENTS.md section 4 and verified CLAUDE.md links to it and exposes the exact retained ownership sentence.`
- <code>Searched `docs/`, `.agents/skills/`, `skills/`, `README.md`, and `CONTRIBUTING.md` for `quota-axi-interpretation-hints-h3|interim rule|weakest`.</code>
- <code>Verified the retained assertion remains in `tests/fm-instruction-owners.test.sh` and the removed clause is absent from both changed files.</code>
- `Confirmed testing left the worktree clean.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
