### PR TITLE
feat: add verified Kimi crewmate adapter

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -84,7 +84,7 @@ The daemon constructs every current injection as the `away-supervisor` kind owne
 The bare `FM_INJECT_MARK` form remains accepted for legacy daemon escalations during rollout.
 U+2063 has no normal keyboard keystroke and survives terminal transport as UTF-8 text.
 This is how firstmate tells a daemon escalation apart from a real message in the same pane.
-The operational prefix travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, and grok.
+The operational prefix travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, grok, and kimi.
 
 ## Busy-guard and composer guard
 

--- a/.agents/skills/firstmate-orca/SKILL.md
+++ b/.agents/skills/firstmate-orca/SKILL.md
@@ -13,7 +13,7 @@ It does not replace `AGENTS.md`, `docs/orca-backend.md`, or `harness-adapters`.
 
 Orca is a runtime backend, not an agent harness.
 The runtime backend owns the task endpoint and, for Orca, the task worktree.
-The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, or `grok`.
+The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, `grok`, or `kimi`.
 Load `harness-adapters` for harness-specific launch, interrupt, resume, trust-dialog, and skill-invocation facts.
 
 Implementation details, metadata fields, teardown guarantees, and limitations live in `docs/orca-backend.md`.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -354,7 +354,7 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 | Binary | Executable `kimi` from `PATH`, then executable `$HOME/.kimi-code/bin/kimi`; spawning refuses if neither exists. |
 | Launch | Bare interactive TUI with `--auto`, followed by readiness-gated pointer delivery; positional prompts are rejected. |
 | Models | `kimi-code/kimi-for-coding` (default), `kimi-code/kimi-for-coding-highspeed`, `kimi-code/k3`, and `kimi-code/k3-256k`. |
-| Busy-pane signature | A transient line with optional leading whitespace, a rotating moon-phase glyph, the ` · ` separator, and rotating `Tip:` text; the line is absent when idle. |
+| Busy-pane signature | A transient line with optional leading whitespace, a rotating moon-phase glyph, optional whitespace around `·`, and optional trailing content; the line is absent when idle. |
 | Exit command | `/exit` |
 | Interrupt | Single Escape, which prints `Interrupted by user`. |
 | Skill invocation | `/<skill>`, for example `/no-mistakes`; firstmate skills are discovered. |
@@ -370,7 +370,8 @@ This launch-then-send shape is mandatory because Kimi rejects a positional brief
 Sending before readiness was reproduced as a silent drop with a zero exit status, an empty composer, `context: 0%`, no echoed user message, and a healthy-looking idle pane.
 The brief path must be absolute because the brief lives outside the task worktree, and Kimi reads it there without `--add-dir`.
 
-The observed live spinner shape is optional leading whitespace, a moon-phase glyph, whitespace, `·`, whitespace, and rotating tip text, with the same shape observed during tool execution.
+Observed live spinner captures included optional leading whitespace, a moon-phase glyph, whitespace around `·`, and rotating tip text, with the same shape observed during tool execution.
+Because those prose examples illustrate the spinner shape rather than define exact bytes, the matcher permits zero whitespace around `·` and does not require trailing tip text.
 Kimi's footer tip rotates independently and can display `ctrl+c: cancel` while completely idle, so tip text is never used as its busy signature without the leading moon-plus-middot spinner structure.
 The idle status bar can contain lowercase `thinking`, which is the model's effort label rather than a busy signal.
 The spinner match covers the full moon-phase glyph set rather than one frame, but it remains locale- and emoji-font-sensitive because Kimi exposes no stable ASCII busy token.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -370,7 +370,7 @@ This launch-then-send shape is mandatory because Kimi rejects a positional brief
 Sending before readiness was reproduced as a silent drop with a zero exit status, an empty composer, `context: 0%`, no echoed user message, and a healthy-looking idle pane.
 The brief path must be absolute because the brief lives outside the task worktree, and Kimi reads it there without `--add-dir`.
 
-A live spinner capture is ` 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"`, with the same moon-plus-middot shape observed during tool execution.
+The observed live spinner shape is optional leading whitespace, a moon-phase glyph, whitespace, `·`, whitespace, and rotating tip text, with the same shape observed during tool execution.
 Kimi's footer tip rotates independently and can display `ctrl+c: cancel` while completely idle, so tip text is never used as its busy signature without the leading moon-plus-middot spinner structure.
 The idle status bar can contain lowercase `thinking`, which is the model's effort label rather than a busy signal.
 The spinner match covers the full moon-phase glyph set rather than one frame, but it remains locale- and emoji-font-sensitive because Kimi exposes no stable ASCII busy token.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -354,7 +354,7 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 | Binary | Executable `kimi` from `PATH`, then executable `$HOME/.kimi-code/bin/kimi`; spawning refuses if neither exists. |
 | Launch | Bare interactive TUI with `--auto`, followed by readiness-gated pointer delivery; positional prompts are rejected. |
 | Models | `kimi-code/kimi-for-coding` (default), `kimi-code/kimi-for-coding-highspeed`, `kimi-code/k3`, and `kimi-code/k3-256k`. |
-| Busy-pane signature | A transient line containing only a rotating moon-phase glyph followed by `Thinking`; the line is absent when idle. |
+| Busy-pane signature | A transient line with leading whitespace, a rotating moon-phase glyph, the ` · ` separator, and rotating `Tip:` text; the line is absent when idle. |
 | Exit command | `/exit` |
 | Interrupt | Single Escape, which prints `Interrupted by user`. |
 | Skill invocation | `/<skill>`, for example `/no-mistakes`; firstmate skills are discovered. |
@@ -370,7 +370,9 @@ This launch-then-send shape is mandatory because Kimi rejects a positional brief
 Sending before readiness was reproduced as a silent drop with a zero exit status, an empty composer, `context: 0%`, no echoed user message, and a healthy-looking idle pane.
 The brief path must be absolute because the brief lives outside the task worktree, and Kimi reads it there without `--add-dir`.
 
-Kimi's footer tip rotates independently and can display `ctrl+c: cancel` while completely idle, so tip text is never used as its busy signature.
+A live spinner capture is `  🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"`, with the same moon-plus-middot shape observed during tool execution.
+Kimi's footer tip rotates independently and can display `ctrl+c: cancel` while completely idle, so tip text is never used as its busy signature without the leading moon-plus-middot spinner structure.
+The idle status bar can contain lowercase `thinking`, which is the model's effort label rather than a busy signal.
 The spinner match covers the full moon-phase glyph set rather than one frame, but it remains locale- and emoji-font-sensitive because Kimi exposes no stable ASCII busy token.
 
 [`docs/turnend-guard.md`](../../../docs/turnend-guard.md) owns Kimi's verified global hook surface, approval boundary, and absence from the enabled integrations.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and kimi.
 user-invocable: false
 metadata:
   internal: true
@@ -25,7 +25,7 @@ If `config/crew-harness` is unset or `default`, there is no concrete value to in
 Inheritance also copies the literal `config/crew-dispatch.json` file, so secondmates apply the same best-fit profile rules for their own crewmates.
 
 Each adapter splits into mechanics and knowledge.
-The per-task mechanics, including launch command, autonomy flag, and crewmate turn-end hook, live in `bin/fm-spawn.sh`.
+The per-task mechanics, including launch command, autonomy flag, and any enabled crewmate turn-end hook, live in `bin/fm-spawn.sh`.
 The primary-session "no turn ends blind" guard contract and harness hook installation paths live in `docs/turnend-guard.md`.
 The primary-session watcher wake protocols are rendered from `docs/supervision-protocols/` by `bin/fm-supervision-instructions.sh`.
 The supervision knowledge lives here: busy signature, exit command, interrupt, dialogs, resume behavior, skill invocation, and quirks.
@@ -50,16 +50,17 @@ Use that value for interrupt, exit, resume, and skill-invocation facts.
 
 ## Primary turn-end guard
 
-Every verified primary harness has an empirically validated hook path for the "no turn ends blind" guard.
+The primary integrations for `claude`, `codex`, `opencode`, `pi`, and `grok` have empirically validated hook paths for the "no turn ends blind" guard.
 `claude` and `codex` block directly through Stop hooks that preserve exit status 2 and stderr from `bin/fm-turnend-guard.sh`.
 `opencode`, `pi`, and `grok` expose passive lifecycle callbacks for this purpose, so their tracked primary adapters force one bounded follow-up or resume when the shared predicate blocks.
+The kimi crewmate adapter has no enabled primary or per-turn hook integration because its only verified configuration surface is global and requires captain approval.
 The exact hook files, commands, scoping rules, and fail-open tradeoffs are owned by `docs/turnend-guard.md`.
 `docs/verification/supervision.md` "Turn-end guard" owns active validation evidence.
 When changing any primary turn-end hook, validate the real harness behavior in a scratch project or throwaway home before trusting it, then update that doc and the relevant concise fact below.
 
 ## Primary pre-arm (PreToolUse) seatbelt
 
-Every verified primary harness also has a wired PreToolUse-equivalent hook that denies a watcher-arm anti-pattern (shell `&`, truncating pipe, bundling, broad `pkill -f fm-watch`) before it runs.
+The primary integrations for `claude`, `codex`, `opencode`, `pi`, and `grok` also have wired PreToolUse-equivalent hooks that deny a watcher-arm anti-pattern (shell `&`, truncating pipe, bundling, broad `pkill -f fm-watch`) before it runs.
 `claude` and `codex` block directly through PreToolUse hooks; `grok` blocks the same way but requires every `$VAR` reference in its hook `command` string to carry an inline `:-default` or it fails to launch the hook entirely.
 `opencode` and `pi` block by throwing from `tool.execute.before` / returning `{block: true}` from `tool_call`.
 The exact hook files, commands, output-shaping quirks (Claude Code only honors the deny when stdout is empty), and validation transcripts are owned by `docs/arm-pretool-check.md`.
@@ -121,6 +122,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-13 on Pi 0.80.6. `pi --help` advertises `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; `pi --print --model openai-codex/gpt-5.6-sol --thinking max 'Reply with exactly OK.'` completed successfully. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
 
 ### Model support discovery
 
@@ -134,6 +136,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | opencode | Run `opencode models [provider]`, which lists available provider/model identifiers. |
 | pi | Run `pi --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |
+| kimi | Run `kimi provider list --json`, which lists the current provider and model configuration. |
 
 For an unfamiliar harness or model namespace, establish support and provider identity from that harness's authoritative CLI help, model listing, or current documentation rather than guessing from a name or prefix.
 If those sources do not establish the relationship needed for dispatch, fail loudly and report the unresolved candidate.
@@ -151,6 +154,13 @@ Natural language is acceptable if uncertain.
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) already handles this correctly by reading the cursor row; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
+- kimi: `/<skill>`, for example `/no-mistakes`.
+
+## Submission acknowledgement hazards
+
+A send or key action reporting success is not proof that the intended action happened.
+OpenCode can accept and queue an Enter while leaving text visible, Grok can consume Enter in its slash popup without submitting, and Kimi can silently drop a message sent before readiness even though the send returns success.
+The shared symptom is a healthy-looking pane with no work in progress, so each adapter must verify the observable postcondition that is specific to its TUI.
 
 ## claude (VERIFIED; busy signature re-verified 2026-07-25 on Claude Code 2.1.220)
 
@@ -334,3 +344,36 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## kimi (VERIFIED 2026-07-25, kimi 0.29.1)
+
+Kimi Code CLI must be launched by the verified absolute binary path because it is not on `PATH`.
+
+| Fact | Value |
+|---|---|
+| Binary | `/Users/kunchen/.kimi-code/bin/kimi` |
+| Launch | Bare interactive TUI with `--auto`, followed by readiness-gated pointer delivery; positional prompts are rejected. |
+| Models | `kimi-code/kimi-for-coding` (default), `kimi-code/kimi-for-coding-highspeed`, `kimi-code/k3`, and `kimi-code/k3-256k`. |
+| Busy-pane signature | A transient spinner line containing a rotating moon-phase glyph; the line is absent when idle. |
+| Exit command | `/exit` |
+| Interrupt | Single Escape, which prints `Interrupted by user`. |
+| Skill invocation | `/<skill>`, for example `/no-mistakes`; firstmate skills are discovered. |
+| Autonomy | `--auto`; `-y` and `--yolo` are weaker and are not used. |
+| Trust dialog | None on a clean first launch in a fresh pooled worktree. |
+| Slash submission | One Enter submits, with no popup swallow or settle hazard. |
+| Environment marker | None; detection relies on process ancestry command name `kimi`. |
+| Composer | Bordered box with a bare `>` prompt glyph and no observed ghost or placeholder text. |
+| Effort | No reasoning-effort flag exists, so requested effort is recorded in task metadata but omitted from launch. |
+
+`fm-spawn.sh` launches Kimi bare, waits for the composer box or `Welcome to Kimi Code!`, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires a cleared composer plus either the echoed `✨` submission or nonzero context before accepting delivery.
+This launch-then-send shape is mandatory because Kimi rejects a positional brief as an unknown command.
+Sending before readiness was reproduced as a silent drop with a zero exit status, an empty composer, `context: 0%`, no echoed user message, and a healthy-looking idle pane.
+The brief path must be absolute because the brief lives outside the task worktree, and Kimi reads it there without `--add-dir`.
+
+Kimi's footer tip rotates independently and can display `ctrl+c: cancel` while completely idle, so tip text is never used as its busy signature.
+The spinner match covers the full moon-phase glyph set rather than one frame, but it remains locale- and emoji-font-sensitive because Kimi exposes no stable ASCII busy token.
+
+Kimi supports global `[[hooks]]` in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
+Kimi has no project-level hook configuration, so firstmate does not create or modify that global file without the captain's approval.
+The current adapter installs no Kimi hook, writes no Kimi turn-end marker, and falls back to idle detection.
+That fallback is the weakest idle detection of any supported adapter because Kimi has no stable ASCII busy token, so turn completion can only be inferred from the fragile moon spinner disappearing and the pane becoming stable.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -53,7 +53,7 @@ Use that value for interrupt, exit, resume, and skill-invocation facts.
 The primary integrations for `claude`, `codex`, `opencode`, `pi`, and `grok` have empirically validated hook paths for the "no turn ends blind" guard.
 `claude` and `codex` block directly through Stop hooks that preserve exit status 2 and stderr from `bin/fm-turnend-guard.sh`.
 `opencode`, `pi`, and `grok` expose passive lifecycle callbacks for this purpose, so their tracked primary adapters force one bounded follow-up or resume when the shared predicate blocks.
