### PR TITLE
feat(bin): detect harness build drift and repair instruction-surface consistency

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -103,45 +103,22 @@ Either condition, or any composer verdict other than `empty`, defers the injecti
 In afk mode the composer guard is belt-and-suspenders (no human is typing), but it protects against the race window between the captain returning and their message landing, a dead shell, and the daemon's own previous injection sitting unsent.
 
 **Max-defer escape (the daemon must never silently wedge).**
-If anything stays buffered past `FM_MAX_DEFER_SECS` (default 300), the daemon
-attempts one normal flush, which still requires an idle pane and an affirmatively empty composer.
+If anything stays buffered past `FM_MAX_DEFER_SECS` (default 300s), the daemon attempts one normal flush, which still requires an idle pane and an affirmatively empty composer.
 The alarm is defense in depth rather than a substitute for keeping every genuinely idle supported composer injectable.
-If that submit cannot be confirmed, it raises a loud, rate-limited wedge alarm:
-an ERROR in the daemon log, a durable
-`state/.subsuper-inject-wedged` marker (surface it on the "while you were out"
-catch-up if present), a tmux status-line flash when applicable, and a configurable backend-independent active alert.
+If that submit cannot be confirmed, it raises a loud, rate-limited wedge alarm: an ERROR in the daemon log, a durable `state/.subsuper-inject-wedged` marker (surface it on the "while you were out" catch-up if present), a tmux status-line flash when applicable, and a configurable backend-independent active alert.
 `docs/wedge-alarm.md` owns the alert channel setup, and `docs/verification/supervision.md` "Wedge-alarm channels" owns active evidence.
 So a guard false-positive becomes a visible stall, never an unbounded silent no-op.
 
 ## Submit model
 
-The digest is typed **once** (`send-keys -l` on tmux, `pane send-text` on
-herdr - both literal, non-submitting sends), then submitted with Enter and
-**verified** through the selected backend's submit primitive.
-Enter is retried (Enter only, never a retype) until the backend confirms the
-submit landed.
-For tmux that confirmation is a cleared composer, using the same corrected,
-border-aware detector as the composer guard.
-For herdr, normal idle-baseline submits are confirmed by native agent-state showing a real turn started; the ANSI-aware composer classifier remains the affirmative-empty pre-injection guard and conservative fallback for non-idle or unreadable baselines.
-A bordered-empty or ghost-only composer is recognized as empty where that backend uses composer confirmation, rather than mistaken for a swallowed Enter.
-`fm-send.sh` uses the same primitive and exits non-zero
-when a steer's Enter is positively swallowed, so firstmate learns an instruction
-did not land instead of leaving it unsubmitted.
+The digest is typed **once** (`send-keys -l` on tmux, `pane send-text` on herdr - both literal, non-submitting sends), then submitted with Enter and **verified** through the selected backend's submit primitive.
+Enter is retried (Enter only, never a retype) until that primitive reports `empty` as its caller-facing success verdict.
+For tmux that verdict means the shared-ghost-aware, border-aware composer cleared, read with the same detector as the composer guard.
+For herdr, normal idle-baseline submits are confirmed by native agent-state showing a real turn started; the ANSI-aware structural classifier remains the affirmative-empty pre-injection guard and conservative fallback for non-idle or unreadable baselines.
+A bordered-empty or ghost-only composer is recognized as empty where a composer read is the active confirmation signal, rather than mistaken for a swallowed Enter.
+`fm-send.sh` uses the same primitive and exits non-zero when a steer's Enter is positively swallowed, so firstmate learns an instruction did not land instead of leaving it unsubmitted.
 
-**Busy-queued Enter exception (tmux backend, opencode 1.18.4).** While opencode
-is mid-turn, Enter is accepted and queued for after the current turn but the
-composer keeps showing the typed text the whole time, so the cleared-composer
-check alone false-positives on a swallowed Enter for every steer sent to a
-busy opencode pane. The shared `fm_tmux_submit_enter_core` falls back to
-`fm_pane_is_busy` once the Enter-retry budget is spent: a busy pane means the
-Enter was accepted and queued (reported as `empty` so the caller does not
-re-send), while an idle pane keeps `pending` as a genuine swallow. The
-strict-buffer-clears-only-on-`empty` policy above still holds for the daemon
-and the lenient-`pending`-fails-for-`fm-send` policy still holds for steer
-verification - this exception is a busy-queue is treated as a delivered
-Enter, not a swallowed one. The herdr adapter observes the same opencode
-behavior but needs a separate fix; the gap is recorded in
-`docs/herdr-backend.md` rather than papered over here.
+A busy opencode pane is the one case where a still-typed composer means a queued Enter rather than a swallowed one; the [`harness-adapters` skill](../harness-adapters/SKILL.md)'s opencode section owns that exception and its herdr gap.
 
 ## Classification policy
 
@@ -189,22 +166,8 @@ the operational prefix lets firstmate distinguish it from a real captain message
   They read the composer shape from a separately ANSI-stripped plain row because a dark TRUECOLOR border can be stripped with ghost content.
   A ghost-only or idle bordered composer such as claude's `│ > ... │` therefore reads empty without allowing an unbordered shell prompt to do the same.
   `FM_COMPOSER_IDLE_RE` still overrides tmux empty-composer matching after shared ghost and border stripping, and `FM_BUSY_REGEX` overrides busy footers.
-- **Max-defer escape** - the daemon must never silently wedge. If anything stays
-  buffered past `FM_MAX_DEFER_SECS` (default 300s), the daemon attempts one
-  normal flush, which still requires an idle pane and an affirmatively empty composer. If that
-  cannot confirm a submit, it raises a loud, rate-limited wedge alarm: ERROR log,
-  durable `state/.subsuper-inject-wedged` marker, a tmux status-line flash when
-  applicable, and a backend-independent active alert. A
-  composer false-positive surfaces as a visible stall, never an unbounded silent
-  no-op.
-- **Verified type-once submit model** - the digest is typed once (`send-keys -l`
-  on tmux, `pane send-text` on herdr), then submitted with Enter and verified.
-  Enter is retried, Enter only and never a retype, until the backend submit
-  primitive reports `empty` as its caller-facing success verdict.
-  For tmux that verdict means the shared-ghost-aware and border-aware composer
-  cleared.
-  For herdr's normal idle-baseline path it means native agent-state observed a real turn start; herdr uses the ANSI-aware structural classifier for the pre-injection composer guard and fallback paths.
-  This lets ghost-only or bordered-empty composers count as empty where a composer read is the active confirmation signal.
+- **Max-defer escape** - the daemon must never silently wedge; "Busy-guard and composer guard" above owns the full escape, alarm, and evidence contract.
+- **Verified type-once submit model** - "Submit model" above owns the type-once, Enter-retry, and per-backend confirmation contract.
 - **Marker strip** - `strip_injection_marker` removes the current operational
   prefix or legacy bare marker before classification or relay, so the digest
   text firstmate sees is clean.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, HARNESS_DRIFT, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -48,5 +48,10 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Investigate the reason because that secondmate is not guaranteed live.
 - `NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>` - the secondmate sweep fast-forwarded a running secondmate home and its loaded instruction surface (`AGENTS.md`, `bin/`, or `.agents/skills/`) changed, but the deterministic `fm-send.sh fm-<id>` re-read nudge failed.
   Inspect the reason, keep the pending marker under `state/.secondmate-nudge-pending/` intact, and rerun session start after the endpoint or metadata issue is fixed so bootstrap can retry the exact same marked send.
+- `HARNESS_DRIFT: <harness> recorded <stamp>, installed <version>|not installed here|installed build unreadable` - the build a harness's recorded facts were checked against no longer matches what is installed, in either direction, or that harness is absent from this machine.
+  This never blocks work and needs no captain report on its own: drift is expected whenever a harness updates.
+  Treat it as a standing caveat on the [`harness-adapters` skill](../harness-adapters/SKILL.md)'s facts for that harness - busy signature, exit command, interrupt, dialogs, resume, skill invocation, and quirks - and re-verify the ones a task actually depends on before trusting them.
+  A drifted busy signature is the failure mode that already bit: it makes healthy workers look stopped.
+  When you do re-verify a fact against the current build, update that harness's line in the skill's recorded-build-stamps block in the same change, which is what clears the line.
 - `FMX: X mode on ...` / `FMX: X mode off ...` - bootstrap confirmed or removed the local X-mode poll artifacts (`docs/configuration.md` "X mode (.env)").
   Only when a running watcher needs the cadence transition applied immediately, restart the home-scoped watcher through the emitted harness supervision protocol; bootstrap deliberately never restarts the watcher itself.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, HARNESS_DRIFT, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -48,10 +48,5 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Investigate the reason because that secondmate is not guaranteed live.
 - `NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>` - the secondmate sweep fast-forwarded a running secondmate home and its loaded instruction surface (`AGENTS.md`, `bin/`, or `.agents/skills/`) changed, but the deterministic `fm-send.sh fm-<id>` re-read nudge failed.
   Inspect the reason, keep the pending marker under `state/.secondmate-nudge-pending/` intact, and rerun session start after the endpoint or metadata issue is fixed so bootstrap can retry the exact same marked send.
-- `HARNESS_DRIFT: <harness> recorded <stamp>, installed <version>|not installed here|installed build unreadable` - the build a harness's recorded facts were checked against no longer matches what is installed, in either direction, or that harness is absent from this machine.
-  This never blocks work and needs no captain report on its own: drift is expected whenever a harness updates.
-  Treat it as a standing caveat on the [`harness-adapters` skill](../harness-adapters/SKILL.md)'s facts for that harness - busy signature, exit command, interrupt, dialogs, resume, skill invocation, and quirks - and re-verify the ones a task actually depends on before trusting them.
-  A drifted busy signature is the failure mode that already bit: it makes healthy workers look stopped.
-  When you do re-verify a fact against the current build, update that harness's line in the skill's recorded-build-stamps block in the same change, which is what clears the line.
 - `FMX: X mode on ...` / `FMX: X mode off ...` - bootstrap confirmed or removed the local X-mode poll artifacts (`docs/configuration.md` "X mode (.env)").
   Only when a running watcher needs the cadence transition applied immediately, restart the home-scoped watcher through the emitted harness supervision protocol; bootstrap deliberately never restarts the watcher itself.

--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -12,8 +12,8 @@ metadata:
 # firstmate-coding-guidelines
 
 Load this before changing firstmate's shared, tracked material, as defined by `AGENTS.md` section 1.
