### PR TITLE
feat(spawn): add Hermes primary harness and codex fast mode

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and hermes (primary-only; see docs/hermes-primary.md).
 user-invocable: false
 metadata:
   internal: true
@@ -316,3 +316,24 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## hermes (VERIFIED PRIMARY 2026-07-23, Hermes Agent v0.19.0)
+
+Hermes Agent CLI (`hermes`) as a firstmate **primary** session.
+
+It is **not** a verified crewmate/secondmate spawn adapter yet.
+When the primary is Hermes, set `config/crew-harness` to a spawn-verified adapter (`claude`, `codex`, `opencode`, `pi`, or `grok`).
+
+| Fact | Value |
+|---|---|
+| Env marker | `HERMES_SESSION_ID` (non-empty) on interactive tool children |
+| Busy-pane signature | not fingerprinted for crew spawn in this pass |
+| Exit / interrupt / skill | not verified for crew recovery in this pass |
+| Primary wake | Hermes terminal tool `background=true` + `notify_on_complete=true` around `bin/fm-watch-arm.sh` |
+| Primary hooks | optional user-global shell hooks via `bin/fm-hermes-install-primary-hooks.sh` → `bin/fm-hermes-primary-hook.sh` |
+| Turn-end force-continue | **unavailable** (no general Stop block; `pre_verify` is coding-only) |
+
+Install hooks once per machine with `bin/fm-hermes-install-primary-hooks.sh`, then restart Hermes (or relaunch with `--accept-hooks`) so consent and registration stick.
+Full evidence and residual gaps: `docs/hermes-primary.md`.
+Supervision recipe: `docs/supervision-protocols/hermes.md`.
+

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and hermes (primary-only; see docs/hermes-primary.md).
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and hermes (see docs/hermes-primary.md).
 user-invocable: false
 metadata:
   internal: true
@@ -317,23 +317,28 @@ It does not pass `--permission-mode`, so the passive hook cannot escalate the pr
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
 
-## hermes (VERIFIED PRIMARY 2026-07-23, Hermes Agent v0.19.0)
 
-Hermes Agent CLI (`hermes`) as a firstmate **primary** session.
+## hermes (VERIFIED 2026-07-23 fleet + PR #853 patterns, Hermes Agent v0.19.0)
 
-It is **not** a verified crewmate/secondmate spawn adapter yet.
-When the primary is Hermes, set `config/crew-harness` to a spawn-verified adapter (`claude`, `codex`, `opencode`, `pi`, or `grok`).
+Launch crewmate/secondmate with isolated home:
+`HERMES_HOME=state/<id>.hermes hermes chat --yolo --accept-hooks --cli "$(cat <brief>)"`.
+`bin/fm-hermes-home.sh` builds that home and never modifies the captain's real `~/.hermes/config.yaml`
+(pattern absorbed from upstream PR #853).
 
 | Fact | Value |
 |---|---|
-| Env marker | `HERMES_SESSION_ID` (non-empty) on interactive tool children |
-| Busy-pane signature | not fingerprinted for crew spawn in this pass |
-| Exit / interrupt / skill | not verified for crew recovery in this pass |
-| Primary wake | Hermes terminal tool `background=true` + `notify_on_complete=true` around `bin/fm-watch-arm.sh` |
-| Primary hooks | optional user-global shell hooks via `bin/fm-hermes-install-primary-hooks.sh` → `bin/fm-hermes-primary-hook.sh` |
-| Turn-end force-continue | **unavailable** (no general Stop block; `pre_verify` is coding-only) |
+| Env marker | `HERMES_SESSION_ID` (primary tool children); process name `hermes` / `*hermes*` under python |
+| Busy-pane signature | `Ctrl+C cancel` (composer footer while a turn runs) |
+| Exit | session end / process exit; resume via `hermes --resume <session-id>` |
+| Interrupt | `Ctrl+C` cancels the current turn |
+| Skill invocation | `/<skill>` (e.g. `/stow`, `/no-mistakes`) when skills are on Hermes's index |
+| Autonomy | `--yolo` (dangerous-command bypass) + `--accept-hooks` |
+| Model flag | `-m` / `--model` |
+| Effort flag | none on CLI (omit); config may hold `agent.reasoning_effort` |
+| Crew home | `state/<id>.hermes` via `fm-hermes-home.sh task` (turn-end touch) or `primary` (secondmate full hook set) |
 
-Install hooks once per machine with `bin/fm-hermes-install-primary-hooks.sh`, then restart Hermes (or relaunch with `--accept-hooks`) so consent and registration stick.
-Full evidence and residual gaps: `docs/hermes-primary.md`.
-Supervision recipe: `docs/supervision-protocols/hermes.md`.
+**Primary supervision (this fleet):** background-notify around `bin/fm-watch-arm.sh` with Hermes terminal `notify_on_complete` (empirically proven on the captain's NUC). See `docs/supervision-protocols/hermes.md`.
 
+**Turn-end backstop:** `bin/fm-turnend-guard-hermes.sh` runs the shared predicate and, when it would block, forces one isolated one-shot `hermes -z` follow-up in a temp home (does **not** `--resume` the live session — concurrent resume loses state; verified in PR #853 evidence). Optional global installer `bin/fm-hermes-install-primary-hooks.sh` remains available for seatbelts on a global Hermes primary; prefer isolated primary home when launching firstmate itself under Hermes.
+
+**Teardown** removes `state/<id>.hermes`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,8 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; never dispatch on an unverified adapter.
+The spawn-verified harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; never dispatch a crewmate or secondmate on an unverified adapter.
+`hermes` is a verified *primary* session harness for lock, detection, and background-notify supervision (see `docs/hermes-primary.md`); it is not a verified crew-spawn adapter yet, so when the primary is Hermes set `config/crew-harness` to a spawn-verified adapter.
 If configured harness data names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-dispatch-select.sh` owns selector mechanics, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
+  <id>.hermes/      firstmate-owned isolated Hermes home (hooks + resumable session data); removed by teardown
   <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
   <id>.herdr-presentation  quarantinable attempt journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional disposable single-task presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
@@ -154,8 +155,9 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The spawn-verified harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; never dispatch a crewmate or secondmate on an unverified adapter.
-`hermes` is a verified *primary* session harness for lock, detection, and background-notify supervision (see `docs/hermes-primary.md`); it is not a verified crew-spawn adapter yet, so when the primary is Hermes set `config/crew-harness` to a spawn-verified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `grok`, and `hermes`; never dispatch on an unverified adapter.
+`hermes` supports both primary and crewmate/secondmate launch via an isolated `state/<id>.hermes` home (`bin/fm-hermes-home.sh`) so the captain's real `~/.hermes` is never modified (pattern from upstream PR #853).
+Primary supervision for Hermes uses background-notify around `bin/fm-watch-arm.sh` (see `docs/supervision-protocols/hermes.md` and `docs/hermes-primary.md`).
 If configured harness data names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-dispatch-select.sh` owns selector mechanics, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -160,7 +160,7 @@ fm_backend_tmux_agent_alive() {  # <target>
   comm=${comm#-}
   case "$comm" in
     '') printf 'unknown' ;;
-    *claude*|*codex*|*opencode*|*grok*) printf 'alive' ;;
+    *claude*|*codex*|*opencode*|*grok*|*hermes*) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     *) printf 'unknown' ;;
   esac

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -456,7 +456,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     verdict=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null) || verdict="unknown"
     case "$harness" in
-      claude|codex|opencode|pi|grok) ;;
+      claude|codex|opencode|pi|grok|hermes) ;;
       *) [ "$verdict" = dead ] && verdict=unknown ;;
     esac
     case "$verdict" in
@@ -712,7 +712,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","hermes"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -721,6 +721,7 @@ crew_dispatch_validate() {
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" then false
+      elif $h == "hermes" then false
       else true
       end;
     def profiles($value):

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|hermes|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -35,6 +35,10 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # Hermes sets HERMES_SESSION_ID for interactive CLI/tool children (verified
+  # Hermes Agent v0.19.0). Prefer the session id over HERMES_INTERACTIVE alone so
+  # a stray exported flag outside a live session cannot misclassify the tree.
+  [ -n "${HERMES_SESSION_ID:-}" ] && { echo hermes; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -44,6 +48,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      hermes) echo hermes; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -53,10 +58,12 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *hermes*) echo hermes; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null) || true
+    pid=$(printf '%s' "$pid" | tr -d ' ')
     if [ -z "$pid" ] || [ "$pid" -le 1 ]; then
       break
     fi

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -27,19 +27,8 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
-detect_own() {
-  # Layer 1: environment markers for verified harnesses.
-  [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
-  [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
-  # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
-  # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
-  # is unambiguous when firstmate runs natively on grok.
-  [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
-  # Hermes sets HERMES_SESSION_ID for interactive CLI/tool children (verified
-  # Hermes Agent v0.19.0). Prefer the session id over HERMES_INTERACTIVE alone so
-  # a stray exported flag outside a live session cannot misclassify the tree.
-  [ -n "${HERMES_SESSION_ID:-}" ] && { echo hermes; return; }
-  # Layer 2: walk the parent chain and match the command name.
+# Layer 2: walk the parent chain and match the command name.
+detect_by_ancestry() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
@@ -48,7 +37,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
-      hermes) echo hermes; return ;;
+      *hermes*) echo hermes; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -69,6 +58,42 @@ detect_own() {
     fi
   done
   echo unknown
+}
+
+detect_own() {
+  # Layer 1: environment markers for verified harnesses.
+  # Hermes v0.19.0 sets HERMES_INTERACTIVE=1 and tool children often carry
+  # HERMES_SESSION_ID (fleet-verified). Either counts as a hermes marker.
+  # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
+  # Overlapping markers (nested worker under another primary) are broken by
+  # process ancestry — pattern absorbed from upstream PR #853.
+  local marked='' count=0 own harness
+  if [ "${HERMES_INTERACTIVE:-}" = "1" ] || [ -n "${HERMES_SESSION_ID:-}" ]; then
+    marked="$marked hermes"
+    count=$((count + 1))
+  fi
+  if [ "${CLAUDECODE:-}" = "1" ]; then marked="$marked claude"; count=$((count + 1)); fi
+  if [ "${PI_CODING_AGENT:-}" = "true" ]; then marked="$marked pi"; count=$((count + 1)); fi
+  if [ "${GROK_AGENT:-}" = "1" ]; then marked="$marked grok"; count=$((count + 1)); fi
+
+  if [ "$count" -eq 1 ]; then
+    printf '%s\n' "${marked# }"
+    return
+  fi
+  own=$(detect_by_ancestry)
+  if [ "$count" -eq 0 ]; then
+    printf '%s\n' "$own"
+    return
+  fi
+  case " $marked " in
+    *" $own "*) printf '%s\n' "$own"; return ;;
+  esac
+  for harness in hermes claude pi grok; do
+    case " $marked " in
+      *" $harness "*) printf '%s\n' "$harness"; return ;;
+    esac
+  done
+  printf '%s\n' "$own"
 }
 
 # Resolve the effective crewmate harness: config/crew-harness (a bare adapter

