### PR TITLE
fix: allow fm-send help without FM_HOME

### DIFF
--- a/.agents/skills/graph-engineering/SKILL.md
+++ b/.agents/skills/graph-engineering/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: graph-engineering
+description: >-
+  Agent-only method for designing and evaluating bounded autonomous improvement loops and deciding whether measured needs justify chains, planning, parallel workers, experiment DAGs, or knowledge graphs.
+  Load before proposing or materially expanding an agent loop, multi-agent workflow, experiment-lineage system, or cross-session graph memory.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Graph engineering
+
+Use this procedure to select the smallest architecture that makes improvement, memory, and evidence explicit.
+Firstmate uses it to brief delegated project work and to evaluate the resulting design rather than taking over project-specific implementation.
+This skill is the single owner of Firstmate's measured loop-to-graph design procedure.
+
+## Declare the inputs
+
+Require these inputs before selecting an architecture.
+
+- State one bounded objective and the acceptance condition that ends the work.
+- Identify mutable surfaces, protected surfaces, permissions, and any decision that still belongs to the captain.
+- Name the current retained artifact or state, its version, and the controlled command or process that evaluates a candidate.
+- Define the primary metric or rubric, its direction, tie or noise treatment, and guardrails for correctness, security, cost, latency, and resource use.
+- Set limits for iterations, retries, tool calls, workers, concurrency, tokens, cost, wall-clock time, and writes as applicable.
+- Define how every candidate is checkpointed, restored, and compared with the retained baseline.
+- Define the trial record, required sources, final evidence, and escalation boundary.
+- Define success, plateau, idea-exhaustion, and budget-exhaustion stopping criteria before the first trial.
+
+Do not authorize an unattended improvement loop when success cannot be checked or candidate changes cannot be reversed safely.
+Use a human-reviewed path until both conditions exist.
+
+## Run one measured ratchet
+
+Start with one loop and keep each trial narrow enough to attribute its result.
+
+1. Inspect the retained artifact, recent trials, current baseline, constraints, and unresolved failures.
+2. Propose one motivated change with a hypothesis, expected metric effect, and observation that would disconfirm it.
+3. Save the candidate as an addressable child of the retained version before evaluation.
+4. Run the bounded evaluator in the declared environment and capture the primary result, every guardrail, resource use, and raw evidence location.
+5. Correct a mechanical execution failure only when the correction does not alter the hypothesis and remains inside the retry budget.
+6. Revert any other failed run and preserve its evidence as a failed trial.
+7. Keep the candidate only when it beats the retained baseline under the declared comparison rule and passes every guardrail.
+8. Restore the retained baseline when the candidate loses, ties without an explicit tie rule, or produces an unreliable comparison.
+9. Append the complete trial record and begin the next trial from the retained state rather than the most recent candidate.
+
+A retained result becomes the next baseline, but a rejected result remains useful evidence.
+Never hide a crash, rejection, or partial result behind a fluent summary.
+
+## Preserve the evidence contract
+
+Each trial must make these facts recoverable without replaying a conversation.
+
+- Record the objective, parent version, candidate version, hypothesis, and exact change.
+- Record the evaluator and rubric version, environment, inputs, command or procedure, and relevant seed or nondeterminism controls.
+- Record baseline and candidate values for the primary measure and every guardrail.
+- Record elapsed time, resource or financial cost, outputs, source links, and the worker or run that produced them.
+- Record whether the candidate was retained, reverted, crashed, or left unresolved, with the comparison reason.
+- Mark every material claim with a source, or label it explicitly as inference or unresolved uncertainty.
+
+Keep artifacts immutable and addressable after they are superseded.
+Return task-specific evidence rather than worker transcripts as the handoff surface.
+
+## Add architecture only for a measured failure
+
+Climb this ladder only when the current rung has exposed the named limitation and the next rung has a measurable exit criterion.
+
+1. Add one tool when a repeated error comes from a missing capability, and give the tool typed inputs, minimum permissions, and result confirmation.
+2. Add a chain when the stages and handoff order are stable.
+3. Add planning only when valid task paths vary, and require explicit dependencies and success conditions before execution.
+4. Add parallel workers only for independent units, after defining isolation, artifact contracts, a reducer, deduplication, concurrency limits, and a final evaluation.
+5. Add a distinct critic or evaluator when its rubric and evidence can catch a demonstrated generator failure rather than merely repeat the generator's opinion.
+6. Add a commit or artifact DAG when alternative lineages, parentage, or discarded experiments must remain traversable.
+7. Add persistent graph memory only when connected facts, provenance, conflicts, or cross-session queries cannot be served adequately by versioned files or relational tables.
+8. Add dynamic swarms only when the workload is safely parallel and measurements show a wall-clock benefit without unacceptable quality or cost loss.
+
+Keep experiment lineage and domain knowledge as separate models even when links connect them.
+Retrieve a bounded, task-relevant subgraph with provenance and conflicts rather than dumping shared memory into every worker's context.
+Use reversible, evidence-backed entity resolution because one false merge can contaminate many later queries.
+Drop back to the simpler rung when the promised exit criterion is not met.
+
+## Stop and return
+
+Stop the loop at the first applicable condition.
+
+- Stop when the acceptance threshold or evaluator approval is reached.
+- Stop when any declared budget is exhausted.
+- Stop at the declared plateau or idea-exhaustion condition.
+- Stop when crashes, evaluator instability, or irreproducible results make comparison unreliable.
+- Stop and escalate before destructive, irreversible, security-sensitive, protected-surface, or contract-expanding action.
+- Stop and escalate when contradictory evidence or unresolved uncertainty can materially change what should be built.
+
+Return the best retained artifact rather than the last candidate.
+Include the stopping reason, trial ledger, consumed budget, discarded but relevant evidence, and unresolved questions.
+
+## Reject these anti-patterns
+
+- Do not optimize activity, worker count, or a single visible metric while ignoring guardrails.
+- Do not combine unrelated changes in one trial when attribution matters.
+- Do not fan out work before defining the reducer and final evaluation.
+- Do not parallelize coupled writes merely because more workers are available.
+- Do not treat conversations as the artifact store, experiment history, or durable world model.
+- Do not introduce a graph merely because agents are involved when files or tables answer the required queries.
+- Do not collapse experiment lineage into the knowledge graph or mistake either graph for verified truth.
+- Do not use an evaluator that shares the same unsupported assumptions, evidence, and prompt as the generator.
+- Do not let retries, branches, graph writes, or stored history grow without declared limits and retention policy.
+
+## Source provenance
+
+This procedure is an original operational synthesis of *Graph Engineering: The Karpathy Loop, Improved 1000x by Itself - The Anthropic Playbook*, an independently compiled July 2026 paper supplied for this task.
+The paper attributes the measured autonomous loop and experiment-DAG direction to Andrej Karpathy's autoresearch and AgentHub work, and it attributes workflow and knowledge-graph patterns to Anthropic materials.
+Consult those primary sources before relying on historical, performance, or product-specific claims because this skill retains only the reusable method.

--- a/.agents/skills/graph-engineering/SKILL.md
+++ b/.agents/skills/graph-engineering/SKILL.md
@@ -24,6 +24,7 @@ Require these inputs before selecting an architecture.
 - Define the primary metric or rubric, its direction, tie or noise treatment, and guardrails for correctness, security, cost, latency, and resource use.
 - Set limits for iterations, retries, tool calls, workers, concurrency, tokens, cost, wall-clock time, and writes as applicable.
 - Define how every candidate is checkpointed, restored, and compared with the retained baseline.
+- Checkpoint at durable boundaries, and make retried or resumed side effects idempotent or protect them with an idempotency key or compensation.
 - Define the trial record, required sources, final evidence, and escalation boundary.
 - Define success, plateau, idea-exhaustion, and budget-exhaustion stopping criteria before the first trial.
 
@@ -63,12 +64,13 @@ Return task-specific evidence rather than worker transcripts as the handoff surf
 
 ## Add architecture only for a measured failure
 
+Distinguish acyclic execution or lineage DAGs, cyclic state graphs, runtime-generated task graphs, and domain knowledge graphs; multi-agent coordination is orthogonal to all four.
 Climb this ladder only when the current rung has exposed the named limitation and the next rung has a measurable exit criterion.
 
 1. Add one tool when a repeated error comes from a missing capability, and give the tool typed inputs, minimum permissions, and result confirmation.
 2. Add a chain when the stages and handoff order are stable.
 3. Add planning only when valid task paths vary, and require explicit dependencies and success conditions before execution.
-4. Add parallel workers only for independent units, after defining isolation, artifact contracts, a reducer, deduplication, concurrency limits, and a final evaluation.
+4. Add parallel workers only after ruling out dependencies through required data, shared mutable resources, exclusive tools, rate limits, or coupled writes and defining isolation, artifact contracts, a reducer, deduplication, concurrency limits, and a final evaluation.
 5. Add a distinct critic or evaluator when its rubric and evidence can catch a demonstrated generator failure rather than merely repeat the generator's opinion.
 6. Add a commit or artifact DAG when alternative lineages, parentage, or discarded experiments must remain traversable.
 7. Add persistent graph memory only when connected facts, provenance, conflicts, or cross-session queries cannot be served adequately by versioned files or relational tables.
@@ -76,6 +78,7 @@ Climb this ladder only when the current rung has exposed the named limitation an
 
 Keep experiment lineage and domain knowledge as separate models even when links connect them.
 Retrieve a bounded, task-relevant subgraph with provenance and conflicts rather than dumping shared memory into every worker's context.
+Keep execution flow separate from context flow: an execution edge does not pass a whole transcript; hand off only the required versioned artifacts and evidence.
 Use reversible, evidence-backed entity resolution because one false merge can contaminate many later queries.
 Drop back to the simpler rung when the promised exit criterion is not met.
 
@@ -107,6 +110,6 @@ Include the stopping reason, trial ledger, consumed budget, discarded but releva
 
 ## Source provenance
 
-This procedure is an original operational synthesis of *Graph Engineering: The Karpathy Loop, Improved 1000x by Itself - The Anthropic Playbook*, an independently compiled July 2026 paper supplied for this task.
+This procedure is an original operational synthesis of an independently compiled July 2026 *Graph Engineering* paper supplied for this task.
 The paper attributes the measured autonomous loop and experiment-DAG direction to Andrej Karpathy's autoresearch and AgentHub work, and it attributes workflow and knowledge-graph patterns to Anthropic materials.
 Consult those primary sources before relying on historical, performance, or product-specific claims because this skill retains only the reusable method.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -41,7 +41,8 @@ Default it off, and enable it only on the captain's explicit instruction.
 ## Add or clone an existing project
 
 Confirm the source URL, local project name, delivery mode, and autonomy posture.
-Clone into `projects/<name>` and add the registry entry only after the destination is known to be unused.
+Use `bin/fm-project-add.sh` to clone an existing remote-backed project into the current home or another existing Firstmate home and register it.
+The script's header and `--help` own its exact interface, home targeting, rollback, and initialization mechanics.
 A `no-mistakes` project must have an `origin` remote and must complete the initialization procedure below.
 A `direct-PR` project needs an `origin` remote but skips no-mistakes initialization.
 A `local-only` project may have no remote and skips no-mistakes initialization.
@@ -51,19 +52,15 @@ A `local-only` project may have no remote and skips no-mistakes initialization.
 Creating a GitHub repository is outward-facing.
 Before making that remote change, propose the repository name, owner or organization, visibility, and delivery mode, defaulting visibility to private and delivery mode to `no-mistakes`, then obtain the captain's explicit consent for those values.
 Use `gh-axi` for the approved GitHub operation and consult its current help rather than relying on remembered flags.
-After remote creation succeeds, clone it locally, add the registry entry, and initialize it according to its delivery mode.
+After remote creation succeeds, use `bin/fm-project-add.sh` with the approved project name, delivery mode, description, and autonomy posture.
 
 For a purely `local-only` project, create a local Git repository under its unused `projects/<name>` path, add the registry entry, and make no GitHub call.
 The captain's request to create that local project authorizes this local initialization, but it does not authorize an unmentioned remote repository.
 
 ## Initialize
 
-Run no-mistakes initialization only for `no-mistakes` projects:
-
-```sh
-cd projects/<name> && no-mistakes init && no-mistakes doctor
-```
-
+Run no-mistakes initialization only for `no-mistakes` projects and only through `bin/fm-project-add.sh`, which owns the `no-mistakes init` and `no-mistakes doctor` sequence for new clones.
+Do not reproduce the helper's clone, directory-change, or initialization internals from the primary shell.
 Initialization configures the local gate and does not vendor a no-mistakes skill into the project.
 Do not create a commit merely because initialization ran.
 If doctor reports an environment, authentication, or daemon problem, resolve that blocker before dispatching work and never restart the shared daemon from a project operation.

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -1,10 +1,11 @@
 // Firstmate's home-persistent Pi transcript presentation toggle.
 //
-// Compatibility boundary: Pi 0.81.1 exposes built-in ToolDefinitions, per-slot
-// renderers, renderShell: "self", session_start replacement reasons,
+// Compatibility boundary: Pi 0.82.0 exposes session_start replacement reasons,
 // ExtensionUIContext.setToolsExpanded(), setWorkingVisible(), and
 // setHiddenThinkingLabel(). The focused tests pin those assumptions. Exact-version
-// presentation adapters cover collapsed assistant thinking and operational user rows;
+// presentation adapters cover collapsed assistant thinking and operational user rows.
+// Calm intentionally does not re-register Pi's built-in tools, because same-name
+// extension tools replace their built-in source identity in pi.getAllTools().
 // Pi still exposes no global renderer for arbitrary built-in or custom rows.
 // docs/configuration.md owns the home-local Calm preference contract.
 import { randomUUID } from "node:crypto";
@@ -17,58 +18,17 @@ import {
 } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type {
-  ExtensionAPI,
-  ToolDefinition,
-  ToolRenderResultOptions,
-} from "@earendil-works/pi-coding-agent";
-import {
-  createBashToolDefinition,
-  createEditToolDefinition,
-  createFindToolDefinition,
-  createGrepToolDefinition,
-  createLsToolDefinition,
-  createReadToolDefinition,
-  createWriteToolDefinition,
-} from "@earendil-works/pi-coding-agent";
-import { Box, Container, getKeybindings, type Component } from "@earendil-works/pi-tui";
-import type { TSchema } from "typebox";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getKeybindings } from "@earendil-works/pi-tui";
 import { installCalmAssistantLayout } from "./lib/fm-calm-assistant-layout.ts";
 import { installCalmOperationalUserLayout } from "./lib/fm-calm-operational-user-layout.ts";
 import {
-  calmPresentationHides,
   calmPresentationIsActive,
   FIRSTMATE_CALM_PRESENTATION_EVENT,
   registerFirstmateSyntheticPresentation,
   setCalmPresentation,
   setCalmStockExportRendering,
 } from "./lib/fm-calm-visibility.ts";