-It exists because `AGENTS.md` grew from 585 to 958 lines between its last two restructures, entirely from conditional detail added inline instead of routed to its right home.
-Applying the rules below on every change is what keeps that from happening again.
+It exists because `AGENTS.md` bloats whenever conditional detail is added inline instead of routed to its right home, and every session of every fleet member pays that cost whether or not it hits the situation the detail describes.
+Applying the rules below on every change is what keeps that from happening.
 
 ## Knowledge-placement decision tree
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -39,7 +39,9 @@ If the captain asks for a new harness, propose verifying it first: spawn a trivi
 
 Every fact in the per-harness sections below was established by one manual observation against one build, so a fact stops describing reality the moment that harness updates.
 The block below is the single machine-readable owner of the newest build each harness section's facts were checked against.
-`bin/fm-harness-drift.sh` parses it, compares it to the installed binaries, and prints one `HARNESS_DRIFT:` line per mismatch at session start; the dated stamps inside the prose stay as historical observation records.
+`bin/fm-harness-drift.sh` parses it, compares it to the installed binaries, and prints one `HARNESS_DRIFT:` line per mismatch; the dated stamps inside the prose stay as historical observation records.
+Run it deliberately, before relying on a harness fact you have not re-verified yourself.
+`bin/fm-bootstrap.sh` runs it only under `FM_BOOTSTRAP_VERBOSE_FACTS=1` and reports each line as a `BOOTSTRAP_INFO:` fact, because the comparison launches a `--version` probe per recorded harness and drift needs no action.
 When you re-verify a harness against a newer build, update its line here in the same change.
 
 ```fm-harness-builds
@@ -52,9 +54,11 @@ pi 0.80.6
 
 `docs/verification/harness-builds.md` owns the mechanism record and its active dated evidence.
 
-Drift is expected and blocks nothing.
+Drift is expected, blocks nothing, and needs no captain report on its own.
 A drift line means the facts for that harness need re-verification before you rely on them, in either direction: a stamp ahead of the installed build is as stale as one behind it, because neither describes the build that is actually running.
-An absent harness means none of its recorded facts are verified against anything present on this machine.
+A `not installed here` line says the same thing about a harness absent from the home the check ran on.
+A drifted busy signature is the failure mode that already bit: it makes healthy workers look stopped.
+Re-verify the facts a task actually depends on - busy signature, exit command, interrupt, dialogs, resume, skill invocation, and quirks - and update that harness's line in the block above in the same change, which is what clears the line.
 
 ## Detection
 
@@ -272,11 +276,6 @@ The companion `.opencode/plugins/fm-primary-watch-arm.js` owns normal TUI watche
 The follow-up was verified in the interactive TUI; `opencode run` can exit before displaying a queued follow-up, so the adapter is fail-open in headless mode.
 
 ## pi (VERIFIED 2026-06-11)
-
-**Pi is not installed on this machine (observed 2026-07-25): `command -v pi` resolves nothing.**
-Every fact in this section, including the launch-profile row and the primary-session guard fact, is therefore unverified against any currently present Pi build; treat it as knowledge awaiting re-verification, not as a current description.
-Re-verify against the installed build before dispatching a crewmate or secondmate on pi, and re-stamp the recorded build above in the same change.
-`bin/fm-harness-drift.sh` reports this absence at session start, so it self-corrects on a home where pi is present.
 
 | Fact | Value |
 |---|---|

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -35,6 +35,27 @@ If `config/crew-harness` or `config/secondmate-harness` names an unverified adap
 Do not pause current work for that future-verification choice, and never launch an unverified adapter.
 If the captain asks for a new harness, propose verifying it first: spawn a trivial supervised task using `fm-spawn`'s raw-launch-command escape hatch, confirm every fact empirically, then record the mechanics in `fm-spawn`, the busy signature in `fm-watch.sh` and `fm-tmux-lib.sh` defaults, any needed `FM_COMPOSER_IDLE_RE` empty-composer override plus any novel bare agent prompt glyph in `bin/fm-composer-lib.sh`'s shared composer classifier (the one fleet-wide owner of the empty/dead-shell/pending decision, so a new harness's own idle composer is not misread as a dead shell), the tmux agent-process liveness classification in `bin/backends/tmux.sh` when the harness can launch a secondmate, and the verified knowledge here.
 
+## Recorded build stamps
+
+Every fact in the per-harness sections below was established by one manual observation against one build, so a fact stops describing reality the moment that harness updates.
+The block below is the single machine-readable owner of the newest build each harness section's facts were checked against.
+`bin/fm-harness-drift.sh` parses it, compares it to the installed binaries, and prints one `HARNESS_DRIFT:` line per mismatch at session start; the dated stamps inside the prose stay as historical observation records.
+When you re-verify a harness against a newer build, update its line here in the same change.
+
+```fm-harness-builds
+claude 2.1.219
+codex 0.144.4
+grok 0.2.103
+opencode 1.18.4
+pi 0.80.6
+```
+
+`docs/verification/harness-builds.md` owns the mechanism record and its active dated evidence.
+
+Drift is expected and blocks nothing.
+A drift line means the facts for that harness need re-verification before you rely on them, in either direction: a stamp ahead of the installed build is as stale as one behind it, because neither describes the build that is actually running.
+An absent harness means none of its recorded facts are verified against anything present on this machine.
+
 ## Detection
 
 `bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry.
@@ -251,6 +272,11 @@ The companion `.opencode/plugins/fm-primary-watch-arm.js` owns normal TUI watche
 The follow-up was verified in the interactive TUI; `opencode run` can exit before displaying a queued follow-up, so the adapter is fail-open in headless mode.
 
 ## pi (VERIFIED 2026-06-11)
+
+**Pi is not installed on this machine (observed 2026-07-25): `command -v pi` resolves nothing.**
+Every fact in this section, including the launch-profile row and the primary-session guard fact, is therefore unverified against any currently present Pi build; treat it as knowledge awaiting re-verification, not as a current description.
+Re-verify against the installed build before dispatching a crewmate or secondmate on pi, and re-stamp the recorded build above in the same change.
+`bin/fm-harness-drift.sh` reports this absence at session start, so it self-corrects on a home where pi is present.
 
 | Fact | Value |
 |---|---|

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -277,6 +277,9 @@ The follow-up was verified in the interactive TUI; `opencode run` can exit befor
 
 ## pi (VERIFIED 2026-06-11)
 
+**Currency of this record: stamped 2026-06-11, with no later observation against a present Pi build recorded since.**
+Treat every fact in this section, including the launch-profile row and the primary-session guard fact, as knowledge awaiting re-verification rather than a current description.
+
 | Fact | Value |
 |---|---|
 | Busy-pane signature | `Working...` (braille spinner prefix; no `esc to interrupt` text) |

