### PR TITLE
fix: harden Kimi submission and spinner matching

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -354,7 +354,7 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 | Binary | Executable `kimi` from `PATH`, then executable `$HOME/.kimi-code/bin/kimi`; spawning refuses if neither exists. |
 | Launch | Bare interactive TUI with `--auto`, followed by readiness-gated pointer delivery; positional prompts are rejected. |
 | Models | `kimi-code/kimi-for-coding` (default), `kimi-code/kimi-for-coding-highspeed`, `kimi-code/k3`, and `kimi-code/k3-256k`. |
-| Busy-pane signature | A transient line with optional leading whitespace, a rotating moon-phase glyph, optional whitespace around `·`, and optional trailing content; the line is absent when idle. |
+| Busy-pane signature | A transient line with optional leading whitespace, a rotating moon-phase glyph, required whitespace on both sides of `·`, and optional trailing content; the line is absent when idle. |
 | Exit command | `/exit` |
 | Interrupt | Single Escape, which prints `Interrupted by user`. |
 | Skill invocation | `/<skill>`, for example `/no-mistakes`; firstmate skills are discovered. |
@@ -371,7 +371,9 @@ Sending before readiness was reproduced as a silent drop with a zero exit status
 The brief path must be absolute because the brief lives outside the task worktree, and Kimi reads it there without `--add-dir`.
 
 Observed live spinner captures included optional leading whitespace, a moon-phase glyph, whitespace around `·`, and rotating tip text, with the same shape observed during tool execution.
-Because those prose examples illustrate the spinner shape rather than define exact bytes, the matcher permits zero whitespace around `·` and does not require trailing tip text.
+Because every captured spinner row had whitespace on both sides of `·`, the matcher requires that whitespace, deliberately does not match the never-observed zero-whitespace form, and does not require trailing tip text.
+The startup input-readiness window is the established cause of Kimi's first-Enter delivery defect: the banner is not the cause, and Grok's cursor-row quirk does not apply.
+No rendering signal is trustworthy for proving that Kimi will accept input during this window, so delivery retries Enter through the shared submit core and retains the existing postcondition verification rather than relaxing readiness or delivery checks.
 Kimi's footer tip rotates independently and can display `ctrl+c: cancel` while completely idle, so tip text is never used as its busy signature without the leading moon-plus-middot spinner structure.
 The idle status bar can contain lowercase `thinking`, which is the model's effort label rather than a busy signal.
 The spinner match covers the full moon-phase glyph set rather than one frame, but it remains locale- and emoji-font-sensitive because Kimi exposes no stable ASCII busy token.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1483,7 +1483,7 @@ if [ "$HARNESS" = kimi ]; then
   KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}
   KIMI_SUBMIT_VERDICT=$(fm_backend_send_text_submit \
     "$BACKEND" "$T" "$KIMI_POINTER" "$KIMI_SUBMIT_RETRIES" \
-    "$KIMI_SUBMIT_SLEEP" "$KIMI_SUBMIT_SETTLE") || {
+    "$KIMI_SUBMIT_SLEEP" "$KIMI_SUBMIT_SETTLE" "$W") || {
     kimi_spawn_fail "kimi brief pointer could not be submitted"
     exit 1
   }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1478,11 +1478,16 @@ if [ "$HARNESS" = kimi ]; then
     exit 1
   fi
   KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
-  if ! spawn_send_literal "$T" "$KIMI_POINTER"; then
-    kimi_spawn_fail "kimi brief pointer could not be typed"
+  KIMI_SUBMIT_RETRIES=${FM_KIMI_SUBMIT_RETRIES:-3}
+  KIMI_SUBMIT_SLEEP=${FM_KIMI_SUBMIT_SLEEP:-${FM_KIMI_POLL_INTERVAL:-0.5}}
+  KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}
+  KIMI_SUBMIT_VERDICT=$(fm_backend_send_text_submit \
+    "$BACKEND" "$T" "$KIMI_POINTER" "$KIMI_SUBMIT_RETRIES" \
+    "$KIMI_SUBMIT_SLEEP" "$KIMI_SUBMIT_SETTLE") || {
+    kimi_spawn_fail "kimi brief pointer could not be submitted"
     exit 1
-  fi
-  if ! spawn_send_key "$T" Enter; then
+  }
+  if [ "$KIMI_SUBMIT_VERDICT" = send-failed ]; then
     kimi_spawn_fail "kimi brief pointer could not be submitted"
     exit 1
   fi

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -67,12 +67,13 @@
 # signature separate from the shared default because that shape is not generic
 # enough to classify arbitrary harness output safely.
 # Kimi's anchored moon-phase spinner is separate because bare moon glyphs in
