### PR TITLE
feat(bin): add guarded Kimi turn-end wake

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -53,7 +53,7 @@ Use that value for interrupt, exit, resume, and skill-invocation facts.
 The primary integrations for `claude`, `codex`, `opencode`, `pi`, and `grok` have empirically validated hook paths for the "no turn ends blind" guard.
 `claude` and `codex` block directly through Stop hooks that preserve exit status 2 and stderr from `bin/fm-turnend-guard.sh`.
 `opencode`, `pi`, and `grok` expose passive lifecycle callbacks for this purpose, so their tracked primary adapters force one bounded follow-up or resume when the shared predicate blocks.
-Kimi is outside the current turn-end integration scope; `docs/turnend-guard.md` owns the global-configuration boundary.
+Kimi is outside the primary turn-end guard scope, while `docs/turnend-guard.md` owns its separate guarded global hook for crew wake signals.
 The exact hook files, commands, scoping rules, and fail-open tradeoffs are owned by `docs/turnend-guard.md`.
 `docs/verification/supervision.md` "Turn-end guard" owns active validation evidence.
 When changing any primary turn-end hook, validate the real harness behavior in a scratch project or throwaway home before trusting it, then update that doc and the relevant concise fact below.
@@ -378,6 +378,8 @@ Kimi's footer tip rotates independently and can display `ctrl+c: cancel` while c
 The idle status bar can contain lowercase `thinking`, which is the model's effort label rather than a busy signal.
 The spinner match covers the full moon-phase glyph set rather than one frame, but it remains locale- and emoji-font-sensitive because Kimi exposes no stable ASCII busy token.
 
-[`docs/turnend-guard.md`](../../../docs/turnend-guard.md) owns Kimi's verified global hook surface, approval boundary, and absence from the enabled integrations.
-The current adapter falls back to idle detection.
-That fallback is the weakest idle detection of any supported adapter because Kimi has no stable ASCII busy token, so turn completion can only be inferred from the fragile moon spinner disappearing and the pane becoming stable.
+[`docs/turnend-guard.md`](../../../docs/turnend-guard.md) owns Kimi's verified global hook surface and captain-approved crew wake integration.
+`fm-spawn.sh` installs one marker-delimited Firstmate entry in `$HOME/.kimi-code/config.toml`, one silent always-zero hook script, and one private token registry under `$HOME/.kimi-code/fm-turn-end.d/`.
+Each Kimi crew worktree receives a gitignored `.fm-kimi-turnend` token pointer, and the global hook touches that task's `state/<id>.turn-ended` only when the Stop payload's `cwd`, pointer, and registry entry all agree.
+A guarded silent hook cannot be verified from absence of effect, so prove invocation with an unguarded probe before concluding that the hook did not fire.
+The guarded turn-end signal supplements the pane busy signature, whose locale- and emoji-font-sensitive limits still apply while a turn is running.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
+  <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
   <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution

--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Install or remove Firstmate's guarded Kimi crew turn-end hook.
+#
+# This command is the sole owner of the text-level edit to
+# $HOME/.kimi-code/config.toml. It validates the existing TOML but never
+# serializes it: install adds or replaces one marker-delimited Firstmate region,
+# and remove excises only that region. Missing, malformed, symlinked, partially
+# marked, or otherwise surprising config is refused without a config write.
+#
+# The installed Stop hook always exits 0 and stays silent. It reads cwd from the
+# hook payload, checks for a .fm-kimi-turnend pointer before registry work, and
+# touches a task turn-end marker only when the pointer names a Firstmate-created
+# token in $HOME/.kimi-code/fm-turn-end.d/.
+#
+# Usage:
+#   fm-kimi-turnend-hook.sh install
+#   fm-kimi-turnend-hook.sh remove
+set -u
+
+case "${1:-}" in
+  install|remove) ACTION=$1 ;;
+  -h|--help)
+    sed -n '2,18{s/^# \{0,1\}//;p;}' "$0"
+    exit 0
+    ;;
+  *)
+    printf 'usage: %s install|remove\n' "${0##*/}" >&2
+    exit 2
+    ;;
+esac
+
+if [ -z "${HOME:-}" ]; then
+  printf 'fm-kimi-turnend-hook: refused: HOME is unset.\n' >&2
+  exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  printf 'fm-kimi-turnend-hook: refused: python3 with tomllib is required to validate config.toml.\n' >&2
+  exit 1
+fi
+
+python3 - "$ACTION" "$HOME/.kimi-code" <<'PY'
+import os
+import re
+import shutil
+import stat
+import sys
+import tempfile
+
+try:
+    import tomllib
+except ImportError:
+    print(
+        "fm-kimi-turnend-hook: refused: python3 with tomllib is required to validate config.toml.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+ACTION = sys.argv[1]
+CONFIG_DIR = sys.argv[2]
+CONFIG = os.path.join(CONFIG_DIR, "config.toml")
+HOOK = os.path.join(CONFIG_DIR, "fm-turn-end.sh")
+REGISTRY = os.path.join(CONFIG_DIR, "fm-turn-end.d")
+BEGIN = b"# BEGIN FIRSTMATE KIMI TURN-END HOOK"
+BEGIN_OWNS_NEWLINE = BEGIN + b" (OWNS PRECEDING NEWLINE)"
+END = b"# END FIRSTMATE KIMI TURN-END HOOK"
+IDENTIFIER = b"FIRSTMATE KIMI TURN-END HOOK"
+HOOK_NAME = b"fm-turn-end.sh"
+TOKEN_NAME = re.compile(r"fm\.[A-Za-z0-9]{12}\Z")
+
+HOOK_BYTES = b'''#!/usr/bin/env bash
+# Firstmate Kimi turn-end hook. Managed by fm-kimi-turnend-hook.sh.
+# This hook is deliberately passive: every path is silent and exits zero.
+set +e
+exec >/dev/null 2>&1
+payload=
+IFS= read -r payload || [ -n "$payload" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+workspace=$(jq -er 'select(.hook_event_name == "Stop") | .cwd | strings | select(length > 0)' <<< "$payload" 2>/dev/null) || exit 0
+pointer="$workspace/.fm-kimi-turnend"
+[ -f "$pointer" ] || exit 0
+first=
+IFS= read -r -n 256 first < "$pointer" 2>/dev/null || [ -n "$first" ] || exit 0
+case "$first" in token=*) token=${first#token=} ;; *) exit 0 ;; esac
+case "$token" in fm.????????????) : ;; *) exit 0 ;; esac
+case "$token" in *[!A-Za-z0-9._-]*) exit 0 ;; esac
+auth_dir=${HOME:-}/.kimi-code/fm-turn-end.d
+[ -n "${HOME:-}" ] || exit 0
+target=$(cat "$auth_dir/$token" 2>/dev/null) || exit 0
+case "$target" in /*.turn-ended) : ;; *) exit 0 ;; esac
+touch -- "$target" 2>/dev/null || true
+exit 0
+'''
+
+
+def refuse(reason: str) -> None:
+    print(f"fm-kimi-turnend-hook: refused: {reason}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def regular_not_symlink(path: str, label: str) -> os.stat_result:
+    try:
+        info = os.lstat(path)
+    except FileNotFoundError:
+        refuse(f"{label} is missing at {path}.")
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        refuse(f"{label} is not a regular non-symlink file at {path}.")
+    return info
+
+
+def parse_toml(data: bytes, label: str):
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        refuse(f"{label} is not UTF-8: {error}.")
+    try:
+        parsed = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as error:
+        refuse(f"{label} is malformed TOML: {error}.")
+    hooks = parsed.get("hooks")
+    if hooks is not None and not isinstance(hooks, list):
+        refuse(f"{label} has an unexpected non-array 'hooks' value.")
+    return parsed
+
+
+def locate_region(data: bytes):
+    normal_count = data.count(BEGIN + b"\n")
+    owned_count = data.count(BEGIN_OWNS_NEWLINE + b"\n")
+    end_count = data.count(END)
+    identifier_count = data.count(IDENTIFIER)
+    if normal_count + owned_count == 0 and end_count == 0 and identifier_count == 0:
+        return None
+    if normal_count + owned_count != 1 or end_count != 1 or identifier_count != 2:
+        refuse("config.toml has partial, duplicated, or altered Firstmate region markers.")
+    marker = BEGIN_OWNS_NEWLINE if owned_count else BEGIN
+    marker_at = data.find(marker)
+    if marker_at != 0 and data[marker_at - 1 : marker_at] != b"\n":
+        refuse("the Firstmate begin marker is not at a line boundary.")
+    start = marker_at
+    if owned_count:
+        if marker_at == 0 or data[marker_at - 1 : marker_at] != b"\n":
+            refuse("the Firstmate region claims a preceding newline that is absent.")
+        start -= 1
+    end_at = data.find(END, marker_at + len(marker))
+    if end_at < 0:
+        refuse("the Firstmate end marker is missing.")
+    after = end_at + len(END)
+    if after < len(data):
+        if data[after : after + 1] != b"\n":
+            refuse("the Firstmate end marker is not a complete line.")
+        after += 1
+    return start, after, marker
+
+
+def block(marker: bytes) -> bytes:
+    return b"\n".join(
+        (
+            marker,
+            b"[[hooks]]",
+            b'event = "Stop"',
+            b'matcher = "^$"',
+            b'command = "bash \\"$HOME/.kimi-code/fm-turn-end.sh\\" >/dev/null 2>&1 || true"',
+            b"timeout = 1",
+            END,
+            b"",
+        )
+    )
+
+
+def atomic_write(path: str, data: bytes, mode: int) -> None:
+    fd, temporary = tempfile.mkstemp(prefix=f".{os.path.basename(path)}.", dir=os.path.dirname(path))
+    try:
+        os.fchmod(fd, mode)
+        with os.fdopen(fd, "wb") as stream:
+            fd = -1
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except Exception:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def validate_firstmate_files_for_remove() -> None:
+    if os.path.lexists(HOOK):
+        info = regular_not_symlink(HOOK, "Firstmate hook script")
+        with open(HOOK, "rb") as stream:
+            if stream.read() != HOOK_BYTES:
+                refuse(f"Firstmate hook script has unexpected content at {HOOK}.")
+        if stat.S_IMODE(info.st_mode) & 0o077:
+            refuse(f"Firstmate hook script has unexpectedly broad permissions at {HOOK}.")
+    if os.path.lexists(REGISTRY):
+        info = os.lstat(REGISTRY)
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+            refuse(f"Firstmate registry is not a regular directory at {REGISTRY}.")
+        for name in os.listdir(REGISTRY):
+            path = os.path.join(REGISTRY, name)
+            child = os.lstat(path)
+            if not TOKEN_NAME.fullmatch(name) or stat.S_ISLNK(child.st_mode) or not stat.S_ISREG(child.st_mode):
+                refuse(f"Firstmate registry contains an unexpected entry at {path}.")
+
+
+try:
+    if not os.path.isdir(CONFIG_DIR) or os.path.islink(CONFIG_DIR):
+        refuse(f"Kimi config directory is missing or unexpected at {CONFIG_DIR}.")
+    config_info = regular_not_symlink(CONFIG, "Kimi config")
+    with open(CONFIG, "rb") as stream:
+        original = stream.read()
+    parse_toml(original, "config.toml")
+    region = locate_region(original)
+    outside = original if region is None else original[: region[0]] + original[region[1] :]
+    if HOOK_NAME in outside:
+        refuse("config.toml references fm-turn-end.sh outside the Firstmate-owned region.")
+
+    if ACTION == "install":
+        if os.path.lexists(REGISTRY):
+            info = os.lstat(REGISTRY)
+            if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+                refuse(f"Firstmate registry is not a regular directory at {REGISTRY}.")
+        if os.path.lexists(HOOK):
+            regular_not_symlink(HOOK, "Firstmate hook script")
+            with open(HOOK, "rb") as stream:
+                existing_hook = stream.read()
+            if existing_hook != HOOK_BYTES and not existing_hook.startswith(
+                b"#!/usr/bin/env bash\n# Firstmate Kimi turn-end hook."
+            ):
+                refuse(f"Firstmate hook path has unexpected content at {HOOK}.")
+        if region is None:
+            marker = BEGIN if original.endswith(b"\n") else BEGIN_OWNS_NEWLINE
+            addition = block(marker)
+            candidate = original + (b"" if original.endswith(b"\n") else b"\n") + addition
+        else:
+            candidate = original[: region[0]] + (
+                (b"\n" if region[2] == BEGIN_OWNS_NEWLINE else b"") + block(region[2])
+            ) + original[region[1] :]
+        parse_toml(candidate, "updated config.toml")
+        os.makedirs(REGISTRY, mode=0o700, exist_ok=True)
+        os.chmod(REGISTRY, 0o700)
+        installed_hook = None
+        if os.path.exists(HOOK):
+            with open(HOOK, "rb") as stream:
+                installed_hook = stream.read()
+        if installed_hook != HOOK_BYTES or stat.S_IMODE(os.stat(HOOK).st_mode) != 0o700:
+            atomic_write(HOOK, HOOK_BYTES, 0o700)
+        if candidate != original:
+            atomic_write(CONFIG, candidate, stat.S_IMODE(config_info.st_mode))
+    else:
+        validate_firstmate_files_for_remove()
+        candidate = outside
+        parse_toml(candidate, "config.toml after Firstmate region removal")
+        if candidate != original:
+            atomic_write(CONFIG, candidate, stat.S_IMODE(config_info.st_mode))
+        if os.path.lexists(HOOK):
+            os.unlink(HOOK)
+        if os.path.lexists(REGISTRY):
+            shutil.rmtree(REGISTRY)
+except OSError as error:
+    refuse(f"filesystem operation failed: {error}.")
+PY

--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -170,6 +170,13 @@ def block(marker: bytes) -> bytes:
     )
 
 
+def without_region(data: bytes, region) -> bytes:
+    prefix = data[: region[0]]
+    suffix = data[region[1] :]
+    separator = b"\n" if region[2] == BEGIN_OWNS_NEWLINE and suffix else b""
+    return prefix + separator + suffix
+
+
 def atomic_write(path: str, data: bytes, mode: int) -> None:
     fd, temporary = tempfile.mkstemp(prefix=f".{os.path.basename(path)}.", dir=os.path.dirname(path))
     try:
@@ -217,7 +224,7 @@ try:
         original = stream.read()
     parse_toml(original, "config.toml")
     region = locate_region(original)
-    outside = original if region is None else original[: region[0]] + original[region[1] :]
+    outside = original if region is None else without_region(original, region)
     if HOOK_NAME in outside:
         refuse("config.toml references fm-turn-end.sh outside the Firstmate-owned region.")
 

--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -37,6 +37,10 @@ if ! command -v python3 >/dev/null 2>&1; then
   printf 'fm-kimi-turnend-hook: refused: python3 with tomllib is required to validate config.toml.\n' >&2
   exit 1
 fi
+if [ "$ACTION" = install ] && ! command -v jq >/dev/null 2>&1; then
+  printf 'fm-kimi-turnend-hook: refused: jq is required by the installed Kimi turn-end hook.\n' >&2
+  exit 1
+fi
 
 python3 - "$ACTION" "$HOME/.kimi-code" <<'PY'
 import os

--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -173,6 +173,7 @@ def block(marker: bytes) -> bytes:
 def without_region(data: bytes, region) -> bytes:
     prefix = data[: region[0]]
     suffix = data[region[1] :]
+    # Retain a newline so removal cannot join the captain's preceding line to content appended after installation.
     separator = b"\n" if region[2] == BEGIN_OWNS_NEWLINE and suffix else b""
     return prefix + separator + suffix
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -102,7 +102,8 @@
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
-# Kimi has no enabled hook because its only verified Stop-hook configuration is global.
+# Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
+# a firstmate-owned global hook and registry, and a gitignored per-task pointer.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<backend-target> worktree=<path>
@@ -450,8 +451,8 @@ launch_template() {
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # Kimi Code rejects a positional prompt, so it launches bare and receives
     # only an absolute brief pointer after the TUI readiness gate below.
-    # No turn-end placeholder belongs here because its only verified Stop hook
-    # is global configuration and is not enabled without captain approval.
+    # Its turn-end signal is a globally configured Stop hook plus a guarded
+    # per-task worktree token, so no launch placeholder belongs here.
     kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
     *) return 1 ;;
   esac
@@ -615,6 +616,12 @@ case "$LAUNCH" in
   *__KIMIBIN__*)
     KIMI_BIN=$(resolve_kimi_binary) || exit 1
     LAUNCH=${LAUNCH//__KIMIBIN__/$(shell_quote "$KIMI_BIN")}
+    if [ "$KIND" != secondmate ]; then
+      "$FM_ROOT/bin/fm-kimi-turnend-hook.sh" install || {
+        echo "error: refusing Kimi spawn because the global turn-end hook could not be installed safely" >&2
+        exit 1
+      }
+    fi
     ;;
 esac
 
@@ -1278,12 +1285,11 @@ mkdir -p "$TASK_TMP/gotmp"
 
 # Per-harness turn-end hook where enabled: a file that touches
 # state/<id>.turn-ended when the agent finishes a turn. Worktree-resident hooks
-# are kept out of git's view so they never block teardown's dirty check or leak
-# into a commit. Kimi has no path because its global-only hook is not enabled.
+# and token pointers stay out of git's view so they never block teardown's dirty
+# check or leak into a commit.
 mkdir -p "$STATE"
 STATE_REAL=$(cd "$STATE" && pwd -P)
-TURNEND=
-[ "$HARNESS" = kimi ] || TURNEND="$STATE_REAL/$ID.turn-ended"
+TURNEND="$STATE_REAL/$ID.turn-ended"
 exclude_path() {
   local rel=$1 EXCL
   EXCL=$(git -C "$WT" rev-parse --git-path info/exclude 2>/dev/null || true)
@@ -1377,6 +1383,21 @@ EOF
       printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$GROK_HOOKS_DIR/fm-turn-end.json"
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
+      ;;
+    kimi*)
+      # Kimi's Stop hook is global, but it is inert unless cwd contains this
+      # task's token pointer and the token resolves through Firstmate's private
+      # registry. The installer above owns the format-preserving config edit and
+      # the always-zero, silent hook script.
+      KIMI_AUTH_DIR="$HOME/.kimi-code/fm-turn-end.d"
+      old_umask=$(umask)
+      umask 077
+      auth_file=$(mktemp "$KIMI_AUTH_DIR/fm.XXXXXXXXXXXX")
+      umask "$old_umask"
+      printf '%s\n' "$TURNEND" > "$auth_file"
+      printf '%s\n' "${auth_file##*/}" > "$STATE/$ID.kimi-turnend-token"
+      printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-kimi-turnend"
+      exclude_path '.fm-kimi-turnend'
       ;;
   esac
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -196,6 +196,14 @@ remove_grok_turnend_auth() {
   rm -f "$hooks_dir/$token"
 }
 
+remove_kimi_turnend_auth() {
+  local state_dir=$1 id=$2 token hooks_dir
+  token=$(cat "$state_dir/$id.kimi-turnend-token" 2>/dev/null || true)
+  case "$token" in ''|*[!A-Za-z0-9._-]*) return 0 ;; esac
+  hooks_dir="$HOME/.kimi-code/fm-turn-end.d"
+  rm -f "$hooks_dir/$token"
+}
+
 validate_pr_poll_cleanup() {
   local state_dir=$1 id=$2 quarantine state_device artifact has_artifact=0
   fm_task_id_path_safe "$id" || return 0
@@ -672,7 +680,7 @@ validate_worktree_teardown_safety() {
     echo "Restore the git index state, or get the captain's explicit OK to discard, then --force." >&2
     return 1
   fi
-  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$)' | head -1 || true)
+  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-(grok|kimi)-turnend$)' | head -1 || true)
 
   if ! unpushed_raw=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null); then
     if worktree_safety_blocked_by_lock "commits not on a remote"; then