-The kimi crewmate adapter has no enabled primary or per-turn hook integration because its only verified configuration surface is global and requires captain approval.
+Kimi is outside the current turn-end integration scope; `docs/turnend-guard.md` owns the global-configuration boundary.
 The exact hook files, commands, scoping rules, and fail-open tradeoffs are owned by `docs/turnend-guard.md`.
 `docs/verification/supervision.md` "Turn-end guard" owns active validation evidence.
 When changing any primary turn-end hook, validate the real harness behavior in a scratch project or throwaway home before trusting it, then update that doc and the relevant concise fact below.
@@ -373,7 +373,6 @@ The brief path must be absolute because the brief lives outside the task worktre
 Kimi's footer tip rotates independently and can display `ctrl+c: cancel` while completely idle, so tip text is never used as its busy signature.
 The spinner match covers the full moon-phase glyph set rather than one frame, but it remains locale- and emoji-font-sensitive because Kimi exposes no stable ASCII busy token.
 
-Kimi supports global `[[hooks]]` in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
-Kimi has no project-level hook configuration, so firstmate does not create or modify that global file without the captain's approval.
-The current adapter installs no Kimi hook, writes no Kimi turn-end marker, and falls back to idle detection.
+[`docs/turnend-guard.md`](../../../docs/turnend-guard.md) owns Kimi's verified global hook surface, approval boundary, and absence from the enabled integrations.
+The current adapter falls back to idle detection.
 That fallback is the weakest idle detection of any supported adapter because Kimi has no stable ASCII busy token, so turn completion can only be inferred from the fragile moon spinner disappearing and the pane becoming stable.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -370,7 +370,7 @@ This launch-then-send shape is mandatory because Kimi rejects a positional brief
 Sending before readiness was reproduced as a silent drop with a zero exit status, an empty composer, `context: 0%`, no echoed user message, and a healthy-looking idle pane.
 The brief path must be absolute because the brief lives outside the task worktree, and Kimi reads it there without `--add-dir`.
 
-A live spinner capture is `  🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"`, with the same moon-plus-middot shape observed during tool execution.
+A live spinner capture is ` 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"`, with the same moon-plus-middot shape observed during tool execution.
 Kimi's footer tip rotates independently and can display `ctrl+c: cancel` while completely idle, so tip text is never used as its busy signature without the leading moon-plus-middot spinner structure.
 The idle status bar can contain lowercase `thinking`, which is the model's effort label rather than a busy signal.
 The spinner match covers the full moon-phase glyph set rather than one frame, but it remains locale- and emoji-font-sensitive because Kimi exposes no stable ASCII busy token.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -354,7 +354,7 @@ Kimi Code CLI must be launched by the verified absolute binary path because it i
 | Binary | `/Users/kunchen/.kimi-code/bin/kimi` |
 | Launch | Bare interactive TUI with `--auto`, followed by readiness-gated pointer delivery; positional prompts are rejected. |
 | Models | `kimi-code/kimi-for-coding` (default), `kimi-code/kimi-for-coding-highspeed`, `kimi-code/k3`, and `kimi-code/k3-256k`. |
-| Busy-pane signature | A transient spinner line containing a rotating moon-phase glyph; the line is absent when idle. |
+| Busy-pane signature | A transient line containing only a rotating moon-phase glyph followed by `Thinking`; the line is absent when idle. |
 | Exit command | `/exit` |
 | Interrupt | Single Escape, which prints `Interrupted by user`. |
 | Skill invocation | `/<skill>`, for example `/no-mistakes`; firstmate skills are discovered. |

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -347,11 +347,11 @@ Grok's primary watcher protocol is Claude-shaped background-notify around `bin/f
 
 ## kimi (VERIFIED 2026-07-25, kimi 0.29.1)
 
-Kimi Code CLI must be launched by the verified absolute binary path because it is not on `PATH`.
+Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back to the executable `$HOME/.kimi-code/bin/kimi`.
 
 | Fact | Value |
 |---|---|
-| Binary | `/Users/kunchen/.kimi-code/bin/kimi` |
+| Binary | Executable `kimi` from `PATH`, then executable `$HOME/.kimi-code/bin/kimi`; spawning refuses if neither exists. |
 | Launch | Bare interactive TUI with `--auto`, followed by readiness-gated pointer delivery; positional prompts are rejected. |
 | Models | `kimi-code/kimi-for-coding` (default), `kimi-code/kimi-for-coding-highspeed`, `kimi-code/k3`, and `kimi-code/k3-256k`. |
 | Busy-pane signature | A transient line containing only a rotating moon-phase glyph followed by `Thinking`; the line is absent when idle. |

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -354,7 +354,7 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 | Binary | Executable `kimi` from `PATH`, then executable `$HOME/.kimi-code/bin/kimi`; spawning refuses if neither exists. |
 | Launch | Bare interactive TUI with `--auto`, followed by readiness-gated pointer delivery; positional prompts are rejected. |
 | Models | `kimi-code/kimi-for-coding` (default), `kimi-code/kimi-for-coding-highspeed`, `kimi-code/k3`, and `kimi-code/k3-256k`. |
-| Busy-pane signature | A transient line with leading whitespace, a rotating moon-phase glyph, the ` · ` separator, and rotating `Tip:` text; the line is absent when idle. |
+| Busy-pane signature | A transient line with optional leading whitespace, a rotating moon-phase glyph, the ` · ` separator, and rotating `Tip:` text; the line is absent when idle. |
 | Exit command | `/exit` |
 | Interrupt | Single Escape, which prints `Interrupted by user`. |
 | Skill invocation | `/<skill>`, for example `/no-mistakes`; firstmate skills are discovered. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `grok`, and `kimi`; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 
 ### Requirements
 
-- A verified agent harness: Claude Code, Grok, Pi, Codex, or OpenCode.
+- A verified primary agent harness: Claude Code, Grok, Pi, Codex, or OpenCode.
 - Git and the GitHub CLI, authenticated through `gh auth login`.
 - The CLI and dependencies for your selected runtime backend; tmux is the reference default.
 

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -181,7 +181,7 @@ fm_backend_tmux_agent_state() {  # <target>
   }
   comm=${comm#-}
   case "$comm" in
-    *claude*|*codex*|*opencode*|*grok*) printf 'alive' ;;
+    *claude*|*codex*|*opencode*|*grok*|*kimi*) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     '') printf 'unreadable' ;;
     *) printf 'ambiguous' ;;

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -436,7 +436,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
     case "$harness" in
-      claude|codex|opencode|pi|grok) ;;
+      claude|codex|opencode|pi|grok|kimi) ;;
       *)
         case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
         ;;
@@ -713,7 +713,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","kimi"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -721,7 +721,7 @@ crew_dispatch_validate() {
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "opencode" then false
+      elif $h == "opencode" or $h == "kimi" then false
       else true
       end;
     def profiles($value):

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|kimi|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -29,6 +29,12 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
+  # Keep marker detection before ancestry detection as an explicit precedence rule.
+  # Only claude, pi, and grok set verified markers of their own; codex, opencode,
+  # and kimi are markerless, so a foreign marker retained in a terminal
+  # multiplexer's stored environment can silently misidentify one of them before
+  # ancestry is consulted. This is a precedence hazard, not evidence that
+  # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
   # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
@@ -44,6 +50,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      kimi) echo kimi; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.

--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -573,8 +573,8 @@ fm_pending_reply_fallback_idle_eligible() {  # <record-path>
   [ "$age" -ge "$grace" ]
 }
 
-fm_pending_reply_backend_observation() {  # <backend> <target> [expected-label]
-  local backend=$1 target=$2 expected_label=${3-} native tail40
+fm_pending_reply_backend_observation() {  # <backend> <target> [expected-label] [harness]
+  local backend=$1 target=$2 expected_label=${3-} harness=${4-} native tail40
   native=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null || printf 'unknown')
   case "$native" in
     busy|idle) printf '%s' "$native"; return 0 ;;
@@ -582,7 +582,7 @@ fm_pending_reply_backend_observation() {  # <backend> <target> [expected-label]
   tail40=$(fm_backend_capture "$backend" "$target" 40 "$expected_label" 2>/dev/null) \
     || { printf 'unknown'; return 0; }
   if printf '%s' "$tail40" | grep -v '^[[:space:]]*$' | tail -6 \
-    | grep -qiE "${FM_BUSY_REGEX:-$FM_TMUX_BUSY_REGEX_DEFAULT}"; then
+    | fm_busy_lines_match "$harness"; then
     printf 'busy'
   else
     printf 'fallback-idle'
@@ -925,7 +925,7 @@ fm_pending_reply_tick_one() {  # <state-dir> <corr_id> <busy_state> [secondmate-
 # Never scrapes secondmate conversation; uses only parent status, backend busy
 # state, and optional secondmate-home wrong-home path checks.
 fm_pending_reply_tick() {  # <state-dir>
-  local state=$1 dir rec corr task_id phase delivered meta backend target label busy sm_home
+  local state=$1 dir rec corr task_id phase delivered meta backend target label busy sm_home harness
   local observation observation_task found i
   local -a observation_tasks=() observation_values=()
   dir=$(fm_pending_reply_dir "$state")
@@ -986,10 +986,12 @@ fm_pending_reply_tick() {  # <state-dir>
     target=
     busy=unknown
     sm_home=
+    harness=
     if [ -f "$meta" ]; then
       backend=$(fm_backend_of_meta "$meta")
       target=$(fm_backend_target_of_meta "$meta")
       sm_home=$(fm_meta_get "$meta" home)
+      harness=$(fm_meta_get "$meta" harness)
       if [ -n "$target" ]; then
         label="fm-$task_id"
         observation=
@@ -1002,7 +1004,7 @@ fm_pending_reply_tick() {  # <state-dir>
           break
         done
         if [ "$found" = 0 ]; then
-          observation=$(fm_pending_reply_backend_observation "$backend" "$target" "$label")
+          observation=$(fm_pending_reply_backend_observation "$backend" "$target" "$label" "$harness")
           observation_tasks+=("$task_id")
           observation_values+=("$observation")
         fi

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -9,7 +9,7 @@
 # This file is sourced by scripts and has no side effects on source.
 
 # Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|^pi$'
+FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$'
 
 # Walk the current process ancestry (up to 8 hops) and print the first pid whose
 # command looks like a verified harness. The harness pid lives as long as the

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -59,7 +59,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|kimi)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -101,7 +101,8 @@
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
-# Per-harness turn-end hooks are installed automatically; some live outside the worktree.
+# Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
+# Kimi has no enabled hook because its only verified Stop-hook configuration is global.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<backend-target> worktree=<path>
@@ -386,7 +387,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|kimi)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -447,6 +448,11 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # Kimi Code rejects a positional prompt, so it launches bare and receives
+    # only an absolute brief pointer after the TUI readiness gate below.
+    # No turn-end placeholder belongs here because its only verified Stop hook
+    # is global configuration and is not enabled without captain approval.
+    kimi) printf '%s' '/Users/kunchen/.kimi-code/bin/kimi __MODELFLAG__--auto' ;;
     *) return 1 ;;
   esac
 }
@@ -534,7 +540,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|grok)
+    claude|codex|opencode|pi|grok|kimi)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -576,6 +582,8 @@ effort_flag_for_harness() {
     # opencode's interactive `opencode --prompt` launch has a verified --model
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
+    # kimi likewise has no reasoning-effort flag; the requested axis stays in
+    # task metadata but never reaches the launch command.
   esac
 }
 
@@ -754,6 +762,8 @@ else
   BRIEF="$DATA/$ID/brief.md"
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
+BRIEF_DIR_REAL=$(cd "$(dirname "$BRIEF")" && pwd -P)
+BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
 
 # PROJ_ABS can still carry a symlinked path component (e.g. macOS's /tmp ->
 # /private/tmp) when it came from the ship/scout branch's logical `pwd` above.
@@ -1125,6 +1135,58 @@ spawn_send_key() {  # <target> <key>
     cmux) fm_backend_cmux_send_key "$1" "$2" "$W" ;;
   esac
 }
+
+kimi_capture() {
+  fm_backend_capture "$BACKEND" "$T" 120 "$W" 2>/dev/null || true
+}
+
+kimi_capture_has_empty_composer() {  # <plain-pane-capture>
+  printf '%s\n' "$1" \
+    | grep -Eq '^[[:space:]]*(│|┃|\|)[[:space:]]*>[[:space:]]*(│|┃|\|)[[:space:]]*$'
+}
+
+kimi_wait_for_ready() {
+  local pane i=0 max=${FM_KIMI_READY_POLLS:-60} interval=${FM_KIMI_POLL_INTERVAL:-0.5}
+  while [ "$i" -lt "$max" ]; do
+    pane=$(kimi_capture)
+    if printf '%s\n' "$pane" | grep -Fq 'Welcome to Kimi Code!' \
+       || kimi_capture_has_empty_composer "$pane"; then
+      return 0
+    fi
+    i=$((i + 1))
+    [ "$i" -ge "$max" ] || sleep "$interval"
+  done
+  return 1
+}
+
+kimi_delivery_is_confirmed() {  # <plain-pane-capture>
+  local pane=$1
+  kimi_capture_has_empty_composer "$pane" || return 1
+  if { printf '%s\n' "$pane" | grep -Fq '✨' \
+       && printf '%s\n' "$pane" | grep -Fq 'Read the brief at'; } \
+     || printf '%s\n' "$pane" \
+       | grep -qiE 'context:[[:space:]]*(0\.[0-9]*[1-9][0-9]*|[1-9][0-9]*([.][0-9]+)?)[[:space:]]*%'; then
+    return 0
+  fi
+  return 1
+}
+
+kimi_wait_for_delivery() {
+  local pane i=0 max=${FM_KIMI_DELIVERY_POLLS:-40} interval=${FM_KIMI_POLL_INTERVAL:-0.5}
+  while [ "$i" -lt "$max" ]; do
+    pane=$(kimi_capture)
+    kimi_delivery_is_confirmed "$pane" && return 0
+    i=$((i + 1))
+    [ "$i" -ge "$max" ] || sleep "$interval"
+  done
+  return 1
+}
+
+kimi_spawn_fail() {  # <detail>
+  printf 'failed: %s\n' "$1" >> "$STATE/$ID.status"
+  echo "error: $1; inspect window $T" >&2
+}
+
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
@@ -1183,12 +1245,14 @@ fi
 TASK_TMP="/tmp/fm-$ID"
 mkdir -p "$TASK_TMP/gotmp"
 
