### PR TITLE
fix(bin): let a declared pause outrank a done or cancelled run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,7 @@ Require the matching `resolved` event, forbid `--yes`, and require the worker to
 Resume fleet supervision immediately after the decision lands.
 
 Judge validation by the current-code-matched run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
-Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed or cancelled is failed.
+Its header owns the exact run-step-to-state mapping, including when a declared `paused:` outranks a terminal run outcome; on a parked approval or fix-review state, require the worker to follow the active gate help.
 A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership; steer it back to the gate response flow.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.
 

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -34,7 +34,12 @@
 #      the active step is ci, `axi status` alone cannot tell "still waiting on
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
 #      a ci-step log-tail check overrides working -> done once checks read
-#      green, so a green PR is never silently read as still-validating.
+#      green, so a green PR is never silently read as still-validating. ALSO:
+#      when the attributed run is already TERMINAL (done/failed, including
+#      cancelled) and the status log's last verb is a declared paused:, emit
+#      paused with source status-log and keep the terminal run outcome as
+#      secondary detail - a historical record must not overrule a fresher
+#      self-declared wait. Active and parked runs still outrank a pause line.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
@@ -589,6 +594,19 @@ if [ "$HAVE_RUN" = 1 ]; then
         else
           RUN_DETAIL="$RUN_DETAIL${SEP}status-log superseded (run $RUN_STATE)"
         fi
+      fi
+      ;;
+  esac
+
+  # Declared pause outranks a TERMINAL (historical) run only. Active/parked
+  # runs still win: the crew is mid-validation, so a pause line is stale.
+  # Mirror the CI-green status-log override shape: emit from status-log and
+  # keep the prior run-step outcome as secondary detail so a supervisor still
+  # sees that the run cancelled/failed/completed.
+  case "$RUN_STATE" in
+    failed|done)
+      if status_is_paused "$LOG_LINE"; then
+        emit paused status-log "$(status_line_note "$LOG_LINE")${SEP}$RUN_DETAIL"
       fi
       ;;
   esac

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -35,11 +35,19 @@
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
 #      a ci-step log-tail check overrides working -> done once checks read
 #      green, so a green PR is never silently read as still-validating. ALSO:
-#      when the attributed run is already TERMINAL (done/failed, including
-#      cancelled) and the status log's last verb is a declared paused:, emit
-#      paused with source status-log and keep the terminal run outcome as
-#      secondary detail - a historical record must not overrule a fresher
-#      self-declared wait. Active and parked runs still outrank a pause line.
+#      when the run reached a TRUE terminal outcome of done or cancelled and the
+#      status log's last verb is a declared paused:, emit paused with source
+#      status-log and keep the terminal run outcome as the LEADING detail - a
+#      historical record must not overrule a self-declared wait. That override
+#      is keyed on the run's own terminal outcome, never on the mapped state, so
+#      the ci-green case above (mapped done while the run is still monitoring)
+#      stays an active run. Active and parked runs still outrank a pause line,
+#      and a terminal FAILED run always surfaces as failed: neither the status
+#      log's lines nor `axi status` carries a timestamp, so there is no way to
+#      prove the pause is fresher than the failure, and a pause appended before
+#      or during a run that then failed would otherwise mask real work failure.
+#      Cancelled is a supervisor abort rather than a work failure, so it stays
+#      overridable.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
@@ -488,6 +496,11 @@ fi
 if [ "$HAVE_RUN" = 1 ]; then
   RUN_STATE=working
   RUN_DETAIL=""
+  # The run's own TERMINAL outcome, independent of the mapped RUN_STATE:
+  # none (still active, whatever the mapping says), done, cancelled, or failed.
+  # Only the run's own reported outcome/status sets this, so a mapping override
+  # (ci-green -> done while the run keeps monitoring) never reads as terminal.
+  RUN_TERMINAL=none
   CI_STEP_STATUS=""
   CI_LOG_STATE=""
   RUN_STATUS=""
@@ -501,9 +514,9 @@ if [ "$HAVE_RUN" = 1 ]; then
     # coarse-vs-full distinction, so a real gate is never silently missed.
     case "$COARSE_STATUS" in
       running)   RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
-      completed) RUN_STATE="done";  RUN_DETAIL="run completed" ;;
-      failed)    RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
-      cancelled) RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
+      completed) RUN_STATE="done";  RUN_DETAIL="run completed"; RUN_TERMINAL="done" ;;
+      failed)    RUN_STATE=failed;  RUN_DETAIL="run failed"; RUN_TERMINAL=failed ;;
+      cancelled) RUN_STATE=failed;  RUN_DETAIL="run cancelled"; RUN_TERMINAL=cancelled ;;
       *)         RUN_STATE=unknown; RUN_DETAIL="runs list status: $COARSE_STATUS" ;;
     esac
   else
@@ -517,10 +530,10 @@ if [ "$HAVE_RUN" = 1 ]; then
 
     if [ -n "$outcome" ]; then
       case "$outcome" in
-        passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merged/closed" ;;
-        checks-passed) RUN_STATE="done"; RUN_DETAIL="checks green: PR ready for review" ;;
-        failed)        RUN_STATE=failed; RUN_DETAIL="run failed" ;;
-        cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled" ;;
+        passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merged/closed"; RUN_TERMINAL="done" ;;
+        checks-passed) RUN_STATE="done"; RUN_DETAIL="checks green: PR ready for review"; RUN_TERMINAL="done" ;;
+        failed)        RUN_STATE=failed; RUN_DETAIL="run failed"; RUN_TERMINAL=failed ;;
+        cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled"; RUN_TERMINAL=cancelled ;;
         *)             RUN_STATE=unknown; RUN_DETAIL="outcome: $outcome" ;;
       esac
     elif [ -n "$awaiting" ] || [ "$status" = awaiting_approval ] || [ "$status" = fix_review ] || [ -n "$gate_status" ] || [ "$has_gate" = 1 ]; then