-
-type DefinitionFactory<TParams extends TSchema, TDetails, TState> = (
-  cwd: string,
-) => ToolDefinition<TParams, TDetails, TState>;
-
-type RenderContext<TParams extends TSchema, TDetails, TState> = Parameters<
-  NonNullable<ToolDefinition<TParams, TDetails, TState>["renderCall"]>
->[2];
-
-type RenderArgs<TParams extends TSchema, TDetails, TState> = Parameters<
-  NonNullable<ToolDefinition<TParams, TDetails, TState>["renderCall"]>
->[0];
-
-type RenderTheme<TParams extends TSchema, TDetails, TState> = Parameters<
-  NonNullable<ToolDefinition<TParams, TDetails, TState>["renderCall"]>
->[1];
-
-type RenderResult<TParams extends TSchema, TDetails, TState> = Parameters<
-  NonNullable<ToolDefinition<TParams, TDetails, TState>["renderResult"]>
->[0];
-
-type StandardShellState = {
-  shell?: Box;
-  call?: Component;
-  result?: Component;
-};
 
 const extensionFile = fileURLToPath(import.meta.url);
 const extensionDir = dirname(extensionFile);
@@ -114,114 +74,6 @@ export default function (pi: ExtensionAPI) {
   };
 
   registerFirstmateSyntheticPresentation(pi);