--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -18,18 +18,18 @@ The goal is a session that is safe to reset or destroy because everything durabl
 1. **Sweep the session for uncaptured durable knowledge.**
    Read back over this conversation and look for:
    - Operational learnings: fleet-local facts and gotchas discovered while operating firstmate (a script's sharp edge, a harness quirk, a recurring false alarm and its real cause).
-   - Captain preferences expressed in passing: a working-style or approval preference the captain stated conversationally rather than through the destination selected by AGENTS.md's knowledge-routing table.
+   - Captain preferences expressed in passing: a working-style or approval preference the captain stated conversationally rather than through the destination selected by AGENTS.md section 6's "Route durable knowledge to its most specific owner" list.
    - Project-intrinsic facts discovered: build, test, release, or architecture facts about a project that belong in that project's own `AGENTS.md`.
    - Decisions made: a standing choice the captain made this session that should outlive it.
    - Undone next steps: anything left open that has not yet been filed as backlog work.
 
-2. **Route each finding using AGENTS.md's knowledge-routing table.**
-   AGENTS.md (section 6, "Knowledge routing") is the single source of truth for where each kind of knowledge belongs.
-   Read that table and route each finding there instead of re-deriving the mapping here.
+2. **Route each finding using AGENTS.md section 6's owner list.**
+   AGENTS.md section 6's "Route durable knowledge to its most specific owner" list is the single source of truth for where each kind of knowledge belongs.
+   Read that list and route each finding there instead of re-deriving the mapping here.
 
 3. **Write within firstmate's existing write boundaries.**
    This skill does not grant any new write permission; it only prompts firstmate to use the boundaries that already exist (AGENTS.md section 1):
-   - Captain preferences and fleet-local operational facts: hand-write directly to the destination selected by AGENTS.md's knowledge-routing table, using inspect-then-update every time.
+   - Captain preferences and fleet-local operational facts: hand-write directly to the destination selected by AGENTS.md section 6's "Route durable knowledge to its most specific owner" list, using inspect-then-update every time.
      Before writing, inspect the destination, find the existing bullet or section the finding duplicates or supersedes, and rewrite it in place rather than adding a new trailing entry.
      `data/learnings.md` may not exist yet; create it on first local learning, in the same dated, evidence-backed, curated style as the captain-preference files.
    - Project-intrinsic knowledge: never hand-write a project's `AGENTS.md`.
@@ -49,7 +49,7 @@ The goal is a session that is safe to reset or destroy because everything durabl
    - Can this be a one-sentence rewrite instead of a new entry?
    - Should an older bullet or note be deleted, retired, or archived because it is now obsolete?
    When a finding overlaps or supersedes something already on disk, rewrite or prune the existing entry instead of piling on a new one.
-   Graduation moves are limited to exactly three: promote a learning to the shared `AGENTS.md` via PR, fold it into the captain-preference destination selected by AGENTS.md, or delete a stale entry.
+   Graduation moves are limited to exactly three: promote a learning to the shared `AGENTS.md` via PR, fold it into the captain-preference destination selected by AGENTS.md section 6's "Route durable knowledge to its most specific owner" list, or delete a stale entry.
    Do not invent other graduation paths.
 
 5. **Report to the captain.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ If the session lock cannot be acquired and verified, report its exact diagnostic
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
 
 1. **Lock** - acquires the per-home session lock first, before anything mutates shared state.
-2. **Bootstrap** - detect-only checks (tool/version problems, GitHub auth, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
+2. **Bootstrap** - detect-only checks (tool/version problems, GitHub auth, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status, recorded-versus-installed harness build drift) always run, but routine confirmations stay silent by default.
    When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
    Home-local stale Herdr projection cleanup and the five bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, the local secondmate fast-forward sweep, the secondmate liveness sweep, and X-mode artifact writes - run only when this session actually holds the lock from step 1.
    The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous or unreadable targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`).
@@ -420,6 +420,7 @@ Do not surface automatic fixes, retries, routine progress, or internal supervisi
 When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.
 Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.
+When the captain invokes `/bearings` or asks where things stand - a bearings report, morning brief, status report, catch-up, or "what's in the works" - load the `bearings` skill.
 Whenever a PR is mentioned, include its full `https://...` URL before any shorthand reference.
 Mention cost as a courtesy when unusually much work is running, but never block on it.
 
@@ -468,7 +469,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, `HARNESS_DRIFT:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ If the session lock cannot be acquired and verified, report its exact diagnostic
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
 
 1. **Lock** - acquires the per-home session lock first, before anything mutates shared state.
-2. **Bootstrap** - detect-only checks (tool/version problems, GitHub auth, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status, recorded-versus-installed harness build drift) always run, but routine confirmations stay silent by default.
+2. **Bootstrap** - detect-only checks (tool/version problems, GitHub auth, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
    When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
    Home-local stale Herdr projection cleanup and the five bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, the local secondmate fast-forward sweep, the secondmate liveness sweep, and X-mode artifact writes - run only when this session actually holds the lock from step 1.
    The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous or unreadable targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`).
@@ -469,7 +469,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, `HARNESS_DRIFT:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - maintainer verification for GitLab merge watching on arbitrary instances.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's current "no turn ends blind" backstop, scope, loop safety, and compatibility limits.
 - [docs/verification/supervision.md](docs/verification/supervision.md) - active maintainer verification for session-start, guard, continuity, and wedge integrations.
+- [docs/verification/harness-builds.md](docs/verification/harness-builds.md) - active maintainer verification for the recorded harness build stamps and their detect-only drift check.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [docs/documentation-audiences.md](docs/documentation-audiences.md) - documentation audiences and the machine-checked placement boundary.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -16,7 +16,7 @@
 #                 "NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>",
 #                 "BOOTSTRAP_INFO: nudged fm-<id> with '<message>'",
 #                 "SECONDMATE_LIVENESS: secondmate <id>: skipped: <reason>|respawn failed after <cause>: <reason>",
-#                 "HARNESS_DRIFT: <harness> recorded <stamp>, installed <version>|not installed here|installed build unreadable",
+#                 "BOOTSTRAP_INFO: HARNESS_DRIFT: <harness> recorded <stamp>, installed <version>|not installed here|installed build unreadable",
 #                 "FMX: X mode on ..." or "FMX: X mode off ...".
 #          When a RUNNING secondmate worktree is fast-forwarded to firstmate's
 #          own current default-branch commit (a purely LOCAL fast-forward, never
@@ -42,11 +42,14 @@
 #          failed names whether the endpoint was missing or agent-less.
 #          Already-live and successfully relaunched secondmates are silent
 #          unless FM_BOOTSTRAP_VERBOSE_FACTS=1 requests BOOTSTRAP_INFO facts.
-#          HARNESS_DRIFT lines compare the build stamps recorded in
+#          HARNESS_DRIFT facts compare the build stamps recorded in
 #          .agents/skills/harness-adapters/SKILL.md against the harness binaries
 #          installed here, so a documented harness fact cannot silently expire.
 #          bin/fm-harness-drift.sh owns that comparison and its exact wording; it
-#          is read-only, runs in detect-only sessions too, and never blocks work.
+#          is read-only and never blocks work. Because it probes every recorded
+#          harness with its own --version and drift needs no action, bootstrap
+#          runs it only under FM_BOOTSTRAP_VERBOSE_FACTS=1 and reports it as a
+#          BOOTSTRAP_INFO fact; run the script directly for an on-demand check.
 #          A TANGLE line means the firstmate primary checkout (FM_ROOT) is stranded
 #          on a feature branch instead of its default branch - a crewmate's work
 #          landed in the primary instead of its own worktree; restore it per the line.
@@ -869,9 +872,13 @@ if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] && [ -n "$crew" ] && [ "$crew" != 
   echo "BOOTSTRAP_INFO: crew harness override active: $crew"
 fi
 crew_dispatch_validate
-# Read-only, so it runs in detect-only sessions too. Silent when every recorded
-# harness build stamp still matches the installed binary.
-"$SCRIPT_DIR/fm-harness-drift.sh" || true
+# Opt-in only. The comparison launches a `--version` probe per recorded harness,
+# and drift needs no action, so it is a verbose BOOTSTRAP_INFO fact rather than a
+# cost every session start pays. Read-only, so the opt-in holds in a detect-only
+# session too. Silent when every recorded stamp matches the installed binary.
+if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ]; then
+  "$SCRIPT_DIR/fm-harness-drift.sh" | sed 's/^/BOOTSTRAP_INFO: /' || true
+fi
 if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] \
   && ! fm_backlog_backend_manual "$CONFIG" && fm_tasks_axi_compatible; then
   echo "BOOTSTRAP_INFO: tasks-axi available"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -16,6 +16,7 @@
 #                 "NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>",
 #                 "BOOTSTRAP_INFO: nudged fm-<id> with '<message>'",
 #                 "SECONDMATE_LIVENESS: secondmate <id>: skipped: <reason>|respawn failed after <cause>: <reason>",
+#                 "HARNESS_DRIFT: <harness> recorded <stamp>, installed <version>|not installed here|installed build unreadable",
 #                 "FMX: X mode on ..." or "FMX: X mode off ...".
 #          When a RUNNING secondmate worktree is fast-forwarded to firstmate's
 #          own current default-branch commit (a purely LOCAL fast-forward, never
@@ -41,6 +42,11 @@
 #          failed names whether the endpoint was missing or agent-less.
 #          Already-live and successfully relaunched secondmates are silent
 #          unless FM_BOOTSTRAP_VERBOSE_FACTS=1 requests BOOTSTRAP_INFO facts.
+#          HARNESS_DRIFT lines compare the build stamps recorded in
+#          .agents/skills/harness-adapters/SKILL.md against the harness binaries
+#          installed here, so a documented harness fact cannot silently expire.
+#          bin/fm-harness-drift.sh owns that comparison and its exact wording; it
+#          is read-only, runs in detect-only sessions too, and never blocks work.
 #          A TANGLE line means the firstmate primary checkout (FM_ROOT) is stranded
 #          on a feature branch instead of its default branch - a crewmate's work
 #          landed in the primary instead of its own worktree; restore it per the line.
@@ -863,6 +869,9 @@ if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] && [ -n "$crew" ] && [ "$crew" != 
   echo "BOOTSTRAP_INFO: crew harness override active: $crew"
 fi
 crew_dispatch_validate
+# Read-only, so it runs in detect-only sessions too. Silent when every recorded
+# harness build stamp still matches the installed binary.
+"$SCRIPT_DIR/fm-harness-drift.sh" || true
 if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] \
   && ! fm_backlog_backend_manual "$CONFIG" && fm_tasks_axi_compatible; then
   echo "BOOTSTRAP_INFO: tasks-axi available"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -44,7 +44,9 @@
 #          unless FM_BOOTSTRAP_VERBOSE_FACTS=1 requests BOOTSTRAP_INFO facts.
 #          HARNESS_DRIFT facts compare the build stamps recorded in
 #          .agents/skills/harness-adapters/SKILL.md against the harness binaries
-#          installed here, so a documented harness fact cannot silently expire.
+#          installed here. The comparison is opt-in and no session start runs it
+#          by default, so a documented harness fact CAN expire unobserved until
+#          someone runs the check deliberately.
 #          bin/fm-harness-drift.sh owns that comparison and its exact wording; it
 #          is read-only and never blocks work. Because it probes every recorded
 #          harness with its own --version and drift needs no action, bootstrap

--- a/bin/fm-harness-drift.sh
+++ b/bin/fm-harness-drift.sh
@@ -52,7 +52,7 @@ usage() {
 
 # Bounded probe with the same portable ladder fm-fleet-snapshot.sh uses. When no
 # bounding tool exists at all, run the probe directly rather than reporting every
-# harness unreadable: a false drift storm at every session start is worse than an
+# harness unreadable: a false drift storm on every run is worse than an
 # unbounded `--version` call on a host with no timeout, gtimeout, or perl.
 run_timed() {  # <seconds> <command...>
   local seconds=$1
@@ -110,7 +110,7 @@ malformed=0
 while IFS= read -r line; do
   case "$line" in ''|'#'*) continue ;; esac
   # A blank or whitespace-only line inside the block is spacing, not a malformed
-  # stamp; treating it as one would raise a false alarm at every session start.
+  # stamp; treating it as one would raise a false alarm on every run.
   [ -n "${line//[[:space:]]/}" ] || continue
   harness=${line%% *}
   recorded=${line#* }

--- a/bin/fm-harness-drift.sh
+++ b/bin/fm-harness-drift.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# fm-harness-drift.sh - detect-only drift between the harness build stamps
+# recorded in .agents/skills/harness-adapters/SKILL.md and the harness binaries
+# installed on this machine.
+#
+# Every harness fact in that skill was established by one manual observation
+# against one build. Nothing used to compare those stamps to the installed
+# runtimes, so a fact stopped describing reality the moment a harness updated
+# and no signal fired. This check is that signal.
+#
+# Usage:
+#   fm-harness-drift.sh           print one line per drifted or absent harness;
+#                                 silent when every stamp matches; always exit 0
+#   fm-harness-drift.sh --stamps  print the parsed "<harness> <version>" stamps
+#   fm-harness-drift.sh --help    print this usage
+#
+# Lines (the stamp source owns which harnesses appear):
+#   "HARNESS_DRIFT: <harness> recorded <stamp>, installed <version>"
+#   "HARNESS_DRIFT: <harness> recorded <stamp>, not installed here"
+#   "HARNESS_DRIFT: <harness> recorded <stamp>, installed build unreadable"
+#   "HARNESS_DRIFT: recorded build stamps unreadable in <path>"
+#
+# Three outcomes are distinguished per harness: the stamp equals the installed
+# build (silent), the stamp differs from the installed build (drift, in EITHER
+# direction - a stamp ahead of the installed build describes a build nobody is
+# running just as much as one behind it), and the harness is absent (drift).
+#
+# It is detect-only by construction: it never edits the skill, never installs
+# anything, and always exits 0 so a drifted fleet still starts. Drift is normal
+# and expected; the defect this fixes is drift being invisible, not drift
+# existing. Do not turn it into a gate.
+#
+# Test overrides: FM_HARNESS_DRIFT_SKILL selects the stamp source file, and
+# FM_HARNESS_DRIFT_TIMEOUT (default 10) bounds each `<harness> --version` probe.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_CODE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# The stamps live with the tracked skill, which always ships from the code root,
+# never from a per-home FM_HOME.
+SKILL="${FM_HARNESS_DRIFT_SKILL:-$FM_CODE_ROOT/.agents/skills/harness-adapters/SKILL.md}"
+PROBE_TIMEOUT="${FM_HARNESS_DRIFT_TIMEOUT:-10}"
+case "$PROBE_TIMEOUT" in ''|*[!0-9]*) PROBE_TIMEOUT=10 ;; esac
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+# Bounded probe with the same portable ladder fm-fleet-snapshot.sh uses. When no
+# bounding tool exists at all, run the probe directly rather than reporting every
+# harness unreadable: a false drift storm at every session start is worse than an
+# unbounded `--version` call on a host with no timeout, gtimeout, or perl.
+run_timed() {  # <seconds> <command...>
+  local seconds=$1
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$seconds" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$seconds" "$@"
+  elif command -v perl >/dev/null 2>&1; then
+    perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
+# Read the fenced ```fm-harness-builds block. A unique info string keeps this
+# unambiguous next to the skill's many ordinary Markdown tables and fences.
+read_stamps() {
+  [ -f "$SKILL" ] || return 0
+  awk '
+    /^```fm-harness-builds[[:space:]]*$/ { inblock = 1; next }
+    inblock && /^```/ { exit }
+    inblock { print }
+  ' "$SKILL"
+}
+
+# First dotted version-looking token of a `--version` line. Covers every verified
+# harness shape: "2.1.220 (Claude Code)", "codex-cli 0.145.0", "1.18.3", and
+# "grok 0.2.112 (9bbd559437aa) [stable]".
+installed_version() {  # <harness>
+  local out
+  out=$(run_timed "$PROBE_TIMEOUT" "$1" --version 2>/dev/null) || return 1
+  printf '%s\n' "$out" | grep -Eo '[0-9]+\.[0-9]+(\.[0-9]+)*' | head -1
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  --stamps)
+    read_stamps
+    exit 0
+    ;;
+  '') ;;
+  *)
+    echo "usage: fm-harness-drift.sh [--stamps|--help]" >&2
+    exit 2
+    ;;
+esac
+
+stamps=$(read_stamps)
+parsed=0
+malformed=0
+while IFS= read -r line; do
+  case "$line" in ''|'#'*) continue ;; esac
+  # A blank or whitespace-only line inside the block is spacing, not a malformed
+  # stamp; treating it as one would raise a false alarm at every session start.
+  [ -n "${line//[[:space:]]/}" ] || continue
+  harness=${line%% *}
+  recorded=${line#* }
+  case "$harness" in *[!a-z0-9-]*|'') malformed=1; continue ;; esac
+  # A line with no space leaves recorded == line, which is malformed, not a stamp.
+  if [ "$recorded" = "$line" ]; then malformed=1; continue; fi
+  case "$recorded" in ''|*[!0-9.]*) malformed=1; continue ;; esac
+  parsed=$((parsed + 1))
+  if ! command -v "$harness" >/dev/null 2>&1; then
+    echo "HARNESS_DRIFT: $harness recorded $recorded, not installed here"
+    continue
+  fi
+  if ! found=$(installed_version "$harness") || [ -z "$found" ]; then
+    echo "HARNESS_DRIFT: $harness recorded $recorded, installed build unreadable"
+    continue
+  fi
+  [ "$found" = "$recorded" ] && continue
+  echo "HARNESS_DRIFT: $harness recorded $recorded, installed $found"
+done <<EOF
+$stamps
+EOF
+
+if [ "$parsed" -eq 0 ] || [ "$malformed" -eq 1 ]; then
+  echo "HARNESS_DRIFT: recorded build stamps unreadable in $SKILL"
+fi
+
+exit 0

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -122,6 +122,7 @@ family_for_basename() {
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
+    fm-harness-drift.test.sh|\
     fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
@@ -658,6 +659,10 @@ families_for_changed_path() {
     bin/fm-secondmate*|bin/fm-home-seed.sh|bin/fm-backlog-handoff.sh|\
     bin/fm-config-inherit-lib.sh|bin/fm-config-push.sh|bin/fm-shared*)
       printf '%s\n' secondmate
+      ;;
+    bin/fm-harness-drift.sh)
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' session-bootstrap
       ;;
     bin/fm-session-start.sh|bin/fm-bootstrap.sh|bin/fm-fleet-sync.sh|\
     bin/fm-sessionstart-nudge.sh|bin/fm-tangle*|bin/fm-update.sh|\

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -78,6 +78,10 @@
       "target": "docs/verification/supervision.md"
     },
     {
+      "source": ".agents/skills/harness-adapters/SKILL.md",
+      "target": "docs/verification/harness-builds.md"
+    },
+    {
       "source": "docs/tmux-backend.md",
       "target": "docs/verification/runtime-backends.md"
     },