-# Per-harness turn-end hook: a file that touches state/<id>.turn-ended when the
-# agent finishes a turn. Worktree-resident hooks are kept out of git's view so
-# they never block teardown's dirty check or leak into a commit.
+# Per-harness turn-end hook where enabled: a file that touches
+# state/<id>.turn-ended when the agent finishes a turn. Worktree-resident hooks
+# are kept out of git's view so they never block teardown's dirty check or leak
+# into a commit. Kimi has no path because its global-only hook is not enabled.
 mkdir -p "$STATE"
 STATE_REAL=$(cd "$STATE" && pwd -P)
-TURNEND="$STATE_REAL/$ID.turn-ended"
+TURNEND=
+[ "$HARNESS" = kimi ] || TURNEND="$STATE_REAL/$ID.turn-ended"
 exclude_path() {
   local rel=$1 EXCL
   EXCL=$(git -C "$WT" rev-parse --git-path info/exclude 2>/dev/null || true)
@@ -1377,6 +1441,25 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
+if [ "$HARNESS" = kimi ]; then
+  if ! kimi_wait_for_ready; then
+    kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"
+    exit 1
+  fi
+  KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
+  if ! spawn_send_literal "$T" "$KIMI_POINTER"; then
+    kimi_spawn_fail "kimi brief pointer could not be typed"
+    exit 1
+  fi
+  if ! spawn_send_key "$T" Enter; then
+    kimi_spawn_fail "kimi brief pointer could not be submitted"
+    exit 1
+  fi
+  if ! kimi_wait_for_delivery; then
+    kimi_spawn_fail "kimi brief pointer delivery was not confirmed"
+    exit 1
+  fi
+fi
 if [ "$KIND" = secondmate ]; then
   if ! fm_config_reread_discard_pending "$PROJ_ABS" "$ID" "$FM_HOME"; then
     if fm_config_reread_quarantine_pending "$PROJ_ABS" "$ID" "$FM_HOME"; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -452,7 +452,7 @@ launch_template() {
     # only an absolute brief pointer after the TUI readiness gate below.
     # No turn-end placeholder belongs here because its only verified Stop hook
     # is global configuration and is not enabled without captain approval.
-    kimi) printf '%s' '/Users/kunchen/.kimi-code/bin/kimi __MODELFLAG__--auto' ;;
+    kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
     *) return 1 ;;
   esac
 }
@@ -536,6 +536,30 @@ shell_quote() {
   printf "'"
 }
 
