### PR TITLE
fix: support macOS Bash 3.2 in brief scaffolding

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -217,13 +217,19 @@ HERDR_SECTION=$(printf '%s\n' \
 'Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.' \
 'The captain fleet uses the running `default` session.')
 else
-HERDR_SECTION=$(cat <<'EOF'
+# Capture multi-line text with a heredoc outside command substitution.
+# `VAR=$(cat <<EOF ...)` breaks bash 3.2's parser when the body contains an
+# apostrophe (or certain other quote-like characters): the lexer still tracks
+# quote state while scanning for the matching `)` of `$(...)`, so `bash -n`
+# fails on the whole script. `read -r -d ''` keeps the heredoc at statement
+# level and is bash 3.2-safe. read returns non-zero at EOF without a NUL
+# delimiter, so `|| true` is required under `set -e`.
+read -r -d '' HERDR_SECTION <<'EOF' || true
 # Herdr lifecycle declaration - NOT ENABLED
 **HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
 If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
 Do not add Herdr lifecycle commands to this unguarded brief by hand.
 EOF
-)
 fi
 
 if [ "$KIND" = scout ]; then
@@ -285,19 +291,19 @@ case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
+    # See HERDR_SECTION note above: no `$(cat <<EOF)` (bash 3.2 parse trap).
+    read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
-)
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
+    read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
@@ -305,13 +311,14 @@ Keep your branch a clean fast-forward onto the current default branch - if \`mai
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
-)
     ;;
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
+    # Body intentionally contains "firstmate's" (apostrophe): must not live inside
+    # `$(cat <<EOF)` or bash 3.2 rejects the whole script (issue #958).
+    read -r -d '' DOD <<EOF || true
 # Definition of done
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
@@ -329,7 +336,6 @@ Two firstmate-specific rules layer on top of that guidance:
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
-)
     ;;
 esac
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1,32 +1,69 @@
 #!/usr/bin/env bash
 # Behavior tests for bin/fm-brief.sh.
 #
-# Regression coverage for the heredoc-in-command-substitution parse bug (issue
-# #166): each ship-mode branch builds its Definition-of-done text with
-# `VAR=$(cat <<EOF ... EOF)`. Bash's lexer tracks quote state through the
-# heredoc body while it scans for the matching `)` of the command
-# substitution, so a single unescaped apostrophe anywhere in that body breaks
-# parsing of the *entire rest of the script* - `bash -n` fails, not just the
-# generated brief. A plain `cat > file <<EOF ... EOF` (not wrapped in `$(...)`)
-# is unaffected, so the secondmate charter block does not need this guard.
+# Regression coverage for the heredoc-in-command-substitution parse bug (issues
+# #166 and #958): ship-mode Definition-of-done text and the unguarded Herdr
+# declaration used to be built with `VAR=$(cat <<EOF ... EOF)`. Bash's lexer
+# tracks quote state through the heredoc body while it scans for the matching
+# `)` of the command substitution, so a single unescaped apostrophe anywhere
+# in that body breaks parsing of the *entire rest of the script* - `bash -n`
+# fails, not just the generated brief. macOS system bash 3.2.57 is the
+# fail-closed target (issue #958); newer bash often still parses the same
+# file. The fix captures multi-line bodies with statement-level
+# `read -r -d '' VAR <<EOF` (heredoc outside `$(...)`). A plain
+# `cat > file <<EOF ... EOF` (not wrapped in `$(...)`) is unaffected, so the
+# secondmate charter block does not need this guard.
 set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+# Explicit macOS-system-bash path: issue #958 only reproduces on bash 3.2's
+# parser. Prefer /bin/bash so CI/dev machines with a newer `bash` on PATH still
+# exercise the captain-machine interpreter when it is present.
+SYSTEM_BASH=/bin/bash
+if [ ! -x "$SYSTEM_BASH" ]; then
+  SYSTEM_BASH=$(command -v bash)
+fi
+
 TMP_ROOT=$(fm_test_tmproot fm-brief)
 BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
 
-# The script itself must always parse. This is the direct regression test for
-# issue #166: a stray apostrophe in any of the three DOD heredoc bodies
-# (no-mistakes/direct-PR/local-only) breaks `bash -n` on the whole file.
+# The script itself must always parse under system bash. This is the direct
+# regression test for issues #166/#958: a stray apostrophe in any
+# `$(cat <<EOF)` multi-line capture (no-mistakes DOD currently carries
+# "firstmate's") breaks `bash -n` on the whole file under bash 3.2.
 test_script_parses() {
-  local out rc
-  out=$(bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
-  expect_code 0 "$rc" "bash -n bin/fm-brief.sh must parse cleanly (got: $out)"
-  [ -z "$out" ] || fail "bash -n bin/fm-brief.sh emitted unexpected output: $out"
-  pass "fm-brief.sh: bash -n succeeds"
+  local out rc ver
+  ver=$("$SYSTEM_BASH" --version | head -1)
+  out=$("$SYSTEM_BASH" -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
+  expect_code 0 "$rc" "$SYSTEM_BASH -n bin/fm-brief.sh must parse cleanly under $ver (got: $out)"
+  [ -z "$out" ] || fail "$SYSTEM_BASH -n bin/fm-brief.sh emitted unexpected output: $out"
+  pass "fm-brief.sh: $SYSTEM_BASH -n succeeds ($ver)"
+}
+
+# End-to-end: actually run the scaffold under system bash (not only `bash -n`)
+# so a parse-time success that still fails at runtime cannot slip through, and
+# the no-mistakes DOD keeps its intentional apostrophe in the generated brief.
+test_scaffold_runs_under_system_bash() {
+  local home id brief status ver
+  home="$TMP_ROOT/system-bash-home"
+  mkdir -p "$home/data"
+  id="brief-system-bash-e1"
+  ver=$("$SYSTEM_BASH" --version | head -1)
+  FM_HOME="$home" "$SYSTEM_BASH" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1; status=$?
+  expect_code 0 "$status" "fm-brief.sh under $SYSTEM_BASH ($ver) should exit 0"
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "system-bash scaffold did not write a brief"
+  assert_grep "# Definition of done" "$brief" "system-bash brief missing Definition of done"
+  assert_grep "{TASK}" "$brief" "system-bash brief missing the {TASK} placeholder"
+  assert_grep "firstmate's authority check" "$brief" \
+    "system-bash brief lost the apostrophe wording that used to break bash 3.2 parsing"
+  assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
+    "system-bash brief missing nonterminal working: gate protection"
+  assert_no_grep "EOF" "$brief" "system-bash brief leaked a heredoc EOF marker"
+  pass "fm-brief.sh: scaffold runs under $SYSTEM_BASH ($ver)"
 }
 
 test_help_includes_entire_header() {
@@ -383,6 +420,7 @@ test_scout_and_secondmate_scaffold() {
 }
 
 test_script_parses
+test_scaffold_runs_under_system_bash
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review


### PR DESCRIPTION
## Intent

Korjaa bin/fm-brief.sh niin ettei se enää kaadu macOS:n järjestelmä-bashilla (GNU bash 3.2.57). Issue #958: scaffold fails to parse on macOS system bash 3.2 (line 314: unexpected EOF while looking for matching ')'). Älä nosta bash-vaatimusta; pidä scaffoldin tuloste ja turvasopimukset identtisinä; korjaa vain bash-yhteensopivuus. Lisää regressiotesti joka ajaa scaffoldin järjestelmä-bashilla. Pidä muutos rajattuna fm-brief.sh:ään ja sen testiin.

## What Changed

- Replaced heredoc command substitutions in `fm-brief.sh` with Bash 3.2-compatible statement-level captures while preserving generated brief content and safety contracts.
- Added system-Bash parse and end-to-end scaffold regression coverage, including checks for required brief content and leaked heredoc markers.

## Risk Assessment

✅ Low: Captain, the bounded change removes the Bash 3.2-incompatible heredoc command substitutions while preserving scaffold text and safety contracts, with a system-Bash parse-and-run regression test.

## Testing

Diffin rajaus tarkastettiin, kohdennettu fm-brief-testitiedosto ajettiin GNU bash 3.2.57:llä, ja erillinen käyttäjätason scaffold-ajo loi briefin onnistuneesti säilyttäen tarkistetut turvasopimukset; CLI-transkripti tallennettiin evidence-hakemistoon eikä työpuuhun jäänyt testijälkiä.

<details>
<summary>Evidence: GNU bash 3.2 scaffold -ajo ja generoitu turvasopimus</summary>

```text
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