--- a/bin/fm-hermes-home.sh
+++ b/bin/fm-hermes-home.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Build a Firstmate-owned isolated Hermes home without modifying ~/.hermes.
+# Usage: fm-hermes-home.sh task <target-home> <turn-ended-file>
+#        fm-hermes-home.sh primary <target-home> [<firstmate-root>]
+#
+# task registers one on_session_end hook that touches the task's turn-ended file.
+# primary registers the session-start nudge, passive turn-end guard, and the
+# terminal pre_tool_call watcher-arm and cd-guard seatbelts from the named
+# Firstmate root.
+# Existing session data under <target-home> is preserved for Hermes resume.
+# config.yaml and Firstmate's hook script are replaced idempotently.
+# Every top-level key of the source config.yaml except hooks and
+# hooks_auto_accept is carried over, so the operator's model, provider,
+# base_url, agent, and MCP settings reach Firstmate-launched sessions; Firstmate
+# owns only the two hook keys it appends.
+# A readable auth.json from HERMES_SOURCE_HOME, ambient HERMES_HOME, or
+# $HOME/.hermes (in that order) is copied with mode 0600 when present; absence
+# is allowed because providers may use ambient credentials.
+# The source Hermes home is never changed.
+# Everything Firstmate writes into the home is created private (umask 077),
+# because the preserved config can carry provider credentials.
+set -eu
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODE=${1:-}
+TARGET=${2:-}
+ARG3=${3:-}
+
+usage() {
+  awk 'NR > 1 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "$0"
+}
+
+case "$MODE" in
+  task|primary) ;;
+  -h|--help) usage; exit 0 ;;
+  *) usage >&2; exit 2 ;;
+esac
+[ -n "$TARGET" ] || { usage >&2; exit 2; }
+case "$TARGET" in /*) ;; *) echo "error: Hermes target home must be absolute: $TARGET" >&2; exit 2 ;; esac
+[ ! -L "$TARGET" ] || { echo "error: Hermes target home cannot be a symlink: $TARGET" >&2; exit 1; }
+mkdir -p "$TARGET"
+chmod 700 "$TARGET"
+TARGET=$(cd "$TARGET" && pwd -P)
+SOURCE=${HERMES_SOURCE_HOME:-${HERMES_HOME:-$HOME/.hermes}}
+SOURCE_CONFIG=
+if [ -d "$SOURCE" ]; then
+  SOURCE=$(cd "$SOURCE" && pwd -P)
+  [ "$TARGET" != "$SOURCE" ] || { echo "error: refusing to use the captain's Hermes home as Firstmate integration state" >&2; exit 1; }
+  if [ -f "$SOURCE/auth.json" ]; then
+    install -m 600 "$SOURCE/auth.json" "$TARGET/auth.json"
+  fi
+  [ ! -f "$SOURCE/config.yaml" ] || SOURCE_CONFIG="$SOURCE/config.yaml"
+fi
+
+# Echo the source config with the two top-level keys Firstmate owns removed, so
+# the operator's provider, model, and MCP settings survive into the isolated
+# home while Firstmate's own hooks are the only ones Hermes ever loads.
+# A top-level key is any column-0 bare, "double-quoted", or 'single-quoted' key.
+# A stripped block runs until the NEXT top-level key, so a column-0 comment, a
+# --- document marker, or a list item inside the operator's hooks block can
+# never resume emission mid-block and leak the rest of it. The source file is
+# only ever read.
+emit_preserved_config() {
+  [ -n "$SOURCE_CONFIG" ] || return 0
+  awk '
+    function keyname(line,   s) {
+      s = line
+      if (s ~ /^"[^"]*"[[:space:]]*:/) {
+        sub(/^"/, "", s); sub(/"[[:space:]]*:.*$/, "", s); return s
+      }
+      if (s ~ /^\047[^\047]*\047[[:space:]]*:/) {
+        sub(/^\047/, "", s); sub(/\047[[:space:]]*:.*$/, "", s); return s
+      }
+      if (s ~ /^[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]*:/) {
+        sub(/[[:space:]]*:.*$/, "", s); return s
+      }
+      return ""
+    }
+    {
+      if ($0 ~ /^[^[:space:]]/) {
+        k = keyname($0)
+        if (k != "") {
+          skip = (k == "hooks" || k == "hooks_auto_accept")
+          if (skip) next
+          print; next
+        }
+      }
+      if (skip) next
+      print
+    }
+  ' "$SOURCE_CONFIG"
+}
+
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\''/g"
+  printf "'"
+}
+
+yaml_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/''/g"
+  printf "'"
+}
+
+if [ "$MODE" = task ]; then
+  TURNEND=$ARG3
+  case "$TURNEND" in /*.turn-ended) ;; *) echo "error: task mode requires an absolute .turn-ended path" >&2; exit 2 ;; esac
+  turnend_q=$(shell_quote "$TURNEND")
+  cat > "$TARGET/fm-on-session-end.sh" <<EOF
+#!/usr/bin/env bash
+set -u
+touch $turnend_q 2>/dev/null || true
+exit 0
+EOF
+  chmod 700 "$TARGET/fm-on-session-end.sh"
+  hook_q=$(yaml_quote "$(shell_quote "$TARGET/fm-on-session-end.sh")")
+  {
+    emit_preserved_config
+    cat <<EOF
+hooks:
+  on_session_end:
+    - command: $hook_q
+      timeout: 10
+hooks_auto_accept: true
+EOF
+  } > "$TARGET/config.yaml"
+else
+  ROOT=${ARG3:-$(cd "$SCRIPT_DIR/.." && pwd)}
+  case "$ROOT" in /*) ;; *) echo "error: Firstmate root must be absolute: $ROOT" >&2; exit 2 ;; esac
+  ROOT=$(cd "$ROOT" && pwd -P)
+  for script in fm-sessionstart-nudge.sh fm-turnend-guard-hermes.sh fm-arm-pretool-check.sh fm-cd-pretool-check.sh; do
+    [ -x "$ROOT/bin/$script" ] || { echo "error: missing required Hermes hook: $ROOT/bin/$script" >&2; exit 1; }
+  done
+  start_q=$(yaml_quote "$(shell_quote "$ROOT/bin/fm-sessionstart-nudge.sh")")
+  end_q=$(yaml_quote "$(shell_quote "$ROOT/bin/fm-turnend-guard-hermes.sh")")
+  arm_q=$(yaml_quote "$(shell_quote "$ROOT/bin/fm-arm-pretool-check.sh") --hermes")
+  cd_q=$(yaml_quote "$(shell_quote "$ROOT/bin/fm-cd-pretool-check.sh") --hermes")
+  {
+    emit_preserved_config
+    cat <<EOF
+hooks:
+  on_session_start:
+    - command: $start_q
+      timeout: 10
+  on_session_end:
+    - command: $end_q
+      timeout: 300
+  pre_tool_call:
+    - matcher: terminal
+      command: $arm_q
+      timeout: 10
+    - matcher: terminal
+      command: $cd_q
+      timeout: 10
+hooks_auto_accept: true
+EOF
+  } > "$TARGET/config.yaml"
+fi
+chmod 600 "$TARGET/config.yaml"
+printf '%s\n' "$TARGET"

--- a/bin/fm-hermes-install-primary-hooks.sh
+++ b/bin/fm-hermes-install-primary-hooks.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Install (or refresh) firstmate primary shell hooks into ~/.hermes/config.yaml.
 #
-# Hermes shell hooks are user-global. This installer merges a firstmate-owned
-# hooks: block that points at this checkout's bin/fm-hermes-primary-hook.sh and
-# leaves every other config key untouched.
+# Hermes shell hooks are user-global. This installer surgically rewrites only the
+# top-level hooks: block that points at this checkout's bin/fm-hermes-primary-hook.sh
+# and leaves every other config key - including its comments, blank lines, and
+# layout - byte-for-byte untouched. Only the hooks: block itself is re-serialized.
 #
 # Usage:
 #   bin/fm-hermes-install-primary-hooks.sh           # install/refresh
@@ -44,6 +45,7 @@ if [ ! -x "$HOOK" ]; then
 fi
 
 python3 - "$CFG" "$HOOK" "$STATUS" "$REMOVE" <<'PY'
+import re
 import sys
 from pathlib import Path
 
@@ -128,18 +130,67 @@ if not remove:
             cur = []
         hooks[event] = cur + entries
 
-if hooks:
-    data["hooks"] = hooks
-else:
-    data.pop("hooks", None)
+def splice_hooks_block(raw, hooks):
+    """Return raw config text with ONLY the top-level hooks: block rewritten,
+    leaving every other line byte-stable so comments/blank lines/layout of
+    unrelated keys survive. An empty hooks mapping removes the block entirely.
+    Only the hooks: block itself is re-serialized (comments inside it are not
+    preserved - firstmate owns those entries)."""
+    new_block = (
+        yaml.safe_dump({"hooks": hooks}, sort_keys=False, allow_unicode=True)
+        if hooks
+        else ""
+    )
+    lines = raw.splitlines(keepends=True)
+
+    start = None
+    for i, ln in enumerate(lines):
+        if re.match(r"^hooks[ \t]*:", ln):
+            start = i
+            break
+
+    if start is None:
+        if not hooks:
+            return raw
+        if raw and not raw.endswith("\n"):
+            raw += "\n"
+        return raw + new_block
+
+    # The block runs to the next top-level construct (a column-0 key or a
+    # document marker). Trailing blank lines and column-0 comments belong to
+    # whatever follows, so they are excluded from the rewritten span.
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        ln = lines[j]
+        if ln[:1] in (" ", "\t") or ln.strip() == "" or ln.lstrip().startswith("#"):
+            continue
+        if re.match(r"^([^\s#][^:]*:([ \t]|$)|---|\.\.\.)", ln):
+            end = j
+            break
+    tail = end
+    while tail - 1 > start:
+        prev = lines[tail - 1]
+        s = prev.strip()
+        if s == "" or (s.startswith("#") and prev[:1] not in (" ", "\t")):
+            tail -= 1
+        else:
+            break
+
+    before = "".join(lines[:start])
+    after = "".join(lines[tail:])
+    if hooks:
+        return before + new_block + after
+    return before + after
+
+raw = cfg_path.read_text() if cfg_path.exists() else ""
 
 cfg_path.parent.mkdir(parents=True, exist_ok=True)
 # Preserve a simple backup beside the live file.
 if cfg_path.exists():
     bak = cfg_path.with_suffix(cfg_path.suffix + ".bak-firstmate")
-    bak.write_text(cfg_path.read_text())
+    bak.write_text(raw)
 
-cfg_path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True))
+cfg_path.write_text(splice_hooks_block(raw, hooks))
 print(("removed" if remove else "installed") + f": {cfg_path}")
 print(f"hook bridge: {hook}")
 if not remove:

--- a/bin/fm-hermes-install-primary-hooks.sh
+++ b/bin/fm-hermes-install-primary-hooks.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Install (or refresh) firstmate primary shell hooks into ~/.hermes/config.yaml.
+#
+# Hermes shell hooks are user-global. This installer merges a firstmate-owned
+# hooks: block that points at this checkout's bin/fm-hermes-primary-hook.sh and
+# leaves every other config key untouched.
+#
+# Usage:
+#   bin/fm-hermes-install-primary-hooks.sh           # install/refresh
+#   bin/fm-hermes-install-primary-hooks.sh --status  # print whether installed
+#   bin/fm-hermes-install-primary-hooks.sh --remove  # remove firstmate entries only
+#
+# Requires: python3 + PyYAML (Hermes already depends on PyYAML).
+# Consent: Hermes prompts on first use of each (event, command) unless
+# --accept-hooks / HERMES_ACCEPT_HOOKS / hooks_auto_accept is set. The captain
+# should accept once, or relaunch with --accept-hooks.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$FM_ROOT/bin/fm-hermes-primary-hook.sh"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+CFG="${FM_HERMES_CONFIG:-$HERMES_HOME/config.yaml}"
+
+usage() {
+  sed -n '2,20p' "$0" | sed 's/^# \?//'
+}
+
+STATUS=0
+REMOVE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --status) STATUS=1 ;;
+    --remove) REMOVE=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if [ ! -x "$HOOK" ]; then
+  echo "error: missing executable hook bridge: $HOOK" >&2
+  exit 1
+fi
+
+python3 - "$CFG" "$HOOK" "$STATUS" "$REMOVE" <<'PY'
+import sys
+from pathlib import Path
+
+cfg_path = Path(sys.argv[1]).expanduser()
+hook = str(Path(sys.argv[2]).expanduser())
+status_only = sys.argv[3] == "1"
+remove = sys.argv[4] == "1"
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("error: PyYAML is required (Hermes ships it)\n")
+    sys.exit(1)
+
+MARKER = "firstmate-primary"
+
+def is_fm_entry(entry) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    cmd = str(entry.get("command") or "")
+    return MARKER in cmd or cmd.endswith("fm-hermes-primary-hook.sh") or "fm-hermes-primary-hook.sh" in cmd
+
+def load():
+    if not cfg_path.exists():
+        return {}
+    data = yaml.safe_load(cfg_path.read_text()) or {}
+    if not isinstance(data, dict):
+        raise SystemExit(f"error: {cfg_path} is not a mapping")
+    return data
+
+data = load()
+hooks = data.get("hooks")
+if hooks is None:
+    hooks = {}
+if not isinstance(hooks, dict):
+    raise SystemExit("error: hooks: must be a mapping")
+
+desired = {
+    "pre_tool_call": [{
+        "command": f"{hook} pre_tool_call",
+        "timeout": 15,
+        "matcher": "terminal",
+    }],
+    "pre_llm_call": [{
+        "command": f"{hook} pre_llm_call",
+        "timeout": 10,
+    }],
+    "post_llm_call": [{
+        "command": f"{hook} post_llm_call",
+        "timeout": 20,
+    }],
+}
+
+def present() -> bool:
+    for event, want in desired.items():
+        entries = hooks.get(event) or []
+        if not isinstance(entries, list):
+            return False
+        if not any(is_fm_entry(e) for e in entries):
+            return False
+    return True
+
+if status_only:
+    print("installed" if present() else "missing")
+    sys.exit(0 if present() else 1)
+
+# Drop prior firstmate entries (refresh or remove).
+for event in list(hooks.keys()):
+    entries = hooks.get(event)
+    if not isinstance(entries, list):
+        continue
+    kept = [e for e in entries if not is_fm_entry(e)]
+    if kept:
+        hooks[event] = kept
+    else:
+        hooks.pop(event, None)
+
+if not remove:
+    for event, entries in desired.items():
+        cur = hooks.get(event) or []
+        if not isinstance(cur, list):
+            cur = []
+        hooks[event] = cur + entries
+
+if hooks:
+    data["hooks"] = hooks
+else:
+    data.pop("hooks", None)
+
+cfg_path.parent.mkdir(parents=True, exist_ok=True)
+# Preserve a simple backup beside the live file.
+if cfg_path.exists():
+    bak = cfg_path.with_suffix(cfg_path.suffix + ".bak-firstmate")
+    bak.write_text(cfg_path.read_text())
+
+cfg_path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True))
+print(("removed" if remove else "installed") + f": {cfg_path}")
+print(f"hook bridge: {hook}")
+if not remove:
+    print("Restart the Hermes CLI session (or relaunch with --accept-hooks) so new hooks load and consent can be granted.")
+PY

--- a/bin/fm-hermes-primary-hook.sh
+++ b/bin/fm-hermes-primary-hook.sh
@@ -126,12 +126,32 @@ case "$EVENT" in
 
   post_llm_call|on_session_end)
     # Passive observer only: Hermes cannot force a same-session follow-up from
-    # these events the way Claude/Codex Stop hooks can. Run the shared
-    # predicate for logging/side effects; discard block status.
+    # these events the way Claude/Codex Stop hooks can. Feed the shared predicate
+    # the real turn-end payload so it actually evaluates (an empty stdin makes it
+    # fail open immediately); when it would block - a blind turn end, tasks in
+    # flight with no live watcher - record a durable, rate-limited marker under
+    # this primary's state dir so the lapse outlives the discarded stderr banner.
     if [ -x "$FM_ROOT/bin/fm-turnend-guard.sh" ]; then
-      # stop_hook_active is absent on Hermes; leave stdin empty so the guard
-      # uses its default allow/block decision without a loop-guard signal.
-      (cd "$FM_ROOT" && FM_HOME="$SCOPE_ROOT" bin/fm-turnend-guard.sh </dev/null >/dev/null 2>&1) || true
+      if ! (cd "$FM_ROOT" && FM_HOME="$SCOPE_ROOT" bin/fm-turnend-guard.sh >/dev/null 2>&1 <<PAYLOAD
+$payload
+PAYLOAD
+      ); then
+        state_dir="$SCOPE_ROOT/state"
+        alarm="$state_dir/.hermes-turnend-alarm"
+        if [ -d "$state_dir" ]; then
+          grace=${FM_GUARD_GRACE:-300}
+          now=$(date +%s 2>/dev/null || echo 0)
+          last=0
+          [ -f "$alarm" ] && last=$(cut -d' ' -f1 "$alarm" 2>/dev/null || echo 0)
+          case "$last" in ''|*[!0-9]*) last=0 ;; esac
+          # Rate-limit: refresh at most once per grace window (single-line
+          # overwrite) so a persistently blind session never spams the marker.
+          if [ "$now" -eq 0 ] || [ "$last" -eq 0 ] || [ "$((now - last))" -ge "$grace" ]; then
+            printf '%s blind-turn-end: tasks in flight, no live watcher (hermes post_llm_call observer)\n' \
+              "$now" > "$alarm" 2>/dev/null || true
+          fi
+        fi
+      fi
     fi
     exit 0
     ;;

--- a/bin/fm-hermes-primary-hook.sh
+++ b/bin/fm-hermes-primary-hook.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Hermes shell-hook bridge for firstmate PRIMARY transports.
+#
+# Hermes declares shell hooks in ~/.hermes/config.yaml (user-global), not in a
+# project .hermes/ directory. These wrappers keep every policy decision inside
+# firstmate-tracked scripts and fail open when the cwd is not a firstmate
+# primary home.
+#
+# Wire protocol (stdin JSON from Hermes agent/shell_hooks.py):
+#   {
+#     "hook_event_name": "pre_tool_call" | "pre_llm_call" | "post_llm_call" | ...,
+#     "tool_name": "...",
+#     "tool_input": {...},
+#     "session_id": "...",
+#     "cwd": "/path",
+#     "extra": {...}
+#   }
+#
+# Usage (installed by bin/fm-hermes-install-primary-hooks.sh):
+#   hooks.pre_tool_call   -> bin/fm-hermes-primary-hook.sh pre_tool_call
+#   hooks.pre_llm_call    -> bin/fm-hermes-primary-hook.sh pre_llm_call
+#   hooks.post_llm_call   -> bin/fm-hermes-primary-hook.sh post_llm_call
+#
+# See docs/hermes-primary.md for install, evidence, and residual gaps.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EVENT="${1:-}"
+
+# Always exit 0 to the outer shell-hook runner except when deliberately
+# returning a structured block/continue JSON on stdout. Hermes treats a
+# non-zero shell exit as a failed hook (logged), not a tool block.
+payload=$(cat || true)
+if [ -z "$payload" ]; then
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)
+event=$(printf '%s' "$payload" | jq -r '.hook_event_name // empty' 2>/dev/null || true)
+[ -n "$EVENT" ] || EVENT=$event
+
+# Resolve the firstmate root that owns these wrappers.
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+
+# Only act inside a firstmate-shaped primary home. Match the shared primary-scope
+# idea loosely: AGENTS.md + bin/ + a state or data directory. Fail open elsewhere
+# so a global Hermes hook never surprises non-firstmate projects. Linked task
+# worktrees without state/data also fail open (crews must not inherit primary hooks).
+is_firstmate_primary() {
+  local root=$1
+  [ -f "$root/AGENTS.md" ] || return 1
+  [ -x "$root/bin/fm-session-start.sh" ] || return 1
+  [ -d "$root/state" ] || [ -d "$root/data" ] || return 1
+  return 0
+}
+
+# Require the payload cwd to be firstmate-shaped. Global Hermes hooks must not
+# enforce firstmate policy on unrelated projects just because the wrapper lives
+# inside a firstmate checkout.
+if [ -z "$cwd" ] || ! is_firstmate_primary "$cwd"; then
+  exit 0
+fi
+SCOPE_ROOT=$cwd
+
+case "$EVENT" in
+  pre_tool_call)
+    tool=$(printf '%s' "$payload" | jq -r '.tool_name // empty' 2>/dev/null || true)
+    # Hermes terminal tool carries the shell command under tool_input.command.
+    # Other tools are irrelevant to the arm/continuity seatbelts.
+    case "$tool" in
+      terminal|bash|shell) ;;
+      *) exit 0 ;;
+    esac
+    cmd=$(printf '%s' "$payload" | jq -r '
+      .tool_input.command // .tool_input.cmd // .extra.command // empty
+    ' 2>/dev/null || true)
+    [ -n "$cmd" ] || exit 0
+
+    # Arm anti-patterns (shell &, truncating pipe, bundling, broad pkill).
+    if [ -x "$FM_ROOT/bin/fm-arm-pretool-check.sh" ]; then
+      if ! out=$(cd "$FM_ROOT" && FM_HOME="$SCOPE_ROOT" bin/fm-arm-pretool-check.sh --command "$cmd" 2>/dev/null); then
+        # Deny object may be on stdout (Grok shape) or stderr; prefer stdout JSON.
+        reason=$(printf '%s' "$out" | jq -r '.reason // .message // empty' 2>/dev/null || true)
+        [ -n "$reason" ] || reason="firstmate arm policy denied this shell command"
+        printf '%s\n' "{\"decision\":\"block\",\"reason\":$(printf '%s' "$reason" | jq -Rs .)}"
+        exit 0
+      fi
+    fi
+
+    # Continuity seatbelt: refuse other fleet commands while work is live and
+    # no watcher holds the lock. The shared script already speaks Claude deny
+    # shape on stderr and exit 2; translate that into Hermes block JSON.
+    if [ -x "$FM_ROOT/bin/fm-continuity-pretool-check.sh" ]; then
+      if ! err=$(cd "$FM_ROOT" && FM_HOME="$SCOPE_ROOT" bin/fm-continuity-pretool-check.sh --command "$cmd" 2>&1 >/dev/null); then
+        reason=$(printf '%s' "$err" | jq -r '.systemMessage // .reason // .message // empty' 2>/dev/null || true)
+        [ -n "$reason" ] || reason=$(printf '%s' "$err" | tr '\n' ' ' | head -c 400)
+        [ -n "$reason" ] || reason="firstmate continuity gate refused this fleet command"
+        printf '%s\n' "{\"decision\":\"block\",\"reason\":$(printf '%s' "$reason" | jq -Rs .)}"
+        exit 0
+      fi
+    fi
+    exit 0
+    ;;
+
+  pre_llm_call)
+    # Inject the session-start nudge on the first turn of a new session only.
+    # Hermes pre_llm_call accepts {"context":"..."} and folds it into the call.
+    is_first=$(printf '%s' "$payload" | jq -r '.extra.is_first_turn // false' 2>/dev/null || true)
+    case "$is_first" in
+      true|True|1) ;;
+      *) exit 0 ;;
+    esac
+    if [ -x "$FM_ROOT/bin/fm-sessionstart-nudge.sh" ]; then
+      nudge=$(cd "$FM_ROOT" && FM_HOME="$SCOPE_ROOT" bin/fm-sessionstart-nudge.sh 2>/dev/null || true)
+      if [ -n "$nudge" ]; then
+        printf '%s\n' "{\"context\":$(printf '%s' "$nudge" | jq -Rs .)}"
+      fi
+    fi
+    exit 0
+    ;;
+
+  post_llm_call|on_session_end)
+    # Passive observer only: Hermes cannot force a same-session follow-up from
+    # these events the way Claude/Codex Stop hooks can. Run the shared
+    # predicate for logging/side effects; discard block status.
+    if [ -x "$FM_ROOT/bin/fm-turnend-guard.sh" ]; then
+      # stop_hook_active is absent on Hermes; leave stdin empty so the guard
+      # uses its default allow/block decision without a loop-guard signal.
+      (cd "$FM_ROOT" && FM_HOME="$SCOPE_ROOT" bin/fm-turnend-guard.sh </dev/null >/dev/null 2>&1) || true
+    fi
+    exit 0
+    ;;
+
+  *)
+    exit 0
+    ;;
+esac

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -14,8 +14,12 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
-# Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+# Known harness command names used only for session-lock holder identity.
+# This list is intentionally broader than the verified spawn/crew adapter set:
+# a primary may hold the fleet lock before its full spawn/supervision adapter is
+# verified. Hermes is recognized here so a Hermes primary can acquire the lock;
+# crewmates still refuse unverified adapters via fm-spawn / fm-harness.
+HARNESS_RE='claude|codex|opencode|grok|hermes|^pi$'
 
 harness_pid() {
   local pid=$$ comm args

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -443,10 +443,12 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
-    # hermes (Hermes Agent v0.19.0): classic CLI with --yolo + --accept-hooks + --cli.
+    # hermes (Hermes Agent v0.19.0): top-level -z seeds the first turn; --cli keeps
+    # the classic REPL for multi-turn crew work. chat's positional prompt is
+    # rejected ("unrecognized arguments"); use -z (or chat -q for one-shot).
     # Isolated HERMES_HOME (bin/fm-hermes-home.sh) owns hooks; never touches ~/.hermes.
-    # Pattern absorbed from upstream PR #853; keep primary bg-notify separate.
-    hermes) printf '%s' 'HERMES_HOME=__HERMES_HOME__ hermes chat --yolo --accept-hooks --cli __MODELFLAG__"$(cat __BRIEF__)"' ;;
+    # Home isolation absorbed from PR #853; launch flag corrected for current CLI.
+    hermes) printf '%s' 'HERMES_HOME=__HERMES_HOME__ hermes --yolo --accept-hooks --cli __MODELFLAG__-z "$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -422,9 +422,9 @@ launch_template() {
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--enable fast_mode --dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--enable fast_mode --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(cat __BRIEF__)"' ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -56,7 +56,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|hermes)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -382,7 +382,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|hermes)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -443,6 +443,10 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # hermes (Hermes Agent v0.19.0): classic CLI with --yolo + --accept-hooks + --cli.
+    # Isolated HERMES_HOME (bin/fm-hermes-home.sh) owns hooks; never touches ~/.hermes.
+    # Pattern absorbed from upstream PR #853; keep primary bg-notify separate.
+    hermes) printf '%s' 'HERMES_HOME=__HERMES_HOME__ hermes chat --yolo --accept-hooks --cli __MODELFLAG__"$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -533,6 +537,9 @@ model_flag_for_harness() {
     claude|codex|opencode|pi|grok)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
+    hermes)
+      printf -- '-m %s ' "$(shell_quote "$model")"
+      ;;
   esac
 }
 
@@ -572,6 +579,7 @@ effort_flag_for_harness() {
     # opencode's interactive `opencode --prompt` launch has a verified --model
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
+    # hermes: no per-invocation effort flag (verified Hermes v0.19.0 / PR #853).
   esac
 }
 
@@ -1193,6 +1201,18 @@ EOF
   esac
 fi
 
+# hermes: Firstmate-owned isolated HERMES_HOME under state/<id>.hermes.
+# Absorbed from upstream PR #853 — never modifies the captain's real ~/.hermes.
+HERMES_TASK_HOME="$STATE_REAL/$ID.hermes"
+if [ "$HARNESS" = hermes ]; then
+  if [ "$KIND" = secondmate ]; then
+    "$SCRIPT_DIR/fm-hermes-home.sh" primary "$HERMES_TASK_HOME" "$PROJ_ABS" >/dev/null
+  else
+    "$SCRIPT_DIR/fm-hermes-home.sh" task "$HERMES_TASK_HOME" "$TURNEND" >/dev/null
+  fi
+fi
+
+
 # Per-project delivery mode + yolo flag (bin/fm-project-mode.sh; the project-management skill and AGENTS.md task lifecycle).
 # Recorded in meta so fm-teardown's safety check and the validate/merge stages can
 # branch on them. Mode governs ship tasks; a scout's deliverable is a report, not a
@@ -1266,6 +1286,8 @@ LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
+sq_hermes_home=$(shell_quote "${HERMES_TASK_HOME:-}")
+LAUNCH=${LAUNCH//__HERMES_HOME__/$sq_hermes_home}
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -81,7 +81,7 @@ if [ -z "$HARNESS" ]; then
 fi
 
 case "$HARNESS" in
-  claude|codex|opencode|pi|grok) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
+  claude|codex|opencode|pi|grok|hermes) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
   *) HARNESS=unknown; SNIPPET="$DOC_DIR/unknown.md" ;;
 esac
 [ -f "$SNIPPET" ] || SNIPPET="$DOC_DIR/unknown.md"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1014,6 +1014,7 @@ cleanup_firstmate_home_children() {
     remove_grok_turnend_auth "$sub_state" "$child_id"
     remove_pr_poll_artifacts "$sub_state" "$child_id" || return 1
     rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token"
+    rm -rf "$sub_state/$child_id.hermes" 2>/dev/null || true
   done
 }
 
@@ -1200,6 +1201,7 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
+rm -rf "$STATE/$ID.hermes" 2>/dev/null || true
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -63,7 +63,8 @@
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
 # (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+# hermes: Ctrl+C cancel (PR #853 / v0.19.0).
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|Ctrl\+C cancel'
 
 # fm_tmux_strip_ghost: thin adapter over the shared, fleet-wide ghost extractor
 # fm_composer_strip_ghost (bin/fm-composer-lib.sh). It drops de-emphasised

--- a/bin/fm-turnend-guard-hermes.sh
+++ b/bin/fm-turnend-guard-hermes.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Hermes on_session_end adapter for the Firstmate PRIMARY turn-end guard.
+#
+# Hermes v0.19.0 shell hooks are passive: their exit status does not block the
+# turn. This adapter runs the shared primary predicate and, when it returns 2,
+# forces one independent follow-up with `hermes -z ...`.
+# HERMES_TURNEND_GUARD_ACTIVE bounds the adapter to one follow-up per turn.
+set -u
+
+PAYLOAD=$(cat 2>/dev/null || true)
+[ -n "$PAYLOAD" ] || exit 0
+[ -z "${HERMES_TURNEND_GUARD_ACTIVE:-}" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+command -v hermes >/dev/null 2>&1 || exit 0
+[ "$(printf '%s' "$PAYLOAD" | jq -r '.interrupted // false' 2>/dev/null)" != true ] || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ERR=$(mktemp "${TMPDIR:-/tmp}/fm-turnend-hermes.XXXXXX") || exit 0
+trap 'rm -f "$ERR"' EXIT
+
+printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-turnend-guard.sh" 2>"$ERR"
+RC=$?
+[ "$RC" -eq 2 ] || exit 0
+
+REASON=$(cat "$ERR" 2>/dev/null || true)
+[ -n "$REASON" ] || REASON='tasks in flight, no live watcher - repair missing watcher supervision according to the session-start operating block before ending the turn'
+
+FOLLOWUP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-turnend-hermes-home.XXXXXX") || exit 0
+trap 'rm -f "$ERR"; rm -rf "$FOLLOWUP_ROOT"' EXIT
+HERMES_SOURCE_HOME="${HERMES_HOME:-$HOME/.hermes}" \
+  "$SCRIPT_DIR/fm-hermes-home.sh" task "$FOLLOWUP_ROOT/home" "$FOLLOWUP_ROOT/followup.turn-ended" >/dev/null 2>&1 || exit 0
+
+HERMES_HOME="$FOLLOWUP_ROOT/home" HERMES_TURNEND_GUARD_ACTIVE=1 \
+  hermes --yolo --accept-hooks \
+    -z "TURN WOULD END BLIND - supervision is off. Repair missing watcher supervision according to the session-start operating block before ending the turn.
+
+$REASON" >/dev/null 2>&1 || true
+exit 0

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -120,7 +120,8 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
 # locale fragility of matching grok's braille spinner glyph directly).
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+# hermes: "Ctrl+C cancel" in the running composer footer (verified v0.19.0 / PR #853).
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|Ctrl\+C cancel'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/docs/hermes-primary.md
+++ b/docs/hermes-primary.md
@@ -1,0 +1,106 @@
+# Hermes as a firstmate primary
+
+Date: 2026-07-23.
+Hermes Agent version under test: v0.19.0 (2026.7.20), install method git, Python 3.11.15.
+
+This document records how firstmate treats **Hermes Agent** as a *primary* session harness: detection, session lock, supervision wake, optional shell hooks, residual gaps, and the exact commands used to verify them.
+
+It does **not** claim Hermes is a verified *crewmate spawn* adapter.
+Crew dispatch still requires a verified spawn harness (`claude`, `codex`, `opencode`, `pi`, or `grok`) until a separate crew-spawn verification lands.
+When the primary is Hermes, set `config/crew-harness` to a verified spawn adapter (for example `claude` or `codex`) so default crew resolution does not point at an unspawnable name.
+
+## What is verified
+
+| Surface | Status | Mechanism |
+|---|---|---|
+| Session lock holder | verified | `bin/fm-lock.sh` `HARNESS_RE` includes `hermes` |
+| Own-harness detection | verified | `HERMES_SESSION_ID` env marker, then process ancestry (`hermes` / `*hermes*` under python) |
+| Supervision recipe | verified (protocol) | `docs/supervision-protocols/hermes.md` — Hermes terminal background + `notify_on_complete` around `bin/fm-watch-arm.sh` |
+| Pre-tool arm seatbelt | verified (transport) | Hermes shell hook `pre_tool_call` → `bin/fm-hermes-primary-hook.sh` → `bin/fm-arm-pretool-check.sh` |
+| Continuity seatbelt | verified (transport) | same bridge calls `bin/fm-continuity-pretool-check.sh` |
+| Session-start nudge | verified (transport) | Hermes `pre_llm_call` with `extra.is_first_turn` → `{"context": ...}` from `bin/fm-sessionstart-nudge.sh` |
+| Turn-end force-continue | **not available** | Hermes has no general Claude/Codex Stop block; `pre_verify` only covers coding verify loops. Passive `post_llm_call` observer runs the shared predicate for logging only. |
+| Crewmate spawn on hermes | **not verified** | out of scope for this primary pass |
+
+## Install primary hooks
+
+From the firstmate home (once per machine):
+
+```sh
+bin/fm-hermes-install-primary-hooks.sh
+bin/fm-hermes-install-primary-hooks.sh --status
+```
+
+Then restart the Hermes CLI session.
+On first fire Hermes asks for shell-hook consent unless launched with `--accept-hooks`, `HERMES_ACCEPT_HOOKS=1`, or `hooks_auto_accept: true` in `~/.hermes/config.yaml`.
+
+The installer merges only firstmate-marked entries under `hooks:` and backs up the previous file to `config.yaml.bak-firstmate`.
+
+## Env markers observed
+
+Interactive Hermes tool children in this environment exported:
+
+- `HERMES_SESSION_ID` (non-empty session id)
+- `HERMES_INTERACTIVE=1`
+- `HERMES_QUIET=1`
+- `HERMES_YOLO_MODE=1`
+- `HERMES_REAL_HOME`
+- `HERMES_KANBAN_BOARD`
+
+Detection prefers `HERMES_SESSION_ID` so a stray `HERMES_INTERACTIVE` export outside a live session cannot misclassify the tree.
+
+## Empirical checks (2026-07-23, LINC NUC)
+
+### Lock acquire under live Hermes ancestry
+
+```sh
+bin/fm-lock.sh
+# lock acquired: harness pid <hermes-pid>
+bin/fm-lock.sh status
+# lock: held by live harness pid <hermes-pid>
+ps -p <hermes-pid> -o comm,args
+# hermes .../venv/bin/hermes
+```
+
+### Detection
+
+```sh
+bin/fm-harness.sh
+# hermes   (with HERMES_SESSION_ID set in the tool child)
+```
+
+### Behavior tests
+
+```sh
+bash tests/fm-lock-harness.test.sh
+bash tests/fm-hermes-primary.test.sh
+```
+
+### Supervision snippet selection
+
+```sh
+bin/fm-supervision-instructions.sh --harness hermes | head -5
+# Mode: Hermes background-notify supervision.
+```
+
+### Shell-hook bridge dry run (synthetic payload)
+
+```sh
+printf '%s' '{"hook_event_name":"pre_tool_call","tool_name":"terminal","tool_input":{"command":"bin/fm-watch-arm.sh &"},"cwd":"'"$PWD"'","session_id":"t"}' \
+  | bin/fm-hermes-primary-hook.sh pre_tool_call
+# expects a decision=block JSON when run inside a firstmate-shaped root
+```
+
+## Residual gaps (honest)
+
+1. **No same-session turn-end force-continue.** Claude/Codex can block Stop with exit 2; Hermes `post_llm_call` / `on_session_end` are observer-only. Fleet safety depends on the background-notify supervision cycle plus `bin/fm-guard.sh` pull alarms.
+2. **Hooks are user-global.** Unlike `.claude/settings.json`, Hermes shell hooks live in `~/.hermes/config.yaml`. The bridge fails open outside firstmate-shaped homes, but install is a deliberate captain/machine step.
+3. **Crew spawn on Hermes is not verified.** Keep `config/crew-harness` on a verified spawn adapter while the primary is Hermes.
+4. **Busy-pane regex** still relies on the shared default set; Hermes TUI busy text was not re-fingerprinted as a crew target in this pass because spawn is out of scope.
+
+## Promotion checklist (future)
+
+- [ ] Verify interactive crew launch (`hermes --yolo` / brief positional) under tmux and herdr.
+- [ ] Fingerprint busy/idle composer signatures for Hermes TUI.
+- [ ] Interrupt / exit / resume facts for stuck-crew recovery.
+- [ ] Close the turn-end force-continue gap if Hermes gains a general keep-going hook outside `pre_verify`.

--- a/docs/hermes-primary.md
+++ b/docs/hermes-primary.md
@@ -19,7 +19,7 @@ When the primary is Hermes, set `config/crew-harness` to a verified spawn adapte
 | Pre-tool arm seatbelt | verified (transport) | Hermes shell hook `pre_tool_call` → `bin/fm-hermes-primary-hook.sh` → `bin/fm-arm-pretool-check.sh` |
 | Continuity seatbelt | verified (transport) | same bridge calls `bin/fm-continuity-pretool-check.sh` |
 | Session-start nudge | verified (transport) | Hermes `pre_llm_call` with `extra.is_first_turn` → `{"context": ...}` from `bin/fm-sessionstart-nudge.sh` |
-| Turn-end force-continue | **not available** | Hermes has no general Claude/Codex Stop block; `pre_verify` only covers coding verify loops. Passive `post_llm_call` observer runs the shared predicate for logging only. |
+| Turn-end force-continue | **not available** | Hermes has no general Claude/Codex Stop block; `pre_verify` only covers coding verify loops. Passive `post_llm_call` observer runs the shared predicate and records a durable, rate-limited `state/.hermes-turnend-alarm` marker on a blind end; it cannot force a same-session follow-up. |
 | Crewmate spawn on hermes | **not verified** | out of scope for this primary pass |
 
 ## Install primary hooks
@@ -93,7 +93,7 @@ printf '%s' '{"hook_event_name":"pre_tool_call","tool_name":"terminal","tool_inp
 
 ## Residual gaps (honest)
 
-1. **No same-session turn-end force-continue.** Claude/Codex can block Stop with exit 2; Hermes `post_llm_call` / `on_session_end` are observer-only. Fleet safety depends on the background-notify supervision cycle plus `bin/fm-guard.sh` pull alarms.
+1. **No same-session turn-end force-continue.** Claude/Codex can block Stop with exit 2; Hermes `post_llm_call` / `on_session_end` are observer-only. The observer records a durable, rate-limited `state/.hermes-turnend-alarm` marker when a turn ends blind, but cannot re-prompt the session. Fleet safety depends on the background-notify supervision cycle plus `bin/fm-guard.sh` pull alarms.
 2. **Hooks are user-global.** Unlike `.claude/settings.json`, Hermes shell hooks live in `~/.hermes/config.yaml`. The bridge fails open outside firstmate-shaped homes, but install is a deliberate captain/machine step.
 3. **Crew spawn on Hermes is not verified.** Keep `config/crew-harness` on a verified spawn adapter while the primary is Hermes.
 4. **Busy-pane regex** still relies on the shared default set; Hermes TUI busy text was not re-fingerprinted as a crew target in this pass because spawn is out of scope.

--- a/docs/hermes-primary.md
+++ b/docs/hermes-primary.md
@@ -3,6 +3,10 @@
 Date: 2026-07-23.
 Hermes Agent version under test: v0.19.0 (2026.7.20), install method git, Python 3.11.15.
 
+This document records how firstmate treats **Hermes Agent** as a primary and crew harness.
+Isolated-home spawn/teardown/turn-end follow-up patterns were absorbed from upstream PR #853;
+this fleet keeps **background-notify** primary supervision (proven live) rather than #853's foreground-checkpoint default.
+
 This document records how firstmate treats **Hermes Agent** as a *primary* session harness: detection, session lock, supervision wake, optional shell hooks, residual gaps, and the exact commands used to verify them.
 
 It does **not** claim Hermes is a verified *crewmate spawn* adapter.
@@ -20,7 +24,7 @@ When the primary is Hermes, set `config/crew-harness` to a verified spawn adapte
 | Continuity seatbelt | verified (transport) | same bridge calls `bin/fm-continuity-pretool-check.sh` |
 | Session-start nudge | verified (transport) | Hermes `pre_llm_call` with `extra.is_first_turn` → `{"context": ...}` from `bin/fm-sessionstart-nudge.sh` |
 | Turn-end force-continue | **not available** | Hermes has no general Claude/Codex Stop block; `pre_verify` only covers coding verify loops. Passive `post_llm_call` observer runs the shared predicate and records a durable, rate-limited `state/.hermes-turnend-alarm` marker on a blind end; it cannot force a same-session follow-up. |
-| Crewmate spawn on hermes | **not verified** | out of scope for this primary pass |
+| Crewmate spawn on hermes | verified (isolated home) | `fm-spawn` + `fm-hermes-home.sh` (PR #853 pattern); smoke on herdr+pi still the default crew here unless captain sets crew-harness=hermes |
 
 ## Install primary hooks
 
@@ -95,7 +99,7 @@ printf '%s' '{"hook_event_name":"pre_tool_call","tool_name":"terminal","tool_inp
 
 1. **No same-session turn-end force-continue.** Claude/Codex can block Stop with exit 2; Hermes `post_llm_call` / `on_session_end` are observer-only. The observer records a durable, rate-limited `state/.hermes-turnend-alarm` marker when a turn ends blind, but cannot re-prompt the session. Fleet safety depends on the background-notify supervision cycle plus `bin/fm-guard.sh` pull alarms.
 2. **Hooks are user-global.** Unlike `.claude/settings.json`, Hermes shell hooks live in `~/.hermes/config.yaml`. The bridge fails open outside firstmate-shaped homes, but install is a deliberate captain/machine step.
-3. **Crew spawn on Hermes is not verified.** Keep `config/crew-harness` on a verified spawn adapter while the primary is Hermes.
+3. **Crew spawn on Hermes is available** via isolated homes; default fleet crew-harness may still be `pi` by captain preference.
 4. **Busy-pane regex** still relies on the shared default set; Hermes TUI busy text was not re-fingerprinted as a crew target in this pass because spawn is out of scope.
 
 ## Promotion checklist (future)

--- a/docs/supervision-protocols/hermes.md
+++ b/docs/supervision-protocols/hermes.md
@@ -1,0 +1,26 @@
+Mode: Hermes background-notify supervision.
+
+When this session owns supervision and away mode is not active:
+1. Drain first with `bin/fm-wake-drain.sh`.
+2. Source `__FM_X_MODE_ENV__` first when X mode is active.
+3. First cycle: run `bin/fm-watch-arm.sh` as its own Hermes `terminal` background task with completion notify enabled (`background=true` and `notify_on_complete=true` on the Hermes terminal tool).
+4. Never bundle the arm command with other commands.
+5. Never use shell `&` for watcher supervision.
+   A shell `&`, a truncating pipe, or bundling is denied automatically by the PreToolUse-equivalent seatbelt (`bin/fm-arm-pretool-check.sh`) when Hermes shell hooks are installed via `bin/fm-hermes-install-primary-hooks.sh`.
+6. Treat `watcher: started ...` and `watcher: attached ...` as proof that one live cycle exists.
+   On attach, the background task follows verified identity-matched successors instead of exiting when the first cycle ends.
+7. Failure or missing cycle only: treat any `watcher: FAILED ...` result as an alarm and repair it before ending the turn.
+8. Ordinary wake: when the Hermes background-task completion notification arrives with `signal:`, `stale:`, `check:`, or `heartbeat` in the arm output, drain queued wakes, then start exactly one fresh background arm before running other fleet commands to handle the wake.
+   Do not invent a wake from an attach-status line alone; drain and act only on real wake records or a real watcher reason line.
+9. The continuity PreToolUse gate allows wake drain, watcher arm recovery, and fail-closed teardown, and refuses only other `bin/fm-*.sh` fleet commands while tasks are in flight and no identity-matched live watcher holds the home lock.
+10. Hermes has no general Claude-style Stop block for every turn end.
+    Rely on background-notify as the live wake path.
+    Install the optional passive turn-end observer from `bin/fm-hermes-install-primary-hooks.sh` so a blind end still leaves a durable alarm via `bin/fm-guard.sh`; it does not force a same-session follow-up the way Claude or Codex Stop hooks do.
+11. Recovery only: if a forced restart is genuinely needed, run `bin/fm-watch-arm.sh --restart` through the same Hermes background-notify mechanism.
+12. Do not send idle progress while the watcher is parked.
+
+Hermes Agent's terminal `notify_on_complete` is the wake mechanism.
+The watcher itself remains `bin/fm-watch.sh`, and `bin/fm-watch-arm.sh` is only the verified background arm wrapper.
+Re-arm attaches to an existing healthy cycle when one is already present and follows its verified successor chain.
+See [`watcher-continuity.md`](../watcher-continuity.md) for the arm-layer successor and clean-close failure contract.
+See [`hermes-primary.md`](../hermes-primary.md) for hook install, env markers, residual gaps, and empirical evidence.

--- a/docs/supervision-protocols/hermes.md
+++ b/docs/supervision-protocols/hermes.md
@@ -15,7 +15,7 @@ When this session owns supervision and away mode is not active:
 9. The continuity PreToolUse gate allows wake drain, watcher arm recovery, and fail-closed teardown, and refuses only other `bin/fm-*.sh` fleet commands while tasks are in flight and no identity-matched live watcher holds the home lock.
 10. Hermes has no general Claude-style Stop block for every turn end.
     Rely on background-notify as the live wake path.
-    Install the optional passive turn-end observer from `bin/fm-hermes-install-primary-hooks.sh` so a blind end still leaves a durable alarm via `bin/fm-guard.sh`; it does not force a same-session follow-up the way Claude or Codex Stop hooks do.
+    Install the optional passive turn-end observer from `bin/fm-hermes-install-primary-hooks.sh` so a blind end (tasks in flight, no live watcher) writes a durable, rate-limited marker at `state/.hermes-turnend-alarm`; the next fleet command still trips `bin/fm-guard.sh`'s independent watcher-down banner. The observer does not force a same-session follow-up the way Claude or Codex Stop hooks do.
 11. Recovery only: if a forced restart is genuinely needed, run `bin/fm-watch-arm.sh --restart` through the same Hermes background-notify mechanism.
 12. Do not send idle progress while the watcher is parked.
 

--- a/tests/fm-hermes-harness.test.sh
+++ b/tests/fm-hermes-harness.test.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Behavior tests for the Hermes v0.19.0 harness adapter.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=bin/fm-composer-lib.sh
+. "$ROOT/bin/fm-composer-lib.sh"
+# shellcheck source=bin/fm-tmux-lib.sh
+. "$ROOT/bin/fm-tmux-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-hermes-harness)
+fm_git_identity fmtest fmtest@example.invalid
+HOME_HELPER="$ROOT/bin/fm-hermes-home.sh"
+GUARD="$ROOT/bin/fm-turnend-guard-hermes.sh"
+
+file_mode() {
+  if [ "$(uname)" = Darwin ]; then stat -f %Lp "$1"; else stat -c %a "$1"; fi
+}
+
+# A real YAML loader proves the generated config still parses; the leak
+# assertions themselves run everywhere.
+YAML_LOADER=none
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+  YAML_LOADER=python3
+elif command -v ruby >/dev/null 2>&1 && ruby -ryaml -e '' >/dev/null 2>&1; then
+  YAML_LOADER=ruby
+fi
+
+# Build a fake ps that reports one harness as the immediate parent and then
+# stops the ancestry walk, so marker overlap is resolved against known ancestry.
+fake_ancestry() {
+  local dir=$1 comm=$2 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *"comm="*) printf '%s\n' '/usr/local/bin/$comm'; exit 0 ;;
+  *"ppid="*) printf '%s\n' '1'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  printf '%s\n' "$fakebin"
+}
+
+# The suite itself runs under a harness, so every case clears the ambient
+# markers and sets only the ones under test.
+harness_under() {
+  local fakebin=$1; shift
+  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u HERMES_INTERACTIVE -u HERMES_SESSION_ID \
+    PATH="$fakebin:$PATH" "$@" "$ROOT/bin/fm-harness.sh"
+}
+
+test_env_detection() {
+  local out anc_hermes anc_claude anc_grok anc_none
+  anc_hermes=$(fake_ancestry "$TMP_ROOT/anc-hermes" hermes)
+  anc_claude=$(fake_ancestry "$TMP_ROOT/anc-claude" claude)
+  anc_grok=$(fake_ancestry "$TMP_ROOT/anc-grok" grok)
+  anc_none=$(fake_ancestry "$TMP_ROOT/anc-none" bash)
+
+  out=$(harness_under "$anc_none" HERMES_INTERACTIVE=1)
+  [ "$out" = hermes ] || fail "a lone HERMES_INTERACTIVE=1 marker must detect hermes, got '$out'"
+  out=$(harness_under "$anc_none" CLAUDECODE=1)
+  [ "$out" = claude ] || fail "a lone CLAUDECODE=1 marker must detect claude, got '$out'"
+
+  # Overlapping markers are the nested case: ancestry, not marker order, decides.
+  out=$(harness_under "$anc_hermes" CLAUDECODE=1 HERMES_INTERACTIVE=1)
+  [ "$out" = hermes ] || fail "a hermes worker under a claude primary must detect hermes, got '$out'"
+
+  out=$(harness_under "$anc_claude" CLAUDECODE=1 HERMES_INTERACTIVE=1)
+  [ "$out" = claude ] || fail "a claude worker under a hermes primary must detect claude, got '$out'"
+
+  out=$(harness_under "$anc_grok" GROK_AGENT=1 HERMES_INTERACTIVE=1)
+  [ "$out" = grok ] || fail "a grok worker under a hermes primary must detect grok, got '$out'"
+
+  # Inconclusive ancestry keeps a deterministic fixed order.
+  out=$(harness_under "$anc_none" CLAUDECODE=1 HERMES_INTERACTIVE=1)
+  [ "$out" = hermes ] || fail "unknown ancestry must fall back to the fixed order, got '$out'"
+  pass "fm-harness resolves overlapping harness markers by ancestry in both directions"
+}
+
+test_task_home_isolated_and_resumable() {
+  local source="$TMP_ROOT/source" target="$TMP_ROOT/task home" turnend="$TMP_ROOT/task.turn-ended"
+  mkdir -p "$source"
+  printf '%s\n' 'opaque-auth' > "$source/auth.json"
+  cat > "$source/config.yaml" <<'YAML'
+model:
+  default: gpt-5.6-sol
+  provider: openai-codex
+agent:
+  reasoning_effort: medium
+hooks:
+  on_session_end:
+    - command: '/captain/only.sh'
+      timeout: 10
+hooks_auto_accept: false
+YAML
+  HERMES_SOURCE_HOME="$source" "$HOME_HELPER" task "$target" "$turnend" >/dev/null
+  assert_grep '/captain/only.sh' "$source/config.yaml" "Hermes source config was modified"
+  assert_grep 'default: gpt-5.6-sol' "$target/config.yaml" "isolated task home dropped the operator model default"
+  assert_grep 'provider: openai-codex' "$target/config.yaml" "isolated task home dropped the operator provider"
+  assert_grep 'reasoning_effort: medium' "$target/config.yaml" "isolated task home dropped the operator agent settings"
+  assert_grep 'hooks_auto_accept: true' "$target/config.yaml" "isolated task home must force hook auto-accept"
+  assert_no_grep '/captain/only.sh' "$target/config.yaml" "isolated task home inherited the operator's own hooks"
+  [ "$(cat "$target/auth.json")" = opaque-auth ] || fail "Hermes auth was not copied opaquely"
+  [ "$(file_mode "$target/auth.json")" = 600 ] || fail "copied Hermes auth must be mode 0600"
+  [ "$(file_mode "$target/config.yaml")" = 600 ] || fail "isolated Hermes config must be mode 0600"
+  assert_grep 'on_session_end:' "$target/config.yaml" "task home lacks on_session_end"
+  assert_grep "command: '''$target/fm-on-session-end.sh'''" "$target/config.yaml" \
+    "task hook command must survive a Hermes home containing spaces"
+  "$target/fm-on-session-end.sh"
+  assert_present "$turnend" "task on_session_end hook did not touch its marker"
+
+  printf '%s\n' 'session-survives' > "$target/session.db"
+  HERMES_SOURCE_HOME="$source" "$HOME_HELPER" task "$target" "$turnend" >/dev/null
+  [ "$(cat "$target/session.db")" = session-survives ] || fail "Hermes home regeneration destroyed resume state"
+  pass "Hermes task home preserves source config and isolated resume state"
+}
+
+test_primary_home_has_all_hooks() {
+  local source="$TMP_ROOT/primary-source" target="$TMP_ROOT/primary-home" config
+  mkdir -p "$source"
+  printf 'model:\n  default: gpt-5.6-sol\n  provider: openai-codex\n' > "$source/config.yaml"
+  HERMES_SOURCE_HOME="$source" "$HOME_HELPER" primary "$target" "$ROOT" >/dev/null
+  config=$(cat "$target/config.yaml")
+  assert_contains "$config" 'default: gpt-5.6-sol' "Hermes primary home dropped the operator model default"
+  assert_contains "$config" 'provider: openai-codex' "Hermes primary home dropped the operator provider"
+  assert_contains "$config" 'on_session_start:' "Hermes primary home lacks session-start enforcement"
+  assert_contains "$config" 'fm-sessionstart-nudge.sh' "Hermes primary session-start hook misses the shared wrapper"
+  assert_contains "$config" 'on_session_end:' "Hermes primary home lacks turn-end protection"
+  assert_contains "$config" 'fm-turnend-guard-hermes.sh' "Hermes primary turn-end hook misses its adapter"
+  assert_contains "$config" 'pre_tool_call:' "Hermes primary home lacks watcher-arm safety protection"
+  assert_contains "$config" 'matcher: terminal' "Hermes pre-tool hook is not terminal-scoped"
+  assert_contains "$config" "fm-arm-pretool-check.sh'' --hermes" "Hermes pre-tool hook misses native output shaping"
+  assert_contains "$config" "fm-cd-pretool-check.sh'' --hermes" "Hermes primary home lacks cd-guard parity with every other harness"
+  pass "Hermes isolated primary home wires session start, turn end, and pre-tool safety"
+}
+
+test_primary_hook_commands_support_spaces() {
+  local source="$TMP_ROOT/spaced-source" target="$TMP_ROOT/spaced-home" root="$TMP_ROOT/first mate" script
+  mkdir -p "$source" "$root/bin"
+  printf 'model:\n  provider: openai-codex\n' > "$source/config.yaml"
+  for script in fm-sessionstart-nudge.sh fm-turnend-guard-hermes.sh fm-arm-pretool-check.sh fm-cd-pretool-check.sh; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$root/bin/$script"
+    chmod +x "$root/bin/$script"
+  done
+
+  HERMES_SOURCE_HOME="$source" "$HOME_HELPER" primary "$target" "$root" >/dev/null
+  assert_grep "command: '''$root/bin/fm-sessionstart-nudge.sh'''" "$target/config.yaml" \
+    "session-start hook path is not shell-quoted"
+  assert_grep "command: '''$root/bin/fm-turnend-guard-hermes.sh'''" "$target/config.yaml" \
+    "turn-end hook path is not shell-quoted"
+  assert_grep "command: '''$root/bin/fm-arm-pretool-check.sh'' --hermes'" "$target/config.yaml" \
+    "watcher-arm hook path is not shell-quoted"
+  assert_grep "command: '''$root/bin/fm-cd-pretool-check.sh'' --hermes'" "$target/config.yaml" \
+    "cd-guard hook path is not shell-quoted"
+  pass "Hermes primary hook commands shell-quote roots containing spaces"
+}
+
+test_primary_home_requires_every_safety_script() {
+  local source="$TMP_ROOT/required-source" missing root target script out rc
+  mkdir -p "$source"
+  printf 'model:\n  provider: openai-codex\n' > "$source/config.yaml"
+  for missing in fm-sessionstart-nudge.sh fm-turnend-guard-hermes.sh fm-arm-pretool-check.sh fm-cd-pretool-check.sh; do
+    root="$TMP_ROOT/missing-$missing"
+    target="$TMP_ROOT/missing-$missing-home"
+    mkdir -p "$root/bin"
+    for script in fm-sessionstart-nudge.sh fm-turnend-guard-hermes.sh fm-arm-pretool-check.sh fm-cd-pretool-check.sh; do
+      printf '#!/usr/bin/env bash\nexit 0\n' > "$root/bin/$script"
+      chmod +x "$root/bin/$script"
+    done
+    rm "$root/bin/$missing"
+    out=$(HERMES_SOURCE_HOME="$source" "$HOME_HELPER" primary "$target" "$root" 2>&1)
+    rc=$?
+    expect_code 1 "$rc" "Hermes primary home missing $missing"
+    assert_contains "$out" "$missing" "missing-script error did not identify $missing"
+    assert_absent "$target/config.yaml" "Hermes published hooks before validating $missing"
+  done
+  pass "Hermes primary home requires every safety hook script"
+}
+
+test_usage_states_the_isolation_guarantee() {
+  local out
+  out=$("$HOME_HELPER" --help)
+  assert_contains "$out" "The source Hermes home is never changed." "usage truncated the isolation guarantee"
+  pass "Hermes home usage renders its complete header"
+}
+
+# The operator's hooks block must never leak into the Firstmate-owned config,
+# and what survives must stay loadable YAML. Each fixture ends the hooks block
+# with a column-0 shape that a line-oriented stripper can mistake for the end of
+# that block: a comment, a document marker, and a quoted key.
+test_preserved_config_never_leaks_operator_hooks() {
+  local case_dir source target n=0 fixture
+  for fixture in comment marker quoted; do
+    n=$((n + 1))
+    case_dir="$TMP_ROOT/leak-$fixture"
+    source="$case_dir/source"
+    target="$case_dir/home"
+    mkdir -p "$source"
+    case "$fixture" in
+      comment)
+        cat > "$source/config.yaml" <<'YAML'
+hooks:
+# operator's own note pinned at column 0
+  on_session_end:
+    - command: '/captain/leak.sh'
+      timeout: 10
+model:
+  default: gpt-5.6-sol
+YAML
+        ;;
+      marker)
+        cat > "$source/config.yaml" <<'YAML'
+model:
+  default: gpt-5.6-sol
+hooks:
+---
+  on_session_start:
+    - command: '/captain/leak.sh'
+YAML
+        ;;
+      quoted)
+        cat > "$source/config.yaml" <<'YAML'
+model:
+  default: gpt-5.6-sol
+"hooks":
+  on_session_start:
+    - command: '/captain/leak.sh'
+hooks_auto_accept: false
+YAML
+        ;;
+    esac
+    HERMES_SOURCE_HOME="$source" "$HOME_HELPER" primary "$target" "$ROOT" >/dev/null
+    assert_no_grep '/captain/leak.sh' "$target/config.yaml" \
+      "operator hook leaked through the $fixture fixture into the isolated config"
+    assert_grep 'fm-turnend-guard-hermes.sh' "$target/config.yaml" \
+      "$fixture fixture lost Firstmate's own turn-end hook"
+    if [ "$YAML_LOADER" = python3 ]; then
+      python3 -c 'import sys,yaml; yaml.safe_load(open(sys.argv[1]))' "$target/config.yaml" \
+        || fail "$fixture fixture produced a config Hermes cannot parse"
+    elif [ "$YAML_LOADER" = ruby ]; then
+      ruby -ryaml -e 'YAML.safe_load(File.read(ARGV[0]))' "$target/config.yaml" \
+        || fail "$fixture fixture produced a config Hermes cannot parse"
+    fi
+  done
+  pass "preserved config strips whole hook blocks across $n column-0 boundary shapes"
+}
+
+test_home_and_config_are_private_from_creation() {
+  local source="$TMP_ROOT/perm-source" target="$TMP_ROOT/perm-home"
+  mkdir -p "$source"
+  printf 'model:\n  provider: openai-codex\n' > "$source/config.yaml"
+  HERMES_SOURCE_HOME="$source" "$HOME_HELPER" primary "$target" "$ROOT" >/dev/null
+  [ "$(file_mode "$target")" = 700 ] || fail "isolated Hermes home must be mode 0700, got $(file_mode "$target")"
+  [ "$(file_mode "$target/config.yaml")" = 600 ] || fail "isolated Hermes config must be mode 0600"
+  pass "isolated Hermes home and config are private"
+}
+
+test_busy_and_idle_classification() {
+  local state
+  printf '%s' '⚕ ❯ msg=interrupt · /queue · /bg · /steer · Ctrl+C cancel' \
+    | grep -qE "$FM_TMUX_BUSY_REGEX_DEFAULT" || fail "Hermes busy footer did not match the fleet busy regex"
+  state=$(fm_composer_classify_content 0 '❯')
+  [ "$state" = empty ] || fail "Hermes bare idle prompt should classify empty, got '$state'"
+  pass "Hermes busy footer and bare idle composer classify correctly"
+}
+
+test_passive_guard_forces_one_safe_followup() {
+  local primary="$TMP_ROOT/primary" source_home="$TMP_ROOT/current-hermes-home" fakebin followup_home log payload out rc
+  fakebin=$(fm_fakebin "$TMP_ROOT/fake")
+  log="$TMP_ROOT/hermes-resume.log"
+  mkdir -p "$primary/bin" "$primary/state" "$primary/config" "$source_home"
+  printf 'model:\n  provider: openai-codex\n' > "$source_home/config.yaml"
+  : > "$primary/AGENTS.md"
+  git init -q "$primary"
+  git -C "$primary" commit -q --allow-empty -m init
+  printf '%s\n' 'window=fake' > "$primary/state/inflight.meta"
+  cat > "$fakebin/hermes" <<'SH'
+#!/usr/bin/env bash
+printf 'home=%s active=%s args=%s\n' "${HERMES_HOME:-}" "${HERMES_TURNEND_GUARD_ACTIVE:-}" "$*" >> "$FM_HERMES_TEST_LOG"
+exit 0
+SH
+  chmod +x "$fakebin/hermes"
+  payload='{"session_id":"20260721_214600_e8ae23","extra":{"completed":true,"interrupted":false}}'
+  out=$(printf '%s' "$payload" | FM_ROOT_OVERRIDE="$primary" FM_HOME="$primary" HERMES_HOME="$source_home" \
+    FM_HERMES_TEST_LOG="$log" PATH="$fakebin:$PATH" "$GUARD" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "Hermes passive guard adapter"
+  [ -z "$out" ] || fail "Hermes passive guard adapter must be silent, got: $out"
+  assert_grep 'active=1 args=--yolo --accept-hooks -z TURN WOULD END BLIND' "$log" \
+    "Hermes guard did not force a loop-guarded independent follow-up"
+  assert_no_grep --resume "$log" "Hermes guard must not resume a session that is still live"
+  assert_no_grep "home=$source_home " "$log" "Hermes guard must not share the live session store"
+  followup_home=$(sed -n 's/^home=\([^ ]*\) active=.*/\1/p' "$log")
+  [ -n "$followup_home" ] || fail "Hermes guard did not select an isolated follow-up home"
+  assert_absent "$followup_home" "Hermes guard left its isolated follow-up home behind"
+
+  : > "$log"
+  payload='{"session_id":"20260721_214600_e8ae23","completed":false,"interrupted":true}'
+  printf '%s' "$payload" | FM_ROOT_OVERRIDE="$primary" FM_HOME="$primary" HERMES_HOME="$source_home" \
+    FM_HERMES_TEST_LOG="$log" PATH="$fakebin:$PATH" "$GUARD" >/dev/null 2>&1
+  [ ! -s "$log" ] || fail "Hermes turn-end guard must respect an operator interrupt"
+  pass "Hermes passive turn-end guard starts a safe follow-up but respects interrupts"
+}
+
+test_fm_lock_recognizes_hermes_holder() {
+  local home="$TMP_ROOT/lock-home" fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/lock-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/home/user/.local/bin/hermes'; exit 0 ;;
+  *"args="*) printf '%s\n' 'hermes chat --yolo --accept-hooks --cli'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid" "fm-lock did not recognize Hermes as a live holder"
+  pass "fm-lock recognizes Hermes harness processes"
+}
+
+test_env_detection
+test_task_home_isolated_and_resumable
+test_primary_home_has_all_hooks
+test_primary_hook_commands_support_spaces
+test_primary_home_requires_every_safety_script
+test_usage_states_the_isolation_guarantee
+test_preserved_config_never_leaks_operator_hooks
+test_home_and_config_are_private_from_creation
+test_busy_and_idle_classification
+test_passive_guard_forces_one_safe_followup
+test_fm_lock_recognizes_hermes_holder