+resolve_kimi_binary() {
+  local candidate dir fallback
+  candidate=$(command -v kimi 2>/dev/null || true)
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    case "$candidate" in
+      /*) printf '%s\n' "$candidate"; return 0 ;;
+      *)
+        dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || dir=
+        if [ -n "$dir" ]; then
+          printf '%s/%s\n' "$dir" "$(basename "$candidate")"
+          return 0
+        fi
+        ;;
+    esac
+  fi
+  fallback="${HOME:-}/.kimi-code/bin/kimi"
+  if [ -n "${HOME:-}" ] && [ -x "$fallback" ]; then
+    printf '%s\n' "$fallback"
+    return 0
+  fi
+  echo "error: kimi executable not found; searched PATH for 'kimi' and fallback '$fallback'" >&2
+  return 1
+}
+
 model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
@@ -586,6 +610,13 @@ effort_flag_for_harness() {
     # task metadata but never reaches the launch command.
   esac
 }
+
+case "$LAUNCH" in
+  *__KIMIBIN__*)
+    KIMI_BIN=$(resolve_kimi_binary) || exit 1
+    LAUNCH=${LAUNCH//__KIMIBIN__/$(shell_quote "$KIMI_BIN")}
+    ;;
+esac
 
 json_escape() {
   printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -122,7 +122,7 @@ family_for_basename() {
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
-    fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
+    fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -78,7 +78,7 @@ FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
 FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
-FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
+FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+[^[:space:]]'
 
 fm_busy_lines_match() {  # [harness]
   local harness=${1:-} lines regex

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -68,17 +68,19 @@
 # enough to classify arbitrary harness output safely.
 # Kimi's anchored moon-phase spinner is separate because bare moon glyphs in
 # ordinary output must not classify another harness as busy. The live spinner
-# row is a moon glyph followed by ` · ` and rotating tip text; the idle status
-# bar's lowercase `thinking` label and independently rotating tip text are not
-# busy signals on their own. The full moon-phase set remains locale- and
-# emoji-font-sensitive because Kimi exposes no stable ASCII busy token.
+# row is a moon glyph followed by ` · ` and rotating tip text, but the matcher
+# stops at the separator because the presence of tip text in every frame is not
+# verified. The idle status bar's lowercase `thinking` label and independently
+# rotating tip text are not busy signals on their own. The full moon-phase set
+# remains locale- and emoji-font-sensitive because Kimi exposes no stable ASCII
+# busy token.
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
 FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
 FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
-FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+[^[:space:]]'
+FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
 
 fm_busy_lines_match() {  # [harness]
   local harness=${1:-} lines regex

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -67,13 +67,14 @@
 # signature separate from the shared default because that shape is not generic
 # enough to classify arbitrary harness output safely.
 # Kimi's anchored moon-phase spinner is separate because bare moon glyphs in
-# ordinary output must not classify another harness as busy. The live spinner
-# row is a moon glyph followed by ` · ` and rotating tip text, but the matcher
-# stops at the separator because the presence of tip text in every frame is not
-# verified. The idle status bar's lowercase `thinking` label and independently
-# rotating tip text are not busy signals on their own. The full moon-phase set
-# remains locale- and emoji-font-sensitive because Kimi exposes no stable ASCII
-# busy token.
+# ordinary output must not classify another harness as busy. Leading whitespace
+# is optional, while whitespace on both sides of the middot is required because
+# every captured row had it; zero-whitespace forms were never observed and are
+# deliberately not matched. The line end stays unanchored because rotating tip
+# text follows but is not required. The idle status bar's lowercase `thinking`
+# label and independently rotating tip text are not busy signals on their own.
+# The full moon-phase set remains locale- and emoji-font-sensitive because Kimi
+# exposes no stable ASCII busy token.
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
 FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -68,11 +68,11 @@
 # enough to classify arbitrary harness output safely.
 # Kimi's anchored moon-phase spinner is separate because bare moon glyphs in
 # ordinary output must not classify another harness as busy. Leading whitespace
-# is optional, while whitespace on both sides of the middot is required because
-# every captured row had it; zero-whitespace forms were never observed and are
-# deliberately not matched. The line end stays unanchored because rotating tip
-# text follows but is not required. The idle status bar's lowercase `thinking`
-# label and independently rotating tip text are not busy signals on their own.
+# and whitespace around the middot are optional because prose examples preserve
+# the spinner's shape rather than defining byte-exact spacing. The line end stays
+# unanchored because rotating tip text follows but is not required. The idle
+# status bar's lowercase `thinking` label and independently rotating tip text are
+# not busy signals on their own.
 # The full moon-phase set remains locale- and emoji-font-sensitive because Kimi
 # exposes no stable ASCII busy token.
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
@@ -81,7 +81,7 @@ FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
 FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
-FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
+FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]*·[[:space:]]*'
 
 fm_busy_lines_match() {  # [harness]
   local harness=${1:-} lines regex

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -66,12 +66,19 @@
 # line has an ellipsis followed by a parenthesized elapsed duration. Keep this
 # signature separate from the shared default because that shape is not generic
 # enough to classify arbitrary harness output safely.
+# Kimi's anchored moon-phase spinner is separate because bare moon glyphs in
+# ordinary output must not classify another harness as busy. The live spinner
+# row is a moon glyph followed by ` · ` and rotating tip text; the idle status
+# bar's lowercase `thinking` label and independently rotating tip text are not
+# busy signals on their own. The full moon-phase set remains locale- and
+# emoji-font-sensitive because Kimi exposes no stable ASCII busy token.
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
 FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
 FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
+FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
 
 fm_busy_lines_match() {  # [harness]
   local harness=${1:-} lines regex
@@ -85,6 +92,7 @@ fm_busy_lines_match() {  # [harness]
       opencode) regex=$FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT ;;
       pi) regex=$FM_TMUX_PI_BUSY_REGEX_DEFAULT ;;
       grok) regex=$FM_TMUX_GROK_BUSY_REGEX_DEFAULT ;;
+      kimi) regex=$FM_TMUX_KIMI_BUSY_REGEX_DEFAULT ;;
       '') regex=$FM_TMUX_BUSY_REGEX_DEFAULT ;;
       *)
         # A supplied harness must never borrow another harness's signature.

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -105,7 +105,8 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
 # grok: "Ctrl+c:cancel". Claude's current spinner signature is matched only for
 # a recorded Claude task because an ellipsis followed by elapsed time is not a
-# safe shared signature for arbitrary harness output.
+# safe shared signature for arbitrary harness output. Kimi's moon-plus-middot
+# spinner signature is likewise matched only for a recorded Kimi task.
 BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,7 +148,7 @@ The session-start bootstrap step keeps valid dispatch configuration silent unles
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and kimi while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -69,7 +69,7 @@ Ordinary user-role near misses remain visible, including quoted current markers,
 
 ## Duplicate-turn regression and semantic boundary
 
-The captain-visible regression reproduced three consecutive times in the persisted Pi session at `/Users/kunchen/.pi/agent/sessions/--Users-kunchen-github-kunchenguid-firstmate--/2026-07-23T16-37-24-672Z_019f8fd6-c440-7641-b2bf-8065dab1622a.jsonl`.
+The captain-visible regression reproduced three consecutive times in a persisted Pi session under `~/.pi/agent/sessions/`.
 Assistant `bb83873b` was followed by hidden custom input `9d087b52` and distinct duplicate assistant `f4232aa3`.
 Assistant `3a388d8c` was followed by adjacent hidden custom inputs `e1914f28` and `cfdefb09` and distinct duplicate assistant `47c81eeb`.
 Distinct provider response identifiers and signatures prove separate model turns rather than duplicate TUI paint.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,10 +174,11 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+claude, codex, opencode, pi, grok, and kimi are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
-Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
+Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
+Kimi currently has no enabled hook integration because its only verified Stop-hook configuration is global and requires captain approval.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
 Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,7 +174,8 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, grok, and kimi are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+claude, codex, opencode, pi, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the narrower set supported for the primary session.
+New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,7 +178,7 @@ claude, codex, opencode, pi, grok, and kimi are all empirically verified; new ha
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
-Kimi currently has no enabled hook integration because its only verified Stop-hook configuration is global and requires captain approval.
+Kimi is outside the enabled integration scope; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its verified hook boundary.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
 Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -46,7 +46,7 @@ Verify setup by spawning a small task and confirming its `fm-<id>` window appear
 
 A target-existence check proves only that the pane exists.
 The deeper tmux agent-liveness probe first verifies exact window membership, then reads `#{pane_current_command}` to distinguish a running harness process from a bare idle shell.
-It classifies recognized Claude, Codex, OpenCode, and Grok process names as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
+It classifies recognized Claude, Codex, OpenCode, Grok, and Kimi process names as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
 Only `dead` and `missing` authorize recovery because a false dead result could launch a duplicate agent.
 
 Pi runs through a generic `node` process name and cannot be attributed confidently from the tmux foreground-process field.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -3,7 +3,7 @@
 This is the authoritative current contract for the "no turn ends blind" primary backstop referenced from AGENTS.md section 8.
 The predicate lives in `bin/fm-turnend-guard.sh`.
 Primary scope lives in `bin/fm-primary-scope-lib.sh`, shared with the native session-start nudge in [`sessionstart-nudge.md`](sessionstart-nudge.md).
-Harness hook files only adapt each verified harness's turn-end mechanism to that shared predicate.
+Harness hook files adapt each enabled primary harness integration's turn-end mechanism to that shared predicate.
 
 Related PreToolUse guards deny unsafe commands before execution rather than detecting a blind turn end afterward.
 Their separate owners are [`arm-pretool-check.md`](arm-pretool-check.md), [`cd-guard.md`](cd-guard.md), and [`subagent-guard.md`](subagent-guard.md).
@@ -72,6 +72,8 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - A valid secondmate home is in scope; an idle secondmate endpoint with no X-mode relay poll remains healthy because it has no supervision need.
 - Claude and Codex block directly, while OpenCode, Pi, and Grok use bounded passive follow-ups.
 - OpenCode headless mode and untrusted Grok project hooks remain fail-open at the host boundary.
+- Kimi Code CLI 0.29.1 exposes only global `[[hooks]]` configuration in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
+- Kimi has no project-level hook configuration, so Firstmate does not modify that global file without captain approval, installs no Kimi hook, and writes no Kimi turn-end marker.
 - Missing `jq` or unreadable hook input remains fail-open.
 - No harness adapter uses a shell ampersand to manufacture supervision.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -29,6 +29,7 @@ zsh
 
 A persistent parent shell waiting for a child remained reported as the parent process, while a shell that directly execed a simple command changed identity with the process itself.
 Claude, Codex, OpenCode, and Grok were observed under their own process names.
+Kimi Code CLI 0.29.1 was observed under `kimi` on 2026-07-25.
 Pi remained a generic `node` process and is intentionally inconclusive.
 
 The OpenCode 1.18.4 busy-queue behavior and the tmux fallback are pinned by:

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -387,7 +387,7 @@ test_ping_state_down() {
   dir="$TMP_ROOT/ping-down"; mkdir -p "$dir/responses"
   fb=$(make_cmux_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" FM_CMUX_FAKE_PING_EXIT=1 \
-    FM_CMUX_FAKE_PING="Error: Socket not found at /Users/x/.local/state/cmux/cmux.sock" \
+    FM_CMUX_FAKE_PING="Error: Socket not found at /home/x/.local/state/cmux/cmux.sock" \
     bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_ping_state' "$ROOT" )
   [ "$out" = down ] || fail "ping_state should report down when the socket does not exist yet, got '$out'"
   pass "fm_backend_cmux_ping_state: reports 'down' when the app is not running yet"
@@ -657,11 +657,11 @@ test_current_path_probes_with_marker() {
   cmux_panes_response "$dir" 2 "bbbbbbbb-1111-1111-1111-111111111111"
   cmux_panes_response "$dir" 4 "bbbbbbbb-1111-1111-1111-111111111111"
   cmux_panes_response "$dir" 6 "bbbbbbbb-1111-1111-1111-111111111111"
-  cmux_read_screen_response "$dir" 7 $'/tmp/proj\n❯ printf marker\n__FM_CMUX_CWD_BEGIN__\n/Users/kunchen/.treehouse/fake-worktree\n__FM_CMUX_CWD_END__\n/Users/kunchen/.treehouse/fake-worktree ❯'
+  cmux_read_screen_response "$dir" 7 $'/tmp/proj\n❯ printf marker\n__FM_CMUX_CWD_BEGIN__\n/home/fixture/.treehouse/fake-worktree\n__FM_CMUX_CWD_END__\n/home/fixture/.treehouse/fake-worktree ❯'
   fb=$(make_cmux_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
     bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_current_path "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111"' "$ROOT" )
-  [ "$out" = "/Users/kunchen/.treehouse/fake-worktree" ] || fail "current_path should read only the marked cwd line, got '$out'"
+  [ "$out" = "/home/fixture/.treehouse/fake-worktree" ] || fail "current_path should read only the marked cwd line, got '$out'"
   assert_contains "$(cat "$dir/log")" "__FM_CMUX_CWD_BEGIN__" "current_path did not send the cwd begin marker"
   assert_contains "$(cat "$dir/log")" "pwd;" "current_path did not send the pwd probe"
   assert_contains "$(cat "$dir/log")" $'\x1f''send-key'$'\x1f''--workspace'$'\x1f''aaaaaaaa-0000-0000-0000-000000000000'$'\x1f''--surface'$'\x1f''bbbbbbbb-1111-1111-1111-111111111111'$'\x1f''enter' \

--- a/tests/fm-backend-zellij.test.sh
+++ b/tests/fm-backend-zellij.test.sh
@@ -664,18 +664,18 @@ test_current_path_probes_with_marker_and_ignores_prompt_paths() {
   zellij_pane_response "$dir" 4 7 3
   zellij_pane_response "$dir" 6 7 3
   printf '%s\n' 'scratch-e2e-project HEAD' \
-    '/Users/kunchen/src/project ❯ printf marker' \
+    '/home/fixture/src/project ❯ printf marker' \
     '__FM_ZELLIJ_CWD_BEGIN__' \
-    '/Users/kunchen/.treehouse/fake-' \
+    '/home/fixture/.treehouse/fake-' \
     'worktree' \
     '__FM_ZELLIJ_CWD_END__' \
-    '/Users/kunchen/.treehouse/fake-worktree ❯' \
+    '/home/fixture/.treehouse/fake-worktree ❯' \
     > "$dir/responses/7.out"
   fb=$(make_zellij_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_ZELLIJ_LOG="$dir/log" FM_ZELLIJ_RESPONSES="$dir/responses" \
     FM_ZELLIJ_SESSION_LIST="firstmate" \
     bash -c '. "$0/bin/backends/zellij.sh"; fm_backend_zellij_current_path firstmate:7' "$ROOT" )
-  [ "$out" = "/Users/kunchen/.treehouse/fake-worktree" ] || fail "current_path should read only the marked cwd line, got '$out'"
+  [ "$out" = "/home/fixture/.treehouse/fake-worktree" ] || fail "current_path should read only the marked cwd line, got '$out'"
   zellij_assert_call_order "$dir/log" $'\x1f''list-panes'$'\x1f''--json' $'\x1f''paste' \
     "current_path did not verify the pane before the cwd probe paste"
   zellij_assert_call_order "$dir/log" $'\x1f''list-panes'$'\x1f''--json' $'\x1f''dump-screen' \
@@ -695,13 +695,13 @@ test_current_path_ignores_tilde_prefixed_banner_lines() {
   zellij_pane_response "$dir" 4 7 3
   zellij_pane_response "$dir" 6 7 3
   printf '%s\n' "🌳 Entered worktree at ~/.treehouse/scratch-e2e-project/1. Type 'exit' to return." \
-    'scratch-e2e-project HEAD' '__FM_ZELLIJ_CWD_BEGIN__' '/Users/kunchen/.treehouse/real-worktree' '__FM_ZELLIJ_CWD_END__' '❯' \
+    'scratch-e2e-project HEAD' '__FM_ZELLIJ_CWD_BEGIN__' '/home/fixture/.treehouse/real-worktree' '__FM_ZELLIJ_CWD_END__' '❯' \
     > "$dir/responses/7.out"
   fb=$(make_zellij_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_ZELLIJ_LOG="$dir/log" FM_ZELLIJ_RESPONSES="$dir/responses" \
     FM_ZELLIJ_SESSION_LIST="firstmate" \
     bash -c '. "$0/bin/backends/zellij.sh"; fm_backend_zellij_current_path firstmate:7' "$ROOT" )
-  [ "$out" = "/Users/kunchen/.treehouse/real-worktree" ] || fail "current_path should skip the ~-prefixed banner line and read the marked cwd output, got '$out'"
+  [ "$out" = "/home/fixture/.treehouse/real-worktree" ] || fail "current_path should skip the ~-prefixed banner line and read the marked cwd output, got '$out'"
   pass "fm_backend_zellij_current_path: never picks up a ~-prefixed banner line as the answer"
 }
 

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -284,7 +284,7 @@ test_backend_detect_cmux_fallback_ancestry_pid_match() {
   # $$ is this test script's own pid - the walk starts there. The cmux app
   # pid (66666) is matched via the lsappinfo bundle-id resolution, with a
   # deliberately non-standard install path so only the pid can match.
-  printf '%s\t77777\t/bin/zsh\n77777\t66666\t/usr/bin/login\n66666\t1\t/Users/x/Custom.app/Contents/MacOS/custom\n' "$$" > "$table"
+  printf '%s\t77777\t/bin/zsh\n77777\t66666\t/usr/bin/login\n66666\t1\t/home/x/Custom.app/Contents/MacOS/custom\n' "$$" > "$table"
 
   (
     unset TMUX HERDR_ENV CMUX_WORKSPACE_ID __CFBundleIdentifier
@@ -304,7 +304,7 @@ test_backend_detect_cmux_fallback_ancestry_comm_match() {
   # lsappinfo resolves nothing (empty output, like the real one for a
   # non-running or non-GUI-visible app); the bundle-shaped comm path is the
   # remaining match, at a non-/Applications install location on purpose.
-  printf '%s\t77777\t/bin/zsh\n77777\t66666\t/usr/bin/login\n66666\t1\t/Users/x/Applications/cmux.app/Contents/MacOS/cmux\n' "$$" > "$table"
+  printf '%s\t77777\t/bin/zsh\n77777\t66666\t/usr/bin/login\n66666\t1\t/home/x/Applications/cmux.app/Contents/MacOS/cmux\n' "$$" > "$table"
 
   (
     unset TMUX HERDR_ENV CMUX_WORKSPACE_ID __CFBundleIdentifier FM_FAKE_LSAPPINFO_OUT

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -776,6 +776,8 @@ unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","us
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
+kimi model profile is accepted^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3"}}]}^empty^
+unsupported kimi effort is flagged^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: kimi:high
 array use with quota-balanced is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}],"select":"quota-balanced"}]}^empty^
 array use without select is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}]}]}^empty^
 one-element array use is accepted^{"rules":[{"when":"focused feature","use":[{"harness":"claude"}]}]}^empty^

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -915,7 +915,7 @@ let adjacent = false;
 let latestInputRole: "user" | "custom" | undefined;
 
 const EXACT_WATCHER_INPUT =
-  "\u2063FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: /Users/kunchen/github/kunchenguid/firstmate/state/oss-triage-t4.status\n\n" +
+  "\u2063FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: /home/fixture/github/kunchenguid/firstmate/state/oss-triage-t4.status\n\n" +
   "Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.";
 
 function monitorInput(suffix: "ONE" | "TWO"): string {
@@ -1086,7 +1086,7 @@ TS
     if [ "$calm_state" = on ]; then
       assert_not_contains "$pane" "MONITOR_${label}_ONE" "Pi follow-up $label case rendered a Calm-hidden operational user row"
       if [ "$label" = exact_watcher ]; then
-        assert_not_contains "$pane" "FIRSTMATE WATCHER WAKE: signal: /Users/kunchen/github/kunchenguid/firstmate/state/oss-triage-t4.status" \
+        assert_not_contains "$pane" "FIRSTMATE WATCHER WAKE: signal: /home/fixture/github/kunchenguid/firstmate/state/oss-triage-t4.status" \
           "Pi exact watcher case rendered the Calm-hidden authoritative payload"
         assert_not_contains "$pane" "Run bin/fm-wake-drain.sh first and handle the queued wake." \
           "Pi exact watcher case rendered the Calm-hidden drain instruction"
@@ -1126,7 +1126,7 @@ const handled = expected === 2
 const expectedOperationalTexts = Array.from({ length: expected }, (_, index) => {
   const suffix = index === 0 ? "ONE" : "TWO";
   return label === "exact_watcher" && suffix === "ONE"
-    ? "\u2063FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: /Users/kunchen/github/kunchenguid/firstmate/state/oss-triage-t4.status\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned."
+    ? "\u2063FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: /home/fixture/github/kunchenguid/firstmate/state/oss-triage-t4.status\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned."
     : label === "legacy_away" && suffix === "ONE"
       ? "\u2063Supervisor escalate (LEGACY_AWAY_E2E)"
       : `\u2063FIRSTMATE_OP: v1 watcher: MONITOR_${label}_${suffix}`;
@@ -1190,7 +1190,7 @@ JS
     done
     assert_contains "$pane" "CAPTAIN_PROMPT_exact_watcher" "Pi restart lost the genuine captain prompt"
     assert_contains "$pane" "MONITOR_HANDLED_exact_watcher_ONE" "Pi restart lost the operational processing response"
-    assert_not_contains "$pane" "FIRSTMATE WATCHER WAKE: signal: /Users/kunchen/github/kunchenguid/firstmate/state/oss-triage-t4.status" \
+    assert_not_contains "$pane" "FIRSTMATE WATCHER WAKE: signal: /home/fixture/github/kunchenguid/firstmate/state/oss-triage-t4.status" \
       "Pi restart replayed the Calm-hidden exact watcher row"
     captain_line=$(printf '%s\n' "$pane" | grep -Fn 'CAPTAIN_ANSWER_exact_watcher' | tail -1 | cut -d: -f1)
     handled_line=$(printf '%s\n' "$pane" | grep -Fn 'MONITOR_HANDLED_exact_watcher_ONE' | tail -1 | cut -d: -f1)
@@ -1203,7 +1203,7 @@ const entries = fs.readFileSync(process.argv[2], "utf8").trim().split("\n").map(
 const text = (content) => typeof content === "string"
   ? content
   : (content ?? []).filter((item) => item.type === "text").map((item) => item.text).join("");
-const exact = "\u2063FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: /Users/kunchen/github/kunchenguid/firstmate/state/oss-triage-t4.status\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.";
+const exact = "\u2063FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: signal: /home/fixture/github/kunchenguid/firstmate/state/oss-triage-t4.status\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.";
 const users = entries.filter((entry) => entry.type === "message" && entry.message.role === "user" && text(entry.message.content) === exact);
 const responses = entries.filter((entry) => entry.type === "message" && entry.message.role === "assistant" && text(entry.message.content) === "MONITOR_HANDLED_exact_watcher_ONE");
 if (users.length !== 1 || responses.length !== 1) {

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -12,7 +12,7 @@ FAKE_LOG="$TMP_ROOT/herdr.log"
 TRIPWIRES="$TMP_ROOT/tripwires"
 REAL_SLEEP=$(command -v sleep)
 mkdir -p "$FAKE_STATE"
-printf '%s\n' '/Users/test/.config/herdr/herdr.sock' > "$FAKE_STATE/default-socket"
+printf '%s\n' '/home/test/.config/herdr/herdr.sock' > "$FAKE_STATE/default-socket"
 : > "$FAKE_LOG"
 
 cat > "$FAKEBIN/herdr" <<'SH'
@@ -176,7 +176,7 @@ test_changed_default_trips_after_teardown() {
   run_with_fake fm_herdr_lab_teardown "$name" >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "changed default fleet state must fail teardown"
   assert_present "$TRIPWIRES/$name.fleet-state.json" "failed tripwire should retain evidence"
-  printf '%s\n' '/Users/test/.config/herdr/herdr.sock' > "$FAKE_STATE/default-socket"
+  printf '%s\n' '/home/test/.config/herdr/herdr.sock' > "$FAKE_STATE/default-socket"
   rm -f "$TRIPWIRES/$name.fleet-state.json"
   pass "fm-herdr-lab: changed default fleet state is a hard failure"
 }

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -25,12 +25,20 @@ test_existing_launch_templates_are_byte_pinned() {
   pass "fm-spawn: the five pre-existing adapters' launch templates stay byte-pinned"
 }
 
+test_tracked_files_have_no_user_absolute_paths() {
+  local pattern="/""Users/" matches
+  matches=$(git -C "$ROOT" grep -n -F "$pattern" -- . || true)
+  [ -z "$matches" ] || fail "tracked files contain user-specific absolute paths: $matches"
+  pass "repository: tracked files contain no user-specific absolute paths"
+}
+
 make_spawn_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+printf '%s\n' "$*" >> "$FM_FAKE_TMUX_CALL_LOG"
 state=$(cat "$FM_FAKE_KIMI_STATE" 2>/dev/null || true)
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "$FM_FAKE_PANE_PATH"; exit 0 ;;
@@ -49,7 +57,7 @@ case "${1:-}" in
     done
     if [ -n "$literal" ]; then
       case "$literal" in
-        /Users/kunchen/.kimi-code/bin/kimi*)
+        *' --auto')
           printf '%s\n' "$literal" >> "$FM_FAKE_LAUNCH_LOG"
           printf 'launched\n' > "$FM_FAKE_KIMI_STATE"
           ;;
@@ -102,6 +110,7 @@ exit 0
 SH
   chmod +x "$fakebin/tmux"
   fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_exit0 "$fakebin" kimi
   printf '%s\n' "$fakebin"
 }
 
@@ -120,19 +129,21 @@ make_spawn_case() {
   : > "$case_dir/launch.log"
   : > "$case_dir/pointer.log"
   : > "$case_dir/kimi.state"
+  : > "$case_dir/tmux-calls.log"
   printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
 }
 
 run_spawn() {
   local case_dir=$1 home=$2 proj=$3 wt=$4 fakebin=$5 id=$6
   shift 6
-  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+  HOME="$home" FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     FM_FAKE_LAUNCH_LOG="$case_dir/launch.log" \
     FM_FAKE_POINTER_LOG="$case_dir/pointer.log" \
     FM_FAKE_KIMI_STATE="$case_dir/kimi.state" \
+    FM_FAKE_TMUX_CALL_LOG="$case_dir/tmux-calls.log" \
     FM_FAKE_BRIEF_REAL="$(cd "$home/data/$id" && pwd -P)/brief.md" \
     FM_KIMI_READY_POLLS=2 FM_KIMI_DELIVERY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
     PATH="$fakebin:$BASE_PATH" \
@@ -157,7 +168,7 @@ test_kimi_launch_then_send_is_verified() {
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
 
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "/Users/kunchen/.kimi-code/bin/kimi --model 'kimi-code/k3' --auto" ] \
+  [ "$launch" = "'$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
     || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
   assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
   assert_not_contains "$launch" "turn-ended" "kimi launch implied a turn-end marker"
@@ -172,6 +183,42 @@ test_kimi_launch_then_send_is_verified() {
   assert_grep 'effort=high' "$meta" "kimi meta did not retain the unsupported effort axis"
   assert_absent "$HOME_DIR/.kimi-code/config.toml" "kimi spawn wrote a global config file"
   pass "fm-spawn: kimi launches bare, waits for readiness, sends an absolute brief pointer, and confirms delivery"
+}
+
+test_kimi_falls_back_to_expanded_home_binary() {
+  local id rec out rc launch fallback
+  id=kimi-fallback-z4
+  rec=$(make_spawn_case fallback "$id")
+  read_spawn_record "$rec"
+  rm "$FAKEBIN_DIR/kimi"
+  fallback="$HOME_DIR/.kimi-code/bin/kimi"
+  mkdir -p "$(dirname "$fallback")"
+  fm_fake_exit0 "$(dirname "$fallback")" kimi
+  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id")
+  rc=$?
+  expect_code 0 "$rc" "Kimi HOME fallback spawn should succeed"
+  launch=$(cat "$CASE_DIR/launch.log")
+  [ "$launch" = "'$fallback' --auto" ] \
+    || fail "Kimi fallback did not expand HOME into an absolute executable: $launch"
+  pass "fm-spawn: Kimi fallback expands the active HOME"
+}
+
+test_kimi_missing_binary_refuses_before_pane_creation() {
+  local id rec out rc fallback
+  id=kimi-missing-z5
+  rec=$(make_spawn_case missing "$id")
+  read_spawn_record "$rec"
+  rm "$FAKEBIN_DIR/kimi"
+  fallback="$HOME_DIR/.kimi-code/bin/kimi"
+  rc=0
+  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "missing Kimi executable should refuse the spawn"
+  assert_contains "$out" "searched PATH for 'kimi'" "missing Kimi diagnostic omitted PATH"
+  assert_contains "$out" "fallback '$fallback'" "missing Kimi diagnostic omitted expanded fallback"
+  if grep -Eq '(^| )new-(session|window)( |$)' "$CASE_DIR/tmux-calls.log"; then
+    fail "missing Kimi executable created a tmux container or pane"
+  fi
+  pass "fm-spawn: missing Kimi executable refuses before pane creation"
 }
 
 test_kimi_unconfirmed_delivery_fails_loudly() {
@@ -223,7 +270,7 @@ for arg in "$@"; do
   prev=$arg
 done
 case "$field:$pid" in
-  comm=:4242) printf '/Users/kunchen/.kimi-code/bin/kimi\n' ;;
+  comm=:4242) printf '/opt/kimi/bin/kimi\n' ;;
   comm=:*) printf '/bin/bash\n' ;;
   ppid=:4242) printf '1\n' ;;
   ppid=:*) printf '4242\n' ;;
@@ -317,8 +364,11 @@ test_kimi_bordered_prompt_needs_no_override() {
   pass "composer classifier: kimi's existing bordered > shape is already safe without an override"
 }
 
+test_tracked_files_have_no_user_absolute_paths
 test_existing_launch_templates_are_byte_pinned
 test_kimi_launch_then_send_is_verified
+test_kimi_falls_back_to_expanded_home_binary
+test_kimi_missing_binary_refuses_before_pane_creation
 test_kimi_unconfirmed_delivery_fails_loudly
 test_kimi_readiness_gate_precedes_pointer
 test_kimi_detection_uses_ancestry_after_markers

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -287,6 +287,33 @@ SH
   pass "fm-harness: markerless kimi is detected by ancestry after env-marker precedence"
 }
 
+test_kimi_session_lock_identity() {
+  local home fakebin out
+  home="$TMP_ROOT/session-lock-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/session-lock-fake")
+  mkdir -p "$home/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/opt/kimi/bin/kimi'; exit 0 ;;
+  *"args="*) printf '%s\n' 'kimi'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+
+  FM_HOME="$home" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" \
+    || fail "fm-lock did not acquire from Kimi ancestry"
+  case "$(cat "$home/state/.lock")" in
+    ''|*[!0-9]*) fail "fm-lock did not record the Kimi harness ancestor" ;;
+  esac
+  printf '%s\n' "$$" > "$home/state/.lock"
+  out=$(FM_HOME="$home" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid" \
+    "fm-lock did not recognize Kimi as a live holder"
+  pass "fm-lock recognizes Kimi ancestry and live lock holders"
+}
+
 test_kimi_busy_signature_is_scoped_to_spinner_lines() {
   local capture phase kimi_regex_lines
   # shellcheck source=/dev/null
@@ -384,6 +411,7 @@ test_kimi_missing_binary_refuses_before_pane_creation
 test_kimi_unconfirmed_delivery_fails_loudly
 test_kimi_readiness_gate_precedes_pointer
 test_kimi_detection_uses_ancestry_after_markers
+test_kimi_session_lock_identity
 test_kimi_busy_signature_is_scoped_to_spinner_lines
 test_watcher_scopes_moon_spinner_to_recorded_kimi_task
 test_kimi_bordered_prompt_needs_no_override

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -327,11 +327,10 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
     esac
   }
   # These fixtures reproduce the observed spinner shape rather than byte-exact
-  # transcriptions. Leading whitespace is deliberately varied, while separator
-  # whitespace stays fixed because every observed capture had it.
+  # transcriptions. Leading and separator whitespace are deliberately varied.
   printf ' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"\n│ > │\n' > "$capture"
   fm_pane_is_busy fake kimi || fail "the first real Kimi spinner shape was not recognized as busy"
-  printf '   🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
+  printf '   🌗·Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
   fm_pane_is_busy fake kimi || fail "the tool-execution Kimi spinner shape was not recognized as busy"
   printf 'ordinary response ending with 🌕\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake kimi; then
@@ -369,7 +368,7 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
 }
 
 test_watcher_scopes_moon_spinner_to_recorded_kimi_task() (
-  local state="$TMP_ROOT/watch-state" busy_capture='  🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
+  local state="$TMP_ROOT/watch-state" busy_capture='  🌑· Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
   mkdir -p "$state"
   printf 'window=fake\nharness=kimi\n' > "$state/kimi-watch.meta"
   unset FM_BUSY_REGEX

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -327,8 +327,8 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
     esac
   }
   # These fixtures reproduce the observed spinner shape rather than byte-exact
-  # transcriptions. Leading whitespace is deliberately varied because the
-  # matcher is whitespace-insensitive by design and must not be pinned to prose.
+  # transcriptions. Leading whitespace is deliberately varied, while separator
+  # whitespace stays fixed because every observed capture had it.
   printf ' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"\n│ > │\n' > "$capture"
   fm_pane_is_busy fake kimi || fail "the first real Kimi spinner shape was not recognized as busy"
   printf '   🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -240,7 +240,7 @@ SH
   pass "fm-harness: markerless kimi is detected by ancestry after env-marker precedence"
 }
 
-test_kimi_busy_signature_uses_all_moon_frames_not_tip_text() {
+test_kimi_busy_signature_is_scoped_to_spinner_lines() {
   local capture phase
   # shellcheck source=/dev/null
   . "$ROOT/bin/fm-tmux-lib.sh"
@@ -254,18 +254,50 @@ test_kimi_busy_signature_uses_all_moon_frames_not_tip_text() {
   }
   for phase in 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘; do
     printf '%s Thinking\n│ > │\n' "$phase" > "$capture"
-    fm_pane_is_busy fake || fail "kimi moon phase $phase was not recognized as busy"
+    fm_pane_is_busy fake kimi || fail "kimi moon phase $phase was not recognized as busy"
   done
+  printf 'ordinary response ending with 🌕\n│ > │\n' > "$capture"
+  if fm_pane_is_busy fake kimi; then
+    fail "a moon outside Kimi's spinner-line shape was misread as busy"
+  fi
+  printf '🌕 Thinking\n│ > │\n' > "$capture"
+  if fm_pane_is_busy fake codex; then
+    fail "Kimi's moon spinner signature leaked into another harness"
+  fi
   printf 'tip: ctrl+c: cancel\n│ > │\n' > "$capture"
-  if fm_pane_is_busy fake; then
+  if fm_pane_is_busy fake kimi; then
     fail "kimi's independently rotating idle tip was misread as busy"
   fi
   for phase in 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘; do
     grep -Fq "$phase" "$ROOT/bin/fm-watch.sh" \
       || fail "fm-watch default is missing kimi moon phase $phase"
   done
-  pass "busy detection: every kimi moon phase is busy while idle tip text is ignored"
+  pass "busy detection: Kimi moon phases require its harness and spinner-line shape"
 }
+
+test_watcher_scopes_moon_spinner_to_recorded_kimi_task() (
+  local state="$TMP_ROOT/watch-state"
+  mkdir -p "$state"
+  printf 'window=fake\nharness=kimi\n' > "$state/kimi-watch.meta"
+  unset FM_BUSY_REGEX
+  FM_HOME="$TMP_ROOT/watch-home"
+  FM_STATE_OVERRIDE="$state"
+  export FM_HOME FM_STATE_OVERRIDE
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-watch.sh"
+  fm_backend_busy_state() { printf 'unknown'; }
+  window_is_busy fake '🌕 Thinking' \
+    || fail "fm-watch did not recognize a recorded Kimi spinner line"
+  printf 'window=fake\nharness=codex\n' > "$state/kimi-watch.meta"
+  if window_is_busy fake '🌕 Thinking'; then
+    fail "fm-watch applied Kimi's moon spinner to a recorded Codex task"
+  fi
+  printf 'window=fake\nharness=kimi\n' > "$state/kimi-watch.meta"
+  if window_is_busy fake 'ordinary response ending with 🌕'; then
+    fail "fm-watch treated an ordinary Kimi moon as a spinner line"
+  fi
+  pass "fm-watch: moon spinner matching is scoped by metadata and line shape"
+)
 
 test_kimi_bordered_prompt_needs_no_override() {
   local out
@@ -283,5 +315,6 @@ test_kimi_launch_then_send_is_verified
 test_kimi_unconfirmed_delivery_fails_loudly
 test_kimi_readiness_gate_precedes_pointer
 test_kimi_detection_uses_ancestry_after_markers
-test_kimi_busy_signature_uses_all_moon_frames_not_tip_text
+test_kimi_busy_signature_is_scoped_to_spinner_lines
+test_watcher_scopes_moon_spinner_to_recorded_kimi_task
 test_kimi_bordered_prompt_needs_no_override

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -288,7 +288,7 @@ SH
 }
 
 test_kimi_busy_signature_is_scoped_to_spinner_lines() {
-  local capture phase
+  local capture phase kimi_regex_lines
   # shellcheck source=/dev/null
   . "$ROOT/bin/fm-tmux-lib.sh"
   unset FM_BUSY_REGEX
@@ -299,35 +299,43 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
       *) return 0 ;;
     esac
   }
-  for phase in 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘; do
-    printf '%s Thinking\n│ > │\n' "$phase" > "$capture"
-    fm_pane_is_busy fake kimi || fail "kimi moon phase $phase was not recognized as busy"
-  done
+  printf '  🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"\n│ > │\n' > "$capture"
+  fm_pane_is_busy fake kimi || fail "the first real Kimi spinner capture was not recognized as busy"
+  printf '  🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
+  fm_pane_is_busy fake kimi || fail "the tool-execution Kimi spinner capture was not recognized as busy"
   printf 'ordinary response ending with 🌕\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake kimi; then
     fail "a moon outside Kimi's spinner-line shape was misread as busy"
   fi
   printf '🌕 Full moon details\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake kimi; then
-    fail "moon-led Kimi output was misread as the complete spinner row"
+    fail "moon-led Kimi output without the middot separator was misread as busy"
   fi
-  printf '🌕 Thinking\n│ > │\n' > "$capture"
+  printf '  🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake codex; then
-    fail "Kimi's moon spinner signature leaked into another harness"
+    fail "Kimi's real spinner signature leaked into another harness"
   fi
   printf 'tip: ctrl+c: cancel\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake kimi; then
     fail "kimi's independently rotating idle tip was misread as busy"
   fi
+  printf 'auto  K2.7 Coding thinking  /some/path\n│ > │\n' > "$capture"
+  if fm_pane_is_busy fake kimi; then
+    fail "Kimi's idle thinking-effort status label was misread as busy"
+  fi
+  kimi_regex_lines=$(grep 'KIMI_BUSY_REGEX' "$ROOT/bin/fm-tmux-lib.sh" "$ROOT/bin/fm-watch.sh")
+  if printf '%s\n' "$kimi_regex_lines" | grep -qi thinking; then
+    fail "Kimi busy regex still depends on a Thinking or thinking token"
+  fi
   for phase in 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘; do
     grep -Fq "$phase" "$ROOT/bin/fm-watch.sh" \
       || fail "fm-watch default is missing kimi moon phase $phase"
   done
-  pass "busy detection: Kimi moon phases require its harness and spinner-line shape"
+  pass "busy detection: real Kimi moon-plus-middot captures require its harness while idle labels stay idle"
 }
 
 test_watcher_scopes_moon_spinner_to_recorded_kimi_task() (
-  local state="$TMP_ROOT/watch-state"
+  local state="$TMP_ROOT/watch-state" busy_capture='  🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
   mkdir -p "$state"
   printf 'window=fake\nharness=kimi\n' > "$state/kimi-watch.meta"
   unset FM_BUSY_REGEX
@@ -338,20 +346,23 @@ test_watcher_scopes_moon_spinner_to_recorded_kimi_task() (
   . "$ROOT/bin/fm-watch.sh"
   # shellcheck disable=SC2329 # Runtime override called by the sourced watcher.
   fm_backend_busy_state() { printf 'unknown'; }
-  window_is_busy fake '🌕 Thinking' \
-    || fail "fm-watch did not recognize a recorded Kimi spinner line"
+  window_is_busy fake "$busy_capture" \
+    || fail "fm-watch did not recognize the real Kimi spinner-line shape"
   printf 'window=fake\nharness=codex\n' > "$state/kimi-watch.meta"
-  if window_is_busy fake '🌕 Thinking'; then
-    fail "fm-watch applied Kimi's moon spinner to a recorded Codex task"
+  if window_is_busy fake "$busy_capture"; then
+    fail "fm-watch applied Kimi's real spinner signature to a recorded Codex task"
   fi
   printf 'window=fake\nharness=kimi\n' > "$state/kimi-watch.meta"
   if window_is_busy fake 'ordinary response ending with 🌕'; then
     fail "fm-watch treated an ordinary Kimi moon as a spinner line"
   fi
   if window_is_busy fake '🌕 Full moon details'; then
-    fail "fm-watch treated moon-led Kimi output as the complete spinner row"
+    fail "fm-watch treated moon-led Kimi output without the middot separator as busy"
   fi
-  pass "fm-watch: moon spinner matching is scoped by metadata and line shape"
+  if window_is_busy fake 'auto  K2.7 Coding thinking  /some/path'; then
+    fail "fm-watch treated Kimi's idle thinking-effort status label as busy"
+  fi
+  pass "fm-watch: real moon-plus-middot spinner matching is scoped by metadata and line shape"
 )
 
 test_kimi_bordered_prompt_needs_no_override() {

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -326,10 +326,13 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
       *) return 0 ;;
     esac
   }
+  # These fixtures reproduce the observed spinner shape rather than byte-exact
+  # transcriptions. Leading whitespace is deliberately varied because the
+  # matcher is whitespace-insensitive by design and must not be pinned to prose.
   printf ' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"\n│ > │\n' > "$capture"
-  fm_pane_is_busy fake kimi || fail "the first real Kimi spinner capture was not recognized as busy"
-  printf ' 🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
-  fm_pane_is_busy fake kimi || fail "the tool-execution Kimi spinner capture was not recognized as busy"
+  fm_pane_is_busy fake kimi || fail "the first real Kimi spinner shape was not recognized as busy"
+  printf '   🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
+  fm_pane_is_busy fake kimi || fail "the tool-execution Kimi spinner shape was not recognized as busy"
   printf 'ordinary response ending with 🌕\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake kimi; then
     fail "a moon outside Kimi's spinner-line shape was misread as busy"
@@ -338,11 +341,7 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
   if fm_pane_is_busy fake kimi; then
     fail "moon-led Kimi output without the middot separator was misread as busy"
   fi
-  printf ' 🌑 · \n│ > │\n' > "$capture"
-  if fm_pane_is_busy fake kimi; then
-    fail "Kimi spinner prefix without following tip text was misread as busy"
-  fi
-  printf ' 🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
+  printf '  🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake codex; then
     fail "Kimi's real spinner signature leaked into another harness"
   fi
@@ -350,7 +349,11 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
   if fm_pane_is_busy fake kimi; then
     fail "kimi's independently rotating idle tip was misread as busy"
   fi
-  printf 'auto K2.7 Coding thinking /some/path\n│ > │\n' > "$capture"
+  printf 'Ctrl+c:cancel\n│ > │\n' > "$capture"
+  if fm_pane_is_busy fake kimi; then
+    fail "Grok's exact busy token leaked into Kimi's harness-scoped matcher"
+  fi
+  printf 'auto  K2.7 Coding thinking  /some/path\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake kimi; then
     fail "Kimi's idle thinking-effort status label was misread as busy"
   fi
@@ -360,13 +363,13 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
   fi
   for phase in 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘; do
     grep -Fq "$phase" "$ROOT/bin/fm-tmux-lib.sh" \
-      || fail "shared Kimi busy regex is missing moon phase $phase"
+      || fail "shared Kimi matcher is missing moon phase $phase"
   done
   pass "busy detection: real Kimi moon-plus-middot captures require its harness while idle labels stay idle"
 }
 
 test_watcher_scopes_moon_spinner_to_recorded_kimi_task() (
-  local state="$TMP_ROOT/watch-state" busy_capture=' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
+  local state="$TMP_ROOT/watch-state" busy_capture='  🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
   mkdir -p "$state"
   printf 'window=fake\nharness=kimi\n' > "$state/kimi-watch.meta"
   unset FM_BUSY_REGEX
@@ -390,10 +393,13 @@ test_watcher_scopes_moon_spinner_to_recorded_kimi_task() (
   if window_is_busy fake '🌕 Full moon details'; then
     fail "fm-watch treated moon-led Kimi output without the middot separator as busy"
   fi
-  if window_is_busy fake 'auto K2.7 Coding thinking /some/path'; then
+  if window_is_busy fake 'auto  K2.7 Coding thinking  /some/path'; then
     fail "fm-watch treated Kimi's idle thinking-effort status label as busy"
   fi
-  pass "fm-watch: real moon-plus-middot spinner matching is scoped by metadata and line shape"
+  if window_is_busy fake 'Ctrl+c:cancel'; then
+    fail "fm-watch let Grok's exact busy token classify a recorded Kimi task busy"
+  fi
+  pass "fm-watch: Kimi spinner matching is metadata-scoped and ignores Grok's busy token"
 )
 
 test_kimi_bordered_prompt_needs_no_override() {

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -260,6 +260,10 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
   if fm_pane_is_busy fake kimi; then
     fail "a moon outside Kimi's spinner-line shape was misread as busy"
   fi
+  printf '🌕 Full moon details\n│ > │\n' > "$capture"
+  if fm_pane_is_busy fake kimi; then
+    fail "moon-led Kimi output was misread as the complete spinner row"
+  fi
   printf '🌕 Thinking\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake codex; then
     fail "Kimi's moon spinner signature leaked into another harness"
@@ -295,6 +299,9 @@ test_watcher_scopes_moon_spinner_to_recorded_kimi_task() (
   printf 'window=fake\nharness=kimi\n' > "$state/kimi-watch.meta"
   if window_is_busy fake 'ordinary response ending with 🌕'; then
     fail "fm-watch treated an ordinary Kimi moon as a spinner line"
+  fi
+  if window_is_busy fake '🌕 Full moon details'; then
+    fail "fm-watch treated moon-led Kimi output as the complete spinner row"
   fi
   pass "fm-watch: moon spinner matching is scoped by metadata and line shape"
 )

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -326,9 +326,9 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
       *) return 0 ;;
     esac
   }
-  printf '  🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"\n│ > │\n' > "$capture"
+  printf ' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"\n│ > │\n' > "$capture"
   fm_pane_is_busy fake kimi || fail "the first real Kimi spinner capture was not recognized as busy"
-  printf '  🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
+  printf ' 🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
   fm_pane_is_busy fake kimi || fail "the tool-execution Kimi spinner capture was not recognized as busy"
   printf 'ordinary response ending with 🌕\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake kimi; then
@@ -338,7 +338,11 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
   if fm_pane_is_busy fake kimi; then
     fail "moon-led Kimi output without the middot separator was misread as busy"
   fi
-  printf '  🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
+  printf ' 🌑 · \n│ > │\n' > "$capture"
+  if fm_pane_is_busy fake kimi; then
+    fail "Kimi spinner prefix without following tip text was misread as busy"
+  fi
+  printf ' 🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake codex; then
     fail "Kimi's real spinner signature leaked into another harness"
   fi
@@ -346,7 +350,7 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
   if fm_pane_is_busy fake kimi; then
     fail "kimi's independently rotating idle tip was misread as busy"
   fi
-  printf 'auto  K2.7 Coding thinking  /some/path\n│ > │\n' > "$capture"
+  printf 'auto K2.7 Coding thinking /some/path\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake kimi; then
     fail "Kimi's idle thinking-effort status label was misread as busy"
   fi
@@ -355,14 +359,14 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
     fail "Kimi busy regex still depends on a Thinking or thinking token"
   fi
   for phase in 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘; do
-    grep -Fq "$phase" "$ROOT/bin/fm-watch.sh" \
-      || fail "fm-watch default is missing kimi moon phase $phase"
+    grep -Fq "$phase" "$ROOT/bin/fm-tmux-lib.sh" \
+      || fail "shared Kimi busy regex is missing moon phase $phase"
   done
   pass "busy detection: real Kimi moon-plus-middot captures require its harness while idle labels stay idle"
 }
 
 test_watcher_scopes_moon_spinner_to_recorded_kimi_task() (
-  local state="$TMP_ROOT/watch-state" busy_capture='  🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
+  local state="$TMP_ROOT/watch-state" busy_capture=' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
   mkdir -p "$state"
   printf 'window=fake\nharness=kimi\n' > "$state/kimi-watch.meta"
   unset FM_BUSY_REGEX
@@ -386,7 +390,7 @@ test_watcher_scopes_moon_spinner_to_recorded_kimi_task() (
   if window_is_busy fake '🌕 Full moon details'; then
     fail "fm-watch treated moon-led Kimi output without the middot separator as busy"
   fi
-  if window_is_busy fake 'auto  K2.7 Coding thinking  /some/path'; then
+  if window_is_busy fake 'auto K2.7 Coding thinking /some/path'; then
     fail "fm-watch treated Kimi's idle thinking-effort status label as busy"
   fi
   pass "fm-watch: real moon-plus-middot spinner matching is scoped by metadata and line shape"

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -336,6 +336,7 @@ test_watcher_scopes_moon_spinner_to_recorded_kimi_task() (
   export FM_HOME FM_STATE_OVERRIDE
   # shellcheck source=/dev/null
   . "$ROOT/bin/fm-watch.sh"
+  # shellcheck disable=SC2329 # Runtime override called by the sourced watcher.
   fm_backend_busy_state() { printf 'unknown'; }
   window_is_busy fake '🌕 Thinking' \
     || fail "fm-watch did not recognize a recorded Kimi spinner line"

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Behavior tests for the verified Kimi Code CLI crewmate adapter.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-kimi-harness)
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+
+assert_source_line() {
+  local line=$1
+  grep -Fqx -- "$line" "$SPAWN" || fail "existing launch template changed: $line"
+}
+
+test_existing_launch_templates_are_byte_pinned() {
+  assert_source_line "    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__\"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"' ;;"
+  assert_source_line "        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
+  assert_source_line "        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c \"notify=[\\\"bash\\\",\\\"-c\\\",\\\"touch __TURNEND__\\\"]\" \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
+  assert_source_line "    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\\''{\"permission\":{\"*\":\"allow\"}}'\\'' opencode __MODELFLAG__--prompt \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"' ;;"
+  assert_source_line "        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
+  assert_source_line "        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
+  assert_source_line "    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__\"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"' ;;"
+  pass "fm-spawn: the five pre-existing adapters' launch templates stay byte-pinned"
+}
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+state=$(cat "$FM_FAKE_KIMI_STATE" 2>/dev/null || true)
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "$FM_FAKE_PANE_PATH"; exit 0 ;;
+  *"#{cursor_y}"*) printf '0\n'; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    prev=
+    literal=
+    for arg in "$@"; do
+      if [ "$prev" = -l ]; then literal=$arg; break; fi
+      prev=$arg
+    done
+    if [ -n "$literal" ]; then
+      case "$literal" in
+        /Users/kunchen/.kimi-code/bin/kimi*)
+          printf '%s\n' "$literal" >> "$FM_FAKE_LAUNCH_LOG"
+          printf 'launched\n' > "$FM_FAKE_KIMI_STATE"
+          ;;
+        *)
+          printf '%s\n' "$literal" >> "$FM_FAKE_POINTER_LOG"
+          printf 'pointer-typed\n' > "$FM_FAKE_KIMI_STATE"
+          ;;
+      esac
+      exit 0
+    fi
+    case " $* " in
+      *' Enter '*)
+        case "$state" in
+          launched)
+            if [ "${FM_FAKE_KIMI_READY:-yes}" = yes ]; then
+              printf 'ready\n' > "$FM_FAKE_KIMI_STATE"
+            fi
+            ;;
+          pointer-typed)
+            if [ "${FM_FAKE_KIMI_DELIVERY:-yes}" = yes ]; then
+              printf 'delivered\n' > "$FM_FAKE_KIMI_STATE"
+            else
+              printf 'ready\n' > "$FM_FAKE_KIMI_STATE"
+            fi
+            ;;
+        esac
+        ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    case "$state" in
+      ready)
+        printf 'Welcome to Kimi Code!\ncontext: 0%% (0/256k)\n│ > │\n'
+        ;;
+      pointer-typed)
+        printf 'context: 0%% (0/256k)\n│ > pending │\n'
+        ;;
+      delivered)
+        printf '✨ Read the brief at %s and follow it exactly.\ncontext: 1%% (2k/256k)\n│ > │\n' "$FM_FAKE_BRIEF_REAL"
+        ;;
+      *)
+        printf 'shell starting\n$ \n'
+        ;;
+    esac
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {
+  local name=$1 id=$2 case_dir home proj wt fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief for kimi\n' > "$home/data/$id/brief.md"
+  printf 'kimi\n' > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  touch "$home/state/.last-watcher-beat"
+  : > "$case_dir/launch.log"
+  : > "$case_dir/pointer.log"
+  : > "$case_dir/kimi.state"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
+}
+
+run_spawn() {
+  local case_dir=$1 home=$2 proj=$3 wt=$4 fakebin=$5 id=$6
+  shift 6
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$case_dir/launch.log" \
+    FM_FAKE_POINTER_LOG="$case_dir/pointer.log" \
+    FM_FAKE_KIMI_STATE="$case_dir/kimi.state" \
+    FM_FAKE_BRIEF_REAL="$(cd "$home/data/$id" && pwd -P)/brief.md" \
+    FM_KIMI_READY_POLLS=2 FM_KIMI_DELIVERY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
+    PATH="$fakebin:$BASE_PATH" \
+    "$SPAWN" "$id" "$proj" --harness kimi "$@" 2>&1
+}
+
+read_spawn_record() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR <<EOF
+$1
+EOF
+}
+
+test_kimi_launch_then_send_is_verified() {
+  local id rec out rc launch pointer brief_real meta
+  id=kimi-success-z1
+  rec=$(make_spawn_case success "$id")
+  read_spawn_record "$rec"
+  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" \
+    --model kimi-code/k3 --effort high)
+  rc=$?
+  expect_code 0 "$rc" "verified kimi launch-then-send should succeed"
+  assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
+
+  launch=$(cat "$CASE_DIR/launch.log")
+  [ "$launch" = "/Users/kunchen/.kimi-code/bin/kimi --model 'kimi-code/k3' --auto" ] \
+    || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
+  assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
+  assert_not_contains "$launch" "turn-ended" "kimi launch implied a turn-end marker"
+  assert_not_contains "$launch" "__TURNEND__" "kimi launch retained a turn-end placeholder"
+
+  brief_real="$(cd "$HOME_DIR/data/$id" && pwd -P)/brief.md"
+  pointer=$(cat "$CASE_DIR/pointer.log")
+  [ "$pointer" = "Read the brief at $brief_real and follow it exactly." ] \
+    || fail "kimi pointer was not the exact absolute-path-only instruction: $pointer"
+  meta="$HOME_DIR/state/$id.meta"
+  assert_grep 'model=kimi-code/k3' "$meta" "kimi meta lost the requested model"
+  assert_grep 'effort=high' "$meta" "kimi meta did not retain the unsupported effort axis"
+  assert_absent "$HOME_DIR/.kimi-code/config.toml" "kimi spawn wrote a global config file"
+  pass "fm-spawn: kimi launches bare, waits for readiness, sends an absolute brief pointer, and confirms delivery"
+}
+
+test_kimi_unconfirmed_delivery_fails_loudly() {
+  local id rec out rc
+  id=kimi-drop-z2
+  rec=$(make_spawn_case drop "$id")
+  read_spawn_record "$rec"
+  rc=0
+  out=$(FM_FAKE_KIMI_DELIVERY=no run_spawn \
+    "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "an unconfirmed kimi delivery should fail"
+  assert_contains "$out" "kimi brief pointer delivery was not confirmed" \
+    "unconfirmed kimi delivery lacked a loud diagnostic"
+  assert_grep 'failed: kimi brief pointer delivery was not confirmed' "$HOME_DIR/state/$id.status" \
+    "unconfirmed kimi delivery did not leave a supervisor-visible failure"
+  pass "fm-spawn: kimi treats a silent pointer drop as a failed spawn"
+}
+
+test_kimi_readiness_gate_precedes_pointer() {
+  local id rec out rc
+  id=kimi-not-ready-z3
+  rec=$(make_spawn_case not-ready "$id")
+  read_spawn_record "$rec"
+  rc=0
+  out=$(FM_FAKE_KIMI_READY=no run_spawn \
+    "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "kimi spawn without a ready signal should fail"
+  assert_contains "$out" "kimi did not show a verified ready signal" \
+    "kimi readiness failure lacked a loud diagnostic"
+  [ ! -s "$CASE_DIR/pointer.log" ] || fail "kimi pointer was sent before readiness"
+  pass "fm-spawn: kimi never sends the brief pointer before an observable ready signal"
+}
+
+test_kimi_detection_uses_ancestry_after_markers() {
+  local dir fakebin cfg out
+  dir="$TMP_ROOT/detection"
+  fakebin=$(fm_fakebin "$dir")
+  cfg="$dir/config"
+  mkdir -p "$cfg"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field=
+pid=
+prev=
+for arg in "$@"; do
+  [ "$prev" = -o ] && field=$arg
+  [ "$prev" = -p ] && pid=$arg
+  prev=$arg
+done
+case "$field:$pid" in
+  comm=:4242) printf '/Users/kunchen/.kimi-code/bin/kimi\n' ;;
+  comm=:*) printf '/bin/bash\n' ;;
+  ppid=:4242) printf '1\n' ;;
+  ppid=:*) printf '4242\n' ;;
+  args=:*) printf 'bash\n' ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
+  [ "$out" = kimi ] || fail "kimi ancestry detection returned '$out'"
+  out=$(CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
+  [ "$out" = claude ] || fail "verified env-marker precedence changed, got '$out'"
+  pass "fm-harness: markerless kimi is detected by ancestry after env-marker precedence"
+}
+
+test_kimi_busy_signature_uses_all_moon_frames_not_tip_text() {
+  local capture phase
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-tmux-lib.sh"
+  unset FM_BUSY_REGEX
+  capture="$TMP_ROOT/busy-pane"
+  tmux() {
+    case "${1:-}" in
+      capture-pane) cat "$capture" ;;
+      *) return 0 ;;
+    esac
+  }
+  for phase in 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘; do
+    printf '%s Thinking\n│ > │\n' "$phase" > "$capture"
+    fm_pane_is_busy fake || fail "kimi moon phase $phase was not recognized as busy"
+  done
+  printf 'tip: ctrl+c: cancel\n│ > │\n' > "$capture"
+  if fm_pane_is_busy fake; then
+    fail "kimi's independently rotating idle tip was misread as busy"
+  fi
+  for phase in 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘; do
+    grep -Fq "$phase" "$ROOT/bin/fm-watch.sh" \
+      || fail "fm-watch default is missing kimi moon phase $phase"
+  done
+  pass "busy detection: every kimi moon phase is busy while idle tip text is ignored"
+}
+
+test_kimi_bordered_prompt_needs_no_override() {
+  local out
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-composer-lib.sh"
+  out=$(fm_composer_classify_content 1 '>')
+  [ "$out" = empty ] || fail "kimi's bordered bare > composer should read empty, got '$out'"
+  out=$(fm_composer_classify_content 0 '>')
+  [ "$out" = unknown ] || fail "an unbordered dead-shell > must stay unknown, got '$out'"
+  pass "composer classifier: kimi's existing bordered > shape is already safe without an override"
+}
+
+test_existing_launch_templates_are_byte_pinned
+test_kimi_launch_then_send_is_verified
+test_kimi_unconfirmed_delivery_fails_loudly
+test_kimi_readiness_gate_precedes_pointer
+test_kimi_detection_uses_ancestry_after_markers
+test_kimi_busy_signature_uses_all_moon_frames_not_tip_text
+test_kimi_bordered_prompt_needs_no_override

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -717,6 +717,8 @@ test_kimi_capture_fallback_uses_recorded_harness() (
   state="$home/state"
   sm_home="$home/sm"
   mkdir -p "$sm_home/state"
+  # This fixture clock is intentionally scoped to the isolated subshell.
+  # shellcheck disable=SC2030,SC2031
   export FM_PENDING_REPLY_NOW=10020
   corr=$(fm_pending_reply_create "$home" "$state" hibit "kimi fallback")
   fm_pending_reply_mark_delivered "$state" "$corr"
@@ -767,11 +769,15 @@ test_tick_skips_terminal_and_reuses_target_observation() {
     fm_write_secondmate_meta "$state/hibit.meta" "$home/hibit" "sess:fm-hibit"
     fm_write_secondmate_meta "$state/resolved.meta" "$home/resolved" "sess:fm-resolved"
     fm_write_secondmate_meta "$state/escalated.meta" "$home/escalated" "sess:fm-escalated"
+    # Runtime overrides called indirectly by the pending-reply tick.
+    # shellcheck disable=SC2329
     fm_backend_busy_state() {
       printf '%s\t%s\n' "$1" "$2" >> "$probe_log"
       printf 'busy'
     }
+    # shellcheck disable=SC2329
     fm_backend_capture() { fail "native busy observations should not capture"; }
+    # shellcheck disable=SC2329
     fm_pending_reply_find_resolve_line() {
       local status_file=$1 corr=$2 line
       printf '%s\t%s\n' "$status_file" "$corr" >> "$scan_log"

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -678,6 +678,7 @@ test_unknown_backend_state_uses_capture_fallback() {
       corr=$(fm_pending_reply_create "$home" "$state" "hibit" "$backend fallback")
       fm_pending_reply_mark_delivered "$state" "$corr"
       fm_write_secondmate_meta "$state/hibit.meta" "$sm_home" "session:fm-hibit"
+      printf 'harness=pi\n' >> "$state/hibit.meta"
       [ "$backend" = tmux ] || printf 'backend=%s\n' "$backend" >> "$state/hibit.meta"
       fm_backend_busy_state() { printf 'unknown'; }
       fm_backend_capture() { printf '%s' "$FM_PENDING_TEST_CAPTURE"; }

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -711,6 +711,33 @@ test_unknown_backend_state_uses_capture_fallback() {
   pass "tmux and zellij unknown states use bounded capture fallback"
 }
 
+test_kimi_capture_fallback_uses_recorded_harness() (
+  local home state corr rec sm_home
+  home=$(setup_parent kimi-fallback)
+  state="$home/state"
+  sm_home="$home/sm"
+  mkdir -p "$sm_home/state"
+  export FM_PENDING_REPLY_NOW=10020
+  corr=$(fm_pending_reply_create "$home" "$state" hibit "kimi fallback")
+  fm_pending_reply_mark_delivered "$state" "$corr"
+  fm_write_secondmate_meta "$state/hibit.meta" "$sm_home" "session:fm-hibit"
+  printf 'harness=kimi\n' >> "$state/hibit.meta"
+  fm_backend_busy_state() { printf 'unknown'; }
+  fm_backend_capture() {
+    printf ' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
+  }
+
+  [ "$(fm_pending_reply_backend_observation tmux session:fm-hibit fm-hibit codex)" = fallback-idle ] \
+    || fail "Kimi spinner leaked into another harness"
+  fm_pending_reply_tick "$state"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  [ "$(fm_pending_reply_get "$rec" turn_seen_busy)" = 1 ] \
+    || fail "recorded Kimi spinner was not observed as busy"
+  [ "$(phase_of "$state" "$corr")" = awaiting_report ] \
+    || fail "working Kimi secondmate entered recovery"
+  pass "pending replies scope Kimi capture fallback by recorded harness"
+)
+
 test_tick_skips_terminal_and_reuses_target_observation() {
   (
     local home state open1 open2 resolved escalated rec probe_log probes scan_log scans snapshot
@@ -890,6 +917,7 @@ test_document_pointer_resolves
 test_helper_report_resolves
 test_busy_idle_observation_via_backend_abstraction
 test_unknown_backend_state_uses_capture_fallback
+test_kimi_capture_fallback_uses_recorded_harness
 test_tick_skips_terminal_and_reuses_target_observation
 test_correlations_reuse_only_for_matching_open_task
 test_tick_end_to_end_missed_then_escalate

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -677,8 +677,7 @@ test_unknown_backend_state_uses_capture_fallback() {
       export FM_PENDING_REPLY_NOW=10000
       corr=$(fm_pending_reply_create "$home" "$state" "hibit" "$backend fallback")
       fm_pending_reply_mark_delivered "$state" "$corr"
-      fm_write_secondmate_meta "$state/hibit.meta" "$sm_home" "session:fm-hibit"
-      printf 'harness=pi\n' >> "$state/hibit.meta"
+      fm_write_secondmate_meta "$state/hibit.meta" "$sm_home" "session:fm-hibit" alpha pi
       [ "$backend" = tmux ] || printf 'backend=%s\n' "$backend" >> "$state/hibit.meta"
       fm_backend_busy_state() { printf 'unknown'; }
       fm_backend_capture() { printf '%s' "$FM_PENDING_TEST_CAPTURE"; }
@@ -723,15 +722,17 @@ test_kimi_capture_fallback_uses_recorded_harness() (
   export FM_PENDING_REPLY_NOW=10020
   corr=$(fm_pending_reply_create "$home" "$state" hibit "kimi fallback")
   fm_pending_reply_mark_delivered "$state" "$corr"
-  fm_write_secondmate_meta "$state/hibit.meta" "$sm_home" "session:fm-hibit"
-  printf 'harness=kimi\n' >> "$state/hibit.meta"
+  fm_write_secondmate_meta "$state/hibit.meta" "$sm_home" "session:fm-hibit" alpha kimi
   fm_backend_busy_state() { printf 'unknown'; }
-  fm_backend_capture() {
-    printf ' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
-  }
+  fm_backend_capture() { printf '%s' "$FM_PENDING_KIMI_CAPTURE"; }
+  export FM_PENDING_KIMI_CAPTURE=' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
 
   [ "$(fm_pending_reply_backend_observation tmux session:fm-hibit fm-hibit codex)" = fallback-idle ] \
     || fail "Kimi spinner leaked into another harness"
+  export FM_PENDING_KIMI_CAPTURE='Ctrl+c:cancel'
+  [ "$(fm_pending_reply_backend_observation tmux session:fm-hibit fm-hibit kimi)" = fallback-idle ] \
+    || fail "Grok's exact busy token leaked into Kimi pending-reply observation"
+  export FM_PENDING_KIMI_CAPTURE=' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
   fm_pending_reply_tick "$state"
   rec=$(fm_pending_reply_path "$state" "$corr")
   [ "$(fm_pending_reply_get "$rec" turn_seen_busy)" = 1 ] \

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -725,14 +725,14 @@ test_kimi_capture_fallback_uses_recorded_harness() (
   fm_write_secondmate_meta "$state/hibit.meta" "$sm_home" "session:fm-hibit" alpha kimi
   fm_backend_busy_state() { printf 'unknown'; }
   fm_backend_capture() { printf '%s' "$FM_PENDING_KIMI_CAPTURE"; }
-  export FM_PENDING_KIMI_CAPTURE=' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
+  export FM_PENDING_KIMI_CAPTURE=' 🌑 ·Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
 
   [ "$(fm_pending_reply_backend_observation tmux session:fm-hibit fm-hibit codex)" = fallback-idle ] \
     || fail "Kimi spinner leaked into another harness"
   export FM_PENDING_KIMI_CAPTURE='Ctrl+c:cancel'
   [ "$(fm_pending_reply_backend_observation tmux session:fm-hibit fm-hibit kimi)" = fallback-idle ] \
     || fail "Grok's exact busy token leaked into Kimi pending-reply observation"
-  export FM_PENDING_KIMI_CAPTURE=' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
+  export FM_PENDING_KIMI_CAPTURE=' 🌑 ·Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
   fm_pending_reply_tick "$state"
   rec=$(fm_pending_reply_path "$state" "$corr")
   [ "$(fm_pending_reply_get "$rec" turn_seen_busy)" = 1 ] \

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -97,7 +97,7 @@ SH
 test_tmux_agent_state_classifies() {
   local fb out
 
-  for harness in claude codex opencode grok; do
+  for harness in claude codex opencode grok kimi; do
     fb=$(make_probe_tmux "$TMP_ROOT/tmux-$harness" "$harness")
     out=$(PATH="$fb:$BASE_PATH" bash -c '. "$0/bin/fm-backend.sh"; fm_backend_agent_state tmux sess:win' "$ROOT")
     [ "$out" = alive ] || fail "a live $harness foreground process should classify as alive, got '$out'"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -452,7 +452,7 @@ EOF
 
 run_session_start_secondmate() {
   local root=$1 home=$2 fakebin=$3 mate=$4 log=$5 spawned=$6 mode=$7
-  FM_BACKEND=tmux FM_FAKE_TMUX_MODE="$mode" FM_FAKE_TMUX_LOG="$log" \
+  TMUX='' FM_BACKEND=tmux FM_FAKE_TMUX_MODE="$mode" FM_FAKE_TMUX_LOG="$log" \
     FM_FAKE_TMUX_SPAWNED="$spawned" FM_FAKE_SECOND_MATE_HOME="$mate" \
     FM_FAKE_SECOND_MATE_ID="$SESSION_START_SECOND_MATE_ID" \
     run_session_start "$home" "$root" "$fakebin:$BASE_PATH"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -151,17 +151,17 @@ fm_write_meta() {
   done
 }
 
-# fm_write_secondmate_meta <file> <home> [window] [projects]: write the standard
-# kind=secondmate meta block used across the secondmate suites. window defaults
-# to firstmate:fm-<basename-of-home-dir's parent id>? No - window is explicit;
-# defaults to firstmate:fm-domain and projects to alpha to match the common case.
+# fm_write_secondmate_meta <file> <home> [window] [projects] [harness]: write the
+# standard kind=secondmate meta block used across the secondmate suites. window
+# is explicit and defaults to firstmate:fm-domain, projects defaults to alpha,
+# and harness defaults to echo to match the common case.
 fm_write_secondmate_meta() {
-  local file=$1 home=$2 window=${3:-firstmate:fm-domain} projects=${4:-alpha}
+  local file=$1 home=$2 window=${3:-firstmate:fm-domain} projects=${4:-alpha} harness=${5:-echo}
   fm_write_meta "$file" \
     "window=$window" \
     "worktree=$home" \
     "project=$home" \
-    "harness=echo" \
+    "harness=$harness" \
     "kind=secondmate" \
     "mode=secondmate" \
     "yolo=off" \


### PR DESCRIPTION
## Intent

Add Kimi Code CLI 0.29.1 as a verified Firstmate crewmate harness adapter without changing the five existing launch templates. Resolve kimi from PATH first with an executable HOME/.kimi-code/bin/kimi fallback and refuse before pane creation if neither exists. Launch bare with --auto and optional --model, record but do not emit effort, wait for observable readiness, send only an absolute brief-pointer instruction, and verify delivery so silent drops cannot look healthy. Add ancestry detection after environment markers, tmux liveness, composer safety, verified documentation, and no enabled turn-end hook because Kimi hooks are global-only and require captain approval. Register Kimi into the landed shared per-harness busy matcher rather than duplicating fm_busy_lines_match: match the full moon-phase set plus the middot separator with optional whitespace, leave the line end unanchored and do not require following tip text, keep locale and emoji fragility documented, preserve the legacy empty-harness fallback, and ensure nonempty harnesses use only their own verified signature. Thread recorded harness metadata through pending-reply observation. Deliberately vary spinner fixture whitespace because prose examples are shape-illustrative rather than byte-authoritative. Prove Kimi is busy only for moon-plus-middot spinner rows and that Kimi ignores Grok's exact Ctrl+c:cancel token across the shared matcher, watcher metadata path, and pending-reply fallback. Do not write global Kimi configuration or imply per-turn wake support.

## What Changed

- Add a verified Kimi Code CLI adapter for crewmate and secondmate launches, including executable resolution, readiness checks, absolute brief-pointer delivery, and delivery confirmation.
- Extend harness detection, liveness, and pending-reply observation with Kimi metadata and a harness-scoped moon-plus-middot busy signature.
- Add focused Kimi adapter tests and document launch behavior, spinner limitations, and the intentionally disabled global-only turn-end hook.

## Risk Assessment

✅ Low: The clarification now accurately documents the observed separator contract, and the complete adapter change remains well-bounded with no other substantiated source defects or intent contradictions.

## Testing

No prior baseline commands were supplied. Focused spawn, readiness, delivery, matcher, watcher, pending-reply, ancestry, composer, and secondmate-liveness tests passed; a direct Kimi 0.29.1 matcher transcript confirms the required end-user supervision boundaries after the optional-whitespace fix.

<details>
<summary>Evidence: Initial targeted validation</summary>

```text
FM_TEST_BEGIN 2026-07-26T02:14:04Z tests/fm-kimi-harness.test.sh family=pure-contract-unit expected_gate_skip=none
ok - repository: tracked files contain no user-specific absolute paths
ok - fm-spawn: the five pre-existing adapters' launch templates stay byte-pinned
ok - fm-spawn: kimi launches bare, waits for readiness, sends an absolute brief pointer, and confirms delivery
ok - fm-spawn: Kimi fallback expands the active HOME
ok - fm-spawn: missing Kimi executable refuses before pane creation
ok - fm-spawn: kimi treats a silent pointer drop as a failed spawn
ok - fm-spawn: kimi never sends the brief pointer before an observable ready signal
ok - fm-harness: markerless kimi is detected by ancestry after env-marker precedence
lock acquired: harness pid 96539
ok - fm-lock recognizes Kimi ancestry and live lock holders
ok - busy detection: real Kimi moon-plus-middot captures require its harness while idle labels stay idle
ok - fm-watch: Kimi spinner matching is metadata-scoped and ignores Grok's busy token
ok - composer classifier: kimi's existing bordered > shape is already safe without an override
FM_TEST_END 2026-07-26T02:14:15Z tests/fm-kimi-harness.test.sh exit=0 duration_ms=10314 gate_skip=false
FM_TEST_BEGIN 2026-07-26T02:14:15Z tests/fm-pending-reply.test.sh family=unclassified expected_gate_skip=none
ok - normal correlated reply resolves once (idempotent)
ok - completed turn with no report triggers exactly one recovery
ok - recovery attempts reconcile without reinjection
ok - recovery reply resolves the original expectation
ok - second missed turn escalates once and remains durable
ok - failed escalation publication remains retryable and publishes once
ok - transport success cannot masquerade as reply success
ok - undelivered records remain immutable across scan paths
ok - delivery confirmation fallback reconciles durably
ok - unrelated events and stale correlation ids cannot resolve
ok - restart preserves expectation and exact parent destination
ok - wrong-home reports are detected but do not silently acknowledge
ok - direct unmarked captain input creates no expectation
ok - fm-send marked secondmate path creates pending and embeds corr
ok - status-pointed document resolves the expectation
ok - optional helper report resolves without being required for correctness
ok - backend busy/idle observation covers Pi/Claude paths without conversation scrape
ok - tmux and zellij unknown states use bounded capture fallback
ok - pending replies scope Kimi capture fallback by recorded harness
ok - tick skips terminal records and reuses target observations
ok - correlations are reused only for matching open task records
ok - tick end-to-end: miss -> one recovery -> escalate -> durable
ok - failed transport discards undelivered expectation only
ok - all pending-reply tests passed
FM_TEST_END 2026-07-26T02:14:25Z tests/fm-pending-reply.test.sh exit=0 duration_ms=9734 gate_skip=false
FM_TEST_BEGIN 2026-07-26T02:14:25Z tests/fm-secondmate-liveness.test.sh family=secondmate expected_gate_skip=none
ok - fm_backend_tmux_agent_state: separates live, dead, missing, ambiguous, and unreadable
ok - fm_backend_tmux_agent_state: rejects malformed targets before probing tmux
ok - fm_backend_herdr_agent_state: preserves missing/no-agent/live/unknown husk behavior
ok - fm_backend_agent_state: routes tmux/Herdr and keeps Zellij unverified
ok - sweep: a confirmed-dead secondmate endpoint is killed and respawned
ok - sweep: an already-live secondmate is untouched and distinguishable in verbose diagnostics
ok - sweep: an authoritatively missing Pi secondmate window is relaunched
ok - sweep: an existing ambiguous Pi process prevents duplicate recovery
ok - sweep: transient target unreadability never licenses recovery
ok - sweep: failed relaunch diagnostics distinguish a confidently missing endpoint
ok - sweep: an unverified harness blocks recovery with a concrete diagnostic
ok - sweep: idempotent by construction - a live secondmate is never re-touched on a later run
ok - sweep: skipped entirely under FM_BOOTSTRAP_DETECT_ONLY=1, exactly like the other mutating sweeps
ok - sweep: a silent no-op with no kind=secondmate meta present (a secondmate home's own natural scoping)
# all fm-secondmate-liveness tests passed
FM_TEST_END 2026-07-26T02:14:46Z tests/fm-secondmate-liveness.test.sh exit=0 duration_ms=21093 gate_skip=false
FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0 duration_ms=41259
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=10314 failed=0
FM_TEST_SUMMARY_FAMILY family=secondmate count=1 duration_ms=21093 failed=0
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=9734 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-secondmate-liveness.test.sh duration_ms=21093
FM_TEST_SLOWEST rank=2 script=tests/fm-kimi-harness.test.sh duration_ms=10314
FM_TEST_SLOWEST rank=3 script=tests/fm-pending-reply.test.sh duration_ms=9734
```
</details>
<details>
<summary>Evidence: Post-fix targeted validation</summary>

```text
FM_TEST_BEGIN 2026-07-26T02:15:58Z tests/fm-kimi-harness.test.sh family=pure-contract-unit expected_gate_skip=none
ok - repository: tracked files contain no user-specific absolute paths
ok - fm-spawn: the five pre-existing adapters' launch templates stay byte-pinned
ok - fm-spawn: kimi launches bare, waits for readiness, sends an absolute brief pointer, and confirms delivery
ok - fm-spawn: Kimi fallback expands the active HOME
ok - fm-spawn: missing Kimi executable refuses before pane creation
ok - fm-spawn: kimi treats a silent pointer drop as a failed spawn
ok - fm-spawn: kimi never sends the brief pointer before an observable ready signal
ok - fm-harness: markerless kimi is detected by ancestry after env-marker precedence
lock acquired: harness pid 42158
ok - fm-lock recognizes Kimi ancestry and live lock holders
ok - busy detection: real Kimi moon-plus-middot captures require its harness while idle labels stay idle
ok - fm-watch: Kimi spinner matching is metadata-scoped and ignores Grok's busy token
ok - composer classifier: kimi's existing bordered > shape is already safe without an override
FM_TEST_END 2026-07-26T02:16:08Z tests/fm-kimi-harness.test.sh exit=0 duration_ms=10642 gate_skip=false
FM_TEST_BEGIN 2026-07-26T02:16:08Z tests/fm-pending-reply.test.sh family=unclassified expected_gate_skip=none
ok - normal correlated reply resolves once (idempotent)
ok - completed turn with no report triggers exactly one recovery
ok - recovery attempts reconcile without reinjection
ok - recovery reply resolves the original expectation
ok - second missed turn escalates once and remains durable
ok - failed escalation publication remains retryable and publishes once
ok - transport success cannot masquerade as reply success
ok - undelivered records remain immutable across scan paths
ok - delivery confirmation fallback reconciles durably
ok - unrelated events and stale correlation ids cannot resolve
ok - restart preserves expectation and exact parent destination
ok - wrong-home reports are detected but do not silently acknowledge
ok - direct unmarked captain input creates no expectation
ok - fm-send marked secondmate path creates pending and embeds corr
ok - status-pointed document resolves the expectation
ok - optional helper report resolves without being required for correctness
ok - backend busy/idle observation covers Pi/Claude paths without conversation scrape
ok - tmux and zellij unknown states use bounded capture fallback
ok - pending replies scope Kimi capture fallback by recorded harness
ok - tick skips terminal records and reuses target observations
ok - correlations are reused only for matching open task records
ok - tick end-to-end: miss -> one recovery -> escalate -> durable
ok - failed transport discards undelivered expectation only
ok - all pending-reply tests passed
FM_TEST_END 2026-07-26T02:16:18Z tests/fm-pending-reply.test.sh exit=0 duration_ms=9478 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=20199
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=10642 failed=0
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=9478 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-kimi-harness.test.sh duration_ms=10642
FM_TEST_SLOWEST rank=2 script=tests/fm-pending-reply.test.sh duration_ms=9478
```
</details>
<details>
<summary>Evidence: Shared matcher behavior matrix</summary>

`Kimi 0.29.1 accepts spaced, unspaced, and one-sided-space moon-plus-middot rows as busy. Moon-only output and Grok's Ctrl+c:cancel remain idle for Kimi; the legacy empty-harness fallback still recognizes Grok.`

```text
Kimi binary: /Users/kunchen/.kimi-code/bin/kimi
Kimi version: 0.29.1
spaced observed spinner                  harness=kimi    result=busy sample= 🌑 · Tip: task
zero separator whitespace                harness=kimi    result=busy sample=🌗·Tip: tool
left-side whitespace only                harness=kimi    result=busy sample=🌕 ·Tip: task
right-side whitespace only               harness=kimi    result=busy sample=🌘· Tip: task
moon without middot                      harness=kimi    result=idle sample=🌕 Full moon details
Grok exact token under Kimi              harness=kimi    result=idle sample=Ctrl+c:cancel
Kimi spinner under Codex                 harness=codex   result=idle sample=🌑·Tip: task
legacy empty-harness fallback            harness=legacy  result=busy sample=Ctrl+c:cancel
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-tmux-lib.sh:83` - Required intent says to match the moon-phase plus middot separator &#34;with optional whitespace&#34; and not require following tip text, but the added regex uses `[[:space:]]+` on both sides of `·`. Spinner rows such as `🌑·Tip` or a middot ending the row remain reachable but are classified idle. Use `*` around the separator and add zero/varied-whitespace fixtures.

🔧 Fix: Clarify observed Kimi spinner whitespace contract
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-kimi-harness.test.sh tests/fm-pending-reply.test.sh tests/fm-secondmate-liveness.test.sh`
- <code>After the targeted fix: `bin/fm-test-run.sh tests/fm-kimi-harness.test.sh tests/fm-pending-reply.test.sh`</code>
- `$HOME/.kimi-code/bin/kimi --version`
- <code>Direct `fm_busy_lines_match` matrix covering all separator-spacing forms, wrong-harness isolation, Grok-token rejection, moon-without-middot rejection, and legacy empty-harness behavior</code>
- `Inspected the final worktree for transient test artifacts; only the intentional matcher and focused test corrections remain modified`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