@@ -542,9 +555,9 @@ if [ "$HAVE_RUN" = 1 ]; then
       case "$status" in
         ci)             RUN_STATE=working; RUN_DETAIL="ci running" ;;
         running|fixing) RUN_STATE=working; RUN_DETAIL="validating ($status)" ;;
-        completed)      RUN_STATE="done"; RUN_DETAIL="run completed" ;;
-        failed)         RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
-        cancelled)      RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
+        completed)      RUN_STATE="done"; RUN_DETAIL="run completed"; RUN_TERMINAL="done" ;;
+        failed)         RUN_STATE=failed;  RUN_DETAIL="run failed"; RUN_TERMINAL=failed ;;
+        cancelled)      RUN_STATE=failed;  RUN_DETAIL="run cancelled"; RUN_TERMINAL=cancelled ;;
         "")             RUN_STATE=working; RUN_DETAIL="run active" ;;
         *)              RUN_STATE=working; RUN_DETAIL="run active ($status)" ;;
       esac
@@ -598,15 +611,28 @@ if [ "$HAVE_RUN" = 1 ]; then
       ;;
   esac
 
-  # Declared pause outranks a TERMINAL (historical) run only. Active/parked
-  # runs still win: the crew is mid-validation, so a pause line is stale.
-  # Mirror the CI-green status-log override shape: emit from status-log and
-  # keep the prior run-step outcome as secondary detail so a supervisor still
-  # sees that the run cancelled/failed/completed.
-  case "$RUN_STATE" in
-    failed|done)
+  # Declared pause outranks a run that reached a TRUE terminal outcome, and only
+  # done or cancelled. Keyed on RUN_TERMINAL, not on the mapped RUN_STATE, so an
+  # active run the ci-green check mapped to done is still an active run and wins.
+  # Active/parked runs win for the same reason: the crew is mid-validation, so a
+  # pause line is stale. A terminal FAILED run also wins, deliberately: no
+  # freshness signal exists to prove the pause came AFTER the failure (status-log
+  # lines carry no timestamp, and `axi status` reports no completion time), and a
+  # pause appended before or during the run would otherwise mask a real failure
+  # behind a benign external wait. Cancelled is a supervisor abort, not failed
+  # work, so it stays overridable. Mirror the CI-green status-log override shape:
+  # emit from status-log with the terminal run outcome LEADING the detail, so the
+  # fact that the run finished survives downstream truncation, and the pause
+  # reason follows.
+  case "$RUN_TERMINAL" in
+    done|cancelled)
       if status_is_paused "$LOG_LINE"; then
-        emit paused status-log "$(status_line_note "$LOG_LINE")${SEP}$RUN_DETAIL"
+        pause_note=$(status_line_note "$LOG_LINE")
+        if [ -n "$pause_note" ]; then
+          emit paused status-log "$RUN_DETAIL${SEP}$pause_note"
+        else
+          emit paused status-log "$RUN_DETAIL"
+        fi
       fi
       ;;
   esac

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,9 +32,12 @@ Crew status files are append-only wake-event logs, not current-state fields.
 The script header owns the exact run-head ancestry rules.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