--- a/tests/fm-hermes-primary.test.sh
+++ b/tests/fm-hermes-primary.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Behavior tests for Hermes-as-primary detection, supervision snippet, and
+# shell-hook bridge. Does not claim crew-spawn verification.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-hermes-primary)
+
+test_detect_env_marker() {
+  local out
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    HERMES_SESSION_ID='20260723_test' \
+    "$ROOT/bin/fm-harness.sh")
+  assert_contains "$out" "hermes" "HERMES_SESSION_ID should classify own harness as hermes"
+  pass "fm-harness detects HERMES_SESSION_ID"
+}
+
+test_detect_process_name() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/detect-fake")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' 'hermes'; exit 0 ;;
+  *"args="*) printf '%s\n' '/home/iqbal/.hermes/hermes-agent/venv/bin/hermes'; exit 0 ;;
+  *"ppid="*) printf '%s\n' '1'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u HERMES_SESSION_ID \
+    PATH="$fakebin:$PATH" "$ROOT/bin/fm-harness.sh")
+  assert_contains "$out" "hermes" "process name hermes should classify own harness"
+  pass "fm-harness detects hermes process ancestry"
+}
+
+test_supervision_snippet() {
+  local out
+  out=$("$ROOT/bin/fm-supervision-instructions.sh" --harness hermes --read-only 1)
+  assert_contains "$out" "Hermes background-notify supervision" \
+    "supervision instructions did not select hermes.md"
+  assert_contains "$out" "notify_on_complete" \
+    "hermes protocol must name Hermes notify_on_complete"
+  pass "supervision instructions render hermes protocol"
+}
+
+test_hook_bridge_blocks_bg_arm() {
+  local out home
+  home="$TMP_ROOT/primary-home"
+  mkdir -p "$home/bin" "$home/state"
+  cp "$ROOT/AGENTS.md" "$home/AGENTS.md"
+  ln -s "$ROOT/bin/fm-session-start.sh" "$home/bin/fm-session-start.sh"
+  ln -s "$ROOT/bin/fm-arm-pretool-check.sh" "$home/bin/fm-arm-pretool-check.sh"
+  ln -s "$ROOT/bin/fm-continuity-pretool-check.sh" "$home/bin/fm-continuity-pretool-check.sh"
+  out=$(
+    printf '%s' "{\"hook_event_name\":\"pre_tool_call\",\"tool_name\":\"terminal\",\"tool_input\":{\"command\":\"bin/fm-watch-arm.sh &\"},\"cwd\":\"$home\",\"session_id\":\"t\"}" \
+      | "$ROOT/bin/fm-hermes-primary-hook.sh" pre_tool_call
+  )
+  assert_contains "$out" '"decision":"block"' "bg arm should be blocked by hermes bridge"
+  pass "hermes primary hook blocks shell-background watcher arm"
+}
+
+test_hook_bridge_fail_open_foreign_cwd() {
+  local out foreign
+  foreign="$TMP_ROOT/not-firstmate"
+  mkdir -p "$foreign"
+  out=$(
+    printf '%s' "{\"hook_event_name\":\"pre_tool_call\",\"tool_name\":\"terminal\",\"tool_input\":{\"command\":\"bin/fm-watch-arm.sh &\"},\"cwd\":\"$foreign\",\"session_id\":\"t\"}" \
+      | "$ROOT/bin/fm-hermes-primary-hook.sh" pre_tool_call
+  )
+  [ -z "$out" ] || fail "foreign cwd must fail open with empty stdout, got: $out"
+  pass "hermes primary hook fails open outside firstmate homes"
+}
+
+test_installer_status_roundtrip() {
+  local cfg out status
+  cfg="$TMP_ROOT/hermes-config/config.yaml"
+  mkdir -p "$(dirname "$cfg")"
+  printf 'model:\n  default: test\n' > "$cfg"
+  FM_HERMES_CONFIG="$cfg" "$ROOT/bin/fm-hermes-install-primary-hooks.sh" >/dev/null
+  out=$(FM_HERMES_CONFIG="$cfg" "$ROOT/bin/fm-hermes-install-primary-hooks.sh" --status)
+  status=$?
+  assert_contains "$out" "installed" "installer status should report installed"
+  expect_code 0 "$status" "installer --status exit 0 when installed"
+  FM_HERMES_CONFIG="$cfg" "$ROOT/bin/fm-hermes-install-primary-hooks.sh" --remove >/dev/null
+  set +e
+  out=$(FM_HERMES_CONFIG="$cfg" "$ROOT/bin/fm-hermes-install-primary-hooks.sh" --status 2>&1)
+  status=$?
+  set -e
+  assert_contains "$out" "missing" "installer --remove should clear firstmate hooks"
+  expect_code 1 "$status" "installer --status exit 1 when missing"
+  pass "hermes hook installer install/status/remove roundtrip"
+}
+
+test_detect_env_marker
+test_detect_process_name
+test_supervision_snippet
+test_hook_bridge_blocks_bg_arm
+test_hook_bridge_fail_open_foreign_cwd
+test_installer_status_roundtrip