@@ -1002,12 +1010,14 @@ cleanup_firstmate_home_children() {
     elif [ "$child_backend" = orca ]; then
       if [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
         validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
+          "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
+        "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
         if teardown_treehouse_return "$child_wt" "$child_proj" "child worktree"; then
           :
@@ -1023,8 +1033,11 @@ cleanup_firstmate_home_children() {
       fi
     fi
     remove_grok_turnend_auth "$sub_state" "$child_id"
+    remove_kimi_turnend_auth "$sub_state" "$child_id"
     remove_pr_poll_artifacts "$sub_state" "$child_id" || return 1
-    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token"
+    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" \
+      "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
+      "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token"
   done
 }
 
@@ -1114,7 +1127,8 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
         git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
       fi
     fi
-    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+      "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   fi
   [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
   fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
@@ -1126,7 +1140,8 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+    "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
   # the project. teardown_treehouse_return tolerates transient and stale git locks
@@ -1205,12 +1220,15 @@ if [ "$KIND" = secondmate ]; then
   remove_secondmate_registry_entry "$ID"
 fi
 remove_grok_turnend_auth "$STATE" "$ID"
+remove_kimi_turnend_auth "$STATE" "$ID"
 fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
-rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
+rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
+  "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
+  "$STATE/$ID.kimi-turnend-token"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,7 +197,8 @@ Those inherited values are defaults and rules only; `fm-spawn` still permits a c
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install`, drops a per-task `.fm-kimi-turnend` pointer in the worktree, and records the matching private registry token for teardown.
-The Kimi installer requires `python3` with `tomllib` and `jq`, validates but never serializes the captain's existing TOML, and refuses before writing when either requirement is unavailable.
+Kimi continues to use the captain's normal Kimi home, including the existing config, skills, and memory; Firstmate does not create an isolated Kimi home.
+The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, or surprising or when either tool requirement is unavailable.
 Its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
 For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,7 +179,7 @@ New harnesses get verified through a supervised trial task before joining the se
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
-Kimi is outside the enabled integration scope; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its verified hook boundary.
+Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
 Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.
@@ -196,6 +196,8 @@ The inherited-local-material contract is owned by [`secondmate-provisioning`](..
 Those inherited values are defaults and rules only; `fm-spawn` still permits a consciously chosen explicit runtime outside the config.
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
+For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install`, drops a per-task `.fm-kimi-turnend` pointer in the worktree, and records the matching private registry token for teardown.
+The Kimi installer validates but never serializes the captain's existing TOML, and its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
 For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,7 +197,8 @@ Those inherited values are defaults and rules only; `fm-spawn` still permits a c
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install`, drops a per-task `.fm-kimi-turnend` pointer in the worktree, and records the matching private registry token for teardown.
-The Kimi installer validates but never serializes the captain's existing TOML, and its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
+The Kimi installer requires `python3` with `tomllib` and `jq`, validates but never serializes the captain's existing TOML, and refuses before writing when either requirement is unavailable.
+Its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
 For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -32,6 +32,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
+| `fm-kimi-turnend-hook.sh` | Surgically install or remove Kimi's guarded global crew turn-end hook                |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |
 | `fm-subagent-pretool-check.sh` | Primary-home delegation-shape PreToolUse guard (docs/subagent-guard.md) |

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -76,7 +76,9 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - Kimi has no project-level hook configuration and remains outside the primary guard integrations above.
 - Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to edit only one marker-delimited Firstmate region in that global config and install a silent always-zero hook.
 - The hook remains inert unless the payload `cwd` contains a per-task token pointer that resolves through Firstmate's private registry to one `state/<id>.turn-ended` marker.
-- Missing `jq` or unreadable hook input remains fail-open.
+- Installation refuses before writing unless `python3` with `tomllib` and `jq` are available.
+- If `jq` is removed after installation, the hook remains silent and exits 0, turn-end wakes stop, and Kimi crews fall back to idle detection.
+- Unreadable hook input remains fail-open.
 - No harness adapter uses a shell ampersand to manufacture supervision.
 
 ## Regression coverage

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -73,13 +73,16 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - Claude and Codex block directly, while OpenCode, Pi, and Grok use bounded passive follow-ups.
 - OpenCode headless mode and untrusted Grok project hooks remain fail-open at the host boundary.
 - Kimi Code CLI 0.29.1 exposes only global `[[hooks]]` configuration in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
-- Kimi has no project-level hook configuration, so Firstmate does not modify that global file without captain approval, installs no Kimi hook, and writes no Kimi turn-end marker.
+- Kimi has no project-level hook configuration and remains outside the primary guard integrations above.
+- Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to edit only one marker-delimited Firstmate region in that global config and install a silent always-zero hook.
+- The hook remains inert unless the payload `cwd` contains a per-task token pointer that resolves through Firstmate's private registry to one `state/<id>.turn-ended` marker.
 - Missing `jq` or unreadable hook input remains fail-open.
 - No harness adapter uses a shell ampersand to manufacture supervision.
 
 ## Regression coverage
 
-`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five registrations, and Grok resume permission and recursion safety.
+`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, and Grok resume permission and recursion safety.
+`tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.
 [`verification/supervision.md`](verification/supervision.md#turn-end-guard) records the active cross-harness empirical evidence, including the 2026-07-24 Claude `asyncRewake` revalidation.

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -6,8 +6,11 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+KIMI_HOOK="$ROOT/bin/fm-kimi-turnend-hook.sh"
 TMP_ROOT=$(fm_test_tmproot fm-kimi-harness)
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+PYTHON_BIN_DIR=$(dirname "$(command -v python3)")
+BASE_PATH=${FM_TEST_BASE_PATH:-$PYTHON_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin}
 
 assert_source_line() {
   local line=$1
@@ -114,7 +117,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
   fm_fake_exit0 "$fakebin" kimi
   printf '%s\n' "$fakebin"
 }
@@ -126,7 +129,8 @@ make_spawn_case() {
   proj="$case_dir/project"
   wt="$case_dir/wt"
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
-  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" "$home/.kimi-code"
+  printf '# Kimi test config\ndefault_model = "test"\n' > "$home/.kimi-code/config.toml"
   printf 'brief for kimi\n' > "$home/data/$id/brief.md"
   printf 'kimi\n' > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
@@ -179,7 +183,7 @@ test_kimi_launch_then_send_is_verified() {
   [ "$launch" = "'$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
     || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
   assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
-  assert_not_contains "$launch" "turn-ended" "kimi launch implied a turn-end marker"
+  assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
   assert_not_contains "$launch" "__TURNEND__" "kimi launch retained a turn-end placeholder"
 
   brief_real="$(cd "$HOME_DIR/data/$id" && pwd -P)/brief.md"
@@ -189,8 +193,162 @@ test_kimi_launch_then_send_is_verified() {
   meta="$HOME_DIR/state/$id.meta"
   assert_grep 'model=kimi-code/k3' "$meta" "kimi meta lost the requested model"
   assert_grep 'effort=high' "$meta" "kimi meta did not retain the unsupported effort axis"
-  assert_absent "$HOME_DIR/.kimi-code/config.toml" "kimi spawn wrote a global config file"
-  pass "fm-spawn: kimi launches bare, waits for readiness, sends an absolute brief pointer, and confirms delivery"
+  assert_grep 'BEGIN FIRSTMATE KIMI TURN-END HOOK' "$HOME_DIR/.kimi-code/config.toml" \
+    "kimi spawn did not install its guarded global hook region"
+  assert_grep 'token=' "$WT_DIR/.fm-kimi-turnend" "kimi spawn did not write its token pointer"
+  assert_present "$HOME_DIR/state/$id.kimi-turnend-token" "kimi spawn did not record its token"
+  pass "fm-spawn: kimi launches, delivers its brief, and registers a guarded turn-end token"
+}
+
+test_kimi_hook_install_is_surgical_idempotent_and_removable() {
+  local home config original once stripped count
+  home="$TMP_ROOT/config-surgery"
+  config="$home/.kimi-code/config.toml"
+  original="$home/original.toml"
+  once="$home/once.toml"
+  stripped="$home/stripped.toml"
+  mkdir -p "$home/.kimi-code"
+  cat > "$config" <<'EOF'
+# Captain's leading comment stays exactly here.
+
+[ui]
+theme = "night" # inline comment
+show_usage = true
+
+# Foreign hook with intentionally unusual key ordering.
+[[hooks]]
+timeout=17
+command = "printf foreign"
+matcher=""
+event = "Stop"
+
+[providers.example]
+model = "some/model"
+# Final comment and blank line follow.
+
+EOF
+  cp "$config" "$original"
+
+  HOME="$home" "$KIMI_HOOK" install || fail "Kimi hook install refused a realistic config"
+  cp "$config" "$once"
+  HOME="$home" "$KIMI_HOOK" install || fail "second Kimi hook install failed"
+  cmp -s "$once" "$config" || fail "second Kimi hook install changed config bytes"
+  count=$(grep -c '^# BEGIN FIRSTMATE KIMI TURN-END HOOK' "$config")
+  [ "$count" -eq 1 ] || fail "idempotent install left $count Firstmate regions"
+
+  HOME="$home" "$KIMI_HOOK" remove || fail "Kimi hook removal failed"
+  cp "$config" "$stripped"
+  cmp -s "$original" "$stripped" \
+    || fail "config with the Firstmate region excised was not byte-identical to the original"
+  assert_absent "$home/.kimi-code/fm-turn-end.sh" "removal left the Firstmate hook script"
+  assert_absent "$home/.kimi-code/fm-turn-end.d" "removal left the Firstmate registry"
+  pass "Kimi hook install is idempotent and removal restores every foreign config byte"
+}
+
+test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config() {
+  local missing malformed partial out rc
+  missing="$TMP_ROOT/config-missing"
+  malformed="$TMP_ROOT/config-malformed"
+  partial="$TMP_ROOT/config-partial"
+  mkdir -p "$missing/.kimi-code" "$malformed/.kimi-code" "$partial/.kimi-code"
+
+  rc=0
+  out=$(HOME="$missing" "$KIMI_HOOK" install 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "missing Kimi config was accepted"
+  assert_contains "$out" "Kimi config is missing" "missing config refusal lacked its concrete reason"
+  assert_absent "$missing/.kimi-code/fm-turn-end.sh" "missing config refusal wrote the hook script"
+
+  printf '[broken\n' > "$malformed/.kimi-code/config.toml"
+  cp "$malformed/.kimi-code/config.toml" "$malformed/before"
+  rc=0
+  out=$(HOME="$malformed" "$KIMI_HOOK" install 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "malformed Kimi config was accepted"
+  assert_contains "$out" "malformed TOML" "malformed config refusal lacked its concrete reason"
+  cmp -s "$malformed/before" "$malformed/.kimi-code/config.toml" \
+    || fail "malformed config refusal changed config bytes"
+  assert_absent "$malformed/.kimi-code/fm-turn-end.sh" "malformed config refusal wrote the hook script"
+
+  printf '# BEGIN FIRSTMATE KIMI TURN-END HOOK\n' > "$partial/.kimi-code/config.toml"
+  cp "$partial/.kimi-code/config.toml" "$partial/before"
+  rc=0
+  out=$(HOME="$partial" "$KIMI_HOOK" install 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "partial Firstmate marker was accepted"
+  assert_contains "$out" "partial, duplicated, or altered" "partial marker refusal lacked its concrete reason"
+  cmp -s "$partial/before" "$partial/.kimi-code/config.toml" \
+    || fail "partial marker refusal changed config bytes"
+  pass "Kimi hook install refuses missing, malformed, and surprising config without writing"
+}
+
+test_kimi_hook_is_silent_and_requires_registered_workspace_token() {
+  local id rec out rc hook target token no_token snapshot_before snapshot_after
+  id=kimi-hook-auth-z6
+  rec=$(make_spawn_case hook-auth "$id")
+  read_spawn_record "$rec"
+  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id")
+  rc=$?
+  expect_code 0 "$rc" "Kimi spawn should succeed before hook authentication checks"
+  hook="$HOME_DIR/.kimi-code/fm-turn-end.sh"
+  target="$HOME_DIR/state/$id.turn-ended"
+  token=$(sed -n 's/^token=//p' "$WT_DIR/.fm-kimi-turnend")
+  assert_present "$HOME_DIR/.kimi-code/fm-turn-end.d/$token" "Kimi registry token is missing"
+
+  no_token="$CASE_DIR/no-token-workspace"
+  mkdir -p "$no_token"
+  snapshot_before=$(find "$no_token" -mindepth 1 -print)
+  out=$(printf '{"hook_event_name":"Stop","session_id":"ordinary","cwd":"%s","stop_hook_active":false}\n' "$no_token" \
+    | HOME="$HOME_DIR" bash "$hook" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "Kimi hook must never block a tokenless session"
+  [ -z "$out" ] || fail "Kimi hook printed into a tokenless session: $out"
+  snapshot_after=$(find "$no_token" -mindepth 1 -print)
+  [ "$snapshot_before" = "$snapshot_after" ] || fail "Kimi hook wrote inside a tokenless workspace"
+  assert_absent "$target" "tokenless Kimi hook invocation touched a task marker"
+
+  printf 'token=%s\n' "$token" > "$WT_DIR/.fm-kimi-turnend"
+  out=$(printf '{"hook_event_name":"Stop","session_id":"crew","cwd":"%s","stop_hook_active":false}\n' "$WT_DIR" \
+    | HOME="$HOME_DIR" bash "$hook" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "registered Kimi hook invocation did not exit zero"
+  [ -z "$out" ] || fail "registered Kimi hook invocation printed output: $out"
+  assert_present "$target" "registered Kimi hook invocation did not touch the turn-end marker"
+  pass "Kimi hook stays silent and inert without a Firstmate registry token"
+}
+
+test_kimi_spawn_refuses_unsafe_global_config_before_pane_creation() {
+  local id rec out rc
+  id=kimi-config-refuse-z7
+  rec=$(make_spawn_case config-refuse "$id")
+  read_spawn_record "$rec"
+  printf '[malformed\n' > "$HOME_DIR/.kimi-code/config.toml"
+  rc=0
+  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "Kimi spawn accepted malformed global config"
+  assert_contains "$out" "malformed TOML" "Kimi spawn omitted the concrete config refusal"
+  if grep -Eq '(^| )new-(session|window)( |$)' "$CASE_DIR/tmux-calls.log"; then
+    fail "unsafe Kimi config refusal created a tmux container or pane"
+  fi
+  pass "fm-spawn: unsafe Kimi global config refuses before pane creation"
+}
+
+test_kimi_teardown_removes_pointer_and_registry_token() {
+  local id rec out rc token
+  id=kimi-teardown-z8
+  rec=$(make_spawn_case teardown "$id")
+  read_spawn_record "$rec"
+  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id")
+  rc=$?
+  expect_code 0 "$rc" "Kimi spawn should succeed before teardown"
+  token=$(sed -n 's/^token=//p' "$WT_DIR/.fm-kimi-turnend")
+
+  HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 PATH="$FAKEBIN_DIR:$BASE_PATH" \
+    "$TEARDOWN" "$id" --force >/dev/null 2>&1 || fail "Kimi teardown failed"
+  assert_absent "$WT_DIR/.fm-kimi-turnend" "Kimi token pointer survived teardown"
+  assert_absent "$HOME_DIR/.kimi-code/fm-turn-end.d/$token" "Kimi registry token survived teardown"
+  assert_absent "$HOME_DIR/state/$id.kimi-turnend-token" "Kimi token state survived teardown"
+  pass "fm-teardown: Kimi task pointer and registry token are removed"
 }
 
 test_kimi_falls_back_to_expanded_home_binary() {
@@ -423,7 +581,12 @@ test_kimi_bordered_prompt_needs_no_override() {
 
 test_tracked_files_have_no_user_absolute_paths
 test_existing_launch_templates_are_byte_pinned
+test_kimi_hook_install_is_surgical_idempotent_and_removable
+test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config
 test_kimi_launch_then_send_is_verified
+test_kimi_hook_is_silent_and_requires_registered_workspace_token
+test_kimi_spawn_refuses_unsafe_global_config_before_pane_creation
+test_kimi_teardown_removes_pointer_and_registry_token
 test_kimi_falls_back_to_expanded_home_binary
 test_kimi_missing_binary_refuses_before_pane_creation
 test_kimi_unconfirmed_delivery_fails_loudly

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -279,8 +279,30 @@ test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config() {
   pass "Kimi hook install refuses missing, malformed, and surprising config without writing"
 }
 
+test_kimi_hook_install_refuses_without_jq() {
+  local home config before fakebin out rc
+  home="$TMP_ROOT/config-no-jq"
+  config="$home/.kimi-code/config.toml"
+  before="$home/config-before.toml"
+  fakebin=$(fm_fakebin "$home/no-jq")
+  mkdir -p "$home/.kimi-code"
+  printf '# Captain config\nmodel = "test"\n' > "$config"
+  cp "$config" "$before"
+  ln -s "$(command -v bash)" "$fakebin/bash"
+  ln -s "$(command -v python3)" "$fakebin/python3"
+
+  rc=0
+  out=$(HOME="$home" PATH="$fakebin" "$KIMI_HOOK" install 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "Kimi hook install succeeded without jq"
+  assert_contains "$out" "jq is required" "missing-jq refusal did not name jq"
+  cmp -s "$before" "$config" || fail "missing-jq refusal changed config bytes"
+  assert_absent "$home/.kimi-code/fm-turn-end.sh" "missing-jq refusal wrote the hook script"
+  assert_absent "$home/.kimi-code/fm-turn-end.d" "missing-jq refusal wrote the registry"
+  pass "Kimi hook install refuses without jq before any config write"
+}
+
 test_kimi_hook_is_silent_and_requires_registered_workspace_token() {
-  local id rec out rc hook target token no_token snapshot_before snapshot_after
+  local id rec out rc hook target token no_token snapshot_before snapshot_after fakebin
   id=kimi-hook-auth-z6
   rec=$(make_spawn_case hook-auth "$id")
   read_spawn_record "$rec"
@@ -311,6 +333,16 @@ test_kimi_hook_is_silent_and_requires_registered_workspace_token() {
   expect_code 0 "$rc" "registered Kimi hook invocation did not exit zero"
   [ -z "$out" ] || fail "registered Kimi hook invocation printed output: $out"
   assert_present "$target" "registered Kimi hook invocation did not touch the turn-end marker"
+
+  rm "$target"
+  fakebin=$(fm_fakebin "$CASE_DIR/no-jq")
+  ln -s "$(command -v bash)" "$fakebin/bash"
+  out=$(printf '{"hook_event_name":"Stop","session_id":"crew","cwd":"%s","stop_hook_active":false}\n' "$WT_DIR" \
+    | HOME="$HOME_DIR" PATH="$fakebin" "$hook" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "Kimi hook without jq must still exit zero"
+  [ -z "$out" ] || fail "Kimi hook without jq printed output: $out"
+  assert_absent "$target" "Kimi hook without jq touched the turn-end marker"
   pass "Kimi hook stays silent and inert without a Firstmate registry token"
 }
 
@@ -583,6 +615,7 @@ test_tracked_files_have_no_user_absolute_paths
 test_existing_launch_templates_are_byte_pinned
 test_kimi_hook_install_is_surgical_idempotent_and_removable
 test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config
+test_kimi_hook_install_refuses_without_jq
 test_kimi_launch_then_send_is_verified
 test_kimi_hook_is_silent_and_requires_registered_workspace_token
 test_kimi_spawn_refuses_unsafe_global_config_before_pane_creation

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -9,7 +9,9 @@ SPAWN="$ROOT/bin/fm-spawn.sh"
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 KIMI_HOOK="$ROOT/bin/fm-kimi-turnend-hook.sh"
 TMP_ROOT=$(fm_test_tmproot fm-kimi-harness)
-PYTHON_BIN_DIR=$(dirname "$(command -v python3)")
+PYTHON_BIN=$(command -v python3) || fail "test needs python3"
+PYTHON_BIN_DIR=$(dirname "$PYTHON_BIN")
+JQ_BIN=$(command -v jq) || fail "test needs jq"
 BASE_PATH=${FM_TEST_BASE_PATH:-$PYTHON_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin}
 
 assert_source_line() {
@@ -119,6 +121,7 @@ SH
   chmod +x "$fakebin/tmux"
   fm_fake_exit0 "$fakebin" treehouse gh-axi gh
   fm_fake_exit0 "$fakebin" kimi
+  ln -s "$JQ_BIN" "$fakebin/jq"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -248,6 +248,43 @@ EOF
   pass "Kimi hook install is idempotent and removal restores every foreign config byte"
 }
 
+test_kimi_hook_remove_preserves_owned_newline_boundary() {
+  local appended config expected home original
+  home="$TMP_ROOT/config-owned-newline"
+  config="$home/.kimi-code/config.toml"
+  original="$home/original.toml"
+  expected="$home/expected.toml"
+  appended="$home/appended.toml"
+  mkdir -p "$home/.kimi-code"
+  printf 'default_model = "test"' > "$config"
+  cp "$config" "$original"
+
+  HOME="$home" "$KIMI_HOOK" install || fail "Kimi hook install refused config without a final newline"
+  HOME="$home" "$KIMI_HOOK" remove || fail "Kimi hook removal failed without appended config"
+  cmp -s "$original" "$config" \
+    || fail "pristine removal did not restore the absent final newline byte-identically"
+
+  HOME="$home" "$KIMI_HOOK" install || fail "second Kimi hook install refused config without a final newline"
+  printf '[captain]\nenabled = true\n' > "$appended"
+  cat "$appended" >> "$config"
+  HOME="$home" "$KIMI_HOOK" remove || fail "Kimi hook removal joined config appended after its region"
+  {
+    cat "$original"
+    printf '\n'
+    cat "$appended"
+  } > "$expected"
+  cmp -s "$expected" "$config" \
+    || fail "removal did not preserve appended captain config on its own line"
+  "$PYTHON_BIN" - "$config" <<'PY' || fail "config with appended captain TOML did not parse after removal"
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as stream:
+    tomllib.load(stream)
+PY
+  pass "Kimi hook removal preserves owned newline boundaries and pristine bytes"
+}
+
 test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config() {
   local missing malformed partial out rc
   missing="$TMP_ROOT/config-missing"
@@ -617,6 +654,7 @@ test_kimi_bordered_prompt_needs_no_override() {
 test_tracked_files_have_no_user_absolute_paths
 test_existing_launch_templates_are_byte_pinned
 test_kimi_hook_install_is_surgical_idempotent_and_removable
+test_kimi_hook_remove_preserves_owned_newline_boundary
 test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config
 test_kimi_hook_install_refuses_without_jq
 test_kimi_launch_then_send_is_verified


### PR DESCRIPTION
## Intent

Enable Firstmate's Kimi Stop turn-end wake through a guarded per-worktree token and private registry while preserving the captain's shared Kimi config, skills, and memory. Install only a surgical marker-delimited Firstmate-owned region in ~/.kimi-code/config.toml, preserve every unrelated byte, remain idempotent and removable, fail closed on missing or malformed config and on missing jq, keep the runtime hook silent and always exit 0, and ensure sessions without a Firstmate token are unaffected. Do not use an isolated Kimi home or a second JSON parser fallback. The PR body must state the exact removal command 'bin/fm-kimi-turnend-hook.sh remove' and include demonstrated no-interference evidence: a real non-Firstmate session with the hook installed and no token completed normally in 4.05 seconds with zero hook output and no side effect in cwd; across 10 no-token hook runs the measured overhead was median 9.8 ms and maximum 11.6 ms, about 0.24 percent of that turn. It must also report the real positive proof that a registered Firstmate target was touched. Validate the rebased change fully through green CI.

## What Changed

- Add a guarded, silent Kimi Stop hook that surgically preserves shared config, skills, and memory; installation fails closed on unsafe config or missing `jq`, stays idempotent, and can be removed with `bin/fm-kimi-turnend-hook.sh remove`.
- Register per-worktree tokens during Kimi crew spawn, touch only the authorized task turn-end marker, and clean up pointers and private registry entries during teardown.
- Demonstrate no interference: a real non-Firstmate session completed normally in 4.05 seconds with zero hook output and no cwd side effects; 10 no-token runs measured 9.8 ms median and 11.6 ms maximum overhead, about 0.24% of that turn, while a registered Firstmate target was successfully touched.

## Risk Assessment

✅ Low: The boundary fix now preserves appended captain TOML while retaining byte-identical pristine removal, includes focused regression coverage, and documents the deliberate newline behavior.

## Testing

No separate baseline output was supplied. The focused Kimi harness test passed, and the recorded end-to-end flow demonstrated preservation of captain config, skills, memory, and a foreign hook; mode-700 registry creation; silent zero-exit no-token behavior with no cwd or target side effect; a registered target touch; idempotent installation; and byte-identical removal.

<details>
<summary>Evidence: Kimi turn-end end-to-end transcript</summary>

```text
Kimi guarded turn-end hook end-to-end evidence
config_marker_count_after_install=1
captain_skills_line_preserved=1
captain_memory_line_preserved=1
foreign_hook_line_preserved=1
private_registry_permissions=700
idempotent_second_install=yes
ordinary_session_exit=0
ordinary_session_hook_output_bytes=0
ordinary_session_cwd_entries=0
target_touched_after_ordinary_session=no
registered_session_exit=0
registered_session_hook_output_bytes=0
registered_target_touched=yes
config_byte_identical_after_remove=yes
managed_hook_removed=yes
private_registry_removed=yes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-kimi-turnend-hook.sh:220` - The required behavior says the installer must &#34;remain idempotent and removable&#34; and &#34;preserve every unrelated byte,&#34; but `outside = original[: region[0]] + original[region[1]:]` can make removal fail after a normal edit. If the original config lacked a final newline, install uses the marker that owns the preceding newline; if the captain later appends valid TOML below the installed block, removal consumes both boundary newlines and concatenates the original final line with the appended first line. The resulting TOML is invalid, so `remove` refuses. Reconstruct this boundary so a Firstmate-owned separator is retained when a suffix exists, and cover the no-final-newline -&gt; install -&gt; append -&gt; remove sequence.

🔧 Fix: Preserve Kimi config boundaries during hook removal
1 warning still open:
- ⚠️ `bin/fm-kimi-turnend-hook.sh:176` - The chosen fix explicitly required a comment explaining that the retained newline prevents joining the captain&#39;s preceding line to content appended after installation, but the new `separator` branch has no such comment. Add that explanation immediately above this branch so this deliberately asymmetric removal behavior is not later mistaken for an unnecessary newline.

🔧 Fix: Document Kimi removal newline safeguard
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-kimi-harness.test.sh`
- <code>Manual isolated-home flow: install twice, invoke a tokenless Stop payload, invoke a registered Stop payload, then run `bin/fm-kimi-turnend-hook.sh remove` and compare the restored config byte-for-byte</code>
- <code>`git status --short` after testing to verify no transient worktree artifacts remained</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