+A second exception covers a run that already reached a terminal outcome: when that outcome is done or cancelled and the status log's last verb is a declared external wait, the crew reports `paused` from the status log with the terminal run outcome leading the detail, because a finished run record must not permanently overrule a self-declared wait.
+That exception is keyed on the run's own terminal outcome rather than the mapped state, so an actively monitored checks-green run still reports done, and a terminal failed run always surfaces as failed: neither the status log nor `axi status` timestamps its events, so a pause appended before or during the run cannot be distinguished from one declared after it, and masking a real work failure behind a benign wait is the worse error.
+Cancelled is a supervisor abort rather than failed work, so it stays overridable.
 Only when no matching run exists does it fall back to the pane busy-signature and then a status-log event whose verb maps to a recognized run-state; a dead pane without a run reports unknown instead of trusting a stale log.
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
-In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.
+In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason, as does the terminal done/cancelled exception above.
 For herdr, that pane fallback trusts a native `busy` verdict outright, but corroborates native `idle` or unknown verdicts against the recorded harness's rendered busy signature before deciding the crew is not working.
 For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, and secondmate return-channel guidance.
 `bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -13,8 +13,9 @@
 #   (b) needs-decision/blocked log + resumed run = SUPERSEDED     -> run-step
 #   (c) genuine parked run + needs-decision log = NOT superseded  -> run-step
 #   (d) terminal run-step (passed/failed) is authoritative        -> run-step
-#   (d') terminal run + trailing paused: -> paused (status-log), terminal detail kept;
-#       active/parked runs still outrank a declared pause
+#   (d') terminal done/cancelled run + trailing paused: -> paused (status-log),
+#       terminal detail leading; a terminal FAILED run, active/parked runs, and an
+#       actively-monitored ci-green run all still outrank a declared pause
 #   (e) cross-branch attribution: this branch's own run found via list lookup
 #   (f) no run + busy pane                                        -> pane
 #   (g) no run + idle pane falls to the status-log verb           -> status-log
@@ -704,9 +705,11 @@ test_terminal_failed() {
   pass "terminal failed run is authoritative"
 }
 
-# (d') A trailing declared pause outranks a TERMINAL attributed run only.
-# Active/parked runs still win. Terminal outcome stays as secondary detail so
-# a supervisor reading the one-liner still learns the run cancelled/failed/done.
+# (d') A trailing declared pause outranks an attributed run only when that run
+# reached a TRUE terminal outcome of done or cancelled. Active, parked, ci-green
+# monitoring, and terminal FAILED runs all still win. The terminal outcome leads
+# the detail so a supervisor reading the truncated one-liner still learns the run
+# finished.
 test_terminal_cancelled_plus_paused() {
   reset_fakes
   local d; d=$(new_case cancelled-paused)
@@ -725,7 +728,11 @@ test_terminal_cancelled_plus_paused() {
   pass "terminal cancelled + trailing paused: reports paused with run cancelled detail"
 }
 
-test_terminal_failed_plus_paused() {
+# A genuine run FAILURE is never absorbed by a trailing paused:. Nothing in the
+# status log or `axi status` timestamps either event, so a pause appended before
+# or during the run cannot be told from one declared after it - masking real work
+# failure behind a benign external wait. Failure wins; cancelled (above) does not.
+test_terminal_failed_plus_paused_surfaces_failure() {
   reset_fakes
   local d; d=$(new_case failed-paused)
   make_repo_on_branch "$d/wt" fm/feat-fail-pause
@@ -735,12 +742,49 @@ test_terminal_failed_plus_paused() {
   FM_FAKE_AXI_STATUS="$(run_failed fm/feat-fail-pause)"
   FM_FAKE_BUSY=0
   local out; out=$(run_crew_state "$d" feat-fail-pause)
-  assert_contains "$out" "state: paused" "failed + paused: -> paused"
-  assert_contains "$out" "source: status-log" "failed + paused: is status-log sourced"
-  assert_contains "$out" "waiting on external rate-limit reset" "pause reason is carried"
-  assert_contains "$out" "run failed" "terminal failed outcome survives as secondary detail"
-  assert_not_contains "$out" "state: failed" "failed must not remain primary state over paused:"
-  pass "terminal failed + trailing paused: reports paused with run failed detail"
+  assert_contains "$out" "state: failed" "failed + paused: keeps surfacing the failure"
+  assert_contains "$out" "source: run-step" "failed + paused: stays run-step sourced"
+  assert_contains "$out" "run failed" "failure detail is reported"
+  assert_not_contains "$out" "state: paused" "paused: must not mask a genuine run failure"
+  pass "terminal failed + trailing paused: still reports failed"
+}
+
+# A bare paused: with no reason must not emit a doubled separator.
+test_terminal_cancelled_plus_bare_paused() {
+  reset_fakes
+  local d; d=$(new_case cancelled-bare-paused)
+  make_repo_on_branch "$d/wt" fm/feat-bare-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-bare-pause.meta" "window=fm:fm-feat-bare-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused:\n' > "$d/state/feat-bare-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_cancelled fm/feat-bare-pause)"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-bare-pause)
+  assert_contains "$out" "state: paused" "cancelled + bare paused: -> paused"
+  assert_contains "$out" "run cancelled" "terminal cancelled outcome is the detail"
+  assert_not_contains "$out" " ·  · " "empty pause note must not double the separator"
+  pass "cancelled + bare paused: emits a single separator"
+}
+
+# Regression for the ci-green mapping: an ACTIVE run whose ci log reads green is
+# mapped to done while it keeps monitoring for merge/close. That is not a
+# terminal outcome, so a trailing paused: must not take it over.
+test_ci_green_monitoring_outranks_paused() {
+  reset_fakes
+  local d; d=$(new_case ci-green-outranks-pause)
+  make_repo_on_branch "$d/wt" fm/feat-cigreen-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cigreen-pause.meta" "window=fm:fm-feat-cigreen-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused: awaiting maintainer merge\n' > "$d/state/feat-cigreen-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-cigreen-pause)"
+  FM_FAKE_CI_LOGS="all CI checks passed - still monitoring until merged or closed"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-cigreen-pause)
+  assert_contains "$out" "state: done" "ci-green monitoring run outranks trailing paused:"
+  assert_contains "$out" "source: run-step" "ci-green monitoring stays run-step sourced"
+  assert_contains "$out" "still monitoring for merge/close" "ci-green detail is preserved"
+  assert_not_contains "$out" "state: paused" "paused: must not beat an actively monitored ci-green run"
+  pass "ci-green (still monitoring) run still outranks a declared pause"
 }
 
 test_terminal_done_plus_paused() {
@@ -1370,10 +1414,12 @@ test_top_level_fixing_done_log_stays_working
 test_terminal_passed
 test_terminal_failed
 test_terminal_cancelled_plus_paused
-test_terminal_failed_plus_paused
+test_terminal_failed_plus_paused_surfaces_failure
+test_terminal_cancelled_plus_bare_paused
 test_terminal_done_plus_paused
 test_active_run_outranks_paused
 test_parked_run_outranks_paused
+test_ci_green_monitoring_outranks_paused
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -13,6 +13,8 @@
 #   (b) needs-decision/blocked log + resumed run = SUPERSEDED     -> run-step
 #   (c) genuine parked run + needs-decision log = NOT superseded  -> run-step
 #   (d) terminal run-step (passed/failed) is authoritative        -> run-step
+#   (d') terminal run + trailing paused: -> paused (status-log), terminal detail kept;
+#       active/parked runs still outrank a declared pause
 #   (e) cross-branch attribution: this branch's own run found via list lookup
 #   (f) no run + busy pane                                        -> pane
 #   (g) no run + idle pane falls to the status-log verb           -> status-log
@@ -280,6 +282,32 @@ run:
   pr: ""
   findings: none
 outcome: failed
+EOF
+}
+
+run_cancelled() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: cancelled
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: ""
+  findings: none
+outcome: cancelled
+EOF
+}
+
+run_checks_passed() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: "https://github.com/o/r/pull/1"
+  findings: none
+outcome: checks-passed
 EOF
 }
 
@@ -674,6 +702,95 @@ test_terminal_failed() {
   assert_contains "$out" "state: failed" "failed run -> failed"
   assert_contains "$out" "source: run-step" "failed -> run-step source"
   pass "terminal failed run is authoritative"
+}
+
+# (d') A trailing declared pause outranks a TERMINAL attributed run only.
+# Active/parked runs still win. Terminal outcome stays as secondary detail so
+# a supervisor reading the one-liner still learns the run cancelled/failed/done.
+test_terminal_cancelled_plus_paused() {
+  reset_fakes
+  local d; d=$(new_case cancelled-paused)
+  make_repo_on_branch "$d/wt" fm/feat-cancel-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cancel-pause.meta" "window=fm:fm-feat-cancel-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused: holding for upstream maintainer merge\n' > "$d/state/feat-cancel-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_cancelled fm/feat-cancel-pause)"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-cancel-pause)
+  assert_contains "$out" "state: paused" "cancelled + paused: -> paused"
+  assert_contains "$out" "source: status-log" "cancelled + paused: is status-log sourced"
+  assert_contains "$out" "holding for upstream maintainer merge" "pause reason is carried"
+  assert_contains "$out" "run cancelled" "terminal cancelled outcome survives as secondary detail"
+  assert_not_contains "$out" "state: failed" "cancelled must not remain primary state over paused:"
+  pass "terminal cancelled + trailing paused: reports paused with run cancelled detail"
+}
+
+test_terminal_failed_plus_paused() {
+  reset_fakes
+  local d; d=$(new_case failed-paused)
+  make_repo_on_branch "$d/wt" fm/feat-fail-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-fail-pause.meta" "window=fm:fm-feat-fail-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused: waiting on external rate-limit reset\n' > "$d/state/feat-fail-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-fail-pause)"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-fail-pause)
+  assert_contains "$out" "state: paused" "failed + paused: -> paused"
+  assert_contains "$out" "source: status-log" "failed + paused: is status-log sourced"
+  assert_contains "$out" "waiting on external rate-limit reset" "pause reason is carried"
+  assert_contains "$out" "run failed" "terminal failed outcome survives as secondary detail"
+  assert_not_contains "$out" "state: failed" "failed must not remain primary state over paused:"
+  pass "terminal failed + trailing paused: reports paused with run failed detail"
+}
+
+test_terminal_done_plus_paused() {
+  reset_fakes
+  local d; d=$(new_case done-paused)
+  make_repo_on_branch "$d/wt" fm/feat-done-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-done-pause.meta" "window=fm:fm-feat-done-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused: PR open and mergeable, awaiting maintainer merge\n' > "$d/state/feat-done-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_checks_passed fm/feat-done-pause)"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-done-pause)
+  assert_contains "$out" "state: paused" "done + paused: -> paused"
+  assert_contains "$out" "source: status-log" "done + paused: is status-log sourced"
+  assert_contains "$out" "PR open and mergeable, awaiting maintainer merge" "pause reason is carried"
+  assert_contains "$out" "checks green" "terminal done outcome survives as secondary detail"
+  assert_not_contains "$out" "state: done" "done must not remain primary state over paused:"
+  pass "terminal done + trailing paused: reports paused with terminal outcome detail"
+}
+
+test_active_run_outranks_paused() {
+  reset_fakes
+  local d; d=$(new_case active-outranks-pause)
+  make_repo_on_branch "$d/wt" fm/feat-active-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-active-pause.meta" "window=fm:fm-feat-active-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused: holding for external wait\n' > "$d/state/feat-active-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-active-pause)"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-active-pause)
+  assert_contains "$out" "state: working" "active run outranks trailing paused:"
+  assert_contains "$out" "source: run-step" "active run remains run-step sourced"
+  assert_not_contains "$out" "state: paused" "paused: must not beat an active run"
+  pass "active (working) run still outranks a declared pause"
+}
+
+test_parked_run_outranks_paused() {
+  reset_fakes
+  local d; d=$(new_case parked-outranks-pause)
+  make_repo_on_branch "$d/wt" fm/feat-parked-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-parked-pause.meta" "window=fm:fm-feat-parked-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused: holding for external wait\n' > "$d/state/feat-parked-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-parked-pause)"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-parked-pause)
+  assert_contains "$out" "state: parked" "parked run outranks trailing paused:"
+  assert_contains "$out" "source: run-step" "parked run remains run-step sourced"
+  assert_not_contains "$out" "state: paused" "paused: must not beat a parked run"
+  pass "parked run still outranks a declared pause"
 }
 
 # (e) cross-branch attribution: `axi status` returns ANOTHER branch's run (the
@@ -1252,6 +1369,11 @@ test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
 test_terminal_failed
+test_terminal_cancelled_plus_paused
+test_terminal_failed_plus_paused
+test_terminal_done_plus_paused
+test_active_run_outranks_paused
+test_parked_run_outranks_paused
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status


### PR DESCRIPTION
## Intent

Let a crew's declared `paused:` survive an attributed *terminal historical* no-mistakes validation run, so a correct pause is not permanently overruled by a stale run record.

Correctness fix only (not a claimed 75-second stale loop): when `bin/fm-crew-state.sh` has `HAVE_RUN=1` for a true terminal outcome of **done** or **cancelled** (not the mapped presentation state) and the status log's last verb is `paused:`, emit `state: paused` with `source: status-log`, retaining the terminal run outcome as leading secondary detail. Mirror the existing CI-green status-log override shape for that emit style.

What outranks a pause, by design:

- **Active / working and parked** runs still outrank a declared pause (including a CI-green run still monitoring for merge that is only *mapped* to done).
- A genuine **failed** run is **not** pause-overridable. An abort (`cancelled`) is a supervisor decision; overriding it with the crew's own pause declaration is sound. A failed run is the work itself failing and must surface whether or not any pause line is fresher. That restriction is the final accepted scope, not a temporary fallback.

Rejected: changing only `crew_absorb_class` or `pause_state_class` (dual-authority drift); stopping terminal attribution entirely; TTL on cancelled runs; teardown on abort. Residuals left by design: live-agent first surface, no-verb turn-end while paused, hourly forgotten-pause re-surface.

Tests cover cancelled/done + trailing paused (override), failed + trailing paused (still failed), and negatives that working/parked/ci-green-monitoring still win. No claim this eliminates residual first-surface or signal spam.

## What Changed

- `bin/fm-crew-state.sh` tracks the attributed run's own terminal outcome (`RUN_TERMINAL`: none/done/cancelled/failed) alongside the mapped `RUN_STATE`, set only from the run's reported outcome/status across the coarse, outcome, and bare-status paths (not from CI-green presentation mapping).
- When that outcome is genuinely terminal `done` or `cancelled` and the status log's last verb is `paused:`, the crew is emitted as `state: paused · source: status-log` with the **run outcome leading** the detail and the pause reason following (and no doubled separator when the pause carries no reason).
- A terminal `failed` run continues to report `failed` even if the last status verb is `paused:`, so a validation failure is not demoted to a quiet external wait. Active, parked, and CI-green-still-monitoring runs likewise outrank pause.
- `tests/fm-crew-state.test.sh` adds cases for cancelled/done + paused, bare paused separator, failed-stays-failed, and active/parked/ci-green negatives; `docs/architecture.md` documents the second status-log exception and `AGENTS.md` points at the script header as the owner of the run-step-to-state mapping instead of restating it.

## Risk Assessment

Low: Review-driven corrections gate the override on true terminal outcomes (so mapped CI-green done stays active authority), keep genuine failures visible by design, put terminal detail first for truncation, fix the empty-note separator, and document the exception. Scope is narrower than the first draft intent: `failed` is intentionally not pause-overridable.

## Testing

Exercised the targeted crew-state suite (all cases pass, including the new pause-vs-terminal-run ones) and the watch-triage suite that consumes the verdict, then demonstrated the change end-to-end on a hermetic fleet fixture: with a cancelled run plus a declared pause the helper flips from `state: failed · source: run-step · run cancelled` to `state: paused · source: status-log · run cancelled · holding for upstream maintainer merge`, the watcher's absorb class flips from `none` (wake surfaces) to `paused` (absorbed), and the human `fm-fleet-view.sh` table cell flips from `failed / run-step` to `paused / status-log`; the done/checks-passed case behaves the same, while failed, active, and parked runs stay failed/working/parked with or without a trailing pause line. No screenshot applies - the affected surfaces are shell CLI output and a Markdown fleet table, both captured verbatim in the transcript artifact.

<details>
<summary>Evidence: End-to-end before/after transcript (crew-state verdict, watcher absorb class, rendered fleet view)</summary>

<code>SCENARIO: supervisor CANCELLED the validation run, crew declared a pause&#10;status log (tail): paused: holding for upstream maintainer merge&#10;BEFORE (c64ad1c) crew-state : state: failed · source: run-step · run cancelled&#10;BEFORE (c64ad1c) absorb : none&#10;AFTER (HEAD) crew-state : state: paused · source: status-log · run cancelled · holding for upstream maintainer merge&#10;AFTER (HEAD) absorb : paused&#10;&#10;SCENARIO: run finished DONE (checks green) , crew declared a pause&#10;BEFORE (c64ad1c) crew-state : state: done · source: run-step · checks green: PR ready for review&#10;AFTER (HEAD) crew-state : state: paused · source: status-log · checks green: PR ready for review · holding for upstream maintainer merge&#10;&#10;SCENARIO: run FAILED (must stay visible) + same pause line&#10;BEFORE (c64ad1c) crew-state : state: failed · source: run-step · run failed&#10;AFTER (HEAD) crew-state : state: failed · source: run-step · run failed&#10;&#10;SCENARIO: run still ACTIVE (working) + same pause line&#10;AFTER (HEAD) crew-state : state: working · source: run-step · validating (running)&#10;&#10;HUMAN FLEET VIEW (bin/fm-fleet-view.sh) - cancelled run + declared pause&#10;--- BEFORE (c64ad1c) ---&#10;| upstream-merge | failed / run-step | ship | alpha | tmux | present | https://github.com/o/r/pull/12 | ... |&#10;--- AFTER (HEAD) ---&#10;| upstream-merge | paused / status-log | ship | alpha | tmux | present | https://github.com/o/r/pull/12 | ... |</code>

```text
==============================================================
SCENARIO: supervisor CANCELLED the validation run, crew declared a pause
  status log (tail): paused: holding for upstream maintainer merge
  no-mistakes axi status run outcome: status cancelled cancelled 