$ FM_HOME=<evidence-home> /bin/bash bin/fm-brief.sh brief-bash32-e2e demo-project
warn: no registry at /var/folders/_7/g__lbpks7bvb7_3fqhncphnm0000gp/T/no-mistakes-evidence/01KYDZSYE3X91DX2VJFJ4T9NAT/fm-brief-e2e.qc4czR/data/projects.md; defaulting demo-project to no-mistakes off
scaffolded: /var/folders/_7/g__lbpks7bvb7_3fqhncphnm0000gp/T/no-mistakes-evidence/01KYDZSYE3X91DX2VJFJ4T9NAT/fm-brief-e2e.qc4czR/data/brief-bash32-e2e/brief.md (ship, mode=no-mistakes; replace {TASK})
exit=0
brief_created=yes

$ selected generated brief content
# Herdr lifecycle declaration - NOT ENABLED
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
# Definition of done
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

$ heredoc marker leak check
no EOF marker found
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff aca3ad100ffcb43873837486a0f24ad3e6cdc7fa..d294897db577a331ae469078b6424f9d7e03d715 -- bin/fm-brief.sh tests/fm-brief.test.sh` — muutosalueen ja regressiotestin tarkastus</code>
- <code>`/bin/bash --version | head -1` — todettu GNU bash 3.2.57</code>
- <code>`/bin/bash tests/fm-brief.test.sh` — kohdennetut fm-brief-käyttäytymis- ja regressiotestit</code>
- <code>`FM_HOME=&lt;evidence-home&gt; /bin/bash bin/fm-brief.sh brief-bash32-e2e demo-project` — todellinen käyttäjätason scaffold-ajo</code>
- <code>Generoidun `brief.md`:n tarkastus: Definition of done, Herdr-turvaportti, `working:`-portti, apostrofin sisältävä authority check ja ettei EOF-merkintää vuotanut</code>
- <code>`git status --short` — testaus ei jättänyt työpuuhun muutoksia</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