-# ordinary output must not classify another harness as busy. Leading whitespace
-# and whitespace around the middot are optional because prose examples preserve
-# the spinner's shape rather than defining byte-exact spacing. The line end stays
-# unanchored because rotating tip text follows but is not required. The idle
-# status bar's lowercase `thinking` label and independently rotating tip text are
-# not busy signals on their own.
+# ordinary output must not classify another harness as busy. Leading whitespace is
+# OPTIONAL; whitespace on both sides of the separator is REQUIRED because every
+# captured spinner row had it. A zero-whitespace form has NEVER been observed and
+# is deliberately not matched. The line end is intentionally unanchored because
+# rotating tip text follows and is not required to be present. The idle status
+# bar's lowercase `thinking` label and independently rotating tip text are not
+# busy signals on their own.
 # The full moon-phase set remains locale- and emoji-font-sensitive because Kimi
 # exposes no stable ASCII busy token.
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
@@ -81,7 +82,7 @@ FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
 FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
-FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]*·[[:space:]]*'
+FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
 
 fm_busy_lines_match() {  # [harness]
   local harness=${1:-} lines regex

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -78,7 +78,12 @@ case "${1:-}" in
             ;;
           pointer-typed)
             if [ "${FM_FAKE_KIMI_DELIVERY:-yes}" = yes ]; then
-              printf 'delivered\n' > "$FM_FAKE_KIMI_STATE"
+              if [ "${FM_FAKE_KIMI_SWALLOW_FIRST:-no}" = yes ] \
+                 && [ ! -f "$FM_FAKE_KIMI_SWALLOWED" ]; then
+                : > "$FM_FAKE_KIMI_SWALLOWED"
+              else
+                printf 'delivered\n' > "$FM_FAKE_KIMI_STATE"
+              fi
             else
               printf 'ready\n' > "$FM_FAKE_KIMI_STATE"
             fi
