### PR TITLE
feat: add guarded localhost-only FreeLLMAPI lane

### DIFF
--- a/bin/fm-freellmapi.sh
+++ b/bin/fm-freellmapi.sh
@@ -64,6 +64,7 @@ KEY_FILE="$LANE_HOME/encryption.key"
 CRED_FILE="$LANE_HOME/dashboard.credentials"
 RUN_DIR="$LANE_HOME/run"
 PID_FILE="$RUN_DIR/server.pid"
+IDENTITY_FILE="$RUN_DIR/server.identity"
 LOG_FILE="$RUN_DIR/server.log"
 ENV_FILE="$FM_HOME/.env"
 
@@ -99,15 +100,24 @@ pid_alive() {
   kill -0 "$1" 2>/dev/null
 }
 
-# The recorded pid must still be this lane's server before any signal is sent.
-# A recycled pid after a crash must never cause a kill of an unrelated process.
+process_start_identity() {
+  ps -p "$1" -o lstart= 2>/dev/null
+}
+
 pid_is_our_server() {
-  local pid=$1 cmd
+  local pid=$1 cmd cwd recorded current
+  [ -f "$IDENTITY_FILE" ] || return 1
+  recorded=$(cat "$IDENTITY_FILE" 2>/dev/null || true)
+  [ -n "$recorded" ] || return 1
+  current=$(process_start_identity "$pid") || return 1
+  [ "$current" = "$recorded" ] || return 1
   cmd=$(ps -p "$pid" -o command= 2>/dev/null || true)
-  case "$cmd" in
-    *"dist/index.js"*) return 0 ;;
+  case " $cmd " in
+    *" $APP_DIR/server/dist/index.js "*) ;;
     *) return 1 ;;
   esac
