### PR TITLE
test(watcher): cover drift-free pid identity for issue #1014

### DIFF
--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -916,6 +916,75 @@ test_pid_identity_is_locale_invariant() {
   pass "fm_pid_identity is locale-invariant across LC_ALL/LC_TIME"
 }
 
+test_macos_pid_identity_uses_ps_fallback_without_proc() {
+  local dir state fakebin no_proc marker identity
+  dir=$(make_case macos-pid-identity-ps-fallback)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  no_proc="$dir/no-proc"
+  marker="$dir/ps-called"
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf 'Darwin\n'
+SH
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' called > "$FM_TEST_PS_MARKER"
+printf '   Sat Jul 25 01:33:07 2026 bash /portable/fm-watch.sh\n'
+SH
+  chmod +x "$fakebin/uname" "$fakebin/ps"
+
+  identity=$(PATH="$fakebin:$PATH" FM_TEST_PS_MARKER="$marker" FM_PROC_ROOT_OVERRIDE="$no_proc" \
+    FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$$") \
+    || fail "could not read process identity through the ps fallback"
+
+  [ -e "$marker" ] || fail "fm_pid_identity did not invoke ps when proc was unavailable"
+  [ "$identity" = 'Sat Jul 25 01:33:07 2026 bash /portable/fm-watch.sh' ] \
+    || fail "fm_pid_identity changed the portable ps fallback output ('$identity')"
+  pass "macOS fm_pid_identity preserves the ps fallback when proc is unavailable"
+}
+
+test_linux_pid_identity_is_stable_across_immediate_reads() {
+  local dir state fakebin counter live first second
+  [ "$(uname)" = Linux ] || {
+    pass "Linux fresh-process identity regression skipped on non-Linux host"
+    return
+  }
+  dir=$(make_case linux-fresh-pid-identity)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  counter="$dir/ps-calls"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+count=0
+[ ! -e "$FM_TEST_PS_COUNTER" ] || read -r count < "$FM_TEST_PS_COUNTER"
+count=$((count + 1))
+printf '%s\n' "$count" > "$FM_TEST_PS_COUNTER"
+printf 'Sat Jul 25 01:33:0%s 2026 sleep 300\n' "$count"
+SH
+  chmod +x "$fakebin/ps"
+
+  sleep 300 &
+  live=$!
+  first=$(PATH="$fakebin:$PATH" FM_TEST_PS_COUNTER="$counter" FM_STATE_OVERRIDE="$state" \
+    bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$live") \
+    || fail "could not read fresh Linux process identity"
+  second=$(PATH="$fakebin:$PATH" FM_TEST_PS_COUNTER="$counter" FM_STATE_OVERRIDE="$state" \
+    bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$live") \
+    || fail "could not immediately re-read fresh Linux process identity"
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+
+  [ "$second" = "$first" ] \
+    || fail "fresh Linux process identity changed across immediate reads (first '$first', second '$second')"
+  case "$first" in
+    linux-starttime=*) ;;
+    *) fail "fresh Linux process identity did not use proc starttime ('$first')" ;;
+  esac
+  [ ! -e "$counter" ] || fail "fresh Linux process identity invoked the drifting ps fallback"
+  pass "fresh Linux process identity is immediately stable and bypasses ps"
+}
+
 write_fake_proc_identity() {
   local proc_root=$1 pid=$2 starttime=$3
   mkdir -p "$proc_root/$pid"
@@ -958,6 +1027,8 @@ test_linux_pid_identity_ignores_wall_clock_and_detects_pid_reuse() {
 
 test_singleton_start
 test_pid_identity_is_locale_invariant
+test_macos_pid_identity_uses_ps_fallback_without_proc
+test_linux_pid_identity_is_stable_across_immediate_reads
 test_linux_pid_identity_ignores_wall_clock_and_detects_pid_reuse
 test_stale_watch_lock_reclaimed
 test_live_stale_watch_lock_is_actionable


### PR DESCRIPTION
## Intent

Fix kunchenguid/firstmate issue #1014 by ensuring fm-watch.sh watcher PID identity is drift-free on Linux through /proc/<pid>/stat field 22, parsed after the comm field's closing parenthesis, while preserving the existing ps -o lstart fallback for macOS and hosts without usable /proc. The shared fm_pid_identity write and comparison path must remain consistent for watcher-continuity and turn-end guards across every supported primary harness and runtime backend. Add deterministic regression coverage for two immediate reads of a fresh Linux PID, proof that the Linux /proc path bypasses drifting ps output, and the macOS/no-/proc ps fallback. Do not alter PR #1015's wedge/progress subject matter. Current main already contains the requested production implementation from merged PR #752, so this branch intentionally adds the explicit #1014 regression cases that prove and preserve that behavior. The PR description must include Fixes #1014.

## What Changed

- Added `test_linux_pid_identity_is_stable_across_immediate_reads` to `tests/fm-watcher-lock.test.sh`, proving that two immediate `fm_pid_identity` reads of a fresh Linux PID return the same `/proc/<pid>/stat`-derived starttime and never fall through to the drifting `ps` fallback.
- Added `test_macos_pid_identity_uses_ps_fallback_without_proc`, confirming the existing `ps -o lstart=` fallback is invoked and its output preserved unchanged when `/proc` is unavailable (macOS/no-proc hosts).
- Wired both new regression cases into the existing test runner sequence alongside the current locale-invariance and pid-reuse coverage; no production code (`bin/fm-wake-lib.sh`) was modified.

Fixes #1014

## Risk Assessment

✅ Low: The change is purely additive test coverage (no production code touched) that exercises the already-merged fm_pid_identity implementation: it verifies the macOS/no-proc ps fallback is preserved, and that a fresh Linux PID's /proc-based identity is stable across two immediate reads and never falls back to the drifting ps path, matching the intent's required regression cases.

## Testing

Ran the full tests/fm-watcher-lock.test.sh suite natively on Linux (Ubuntu 24.04, WSL2): all 30 checks passed (exit 0), including the two new #1014 regression tests — one proving two immediate reads of a fresh Linux PID return a stable `linux-starttime=...` identity without ever invoking the drifting `ps` fallback, and one proving the macOS/no-/proc path still routes through and preserves the `ps -o lstart=` fallback output. Diffed base against target commit and confirmed the change is test-only; the production /proc-field-22 implementation in bin/fm-wake-lib.sh (fm_pid_identity) is unmodified, matching the stated intent that it was already merged via PR #752 and this branch only adds proving regression coverage. No related files (fm-watch.sh, fm-afk-start.sh, fm-supervise-daemon.sh, fm-afk-launch.sh) were touched. Working tree is clean after the run with no transient artifacts left behind.

<details>
<summary>Evidence: fm-watcher-lock.test.sh full run output (30/30 passing, including the two new #1014 regression tests)</summary>

```text
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - macOS fm_pid_identity preserves the ps fallback when proc is unavailable
ok - fresh Linux process identity is immediately stable and bypasses ps
ok - Linux process identity ignores simulated btime changes
ok - Linux process identity detects pid reuse
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when fresh
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart refuses to signal a reused pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts+confirms a fresh watcher on a clean lock and self-heals a dead-pid lock (never healthy off a dead pid)
ok - arm cleans child watcher and temp output on HUP
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 487758 but heartbeat is stale for 838302525s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-watcher-lock.test.sh` (full targeted suite for the watcher lock/pid-identity module, run natively on Linux so both the Linux-specific and macOS-fallback tests execute rather than skip)</code>
- <code>`git diff 34213e6..002cfdb --stat` to confirm only the test file changed and bin/fm-wake-lib.sh (fm_pid_identity) is untouched, consistent with the intent that production logic already exists on main</code>
- <code>Manual read of bin/fm-wake-lib.sh:26-57 to confirm fm_pid_identity parses /proc/&lt;pid&gt;/stat field 22 after the comm close-paren, falls back to `ps -o lstart=` with LC_ALL=C when /proc is unavailable, and is the single shared path used by callers</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