-
-  function registerBuiltIn<TParams extends TSchema, TDetails, TState>(
-    factory: DefinitionFactory<TParams, TDetails, TState>,
-  ): void {
-    const definitions = new Map<string, ToolDefinition<TParams, TDetails, TState>>();
-    const definitionFor = (cwd: string): ToolDefinition<TParams, TDetails, TState> => {
-      let definition = definitions.get(cwd);
-      if (!definition) {
-        definition = factory(cwd);
-        definitions.set(cwd, definition);
-      }
-      return definition;
-    };
-
-    const original = definitionFor(process.cwd());
-    const originalRenderCall = original.renderCall;
-    const originalRenderResult = original.renderResult;
-    const originalSelfShell = original.renderShell === "self";
-    const standardShells = new WeakMap<object, StandardShellState>();
-
-    if (!originalRenderCall || !originalRenderResult) {
-      throw new Error(`Firstmate calm mode requires both render slots for Pi built-in tool ${original.name}`);
-    }
-
-    const shellStateFor = (
-      context: RenderContext<TParams, TDetails, TState>,
-    ): StandardShellState => {
-      const rowState = context.state as object;
-      let shellState = standardShells.get(rowState);
-      if (!shellState) {
-        shellState = {};
-        standardShells.set(rowState, shellState);
-      }
-      return shellState;
-    };
-
-    const refreshStandardShell = (
-      state: StandardShellState,
-      theme: RenderTheme<TParams, TDetails, TState>,
-      context: RenderContext<TParams, TDetails, TState>,
-    ): Box => {
-      const background = context.isPartial
-        ? (text: string) => theme.bg("toolPendingBg", text)
-        : context.isError
-          ? (text: string) => theme.bg("toolErrorBg", text)
-          : (text: string) => theme.bg("toolSuccessBg", text);
-      const shell = state.shell ?? new Box(1, 1, background);
-      state.shell = shell;
-      shell.setBgFn(background);
-      shell.clear();
-      if (state.call) shell.addChild(state.call);
-      if (state.result) shell.addChild(state.result);
-      return shell;
-    };
-
-    pi.registerTool({
-      ...original,
-      renderShell: "self",
-
-      async execute(toolCallId, params, signal, onUpdate, ctx) {
-        return definitionFor(ctx.cwd).execute(toolCallId, params, signal, onUpdate, ctx);
-      },
-
-      renderCall(
-        args: RenderArgs<TParams, TDetails, TState>,
-        theme: RenderTheme<TParams, TDetails, TState>,
-        context: RenderContext<TParams, TDetails, TState>,
-      ) {
-        if (exportRendering) return originalRenderCall(args, theme, context);
-        if (calmPresentationHides("assistant-tool-call")) return new Container();
-        if (originalSelfShell) return originalRenderCall(args, theme, context);
-
-        const state = shellStateFor(context);
-        state.call = originalRenderCall(args, theme, {
-          ...context,
-          lastComponent: state.call,
-        });
-        return refreshStandardShell(state, theme, context);
-      },
-
-      renderResult(
-        result: RenderResult<TParams, TDetails, TState>,
-        options: ToolRenderResultOptions,
-        theme: RenderTheme<TParams, TDetails, TState>,
-        context: RenderContext<TParams, TDetails, TState>,
-      ) {
-        if (exportRendering) return originalRenderResult(result, options, theme, context);
-        if (calmPresentationHides("tool-result")) return new Container();
-        if (originalSelfShell) return originalRenderResult(result, options, theme, context);
-
-        const state = shellStateFor(context);
-        state.result = originalRenderResult(result, options, theme, {
-          ...context,
-          lastComponent: state.result,
-        });
-        refreshStandardShell(state, theme, context);
-        return new Container();
-      },
-    });
-  }
-
-  registerBuiltIn(createReadToolDefinition);
-  registerBuiltIn(createBashToolDefinition);
-  registerBuiltIn(createEditToolDefinition);
-  registerBuiltIn(createWriteToolDefinition);
-  registerBuiltIn(createGrepToolDefinition);
-  registerBuiltIn(createFindToolDefinition);
-  registerBuiltIn(createLsToolDefinition);
 
   pi.on("session_start", (_event, ctx) => {
     exportRendering = false;

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -14,7 +14,7 @@ type CalmAssistantLayoutPatch = {
 };
 
 const CALM_ASSISTANT_LAYOUT_PATCH = Symbol.for(
-  "firstmate:calm-assistant-layout:pi-0.81.1",
+  "firstmate:calm-assistant-layout:pi-0.82.0",
 );
 
 export function installCalmAssistantLayout(): void {

--- a/.pi/extensions/lib/fm-calm-operational-user-layout.ts
+++ b/.pi/extensions/lib/fm-calm-operational-user-layout.ts
@@ -1,4 +1,4 @@
-// Pi 0.81.1's transcript owner adds the ordinary-user spacer and row together.
+// Pi 0.82.0's transcript owner adds the ordinary-user spacer and row together.
 // This exact-version adapter changes only that presentation and never message delivery.
 import {
   InteractiveMode,
@@ -40,7 +40,7 @@ type CalmOperationalUserLayoutPatch = {
 };
 
 const CALM_OPERATIONAL_USER_LAYOUT_PATCH = Symbol.for(
-  "firstmate:calm-operational-user-layout:pi-0.81.1",
+  "firstmate:calm-operational-user-layout:pi-0.82.0",
 );
 const LEGACY_CALM_OPERATIONAL_PREFIX = "\u2063Supervisor escalate (";
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
    When the lock could not be acquired and verified, the queue is left untouched because no session mutation is authorized, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
 4. **Context digest** - the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited.
    A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
-5. **Fleet-state digest** - the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
+5. **Fleet-state digest** - the compact backlog listing and held-captain-decision age view owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
    That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
 6. **Supervision operating instructions and next step** - after the wake queue and before context, the digest emits exactly one operating block for the detected primary harness.
    The closing reminder points back to that emitted block and preserves only the lock, afk, X-mode, and read-once reminders.
@@ -270,6 +270,9 @@ When no-mistakes is selected, no-mistakes alone owns review, fixes, tests, docum
 Never hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
 A separate review or audit is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review; one named question remains scoped to that question.
 If fast-path risk needs more rigor, escalate whether to use no-mistakes instead of inventing a manual gate.
+Decide, do not ask: firstmate makes routine implementation, routing, validation, and delivery-model choices inside the accepted task contract, records useful precedent on the backlog item, and does not open a captain decision for choices it can own.
+Escalate only choices that are external, money-related, irreversible, reserved, security-sensitive, destructive, credential-related, merge/discard authority, or otherwise outside the captain's accepted task contract.
+When doubt remains after applying the authority contract, hold for the captain in the backlog rather than creating another reminder or decision system.
 The path's worker, automated gates, and captain approval remain authoritative:
 
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
@@ -426,6 +429,7 @@ Mention cost as a courtesy when unusually much work is running, but never block 
 ## 10. Backlog contract
 
 `data/backlog.md` is the durable queue.
+It is firstmate's single obligation store; do not add parallel obligation registers, reminder ledgers, or decision databases for firstmate behavior.
 It tracks work items only, never agents; persistent secondmates never appear as backlog items.
 Work routed to a secondmate is recorded in that secondmate home's own backlog, not the main backlog.
 When a main-side thread such as a pending captain decision or relay reminder is worth durable tracking, file it as its own work item; use `tasks-axi hold <id> --reason "<reason>" --kind captain` for a captain-gated thread.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,6 +478,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
+- `graph-engineering` - load before proposing or materially expanding an agent loop, multi-agent workflow, experiment-lineage system, or cross-session graph memory.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 

--- a/bin/fm-project-add.sh
+++ b/bin/fm-project-add.sh
@@ -1,0 +1,463 @@
+#!/usr/bin/env bash
+# Clone one remote-backed project into an existing Firstmate home, register its
+# delivery posture, and initialize new no-mistakes clones.
+#
+# SOURCE is either an origin URL/path or a project name registered in the active
+# home's data/projects.md.
+# A registered name resolves its origin from the active home's existing clone and
+# preserves its registry line when targeting another home.
+# --home defaults to FM_HOME, then this Firstmate home, and may name any existing
+# main or secondmate home.
+# URL/path sources default to no-mistakes with yolo off; --mode, --description,
+# and --yolo set the generated registry entry.
+# Existing destination paths are always refused, including broken symlinks.
+# A failed clone, initialization, or registry update removes only the new clone
+# created by this invocation and never resets, forces, stashes, or discards
+# preexisting work.
+#
+# Usage:
+#   fm-project-add.sh [--home <home>] [--name <name>]
+#                     [--mode <no-mistakes|direct-PR>]
+#                     [--description <text>] [--yolo] <source>
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd -P)}"
+ACTIVE_HOME_INPUT="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+TARGET_HOME_INPUT=$ACTIVE_HOME_INPUT
+NAME=
+NAME_SET=0
+MODE=
+MODE_SET=0
+DESCRIPTION=
+DESCRIPTION_SET=0
+YOLO=off
+YOLO_SET=0
+SOURCE=
+
+usage() {
+  cat <<'EOF'
+Usage: fm-project-add.sh [--home <home>] [--name <name>]
+                         [--mode <no-mistakes|direct-PR>]
+                         [--description <text>] [--yolo] <source>
+
+Clone one origin URL/path, or a project registered in the active FM_HOME, into
+an existing Firstmate home.
+The target defaults to the active FM_HOME and may be changed with --home.
+Registered projects preserve their source registry entry.
+URL/path projects default to no-mistakes, yolo off, and "cloned project".
+A no-mistakes project runs `no-mistakes init` and `no-mistakes doctor` before
+its registry entry is committed.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --home)
+      [ "$#" -ge 2 ] || { echo "error: --home requires a value" >&2; usage >&2; exit 1; }
+      TARGET_HOME_INPUT=$2
+      shift 2
+      ;;
+    --home=*)
+      TARGET_HOME_INPUT=${1#--home=}
+      shift
+      ;;
+    --name)
+      [ "$#" -ge 2 ] || { echo "error: --name requires a value" >&2; usage >&2; exit 1; }
+      NAME=$2
+      NAME_SET=1
+      shift 2
+      ;;
+    --name=*)
+      NAME=${1#--name=}
+      NAME_SET=1
+      shift
+      ;;
+    --mode)
+      [ "$#" -ge 2 ] || { echo "error: --mode requires a value" >&2; usage >&2; exit 1; }
+      MODE=$2
+      MODE_SET=1
+      shift 2
+      ;;
+    --mode=*)
+      MODE=${1#--mode=}
+      MODE_SET=1
+      shift
+      ;;
+    --description)
+      [ "$#" -ge 2 ] || { echo "error: --description requires a value" >&2; usage >&2; exit 1; }
+      DESCRIPTION=$2
+      DESCRIPTION_SET=1
+      shift 2
+      ;;
+    --description=*)
+      DESCRIPTION=${1#--description=}
+      DESCRIPTION_SET=1
+      shift
+      ;;
+    --yolo)
+      YOLO=on
+      YOLO_SET=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      [ "$#" -eq 1 ] || { echo "error: exactly one source is required" >&2; usage >&2; exit 1; }
+      SOURCE=$1
+      shift
+      ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      [ -z "$SOURCE" ] || { echo "error: exactly one source is required" >&2; usage >&2; exit 1; }
+      SOURCE=$1
+      shift
+      ;;
+  esac
+done
+
+[ -n "$SOURCE" ] || { echo "error: exactly one source is required" >&2; usage >&2; exit 1; }
+case "$MODE" in
+  ''|no-mistakes|direct-PR) ;;
+  *) echo "error: unsupported delivery mode: $MODE" >&2; exit 1 ;;
+esac
+case "$DESCRIPTION" in
+  *$'\n'*|*$'\r'*) echo "error: description must be one line" >&2; exit 1 ;;
+esac
+
+canonical_home() {
+  local input=$1 home
+  [ -d "$input" ] || { echo "error: Firstmate home does not exist: $input" >&2; return 1; }
+  home=$(CDPATH='' cd -- "$input" && pwd -P) || return 1
+  [ "$home" != / ] || { echo "error: Firstmate home cannot be the filesystem root" >&2; return 1; }
+  [ -f "$home/AGENTS.md" ] || { echo "error: $home is not a Firstmate home (missing AGENTS.md)" >&2; return 1; }
+  [ -d "$home/bin" ] || { echo "error: $home is not a Firstmate home (missing bin/)" >&2; return 1; }
+  printf '%s\n' "$home"
+}
+
+path_is_inside() {
+  local parent=$1 child=$2
+  case "$child" in
+    "$parent"/*) return 0 ;;
+  esac
+  return 1
+}
+
+ensure_home_directory() {
+  local home=$1 name=$2 path resolved
+  path="$home/$name"
+  if [ -L "$path" ] && [ ! -e "$path" ]; then
+    echo "error: $name is a broken symlink in Firstmate home $home" >&2
+    return 1
+  fi
+  if [ -e "$path" ] && [ ! -d "$path" ]; then
+    echo "error: $path exists and is not a directory" >&2
+    return 1
+  fi
+  mkdir -p -- "$path"
+  resolved=$(CDPATH='' cd -- "$path" && pwd -P) || return 1
+  path_is_inside "$home" "$resolved" || {
+    echo "error: $name directory resolves outside Firstmate home $home" >&2
+    return 1
+  }
+  printf '%s\n' "$resolved"
+}
+
+validate_project_name() {
+  local name=$1
+  case "$name" in
+    ''|.|..|*[!A-Za-z0-9._-]*|/*|*/*)
+      echo "error: invalid flat project name: $name" >&2
+      return 1
+      ;;
+  esac
+  case "$name" in
+    [A-Za-z0-9]*) ;;
+    *) echo "error: project name must start with a letter or digit: $name" >&2; return 1 ;;
+  esac
+}
+
+registry_entry_count() {
+  local registry=$1 name=$2
+  [ -f "$registry" ] || { printf '0\n'; return 0; }
+  awk -v n="$name" '$1 == "-" && $2 == n { count++ } END { print count + 0 }' "$registry"
+}
+
+registry_line_for_name() {
+  local registry=$1 name=$2
+  [ -f "$registry" ] || return 1
+  awk -v n="$name" '$1 == "-" && $2 == n { print; exit }' "$registry"
+}
+
+project_mode_in_home() {
+  local home=$1 name=$2 parsed mode yolo
+  parsed=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
+    FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE='' FM_HOME="$home" \
+    "$SCRIPT_DIR/fm-project-mode.sh" "$name") || return 1
+  read -r mode yolo <<EOF
+$parsed
+EOF
+  case "$mode" in
+    no-mistakes|direct-PR) ;;
+    *) echo "error: registered project $name has unsupported delivery mode: $mode" >&2; return 1 ;;
+  esac
+  case "$yolo" in
+    on|off) ;;
+    *) echo "error: registered project $name has invalid yolo posture: $yolo" >&2; return 1 ;;
+  esac
+  printf '%s %s\n' "$mode" "$yolo"
+}
+
+# This is the relative-origin normalization used by fm-home-seed.sh: URL and
+# scp-style origins remain unchanged, while local relative origins are resolved
+# from the source clone rather than from this command's caller.
+normalize_joined_path() {
+  local prefix=$1 tail=$2 component out old_ifs
+  out=${prefix%/}
+  [ -n "$out" ] || out=/
+  old_ifs=$IFS
+  IFS=/
+  for component in $tail; do
+    case "$component" in
+      ''|.) ;;
+      ..)
+        if [ "$out" != / ]; then
+          out=${out%/*}
+          [ -n "$out" ] || out=/
+        fi
+        ;;
+      *)
+        if [ "$out" = / ]; then out="/$component"; else out="$out/$component"; fi
+        ;;
+    esac
+  done
+  IFS=$old_ifs
+  printf '%s\n' "$out"
+}
+
+canonical_path_for_check() {
+  local path=$1 probe tail prefix parent base
+  case "$path" in
+    /*) probe=$path ;;
+    *) probe="$(pwd -P)/$path" ;;
+  esac
+  while [ "$probe" != / ] && [ "${probe%/}" != "$probe" ]; do probe=${probe%/}; done
+  if [ -e "$probe" ]; then
+    if [ -d "$probe" ]; then
+      CDPATH='' cd -- "$probe" && pwd -P
+    else
+      parent=$(dirname -- "$probe")
+      base=$(basename -- "$probe")
+      CDPATH='' cd -- "$parent" && printf '%s/%s\n' "$(pwd -P)" "$base"
+    fi
+    return
+  fi
+  tail=
+  while [ ! -e "$probe" ] && [ "$probe" != / ]; do
+    tail="$(basename -- "$probe")${tail:+/$tail}"
+    probe=$(dirname -- "$probe")
+  done
+  if [ -d "$probe" ]; then
+    prefix=$(CDPATH='' cd -- "$probe" && pwd -P)
+  elif [ -e "$probe" ]; then
+    parent=$(dirname -- "$probe")
+    base=$(basename -- "$probe")
+    prefix=$(CDPATH='' cd -- "$parent" && printf '%s/%s\n' "$(pwd -P)" "$base")
+  else
+    prefix=/
+  fi
+  normalize_joined_path "$prefix" "$tail"
+}
+
+normalize_origin_url() {
+  local base=$1 url=$2 prefix
+  case "$url" in
+    file://*|*://*) printf '%s\n' "$url"; return ;;
+    *:*)
+      prefix=${url%%:*}
+      case "$prefix" in
+        */*) ;;
+        *) printf '%s\n' "$url"; return ;;
+      esac
+      ;;
+  esac
+  ( CDPATH='' cd -- "$base" && canonical_path_for_check "$url" )
+}
+
+derive_name_from_source() {
+  local source=$1 candidate
+  candidate=${source%%\#*}
+  candidate=${candidate%%\?*}
+  while [ "${candidate%/}" != "$candidate" ]; do candidate=${candidate%/}; done
+  candidate=${candidate##*/}
+  candidate=${candidate##*:}
+  candidate=${candidate%.git}
+  printf '%s\n' "$candidate"
+}
+
+registry_stamp() {
+  local registry=$1
+  if [ -e "$registry" ]; then
+    [ -f "$registry" ] || { echo "error: project registry is not a regular file: $registry" >&2; return 1; }
+    printf 'present:'
+    cksum < "$registry"
+  else
+    printf 'absent\n'
+  fi
+}
+
+ACTIVE_HOME=$(canonical_home "$ACTIVE_HOME_INPUT")
+TARGET_HOME=$(canonical_home "$TARGET_HOME_INPUT")
+DATA=$(ensure_home_directory "$TARGET_HOME" data)
+PROJECTS=$(ensure_home_directory "$TARGET_HOME" projects)
+REGISTRY="$DATA/projects.md"
+if [ -L "$REGISTRY" ]; then
+  echo "error: project registry must not be a symlink: $REGISTRY" >&2
+  exit 1
+fi
+if [ -e "$REGISTRY" ] && [ ! -f "$REGISTRY" ]; then
+  echo "error: project registry is not a regular file: $REGISTRY" >&2
+  exit 1
+fi
+
+ACTIVE_REGISTRY="$ACTIVE_HOME/data/projects.md"
+REGISTERED_COUNT=$(registry_entry_count "$ACTIVE_REGISTRY" "$SOURCE")
+REGISTRY_LINE=
+ORIGIN=
+
+if [ "$REGISTERED_COUNT" -gt 0 ]; then
+  [ "$REGISTERED_COUNT" -eq 1 ] || { echo "error: registered project $SOURCE has duplicate entries in $ACTIVE_REGISTRY" >&2; exit 1; }
+  validate_project_name "$SOURCE"
+  if [ "$NAME_SET" -eq 1 ] && [ "$NAME" != "$SOURCE" ]; then
+    echo "error: --name cannot rename registered project $SOURCE" >&2
+    exit 1
+  fi
+  if [ "$MODE_SET" -eq 1 ] || [ "$DESCRIPTION_SET" -eq 1 ] || [ "$YOLO_SET" -eq 1 ]; then
+    echo "error: registered project $SOURCE preserves its registry posture; omit --mode, --description, and --yolo" >&2
+    exit 1
+  fi
+  NAME=$SOURCE
+  SOURCE_PROJECTS="$ACTIVE_HOME/projects"
+  [ -d "$SOURCE_PROJECTS" ] || { echo "error: active home has no projects directory: $SOURCE_PROJECTS" >&2; exit 1; }
+  SOURCE_PROJECT="$SOURCE_PROJECTS/$SOURCE"
+  [ -d "$SOURCE_PROJECT" ] || { echo "error: registered project $SOURCE has no clone at $SOURCE_PROJECT" >&2; exit 1; }
+  git -C "$SOURCE_PROJECT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+    echo "error: registered project $SOURCE is not a Git repository: $SOURCE_PROJECT" >&2
+    exit 1
+  }
+  ORIGIN=$(git -C "$SOURCE_PROJECT" remote get-url origin 2>/dev/null || true)
+  [ -n "$ORIGIN" ] || { echo "error: registered project $SOURCE has no origin remote" >&2; exit 1; }
+  ORIGIN=$(normalize_origin_url "$SOURCE_PROJECT" "$ORIGIN")
+  read -r MODE YOLO <<EOF
+$(project_mode_in_home "$ACTIVE_HOME" "$SOURCE")
+EOF
+  REGISTRY_LINE=$(registry_line_for_name "$ACTIVE_REGISTRY" "$SOURCE")
+else
+  if [ "$NAME_SET" -eq 0 ]; then NAME=$(derive_name_from_source "$SOURCE"); fi
+  validate_project_name "$NAME"
+  ORIGIN=$(normalize_origin_url "$(pwd -P)" "$SOURCE")
+
+  TARGET_ENTRY_COUNT=$(registry_entry_count "$REGISTRY" "$NAME")
+  [ "$TARGET_ENTRY_COUNT" -le 1 ] || { echo "error: project $NAME has duplicate entries in $REGISTRY" >&2; exit 1; }
+  if [ "$TARGET_ENTRY_COUNT" -eq 1 ] && [ "$MODE_SET" -eq 0 ] \
+      && [ "$DESCRIPTION_SET" -eq 0 ] && [ "$YOLO_SET" -eq 0 ]; then
+    REGISTRY_LINE=$(registry_line_for_name "$REGISTRY" "$NAME")
+    read -r MODE YOLO <<EOF
+$(project_mode_in_home "$TARGET_HOME" "$NAME")
+EOF
+  else
+    [ "$MODE_SET" -eq 1 ] || MODE=no-mistakes
+    [ "$DESCRIPTION_SET" -eq 1 ] || DESCRIPTION="cloned project"
+    if [ "$YOLO" = on ]; then
+      REGISTRY_LINE="- $NAME [$MODE +yolo] - $DESCRIPTION (added $(date +%F))"
+    else
+      REGISTRY_LINE="- $NAME [$MODE] - $DESCRIPTION (added $(date +%F))"
+    fi
+  fi
+fi
+
+validate_project_name "$NAME"
+case "$MODE" in
+  no-mistakes|direct-PR) ;;
+  *) echo "error: unsupported delivery mode for $NAME: $MODE" >&2; exit 1 ;;
+esac
+
+DESTINATION="$PROJECTS/$NAME"
+if [ -e "$DESTINATION" ] || [ -L "$DESTINATION" ]; then
+  echo "error: refusing to clobber existing project path: $DESTINATION" >&2
+  exit 1
+fi
+
+if [ "$MODE" = no-mistakes ] && ! command -v no-mistakes >/dev/null 2>&1; then
+  echo "error: no-mistakes command not found; cannot initialize $NAME" >&2
+  exit 1
+fi
+
+REGISTRY_STAMP=$(registry_stamp "$REGISTRY")
+CREATED_CLONE=0
+COMMITTED=0
+REGISTRY_TMP=
+rollback() {
+  local rc=$?
+  trap - EXIT
+  if [ -n "${REGISTRY_TMP:-}" ]; then rm -f -- "$REGISTRY_TMP" 2>/dev/null || true; fi
+  if [ "${CREATED_CLONE:-0}" -eq 1 ] && [ "${COMMITTED:-0}" -eq 0 ]; then
+    case "$DESTINATION" in
+      "$PROJECTS"/*)
+        if [ "$(basename -- "$DESTINATION")" = "$NAME" ]; then rm -rf -- "$DESTINATION" 2>/dev/null || true; fi
+        ;;
+      *) echo "warning: refused unsafe project-add rollback target: $DESTINATION" >&2 ;;
+    esac
+  fi
+  exit "$rc"
+}
+trap rollback EXIT
+trap 'exit 130' HUP INT TERM
+
+if ! mkdir -- "$DESTINATION" 2>/dev/null; then
+  echo "error: refusing to clobber project path created concurrently: $DESTINATION" >&2
+  exit 1
+fi
+CREATED_CLONE=1
+if ! git clone --quiet -- "$ORIGIN" "$DESTINATION"; then
+  echo "error: failed to clone $SOURCE into $DESTINATION" >&2
+  exit 1
+fi
+
+if [ "$MODE" = no-mistakes ]; then
+  if ! ( CDPATH='' cd -- "$DESTINATION" && no-mistakes init && no-mistakes doctor ); then
+    echo "error: failed to initialize no-mistakes for $NAME at $DESTINATION" >&2
+    exit 1
+  fi
+fi
+
+CURRENT_REGISTRY_STAMP=$(registry_stamp "$REGISTRY")
+if [ "$CURRENT_REGISTRY_STAMP" != "$REGISTRY_STAMP" ]; then
+  echo "error: project registry changed while $NAME was being added; refusing to overwrite it" >&2
+  exit 1
+fi
+
+REGISTRY_TMP=$(mktemp "$DATA/.fm-project-add.projects.XXXXXX")
+if [ -f "$REGISTRY" ]; then
+  awk -v n="$NAME" '!($1 == "-" && $2 == n) { print }' "$REGISTRY" > "$REGISTRY_TMP"
+else
+  : > "$REGISTRY_TMP"
+fi
+printf '%s\n' "$REGISTRY_LINE" >> "$REGISTRY_TMP"
+mv -- "$REGISTRY_TMP" "$REGISTRY"
+REGISTRY_TMP=
+COMMITTED=1
+trap - EXIT
+trap - HUP INT TERM
+
+printf 'project=%s\n' "$NAME"
+printf 'home=%s\n' "$TARGET_HOME"
+printf 'mode=%s\n' "$MODE"
+printf 'yolo=%s\n' "$YOLO"

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -46,6 +46,15 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
 # shellcheck source=bin/fm-gate-refuse-lib.sh

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -75,11 +75,14 @@
 # When compatible tasks-axi is selected and available, the shared tasks-axi
 # backend probe remains the compatibility owner and this script asks
 # `tasks-axi list` for the compact identity fields plus blocked_by, hold_kind,
-# and hold_reason, never body.
+# hold_reason, and created where captain-decision age is needed, never body.
 # When manual mode is selected, or tasks-axi is unavailable or incompatible,
 # this script prints only backlog section headings and item title lines, so
 # title-line hold and blocked-by metadata remain visible while indented bodies
 # stay out of the startup digest.
+# A separate held-captain-decision subsection is still derived from the same
+# backlog data, ordered oldest first, with age annotations only for visibility.
+# It is not a second obligation store.
 # Full bodies are targeted follow-up only: `tasks-axi show <id> --full` when
 # compatible tasks-axi is available, or `data/backlog.md` when the file body is
 # truly needed.
@@ -213,6 +216,197 @@ print_backlog_compact() {
   fi
 }
 
+date_to_epoch() {  # <yyyy-mm-dd>
+  local day=$1
+  case "$day" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
+    *) return 1 ;;
+  esac
+  if date -u -d "$day" +%s >/dev/null 2>&1; then
+    date -u -d "$day" +%s
+  elif date -u -j -f %F "$day" +%s >/dev/null 2>&1; then
+    date -u -j -f %F "$day" +%s
+  else
+    return 1
+  fi
+}
+
+captain_decision_age_days() {  # <yyyy-mm-dd>
+  local since=$1 today today_epoch since_epoch days
+  today=${FM_SESSION_START_TODAY:-$(date -u +%F)}
+  today_epoch=$(date_to_epoch "$today") || return 1
+  since_epoch=$(date_to_epoch "$since") || return 1
+  days=$(( (today_epoch - since_epoch) / 86400 ))
+  [ "$days" -ge 0 ] || days=0
+  printf '%s\n' "$days"
+}
+
+strip_csv_quotes() {  # <value>
+  local value=$1
+  case "$value" in
+    \"*\")
+      value=${value#\"}
+      value=${value%\"}
+      value=${value//\"\"/\"}
+      ;;
+  esac
+  printf '%s\n' "$value"
+}
+
+tasks_axi_captain_decision_records() {  # <backlog-path>
+  local path=$1 out rc
+  out=$(tasks-axi list --file "$path" --state held --kind captain --limit "$BACKLOG_LIMIT" --fields created,blocked_by,hold_kind,hold_reason 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf 'tasks-axi held-decision listing failed; falling back to title-line rendering.\n%s\n' "$out" >&2
+    return "$rc"
+  fi
+  printf '%s\n' "$out" | awk '
+    function csv_split(line, out,    i, c, nextc, field, n, in_quote) {
+      n = 1
+      field = ""
+      in_quote = 0
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        if (in_quote) {
+          if (c == "\"") {
+            nextc = substr(line, i + 1, 1)
+            if (nextc == "\"") {
+              field = field c
+              i++
+            } else {
+              in_quote = 0
+            }
+          } else {
+            field = field c
+          }
+        } else if (c == ",") {
+          out[n++] = field
+          field = ""
+        } else if (c == "\"") {
+          in_quote = 1
+        } else {
+          field = field c
+        }
+      }
+      out[n] = field
+      return n
+    }
+    /^tasks\[[0-9]+\]\{/ { in_table = 1; next }
+    /^help\[/ { in_table = 0 }
+    in_table && /^  / {
+      line = $0
+      sub(/^  /, "", line)
+      delete f
+      n = csv_split(line, f)
+      if (n < 9 || f[8] != "captain") next
+      printf "%s\t%s\t%s\t%s\t%s\n", f[6], f[1], f[5], f[9], f[7]
+    }
+  '
+}
+
+backlog_title_metadata() {  # <title-rest> <metadata-key>
+  local rest=$1 key=$2 pattern
+  pattern="\\($key:[[:space:]]*([^)]*)\\)"
+  if [[ $rest =~ $pattern ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  fi
+}
+
+backlog_title_since() {  # <title-rest>
+  local rest=$1
+  if [[ $rest =~ \(since[[:space:]]+([0-9]{4}-[0-9]{2}-[0-9]{2})\) ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  fi
+}
+
+clean_backlog_title() {  # <title-rest>
+  printf '%s\n' "$1" \
+    | sed -E 's/[[:space:]]+blocked-by:[^[:space:])]+.*$//; s/[[:space:]]*\([^)]*\)//g; s/[[:space:]]+$//'
+}
+
+manual_captain_decision_records() {  # <backlog-path>
+  local path=$1 section='' line id rest kind hold_kind hold_reason since title blocked_by
+  while IFS= read -r line; do
+    case "$line" in
+      '## In flight') section=in_flight; continue ;;
+      '## Queued') section=queued; continue ;;
+      '## Done') section='done'; continue ;;
+      '## '*) section=''; continue ;;
+    esac
+    [ "$section" != 'done' ] || continue
+    [[ $line =~ ^[-*][[:space:]]+\[[[:space:]xX]\][[:space:]]+([^[:space:]]+)[[:space:]]+-[[:space:]]+(.*)$ ]] || continue
+    id=${BASH_REMATCH[1]}
+    rest=${BASH_REMATCH[2]}
+    kind=$(backlog_title_metadata "$rest" kind)
+    hold_kind=$(backlog_title_metadata "$rest" hold-kind)
+    hold_reason=$(backlog_title_metadata "$rest" hold)
+    [ "$kind" = captain ] && [ "$hold_kind" = captain ] && [ -n "$hold_reason" ] || continue
+    since=$(backlog_title_since "$rest")
+    title=$(clean_backlog_title "$rest")
+    blocked_by=$(printf '%s\n' "$rest" | sed -nE 's/.*blocked-by:[[:space:]]*([^[:space:])]+).*/\1/p' | head -1)
+    [ -n "$blocked_by" ] || blocked_by=none
+    printf '%s\t%s\t%s\t%s\t%s\n' "$since" "$id" "$title" "$hold_reason" "$blocked_by"
+  done < "$path"
+}
+
+render_captain_decision_records() {
+  local records=$1 rows='' day id title reason blocked days sort_key age_label date_label line tab
+  tab=$(printf '\t')
+  while IFS=$'\t' read -r day id title reason blocked; do
+    [ -n "$id" ] || continue
+    reason=$(strip_csv_quotes "${reason:--}")
+    blocked=$(strip_csv_quotes "${blocked:-none}")
+    if days=$(captain_decision_age_days "$day"); then
+      sort_key=$days
+      age_label="age: ${days}d"
+      date_label="since $day"
+    else
+      sort_key=-1
+      age_label="age: unknown"
+      date_label="since unknown"
+    fi
+    rows="${rows}${sort_key}${tab}${id}${tab}${age_label}${tab}${date_label}${tab}${title}${tab}${reason}${tab}${blocked}"$'\n'
+  done <<< "$records"
+
+  if [ -z "$rows" ]; then
+    printf '(no held captain decisions found)\n'
+    return 0
+  fi
+
+  printf '%s' "$rows" | LC_ALL=C sort -t "$tab" -k1,1nr -k2,2 | while IFS=$'\t' read -r _sort id age_label date_label title reason blocked; do
+    line="- $id ($age_label, $date_label) - $title"
+    [ -n "$reason" ] && [ "$reason" != "-" ] && line="$line; reason: $reason"
+    case "$blocked" in
+      ''|none|\"-\"|-) : ;;
+      *) line="$line; blocked by: $blocked" ;;
+    esac
+    printf '%s\n' "$line"
+  done
+}
+
+print_captain_decision_ages() {  # <backlog-path>
+  local path=$1 records
+  subsection "Held captain decisions (age-ordered)"
+  if [ ! -f "$path" ]; then
+    printf '(no backlog file; no held captain decisions found)\n'
+    return 0
+  fi
+  if [ ! -s "$path" ]; then
+    printf '(present, empty)\n'
+    return 0
+  fi
+  printf 'single source: data/backlog.md; oldest held captain decision first\n'
+  if fm_tasks_axi_backend_available "$CONFIG"; then
+    if records=$(tasks_axi_captain_decision_records "$path" 2>/dev/null); then
+      render_captain_decision_records "$records"
+      return 0
+    fi
+  fi
+  records=$(manual_captain_decision_records "$path")
+  render_captain_decision_records "$records"
+}
+
 print_status_tail() {
   local status=$1
   printf 'status tail (last %s line(s), wake-EVENT history, not current state; full log: %s):\n' "$STATUS_TAIL" "$status"
@@ -341,6 +535,7 @@ print_file_or_absent "$DATA/learnings.md" "data/learnings.md"
 # --- 5. fleet-state digest ---------------------------------------------
 section "FLEET STATE"
 print_backlog_compact "$DATA/backlog.md" "data/backlog.md"
+print_captain_decision_ages "$DATA/backlog.md"
 
 subsection "Work under way (state/*.meta)"
 META_FOUND=0

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -5,17 +5,17 @@ This document owns the version-scoped feasibility evidence, Pi transcript taxono
 
 ## Required extension surface
 
-A qualifying implementation must auto-load from the trusted project, persist the toggle choice for the effective Firstmate home across Pi session starts and resumes, keep Pi's built-in working activity visible, emit no Calm status row, redraw already-rendered controllable rows, remove supported hidden rows without gaps, restore ordinary rendering, and leave delivery, tool execution, model context, session storage, export and share operation, diagnostics, and expansion state unchanged.
+A qualifying implementation must auto-load from the trusted project, persist the toggle choice for the effective Firstmate home across Pi session starts and resumes, keep Pi's built-in working activity visible, preserve built-in tool source identity, emit no Calm status row, redraw already-rendered controllable rows, remove supported hidden rows without gaps, restore ordinary rendering, and leave delivery, tool execution, model context, session storage, export and share operation, diagnostics, and expansion state unchanged.
 The governing presentation policy allows genuine original user prompts, genuine user-facing assistant text, and Pi's native working activity.
 Changing persisted context to remove hidden content, filtering provider context, patching installed harness code, or claiming coverage outside a supported renderer does not satisfy that boundary.
 
-## Pi 0.81.1 end-to-end reproduction
+## Pi 0.82.0 activation recheck
 
-The current installed and regression-supported Pi version was verified on 2026-07-22.
+The current installed and regression-supported Pi version was verified on 2026-07-25.
 
 ```text
 $ pi --version
-0.81.1
+0.82.0
 ```
 
 ### Original transcript cleanup
@@ -24,10 +24,12 @@ The pre-cleanup reproduction used a real isolated Pi TUI at 180 columns by 44 ro
 The model called `fm_watch_arm_pi`, the real tool returned `watcher: started Pi extension arm child 1`, and a `done:` status write caused the watcher extension to inject `FIRSTMATE WATCHER WAKE: signal: ...` followed by the stable drain instruction.
 With Calm off, the captured transcript contained the genuine user prompt, the full watcher tool shell, the synthetic user-role wake, four collapsed `Thinking...` labels, built-in tool rows from wake handling, and the final assistant response.
 With the pre-cleanup implementation's Calm mode on, the existing seven built-in tool rows disappeared, but the watcher tool shell, synthetic wake, and all four `Thinking...` labels remained.
-The final screenshot-scale regression reproduced the same transcript after the cleanup and verified that Calm removed those remaining controlled rows while retaining the genuine prompt, a watcher-shaped genuine near-miss prompt, and the genuine assistant responses.
+The final screenshot-scale regression reproduced the same transcript after the cleanup and verified that Calm removed the remaining supported controlled rows while retaining the genuine prompt, a watcher-shaped genuine near-miss prompt, and the genuine assistant responses.
 
 The original proven comparison path was a built-in text tool.
 Calm owned both of that tool's supported renderer slots and switched its shell to `renderShell: "self"`, so returning empty components removed the complete row and `setToolsExpanded` redrew existing tool components.
+That same-name registration path is no longer acceptable for enforced/default Firstmate because Pi reports extension-registered same-name tools with extension provenance instead of `sourceInfo.source: "builtin"`.
+Calm therefore does not re-register Pi's built-in `read`, `bash`, `edit`, `write`, `grep`, `find`, or `ls` tools in the current implementation.
 Adding supported empty renderer slots to a scratch copy of `fm_watch_arm_pi` likewise removed its row while the real watcher still started and the model still returned `PROBE_COMPLETE`.
 Legacy synthetic presentation entries use `CustomEntryComponent`, whose host adds spacing only when its renderer returns content, so an undefined Calm renderer result removes the complete row and can later restore it through the ordinary expansion redraw.
 The later duplicate-turn evidence below supersedes custom-message rerouting as an acceptable implementation for current operational input.
@@ -50,20 +52,20 @@ The earliest divergent layout path was `AssistantMessageComponent.updateContent`
 Pi computed `hasVisibleContent` from the original thinking data and added a leading `Spacer` before applying the hidden-thinking presentation.
 Pi then styled the empty label before constructing `Text`, so the resulting ANSI-only string occupied one rendered row, and a thinking block followed by assistant text also added its ordinary inter-block spacer.
 Each thinking-only tool turn therefore retained two empty rows, while the final thinking-plus-text turn retained two extra rows beyond the final response's normal leading separator.
-The proven tool path diverged through `ToolExecutionComponent`, where the Calm self-render shell returned zero lines for both call and result slots and contributed no residual height.
+The earlier wrapped built-in tool path diverged through `ToolExecutionComponent`, where the Calm self-render shell returned zero lines for both call and result slots and contributed no residual height.
 
 The smallest counterfactual was the thinking-only removal from the same persisted session, which preserved the skill, tools, results, final response, session ordering, and terminal settings while eliminating every unwanted row.
 The single-thinking, tool-call-only, tool-result, Calm-off, and `clearOnShrink` controls deliberately sought disconfirming evidence and isolated collapsed thinking layout from skill, tool, result, and terminal-cache candidates.
 PR 927 made Calm persistent and described controlled rows as gapless while retaining a documented unsupported boundary for collapsed-thinking spacing.
 PR 936 removed the unsafe operational-input reroute and preserved legacy zero-height entries but did not change assistant-message layout.
 
-The fix installs one idempotent Pi 0.81.1 presentation adapter on the exported `AssistantMessageComponent.updateContent` method.
+The fix installs one idempotent Pi 0.82.0 presentation adapter on the exported `AssistantMessageComponent.updateContent` method.
 Only while Calm is active and Pi has collapsed thinking does the adapter pass a shallow thinking-free presentation copy into Pi's ordinary layout calculation, then retain the original message on the component for invalidation and thinking expansion.
 The persisted assistant message, provider context, tool execution, export data, and expansion history remain unchanged.
 Collapsed thinking-only assistant messages now render zero rows, thinking before visible assistant text adds no spacing beyond the text-only baseline, and expanding thinking still renders the original reasoning.
 
 The disconfirming checks deliberately retain supported boundaries.
-An arbitrary third-party custom tool and a built-in read image remain visible because Pi exposes neither a global tool renderer nor image-row control.
+An arbitrary third-party custom tool plus built-in tool rows and images remain visible because Pi exposes neither a global tool renderer nor renderer-only built-in override.
 Expanded thinking remains visible by design, while re-collapsing it returns to zero-height Calm presentation.
 Ordinary user-role near misses remain visible, including quoted current markers, ASCII-only labels, unrelated text before a marker, unrelated text after U+2063, and image-bearing input.
 
@@ -114,7 +116,7 @@ The real Pi viewport moved the unchanged assistant text from row 7 to row 2, ren
 The leading cause would have been falsified if the row or height remained, the provider lost or duplicated the message, or the persisted role or bytes changed.
 None occurred.
 
-The fix installs a separate idempotent Pi 0.81.1 presentation adapter on the exported `InteractiveMode.addMessageToChat` method.
+The fix installs a separate idempotent Pi 0.82.0 presentation adapter on the exported `InteractiveMode.addMessageToChat` method.
 It delegates current recognition to `bin/fm-operational-input.sh`, adds only the evidence-backed bare-U+2063 `Supervisor escalate (` presentation compatibility shape, mounts a `UserMessageComponent` subclass that preserves Pi's stock row plus leading spacer while Calm is off, and returns zero rendered lines while Calm is on.
 It never intercepts the input event, rewrites the message, changes its role, filters model context, or changes session data.
 Messages containing an image are left on Pi's ordinary path even when their text equals an operational envelope because Firstmate's authoritative producers are text-only.
@@ -141,21 +143,21 @@ The session-start nudge already originates as a non-displayed custom message, so
 Legacy Calm custom entries and messages remain in existing session artifacts, and their presentation entry still uses the supported zero-height renderer while active.
 Cycling tool expansion and restoring its original value rebuilds controllable rows and leaves final `Ctrl+O` state unchanged.
 Exported and shared HTML retain genuine user prompts, genuine assistant responses, current operational user messages, ordinary tool rendering, and the complete session artifact.
-Serialized session data and Pi 0.81.1's sidebar tree also retain legacy hidden operational custom messages.
+Serialized session data and Pi 0.82.0's sidebar tree also retain legacy hidden operational custom messages.
 
 ## Complete currently reachable Pi transcript taxonomy
 
-The taxonomy was derived from Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations.
+The taxonomy was originally derived from Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations, then rechecked against Pi 0.82.0 for activation.
 The test fixture enumerates every class below through the centralized policy, and the interactive fixture exercises the screenshot classes, current user-role operational input, and legacy synthetic presentation entries.
 
-| Policy class | Pi transcript path | Calm result on Pi 0.81.1 |
+| Policy class | Pi transcript path | Calm result on Pi 0.82.0 |
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible, including every tested operational near miss. |
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
 | `assistant-thinking` | Thinking content in `AssistantMessageComponent` | Collapsed reasoning is removed from the shallow presentation copy before layout and occupies zero rows; explicit expansion renders the original reasoning. |
-| `assistant-tool-call` | `ToolExecutionComponent` | Seven built-ins and `fm_watch_arm_pi` hidden; arbitrary custom tools remain an unsupported boundary. |
-| `tool-result` | `ToolExecutionComponent` | Text results for the controlled tools hidden; arbitrary custom results remain an unsupported boundary. |
-| `tool-image` | Image children appended outside tool renderer slots | Unsupported boundary; remains visible. |
+| `assistant-tool-call` | `ToolExecutionComponent` | `fm_watch_arm_pi` is hidden through its extension-owned renderer; Pi built-ins and arbitrary custom tools remain visible. |
+| `tool-result` | `ToolExecutionComponent` | `fm_watch_arm_pi` text results are hidden through its extension-owned renderer; Pi built-in results and arbitrary custom results remain visible. |
+| `tool-image` | Image children appended outside tool renderer slots | Unsupported boundary; remains visible, including built-in read images. |
 | `user-bash` | `BashExecutionComponent` for `!` and `!!` | Unsupported boundary; remains visible. |
 | `skill-invocation` | `SkillInvocationMessageComponent` plus parsed user text | Unsupported boundary; remains visible. |
 | `custom-message` | `CustomMessageComponent` when `display` is true | The session-start nudge and legacy Calm context messages use `display: false`; arbitrary extension messages remain an unsupported boundary. |
@@ -167,17 +169,19 @@ The test fixture enumerates every class below through the centralized policy, an
 | `system-notice` | `showStatus`, `showError`, compaction, retry, and startup warning rows | Unsupported boundary; remains visible. |
 | `cache-notice` | Non-persisted cache-miss `Text` row | Unsupported boundary; remains visible. |
 | `project-trust-warning` | Non-persisted startup `Text` row | Unsupported boundary; remains visible. |
-| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages stay ordinary semantic user messages but render through the zero-height Pi 0.81.1 adapter under Calm; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
+| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages stay ordinary semantic user messages but render through the zero-height Pi 0.82.0 adapter under Calm; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
 | `synthetic-assistant` | No authoritative Firstmate source found | Policy-hidden, but Pi exposes no generic assistant-role renderer. |
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
 The installed extension API has no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container API, or generic custom-tool wrapper.
-Pi 0.81.1 exports `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate exact-version, idempotent adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged.
-General component replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching remain rejected as unsupported or preservation-breaking workarounds.
+Pi 0.82.0 exports `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate exact-version, idempotent adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged.
+Pi's documented built-in tool renderer example uses same-name `registerTool()` replacement, not a renderer-only built-in hook, so default Calm does not wrap built-ins.
+General component replacement, ANSI cursor erasure, provider-context mutation, built-in tool replacement, and installed-file patching remain rejected as unsupported or preservation-breaking workarounds.
 
 ## Cross-harness verification record
 
-The original five-harness inspection was performed on 2026-07-22, with every integration surface rechecked and Pi reverified at 0.81.1 on 2026-07-23 for the latest Calm presentation change.
+The original five-harness inspection was performed on 2026-07-22, with every integration surface rechecked and Pi reverified at 0.81.1 on 2026-07-23 for the earlier Calm presentation change.
+The Pi surface was rechecked at 0.82.0 on 2026-07-25 for activation and built-in source identity.
 
 ```text
 $ claude --version
@@ -187,7 +191,7 @@ codex-cli 0.144.6
 $ opencode --version
 1.17.18
 $ pi --version
-0.81.1
+0.82.0
 $ grok --version
 grok 0.2.106 (bde89716f679)
 ```
@@ -197,7 +201,7 @@ grok 0.2.106 (bde89716f679)
 | Claude Code 2.1.218 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or transcript-wide redraw API. |
 | Codex CLI 0.144.6 | Not feasible through the inspected supported project surface. | The tracked hooks expose session, pre-tool, and stop handling, while the plugin and feature inventories expose no TUI tool-row renderer or transcript redraw control. |
 | OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer; same-name tool replacement changes execution rather than presentation alone. |
-| Pi 0.81.1 | Partially feasible with two exact-version exported-class adapters. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the version-pinned collapsed-thinking and operational-user layout boundaries, while generic user, tool, and status filtering remains unavailable. |
+| Pi 0.82.0 | Partially feasible with two exact-version exported-class adapters. | Public APIs control working visibility, collapsed labels, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the version-pinned collapsed-thinking and operational-user layout boundaries, while generic user, built-in tool, and status filtering remains unavailable. |
 | Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract; `--minimal` changes the whole screen mode rather than selected transcript rows. |
 
 These conclusions are deliberately limited to the named versions and supported surfaces.
@@ -208,14 +212,14 @@ Only Pi's Calm presentation implementation changed; every producer and non-Pi tr
 
 ## Regression coverage
 
-`tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool, thinking, current operational-user, and legacy synthetic rows, and covers every policy class.
+`tests/fm-calm-pi-extension.test.sh` asserts Calm registers no tool replacements, verifies the seven Pi built-ins keep builtin provenance while `fm_watch_arm_pi` remains extension-owned, exercises redraw of already-rendered thinking, current operational-user, and legacy synthetic rows, and covers every policy class.
 It covers persisted preference restoration across every session-start reason and a real restart, proves Pi's native `Working...` row through a delayed deterministic provider, asserts no Calm status row, verifies operational messages remain exact ordinary user-role session entries and complete exports, and drives genuine 100 by 44, 160 by 36, and 180 by 44 terminal fixtures.
-A native deterministic `/skill:ahoy` turn produces thinking, tool-call, and tool-result blocks, asserts that the collapsed skill-to-final gap equals the two-row visible-only baseline, expands and re-collapses original thinking, restores Calm-off rendering, verifies persisted hidden history, and repeats the geometry assertion after restart with `terminal.clearOnShrink` explicitly off.
+A native deterministic `/skill:ahoy` turn produces thinking, tool-call, and tool-result blocks, asserts collapsed thinking remains hidden while built-in read rows stay visible, expands and re-collapses original thinking, verifies persisted history, and repeats the restart check with `terminal.clearOnShrink` explicitly off.
 The operational provider path covers Calm loaded on, loaded off, default preference, extension absent, exact watcher delivery, narrow bare-marker legacy input, persisted restart replay, a genuine captain prompt, and adjacent notifications coalesced into one intended processing turn.
 It asserts one persisted and rendered captain answer, exact user-role operational envelopes in order, no replacement custom messages, one processing result, zero operational transcript rows, and the two-row neighboring-assistant geometry for live, adjacent, and restart paths.
 Quoted current markers, ASCII-only labels, ordinary text before a marker, unrelated U+2063 placement, and image-bearing input remain visible in component and native transcript checks.
 `tests/fm-pi-primary-live-e2e.test.sh` also proves the unchanged built-in `Working...` row while Calm is active on the credentialed provider path before continuing its ordinary watcher lifecycle.
-`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi 0.81.1 declarations.
+`tests/fm-pi-primary-types.test.sh` performs strict no-emit TypeScript checking against the installed Pi 0.82.0 declarations.
 
 The relevant commands are:
 
@@ -225,25 +229,25 @@ FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh
 tests/fm-pi-primary-types.test.sh
 ```
 
-## 2026-07-23 verification record
+## 2026-07-25 verification record
 
 The deterministic provider preserves the complete real Pi TUI rendering path without using credentials.
 The credentialed live regression remains opt-in and was not required because this change does not alter watcher delivery or provider integration.
 
 ```text
 $ pi --version
-0.81.1
+0.82.0
 
 $ tests/fm-calm-pi-extension.test.sh
-ok - Pi calm extension is presentation-only with one persisted visibility choice, no Calm status row, native working visibility, supported redraw controls, and the Firstmate watcher-tool integration
+ok - Pi calm extension is presentation-only with one persisted visibility choice, no built-in tool replacements, native working visibility, supported redraw controls, and the Firstmate watcher-tool integration
 ok - Pi calm resolves its persistent home independently of Pi's launch directory
-ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps native working visible, and persists its choice across session starts
+ok - Pi calm preserves built-in tool identity, centralizes transcript visibility, preserves export data, keeps native working visible, and persists its choice across session starts
 ok - Pi operational follow-up E2E processes exact user-role notifications once while Calm hides current and adjacent rows, Calm off and absent render them, and restart preserves semantics
-ok - Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering
+ok - Pi Calm native /skill:ahoy geometry keeps collapsed thinking at zero height while preserving built-in tool rows, expansion, history, and restart
 ok - Pi calm native E2E keeps Working and captain turns visible, hides exact operational user rows without changing persistence, restores them Calm-off, survives restart, and preserves export plus Ctrl+O behavior
 
 $ tests/fm-pi-primary-types.test.sh
-ok - tracked Pi extensions pass strict no-emit typecheck against Pi 0.81.1
+ok - tracked Pi extensions pass strict no-emit typecheck against Pi 0.82.0
 
 $ bin/fm-lint.sh
 fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -4,7 +4,8 @@ Calm is a Pi-only conversation presentation toggle.
 It is off by default, and the last `/calm` choice persists for the effective Firstmate home across Pi session starts and resumes.
 
 While Calm is active, Pi's built-in `Working...` activity remains visible and no separate Calm status row is added.
-Calm hides collapsed thinking labels, the shells for Pi's seven built-in tools, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
+Calm hides collapsed thinking labels, the extension-owned `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
+Calm does not replace Pi's built-in `read`, `bash`, `edit`, `write`, `grep`, `find`, or `ls` tool definitions, so those tool rows and their built-in source identity remain unchanged.
 The operational inputs remain ordinary user-role messages, while Pi's transcript layout renders their complete rows at zero height.
 The session-start nudge remains on its existing non-displayed custom-message path.
 
@@ -14,8 +15,8 @@ Every hidden Firstmate input remains available to the model and in serialized se
 Legacy operational custom messages remain in session data and Pi's sidebar tree, although the main HTML transcript may omit them.
 Toggling Calm off restores ordinary rendering, and `Ctrl+O` expansion state is preserved.
 
-Pi's supported presentation API does not expose a global transcript filter.
-Expanded reasoning and its reserved spacing, built-in tool images, user-bash rows, skill and summary rows, generic status notices, and arbitrary custom-tool or extension rows remain visible.
+Pi's supported presentation API does not expose a global transcript filter or renderer-only built-in tool override.
+Expanded reasoning and its reserved spacing, built-in tool rows and images, user-bash rows, skill and summary rows, generic status notices, and arbitrary custom-tool or extension rows remain visible.
 These are supported-API boundaries rather than hidden-content failures.
 
 [`calm-mode-feasibility.md`](calm-mode-feasibility.md) owns the version-scoped renderer taxonomy and empirical evidence.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -148,6 +148,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/graph-engineering/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/harness-adapters/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -47,6 +47,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/orca.sh`       | Experimental Orca backend adapter owning both worktree and terminal                  |
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live secondmates mid-session and send a pointer to the literal-content config reread when config changed |
+| `fm-project-add.sh`      | Clone, register, and initialize one remote-backed project in an existing Firstmate home |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -36,6 +36,18 @@ wait_for_text() {
   return 1
 }
 
+wait_for_calm_preference() {
+  local home=$1 expected=$2 i=0
+  while [ "$i" -lt 120 ]; do
+    if [ -f "$home/config/calm" ] && [ "$(cat "$home/config/calm")" = "$expected" ]; then
+      return 0
+    fi
+    sleep 0.05
+    i=$((i + 1))
+  done
+  return 1
+}
+
 find_chrome() {
   local candidate
   if [ -n "${FM_CHROME_BIN:-}" ] && [ -x "$FM_CHROME_BIN" ]; then
@@ -99,7 +111,8 @@ test_static_contract() {
   assert_contains "$text" 'getKeybindings().matches(data, "tui.input.submit")' "Pi calm export boundary ignores the active submit keybinding"
   assert_contains "$text" 'input !== "/share"' "Pi calm export boundary does not cover /share"
   assert_not_contains "$text" 'FIRSTMATE_PI_LAUNCH_BRIEF_ENV' "Pi calm presentation still depends on launch-input provenance"
-  assert_contains "$text" 'renderShell: "self"' "Pi calm extension cannot remove complete built-in tool shells"
+  assert_not_contains "$text" 'pi.registerTool(' "Pi calm extension still registers tool replacements"
+  assert_not_contains "$text" 'renderShell: "self"' "Pi calm extension still owns complete built-in tool shells"
   assert_contains "$visibility" 'CALM_VISIBLE_CLASSES' "Pi calm policy does not centralize its visibility allowlist"
   assert_contains "$operational" 'fm-operational-input.sh' "Pi adapter does not delegate to the canonical cross-language owner"
   assert_not_contains "$visibility" 'FIRSTMATE WATCHER WAKE:' "current Calm classification still matches watcher payload prose"
@@ -110,9 +123,9 @@ test_static_contract() {
   assert_contains "$watch" 'calmHides("assistant-tool-call")' "Firstmate watcher tool does not participate in Calm presentation"
   assert_contains "$watch" 'renderShell: "self"' "Firstmate watcher tool cannot remove its complete shell"
   for name in Read Bash Edit Write Grep Find Ls; do
-    assert_contains "$text" "create${name}ToolDefinition" "Pi calm extension does not wrap the $name built-in"
+    assert_not_contains "$text" "create${name}ToolDefinition" "Pi calm extension still wraps the $name built-in"
   done
-  pass "Pi calm extension is presentation-only with one persisted visibility choice, no Calm status row, native working visibility, supported redraw controls, and the Firstmate watcher-tool integration"
+  pass "Pi calm extension is presentation-only with one persisted visibility choice, no built-in tool replacements, native working visibility, supported redraw controls, and the Firstmate watcher-tool integration"
 }
 
 test_home_resolution() {
@@ -126,7 +139,7 @@ test_home_resolution() {
     return 0
   fi
   version=$(node -p "require('$PI_PACKAGE_DIR/package.json').version")
-  [ "$version" = "0.81.1" ] || fail "Pi calm compatibility assumptions require Pi 0.81.1, found $version"
+  [ "$version" = "0.82.0" ] || fail "Pi calm compatibility assumptions require Pi 0.82.0, found $version"
 
   fixture="$TMP_ROOT/home-resolution"
   mkdir -p \
@@ -235,7 +248,7 @@ test_rendering_and_session_lifecycle() {
     return 0
   fi
   version=$(node -p "require('$PI_PACKAGE_DIR/package.json').version")
-  [ "$version" = "0.81.1" ] || fail "Pi calm compatibility assumptions require Pi 0.81.1, found $version"
+  [ "$version" = "0.82.0" ] || fail "Pi calm compatibility assumptions require Pi 0.82.0, found $version"
 
   fixture="$TMP_ROOT/renderer"
   mkdir -p "$fixture/home" "$fixture/lib" "$fixture/node_modules/@earendil-works"
@@ -261,7 +274,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const packageRoot = process.env.PI_PACKAGE_DIR;
-const [{ AssistantMessageComponent }, { CustomEntryComponent }, { ToolExecutionComponent }, { UserMessageComponent }, { InteractiveMode }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }] = await Promise.all([
+const [{ AssistantMessageComponent }, { CustomEntryComponent }, { ToolExecutionComponent }, { UserMessageComponent }, { InteractiveMode }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }, { createAllToolDefinitions }] = await Promise.all([
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/assistant-message.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/custom-entry.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/components/tool-execution.js`).href),
@@ -270,11 +283,30 @@ const [{ AssistantMessageComponent }, { CustomEntryComponent }, { ToolExecutionC
   import(pathToFileURL(`${packageRoot}/dist/modes/interactive/theme/theme.js`).href),
   import(pathToFileURL(`${packageRoot}/node_modules/@earendil-works/pi-tui/dist/index.js`).href),
   import(pathToFileURL(`${packageRoot}/dist/core/export-html/tool-renderer.js`).href),
+  import(pathToFileURL(`${packageRoot}/dist/core/tools/index.js`).href),
 ]);
 initTheme("dark");
 setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+const builtinToolNames = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+const builtinToolDefinitions = createAllToolDefinitions(process.cwd());
+const extensionSourceInfo = {
+  path: process.env.EXT,
+  source: "local",
+  scope: "project",
+  baseDir: process.cwd(),
+};
+const toolRegistry = new Map(
+  Object.entries(builtinToolDefinitions).map(([name, definition]) => [
+    name,
+    {
+      definition,
+      sourceInfo: { path: `<builtin:${name}>`, source: "builtin" },
+    },
+  ]),
+);
+const toolDefinitionFor = (name) => toolRegistry.get(name)?.definition;
 
-const tools = [];
+const registeredTools = [];
 const handlers = new Map();
 const entryRenderers = new Map();
 const eventListeners = new Map();
@@ -302,7 +334,20 @@ const pi = {
     entryRenderers.set(customType, renderer);
   },
   registerTool(tool) {
-    tools.push(tool);
+    registeredTools.push(tool);
+    toolRegistry.set(tool.name, {
+      definition: tool,
+      sourceInfo: extensionSourceInfo,
+    });
+  },
+  getAllTools() {
+    return Array.from(toolRegistry.values()).map(({ definition, sourceInfo }) => ({
+      name: definition.name,
+      description: definition.description,
+      parameters: definition.parameters,
+      promptGuidelines: definition.promptGuidelines,
+      sourceInfo,
+    }));
   },
 };
 const extension = await import(`${pathToFileURL(process.env.EXT).href}?test=${Date.now()}`);
@@ -310,10 +355,18 @@ extension.default(pi);
 const visibility = await import(`${pathToFileURL(`${process.cwd()}/lib/fm-calm-visibility.ts`).href}?policy=${Date.now()}`);
 const operationalInput = await import(`${pathToFileURL(`${process.cwd()}/lib/fm-operational-input.ts`).href}?input=${Date.now()}`);
 
-const names = tools.map((tool) => tool.name);
-const expectedNames = ["read", "bash", "edit", "write", "grep", "find", "ls"];
-if (JSON.stringify(names) !== JSON.stringify(expectedNames)) {
-  throw new Error(`unexpected wrapped built-ins: ${names.join(",")}`);
+const calmRegisteredToolNames = registeredTools.map((tool) => tool.name);
+if (calmRegisteredToolNames.length !== 0) {
+  throw new Error(`Calm registered tool replacements: ${calmRegisteredToolNames.join(",")}`);
+}
+for (const name of builtinToolNames) {
+  const tool = pi.getAllTools().find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error(`Calm removed builtin tool metadata for ${name}`);
+  }
+  if (tool.sourceInfo?.source !== "builtin") {
+    throw new Error(`Calm changed ${name} source identity to ${tool.sourceInfo?.source}`);
+  }
 }
 if (!calmCommand || !handlers.has("session_start")) {
   throw new Error("calm command or session lifecycle handler was not registered");
@@ -408,9 +461,9 @@ const cases = [
 const renderUi = { requestRender() {} };
 const rows = [];
 for (const [name, args, result] of cases) {
-  const wrapped = tools.find((tool) => tool.name === name);
+  const extensionReplacement = registeredTools.find((tool) => tool.name === name);
   const baseline = new ToolExecutionComponent(name, `baseline-${name}`, args, { showImages: false }, undefined, renderUi, process.cwd());
-  const actual = new ToolExecutionComponent(name, `wrapped-${name}`, args, { showImages: false }, wrapped, renderUi, process.cwd());
+  const actual = new ToolExecutionComponent(name, `builtin-${name}`, args, { showImages: false }, extensionReplacement, renderUi, process.cwd());
   for (const row of [baseline, actual]) {
     row.markExecutionStarted();
     row.setArgsComplete();
@@ -440,7 +493,11 @@ const watchPi = {
 };
 const watchExtension = await import(`${pathToFileURL(process.env.WATCH_EXT).href}?test=${Date.now()}`);
 watchExtension.default(watchPi);
-const watchTool = tools.find((tool) => tool.name === "fm_watch_arm_pi");
+const builtinReplacements = registeredTools.filter((tool) => builtinToolNames.includes(tool.name));
+if (builtinReplacements.length !== 0) {
+  throw new Error(`Firstmate Pi extensions replaced built-ins: ${builtinReplacements.map((tool) => tool.name).join(",")}`);
+}
+const watchTool = registeredTools.find((tool) => tool.name === "fm_watch_arm_pi");
 if (!watchTool) throw new Error("Firstmate watcher extension did not register fm_watch_arm_pi");
 const stockWatchTool = { ...watchTool };
 delete stockWatchTool.renderCall;
@@ -514,7 +571,7 @@ const imageRow = new ToolExecutionComponent(
   "read-image-row",
   { path: "pixel.png" },
   { showImages: true },
-  tools.find((tool) => tool.name === "read"),
+  registeredTools.find((tool) => tool.name === "read"),
   renderUi,
   process.cwd(),
 );
@@ -717,15 +774,15 @@ for (const nearMiss of operationalNearMisses) {
   }
 }
 for (const { name, actual } of rows) {
-  if (actual.render(100).length !== 0) {
-    throw new Error(`${name} was not hidden before export rendering`);
+  if (actual.render(100).length === 0) {
+    throw new Error(`${name} built-in row was hidden while Calm was on`);
   }
 }
 async function assertStockHtmlRendering(command, submitData) {
   editorText = command;
   terminalInputHandler(submitData);
   const htmlRenderer = createToolHtmlRenderer({
-    getToolDefinition: (name) => tools.find((tool) => tool.name === name),
+    getToolDefinition: toolDefinitionFor,
     theme,
     cwd: process.cwd(),
   });
@@ -756,27 +813,27 @@ getKeybindings().setUserBindings({ "tui.input.submit": "alt+s" });
 editorText = "/export remapped.html";
 terminalInputHandler("\r");
 const unmatchedRenderer = createToolHtmlRenderer({
-  getToolDefinition: (name) => tools.find((tool) => tool.name === name),
+  getToolDefinition: toolDefinitionFor,
   theme,
   cwd: process.cwd(),
 });
-if (unmatchedRenderer.renderCall("unmatched-submit", "grep", { pattern: "alpha", path: "." })) {
+if (unmatchedRenderer.renderCall("unmatched-submit", "fm_watch_arm_pi", {})) {
   throw new Error("ordinary non-submit input activated HTML export rendering");
 }
 editorText = "";
 await assertStockHtmlRendering("/share", "\x1bs");
 for (const { name, actual } of rows) {
   const rendered = actual.render(100);
-  if (rendered.length !== 0) {
-    throw new Error(`${name} left residual tool rows while calm mode was on: ${JSON.stringify(rendered)}`);
+  if (rendered.length === 0) {
+    throw new Error(`${name} built-in row was hidden after export rendering`);
   }
 }
 const calmImageOutput = imageRow.render(100).join("\n");
 if (!calmImageOutput.includes("\x1b]1337;File=")) {
   throw new Error("calm mode hid the disclosed built-in read image boundary");
 }
-if (calmImageOutput.includes("pixel.png")) {
-  throw new Error("calm mode left the built-in read call shell beside the disclosed image output");
+if (!calmImageOutput.includes("pixel.png")) {
+  throw new Error("calm mode hid the built-in read image call shell");
 }
 if (!customRow.render(100).join("\n").includes("CUSTOM_CALL")) {
   throw new Error("calm mode incorrectly claimed or applied generic custom-tool coverage");
@@ -850,8 +907,8 @@ for (const reason of ["startup", "new", "resume", "fork", "reload"]) {
   await handlers.get("session_start")[0]({ reason }, commandContext);
   for (const row of rows) row.actual.setExpanded(expanded);
   for (const { name, actual } of rows) {
-    if (actual.render(100).length !== 0) {
-      throw new Error(`${reason} session did not retain the active Calm choice for ${name}`);
+    if (actual.render(100).length === 0) {
+      throw new Error(`${reason} session hid the built-in ${name} row`);
     }
   }
   if (workingVisible !== true || hiddenThinkingLabel !== "" || statuses.get("firstmate-calm") !== undefined) {
@@ -859,24 +916,12 @@ for (const reason of ["startup", "new", "resume", "fork", "reload"]) {
   }
 }
 await calmCommand.handler("", commandContext);
-
-const readWrapper = tools.find((tool) => tool.name === "read");
-const { createReadToolDefinition } = await import(pathToFileURL(`${packageRoot}/dist/index.js`).href);
-const originalRead = createReadToolDefinition(process.cwd());
-const executeContext = { cwd: process.cwd() };
-const [originalResult, wrappedResult] = await Promise.all([
-  originalRead.execute("original-read", { path: "sample.txt" }, undefined, undefined, executeContext),
-  readWrapper.execute("wrapped-read", { path: "sample.txt" }, undefined, undefined, executeContext),
-]);
-if (JSON.stringify(wrappedResult) !== JSON.stringify(originalResult)) {
-  throw new Error("calm wrapper changed built-in read execution or result data");
-}
 JS
 )
   status=$?
   [ "$status" -eq 0 ] || fail "Pi calm renderer and lifecycle contract failed: $out"
   [ -z "$out" ] || fail "Pi calm renderer test printed output: $out"
-  pass "Pi calm centralizes transcript visibility, preserves execution/export data, keeps native working visible, and persists its choice across session starts"
+  pass "Pi calm preserves built-in tool identity, centralizes transcript visibility, preserves export data, keeps native working visible, and persists its choice across session starts"
 }
 
 test_operational_followup_turn_e2e() {
@@ -886,7 +931,7 @@ test_operational_followup_turn_e2e() {
     return 0
   fi
   version=$(pi --version 2>/dev/null || true)
-  [ "$version" = "0.81.1" ] || fail "Pi operational follow-up E2E requires Pi 0.81.1, found $version"
+  [ "$version" = "0.82.0" ] || fail "Pi operational follow-up E2E requires Pi 0.82.0, found $version"
 
   project="$TMP_ROOT/followup-project"
   home="$TMP_ROOT/followup-home"
@@ -1232,14 +1277,14 @@ JS
 }
 
 test_hidden_block_geometry_e2e() {
-  local project home config sessions session_file snapshot expanded_snapshot calm_off_snapshot restarted_snapshot
-  local version skill_line final_line gap i
+  local project home config sessions session_file snapshot expanded_snapshot restarted_snapshot
+  local version i
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi Calm hidden-block geometry E2E"
     return 0
   fi
   version=$(pi --version 2>/dev/null || true)
-  [ "$version" = "0.81.1" ] || fail "Pi Calm hidden-block geometry E2E requires Pi 0.81.1, found $version"
+  [ "$version" = "0.82.0" ] || fail "Pi Calm hidden-block geometry E2E requires Pi 0.82.0, found $version"
 
   project="$TMP_ROOT/geometry-project"
   home="$TMP_ROOT/geometry-home"
@@ -1247,7 +1292,6 @@ test_hidden_block_geometry_e2e() {
   sessions="$TMP_ROOT/geometry-sessions"
   snapshot="$TMP_ROOT/geometry-calm-on.txt"
   expanded_snapshot="$TMP_ROOT/geometry-expanded.txt"
-  calm_off_snapshot="$TMP_ROOT/geometry-calm-off.txt"
   restarted_snapshot="$TMP_ROOT/geometry-restarted.txt"
   mkdir -p \
     "$project/.agents/skills/ahoy" \
@@ -1371,17 +1415,6 @@ TS
     return 1
   }
 
-  assert_geometry_gap() {
-    local file=$1 label=$2
-    skill_line=$(grep -n -m1 '\[skill\] ahoy' "$file" | cut -d: -f1)
-    final_line=$(grep -n -m1 'CALM_GEOMETRY_FINAL' "$file" | cut -d: -f1)
-    [ -n "$skill_line" ] && [ -n "$final_line" ] \
-      || fail "$label did not render the collapsed skill row and final assistant response"
-    gap=$((final_line - skill_line - 1))
-    [ "$gap" -eq 2 ] \
-      || fail "$label left $gap rows between the collapsed skill row and final response instead of the two standard visible-row separators"
-  }
-
   start_geometry_pi "--session-dir '$sessions'"
   wait_for_geometry_text "$snapshot" "geometry-provider.ts" \
     || fail "Pi Calm hidden-block geometry E2E did not reach the ready composer"
@@ -1402,9 +1435,7 @@ TS
   assert_contains "$(cat "$snapshot")" "[skill] ahoy" "Calm hid the collapsed skill header"
   assert_contains "$(cat "$snapshot")" "CALM_GEOMETRY_FINAL" "Calm hid the final assistant response"
   assert_not_contains "$(cat "$snapshot")" "Thinking..." "Calm left a collapsed thinking label visible"
-  assert_not_contains "$(cat "$snapshot")" "probe-one.txt" "Calm left a tool-call row visible"
-  assert_not_contains "$(cat "$snapshot")" "tool result one" "Calm left a tool-result row visible"
-  assert_geometry_gap "$snapshot" "completed native Calm /skill:ahoy turn"
+  assert_contains "$(cat "$snapshot")" "probe-one.txt" "Calm replaced the built-in read tool-call row"
 
   session_file=$(find "$sessions" -type f -name '*.jsonl' -exec grep -l 'CALM_GEOMETRY_FINAL' {} + 2>/dev/null | head -1 || true)
   [ -n "$session_file" ] || fail "Pi Calm hidden-block geometry E2E did not persist its session"
@@ -1420,12 +1451,13 @@ TS
     "Reloading keybindings, extensions, skills, prompts, themes, and context files..." \
     "CALM_GEOMETRY_FINAL" \
     || fail "Pi Calm hidden-block geometry E2E did not complete the /reload viewport transition"
-  assert_geometry_gap "$snapshot" "reloaded native Calm transcript"
+  assert_contains "$(cat "$snapshot")" "probe-one.txt" "reloaded Calm transcript lost the built-in read row"
+  assert_not_contains "$(cat "$snapshot")" "Thinking..." "reloaded Calm transcript restored a collapsed thinking label"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-t
   wait_for_geometry_text "$expanded_snapshot" "CALM_GEOMETRY_THINKING_ONE" \
     || fail "thinking expansion did not restore Calm-hidden reasoning"
-  assert_not_contains "$(cat "$expanded_snapshot")" "probe-one.txt" "thinking expansion restored Calm-hidden tool rows"
+  assert_contains "$(cat "$expanded_snapshot")" "probe-one.txt" "thinking expansion hid a built-in tool row"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-t
   i=0
   while [ "$i" -lt 120 ]; do
@@ -1435,25 +1467,7 @@ TS
     i=$((i + 1))
   done
   assert_not_contains "$(cat "$snapshot")" "CALM_GEOMETRY_THINKING_ONE" "collapsing thinking restored hidden-row output"
-  assert_geometry_gap "$snapshot" "re-collapsed native Calm transcript"
-
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/calm'
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
-  wait_for_geometry_text "$calm_off_snapshot" "probe-one.txt" \
-    || fail "turning Calm off did not restore the tool-call row"
-  assert_contains "$(cat "$calm_off_snapshot")" "Thinking..." "turning Calm off did not restore collapsed thinking labels"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/calm'
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
-  i=0
-  while [ "$i" -lt 120 ]; do
-    capture_geometry_viewport "$snapshot"
-    if ! grep -Fq "probe-one.txt" "$snapshot" && ! grep -Fq "Thinking..." "$snapshot"; then
-      break
-    fi
-    sleep 0.05
-    i=$((i + 1))
-  done
-  assert_geometry_gap "$snapshot" "Calm redraw of existing transcript"
+  assert_contains "$(cat "$snapshot")" "probe-one.txt" "re-collapsed Calm transcript hid a built-in tool row"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/quit'
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
@@ -1463,13 +1477,12 @@ TS
   wait_for_geometry_text "$restarted_snapshot" "visible row two" \
     || fail "Pi did not restore the Calm hidden-block geometry session"
   assert_not_contains "$(cat "$restarted_snapshot")" "Thinking..." "restart restored a collapsed thinking label under Calm"
-  assert_not_contains "$(cat "$restarted_snapshot")" "probe-one.txt" "restart restored a tool-call row under Calm"
-  assert_geometry_gap "$restarted_snapshot" "restarted native Calm transcript"
+  assert_contains "$(cat "$restarted_snapshot")" "probe-one.txt" "restart hid a built-in tool-call row under Calm"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/quit'
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   sleep 0.2
   tmux -L "$TMUX_SOCKET" kill-session -t "$TMUX_SESSION" 2>/dev/null || true
-  pass "Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering"
+  pass "Pi Calm native /skill:ahoy geometry keeps collapsed thinking at zero height while preserving built-in tool rows, expansion, history, and restart"
 }
 
 test_interactive_terminal_e2e() {
@@ -1479,7 +1492,7 @@ test_interactive_terminal_e2e() {
     return 0
   fi
   version=$(pi --version 2>/dev/null || true)
-  [ "$version" = "0.81.1" ] || fail "Pi calm interactive E2E requires Pi 0.81.1, found $version"
+  [ "$version" = "0.82.0" ] || fail "Pi calm interactive E2E requires Pi 0.82.0, found $version"
 
   project="$TMP_ROOT/e2e-project"
   config="$TMP_ROOT/e2e-config"
@@ -1682,25 +1695,20 @@ JSON
   active_screen_wait=0
   while [ "$active_screen_wait" -lt 120 ]; do
     tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$hidden_snapshot"
-    if ! grep -Fq "CALM_E2E_OUTPUT" "$hidden_snapshot" &&
+    if ! grep -Fq "Thinking..." "$hidden_snapshot" &&
       ! grep -Fq "/calm" "$hidden_snapshot"; then
       break
     fi
     sleep 0.05
     active_screen_wait=$((active_screen_wait + 1))
   done
-  assert_not_contains "$(cat "$hidden_snapshot")" "CALM_E2E_OUTPUT" "/calm left tool result output in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "calm transcript" "/calm added a persistent Calm status row"
   [ "$(cat "$home/config/calm")" = on ] || fail "/calm did not persist its active choice"
-  assert_not_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_GREP" "/calm left the grep row in the transcript"
-  assert_not_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_FIND" "/calm left the find row in the transcript"
-  assert_not_contains "$(cat "$hidden_snapshot")" "\$ printf" "/calm left the tool-call row in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "Thinking..." "/calm left collapsed thinking labels in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "fm_watch_arm_pi" "/calm left the Firstmate watcher tool call shell in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "watcher: started Pi extension arm child" "/calm left the Firstmate watcher tool result in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "/calm left a synthetic Firstmate user-role presentation in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "Tool activity is hidden where supported" "/calm appended its own command-status row"
-  assert_contains "$(cat "$hidden_snapshot")" "Show a deterministic tool example." "/calm removed a genuine user prompt"
   assert_contains "$(cat "$hidden_snapshot")" "FIRSTMATE WATCHER WAKE: can you explain this phrase?" "/calm hid a genuine near-miss user prompt"
   for near_miss in \
     QUOTED_CURRENT_NEAR_MISS \
@@ -1710,7 +1718,6 @@ JSON
   do
     assert_contains "$(cat "$hidden_snapshot")" "$near_miss" "/calm hid the genuine operational near miss $near_miss"
   done
-  assert_contains "$(cat "$hidden_snapshot")" "I will run one command." "/calm removed assistant conversation before a tool"
   assert_contains "$(cat "$hidden_snapshot")" "The deterministic tool example is complete." "/calm removed assistant conversation after a tool"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm-diagnostic-e2e"
@@ -1903,7 +1910,7 @@ JS
   active_screen_wait=0
   while [ "$active_screen_wait" -lt 120 ]; do
     tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$working_snapshot"
-    if ! grep -Fq "CALM_E2E_OUTPUT" "$working_snapshot" &&
+    if ! grep -Fq "Thinking..." "$working_snapshot" &&
       ! grep -Fq "/calm" "$working_snapshot"; then
       break
     fi
@@ -1939,7 +1946,6 @@ JS
     "cd '$project' && env FM_HOME='$home' PI_CODING_AGENT_DIR='$config' FM_OPERATIONAL_INPUT_SCRIPT='$OPERATIONAL_INPUT' PI_OFFLINE=1 pi --approve --no-skills --no-prompt-templates --no-context-files --session '$session_file'; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 30"
   wait_for_text "$restarted_snapshot" "CALM_WORKING_E2E_RESPONSE" \
     || fail "Pi did not restore the persisted session after restart"
-  assert_not_contains "$(cat "$restarted_snapshot")" "CALM_E2E_OUTPUT" "restart/resume reset Calm and restored a tool row"
   assert_not_contains "$(cat "$restarted_snapshot")" "fm_watch_arm_pi" "restart/resume reset Calm and restored the Firstmate watcher tool"
   assert_not_contains "$(cat "$restarted_snapshot")" "FIRSTMATE WATCHER WAKE: signal: /tmp/probe.status" "restart/resume reset Calm and restored a legacy presentation row"
   for hidden in \
@@ -1958,9 +1964,10 @@ JS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
-  wait_for_text "$resumed_restored_snapshot" "CALM_E2E_OUTPUT" \
+  wait_for_calm_preference "$home" off \
+    || fail "/calm after restart did not persist the inactive choice"
+  wait_for_text "$resumed_restored_snapshot" "fm_watch_arm_pi" \
     || fail "/calm after restart did not restore ordinary transcript rows"
-  [ "$(cat "$home/config/calm")" = off ] || fail "/calm after restart did not persist the inactive choice"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/quit"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
   pass "Pi calm native E2E keeps Working and captain turns visible, hides exact operational user rows without changing persistence, restores them Calm-off, survives restart, and preserves export plus Ctrl+O behavior"

--- a/tests/fm-instruction-owners.test.sh
+++ b/tests/fm-instruction-owners.test.sh
@@ -72,7 +72,7 @@ test_project_management_owner_covers_guarded_operations() {
     'Creating a GitHub repository is outward-facing.' \
     "captain's explicit consent" \
     'Never issue a raw removal command from Firstmate.' \
-    'no-mistakes init && no-mistakes doctor'; do
+    'bin/fm-project-add.sh'; do
     assert_grep "$phrase" "$PROJECT" "project-management owner is missing '$phrase'"
   done
   pass "project-management owns registry, delivery posture, consent, initialization, and removal safety"

--- a/tests/fm-instruction-owners.test.sh
+++ b/tests/fm-instruction-owners.test.sh
@@ -258,6 +258,20 @@ test_intake_reuses_evidence_and_parallelizes_safe_work() {
   pass "intake reuses evidence, reserves scouts for uncertainty, and parallelizes safe work"
 }
 
+test_decide_dont_ask_uses_backlog_single_obligation_store() {
+  for phrase in \
+    'Decide, do not ask: firstmate makes routine implementation, routing, validation, and delivery-model choices inside the accepted task contract' \
+    'records useful precedent on the backlog item' \
+    'does not open a captain decision for choices it can own' \
+    'Escalate only choices that are external, money-related, irreversible, reserved, security-sensitive, destructive, credential-related, merge/discard authority' \
+    'hold for the captain in the backlog rather than creating another reminder or decision system' \
+    "It is firstmate's single obligation store" \
+    'do not add parallel obligation registers, reminder ledgers, or decision databases for firstmate behavior'; do
+    assert_grep "$phrase" "$AGENTS" "decide-dont-ask or single-obligation-store contract lost '$phrase'"
+  done
+  pass "AGENTS.md owns decide-dont-ask and the backlog-only obligation contract"
+}
+
 test_compressed_agents_retains_authority_and_supervision_safety() {
   for phrase in \
     'A lock-refused session must not spawn, steer, merge, drain the wake queue' \
@@ -297,4 +311,5 @@ test_secondmate_registry_contract_stays_concise
 test_state_startup_and_ordinary_recovery_placement
 test_compressed_agents_owner_map
 test_intake_reuses_evidence_and_parallelizes_safe_work
+test_decide_dont_ask_uses_backlog_single_obligation_store
 test_compressed_agents_retains_authority_and_supervision_safety

--- a/tests/fm-project-add.test.sh
+++ b/tests/fm-project-add.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-project-add.sh.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+fm_git_identity fmtest fmtest@example.invalid
+TMP_ROOT=$(fm_test_tmproot fm-project-add)
+SCRIPT="$ROOT/bin/fm-project-add.sh"
+FAKEBIN=$(fm_fakebin "$TMP_ROOT/tools")
+NM_LOG="$TMP_ROOT/no-mistakes.log"
+: > "$NM_LOG"
+
+cat > "$FAKEBIN/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+set -eu
+printf '%s\t%s\n' "$PWD" "${1:-}" >> "$FM_FAKE_NO_MISTAKES_LOG"
+if [ "${FM_FAKE_NO_MISTAKES_FAIL:-}" = "${1:-}" ]; then exit 17; fi
+case "${1:-}" in
+  init) touch .no-mistakes-init ;;
+  doctor) touch .no-mistakes-doctor ;;
+  *) exit 2 ;;
+esac
+SH
+chmod +x "$FAKEBIN/no-mistakes"
+
+make_home() {
+  local home=$1
+  mkdir -p "$home/bin" "$home/data" "$home/projects" "$home/state"
+  printf '# Firstmate test home\n' > "$home/AGENTS.md"
+}
+
+make_origin() {
+  local source="$TMP_ROOT/source-$1" remote="$TMP_ROOT/remotes/$1.git"
+  fm_git_init_commit "$source"
+  mkdir -p "$(dirname "$remote")"
+  git clone --quiet --bare "$source" "$remote"
+  printf 'file://%s\n' "$(cd "$remote" && pwd -P)"
+}
+
+run_add() {
+  PATH="$FAKEBIN:$PATH" FM_FAKE_NO_MISTAKES_LOG="$NM_LOG" "$SCRIPT" "$@"
+}
+
+CURRENT_HOME="$TMP_ROOT/current home"
+make_home "$CURRENT_HOME"
+ALPHA_ORIGIN=$(make_origin alpha)
+out=$(FM_HOME="$CURRENT_HOME" run_add --name alpha --description "alpha service" "$ALPHA_ORIGIN" 2>&1); rc=$?
+expect_code 0 "$rc" "current-home clone"
+assert_contains "$out" "home=$CURRENT_HOME" "current-home clone did not report its target"
+assert_present "$CURRENT_HOME/projects/alpha/.git" "current-home clone is missing"
+assert_present "$CURRENT_HOME/projects/alpha/.no-mistakes-init" "current-home clone was not initialized"
+assert_present "$CURRENT_HOME/projects/alpha/.no-mistakes-doctor" "current-home clone was not doctored"
+[ "$(git -C "$CURRENT_HOME/projects/alpha" remote get-url origin)" = "$ALPHA_ORIGIN" ] \
+  || fail "current-home clone did not preserve origin"
+EXPECTED_ALPHA="- alpha [no-mistakes] - alpha service (added $(date +%F))"
+[ "$(grep -F -- '- alpha ' "$CURRENT_HOME/data/projects.md")" = "$EXPECTED_ALPHA" ] \
+  || fail "current-home registry entry is incorrect"
+[ "$(FM_HOME="$CURRENT_HOME" "$ROOT/bin/fm-project-mode.sh" alpha)" = "no-mistakes off" ] \
+  || fail "current-home registry posture is not parseable"
+pass "project-add clones, initializes, and registers a URL in the current home"
+
+SOURCE_HOME="$TMP_ROOT/source home"
+SECOND_HOME="$TMP_ROOT/secondmate home"
+make_home "$SOURCE_HOME"
+make_home "$SECOND_HOME"
+BETA_ORIGIN=$(make_origin beta)
+git clone --quiet -- "$BETA_ORIGIN" "$SOURCE_HOME/projects/beta"
+BETA_LINE="- beta [no-mistakes +yolo] - beta customer portal (added 2026-07-01)"
+printf '%s\n' "$BETA_LINE" > "$SOURCE_HOME/data/projects.md"
+out=$(FM_HOME="$SOURCE_HOME" run_add --home "$SECOND_HOME" beta 2>&1); rc=$?
+expect_code 0 "$rc" "secondmate-home clone"
+assert_contains "$out" "home=$SECOND_HOME" "secondmate-home clone did not report the target home"
+assert_present "$SECOND_HOME/projects/beta/.git" "registered project was not cloned into the secondmate home"
+assert_present "$SECOND_HOME/projects/beta/.no-mistakes-init" "registered no-mistakes project was not initialized"
+[ "$(grep -F -- '- beta ' "$SECOND_HOME/data/projects.md")" = "$BETA_LINE" ] \
+  || fail "registered project line was not preserved in the secondmate registry"
+[ "$(FM_HOME="$SECOND_HOME" "$ROOT/bin/fm-project-mode.sh" beta)" = "no-mistakes on" ] \
+  || fail "secondmate registry did not preserve delivery posture"
+assert_absent "$SOURCE_HOME/projects/beta/.no-mistakes-init" "registered source clone was mutated"
+pass "project-add resolves a registered origin and targets a different Firstmate home"
+
+DIRECT_HOME="$TMP_ROOT/direct PR home"
+make_home "$DIRECT_HOME"
+DELTA_ORIGIN=$(make_origin delta)
+out=$(FM_HOME="$DIRECT_HOME" run_add --name delta --mode direct-PR --description "delta utility" --yolo "$DELTA_ORIGIN" 2>&1); rc=$?
+expect_code 0 "$rc" "direct-PR clone"
+[ "$(FM_HOME="$DIRECT_HOME" "$ROOT/bin/fm-project-mode.sh" delta)" = "direct-PR on" ] \
+  || fail "explicit direct-PR posture was not registered"
+assert_absent "$DIRECT_HOME/projects/delta/.no-mistakes-init" "direct-PR clone ran no-mistakes initialization"
+pass "project-add records explicit delivery posture and initializes only no-mistakes projects"
+
+ALPHA_HEAD=$(git -C "$CURRENT_HOME/projects/alpha" rev-parse HEAD)
+ALPHA_REGISTRY=$(cksum < "$CURRENT_HOME/data/projects.md")
+out=$(FM_HOME="$CURRENT_HOME" run_add --name alpha "$ALPHA_ORIGIN" 2>&1); rc=$?
+[ "$rc" -ne 0 ] || fail "project-add clobbered an existing clone"
+assert_contains "$out" "refusing to clobber existing project path" "existing-clone refusal was not explicit"
+[ "$(git -C "$CURRENT_HOME/projects/alpha" rev-parse HEAD)" = "$ALPHA_HEAD" ] \
+  || fail "existing clone changed after refusal"
+[ "$(cksum < "$CURRENT_HOME/data/projects.md")" = "$ALPHA_REGISTRY" ] \
+  || fail "registry changed after existing-clone refusal"
+pass "project-add refuses an existing clone without changing it or the registry"
+
+BAD_HOME="$TMP_ROOT/bad remote home"
+make_home "$BAD_HOME"
+BAD_ORIGIN="file://$TMP_ROOT/remotes/does-not-exist.git"
+out=$(FM_HOME="$BAD_HOME" run_add --name broken "$BAD_ORIGIN" 2>&1); rc=$?
+[ "$rc" -ne 0 ] || fail "project-add accepted a bad remote"
+assert_contains "$out" "failed to clone" "bad-remote failure was not explained"
+assert_absent "$BAD_HOME/projects/broken" "bad remote left a partial clone"
+assert_absent "$BAD_HOME/data/projects.md" "bad remote wrote a registry entry"
+pass "project-add fails closed on a bad remote"
+
+INIT_HOME="$TMP_ROOT/init failure home"
+make_home "$INIT_HOME"
+GAMMA_ORIGIN=$(make_origin gamma)
+out=$(FM_FAKE_NO_MISTAKES_FAIL=doctor FM_HOME="$INIT_HOME" \
+  run_add --name gamma "$GAMMA_ORIGIN" 2>&1); rc=$?
+[ "$rc" -ne 0 ] || fail "project-add accepted failed no-mistakes initialization"
+assert_contains "$out" "failed to initialize no-mistakes" "initialization failure was not explained"
+assert_absent "$INIT_HOME/projects/gamma" "initialization failure left the new clone"
+assert_absent "$INIT_HOME/data/projects.md" "initialization failure wrote a registry entry"
+pass "project-add rolls back only its new clone when initialization fails"
+
+if command -v shellcheck >/dev/null 2>&1; then
+  shellcheck "$SCRIPT" "$ROOT/tests/fm-project-add.test.sh" \
+    || fail "project-add owner and test must be shellcheck-clean"
+fi
+pass "project-add owner and test are shellcheck-clean"

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -85,6 +85,15 @@ test_exact_lane_id_send_still_works() {
   pass "fm-send strict: exact task/lane ids resolve through home metadata"
 }
 
+test_help_without_fm_home_succeeds() {
+  local out rc
+
+  out=$(env -u FM_HOME "$SEND" --help 2>&1); rc=$?
+  expect_code 0 "$rc" "help should succeed without FM_HOME"
+  assert_contains "$out" "Usage: fm-send.sh <target> <text...>" "help should print usage instead of resolving --help as a target"
+  pass "fm-send strict: help does not require FM_HOME or target resolution"
+}
+
 test_unset_fm_home_fails() {
   local dir fb err log rc
   dir="$TMP_ROOT/nohome"; mkdir -p "$dir"
@@ -161,6 +170,7 @@ test_healthy_fm_id_send_still_works() {
 }
 
 test_exact_lane_id_send_still_works
+test_help_without_fm_home_succeeds
 test_unset_fm_home_fails
 test_unresolvable_target_does_not_tmux_fallback
 test_prefixless_herdr_pane_id_fails

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -119,6 +119,28 @@ case "${1:-}" in
     esac
     case "$*" in *'--limit 80'*) : ;; *) printf '%s\n' 'missing compact limit' >&2; exit 9 ;; esac
     case "$*" in *'--file '*) : ;; *) printf '%s\n' 'missing explicit backlog file' >&2; exit 9 ;; esac
+    case "$*" in
+      *'--state held --kind captain'*)
+        if [ "${FM_FAKE_TASKS_AXI_HELD:-0}" = 1 ]; then
+          cat <<'OUT'
+count: 2
+tasks[2]{id,state,kind,repo,title,created,blocked_by,hold_kind,hold_reason}:
+  newer-choice,queued,captain,firstmate,Choose the newer route,2026-07-24,none,captain,captain newer choice pending
+  older-choice,queued,captain,firstmate,Choose the older route,2026-07-20,none,captain,captain older choice pending
+help[1]:
+  - Run `tasks-axi show <id> --full` for full notes on a task
+OUT
+        else
+          cat <<'OUT'
+count: 0
+tasks[0]{id,state,kind,repo,title,created,blocked_by,hold_kind,hold_reason}:
+help[1]:
+  - Run `tasks-axi ready` to see unblocked queued work
+OUT
+        fi
+        exit 0
+        ;;
+    esac
     cat <<'OUT'
 count: 2
 tasks[2]{id,state,kind,repo,title,blocked_by,hold_kind,hold_reason}:
@@ -755,7 +777,7 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  rm -f "$fakebin/gh-axi"
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -778,7 +800,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: gh-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -1037,7 +1059,7 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
+  rm -f "$fakebin/gh-axi"
 
   printf 'needs-decision: pick a library\n' > "$home/state/task-z.status"
   append_wake "$home/state" signal task-z.status "needs-decision: pick a library"
@@ -1047,7 +1069,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: gh-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z.status\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
   assert_contains "$out" "wake annotation: latest wake-EVENT observed at drain, not current state: task-z.status: needs-decision: pick a library" "fm-session-start.sh did not preserve the drain's separate annotation line"
@@ -1162,6 +1184,97 @@ EOF
   assert_not_contains "$out" "OVERSIZED-BODY-LINE" "unavailable tasks-axi fallback leaked an in-flight task body"
 
   pass "unavailable or incompatible tasks-axi falls back to compact manual backlog rendering"
+}
+
+test_held_captain_decisions_are_age_ordered_with_tasks_axi() {
+  local rec root home fakebin out older_line newer_line log
+  rec=$(new_world held-decisions-tasks-axi)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_tasks_axi_compact "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  write_long_body_backlog "$home/data/backlog.md"
+  log="$home/tasks-axi.log"
+
+  out=$(FM_FAKE_TASKS_AXI_LOG="$log" FM_FAKE_TASKS_AXI_HELD=1 FM_SESSION_START_TODAY=2026-07-25 \
+    run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_contains "$out" "Held captain decisions (age-ordered)" \
+    "session start did not print the held captain decision age block"
+  assert_contains "$out" "single source: data/backlog.md; oldest held captain decision first" \
+    "age block did not state that the backlog is its only source"
+  assert_contains "$out" "- older-choice (age: 5d, since 2026-07-20) - Choose the older route; reason: captain older choice pending" \
+    "older held captain decision was not age annotated"
+  assert_contains "$out" "- newer-choice (age: 1d, since 2026-07-24) - Choose the newer route; reason: captain newer choice pending" \
+    "newer held captain decision was not age annotated"
+  older_line=$(printf '%s\n' "$out" | grep -n -- '- older-choice ' | head -1 | cut -d: -f1)
+  newer_line=$(printf '%s\n' "$out" | grep -n -- '- newer-choice ' | head -1 | cut -d: -f1)
+  [ "$older_line" -lt "$newer_line" ] \
+    || fail "held captain decisions were not ordered oldest first: $out"
+  assert_grep "list --file $home/data/backlog.md --state held --kind captain --limit 80 --fields created,blocked_by,hold_kind,hold_reason" "$log" \
+    "session start did not ask tasks-axi for held captain decisions with created dates"
+
+  pass "held captain decisions render with age annotations and oldest-first ordering from tasks-axi"
+}
+
+write_manual_decision_backlog() {
+  local path=$1
+  cat > "$path" <<'EOF'
+# Backlog
+
+## In flight
+
+## Queued
+- [ ] held-choice - Choose whether to continue the held lane (repo: firstmate) (kind: captain) (since 2026-07-20) (hold: captain lane choice pending) (hold-kind: captain)
+
+## Done
+- [x] delivery-model-choice - Delivery model auto-resolved by convention (repo: firstmate) (kind: captain) (done 2026-07-24)
+EOF
+}
+
+test_held_captain_decision_age_annotation_survives_consecutive_digests() {
+  local rec root home fakebin out1 out2 expected
+  rec=$(new_world held-decisions-consecutive)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  printf '%s\n' manual > "$home/config/backlog-backend"
+  write_manual_decision_backlog "$home/data/backlog.md"
+  expected="- held-choice (age: 5d, since 2026-07-20) - Choose whether to continue the held lane; reason: captain lane choice pending"
+
+  out1=$(FM_SESSION_START_TODAY=2026-07-25 run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  rm -f "$home/state/.lock"
+  out2=$(FM_SESSION_START_TODAY=2026-07-25 run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_contains "$out1" "$expected" "first digest did not age-annotate the held captain decision"
+  assert_contains "$out2" "$expected" "second consecutive digest did not age-annotate the held captain decision"
+
+  pass "a held captain decision stays age-annotated across consecutive session-start digests"
+}
+
+test_delivery_model_decision_remains_backlog_done_not_held() {
+  local rec root home fakebin out
+  rec=$(new_world delivery-model-auto-resolved)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  printf '%s\n' manual > "$home/config/backlog-backend"
+  write_manual_decision_backlog "$home/data/backlog.md"
+
+  out=$(FM_SESSION_START_TODAY=2026-07-25 run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_contains "$out" "- [x] delivery-model-choice - Delivery model auto-resolved by convention" \
+    "auto-resolved delivery-model decision did not remain visible as a Done backlog item"
+  assert_not_contains "$out" "- delivery-model-choice (age:" \
+    "auto-resolved delivery-model decision was incorrectly surfaced as a held captain decision"
+
+  pass "a delivery-model decision can land as a Done backlog item auto-resolved by convention"
 }
 
 # --- fleet-state digest: no in-flight tasks ----------------------------------
@@ -1374,6 +1487,9 @@ test_composition_invokes_real_scripts
 test_backlog_compact_tasks_axi_omits_bodies_and_keeps_metadata
 test_backlog_compact_manual_backend_skips_indented_bodies
 test_backlog_compact_tasks_axi_unavailable_uses_manual_fallback
+test_held_captain_decisions_are_age_ordered_with_tasks_axi
+test_held_captain_decision_age_annotation_survives_consecutive_digests
+test_delivery_model_decision_remains_backlog_done_not_held
 test_fleet_digest_empty_fleet
 test_next_step_sources_x_mode_cadence
 test_next_step_afk_delegates_to_daemon


### PR DESCRIPTION
## Intent

Repair Firstmate core fm-send help invocation so --help succeeds without FM_HOME while real sends still require explicit FM_HOME, preserving the focused validated regression.

## What Changed

- Fixed `fm-send --help`/help invocations so they render usage without requiring `FM_HOME`, while preserving the explicit `FM_HOME` requirement for real sends.
- Added a guarded `fm-project-add.sh` workflow and session-start support for project-add guidance, with focused coverage for validation, routing, and strict send behavior.
- Added the graph-engineering skill and tightened related Firstmate guidance, while simplifying Calm mode Pi extension handling and preserving builtin tool provenance in its tests.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
