### PR TITLE
fix(bin): make fm-brief DOD heredocs bash 3.2-safe

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -285,19 +285,18 @@ case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
+    read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
-)
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
+    read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
@@ -305,13 +304,12 @@ Keep your branch a clean fast-forward onto the current default branch - if \`mai
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
-)
     ;;
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
+    read -r -d '' DOD <<EOF || true
 # Definition of done
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
@@ -329,7 +327,6 @@ Two firstmate-specific rules layer on top of that guidance:
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
-)
     ;;
 esac
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -2,13 +2,16 @@
 # Behavior tests for bin/fm-brief.sh.
 #
 # Regression coverage for the heredoc-in-command-substitution parse bug (issue
-# #166): each ship-mode branch builds its Definition-of-done text with
-# `VAR=$(cat <<EOF ... EOF)`. Bash's lexer tracks quote state through the
-# heredoc body while it scans for the matching `)` of the command
-# substitution, so a single unescaped apostrophe anywhere in that body breaks
-# parsing of the *entire rest of the script* - `bash -n` fails, not just the
-# generated brief. A plain `cat > file <<EOF ... EOF` (not wrapped in `$(...)`)
-# is unaffected, so the secondmate charter block does not need this guard.
+# #166, recurred under stock macOS bash 3.2.57 on 2026-07-24/25). Bash 3.2's
+# command-substitution scanner tracks quote state through a heredoc body
+# nested inside `$(cat <<EOF ... EOF)`, so a single unescaped apostrophe
+# anywhere in that body breaks parsing of the *entire rest of the script* -
+# `bash -n` fails, not just the generated brief; bash 4+ parses it fine. Each
+# ship-mode DOD block now assigns via `read -r -d '' VAR <<EOF ... EOF`
+# instead, which is not itself a command substitution, so it stays 3.2-safe
+# regardless of future apostrophes in the body. A plain `cat > file <<EOF ...
+# EOF` (not wrapped in `$(...)`) was never affected, so the secondmate
+# charter block never needed this guard.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -27,6 +30,20 @@ test_script_parses() {
   expect_code 0 "$rc" "bash -n bin/fm-brief.sh must parse cleanly (got: $out)"
   [ -z "$out" ] || fail "bash -n bin/fm-brief.sh emitted unexpected output: $out"
   pass "fm-brief.sh: bash -n succeeds"
+}
+
+# Pin the exact regression: stock macOS bash 3.2.57 parses the whole bin/
+# directory clean, not just the ambient `bash` on the test runner (which may
+# already be a newer bash that never exhibited the bug).
+test_script_parses_under_stock_macos_bash() {
+  local script out rc
+  [ -x /bin/bash ] || { pass "fm-brief.sh: /bin/bash -n check skipped without /bin/bash"; return 0; }
+  for script in "$ROOT"/bin/*.sh; do
+    out=$(/bin/bash -n "$script" 2>&1); rc=$?
+    expect_code 0 "$rc" "/bin/bash -n $script must parse cleanly (got: $out)"
+    [ -z "$out" ] || fail "/bin/bash -n $script emitted unexpected output: $out"
+  done
+  pass "fm-brief.sh: /bin/bash -n succeeds across bin/*.sh"
 }
 
 test_help_includes_entire_header() {
@@ -383,6 +400,7 @@ test_scout_and_secondmate_scaffold() {
 }
 
 test_script_parses
+test_script_parses_under_stock_macos_bash
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review


### PR DESCRIPTION
## Intent

Fix bin/fm-brief.sh so it parses and runs under stock macOS bash 3.2.57, without changing brief-generation behavior on newer bash: restructure the three ship-mode Definition-of-done heredocs that were nested inside a $(cat <<EOF...) command substitution (which breaks under bash 3.2 when the body contains any unescaped apostrophe) into read -r -d '' assignments instead, and extend the colocated test to enforce /bin/bash -n over bin/*.sh.

## What Changed
- Replaced the three ship-mode `DOD=$(cat <<EOF ... EOF)` command-substitution heredocs in `bin/fm-brief.sh` (direct-PR, local-only, and default no-mistakes modes) with `read -r -d '' DOD <<EOF ... EOF || true` assignments, since bash 3.2's lexer breaks on a heredoc nested inside `$(...)` when the body contains an unescaped apostrophe.
- Extended `tests/fm-brief.test.sh` with `test_script_parses_under_stock_macos_bash`, which runs `/bin/bash -n` against every script under `bin/*.sh` to pin the regression against the machine's actual stock bash rather than relying on the test runner's ambient (possibly newer) bash.
- Updated the regression-coverage comment in the test file to describe the new `read -r -d ''` approach and the recurrence under stock macOS bash 3.2.57.

## Risk Assessment

✅ Low: The change is a narrowly-scoped, mechanical restructuring of three heredoc assignments to a bash-3.2-safe idiom plus an added test guard; verified the `read -r -d ''` pattern preserves identical trailing-newline stripping behavior versus the old `$(cat <<EOF...)` form and correctly handles `set -eu` via `|| true`.

## Testing

Confirmed the base commit genuinely fails `bash -n` under this machine's stock bash 3.2.57 (unexpected EOF / syntax error from the nested heredoc-in-command-substitution), and that the target commit fixes this: `bash -n` and full script execution (--help) succeed under 3.2.57, and the full fm-brief.test.sh suite (15 tests) passes, including the new /bin/bash -n sweep over bin/*.sh and the existing tests that verify generated DOD/brief content is unchanged for all three ship modes.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh (all 15 tests pass, including new test_script_parses_under_stock_macos_bash)`
- `/bin/bash -n bin/fm-brief.sh (direct parse check on the machine's actual bash 3.2.57)`
- `/bin/bash bin/fm-brief.sh --help (confirms script still runs correctly under bash 3.2.57)`
- `/bin/bash -n against base commit 39b450b's bin/fm-brief.sh to confirm the regression is real (fails with 'unexpected EOF while looking for matching )' at line 314, syntax error at line 388)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