@@ -143,6 +148,8 @@ run_spawn() {
     FM_FAKE_LAUNCH_LOG="$case_dir/launch.log" \
     FM_FAKE_POINTER_LOG="$case_dir/pointer.log" \
     FM_FAKE_KIMI_STATE="$case_dir/kimi.state" \
+    FM_FAKE_KIMI_SWALLOWED="$case_dir/kimi.swallowed" \
+    FM_FAKE_KIMI_SWALLOW_FIRST="${FM_FAKE_KIMI_SWALLOW_FIRST:-no}" \
     FM_FAKE_TMUX_CALL_LOG="$case_dir/tmux-calls.log" \
     FM_FAKE_BRIEF_REAL="$(cd "$home/data/$id" && pwd -P)/brief.md" \
     FM_KIMI_READY_POLLS=2 FM_KIMI_DELIVERY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
@@ -161,7 +168,8 @@ test_kimi_launch_then_send_is_verified() {
   id=kimi-success-z1
   rec=$(make_spawn_case success "$id")
   read_spawn_record "$rec"
-  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" \
+  out=$(FM_FAKE_KIMI_SWALLOW_FIRST=yes run_spawn \
+    "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" \
     --model kimi-code/k3 --effort high)
   rc=$?
   expect_code 0 "$rc" "verified kimi launch-then-send should succeed"
@@ -327,10 +335,11 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
     esac
   }
   # These fixtures reproduce the observed spinner shape rather than byte-exact
-  # transcriptions. Leading and separator whitespace are deliberately varied.
+  # transcriptions. Leading whitespace is deliberately varied; separator whitespace
+  # follows the captured contract.
   printf ' 🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"\n│ > │\n' > "$capture"
   fm_pane_is_busy fake kimi || fail "the first real Kimi spinner shape was not recognized as busy"
-  printf '   🌗·Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
+  printf '   🌗 · Tip: /plugins: manage plugins ...\n│ > │\n' > "$capture"
   fm_pane_is_busy fake kimi || fail "the tool-execution Kimi spinner shape was not recognized as busy"
   printf 'ordinary response ending with 🌕\n│ > │\n' > "$capture"
   if fm_pane_is_busy fake kimi; then
@@ -368,7 +377,7 @@ test_kimi_busy_signature_is_scoped_to_spinner_lines() {
 }
 
 test_watcher_scopes_moon_spinner_to_recorded_kimi_task() (
-  local state="$TMP_ROOT/watch-state" busy_capture='  🌑· Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
+  local state="$TMP_ROOT/watch-state" busy_capture='  🌑 · Tip: ask Kimi to schedule tasks, e.g. "remind me at 5pm"'
   mkdir -p "$state"
   printf 'window=fake\nharness=kimi\n' > "$state/kimi-watch.meta"
   unset FM_BUSY_REGEX


### PR DESCRIPTION
## Intent

Fix the blocking Kimi first-Enter delivery defect by routing brief-pointer delivery through the shared verify-and-retry-Enter submit core, typing the pointer once and retrying Enter only while preserving the existing readiness gate and Kimi delivery postconditions: composer clearing, sparkle echo, and context leaving 0%. Keep unconfirmed delivery as a loud spawn failure. In the same PR, make the independent Kimi spinner conformance correction by requiring whitespace on both sides of the middot, preserve varied leading-whitespace fixtures without adding a never-observed zero-whitespace fixture, add the auditable matcher contract comment, and align harness-adapters documentation. Describe the spinner change as conformance rather than live breakage. The PR body must state that it carries two independent fixes and that reverting one reverts the other. Do not touch other harness signatures.

## What Changed

- Route Kimi brief-pointer delivery through the shared verified submit core, typing the pointer once and retrying Enter while preserving readiness checks, delivery postconditions, target ownership, and loud failure.
- Tighten Kimi spinner matching to require whitespace on both sides of the middot, align adapter documentation, and cover swallowed-first-Enter and observed-whitespace cases in the harness tests.
- These are two independent fixes shipped in one PR; reverting the PR reverts both together.

## Risk Assessment

✅ Low: The follow-up preserves the established Zellij and cmux target-ownership guard while the complete branch remains a well-bounded implementation of the Kimi submission retry and spinner conformance requirements.

## Testing

Inspected the base-to-target delta, ran the focused Kimi harness suite, and captured deterministic tmux/Kimi test-double evidence demonstrating the complete delivery and spinner contracts; all checks passed, the worktree remained clean, and no screenshot was produced because this is a terminal-only flow whose actual rendered surface is preserved in the transcript.

<details>
<summary>Evidence: Focused Kimi harness test log</summary>

```text
ok - repository: tracked files contain no user-specific absolute paths
ok - fm-spawn: the five pre-existing adapters' launch templates stay byte-pinned
ok - fm-spawn: kimi launches bare, waits for readiness, sends an absolute brief pointer, and confirms delivery
ok - fm-spawn: Kimi fallback expands the active HOME
ok - fm-spawn: missing Kimi executable refuses before pane creation
ok - fm-spawn: kimi treats a silent pointer drop as a failed spawn
ok - fm-spawn: kimi never sends the brief pointer before an observable ready signal
ok - fm-harness: markerless kimi is detected by ancestry after env-marker precedence
lock acquired: harness pid 92901
ok - fm-lock recognizes Kimi ancestry and live lock holders
ok - busy detection: real Kimi moon-plus-middot captures require its harness while idle labels stay idle
ok - fm-watch: Kimi spinner matching is metadata-scoped and ignores Grok's busy token
ok - composer classifier: kimi's existing bordered > shape is already safe without an override
```
</details>
<details>
<summary>Evidence: Kimi delivery and spinner behavior transcript</summary>

```text
Kimi first-Enter delivery end-to-end test-double transcript
swallowed-first-enter: observed
pointer-type-count: 1
pointer: Read the brief at /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-kimi-harness.d5EbzH/success/home/data/kimi-success-z1/brief.md and follow it exactly.
pointer-submit-actions:
  send-keys -t firstmate:fm-kimi-success-z1 -l Read the brief at /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-kimi-harness.d5EbzH/success/home/data/kimi-success-z1/brief.md and follow it exactly.
  send-keys -t firstmate:fm-kimi-success-z1 Enter
  send-keys -t firstmate:fm-kimi-success-z1 Enter
  send-keys -t firstmate:fm-kimi-success-z1 Enter
final-delivery-state: delivered
final-rendered-pane:
✨ Read the brief at /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-kimi-harness.d5EbzH/success/home/data/kimi-success-z1/brief.md and follow it exactly.
context: 1% (2k/256k)
│ > │
unconfirmed-delivery-status: failed: kimi brief pointer delivery was not confirmed

Kimi spinner matcher counterfactual matrix
observed-leading-one [kimi]: busy |  🌑 · Tip: ask Kimi to schedule tasks
observed-leading-three [kimi]: busy |    🌗 · Tip: /plugins: manage plugins ...
counterfactual-no-left-space [kimi]: idle | 🌑· Tip: no left separator space
counterfactual-no-right-space [kimi]: idle | 🌑 ·Tip: no right separator space
counterfactual-no-separator-spaces [kimi]: idle | 🌑·Tip: no separator spaces
harness-scope-control [codex]: idle |   🌗 · Tip: /plugins: manage plugins ...
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-spawn.sh:1486` - The shared submit call omits the optional expected task label. The previous Zellij and cmux paths passed `$W` to every literal-send and Enter operation, allowing their adapters to reject a recycled pane or surface ID that now belongs to another task. A Kimi target replaced between readiness confirmation and submission can therefore receive the brief pointer without the ownership check. Pass `$W` as the dispatcher&#39;s seventh argument so these adapters retain their existing identity guard.

🔧 Fix: Preserve Kimi submit target ownership guard
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --unified=12 c64ad1c42550534d56ff381cadc9072195a92357..cdf91f62d942cd788cdc6a8f964add5acb8b7989 -- bin/fm-spawn.sh bin/fm-tmux-lib.sh tests/fm-kimi-harness.test.sh .agents/skills/harness-adapters/SKILL.md`
- `bash -c '. tests/lib.sh; fm_test_cleanup() { :; }; . tests/fm-kimi-harness.test.sh'`
- `Inspected the preserved fake-tmux call sequence, final rendered Kimi pane, and supervisor-visible silent-drop status`
- <code>Exercised `fm_busy_lines_match` with observed varied-leading-whitespace Kimi rows, separator-whitespace counterfactuals, and a Codex scope control</code>
- <code>Verified target `HEAD` and confirmed no other backend or watcher harness-signature files changed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