+  cwd=$(lsof -nP -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p') || return 1
+  [ "$cwd" = "$APP_DIR/server" ]
 }
 
 running_pid() {
@@ -275,21 +285,27 @@ cmd_start() {
     ENCRYPTION_KEY="$(cat "$KEY_FILE")" \
     FREEAPI_DB_PATH="$DB_PATH" \
     CATALOG_SYNC_DISABLED="$sync_disabled" \
-    nohup node dist/index.js >> "$LOG_FILE" 2>&1 &
+    nohup node "$APP_DIR/server/dist/index.js" >> "$LOG_FILE" 2>&1 &
     printf '%s\n' "$!" > "$PID_FILE"
   ) || die "could not launch the server from $APP_DIR/server"
-  chmod 600 "$PID_FILE" "$LOG_FILE" 2>/dev/null || true
 
   local pid waited=0
   pid=$(cat "$PID_FILE")
+  if ! process_start_identity "$pid" > "$IDENTITY_FILE.tmp" || [ ! -s "$IDENTITY_FILE.tmp" ]; then
+    stop_pid "$pid"
+    rm -f "$PID_FILE" "$IDENTITY_FILE.tmp"
+    die "could not record the server process start identity; server stopped"
+  fi
+  mv "$IDENTITY_FILE.tmp" "$IDENTITY_FILE"
+  chmod 600 "$PID_FILE" "$IDENTITY_FILE" "$LOG_FILE" 2>/dev/null || true
   until ping_ok "$port"; do
     if ! pid_alive "$pid"; then
-      rm -f "$PID_FILE"
+      rm -f "$PID_FILE" "$IDENTITY_FILE"
       die "server exited during startup; see log at $LOG_FILE (not printed here by policy)"
     fi
     if [ "$waited" -ge "$FM_FREELLMAPI_START_TIMEOUT" ]; then
       stop_pid "$pid"
-      rm -f "$PID_FILE"
+      rm -f "$PID_FILE" "$IDENTITY_FILE"
       die "server did not answer /api/ping on 127.0.0.1:$port within ${FM_FREELLMAPI_START_TIMEOUT}s; stopped it; see log at $LOG_FILE"
     fi
     sleep 1
@@ -298,7 +314,7 @@ cmd_start() {
 
   if ! verify_loopback_only "$pid"; then
     stop_pid "$pid"
-    rm -f "$PID_FILE"
+    rm -f "$PID_FILE" "$IDENTITY_FILE"
     die "REFUSED: could not prove every listener is bound to 127.0.0.1; server stopped (a non-loopback or unverifiable binding is never tolerated)"
   fi
 
@@ -378,9 +394,12 @@ dashboard_token() {
 
 cmd_seed_keys() {
   [ "$#" -ge 1 ] || die "usage: fm-freellmapi.sh seed-keys <platform>=<ENV_VAR> [...]"
-  local port=${FM_FREELLMAPI_PORT:-$FM_FREELLMAPI_DEFAULT_PORT}
+  local port=${FM_FREELLMAPI_PORT:-$FM_FREELLMAPI_DEFAULT_PORT} pid
   require_tool curl
   [ -f "$ENV_FILE" ] || die "fleet .env not found at $ENV_FILE; nothing to seed from"
+  pid=$(running_pid) || die "no live recorded lane process; start it before seeding keys"
+  verify_loopback_only "$pid" \
+    || die "recorded lane process has a non-loopback or unverifiable listener; refusing to send secrets"
   ping_ok "$port" || die "service is not answering on 127.0.0.1:$port; start it first"
 
   # Validate the whole request before the first write so a typo cannot leave a
@@ -452,16 +471,16 @@ cmd_stop() {
   local pid
   [ -f "$PID_FILE" ] || die "not running (no pid record at $PID_FILE)"
   pid=$(cat "$PID_FILE" 2>/dev/null || true)
-  case "$pid" in ''|*[!0-9]*) rm -f "$PID_FILE"; die "pid record at $PID_FILE was malformed; removed it" ;; esac
+  case "$pid" in ''|*[!0-9]*) rm -f "$PID_FILE" "$IDENTITY_FILE"; die "pid record at $PID_FILE was malformed; removed it" ;; esac
   if ! pid_alive "$pid"; then
-    rm -f "$PID_FILE"
+    rm -f "$PID_FILE" "$IDENTITY_FILE"
     printf 'fm-freellmapi.sh: was not running (stale pid record removed)\n'
     return 0
   fi
   pid_is_our_server "$pid" \
     || die "pid $pid is not this lane's server process; refusing to signal it (remove $PID_FILE by hand after checking)"
   stop_pid "$pid"
-  rm -f "$PID_FILE"
+  rm -f "$PID_FILE" "$IDENTITY_FILE"
   printf 'fm-freellmapi.sh: stopped (pid %s)\n' "$pid"
 }
 

--- a/bin/fm-freellmapi.sh
+++ b/bin/fm-freellmapi.sh
@@ -260,8 +260,19 @@ cmd_start() {
   [ -f "$APP_DIR/server/dist/index.js" ] \
     || die "no built install at $APP_DIR; run: fm-freellmapi.sh install --accept-risks"
 
-  if running_pid >/dev/null; then
-    die "already running (pid $(cat "$PID_FILE")); use status or stop"
+  local recorded_pid
+  if [ -f "$PID_FILE" ]; then
+    recorded_pid=$(cat "$PID_FILE" 2>/dev/null || true)
+    case "$recorded_pid" in
+      ''|*[!0-9]*) ;;
+      *)
+        if pid_alive "$recorded_pid"; then
+          pid_is_our_server "$recorded_pid" \
+            || die "pid $recorded_pid is live but its lane identity cannot authenticate it; refusing to overwrite the pid record"
+          die "already running (pid $recorded_pid); use status or stop"
+        fi
+        ;;
+    esac
   fi
 
   ensure_encryption_key

--- a/bin/fm-freellmapi.sh
+++ b/bin/fm-freellmapi.sh
@@ -30,11 +30,15 @@
 #   - Secret values (provider keys, ENCRYPTION_KEY, dashboard password, session
 #     token) never appear in stdout, stderr, argv, this script's error messages,
 #     or files other than the mode-0600 secret files listed above. Secrets travel
-#     to child processes via environment or stdin only, never command arguments,
-#     so they cannot surface in a process listing.
+#     to child processes via environment or stdin only, never command arguments
+#     (never on argv; not printed). At runtime they live only in process env,
+#     mode-0600 files, and stdin pipes; the same OS user can still inspect those
+#     (for example /proc/<pid>/environ on Linux). Do not run this script under
+#     shell xtrace (bash -x or set -o xtrace): it dumps env assignments and pipes.
 #   - This script never prints the server log; on failure it prints the log path.
-#   - start and status fail unless every TCP listener of the server process is
-#     bound to 127.0.0.1; a non-loopback listener is stopped, never tolerated.
+#   - start verifies every TCP listener of the server process is bound to
+#     127.0.0.1 and stops the server if verification fails; status fails with a
+#     warning on the same condition but does not stop (use stop for that).
 #   - install refuses to run without --accept-risks and restates the known
 #     dependency-vulnerability findings every time.
 set -eu
@@ -69,7 +73,8 @@ die() {
 }
 
 usage() {
-  sed -n '2,39{s/^# \{0,1\}//;p;}' "$SCRIPT_DIR/fm-freellmapi.sh"
+  # Print the header comment through the last contract bullet (before set -eu).
+  sed -n '2,43{s/^# \{0,1\}//;p;}' "$SCRIPT_DIR/fm-freellmapi.sh"
 }
 
 print_risks() {
@@ -257,8 +262,9 @@ cmd_start() {
   local sync_disabled=1
   [ "$catalog_sync" -eq 1 ] && sync_disabled=0
 
-  # The key is passed via environment, never argv, so it cannot appear in a
-  # process listing. NODE_ENV=production makes upstream refuse to fall back to
+  # The key is passed via environment, never argv (so argv / ps args stay clean).
+  # It still lives in the node process env for the whole run; same-user tools
+  # can inspect that. NODE_ENV=production makes upstream refuse to fall back to
   # any implicit dev key. The background command is a simple command so $! is
   # the node pid itself, not a wrapping subshell.
   (
@@ -319,7 +325,9 @@ cmd_status() {
     return 1
   fi
   if ! verify_loopback_only "$pid"; then
-    printf 'fm-freellmapi.sh: WARNING: pid %s has a non-loopback or unverifiable listener; stop it now\n' "$pid" >&2
+    # status alerts only; start is the path that stops a bad bind. Operators
+    # must run stop (or restart via start) after this warning.
+    printf 'fm-freellmapi.sh: WARNING: pid %s has a non-loopback or unverifiable listener; run stop (status does not stop)\n' "$pid" >&2
     return 1
   fi
   printf 'fm-freellmapi.sh: running on http://127.0.0.1:%s (loopback binding verified, pid %s)\n' "$port" "$pid"

--- a/bin/fm-freellmapi.sh
+++ b/bin/fm-freellmapi.sh
@@ -47,8 +47,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 
-# Exact pin - change only after re-verifying the upstream commit the way
-# data/freellmapi-koeajo/report.md did (repo authenticity, CI, key handling).
+# Exact pin - change only after re-verifying upstream authenticity, CI, and key
+# handling and updating the safety-contract regression coverage.
 FM_FREELLMAPI_REPO_URL=https://github.com/tashfeenahmed/freellmapi.git
 FM_FREELLMAPI_PIN=526c86349891bd336b470481ee2d732cd8e13c14
 FM_FREELLMAPI_PIN_DATE=2026-07-20
@@ -88,7 +88,7 @@ KNOWN RISKS - FreeLLMAPI lane (pin $FM_FREELLMAPI_PIN, $FM_FREELLMAPI_PIN_DATE):
     some keyless providers may use prompts for training.
   - This service is for ISOLATED LOCAL USE ONLY: localhost binding, no tunnel,
     no port forwarding, no sensitive content, never a primary-model substitute.
-  Full policy: docs/freellmapi-lane.md and data/freellmapi-koeajo/report.md.
+  Full policy: docs/freellmapi-lane.md.
 EOF
 }
 

--- a/bin/fm-freellmapi.sh
+++ b/bin/fm-freellmapi.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+# fm-freellmapi.sh - manage the fleet's pinned, localhost-only FreeLLMAPI lane.
+#
+# FreeLLMAPI (https://github.com/tashfeenahmed/freellmapi, MIT) is a third-party
+# local proxy that pools free-tier LLM provider keys behind one OpenAI-compatible
+# endpoint. This script is the single owner of the fleet's vetted install: it
+# pins one audited upstream commit, generates the mandatory ENCRYPTION_KEY
+# without ever printing it, starts the service bound to 127.0.0.1 only, verifies
+# that binding before declaring success, seeds provider keys from the fleet's
+# gitignored .env without exposing their values, and stops the service cleanly.
+# Non-sensitive bulk/scout use only - docs/freellmapi-lane.md owns the usage
+# policy, known-risk statement, and removal procedure.
+#
+# Usage:
+#   fm-freellmapi.sh install --accept-risks     install or repair the pinned build
+#   fm-freellmapi.sh start [--port <p>] [--catalog-sync]
+#   fm-freellmapi.sh status [--port <p>]
+#   fm-freellmapi.sh seed-keys <platform>=<ENV_VAR> [<platform>=<ENV_VAR> ...]
+#   fm-freellmapi.sh stop
+#   fm-freellmapi.sh --help
+#
+# The install lives under $FM_HOME/data/freellmapi (gitignored, chmod 0700):
+#   app/                 upstream checkout at the exact pinned commit, built
+#   db/freeapi.db        service state, kept outside app/ so reinstall preserves it
+#   encryption.key       generated 64-hex AES-256-GCM key, mode 0600
+#   dashboard.credentials generated local dashboard login, mode 0600
+#   run/server.pid run/server.log  runtime records
+#
+# Secret-safety contract (the reason this wrapper exists):
+#   - Secret values (provider keys, ENCRYPTION_KEY, dashboard password, session
+#     token) never appear in stdout, stderr, argv, this script's error messages,
+#     or files other than the mode-0600 secret files listed above. Secrets travel
+#     to child processes via environment or stdin only, never command arguments,
+#     so they cannot surface in a process listing.
+#   - This script never prints the server log; on failure it prints the log path.
+#   - start and status fail unless every TCP listener of the server process is
+#     bound to 127.0.0.1; a non-loopback listener is stopped, never tolerated.
+#   - install refuses to run without --accept-risks and restates the known
+#     dependency-vulnerability findings every time.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+# Exact pin - change only after re-verifying the upstream commit the way
+# data/freellmapi-koeajo/report.md did (repo authenticity, CI, key handling).
+FM_FREELLMAPI_REPO_URL=https://github.com/tashfeenahmed/freellmapi.git
+FM_FREELLMAPI_PIN=526c86349891bd336b470481ee2d732cd8e13c14
+FM_FREELLMAPI_PIN_DATE=2026-07-20
+
+FM_FREELLMAPI_DEFAULT_PORT=3001
+FM_FREELLMAPI_START_TIMEOUT=${FM_FREELLMAPI_START_TIMEOUT:-30}
+FM_FREELLMAPI_STOP_TIMEOUT=${FM_FREELLMAPI_STOP_TIMEOUT:-10}
+
+LANE_HOME="$FM_HOME/data/freellmapi"
+APP_DIR="$LANE_HOME/app"
+DB_PATH="$LANE_HOME/db/freeapi.db"
+KEY_FILE="$LANE_HOME/encryption.key"
+CRED_FILE="$LANE_HOME/dashboard.credentials"
+RUN_DIR="$LANE_HOME/run"
+PID_FILE="$RUN_DIR/server.pid"
+LOG_FILE="$RUN_DIR/server.log"
+ENV_FILE="$FM_HOME/.env"
+
+die() {
+  printf 'fm-freellmapi.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  sed -n '2,39{s/^# \{0,1\}//;p;}' "$SCRIPT_DIR/fm-freellmapi.sh"
+}
+
+print_risks() {
+  cat <<EOF
+KNOWN RISKS - FreeLLMAPI lane (pin $FM_FREELLMAPI_PIN, $FM_FREELLMAPI_PIN_DATE):
+  - npm ci at this pin reported 21 dependency vulnerabilities
+    (3 critical, 7 high, 9 moderate, 2 low; npm audit 2026-07-24).
+  - npm ci executes dependency install scripts (native modules build at install).
+  - Every prompt sent through the lane goes to third-party free providers;
+    some keyless providers may use prompts for training.
+  - This service is for ISOLATED LOCAL USE ONLY: localhost binding, no tunnel,
+    no port forwarding, no sensitive content, never a primary-model substitute.
+  Full policy: docs/freellmapi-lane.md and data/freellmapi-koeajo/report.md.
+EOF
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || die "required tool '$1' not found on PATH"
+}
+
+pid_alive() {
+  kill -0 "$1" 2>/dev/null
+}
+
+# The recorded pid must still be this lane's server before any signal is sent.
+# A recycled pid after a crash must never cause a kill of an unrelated process.
+pid_is_our_server() {
+  local pid=$1 cmd
+  cmd=$(ps -p "$pid" -o command= 2>/dev/null || true)
+  case "$cmd" in
+    *"dist/index.js"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+running_pid() {
+  local pid
+  [ -f "$PID_FILE" ] || return 1
+  pid=$(cat "$PID_FILE" 2>/dev/null || true)
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  pid_alive "$pid" && pid_is_our_server "$pid" || return 1
+  printf '%s\n' "$pid"
+}
+
+validate_port() {
+  case "$1" in
+    ''|*[!0-9]*) die "invalid port '$1'" ;;
+  esac
+  [ "$1" -ge 1 ] && [ "$1" -le 65535 ] || die "invalid port '$1'"
+}
+
+# Fail closed unless every TCP listener owned by the server pid is bound to
+# 127.0.0.1. Verification is mandatory: if lsof is missing or fails, the caller
+# must treat the service as unverified and stop it.
+verify_loopback_only() {
+  local pid=$1 listeners bad
+  command -v lsof >/dev/null 2>&1 || return 1
+  listeners=$(lsof -nP -a -p "$pid" -iTCP -sTCP:LISTEN 2>/dev/null | awk 'NR > 1 {print $(NF-1)}') || return 1
+  [ -n "$listeners" ] || return 1
+  bad=$(printf '%s\n' "$listeners" | grep -v '^127\.0\.0\.1:' || true)
+  [ -z "$bad" ]
+}
+
+ping_ok() {
+  local port=$1
+  curl -fsS --max-time 2 -o /dev/null "http://127.0.0.1:$port/api/ping" 2>/dev/null
+}
+
+ensure_lane_home() {
+  mkdir -p "$LANE_HOME"
+  chmod 700 "$LANE_HOME"
+}
+
+ensure_encryption_key() {
+  local key
+  if [ ! -f "$KEY_FILE" ]; then
+    require_tool openssl
+    ensure_lane_home
+    ( umask 077 && openssl rand -hex 32 > "$KEY_FILE.tmp" && mv "$KEY_FILE.tmp" "$KEY_FILE" )
+    printf 'fm-freellmapi.sh: generated new ENCRYPTION_KEY at %s (value not shown)\n' "$KEY_FILE" >&2
+  fi
+  key=$(cat "$KEY_FILE")
+  case "$key" in
+    *[!0-9a-f]*|'') die "encryption key at $KEY_FILE is not 64 lowercase hex chars; refusing to start (regenerate by removing the file - existing stored provider keys become unreadable)" ;;
+  esac
+  [ "${#key}" -eq 64 ] || die "encryption key at $KEY_FILE is not 64 lowercase hex chars; refusing to start (regenerate by removing the file - existing stored provider keys become unreadable)"
+}
+
+# Read one variable's value from the fleet's gitignored .env without sourcing it
+# (sourcing would execute arbitrary content). Prints the value to stdout for the
+# caller to capture; the value must never be echoed anywhere else.
+env_file_value() {
+  local name=$1 value
+  value=$(awk -v name="$name" '
+    {
+      line = $0
+      sub(/^[[:space:]]*/, "", line)
+      sub(/^export[[:space:]]+/, "", line)
+      eq = index(line, "=")
+      if (eq > 1 && substr(line, 1, eq - 1) == name) { val = substr(line, eq + 1) }
+    }
+    END { printf "%s", val }
+  ' "$ENV_FILE")
+  case "$value" in
+    \"*\") value=${value#\"}; value=${value%\"} ;;
+    \'*\') value=${value#\'}; value=${value%\'} ;;
+  esac
+  [ -n "$value" ] || return 1
+  printf '%s' "$value"
+}
+
+cmd_install() {
+  local accept=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --accept-risks) accept=1; shift ;;
+      *) die "unknown install option '$1'" ;;
+    esac
+  done
+  print_risks >&2
+  if [ "$accept" -ne 1 ]; then
+    die "refusing to install without --accept-risks (read the risk statement above and docs/freellmapi-lane.md first)"
+  fi
+  require_tool git
+  require_tool npm
+  require_tool node
+
+  ensure_lane_home
+  mkdir -p "$(dirname "$DB_PATH")" "$RUN_DIR"
+
+  if [ ! -d "$APP_DIR/.git" ]; then
+    mkdir -p "$APP_DIR"
+    git -C "$APP_DIR" init -q
+    git -C "$APP_DIR" remote add origin "$FM_FREELLMAPI_REPO_URL"
+  fi
+  printf 'fm-freellmapi.sh: fetching pinned commit %s\n' "$FM_FREELLMAPI_PIN" >&2
+  git -C "$APP_DIR" fetch -q --depth 1 origin "$FM_FREELLMAPI_PIN" \
+    || die "could not fetch pinned commit $FM_FREELLMAPI_PIN from $FM_FREELLMAPI_REPO_URL"
+  git -C "$APP_DIR" checkout -q --detach "$FM_FREELLMAPI_PIN" \
+    || die "could not check out pinned commit $FM_FREELLMAPI_PIN"
+
+  local head_sha
+  head_sha=$(git -C "$APP_DIR" rev-parse HEAD)
+  [ "$head_sha" = "$FM_FREELLMAPI_PIN" ] \
+    || die "checkout mismatch: HEAD is $head_sha, expected pinned $FM_FREELLMAPI_PIN; refusing to build unverified content"
+
+  printf 'fm-freellmapi.sh: installing lockfile-pinned dependencies (npm ci)\n' >&2
+  ( cd "$APP_DIR" && npm ci ) || die "npm ci failed in $APP_DIR"
+  printf 'fm-freellmapi.sh: building server and dashboard\n' >&2
+  ( cd "$APP_DIR" && npm run build ) || die "npm run build failed in $APP_DIR"
+
+  printf 'fm-freellmapi.sh: installed FreeLLMAPI at pinned commit %s under %s\n' \
+    "$FM_FREELLMAPI_PIN" "$APP_DIR"
+  printf 'fm-freellmapi.sh: next: fm-freellmapi.sh start\n'
+}
+
+cmd_start() {
+  local port=${FM_FREELLMAPI_PORT:-$FM_FREELLMAPI_DEFAULT_PORT} catalog_sync=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --port) [ "$#" -ge 2 ] || die "--port requires a value"; port=$2; shift 2 ;;
+      --port=*) port=${1#*=}; shift ;;
+      --catalog-sync) catalog_sync=1; shift ;;
+      *) die "unknown start option '$1'" ;;
+    esac
+  done
+  validate_port "$port"
+  require_tool node
+  require_tool curl
+  command -v lsof >/dev/null 2>&1 \
+    || die "lsof is required to verify the localhost-only binding; refusing to start unverifiable"
+
+  [ -f "$APP_DIR/server/dist/index.js" ] \
+    || die "no built install at $APP_DIR; run: fm-freellmapi.sh install --accept-risks"
+
+  if running_pid >/dev/null; then
+    die "already running (pid $(cat "$PID_FILE")); use status or stop"
+  fi
+
+  ensure_encryption_key
+  mkdir -p "$RUN_DIR" "$(dirname "$DB_PATH")"
+
+  # CATALOG_SYNC_DISABLED=1 is the default: the pinned snapshot catalog works
+  # offline and the lane keeps zero background egress unless opted in.
+  local sync_disabled=1
+  [ "$catalog_sync" -eq 1 ] && sync_disabled=0
+
+  # The key is passed via environment, never argv, so it cannot appear in a
+  # process listing. NODE_ENV=production makes upstream refuse to fall back to
+  # any implicit dev key. The background command is a simple command so $! is
+  # the node pid itself, not a wrapping subshell.
+  (
+    cd "$APP_DIR/server" || exit 1
+    NODE_ENV=production \
+    HOST=127.0.0.1 \
+    PORT="$port" \
+    ENCRYPTION_KEY="$(cat "$KEY_FILE")" \
+    FREEAPI_DB_PATH="$DB_PATH" \
+    CATALOG_SYNC_DISABLED="$sync_disabled" \
+    nohup node dist/index.js >> "$LOG_FILE" 2>&1 &
+    printf '%s\n' "$!" > "$PID_FILE"
+  ) || die "could not launch the server from $APP_DIR/server"
+  chmod 600 "$PID_FILE" "$LOG_FILE" 2>/dev/null || true
+
+  local pid waited=0
+  pid=$(cat "$PID_FILE")
+  until ping_ok "$port"; do
+    if ! pid_alive "$pid"; then
+      rm -f "$PID_FILE"
+      die "server exited during startup; see log at $LOG_FILE (not printed here by policy)"
+    fi
+    if [ "$waited" -ge "$FM_FREELLMAPI_START_TIMEOUT" ]; then
+      stop_pid "$pid"
+      rm -f "$PID_FILE"
+      die "server did not answer /api/ping on 127.0.0.1:$port within ${FM_FREELLMAPI_START_TIMEOUT}s; stopped it; see log at $LOG_FILE"
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  if ! verify_loopback_only "$pid"; then
+    stop_pid "$pid"
+    rm -f "$PID_FILE"
+    die "REFUSED: could not prove every listener is bound to 127.0.0.1; server stopped (a non-loopback or unverifiable binding is never tolerated)"
+  fi
+
+  printf 'fm-freellmapi.sh: running on http://127.0.0.1:%s (loopback binding verified, pid %s)\n' "$port" "$pid"
+  printf 'fm-freellmapi.sh: non-sensitive bulk/scout use only - see docs/freellmapi-lane.md\n'
+}
+
+cmd_status() {
+  local port=${FM_FREELLMAPI_PORT:-$FM_FREELLMAPI_DEFAULT_PORT} pid
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --port) [ "$#" -ge 2 ] || die "--port requires a value"; port=$2; shift 2 ;;
+      --port=*) port=${1#*=}; shift ;;
+      *) die "unknown status option '$1'" ;;
+    esac
+  done
+  validate_port "$port"
+  if ! pid=$(running_pid); then
+    printf 'fm-freellmapi.sh: not running\n'
+    return 1
+  fi
+  if ! ping_ok "$port"; then
+    printf 'fm-freellmapi.sh: pid %s is alive but /api/ping on 127.0.0.1:%s failed\n' "$pid" "$port"
+    return 1
+  fi
+  if ! verify_loopback_only "$pid"; then
+    printf 'fm-freellmapi.sh: WARNING: pid %s has a non-loopback or unverifiable listener; stop it now\n' "$pid" >&2
+    return 1
+  fi
+  printf 'fm-freellmapi.sh: running on http://127.0.0.1:%s (loopback binding verified, pid %s)\n' "$port" "$pid"
+}
+
+# Obtain a dashboard session token into DASHBOARD_TOKEN using generated
+# credentials stored only in the mode-0600 credentials file.
+# First run claims the fresh install over loopback; later runs log in.
+dashboard_token() {
+  local port=$1 email password status_json needs token_json token
+  if [ ! -f "$CRED_FILE" ]; then
+    require_tool openssl
+    ensure_lane_home
+    ( umask 077 && {
+        printf 'email=firstmate-lane@localhost.local\n'
+        printf 'password=%s\n' "$(openssl rand -hex 24)"
+      } > "$CRED_FILE.tmp" && mv "$CRED_FILE.tmp" "$CRED_FILE" )
+    printf 'fm-freellmapi.sh: generated dashboard credentials at %s (value not shown)\n' "$CRED_FILE" >&2
+  fi
+  email=$(awk -F= '$1 == "email" {print $2}' "$CRED_FILE")
+  password=$(awk -F= '$1 == "password" {print $2}' "$CRED_FILE")
+  [ -n "$email" ] && [ -n "$password" ] \
+    || die "credentials file $CRED_FILE is malformed; remove it to regenerate"
+
+  status_json=$(curl -fsS --max-time 5 "http://127.0.0.1:$port/api/auth/status") \
+    || die "could not read dashboard auth status on 127.0.0.1:$port"
+  case "$status_json" in
+    *'"needsSetup":true'*) needs=1 ;;
+    *) needs=0 ;;
+  esac
+
+  # Credentials travel via stdin, never argv.
+  if [ "$needs" -eq 1 ]; then
+    token_json=$(printf '{"email":"%s","password":"%s"}' "$email" "$password" \
+      | curl -fsS --max-time 5 -H 'Content-Type: application/json' -d @- \
+          "http://127.0.0.1:$port/api/auth/setup") \
+      || die "dashboard first-run setup failed on 127.0.0.1:$port"
+  else
+    token_json=$(printf '{"email":"%s","password":"%s"}' "$email" "$password" \
+      | curl -fsS --max-time 5 -H 'Content-Type: application/json' -d @- \
+          "http://127.0.0.1:$port/api/auth/login") \
+      || die "dashboard login failed on 127.0.0.1:$port (if the dashboard was claimed manually, remove $CRED_FILE and reset the install)"
+  fi
+  token=$(printf '%s' "$token_json" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+  [ -n "$token" ] || die "dashboard did not return a session token"
+  DASHBOARD_TOKEN=$token
+}
+
+cmd_seed_keys() {
+  [ "$#" -ge 1 ] || die "usage: fm-freellmapi.sh seed-keys <platform>=<ENV_VAR> [...]"
+  local port=${FM_FREELLMAPI_PORT:-$FM_FREELLMAPI_DEFAULT_PORT}
+  require_tool curl
+  [ -f "$ENV_FILE" ] || die "fleet .env not found at $ENV_FILE; nothing to seed from"
+  ping_ok "$port" || die "service is not answering on 127.0.0.1:$port; start it first"
+
+  # Validate the whole request before the first write so a typo cannot leave a
+  # half-seeded key set.
+  local mapping platform var value
+  for mapping in "$@"; do
+    case "$mapping" in
+      *=*) ;;
+      *) die "invalid mapping '$mapping'; expected <platform>=<ENV_VAR>" ;;
+    esac
+    platform=${mapping%%=*}
+    var=${mapping#*=}
+    case "$platform" in
+      ''|*[!a-z0-9_-]*) die "invalid platform name '$platform'" ;;
+    esac
+    case "$var" in
+      ''|*[!A-Z0-9_]*) die "invalid env var name '$var'; expected an UPPER_SNAKE name from $ENV_FILE" ;;
+    esac
+    value=$(env_file_value "$var") || die "$var is missing or empty in $ENV_FILE"
+    case "$value" in
+      *[\"\\]*|*[![:print:]]*) die "$var contains characters this tool refuses to forward (quote, backslash, or non-printable); seed it via the dashboard instead" ;;
+    esac
+  done
+
+  local hdr
+  SEED_TMPDIR=$(umask 077 && mktemp -d "${TMPDIR:-/tmp}/fm-freellmapi.XXXXXX")
+  trap 'rm -rf "$SEED_TMPDIR"' EXIT
+  DASHBOARD_TOKEN=
+  dashboard_token "$port"
+  hdr="$SEED_TMPDIR/auth-header"
+  # The token reaches curl through a header file, never argv.
+  ( umask 077 && printf 'Authorization: Bearer %s\n' "$DASHBOARD_TOKEN" > "$hdr" )
+
+  local http_code
+  for mapping in "$@"; do
+    platform=${mapping%%=*}
+    var=${mapping#*=}
+    value=$(env_file_value "$var") || die "$var is missing or empty in $ENV_FILE"
+    # The key value travels via stdin, never argv; the response body (which
+    # echoes a masked copy) is discarded.
+    http_code=$(printf '{"platform":"%s","key":"%s","label":"%s"}' "$platform" "$value" "$var" \
+      | curl -sS --max-time 10 -o /dev/null -w '%{http_code}' \
+          -H 'Content-Type: application/json' -H "@$hdr" -d @- \
+          "http://127.0.0.1:$port/api/keys") \
+      || die "could not reach /api/keys on 127.0.0.1:$port"
+    case "$http_code" in
+      200|201) printf 'fm-freellmapi.sh: seeded %s key from %s (value not shown)\n' "$platform" "$var" ;;
+      *) die "seeding $platform key from $var failed (HTTP $http_code); the key value was not printed anywhere" ;;
+    esac
+  done
+}
+
+stop_pid() {
+  local pid=$1 waited=0
+  kill -TERM "$pid" 2>/dev/null || true
+  while pid_alive "$pid"; do
+    if [ "$waited" -ge "$FM_FREELLMAPI_STOP_TIMEOUT" ]; then
+      kill -KILL "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+}
+
+cmd_stop() {
+  [ "$#" -eq 0 ] || die "stop takes no options"
+  local pid
+  [ -f "$PID_FILE" ] || die "not running (no pid record at $PID_FILE)"
+  pid=$(cat "$PID_FILE" 2>/dev/null || true)
+  case "$pid" in ''|*[!0-9]*) rm -f "$PID_FILE"; die "pid record at $PID_FILE was malformed; removed it" ;; esac
+  if ! pid_alive "$pid"; then
+    rm -f "$PID_FILE"
+    printf 'fm-freellmapi.sh: was not running (stale pid record removed)\n'
+    return 0
+  fi
+  pid_is_our_server "$pid" \
+    || die "pid $pid is not this lane's server process; refusing to signal it (remove $PID_FILE by hand after checking)"
+  stop_pid "$pid"
+  rm -f "$PID_FILE"
+  printf 'fm-freellmapi.sh: stopped (pid %s)\n' "$pid"
+}
+
+[ "$#" -ge 1 ] || { usage >&2; exit 2; }
+COMMAND=$1
+shift
+case "$COMMAND" in
+  install) cmd_install "$@" ;;
+  start) cmd_start "$@" ;;
+  status) cmd_status "$@" ;;
+  seed-keys) cmd_seed_keys "$@" ;;
+  stop) cmd_stop "$@" ;;
+  --help|-h|help) usage ;;
+  *) usage >&2; die "unknown command '$COMMAND'" ;;
+esac

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -122,7 +122,8 @@ family_for_basename() {
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
-    fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
+    fm-freellmapi.test.sh|fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|\
+    fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -244,6 +244,10 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/freellmapi-lane.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/gitlab-merge-watch.md",
       "audience": "maintainer-verification"
     },