--------------------------------------------------------------
  BEFORE (c64ad1c)  crew-state : state: failed · source: run-step · run cancelled
  BEFORE (c64ad1c)  absorb     : none
  AFTER  (HEAD)     crew-state : state: paused · source: status-log · run cancelled · holding for upstream maintainer merge
  AFTER  (HEAD)     absorb     : paused

==============================================================
SCENARIO: run finished DONE (checks green, PR merged/closed path), crew declared a pause
  status log (tail): paused: holding for upstream maintainer merge
  no-mistakes axi status run outcome: status completed checks-passed 
--------------------------------------------------------------
  BEFORE (c64ad1c)  crew-state : state: done · source: run-step · checks green: PR ready for review
  BEFORE (c64ad1c)  absorb     : none
  AFTER  (HEAD)     crew-state : state: paused · source: status-log · checks green: PR ready for review · holding for upstream maintainer merge
  AFTER  (HEAD)     absorb     : paused

==============================================================
SCENARIO: run FAILED (must stay visible) + same pause line
  status log (tail): paused: holding for upstream maintainer merge
  no-mistakes axi status run outcome: status failed failed 
--------------------------------------------------------------
  BEFORE (c64ad1c)  crew-state : state: failed · source: run-step · run failed
  BEFORE (c64ad1c)  absorb     : none
  AFTER  (HEAD)     crew-state : state: failed · source: run-step · run failed
  AFTER  (HEAD)     absorb     : none