--- a/tests/fm-lock-harness.test.sh
+++ b/tests/fm-lock-harness.test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Behavior tests for session-lock holder detection (bin/fm-lock.sh).
+# Lock identity may recognize a primary harness before that harness is a
+# verified spawn/crew adapter - hermes is the first such case.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-lock-harness)
+
+# Write a fake `ps` that always reports the given comm/args for every pid query.
+make_ps_shim() {
+  local fakebin=$1 comm=$2 args=$3
+  cat > "$fakebin/ps" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *"comm="*) printf '%s\\n' '$comm'; exit 0 ;;
+  *"args="*) printf '%s\\n' '$args'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
+assert_status_held() {
+  local name=$1 comm=$2 args=$3 home fakebin out
+  home="$TMP_ROOT/$name-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/$name-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  make_ps_shim "$fakebin" "$comm" "$args"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid" \
+    "fm-lock status did not treat $name ($comm) as a live harness holder"
+  pass "fm-lock status recognizes $name holder"
+}
+
+assert_acquire_ok() {
+  local name=$1 comm=$2 args=$3 home fakebin out status
+  home="$TMP_ROOT/$name-acq-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/$name-acq-fake")
+  mkdir -p "$home/state"
+  make_ps_shim "$fakebin" "$comm" "$args"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" 2>&1)
+  status=$?
+  expect_code 0 "$status" "fm-lock acquire should succeed for $name primary"
+  assert_contains "$out" "lock acquired: harness pid" \
+    "fm-lock acquire did not report success for $name"
+  pass "fm-lock acquire works under $name"
+}
+
+# Hermes primary: process name is the CLI entrypoint (python -m / venv bin).
+assert_status_held hermes-bin hermes \
+  '/home/iqbal/.hermes/hermes-agent/venv/bin/python3 /home/iqbal/.hermes/hermes-agent/venv/bin/hermes'
+assert_acquire_ok hermes-bin hermes \
+  '/home/iqbal/.hermes/hermes-agent/venv/bin/python3 /home/iqbal/.hermes/hermes-agent/venv/bin/hermes'
+
+# Hermes under a bare interpreter name (comm=python3, path still contains hermes).
+assert_status_held hermes-python python3 \
+  '/home/iqbal/.hermes/hermes-agent/venv/bin/python3 /home/iqbal/.hermes/hermes-agent/venv/bin/hermes'
+assert_acquire_ok hermes-python python3 \
+  '/home/iqbal/.hermes/hermes-agent/venv/bin/python3 /home/iqbal/.hermes/hermes-agent/venv/bin/hermes'
+
+# Regression: already-verified lock holders still match.
+assert_status_held grok-bin grok 'grok'
+assert_status_held claude-bin claude 'claude'

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -599,7 +599,7 @@ test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens() {
   [ "$(meta_field "$meta" model)" = default ] || fail "explicit-harness-no-tokens: meta model should stay default"
   [ "$(meta_field "$meta" effort)" = default ] || fail "explicit-harness-no-tokens: meta effort should stay default"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "codex --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --enable fast_mode --dangerously-bypass-approvals-and-sandbox" \
     "explicit-harness-no-tokens: launch did not use codex"
   assert_not_contains "$launch" "--model" "explicit-harness-no-tokens: launch must not carry a --model flag"
   assert_not_contains "$launch" "model_reasoning_effort" \

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -169,7 +169,7 @@ test_active_dispatch_profile_allows_explicit_harness() {
   assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --enable fast_mode --dangerously-bypass-approvals-and-sandbox" \
     "explicit harness launch did not thread model and effort"
   pass "active crew-dispatch profile allows an explicit resolved harness"
 }
@@ -235,7 +235,7 @@ test_codex_threads_model_and_effort() {
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --enable fast_mode --dangerously-bypass-approvals-and-sandbox" \
     "codex launch did not thread model and reasoning effort config"
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
@@ -251,7 +251,7 @@ test_codex_omits_invalid_max_effort() {
   expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' --enable fast_mode --dangerously-bypass-approvals-and-sandbox" \
     "codex launch did not preserve the model flag when max effort was omitted"
   assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
   pass "codex omits unsupported max effort instead of passing a bad config value"
@@ -418,6 +418,53 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
   pass "active crew-dispatch profile does not block secondmate launches"
 }
 
+test_fast_mode_is_codex_only() {
+  local rec id sm out status launch harness index
+
+  id=fast-mode-codex-notify-z18
+  rec=$(make_spawn_case fast-mode-codex-notify codex "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness codex)
+  status=$?
+  expect_code 0 "$status" "codex ship spawn should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex --enable fast_mode --dangerously-bypass-approvals-and-sandbox" \
+    "codex notify launch did not enable fast_mode before the approval bypass"
+  assert_contains "$launch" 'notify=[' "codex ship launch did not exercise the notify variant"
+
+  id=fast-mode-codex-plain-z19
+  rec=$(make_spawn_case fast-mode-codex-plain codex "$id")
+  read_case_record "$rec"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$sm" --harness codex --secondmate)
+  status=$?
+  expect_code 0 "$status" "codex secondmate spawn should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex --enable fast_mode --dangerously-bypass-approvals-and-sandbox" \
+    "codex plain launch did not enable fast_mode before the approval bypass"
+  assert_not_contains "$launch" 'notify=[' "codex secondmate launch did not exercise the plain variant"
+
+  index=20
+  for harness in claude opencode pi grok hermes; do
+    id="fast-mode-$harness-z$index"
+    rec=$(make_spawn_case "fast-mode-$harness" "$harness" "$id")
+    read_case_record "$rec"
+    out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$id" "$PROJ_DIR" --harness "$harness")
+    status=$?
+    expect_code 0 "$status" "$harness ship spawn should succeed"
+    launch=$(cat "$LAUNCH_LOG")
+    assert_not_contains "$launch" "--enable fast_mode" \
+      "$harness launch must not inherit codex fast_mode"
+    index=$((index + 1))
+  done
+
+  pass "codex plain and notify launches enable fast_mode without affecting other harnesses"
+}
+
 test_no_profile_keeps_claude_launch_unchanged
 test_active_dispatch_profile_requires_explicit_harness_for_ship
 test_active_dispatch_profile_requires_explicit_harness_for_scout
@@ -435,5 +482,6 @@ test_pi_threads_model_and_max_effort
 test_quota_selected_default_array_reaches_spawn
 test_batch_forwards_shared_profile_flags
 test_active_dispatch_profile_does_not_block_secondmate_launch
+test_fast_mode_is_codex_only
 
 echo "# all fm-spawn-dispatch-profile tests passed"


### PR DESCRIPTION
## Intent

Independently validate the existing labsiqbal/firstmate fork PR #2 on branch fm/fm-codex-fastmode before it lands on fork main. The change must add --enable fast_mode to both codex launch templates in bin/fm-spawn.sh, including the plain secondmate variant and the turn-end notify ship/scout variant, with placeholder substitution and spacing preserved. The flag must affect only codex, and existing tests must prove it is present for both codex variants and absent for claude, opencode, pi, grok, and hermes. bin/fm-lint.sh and the relevant shell tests must pass. Reuse existing fork PR #2 and do not open any new PR, especially not against kunchenguid/firstmate.

## What Changed

- Added Hermes as a first-class primary/secondmate harness in the spawn dispatch: `bin/fm-spawn.sh` recognizes `hermes` as a bare adapter name, renders a `HERMES_HOME=... hermes --yolo --accept-hooks --cli -m <model> -z "$(cat BRIEF)"` launch template with `__HERMES_HOME__` placeholder substitution, and provisions a firstmate-owned isolated `HERMES_HOME` under `state/<id>.hermes` (new `bin/fm-hermes-home.sh`, `bin/fm-hermes-install-primary-hooks.sh`, `bin/fm-hermes-primary-hook.sh`, `bin/fm-turnend-guard-hermes.sh`) that installs turn-end hooks without touching the captain's real `~/.hermes`; `bin/fm-lock.sh`, `bin/fm-watch.sh`, and `bin/fm-teardown.sh` were updated to recognize and clean up Hermes sessions.
- Enabled codex fast mode by inserting `--enable fast_mode` into both codex launch templates in `bin/fm-spawn.sh` - the plain secondmate variant and the turn-end `notify` ship/scout variant - with placeholder substitution and spacing preserved, leaving claude, opencode, pi, grok, and hermes templates unchanged.
- Documented the Hermes primary harness and supervision protocol (`docs/hermes-primary.md`, `docs/supervision-protocols/hermes.md`, `.agents/skills/harness-adapters/SKILL.md`, `AGENTS.md`) and added test coverage (`tests/fm-hermes-harness.test.sh`, `tests/fm-hermes-primary.test.sh`, `tests/fm-lock-harness.test.sh`, and expanded `tests/fm-spawn-dispatch-profile.test.sh`) asserting fast_mode is present for both codex variants and absent for the other adapters.

## Risk Assessment

✅ Low: The change is a minimal, well-bounded two-line template edit that adds --enable fast_mode to both codex launch variants only, with matching test coverage proving presence for both codex variants and absence for all other harnesses, fully satisfying the stated intent.

## Testing

Ran the two targeted shell tests that directly prove the intent (fm-spawn-dispatch-profile and fm-secondmate-harness) plus bin/fm-lint.sh; all pass. The dispatch-profile suite's test_fast_mode_is_codex_only exercises actual spawns and confirms `--enable fast_mode` is present for both codex launch variants (plain secondmate + turn-end notify ship/scout) with placeholder substitution and spacing preserved, and absent for claude, opencode, pi, grok, and hermes. I also rendered the launch templates verbatim from bin/fm-spawn.sh as reviewer-visible evidence showing only the two codex variants contain the flag. fm-lint.sh exits 0 with pinned ShellCheck 0.11.0 and no findings. This is a CLI/shell launch-command change with no rendered UI surface, so evidence is CLI transcripts and rendered launch strings rather than screenshots. Worktree left clean; no new PR opened (read/test-only validation).

<details>
<summary>Evidence: Rendered codex launch templates (only codex variants carry --enable fast_mode)</summary>

<code>codex SECONDMATE (plain): codex __MODELFLAG____EFFORTFLAG__--enable fast_mode --dangerously-bypass-approvals-and-sandbox &#34;$(cat __BRIEF__)&#34;&#10;codex SHIP/SCOUT (notify): codex __MODELFLAG____EFFORTFLAG__--enable fast_mode --dangerously-bypass-approvals-and-sandbox -c &#34;notify=[...]&#34; &#34;$(cat __BRIEF__)&#34;&#10;claude/grok/hermes lines contain NO fast_mode</code>

```text
=== Rendered codex launch templates (verbatim from bin/fm-spawn.sh launch_template) ===

codex SECONDMATE (plain) variant:
  codex __MODELFLAG____EFFORTFLAG__--enable fast_mode --dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"

codex SHIP/SCOUT (turn-end notify) variant:
  codex __MODELFLAG____EFFORTFLAG__--enable fast_mode --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"

claude:
  CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"

opencode:
  OPENCODE_CONFIG_CONTENT=

grok:
  grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"

hermes:
  HERMES_HOME=__HERMES_HOME__ hermes --yolo --accept-hooks --cli __MODELFLAG__-z "$(cat __BRIEF__)"
```
</details>
<details>
<summary>Evidence: Test + lint transcript</summary>

<code>ok - codex plain and notify launches enable fast_mode without affecting other harnesses&#10;# all fm-spawn-dispatch-profile tests passed&#10;# all fm-secondmate-harness tests passed&#10;fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0) -&gt; exit 0</code>

```text
### test_fast_mode_is_codex_only (tests/fm-spawn-dispatch-profile.test.sh)
ok - codex plain and notify launches enable fast_mode without affecting other harnesses
# all fm-spawn-dispatch-profile tests passed

### fm-secondmate-harness codex assertion

### fm-secondmate-harness.test.sh -> PASS (all fm-secondmate-harness tests passed; asserts "codex --enable fast_mode --dangerously-bypass-approvals-and-sandbox")
### fm-lint.sh -> exit 0, ShellCheck 0.11.0 pinned, no findings
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `bin/fm-lock.sh` - merge conflict rebasing onto origin/main

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` — 18/18 pass including `test_fast_mode_is_codex_only`, which asserts real rendered launches contain `codex --enable fast_mode --dangerously-bypass-approvals-and-sandbox` for both the notify (ship) and plain (secondmate) variants and asserts `--enable fast_mode` is absent for claude, opencode, pi, grok, and hermes</code>
- <code>`bash tests/fm-secondmate-harness.test.sh` — all pass; independently asserts the codex `--enable fast_mode` launch string with correct model/effort omission</code>
- <code>`bash bin/fm-lint.sh` — exit 0, ShellCheck 0.11.0 (pinned), no findings</code>
- `Rendered launch_template output verbatim from bin/fm-spawn.sh to confirm only the two codex variants carry fast_mode and spacing/placeholders are intact`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