--- a/docs/freellmapi-lane.md
+++ b/docs/freellmapi-lane.md
@@ -7,8 +7,7 @@ The lane is opt-in tooling only: nothing in firstmate dispatches to it automatic
 ## What this lane is
 
 FreeLLMAPI (https://github.com/tashfeenahmed/freellmapi, MIT) is a third-party local proxy that pools free-tier LLM provider keys behind one OpenAI-compatible endpoint on localhost, with automatic fallback across providers.
-The fleet's verified evaluation of the upstream project - repo authenticity, key handling, prompt egress, realistic capacity - is `data/freellmapi-koeajo/report.md` (scout, 2026-07-24); this document does not restate it.
-The install is pinned to the exact audited commit `526c8634` (2026-07-20); the pin changes only after re-verifying a new commit the way that report did.
+The install is pinned to the exact audited commit `526c8634` (2026-07-20); the pin changes only after re-verifying upstream authenticity, CI, and key handling and updating the safety-contract regression coverage.
 
 ## Allowed and forbidden use
 
@@ -51,7 +50,7 @@ Secrets are never printed and never placed on argv.
 At runtime they live only in process environment, mode-0600 files, and stdin pipes; the same OS user can still inspect those (for example process environment on many platforms).
 Never run `bin/fm-freellmapi.sh` under shell xtrace (`bash -x`, `set -o xtrace`, or an equivalent debug wrapper): tracing dumps assignments and piped bodies and will leak keys into the terminal and shell logs.
 
-Catalog sync to `api.freellmapi.co` is disabled by default so the lane has zero background egress; `start --catalog-sync` opts in to the signed metadata-only sync described in the scout report.
+Catalog sync to `api.freellmapi.co` is disabled by default so the lane has zero background egress; `start --catalog-sync` opts in to that metadata refresh.
 
 ## Disabling and removing the lane
 

--- a/docs/freellmapi-lane.md
+++ b/docs/freellmapi-lane.md
@@ -1,0 +1,53 @@
+# FreeLLMAPI lane
+
+This document owns the fleet's usage policy for the optional FreeLLMAPI bulk/research lane.
+`bin/fm-freellmapi.sh` is the single owner of the mechanics (install, start, status, seed-keys, stop); read its header and `--help` for exact commands and the secret-safety contract.
+The lane is opt-in tooling only: nothing in firstmate dispatches to it automatically, and enabling it for any routing or profile path is a separate captain decision.
+
+## What this lane is
+
+FreeLLMAPI (https://github.com/tashfeenahmed/freellmapi, MIT) is a third-party local proxy that pools free-tier LLM provider keys behind one OpenAI-compatible endpoint on localhost, with automatic fallback across providers.
+The fleet's verified evaluation of the upstream project - repo authenticity, key handling, prompt egress, realistic capacity - is `data/freellmapi-koeajo/report.md` (scout, 2026-07-24); this document does not restate it.
+The install is pinned to the exact audited commit `526c8634` (2026-07-20); the pin changes only after re-verifying a new commit the way that report did.
+
+## Allowed and forbidden use
+
+Allowed - non-sensitive bulk and research work only:
+
+- Summaries and classification over public material (public READMEs, issues, docs).
+- Scout-style probe calls and cheap first drafts that a primary model later reviews.
+- Experiments that need volume more than quality.
+
+Forbidden - always:
+
+- Any sensitive content: captain data, project source code that is not public, credentials, personal data, strategy.
+- Use as a substitute for the primary model in real project work.
+- Exposing the service beyond this machine: no `0.0.0.0`, no port forwarding, no tunnel, no reverse proxy.
+- Paid production provider keys; the lane takes free-tier keys only.
+
+Every prompt sent through the lane goes to third-party free providers, and some keyless providers may use prompts for training.
+Treat everything sent through the lane as visible to those third parties.
+
+## Known risks (stated, not hidden)
+
+- The pinned dependency tree reported 21 npm audit vulnerabilities (3 critical, 7 high, 9 moderate, 2 low) on 2026-07-24, and `npm ci` executes dependency install scripts.
+- Free-tier models follow instructions unreliably and empty completions are common; capacity numbers in upstream marketing are catalog-label sums, not deliverable throughput.
+- Provider terms of service constrain use (for example NVIDIA free tier is eval-only); the lane operator remains responsible for respecting them.
+
+`fm-freellmapi.sh install` restates the vulnerability findings on every run and refuses to proceed without `--accept-risks`.
+
+## Running the lane
+
+- Install once: `bin/fm-freellmapi.sh install --accept-risks` (pinned fetch, lockfile-pinned `npm ci`, build).
+- Start: `bin/fm-freellmapi.sh start` - generates the mandatory `ENCRYPTION_KEY` on first start (never printed), binds to `127.0.0.1` only, and refuses to stay up unless the loopback-only binding is verified.
+- Seed provider keys from the fleet's gitignored `.env`: `bin/fm-freellmapi.sh seed-keys google=GEMINI_API_KEY` - values travel via stdin and environment only, never argv or output.
+- Check: `bin/fm-freellmapi.sh status`; stop: `bin/fm-freellmapi.sh stop`.
+- Everything the lane stores (checkout, database, generated secrets, runtime records) lives under `$FM_HOME/data/freellmapi/`, which is gitignored and mode 0700.
+
+Catalog sync to `api.freellmapi.co` is disabled by default so the lane has zero background egress; `start --catalog-sync` opts in to the signed metadata-only sync described in the scout report.
+
+## Disabling and removing the lane
+
+- Disable: `bin/fm-freellmapi.sh stop`; the lane stays installed but nothing runs and nothing routes to it.
+- Remove completely: stop the service, then delete `$FM_HOME/data/freellmapi/`.
+- Removal deletes the generated `ENCRYPTION_KEY` and with it access to every provider key stored in the lane's database; the original key material in the fleet `.env` is untouched.

--- a/docs/freellmapi-lane.md
+++ b/docs/freellmapi-lane.md
@@ -39,10 +39,17 @@ Treat everything sent through the lane as visible to those third parties.
 ## Running the lane
 
 - Install once: `bin/fm-freellmapi.sh install --accept-risks` (pinned fetch, lockfile-pinned `npm ci`, build).
-- Start: `bin/fm-freellmapi.sh start` - generates the mandatory `ENCRYPTION_KEY` on first start (never printed), binds to `127.0.0.1` only, and refuses to stay up unless the loopback-only binding is verified.
+- Start: `bin/fm-freellmapi.sh start` - generates the mandatory `ENCRYPTION_KEY` on first start (never printed), binds to `127.0.0.1` only, and stops the process if loopback-only binding cannot be verified.
 - Seed provider keys from the fleet's gitignored `.env`: `bin/fm-freellmapi.sh seed-keys google=GEMINI_API_KEY` - values travel via stdin and environment only, never argv or output.
-- Check: `bin/fm-freellmapi.sh status`; stop: `bin/fm-freellmapi.sh stop`.
+- Check: `bin/fm-freellmapi.sh status` reports health and fails with a warning if a non-loopback listener is found; it does not stop the process (use `stop` for that).
+- Stop: `bin/fm-freellmapi.sh stop`.
 - Everything the lane stores (checkout, database, generated secrets, runtime records) lives under `$FM_HOME/data/freellmapi/`, which is gitignored and mode 0700.
+
+### Secret handling limits
+
+Secrets are never printed and never placed on argv.
+At runtime they live only in process environment, mode-0600 files, and stdin pipes; the same OS user can still inspect those (for example process environment on many platforms).
+Never run `bin/fm-freellmapi.sh` under shell xtrace (`bash -x`, `set -o xtrace`, or an equivalent debug wrapper): tracing dumps assignments and piped bodies and will leak keys into the terminal and shell logs.
 
 Catalog sync to `api.freellmapi.co` is disabled by default so the lane has zero background egress; `start --catalog-sync` opts in to the signed metadata-only sync described in the scout report.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -23,6 +23,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |
 | `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |
+| `fm-freellmapi.sh`       | Manage the pinned, localhost-only FreeLLMAPI bulk/research lane without exposing key values (docs/freellmapi-lane.md) |
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |

--- a/tests/fm-freellmapi.test.sh
+++ b/tests/fm-freellmapi.test.sh
@@ -144,6 +144,13 @@ test_static_pin_and_safety_contract() {
   assert_grep 'NODE_ENV=production' "$TOOL" "tool must run upstream in production mode so a dev fallback key is refused"
   assert_grep '--accept-risks' "$TOOL" "install must be gated on explicit risk acceptance"
   assert_no_grep 'set -x' "$TOOL" "tool must never enable shell tracing around secrets"
+  # Honest secret contract: argv protection, not absolute process-listing immunity.
+  assert_grep 'never on argv' "$TOOL" "tool must state secrets are never on argv"
+  assert_grep 'same OS user can still inspect' "$TOOL" "tool must not overclaim process-env secrecy"
+  assert_no_grep 'cannot surface in a process listing' "$TOOL" "tool must not claim absolute process-listing protection"
+  # status alerts; only start stops a bad bind.
+  assert_grep 'status fails with a' "$TOOL" "help must say status fails without stopping"
+  assert_grep 'does not stop' "$TOOL" "help must say status does not stop on bad bind"
   pass "static pin and safety contract"
 }
 
@@ -155,6 +162,7 @@ test_help_states_policy() {
   expect_code 0 "$code" "--help exit"
   assert_contains "$out" "127.0.0.1" "help must state the localhost-only binding"
   assert_contains "$out" "never appear in stdout" "help must state the secret-safety contract"
+  assert_contains "$out" "same OS user can still inspect" "help must not overclaim process-env secrecy"
   assert_contains "$out" "docs/freellmapi-lane.md" "help must point at the lane policy doc"
   pass "help states policy"
 }
@@ -401,6 +409,34 @@ EOF
   pass "status reports not running"
 }
 
+test_status_warns_on_non_loopback_without_stopping() {
+  local root home fakebin cap pid alive
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  built_install "$home"
+  run_tool "$home" "$fakebin" start
+  expect_code 0 "$CODE" "start before status"
+  pid=$(cat "$home/data/freellmapi/run/server.pid")
+  set +e
+  OUT=$(FM_HOME="$home" PATH="$fakebin:$PATH" FAKE_LSOF_ADDR=0.0.0.0 \
+    FM_FREELLMAPI_STOP_TIMEOUT=2 "$TOOL" status 2>&1)
+  CODE=$?
+  set -e
+  [ "$CODE" -ne 0 ] || fail "status must fail when a listener is not loopback"
+  assert_contains "$OUT" "WARNING" "status must warn on non-loopback bind"
+  assert_contains "$OUT" "status does not stop" "status must say it does not stop"
+  alive=0
+  kill -0 "$pid" 2>/dev/null && alive=1
+  [ "$alive" -eq 1 ] || fail "status must not stop the server (only start/stop do)"
+  assert_absent "$cap/node-signal.capture" "status must not send TERM on bad bind"
+  stop_lane "$home" "$fakebin"
+  pass "status warns on non-loopback without stopping"
+}
+
 test_stop_gracefully_terminates() {
   local root home fakebin cap
   root=$(fm_test_tmproot fm-freellmapi)
@@ -472,6 +508,7 @@ test_seed_keys_refuses_missing_env_and_var
 test_seed_keys_sends_value_via_stdin_only
 test_seed_keys_refuses_injection_prone_value
 test_status_reports_not_running
+test_status_warns_on_non_loopback_without_stopping
 test_stop_gracefully_terminates
 test_stop_refuses_foreign_pid
 test_stop_without_pid_record

--- a/tests/fm-freellmapi.test.sh
+++ b/tests/fm-freellmapi.test.sh
@@ -99,6 +99,13 @@ SH
   cat > "$fakebin/lsof" <<SH
 #!/usr/bin/env bash
 [ "\${FAKE_LSOF_EXIT:-0}" = 0 ] || exit "\$FAKE_LSOF_EXIT"
+for a in "\$@"; do
+  if [ "\$a" = cwd ]; then
+    printf 'p%s\n' "\$4"
+    printf 'n%s\n' '$(dirname "$cap")/home/data/freellmapi/app/server'
+    exit 0
+  fi
+done
 printf 'COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\n'
 printf 'node 999 u 23u IPv4 0x0 0t0 TCP %s:3001 (LISTEN)\n' "\${FAKE_LSOF_ADDR:-127.0.0.1}"
 SH
@@ -349,10 +356,33 @@ EOF
   assert_contains "$OUT" ".env not found" "refusal must name the missing .env"
 
   printf 'OTHER_VAR=x\n' > "$home/.env"
+  built_install "$home"
+  run_tool "$home" "$fakebin" start
+  expect_code 0 "$CODE" "start before checking a missing seed variable"
   run_tool "$home" "$fakebin" seed-keys google=GEMINI_API_KEY
   [ "$CODE" -ne 0 ] || fail "seed-keys with a missing var must fail"
   assert_contains "$OUT" "GEMINI_API_KEY is missing or empty" "refusal must name the variable, not a value"
+  stop_lane "$home" "$fakebin"
   pass "seed-keys refuses missing .env and missing variable"
+}
+
+test_seed_keys_refuses_unrecorded_service_before_secrets() {
+  local root home fakebin cap fake_key
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  fake_key="fake-test-key-unrecorded-service"
+  printf 'GEMINI_API_KEY=%s\n' "$fake_key" > "$home/.env"
+  run_tool "$home" "$fakebin" seed-keys google=GEMINI_API_KEY
+  [ "$CODE" -ne 0 ] || fail "seed-keys must refuse a service without a live recorded lane pid"
+  assert_contains "$OUT" "live recorded lane" "refusal must require the recorded lane process"
+  assert_absent "$home/data/freellmapi/dashboard.credentials" "refusal must happen before dashboard credentials are generated"
+  assert_absent "$cap/curl-stdin.log" "refusal must happen before any secret-bearing request"
+  assert_not_contains "$OUT" "$fake_key" "refusal must not print the provider key"
+  pass "seed-keys refuses an unrecorded service before secrets"
 }
 
 test_seed_keys_sends_value_via_stdin_only() {
@@ -365,6 +395,9 @@ EOF
   server_fakes "$fakebin" "$cap"
   fake_key="fake-test-key-AIzaNotARealKey123456"
   printf 'GEMINI_API_KEY=%s\n' "$fake_key" > "$home/.env"
+  built_install "$home"
+  run_tool "$home" "$fakebin" start
+  expect_code 0 "$CODE" "start before seed-keys"
   run_tool "$home" "$fakebin" seed-keys google=GEMINI_API_KEY
   expect_code 0 "$CODE" "seed-keys"
   assert_contains "$OUT" "seeded google key from GEMINI_API_KEY" "seed-keys must confirm by variable name"
@@ -373,6 +406,7 @@ EOF
   assert_no_grep "$fake_key" "$cap/curl-argv.log" "key value must never appear in curl argv"
   assert_no_grep 'fake-session-token-1234' "$cap/curl-argv.log" "session token must never appear in curl argv"
   assert_grep '"label":"GEMINI_API_KEY"' "$cap/curl-stdin.log" "label must be the env var name"
+  stop_lane "$home" "$fakebin"
   pass "seed-keys sends the value via stdin only"
 }
 
@@ -385,11 +419,15 @@ EOF
   cap="$root/cap"
   server_fakes "$fakebin" "$cap"
   printf 'BAD_KEY=va"lue\n' > "$home/.env"
+  built_install "$home"
+  run_tool "$home" "$fakebin" start
+  expect_code 0 "$CODE" "start before refusing an injection-prone seed value"
   run_tool "$home" "$fakebin" seed-keys google=BAD_KEY
   [ "$CODE" -ne 0 ] || fail "seed-keys must refuse a quote-bearing value"
   assert_contains "$OUT" "refuses to forward" "refusal must explain without echoing the value"
   assert_not_contains "$OUT" 'va"lue' "refused value must not be echoed"
   assert_absent "$cap/curl-stdin.log" "no request body may be sent for a refused value"
+  stop_lane "$home" "$fakebin"
   pass "seed-keys refuses an injection-prone value"
 }
 
@@ -480,6 +518,30 @@ EOF
   pass "stop refuses a foreign pid"
 }
 
+test_stop_refuses_reused_pid_identity() {
+  local root home fakebin cap pid alive
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  built_install "$home"
+  run_tool "$home" "$fakebin" start
+  expect_code 0 "$CODE" "start before simulating pid reuse"
+  pid=$(cat "$home/data/freellmapi/run/server.pid")
+  printf 'different-process-start-identity\n' > "$home/data/freellmapi/run/server.identity"
+  run_tool "$home" "$fakebin" stop
+  [ "$CODE" -ne 0 ] || fail "stop must reject a pid whose recorded start identity changed"
+  alive=0
+  kill -0 "$pid" 2>/dev/null && alive=1
+  [ "$alive" -eq 1 ] || fail "stop must not signal a process after pid identity mismatch"
+  assert_contains "$OUT" "refusing to signal" "identity mismatch refusal must be explicit"
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "stop refuses a reused pid identity"
+}
+
 test_stop_without_pid_record() {
   local root home fakebin cap
   root=$(fm_test_tmproot fm-freellmapi)
@@ -505,12 +567,14 @@ test_start_stops_service_on_non_loopback_listener
 test_start_fails_closed_when_binding_unverifiable
 test_start_refuses_malformed_encryption_key
 test_seed_keys_refuses_missing_env_and_var
+test_seed_keys_refuses_unrecorded_service_before_secrets
 test_seed_keys_sends_value_via_stdin_only
 test_seed_keys_refuses_injection_prone_value
 test_status_reports_not_running
 test_status_warns_on_non_loopback_without_stopping
 test_stop_gracefully_terminates
 test_stop_refuses_foreign_pid
+test_stop_refuses_reused_pid_identity
 test_stop_without_pid_record
 
 echo "fm-freellmapi tests passed"

--- a/tests/fm-freellmapi.test.sh
+++ b/tests/fm-freellmapi.test.sh
@@ -322,6 +322,37 @@ EOF
   pass "start fails closed when the binding is unverifiable"
 }
 
+test_start_preserves_unverifiable_live_pid_record() {
+  local root home fakebin cap pid recorded
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  built_install "$home"
+  run_tool "$home" "$fakebin" start
+  expect_code 0 "$CODE" "initial start"
+  pid=$(cat "$home/data/freellmapi/run/server.pid")
+  rm "$home/data/freellmapi/run/server.identity"
+
+  set +e
+  OUT=$(FM_HOME="$home" PATH="$fakebin:$PATH" FAKE_LSOF_EXIT=1 \
+    FM_FREELLMAPI_START_TIMEOUT=3 FM_FREELLMAPI_STOP_TIMEOUT=2 "$TOOL" start 2>&1)
+  CODE=$?
+  set -e
+  [ "$CODE" -ne 0 ] || fail "start must refuse an unauthenticated live pid record"
+  recorded=$(cat "$home/data/freellmapi/run/server.pid")
+  [ "$recorded" = "$pid" ] || fail "refused start must preserve the original live pid record"
+  assert_absent "$home/data/freellmapi/run/server.identity" "refused start must not replace the missing identity record"
+  assert_absent "$cap/node-signal.capture" "refused start must not signal the unauthenticated live process"
+  assert_contains "$OUT" "cannot authenticate" "refusal must explain the live record cannot be authenticated"
+
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "start preserves an unverifiable live pid record"
+}
+
 test_start_refuses_malformed_encryption_key() {
   local root home fakebin cap
   root=$(fm_test_tmproot fm-freellmapi)
@@ -565,6 +596,7 @@ test_start_refuses_without_install
 test_start_binds_loopback_and_never_leaks_key
 test_start_stops_service_on_non_loopback_listener
 test_start_fails_closed_when_binding_unverifiable
+test_start_preserves_unverifiable_live_pid_record
 test_start_refuses_malformed_encryption_key
 test_seed_keys_refuses_missing_env_and_var
 test_seed_keys_refuses_unrecorded_service_before_secrets

--- a/tests/fm-freellmapi.test.sh
+++ b/tests/fm-freellmapi.test.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-freellmapi.sh - the pinned, localhost-only
+# FreeLLMAPI lane manager. These tests never install the real upstream, never
+# start the real service, and never touch a real API key: git, npm, node, curl,
+# and lsof are PATH shims, and every "key" is an invented fake value whose only
+# job is to prove it cannot leak into stdout, stderr, argv, or the wrapper log.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TOOL="$ROOT/bin/fm-freellmapi.sh"
+PIN=526c86349891bd336b470481ee2d732cd8e13c14
+
+assert_present "$TOOL" "bin/fm-freellmapi.sh is missing"
+[ -x "$TOOL" ] || fail "fm-freellmapi.sh must be executable"
+
+# --- fixture builders --------------------------------------------------------
+
+# fresh_home <root>: build an isolated FM_HOME with a fakebin and echo both
+# paths as "home fakebin".
+fresh_home() {
+  local root=$1 home fakebin
+  home="$root/home"
+  mkdir -p "$home/data"
+  fakebin=$(fm_fakebin "$root")
+  printf '%s %s\n' "$home" "$fakebin"
+}
+
+# install_fakes <fakebin> <capture-dir>: git/npm/node shims that record argv.
+install_fakes() {
+  local fakebin=$1 cap=$2
+  mkdir -p "$cap"
+  cat > "$fakebin/git" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> '$cap/git.log'
+for a in "\$@"; do
+  [ "\$a" = HEAD ] && { printf '%s\n' "\${FAKE_GIT_HEAD:-$PIN}"; exit 0; }
+done
+exit 0
+SH
+  cat > "$fakebin/npm" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> '$cap/npm.log'
+exit 0
+SH
+  cat > "$fakebin/node" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fakebin/git" "$fakebin/npm" "$fakebin/node"
+}
+
+# server_fakes <fakebin> <capture-dir>: node/curl/lsof shims for start/stop.
+# The fake node records its environment shape (never raw secret values except
+# into the private capture file the test greps) and stays alive until TERM.
+server_fakes() {
+  local fakebin=$1 cap=$2
+  mkdir -p "$cap"
+  cat > "$fakebin/node" <<SH
+#!/usr/bin/env bash
+{
+  printf 'argv=%s\n' "\$*"
+  printf 'host=%s\n' "\${HOST:-unset}"
+  printf 'port=%s\n' "\${PORT:-unset}"
+  printf 'node_env=%s\n' "\${NODE_ENV:-unset}"
+  printf 'catalog_sync_disabled=%s\n' "\${CATALOG_SYNC_DISABLED:-unset}"
+  printf 'encryption_key=%s\n' "\${ENCRYPTION_KEY:-unset}"
+} > '$cap/node-env.capture'
+trap 'echo term >> "'$cap'/node-signal.capture"; exit 0' TERM
+# Bounded lifetime so a failed assertion can never leak an immortal process.
+i=0
+while [ "\$i" -lt 120 ]; do sleep 1; i=\$((i + 1)); done
+SH
+  cat > "$fakebin/curl" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> '$cap/curl-argv.log'
+url=''
+for a in "\$@"; do case "\$a" in http*) url=\$a ;; esac; done
+# Read stdin only when the caller actually pipes a body (-d @-), so plain
+# GET-style calls can never block on an inherited stdin.
+for a in "\$@"; do
+  if [ "\$a" = '@-' ]; then
+    body=\$(cat)
+    printf '%s\n' "\$body" >> '$cap/curl-stdin.log'
+    break
+  fi
+done
+case "\$url" in
+  */api/ping) exit "\${FAKE_PING_EXIT:-0}" ;;
+  */api/auth/status) printf '{"needsSetup":%s,"authenticated":false}' "\${FAKE_NEEDS_SETUP:-true}" ;;
+  */api/auth/setup|*/api/auth/login) printf '{"token":"fake-session-token-1234"}' ;;
+  */api/keys)
+    for a in "\$@"; do case "\$a" in %*http_code*) printf '%s' "\${FAKE_KEYS_HTTP:-201}"; exit 0 ;; esac; done
+    exit 0 ;;
+esac
+exit 0
+SH
+  cat > "$fakebin/lsof" <<SH
+#!/usr/bin/env bash
+[ "\${FAKE_LSOF_EXIT:-0}" = 0 ] || exit "\$FAKE_LSOF_EXIT"
+printf 'COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\n'
+printf 'node 999 u 23u IPv4 0x0 0t0 TCP %s:3001 (LISTEN)\n' "\${FAKE_LSOF_ADDR:-127.0.0.1}"
+SH
+  chmod +x "$fakebin/node" "$fakebin/curl" "$fakebin/lsof"
+}
+
+# built_install <home>: pretend install completed so start can proceed.
+built_install() {
+  mkdir -p "$1/data/freellmapi/app/server/dist"
+  : > "$1/data/freellmapi/app/server/dist/index.js"
+}
+
+file_mode() { # <path>: print the octal permission bits, portably
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %Lp "$1"
+  else
+    stat -c %a "$1"
+  fi
+}
+
+run_tool() { # <home> <fakebin> <args...>; captures OUT and CODE
+  local home=$1 fakebin=$2
+  shift 2
+  set +e
+  OUT=$(FM_HOME="$home" PATH="$fakebin:$PATH" FM_FREELLMAPI_START_TIMEOUT=3 \
+    FM_FREELLMAPI_STOP_TIMEOUT=2 "$TOOL" "$@" 2>&1)
+  CODE=$?
+  set -e
+}
+
+stop_lane() { # <home> <fakebin>: best-effort cleanup of a started fake server
+  run_tool "$1" "$2" stop || true
+}
+
+# --- static contract ---------------------------------------------------------
+
+test_static_pin_and_safety_contract() {
+  assert_grep "$PIN" "$TOOL" "tool must pin the full audited upstream commit SHA"
+  assert_no_grep 'clone https' "$TOOL" "tool must fetch the pin, not clone a moving branch"
+  assert_no_grep ':latest' "$TOOL" "tool must not reference a floating latest tag"
+  assert_grep 'HOST=127.0.0.1' "$TOOL" "tool must force the loopback bind host"
+  assert_no_grep '0.0.0.0' "$TOOL" "tool must never mention binding to 0.0.0.0"
+  assert_grep 'NODE_ENV=production' "$TOOL" "tool must run upstream in production mode so a dev fallback key is refused"
+  assert_grep '--accept-risks' "$TOOL" "install must be gated on explicit risk acceptance"
+  assert_no_grep 'set -x' "$TOOL" "tool must never enable shell tracing around secrets"
+  pass "static pin and safety contract"
+}
+
+test_help_states_policy() {
+  set +e
+  out=$("$TOOL" --help 2>&1)
+  code=$?
+  set -e
+  expect_code 0 "$code" "--help exit"
+  assert_contains "$out" "127.0.0.1" "help must state the localhost-only binding"
+  assert_contains "$out" "never appear in stdout" "help must state the secret-safety contract"
+  assert_contains "$out" "docs/freellmapi-lane.md" "help must point at the lane policy doc"
+  pass "help states policy"
+}
+
+# --- install -----------------------------------------------------------------
+
+test_install_refuses_without_risk_acceptance() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  install_fakes "$fakebin" "$cap"
+  run_tool "$home" "$fakebin" install
+  [ "$CODE" -ne 0 ] || fail "install without --accept-risks must fail"
+  assert_contains "$OUT" "3 critical" "refusal must restate the known vulnerability counts"
+  assert_contains "$OUT" "accept-risks" "refusal must name the required flag"
+  assert_absent "$cap/git.log" "refused install must not touch git"
+  pass "install refuses without risk acceptance"
+}
+
+test_install_fetches_exact_pin() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  install_fakes "$fakebin" "$cap"
+  run_tool "$home" "$fakebin" install --accept-risks
+  expect_code 0 "$CODE" "install --accept-risks"
+  assert_grep "fetch -q --depth 1 origin $PIN" "$cap/git.log" "install must fetch exactly the pinned commit"
+  assert_grep "checkout -q --detach $PIN" "$cap/git.log" "install must check out exactly the pinned commit"
+  assert_grep 'ci' "$cap/npm.log" "install must use lockfile-pinned npm ci"
+  assert_grep 'run build' "$cap/npm.log" "install must build the pinned checkout"
+  assert_contains "$OUT" "3 critical" "install must restate the known vulnerability counts"
+  pass "install fetches the exact pin"
+}
+
+test_install_refuses_head_mismatch() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  install_fakes "$fakebin" "$cap"
+  set +e
+  OUT=$(FM_HOME="$home" PATH="$fakebin:$PATH" FAKE_GIT_HEAD=deadbeef "$TOOL" install --accept-risks 2>&1)
+  CODE=$?
+  set -e
+  [ "$CODE" -ne 0 ] || fail "install must fail when the checkout does not match the pin"
+  assert_contains "$OUT" "checkout mismatch" "mismatch must be named"
+  assert_absent "$cap/npm.log" "unverified content must never be built"
+  pass "install refuses a pin mismatch"
+}
+
+# --- start -------------------------------------------------------------------
+
+test_start_refuses_without_install() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  run_tool "$home" "$fakebin" start
+  [ "$CODE" -ne 0 ] || fail "start without an install must fail"
+  assert_contains "$OUT" "install --accept-risks" "refusal must point at the install command"
+  pass "start refuses without install"
+}
+
+test_start_binds_loopback_and_never_leaks_key() {
+  local root home fakebin cap key perms argv_line log
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  built_install "$home"
+  run_tool "$home" "$fakebin" start
+  expect_code 0 "$CODE" "start"
+  assert_contains "$OUT" "http://127.0.0.1:3001" "start must report the loopback endpoint"
+  assert_contains "$OUT" "loopback binding verified" "start must report the verified binding"
+
+  key=$(cat "$home/data/freellmapi/encryption.key")
+  [ "${#key}" -eq 64 ] || fail "generated encryption key must be 64 hex chars"
+  case "$key" in *[!0-9a-f]*) fail "generated encryption key must be lowercase hex" ;; esac
+  perms=$(file_mode "$home/data/freellmapi/encryption.key")
+  [ "$perms" = 600 ] || fail "encryption key file must be mode 0600, got $perms"
+
+  assert_not_contains "$OUT" "$key" "encryption key value must never reach stdout/stderr"
+  assert_grep 'host=127.0.0.1' "$cap/node-env.capture" "server must receive HOST=127.0.0.1"
+  assert_grep 'node_env=production' "$cap/node-env.capture" "server must run in production mode"
+  assert_grep 'catalog_sync_disabled=1' "$cap/node-env.capture" "catalog sync must be off by default"
+  assert_grep "encryption_key=$key" "$cap/node-env.capture" "server must receive the key via environment"
+  argv_line=$(grep '^argv=' "$cap/node-env.capture")
+  case "$argv_line" in
+    *"$key"*) fail "encryption key must never be passed as an argument" ;;
+  esac
+  assert_present "$home/data/freellmapi/run/server.pid" "start must record the server pid"
+  log="$home/data/freellmapi/run/server.log"
+  [ ! -s "$log" ] || assert_no_grep "$key" "$log" "encryption key must never reach the wrapper log"
+
+  stop_lane "$home" "$fakebin"
+  pass "start binds loopback and never leaks the key"
+}
+
+test_start_stops_service_on_non_loopback_listener() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  built_install "$home"
+  set +e
+  OUT=$(FM_HOME="$home" PATH="$fakebin:$PATH" FAKE_LSOF_ADDR=0.0.0.0 \
+    FM_FREELLMAPI_START_TIMEOUT=3 FM_FREELLMAPI_STOP_TIMEOUT=2 "$TOOL" start 2>&1)
+  CODE=$?
+  set -e
+  [ "$CODE" -ne 0 ] || fail "start must fail when a listener is not loopback"
+  assert_contains "$OUT" "REFUSED" "non-loopback binding must be refused loudly"
+  assert_absent "$home/data/freellmapi/run/server.pid" "refused start must not leave a pid record"
+  assert_present "$cap/node-signal.capture" "refused start must stop the spawned server"
+  pass "start stops the service on a non-loopback listener"
+}
+
+test_start_fails_closed_when_binding_unverifiable() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  built_install "$home"
+  set +e
+  OUT=$(FM_HOME="$home" PATH="$fakebin:$PATH" FAKE_LSOF_EXIT=1 \
+    FM_FREELLMAPI_START_TIMEOUT=3 FM_FREELLMAPI_STOP_TIMEOUT=2 "$TOOL" start 2>&1)
+  CODE=$?
+  set -e
+  [ "$CODE" -ne 0 ] || fail "start must fail when the binding cannot be verified"
+  assert_contains "$OUT" "REFUSED" "unverifiable binding must be refused, not tolerated"
+  assert_present "$cap/node-signal.capture" "unverifiable start must stop the spawned server"
+  pass "start fails closed when the binding is unverifiable"
+}
+
+test_start_refuses_malformed_encryption_key() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  built_install "$home"
+  mkdir -p "$home/data/freellmapi"
+  printf 'short-and-invalid\n' > "$home/data/freellmapi/encryption.key"
+  run_tool "$home" "$fakebin" start
+  [ "$CODE" -ne 0 ] || fail "start must refuse a malformed encryption key"
+  assert_contains "$OUT" "64 lowercase hex" "refusal must state the expected key shape"
+  assert_not_contains "$OUT" "short-and-invalid" "even a malformed key value must not be echoed"
+  assert_absent "$cap/node-env.capture" "server must not start with a malformed key"
+  pass "start refuses a malformed encryption key"
+}
+
+# --- seed-keys ---------------------------------------------------------------
+
+test_seed_keys_refuses_missing_env_and_var() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  run_tool "$home" "$fakebin" seed-keys google=GEMINI_API_KEY
+  [ "$CODE" -ne 0 ] || fail "seed-keys without a fleet .env must fail"
+  assert_contains "$OUT" ".env not found" "refusal must name the missing .env"
+
+  printf 'OTHER_VAR=x\n' > "$home/.env"
+  run_tool "$home" "$fakebin" seed-keys google=GEMINI_API_KEY
+  [ "$CODE" -ne 0 ] || fail "seed-keys with a missing var must fail"
+  assert_contains "$OUT" "GEMINI_API_KEY is missing or empty" "refusal must name the variable, not a value"
+  pass "seed-keys refuses missing .env and missing variable"
+}
+
+test_seed_keys_sends_value_via_stdin_only() {
+  local root home fakebin cap fake_key
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  fake_key="fake-test-key-AIzaNotARealKey123456"
+  printf 'GEMINI_API_KEY=%s\n' "$fake_key" > "$home/.env"
+  run_tool "$home" "$fakebin" seed-keys google=GEMINI_API_KEY
+  expect_code 0 "$CODE" "seed-keys"
+  assert_contains "$OUT" "seeded google key from GEMINI_API_KEY" "seed-keys must confirm by variable name"
+  assert_not_contains "$OUT" "$fake_key" "key value must never reach stdout/stderr"
+  assert_grep "$fake_key" "$cap/curl-stdin.log" "key value must travel via stdin body"
+  assert_no_grep "$fake_key" "$cap/curl-argv.log" "key value must never appear in curl argv"
+  assert_no_grep 'fake-session-token-1234' "$cap/curl-argv.log" "session token must never appear in curl argv"
+  assert_grep '"label":"GEMINI_API_KEY"' "$cap/curl-stdin.log" "label must be the env var name"
+  pass "seed-keys sends the value via stdin only"
+}
+
+test_seed_keys_refuses_injection_prone_value() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  printf 'BAD_KEY=va"lue\n' > "$home/.env"
+  run_tool "$home" "$fakebin" seed-keys google=BAD_KEY
+  [ "$CODE" -ne 0 ] || fail "seed-keys must refuse a quote-bearing value"
+  assert_contains "$OUT" "refuses to forward" "refusal must explain without echoing the value"
+  assert_not_contains "$OUT" 'va"lue' "refused value must not be echoed"
+  assert_absent "$cap/curl-stdin.log" "no request body may be sent for a refused value"
+  pass "seed-keys refuses an injection-prone value"
+}
+
+# --- status and stop ---------------------------------------------------------
+
+test_status_reports_not_running() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  run_tool "$home" "$fakebin" status
+  [ "$CODE" -ne 0 ] || fail "status must be non-zero when not running"
+  assert_contains "$OUT" "not running" "status must say it is not running"
+  pass "status reports not running"
+}
+
+test_stop_gracefully_terminates() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  built_install "$home"
+  run_tool "$home" "$fakebin" start
+  expect_code 0 "$CODE" "start before stop"
+  run_tool "$home" "$fakebin" stop
+  expect_code 0 "$CODE" "stop"
+  assert_contains "$OUT" "stopped" "stop must confirm"
+  assert_grep 'term' "$cap/node-signal.capture" "stop must deliver SIGTERM, not SIGKILL first"
+  assert_absent "$home/data/freellmapi/run/server.pid" "stop must remove the pid record"
+  pass "stop gracefully terminates"
+}
+
+test_stop_refuses_foreign_pid() {
+  local root home fakebin cap foreign
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  sleep 300 &
+  foreign=$!
+  mkdir -p "$home/data/freellmapi/run"
+  printf '%s\n' "$foreign" > "$home/data/freellmapi/run/server.pid"
+  run_tool "$home" "$fakebin" stop
+  code=$CODE
+  alive=0
+  kill -0 "$foreign" 2>/dev/null && alive=1
+  kill "$foreign" 2>/dev/null || true
+  wait "$foreign" 2>/dev/null || true
+  [ "$code" -ne 0 ] || fail "stop must refuse a pid that is not this lane's server"
+  [ "$alive" -eq 1 ] || fail "stop must not kill an unrelated process"
+  assert_contains "$OUT" "refusing to signal" "refusal must be explicit"
+  pass "stop refuses a foreign pid"
+}
+
+test_stop_without_pid_record() {
+  local root home fakebin cap
+  root=$(fm_test_tmproot fm-freellmapi)
+  read -r home fakebin <<EOF
+$(fresh_home "$root")
+EOF
+  cap="$root/cap"
+  server_fakes "$fakebin" "$cap"
+  run_tool "$home" "$fakebin" stop
+  [ "$CODE" -ne 0 ] || fail "stop without a pid record must fail loudly"
+  assert_contains "$OUT" "not running" "stop must explain there is nothing to stop"
+  pass "stop without a pid record refuses clearly"
+}
+
+test_static_pin_and_safety_contract
+test_help_states_policy
+test_install_refuses_without_risk_acceptance
+test_install_fetches_exact_pin
+test_install_refuses_head_mismatch
+test_start_refuses_without_install
+test_start_binds_loopback_and_never_leaks_key
+test_start_stops_service_on_non_loopback_listener
+test_start_fails_closed_when_binding_unverifiable
+test_start_refuses_malformed_encryption_key
+test_seed_keys_refuses_missing_env_and_var
+test_seed_keys_sends_value_via_stdin_only
+test_seed_keys_refuses_injection_prone_value
+test_status_reports_not_running
+test_stop_gracefully_terminates
+test_stop_refuses_foreign_pid
+test_stop_without_pid_record
+
+echo "fm-freellmapi tests passed"


### PR DESCRIPTION
## Intent

Build a vetted, safe way for the firstmate fleet to run FreeLLMAPI as a local cheap bulk/research lane, with the captain condition that API keys are handled carefully. Deliver: (1) bin/fm-freellmapi.sh runner that pins FreeLLMAPI to an audited commit, generates ENCRYPTION_KEY safely, binds only to 127.0.0.1, health-checks, and stops cleanly without leaking secrets to stdout/logs/argv; (2) docs/freellmapi-lane.md for allowed/forbidden use, known risks (dependency vulns, third-party prompt egress), and removal; (3) tests for no secret leakage, localhost-only bind, and fail-closed config. Do not wire the lane into any automatic dispatch or profile path. Follow-up correction after external review: honest secret-safety claims (never on argv/not printed; live only in process env, mode-0600 files, stdin; same OS user can still inspect; warn about shell xtrace), status only alerts on non-loopback while start stops, and branch rebased cleanly onto main so the PR contains only this work. Local merge of fm-test-run.sh family list kept main's documentation-audiences entry and added fm-freellmapi.test.sh.

## What Changed

- Add an opt-in FreeLLMAPI runner pinned to an audited commit, with explicit risk acceptance, localhost-only startup verification, health checks, key seeding, and clean shutdown.
- Harden secret and process handling with mode-0600 files, stdin/environment transport, recorded process identity, and fail-closed behavior for unverifiable listeners or live PID records.
- Document allowed use, known risks, and removal, and register behavior tests covering secret leakage, loopback binding, process identity, and configuration failures.

## Risk Assessment

✅ Low: The latest change correctly refuses to overwrite a live but unauthenticated PID record, and the complete FreeLLMAPI lane now satisfies the reviewed safety and intent constraints without additional material source risks.

## Testing

Diff and clean-worktree baselines were checked; the focused FreeLLMAPI suite exercised pinned installation, secret non-leakage, localhost-only binding, fail-closed startup, non-loopback status behavior, key seeding, and graceful/identity-safe stopping, while a reviewer-visible CLI transcript demonstrated policy help and real refusal paths. Everything passed with no actionable findings; no screenshot was produced because this is a CLI-only change, and no broad suite, lint, static analysis, push, PR, or CI phase was run.

<details>
<summary>Evidence: FreeLLMAPI end-user CLI transcript</summary>

```text
$ bin/fm-freellmapi.sh --help
fm-freellmapi.sh - manage the fleet's pinned, localhost-only FreeLLMAPI lane.

FreeLLMAPI (https://github.com/tashfeenahmed/freellmapi, MIT) is a third-party
local proxy that pools free-tier LLM provider keys behind one OpenAI-compatible
endpoint. This script is the single owner of the fleet's vetted install: it
pins one audited upstream commit, generates the mandatory ENCRYPTION_KEY
without ever printing it, starts the service bound to 127.0.0.1 only, verifies
that binding before declaring success, seeds provider keys from the fleet's
gitignored .env without exposing their values, and stops the service cleanly.
Non-sensitive bulk/scout use only - docs/freellmapi-lane.md owns the usage
policy, known-risk statement, and removal procedure.

Usage:
  fm-freellmapi.sh install --accept-risks     install or repair the pinned build
  fm-freellmapi.sh start [--port <p>] [--catalog-sync]
  fm-freellmapi.sh status [--port <p>]
  fm-freellmapi.sh seed-keys <platform>=<ENV_VAR> [<platform>=<ENV_VAR> ...]
  fm-freellmapi.sh stop
  fm-freellmapi.sh --help

The install lives under $FM_HOME/data/freellmapi (gitignored, chmod 0700):
  app/                 upstream checkout at the exact pinned commit, built
  db/freeapi.db        service state, kept outside app/ so reinstall preserves it
  encryption.key       generated 64-hex AES-256-GCM key, mode 0600
  dashboard.credentials generated local dashboard login, mode 0600
  run/server.pid run/server.log  runtime records

Secret-safety contract (the reason this wrapper exists):
  - Secret values (provider keys, ENCRYPTION_KEY, dashboard password, session
    token) never appear in stdout, stderr, argv, this script's error messages,
    or files other than the mode-0600 secret files listed above. Secrets travel
    to child processes via environment or stdin only, never command arguments
    (never on argv; not printed). At runtime they live only in process env,
    mode-0600 files, and stdin pipes; the same OS user can still inspect those
    (for example /proc/<pid>/environ on Linux). Do not run this script under
    shell xtrace (bash -x or set -o xtrace): it dumps env assignments and pipes.
  - This script never prints the server log; on failure it prints the log path.
  - start verifies every TCP listener of the server process is bound to
    127.0.0.1 and stops the server if verification fails; status fails with a
    warning on the same condition but does not stop (use stop for that).
  - install refuses to run without --accept-risks and restates the known
    dependency-vulnerability findings every time.

$ FM_HOME=<isolated-home> bin/fm-freellmapi.sh status
fm-freellmapi.sh: not running
[exit: 1]

$ FM_HOME=<isolated-home> bin/fm-freellmapi.sh install
KNOWN RISKS - FreeLLMAPI lane (pin 526c86349891bd336b470481ee2d732cd8e13c14, 2026-07-20):
  - npm ci at this pin reported 21 dependency vulnerabilities
    (3 critical, 7 high, 9 moderate, 2 low; npm audit 2026-07-24).
  - npm ci executes dependency install scripts (native modules build at install).
  - Every prompt sent through the lane goes to third-party free providers;
    some keyless providers may use prompts for training.
  - This service is for ISOLATED LOCAL USE ONLY: localhost binding, no tunnel,
    no port forwarding, no sensitive content, never a primary-model substitute.
  Full policy: docs/freellmapi-lane.md and data/freellmapi-koeajo/report.md.
fm-freellmapi.sh: refusing to install without --accept-risks (read the risk statement above and docs/freellmapi-lane.md first)
[exit: 1]

$ FM_HOME=<isolated-home> bin/fm-freellmapi.sh start (malformed mode-0600 ENCRYPTION_KEY)
fm-freellmapi.sh: encryption key at /var/folders/_7/g__lbpks7bvb7_3fqhncphnm0000gp/T/no-mistakes-evidence/01KYDZT1RR518JMEN92DXSGN16/isolated-home/data/freellmapi/encryption.key is not 64 lowercase hex chars; refusing to start (regenerate by removing the file - existing stored provider keys become unreadable)
[exit: 1]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-test-run.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-freellmapi.sh:384` - `seed-keys` authenticates the target only with `/api/ping`. If the lane has stopped and another localhost service answers that path on port 3001, the command sends generated dashboard credentials and provider keys to that unrelated process. Require a live recorded lane PID and verify its loopback-only listener before `dashboard_token` or any secret-bearing request.
- 🚨 `bin/fm-freellmapi.sh:108` - The stale-PID guard accepts any process whose command contains `dist/index.js`. After PID reuse, `stop` can therefore SIGTERM/SIGKILL an unrelated Node service with that common entrypoint. Bind identity to this lane&#39;s exact executable/cwd or record and validate a process-start identity before signaling.

🔧 Fix: Harden FreeLLMAPI process identity and secret seeding
1 error still open:
- 🚨 `bin/fm-freellmapi.sh:263` - `running_pid` conflates “no process” with “a live recorded PID whose identity file is missing/corrupt.” In the latter case `start` launches another server; the original can satisfy `/api/ping`, the new process then fails listener verification, and cleanup removes the shared PID/identity records while leaving the original server running and no longer stoppable through this tool. Before launching, detect a live PID record that cannot be authenticated and refuse without overwriting its records.

🔧 Fix: Preserve unauthenticated live FreeLLMAPI PID records
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat aca3ad100ffcb43873837486a0f24ad3e6cdc7fa..42809d2f82097ae1a001ba54c841c90c5ba48c6f`
- `git diff --name-status aca3ad100ffcb43873837486a0f24ad3e6cdc7fa..42809d2f82097ae1a001ba54c841c90c5ba48c6f`
- `bash tests/fm-freellmapi.test.sh`
- <code>Manual CLI check: `bin/fm-freellmapi.sh --help`, isolated `status`, risk-unaccepted `install`, and malformed mode-0600 encryption-key `start`</code>
- <code>`rg -n &#34;freellmapi|FreeLLMAPI&#34; bin docs .agents .github README.md CONTRIBUTING.md ...` to confirm no automatic dispatch/profile wiring</code>
- <code>`git status --short` after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