==============================================================
SCENARIO: run still ACTIVE (working) + same pause line
  status log (tail): paused: holding for upstream maintainer merge
  no-mistakes axi status run outcome: status running 
--------------------------------------------------------------
  BEFORE (c64ad1c)  crew-state : state: working · source: run-step · validating (running)
  BEFORE (c64ad1c)  absorb     : working
  AFTER  (HEAD)     crew-state : state: working · source: run-step · validating (running)
  AFTER  (HEAD)     absorb     : working

==============================================================
HUMAN FLEET VIEW (bin/fm-fleet-view.sh) - cancelled run + declared pause
==============================================================
--- BEFORE (c64ad1c) ---
# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /var/folders/1t/12j9b68s5tj28wbq7wd_6fm80000gn/T/no-mistakes-evidence/01KYE4PR9ZWV4TGSRYQ1TQBMNT/work/fmhome

## Under Way
| ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| upstream-merge | failed / run-step | ship | alpha | tmux | present | https://github.com/o/r/pull/12 | /var/folders/1t/12j9b68s5tj28wbq7wd_6fm80000gn/T/no-mistakes-evidence/01KYE4PR9ZWV4TGSRYQ1TQBMNT/work/fmhome/projects/upstream-merge-worktree | bin/fm-peek.sh fm-upstream-merge |