@@ -301,6 +305,10 @@
     },
     {
       "path": "docs/verification/runtime-backends.md",
+      "audience": "maintainer-verification"
+    },
+    {
+      "path": "docs/verification/harness-builds.md",
       "audience": "maintainer-verification"
     },
     {

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -85,6 +85,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
+| `fm-harness-drift.sh`    | Detect-only comparison of recorded harness build stamps against the installed binaries |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared X-mode config, relay, and reply-threading helpers                             |
 | `fm-x-poll.sh`           | One bounded X relay poll: stash newly offered mentions and emit their once-only wake |

--- a/docs/verification/harness-builds.md
+++ b/docs/verification/harness-builds.md
@@ -4,7 +4,7 @@ Audience: maintainer verification.
 
 This record supports the current guarantee that a documented harness fact cannot silently expire.
 Every fact in the `harness-adapters` skill was established by one manual observation against one build, and nothing used to compare those stamps to the installed runtimes.
-`bin/fm-harness-drift.sh` is that comparison; its header owns the exact flags and line formats, and `.agents/skills/bootstrap-diagnostics/SKILL.md` owns the response to a reported line.
+`bin/fm-harness-drift.sh` is that comparison; its header owns the exact flags and line formats, and the `harness-adapters` skill's "Recorded build stamps" section owns both the stamps and the response to a reported line.
 Task chronology and delivery transcripts stay in private reports or PR evidence.
 
 ## Mechanism
@@ -16,7 +16,8 @@ The check parses that block, probes each harness with a bounded `<harness> --ver
 It distinguishes three per-harness outcomes: the stamp equals the installed build (silent), the stamp differs in either direction (drift), and the harness is absent (drift).
 A stamp ahead of the installed build is drift, not a match, because it describes a build nobody is running.
 The check is detect-only: it never edits the skill, never installs anything, and always exits 0, so drift never blocks a session.
-`bin/fm-bootstrap.sh` runs it among the read-only detect checks, so it also runs in a lock-refused detect-only session.
+It is run deliberately rather than on every session start, because each recorded harness costs a `--version` launch and a drift line needs no action.
+`bin/fm-bootstrap.sh` runs it only under `FM_BOOTSTRAP_VERBOSE_FACTS=1`, prefixing each line as a `BOOTSTRAP_INFO:` fact; being read-only, that opt-in also holds in a lock-refused detect-only session.
 
 ## Verified on 2026-07-25
 

--- a/docs/verification/harness-builds.md
+++ b/docs/verification/harness-builds.md
@@ -21,7 +21,7 @@ It is run deliberately rather than on every session start, because each recorded
 
 ## Verified on 2026-07-25
 
-Installed builds, from the harness binaries on PATH:
+Installed builds on the machine this record was made on, from the harness binaries on PATH:
 
 ```sh
 for h in claude codex opencode pi grok; do

--- a/docs/verification/harness-builds.md
+++ b/docs/verification/harness-builds.md
@@ -2,7 +2,7 @@
 
 Audience: maintainer verification.
 
-This record supports the current guarantee that a documented harness fact cannot silently expire.
+This record supports a comparison that is run deliberately, not a standing guarantee that a documented harness fact cannot silently expire.
 Every fact in the `harness-adapters` skill was established by one manual observation against one build, and nothing used to compare those stamps to the installed runtimes.
 `bin/fm-harness-drift.sh` is that comparison; its header owns the exact flags and line formats, and the `harness-adapters` skill's "Recorded build stamps" section owns both the stamps and the response to a reported line.
 Task chronology and delivery transcripts stay in private reports or PR evidence.
@@ -76,7 +76,11 @@ All five verified harnesses had drifted when the check was introduced, which is 
 The opencode line shows the doc-ahead direction, and the pi line shows the absent case.
 The silent case is covered by `tests/fm-harness-drift.test.sh`, which also pins the version-parsing shapes above, the malformed and missing stamp-source reports, and the read-only property.
 
-## Known limit
+## Known limits
+
+The check only says something when someone runs it.
+It is opt-in, no session start runs it by default, and nothing else watches the installed builds, so on a home where nobody runs it a harness update expires a documented fact with no signal at all.
+That gap is real and is left open here on purpose: the earlier unconditional session-start invocation cost every home a `--version` probe per recorded harness for a fact that needs no action, and closing the gap without that cost is separate work.
 
 The check compares build identity, not fact validity.
 A harness can update without changing any documented fact, so a drift line means "re-verify before relying on this", never "this fact is wrong".

--- a/docs/verification/harness-builds.md
+++ b/docs/verification/harness-builds.md
@@ -1,0 +1,82 @@
+# Harness build-stamp drift verification
+
+Audience: maintainer verification.
+
+This record supports the current guarantee that a documented harness fact cannot silently expire.
+Every fact in the `harness-adapters` skill was established by one manual observation against one build, and nothing used to compare those stamps to the installed runtimes.
+`bin/fm-harness-drift.sh` is that comparison; its header owns the exact flags and line formats, and `.agents/skills/bootstrap-diagnostics/SKILL.md` owns the response to a reported line.
+Task chronology and delivery transcripts stay in private reports or PR evidence.
+
+## Mechanism
+
+The recorded stamps live in one fenced `fm-harness-builds` block in `.agents/skills/harness-adapters/SKILL.md`, one `<harness> <version>` line each.
+That block is the single owner of the newest build each harness section's facts were checked against; the dated stamps inside the surrounding prose are historical observation records, not the compared value.
+The check parses that block, probes each harness with a bounded `<harness> --version`, and takes the first dotted version token of the output.
+
+It distinguishes three per-harness outcomes: the stamp equals the installed build (silent), the stamp differs in either direction (drift), and the harness is absent (drift).
+A stamp ahead of the installed build is drift, not a match, because it describes a build nobody is running.
+The check is detect-only: it never edits the skill, never installs anything, and always exits 0, so drift never blocks a session.
+`bin/fm-bootstrap.sh` runs it among the read-only detect checks, so it also runs in a lock-refused detect-only session.
+
+## Verified on 2026-07-25
+
+Installed builds, from the harness binaries on PATH:
+
+```sh
+for h in claude codex opencode pi grok; do
+  printf '%s: ' "$h"
+  command -v "$h" >/dev/null 2>&1 && "$h" --version 2>&1 | head -1 || echo "NOT INSTALLED"
+done
+```
+
+Exact output:
+
+```
+claude: 2.1.220 (Claude Code)
+codex: codex-cli 0.145.0
+opencode: 1.18.3
+pi: NOT INSTALLED
+grok: grok 0.2.112 (9bbd559437aa) [stable]
+```
+
+Recorded stamps at the time of this record:
+
+```sh
+bin/fm-harness-drift.sh --stamps
+```
+
+Exact output:
+
+```
+claude 2.1.219
+codex 0.144.4
+grok 0.2.103
+opencode 1.18.4
+pi 0.80.6
+```
+
+Drift report:
+
+```sh
+bin/fm-harness-drift.sh
+```
+
+Exact output:
+
+```
+HARNESS_DRIFT: claude recorded 2.1.219, installed 2.1.220
+HARNESS_DRIFT: codex recorded 0.144.4, installed 0.145.0
+HARNESS_DRIFT: grok recorded 0.2.103, installed 0.2.112
+HARNESS_DRIFT: opencode recorded 1.18.4, installed 1.18.3
+HARNESS_DRIFT: pi recorded 0.80.6, not installed here
+```
+
+All five verified harnesses had drifted when the check was introduced, which is why the mechanism matters more than any single stale fact.
+The opencode line shows the doc-ahead direction, and the pi line shows the absent case.
+The silent case is covered by `tests/fm-harness-drift.test.sh`, which also pins the version-parsing shapes above, the malformed and missing stamp-source reports, and the read-only property.
+
+## Known limit
+
+The check compares build identity, not fact validity.
+A harness can update without changing any documented fact, so a drift line means "re-verify before relying on this", never "this fact is wrong".
+Clearing a line requires re-verifying that harness's facts and re-stamping its line in the skill; the check deliberately cannot do that itself.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -71,6 +71,7 @@ SH
   chmod +x "$fakebin/no-mistakes"
   add_tasks_axi "$fakebin" "0.1.1"
   add_quota_axi "$fakebin"
+  fm_fake_stamped_harnesses "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-harness-drift.test.sh
+++ b/tests/fm-harness-drift.test.sh
@@ -199,16 +199,44 @@ EOF
   pass "the tracked skill records one parseable build stamp per verified harness"
 }
 