## Queued
No queued backlog records found.

## Done
No done backlog records found.

## Secondmates
For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.
```
</details>
<details>
<summary>Evidence: Reproduction driver for the end-to-end evidence (ROOT=&lt;repo&gt; OUT=&lt;dir&gt; bash e2e-pause-vs-terminal-run.sh)</summary>

```text
#!/usr/bin/env bash
# End-to-end demo of the "declared pause survives a terminal run record" fix,
# exercised the way a supervisor actually sees it:
#   1. bin/fm-crew-state.sh   - the authoritative one-line crew state
#   2. crew_absorb_class      - the watcher's absorb/surface decision
#   3. bin/fm-fleet-view.sh   - the human-facing fleet table
# Run twice per scenario: the BASE script (c64ad1c) vs the FIXED script (HEAD).
set -u
ROOT=${ROOT:?}
OUT=${OUT:?}
WORK=$OUT/work
rm -rf "$WORK"; mkdir -p "$WORK"

# A full bin/ copy whose fm-crew-state.sh is the BASE (pre-fix) version, so both
# the helper and the fleet renderer can be run against pre-fix behaviour with all
# sibling libraries resolvable.
BASE_BIN=$WORK/base-bin
cp -R "$ROOT/bin" "$BASE_BIN"
BASE_SCRIPT=$BASE_BIN/fm-crew-state.sh
git -C "$ROOT" show c64ad1c:bin/fm-crew-state.sh > "$BASE_SCRIPT"
chmod +x "$BASE_SCRIPT"

FAKEBIN=$WORK/fakebin
mkdir -p "$FAKEBIN"
cat > "$FAKEBIN/no-mistakes" <<'SH'
#!/usr/bin/env bash
set -u
case "${1:-}" in
  axi)
    shift
    case "${1:-}" in
      status) shift; printf '%s\n' "${FM_FAKE_AXI_STATUS:-}" ;;
      logs)   printf '%s\n' "${FM_FAKE_CI_LOGS:-}" ;;
    esac ;;
  runs) printf '%s\n' "${FM_FAKE_RUNS_LIST:-}" ;;
esac
exit 0
SH
cat > "$FAKEBIN/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "${1:-}" in
  list-windows)   sed -n 's/^window=[^:]*://p' "${FM_HOME:?}"/state/*.meta ;;
  display-message) printf '%%1\n' ;;
  capture-pane)   printf 'all quiet\n> \n' ;;   # idle pane: the crew is waiting
esac
exit 0
SH
chmod +x "$FAKEBIN/no-mistakes" "$FAKEBIN/tmux"

HOME_DIR=$WORK/fmhome
mkdir -p "$HOME_DIR/state" "$HOME_DIR/data" "$HOME_DIR/projects" "$HOME_DIR/config"
WT=$HOME_DIR/projects/upstream-merge-worktree
mkdir -p "$WT"
git -C "$WT" init -q
git -C "$WT" -c user.name=fmtest -c user.email=fmtest@example.invalid commit -q --allow-empty -m init
git -C "$WT" checkout -q -b fm/upstream-merge
HEAD_SHA=$(git -C "$WT" rev-parse HEAD)

cat > "$HOME_DIR/data/backlog.md" <<EOF
## In flight
- [ ] upstream-merge - Upstream Merge https://github.com/o/r/pull/12 (repo: alpha) (kind: ship) (since 2026-07-26)
EOF
{ printf 'window=firstmate:fm-upstream-merge\n'
  printf 'worktree=%s\n' "$WT"
  printf 'project=alpha\nharness=codex\nkind=ship\nmode=ship\nyolo=off\n'
  printf 'pr=https://github.com/o/r/pull/12\n'; } > "$HOME_DIR/state/upstream-merge.meta"

# The crew's own append-only event log: it worked, then declared an external wait.
{ printf 'working: opened PR 12, validation running\n'
  printf 'paused: holding for upstream maintainer merge\n'; } > "$HOME_DIR/state/upstream-merge.status"

run_state() {  # <script>
  PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
    FM_DATA_OVERRIDE="$HOME_DIR/data" FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" \
    FM_CONFIG_OVERRIDE="$HOME_DIR/config" "$1" upstream-merge
}

absorb_class() {  # <script>
  PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
    FM_DATA_OVERRIDE="$HOME_DIR/data" FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" \
    FM_CONFIG_OVERRIDE="$HOME_DIR/config" FM_CREW_STATE_BIN="$1" \
    bash -c '. "$0"/bin/fm-classify-lib.sh; crew_absorb_class upstream-merge; echo' "$ROOT"
}

fleet_view() {  # <bin-dir>
  PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" "$1/fm-fleet-view.sh"
}

scenario() {  # <label> <axi-status-fixture>
  FM_FAKE_AXI_STATUS=$2; export FM_FAKE_AXI_STATUS
  echo "=============================================================="
  echo "SCENARIO: $1"
  echo "  status log (tail): $(tail -1 "$HOME_DIR/state/upstream-merge.status")"
  echo "  no-mistakes axi status run outcome: $(printf '%s\n' "$2" | sed -n 's/^outcome: //p;s/^  status: /status /p' | tr '\n' ' ')"
  echo "--------------------------------------------------------------"
  printf '  BEFORE (c64ad1c)  crew-state : %s\n' "$(run_state "$BASE_SCRIPT")"
  printf '  BEFORE (c64ad1c)  absorb     : %s\n' "$(absorb_class "$BASE_SCRIPT")"
  printf '  AFTER  (HEAD)     crew-state : %s\n' "$(run_state "$ROOT/bin/fm-crew-state.sh")"
  printf '  AFTER  (HEAD)     absorb     : %s\n' "$(absorb_class "$ROOT/bin/fm-crew-state.sh")"
  echo
}

run_cancelled=$(cat <<EOF
run:
  id: "01RUN"
  branch: fm/upstream-merge
  status: cancelled
  head: "$HEAD_SHA"
  pr: ""
  findings: none
outcome: cancelled
EOF
)
run_checks_passed=$(cat <<EOF
run:
  id: "01RUN"
  branch: fm/upstream-merge
  status: completed
  head: "$HEAD_SHA"
  pr: "https://github.com/o/r/pull/12"
  findings: none
outcome: checks-passed
EOF
)
run_failed=$(cat <<EOF
run:
  id: "01RUN"
  branch: fm/upstream-merge
  status: failed
  head: "$HEAD_SHA"
  pr: ""
  findings: 2
outcome: failed
EOF
)
run_running=$(cat <<EOF
run:
  id: "01RUN"
  branch: fm/upstream-merge
  status: running
  head: "$HEAD_SHA"
  pr: ""
  findings: none
EOF
)

scenario "supervisor CANCELLED the validation run, crew declared a pause" "$run_cancelled"
scenario "run finished DONE (checks green, PR merged/closed path), crew declared a pause" "$run_checks_passed"
scenario "run FAILED (must stay visible) + same pause line" "$run_failed"
scenario "run still ACTIVE (working) + same pause line" "$run_running"

echo "=============================================================="
echo "HUMAN FLEET VIEW (bin/fm-fleet-view.sh) - cancelled run + declared pause"
echo "=============================================================="
FM_FAKE_AXI_STATUS=$run_cancelled; export FM_FAKE_AXI_STATUS
echo "--- BEFORE (c64ad1c) ---"
fleet_view "$BASE_BIN"
echo
echo "--- AFTER (HEAD) ---"
fleet_view "$ROOT/bin"
```
</details>
- Outcome: ⚠️ 1 info across 1 run (15m22s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `bin/fm-crew-state.sh:607` - The new override keys on the mapped RUN_STATE (`failed|done`), not on whether the run actually reached a terminal outcome. RUN_STATE is also set to `done` at bin/fm-crew-state.sh:557 for a run whose status is still `ci`/`running` when the ci-step log tail reads green (detail: &#34;checks green: PR ready for review (still monitoring for merge/close)&#34;) - that run is active, not historical. The intent states as required: &#34;Active/working and parked runs must still outrank a declared pause&#34;, and the new header comment itself says the override applies &#34;when the attributed run is already TERMINAL&#34;; neither holds for this path. Failure scenario: a crew appended `paused: awaiting maintainer merge` while its run is still in the CI-monitor phase; checks go green, so RUN_STATE becomes `done` at line 557, the new case at line 607 matches, and the crew is reported `state: paused · source: status-log` instead of `done` - the fleet/bearings view loses the &#34;PR ready for review&#34; signal for an actively-monitored run. Gating on the terminal branches themselves (outcome passed/checks-passed/failed/cancelled, coarse completed/failed/cancelled, or bare status completed/failed/cancelled) rather than on the post-override RUN_STATE would keep the ci-green case out.
- ⚠️ `bin/fm-crew-state.sh:608` - The override has no ordering or freshness signal: it only asks whether the status log&#39;s LAST verb is `paused:`. It therefore cannot distinguish the motivating case (a pause declared AFTER a historical run ended) from a pause declared BEFORE or DURING a run that subsequently failed - the intent&#39;s own framing is &#34;a crew&#39;s freshly declared paused:&#34;. Because crews append sparsely during validation (AGENTS.md status contract), a pause line stays last for the whole run. Failure scenario: crew appends `paused: waiting on vendor rate-limit reset` while its no-mistakes run is in ci; CI goes red and the run ends `outcome: failed`; crew-state now reports `state: paused` with the failure demoted to trailing detail, so the fleet snapshot/bearings surface a benign external wait and the real validation failure is only re-checked on the hourly pause cadence instead of surfacing as `failed`. This masking is not among the residuals the intent lists as accepted (live-agent first surface, no-verb turn-end while paused, hourly forgotten-pause re-surface), so it needs an explicit call. Note TTL was rejected, but a status-file-mtime vs run-attribution ordering check is a different mechanism if you want one.
- ℹ️ `bin/fm-crew-state.sh:609` - The retained terminal outcome is appended LAST in the emitted detail (`&lt;pause note&gt; · &lt;run detail&gt;`), which makes it the first text dropped by downstream truncation. bin/fm-bearings-snapshot.sh:378-379 renders `current_state.detail` through `trunc(90)` for the in-flight rows. Failure scenario: a crew with `paused: holding until the upstream vendor publishes the 2.4 release and the mirror re-syncs` plus a cancelled run emits detail of ~95+ chars, so bearings shows only the pause reason with an ellipsis and the &#34;run cancelled&#34; evidence the intent wants retained as secondary detail never reaches the reader. Putting the run outcome before the pause note, or shortening it, keeps the terminal fact inside the 90-char budget.
- ℹ️ `bin/fm-crew-state.sh:609` - When the pause line carries no reason, `status_line_note` returns empty and the detail argument becomes `&#34; · &lt;run detail&gt;&#34;`, producing a doubled separator in the canonical line. Failure scenario: status log&#39;s last line is a bare `paused:` with a cancelled run - the emitted line is `state: paused · source: status-log ·  · run cancelled`, and bin/fm-fleet-snapshot.sh:219 parses `detail` as `&#34; · run cancelled&#34;` with a leading separator, which then renders verbatim in the bearings `doing` column. Building the detail conditionally (use `$RUN_DETAIL` alone when the note is empty) avoids it.
- ⚠️ `docs/architecture.md:31` - docs/architecture.md owns the crew-state mechanism (AGENTS.md:331) and now contradicts the code in two places. Line 31 states the helper &#34;keeps that run-step authoritative even if the pane has closed&#34; with only the ci-log-tail exception spelled out at lines 33-34; line 37 states &#34;In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason&#34; - i.e. paused is described as reachable ONLY on the no-run fallback path. After this change a declared pause also overrides an attributed terminal run outside that fallback. Failure scenario: a reader (or a future change) follows line 31/37 and concludes an attributed failed/cancelled run always reports `failed`, then builds surfacing logic on that guarantee, which the new bin/fm-crew-state.sh:601-612 block breaks. The ci exception is documented at that level of detail; this second exception should be too.

🔧 Fix: gate pause override on true terminal outcome, keep failures visible
2 infos still open:
- ℹ️ `bin/fm-crew-state.sh:628` - Flagging per intent-conformance: the change now contradicts the literal User intent text on the `failed` outcome. The intent states as required: &#34;when bin/fm-crew-state.sh has HAVE_RUN=1 for a terminal outcome (failed including cancelled, or done) and the status log&#39;s last verb is paused:, emit state paused with source status-log&#34;, and &#34;Tests added for cancelled/failed/done + trailing paused&#34;. The contradicting hunk is `case &#34;$RUN_TERMINAL&#34; in done|cancelled)` at bin/fm-crew-state.sh:627-628, which excludes `failed`, plus tests/fm-crew-state.test.sh:735-751 where the former `test_terminal_failed_plus_paused` is replaced by `test_terminal_failed_plus_paused_surfaces_failure`, now asserting `state: failed` / `source: run-step` and `assert_not_contains &#34;state: paused&#34;`. This divergence is the author&#39;s own round-1 decision (key=review-gate: &#34;If NO reliable freshness signal exists, fail SAFE ... Cancelled ... may still be overridden by pause; failed (work failed) must surface. Prefer surfacing.&#34;), so the code is almost certainly right and the resolution is to update the intent/PR description rather than the code. Failure scenario if left unresolved: the PR body and the recorded acceptance criteria claim `failed` + trailing `paused:` reports `paused`, while the shipped behavior and its test assert the opposite - a later reader or change re-introduces the failed-override believing it was the agreed contract.
- ℹ️ `bin/fm-crew-state.sh:619` - The load-bearing rationale comment states &#34;no freshness signal exists to prove the pause came AFTER the failure (status-log lines carry no timestamp, and `axi status` reports no completion time)&#34;, mirrored in docs/architecture.md:36 (&#34;neither the status log nor `axi status` timestamps its events&#34;). That is accurate for the primary `axi status` path and for status-log lines, but this same file documents at bin/fm-crew-state.sh:387-388 that the coarse `no-mistakes runs` rows are &#34;newest-first, columns \&#34;&lt;status&gt; &lt;branch&gt; &lt;short-sha&gt; &lt;date&gt; [&lt;pr-url&gt;]\&#34;&#34; - i.e. a date IS present on the coarse fallback path, and the status file&#39;s mtime is always readable. Failure scenario: a future change reads the comment as &#34;no timestamp exists anywhere in this script&#39;s inputs&#34; and rules out an ordering check that is in fact partially available. No code change needed - a coarse-only freshness rule would give the two attribution paths different pause semantics, which is exactly the dual-authority drift the intent rejects, and the fail-safe (surface failures) is the safer branch either way; only the absoluteness of the claim is worth narrowing to &#34;no per-event timestamp on the attributed-run path&#34;.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `bin/fm-crew-state.sh:614` - Intent text says the pause override should apply to &#34;a terminal outcome (failed including cancelled, or done)&#34;, but the shipped behavior (head commit b96b202, &#34;keep failures visible&#34;) deliberately excludes terminal failed: a failed run + trailing `paused:` still reports `state: failed · source: run-step`. The added test `test_terminal_failed_plus_paused_surfaces_failure` and the intent&#39;s rejected-alternatives section encode that narrower choice, so this reads as a conscious review-driven narrowing rather than a defect - flagged only so the reviewer confirms the narrower scope is what they want.
- <code>`bash tests/fm-crew-state.test.sh` (whole file; includes the 7 new cases: cancelled+paused, failed+paused stays failed, cancelled+bare paused separator, done/checks-passed+paused, active outranks paused, parked outranks paused, ci-green monitoring outranks paused)</code>
- <code>`bash tests/fm-watch-triage.test.sh` (the only suite exercising crew_absorb_class / crew_is_paused, the downstream consumer of this verdict)</code>
- <code>Manual end-to-end: hermetic FM_HOME with a real git worktree on `fm/upstream-merge`, fake `no-mistakes axi status` and `tmux` (idle pane), status log ending `paused: holding for upstream maintainer merge`; ran `bin/fm-crew-state.sh upstream-merge` and `crew_absorb_class upstream-merge` against both the base (c64ad1c) and target (b96b202) scripts across cancelled / done / failed / active run fixtures</code>
- <code>Manual end-to-end: `bin/fm-fleet-view.sh` rendered over the same fixture with base vs target `bin/`, showing the human fleet table cell change from `failed / run-step` to `paused / status-log`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