-test_bootstrap_wires_the_check_and_owns_the_label() {
-  assert_grep 'fm-harness-drift.sh' "$ROOT/bin/fm-bootstrap.sh" \
-    "bootstrap does not run the harness build-drift check"
-  assert_grep 'HARNESS_DRIFT:' "$ROOT/bin/fm-bootstrap.sh" \
-    "bootstrap's header does not own the HARNESS_DRIFT line format"
-  assert_grep 'HARNESS_DRIFT' "$ROOT/.agents/skills/bootstrap-diagnostics/SKILL.md" \
-    "bootstrap-diagnostics has no response entry for HARNESS_DRIFT"
-  assert_grep 'HARNESS_DRIFT:' "$ROOT/AGENTS.md" \
-    "AGENTS.md section 13 does not list HARNESS_DRIFT as a bootstrap-diagnostics trigger"
-  pass "the drift check is wired into bootstrap with a documented response"
+test_bootstrap_runs_the_check_only_as_an_opt_in_fact() {
+  local guarded
+  assert_grep 'BOOTSTRAP_INFO: HARNESS_DRIFT:' "$ROOT/bin/fm-bootstrap.sh" \
+    "bootstrap's header does not own the emitted HARNESS_DRIFT fact format"
+  assert_grep 'HARNESS_DRIFT' "$ROOT/.agents/skills/harness-adapters/SKILL.md" \
+    "harness-adapters does not own the response to a drift line"
+
+  # The comparison costs one `--version` launch per recorded harness and a drift
+  # line needs no action, so bootstrap may only run it inside the existing
+  # verbose-facts opt-in, and only ever as a BOOTSTRAP_INFO fact.
+  # Comment lines are skipped deliberately: the header names both the env var and
+  # the script, so a comment-blind scan would pass on prose alone.
+  guarded=$(awk '
+    /^[[:space:]]*#/ { next }
+    /^if \[ "\$\{FM_BOOTSTRAP_VERBOSE_FACTS:-0\}" = 1 \]/ { guard = 1; next }
+    /^fi$/ { guard = 0 }
+    guard && /fm-harness-drift\.sh/ { print }
+  ' "$ROOT/bin/fm-bootstrap.sh")
+  [ -n "$guarded" ] \
+    || fail "bootstrap must run fm-harness-drift.sh only under FM_BOOTSTRAP_VERBOSE_FACTS"
+  assert_contains "$guarded" 'BOOTSTRAP_INFO' \
+    "bootstrap must report drift as a BOOTSTRAP_INFO fact, not a bare diagnostic line"
+
+  # A fact that needs no action must not be an actionable line that mandates
+  # loading bootstrap-diagnostics at every session start of every home.
+  assert_no_grep 'HARNESS_DRIFT' "$ROOT/.agents/skills/bootstrap-diagnostics/SKILL.md" \
+    "bootstrap-diagnostics still treats HARNESS_DRIFT as an actionable line"
+  assert_no_grep 'HARNESS_DRIFT' "$ROOT/AGENTS.md" \
+    "AGENTS.md still lists HARNESS_DRIFT as a bootstrap-diagnostics trigger"
+  pass "bootstrap runs the drift check only as an opt-in BOOTSTRAP_INFO fact"
+}
+
+test_no_surface_asserts_a_local_installation_state() {
+  # A stamp source is shared by every home, so a claim about which harnesses are
+  # installed on one machine is false on the next one that loads it.
+  assert_no_grep 'not installed on this machine' "$SKILL" \
+    "the shared skill asserts a machine-local installation state"
+  pass "the shared skill states recorded stamps, not one machine's install state"
 }
 
 test_skill_keeps_one_owner_for_each_stamp() {
@@ -228,5 +256,6 @@ test_version_shapes_of_every_verified_harness
 test_malformed_and_missing_block_are_reported
 test_check_never_writes_to_its_source
 test_tracked_skill_stamps_cover_the_verified_harnesses
-test_bootstrap_wires_the_check_and_owns_the_label
+test_bootstrap_runs_the_check_only_as_an_opt_in_fact
+test_no_surface_asserts_a_local_installation_state
 test_skill_keeps_one_owner_for_each_stamp

--- a/tests/fm-harness-drift.test.sh
+++ b/tests/fm-harness-drift.test.sh
@@ -200,7 +200,7 @@ EOF
 }
 
 test_bootstrap_runs_the_check_only_as_an_opt_in_fact() {
-  local guarded
+  local calls guarded
   assert_grep 'BOOTSTRAP_INFO: HARNESS_DRIFT:' "$ROOT/bin/fm-bootstrap.sh" \
     "bootstrap's header does not own the emitted HARNESS_DRIFT fact format"
   assert_grep 'HARNESS_DRIFT' "$ROOT/.agents/skills/harness-adapters/SKILL.md" \
@@ -209,16 +209,27 @@ test_bootstrap_runs_the_check_only_as_an_opt_in_fact() {
   # The comparison costs one `--version` launch per recorded harness and a drift
   # line needs no action, so bootstrap may only run it inside the existing
   # verbose-facts opt-in, and only ever as a BOOTSTRAP_INFO fact.
+  #
+  # Both halves are asserted, because proving one guarded call exists does not
+  # prove no unguarded call does: a second unconditional invocation would restore
+  # the per-session-start probe cost while leaving a guarded-call check green.
   # Comment lines are skipped deliberately: the header names both the env var and
   # the script, so a comment-blind scan would pass on prose alone.
+  calls=$(awk '
+    /^[[:space:]]*#/ { next }
+    /fm-harness-drift\.sh/ { print }
+  ' "$ROOT/bin/fm-bootstrap.sh")
+  [ "$(printf '%s\n' "$calls" | grep -c .)" -eq 1 ] \
+    || fail "bootstrap must invoke fm-harness-drift.sh exactly once, found:"$'\n'"$calls"
+
   guarded=$(awk '
     /^[[:space:]]*#/ { next }
-    /^if \[ "\$\{FM_BOOTSTRAP_VERBOSE_FACTS:-0\}" = 1 \]/ { guard = 1; next }
-    /^fi$/ { guard = 0 }
+    /FM_BOOTSTRAP_VERBOSE_FACTS/ && /then$/ { guard = 1; next }
+    /^[[:space:]]*fi$/ { guard = 0 }
     guard && /fm-harness-drift\.sh/ { print }
   ' "$ROOT/bin/fm-bootstrap.sh")
-  [ -n "$guarded" ] \
-    || fail "bootstrap must run fm-harness-drift.sh only under FM_BOOTSTRAP_VERBOSE_FACTS"
+  [ "$guarded" = "$calls" ] \
+    || fail "bootstrap must run fm-harness-drift.sh only under FM_BOOTSTRAP_VERBOSE_FACTS"$'\n'"guarded: $guarded"$'\n'"all:     $calls"
   assert_contains "$guarded" 'BOOTSTRAP_INFO' \
     "bootstrap must report drift as a BOOTSTRAP_INFO fact, not a bare diagnostic line"
 

--- a/tests/fm-harness-drift.test.sh
+++ b/tests/fm-harness-drift.test.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-harness-drift.sh, the detect-only comparison between the
+# harness build stamps recorded in harness-adapters/SKILL.md and the harness
+# binaries installed on this machine.
+#
+# The three per-harness outcomes are pinned: stamp equals installed build
+# (silent), stamp differs in EITHER direction (drift), and harness absent
+# (drift). The version parser is exercised against the real `--version` output
+# shapes of all five verified harnesses, because a shape this parser cannot read
+# would silently report every build as unreadable. The detect-only property is
+# pinned too: the check must never write to its own stamp source.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+DRIFT="$ROOT/bin/fm-harness-drift.sh"
+SKILL="$ROOT/.agents/skills/harness-adapters/SKILL.md"
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+TMP_ROOT=$(fm_test_tmproot fm-harness-drift-tests)
+
+# Write a stamp source shaped like the real skill: the fenced block sits among
+# ordinary prose and other fenced blocks, so the parser must key on the info
+# string rather than on "the first fence".
+write_stamps() {  # <file> <"harness version">...
+  local file=$1
+  shift
+  # shellcheck disable=SC2016 # Literal Markdown fence backticks, not substitution.
+  {
+    printf '# harness-adapters\n\nProse before the block.\n\n'
+    printf '```\nan unrelated fenced block\n```\n\n'
+    printf '```fm-harness-builds\n'
+    printf '%s\n' "$@"
+    printf '```\n\nProse after the block.\n'
+  } > "$file"
+}
+
+# A fake harness binary printing one exact `--version` line.
+fake_harness() {  # <fakebin> <name> <version-output>
+  local fakebin=$1 name=$2 out=$3
+  cat > "$fakebin/$name" <<SH
+#!/usr/bin/env bash
+[ "\${1:-}" = --version ] && { printf '%s\n' '$out'; exit 0; }
+exit 0
+SH
+  chmod +x "$fakebin/$name"
+}
+
+run_drift() {  # <fakebin> <stampfile>
+  PATH="$1:$BASE_PATH" FM_HARNESS_DRIFT_SKILL="$2" "$DRIFT" 2>&1
+}
+
+test_matching_stamp_is_silent() {
+  local dir="$TMP_ROOT/match" fakebin out rc
+  mkdir -p "$dir"
+  fakebin=$(fm_fakebin "$dir")
+  fake_harness "$fakebin" claude '2.1.220 (Claude Code)'
+  write_stamps "$dir/skill.md" 'claude 2.1.220'
+
+  out=$(run_drift "$fakebin" "$dir/skill.md")
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "a matching stamp must exit 0, got $rc"
+  [ -z "$out" ] || fail "a matching stamp must print nothing, got: $out"
+  pass "a stamp equal to the installed build is silent"
+}
+
+test_installed_newer_is_drift() {
+  local dir="$TMP_ROOT/newer" fakebin out
+  mkdir -p "$dir"
+  fakebin=$(fm_fakebin "$dir")
+  fake_harness "$fakebin" codex 'codex-cli 0.145.0'
+  write_stamps "$dir/skill.md" 'codex 0.144.4'
+
+  out=$(run_drift "$fakebin" "$dir/skill.md")
+  assert_contains "$out" 'HARNESS_DRIFT: codex recorded 0.144.4, installed 0.145.0' \
+    "a stamp behind the installed build must report drift"
+  pass "a stamp behind the installed build reports drift"
+}
+
+test_doc_ahead_of_installed_is_drift() {
+  local dir="$TMP_ROOT/ahead" fakebin out
+  mkdir -p "$dir"
+  fakebin=$(fm_fakebin "$dir")
+  # Today's real opencode case: the doc records a build newer than the one
+  # installed. That is drift, not a match.
+  fake_harness "$fakebin" opencode '1.18.3'
+  write_stamps "$dir/skill.md" 'opencode 1.18.4'
+
+  out=$(run_drift "$fakebin" "$dir/skill.md")
+  assert_contains "$out" 'HARNESS_DRIFT: opencode recorded 1.18.4, installed 1.18.3' \
+    "a stamp ahead of the installed build must report drift, not a match"
+  pass "a stamp ahead of the installed build reports drift"
+}
+
+test_absent_harness_is_distinguished() {
+  local dir="$TMP_ROOT/absent" fakebin out
+  mkdir -p "$dir"
+  fakebin=$(fm_fakebin "$dir")
+  write_stamps "$dir/skill.md" 'pi 0.80.6'
+
+  out=$(run_drift "$fakebin" "$dir/skill.md")
+  assert_contains "$out" 'HARNESS_DRIFT: pi recorded 0.80.6, not installed here' \
+    "an absent harness must be distinguished from a version mismatch"
+  assert_not_contains "$out" 'installed 0' \
+    "an absent harness must not report an installed version"
+  pass "an absent harness is distinguished from a version mismatch"
+}
+
+test_unreadable_version_is_reported() {
+  local dir="$TMP_ROOT/unreadable" fakebin out
+  mkdir -p "$dir"
+  fakebin=$(fm_fakebin "$dir")
+  fake_harness "$fakebin" grok 'no version here'
+  write_stamps "$dir/skill.md" 'grok 0.2.103'
+
+  out=$(run_drift "$fakebin" "$dir/skill.md")
+  assert_contains "$out" 'HARNESS_DRIFT: grok recorded 0.2.103, installed build unreadable' \
+    "an installed harness with no parseable version must be reported, not silently matched"
+  pass "an installed harness with an unreadable version is reported"
+}
+
+test_version_shapes_of_every_verified_harness() {
+  local dir="$TMP_ROOT/shapes" fakebin out
+  mkdir -p "$dir"
+  fakebin=$(fm_fakebin "$dir")
+  # The exact `--version` first lines observed on 2026-07-25.
+  fake_harness "$fakebin" claude '2.1.220 (Claude Code)'
+  fake_harness "$fakebin" codex 'codex-cli 0.145.0'
+  fake_harness "$fakebin" opencode '1.18.3'
+  fake_harness "$fakebin" grok 'grok 0.2.112 (9bbd559437aa) [stable]'
+  fake_harness "$fakebin" pi 'pi 0.80.6'
+  write_stamps "$dir/skill.md" \
+    'claude 2.1.220' 'codex 0.145.0' 'opencode 1.18.3' 'grok 0.2.112' 'pi 0.80.6'
+
+  out=$(run_drift "$fakebin" "$dir/skill.md")
+  [ -z "$out" ] || fail "every verified harness version shape must parse, got: $out"
+  pass "the version parser reads every verified harness --version shape"
+}
+
+test_malformed_and_missing_block_are_reported() {
+  local dir="$TMP_ROOT/malformed" fakebin out
+  mkdir -p "$dir"
+  fakebin=$(fm_fakebin "$dir")
+
+  printf '# no stamps here\n' > "$dir/none.md"
+  out=$(run_drift "$fakebin" "$dir/none.md")
+  assert_contains "$out" 'HARNESS_DRIFT: recorded build stamps unreadable' \
+    "a stamp source with no block must report itself unreadable, not pass silently"
+
+  # Blank spacing inside the block is not a malformed stamp.
+  fake_harness "$fakebin" claude '2.1.220 (Claude Code)'
+  write_stamps "$dir/spaced.md" 'claude 2.1.220' '' '   '
+  out=$(run_drift "$fakebin" "$dir/spaced.md")
+  [ -z "$out" ] || fail "blank lines inside the block must not raise a false alarm, got: $out"
+
+  write_stamps "$dir/bad.md" 'claude'
+  out=$(run_drift "$fakebin" "$dir/bad.md")
+  assert_contains "$out" 'HARNESS_DRIFT: recorded build stamps unreadable' \
+    "a malformed stamp line must report the source unreadable"
+
+  out=$(run_drift "$fakebin" "$dir/missing.md")
+  assert_contains "$out" 'HARNESS_DRIFT: recorded build stamps unreadable' \
+    "a missing stamp source must report itself unreadable"
+  pass "a missing, empty, or malformed stamp source is reported"
+}
+
+test_check_never_writes_to_its_source() {
+  local dir="$TMP_ROOT/readonly" fakebin before after
+  mkdir -p "$dir"
+  fakebin=$(fm_fakebin "$dir")
+  write_stamps "$dir/skill.md" 'codex 0.144.4' 'pi 0.80.6'
+  before=$(cksum < "$dir/skill.md")
+
+  run_drift "$fakebin" "$dir/skill.md" >/dev/null
+  after=$(cksum < "$dir/skill.md")
+  [ "$before" = "$after" ] || fail "the drift check must never edit its stamp source"
+  pass "the drift check leaves its stamp source untouched"
+}
+
+# --- contract against the real tracked skill --------------------------------
+
+test_tracked_skill_stamps_cover_the_verified_harnesses() {
+  local stamps names
+  stamps=$("$DRIFT" --stamps)
+  [ -n "$stamps" ] || fail "the tracked skill has no parseable recorded-build-stamps block"
+  names=$(printf '%s\n' "$stamps" | awk '{print $1}' | LC_ALL=C sort | tr '\n' ' ')
+  [ "$names" = "claude codex grok opencode pi " ] \
+    || fail "recorded stamps must cover exactly AGENTS.md section 4's verified harnesses, got: $names"
+  # Heredoc, not a pipe: fail() exits, and an exit inside a pipeline subshell
+  # would let a malformed stamp pass silently.
+  while IFS= read -r line; do
+    case "$line" in
+      *' '[0-9]*.[0-9]*) : ;;
+      *) fail "malformed recorded stamp: $line" ;;
+    esac
+  done <<EOF
+$stamps
+EOF
+  pass "the tracked skill records one parseable build stamp per verified harness"
+}
+
+test_bootstrap_wires_the_check_and_owns_the_label() {
+  assert_grep 'fm-harness-drift.sh' "$ROOT/bin/fm-bootstrap.sh" \
+    "bootstrap does not run the harness build-drift check"
+  assert_grep 'HARNESS_DRIFT:' "$ROOT/bin/fm-bootstrap.sh" \
+    "bootstrap's header does not own the HARNESS_DRIFT line format"
+  assert_grep 'HARNESS_DRIFT' "$ROOT/.agents/skills/bootstrap-diagnostics/SKILL.md" \
+    "bootstrap-diagnostics has no response entry for HARNESS_DRIFT"
+  assert_grep 'HARNESS_DRIFT:' "$ROOT/AGENTS.md" \
+    "AGENTS.md section 13 does not list HARNESS_DRIFT as a bootstrap-diagnostics trigger"
+  pass "the drift check is wired into bootstrap with a documented response"
+}
+
+test_skill_keeps_one_owner_for_each_stamp() {
+  local fences
+  fences=$(grep -c '^```fm-harness-builds' "$SKILL")
+  [ "$fences" -eq 1 ] \
+    || fail "exactly one recorded-build-stamps block must own the stamps, found $fences"
+  pass "exactly one block owns the recorded build stamps"
+}
+
+test_matching_stamp_is_silent
+test_installed_newer_is_drift
+test_doc_ahead_of_installed_is_drift
+test_absent_harness_is_distinguished
+test_unreadable_version_is_reported
+test_version_shapes_of_every_verified_harness
+test_malformed_and_missing_block_are_reported
+test_check_never_writes_to_its_source
+test_tracked_skill_stamps_cover_the_verified_harnesses
+test_bootstrap_wires_the_check_and_owns_the_label
+test_skill_keeps_one_owner_for_each_stamp

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -272,7 +272,7 @@ make_seeded_home() {
 # Runs fm-spawn.sh in secondmate mode. FM_ROOT is the real repo (so fm-harness.sh
 # resolves), the primary config dir is <world>/home/config, and CLAUDECODE pins
 # detect_own. stderr is discarded (the local-HEAD ff sync harmlessly skips a
-# non-worktree home). Inspect <world>/home/state/<id>.meta and <home>/config after.
+# non-worktree home). Inspect <world>/home/state/<id>.meta and <home>/config after.  # leak-ok
 spawn_secondmate() {
   local world=$1 id=$2 home=$3 harness=${4:-} fakebin
   mkdir -p "$world/home/state" "$world/home/data"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -777,6 +777,7 @@ fi
 exit 0
 SH
   chmod +x "$fakebin/no-mistakes"
+  fm_fake_stamped_harnesses "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -350,6 +350,7 @@ SH
 exit 0
 SH
   chmod +x "$fakebin/quota-axi"
+  fm_fake_stamped_harnesses "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -83,6 +83,7 @@ fi
 exit 0
 SH
   chmod +x "$fakebin/no-mistakes"
+  fm_fake_stamped_harnesses "$fakebin"
   printf '%s\n' manual > "${fakebin%/*}/home-placeholder" 2>/dev/null || true
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -104,12 +104,13 @@ SH
 # recorded in harness-adapters/SKILL.md, each reporting exactly its recorded
 # build.
 #
-# bin/fm-bootstrap.sh runs the read-only harness build-drift check, which
-# compares those stamps against the harnesses on PATH. A hermetic fakebin PATH
-# has none of them, so without this every bootstrap silence assertion would fail
-# on a drift line per harness. Declaring them present at their recorded build
-# keeps the real check running while silence still means silence. The drift
-# outcomes themselves belong to tests/fm-harness-drift.test.sh.
+# Under FM_BOOTSTRAP_VERBOSE_FACTS=1, bin/fm-bootstrap.sh runs the read-only
+# harness build-drift check, which compares those stamps against the harnesses on
+# PATH. A hermetic fakebin PATH has none of them, so without this every verbose
+# BOOTSTRAP_INFO assertion would also carry a drift fact per harness. Declaring
+# them present at their recorded build keeps the real check running while silence
+# still means silence. The drift outcomes themselves belong to
+# tests/fm-harness-drift.test.sh.
 fm_fake_stamped_harnesses() {
   local fakebin=$1 harness version
   while read -r harness version; do

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -100,6 +100,31 @@ SH
   done
 }
 
+# fm_fake_stamped_harnesses <fakebin>: install one fake binary per harness
+# recorded in harness-adapters/SKILL.md, each reporting exactly its recorded
+# build.
+#
+# bin/fm-bootstrap.sh runs the read-only harness build-drift check, which
+# compares those stamps against the harnesses on PATH. A hermetic fakebin PATH
+# has none of them, so without this every bootstrap silence assertion would fail
+# on a drift line per harness. Declaring them present at their recorded build
+# keeps the real check running while silence still means silence. The drift
+# outcomes themselves belong to tests/fm-harness-drift.test.sh.
+fm_fake_stamped_harnesses() {
+  local fakebin=$1 harness version
+  while read -r harness version; do
+    [ -n "$harness" ] || continue
+    cat > "$fakebin/$harness" <<SH
+#!/usr/bin/env bash
+[ "\${1:-}" = --version ] && { printf '%s\n' '$version'; exit 0; }
+exit 0
+SH
+    chmod +x "$fakebin/$harness"
+  done <<EOF
+$("$ROOT/bin/fm-harness-drift.sh" --stamps)
+EOF
+}
+
 # --- deterministic git identity and fixtures --------------------------------
 
 # fm_git_identity [name] [email]: export a fixed author/committer identity so


### PR DESCRIPTION
## Intent

Clear the pre-push leak-check gate that blocked the already-complete instruction-surface fix branch (fm/instr-fix at 357a778). That branch carries six instruction-surface fixes plus a detect-only harness build-drift check; that content is done and must not be redone or expanded. The only new change is a single leak-ok end-of-line marker on the one remaining HOMEPATH false positive in tests/fm-secondmate-harness.test.sh:275 (a documentation placeholder <world>/home/state that the scanner misreads because > is not path-blocklisted). Do not add more markers, do not change the detector, do not amend 357a778, do not merge - open a PR for the upstream maintainer. Push must succeed without --no-verify.

## What Changed

- Adds `bin/fm-harness-drift.sh`, a detect-only check that parses a new machine-readable `fm-harness-builds` stamp block in `.agents/skills/harness-adapters/SKILL.md` and reports, per harness, whether the recorded stamp matches the installed binary, drifts in either direction, is absent, or is unreadable. It never edits or installs and always exits 0. `bin/fm-bootstrap.sh` runs it as a `BOOTSTRAP_INFO: HARNESS_DRIFT:` fact only under `FM_BOOTSTRAP_VERBOSE_FACTS=1`, after review demoted it from an unconditional session-start probe; otherwise it is run on demand.
- Repairs six consistency defects in the always-loaded instruction surfaces: the `stow` knowledge-routing pointer now names a section and list that actually exist in AGENTS.md, AGENTS.md section 9 gains an inline `bearings` trigger, the opencode busy-queued-Enter contract and afk's two self-duplicated contracts collapse to one owner each with cross-references, `firstmate-coding-guidelines` drops a stale line-count measurement from a forward instruction, and the pi adapter record carries a dated currency caveat instead of an unqualified verified header.
- Adds `tests/fm-harness-drift.test.sh` covering the outcome cases, the real `--version` shapes of all five harnesses, malformed and missing stamp sources, the read-only property, and a guard that bootstrap invokes the script exactly once behind the verbose flag; adds a shared `fm_fake_stamped_harnesses` helper in `tests/lib.sh` so hermetic silence-asserting suites still exercise the check; records the mechanism in `docs/verification/harness-builds.md` and indexes it in README, `docs/scripts.md`, and `docs/documentation-audiences.json`; marks one known HOMEPATH false positive in `tests/fm-secondmate-harness.test.sh` with `leak-ok` so the pre-push leak gate passes without `--no-verify`.

## Risk Assessment

✅ Low: Both round-2 findings are fully resolved with honest documentation and a strictly stronger, less brittle regression guard that I verified extracts the correct lines, leaving only one informational note about the test also pinning the call site as mandatory.

## Testing

I reproduced the end-user push experience by running the actual leak-check pre-push hook with the stdin git supplies for a new-branch push: at the pre-marker commit it prints GATE: fail with the HOMEPATH hit on tests/fm-secondmate-harness.test.sh:275 and exits 1, and at the branch tip it prints GATE: pass over 17 scanned objects with one suppressed line and exits 0, so the push clears without --no-verify. I confirmed the branch adds exactly one leak-ok marker, that it suppresses a real hit (no stale-suppression warning), and that no scanner or detector file is modified. The behavior test owning the edited file passes, and because the two review commits after the marker also touched the bootstrap and drift-check surfaces I ran those two suites as well; all passed. Working tree left clean, with evidence written only to the evidence directory.

<details>
<summary>Evidence: Real pre-push hook transcript (blocked before marker, passes after)</summary>

<code>--- BEFORE the marker: HEAD = 617b22c ---&#10;[HOMEPATH] 絶対ホームパス ── ~ / $HOME へ相対化 (1)&#10;tests/fm-secondmate-harness.test.sh:275 /home/s***&#10;[SCAN-SET] 列挙 18 件 / 本文走査 18&#10;GATE: fail (巻き込み危険 1 件 ...)&#10;leak-check(push): push を中止 ── 上の hit を処置してから再 push&#10;hook exit = 1&#10;&#10;--- AFTER the marker: HEAD = 9f8daa6 ---&#10;[SCAN-SET] 列挙 17 件 / 本文走査 17&#10;`leak-ok` で全検出器を通さなかった行: 1&#10;GATE: pass (PII/secret/実データの巻き込みなし ── 17 件を全数走査)&#10;hook exit = 0</code>

```text
$ # real leak-check pre-push hook, new-branch push of fm/instr-fix (stdin as git supplies it)

--- BEFORE the marker: HEAD = 617b22c (instruction-surface fixes only) ---

[HOMEPATH] 絶対ホームパス ── ~ / $HOME へ相対化  (1)
  tests/fm-secondmate-harness.test.sh:275  /home/s***

[SCAN-SET] 列挙 18 件 / 本文走査 18 (読んだ中身: object 18)
[DENY-INSTRUMENT] 検出器 inactive ── denylist に有効語なし(実名/顧客名は未検査。0 件は clean の意味ではない)
  repo 単位で張る: <repo root>/.leak-denylist (gitignore 必須・`re:` で pattern も可)
GATE: fail (巻き込み危険 1 件 ── 上を redact / placeholder / .gitignore で処置してから commit)
  .gitignore 追記案(実データ/秘密はローカル退避先を gitignore):

leak-check(push): push を中止 ── 上の hit を処置してから再 push
  緊急で通す時のみ: git push --no-verify
hook exit = 1

--- AFTER the marker: HEAD = 9f8daa6 (branch tip being pushed) ---

[SCAN-SET] 列挙 17 件 / 本文走査 17 (読んだ中身: object 17)
  `leak-ok` で全検出器を通さなかった行: 1
[DENY-INSTRUMENT] 検出器 inactive ── denylist に有効語なし(実名/顧客名は未検査。0 件は clean の意味ではない)
  repo 単位で張る: <repo root>/.leak-denylist (gitignore 必須・`re:` で pattern も可)
GATE: pass (PII/secret/実データの巻き込みなし ── 17 件を全数走査)
hook exit = 0
```
</details>
<details>
<summary>Evidence: leak_scan.sh --records-from before/after comparison</summary>

```text
##### pre-push simulation: pushing 617b22c (remote base 34213e6) #####

[HOMEPATH] 絶対ホームパス ── ~ / $HOME へ相対化  (1)
  tests/fm-secondmate-harness.test.sh:275  /home/s***

[SCAN-SET] 列挙 18 件 / 本文走査 18 (読んだ中身: object 18)
[DENY-INSTRUMENT] 検出器 inactive ── denylist に有効語なし(実名/顧客名は未検査。0 件は clean の意味ではない)
  repo 単位で張る: <repo root>/.leak-denylist (gitignore 必須・`re:` で pattern も可)
GATE: fail (巻き込み危険 1 件 ── 上を redact / placeholder / .gitignore で処置してから commit)
  .gitignore 追記案(実データ/秘密はローカル退避先を gitignore):
EXIT=1

##### pre-push simulation: pushing 9f8daa6 (remote base 34213e6) #####

[SCAN-SET] 列挙 17 件 / 本文走査 17 (読んだ中身: object 17)
  `leak-ok` で全検出器を通さなかった行: 1
[DENY-INSTRUMENT] 検出器 inactive ── denylist に有効語なし(実名/顧客名は未検査。0 件は clean の意味ではない)
  repo 単位で張る: <repo root>/.leak-denylist (gitignore 必須・`re:` で pattern も可)
GATE: pass (PII/secret/実データの巻き込みなし ── 17 件を全数走査)
EXIT=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `.agents/skills/harness-adapters/SKILL.md:276` - A machine-local observation is baked into a shared tracked instruction surface: &#34;**Pi is not installed on this machine (observed 2026-07-25): `command -v pi` resolves nothing.**&#34;. Per AGENTS.md section 12, `.agents/skills/` is loaded verbatim by every running firstmate and secondmate home, so on any home where pi *is* installed this bolded lead sentence is simply false, and the following sentence (&#34;Every fact in this section ... is therefore unverified against any currently present Pi build&#34;) inherits that falsehood. Line 279 acknowledges the drift check &#34;self-corrects on a home where pi is present&#34; - which is the argument for letting `fm-harness-drift.sh` report the absence at session start and *not* freezing it into the skill text. This is the same rotting-fact problem this branch deliberately removed from firstmate-coding-guidelines (the &#34;grew from 585 to 958 lines&#34; claim).
- ⚠️ `.agents/skills/harness-adapters/SKILL.md:46` - All five recorded stamps ship known-drifted (docs/verification/harness-builds.md:549-554 records the check emitting a drift line for every one of claude, codex, grok, opencode, and pi on introduction). Combined with AGENTS.md:472 and bootstrap-diagnostics/SKILL.md:95, which add `HARNESS_DRIFT:` to the list of actionable lines that mandate loading the `bootstrap-diagnostics` skill, every session start of every fleet member now prints five drift lines and is required to load that skill - only to read &#34;This never blocks work and needs no captain report on its own&#34; (bootstrap-diagnostics/SKILL.md:104). The signal is on from day one and can only be cleared by manually re-verifying five harnesses, so the one failure mode it exists to catch (a drifted busy signature) arrives inside permanent noise, and every session pays the skill-load context cost that firstmate-coding-guidelines exists to prevent. Consider either re-stamping to the currently installed builds as part of this change, or exempting HARNESS_DRIFT from the mandatory bootstrap-diagnostics load trigger.
- ⚠️ `bin/fm-bootstrap.sh:874` - The drift check is invoked synchronously in the session-start bootstrap path and probes every recorded harness with `&lt;harness&gt; --version` on every run, with no caching. Measured on this machine: `bin/fm-harness-drift.sh` took ~0.94s wall (opencode alone ~0.45s), added to every session start. Worst case is bounded only by FM_HARNESS_DRIFT_TIMEOUT (default 10s) per harness, so five hanging or slow-starting harnesses can add ~50s to session start before the digest appears. The same cost is multiplied across the test suite - fm-x-mode.test.sh alone invokes fm-bootstrap.sh a dozen-plus times with the ambient PATH, where the probes hit real binaries. A build stamp changes at most once per harness upgrade, so a cached result (e.g. a state marker keyed on the harness binaries&#39; mtimes, refreshed daily) would preserve the signal at near-zero recurring cost.
- ℹ️ `tests/fm-secondmate-harness.test.sh:275` - leak_scan.sh&#39;s suppression is line-scoped and category-wide (`SUPPRESS = &#39;leak-ok&#39;` ... &#34;この文字列を含む行は全カテゴリで除外&#34;): the marker `continue`s past SECRET, EMAIL, HOMEPATH, and DENY for that whole line, not just the HOMEPATH detector that false-positived. Here the suppressed line is a fixed prose comment, so the exposure is negligible, and the scanner&#39;s own STALE-SUPPRESSION audit reports the marker is actively suppressing a hit rather than sitting dead. Noting the property only so a future edit to that comment line is not assumed to be re-scanned.
- ℹ️ `tests/fm-secondmate-harness.test.sh:275` - The intent says &#34;do not amend 357a778&#34;. The branch head&#39;s parent is 617b22c, not 357a778: same author timestamp (2026-07-25 21:12:43 +0900), new committer timestamp, reparented from 3f71cdd onto 34213e6. The rewrite is a clean rebase that absorbs upstream #1039 (dropping the superseded interim quota-window rule from AGENTS.md:171 and its assertion phrase from tests/fm-instruction-owners.test.sh:118); all six instruction-surface fixes and the drift check are byte-identical. No content was redone or expanded, but the branch no longer carries the commit id named in the intent.
- ℹ️ `bin/fm-harness-drift.sh:25` - The either-direction drift rationale is restated near-verbatim in four places: this header (lines 24-27), harness-adapters/SKILL.md:151, docs/verification/harness-builds.md:499, and bootstrap-diagnostics/SKILL.md:103. The owner split is otherwise clean (script owns flags and line formats, skill owns stamps, verification doc owns evidence, bootstrap-diagnostics owns the response), so a single owner for the rationale with pointers from the other three would match the single-ownership discipline the rest of this branch is enforcing.

🔧 Fix: demote harness drift check to opt-in informational fact
4 infos still open:
- ℹ️ `bin/fm-bootstrap.sh:47` - Two surfaces still assert the pre-demotion guarantee. bin/fm-bootstrap.sh:47 says the comparison runs &#34;so a documented harness fact cannot silently expire&#34;, and docs/verification/harness-builds.md:5 says &#34;This record supports the current guarantee that a documented harness fact cannot silently expire&#34;. After this commit nothing runs the comparison by default: on a home that never sets FM_BOOTSTRAP_VERBOSE_FACTS=1 and never invokes bin/fm-harness-drift.sh, a harness update expires a fact with no signal at all - precisely the state bin/fm-harness-drift.sh:7-9 describes as the defect the check was written to fix. The demotion is the right call and harness-adapters:43 states the new contract correctly (&#34;Run it deliberately, before relying on a harness fact you have not re-verified yourself&#34;); only these two leftover &#34;cannot silently expire&#34;/&#34;guarantee&#34; phrasings now overstate what ships.
- ℹ️ `tests/fm-harness-drift.test.sh:212` - The new regression guard proves that *a* guarded invocation exists (`guarded` non-empty, containing BOOTSTRAP_INFO) but never proves that *no unguarded* invocation exists. A future edit that adds a second, unconditional `&#34;$SCRIPT_DIR/fm-harness-drift.sh&#34;` outside the FM_BOOTSTRAP_VERBOSE_FACTS block leaves this test green while reintroducing the exact per-session-start probe cost this commit removed - and tests/fm-bootstrap.test.sh&#39;s silence assertions would not catch it either, because fm_fake_stamped_harnesses seeds the harnesses at their recorded stamps so the check stays silent there. Inverting the awk to collect occurrences where `guard` is 0 and failing on any would close the hole. Related brittleness: the extractor keys on the exact source shape (`^if [ &#34;${FM_BOOTSTRAP_VERBOSE_FACTS:-0}&#34; = 1 ]` at column 0, terminated by `^fi$`), so an indentation or nesting change fails the test with a misleading message even when behavior is correct.
- ℹ️ `tests/lib.sh:114` - With the drift check gated behind FM_BOOTSTRAP_VERBOSE_FACTS=1, fm_fake_stamped_harnesses is load-bearing at only one of its four call sites. No script under bin/ ever sets that variable (it is caller-supplied only), and tests/fm-bootstrap.test.sh:743 is the sole test that passes it, so the seeding at tests/fm-session-start.test.sh:86, tests/fm-secondmate-harness.test.sh:780, and tests/fm-secondmate-sync.test.sh:353 now installs five fake harness binaries into hermetic fakebins for a check that never runs in those suites. It is inert rather than harmful - no bin/ code does `command -v &lt;harness&gt;` - and the helper&#39;s updated comment already narrows its stated purpose to the verbose path. Recording it only so the three redundant call sites are a known cleanup, not a lost invariant; not proposing removal in this tightly scoped round.
- ℹ️ `.agents/skills/harness-adapters/SKILL.md:42` - The stated intent says the six instruction-surface fixes plus the drift check &#34;is done and must not be redone or expanded&#34; and that &#34;The only new change is a single leak-ok end-of-line marker&#34;. Commit 0a44d94 edits eight files of that content (harness-adapters, bootstrap-diagnostics, AGENTS.md, fm-bootstrap.sh, fm-harness-drift.sh, harness-builds.md, and two test files). This is not treated as a contradiction because the round-1 review loop carries explicit user direction to make exactly these three corrections (&#34;All three are defects this branch itself introduced, so fix them; do not expand scope beyond correcting them&#34;), which is a later and more specific authorization from the same user. The commit stays inside that authorization: it touches only the drift-check surfaces, and bootstrap-diagnostics/SKILL.md is now byte-identical to the base commit. Recorded for traceability only.

🔧 Fix: state drift check gap honestly, harden invocation guard test
1 info still open:
- ℹ️ `tests/fm-harness-drift.test.sh:220` - The hardened guard asserts the invocation count is exactly 1, which encodes two invariants: no unguarded call (the requested one) and at least one call. The second half means a future maintainer who takes the drift check fully on-demand by deleting the bootstrap call site entirely - the direction round 1 explicitly preferred (&#34;Removing the call site is preferred over making the probe faster&#34;) - gets a test failure reading &#34;bootstrap must invoke fm-harness-drift.sh exactly once&#34; even though that state is strictly cheaper and still correct. It fails closed with a legible message rather than silently, and it accurately pins today&#39;s design, so this is a note rather than a defect; changing `-eq 1` to `-le 1` would keep the anti-regression half without forbidding removal.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`sh ~/.claude/skills/leak-check/hooks/pre-push` fed the real git pre-push stdin record for a new-branch push of fm/instr-fix, at 617b22c (fail, exit 1) and at 9f8daa6 (pass, exit 0)</code>
- <code>`sh ~/.claude/skills/leak-check/leak_scan.sh --records-from &lt;git diff --raw -z 34213e6..&lt;sha&gt;&gt;` for both commits, confirming the single HOMEPATH hit disappears and one line is recorded as suppressed with no STALE-SUPPRESSION warning</code>
- `bash bin/fm-test-run.sh tests/fm-secondmate-harness.test.sh`
- `bash bin/fm-test-run.sh tests/fm-harness-drift.test.sh tests/fm-bootstrap.test.sh`
- <code>`grep -rn &#34;leak-ok&#34;` over the tracked tree plus `git diff 34213e6..9f8daa6 -U0 | grep -c &#39;^+.*leak-ok&#39;` to confirm exactly one marker was added and only one exists</code>
- <code>`git diff --name-only 34213e6..9f8daa6 | grep -iE &#39;leak|scan&#39;` to confirm the detector is untouched</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `.agents/skills/harness-adapters/SKILL.md:278` - The sixth instruction-surface fix described in 617b22c&#39;s commit message - marking the pi section as unverified against any present build, kept-and-marked per an explicit captain decision - is no longer in the tree. Review commit 0a44d94 removed all four sentences of that marking because one of them (&#34;reports this absence at session start&#34;) became false when the drift check went opt-in. The pi section now reads &#34;## pi (VERIFIED 2026-06-11)&#34; with no currency caveat, while docs/verification/harness-builds.md, added by this same change, records `pi: NOT INSTALLED`. I did not restore it: the user intent freezes the branch&#39;s six fixes as done and not to be redone, and there is a real placement argument for the removal - &#34;pi is not installed on this machine&#34; is a home-local observation, and its owner is now the dated evidence in docs/verification/harness-builds.md plus the drift check itself, not the always-shipped shared skill. The residual gap is only that the pi header claims currency the generic &#34;Recorded build stamps&#34; caveat softens rather than states. Maintainer call: accept the generic caveat as sufficient, or re-add a one-line pi caveat without the false session-start claim.

🔧 Fix: restore dated currency caveat on pi adapter record
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
