### PR TITLE
feat: add optional host-root mode

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -100,6 +100,26 @@ OpenCode uses `.opencode/plugins/fm-primary-watch-arm.js`, which coordinates wit
 Pi uses the tracked `.pi/extensions/fm-primary-turnend-guard.ts` plus the tracked `.pi/extensions/fm-primary-pi-watch.ts`, both project-local extensions Pi auto-discovers once trusted.
 When changing any primary watcher adapter, update `docs/supervision-protocols/`, `docs/turnend-guard.md` if a shared idle or turn-end hook changed, and the relevant concise fact below.
 
+## Host-root task integration
+
+When `FM_HOST_ROOT` is set for an ordinary ship or scout, the harness starts from that physical host root and receives the isolated target separately as `FM_TARGET_WORKTREE`.
+The host's discovered instructions and lifecycle adapters remain authoritative; target instructions are read explicitly under the host-root brief before edits.
+FirstMate adds exactly one task turn-end signal without writing host configuration:
+
+| Harness | Additive task signal in host-root mode |
+|---|---|
+| claude | An additional state-owned settings file passed with `--settings`; Claude continues loading host project settings. |
+| codex | The existing per-launch `notify` command; host `.codex/hooks.json` remains untouched. |
+| opencode | A state-owned task plugin named through `OPENCODE_CONFIG_CONTENT`; host project plugins continue to auto-load from the launch cwd. |
+| pi | The existing explicit state-owned `-e` task extension; host project extensions continue to auto-load after host trust. |
+| grok | The guarded global FirstMate Stop hook reads a per-process `FM_GROK_TURNEND_TOKEN`; host project hooks remain untouched and no pointer is written into the host repository. |
+| kimi | The guarded global FirstMate Stop hook reads a per-process `FM_KIMI_TURNEND_TOKEN`; host configuration remains otherwise untouched and no pointer is written into the host repository. |
+
+Default worktree-root launches retain their existing hook locations and command shapes.
+Secondmate launches explicitly clear inherited `FM_HOST_ROOT` and `FM_TARGET_WORKTREE` and retain their isolated-home adapters.
+
+[`docs/verification/supervision.md`](../../../docs/verification/supervision.md#host-root-task-integration) owns the dated lifecycle evidence and current live-verification limits for these task adapters.
+
 ## Launch profile axes
 
 `bin/fm-spawn.sh` accepts concrete `--harness`, `--model`, and `--effort` values chosen by firstmate at intake.

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -64,6 +64,7 @@ Release happens only on explicit retirement or seed rollback, never on routine r
 `bin/fm-home-seed.sh` copies the charter into the secondmate home as `data/charter.md`.
 It also writes the required `.fm-secondmate-home` identity marker, which is gitignored and must remain in place for home validation.
 `bin/fm-spawn.sh --secondmate` launches it through the secondmate harness path, resolving `config/secondmate-harness` -> `config/crew-harness` -> the primary's own harness unless an explicit per-spawn harness override is passed.
+Secondmates remain outside optional host-root mode: their launch prefix clears any inherited `FM_HOST_ROOT` and `FM_TARGET_WORKTREE`, their metadata has no `host_root=`, and their startup cwd remains the isolated FirstMate home.
 
 `config/secondmate-harness` may also pin a concrete model and effort for the secondmate agent, in the SAME file rather than a new one: the format is a single whitespace-separated line `<harness> [<model>] [<effort>]`, with only the first non-empty, non-comment line parsed.
 A bare `<harness>` (today's format, e.g. `claude`) behaves exactly as before - harness only, no model/effort flag - so this is fully backward-compatible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,8 @@ Never add an agent name as a commit co-author.
 
 `docs/configuration.md` is the single owner of the top-level operational-home layout and configuration schemas; each producing script's header and help own exact child fields and mutation mechanics.
 `FM_HOME` selects an instance's private `data/`, `state/`, `config/`, and `projects/`, while scripts continue to come from their tracked code root.
-Each secondmate has a persistent isolated `FM_HOME`, including its own state, backlog, projects, and session lock.
+Optional `FM_HOST_ROOT` keeps another repository authoritative for instructions, lifecycle, and cwd while ordinary task edits stay under explicit `FM_TARGET_WORKTREE`; `docs/configuration.md` owns the four-root contract.
+Each secondmate has a persistent isolated `FM_HOME`, including its own state, backlog, projects, and session lock, and secondmate launches clear any inherited host-root variables.
 `bin/fm-send.sh` fails closed unless `FM_HOME` is explicit, so a steer cannot silently resolve against another home.
 
 Tracked files hold shared instructions and tooling; `data/` holds durable private fleet records; `state/` holds volatile runtime records and append-only status events; `config/` holds local operating choices; and `projects/` contains clones that are read-only to firstmate.
@@ -88,7 +89,7 @@ state/               volatile runtime signals; gitignored
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
   <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; an ordinary host-root task also records host_root=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
   <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 - **One liaison** - you talk only to the first mate; it dispatches, supervises, escalates only real decisions, and reports plain outcomes.
 - **A visible crew** - every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.
 - **Disposable worktrees** - each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides.
+- **Optional host-root mode** - an explicitly integrated supervisor can keep an existing command-center repository authoritative for instructions, lifecycle hooks, and worker cwd while FirstMate retains its own code/home and every task edits an explicit isolated target worktree; see [configuration](docs/configuration.md#host-root-mode-fm_host_root).
 - **Two task shapes** - ship tasks deliver authorized changes; scout tasks leave standalone investigation reports when the intake contract warrants separate research.
 - **Explicit project modes** - each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.
 - **Optional secondmates** - opt in to persistent second mates that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, supervising project clones or a project-less firstmate-repo domain, kept on the primary firstmate version by guarded local fast-forwards and checked for live agent processes at session start.
@@ -82,7 +83,8 @@ git clone https://github.com/kunchenguid/firstmate
 cd firstmate
 ```
 
-Then launch one of the co-primary harnesses; AGENTS.md takes over from there:
+Then launch one of the co-primary harnesses; AGENTS.md takes over from there.
+For the low-level opt-in contract used by an explicit host integration, see [Host-root mode](docs/configuration.md#host-root-mode-fm_host_root).
 
 **Claude Code**
 

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -350,8 +350,14 @@ fm_backend_cmux_surface_id_for_workspace() {  # <workspace_id>
 # workspace/surface/pane create all default focus to false) - no
 # focus-restore dance is needed, unlike zellij. Echoes "<workspace_id>
 # <surface_id>" on success.
+# Creation-state globals are consumed by fm-spawn after direct function calls.
+# shellcheck disable=SC2034
 fm_backend_cmux_create_task() {  # <label> <cwd>
   local label=$1 cwd=$2 title dup out wsid sfid
+  FM_BACKEND_CREATE_OCCURRED=0
+  FM_BACKEND_CREATED_TARGET=
+  FM_BACKEND_CREATED_CMUX_WORKSPACE_ID=
+  FM_BACKEND_CREATED_CMUX_SURFACE_ID=
   title=$(fm_backend_cmux_scoped_title "$label")
   dup=$(fm_backend_cmux_workspace_id_for_label "$title")
   if [ -n "$dup" ]; then
@@ -362,9 +368,13 @@ fm_backend_cmux_create_task() {  # <label> <cwd>
     echo "error: cmux new-workspace failed for '$title': $out" >&2
     return 1
   }
+  FM_BACKEND_CREATE_OCCURRED=1
   wsid=$(fm_backend_cmux_workspace_id_for_label "$title")
+  FM_BACKEND_CREATED_CMUX_WORKSPACE_ID=$wsid
   [ -n "$wsid" ] || { echo "error: could not resolve a cmux workspace id for '$title' after creation" >&2; return 1; }
   sfid=$(fm_backend_cmux_surface_id_for_workspace "$wsid")
+  FM_BACKEND_CREATED_CMUX_SURFACE_ID=$sfid
+  [ -z "$sfid" ] || FM_BACKEND_CREATED_TARGET="$wsid:$sfid"
   [ -n "$sfid" ] || { echo "error: could not resolve the default surface for cmux workspace '$title' ($wsid)" >&2; return 1; }
   printf '%s %s' "$wsid" "$sfid"
 }
@@ -429,6 +439,36 @@ fm_backend_cmux_target_ready() {  # <target> [expected-label]
     return 0
   fi
   fm_backend_cmux_surface_exists "$FM_BACKEND_CMUX_WORKSPACE" "$FM_BACKEND_CMUX_SURFACE"
+}
+
+# Tri-state endpoint probe for destructive cleanup. A successful workspace
+# inventory proves presence or absence; socket/auth/JSON failures stay unknown.
+fm_backend_cmux_target_state() {  # <target> [expected-label] -> present|absent|unknown
+  local expected_label=${2:-} expected_title workspaces
+  fm_backend_cmux_parse_target "$1" || { printf 'unknown'; return 0; }
+  [ "$(fm_backend_cmux_ping_state)" = ok ] || { printf 'unknown'; return 0; }
+  workspaces=$(fm_backend_cmux_cli workspace list --json --id-format uuids 2>&1) || {
+    printf 'unknown'
+    return 0
+  }
+  if ! printf '%s' "$workspaces" | jq -e '.workspaces | type == "array"' >/dev/null 2>&1; then
+    printf 'unknown'
+    return 0
+  fi
+  if printf '%s' "$workspaces" | jq -e --arg id "$FM_BACKEND_CMUX_WORKSPACE" \
+    'any(.workspaces[]?; .id == $id)' >/dev/null 2>&1; then
+    printf 'present'
+    return 0
+  fi
+  if [ -n "$expected_label" ]; then
+    expected_title=$(fm_backend_cmux_scoped_title "$expected_label")
+    if printf '%s' "$workspaces" | jq -e --arg title "$expected_title" \
+      'any(.workspaces[]?; .title == $title)' >/dev/null 2>&1; then
+      printf 'present'
+      return 0
+    fi
+  fi
+  printf 'absent'
 }
 
 # fm_backend_cmux_current_path: the live foreground process's cwd, or empty on

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1134,8 +1134,14 @@ fm_backend_herdr_agent_alive() {  # <target>
 # the safety argument). An ADOPTED workspace's caller always passes an empty
 # 4th arg, so this function never even queries for a prune candidate in that
 # case. Echoes "<tab_id> <pane_id>" on success.
+# Creation-state globals are consumed by fm-spawn after direct function calls.
+# shellcheck disable=SC2034
 fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_tab_id>
   local container=$1 label=$2 cwd=$3 seeded_tab_id=${4:-} session wsid list dup_tabs dup dup_pane dup_tab_ids out tab_id pane_id remaining_dup_tabs
+  FM_BACKEND_CREATE_OCCURRED=0
+  FM_BACKEND_CREATED_TARGET=
+  FM_BACKEND_CREATED_HERDR_TAB_ID=
+  FM_BACKEND_CREATED_HERDR_PANE_ID=
   session=${container%%:*}
   wsid=${container#*:}
   list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
@@ -1158,8 +1164,12 @@ $dup_tabs
 EOF
   fi
   out=$(fm_backend_herdr_cli "$session" tab create --workspace "$wsid" --cwd "$cwd" --label "$label" --no-focus 2>/dev/null) || return 1
+  FM_BACKEND_CREATE_OCCURRED=1
   tab_id=$(printf '%s' "$out" | jq -r '.result.tab.tab_id // empty' 2>/dev/null)
   pane_id=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
+  FM_BACKEND_CREATED_HERDR_TAB_ID=$tab_id
+  FM_BACKEND_CREATED_HERDR_PANE_ID=$pane_id
+  [ -z "$pane_id" ] || FM_BACKEND_CREATED_TARGET="$session:$pane_id"
   if [ -z "$tab_id" ] || [ -z "$pane_id" ]; then
     echo "error: could not parse tab/pane id from herdr tab create output" >&2
     return 1
@@ -2086,6 +2096,22 @@ fm_backend_herdr_send_text_submit() {  # <target> <text> <retries> <enter-sleep>
     i=$((i + 1))
     [ "$i" -lt "$retries" ] || { printf 'pending'; return 0; }
   done
+}
+
+# Tri-state endpoint probe for destructive cleanup. Only Herdr's typed
+# pane_not_found response proves absence; malformed, unreachable, or other
+# error responses stay unknown.
+fm_backend_herdr_target_state() {  # <target> -> present|absent|unknown
+  local out code pane_id
+  fm_backend_herdr_parse_target "$1" || { printf 'unknown'; return 0; }
+  out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>&1)
+  code=$(printf '%s' "$out" | jq -r '.error.code // empty' 2>/dev/null)
+  if [ -n "$code" ]; then
+    [ "$code" = pane_not_found ] && printf 'absent' || printf 'unknown'
+    return 0
+  fi
+  pane_id=$(printf '%s' "$out" | jq -r '.result.pane.pane_id // empty' 2>/dev/null)
+  [ "$pane_id" = "$FM_BACKEND_HERDR_PANE" ] && printf 'present' || printf 'unknown'
 }
 
 # fm_backend_herdr_kill: remove the task's pane, best-effort (mirrors

--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -139,10 +139,9 @@ fm_backend_orca_worktree_create() {  # <project-path> <name>
   terminal=$(printf '%s' "$out" | fm_backend_orca_json_get worktree-terminal-handle 2>/dev/null || true)
   wt_path=$(printf '%s' "$out" | fm_backend_orca_json_get worktree-path) || {
     echo "error: orca worktree create did not return a path for $name" >&2
-    [ -z "$terminal" ] || fm_backend_orca_kill "$terminal" >/dev/null 2>&1 || true
-    if fm_backend_orca_remove_worktree "$wt_id" >/dev/null; then
-      return 1
-    fi
+    # The worktree exists, but pathless creation is not safe to clean up here:
+    # a terminal must be confirmed absent before its owning worktree can be
+    # removed. Return the recoverable ids to fm-spawn's verified rollback path.
     if [ -n "$terminal" ]; then
       printf '%s\t\t%s' "$wt_id" "$terminal"
     else
@@ -169,6 +168,47 @@ fm_backend_orca_send_text_line() {  # <terminal-id> <text>
   local terminal=$1 text=$2
   fm_backend_orca_tool_check || return 1
   fm_backend_orca_run_json orca terminal send --terminal "$terminal" --text "$text" --enter --json
+}
+
+# Active marker probe used only by spawn-time cwd verification. Orca exposes no
+# structured live foreground cwd, so submit one harmless command and bound the
+# reads waiting for its unique marker pair. One invocation never injects the
+# command more than once, which prevents overlapping probes in a slow terminal.
+fm_backend_orca_current_path() {  # <terminal-id>
+  local terminal=$1 out line candidate in_block path_lines attempt
+  local attempts=${FM_ORCA_CWD_PROBE_ATTEMPTS:-10} delay=${FM_ORCA_CWD_PROBE_DELAY:-0.1}
+  local nonce="${BASHPID:-$$}_${RANDOM:-0}"
+  local begin="__FM_ORCA_CWD_BEGIN_${nonce}__" end="__FM_ORCA_CWD_END_${nonce}__"
+  case "$attempts" in ''|*[!0-9]*|0) attempts=10 ;; esac
+  fm_backend_orca_send_text_line "$terminal" "printf '%s\\n' '$begin'; pwd -P; printf '%s\\n' '$end'" || return 0
+  for ((attempt = 0; attempt < attempts; attempt += 1)); do
+    out=$(fm_backend_orca_read_text_paged "$terminal" 200 2>/dev/null || true)
+    in_block=0
+    candidate=
+    path_lines=0
+    while IFS= read -r line; do
+      if [ "$line" = "$begin" ]; then
+        in_block=1
+        candidate=
+        path_lines=0
+        continue
+      fi
+      if [ "$line" = "$end" ]; then
+        if [ "$path_lines" -eq 1 ]; then
+          case "$candidate" in
+            /*) printf '%s' "$candidate"; return 0 ;;
+          esac
+        fi
+        in_block=0
+        continue
+      fi
+      [ "$in_block" -eq 1 ] || continue
+      candidate=$line
+      path_lines=$((path_lines + 1))
+    done < <(printf '%s\n' "$out")
+    [ "$attempt" -ge $((attempts - 1)) ] || sleep "$delay"
+  done
+  return 0
 }
 
 fm_backend_orca_send_literal() {  # <terminal-id> <text>
@@ -201,6 +241,27 @@ fm_backend_orca_capture() {  # <terminal-id> <lines>
   fm_backend_orca_tool_check || return 1
   out=$(orca terminal read --terminal "$terminal" --limit "$lines" --json) || return 1
   fm_backend_orca_json_text "$out"
+}
+
+# Tri-state endpoint probe for destructive cleanup. Only Orca's typed stale
+# handle response proves absence; every transport, parse, or other API error is
+# unknown and therefore cannot license worktree removal.
+fm_backend_orca_target_state() {  # <terminal-id> -> present|absent|unknown
+  local out
+  fm_backend_orca_tool_check || { printf 'unknown'; return 0; }
+  out=$(orca terminal read --terminal "$1" --limit 1 --json 2>&1)
+  printf '%s' "$out" | node -e '
+const fs = require("fs");
+let data;
+try { data = JSON.parse(fs.readFileSync(0, "utf8")); }
+catch { process.stdout.write("unknown"); process.exit(0); }
+if (data && data.ok === false) {
+  const code = data.error && data.error.code;
+  process.stdout.write(code === "terminal_handle_stale" ? "absent" : "unknown");
+} else {
+  process.stdout.write("present");
+}
+'
 }
 
 fm_backend_orca_json_text() {  # <json>

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -117,6 +117,29 @@ fm_backend_tmux_send_literal() {  # <target> <text>
   tmux send-keys -t "$1" -l "$2"
 }
 
+# Tri-state endpoint probe for destructive cleanup. Enumerate exact handles:
+# `display-message -t` silently falls back to the active window when a named
+# target disappeared, which would report a killed worker as still present.
+# A readable inventory proves presence/absence; control-plane failures stay unknown.
+fm_backend_tmux_target_state() {  # <target> -> present|absent|unknown
+  local target=$1 out status pane_id window_id named indexed
+  out=$(tmux list-panes -a -F '#{pane_id}|#{window_id}|#{session_name}:#{window_name}|#{session_name}:#{window_index}.#{pane_index}' 2>&1)
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    while IFS='|' read -r pane_id window_id named indexed; do
+      case "$target" in
+        "$pane_id"|"$window_id"|"$named"|"$indexed") printf 'present'; return 0 ;;
+      esac
+    done <<< "$out"
+    printf 'absent'
+  else
+    case "$out" in
+      *'no server running'*|*'no sessions'*) printf 'absent' ;;
+      *) printf 'unknown' ;;
+    esac
+  fi
+}
+
 # fm_backend_tmux_kill: remove the task's window, best-effort. Mirrors
 # fm-teardown.sh's `tmux kill-window -t "$T" 2>/dev/null || true`.
 fm_backend_tmux_kill() {  # <target>

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -325,8 +325,14 @@ fm_backend_zellij_tab_matches_label() {  # <session> <tab_id> <label>
 # spawn). Best-effort: a failure to restore never fails the spawn.
 #
 # Echoes "<tab_id> <pane_id>" on success.
+# Creation-state globals are consumed by fm-spawn after direct function calls.
+# shellcheck disable=SC2034
 fm_backend_zellij_create_task() {  # <session> <label> <cwd>
   local session=$1 label=$2 cwd=$3 title tabs dup prev_active tab_id pane_id
+  FM_BACKEND_CREATE_OCCURRED=0
+  FM_BACKEND_CREATED_TARGET=
+  FM_BACKEND_CREATED_ZELLIJ_TAB_ID=
+  FM_BACKEND_CREATED_ZELLIJ_PANE_ID=
   fm_backend_zellij_session_exists "$session" || { echo "error: zellij session '$session' does not exist; run container_ensure first" >&2; return 1; }
   title=$(fm_backend_zellij_scoped_title "$label")
   tabs=$(fm_backend_zellij_cli "$session" action list-tabs --json 2>/dev/null)
@@ -337,6 +343,8 @@ fm_backend_zellij_create_task() {  # <session> <label> <cwd>
   fi
   prev_active=$(printf '%s' "$tabs" | jq -r '.[]? | select(.active == true) | .tab_id' 2>/dev/null | head -1)
   tab_id=$(fm_backend_zellij_cli "$session" action new-tab --cwd "$cwd" --name "$title" 2>/dev/null | tr -d '[:space:]')
+  FM_BACKEND_CREATE_OCCURRED=1
+  FM_BACKEND_CREATED_ZELLIJ_TAB_ID=$tab_id
   case "$tab_id" in
     ''|*[!0-9]*)
       echo "error: zellij new-tab did not return a numeric tab id for '$title' (got '$tab_id'; session '$session' may not exist)" >&2
@@ -344,6 +352,8 @@ fm_backend_zellij_create_task() {  # <session> <label> <cwd>
       ;;
   esac
   pane_id=$(fm_backend_zellij_pane_for_tab "$session" "$tab_id")
+  FM_BACKEND_CREATED_ZELLIJ_PANE_ID=$pane_id
+  [ -z "$pane_id" ] || FM_BACKEND_CREATED_TARGET="$session:$pane_id"
   if [ -z "$pane_id" ]; then
     echo "error: could not find a terminal pane for zellij tab $tab_id (session '$session')" >&2
     return 1
@@ -379,6 +389,38 @@ fm_backend_zellij_target_ready() {  # <target> [expected-label]
     return $?
   fi
   fm_backend_zellij_pane_exists "$FM_BACKEND_ZELLIJ_SESSION" "$FM_BACKEND_ZELLIJ_PANE"
+}
+
+# Tri-state endpoint probe for destructive cleanup. Zellij action exit codes
+# cannot prove absence, so first require a readable session list and then parse
+# the pane list structurally; malformed or unreachable output stays unknown.
+fm_backend_zellij_target_state() {  # <target> -> present|absent|unknown
+  local sessions status panes
+  fm_backend_zellij_parse_target "$1" || { printf 'unknown'; return 0; }
+  sessions=$(zellij list-sessions --short --no-formatting 2>&1)
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    case "$sessions" in
+      *'No active zellij sessions found'*|*'No sessions found'*) printf 'absent' ;;
+      *) printf 'unknown' ;;
+    esac
+    return 0
+  fi
+  if ! printf '%s\n' "$sessions" | grep -qxF "$FM_BACKEND_ZELLIJ_SESSION"; then
+    printf 'absent'
+    return 0
+  fi
+  panes=$(fm_backend_zellij_cli "$FM_BACKEND_ZELLIJ_SESSION" action list-panes --json 2>&1)
+  if ! printf '%s' "$panes" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    printf 'unknown'
+    return 0
+  fi
+  if printf '%s' "$panes" | jq -e --arg pane "$FM_BACKEND_ZELLIJ_PANE" \
+    '[.[]? | select((.id | tostring) == $pane and .is_plugin == false)] | length > 0' >/dev/null 2>&1; then
+    printf 'present'
+  else
+    printf 'absent'
+  fi
 }
 
 # fm_backend_zellij_current_path: the live pane's cwd, or empty on any error.

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -712,6 +712,45 @@ fm_backend_target_exists() {  # <backend> <target> [expected-label]
 # classifier. Zellij remains unverified because its secondmate ghost-tab and
 # agent-process recovery path has not been empirically validated. Orca and cmux
 # do not support secondmate spawns.
+# Tri-state existence probe for destructive cleanup. Unlike the historical
+# boolean liveness helper above, an unreadable control plane is unknown rather
+# than absent and therefore cannot authorize worktree reuse.
+fm_backend_target_state() {  # <backend> <target> [expected-label] -> present|absent|unknown
+  local backend=$1 target=$2 expected_label=${3:-}
+  fm_backend_source "$backend" || { printf 'unknown'; return 0; }
+  case "$backend" in
+    tmux) fm_backend_tmux_target_state "$target" ;;
+    herdr) fm_backend_herdr_target_state "$target" ;;
+    zellij) fm_backend_zellij_target_state "$target" ;;
+    orca) fm_backend_orca_target_state "$target" ;;
+    cmux) fm_backend_cmux_target_state "$target" "$expected_label" ;;
+    *) printf 'unknown' ;;
+  esac
+}
+
+# Stop a task endpoint and prove it disappeared before any caller recycles or
+# removes the task's worktree. Kill adapters remain idempotent; this stricter
+# owner is for destructive cleanup paths that must not trust best-effort close.
+fm_backend_stop_and_verify() {  # <backend> <target> [zellij-tab-id] [expected-label]
+  local backend=$1 target=$2 expected_label=${4:-} attempts=${FM_BACKEND_STOP_ATTEMPTS:-20} delay=${FM_BACKEND_STOP_DELAY:-0.1} i=0 state=unknown
+  [ -n "$target" ] || return 0
+  case "$attempts" in ''|*[!0-9]*|0) attempts=20 ;; esac
+  fm_backend_kill "$@" || return 1
+  while [ "$i" -lt "$attempts" ]; do
+    state=$(fm_backend_target_state "$backend" "$target" "$expected_label")
+    [ "$state" = absent ] && return 0
+    i=$((i + 1))
+    [ "$i" -ge "$attempts" ] || sleep "$delay"
+  done
+  if [ "$state" = present ]; then
+    echo "error: backend endpoint $target still exists after stop; refusing destructive cleanup" >&2
+  else
+    echo "error: backend endpoint $target could not be confirmed absent after stop; refusing destructive cleanup" >&2
+  fi
+  return 1
+}
+
+# Implement the recovery-grade state contract described above.
 fm_backend_agent_state() {  # <backend> <target>
   local backend=$1 target=$2
   fm_backend_source "$backend" || { printf 'unverified'; return 0; }

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -733,7 +733,7 @@ fm_backend_target_state() {  # <backend> <target> [expected-label] -> present|ab
 # owner is for destructive cleanup paths that must not trust best-effort close.
 fm_backend_stop_and_verify() {  # <backend> <target> [zellij-tab-id] [expected-label]
   local backend=$1 target=$2 expected_label=${4:-} attempts=${FM_BACKEND_STOP_ATTEMPTS:-20} delay=${FM_BACKEND_STOP_DELAY:-0.1} i=0 state=unknown
-  [ -n "$target" ] || return 0
+  [ -n "$target" ] || { echo "error: missing backend endpoint id; refusing destructive cleanup" >&2; return 1; }
   case "$attempts" in ''|*[!0-9]*|0) attempts=20 ;; esac
   fm_backend_kill "$@" || return 1
   while [ "$i" -lt "$attempts" ]; do

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -46,6 +46,8 @@
 # self-governance section when a touched project AGENTS.md lacks it.
 # Refuses to overwrite an existing brief.
 set -eu
+# Paths and names are literal replacement data; never expand '&' as the matched placeholder.
+shopt -u patsub_replacement 2>/dev/null || true
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -65,6 +67,8 @@ esac
 . "$SCRIPT_DIR/fm-marker-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
@@ -95,6 +99,16 @@ if [ "$NO_PROJECTS" -eq 1 ] && [ "$KIND" != secondmate ]; then
   exit 1
 fi
 
+HOST_MODE=0
+HOST_ROOT=
+if fm_host_root_enabled; then
+  fm_host_root_assert_session_cwd "$FM_ROOT" || exit $?
+  if [ "$KIND" != secondmate ]; then
+    HOST_ROOT=$(fm_host_root_resolve "$FM_ROOT") || exit $?
+    HOST_MODE=1
+  fi
+fi
+
 BRIEF="$DATA/$ID/brief.md"
 [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
 mkdir -p "$DATA/$ID"
@@ -106,6 +120,43 @@ shell_quote() {
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
+CREW_INTRO='You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.'
+EXECUTION_MARKER=
+EXECUTION_SECTION=
+SETUP_LOCATION="You are in a disposable git worktree of __REPO__, at a detached HEAD on a clean default branch."
+STAY_RULE="Stay inside this worktree; modify nothing outside it."
+SCOUT_STAY_RULE="Stay inside this worktree; the only files you may write outside it are the report and the status file below."
+BRANCH_COMMAND="\`git checkout -b fm/$ID\`"
+PROJECT_MEMORY_TARGET="."
+PROJECT_MEMORY_CONTEXT='in the worktree'
+if [ "$HOST_MODE" -eq 1 ]; then
+  EXECUTION_MARKER='<!-- firstmate-execution-mode: host-root -->'
+  EXECUTION_SECTION=$(cat <<'EOF'
+# Host-root execution contract
+Your top-level process cwd is the physical host instruction root `__HOST_ROOT__`, not the target repository.
+The host root is authoritative for identity, startup, lifecycle, and cross-repository safety; keep it read-only except for effects produced by its own native lifecycle hooks.
+The isolated target worktree is the exact path in `$FM_TARGET_WORKTREE`.
+Before any edit, verify `[ "$(pwd -P)" = "$FM_HOST_ROOT" ]` and verify the physical result of `git -C "$FM_TARGET_WORKTREE" rev-parse --show-toplevel` equals the physical `$FM_TARGET_WORKTREE` path.
+Use `git -C "$FM_TARGET_WORKTREE" worktree list --porcelain` to identify the target primary clone and confirm its physical path differs from `$FM_TARGET_WORKTREE`.
+Read the target worktree root instructions and every applicable nested instruction file before editing; host instructions remain authoritative when the two surfaces conflict, and an unresolved conflict is a needs-decision rather than permission to guess.
+Use absolute paths, `git -C "$FM_TARGET_WORKTREE" ...`, or a scoped subshell for every target operation while keeping the top-level process cwd at the host root.
+Run tests, builds, GitHub tooling, and no-mistakes against `$FM_TARGET_WORKTREE` only; never run a bare target command from the host repository.
+EOF
+)
+  EXECUTION_SECTION=${EXECUTION_SECTION//__HOST_ROOT__/$HOST_ROOT}
+  CREW_INTRO="$CREW_INTRO"$'\n'"$EXECUTION_MARKER"$'\n'"$EXECUTION_SECTION"
+  # shellcheck disable=SC2016  # These variables are literal Markdown instructions for the worker.
+  SETUP_LOCATION='You are launched from the host instruction root; the disposable target git worktree is in `$FM_TARGET_WORKTREE` at a detached HEAD on a clean default branch.'
+  # shellcheck disable=SC2016
+  STAY_RULE='Keep the host root read-only and write target code only under `$FM_TARGET_WORKTREE`; the report and status file named below are the only other task artifacts you may write.'
+  # shellcheck disable=SC2016
+  SCOUT_STAY_RULE='Keep the host root read-only and write target code only under `$FM_TARGET_WORKTREE`; the report and status file below are the only other task artifacts you may write.'
+  # shellcheck disable=SC2016
+  BRANCH_COMMAND='`git -C "$FM_TARGET_WORKTREE" checkout -b fm/'"$ID"'`'
+  # shellcheck disable=SC2016
+  PROJECT_MEMORY_TARGET='"$FM_TARGET_WORKTREE"'
+  PROJECT_MEMORY_CONTEXT='for the target worktree'
+fi
 
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""
@@ -193,6 +244,18 @@ exit 0
 fi
 
 REPO=${POS[1]}
+SETUP_LOCATION=${SETUP_LOCATION//__REPO__/$REPO}
+if [ "$HOST_MODE" -eq 1 ]; then
+  # shellcheck disable=SC2016  # Literal Markdown, not shell expansion.
+  ISOLATION_SECTION='**Verify isolation before anything else.** Follow the host-root execution contract above. If the host cwd or target worktree check fails, append `blocked: host-root or isolated target verification failed` and stop before branching or editing.'
+else
+  ISOLATION_SECTION=$(cat <<'EOF'
+**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
+The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
+If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.
+EOF
+)
+fi
 
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
@@ -228,7 +291,7 @@ fi
 
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
-You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+$CREW_INTRO
 
 # Task
 {TASK}
@@ -236,14 +299,14 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 $HERDR_SECTION
 
 # Setup
-You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+$SETUP_LOCATION
 This is a SCOUT task: the deliverable is a written report, not a PR.
 The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
 The report is the only thing that survives, so anything worth keeping must be in it.
 
 # Rules
 1. Never push to any remote and never open a PR.
-2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
+2. $SCOUT_STAY_RULE
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -308,10 +371,36 @@ EOF
 )
     ;;
   *)  # no-mistakes (default)
-    SETUP2="
+    if [ "$HOST_MODE" -eq 1 ]; then
+      SETUP2="
+2. Run \`(cd \"\$FM_TARGET_WORKTREE\" && no-mistakes doctor)\`; if it reports the repo is not initialized there, run \`(cd \"\$FM_TARGET_WORKTREE\" && no-mistakes init)\`."
+    else
+      SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
+    fi
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
+    if [ "$HOST_MODE" -eq 1 ]; then
+      DOD=$(cat <<'EOF'
+# Definition of done
+The task is complete only when committed on your branch.
+When you believe it is complete, append `done: {summary}` to the status file and stop.
+Firstmate will then instruct you to invoke /no-mistakes for `$FM_TARGET_WORKTREE` to validate and ship a PR.
+Before invoking it, name that target explicitly and run every no-mistakes CLI command through `(cd "$FM_TARGET_WORKTREE" && no-mistakes ...)`; never let validation default to the host cwd.
+
+You drive no-mistakes by responding to its gates, not by implementing fixes.
+Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `(cd "$FM_TARGET_WORKTREE" && no-mistakes axi run --help)` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
+Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+
+Two firstmate-specific rules layer on top of that guidance:
+- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
+  When the decision comes back, feed it to the gate through `(cd "$FM_TARGET_WORKTREE" && no-mistakes axi respond ...)` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
+- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
+
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
+EOF
+)
+    else
+      DOD=$(cat <<EOF
 # Definition of done
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
@@ -330,11 +419,12 @@ Two firstmate-specific rules layer on top of that guidance:
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
 )
+    fi
     ;;
 esac
 
 cat > "$BRIEF" <<EOF
-You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+$CREW_INTRO
 
 # Task
 {TASK}
@@ -342,17 +432,15 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 $HERDR_SECTION
 
 # Setup
-You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+$SETUP_LOCATION
 
-**Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
-The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
-If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
+$ISOLATION_SECTION
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+1. First action: create your branch: $BRANCH_COMMAND$SETUP2
 
 # Rules
 $RULE1
-2. Stay inside this worktree; modify nothing outside it.
+2. $STAY_RULE
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -376,7 +464,7 @@ $RULE1
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 
 # Project memory
-If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
+If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh $PROJECT_MEMORY_TARGET\` $PROJECT_MEMORY_CONTEXT.
 Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -109,6 +109,17 @@ if fm_host_root_enabled; then
   fi
 fi
 
+HOST_SHIP_MODE=
+if [ "$HOST_MODE" -eq 1 ] && [ "$KIND" = ship ] && [ -n "${POS[1]:-}" ]; then
+  read -r HOST_SHIP_MODE _ <<EOF
+$("$FM_ROOT/bin/fm-project-mode.sh" "${POS[1]}")
+EOF
+  if [ "$HOST_SHIP_MODE" = local-only ]; then
+    echo "error: host-root mode does not support local-only project ${POS[1]}" >&2
+    exit 1
+  fi
+fi
+
 BRIEF="$DATA/$ID/brief.md"
 [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
 mkdir -p "$DATA/$ID"
@@ -340,9 +351,13 @@ fi
 # Ship task: shape Setup / Rule 1 / Definition of done by the project's delivery mode.
 # yolo does not affect the brief because the worker never owns approval decisions;
 # firstmate applies the authority contract in AGENTS.md section 7, so discard it.
-read -r MODE _ <<EOF
+if [ -n "$HOST_SHIP_MODE" ]; then
+  MODE=$HOST_SHIP_MODE
+else
+  read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
+fi
 
 case "$MODE" in
   direct-PR)

--- a/bin/fm-check-register.sh
+++ b/bin/fm-check-register.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Bind an intentional custom watcher check to its current bytes.
+# Host-root tasks bind to their recorded physical host cwd before trust-file mutation.
 # Usage: fm-check-register.sh <id>
 set -u
 
@@ -12,6 +13,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-check-lib.sh
 . "$SCRIPT_DIR/fm-check-lib.sh"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 
 if [ "$#" -ne 1 ] || ! fm_pr_task_id_valid "$1"; then
   echo "error: invalid custom check registration" >&2
@@ -19,6 +22,12 @@ if [ "$#" -ne 1 ] || ! fm_pr_task_id_valid "$1"; then
 fi
 
 ID=$1
+META="$STATE/$ID.meta"
+if [ -f "$META" ]; then
+  fm_host_root_assert_task_cwd "$FM_ROOT" "$META" || exit $?
+else
+  fm_host_root_assert_session_cwd "$FM_ROOT" || exit $?
+fi
 CHECK="$STATE/$ID.check.sh"
 TRUST="$STATE/$ID.check-trust"
 [ -d "$STATE" ] && [ ! -L "$STATE" ] || { echo "error: state directory is unavailable" >&2; exit 1; }

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -85,12 +85,28 @@ validate_one_line() {  # <label> <value>
 }
 
 assert_origin_host() {  # <origin-id>
-  local origin=$1 meta="$STATE/$1.meta"
+  local origin=$1 meta="$STATE/$1.meta" owner="$DATA/$1/host-root"
   if [ -f "$meta" ]; then
     fm_host_root_assert_task_cwd "$FM_ROOT" "$meta"
-  else
-    fm_host_root_assert_session_cwd "$FM_ROOT"
+  elif [ -e "$owner" ] || [ -L "$owner" ]; then
+    [ -f "$owner" ] && [ ! -L "$owner" ] || fail "origin host owner is not a regular file: $owner"
+    fm_host_root_assert_task_cwd "$FM_ROOT" "$owner"
+  elif fm_host_root_enabled; then
+    fail "origin $origin has no durable recorded host owner"
   fi
+}
+
+record_origin_host() {  # <origin-id> <meta>
+  local origin=$1 meta=$2 recorded owner="$DATA/$1/host-root"
+  recorded=$(meta_value "$meta" host_root)
+  [ -n "$recorded" ] || return 0
+  if [ -e "$owner" ] || [ -L "$owner" ]; then
+    [ -f "$owner" ] && [ ! -L "$owner" ] || fail "origin host owner is not a regular file: $owner"
+    [ "$(cat "$owner")" = "host_root=$recorded" ] || fail "origin host owner does not match task metadata: $owner"
+    return 0
+  fi
+  (umask 077; printf 'host_root=%s\n' "$recorded" > "$owner") \
+    || fail "could not persist origin host owner: $owner"
 }
 
 sha256_text() {  # <text>
@@ -332,6 +348,9 @@ EOF
 $open
 EOF
 
+  if [ "$has_meta" = 1 ]; then
+    record_origin_host "$origin" "$meta"
+  fi
   if [ "$has_meta" = 1 ]; then
     if [ "$(meta_value "$meta" decisions_reviewed)" != 1 ] || [ "$previous" != "$keys" ]; then
       printf 'decisions_reviewed=1\ndecision_keys=%s\n' "$keys" >> "$meta"

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -15,6 +15,7 @@
 # is idempotent. A different decision key creates a different backlog identity.
 # All backlog mutations run in the active FM_HOME, which keeps main-home and
 # secondmate-home ownership aligned with the work that discovered the decision.
+# Host-root origins bind to their recorded physical host cwd before task or backlog activity.
 #
 # Usage:
 #   fm-decision-hold.sh id <origin-id> <decision-key>
@@ -51,6 +52,9 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-host-root-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 
 usage() {
   awk '
@@ -78,6 +82,15 @@ validate_one_line() {  # <label> <value>
   case "$value" in
     *$'\n'*|*$'\r'*) fail "$label must be one line" ;;
   esac
+}
+
+assert_origin_host() {  # <origin-id>
+  local origin=$1 meta="$STATE/$1.meta"
+  if [ -f "$meta" ]; then
+    fm_host_root_assert_task_cwd "$FM_ROOT" "$meta"
+  else
+    fm_host_root_assert_session_cwd "$FM_ROOT"
+  fi
 }
 
 sha256_text() {  # <text>
@@ -243,6 +256,7 @@ command_hold() {
   done
   validate_slug origin-id "$origin"
   validate_slug decision-key "$key"
+  assert_origin_host "$origin" || exit $?
   validate_one_line title "$title"
   validate_one_line reason "$reason"
   case "$reason" in *'('*|*')'*) fail "reason must not contain parentheses (tasks-axi hold contract)" ;; esac
@@ -281,6 +295,7 @@ command_complete() {
   shift
   meta="$STATE/$origin.meta"
   [ -f "$meta" ] && has_meta=1
+  assert_origin_host "$origin" || exit $?
   require_tasks_axi
   origin_exists_here "$origin" || fail "origin $origin is not owned by the active home $FM_HOME"
   if [ "$#" -eq 1 ] && [ "$1" = --none ]; then
@@ -343,6 +358,7 @@ command_verify() {
   validate_slug origin-id "$origin"
   meta="$STATE/$origin.meta"
   [ -f "$meta" ] || fail "origin metadata is absent: $meta"
+  assert_origin_host "$origin" || exit $?
   require_tasks_axi
   reviewed=$(meta_value "$meta" decisions_reviewed)
   [ "$reviewed" = 1 ] || fail "origin $origin has no completed unresolved-decision inventory"
@@ -381,6 +397,7 @@ command_resolve() {
   done
   validate_slug origin-id "$origin"
   validate_slug decision-key "$key"
+  assert_origin_host "$origin" || exit $?
   [ -n "$decision_file" ] || fail "--decision-file is required"
   [ -f "$decision_file" ] || fail "decision file does not exist: $decision_file"
   decision=$(cat "$decision_file")

--- a/bin/fm-gate-refuse-lib.sh
+++ b/bin/fm-gate-refuse-lib.sh
@@ -67,7 +67,7 @@ FM_GATE_REFUSE_EXIT=3
 # no-mistakes gate agent. An optional root anchors the git-common-dir check;
 # callers that omit it retain the historical current-worktree behavior.
 fm_is_gate_agent() {
-  local anchor=${1:-.} common
+  local anchor=${1:-.} anchor_real common candidate
   if [ "${FM_GATE_REFUSE_BYPASS:-}" = 1 ]; then
     return 1
   fi
@@ -75,15 +75,23 @@ fm_is_gate_agent() {
     FM_GATE_REFUSE_REASON='env'
     return 0
   fi
-  common=$(cd "$anchor" 2>/dev/null \
-    && cd "$(git rev-parse --git-common-dir 2>/dev/null || echo /nonexistent)" 2>/dev/null \
-    && pwd -P || true)
-  case "$common" in
-    */.no-mistakes/repos/*.git)
-      FM_GATE_REFUSE_REASON='path'
-      FM_GATE_REFUSE_COMMON=$common
-      return 0 ;;
-  esac
+  # Check both the physical absolute FirstMate code root and the process cwd.
+  # Host mode needs the former so changing cwd cannot hide a gate around FM_ROOT;
+  # normal and gate-validation callers retain the latter backstop.
+  anchor_real=$(cd "$anchor" 2>/dev/null && pwd -P || true)
+  for candidate in "$anchor_real" .; do
+    [ -n "$candidate" ] || continue
+    common=$(cd "$candidate" 2>/dev/null \
+      && cd "$(git rev-parse --git-common-dir 2>/dev/null || echo /nonexistent)" 2>/dev/null \
+      && pwd -P || true)
+    case "$common" in
+      */.no-mistakes/repos/*.git)
+        FM_GATE_REFUSE_REASON='path'
+        FM_GATE_REFUSE_COMMON=$common
+        return 0 ;;
+    esac
+    [ "$candidate" = . ] && break
+  done
   return 1
 }
 

--- a/bin/fm-host-root-lib.sh
+++ b/bin/fm-host-root-lib.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# fm-host-root-lib.sh - validation and command rendering for optional host-root mode.
+#
+# FM_HOST_ROOT is opt-in. When unset or empty, every helper preserves the normal
+# FirstMate-root behavior. When set, the value must resolve to an existing
+# physical directory with the cross-harness AGENTS.md instruction surface, must
+# differ from FM_ROOT, and must be safe for line-based task metadata.
+#
+# fm_host_root_enabled
+# fm_host_root_resolve <fm-root>       # prints the physical host root
+# fm_host_root_assert_session_cwd <fm-root>
+# fm_host_root_assert_task_cwd <fm-root> <task-meta>
+# fm_host_root_paths_overlap <physical-host-root> <physical-target-root>
+# fm_host_root_command <fm-root> <repo-relative-command>
+
+fm_host_root_enabled() {
+  [ -n "${FM_HOST_ROOT:-}" ]
+}
+
+fm_host_root_resolve() {
+  local fm_root=${1:-.} host root_real host_real
+  fm_host_root_enabled || return 1
+  host=$FM_HOST_ROOT
+  case "$host" in
+    *[$'\001'-$'\037'$'\177']*)
+      echo "error: FM_HOST_ROOT contains a control character unsafe for task metadata" >&2
+      return 2
+      ;;
+  esac
+  [ -d "$host" ] || {
+    echo "error: FM_HOST_ROOT is not an existing directory: $host" >&2
+    return 2
+  }
+  host_real=$(cd "$host" 2>/dev/null && pwd -P) || {
+    echo "error: FM_HOST_ROOT cannot be resolved: $host" >&2
+    return 2
+  }
+  case "$host_real" in
+    *[$'\001'-$'\037'$'\177']*)
+      echo "error: resolved FM_HOST_ROOT contains a control character unsafe for task metadata" >&2
+      return 2
+      ;;
+  esac
+  root_real=$(cd "$fm_root" 2>/dev/null && pwd -P) || {
+    echo "error: FM_ROOT cannot be resolved while validating FM_HOST_ROOT: $fm_root" >&2
+    return 2
+  }
+  [ "$host_real" != "$root_real" ] || {
+    echo "error: FM_HOST_ROOT must differ from FM_ROOT; unset FM_HOST_ROOT for normal FirstMate-root operation" >&2
+    return 2
+  }
+  if [ ! -f "$host_real/AGENTS.md" ]; then
+    echo "error: FM_HOST_ROOT has no cross-harness instruction surface (expected AGENTS.md): $host_real" >&2
+    return 2
+  fi
+  printf '%s\n' "$host_real"
+}
+
+fm_host_root_assert_session_cwd() {
+  local fm_root=${1:-.} host cwd
+  fm_host_root_enabled || return 0
+  host=$(fm_host_root_resolve "$fm_root") || return $?
+  cwd=$(pwd -P) || return 2
+  [ "$cwd" = "$host" ] || {
+    echo "error: host-root mode requires the supervisor cwd to be $host (current physical cwd: $cwd)" >&2
+    return 2
+  }
+}
+
+fm_host_root_assert_task_cwd() {
+  local fm_root=$1 meta=$2 recorded kind host ambient cwd
+  recorded=$(sed -n 's/^host_root=//p' "$meta" 2>/dev/null | tail -1)
+  kind=$(sed -n 's/^kind=//p' "$meta" 2>/dev/null | tail -1)
+  if [ -z "$recorded" ]; then
+    if [ "$kind" = secondmate ]; then
+      fm_host_root_assert_session_cwd "$fm_root"
+      return $?
+    fi
+    if fm_host_root_enabled; then
+      echo "error: task metadata $meta has no recorded host_root; refusing ambient host-root authority" >&2
+      return 2
+    fi
+    return 0
+  fi
+  host=$(FM_HOST_ROOT=$recorded fm_host_root_resolve "$fm_root") || return $?
+  [ "$host" = "$recorded" ] || {
+    echo "error: task metadata host_root is not the recorded physical path: $recorded" >&2
+    return 2
+  }
+  if fm_host_root_enabled; then
+    ambient=$(fm_host_root_resolve "$fm_root") || return $?
+    [ "$ambient" = "$host" ] || {
+      echo "error: ambient FM_HOST_ROOT $ambient does not match task metadata host_root $host" >&2
+      return 2
+    }
+  fi
+  cwd=$(pwd -P) || return 2
+  [ "$cwd" = "$host" ] || {
+    echo "error: task action requires the recorded host root cwd $host (current physical cwd: $cwd)" >&2
+    return 2
+  }
+}
+
+fm_host_root_paths_overlap() {
+  local host=$1 target=$2
+  case "$target/" in "$host/"*) return 0 ;; esac
+  case "$host/" in "$target/"*) return 0 ;; esac
+  return 1
+}
+
+fm_host_root_shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+fm_host_root_command() {
+  local fm_root=$1 command=$2 root_real
+  if fm_host_root_enabled; then
+    root_real=$(cd "$fm_root" 2>/dev/null && pwd -P) || return 1
+    fm_host_root_shell_quote "$root_real/$command"
+    printf '\n'
+  else
+    printf '%s\n' "$command"
+  fi
+}

--- a/bin/fm-host-root-lib.sh
+++ b/bin/fm-host-root-lib.sh
@@ -103,8 +103,11 @@ fm_host_root_assert_task_cwd() {
 
 fm_host_root_paths_overlap() {
   local host=$1 target=$2
-  case "$target/" in "$host/"*) return 0 ;; esac
-  case "$host/" in "$target/"*) return 0 ;; esac
+  [ "$host" = "$target" ] && return 0
+  [ "$host" = / ] && return 0
+  [ "$target" = / ] && return 0
+  case "$target" in "$host"/*) return 0 ;; esac
+  case "$host" in "$target"/*) return 0 ;; esac
   return 1
 }
 

--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -8,9 +8,9 @@
 # marked, or otherwise surprising config is refused without a config write.
 #
 # The installed Stop hook always exits 0 and stays silent. It reads cwd from the
-# hook payload, checks for a .fm-kimi-turnend pointer before registry work, and
-# touches a task turn-end marker only when the pointer names a Firstmate-created
-# token in $HOME/.kimi-code/fm-turn-end.d/.
+# hook payload, accepts a launch-scoped FM_KIMI_TURNEND_TOKEN or checks for a
+# .fm-kimi-turnend pointer, and touches a task turn-end marker only when the token
+# names a Firstmate-created entry in $HOME/.kimi-code/fm-turn-end.d/.
 #
 # Usage:
 #   fm-kimi-turnend-hook.sh install
@@ -80,11 +80,14 @@ payload=
 IFS= read -r payload || [ -n "$payload" ] || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
 workspace=$(jq -er 'select(.hook_event_name == "Stop") | .cwd | strings | select(length > 0)' <<< "$payload" 2>/dev/null) || exit 0
-pointer="$workspace/.fm-kimi-turnend"
-[ -f "$pointer" ] || exit 0
-first=
-IFS= read -r -n 256 first < "$pointer" 2>/dev/null || [ -n "$first" ] || exit 0
-case "$first" in token=*) token=${first#token=} ;; *) exit 0 ;; esac
+token=${FM_KIMI_TURNEND_TOKEN:-}
+if [ -z "$token" ]; then
+  pointer="$workspace/.fm-kimi-turnend"
+  [ -f "$pointer" ] || exit 0
+  first=
+  IFS= read -r -n 256 first < "$pointer" 2>/dev/null || [ -n "$first" ] || exit 0
+  case "$first" in token=*) token=${first#token=} ;; *) exit 0 ;; esac
+fi
 case "$token" in fm.????????????) : ;; *) exit 0 ;; esac
 case "$token" in *[!A-Za-z0-9._-]*) exit 0 ;; esac
 auth_dir=${HOME:-}/.kimi-code/fm-turn-end.d

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -22,6 +22,10 @@ ID=${1:?usage: fm-merge-local.sh <task-id>}
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
 fm_host_root_assert_task_cwd "$FM_ROOT" "$META" || exit $?
+if grep -q '^host_root=.' "$META"; then
+  echo "error: local-only merge is unavailable for host-root task $ID" >&2
+  exit 1
+fi
 # The recorded host binding is established before this guard can repair state.
 "$FM_ROOT/bin/fm-guard.sh" || true
 

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -16,10 +16,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
-"$FM_ROOT/bin/fm-guard.sh" || true
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 ID=${1:?usage: fm-merge-local.sh <task-id>}
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+fm_host_root_assert_task_cwd "$FM_ROOT" "$META" || exit $?
+# The recorded host binding is established before this guard can repair state.
+"$FM_ROOT/bin/fm-guard.sh" || true
 
 PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -5,6 +5,8 @@
 # live only in a private sidecar and are never interpolated into shell source.
 # A GitHub pull request URL and a GitLab merge request URL are both accepted,
 # including a merge request on a self-hosted GitLab instance.
+# Host-root tasks bind to their recorded physical host cwd before guard, metadata,
+# poll, or target-worktree activity.
 # Usage: fm-pr-check.sh <task-id> <pr-url>
 set -eu
 
@@ -15,6 +17,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 
 if [ "$#" -ne 2 ]; then
   echo "error: invalid PR check request" >&2
@@ -38,6 +42,7 @@ if [ ! -f "$META" ] || [ -L "$META" ] || [ "$(fm_pr_file_link_count "$META")" !=
   echo "error: task metadata is unavailable" >&2
   exit 1
 fi
+fm_host_root_assert_task_cwd "$FM_ROOT" "$META" || exit $?
 
 # A prior exact merged result may have queued its durable wake immediately
 # before interruption.

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -17,6 +17,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 
 if [ "$#" -lt 2 ]; then
   echo "error: invalid PR merge request" >&2
@@ -69,6 +71,7 @@ if [ ! -f "$META" ] || [ -L "$META" ]; then
   echo "error: task metadata is unavailable" >&2
   exit 1
 fi
+fm_host_root_assert_task_cwd "$FM_ROOT" "$META" || exit $?
 
 "$SCRIPT_DIR/fm-pr-check.sh" "$ID" "$URL"
 grep -qxF "pr=$URL" "$META" || {

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -39,6 +39,7 @@ SHIP_INSTRUCTIONS="review scratch state with git status and git log; reset to a 
 if grep -q '^host_root=.' "$META"; then
   FM_ROOT_REAL=$(cd "$FM_ROOT" && pwd -P)
   SEND=$(fm_host_root_shell_quote "$FM_ROOT_REAL/bin/fm-send.sh")
+  # shellcheck disable=SC2016  # These variables are literal worker instructions.
   SHIP_INSTRUCTIONS='review scratch state with git -C "$FM_TARGET_WORKTREE" status and git -C "$FM_TARGET_WORKTREE" log; reset "$FM_TARGET_WORKTREE" to a clean default-branch base using git -C "$FM_TARGET_WORKTREE"; carry over only intended fix changes under "$FM_TARGET_WORKTREE"; create branch fm/'"$ID"' with git -C "$FM_TARGET_WORKTREE" checkout -b fm/'"$ID"'; implement under "$FM_TARGET_WORKTREE"; run every remaining Git command with git -C "$FM_TARGET_WORKTREE" and every test, build, and validation command through (cd "$FM_TARGET_WORKTREE" && ...); report done'
 fi
 echo "promoted $ID to ship (teardown protection restored)"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -20,6 +20,10 @@ ID=$1
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
 fm_host_root_assert_task_cwd "$FM_ROOT" "$META" || exit $?
+if grep -q '^host_root=.' "$META" && grep -qx 'mode=local-only' "$META"; then
+  echo "error: host-root mode does not support promoting local-only scout $ID" >&2
+  exit 1
+fi
 # The recorded host binding is established before this guard can repair state.
 "$FM_ROOT/bin/fm-guard.sh" || true
 grep -qx 'kind=scout' "$META" || { echo "error: task $ID is not a scout task (kind=scout not in meta)" >&2; exit 1; }
@@ -31,9 +35,11 @@ mv "$TMP" "$META"
 
 HOME_Q=$(printf '%q' "$FM_HOME")
 SEND=bin/fm-send.sh
+SHIP_INSTRUCTIONS="review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement; report done"
 if grep -q '^host_root=.' "$META"; then
   FM_ROOT_REAL=$(cd "$FM_ROOT" && pwd -P)
   SEND=$(fm_host_root_shell_quote "$FM_ROOT_REAL/bin/fm-send.sh")
+  SHIP_INSTRUCTIONS='review scratch state with git -C "$FM_TARGET_WORKTREE" status and git -C "$FM_TARGET_WORKTREE" log; reset "$FM_TARGET_WORKTREE" to a clean default-branch base using git -C "$FM_TARGET_WORKTREE"; carry over only intended fix changes under "$FM_TARGET_WORKTREE"; create branch fm/'"$ID"' with git -C "$FM_TARGET_WORKTREE" checkout -b fm/'"$ID"'; implement under "$FM_TARGET_WORKTREE"; run every remaining Git command with git -C "$FM_TARGET_WORKTREE" and every test, build, and validation command through (cd "$FM_TARGET_WORKTREE" && ...); report done'
 fi
 echo "promoted $ID to ship (teardown protection restored)"
-echo "next: FM_HOME=$HOME_Q $SEND fm-$ID '<ship instructions: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement; report done>'"
+echo "next: FM_HOME=$HOME_Q $SEND fm-$ID '<ship instructions: $SHIP_INSTRUCTIONS>'"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -6,6 +6,7 @@
 # (inventory scratch state, reset to a clean default-branch base, carry over only
 # intended fix changes, create branch fm/<task-id>, implement, then report done
 # according to the project's delivery mode).
+# Host-root tasks bind to their recorded physical host cwd before guard or metadata mutation.
 # Usage: fm-promote.sh <task-id>
 set -eu
 
@@ -13,10 +14,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
-"$FM_ROOT/bin/fm-guard.sh" || true
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 ID=$1
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+fm_host_root_assert_task_cwd "$FM_ROOT" "$META" || exit $?
+# The recorded host binding is established before this guard can repair state.
+"$FM_ROOT/bin/fm-guard.sh" || true
 grep -qx 'kind=scout' "$META" || { echo "error: task $ID is not a scout task (kind=scout not in meta)" >&2; exit 1; }
 
 TMP="$META.tmp"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -30,5 +30,10 @@ echo "kind=ship" >> "$TMP"
 mv "$TMP" "$META"
 
 HOME_Q=$(printf '%q' "$FM_HOME")
+SEND=bin/fm-send.sh
+if grep -q '^host_root=.' "$META"; then
+  FM_ROOT_REAL=$(cd "$FM_ROOT" && pwd -P)
+  SEND=$(fm_host_root_shell_quote "$FM_ROOT_REAL/bin/fm-send.sh")
+fi
 echo "promoted $ID to ship (teardown protection restored)"
-echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement; report done>'"
+echo "next: FM_HOME=$HOME_Q $SEND fm-$ID '<ship instructions: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement; report done>'"

--- a/bin/fm-review-diff.sh
+++ b/bin/fm-review-diff.sh
@@ -53,16 +53,18 @@ PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 [ -n "$PROJ" ] || { echo "error: meta for task $ID is missing project=" >&2; exit 1; }
 [ -d "$WT" ] || { echo "error: worktree for task $ID is missing: $WT" >&2; exit 1; }
 [ -d "$PROJ" ] || { echo "error: project for task $ID is missing: $PROJ" >&2; exit 1; }
+GIT_ROOT=$PROJ
+grep -q '^host_root=.' "$META" && GIT_ROOT=$WT
 
 default_branch() {
   local ref branch
-  ref=$(git -C "$PROJ" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  ref=$(git -C "$GIT_ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
   if [ -n "$ref" ]; then
     echo "${ref#origin/}"
     return 0
   fi
   for branch in main master; do
-    if git -C "$PROJ" show-ref --verify --quiet "refs/heads/$branch"; then
+    if git -C "$GIT_ROOT" show-ref --verify --quiet "refs/heads/$branch"; then
       echo "$branch"
       return 0
     fi
@@ -138,7 +140,7 @@ if [ -n "$PR_URL" ]; then
   fi
 fi
 
-if git -C "$PROJ" remote get-url origin >/dev/null 2>&1; then
+if git -C "$GIT_ROOT" remote get-url origin >/dev/null 2>&1; then
   # Update the remote-tracking ref itself; a bare single-branch fetch can leave
   # origin/<default> stale on some Git versions and only refresh FETCH_HEAD.
   git -C "$WT" fetch origin "+refs/heads/$DEFAULT:refs/remotes/origin/$DEFAULT" --quiet

--- a/bin/fm-review-diff.sh
+++ b/bin/fm-review-diff.sh
@@ -10,6 +10,7 @@
 # only a fallback when fetch fails (stale recorded SHAs must never win over a
 # reachable remote PR head). If neither PR head can be resolved, fall back to
 # the local branch with a warning. Without pr=, compare the local branch.
+# Host-root tasks bind to their recorded physical host cwd before guard or Git activity.
 # Usage: fm-review-diff.sh <task-id> [--stat]
 #   --stat prints only the stat summary; default prints stat summary plus full diff.
 set -eu
@@ -18,7 +19,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
-"$FM_ROOT/bin/fm-guard.sh" || true
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 
 usage() {
   echo "usage: fm-review-diff.sh <task-id> [--stat]" >&2
@@ -41,6 +43,9 @@ esac
 
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+fm_host_root_assert_task_cwd "$FM_ROOT" "$META" || exit $?
+# The recorded host binding is established before this guard can repair state.
+"$FM_ROOT/bin/fm-guard.sh" || true
 
 WT=$(grep '^worktree=' "$META" | cut -d= -f2-)
 PROJ=$(grep '^project=' "$META" | cut -d= -f2-)

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -18,6 +18,9 @@
 # Submission dispatches through the target's recorded backend; the tmux adapter
 # shares its composer/submit core with the away-mode daemon via bin/fm-tmux-lib.sh.
 # Tune with FM_SEND_RETRIES (default 3) / FM_SEND_SLEEP (0.4).
+# A recorded task binds to its physical host_root= metadata before task-data
+# reads, supervision repair, or endpoint mutation; ambient host authority cannot
+# override that ownership.
 # Slash commands, and codex `$...` skill invocations resolved through harness
 # meta, get a longer pre-Enter settle so completion popups do not swallow Enter.
 #
@@ -50,9 +53,11 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
 # shellcheck source=bin/fm-gate-refuse-lib.sh
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never steer
 # a crewmate (see bin/fm-gate-refuse-lib.sh).
-fm_refuse_if_gate_agent
+fm_refuse_if_gate_agent "$FM_ROOT"
 
 if [ -z "${FM_HOME+x}" ] || [ -z "${FM_HOME:-}" ]; then
   echo "error: FM_HOME is not set; fm-send refuses to resolve targets without an explicit firstmate home" >&2
@@ -75,8 +80,6 @@ fi
 . "$SCRIPT_DIR/fm-marker-lib.sh"
 # shellcheck source=bin/fm-pending-reply-lib.sh
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
-
-FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the requested message WILL still be sent.' "$SCRIPT_DIR/fm-guard.sh" || true
 
 fm_send_id_from_meta() {  # <meta-file>
   local base
@@ -115,6 +118,10 @@ fm_send_resolve_target() {  # <raw-target>
 
   meta=$(fm_backend_meta_for_selector "$raw" "$STATE" 2>/dev/null || true)
   if [ -n "$meta" ]; then
+    if [ "$meta" != "${BOUND_META:-}" ]; then
+      fm_host_root_assert_task_cwd "$FM_ROOT" "$meta" || return $?
+      BOUND_META=$meta
+    fi
     RESOLUTION_TRIED="meta=$meta; backend=from-meta"
     target=$(fm_backend_target_of_meta "$meta")
     if [ -z "$target" ]; then
@@ -141,6 +148,10 @@ fm_send_resolve_target() {  # <raw-target>
 
   pane_meta=$(fm_send_meta_for_key_value "$STATE" herdr_pane_id "$raw" 2>/dev/null || true)
   if [ -n "$pane_meta" ]; then
+    if [ "$pane_meta" != "${BOUND_META:-}" ]; then
+      fm_host_root_assert_task_cwd "$FM_ROOT" "$pane_meta" || return $?
+      BOUND_META=$pane_meta
+    fi
     session=$(fm_meta_get "$pane_meta" herdr_session)
     hint="${session:-<herdr-session>}:$raw"
     id=$(fm_send_id_from_meta "$pane_meta")
@@ -150,6 +161,10 @@ fm_send_resolve_target() {  # <raw-target>
 
   meta=$(fm_backend_meta_for_window "$raw" "$STATE" 2>/dev/null || true)
   if [ -n "$meta" ]; then
+    if [ "$meta" != "${BOUND_META:-}" ]; then
+      fm_host_root_assert_task_cwd "$FM_ROOT" "$meta" || return $?
+      BOUND_META=$meta
+    fi
     target=$(fm_backend_target_of_meta "$meta")
     if [ -z "$target" ]; then
       echo "error: no backend target recorded in $meta (tried explicit target '$raw' via recorded window/terminal; backend=from-meta)" >&2
@@ -187,10 +202,26 @@ fm_send_resolve_target() {  # <raw-target>
 }
 
 RAW_TARGET=$1
+CANDIDATE_META=
+BOUND_META=
+if [ -f "$STATE/$RAW_TARGET.meta" ]; then
+  CANDIDATE_META="$STATE/$RAW_TARGET.meta"
+elif [ "${RAW_TARGET#fm-}" != "$RAW_TARGET" ] && [ -f "$STATE/${RAW_TARGET#fm-}.meta" ]; then
+  CANDIDATE_META="$STATE/${RAW_TARGET#fm-}.meta"
+fi
+if [ -n "$CANDIDATE_META" ]; then
+  fm_host_root_assert_task_cwd "$FM_ROOT" "$CANDIDATE_META" || exit $?
+  BOUND_META=$CANDIDATE_META
+fi
 fm_send_resolve_target "$RAW_TARGET" || exit 1
+if [ -z "$TARGET_META" ]; then
+  fm_host_root_assert_session_cwd "$FM_ROOT" || exit $?
+fi
 T=$RESOLVED_TARGET
 shift
 
+# The recorded host binding is established before this guard can repair state.
+FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the requested message WILL still be sent.' "$SCRIPT_DIR/fm-guard.sh" || true
 fm_backend_validate "$TARGET_BACKEND" || exit 1
 
 # Classify a from-firstmate -> secondmate request. Only a task selector resolved

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -85,10 +85,11 @@
 # truly needed.
 #
 # Usage: fm-session-start.sh
-#   Prints the full ordered digest to stdout and always exits 0: this is a
-#   reporting command, not a gate. A lock refusal is reported as a loud
-#   banner inline, never a silent failure or a non-zero exit that would make
-#   an agent skip the rest of the digest.
+#   Prints the full ordered digest to stdout and normally exits 0: this is a
+#   reporting command, not a gate. Explicit host-root mode is the one preflight
+#   exception and exits 2 before mutation when its physical cwd contract fails.
+#   A lock refusal is reported as a loud banner inline, never a silent failure
+#   or a non-zero exit that would make an agent skip the rest of the digest.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -97,6 +98,10 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
+# Host mode must be validated before lock acquisition or any bootstrap mutation.
+fm_host_root_assert_session_cwd "$FM_ROOT" || exit $?
 PRIMARY_HARNESS=$("$SCRIPT_DIR/fm-harness.sh" 2>/dev/null || printf unknown)
 
 # shellcheck source=bin/fm-backend.sh

--- a/bin/fm-sessionstart-nudge.sh
+++ b/bin/fm-sessionstart-nudge.sh
@@ -16,9 +16,14 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-primary-scope-lib.sh"
 # shellcheck source=bin/fm-operational-input.sh
 . "$SCRIPT_DIR/fm-operational-input.sh"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 
 fm_is_gate_agent "$FM_ROOT" && exit 0
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
+if fm_host_root_enabled; then
+  fm_host_root_assert_session_cwd "$FM_ROOT" >/dev/null 2>&1 || exit 0
+fi
 
 lock_is_in_ancestry() {
   local lock_pid pid=$$ _
@@ -37,9 +42,10 @@ lock_is_in_ancestry() {
 }
 
 lock_is_in_ancestry && exit 0
+SESSION_START=$(fm_host_root_command "$FM_ROOT" bin/fm-session-start.sh)
 nudge=
 fm_operational_input_encode session-start \
-  "Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions." \
+  "Run \`$SESSION_START\` now, exactly once, before executing any other instructions." \
   nudge || exit 0
 printf '%s\n' "$nudge"
 exit 0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -62,7 +62,8 @@
 #   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|kimi)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
-#   new adapters.
+#   new adapters. Host-root ordinary tasks reject that escape hatch because only a
+#   named verified adapter can preserve the required task completion safeguard.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
 #   --secondmate spawn, those tokens apply only when this spawn also resolves its
@@ -83,7 +84,13 @@
 #   Before a secondmate launch, the home is locally fast-forwarded to the primary
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
-#   git worktree root distinct from the primary project checkout.
+#   git worktree root distinct from the primary project checkout. With optional
+#   FM_HOST_ROOT set, validation happens before the guard or endpoint mutation;
+#   the endpoint then returns to that physical host cwd and the child receives
+#   the isolated target as FM_TARGET_WORKTREE. Failed spawns before launch submission
+#   stop and verify the endpoint before returning the isolated copy, remove task-owned
+#   pre-record artifacts on success, and retain recovery metadata when rollback is
+#   incomplete. An ambiguous final Enter retains the endpoint, worktree, and metadata.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -101,6 +108,11 @@
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
+#     __CLAUDESETTINGS__ state-owned host-mode Claude task settings path
+#     __CODEXNOTIFY__ shell-quoted complete Codex notify configuration
+#     __OPENCODECONFIG__ shell-quoted host-mode OpenCode config with one task plugin
+#     __GROKTOKEN__ host-mode Grok per-process task hook token
+#     __KIMITOKEN__ host-mode Kimi per-process task hook token
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -110,6 +122,8 @@
 # mode/yolo are resolved per-project from data/projects.md for ship/scout tasks;
 # secondmate spawns record mode=secondmate, yolo=off, home=, and projects=.
 set -eu
+# Paths, flags, and tokens are literal replacement data; never expand '&' as a matched placeholder.
+shopt -u patsub_replacement 2>/dev/null || true
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -128,6 +142,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 SUB_HOME_MARKER=".fm-secondmate-home"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 # shellcheck source=bin/fm-ff-lib.sh
 . "$SCRIPT_DIR/fm-ff-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
@@ -140,12 +156,6 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
-# Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
-# a direct report (see bin/fm-gate-refuse-lib.sh).
-fm_refuse_if_gate_agent
-# Skip the watcher guard when re-exec'd for one pair of a batch (FM_SPAWN_NO_GUARD is
-# set by the batch loop below), so the guard runs once for the batch, not once per pair.
-[ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true
 KIND=ship
 HARNESS_ARG=
 MODEL=
@@ -196,6 +206,24 @@ case "$EFFORT" in
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
 esac
 
+HOST_MODE=0
+HOST_ROOT=
+if fm_host_root_enabled; then
+  fm_host_root_assert_session_cwd "$FM_ROOT" || exit $?
+  if [ "$KIND" != secondmate ]; then
+    HOST_ROOT=$(fm_host_root_resolve "$FM_ROOT") || exit $?
+    HOST_MODE=1
+  fi
+fi
+
+# Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
+# a direct report (see bin/fm-gate-refuse-lib.sh). Anchor to FM_ROOT because host
+# mode deliberately runs from a different repository.
+fm_refuse_if_gate_agent "$FM_ROOT"
+# Host-root validation above must precede the watcher guard because the guard may
+# repair supervision state. Batch re-execs skip it so the guard runs once per batch.
+[ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true
+
 # Backend selection (data/fm-backend-design-d7): explicit --backend, else
 # FM_BACKEND env, else config/backend, else runtime auto-detection, else
 # default tmux (fm_backend_name). fm_backend_validate_spawn refuses unknown or
@@ -221,7 +249,18 @@ fi
 if [ "$BACKEND" = orca ]; then
   fm_backend_orca_runtime_check || exit 1
 fi
+SPAWN_ABORT_CLEANUP=0
+SPAWN_ENDPOINT_CREATED=0
+SPAWN_PRESERVE_WORKTREE=0
 ORCA_ABORT_CLEANUP=0
+SPAWN_CREATE_OUT=
+HERDR_SES=
+HERDR_WORKSPACE_ID=
+HERDR_TAB_ID=
+HERDR_PANE_ID=
+ZELLIJ_SES=
+ZELLIJ_TAB_ID=
+ZELLIJ_PANE_ID=
 ORCA_WORKTREE_ID=
 ORCA_TERMINAL=
 HERDR_PROJECTION_ABORT_CLEANUP=0
@@ -234,6 +273,8 @@ SPAWN_TASK_LOCK=
 SPAWN_TASK_LOCK_HELD=0
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
+CMUX_WORKSPACE_ID=
+CMUX_SURFACE_ID=
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -251,66 +292,6 @@ parse_orca_worktree_result() {
     ORCA_TERMINAL=
   fi
 }
-
-spawn_abort_cleanup() {
-  local status=$?
-  if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ] \
-     && [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" != 1 ]; then
-    if ! spawn_herdr_presentation_order_lock_acquire "${HERDR_PROJECTION_ABORT_SESSION:-}"; then
-      echo "warning: herdr presentation focus lock unavailable; retaining the projection journal and refusing concurrent abort cleanup" >&2
-      HERDR_PROJECTION_ABORT_CLEANUP=0
-    fi
-  fi
-  if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ]; then
-    HERDR_PROJECTION_ABORT_CLEANUP=0
-    fm_backend_herdr_projection_cleanup_exact \
-      "$HERDR_PROJECTION_ABORT_SESSION" \
-      "$HERDR_PROJECTION_ABORT_TASK_PANE" \
-      "$HERDR_PROJECTION_ABORT_SEEDED_PANE" || true
-  fi
-  if [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" = 1 ]; then
-    HERDR_PRESENTATION_ORDER_LOCK_HELD=0
-    fm_lock_release "$HERDR_PRESENTATION_ORDER_LOCK" || true
-  fi
-  if [ "$ORCA_ABORT_CLEANUP" = 1 ]; then
-    ORCA_ABORT_CLEANUP=0
-    if [ -n "${ORCA_TERMINAL:-}" ]; then
-      fm_backend_kill orca "$ORCA_TERMINAL" 2>/dev/null || true
-    fi
-    if [ -n "${ORCA_WORKTREE_ID:-}" ]; then
-      if ! fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null; then
-        mkdir -p "$STATE" 2>/dev/null || true
-        if [ -d "$STATE" ]; then
-          {
-            echo "window=$W"
-            echo "worktree=${WT:-}"
-            echo "project=$PROJ_ABS"
-            echo "harness=$HARNESS"
-            echo "kind=$KIND"
-            echo "mode=${MODE:-no-mistakes}"
-            echo "yolo=${YOLO:-off}"
-            echo "tasktmp=${TASK_TMP:-}"
-            echo "model=${MODEL:-default}"
-            echo "effort=${EFFORT:-default}"
-            echo "backend=orca"
-            echo "orca_worktree_id=$ORCA_WORKTREE_ID"
-            [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
-          } > "$STATE/$ID.meta" 2>/dev/null || true
-        fi
-      fi
-    fi
-  fi
-  if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
-    SPAWN_TASK_LOCK_HELD=0
-    fm_lock_release "$SPAWN_TASK_LOCK" || true
-  fi
-  if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
-    CONFIG_INHERIT_LOCK_HELD=0
-    fm_lock_release "$CONFIG_INHERIT_LOCK" || true
-  fi
-  return "$status"
-}
-trap spawn_abort_cleanup EXIT
 
 # One bounded lock per live Herdr session/socket, shared across all homes.
 # <session> is required so secondmate and primary spawns serialize against the
@@ -336,6 +317,144 @@ spawn_herdr_presentation_order_lock_release() {
   [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" = 1 ] || return 0
   HERDR_PRESENTATION_ORDER_LOCK_HELD=0
   fm_lock_release "$HERDR_PRESENTATION_ORDER_LOCK" || true
+}
+write_abort_meta() {
+  mkdir -p "$STATE" 2>/dev/null || return 0
+  {
+    echo "window=${T:-${W:-fm-$ID}}"
+    echo "worktree=${WT:-}"
+    [ "${HOST_MODE:-0}" -eq 0 ] || echo "host_root=$HOST_ROOT"
+    echo "project=${PROJ_ABS:-}"
+    echo "harness=${HARNESS:-unknown}"
+    echo "kind=$KIND"
+    echo "mode=${MODE:-no-mistakes}"
+    echo "yolo=${YOLO:-off}"
+    echo "tasktmp=${TASK_TMP:-}"
+    echo "model=${MODEL:-default}"
+    echo "effort=${EFFORT:-default}"
+    [ "$BACKEND" = tmux ] || echo "backend=$BACKEND"
+    [ -z "${HERDR_SES:-}" ] || echo "herdr_session=$HERDR_SES"
+    [ -z "${HERDR_WORKSPACE_ID:-}" ] || echo "herdr_workspace_id=$HERDR_WORKSPACE_ID"
+    [ -z "${HERDR_TAB_ID:-}" ] || echo "herdr_tab_id=$HERDR_TAB_ID"
+    [ -z "${HERDR_PANE_ID:-}" ] || echo "herdr_pane_id=$HERDR_PANE_ID"
+    [ -z "${ZELLIJ_SES:-}" ] || echo "zellij_session=$ZELLIJ_SES"
+    [ -z "${ZELLIJ_TAB_ID:-}" ] || echo "zellij_tab_id=$ZELLIJ_TAB_ID"
+    [ -z "${ZELLIJ_PANE_ID:-}" ] || echo "zellij_pane_id=$ZELLIJ_PANE_ID"
+    [ -z "${ORCA_WORKTREE_ID:-}" ] || echo "orca_worktree_id=$ORCA_WORKTREE_ID"
+    [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
+    [ -z "${CMUX_WORKSPACE_ID:-}" ] || echo "cmux_workspace_id=$CMUX_WORKSPACE_ID"
+    [ -z "${CMUX_SURFACE_ID:-}" ] || echo "cmux_surface_id=$CMUX_SURFACE_ID"
+  } > "$STATE/$ID.meta" 2>/dev/null || true
+}
+
+remove_spawn_artifacts() {
+  [ -z "${auth_file:-}" ] || rm -f -- "$auth_file"
+  [ -z "${SPAWN_CREATE_OUT:-}" ] || rm -f -- "$SPAWN_CREATE_OUT"
+  if [ "$KIND" != secondmate ] && [ -n "${WT:-}" ] && [ -d "${WT:-}" ]; then
+    rm -f -- "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+      "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
+  fi
+  rm -f -- "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
+    "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" "$STATE/$ID.kimi-turnend-token" \
+    "$STATE/$ID.claude-settings.json" "$STATE/$ID.opencode-turn-end.js"
+  [ -z "${TASK_TMP:-}" ] || rm -rf -- "$TASK_TMP"
+}
+
+spawn_abort_cleanup() {
+  local status=$? cleanup_failed=0 endpoint_stopped=1
+  if [ "$ORCA_ABORT_CLEANUP" != 1 ] \
+     && [ "$SPAWN_ABORT_CLEANUP" != 1 ] \
+     && [ "$HERDR_PROJECTION_ABORT_CLEANUP" != 1 ]; then
+    spawn_herdr_presentation_order_lock_release
+    if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
+      SPAWN_TASK_LOCK_HELD=0
+      fm_lock_release "$SPAWN_TASK_LOCK" || true
+    fi
+    if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
+      CONFIG_INHERIT_LOCK_HELD=0
+      fm_lock_release "$CONFIG_INHERIT_LOCK" || true
+    fi
+    return "$status"
+  fi
+  if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ] \
+     && [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" != 1 ] \
+     && ! spawn_herdr_presentation_order_lock_acquire "${HERDR_PROJECTION_ABORT_SESSION:-}"; then
+    echo "warning: herdr presentation focus lock unavailable; retaining the projection journal and refusing concurrent abort cleanup" >&2
+    cleanup_failed=1
+  fi
+  if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ] \
+     && [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" = 1 ]; then
+    HERDR_PROJECTION_ABORT_CLEANUP=0
+    fm_backend_herdr_projection_cleanup_exact \
+      "$HERDR_PROJECTION_ABORT_SESSION" \
+      "$HERDR_PROJECTION_ABORT_TASK_PANE" \
+      "$HERDR_PROJECTION_ABORT_SEEDED_PANE" || cleanup_failed=1
+  fi
+  if [ "$ORCA_ABORT_CLEANUP" = 1 ]; then
+    ORCA_ABORT_CLEANUP=0
+    if [ -n "${ORCA_TERMINAL:-}" ] && ! fm_backend_stop_and_verify orca "$ORCA_TERMINAL"; then
+      cleanup_failed=1
+      endpoint_stopped=0
+    fi
+    if [ "$endpoint_stopped" -eq 1 ] && [ -n "${ORCA_WORKTREE_ID:-}" ]; then
+      if [ "$SPAWN_PRESERVE_WORKTREE" = 1 ]; then
+        cleanup_failed=1
+      else
+        fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null || cleanup_failed=1
+      fi
+    fi
+  elif [ "$SPAWN_ABORT_CLEANUP" = 1 ]; then
+    SPAWN_ABORT_CLEANUP=0
+    if [ "$SPAWN_ENDPOINT_CREATED" = 1 ] && [ -z "${T:-}" ]; then
+      # The adapter confirmed creation but could not recover an addressable
+      # endpoint id. Preserve partial ids/labels for manual recovery; never
+      # recycle a worktree while endpoint absence is unknown.
+      cleanup_failed=1
+      endpoint_stopped=0
+    elif [ -n "${T:-}" ] && ! fm_backend_stop_and_verify "$BACKEND" "$T" "${ZELLIJ_TAB_ID:-}" "${W:-fm-$ID}"; then
+      cleanup_failed=1
+      endpoint_stopped=0
+    fi
+    if [ "$endpoint_stopped" -eq 1 ] && [ "$KIND" != secondmate ] && [ -n "${WT:-}" ] && [ -d "${WT:-}" ]; then
+      if [ "$SPAWN_PRESERVE_WORKTREE" = 1 ]; then
+        cleanup_failed=1
+      else
+        (cd "$PROJ_ABS" && treehouse return --force "$WT") >/dev/null 2>&1 || cleanup_failed=1
+      fi
+    fi
+  fi
+  if [ "$cleanup_failed" -ne 0 ]; then
+    write_abort_meta
+    echo "error: spawn cleanup was incomplete; recoverable task metadata remains at $STATE/$ID.meta" >&2
+  else
+    remove_spawn_artifacts
+  fi
+  spawn_herdr_presentation_order_lock_release
+  if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
+    SPAWN_TASK_LOCK_HELD=0
+    fm_lock_release "$SPAWN_TASK_LOCK" || true
+  fi
+  if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
+    CONFIG_INHERIT_LOCK_HELD=0
+    fm_lock_release "$CONFIG_INHERIT_LOCK" || true
+  fi
+  return "$status"
+}
+trap spawn_abort_cleanup EXIT
+
+capture_backend_create() {  # <output-var> <adapter-function> [args...]
+  local output_var=$1 status
+  shift
+  SPAWN_CREATE_OUT=$(mktemp "${TMPDIR:-/tmp}/fm-spawn-create.XXXXXX") || return 1
+  if "$@" > "$SPAWN_CREATE_OUT"; then
+    status=0
+  else
+    status=$?
+  fi
+  printf -v "$output_var" '%s' "$(cat "$SPAWN_CREATE_OUT")"
+  rm -f -- "$SPAWN_CREATE_OUT"
+  SPAWN_CREATE_OUT=
+  return "$status"
 }
 
 # Batch dispatch (see header): when the first positional is an `id=repo` pair, treat every
@@ -425,15 +544,27 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    claude)
+      if [ "$HOST_MODE" -eq 1 ] && [ "$kind" != secondmate ]; then
+        printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --settings __CLAUDESETTINGS__ --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      else
+        printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      fi
+      ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c __CODEXNOTIFY__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
-    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    opencode)
+      if [ "$HOST_MODE" -eq 1 ] && [ "$kind" != secondmate ]; then
+        printf '%s' 'OPENCODE_CONFIG_CONTENT=__OPENCODECONFIG__ opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      else
+        printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      fi
+      ;;
     pi)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
@@ -448,18 +579,32 @@ launch_template() {
     # --dangerously-skip-permissions. grok's turn-end signal does NOT ride the
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
-    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    grok)
+      if [ "$HOST_MODE" -eq 1 ] && [ "$kind" != secondmate ]; then
+        printf '%s' 'FM_GROK_TURNEND_TOKEN=__GROKTOKEN__ grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      else
+        printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      fi
+      ;;
     # Kimi Code rejects a positional prompt, so it launches bare and receives
     # only an absolute brief pointer after the TUI readiness gate below.
-    # Its turn-end signal is a globally configured Stop hook plus a guarded
-    # per-task worktree token, so no launch placeholder belongs here.
-    kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
+    kimi)
+      if [ "$HOST_MODE" -eq 1 ] && [ "$kind" != secondmate ]; then
+        printf '%s' 'FM_KIMI_TURNEND_TOKEN=__KIMITOKEN__ __KIMIBIN__ __MODELFLAG__--auto'
+      else
+        printf '%s' '__KIMIBIN__ __MODELFLAG__--auto'
+      fi
+      ;;
     *) return 1 ;;
   esac
 }
 
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
+    if [ "$HOST_MODE" -eq 1 ]; then
+      echo "error: host-root mode requires a named verified harness so its task completion safeguard cannot be bypassed" >&2
+      exit 2
+    fi
     LAUNCH=$ARG3
     HARNESS=""
     for word in $LAUNCH; do
@@ -802,6 +947,10 @@ fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
 BRIEF_DIR_REAL=$(cd "$(dirname "$BRIEF")" && pwd -P)
 BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
+if [ "$HOST_MODE" -eq 1 ] && ! grep -qxF '<!-- firstmate-execution-mode: host-root -->' "$BRIEF"; then
+  echo "error: host-root mode requires a host-root brief; regenerate $BRIEF with FM_HOST_ROOT set" >&2
+  exit 1
+fi
 
 # PROJ_ABS can still carry a symlinked path component (e.g. macOS's /tmp ->
 # /private/tmp) when it came from the ship/scout branch's logical `pwd` above.
@@ -832,6 +981,15 @@ real_path_or_raw() {  # <path>
 # herdr-sm-spaces-k4). Both branches converge on the same $T ("target") string
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
+spawn_path_is_isolated_worktree() {  # <candidate-path>
+  local candidate=$1 candidate_real top top_real
+  [ -n "$candidate" ] || return 1
+  candidate_real=$(cd "$candidate" 2>/dev/null && pwd -P) || return 1
+  top=$(git -C "$candidate" rev-parse --show-toplevel 2>/dev/null || true)
+  top_real=$(cd "$top" 2>/dev/null && pwd -P) || return 1
+  [ "$candidate_real" = "$top_real" ] && [ "$candidate_real" != "$PROJ_ABS_REAL" ]
+}
+
 validate_spawn_worktree() {  # <source> <inspect-target>
   local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
   wt_real=
@@ -848,6 +1006,32 @@ validate_spawn_worktree() {  # <source> <inspect-target>
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
+  if [ "$HOST_MODE" -eq 1 ] && fm_host_root_paths_overlap "$HOST_ROOT" "$wt_real"; then
+    SPAWN_PRESERVE_WORKTREE=1
+    echo "error: $source resolved overlapping host and target roots (host '$HOST_ROOT'; target '$wt_real'); stopping the endpoint but preserving the path for manual recovery" >&2
+    exit 1
+  fi
+}
+
+arm_created_endpoint_rollback() {
+  [ "${FM_BACKEND_CREATE_OCCURRED:-0}" = 1 ] || return 0
+  SPAWN_ENDPOINT_CREATED=1
+  case "$BACKEND" in
+    herdr)
+      HERDR_TAB_ID=${FM_BACKEND_CREATED_HERDR_TAB_ID:-}
+      HERDR_PANE_ID=${FM_BACKEND_CREATED_HERDR_PANE_ID:-}
+      ;;
+    zellij)
+      ZELLIJ_TAB_ID=${FM_BACKEND_CREATED_ZELLIJ_TAB_ID:-}
+      ZELLIJ_PANE_ID=${FM_BACKEND_CREATED_ZELLIJ_PANE_ID:-}
+      ;;
+    cmux)
+      CMUX_WORKSPACE_ID=${FM_BACKEND_CREATED_CMUX_WORKSPACE_ID:-}
+      CMUX_SURFACE_ID=${FM_BACKEND_CREATED_CMUX_SURFACE_ID:-}
+      ;;
+  esac
+  T=${FM_BACKEND_CREATED_TARGET:-}
+  SPAWN_ABORT_CLEANUP=1
 }
 
 herdr_projection_meta_field_exact() {  # <meta> <key>
@@ -1071,7 +1255,11 @@ case "$BACKEND" in
       HERDR_SEEDED_DEFAULT_TAB_ID=${HERDR_CONTAINER_RAW#*$'\t'}
       HERDR_SES=${CONTAINER%%:*}
       HERDR_WORKSPACE_ID=${CONTAINER#*:}
-      HERDR_TASK_IDS=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_create_task "$CONTAINER" "$W" "$PROJ_ABS" "$HERDR_SEEDED_DEFAULT_TAB_ID") || exit 1
+      if ! FM_HOME="$HERDR_LABEL_HOME" capture_backend_create HERDR_TASK_IDS \
+        fm_backend_herdr_create_task "$CONTAINER" "$W" "$PROJ_ABS" "$HERDR_SEEDED_DEFAULT_TAB_ID"; then
+        arm_created_endpoint_rollback
+        exit 1
+      fi
       read -r HERDR_TAB_ID HERDR_PANE_ID <<EOF
 $HERDR_TASK_IDS
 EOF
@@ -1084,7 +1272,10 @@ EOF
     ;;
   zellij)
     ZELLIJ_SES=$(fm_backend_zellij_container_ensure) || exit 1
-    ZELLIJ_TASK_IDS=$(fm_backend_zellij_create_task "$ZELLIJ_SES" "$W" "$PROJ_ABS") || exit 1
+    if ! capture_backend_create ZELLIJ_TASK_IDS fm_backend_zellij_create_task "$ZELLIJ_SES" "$W" "$PROJ_ABS"; then
+      arm_created_endpoint_rollback
+      exit 1
+    fi
     read -r ZELLIJ_TAB_ID ZELLIJ_PANE_ID <<EOF
 $ZELLIJ_TASK_IDS
 EOF
@@ -1096,7 +1287,10 @@ EOF
     ;;
   cmux)
     fm_backend_cmux_container_ensure || exit 1
-    CMUX_TASK_IDS=$(fm_backend_cmux_create_task "$W" "$PROJ_ABS") || exit 1
+    if ! capture_backend_create CMUX_TASK_IDS fm_backend_cmux_create_task "$W" "$PROJ_ABS"; then
+      arm_created_endpoint_rollback
+      exit 1
+    fi
     read -r CMUX_WORKSPACE_ID CMUX_SURFACE_ID <<EOF
 $CMUX_TASK_IDS
 EOF
@@ -1113,9 +1307,8 @@ EOF
     set -e
     if [ "$ORCA_WT_STATUS" -ne 0 ]; then
       if [ "$ORCA_WT_STATUS" -eq 2 ] && [ -n "$ORCA_WT_RAW" ]; then
-        if parse_orca_worktree_result "$ORCA_WT_RAW" && [ -n "$ORCA_WORKTREE_ID" ]; then
-          ORCA_ABORT_CLEANUP=1
-        fi
+        parse_orca_worktree_result "$ORCA_WT_RAW" || true
+        [ -z "$ORCA_WORKTREE_ID" ] || ORCA_ABORT_CLEANUP=1
       fi
       exit 1
     fi
@@ -1132,6 +1325,14 @@ EOF
     T="$ORCA_TERMINAL"
     ;;
 esac
+# Arm generic rollback only after this invocation demonstrably created its
+# endpoint. Adapter create functions expose partial post-create state so a
+# verification failure cannot leave an unrecorded live endpoint; a duplicate
+# preflight failure leaves FM_BACKEND_CREATE_OCCURRED=0 and owns nothing.
+if [ "$BACKEND" != orca ]; then
+  SPAWN_ENDPOINT_CREATED=1
+  SPAWN_ABORT_CLEANUP=1
+fi
 # #134 robustness: only tmux needs a worktree-detection target distinct from $T -
 # its rename-safe stable window id, set as WT_TARGET=$WID in the tmux branch above.
 # Every other backend addresses its pane/surface by the id already in $T, so default
@@ -1152,6 +1353,7 @@ spawn_current_path() {  # <target>
     tmux) fm_backend_tmux_current_path "$1" ;;
     herdr) fm_backend_herdr_current_path "$1" ;;
     zellij) fm_backend_zellij_current_path "$1" "$W" ;;
+    orca) fm_backend_orca_current_path "$1" ;;
     cmux) fm_backend_cmux_current_path "$1" "$W" ;;
   esac
 }
@@ -1248,31 +1450,47 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # a mismatch just becomes the new candidate rather than resetting the wait, so a
   # pane that is already settled by the first real read only costs the one existing
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
+  WORKTREE_CWD_ATTEMPTS=${FM_WORKTREE_CWD_ATTEMPTS:-60}
+  WORKTREE_CWD_DELAY=${FM_WORKTREE_CWD_DELAY:-1}
+  case "$WORKTREE_CWD_ATTEMPTS" in ''|*[!0-9]*|0) WORKTREE_CWD_ATTEMPTS=60 ;; esac
   candidate=""
-  for _ in $(seq 1 60); do
+  for _ in $(seq 1 "$WORKTREE_CWD_ATTEMPTS"); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ]; then
+    if spawn_path_is_isolated_worktree "$p"; then
       p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
-        if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
-          WT="$p"
-          break
-        fi
-        candidate="$p_real"
-      else
-        candidate=""
+      if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
+        WT="$p"
+        break
       fi
+      candidate="$p_real"
     else
       candidate=""
     fi
-    sleep 1
+    sleep "$WORKTREE_CWD_DELAY"
   done
   if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+    echo "error: treehouse get did not yield an isolated worktree within $WORKTREE_CWD_ATTEMPTS probes (last cwd '${p:-none}'); inspect window $T" >&2
     exit 1
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+fi
+
+if [ "$HOST_MODE" -eq 1 ]; then
+  HOST_CWD_ATTEMPTS=${FM_HOST_CWD_ATTEMPTS:-30}
+  HOST_CWD_DELAY=${FM_HOST_CWD_DELAY:-1}
+  case "$HOST_CWD_ATTEMPTS" in ''|*[!0-9]*|0) HOST_CWD_ATTEMPTS=30 ;; esac
+  spawn_send_text_line "$T" "cd -- $(shell_quote "$HOST_ROOT")"
+  for _ in $(seq 1 "$HOST_CWD_ATTEMPTS"); do
+    p=$(spawn_current_path "$T" || true)
+    [ "$(real_path_or_raw "$p")" = "$HOST_ROOT" ] && break
+    p=
+    sleep "$HOST_CWD_DELAY"
+  done
+  if [ -z "${p:-}" ] || [ "$(real_path_or_raw "$p")" != "$HOST_ROOT" ]; then
+    echo "error: backend endpoint did not enter FM_HOST_ROOT $HOST_ROOT; inspect target $T" >&2
+    exit 1
+  fi
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
@@ -1297,25 +1515,46 @@ exclude_path() {
   mkdir -p "$(dirname "$EXCL")"
   grep -qxF "$rel" "$EXCL" 2>/dev/null || echo "$rel" >> "$EXCL"
 }
+GROK_TASK_TOKEN=
+KIMI_TASK_TOKEN=
 if [ "$KIND" != secondmate ]; then
   case "$HARNESS" in
     claude*)
-      mkdir -p "$WT/.claude"
-      cat > "$WT/.claude/settings.local.json" <<EOF
+      if [ "$HOST_MODE" -eq 1 ]; then
+        hook_command=$(json_escape "touch -- $(shell_quote "$TURNEND")")
+        printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$STATE/$ID.claude-settings.json"
+      else
+        mkdir -p "$WT/.claude"
+        cat > "$WT/.claude/settings.local.json" <<EOF
 {"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$TURNEND'"}]}]}}
 EOF
-      exclude_path '.claude/settings.local.json'
+        exclude_path '.claude/settings.local.json'
+      fi
       ;;
     opencode*)
-      mkdir -p "$WT/.opencode/plugins"
-      cat > "$WT/.opencode/plugins/fm-turn-end.js" <<EOF
+      if [ "$HOST_MODE" -eq 1 ]; then
+        OPENCODE_TASK_PLUGIN="$STATE/$ID.opencode-turn-end.js"
+        turnend_js=$(json_escape "$TURNEND")
+        cat > "$OPENCODE_TASK_PLUGIN" <<EOF
+import { closeSync, openSync } from "node:fs"
+export const FmTurnEnd = async () => ({
+  event: async ({ event }) => {
+    if (event.type === "session.idle") closeSync(openSync("$turnend_js", "a"))
+  },
+})
+EOF
+      else
+        mkdir -p "$WT/.opencode/plugins"
+        OPENCODE_TASK_PLUGIN="$WT/.opencode/plugins/fm-turn-end.js"
+        cat > "$OPENCODE_TASK_PLUGIN" <<EOF
 export const FmTurnEnd = async ({ \$ }) => ({
   event: async ({ event }) => {
     if (event.type === "session.idle") await \$\`touch $TURNEND\`
   },
 })
 EOF
-      exclude_path '.opencode/plugins/fm-turn-end.js'
+        exclude_path '.opencode/plugins/fm-turn-end.js'
+      fi
       ;;
     pi*)
       # Written OUTSIDE the worktree: pi's project-trust gate fires on any extension
@@ -1364,13 +1603,16 @@ EOF
 #!/usr/bin/env bash
 set -u
 auth_dir=$sq_grok_auth_dir
-workspace=\${GROK_WORKSPACE_ROOT:-}
-[ -n "\$workspace" ] || exit 0
-p="\$workspace/.fm-grok-turnend"
-[ -f "\$p" ] || exit 0
-first=
-IFS= read -r -n 256 first < "\$p" 2>/dev/null || [ -n "\$first" ] || exit 0
-case "\$first" in token=*) token=\${first#token=} ;; *) exit 0 ;; esac
+token=\${FM_GROK_TURNEND_TOKEN:-}
+if [ -z "\$token" ]; then
+  workspace=\${GROK_WORKSPACE_ROOT:-}
+  [ -n "\$workspace" ] || exit 0
+  p="\$workspace/.fm-grok-turnend"
+  [ -f "\$p" ] || exit 0
+  first=
+  IFS= read -r -n 256 first < "\$p" 2>/dev/null || [ -n "\$first" ] || exit 0
+  case "\$first" in token=*) token=\${first#token=} ;; *) exit 0 ;; esac
+fi
 case "\$token" in fm.????????????) : ;; *) exit 0 ;; esac
 case "\$token" in *[!A-Za-z0-9._-]*) exit 0 ;; esac
 t=\$(cat "\$auth_dir/\$token" 2>/dev/null) || exit 0
@@ -1381,8 +1623,11 @@ EOF
       chmod +x "$GROK_HOOKS_DIR/fm-turn-end.sh"
       hook_command=$(json_escape "bash $(shell_quote "$GROK_HOOKS_DIR/fm-turn-end.sh")")
       printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$GROK_HOOKS_DIR/fm-turn-end.json"
-      printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
-      exclude_path '.fm-grok-turnend'
+      GROK_TASK_TOKEN=${auth_file##*/}
+      if [ "$HOST_MODE" -eq 0 ]; then
+        printf 'token=%s\n' "$GROK_TASK_TOKEN" > "$WT/.fm-grok-turnend"
+        exclude_path '.fm-grok-turnend'
+      fi
       ;;
     kimi*)
       # Kimi's Stop hook is global, but it is inert unless cwd contains this
@@ -1396,8 +1641,11 @@ EOF
       umask "$old_umask"
       printf '%s\n' "$TURNEND" > "$auth_file"
       printf '%s\n' "${auth_file##*/}" > "$STATE/$ID.kimi-turnend-token"
-      printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-kimi-turnend"
-      exclude_path '.fm-kimi-turnend'
+      KIMI_TASK_TOKEN=${auth_file##*/}
+      if [ "$HOST_MODE" -eq 0 ]; then
+        printf 'token=%s\n' "$KIMI_TASK_TOKEN" > "$WT/.fm-kimi-turnend"
+        exclude_path '.fm-kimi-turnend'
+      fi
       ;;
   esac
 fi
@@ -1423,6 +1671,7 @@ META_WINDOW=$T
 {
   echo "window=$META_WINDOW"
   echo "worktree=$WT"
+  [ "$HOST_MODE" -eq 0 ] || echo "host_root=$HOST_ROOT"
   echo "project=$PROJ_ABS"
   echo "harness=$HARNESS"
   echo "kind=$KIND"
@@ -1459,7 +1708,6 @@ META_WINDOW=$T
     echo "projects=$SECONDMATE_PROJECTS"
   fi
 } > "$STATE/$ID.meta"
-[ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
@@ -1467,6 +1715,16 @@ sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
+sq_claude_settings=$(shell_quote "$STATE/$ID.claude-settings.json")
+sq_codex_notify=$(shell_quote "notify=[\"bash\",\"-c\",\"touch -- $sq_turnend\"]")
+sq_opencode_config=
+if [ "$HOST_MODE" -eq 1 ] && [ "$HARNESS" = opencode ]; then
+  opencode_plugin_url=$(node -e 'process.stdout.write(require("node:url").pathToFileURL(process.argv[1]).href)' \
+    "$OPENCODE_TASK_PLUGIN")
+  opencode_config=$(printf '{"permission":{"*":"allow"},"plugin":["%s"]}' \
+    "$(json_escape "$opencode_plugin_url")")
+  sq_opencode_config=$(shell_quote "$opencode_config")
+fi
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
@@ -1477,9 +1735,20 @@ LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
+LAUNCH=${LAUNCH//__CLAUDESETTINGS__/$sq_claude_settings}
+LAUNCH=${LAUNCH//__CODEXNOTIFY__/$sq_codex_notify}
+LAUNCH=${LAUNCH//__OPENCODECONFIG__/$sq_opencode_config}
+LAUNCH=${LAUNCH//__GROKTOKEN__/$GROK_TASK_TOKEN}
+LAUNCH=${LAUNCH//__KIMITOKEN__/$KIMI_TASK_TOKEN}
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
-  LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"
+  secondmate_root_clear=
+  if [ "${FM_HOST_ROOT+x}" = x ] || [ "${FM_TARGET_WORKTREE+x}" = x ]; then
+    secondmate_root_clear='FM_HOST_ROOT= FM_TARGET_WORKTREE= '
+  fi
+  LAUNCH="${secondmate_root_clear}FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"
+elif [ "$HOST_MODE" -eq 1 ]; then
+  LAUNCH="FM_ROOT_OVERRIDE=$(shell_quote "$FM_ROOT") FM_HOME=$(shell_quote "$FM_HOME") FM_HOST_ROOT=$(shell_quote "$HOST_ROOT") FM_TARGET_WORKTREE=$(shell_quote "$WT") $LAUNCH"
 fi
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
@@ -1492,7 +1761,14 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   HERDR_PROJECTION_ABORT_CLEANUP=0
   spawn_herdr_presentation_order_lock_release
 fi
-spawn_send_key "$T" Enter
+# Enter may reach the shell even when the backend reports an error.
+# Keep the recorded endpoint and worktree instead of risking cleanup after execution began.
+ORCA_ABORT_CLEANUP=0
+SPAWN_ABORT_CLEANUP=0
+if ! spawn_send_key "$T" Enter; then
+  echo "error: launch submission could not be confirmed; endpoint and task metadata were retained for recovery" >&2
+  exit 1
+fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -208,12 +208,50 @@ esac
 
 HOST_MODE=0
 HOST_ROOT=
+MODE=
+YOLO=
 if fm_host_root_enabled; then
   fm_host_root_assert_session_cwd "$FM_ROOT" || exit $?
   if [ "$KIND" != secondmate ]; then
     HOST_ROOT=$(fm_host_root_resolve "$FM_ROOT") || exit $?
     HOST_MODE=1
   fi
+fi
+
+if [ "$HOST_MODE" -eq 1 ] && [ "$KIND" = ship ]; then
+  host_idpart=${POS[0]:-}
+  host_idpart=${host_idpart%%=*}
+  host_projects=()
+  if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$host_idpart" ] \
+     && case "$host_idpart" in */*) false ;; *) true ;; esac; then
+    for host_pair in "${POS[@]}"; do
+      case "$host_pair" in *=*) host_projects+=("${host_pair#*=}") ;; esac
+    done
+  else
+    host_projects+=("${POS[1]:-}")
+  fi
+  for host_project in "${host_projects[@]}"; do
+    [ -n "$host_project" ] || continue
+    host_project_path=$host_project
+    case "$host_project_path" in
+      projects/*) host_project_path="$PROJECTS/${host_project_path#projects/}" ;;
+    esac
+    host_project_name=$(basename "$host_project")
+    if [ -d "$host_project_path" ]; then
+      host_project_name=$(basename "$(cd "$host_project_path" && pwd -P)")
+    fi
+    read -r host_mode host_yolo <<EOF
+$("$FM_ROOT/bin/fm-project-mode.sh" "$host_project_name")
+EOF
+    if [ "$host_mode" = local-only ]; then
+      echo "error: host-root mode does not support local-only project $host_project_name" >&2
+      exit 1
+    fi
+    if [ "${#host_projects[@]}" -eq 1 ]; then
+      MODE=$host_mode
+      YOLO=$host_yolo
+    fi
+  done
 fi
 
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
@@ -392,7 +430,10 @@ spawn_abort_cleanup() {
   fi
   if [ "$ORCA_ABORT_CLEANUP" = 1 ]; then
     ORCA_ABORT_CLEANUP=0
-    if [ -n "${ORCA_TERMINAL:-}" ] && ! fm_backend_stop_and_verify orca "$ORCA_TERMINAL"; then
+    if [ -z "${ORCA_TERMINAL:-}" ]; then
+      cleanup_failed=1
+      endpoint_stopped=0
+    elif ! fm_backend_stop_and_verify orca "$ORCA_TERMINAL"; then
       cleanup_failed=1
       endpoint_stopped=0
     fi
@@ -1662,9 +1703,11 @@ if [ "$KIND" = secondmate ]; then
   SECONDMATE_PROJECTS=$(secondmate_registry_value "$ID" projects || true)
 else
   PROJ_NAME=$(basename "$PROJ_ABS")
-  read -r MODE YOLO <<EOF
+  if [ -z "$MODE" ]; then
+    read -r MODE YOLO <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$PROJ_NAME")
 EOF
+  fi
 fi
 
 META_WINDOW=$T

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -232,14 +232,7 @@ if [ "$HOST_MODE" -eq 1 ] && [ "$KIND" = ship ]; then
   fi
   for host_project in "${host_projects[@]}"; do
     [ -n "$host_project" ] || continue
-    host_project_path=$host_project
-    case "$host_project_path" in
-      projects/*) host_project_path="$PROJECTS/${host_project_path#projects/}" ;;
-    esac
     host_project_name=$(basename "$host_project")
-    if [ -d "$host_project_path" ]; then
-      host_project_name=$(basename "$(cd "$host_project_path" && pwd -P)")
-    fi
     read -r host_mode host_yolo <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$host_project_name")
 EOF

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1014,6 +1014,7 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 }
 
 arm_created_endpoint_rollback() {
+  [ "$HOST_MODE" -eq 1 ] && [ "$KIND" != secondmate ] || return 0
   [ "${FM_BACKEND_CREATE_OCCURRED:-0}" = 1 ] || return 0
   SPAWN_ENDPOINT_CREATED=1
   case "$BACKEND" in
@@ -1329,7 +1330,7 @@ esac
 # endpoint. Adapter create functions expose partial post-create state so a
 # verification failure cannot leave an unrecorded live endpoint; a duplicate
 # preflight failure leaves FM_BACKEND_CREATE_OCCURRED=0 and owns nothing.
-if [ "$BACKEND" != orca ]; then
+if [ "$HOST_MODE" -eq 1 ] && [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   SPAWN_ENDPOINT_CREATED=1
   SPAWN_ABORT_CLEANUP=1
 fi

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -2,6 +2,8 @@
 # Render the primary-harness supervision operating block for session start and
 # the short repair line used by guards and turn-end hooks.
 set -eu
+# Rendered paths are literal replacement data; never expand '&' as the matched placeholder.
+shopt -u patsub_replacement 2>/dev/null || true
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -9,6 +11,9 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$REPO_ROOT}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 DOC_DIR="$REPO_ROOT/docs/supervision-protocols"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
+FM_BIN_PREFIX=bin
 
 HARNESS=
 READ_ONLY=0
@@ -97,6 +102,7 @@ shell_quote() {
   printf "'"
 }
 
+fm_host_root_enabled && FM_BIN_PREFIX=$(shell_quote "$FM_ROOT/bin")
 x_mode_env_sh=$(shell_quote "$x_mode_env")
 
 if [ "$X_MODE" -eq 0 ] && [ -f "$x_mode_env" ]; then
@@ -110,6 +116,9 @@ render_snippet() {
     line=${line//__FM_PI_TURNEND_EXT__/$pi_turnend_ext}
     line=${line//__FM_X_MODE_ENV_SH__/$x_mode_env_sh}
     line=${line//__FM_X_MODE_ENV__/$x_mode_env}
+    if fm_host_root_enabled; then
+      line=${line//bin\/fm-/$FM_BIN_PREFIX/fm-}
+    fi
     printf '%s\n' "$line"
   done < "$SNIPPET"
 }
@@ -134,19 +143,19 @@ repair_line() {
 
   case "$HARNESS" in
     claude)
-      printf '%s%s\n' "$prefix" 'repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task, never shell &.'
+      printf '%srepair missing watcher supervision with %s/fm-watch-arm.sh as its own Claude Code background task, never shell &.\n' "$prefix" "$FM_BIN_PREFIX"
       ;;
     codex)
-      printf '%s%s%s%s\n' "$prefix" 'repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds ' "$checkpoint_seconds" '.'
+      printf '%srepair missing watcher supervision with a foreground checkpoint: %s/fm-watch-checkpoint.sh --seconds %s.\n' "$prefix" "$FM_BIN_PREFIX" "$checkpoint_seconds"
       ;;
     pi)
       printf '%s%s%s%s%s%s\n' "$prefix" 'repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ' "$pi_turnend_ext" ' -e ' "$pi_ext" ' if the extensions are not loaded.'
       ;;
     opencode)
-      printf '%s%s\n' "$prefix" 'repair missing watcher supervision by letting the OpenCode TUI plugin arm after idle; use bin/fm-watch-arm.sh only as a manual recovery probe if the plugin reports failure.'
+      printf '%srepair missing watcher supervision by letting the OpenCode TUI plugin arm after idle; use %s/fm-watch-arm.sh only as a manual recovery probe if the plugin reports failure.\n' "$prefix" "$FM_BIN_PREFIX"
       ;;
     grok)
-      printf '%s%s\n' "$prefix" 'repair missing watcher supervision with bin/fm-watch-arm.sh as its own Grok tracked background task, never shell &.'
+      printf '%srepair missing watcher supervision with %s/fm-watch-arm.sh as its own Grok tracked background task, never shell &.\n' "$prefix" "$FM_BIN_PREFIX"
       ;;
     *)
       printf '%s%s\n' "$prefix" 'repair missing watcher supervision according to the session-start block for this harness; do not use shell &.'

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -166,10 +166,10 @@ repair_line() {
 ordinary_wake_line() {
   case "$HARNESS" in
     claude)
-      printf '%s\n' '- Ordinary wake: the Stop-owned auto-arm (bin/fm-claude-stop-autoarm.sh) already owns watcher continuity; drain and handle the wake, and do not arm another cycle yourself.'
+      printf '%s%s%s\n' '- Ordinary wake: the Stop-owned auto-arm (' "$FM_BIN_PREFIX" '/fm-claude-stop-autoarm.sh) already owns watcher continuity; drain and handle the wake, and do not arm another cycle yourself.'
       ;;
     codex)
-      printf '%s\n' '- Ordinary wake: take the next foreground bin/fm-watch-checkpoint.sh checkpoint as directed below.'
+      printf '%s%s%s\n' '- Ordinary wake: take the next foreground ' "$FM_BIN_PREFIX" '/fm-watch-checkpoint.sh checkpoint as directed below.'
       ;;
     pi)
       printf '%s\n' '- Ordinary wake: the Pi extension already owns watcher continuity; do not arm another cycle.'
@@ -178,7 +178,7 @@ ordinary_wake_line() {
       printf '%s\n' '- Ordinary wake: the OpenCode TUI plugin already owns watcher continuity; do not arm manually.'
       ;;
     grok)
-      printf '%s\n' '- Ordinary wake: re-arm exactly one bin/fm-watch-arm.sh Grok tracked background task as directed below.'
+      printf '%s%s%s\n' '- Ordinary wake: re-arm exactly one ' "$FM_BIN_PREFIX" '/fm-watch-arm.sh Grok tracked background task as directed below.'
       ;;
     *)
       printf '%s\n' '- Ordinary wake: follow the continuation in the harness protocol below; do not use shell &.'

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -34,6 +34,8 @@
 # device. It refuses and preserves task state when that proof fails; otherwise
 # it removes the task's check, trust record, PR sidecar, publication record, and
 # quarantine entries with the rest of the volatile state.
+# Every task endpoint is stopped and verified absent before its isolated copy is
+# changed, returned, or removed.
 # Orca tasks use the same safety checks, then close the recorded terminal and
 # remove the recorded worktree through `orca worktree rm`; teardown never guesses
 # an Orca target from ambient CLI state.
@@ -53,6 +55,8 @@
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
 # Usage: fm-teardown.sh <task-id> [--force]
+#   Host-root task actions bind to the physical host_root= recorded in task
+#   metadata before supervision repair, task-data reads, or cleanup mutation.
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
@@ -104,6 +108,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-lock-lib.sh"
 # shellcheck source=bin/fm-gate-refuse-lib.sh
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
@@ -114,19 +120,20 @@ ID=$1
 FORCE=${2:-}
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never tear
 # down a worktree (see bin/fm-gate-refuse-lib.sh).
-fm_refuse_if_gate_agent
-FM_LOCK_LOG_PREFIX=teardown
-"$FM_ROOT/bin/fm-guard.sh" || true
+fm_refuse_if_gate_agent "$FM_ROOT"
 
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+fm_host_root_assert_task_cwd "$FM_ROOT" "$META" || exit $?
+# The recorded host binding is established before this guard can repair state.
+FM_LOCK_LOG_PREFIX=teardown "$FM_ROOT/bin/fm-guard.sh" || true
 WT=$(grep '^worktree=' "$META" | cut -d= -f2-)
 T=$(grep '^window=' "$META" | cut -d= -f2-)
 PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 BACKEND=$(fm_backend_of_meta "$META")
 if [ "$BACKEND" = orca ]; then
   T_ORCA=$(grep '^terminal=' "$META" | tail -1 | cut -d= -f2- || true)
-  [ -n "$T_ORCA" ] && T=$T_ORCA
+  T=$T_ORCA
 fi
 HOME_PATH=$(grep '^home=' "$META" | cut -d= -f2- || true)
 PR_URL=$(grep '^pr=' "$META" | tail -1 | cut -d= -f2- || true)
@@ -730,6 +737,21 @@ validate_worktree_teardown_safety() {
   fi
 }
 
+validate_worktree_teardown_safety_with_lock_cleanup() {
+  local safety_rc
+  if validate_worktree_teardown_safety; then
+    return 0
+  else
+    safety_rc=$?
+  fi
+  if [ "$safety_rc" -eq "$TEARDOWN_WORKTREE_SAFETY_LOCK_BLOCKED" ]; then
+    cleanup_stale_lock_for_safety_check "$WT" || return 1
+    validate_worktree_teardown_safety
+  else
+    return "$safety_rc"
+  fi
+}
+
 require_orca_worktree_path_match() {
   local worktree_id=$1 inspected=$2 resolved inspected_abs resolved_abs
   resolved=$(fm_backend_worktree_path orca "$worktree_id") || {
@@ -992,13 +1014,15 @@ cleanup_firstmate_home_children() {
       fi
     fi
     if [ -n "$child_t" ]; then
-      if [ "$child_backend" = zellij ]; then
-        # Zellij titles are scoped by the owning home tag, so forced secondmate
-        # cleanup must verify child tabs as that child home, not the parent.
-        ( unset FM_ROOT_OVERRIDE; FM_HOME=$home FM_ROOT=$home fm_backend_kill "$child_backend" "$child_t" "$(meta_value "$child_meta" zellij_tab_id)" "fm-$child_id" ) 2>/dev/null || true
-      else
-        fm_backend_kill "$child_backend" "$child_t" "$(meta_value "$child_meta" zellij_tab_id)" "fm-$child_id" 2>/dev/null || true
-      fi
+      case "$child_backend" in
+        zellij|cmux)
+          # These adapters scope labels and optional socket configuration to the owning home.
+          ( unset FM_ROOT_OVERRIDE FM_CONFIG_OVERRIDE; FM_HOME=$home FM_ROOT=$home fm_backend_stop_and_verify "$child_backend" "$child_t" "$(meta_value "$child_meta" zellij_tab_id)" "fm-$child_id" ) || return 1
+          ;;
+        *)
+          fm_backend_stop_and_verify "$child_backend" "$child_t" "$(meta_value "$child_meta" zellij_tab_id)" "fm-$child_id" || return 1
+          ;;
+      esac
     fi
     if [ "$child_kind" = secondmate ]; then
       child_home=$(meta_value "$child_meta" home)
@@ -1037,7 +1061,8 @@ cleanup_firstmate_home_children() {
     remove_pr_poll_artifacts "$sub_state" "$child_id" || return 1
     rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" \
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
-      "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token"
+      "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
+      "$sub_state/$child_id.claude-settings.json" "$sub_state/$child_id.opencode-turn-end.js"
   done
 }
 
@@ -1071,10 +1096,6 @@ if [ "$KIND" = secondmate ] && [ "$FORCE" != "--force" ]; then
   fi
 fi
 
-if [ "$KIND" = secondmate ] && [ "$FORCE" = "--force" ]; then
-  cleanup_firstmate_home_children "$HOME_PATH"
-fi
-
 if [ "$KIND" = scout ] && [ "$FORCE" != "--force" ]; then
   REPORT="$DATA/$ID/report.md"
   if [ ! -f "$REPORT" ]; then
@@ -1100,21 +1121,78 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != scout ] && [ "$KIND" != secondmate ] &&
   ORCA_PATH_MATCH_VERIFIED=1
 fi
 
-if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
-  if validate_worktree_teardown_safety; then
-    :
-  else
-    safety_rc=$?
-    if [ "$safety_rc" -eq "$TEARDOWN_WORKTREE_SAFETY_LOCK_BLOCKED" ]; then
-      cleanup_stale_lock_for_safety_check "$WT" || exit 1
-      validate_worktree_teardown_safety || exit 1
-    else
-      exit 1
-    fi
+HERDR_PRESENTATION_JOURNAL="$STATE/$ID.herdr-presentation"
+HERDR_PRESENTATION_RETIRE_CANDIDATE=0
+HERDR_PRESENTATION_SESSION=
+HERDR_PRESENTATION_PANE=
+if [ "$BACKEND" = herdr ] \
+   && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
+  fm_backend_source herdr || true
+  HERDR_PRESENTATION_SESSION=$(meta_value "$META" herdr_session)
+  HERDR_PRESENTATION_WORKSPACE=$(meta_value "$META" herdr_workspace_id)
+  HERDR_PRESENTATION_PANE=$(meta_value "$META" herdr_pane_id)
+  if [ -n "$HERDR_PRESENTATION_SESSION" ] \
+     && [ -n "$HERDR_PRESENTATION_WORKSPACE" ] \
+     && [ -n "$HERDR_PRESENTATION_PANE" ] \
+     && [ "$T" = "$HERDR_PRESENTATION_SESSION:$HERDR_PRESENTATION_PANE" ] \
+     && fm_backend_herdr_projection_endpoint_matches_journal \
+       "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_WORKSPACE" \
+       "$HERDR_PRESENTATION_JOURNAL" "$ID"; then
+    HERDR_PRESENTATION_RETIRE_CANDIDATE=1
   fi
 fi
 
-# Best-effort: drop the local task branch so the shared repo does not accumulate refs.
+stop_task_endpoint_and_verify() {
+  local focus_lock='' focus_lock_held=0 attempt=0 endpoint_state
+  if [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" != 1 ]; then
+    fm_backend_stop_and_verify "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID"
+    return
+  fi
+
+  # shellcheck source=bin/fm-wake-lib.sh
+  . "$SCRIPT_DIR/fm-wake-lib.sh"
+  if focus_lock=$(fm_backend_herdr_presentation_session_lock_path "$HERDR_PRESENTATION_SESSION"); then
+    while [ "$attempt" -lt 50 ]; do
+      if fm_lock_try_acquire "$focus_lock"; then
+        focus_lock_held=1
+        break
+      fi
+      sleep 0.1
+      attempt=$((attempt + 1))
+    done
+  fi
+  if [ "$focus_lock_held" != 1 ]; then
+    echo "error: herdr presentation focus lock unavailable; refusing a concurrent focus-unsafe pane close" >&2
+    return 1
+  fi
+  fm_backend_herdr_projection_close_pane_focus_preserving \
+    "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_PANE" 2>/dev/null || true
+  fm_lock_release "$focus_lock" || true
+  endpoint_state=$(fm_backend_target_state herdr "$T" "" 2>/dev/null)
+  if [ "$endpoint_state" != absent ]; then
+    echo "error: exact herdr task pane could not be confirmed absent; refusing destructive cleanup" >&2
+    return 1
+  fi
+  rm -f "$HERDR_PRESENTATION_JOURNAL"
+}
+
+if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
+  validate_worktree_teardown_safety_with_lock_cleanup || exit 1
+fi
+
+if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ] && [ "$ORCA_PATH_MATCH_VERIFIED" != 1 ]; then
+  require_orca_worktree_path_match_if_present "$ORCA_WORKTREE_ID" "$WT" || exit 1
+  ORCA_PATH_MATCH_VERIFIED=1
+fi
+stop_task_endpoint_and_verify || exit 1
+if [ "$BACKEND" = orca ] && [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
+  validate_worktree_teardown_safety_with_lock_cleanup || exit 1
+fi
+if [ "$KIND" = secondmate ] && [ "$FORCE" = "--force" ]; then
+  cleanup_firstmate_home_children "$HOME_PATH"
+fi
+
+# The worker is confirmed stopped before the task branch or isolated copy changes.
 if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
   if [ "$ORCA_PATH_MATCH_VERIFIED" != 1 ]; then
     require_orca_worktree_path_match_if_present "$ORCA_WORKTREE_ID" "$WT" || exit 1
@@ -1130,7 +1208,6 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
     rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
       "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   fi
-  [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
   fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
 elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
@@ -1156,62 +1233,9 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   }
 fi
 
-HERDR_PRESENTATION_JOURNAL="$STATE/$ID.herdr-presentation"
-HERDR_PRESENTATION_RETIRE_CANDIDATE=0
-HERDR_PRESENTATION_SESSION=
-HERDR_PRESENTATION_PANE=
 if [ "$BACKEND" = herdr ] \
+   && [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" != 1 ] \
    && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
-  fm_backend_source herdr || true
-  HERDR_PRESENTATION_SESSION=$(meta_value "$META" herdr_session)
-  HERDR_PRESENTATION_WORKSPACE=$(meta_value "$META" herdr_workspace_id)
-  HERDR_PRESENTATION_PANE=$(meta_value "$META" herdr_pane_id)
-  if [ -n "$HERDR_PRESENTATION_SESSION" ] \
-     && [ -n "$HERDR_PRESENTATION_WORKSPACE" ] \
-     && [ -n "$HERDR_PRESENTATION_PANE" ] \
-     && [ "$T" = "$HERDR_PRESENTATION_SESSION:$HERDR_PRESENTATION_PANE" ] \
-     && fm_backend_herdr_projection_endpoint_matches_journal \
-       "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_WORKSPACE" \
-       "$HERDR_PRESENTATION_JOURNAL" "$ID"; then
-    HERDR_PRESENTATION_RETIRE_CANDIDATE=1
-  fi
-fi
-
-if [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" = 1 ]; then
-  # shellcheck source=bin/fm-wake-lib.sh
-  . "$SCRIPT_DIR/fm-wake-lib.sh"
-  HERDR_PRESENTATION_FOCUS_LOCK=
-  HERDR_PRESENTATION_FOCUS_LOCK_HELD=0
-  HERDR_PRESENTATION_FOCUS_LOCK_ATTEMPT=0
-  if HERDR_PRESENTATION_FOCUS_LOCK=$(fm_backend_herdr_presentation_session_lock_path "$HERDR_PRESENTATION_SESSION"); then
-    while [ "$HERDR_PRESENTATION_FOCUS_LOCK_ATTEMPT" -lt 50 ]; do
-      if fm_lock_try_acquire "$HERDR_PRESENTATION_FOCUS_LOCK"; then
-        HERDR_PRESENTATION_FOCUS_LOCK_HELD=1
-        break
-      fi
-      sleep 0.1
-      HERDR_PRESENTATION_FOCUS_LOCK_ATTEMPT=$((HERDR_PRESENTATION_FOCUS_LOCK_ATTEMPT + 1))
-    done
-  fi
-  if [ "$HERDR_PRESENTATION_FOCUS_LOCK_HELD" = 1 ]; then
-    fm_backend_herdr_projection_close_pane_focus_preserving \
-      "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_PANE" 2>/dev/null || true
-    HERDR_PRESENTATION_FOCUS_LOCK_HELD=0
-    fm_lock_release "$HERDR_PRESENTATION_FOCUS_LOCK" || true
-  else
-    echo "warning: herdr presentation focus lock unavailable; refusing a concurrent focus-unsafe pane close" >&2
-  fi
-elif [ "$BACKEND" != orca ]; then
-  fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
-fi
-if [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" = 1 ]; then
-  if [ "$(fm_backend_herdr_pane_agent_state "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_PANE")" = dead ]; then
-    rm -f "$HERDR_PRESENTATION_JOURNAL"
-  else
-    echo "warning: exact herdr task-pane close could not be confirmed for $ID; retaining the presentation journal and attempting no workspace cleanup" >&2
-  fi
-elif [ "$BACKEND" = herdr ] \
-     && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
   echo "warning: herdr presentation journal for $ID remains quarantined; no workspace cleanup was attempted" >&2
 fi
 if [ "$KIND" = secondmate ]; then
@@ -1228,7 +1252,8 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
-  "$STATE/$ID.kimi-turnend-token"
+  "$STATE/$ID.kimi-turnend-token" \
+  "$STATE/$ID.claude-settings.json" "$STATE/$ID.opencode-turn-end.js"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1017,12 +1017,17 @@ cleanup_firstmate_home_children() {
     fi
     if [ -n "$child_t" ]; then
       case "$child_backend" in
-        zellij|cmux)
-          # These adapters scope labels and optional socket configuration to the owning home.
+        zellij)
+          # Zellij titles are scoped by the owning home tag, so forced secondmate
+          # cleanup must verify child tabs as that child home, not the parent.
+          ( unset FM_ROOT_OVERRIDE; FM_HOME=$home FM_ROOT=$home fm_backend_kill "$child_backend" "$child_t" "$(meta_value "$child_meta" zellij_tab_id)" "fm-$child_id" ) 2>/dev/null || true
+          ;;
+        cmux)
+          # Cmux labels and socket configuration are scoped to the owning home.
           ( unset FM_ROOT_OVERRIDE FM_CONFIG_OVERRIDE; FM_HOME=$home FM_ROOT=$home fm_backend_stop_and_verify "$child_backend" "$child_t" "$(meta_value "$child_meta" zellij_tab_id)" "fm-$child_id" ) || return 1
           ;;
         *)
-          fm_backend_stop_and_verify "$child_backend" "$child_t" "$(meta_value "$child_meta" zellij_tab_id)" "fm-$child_id" || return 1
+          fm_backend_kill "$child_backend" "$child_t" "$(meta_value "$child_meta" zellij_tab_id)" "fm-$child_id" 2>/dev/null || true
           ;;
       esac
     fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -34,8 +34,8 @@
 # device. It refuses and preserves task state when that proof fails; otherwise
 # it removes the task's check, trust record, PR sidecar, publication record, and
 # quarantine entries with the rest of the volatile state.
-# Every task endpoint is stopped and verified absent before its isolated copy is
-# changed, returned, or removed.
+# Every host-root task endpoint is stopped and verified absent before its
+# isolated copy is changed, returned, or removed.
 # Orca tasks use the same safety checks, then close the recorded terminal and
 # remove the recorded worktree through `orca worktree rm`; teardown never guesses
 # an Orca target from ambient CLI state.
@@ -147,6 +147,8 @@ KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 [ -n "$KIND" ] || KIND=ship
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes
+TASK_HOST_MODE=0
+grep -q '^host_root=.' "$META" && TASK_HOST_MODE=1
 
 default_branch() {
   local ref branch
@@ -1096,6 +1098,10 @@ if [ "$KIND" = secondmate ] && [ "$FORCE" != "--force" ]; then
   fi
 fi
 
+if [ "$TASK_HOST_MODE" -eq 0 ] && [ "$KIND" = secondmate ] && [ "$FORCE" = "--force" ]; then
+  cleanup_firstmate_home_children "$HOME_PATH"
+fi
+
 if [ "$KIND" = scout ] && [ "$FORCE" != "--force" ]; then
   REPORT="$DATA/$ID/report.md"
   if [ ! -f "$REPORT" ]; then
@@ -1180,19 +1186,21 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
   validate_worktree_teardown_safety_with_lock_cleanup || exit 1
 fi
 
-if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ] && [ "$ORCA_PATH_MATCH_VERIFIED" != 1 ]; then
-  require_orca_worktree_path_match_if_present "$ORCA_WORKTREE_ID" "$WT" || exit 1
-  ORCA_PATH_MATCH_VERIFIED=1
-fi
-stop_task_endpoint_and_verify || exit 1
-if [ "$BACKEND" = orca ] && [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
-  validate_worktree_teardown_safety_with_lock_cleanup || exit 1
-fi
-if [ "$KIND" = secondmate ] && [ "$FORCE" = "--force" ]; then
-  cleanup_firstmate_home_children "$HOME_PATH"
+if [ "$TASK_HOST_MODE" -eq 1 ]; then
+  if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ] && [ "$ORCA_PATH_MATCH_VERIFIED" != 1 ]; then
+    require_orca_worktree_path_match_if_present "$ORCA_WORKTREE_ID" "$WT" || exit 1
+    ORCA_PATH_MATCH_VERIFIED=1
+  fi
+  stop_task_endpoint_and_verify || exit 1
+  if [ "$BACKEND" = orca ] && [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
+    validate_worktree_teardown_safety_with_lock_cleanup || exit 1
+  fi
+  if [ "$KIND" = secondmate ] && [ "$FORCE" = "--force" ]; then
+    cleanup_firstmate_home_children "$HOME_PATH"
+  fi
 fi
 
-# The worker is confirmed stopped before the task branch or isolated copy changes.
+# Host-root tasks reach this point with the worker confirmed stopped.
 if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
   if [ "$ORCA_PATH_MATCH_VERIFIED" != 1 ]; then
     require_orca_worktree_path_match_if_present "$ORCA_WORKTREE_ID" "$WT" || exit 1
@@ -1207,6 +1215,9 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
     fi
     rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
       "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
+  fi
+  if [ "$TASK_HOST_MODE" -eq 0 ] && [ -n "$T" ]; then
+    fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
   fi
   fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
 elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
@@ -1233,9 +1244,46 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   }
 fi
 
-if [ "$BACKEND" = herdr ] \
-   && [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" != 1 ] \
-   && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
+if [ "$TASK_HOST_MODE" -eq 0 ]; then
+  if [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" = 1 ]; then
+    . "$SCRIPT_DIR/fm-wake-lib.sh"
+    HERDR_PRESENTATION_FOCUS_LOCK=
+    HERDR_PRESENTATION_FOCUS_LOCK_HELD=0
+    HERDR_PRESENTATION_FOCUS_LOCK_ATTEMPT=0
+    if HERDR_PRESENTATION_FOCUS_LOCK=$(fm_backend_herdr_presentation_session_lock_path "$HERDR_PRESENTATION_SESSION"); then
+      while [ "$HERDR_PRESENTATION_FOCUS_LOCK_ATTEMPT" -lt 50 ]; do
+        if fm_lock_try_acquire "$HERDR_PRESENTATION_FOCUS_LOCK"; then
+          HERDR_PRESENTATION_FOCUS_LOCK_HELD=1
+          break
+        fi
+        sleep 0.1
+        HERDR_PRESENTATION_FOCUS_LOCK_ATTEMPT=$((HERDR_PRESENTATION_FOCUS_LOCK_ATTEMPT + 1))
+      done
+    fi
+    if [ "$HERDR_PRESENTATION_FOCUS_LOCK_HELD" = 1 ]; then
+      fm_backend_herdr_projection_close_pane_focus_preserving \
+        "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_PANE" 2>/dev/null || true
+      HERDR_PRESENTATION_FOCUS_LOCK_HELD=0
+      fm_lock_release "$HERDR_PRESENTATION_FOCUS_LOCK" || true
+    else
+      echo "warning: herdr presentation focus lock unavailable; refusing a concurrent focus-unsafe pane close" >&2
+    fi
+  elif [ "$BACKEND" != orca ]; then
+    fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
+  fi
+  if [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" = 1 ]; then
+    if [ "$(fm_backend_herdr_pane_agent_state "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_PANE")" = dead ]; then
+      rm -f "$HERDR_PRESENTATION_JOURNAL"
+    else
+      echo "warning: exact herdr task-pane close could not be confirmed for $ID; retaining the presentation journal and attempting no workspace cleanup" >&2
+    fi
+  elif [ "$BACKEND" = herdr ] \
+       && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
+    echo "warning: herdr presentation journal for $ID remains quarantined; no workspace cleanup was attempted" >&2
+  fi
+elif [ "$BACKEND" = herdr ] \
+     && [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" != 1 ] \
+     && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
   echo "warning: herdr presentation journal for $ID remains quarantined; no workspace cleanup was attempted" >&2
 fi
 if [ "$KIND" = secondmate ]; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1251,6 +1251,7 @@ fi
 
 if [ "$TASK_HOST_MODE" -eq 0 ]; then
   if [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" = 1 ]; then
+    # shellcheck source=bin/fm-wake-lib.sh
     . "$SCRIPT_DIR/fm-wake-lib.sh"
     HERDR_PRESENTATION_FOCUS_LOCK=
     HERDR_PRESENTATION_FOCUS_LOCK_HELD=0

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1197,7 +1197,7 @@ if [ "$TASK_HOST_MODE" -eq 1 ]; then
     ORCA_PATH_MATCH_VERIFIED=1
   fi
   stop_task_endpoint_and_verify || exit 1
-  if [ "$BACKEND" = orca ] && [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
+  if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
     validate_worktree_teardown_safety_with_lock_cleanup || exit 1
   fi
   if [ "$KIND" = secondmate ] && [ "$FORCE" = "--force" ]; then

--- a/bin/fm-x-followup.sh
+++ b/bin/fm-x-followup.sh
@@ -55,6 +55,7 @@
 # The window is FMX_FOLLOWUP_MAX_AGE_SECS (default 604800, 7 days). The cap is
 # FMX_FOLLOWUP_MAX_COUNT (default 3). FMX_NOW_OVERRIDE pins "now" for
 # deterministic tests. Meta read/write lives in fm-x-lib.sh.
+# Host-root tasks bind to their recorded physical host cwd before metadata or post activity.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -63,6 +64,8 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 # shellcheck source=bin/fm-x-lib.sh
 . "$SCRIPT_DIR/fm-x-lib.sh"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 
 usage() {
   echo "usage: fm-x-followup.sh --check <task-id> | <task-id> [--image <path>] [--final] --text-file <path> | <task-id> [--image <path>] [--final] -" >&2
@@ -144,6 +147,11 @@ case "$ID" in
 esac
 
 META="$STATE/$ID.meta"
+if [ -f "$META" ]; then
+  fm_host_root_assert_task_cwd "$FM_ROOT" "$META" || exit $?
+else
+  fm_host_root_assert_session_cwd "$FM_ROOT" || exit $?
+fi
 RID=$(fmx_meta_get "$META" x_request)
 TS=$(fmx_meta_get "$META" x_request_ts)
 COUNT=$(fmx_meta_get "$META" x_followups)

--- a/bin/fm-x-link.sh
+++ b/bin/fm-x-link.sh
@@ -35,6 +35,7 @@
 #
 # Both ids are relay/firstmate slugs that compose a filename, so they are guarded
 # against path traversal even though they come from trusted callers.
+# Host-root tasks bind to their recorded physical host cwd before metadata mutation.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -45,6 +46,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-x-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-host-root-lib.sh
+. "$SCRIPT_DIR/fm-host-root-lib.sh"
 
 usage() {
   echo "usage: fm-x-link.sh <task-id> <request_id> [--carry-count <n> --carry-ts <epoch> [--carry-platform <x|discord>] [--carry-max <n>]]" >&2
@@ -124,6 +127,7 @@ if [ ! -f "$META" ]; then
   echo "fm-x-link: no such task: state/$ID.meta" >&2
   exit 1
 fi
+fm_host_root_assert_task_cwd "$FM_ROOT" "$META" || exit $?
 
 command -v jq >/dev/null 2>&1 || { echo "fm-x-link: jq not found" >&2; exit 1; }
 fmx_load_config

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,7 +115,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 The default launch cwd remains the isolated task worktree.
 When optional `FM_HOST_ROOT` mode is enabled, FirstMate separates its tracked code root, operational home, host instruction root, and target worktree instead: the backend acquires and validates the isolated target first, records it as `worktree=`, returns the endpoint to the physical host root, verifies that cwd, then launches the harness with exact `FM_HOST_ROOT` and `FM_TARGET_WORKTREE` values.
-The target is rejected if it resolves to the host, and a failed host transition cleans the new endpoint and worktree or leaves recoverable metadata when cleanup itself fails.
+The target is rejected if it overlaps the host, and a failed host transition cleans the new endpoint and worktree or leaves recoverable metadata when cleanup itself fails.
 Host instructions and native lifecycle hooks remain authoritative because the harness starts from the host root, while the host-root brief requires applicable target instructions before edits and scopes every target operation explicitly.
 FirstMate task completion signals are added through harness launch configuration or per-process identity rather than by writing host hook files.
 Secondmates keep their isolated-home launch shape and clear both host variables.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,12 +114,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 The default launch cwd remains the isolated task worktree.
-When optional `FM_HOST_ROOT` mode is enabled, FirstMate separates its tracked code root, operational home, host instruction root, and target worktree instead: the backend acquires and validates the isolated target first, records it as `worktree=`, returns the endpoint to the physical host root, verifies that cwd, then launches the harness with exact `FM_HOST_ROOT` and `FM_TARGET_WORKTREE` values.
-The target is rejected if it overlaps the host, and a failed host transition cleans the new endpoint and worktree or leaves recoverable metadata when cleanup itself fails.
-Host instructions and native lifecycle hooks remain authoritative because the harness starts from the host root, while the host-root brief requires applicable target instructions before edits and scopes every target operation explicitly.
-FirstMate task completion signals are added through harness launch configuration or per-process identity rather than by writing host hook files.
-Secondmates keep their isolated-home launch shape and clear both host variables.
-The full four-root contract and validation rules are owned by [configuration.md](configuration.md#host-root-mode-fm_host_root).
+The optional host-root exception is owned by [configuration.md's four-root runtime contract](configuration.md#host-root-mode-fm_host_root).
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,14 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 ## Worktrees, not branches in your checkout
 
+The default launch cwd remains the isolated task worktree.
+When optional `FM_HOST_ROOT` mode is enabled, FirstMate separates its tracked code root, operational home, host instruction root, and target worktree instead: the backend acquires and validates the isolated target first, records it as `worktree=`, returns the endpoint to the physical host root, verifies that cwd, then launches the harness with exact `FM_HOST_ROOT` and `FM_TARGET_WORKTREE` values.
+The target is rejected if it resolves to the host, and a failed host transition cleans the new endpoint and worktree or leaves recoverable metadata when cleanup itself fails.
+Host instructions and native lifecycle hooks remain authoritative because the harness starts from the host root, while the host-root brief requires applicable target instructions before edits and scopes every target operation explicitly.
+FirstMate task completion signals are added through harness launch configuration or per-process identity rather than by writing host hook files.
+Secondmates keep their isolated-home launch shape and clear both host variables.
+The full four-root contract and validation rules are owned by [configuration.md](configuration.md#host-root-mode-fm_host_root).
+
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,8 +201,7 @@ Spawn rejects a cwd-relative legacy brief in host mode rather than weakening tha
 Host-root ship tasks support `no-mistakes` and `direct-PR` delivery; brief generation, spawn, and scout promotion reject `local-only` because its guarded landing path changes the target project's primary checkout.
 
 Harness integration is additive.
-Claude receives an additional task settings file through `--settings`, Codex retains its launch-command notification, OpenCode receives an explicit task plugin in addition to host project plugins, Pi receives its explicit task extension, and Grok and Kimi use per-process task tokens consumed by their guarded global hooks.
-None of these paths writes or replaces host hook configuration, and each task signal is installed once.
+The [`harness-adapters` skill](../.agents/skills/harness-adapters/SKILL.md#host-root-task-integration) owns each harness's task-signal shape; none writes or replaces host hook configuration, and each signal is installed once.
 The host repository's own lifecycle hooks continue to load from the host cwd.
 Host-root ordinary tasks reject raw launch commands because an unverified command cannot guarantee the required task completion safeguard.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,9 +185,9 @@ Host mode separates four roots:
 - `FM_ROOT` is the tracked FirstMate code, skill, documentation, and script root.
 - `FM_HOME` is the private FirstMate operational home that owns `data/`, `state/`, `config/`, and `projects/`.
 - `FM_HOST_ROOT` is the host repository whose instructions, native lifecycle, and cwd remain authoritative.
-- `FM_TARGET_WORKTREE` is the per-task isolated target repository where code changes, Git operations, tests, builds, GitHub operations, and no-mistakes run.
+- `FM_TARGET_WORKTREE` is the per-task isolated target repository where code changes, Git operations, tests, builds, forge operations, and no-mistakes run.
 
-The physical target worktree must differ from both the target project's primary checkout and `FM_HOST_ROOT`.
+The physical target worktree must differ from the target project's primary checkout and must not overlap `FM_HOST_ROOT`.
 Ordinary ship and scout endpoints still acquire and validate their isolated target worktree first, retain it as `worktree=` metadata, then return the endpoint shell to the physical host root before launching the harness.
 A failed host transition stops and verifies the new endpoint before returning the acquired worktree, removes every task-owned pre-record artifact on successful rollback, and retains recovery metadata and the isolated path when endpoint termination or resource cleanup cannot be confirmed.
 An overlap refusal stops the endpoint but never returns or removes the overlapping path automatically.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,10 +194,11 @@ An overlap refusal stops the endpoint but never returns or removes the overlappi
 An unconfirmed final launch submission retains the endpoint, worktree, task safeguards, and metadata because the worker may already be running.
 The child receives exact `FM_HOST_ROOT` and `FM_TARGET_WORKTREE` values, while task actions bind to the recorded physical `host_root=` before reading or changing task data and review, merge, evidence, and teardown continue to use the recorded `worktree=` path.
 Teardown stops and verifies the recorded worker endpoint before changing or returning its isolated copy.
-Orca ship teardown repeats worktree safety checks after the terminal is confirmed stopped and before forced worktree removal.
+Every non-forced host-root ship teardown repeats worktree safety checks after the endpoint is confirmed stopped and before branch deletion or worktree return.
 Host-root briefs carry `<!-- firstmate-execution-mode: host-root -->`, require the worker to read host instructions first and applicable target instructions before edits, keep the host read-only except for host-owned lifecycle effects, and require explicit target paths or scoped subshells.
 The same target scoping applies to the complete no-mistakes lifecycle, including doctor, initialization, run, gate responses, and follow-up help commands; no validation command may default to the host cwd.
 Spawn rejects a cwd-relative legacy brief in host mode rather than weakening that contract silently.
+Host-root ship tasks support `no-mistakes` and `direct-PR` delivery; brief generation and spawn reject `local-only` because its guarded landing path changes the target project's primary checkout.
 
 Harness integration is additive.
 Claude receives an additional task settings file through `--settings`, Codex retains its launch-command notification, OpenCode receives an explicit task plugin in addition to host project plugins, Pi receives its explicit task extension, and Grok and Kimi use per-process task tokens consumed by their guarded global hooks.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,7 +198,7 @@ Every non-forced host-root ship teardown repeats worktree safety checks after th
 Host-root briefs carry `<!-- firstmate-execution-mode: host-root -->`, require the worker to read host instructions first and applicable target instructions before edits, keep the host read-only except for host-owned lifecycle effects, and require explicit target paths or scoped subshells.
 The same target scoping applies to the complete no-mistakes lifecycle, including doctor, initialization, run, gate responses, and follow-up help commands; no validation command may default to the host cwd.
 Spawn rejects a cwd-relative legacy brief in host mode rather than weakening that contract silently.
-Host-root ship tasks support `no-mistakes` and `direct-PR` delivery; brief generation and spawn reject `local-only` because its guarded landing path changes the target project's primary checkout.
+Host-root ship tasks support `no-mistakes` and `direct-PR` delivery; brief generation, spawn, and scout promotion reject `local-only` because its guarded landing path changes the target project's primary checkout.
 
 Harness integration is additive.
 Claude receives an additional task settings file through `--settings`, Codex retains its launch-command notification, OpenCode receives an explicit task plugin in addition to host project plugins, Pi receives its explicit task extension, and Grok and Kimi use per-process task tokens consumed by their guarded global hooks.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,44 @@ The full zellij home label also includes a short hash of the resolved `FM_ROOT` 
 For the cmux backend, `FM_CONFIG_OVERRIDE` overrides where `config/cmux-socket-password` is read from, while `FM_HOME` determines the default config path and readable home prefix embedded in workspace titles.
 The full cmux home label also includes a short hash of the resolved `FM_ROOT` path, and there is no per-home container split.
 
+## Host-root mode (FM_HOST_ROOT)
+
+`FM_HOST_ROOT` is an optional physical instruction root and harness startup cwd for a primary FirstMate home.
+It is a low-level runtime contract for an explicit host integration, not an installer: setting the variable alone does not load FirstMate's supervisor policy or adapters into another repository.
+Unset or empty preserves the normal behavior in which FirstMate runs from its tracked code root.
+When set, the caller must already have loaded the FirstMate policy and required harness adapters additively, the value must resolve to an existing directory containing the cross-harness `AGENTS.md` instruction surface, it must differ from `FM_ROOT`, and the supervisor must be launched with its physical cwd at that directory.
+`bin/fm-session-start.sh` validates that contract before lock acquisition or any bootstrap mutation.
+
+Host mode separates four roots:
+
+- `FM_ROOT` is the tracked FirstMate code, skill, documentation, and script root.
+- `FM_HOME` is the private FirstMate operational home that owns `data/`, `state/`, `config/`, and `projects/`.
+- `FM_HOST_ROOT` is the host repository whose instructions, native lifecycle, and cwd remain authoritative.
+- `FM_TARGET_WORKTREE` is the per-task isolated target repository where code changes, Git operations, tests, builds, GitHub operations, and no-mistakes run.
+
+The physical target worktree must differ from both the target project's primary checkout and `FM_HOST_ROOT`.
+Ordinary ship and scout endpoints still acquire and validate their isolated target worktree first, retain it as `worktree=` metadata, then return the endpoint shell to the physical host root before launching the harness.
+A failed host transition stops and verifies the new endpoint before returning the acquired worktree, removes every task-owned pre-record artifact on successful rollback, and retains recovery metadata and the isolated path when endpoint termination or resource cleanup cannot be confirmed.
+An overlap refusal stops the endpoint but never returns or removes the overlapping path automatically.
+An unconfirmed final launch submission retains the endpoint, worktree, task safeguards, and metadata because the worker may already be running.
+The child receives exact `FM_HOST_ROOT` and `FM_TARGET_WORKTREE` values, while task actions bind to the recorded physical `host_root=` before reading or changing task data and review, merge, evidence, and teardown continue to use the recorded `worktree=` path.
+Teardown stops and verifies the recorded worker endpoint before changing or returning its isolated copy.
+Orca ship teardown repeats worktree safety checks after the terminal is confirmed stopped and before forced worktree removal.
+Host-root briefs carry `<!-- firstmate-execution-mode: host-root -->`, require the worker to read host instructions first and applicable target instructions before edits, keep the host read-only except for host-owned lifecycle effects, and require explicit target paths or scoped subshells.
+The same target scoping applies to the complete no-mistakes lifecycle, including doctor, initialization, run, gate responses, and follow-up help commands; no validation command may default to the host cwd.
+Spawn rejects a cwd-relative legacy brief in host mode rather than weakening that contract silently.
+
+Harness integration is additive.
+Claude receives an additional task settings file through `--settings`, Codex retains its launch-command notification, OpenCode receives an explicit task plugin in addition to host project plugins, Pi receives its explicit task extension, and Grok and Kimi use per-process task tokens consumed by their guarded global hooks.
+None of these paths writes or replaces host hook configuration, and each task signal is installed once.
+The host repository's own lifecycle hooks continue to load from the host cwd.
+Host-root ordinary tasks reject raw launch commands because an unverified command cannot guarantee the required task completion safeguard.
+
+Secondmates are intentionally outside host-root mode.
+Creating a secondmate from a host-mode primary still requires the physical host cwd before brief or spawn mutation.
+A secondmate still launches from its isolated FirstMate home, receives neither `host_root=` metadata nor host-root brief semantics, and its launch explicitly clears inherited `FM_HOST_ROOT` and `FM_TARGET_WORKTREE`.
+A secondmate's own ordinary crews can opt in only through that home's own independently configured primary environment; the main home's roots never leak across the boundary.
+
 ## Harness support
 
 claude, codex, opencode, pi, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the narrower set supported for the primary session.
@@ -196,7 +234,8 @@ The inherited-local-material contract is owned by [`secondmate-provisioning`](..
 Those inherited values are defaults and rules only; `fm-spawn` still permits a consciously chosen explicit runtime outside the config.
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
-For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install`, drops a per-task `.fm-kimi-turnend` pointer in the worktree, and records the matching private registry token for teardown.
+For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install` and records a private registry token for teardown.
+Default launches also drop a per-task `.fm-kimi-turnend` pointer in the worktree, while host-root launches pass the same token only through `FM_KIMI_TURNEND_TOKEN` and never write a pointer into the host repository.
 Kimi continues to use the captain's normal Kimi home, including the existing config, skills, and memory; Firstmate does not create an isolated Kimi home.
 The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, or surprising or when either tool requirement is unavailable.
 Its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
@@ -363,6 +402,8 @@ Runtime tuning via environment variables (defaults shown):
 
 ```sh
 FM_HOME=                 # optional operational home for most scripts, unset means this repo root; fm-send requires it explicitly
+FM_HOST_ROOT=            # optional physical host instruction root and primary/ordinary-worker cwd; unset preserves normal behavior
+FM_TARGET_WORKTREE=      # spawn-owned exact isolated target path for a host-root worker; secondmates clear it
 FM_ROOT_OVERRIDE=        # override firstmate repo root, tangle-guard target, and zellij/cmux home-title hash; also legacy whole-root override when FM_HOME is unset
 FM_STATE_OVERRIDE=       # alternate state dir, mainly for tests
 FM_DATA_OVERRIDE=        # alternate data dir, mainly for tests

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -284,3 +284,4 @@ tests/fm-afk-pi-herdr-return-e2e.test.sh
 
 Real Herdr tests use the named lab helper and default-session tripwire.
 [`verification/runtime-backends.md`](verification/runtime-backends.md#herdr) records the active version, CLI, projection, event, and lifecycle evidence without task-specific chronology.
+`tests/fm-host-root-mode.test.sh` covers the backend-independent host-root contract with fake adapters.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -52,6 +52,7 @@ Exact command flags and response parsing are owned by `bin/backends/orca.sh` and
 `fm-send.sh` types and verifies composer clearance, follows `oldestCursor` when Orca returns a limited page, and retries Enter without retyping when a slash popup first fills an argument placeholder.
 A bare shell row is `unknown`, not an empty agent composer.
 The watcher has no native Orca busy signal and uses the shared terminal-tail fallback.
+In host-root mode, spawn verifies the terminal's physical cwd after moving it to `FM_HOST_ROOT`, then launches with the Orca worktree retained as `FM_TARGET_WORKTREE`.
 
 Cleanup keeps all shared Firstmate safety checks.
 A scout still requires its report and completed decision inventory.

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -2,7 +2,9 @@
 
 AGENTS.md section 3 is the authoritative behavioral contract for session start.
 The tracked native adapters inject one instruction and never run the digest, acquire the lock, perform bootstrap work, drain notifications, or arm supervision themselves.
-The payload starts with U+2063 and the stable `FIRSTMATE_OP: ` label, carries the current `session-start` protocol kind, and retains exactly ``Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.`` as its body.
+The payload starts with U+2063 and the stable `FIRSTMATE_OP: ` label and carries the current `session-start` protocol kind.
+Its body is exactly ``Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.`` in default mode.
+In host-root mode the body uses the absolute `FM_ROOT/bin/fm-session-start.sh` path because the authoritative cwd deliberately has no FirstMate-relative `bin/`.
 The Ahoy skill owns the rule that this marked operational input is never a captain-authored session boundary, including its narrow legacy compatibility cases.
 
 ## Shared wrapper and safety
@@ -12,6 +14,7 @@ It sources `bin/fm-gate-refuse-lib.sh` and stays silent for a no-mistakes gate a
 It shares `bin/fm-primary-scope-lib.sh` with `bin/fm-turnend-guard.sh`, so the hooks use one primary-detection owner.
 The Shared Predicate section of [`turnend-guard.md`](turnend-guard.md#shared-predicate) owns marker validation, plain-checkout detection, and required Firstmate-shaped paths.
 
+When `FM_HOST_ROOT` is set, the wrapper also verifies the hook process is running from that physical host root and stays silent on mismatch.
 Before printing, the wrapper reads `state/.lock` and walks at most eight parents from its own pid, matching `bin/fm-lock.sh` and Pi's `lockOwnership()` ancestry depth.
 If the lock names a live pid in that ancestry, session start already ran in this harness session and the wrapper stays silent.
 Every path exits 0, including malformed state and adapter errors, because a Claude SessionStart exit 2 blocks session initialization.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -88,6 +88,7 @@ tests/fm-composer-ghost.test.sh
 tests/fm-kimi-harness.test.sh
 tests/fm-tmux-submit-busy.test.sh
 tests/fm-bootstrap.test.sh
+tests/fm-host-root-mode.test.sh
 ```
 
 [`verification/runtime-backends.md`](verification/runtime-backends.md#tmux) records the active foreground-process and submit evidence.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -75,7 +75,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - Kimi Code CLI 0.29.1 exposes only global `[[hooks]]` configuration in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
 - Kimi has no project-level hook configuration and remains outside the primary guard integrations above.
 - Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to edit only one marker-delimited Firstmate region in that global config and install a silent always-zero hook.
-- The hook remains inert unless the payload `cwd` contains a per-task token pointer that resolves through Firstmate's private registry to one `state/<id>.turn-ended` marker.
+- The hook remains inert unless a launch-scoped `FM_KIMI_TURNEND_TOKEN` or the payload `cwd`'s per-task token pointer resolves through Firstmate's private registry to one `state/<id>.turn-ended` marker.
 - Installation refuses before writing unless `python3` with `tomllib` and `jq` are available.
 - If `jq` is removed after installation, the hook remains silent and exits 0, turn-end wakes stop, and Kimi crews fall back to idle detection.
 - Unreadable hook input remains fail-open.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -43,6 +43,26 @@ tests/fm-tmux-submit-busy.test.sh
 Expected structural matrix: real text on any content row is pending; all-empty complete boxes are empty; unreadable, incomplete, or unsafe boxes are unknown; and non-bordered panes retain cursor-row compatibility.
 Expected submit matrix: proven pending plus busy is accepted as queued; proven pending plus idle remains pending; ambiguous pending is never converted by the busy exception; and only a proven empty composer succeeds directly.
 
+### Host-root task routing
+
+The rebased host-root path was live-verified on 2026-07-26 with tmux 3.7b, Treehouse 2.0.0, and Codex CLI 0.145.0 on Linux.
+The command shape was:
+
+```sh
+cd "$host"
+TMUX_TMPDIR="$socket_dir" \
+FM_ROOT_OVERRIDE="$firstmate_root" \
+FM_HOME="$firstmate_home" \
+FM_HOST_ROOT="$host" \
+FM_BACKEND=tmux \
+  "$firstmate_root/bin/fm-spawn.sh" "$task_id" "$target_primary" \
+    --harness codex --scout
+```
+
+The worker observed its physical cwd equal to `FM_HOST_ROOT`, its target Git root equal to the physical `FM_TARGET_WORKTREE`, and the target as a detached linked worktree distinct from the clean primary checkout.
+It loaded the host and target `AGENTS.md` files, completed the decision inventory, wrote the scout report outside both repositories, and cleaned up through `bin/fm-teardown.sh`.
+The host's native startup lifecycle remained active, so host-owned lifecycle effects were allowed rather than treated as task edits.
+
 ## Herdr
 
 The compatibility floor is protocol 14.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -59,6 +59,33 @@ The Ahoy first-message boundary was reverified on 2026-07-22 with Pi 0.81.1 and 
 Marked current operational input and the two exact legacy compatibility shapes selected Bearings, while genuine near-miss captain messages remained real boundaries.
 The detailed reconciliation and task chronology stay in the private audit report and PR evidence.
 
+## Host-root task integration
+
+The additive task lifecycle adapters were checked on Linux on 2026-07-19 with Codex 0.144.5, OpenCode 1.17.14, Pi 0.80.10, and Claude Code 2.1.214.
+Codex and OpenCode each loaded the host `AGENTS.md`, emitted one host session-start event, one host completion event, and one task completion event when launched with the state-owned adapter configuration rendered by `bin/fm-spawn.sh`.
+Pi loaded one host extension and one explicit task extension once each for a single-turn probe, and a trusted FirstMate-root run confirmed project extension discovery coexists with an explicit task extension.
+The exact Claude probe was:
+
+```sh
+claude -p --settings "$task_settings" --dangerously-skip-permissions \
+  'Complete one turn and exit.'
+```
+
+The host project `SessionStart` hook fired once, proving `--settings` remains additive to project settings, but organization policy blocked model access before Stop and prevented live task-hook confirmation.
+Grok was unavailable, so its launch-scoped host-root token remains generated and focused-test verified rather than live verified.
+Kimi 0.29.1 launch and global-hook mechanics were live-verified on 2026-07-25, while its launch-scoped host-root token remains focused-test verified rather than live lifecycle verified.
+The reusable deterministic entry points are:
+
+```sh
+tests/fm-host-root-mode.test.sh
+tests/fm-grok-harness.test.sh
+tests/fm-kimi-harness.test.sh
+```
+
+A rebased Codex 0.145.0 scout repeated the integrated path on 2026-07-26 through tmux 3.7b.
+It loaded the host and target instruction surfaces, preserved the separate target worktree, completed the decision inventory, emitted its task completion, retained the report, and cleaned up while the host's native startup lifecycle remained active.
+[`runtime-backends.md`](runtime-backends.md#host-root-task-routing) owns the exact spawn command and path-routing evidence.
+
 ## Turn-end guard
 
 The direct and passive mechanisms were validated across all five harnesses on 2026-07-08 through 2026-07-12, with Claude's replacement Stop-owned path revalidated on 2026-07-24.

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -989,6 +989,67 @@ test_list_live_filters_by_title_prefix() {
   pass "fm_backend_cmux_list_live: lists only this home's scoped task workspaces using plain fm-<id> labels"
 }
 
+# --- fm-teardown.sh: secondmate child-home cleanup ---------------------------
+
+test_forced_secondmate_teardown_uses_child_cmux_config() {
+  local dir state data config home project fb out status child_title
+  dir="$TMP_ROOT/teardown-cmux-secondmate-child"
+  state="$dir/state"; data="$dir/data"; config="$dir/config"; home="$dir/secondmate-home"; project="$dir/project"
+  mkdir -p "$state" "$data" "$config" "$home/state" "$home/data" "$home/config" "$home/projects" "$project" "$dir/responses"
+  printf 'smc\n' > "$home/.fm-secondmate-home"
+  printf 'parent-secret\n' > "$config/cmux-socket-password"
+  printf 'child-secret\n' > "$home/config/cmux-socket-password"
+  fm_write_meta "$state/smc.meta" \
+    "window=firstmate:99" \
+    "worktree=$home" \
+    "project=$home" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=$home"
+  fm_write_meta "$home/state/childc.meta" \
+    "window=ws-child:sf-child" \
+    "backend=cmux" \
+    "cmux_workspace_id=ws-child" \
+    "cmux_surface_id=sf-child" \
+    "worktree=$dir/missing-child-worktree" \
+    "project=$project" \
+    "kind=scout"
+  child_title=$(cmux_expected_scoped_title fm-childc "$home" "$home")
+  cmux_workspace_list_response "$dir" 1 ws-child "$child_title" ws-other default
+  cmux_panes_response "$dir" 2 sf-child
+  cmux_workspace_list_response "$dir" 3 ws-child "$child_title" ws-other default
+  cmux_panes_response "$dir" 4 sf-child
+  cmux_windows_response "$dir" 5 win-child 2
+  cmux_workspace_list_response "$dir" 6 ws-child "$child_title" ws-other default
+  : > "$dir/responses/7.out"
+  printf '{"workspaces":[]}' > "$dir/responses/8.out"
+  fb=$(make_cmux_fakebin "$dir")
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+stopped="${FM_CMUX_LOG}.tmux-stopped"
+case "${1:-}" in
+  kill-window) : > "$stopped" ;;
+  display-message) [ ! -e "$stopped" ] && printf '%%1\n' ;;
+  list-panes) exit 0 ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$fb/tmux"
+  out=$( PATH="$fb:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    "$ROOT/bin/fm-teardown.sh" smc --force 2>&1 )
+  status=$?
+  expect_code 0 "$status" "fm-teardown should force-retire a secondmate with a cmux child: $out"
+  assert_contains "$(cat "$dir/log")" $'close-workspace\x1f--workspace\x1fws-child' \
+    "forced secondmate teardown did not close the child cmux workspace"
+  assert_contains "$(cat "$dir/log")" 'CMUX_SOCKET_PASSWORD=child-secret' \
+    "forced secondmate teardown did not use the child home's cmux password"
+  assert_not_contains "$(cat "$dir/log")" 'CMUX_SOCKET_PASSWORD=parent-secret' \
+    "forced secondmate teardown leaked the parent cmux password into child cleanup"
+  pass "fm-teardown.sh: force cleanup uses the child home for cmux workers"
+}
+
 # --- fm-spawn.sh: --secondmate refuses backend=cmux --------------------------
 
 test_secondmate_spawn_refuses_cmux_backend() {
@@ -1060,4 +1121,5 @@ test_kill_adds_sibling_when_last_in_window
 test_kill_is_best_effort_when_close_workspace_fails
 test_kill_recovers_stale_target_by_label
 test_list_live_filters_by_title_prefix
+test_forced_secondmate_teardown_uses_child_cmux_config
 test_secondmate_spawn_refuses_cmux_backend

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1350,6 +1350,12 @@ test_projected_abort_cleanup_holds_presentation_lock() {
       : > "$STARTED"
       while [ ! -e "$PROCEED" ]; do sleep 0.01; done
     }
+    remove_spawn_artifacts() { :; }
+    spawn_herdr_presentation_order_lock_release() {
+      [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" = 1 ] || return 0
+      HERDR_PRESENTATION_ORDER_LOCK_HELD=0
+      fm_lock_release "$HERDR_PRESENTATION_ORDER_LOCK"
+    }
     fm_lock_try_acquire "$LOCK" || exit 1
     HERDR_PRESENTATION_ORDER_LOCK_HELD=1
     HERDR_PRESENTATION_ORDER_LOCK=$LOCK

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -23,6 +23,9 @@ next=$(( $(cat "$COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
   for a in "$@"; do printf '\x1f%s' "$a"; done
   printf '\n'
 } >> "$LOG"
+if [ "${1:-}" = terminal ] && [ "${2:-}" = close ] && [ -n "${FM_ORCA_CLOSE_MUTATION:-}" ]; then
+  printf 'late worker edit\n' > "$FM_ORCA_CLOSE_MUTATION"
+fi
 if [ "${1:-}" = status ] && [ "${FM_ORCA_STATUS_RESPONSE:-ready}" != sequence ]; then
   printf '{"ok":true,"result":{"runtime":{"reachable":true,"state":"ready"}}}\n'
   exit 0
@@ -65,12 +68,17 @@ add_tmux_fake() {
 #!/usr/bin/env bash
 set -u
 LOG="${FM_ORCA_LOG:?}"
+stopped="${0}.stopped"
 {
   printf 'tmux'
   for a in "$@"; do printf '\x1f%s' "$a"; done
   printf '\n'
 } >> "$LOG"
-exit 0
+case "${1:-}" in
+  kill-window) : > "$stopped" ;;
+  display-message) [ ! -e "$stopped" ] ;;
+  *) exit 0 ;;
+esac
 SH
   chmod +x "$fb/tmux"
 }
@@ -130,7 +138,54 @@ test_runtime_check_refuses_unready_orca_status() {
   status=$?
   [ "$status" -ne 0 ] || fail "runtime_check should fail when Orca runtime is not ready"
   assert_contains "$out" "requires a ready Orca runtime" "runtime_check should explain the readiness requirement"
-  pass "fm_backend_orca_runtime_check: fails closed when runtime is not ready"
+  pass "fm_backend_orca_runtime_check: fails closed when Orca runtime is not ready"
+}
+
+test_current_path_probe_sends_once_and_bounds_reads() {
+  local out counts
+  out=$(FM_ORCA_CWD_PROBE_ATTEMPTS=3 FM_ORCA_CWD_PROBE_DELAY=0 bash -c '
+    . "$1/bin/backends/orca.sh"
+    count_file=$2
+    printf "0\n" > "$count_file"
+    sends=0
+    fm_backend_orca_send_text_line() {
+      sends=$((sends + 1))
+      markers=$(printf "%s\n" "$2" | grep -o "__FM_ORCA_CWD_[A-Z]*_[A-Za-z0-9_]*__")
+      begin=$(printf "%s\n" "$markers" | head -1)
+      end=$(printf "%s\n" "$markers" | tail -1)
+    }
+    fm_backend_orca_read_text_paged() {
+      reads=$(( $(cat "$count_file") + 1 ))
+      printf "%s\n" "$reads" > "$count_file"
+      [ "$reads" -lt 2 ] || printf "%s\n" "$begin" "/tmp/orca root with spaces" "$end"
+    }
+    probe_out=$(mktemp)
+    fm_backend_orca_current_path terminal-1 > "$probe_out"
+    printf "%s\n%s:%s\n" "$(cat "$probe_out")" "$sends" "$(cat "$count_file")"
+    rm -f "$probe_out"
+  ' _ "$ROOT" "$TMP_ROOT/current-path-count")
+  counts=$(printf '%s\n' "$out" | tail -1)
+  [ "$(printf '%s\n' "$out" | head -1)" = '/tmp/orca root with spaces' ] \
+    || fail "current_path did not return the single physical path line"
+  [ "$counts" = '1:2' ] || fail "current_path should send once and stop after the matching read, got $counts"
+
+  out=$(FM_ORCA_CWD_PROBE_ATTEMPTS=3 FM_ORCA_CWD_PROBE_DELAY=0 bash -c '
+    . "$1/bin/backends/orca.sh"
+    count_file=$2
+    printf "0\n" > "$count_file"
+    sends=0
+    fm_backend_orca_send_text_line() { sends=$((sends + 1)); }
+    fm_backend_orca_read_text_paged() {
+      reads=$(( $(cat "$count_file") + 1 ))
+      printf "%s\n" "$reads" > "$count_file"
+    }
+    probe_out=$(mktemp)
+    fm_backend_orca_current_path terminal-2 > "$probe_out"
+    printf "%s:%s:%s\n" "$(cat "$probe_out")" "$sends" "$(cat "$count_file")"
+    rm -f "$probe_out"
+  ' _ "$ROOT" "$TMP_ROOT/current-path-empty-count")
+  [ "$out" = ':1:3' ] || fail "current_path probe was not bounded to one send and three reads, got $out"
+  pass "fm_backend_orca_current_path: one command, unique markers, bounded reads"
 }
 
 test_send_text_submit_verifies_empty_composer_after_enter() {
@@ -415,7 +470,7 @@ test_worktree_and_terminal_helpers_parse_json() {
   pass "Orca lifecycle helpers: register repo, create worktree, create terminal, parse stable ids"
 }
 
-test_worktree_create_removes_worktree_when_path_missing() {
+test_worktree_create_defers_pathless_cleanup_to_verified_rollback() {
   local out status
   orca_case lifecycle-missing-path
   printf '1\n' > "$RESP/1.exit"
@@ -427,11 +482,48 @@ test_worktree_create_removes_worktree_when_path_missing() {
   [ "$status" -ne 0 ] || fail "worktree helper should fail when Orca omits the worktree path"
   assert_contains "$out" "orca worktree create did not return a path for fm-task" \
     "worktree helper did not explain the missing path"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-no-path'$'\x1f''--json' \
-    "worktree helper did not close the implicit terminal when path parsing failed"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-no-path'$'\x1f''--force'$'\x1f''--json' \
-    "worktree helper did not remove the pathless Orca worktree"
-  pass "fm_backend_orca_worktree_create: removes created worktree when path is missing"
+  assert_contains "$out" $'wt-no-path\t\tterm-no-path' \
+    "worktree helper did not return recoverable worktree/terminal ids"
+  assert_no_grep $'orca\x1fterminal\x1fclose' "$LOG" \
+    "pathless helper bypassed verified rollback by closing the terminal itself"
+  assert_no_grep $'orca\x1fworktree\x1frm' "$LOG" \
+    "pathless helper removed a worktree before terminal absence was confirmed"
+  pass "fm_backend_orca_worktree_create: defers pathless cleanup to verified rollback"
+}
+
+test_spawn_preserves_pathless_orca_worktree_when_terminal_stop_is_unknown() {
+  local proj data state config id out status log_text
+  id="orcapathless-termz7"
+  proj="$TMP_ROOT/pathless-terminal-project"
+  data="$TMP_ROOT/pathless-terminal-data"
+  state="$TMP_ROOT/pathless-terminal-state"
+  config="$TMP_ROOT/pathless-terminal-config"
+  fm_git_init_commit "$proj"
+  mkdir -p "$data/$id" "$state" "$config"
+  printf 'brief\n' > "$data/$id/brief.md"
+  touch "$state/.last-watcher-beat"
+  orca_case pathless-terminal-unknown
+  printf '1\n' > "$RESP/1.exit"
+  printf '{"ok":true,"result":{"repo":{"id":"repo-pathless-terminal"}}}\n' > "$RESP/2.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-pathless-terminal"},"terminal":{"handle":"term-pathless-terminal"}}}\n' > "$RESP/3.out"
+  printf '{"ok":true,"result":{}}\n' > "$RESP/4.out"
+  printf 'not-json\n' > "$RESP/5.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 \
+    FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --backend orca 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "Orca spawn should fail when path parsing fails"
+  log_text=$(cat "$LOG")
+  assert_contains "$log_text" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-pathless-terminal'$'\x1f''--json' \
+    "verified rollback did not attempt to stop the pathless terminal"
+  assert_no_grep $'orca\x1fworktree\x1frm' "$LOG" \
+    "unknown terminal state allowed destructive pathless worktree removal"
+  assert_present "$state/$id.meta" "unknown terminal state should preserve recovery metadata"
+  assert_grep 'orca_worktree_id=wt-pathless-terminal' "$state/$id.meta" "metadata missing pathless worktree id"
+  assert_grep 'terminal=term-pathless-terminal' "$state/$id.meta" "metadata missing pathless terminal id"
+  pass "fm-spawn.sh --backend orca: unknown terminal stop preserves pathless worktree and metadata"
 }
 
 test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails() {
@@ -579,6 +671,9 @@ test_spawn_refuses_orca_nonisolated_worktree() {
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-bad"}}}\n' > "$RESP/2.out"
   printf '{"ok":true,"result":{"worktree":{"id":"wt-bad","path":"%s"},"terminal":{"handle":"term-bad"}}}\n' "$proj" > "$RESP/3.out"
+  printf '{"ok":true}\n' > "$RESP/4.out"
+  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/5.out"
+  printf '{"ok":true}\n' > "$RESP/6.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
@@ -680,6 +775,9 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
   printf '{"ok":true,"result":{"repo":{"id":"repo-meta-fail"}}}\n' > "$RESP/2.out"
   printf '{"ok":true,"result":{"worktree":{"id":"wt-meta-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
   printf '{"ok":true,"result":{"terminal":{"handle":"term-meta-fail"}}}\n' > "$RESP/4.out"
+  printf '{"ok":true}\n' > "$RESP/5.out"
+  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/6.out"
+  printf '{"ok":true}\n' > "$RESP/7.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
@@ -791,6 +889,9 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
     "decisions_reviewed=1" "decision_keys="
   orca_case teardown
   printf '{"ok":true,"result":{"worktree":{"id":"wt-teardown","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  printf '{"ok":true}\n' > "$RESP/2.out"
+  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/3.out"
+  printf '{"ok":true}\n' > "$RESP/4.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -863,6 +964,9 @@ test_teardown_removes_orca_worktree_when_path_missing() {
     "backend=orca" "orca_worktree_id=wt-missing-path" \
     "decisions_reviewed=1" "decision_keys="
   orca_case missing-path
+  printf '{"ok":true}\n' > "$RESP/1.out"
+  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/2.out"
+  printf '{"ok":true}\n' > "$RESP/3.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -891,12 +995,14 @@ test_teardown_preserves_metadata_when_orca_remove_error_json() {
   printf 'report\n' > "$data/$id/report.md"
   touch "$state/.last-watcher-beat"
   fm_write_meta "$state/$id.meta" \
-    "window=fm-$id" "worktree=$wt" "project=$proj" \
+    "window=fm-$id" "terminal=term-remove-error" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
     "backend=orca" "orca_worktree_id=wt-remove-error" \
     "decisions_reviewed=1" "decision_keys="
   orca_case remove-error-teardown
-  printf '{"ok":false,"error":{"code":"worktree_not_removed","message":"worktree not removed"}}\n' > "$RESP/1.out"
+  printf '{"ok":true}\n' > "$RESP/1.out"
+  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/2.out"
+  printf '{"ok":false,"error":{"code":"worktree_not_removed","message":"worktree not removed"}}\n' > "$RESP/3.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -987,6 +1093,9 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
     "backend=orca" "orca_worktree_id=wt-ship-match"
   orca_case ship-match
   printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-match","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  printf '{"ok":true}\n' > "$RESP/2.out"
+  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/3.out"
+  printf '{"ok":true}\n' > "$RESP/4.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -1003,6 +1112,42 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
     "teardown did not remove the matched Orca worktree"
   assert_absent "$state/$id.meta" "successful matched teardown should remove task metadata"
   pass "fm-teardown.sh backend=orca: ship teardown requires a matching Orca id path"
+}
+
+test_ship_teardown_rechecks_safety_after_terminal_stop() {
+  local proj wt data state config id out rc neutral
+  id="orcashipracez9"
+  proj="$TMP_ROOT/ship-race-project"
+  wt="$TMP_ROOT/ship-race-wt"
+  data="$TMP_ROOT/ship-race-data"
+  state="$TMP_ROOT/ship-race-state"
+  config="$TMP_ROOT/ship-race-config"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  mkdir -p "$data/$id" "$state" "$config"
+  touch "$state/.last-watcher-beat"
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "terminal=term-ship-race" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
+    "backend=orca" "orca_worktree_id=wt-ship-race"
+  orca_case ship-race
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-race","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  printf '{"ok":true}\n' > "$RESP/2.out"
+  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/3.out"
+  neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ORCA_CLOSE_MUTATION="$wt/late-edit.txt" FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 \
+    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "Orca ship teardown discarded an edit written during terminal stop (log: $(tr '\n' ';' < "$LOG"); status: $(git -C "$wt" status --porcelain 2>/dev/null | tr '\n' ';'))"
+  assert_contains "$out" "uncommitted changes" "post-stop safety refusal did not explain the late edit"
+  assert_present "$wt/late-edit.txt" "post-stop safety refusal lost the late worker edit"
+  assert_present "$state/$id.meta" "post-stop safety refusal removed task metadata"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
+    "post-stop safety refusal removed the Orca worktree"
+  pass "fm-teardown.sh backend=orca: rechecks worktree safety after stopping the terminal"
 }
 
 test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
@@ -1169,6 +1314,9 @@ test_secondmate_force_teardown_removes_orca_child_via_orca() {
     "backend=orca" "orca_worktree_id=wt-child-cleanup"
   orca_case secondmate-child-cleanup
   printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/1.out"
+  printf '{"ok":true}\n' > "$RESP/2.out"
+  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/3.out"
+  printf '{"ok":true}\n' > "$RESP/4.out"
   add_tmux_fake "$FB"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -1282,6 +1430,7 @@ test_capture_falls_back_to_text_fields
 test_capture_fails_on_orca_error_json
 test_runtime_check_accepts_ready_orca_status
 test_runtime_check_refuses_unready_orca_status
+test_current_path_probe_sends_once_and_bounds_reads
 test_send_text_submit_verifies_empty_composer_after_enter
 test_send_text_submit_keeps_current_tail_when_limited
 test_send_text_submit_retries_when_composer_stays_pending
@@ -1301,7 +1450,8 @@ test_worktree_path_resolves_id
 test_dispatcher_sources_orca_and_routes_primitives
 test_json_get_ignores_undocumented_terminal_id_shapes
 test_worktree_and_terminal_helpers_parse_json
-test_worktree_create_removes_worktree_when_path_missing
+test_worktree_create_defers_pathless_cleanup_to_verified_rollback
+test_spawn_preserves_pathless_orca_worktree_when_terminal_stop_is_unknown
 test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails
 test_spawn_writes_orca_metadata_and_launches_harness
 test_spawn_refuses_orca_secondmate_before_home_mutation
@@ -1320,6 +1470,7 @@ test_teardown_preserves_metadata_when_orca_remove_error_json
 test_scout_teardown_refuses_orca_missing_report_when_path_missing
 test_ship_teardown_refuses_orca_missing_worktree_path
 test_ship_teardown_removes_orca_worktree_when_id_path_matches
+test_ship_teardown_rechecks_safety_after_terminal_stop
 test_ship_teardown_refuses_orca_unresolvable_worktree_id
 test_ship_teardown_refuses_orca_id_path_mismatch
 test_teardown_refuses_orca_missing_worktree_id

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -526,7 +526,7 @@ test_spawn_preserves_pathless_orca_worktree_when_terminal_stop_is_unknown() {
   pass "fm-spawn.sh --backend orca: unknown terminal stop preserves pathless worktree and metadata"
 }
 
-test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails() {
+test_spawn_preserves_pathless_orca_worktree_without_terminal_proof() {
   local proj data state config id out status
   id="orcapathlessz6"
   proj="$TMP_ROOT/pathless-cleanup-project"
@@ -541,8 +541,6 @@ test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails() {
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-pathless-cleanup"}}}\n' > "$RESP/2.out"
   printf '{"ok":true,"result":{"worktree":{"id":"wt-pathless-cleanup"}}}\n' > "$RESP/3.out"
-  printf '{"ok":false,"error":{"code":"worktree_not_removed","message":"worktree not removed"}}\n' > "$RESP/4.out"
-  printf '{"ok":false,"error":{"code":"worktree_not_removed","message":"worktree not removed"}}\n' > "$RESP/5.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
@@ -551,14 +549,14 @@ test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails() {
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when path parsing and cleanup fail"
   assert_contains "$out" "orca worktree create did not return a path" \
     "pathless worktree failure should explain the missing path"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-pathless-cleanup'$'\x1f''--force'$'\x1f''--json' \
-    "pathless cleanup should attempt helper-backed worktree removal"
-  assert_present "$state/$id.meta" "failed pathless cleanup should preserve metadata"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
+    "pathless cleanup removed a worktree without terminal absence proof"
+  assert_present "$state/$id.meta" "pathless cleanup should preserve recovery metadata"
   assert_grep "window=fm-$id" "$state/$id.meta" "preserved pathless metadata missing stable window alias"
   assert_grep "backend=orca" "$state/$id.meta" "preserved pathless metadata missing backend=orca"
   assert_grep "orca_worktree_id=wt-pathless-cleanup" "$state/$id.meta" "preserved pathless metadata missing Orca worktree id"
   assert_no_grep "terminal=" "$state/$id.meta" "preserved pathless metadata should not invent a terminal handle"
-  pass "fm-spawn.sh --backend orca: preserves metadata when pathless cleanup fails"
+  pass "fm-spawn.sh --backend orca: preserves a pathless worktree without terminal absence proof"
 }
 
 test_spawn_writes_orca_metadata_and_launches_harness() {
@@ -692,7 +690,7 @@ test_spawn_refuses_orca_nonisolated_worktree() {
   pass "fm-spawn.sh --backend orca: refuses non-isolated worktrees and closes implicit terminals"
 }
 
-test_spawn_removes_orca_worktree_when_terminal_create_fails() {
+test_spawn_preserves_orca_worktree_when_terminal_create_fails_without_handle() {
   local proj wt data state config id out status
   id="orcatermfailz8"
   proj="$TMP_ROOT/terminal-fail-project"
@@ -715,17 +713,19 @@ test_spawn_removes_orca_worktree_when_terminal_create_fails() {
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --backend orca 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when terminal creation fails"
-  assert_absent "$state/$id.meta" "terminal-create abort should not record metadata after successful cleanup"
+  assert_present "$state/$id.meta" "terminal-create failure should preserve recovery metadata without absence proof"
+  assert_grep "orca_worktree_id=wt-terminal-fail" "$state/$id.meta" "preserved metadata missing Orca worktree id"
+  assert_no_grep "terminal=" "$state/$id.meta" "terminal-create failure should not invent a terminal handle"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail'$'\x1f''--title'$'\x1f'"fm-$id"$'\x1f''--json' \
     "Orca spawn should attempt terminal creation before abort cleanup"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail'$'\x1f''--force'$'\x1f''--json' \
-    "Orca spawn should remove the worktree when terminal creation fails"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
+    "Orca spawn removed a worktree after terminal creation may have succeeded without a handle"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
     "Orca spawn should not close a terminal when no handle was recorded"
-  pass "fm-spawn.sh --backend orca: removes worktree when terminal creation fails"
+  pass "fm-spawn.sh --backend orca: preserves worktree when terminal creation fails without a handle"
 }
 
-test_spawn_preserves_orca_metadata_when_abort_cleanup_fails() {
+test_spawn_preserves_orca_metadata_when_terminal_response_has_no_handle() {
   local proj wt data state config id out status
   id="orcacleanupleakz0"
   proj="$TMP_ROOT/cleanup-fail-project"
@@ -741,22 +741,21 @@ test_spawn_preserves_orca_metadata_when_abort_cleanup_fails() {
   printf '1\n' > "$RESP/1.exit"
   printf '{"ok":true,"result":{"repo":{"id":"repo-cleanup-fail"}}}\n' > "$RESP/2.out"
   printf '{"ok":true,"result":{"worktree":{"id":"wt-cleanup-fail","path":"%s"}}}\n' "$wt" > "$RESP/3.out"
-  printf '1\n' > "$RESP/4.exit"
-  printf '1\n' > "$RESP/5.exit"
+  printf '{"ok":true,"result":{"terminal":{"title":"fm-%s"}}}\n' "$id" > "$RESP/4.out"
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --backend orca 2>&1 )
   status=$?
-  [ "$status" -ne 0 ] || fail "Orca spawn should fail when terminal creation and abort cleanup fail"
-  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-cleanup-fail'$'\x1f''--force'$'\x1f''--json' \
-    "Orca spawn should attempt helper cleanup before preserving metadata"
-  assert_present "$state/$id.meta" "failed Orca abort cleanup should preserve metadata"
+  [ "$status" -ne 0 ] || fail "Orca spawn should fail when terminal creation returns no handle"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
+    "Orca spawn removed a worktree after an unparseable terminal-create response"
+  assert_present "$state/$id.meta" "unparseable terminal-create response should preserve metadata"
   assert_grep "window=fm-$id" "$state/$id.meta" "preserved metadata missing stable window alias"
   assert_grep "backend=orca" "$state/$id.meta" "preserved metadata missing backend=orca"
   assert_grep "orca_worktree_id=wt-cleanup-fail" "$state/$id.meta" "preserved metadata missing Orca worktree id"
   assert_no_grep "terminal=" "$state/$id.meta" "preserved metadata should not invent a terminal handle"
-  pass "fm-spawn.sh --backend orca: preserves metadata when abort cleanup fails"
+  pass "fm-spawn.sh --backend orca: preserves metadata when terminal response has no handle"
 }
 
 test_spawn_releases_orca_resources_when_metadata_write_fails() {
@@ -1440,13 +1439,13 @@ test_json_get_ignores_undocumented_terminal_id_shapes
 test_worktree_and_terminal_helpers_parse_json
 test_worktree_create_defers_pathless_cleanup_to_verified_rollback
 test_spawn_preserves_pathless_orca_worktree_when_terminal_stop_is_unknown
-test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails
+test_spawn_preserves_pathless_orca_worktree_without_terminal_proof
 test_spawn_writes_orca_metadata_and_launches_harness
 test_spawn_refuses_orca_secondmate_before_home_mutation
 test_spawn_refuses_orca_when_runtime_not_ready
 test_spawn_refuses_orca_nonisolated_worktree
-test_spawn_removes_orca_worktree_when_terminal_create_fails
-test_spawn_preserves_orca_metadata_when_abort_cleanup_fails
+test_spawn_preserves_orca_worktree_when_terminal_create_fails_without_handle
+test_spawn_preserves_orca_metadata_when_terminal_response_has_no_handle
 test_spawn_releases_orca_resources_when_metadata_write_fails
 test_peek_send_and_crew_state_route_through_orca_meta
 test_peek_and_crew_state_fail_closed_on_orca_error_json

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -889,9 +889,6 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
     "decisions_reviewed=1" "decision_keys="
   orca_case teardown
   printf '{"ok":true,"result":{"worktree":{"id":"wt-teardown","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
-  printf '{"ok":true}\n' > "$RESP/2.out"
-  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/3.out"
-  printf '{"ok":true}\n' > "$RESP/4.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -964,9 +961,6 @@ test_teardown_removes_orca_worktree_when_path_missing() {
     "backend=orca" "orca_worktree_id=wt-missing-path" \
     "decisions_reviewed=1" "decision_keys="
   orca_case missing-path
-  printf '{"ok":true}\n' > "$RESP/1.out"
-  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/2.out"
-  printf '{"ok":true}\n' > "$RESP/3.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -995,14 +989,12 @@ test_teardown_preserves_metadata_when_orca_remove_error_json() {
   printf 'report\n' > "$data/$id/report.md"
   touch "$state/.last-watcher-beat"
   fm_write_meta "$state/$id.meta" \
-    "window=fm-$id" "terminal=term-remove-error" "worktree=$wt" "project=$proj" \
+    "window=fm-$id" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
     "backend=orca" "orca_worktree_id=wt-remove-error" \
     "decisions_reviewed=1" "decision_keys="
   orca_case remove-error-teardown
-  printf '{"ok":true}\n' > "$RESP/1.out"
-  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/2.out"
-  printf '{"ok":false,"error":{"code":"worktree_not_removed","message":"worktree not removed"}}\n' > "$RESP/3.out"
+  printf '{"ok":false,"error":{"code":"worktree_not_removed","message":"worktree not removed"}}\n' > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -1093,9 +1085,6 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
     "backend=orca" "orca_worktree_id=wt-ship-match"
   orca_case ship-match
   printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-match","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
-  printf '{"ok":true}\n' > "$RESP/2.out"
-  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/3.out"
-  printf '{"ok":true}\n' > "$RESP/4.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -1114,30 +1103,32 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   pass "fm-teardown.sh backend=orca: ship teardown requires a matching Orca id path"
 }
 
-test_ship_teardown_rechecks_safety_after_terminal_stop() {
-  local proj wt data state config id out rc neutral
+test_host_ship_teardown_rechecks_safety_after_terminal_stop() {
+  local host proj wt data state config id out rc neutral
   id="orcashipracez9"
+  host="$TMP_ROOT/ship-race-host"
   proj="$TMP_ROOT/ship-race-project"
   wt="$TMP_ROOT/ship-race-wt"
   data="$TMP_ROOT/ship-race-data"
   state="$TMP_ROOT/ship-race-state"
   config="$TMP_ROOT/ship-race-config"
   fm_git_worktree "$proj" "$wt" "fm/$id"
-  mkdir -p "$data/$id" "$state" "$config"
+  mkdir -p "$host" "$data/$id" "$state" "$config"
+  : > "$host/AGENTS.md"
   touch "$state/.last-watcher-beat"
   fm_write_meta "$state/$id.meta" \
     "window=fm-$id" "terminal=term-ship-race" "worktree=$wt" "project=$proj" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
-    "backend=orca" "orca_worktree_id=wt-ship-race"
+    "backend=orca" "orca_worktree_id=wt-ship-race" "host_root=$host"
   orca_case ship-race
   printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-race","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
   printf '{"ok":true}\n' > "$RESP/2.out"
   printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/3.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
-  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+  out=$( cd "$host" && PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ORCA_CLOSE_MUTATION="$wt/late-edit.txt" FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 \
-    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    FM_ROOT_OVERRIDE="$neutral" FM_HOST_ROOT="$host" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
   rc=$?
   set -e
@@ -1147,7 +1138,7 @@ test_ship_teardown_rechecks_safety_after_terminal_stop() {
   assert_present "$state/$id.meta" "post-stop safety refusal removed task metadata"
   assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
     "post-stop safety refusal removed the Orca worktree"
-  pass "fm-teardown.sh backend=orca: rechecks worktree safety after stopping the terminal"
+  pass "fm-teardown.sh host-root backend=orca: rechecks worktree safety after stopping the terminal"
 }
 
 test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
@@ -1314,9 +1305,6 @@ test_secondmate_force_teardown_removes_orca_child_via_orca() {
     "backend=orca" "orca_worktree_id=wt-child-cleanup"
   orca_case secondmate-child-cleanup
   printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/1.out"
-  printf '{"ok":true}\n' > "$RESP/2.out"
-  printf '{"ok":false,"error":{"code":"terminal_handle_stale","message":"terminal gone"}}\n' > "$RESP/3.out"
-  printf '{"ok":true}\n' > "$RESP/4.out"
   add_tmux_fake "$FB"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e
@@ -1470,7 +1458,7 @@ test_teardown_preserves_metadata_when_orca_remove_error_json
 test_scout_teardown_refuses_orca_missing_report_when_path_missing
 test_ship_teardown_refuses_orca_missing_worktree_path
 test_ship_teardown_removes_orca_worktree_when_id_path_matches
-test_ship_teardown_rechecks_safety_after_terminal_stop
+test_host_ship_teardown_rechecks_safety_after_terminal_stop
 test_ship_teardown_refuses_orca_unresolvable_worktree_id
 test_ship_teardown_refuses_orca_id_path_mismatch
 test_teardown_refuses_orca_missing_worktree_id

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -75,6 +75,16 @@ pass "real tmux: fm_backend_tmux_create_task creates a window and refuses a dupl
 
 # --- send text + Enter -------------------------------------------------------
 
+# The operator's tmux default-command may be fish/zsh; make this Bash behavior
+# test explicit instead of assuming the login shell understands Bash syntax.
+tmux send-keys -t "$TARGET" "exec bash --noprofile --norc" Enter
+for _ in $(seq 1 30); do
+  [ "$(tmux display-message -p -t "$TARGET" '#{pane_current_command}')" = bash ] && break
+  sleep 0.1
+done
+[ "$(tmux display-message -p -t "$TARGET" '#{pane_current_command}')" = bash ] \
+  || fail "real tmux: task window did not enter the explicit Bash test shell"
+
 # A newly-created interactive shell can exist before its startup files and line
 # editor are ready to accept Enter. Prove command execution with an output token
 # that does not appear contiguously in the command, retrying the harmless probe

--- a/tests/fm-backend-zellij.test.sh
+++ b/tests/fm-backend-zellij.test.sh
@@ -805,6 +805,7 @@ test_teardown_passes_recorded_tab_id_to_zellij_kill() {
     "decision_keys="
   printf '[]\n' > "$dir/responses/1.out"
   printf '[{"tab_id":3,"name":"fm-zghost"}]\n' > "$dir/responses/2.out"
+  printf '[]\n' > "$dir/responses/4.out"
   fb=$(make_zellij_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_ZELLIJ_LOG="$dir/log" FM_ZELLIJ_RESPONSES="$dir/responses" FM_ZELLIJ_SESSION_LIST="firstmate" \
@@ -841,9 +842,12 @@ test_forced_secondmate_teardown_kills_zellij_children_with_child_home_tag() {
     "project=$project" \
     "kind=scout"
   child_title=$(zellij_expected_scoped_title fm-childz "$home" "$home")
-  zellij_pane_response "$dir" 1 7 4
-  zellij_tab_response "$dir" 2 4 "$child_title"
-  printf '[]\n' > "$dir/responses/3.out"
+  printf '[]\n' > "$dir/responses/1.out"
+  printf '[]\n' > "$dir/responses/2.out"
+  zellij_pane_response "$dir" 3 7 4
+  zellij_tab_response "$dir" 4 4 "$child_title"
+  printf '[]\n' > "$dir/responses/5.out"
+  printf '[]\n' > "$dir/responses/6.out"
   fb=$(make_zellij_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_ROOT_OVERRIDE="$ROOT" \

--- a/tests/fm-backend-zellij.test.sh
+++ b/tests/fm-backend-zellij.test.sh
@@ -842,12 +842,9 @@ test_forced_secondmate_teardown_kills_zellij_children_with_child_home_tag() {
     "project=$project" \
     "kind=scout"
   child_title=$(zellij_expected_scoped_title fm-childz "$home" "$home")
-  printf '[]\n' > "$dir/responses/1.out"
-  printf '[]\n' > "$dir/responses/2.out"
-  zellij_pane_response "$dir" 3 7 4
-  zellij_tab_response "$dir" 4 4 "$child_title"
-  printf '[]\n' > "$dir/responses/5.out"
-  printf '[]\n' > "$dir/responses/6.out"
+  zellij_pane_response "$dir" 1 7 4
+  zellij_tab_response "$dir" 2 4 "$child_title"
+  printf '[]\n' > "$dir/responses/3.out"
   fb=$(make_zellij_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_ROOT_OVERRIDE="$ROOT" \

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -1112,6 +1112,16 @@ test_adapter_target_state_matrices() {
 
 test_stop_and_verify_requires_confirmed_absence() {
   local out status=0
+  out=$(bash -c '
+    . "$1/bin/fm-backend.sh"
+    fm_backend_kill() { printf called; }
+    fm_backend_stop_and_verify tmux ""
+  ' _ "$ROOT" 2>&1) || status=$?
+  expect_code 1 "$status" "a missing endpoint id must refuse destructive cleanup"
+  assert_contains "$out" 'missing backend endpoint id' "missing endpoint refusal did not explain the unsafe metadata"
+  assert_not_contains "$out" 'called' "missing endpoint refusal invoked a backend kill"
+
+  status=0
   out=$(FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 bash -c '
     . "$1/bin/fm-backend.sh"
     fm_backend_kill() { return 0; }

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -112,7 +112,7 @@ BASE_REF=$(resolve_base_ref) \
 # tmux-only conformance run the tmux adapter's behavior is what is under test,
 # and that is unchanged by any later (e.g. non-tmux backend) addition to
 # fm-backend.sh's own dispatch surface.
-OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-decision-hold.sh fm-backend.sh fm-operational-input.sh"
+OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-decision-hold.sh fm-host-root-lib.sh fm-backend.sh fm-operational-input.sh"
 # A pull-request merge may add a new main-only dependency that the branch's older baseline does not have yet.
 OLD_BIN_OPTIONAL_SIBLINGS="fm-pending-reply-lib.sh"
 OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh fm-marker-lib.sh"
@@ -901,8 +901,13 @@ make_teardown_fakebin() {  # <dir> -> echoes fakebin dir; logs tmux+treehouse ca
   cat > "$fb/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+stopped="${0}.stopped"
 { printf 'tmux'; for a in "$@"; do printf '\x1f%s' "$a"; done; printf '\n'; } >> "${FM_TMUX_LOG:?}"
-exit 0
+case "${1:-}" in
+  kill-window) : > "$stopped" ;;
+  display-message) [ ! -e "$stopped" ] ;;
+  *) exit 0 ;;
+esac
 SH
   cat > "$fb/treehouse" <<'SH'
 #!/usr/bin/env bash
@@ -930,7 +935,7 @@ run_teardown_case() {
 }
 
 test_teardown_conformance_old_vs_new() {
-  local old_bin fb proj wt id
+  local old_bin fb proj wt id kill_line verify_line return_line
   local state_old state_new config_old config_new data log_old log_new out_old out_new rc_old rc_new
   old_bin=$(build_old_bin teardown-old)
   proj="$TMP_ROOT/teardown-project"; wt="$TMP_ROOT/teardown-wt"
@@ -962,14 +967,169 @@ test_teardown_conformance_old_vs_new() {
 
   expect_code 0 "$rc_old" "old fm-teardown.sh (scout, report present) should succeed"$'\n'"$out_old"
   expect_code 0 "$rc_new" "new fm-teardown.sh (scout, report present) should succeed"$'\n'"$out_new"
-  diff -u "$log_old" "$log_new" > "$TMP_ROOT/teardown-diff.txt" 2>&1 \
-    || fail "fm-teardown.sh: tmux+treehouse command log differs old vs new"$'\n'"$(cat "$TMP_ROOT/teardown-diff.txt")"
   assert_contains "$(cat "$log_new")" "treehouse"$'\x1f''return'$'\x1f''--force'$'\x1f'"$wt" \
     "teardown did not call treehouse return --force <worktree>"
   assert_contains "$(cat "$log_new")" "tmux"$'\x1f''kill-window'$'\x1f''-t'$'\x1f'"firstmate:fm-$id" \
     "teardown did not call tmux kill-window -t <window>"
+  kill_line=$(grep -n $'^tmux\x1fkill-window\x1f' "$log_new" | head -1 | cut -d: -f1)
+  verify_line=$(awk -v start="$kill_line" 'NR > start && /^tmux\x1flist-panes\x1f/ { print NR; exit }' "$log_new")
+  return_line=$(grep -n $'^treehouse\x1freturn\x1f' "$log_new" | head -1 | cut -d: -f1)
+  [ -n "$kill_line" ] && [ -n "$verify_line" ] && [ -n "$return_line" ] \
+    && [ "$kill_line" -lt "$verify_line" ] && [ "$verify_line" -lt "$return_line" ] \
+    || fail "teardown did not stop, verify, then return the isolated copy"
 
-  pass "fm-teardown.sh: treehouse return + tmux kill-window command log is byte-identical old vs new for a scout task"
+  pass "fm-teardown.sh stops and verifies the endpoint before returning a scout worktree"
+}
+
+test_adapter_post_create_failure_records_ownership() {
+  local out counter="$TMP_ROOT/cmux-create-counter"
+  out=$(bash -c '
+    . "$1/bin/fm-backend.sh"; fm_backend_source herdr
+    fm_backend_herdr_cli() {
+      case "$*" in
+        *"tab list"*) printf "%s" "{\"result\":{\"tabs\":[]}}" ;;
+        *"tab create"*) printf "%s" "{\"result\":{\"tab\":{\"tab_id\":\"tab-7\"}}}" ;;
+      esac
+    }
+    fm_backend_herdr_create_task session:ws fm-task /tmp "" >/dev/null 2>&1
+    rc=$?
+    printf "%s|%s|%s|%s" "$rc" "$FM_BACKEND_CREATE_OCCURRED" "$FM_BACKEND_CREATED_HERDR_TAB_ID" "$FM_BACKEND_CREATED_TARGET"
+  ' _ "$ROOT")
+  [ "$out" = "1|1|tab-7|" ] || fail "herdr did not retain partial post-create ownership: '$out'"
+
+  out=$(bash -c '
+    . "$1/bin/fm-backend.sh"; fm_backend_source zellij
+    fm_backend_zellij_session_exists() { return 0; }
+    fm_backend_zellij_cli() {
+      case "$*" in
+        *"list-tabs"*) printf "%s" "[]" ;;
+        *"new-tab"*) printf "7\n" ;;
+        *"list-panes"*) printf "%s" "[]" ;;
+      esac
+    }
+    fm_backend_zellij_create_task firstmate fm-task /tmp >/dev/null 2>&1
+    rc=$?
+    printf "%s|%s|%s|%s" "$rc" "$FM_BACKEND_CREATE_OCCURRED" "$FM_BACKEND_CREATED_ZELLIJ_TAB_ID" "$FM_BACKEND_CREATED_TARGET"
+  ' _ "$ROOT")
+  [ "$out" = "1|1|7|" ] || fail "zellij did not retain partial post-create ownership: '$out'"
+
+  printf '0\n' > "$counter"
+  out=$(FM_CMUX_CREATE_COUNTER="$counter" bash -c '
+    . "$1/bin/fm-backend.sh"; fm_backend_source cmux
+    fm_backend_cmux_cli() {
+      case "$*" in
+        *"workspace list"*)
+          n=$(cat "$FM_CMUX_CREATE_COUNTER"); n=$((n + 1)); printf "%s" "$n" > "$FM_CMUX_CREATE_COUNTER"
+          if [ "$n" -eq 1 ]; then printf "%s" "{\"workspaces\":[]}"; else printf "%s" "{\"workspaces\":[{\"id\":\"ws-7\",\"title\":\"fm-task\"}]}"; fi
+          ;;
+        *"new-workspace"*) return 0 ;;
+        *"list-panes"*) printf "%s" "{\"panes\":[]}" ;;
+      esac
+    }
+    fm_backend_cmux_scoped_title() { printf fm-task; }
+    fm_backend_cmux_create_task fm-task /tmp >/dev/null 2>&1
+    rc=$?
+    printf "%s|%s|%s|%s" "$rc" "$FM_BACKEND_CREATE_OCCURRED" "$FM_BACKEND_CREATED_CMUX_WORKSPACE_ID" "$FM_BACKEND_CREATED_TARGET"
+  ' _ "$ROOT")
+  [ "$out" = "1|1|ws-7|" ] || fail "cmux did not retain partial post-create ownership: '$out'"
+  pass "post-create adapter failures retain partial endpoint ownership for verified spawn rollback"
+}
+
+test_adapter_target_state_matrices() {
+  local out
+  out=$(bash -c '
+    . "$1/bin/fm-backend.sh"; fm_backend_source tmux
+    tmux() {
+      case "$CASE:${1:-}" in
+        present:list-panes) printf "%%7|@3|session:fm-task|session:3.0\n"; return 0 ;;
+        absent:list-panes) printf "%%1|@1|session:captain|session:1.0\n"; return 0 ;;
+        unknown:list-panes) printf "transport failure\n" >&2; return 1 ;;
+      esac
+    }
+    for CASE in present absent unknown; do fm_backend_tmux_target_state session:fm-task; printf " "; done
+  ' _ "$ROOT")
+  [ "$out" = "present absent unknown " ] || fail "tmux exact-inventory tri-state matrix drifted: '$out'"
+
+  out=$(bash -c '
+    . "$1/bin/fm-backend.sh"; fm_backend_source herdr
+    fm_backend_herdr_cli() {
+      case "$CASE" in
+        present) printf "%s" "{\"result\":{\"pane\":{\"pane_id\":\"w:p\"}}}" ;;
+        absent) printf "%s" "{\"error\":{\"code\":\"pane_not_found\"}}" ;;
+        unknown) printf "%s" "not-json" ;;
+      esac
+    }
+    for CASE in present absent unknown; do fm_backend_herdr_target_state session:w:p; printf " "; done
+  ' _ "$ROOT")
+  [ "$out" = "present absent unknown " ] || fail "herdr tri-state matrix drifted: '$out'"
+
+  out=$(bash -c '
+    . "$1/bin/fm-backend.sh"; fm_backend_source zellij
+    zellij() {
+      if [ "$CASE" = absent ]; then printf "No active zellij sessions found\n"; return 1; fi
+      printf "firstmate\n"
+    }
+    fm_backend_zellij_cli() {
+      case "$CASE" in
+        present) printf "%s" "[{\"id\":7,\"is_plugin\":false}]" ;;
+        unknown) printf "%s" "{\"malformed\":true}" ;;
+      esac
+    }
+    for CASE in present absent unknown; do fm_backend_zellij_target_state firstmate:7; printf " "; done
+  ' _ "$ROOT")
+  [ "$out" = "present absent unknown " ] || fail "zellij tri-state matrix drifted: '$out'"
+
+  out=$(bash -c '
+    . "$1/bin/fm-backend.sh"; fm_backend_source orca
+    fm_backend_orca_tool_check() { return 0; }
+    orca() {
+      case "$CASE" in
+        present) printf "%s" "{\"ok\":true,\"result\":{}}" ;;
+        absent) printf "%s" "{\"ok\":false,\"error\":{\"code\":\"terminal_handle_stale\"}}" ;;
+        unknown) printf "%s" "not-json" ;;
+      esac
+    }
+    for CASE in present absent unknown; do fm_backend_orca_target_state term-7; printf " "; done
+  ' _ "$ROOT")
+  [ "$out" = "present absent unknown " ] || fail "orca tri-state matrix drifted: '$out'"
+
+  out=$(bash -c '
+    . "$1/bin/fm-backend.sh"; fm_backend_source cmux
+    fm_backend_cmux_ping_state() { printf ok; }
+    fm_backend_cmux_cli() {
+      case "$CASE" in
+        present) printf "%s" "{\"workspaces\":[{\"id\":\"ws-7\"}]}" ;;
+        absent) printf "%s" "{\"workspaces\":[]}" ;;
+        unknown) printf "%s" "not-json" ;;
+      esac
+    }
+    for CASE in present absent unknown; do fm_backend_cmux_target_state ws-7:surface-7; printf " "; done
+  ' _ "$ROOT")
+  [ "$out" = "present absent unknown " ] || fail "cmux tri-state matrix drifted: '$out'"
+  pass "all five backend adapters distinguish present, typed absent, and unreadable control planes"
+}
+
+test_stop_and_verify_requires_confirmed_absence() {
+  local out status=0
+  out=$(FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 bash -c '
+    . "$1/bin/fm-backend.sh"
+    fm_backend_kill() { return 0; }
+    fm_backend_target_state() { printf unknown; }
+    fm_backend_stop_and_verify tmux session:fm-task
+  ' _ "$ROOT" 2>&1) || status=$?
+  expect_code 1 "$status" "an unknown post-stop probe must refuse destructive cleanup"
+  assert_contains "$out" 'could not be confirmed absent' "unknown stop verification did not explain the refusal"
+
+  status=0
+  out=$(FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 bash -c '
+    . "$1/bin/fm-backend.sh"
+    fm_backend_kill() { return 0; }
+    fm_backend_target_state() { printf absent; }
+    fm_backend_stop_and_verify tmux session:fm-task
+  ' _ "$ROOT" 2>&1) || status=$?
+  expect_code 0 "$status" "a confirmed absent endpoint should permit cleanup"
+  [ -z "$out" ] || fail "confirmed absence emitted unexpected output: $out"
+  pass "fm_backend_stop_and_verify distinguishes confirmed absence from an unreadable backend"
 }
 
 # --- backend selection loudly refuses an unknown backend --------------------
@@ -1107,6 +1267,9 @@ test_send_conformance_old_vs_new
 test_peek_conformance_old_vs_new
 test_spawn_symlinked_project_prefix_avoids_false_refusal
 test_teardown_conformance_old_vs_new
+test_adapter_post_create_failure_records_ownership
+test_adapter_target_state_matrices
+test_stop_and_verify_requires_confirmed_absence
 test_spawn_refuses_unknown_backend_flag
 test_spawn_refuses_codex_app_backend_flag
 test_spawn_refuses_unknown_fm_backend_env

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -935,7 +935,7 @@ run_teardown_case() {
 }
 
 test_teardown_conformance_old_vs_new() {
-  local old_bin fb proj wt id kill_line verify_line return_line
+  local old_bin fb proj wt id kill_line return_line old_kill_line old_return_line
   local state_old state_new config_old config_new data log_old log_new out_old out_new rc_old rc_new
   old_bin=$(build_old_bin teardown-old)
   proj="$TMP_ROOT/teardown-project"; wt="$TMP_ROOT/teardown-wt"
@@ -972,13 +972,14 @@ test_teardown_conformance_old_vs_new() {
   assert_contains "$(cat "$log_new")" "tmux"$'\x1f''kill-window'$'\x1f''-t'$'\x1f'"firstmate:fm-$id" \
     "teardown did not call tmux kill-window -t <window>"
   kill_line=$(grep -n $'^tmux\x1fkill-window\x1f' "$log_new" | head -1 | cut -d: -f1)
-  verify_line=$(awk -v start="$kill_line" 'NR > start && /^tmux\x1flist-panes\x1f/ { print NR; exit }' "$log_new")
   return_line=$(grep -n $'^treehouse\x1freturn\x1f' "$log_new" | head -1 | cut -d: -f1)
-  [ -n "$kill_line" ] && [ -n "$verify_line" ] && [ -n "$return_line" ] \
-    && [ "$kill_line" -lt "$verify_line" ] && [ "$verify_line" -lt "$return_line" ] \
-    || fail "teardown did not stop, verify, then return the isolated copy"
+  old_kill_line=$(grep -n $'^tmux\x1fkill-window\x1f' "$log_old" | head -1 | cut -d: -f1)
+  old_return_line=$(grep -n $'^treehouse\x1freturn\x1f' "$log_old" | head -1 | cut -d: -f1)
+  [ -n "$kill_line" ] && [ -n "$return_line" ] && [ "$return_line" -lt "$kill_line" ] \
+    && [ -n "$old_kill_line" ] && [ -n "$old_return_line" ] && [ "$old_return_line" -lt "$old_kill_line" ] \
+    || fail "unset teardown no longer returns the isolated copy before best-effort endpoint cleanup"
 
-  pass "fm-teardown.sh stops and verifies the endpoint before returning a scout worktree"
+  pass "fm-teardown.sh preserves unset-mode worktree and endpoint cleanup ordering"
 }
 
 test_adapter_post_create_failure_records_ownership() {

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -119,6 +119,26 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
 }
 
+test_unset_and_empty_host_mode_match() {
+  local home="$TMP_ROOT/default-host-home" expected kind args
+  mkdir -p "$home/data"
+  for kind in ship scout; do
+    args=()
+    [ "$kind" = ship ] || args+=(--scout)
+    env -u FM_HOST_ROOT FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+      "$ROOT/bin/fm-brief.sh" byte-compat sample "${args[@]}" >/dev/null 2>&1
+    expected="$TMP_ROOT/$kind-default-brief.md"
+    cp "$home/data/byte-compat/brief.md" "$expected"
+    rm -rf "$home/data/byte-compat"
+    FM_HOST_ROOT='' FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+      "$ROOT/bin/fm-brief.sh" byte-compat sample "${args[@]}" >/dev/null 2>&1
+    cmp -s "$expected" "$home/data/byte-compat/brief.md" \
+      || fail "$kind brief differs between unset and explicitly empty host mode"
+    rm -rf "$home/data/byte-compat"
+  done
+  pass "fm-brief.sh: unset and empty host mode preserve the same default scaffold"
+}
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
@@ -387,6 +407,7 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_unset_and_empty_host_mode_match
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -15,6 +15,19 @@ TASKS_AXI_BIN=$(command -v tasks-axi || true)
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
 command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found"; exit 0; }
 
+write_stop_aware_tmux() {
+  cat > "$1/tmux" <<'SH'
+#!/usr/bin/env bash
+stopped="${0}.stopped"
+case "${1:-}" in
+  kill-window) : > "$stopped" ;;
+  display-message) [ ! -e "$stopped" ] ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$1/tmux"
+}
+
 make_home() {  # <name>
   local home="$TMP_ROOT/$1" fakebin
   mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
@@ -27,7 +40,8 @@ make_home() {  # <name>
 ## Done
 EOF
   fakebin=$(fm_fakebin "$home")
-  fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$fakebin" treehouse no-mistakes gh gh-axi
+  write_stop_aware_tmux "$fakebin"
   printf '%s\n' "$home"
 }
 
@@ -426,7 +440,8 @@ test_secondmate_hold_stays_in_authoritative_home() {
 ## Done
 EOF
   fakebin=$(fm_fakebin "$mate")
-  fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$fakebin" treehouse no-mistakes gh gh-axi
+  write_stop_aware_tmux "$fakebin"
   origin=sample-mate-review
   mkdir -p "$mate/data/$origin"
   tasks_in "$mate" add "$origin" "Investigate secondmate sample" --kind scout --repo sample --start >/dev/null

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -74,6 +74,7 @@ make_normal_repo() {
 
 GATE_WT=$(make_gate_worktree "$TMP/gate")
 NORMAL_CWD=$(make_normal_repo "$TMP/normal-cwd")
+ln -s "$ROOT/bin" "$NORMAL_CWD/bin"
 
 # --- the shared helper, tested directly -------------------------------------
 
@@ -182,7 +183,7 @@ run_spawn() {
   mkdir -p "$home/data/$id"
   printf 'brief\n' > "$home/data/$id/brief.md"
   ( cd "$cwd" && env -u NO_MISTAKES_GATE -u FM_GATE_REFUSE_BYPASS \
-      "FM_ROOT_OVERRIDE=" "FM_HOME=$home" \
+      "FM_ROOT_OVERRIDE=$NORMAL_CWD" "FM_HOME=$home" \
       "FM_STATE_OVERRIDE=$home/state" "FM_DATA_OVERRIDE=$home/data" \
       "FM_PROJECTS_OVERRIDE=$home/projects" "FM_CONFIG_OVERRIDE=$home/config" \
       "FM_SPAWN_NO_GUARD=1" "FM_FAKE_PANE_PATH=$pane" "TMUX=fake,1,0" \
@@ -356,7 +357,7 @@ SH
 run_teardown() {
   local cwd=$1 case_dir=$2; shift 2
   ( cd "$cwd" && env -u NO_MISTAKES_GATE -u FM_GATE_REFUSE_BYPASS \
-      "FM_ROOT_OVERRIDE=$ROOT" "FM_STATE_OVERRIDE=$case_dir/state" \
+      "FM_ROOT_OVERRIDE=$NORMAL_CWD" "FM_STATE_OVERRIDE=$case_dir/state" \
       "FM_CONFIG_OVERRIDE=$case_dir/config" "PATH=$case_dir/fakebin:$PATH" "$@" \
       "$TEARDOWN" task-x1 ) 2>&1
 }

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -86,6 +86,7 @@ run_guard_lib() {
   (
     cd "$cwd" || exit 111
     unset NO_MISTAKES_GATE FM_GATE_REFUSE_BYPASS
+    # shellcheck disable=SC2030  # The marker is intentionally scoped to this probe subshell.
     case "$marker" in
       set) export NO_MISTAKES_GATE=1 ;;
       empty) export NO_MISTAKES_GATE= ;;
@@ -129,6 +130,25 @@ test_helper_normal_is_noop() {
   expect_code 0 "$rc" "helper: a normal session (neither signal) must not refuse"
   [ -z "$out" ] || fail "helper: normal session printed output: $out"
   pass "fm-gate-refuse-lib: no-op for a normal session (neither signal, set -eu clean)"
+}
+
+test_helper_checks_physical_absolute_root_from_other_cwd() {
+  local root_link="$TMP/gate-root-link" out rc
+  ln -s "$GATE_WT" "$root_link"
+  out=$(
+    (
+      cd "$NORMAL_CWD" || exit 111
+      unset NO_MISTAKES_GATE FM_GATE_REFUSE_BYPASS
+      set -eu
+      # shellcheck source=bin/fm-gate-refuse-lib.sh
+      . "$GATE_LIB"
+      fm_refuse_if_gate_agent "$root_link"
+    ) 2>&1
+  )
+  rc=$?
+  expect_code 3 "$rc" "helper: an explicit gate-root anchor must refuse from a normal cwd"
+  assert_contains "$out" "$PATH_MSG" "helper: explicit physical root check did not identify the gate worktree"
+  pass "fm-gate-refuse-lib: checks the physical absolute FM_ROOT independently of cwd"
 }
 
 # --- fm-spawn ---------------------------------------------------------------
@@ -282,13 +302,21 @@ test_send_refuses_and_admits() {
 # task (HEAD reachable from origin), so a normal teardown genuinely succeeds and a
 # refused one leaves the task untouched (mirrors tests/fm-teardown make_case).
 make_teardown_case() {
-  local name=$1 case_dir fakebin t
+  local name=$1 case_dir fakebin
   case_dir="$TMP/$name"; fakebin="$case_dir/fakebin"
   mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
-  for t in treehouse tmux; do
-    printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/$t"
-    chmod +x "$fakebin/$t"
-  done
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/treehouse"
+  chmod +x "$fakebin/treehouse"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+stopped="${0}.stopped"
+case "${1:-}" in
+  kill-window) : > "$stopped" ;;
+  display-message) [ ! -e "$stopped" ] ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$fakebin/tmux"
   cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 case "${1:-} ${2:-}" in
@@ -394,6 +422,7 @@ test_helper_env_marker_refuses
 test_helper_empty_env_marker_refuses
 test_helper_path_backstop_refuses
 test_helper_normal_is_noop
+test_helper_checks_physical_absolute_root_from_other_cwd
 test_spawn_refuses_and_admits
 test_send_refuses_and_admits
 test_teardown_refuses_and_admits

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -61,8 +61,9 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
-  # fm-gate-refuse-lib.sh: teardown sources it before any fleet mutation.
+  # Gate and host-root libraries are sourced before any teardown mutation.
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
+  ln -s "$ROOT/bin/fm-host-root-lib.sh" "$fake/bin/fm-host-root-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.
   ln -s "$ROOT/bin/fm-pr-lib.sh" "$fake/bin/fm-pr-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
@@ -161,8 +162,9 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
-  # fm-gate-refuse-lib.sh: teardown sources it before any fleet mutation.
+  # Gate and host-root libraries are sourced before any teardown mutation.
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
+  ln -s "$ROOT/bin/fm-host-root-lib.sh" "$fake/bin/fm-host-root-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.
   ln -s "$ROOT/bin/fm-pr-lib.sh" "$fake/bin/fm-pr-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -15,13 +15,16 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+stopped="${0}.stopped"
 case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{pane_current_path}"*) [ ! -e "$stopped" ] && printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit $? ;;
 esac
 case "${1:-}" in
-  display-message) printf 'firstmate\n'; exit 0 ;;
+  display-message) [ ! -e "$stopped" ] && printf 'firstmate\n'; exit $? ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|send-keys|kill-window) exit 0 ;;
+  new-window) rm -f "$stopped"; exit 0 ;;
+  kill-window) : > "$stopped"; exit 0 ;;
+  has-session|new-session|send-keys) exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-host-root-mode.test.sh
+++ b/tests/fm-host-root-mode.test.sh
@@ -160,6 +160,39 @@ test_brief_variants() {
   pass "brief scaffolding has an explicit host variant and unchanged default variant"
 }
 
+test_host_local_only_rejected_before_mutation() {
+  local host="$TMP/local-only-host" home="$TMP/local-only-home" project="$TMP/local-only-target" fake_root="$TMP/local-only-root" guard_marker="$TMP/local-only-guard" out status=0
+  make_host "$host"
+  fm_git_init_commit "$project"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$fake_root/bin"
+  printf '%s\n' "- $(basename "$project") [local-only] - local target (added 2026-07-26)" > "$home/data/projects.md"
+
+  out=$(cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-brief.sh" local-brief "$(basename "$project")" 2>&1) || status=$?
+  expect_code 1 "$status" "host-root brief must reject local-only delivery"
+  assert_contains "$out" "host-root mode does not support local-only project" "host-root brief refusal was not explicit"
+  assert_absent "$home/data/local-brief" "host-root brief created task data before rejecting local-only delivery"
+
+  cp "$ROOT/bin/fm-project-mode.sh" "$fake_root/bin/fm-project-mode.sh"
+  cat > "$fake_root/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+: > "$FM_GUARD_MUTATION"
+SH
+  chmod +x "$fake_root/bin/fm-project-mode.sh" "$fake_root/bin/fm-guard.sh"
+  : > "$fake_root/AGENTS.md"
+  mkdir -p "$home/data/local-spawn"
+  printf '<!-- firstmate-execution-mode: host-root -->\n' > "$home/data/local-spawn/brief.md"
+  status=0
+  out=$(cd "$host" && FM_GUARD_MUTATION="$guard_marker" FM_ROOT_OVERRIDE="$fake_root" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-spawn.sh" local-spawn "$project" codex 2>&1) || status=$?
+  expect_code 1 "$status" "host-root spawn must reject local-only delivery"
+  assert_contains "$out" "host-root mode does not support local-only project" "host-root spawn refusal was not explicit"
+  assert_absent "$guard_marker" "host-root spawn ran the fleet guard before rejecting local-only delivery"
+  assert_absent "$home/state/.spawn-local-spawn.lock" "host-root spawn acquired task state before rejecting local-only delivery"
+  assert_absent "$home/state/local-spawn.meta" "host-root spawn wrote task metadata before rejecting local-only delivery"
+  pass "host-root local-only tasks are rejected before brief or fleet mutation"
+}
+
 make_fakebin() {
   local dir=$1 fb
   fb=$(fm_fakebin "$dir")
@@ -198,7 +231,10 @@ case "${1:-}" in
   list-panes) [ ! -f "$endpoint" ] || printf '%%1|@1|%s|test-session:1.0\n' "${FM_ENDPOINT_TARGET:-test-session:fm-rollback-stuck}" ;;
   has-session|new-session|set-window-option) ;;
   new-window) : > "$endpoint"; printf '%%1\n' ;;
-  kill-window) [ "${FM_REFUSE_STOP:-0}" = 1 ] || rm -f "$endpoint" ;;
+  kill-window)
+    [ -z "${FM_TMUX_KILL_MUTATION:-}" ] || printf 'late worker edit\n' > "$FM_TMUX_KILL_MUTATION"
+    [ "${FM_REFUSE_STOP:-0}" = 1 ] || rm -f "$endpoint"
+    ;;
   send-keys)
     case "$*" in
       *'treehouse get'*) printf '%s\n' "$FM_TARGET_PATH" > "$FM_CURRENT_PATH" ;;
@@ -651,6 +687,19 @@ test_host_teardown_requires_confirmed_stop() {
 
   : > "$log"; : > "$tree_log"; status=0
   out=$(cd "$host" && PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    FM_TMUX_KILL_MUTATION="$wt/late-edit.txt" FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 FM_TMUX_LOG="$log" \
+    FM_ENDPOINT_TARGET=test-session:fm-host-teardown FM_LAUNCH_FILE="$TMP/unused.launch" FM_CURRENT_PATH="$current" \
+    FM_TARGET_PATH="$wt" FM_HOST_PATH="$host" FM_TREEHOUSE_LOG="$tree_log" TMUX=fake \
+    "$ROOT/bin/fm-teardown.sh" host-teardown 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "host-root tmux teardown discarded an edit written during endpoint stop"
+  assert_contains "$out" "uncommitted changes" "post-stop tmux safety refusal did not explain the late edit"
+  assert_present "$wt/late-edit.txt" "post-stop tmux safety refusal lost the late worker edit"
+  assert_present "$home/state/host-teardown.meta" "post-stop tmux safety refusal removed task metadata"
+  assert_no_grep 'return --force' "$tree_log" "post-stop tmux safety refusal returned the worktree"
+  rm -f "$wt/late-edit.txt"
+
+  : > "$log"; : > "$tree_log"; status=0
+  out=$(cd "$host" && PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
     FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 FM_TMUX_LOG="$log" \
     FM_ENDPOINT_TARGET=test-session:fm-host-teardown FM_LAUNCH_FILE="$TMP/unused.launch" FM_CURRENT_PATH="$current" \
     FM_TARGET_PATH="$wt" FM_HOST_PATH="$host" FM_TREEHOUSE_LOG="$tree_log" TMUX=fake \
@@ -723,6 +772,7 @@ test_resolution_and_validation
 test_session_cwd_mismatch_precedes_mutation
 test_host_command_rendering
 test_brief_variants
+test_host_local_only_rejected_before_mutation
 test_spawn_separates_roots
 test_duplicate_spawn_preserves_existing_task
 test_spawn_rejects_host_as_target_and_cleans_failed_transition

--- a/tests/fm-host-root-mode.test.sh
+++ b/tests/fm-host-root-mode.test.sh
@@ -161,14 +161,17 @@ test_brief_variants() {
 }
 
 test_host_local_only_rejected_before_mutation() {
-  local host="$TMP/local-only-host" home="$TMP/local-only-home" project="$TMP/local-only-target" fake_root="$TMP/local-only-root" guard_marker="$TMP/local-only-guard" out status=0
+  local host="$TMP/local-only-host" home="$TMP/local-only-home" project="$TMP/local-only-physical" alias="$TMP/local-only-alias" fake_root="$TMP/local-only-root" guard_marker="$TMP/local-only-guard" out status=0
   make_host "$host"
   fm_git_init_commit "$project"
+  ln -s "$project" "$alias"
   mkdir -p "$home/data" "$home/state" "$home/config" "$fake_root/bin"
-  printf '%s\n' "- $(basename "$project") [local-only] - local target (added 2026-07-26)" > "$home/data/projects.md"
+  printf '%s\n%s\n' \
+    "- $(basename "$alias") [local-only] - local target (added 2026-07-26)" \
+    "- $(basename "$project") [no-mistakes] - physical target (added 2026-07-26)" > "$home/data/projects.md"
 
   out=$(cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
-    "$ROOT/bin/fm-brief.sh" local-brief "$(basename "$project")" 2>&1) || status=$?
+    "$ROOT/bin/fm-brief.sh" local-brief "$(basename "$alias")" 2>&1) || status=$?
   expect_code 1 "$status" "host-root brief must reject local-only delivery"
   assert_contains "$out" "host-root mode does not support local-only project" "host-root brief refusal was not explicit"
   assert_absent "$home/data/local-brief" "host-root brief created task data before rejecting local-only delivery"
@@ -184,7 +187,7 @@ SH
   printf '<!-- firstmate-execution-mode: host-root -->\n' > "$home/data/local-spawn/brief.md"
   status=0
   out=$(cd "$host" && FM_GUARD_MUTATION="$guard_marker" FM_ROOT_OVERRIDE="$fake_root" FM_HOME="$home" FM_HOST_ROOT="$host" \
-    "$ROOT/bin/fm-spawn.sh" local-spawn "$project" codex 2>&1) || status=$?
+    "$ROOT/bin/fm-spawn.sh" local-spawn "$alias" codex 2>&1) || status=$?
   expect_code 1 "$status" "host-root spawn must reject local-only delivery"
   assert_contains "$out" "host-root mode does not support local-only project" "host-root spawn refusal was not explicit"
   assert_absent "$guard_marker" "host-root spawn ran the fleet guard before rejecting local-only delivery"
@@ -478,9 +481,9 @@ test_all_harnesses_add_one_task_safeguard() {
 }
 
 test_mutators_require_host_cwd() {
-  local host="$TMP/mutator-host" other="$TMP/mutator-other" home="$TMP/mutator-home" out status=0
+  local host="$TMP/mutator-host" other="$TMP/mutator-other" home="$TMP/mutator-home" fake_root="$TMP/mutator-root" guard_marker="$TMP/mutator-guard" out status=0
   make_host "$host"
-  mkdir -p "$other" "$home/state"
+  mkdir -p "$other" "$home/state" "$fake_root/bin"
   printf 'window=fake:fm-lane\nworktree=/tmp/target\nhost_root=%s\nproject=/tmp/project\nkind=ship\n' "$host" > "$home/state/lane.meta"
   printf 'window=fake:fm-scout\nworktree=/tmp/scout\nhost_root=%s\nproject=/tmp/project\nkind=scout\n' "$host" > "$home/state/scout.meta"
   out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-send.sh" lane hello 2>&1) || status=$?
@@ -516,10 +519,32 @@ test_mutators_require_host_cwd() {
   out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-promote.sh" scout 2>&1) || status=$?
   expect_code 2 "$status" "fm-promote must reject a host cwd mismatch"
   grep -qx 'kind=scout' "$home/state/scout.meta" || fail "promote mutated task metadata before host validation"
+  printf 'mode=local-only\n' >> "$home/state/scout.meta"
+  cat > "$fake_root/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+: > "$FM_GUARD_MUTATION"
+SH
+  chmod +x "$fake_root/bin/fm-guard.sh"
+  status=0
+  out=$(cd "$host" && FM_GUARD_MUTATION="$guard_marker" FM_ROOT_OVERRIDE="$fake_root" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-promote.sh" scout 2>&1) || status=$?
+  expect_code 1 "$status" "fm-promote must reject a host-root local-only scout"
+  assert_contains "$out" 'host-root mode does not support promoting local-only scout' "host-root local-only promotion refusal was not explicit"
+  assert_absent "$guard_marker" "host-root promotion ran the fleet guard before rejecting local-only delivery"
+  grep -qx 'kind=scout' "$home/state/scout.meta" || fail "local-only promotion mutated task metadata"
+  sed -i '/^mode=local-only$/d' "$home/state/scout.meta"
   status=0
   out=$(cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-promote.sh" scout 2>&1) || status=$?
   expect_code 0 "$status" "fm-promote rejected a recorded host-root scout"
   assert_contains "$out" "'$ROOT/bin/fm-send.sh'" "host-root promotion did not print a quoted absolute fm-send path"
+  assert_contains "$out" 'git -C "$FM_TARGET_WORKTREE" status' "host-root promotion did not scope scratch status"
+  assert_contains "$out" 'git -C "$FM_TARGET_WORKTREE" log' "host-root promotion did not scope scratch history"
+  assert_contains "$out" 'git -C "$FM_TARGET_WORKTREE" checkout -b fm/scout' "host-root promotion did not scope branch creation"
+  assert_contains "$out" '(cd "$FM_TARGET_WORKTREE" && ...)' "host-root promotion did not scope validation commands"
+  printf 'window=fake:fm-plain\nworktree=/tmp/plain\nproject=/tmp/project\nkind=scout\n' > "$home/state/plain.meta"
+  status=0
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" "$ROOT/bin/fm-promote.sh" plain 2>&1) || status=$?
+  expect_code 0 "$status" "fm-promote changed default-mode promotion"
+  assert_contains "$out" '<ship instructions: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/plain; implement; report done>' "default-mode promotion instructions changed"
   status=0
   out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-check-register.sh" lane 2>&1) || status=$?
   expect_code 2 "$status" "fm-check-register must reject a host cwd mismatch"

--- a/tests/fm-host-root-mode.test.sh
+++ b/tests/fm-host-root-mode.test.sh
@@ -536,9 +536,13 @@ SH
   out=$(cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-promote.sh" scout 2>&1) || status=$?
   expect_code 0 "$status" "fm-promote rejected a recorded host-root scout"
   assert_contains "$out" "'$ROOT/bin/fm-send.sh'" "host-root promotion did not print a quoted absolute fm-send path"
+  # shellcheck disable=SC2016  # Assertions intentionally match literal worker variables.
   assert_contains "$out" 'git -C "$FM_TARGET_WORKTREE" status' "host-root promotion did not scope scratch status"
+  # shellcheck disable=SC2016
   assert_contains "$out" 'git -C "$FM_TARGET_WORKTREE" log' "host-root promotion did not scope scratch history"
+  # shellcheck disable=SC2016
   assert_contains "$out" 'git -C "$FM_TARGET_WORKTREE" checkout -b fm/scout' "host-root promotion did not scope branch creation"
+  # shellcheck disable=SC2016
   assert_contains "$out" '(cd "$FM_TARGET_WORKTREE" && ...)' "host-root promotion did not scope validation commands"
   printf 'window=fake:fm-plain\nworktree=/tmp/plain\nproject=/tmp/project\nkind=scout\n' > "$home/state/plain.meta"
   status=0

--- a/tests/fm-host-root-mode.test.sh
+++ b/tests/fm-host-root-mode.test.sh
@@ -62,6 +62,8 @@ test_resolution_and_validation() {
   if paths_overlap "$host" "$TMP/host-with-similar-prefix"; then
     fail "sibling paths with a shared prefix were classified as overlapping"
   fi
+  paths_overlap / "$host" || fail "filesystem root was not classified as an ancestor"
+  paths_overlap "$host" / || fail "filesystem root was not classified as an enclosing target"
   pass "host-root library resolves physical paths and rejects unsafe, harness-specific, or overlapping roots"
 }
 
@@ -102,7 +104,7 @@ SH
 }
 
 test_host_command_rendering() {
-  local host="$TMP/render & host" home="$TMP/render-home" fake_root="$TMP/FirstMate & root's copy" rendered supervision command argv
+  local host="$TMP/render & host" home="$TMP/render-home" fake_root="$TMP/FirstMate & root's copy" rendered supervision command argv harness
   make_host "$host"; mkdir -p "$home/state" "$home/config" "$fake_root/bin"
   argv="$TMP/rendered-argv"
   cat > "$fake_root/bin/argv-probe" <<'SH'
@@ -122,6 +124,12 @@ SH
   command=$(printf '%s\n' "$supervision" | sed -n 's/.*checkpoint: \(.*\) --seconds.*/\1/p')
   FM_ARGV_LOG="$argv" bash -c "$command --seconds 7"
   [ "$(cat "$argv")" = $'--seconds\n7' ] || fail "rendered supervision command did not preserve argv"
+  for harness in claude codex grok; do
+    supervision=$(FM_ROOT_OVERRIDE="$fake_root" FM_HOME="$home" FM_HOST_ROOT="$host" \
+      "$ROOT/bin/fm-supervision-instructions.sh" --harness "$harness")
+    assert_contains "$supervision" "FirstMate & root'\\''s copy/bin'/fm-" \
+      "$harness ordinary-wake command did not use the absolute FirstMate path"
+  done
   pass "host mode shell-quotes absolute commands and preserves argv"
 }
 
@@ -187,7 +195,7 @@ case "${1:-}" in
     fi
     ;;
   list-windows) [ -z "${FM_EXISTING_WINDOW:-}" ] || printf '%s\n' "$FM_EXISTING_WINDOW" ;;
-  list-panes) [ ! -f "$endpoint" ] || printf '%%1|@1|test-session:fm-rollback-stuck|test-session:1.0\n' ;;
+  list-panes) [ ! -f "$endpoint" ] || printf '%%1|@1|%s|test-session:1.0\n' "${FM_ENDPOINT_TARGET:-test-session:fm-rollback-stuck}" ;;
   has-session|new-session|set-window-option) ;;
   new-window) : > "$endpoint"; printf '%%1\n' ;;
   kill-window) [ "${FM_REFUSE_STOP:-0}" = 1 ] || rm -f "$endpoint" ;;
@@ -452,6 +460,10 @@ test_mutators_require_host_cwd() {
   expect_code 2 "$status" "fm-merge-local must reject a host cwd mismatch"
   assert_present "$home/state/lane.meta" "local merge mutated task state before host validation"
   status=0
+  out=$(cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-merge-local.sh" lane 2>&1) || status=$?
+  expect_code 1 "$status" "fm-merge-local must refuse host-root local-only tasks"
+  assert_contains "$out" 'local-only merge is unavailable for host-root task' "host-root local merge refusal was not explicit"
+  status=0
   out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-pr-merge.sh" lane https://github.com/example/repo/pull/1 2>&1) || status=$?
   expect_code 2 "$status" "fm-pr-merge must reject a host cwd mismatch"
   assert_present "$home/state/lane.meta" "PR merge mutated task state before host validation"
@@ -468,6 +480,10 @@ test_mutators_require_host_cwd() {
   out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-promote.sh" scout 2>&1) || status=$?
   expect_code 2 "$status" "fm-promote must reject a host cwd mismatch"
   grep -qx 'kind=scout' "$home/state/scout.meta" || fail "promote mutated task metadata before host validation"
+  status=0
+  out=$(cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-promote.sh" scout 2>&1) || status=$?
+  expect_code 0 "$status" "fm-promote rejected a recorded host-root scout"
+  assert_contains "$out" "'$ROOT/bin/fm-send.sh'" "host-root promotion did not print a quoted absolute fm-send path"
   status=0
   out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-check-register.sh" lane 2>&1) || status=$?
   expect_code 2 "$status" "fm-check-register must reject a host cwd mismatch"
@@ -510,11 +526,12 @@ test_secondmate_actions_keep_supervisor_host_authority() {
 }
 
 test_spawn_rollback_is_transactional() {
-  local host="$TMP/rollback-host" home="$TMP/rollback-home" project="$TMP/rollback-target" wt="$TMP/rollback-wt" stuck_wt="$TMP/rollback-stuck-wt" uncertain_wt="$TMP/rollback-uncertain-wt" fb log current tree_log out status=0
+  local host="$TMP/rollback-host" home="$TMP/rollback-home" project="$TMP/rollback-target" wt="$TMP/rollback-wt" stuck_wt="$TMP/rollback-stuck-wt" uncertain_wt="$TMP/rollback-uncertain-wt" unset_wt="$TMP/rollback-unset-wt" fb log current tree_log out status=0
   make_host "$host"; mkdir -p "$home/data" "$home/state" "$home/config"; fm_git_init_commit "$project"
   git -C "$project" worktree add -q --detach "$wt"
   git -C "$project" worktree add -q --detach "$stuck_wt"
   git -C "$project" worktree add -q --detach "$uncertain_wt"
+  git -C "$project" worktree add -q --detach "$unset_wt"
   for id in rollback-clean rollback-stuck rollback-uncertain; do
     (cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
       "$ROOT/bin/fm-brief.sh" "$id" target >/dev/null 2>&1)
@@ -560,7 +577,91 @@ test_spawn_rollback_is_transactional() {
   assert_present "/tmp/fm-rollback-uncertain" "ambiguous Enter failure removed its task temp root"
   rm -rf "/tmp/fm-rollback-uncertain"
   rm -f "$home/state/rollback-uncertain.meta" "$home/state/rollback-uncertain.pi-ext.ts" "$current.endpoint"
-  pass "spawn rollback cleans pre-launch failures and preserves ambiguous launch submissions"
+
+  env -u FM_HOST_ROOT FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    "$ROOT/bin/fm-brief.sh" rollback-unset target >/dev/null 2>&1
+  : > "$log"; : > "$tree_log"; printf '%s\n' "$project" > "$current"; status=0
+  out=$(cd "$host" && env -u FM_HOST_ROOT PATH="$fb:$PATH" FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_FAIL_LAUNCH_SEND=1 FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$TMP/rollback-unset.launch" \
+    FM_CURRENT_PATH="$current" FM_TARGET_PATH="$unset_wt" FM_HOST_PATH="$host" FM_TREEHOUSE_LOG="$tree_log" TMUX=fake \
+    "$ROOT/bin/fm-spawn.sh" rollback-unset "$project" pi 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "unset-mode injected launch failure unexpectedly succeeded"
+  assert_no_grep 'kill-window' "$log" "unset-mode launch failure changed upstream endpoint cleanup"
+  assert_no_grep 'return --force' "$tree_log" "unset-mode launch failure changed upstream worktree cleanup"
+  assert_present "$home/state/rollback-unset.meta" "unset-mode launch failure removed upstream task metadata"
+  assert_present "$current.endpoint" "unset-mode launch failure stopped the endpoint"
+  rm -rf "/tmp/fm-rollback-unset"
+  rm -f "$home/state/rollback-unset.meta" "$home/state/rollback-unset.pi-ext.ts" "$current.endpoint"
+  pass "spawn rollback stays host-scoped and preserves ambiguous launch submissions"
+}
+
+test_decision_actions_use_durable_host_owner() {
+  local host="$TMP/decision-host" home="$TMP/decision-home" id=decision-scout fb owner out status=0
+  make_host "$host"
+  mkdir -p "$home/data/$id" "$home/state" "$home/config"
+  printf '# Decision report\n' > "$home/data/$id/report.md"
+  printf 'done: report complete\n' > "$home/state/$id.status"
+  printf 'window=fake:fm-%s\nworktree=/tmp/decision-target\nhost_root=%s\nproject=/tmp/project\nkind=scout\n' \
+    "$id" "$host" > "$home/state/$id.meta"
+  fb=$(fm_fakebin "$TMP/fake-decision-owner")
+  cat > "$fb/tasks-axi" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "--version ") printf '%s\n' 'tasks-axi 0.2.2' ;;
+  "update --help") printf '%s\n' '--archive-body' ;;
+  "mv --help") printf '%s\n' '[<id>...]' ;;
+  "hold --help") printf '%s\n' '--kind captain' ;;
+esac
+SH
+  chmod +x "$fb/tasks-axi"
+  (cd "$host" && PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-decision-hold.sh" complete "$id" --none >/dev/null) \
+    || fail "live host-root completion could not persist ownership"
+  owner="$home/data/$id/host-root"
+  assert_grep "host_root=$host" "$owner" "completion did not persist the recorded host owner"
+  rm "$home/state/$id.meta"
+  (cd "$host" && PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-decision-hold.sh" complete "$id" --none >/dev/null) \
+    || fail "post-metadata completion rejected its durable host owner"
+  rm "$owner"
+  out=$(cd "$host" && PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-decision-hold.sh" complete "$id" --none 2>&1) || status=$?
+  expect_code 1 "$status" "post-metadata completion trusted ambient host authority"
+  assert_contains "$out" 'has no durable recorded host owner' "missing durable host owner refusal was not explicit"
+  pass "post-metadata decision actions require durable recorded host ownership"
+}
+
+test_host_teardown_requires_confirmed_stop() {
+  local host="$TMP/teardown-host" home="$TMP/teardown-home" project="$TMP/teardown-project" wt="$TMP/teardown-wt" fb log current tree_log out status=0 kill_line verify_line return_line
+  make_host "$host"; mkdir -p "$home/data" "$home/state" "$home/config"; fm_git_init_commit "$project"
+  git -C "$project" worktree add -q --detach "$wt"
+  printf 'window=test-session:fm-host-teardown\nworktree=%s\nhost_root=%s\nproject=%s\nkind=ship\nmode=local-only\n' \
+    "$wt" "$host" "$project" > "$home/state/host-teardown.meta"
+  fb=$(make_fakebin "$TMP/fake-host-teardown")
+  log="$TMP/host-teardown.log"; current="$TMP/host-teardown.current"; tree_log="$TMP/host-teardown-treehouse.log"
+  printf '%s\n' "$host" > "$current"; : > "$current.endpoint"; : > "$log"; : > "$tree_log"
+  out=$(cd "$host" && PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    FM_REFUSE_STOP=1 FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 FM_TMUX_LOG="$log" \
+    FM_ENDPOINT_TARGET=test-session:fm-host-teardown FM_LAUNCH_FILE="$TMP/unused.launch" FM_CURRENT_PATH="$current" \
+    FM_TARGET_PATH="$wt" FM_HOST_PATH="$host" FM_TREEHOUSE_LOG="$tree_log" TMUX=fake \
+    "$ROOT/bin/fm-teardown.sh" host-teardown --force 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "host-root teardown accepted an unconfirmed endpoint stop"
+  assert_no_grep 'return --force' "$tree_log" "host-root teardown recycled work before confirming endpoint absence"
+  assert_present "$home/state/host-teardown.meta" "host-root teardown removed recovery metadata after stop refusal"
+
+  : > "$log"; : > "$tree_log"; status=0
+  out=$(cd "$host" && PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 FM_TMUX_LOG="$log" \
+    FM_ENDPOINT_TARGET=test-session:fm-host-teardown FM_LAUNCH_FILE="$TMP/unused.launch" FM_CURRENT_PATH="$current" \
+    FM_TARGET_PATH="$wt" FM_HOST_PATH="$host" FM_TREEHOUSE_LOG="$tree_log" TMUX=fake \
+    "$ROOT/bin/fm-teardown.sh" host-teardown --force 2>&1) || status=$?
+  expect_code 0 "$status" "host-root teardown failed after confirmed endpoint stop: $out"
+  kill_line=$(grep -n 'kill-window' "$log" | tail -1 | cut -d: -f1)
+  verify_line=$(awk -v start="$kill_line" 'NR > start && /list-panes/ { print NR; exit }' "$log")
+  return_line=$(grep -n 'return --force' "$tree_log" | head -1 | cut -d: -f1)
+  [ -n "$kill_line" ] && [ -n "$verify_line" ] && [ -n "$return_line" ] \
+    || fail "host-root teardown did not stop, verify, and return its isolated copy"
+  pass "host-root teardown confirms endpoint absence before worktree cleanup"
 }
 
 test_task_actions_use_recorded_host_root() {
@@ -630,5 +731,7 @@ test_all_harnesses_add_one_task_safeguard
 test_mutators_require_host_cwd
 test_secondmate_actions_keep_supervisor_host_authority
 test_spawn_rollback_is_transactional
+test_decision_actions_use_durable_host_owner
+test_host_teardown_requires_confirmed_stop
 test_task_actions_use_recorded_host_root
 test_spawn_rejects_old_brief_and_secondmate_clears_roots

--- a/tests/fm-host-root-mode.test.sh
+++ b/tests/fm-host-root-mode.test.sh
@@ -1,0 +1,634 @@
+#!/usr/bin/env bash
+# Focused behavior tests for the opt-in FM_HOST_ROOT four-root contract.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP=$(fm_test_tmproot fm-host-root-mode)
+LIB="$ROOT/bin/fm-host-root-lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+make_host() {
+  local path=$1
+  fm_git_init_commit "$path"
+  : > "$path/AGENTS.md"
+  git -C "$path" add AGENTS.md
+  git -C "$path" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm instructions
+}
+
+resolve_host() {
+  FM_HOST_ROOT=$1 bash -c '. "$1"; fm_host_root_resolve "$2"' _ "$LIB" "$ROOT"
+}
+
+paths_overlap() {
+  bash -c '. "$1"; fm_host_root_paths_overlap "$2" "$3"' _ "$LIB" "$1" "$2"
+}
+
+test_resolution_and_validation() {
+  local host="$TMP/host with spaces and apostrophe's" link="$TMP/host-link" unsafe_target out status=0
+  make_host "$host"
+  ln -s "$host" "$link"
+  out=$(resolve_host "$link") || status=$?
+  expect_code 0 "$status" "symlinked host root should resolve"
+  [ "$out" = "$(cd "$host" && pwd -P)" ] || fail "host root did not resolve physically: $out"
+
+  status=0
+  FM_HOST_ROOT="$TMP/missing" bash -c '. "$1"; fm_host_root_resolve "$2"' _ "$LIB" "$ROOT" >/dev/null 2>&1 || status=$?
+  expect_code 2 "$status" "missing host root must fail"
+  status=0
+  FM_HOST_ROOT="$ROOT" bash -c '. "$1"; fm_host_root_resolve "$2"' _ "$LIB" "$ROOT" >/dev/null 2>&1 || status=$?
+  expect_code 2 "$status" "host root equal to FM_ROOT must fail"
+  status=0
+  FM_HOST_ROOT=$'bad\nroot' bash -c '. "$1"; fm_host_root_resolve "$2"' _ "$LIB" "$ROOT" >/dev/null 2>&1 || status=$?
+  expect_code 2 "$status" "newline-unsafe host root must fail"
+  status=0
+  FM_HOST_ROOT=$'bad\aroot' bash -c '. "$1"; fm_host_root_resolve "$2"' _ "$LIB" "$ROOT" >/dev/null 2>&1 || status=$?
+  expect_code 2 "$status" "all metadata-unsafe control characters must fail"
+  unsafe_target="$TMP/resolved"$'\n'"host"
+  make_host "$unsafe_target"
+  ln -s "$unsafe_target" "$TMP/clean-host-link"
+  status=0
+  FM_HOST_ROOT="$TMP/clean-host-link" bash -c '. "$1"; fm_host_root_resolve "$2"' _ "$LIB" "$ROOT" >/dev/null 2>&1 || status=$?
+  expect_code 2 "$status" "control characters introduced by physical resolution must fail"
+  mkdir -p "$TMP/claude-only-host"
+  : > "$TMP/claude-only-host/CLAUDE.md"
+  status=0
+  FM_HOST_ROOT="$TMP/claude-only-host" bash -c '. "$1"; fm_host_root_resolve "$2"' _ "$LIB" "$ROOT" >/dev/null 2>&1 || status=$?
+  expect_code 2 "$status" "a Claude-only instruction surface must not admit non-Claude workers"
+  paths_overlap "$host" "$host" || fail "equal host and target roots were not classified as overlapping"
+  paths_overlap "$host" "$host/nested-target" || fail "target nested under host was not classified as overlapping"
+  paths_overlap "$host/nested-host" "$host" || fail "host nested under target was not classified as overlapping"
+  if paths_overlap "$host" "$TMP/host-with-similar-prefix"; then
+    fail "sibling paths with a shared prefix were classified as overlapping"
+  fi
+  pass "host-root library resolves physical paths and rejects unsafe, harness-specific, or overlapping roots"
+}
+
+test_session_cwd_mismatch_precedes_mutation() {
+  local host="$TMP/session-host" home="$TMP/session-home" other="$TMP/session-other" fake_root out status=0
+  make_host "$host"; mkdir -p "$home/state" "$home/data" "$home/config" "$other"
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-session-start.sh" 2>&1) || status=$?
+  expect_code 2 "$status" "session-start host cwd mismatch must fail"
+  assert_contains "$out" 'requires the supervisor cwd' "session-start mismatch did not explain the host cwd"
+  [ -z "$(find "$home/state" -mindepth 1 -print -quit)" ] || fail "session-start mismatch mutated state before refusal"
+
+  fake_root="$TMP/guard-root"
+  mkdir -p "$fake_root/bin"
+  : > "$fake_root/AGENTS.md"
+  cat > "$fake_root/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+: > "$FM_GUARD_MUTATION"
+SH
+  chmod +x "$fake_root/bin/fm-guard.sh"
+  status=0
+  (cd "$other" && FM_GUARD_MUTATION="$TMP/guard-ran" FM_ROOT_OVERRIDE="$fake_root" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-spawn.sh" guarded "$TMP/missing-project" codex >/dev/null 2>&1) || status=$?
+  expect_code 2 "$status" "spawn host cwd mismatch must fail"
+  assert_absent "$TMP/guard-ran" "spawn ran the supervision guard before host validation"
+
+  status=0
+  (cd "$other" && FM_ROOT_OVERRIDE="$fake_root" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-brief.sh" guarded-mate --secondmate --no-projects >/dev/null 2>&1) || status=$?
+  expect_code 2 "$status" "secondmate brief host cwd mismatch must fail"
+  assert_absent "$home/data/guarded-mate" "secondmate brief mutated task data before host validation"
+
+  status=0
+  (cd "$other" && FM_GUARD_MUTATION="$TMP/guard-ran" FM_ROOT_OVERRIDE="$fake_root" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-spawn.sh" guarded-mate "$TMP/missing-home" codex --secondmate >/dev/null 2>&1) || status=$?
+  expect_code 2 "$status" "secondmate spawn host cwd mismatch must fail"
+  assert_absent "$TMP/guard-ran" "secondmate spawn ran the supervision guard before host validation"
+  pass "host cwd mismatch is rejected before session, brief, or spawn mutation"
+}
+
+test_host_command_rendering() {
+  local host="$TMP/render & host" home="$TMP/render-home" fake_root="$TMP/FirstMate & root's copy" rendered supervision command argv
+  make_host "$host"; mkdir -p "$home/state" "$home/config" "$fake_root/bin"
+  argv="$TMP/rendered-argv"
+  cat > "$fake_root/bin/argv-probe" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$FM_ARGV_LOG"
+SH
+  cp "$fake_root/bin/argv-probe" "$fake_root/bin/fm-watch-checkpoint.sh"
+  chmod +x "$fake_root/bin/argv-probe" "$fake_root/bin/fm-watch-checkpoint.sh"
+  rendered=$(FM_HOST_ROOT="$host" bash -c '. "$1"; fm_host_root_command "$2" bin/argv-probe' _ "$LIB" "$fake_root")
+  FM_ARGV_LOG="$argv" bash -c "$rendered one 'two words' \"apostrophe's\""
+  [ "$(cat "$argv")" = $'one\ntwo words\napostrophe\x27s' ] || fail "quoted host command did not preserve argv"
+
+  supervision=$(FM_ROOT_OVERRIDE="$fake_root" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-supervision-instructions.sh" --harness codex --repair-line)
+  assert_contains "$supervision" "FirstMate & root'\\''s copy/bin'/fm-watch-checkpoint.sh" \
+    "host supervision did not shell-quote its absolute command"
+  command=$(printf '%s\n' "$supervision" | sed -n 's/.*checkpoint: \(.*\) --seconds.*/\1/p')
+  FM_ARGV_LOG="$argv" bash -c "$command --seconds 7"
+  [ "$(cat "$argv")" = $'--seconds\n7' ] || fail "rendered supervision command did not preserve argv"
+  pass "host mode shell-quotes absolute commands and preserves argv"
+}
+
+test_brief_variants() {
+  local host="$TMP/brief & host" home="$TMP/brief-home" brief normal_home="$TMP/normal-home"
+  make_host "$host"
+  mkdir -p "$home/data" "$normal_home/data"
+  (cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-brief.sh" lane-host alpha >/dev/null 2>&1)
+  brief="$home/data/lane-host/brief.md"
+  assert_grep '<!-- firstmate-execution-mode: host-root -->' "$brief" "host brief marker missing"
+  assert_contains "$(cat "$brief")" "$host" "host brief corrupted the literal host path"
+  # shellcheck disable=SC2016  # Assertions intentionally match literal worker variables.
+  assert_contains "$(cat "$brief")" 'git -C "$FM_TARGET_WORKTREE"' "host brief does not scope Git to the target"
+  assert_grep 'Read the target worktree root instructions' "$brief" "host brief does not require target instructions"
+  assert_grep 'top-level process cwd at the host root' "$brief" "host brief does not preserve host cwd"
+  # shellcheck disable=SC2016
+  assert_contains "$(cat "$brief")" '(cd "$FM_TARGET_WORKTREE" && no-mistakes doctor)' "host brief does not scope no-mistakes setup"
+  # shellcheck disable=SC2016
+  assert_contains "$(cat "$brief")" '(cd "$FM_TARGET_WORKTREE" && no-mistakes axi run --help)' "host brief does not scope no-mistakes help"
+  # shellcheck disable=SC2016
+  assert_contains "$(cat "$brief")" '(cd "$FM_TARGET_WORKTREE" && no-mistakes axi respond ...)' "host brief does not scope no-mistakes responses"
+  assert_no_grep '`no-mistakes axi' "$brief" "host brief leaves a bare no-mistakes CLI command"
+
+  FM_HOME="$normal_home" "$ROOT/bin/fm-brief.sh" lane-normal 'alpha & beta' >/dev/null 2>&1
+  assert_no_grep 'firstmate-execution-mode: host-root' "$normal_home/data/lane-normal/brief.md" "default brief changed execution mode"
+  assert_contains "$(cat "$normal_home/data/lane-normal/brief.md")" 'alpha & beta' "default brief corrupted the literal repository name"
+  assert_grep 'git checkout -b fm/lane-normal' "$normal_home/data/lane-normal/brief.md" "default brief lost its normal branch command"
+  pass "brief scaffolding has an explicit host variant and unchanged default variant"
+}
+
+make_fakebin() {
+  local dir=$1 fb
+  fb=$(fm_fakebin "$dir")
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\037' "$@" >> "$FM_TMUX_LOG"; printf '\n' >> "$FM_TMUX_LOG"
+endpoint=${FM_ENDPOINT_ALIVE:-$FM_CURRENT_PATH.endpoint}
+if [ "${1:-}" = send-keys ] && printf '%s\n' "$*" | grep -q -- ' -l '; then
+  case "${*: -1}" in
+    'Read the brief at '*' and follow it exactly.') : ;;
+    *) printf '%s' "${*: -1}" > "$FM_LAUNCH_FILE" ;;
+  esac
+  : > "$FM_LAUNCH_FILE.literal"
+  [ "${FM_FAIL_LAUNCH_SEND:-0}" != 1 ] || exit 91
+fi
+if [ "${1:-}" = send-keys ] && [ "${*: -1}" = Enter ] && [ -f "$FM_LAUNCH_FILE.literal" ]; then
+  [ "${FM_FAIL_LAUNCH_ENTER:-0}" != 1 ] || exit 92
+fi
+case "${1:-}" in
+  display-message)
+    case "$*" in
+      *'#{pane_current_path}'*) [ -f "$endpoint" ] && cat "$FM_CURRENT_PATH" ;;
+      *'#{cursor_y}'*) printf '0\n' ;;
+      *'#{window_id}'*) [ -f "$endpoint" ] && printf '%%1\n' ;;
+      *'#{pane_id}'*) [ -f "$endpoint" ] && printf '%%1\n' ;;
+      *) printf 'test-session\n' ;;
+    esac
+    ;;
+  capture-pane)
+    if [ "${FM_FAKE_KIMI:-0}" = 1 ]; then
+      printf 'Welcome to Kimi Code!\n│ > │\ncontext: 1%%\n'
+    fi
+    ;;
+  list-windows) [ -z "${FM_EXISTING_WINDOW:-}" ] || printf '%s\n' "$FM_EXISTING_WINDOW" ;;
+  list-panes) [ ! -f "$endpoint" ] || printf '%%1|@1|test-session:fm-rollback-stuck|test-session:1.0\n' ;;
+  has-session|new-session|set-window-option) ;;
+  new-window) : > "$endpoint"; printf '%%1\n' ;;
+  kill-window) [ "${FM_REFUSE_STOP:-0}" = 1 ] || rm -f "$endpoint" ;;
+  send-keys)
+    case "$*" in
+      *'treehouse get'*) printf '%s\n' "$FM_TARGET_PATH" > "$FM_CURRENT_PATH" ;;
+      *'cd -- '* ) [ "${FM_REFUSE_HOST_MOVE:-0}" = 1 ] || printf '%s\n' "$FM_HOST_PATH" > "$FM_CURRENT_PATH" ;;
+    esac
+    ;;
+esac
+SH
+  chmod +x "$fb/tmux"
+  cat > "$fb/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -z "${FM_TREEHOUSE_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_TREEHOUSE_LOG"
+exit 0
+SH
+  chmod +x "$fb/treehouse"
+  cat > "$fb/codex" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -z "${FM_CODEX_ARGV:-}" ] || printf '%s\0' "$@" > "$FM_CODEX_ARGV"
+printf 'cwd=%s\nhost=%s\ntarget=%s\n' "$(pwd -P)" "${FM_HOST_ROOT:-}" "${FM_TARGET_WORKTREE:-}" > "$FM_WORKER_OBS"
+printf 'target edit\n' > "$FM_TARGET_WORKTREE/worker-edit.txt"
+SH
+  chmod +x "$fb/codex"
+  cat > "$fb/kimi" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fb/kimi"
+  printf '%s\n' "$fb"
+}
+
+test_spawn_separates_roots() {
+  local host="$TMP/spawn & host" home="$TMP/spawn home's & #%?" project="$TMP/target & repo" wt="$TMP/target & worktree" fb log current launch obs argv turnend meta before after tree_line cd_line launch_line
+  make_host "$host"
+  mkdir -p "$home/data/lane" "$home/state" "$home/config"
+  fm_git_init_commit "$project"
+  git -C "$project" worktree add -q --detach "$wt"
+  (cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-brief.sh" lane "$(basename "$project")" >/dev/null 2>&1)
+  fb=$(make_fakebin "$TMP/fake")
+  log="$TMP/tmux.log"; current="$TMP/current"; launch="$TMP/launch"; obs="$TMP/worker-observation"; argv="$TMP/codex.argv"
+  printf '%s\n' "$project" > "$current"
+  before=$(git -C "$host" status --porcelain)
+  (cd "$host" && PATH="$fb:$PATH" FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$launch" FM_CURRENT_PATH="$current" FM_TARGET_PATH="$wt" FM_HOST_PATH="$host" TMUX=fake \
+    "$ROOT/bin/fm-spawn.sh" lane "$project" codex > "$TMP/spawn.out" 2>&1) \
+    || fail "host-root spawn failed: $(cat "$TMP/spawn.out")"
+  meta="$home/state/lane.meta"
+  assert_grep "worktree=$wt" "$meta" "spawn meta lost target worktree"
+  assert_grep "host_root=$host" "$meta" "spawn meta lost host root"
+  assert_contains "$(cat "$log")" "FM_TARGET_WORKTREE='$wt'" "child launch did not export exact target worktree"
+  assert_contains "$(cat "$log")" "FM_HOST_ROOT='$host'" "child launch did not export exact host root"
+  assert_contains "$(cat "$log")" 'notify=[' "Codex FirstMate turn-end safeguard was not retained"
+  [ "$(cat "$current")" = "$host" ] || fail "endpoint did not finish at physical host root"
+  tree_line=$(grep -nF 'treehouse get' "$log" | head -1 | cut -d: -f1)
+  cd_line=$(grep -nF 'cd --' "$log" | head -1 | cut -d: -f1)
+  launch_line=$(grep -nF 'FM_TARGET_WORKTREE=' "$log" | head -1 | cut -d: -f1)
+  [ "$tree_line" -lt "$cd_line" ] && [ "$cd_line" -lt "$launch_line" ] || fail "spawn order was not worktree then host root then harness"
+  (cd "$host" && PATH="$fb:$PATH" FM_WORKER_OBS="$obs" FM_CODEX_ARGV="$argv" bash -c "$(cat "$launch")")
+  assert_grep "cwd=$host" "$obs" "worker harness did not start from the host root"
+  assert_grep "host=$host" "$obs" "worker did not receive the exact host root"
+  assert_grep "target=$wt" "$obs" "worker did not receive the exact target worktree"
+  turnend="$(cd "$home/state" && pwd -P)/lane.turn-ended"
+  python3 - "$argv" "$turnend" <<'PY' || fail "Codex notify argv did not preserve the hostile turn-end path"
+import pathlib, subprocess, sys
+args = pathlib.Path(sys.argv[1]).read_bytes().split(b"\0")
+args = [a.decode() for a in args if a]
+assert args.count("-c") == 1, args
+i = args.index("-c")
+config = args[i + 1]
+assert config.startswith('notify=["bash","-c","touch -- '), config
+assert config.endswith('"]'), config
+subprocess.run(["bash", "-c", config[len('notify=["bash","-c","'):-2]], check=True)
+PY
+  assert_present "$turnend" "Codex notify command did not touch the exact hostile path"
+  assert_present "$wt/worker-edit.txt" "disposable worker probe did not edit the target worktree"
+  assert_absent "$host/worker-edit.txt" "disposable worker probe edited the host root"
+  after=$(git -C "$host" status --porcelain)
+  [ "$before" = "$after" ] || fail "host working tree changed during spawn or worker probe"
+  pass "spawn orders and separates host cwd, target metadata, child environment, and target-only edits"
+}
+
+test_duplicate_spawn_preserves_existing_task() {
+  local host="$TMP/duplicate-host" home="$TMP/duplicate-home" project="$TMP/duplicate-target" fb log current launch out status=0
+  make_host "$host"
+  fm_git_init_commit "$project"
+  mkdir -p "$home/data/lane" "$home/state" "$home/config"
+  (cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-brief.sh" lane target >/dev/null 2>&1)
+  printf 'window=test-session:fm-lane\nworktree=/tmp/existing-worktree\nhost_root=%s\nproject=%s\nkind=ship\n' \
+    "$host" "$project" > "$home/state/lane.meta"
+  printf 'working: existing task\n' > "$home/state/lane.status"
+  cp "$home/state/lane.meta" "$TMP/existing.meta"
+  cp "$home/state/lane.status" "$TMP/existing.status"
+  fb=$(make_fakebin "$TMP/fake-duplicate")
+  log="$TMP/duplicate.log"; current="$TMP/duplicate.current"; launch="$TMP/duplicate.launch"
+  printf '%s\n' "$project" > "$current"
+  : > "$current.endpoint"
+
+  out=$(cd "$host" && PATH="$fb:$PATH" FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    FM_EXISTING_WINDOW=fm-lane FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$launch" FM_CURRENT_PATH="$current" \
+    FM_TARGET_PATH=/tmp/unused FM_HOST_PATH="$host" TMUX=fake \
+    "$ROOT/bin/fm-spawn.sh" lane "$project" codex 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "duplicate spawn unexpectedly succeeded"
+  assert_contains "$out" 'window test-session:fm-lane already exists' "duplicate spawn refusal was not explicit"
+  assert_no_grep 'kill-window' "$log" "duplicate spawn killed the existing task endpoint"
+  cmp -s "$TMP/existing.meta" "$home/state/lane.meta" || fail "duplicate spawn changed existing metadata"
+  cmp -s "$TMP/existing.status" "$home/state/lane.status" || fail "duplicate spawn changed existing status"
+  assert_present "$current.endpoint" "duplicate spawn removed the existing endpoint"
+  pass "duplicate spawn preserves the existing endpoint and task records"
+}
+
+test_spawn_rejects_host_as_target_and_cleans_failed_transition() {
+  local host="$TMP/refusal-host" home="$TMP/refusal-home" project="$TMP/refusal-target" wt="$TMP/refusal-wt" fb log current tree_log out status=0
+  make_host "$host"
+  mkdir -p "$home/data/host-target" "$home/data/move-fail" "$home/state" "$home/config"
+  fm_git_init_commit "$project"
+  git -C "$project" worktree add -q --detach "$wt"
+  (cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-brief.sh" host-target target >/dev/null 2>&1)
+  (cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-brief.sh" move-fail target >/dev/null 2>&1)
+  fb=$(make_fakebin "$TMP/fake-refusals")
+  log="$TMP/refusals.log"; current="$TMP/refusals.current"; tree_log="$TMP/treehouse.log"
+
+  printf '%s\n' "$project" > "$current"
+  out=$(cd "$host" && PATH="$fb:$PATH" FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$TMP/refusal.launch" FM_CURRENT_PATH="$current" FM_TARGET_PATH="$host" \
+    FM_HOST_PATH="$host" FM_TREEHOUSE_LOG="$tree_log" TMUX=fake \
+    "$ROOT/bin/fm-spawn.sh" host-target "$project" codex 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "spawn accepted FM_HOST_ROOT as the target worktree"
+  assert_contains "$out" 'overlapping host and target roots' "host-as-target refusal was not explicit"
+  assert_contains "$(cat "$log")" 'kill-window' "host-as-target refusal leaked its tmux endpoint"
+  assert_no_grep 'return --force' "$tree_log" "host-as-target refusal tried to recycle the authoritative host path"
+  assert_present "$home/state/host-target.meta" "host-as-target refusal lost recovery metadata for the preserved path"
+
+  : > "$log"; : > "$tree_log"; printf '%s\n' "$project" > "$current"; status=0
+  out=$(cd "$host" && PATH="$fb:$PATH" FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    FM_HOST_CWD_ATTEMPTS=1 FM_HOST_CWD_DELAY=0 FM_REFUSE_HOST_MOVE=1 \
+    FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$TMP/move-fail.launch" FM_CURRENT_PATH="$current" FM_TARGET_PATH="$wt" \
+    FM_HOST_PATH="$host" FM_TREEHOUSE_LOG="$tree_log" TMUX=fake \
+    "$ROOT/bin/fm-spawn.sh" move-fail "$project" codex 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "spawn accepted a backend that never entered FM_HOST_ROOT"
+  assert_contains "$out" 'did not enter FM_HOST_ROOT' "host transition failure was not explicit"
+  assert_contains "$(cat "$log")" 'kill-window' "failed host transition leaked its tmux endpoint"
+  assert_grep 'return --force' "$tree_log" "failed host transition did not return the acquired worktree"
+  assert_absent "$home/state/move-fail.meta" "successful transition cleanup left recovery metadata"
+  pass "host overlap preserves the path while ordinary transition failures clean their resources"
+}
+
+test_orca_active_cwd_probe() {
+  local out
+  out=$(bash -c '
+    . "$1/bin/backends/orca.sh"
+    fm_backend_orca_send_text_line() {
+      markers=$(printf "%s\n" "$2" | grep -o "__FM_ORCA_CWD_[A-Z]*_[A-Za-z0-9_]*__")
+      begin=$(printf "%s\n" "$markers" | head -1)
+      end=$(printf "%s\n" "$markers" | tail -1)
+    }
+    fm_backend_orca_read_text_paged() {
+      printf "%s\n" "$begin" "/tmp/orca host" "$end"
+    }
+    fm_backend_orca_current_path terminal-1
+  ' _ "$ROOT")
+  [ "$out" = "/tmp/orca host" ] || fail "Orca active cwd probe returned '$out'"
+  pass "Orca backend reads the live shell cwd through a bounded marker probe"
+}
+
+test_all_harnesses_add_one_task_safeguard() {
+  local host="$TMP/adapters-host" home="$TMP/adapter home's #%?" project="$TMP/adapters-target" before after harness id wt fb log current launch text count out status=0
+  make_host "$host"
+  fm_git_init_commit "$project"
+  mkdir -p "$home/data" "$home/state" "$home/config"
+  mkdir -p "$TMP/harness-home/.kimi-code"
+  printf 'default_model = "test"\n' > "$TMP/harness-home/.kimi-code/config.toml"
+  before=$(git -C "$host" status --porcelain)
+  for harness in claude codex opencode pi grok kimi; do
+    id="adapter-$harness"
+    wt="$TMP/$id-wt"
+    git -C "$project" worktree add -q --detach "$wt"
+    (cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-brief.sh" "$id" "$(basename "$project")" >/dev/null 2>&1)
+    fb=$(make_fakebin "$TMP/fake-$harness")
+    log="$TMP/$id.log"; current="$TMP/$id.current"; launch="$TMP/$id.launch"
+    printf '%s\n' "$project" > "$current"
+    (cd "$host" && HOME="$TMP/harness-home" PATH="$fb:$PATH" FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+      FM_FAKE_KIMI=1 FM_KIMI_READY_POLLS=1 FM_KIMI_DELIVERY_POLLS=1 FM_KIMI_POLL_INTERVAL=0 \
+      FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$launch" FM_CURRENT_PATH="$current" FM_TARGET_PATH="$wt" FM_HOST_PATH="$host" TMUX=fake \
+      "$ROOT/bin/fm-spawn.sh" "$id" "$project" "$harness" >/dev/null)
+    text=$(cat "$launch")
+    bash -n -c "$text" || fail "$harness host-root launch is not valid shell"
+    case "$harness" in
+      claude)
+        count=$(printf '%s' "$text" | grep -o -- '--settings' | wc -l | tr -d ' ')
+        [ "$count" -eq 1 ] || fail "Claude task settings appeared $count times"
+        assert_present "$home/state/$id.claude-settings.json" "Claude task settings file missing"
+        node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$home/state/$id.claude-settings.json" \
+          || fail "Claude task settings are invalid JSON"
+        ;;
+      codex)
+        count=$(printf '%s' "$text" | grep -oF 'notify=[' | wc -l | tr -d ' ')
+        [ "$count" -eq 1 ] || fail "Codex notify safeguard appeared $count times"
+        ;;
+      opencode)
+        count=$(printf '%s' "$text" | grep -oF 'opencode-turn-end.js' | wc -l | tr -d ' ')
+        [ "$count" -eq 1 ] || fail "OpenCode task plugin appeared $count times"
+        assert_present "$home/state/$id.opencode-turn-end.js" "OpenCode task plugin missing"
+        assert_contains "$text" '%23%25%3F' "OpenCode task plugin file URL did not encode path metacharacters"
+        node --check "$home/state/$id.opencode-turn-end.js" >/dev/null \
+          || fail "OpenCode task plugin is invalid JavaScript"
+        ;;
+      pi)
+        count=$(printf '%s' "$text" | grep -oF "$id.pi-ext.ts" | wc -l | tr -d ' ')
+        [ "$count" -eq 1 ] || fail "Pi task extension appeared $count times"
+        assert_present "$home/state/$id.pi-ext.ts" "Pi task extension missing"
+        ;;
+      grok)
+        count=$(printf '%s' "$text" | grep -oF 'FM_GROK_TURNEND_TOKEN=' | wc -l | tr -d ' ')
+        [ "$count" -eq 1 ] || fail "Grok task token appeared $count times"
+        assert_absent "$host/.fm-grok-turnend" "Grok host launch wrote a task pointer into the host"
+        ;;
+      kimi)
+        count=$(printf '%s' "$text" | grep -oF 'FM_KIMI_TURNEND_TOKEN=' | wc -l | tr -d ' ')
+        [ "$count" -eq 1 ] || fail "Kimi task token appeared $count times"
+        assert_present "$home/state/$id.kimi-turnend-token" "Kimi task token state is missing"
+        assert_absent "$host/.fm-kimi-turnend" "Kimi host launch wrote a task pointer into the host"
+        ;;
+    esac
+    rm -rf "/tmp/fm-$id"
+  done
+
+  id=adapter-raw
+  (cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-brief.sh" "$id" "$(basename "$project")" >/dev/null 2>&1)
+  out=$(cd "$host" && FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$project" 'claude --dangerously-skip-permissions' 2>&1) || status=$?
+  expect_code 2 "$status" "host mode must reject a raw launch command without a verified task safeguard"
+  assert_contains "$out" 'requires a named verified harness' "raw host launch refusal was not explicit"
+  assert_absent "$home/state/$id.meta" "raw host launch mutated task state before refusal"
+
+  after=$(git -C "$host" status --porcelain)
+  [ "$before" = "$after" ] || fail "harness integration rewrote host configuration"
+  pass "all six harnesses add one task safeguard without changing host hooks"
+}
+
+test_mutators_require_host_cwd() {
+  local host="$TMP/mutator-host" other="$TMP/mutator-other" home="$TMP/mutator-home" out status=0
+  make_host "$host"
+  mkdir -p "$other" "$home/state"
+  printf 'window=fake:fm-lane\nworktree=/tmp/target\nhost_root=%s\nproject=/tmp/project\nkind=ship\n' "$host" > "$home/state/lane.meta"
+  printf 'window=fake:fm-scout\nworktree=/tmp/scout\nhost_root=%s\nproject=/tmp/project\nkind=scout\n' "$host" > "$home/state/scout.meta"
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-send.sh" lane hello 2>&1) || status=$?
+  expect_code 2 "$status" "fm-send must reject a host cwd mismatch"
+  assert_contains "$out" 'requires the recorded host root cwd' "fm-send host mismatch was not explicit"
+  status=0
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-teardown.sh" lane 2>&1) || status=$?
+  expect_code 2 "$status" "fm-teardown must reject a host cwd mismatch"
+  assert_present "$home/state/lane.meta" "teardown mutated task state before host validation"
+  printf 'mode=local-only\n' >> "$home/state/lane.meta"
+  status=0
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-merge-local.sh" lane 2>&1) || status=$?
+  expect_code 2 "$status" "fm-merge-local must reject a host cwd mismatch"
+  assert_present "$home/state/lane.meta" "local merge mutated task state before host validation"
+  status=0
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-pr-merge.sh" lane https://github.com/example/repo/pull/1 2>&1) || status=$?
+  expect_code 2 "$status" "fm-pr-merge must reject a host cwd mismatch"
+  assert_present "$home/state/lane.meta" "PR merge mutated task state before host validation"
+  status=0
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-pr-check.sh" lane https://github.com/example/repo/pull/1 2>&1) || status=$?
+  expect_code 2 "$status" "fm-pr-check must reject a host cwd mismatch"
+  if grep -q '^pr=' "$home/state/lane.meta"; then
+    fail "PR check mutated task metadata before host validation"
+  fi
+  status=0
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-review-diff.sh" lane --stat 2>&1) || status=$?
+  expect_code 2 "$status" "fm-review-diff must reject a host cwd mismatch"
+  status=0
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-promote.sh" scout 2>&1) || status=$?
+  expect_code 2 "$status" "fm-promote must reject a host cwd mismatch"
+  grep -qx 'kind=scout' "$home/state/scout.meta" || fail "promote mutated task metadata before host validation"
+  status=0
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-check-register.sh" lane 2>&1) || status=$?
+  expect_code 2 "$status" "fm-check-register must reject a host cwd mismatch"
+  assert_absent "$home/state/lane.check-trust" "check registration mutated trust state before host validation"
+  status=0
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-decision-hold.sh" complete lane --none 2>&1) || status=$?
+  expect_code 2 "$status" "fm-decision-hold must reject a host cwd mismatch"
+  status=0
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-x-followup.sh" --check lane 2>&1) || status=$?
+  expect_code 2 "$status" "fm-x-followup must reject a host cwd mismatch"
+  status=0
+  out=$(cd "$other" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-x-link.sh" lane request-1 2>&1) || status=$?
+  expect_code 2 "$status" "fm-x-link must reject a host cwd mismatch"
+  pass "task lifecycle actions reject host cwd mismatch before mutation"
+}
+
+test_secondmate_actions_keep_supervisor_host_authority() {
+  local host="$TMP/secondmate-action-host" other="$TMP/secondmate-action-other" meta="$TMP/secondmate-action.meta" ordinary="$TMP/ordinary-action.meta" out status=0
+  make_host "$host"
+  mkdir -p "$other"
+  printf 'window=fm-mate\nworktree=/tmp/mate\nkind=secondmate\n' > "$meta"
+  printf 'window=fm-task\nworktree=/tmp/task\nkind=ship\n' > "$ordinary"
+
+  (cd "$host" && FM_HOST_ROOT="$host" bash -c '. "$1"; fm_host_root_assert_task_cwd "$2" "$3"' _ "$LIB" "$ROOT" "$meta") \
+    || status=$?
+  expect_code 0 "$status" "secondmate action should use the primary supervisor host cwd without host_root metadata"
+
+  status=0
+  out=$(cd "$other" && FM_HOST_ROOT="$host" bash -c '. "$1"; fm_host_root_assert_task_cwd "$2" "$3"' _ "$LIB" "$ROOT" "$meta" 2>&1) \
+    || status=$?
+  expect_code 2 "$status" "secondmate action must still reject a supervisor host cwd mismatch"
+  assert_contains "$out" 'requires the supervisor cwd' "secondmate cwd mismatch did not preserve primary host authority"
+
+  status=0
+  out=$(cd "$host" && FM_HOST_ROOT="$host" bash -c '. "$1"; fm_host_root_assert_task_cwd "$2" "$3"' _ "$LIB" "$ROOT" "$ordinary" 2>&1) \
+    || status=$?
+  expect_code 2 "$status" "ordinary task without host_root metadata must remain rejected"
+  assert_contains "$out" 'has no recorded host_root' "secondmate exception weakened ordinary task ownership"
+  pass "secondmate actions retain primary host cwd authority without inheriting host_root metadata"
+}
+
+test_spawn_rollback_is_transactional() {
+  local host="$TMP/rollback-host" home="$TMP/rollback-home" project="$TMP/rollback-target" wt="$TMP/rollback-wt" stuck_wt="$TMP/rollback-stuck-wt" uncertain_wt="$TMP/rollback-uncertain-wt" fb log current tree_log out status=0
+  make_host "$host"; mkdir -p "$home/data" "$home/state" "$home/config"; fm_git_init_commit "$project"
+  git -C "$project" worktree add -q --detach "$wt"
+  git -C "$project" worktree add -q --detach "$stuck_wt"
+  git -C "$project" worktree add -q --detach "$uncertain_wt"
+  for id in rollback-clean rollback-stuck rollback-uncertain; do
+    (cd "$host" && FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+      "$ROOT/bin/fm-brief.sh" "$id" target >/dev/null 2>&1)
+  done
+  fb=$(make_fakebin "$TMP/fake-rollback")
+  log="$TMP/rollback.log"; current="$TMP/rollback.current"; tree_log="$TMP/rollback-treehouse.log"
+  printf '%s\n' "$project" > "$current"
+  out=$(cd "$host" && PATH="$fb:$PATH" FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    FM_FAIL_LAUNCH_SEND=1 FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$TMP/rollback.launch" \
+    FM_CURRENT_PATH="$current" FM_TARGET_PATH="$wt" FM_HOST_PATH="$host" FM_TREEHOUSE_LOG="$tree_log" TMUX=fake \
+    "$ROOT/bin/fm-spawn.sh" rollback-clean "$project" pi 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "injected launch failure unexpectedly succeeded"
+  assert_grep 'return --force' "$tree_log" "successful rollback did not return the isolated copy"
+  assert_absent "$home/state/rollback-clean.meta" "successful rollback left metadata"
+  assert_absent "$home/state/rollback-clean.pi-ext.ts" "successful rollback left its pre-record Pi artifact"
+  assert_absent "/tmp/fm-rollback-clean" "successful rollback left its task temp root"
+
+  : > "$log"; : > "$tree_log"; printf '%s\n' "$project" > "$current"; status=0
+  out=$(cd "$host" && PATH="$fb:$PATH" FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    FM_FAIL_LAUNCH_SEND=1 FM_REFUSE_STOP=1 FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 FM_TMUX_LOG="$log" \
+    FM_LAUNCH_FILE="$TMP/rollback-stuck.launch" FM_CURRENT_PATH="$current" FM_TARGET_PATH="$stuck_wt" FM_HOST_PATH="$host" \
+    FM_TREEHOUSE_LOG="$tree_log" TMUX=fake "$ROOT/bin/fm-spawn.sh" rollback-stuck "$project" pi 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "injected stop failure unexpectedly succeeded"
+  assert_contains "$out" 'still exists after stop' "failed endpoint termination was not explicit (backend log: $(tr '\n' ';' < "$log"))"
+  assert_no_grep 'return --force' "$tree_log" "rollback reused the isolated copy after unconfirmed termination"
+  assert_present "$home/state/rollback-stuck.meta" "failed rollback lost recovery metadata"
+  assert_present "$home/state/rollback-stuck.pi-ext.ts" "failed rollback discarded a recoverable pre-record artifact"
+  assert_present "/tmp/fm-rollback-stuck" "failed rollback discarded its recoverable task temp root"
+  rm -rf "/tmp/fm-rollback-stuck"
+  rm -f "$home/state/rollback-stuck.meta" "$home/state/rollback-stuck.pi-ext.ts" "$current.endpoint"
+
+  : > "$log"; : > "$tree_log"; printf '%s\n' "$project" > "$current"; status=0
+  out=$(cd "$host" && PATH="$fb:$PATH" FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" \
+    FM_FAIL_LAUNCH_ENTER=1 FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$TMP/rollback-uncertain.launch" \
+    FM_CURRENT_PATH="$current" FM_TARGET_PATH="$uncertain_wt" FM_HOST_PATH="$host" FM_TREEHOUSE_LOG="$tree_log" TMUX=fake \
+    "$ROOT/bin/fm-spawn.sh" rollback-uncertain "$project" pi 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "ambiguous Enter failure unexpectedly succeeded"
+  assert_contains "$out" 'launch submission could not be confirmed' "ambiguous Enter failure did not explain the retained task"
+  assert_no_grep 'kill-window' "$log" "ambiguous Enter failure killed a possibly running worker"
+  assert_no_grep 'return --force' "$tree_log" "ambiguous Enter failure recycled a possibly active worktree"
+  assert_present "$home/state/rollback-uncertain.meta" "ambiguous Enter failure lost task metadata"
+  assert_present "$home/state/rollback-uncertain.pi-ext.ts" "ambiguous Enter failure lost its task safeguard"
+  assert_present "/tmp/fm-rollback-uncertain" "ambiguous Enter failure removed its task temp root"
+  rm -rf "/tmp/fm-rollback-uncertain"
+  rm -f "$home/state/rollback-uncertain.meta" "$home/state/rollback-uncertain.pi-ext.ts" "$current.endpoint"
+  pass "spawn rollback cleans pre-launch failures and preserves ambiguous launch submissions"
+}
+
+test_task_actions_use_recorded_host_root() {
+  local host="$TMP/recorded-host" wrong="$TMP/wrong-host" home="$TMP/recorded-home" fb log current out status=0
+  make_host "$host"; make_host "$wrong"; mkdir -p "$home/state" "$home/config"
+  printf 'window=test-session:fm-lane\nworktree=/tmp/target\nhost_root=%s\nproject=/tmp/project\nkind=ship\n' "$host" > "$home/state/lane.meta"
+  fb=$(make_fakebin "$TMP/fake-recorded-host")
+  log="$TMP/recorded-host.log"; current="$TMP/recorded-host.current"
+  : > "$log"; printf '%s\n' "$host" > "$current"; : > "$current.endpoint"
+  out=$(cd "$wrong" && PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$wrong" \
+    FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$TMP/unused.launch" FM_CURRENT_PATH="$current" FM_TARGET_PATH=/tmp/target FM_HOST_PATH="$host" \
+    "$ROOT/bin/fm-send.sh" lane hello 2>&1) || status=$?
+  expect_code 2 "$status" "send must reject an ambient host that differs from task ownership"
+  assert_contains "$out" 'does not match task metadata host_root' "send did not identify recorded host ownership"
+  assert_no_grep 'send-keys' "$log" "send touched the endpoint before recorded-host validation"
+  status=0
+  out=$(cd "$wrong" && PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$wrong" \
+    FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$TMP/unused.launch" FM_CURRENT_PATH="$current" FM_TARGET_PATH=/tmp/target FM_HOST_PATH="$host" \
+    "$ROOT/bin/fm-teardown.sh" lane --force 2>&1) || status=$?
+  expect_code 2 "$status" "teardown must reject an ambient host that differs from task ownership"
+  assert_present "$home/state/lane.meta" "teardown changed task data before recorded-host validation"
+  pass "task actions bind to recorded physical host ownership before endpoint or task mutation"
+}
+
+test_spawn_rejects_old_brief_and_secondmate_clears_roots() {
+  local host="$TMP/reject-host" home="$TMP/reject-home" project="$TMP/reject-target" subhome="$TMP/secondmate-home" fb log current launch meta out status=0
+  make_host "$host"; mkdir -p "$home/data/old" "$home/state" "$home/config"; printf 'old brief\n' > "$home/data/old/brief.md"; fm_git_init_commit "$project"
+  out=$(cd "$host" && FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_HOST_ROOT="$host" "$ROOT/bin/fm-spawn.sh" old "$project" codex 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "host spawn accepted a cwd-relative old brief"
+  assert_contains "$out" 'requires a host-root brief' "old-brief rejection was not explicit"
+
+  mkdir -p "$subhome/bin" "$subhome/data"
+  printf '# Secondmate\n' > "$subhome/AGENTS.md"
+  printf 'mate\n' > "$subhome/.fm-secondmate-home"
+  printf 'charter\n' > "$subhome/data/charter.md"
+  fb=$(make_fakebin "$TMP/fake-secondmate")
+  log="$TMP/secondmate.log"; current="$TMP/secondmate.current"; launch="$TMP/secondmate.launch"
+  printf '%s\n' "$subhome" > "$current"
+  (cd "$host" && PATH="$fb:$PATH" FM_SPAWN_NO_GUARD=1 FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_HOST_ROOT="$host" FM_TARGET_WORKTREE=/should-not-leak FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$launch" \
+    FM_CURRENT_PATH="$current" FM_TARGET_PATH="$subhome" FM_HOST_PATH="$host" TMUX=fake \
+    "$ROOT/bin/fm-spawn.sh" mate "$subhome" codex --secondmate >/dev/null 2>&1)
+  assert_contains "$(cat "$launch")" 'FM_HOST_ROOT= FM_TARGET_WORKTREE=' "secondmate launch did not clear both host variables"
+  meta="$home/state/mate.meta"
+  assert_no_grep '^host_root=' "$meta" "secondmate metadata inherited host_root"
+  assert_grep "worktree=$subhome" "$meta" "secondmate lost its isolated-home worktree"
+
+  : > "$launch"; printf '%s\n' "$subhome" > "$current"
+  (cd "$host" && env -u FM_HOST_ROOT -u FM_TARGET_WORKTREE PATH="$fb:$PATH" FM_SPAWN_NO_GUARD=1 \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_TMUX_LOG="$log" FM_LAUNCH_FILE="$launch" \
+    FM_CURRENT_PATH="$current" FM_TARGET_PATH="$subhome" FM_HOST_PATH="$host" TMUX=fake \
+    "$ROOT/bin/fm-spawn.sh" mate-unset "$subhome" codex --secondmate >/dev/null 2>&1)
+  assert_not_contains "$(cat "$launch")" 'FM_HOST_ROOT=' "unset-mode secondmate launch changed its historical environment prefix"
+  assert_not_contains "$(cat "$launch")" 'FM_TARGET_WORKTREE=' "unset-mode secondmate launch set a new empty target variable"
+  pass "host spawn rejects old briefs, clears inherited secondmate roots, and preserves unset launches"
+}
+
+test_resolution_and_validation
+test_session_cwd_mismatch_precedes_mutation
+test_host_command_rendering
+test_brief_variants
+test_spawn_separates_roots
+test_duplicate_spawn_preserves_existing_task
+test_spawn_rejects_host_as_target_and_cleans_failed_transition
+test_orca_active_cwd_probe
+test_all_harnesses_add_one_task_safeguard
+test_mutators_require_host_cwd
+test_secondmate_actions_keep_supervisor_host_authority
+test_spawn_rollback_is_transactional
+test_task_actions_use_recorded_host_root
+test_spawn_rejects_old_brief_and_secondmate_clears_roots

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -19,15 +19,15 @@ assert_source_line() {
   grep -Fqx -- "$line" "$SPAWN" || fail "existing launch template changed: $line"
 }
 
-test_existing_launch_templates_are_byte_pinned() {
-  assert_source_line "    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__\"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"' ;;"
+test_existing_launch_templates_retain_operational_input() {
+  assert_source_line "        printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__\"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
   assert_source_line "        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
-  assert_source_line "        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c \"notify=[\\\"bash\\\",\\\"-c\\\",\\\"touch __TURNEND__\\\"]\" \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
-  assert_source_line "    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\\''{\"permission\":{\"*\":\"allow\"}}'\\'' opencode __MODELFLAG__--prompt \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"' ;;"
+  assert_source_line "        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c __CODEXNOTIFY__ \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
+  assert_source_line "        printf '%s' 'OPENCODE_CONFIG_CONTENT='\\''{\"permission\":{\"*\":\"allow\"}}'\\'' opencode __MODELFLAG__--prompt \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
   assert_source_line "        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
   assert_source_line "        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
-  assert_source_line "    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__\"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"' ;;"
-  pass "fm-spawn: the five pre-existing adapters' launch templates stay byte-pinned"
+  assert_source_line "        printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__\"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
+  pass "fm-spawn: the five pre-existing adapters retain typed launch-brief input"
 }
 
 test_tracked_files_have_no_user_absolute_paths() {
@@ -43,8 +43,10 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
-printf '%s\n' "$*" >> "$FM_FAKE_TMUX_CALL_LOG"
-state=$(cat "$FM_FAKE_KIMI_STATE" 2>/dev/null || true)
+call_log=${FM_FAKE_TMUX_CALL_LOG:-/dev/null}
+state_file=${FM_FAKE_KIMI_STATE:-/dev/null}
+printf '%s\n' "$*" >> "$call_log"
+state=$(cat "$state_file" 2>/dev/null || true)
 fake_screen() {
   case "$state" in
     ready)
@@ -388,6 +390,14 @@ test_kimi_hook_is_silent_and_requires_registered_workspace_token() {
   [ "$snapshot_before" = "$snapshot_after" ] || fail "Kimi hook wrote inside a tokenless workspace"
   assert_absent "$target" "tokenless Kimi hook invocation touched a task marker"
 
+  out=$(printf '{"hook_event_name":"Stop","session_id":"host-root-crew","cwd":"%s","stop_hook_active":false}\n' "$no_token" \
+    | HOME="$HOME_DIR" FM_KIMI_TURNEND_TOKEN="$token" bash "$hook" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "launch-scoped Kimi hook invocation did not exit zero"
+  [ -z "$out" ] || fail "launch-scoped Kimi hook invocation printed output: $out"
+  assert_present "$target" "launch-scoped Kimi token did not touch the turn-end marker"
+  rm "$target"
+
   printf 'token=%s\n' "$token" > "$WT_DIR/.fm-kimi-turnend"
   out=$(printf '{"hook_event_name":"Stop","session_id":"crew","cwd":"%s","stop_hook_active":false}\n' "$WT_DIR" \
     | HOME="$HOME_DIR" bash "$hook" 2>&1)
@@ -405,7 +415,7 @@ test_kimi_hook_is_silent_and_requires_registered_workspace_token() {
   expect_code 0 "$rc" "Kimi hook without jq must still exit zero"
   [ -z "$out" ] || fail "Kimi hook without jq printed output: $out"
   assert_absent "$target" "Kimi hook without jq touched the turn-end marker"
-  pass "Kimi hook stays silent and inert without a Firstmate registry token"
+  pass "Kimi hook accepts launch-scoped or workspace tokens and stays inert without either"
 }
 
 test_kimi_spawn_refuses_unsafe_global_config_before_pane_creation() {
@@ -434,11 +444,11 @@ test_kimi_teardown_removes_pointer_and_registry_token() {
   expect_code 0 "$rc" "Kimi spawn should succeed before teardown"
   token=$(sed -n 's/^token=//p' "$WT_DIR/.fm-kimi-turnend")
 
-  HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME_DIR" \
+  out=$(HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME_DIR" \
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 PATH="$FAKEBIN_DIR:$BASE_PATH" \
-    "$TEARDOWN" "$id" --force >/dev/null 2>&1 || fail "Kimi teardown failed"
+    "$TEARDOWN" "$id" --force 2>&1) || fail "Kimi teardown failed: $out"
   assert_absent "$WT_DIR/.fm-kimi-turnend" "Kimi token pointer survived teardown"
   assert_absent "$HOME_DIR/.kimi-code/fm-turn-end.d/$token" "Kimi registry token survived teardown"
   assert_absent "$HOME_DIR/state/$id.kimi-turnend-token" "Kimi token state survived teardown"
@@ -674,7 +684,7 @@ test_kimi_bordered_prompt_needs_no_override() {
 }
 
 test_tracked_files_have_no_user_absolute_paths
-test_existing_launch_templates_are_byte_pinned
+test_existing_launch_templates_retain_operational_input
 test_kimi_hook_install_is_surgical_idempotent_and_removable
 test_kimi_hook_remove_preserves_owned_newline_boundary
 test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -35,6 +35,20 @@ file_mode() {
   fi
 }
 
+write_stop_aware_tmux() {
+  local path=$1
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+stopped="${0}.stopped"
+case "${1:-}" in
+  kill-window) : > "$stopped" ;;
+  display-message) [ ! -e "$stopped" ] ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod 0700 "$path"
+}
+
 state_snapshot() {
   local state=$1 file
   (
@@ -577,11 +591,7 @@ test_valid_recording_and_merge_derivation() {
   fm_pr_poll_artifacts_valid "$dir/home/state" Task_A.1 "$POLL" \
     || fail "safe lifecycle-compatible task ID did not publish an authenticated poll"
   rm -rf "$dir/wt"
-  cat > "$dir/fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod 0700 "$dir/fakebin/tmux"
+  write_stop_aware_tmux "$dir/fakebin/tmux"
   touch "$dir/home/state/.last-watcher-beat"
   FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" PATH="$dir/fakebin:$BASE_PATH" \
     "$TEARDOWN" Task_A.1 --force > "$dir/teardown.out" 2> "$dir/teardown.err" \
@@ -602,11 +612,7 @@ SH
     printf 'reserved migration evidence\n' \
       > "$dir/home/state/.pr-check-quarantine/!noncanonical.check.evidence"
     chmod 0600 "$dir/home/state/.pr-check-quarantine/!noncanonical.check.evidence"
-    cat > "$dir/fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-    chmod 0700 "$dir/fakebin/tmux"
+    write_stop_aware_tmux "$dir/fakebin/tmux"
     touch "$dir/home/state/.last-watcher-beat"
     mkdir "$dir/home/state/$id.check.sh"
     set +e
@@ -1841,11 +1847,7 @@ test_obligation_namespace_compatibility() {
     "project=$dir/project" \
     'kind=ship' \
     'mode=local-only'
-  cat > "$dir/fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod 0700 "$dir/fakebin/tmux"
+  write_stop_aware_tmux "$dir/fakebin/tmux"
   touch "$state/.last-watcher-beat"
   set +e
   FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" PATH="$dir/fakebin:$BASE_PATH" \
@@ -2616,11 +2618,7 @@ test_teardown_removes_poll_artifacts() {
   chmod 0700 "$dir/home/state/.pr-check-quarantine"
   printf 'legacy\n' > "$dir/home/state/.pr-check-quarantine/task-a.check.abc123"
   chmod 0600 "$dir/home/state/.pr-check-quarantine/task-a.check.abc123"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
+  write_stop_aware_tmux "$fakebin/tmux"
   touch "$dir/home/state/.last-watcher-beat"
 
   FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" PATH="$fakebin:$BASE_PATH" \
@@ -2674,11 +2672,7 @@ SH
   printf 'noncanonical evidence\n' > "$dir/home/state/.pr-check-quarantine/!noncanonical.check.abc123"
   chmod 0600 "$dir/home/state/.pr-check-quarantine/invalid.check.abc123" \
     "$dir/home/state/.pr-check-quarantine/!noncanonical.check.abc123"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-  chmod +x "$fakebin/tmux"
+  write_stop_aware_tmux "$fakebin/tmux"
   touch "$dir/home/state/.last-watcher-beat"
 
   FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" PATH="$fakebin:$BASE_PATH" \

--- a/tests/fm-review-diff.test.sh
+++ b/tests/fm-review-diff.test.sh
@@ -169,8 +169,49 @@ test_unreachable_pr_head_falls_back_with_warning() {
   pass "fm-review-diff falls back to local branch with a warning when PR head is unreachable"
 }
 
+test_host_mode_scopes_every_git_command_to_worktree() {
+  local case_dir host fake_root fb git_log real_git out
+  case_dir=$(make_case host-scoped)
+  host="$case_dir/host"
+  fake_root="$case_dir/fake-root"
+  fb="$case_dir/fakebin"
+  git_log="$case_dir/git.log"
+  real_git=$(command -v git)
+  mkdir -p "$host" "$fake_root/bin" "$fb"
+  : > "$host/AGENTS.md"
+  cat > "$fake_root/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fake_root/bin/fm-guard.sh"
+  cat > "$fb/git" <<'SH'
+#!/usr/bin/env bash
+printf 'git' >> "$FM_GIT_LOG"
+for arg in "$@"; do printf '\037%s' "$arg" >> "$FM_GIT_LOG"; done
+printf '\n' >> "$FM_GIT_LOG"
+exec "$FM_REAL_GIT" "$@"
+SH
+  chmod +x "$fb/git"
+  printf 'host-scoped\n' > "$case_dir/wt/feature.txt"
+  git -C "$case_dir/wt" add feature.txt
+  git -C "$case_dir/wt" commit -qm "host scoped review"
+  write_task_meta "$case_dir" "host_root=$host"
+
+  out=$(cd "$host" && PATH="$fb:$PATH" FM_REAL_GIT="$real_git" FM_GIT_LOG="$git_log" \
+    FM_ROOT_OVERRIDE="$fake_root" FM_STATE_OVERRIDE="$case_dir/state" FM_HOST_ROOT="$host" \
+    "$REVIEW_DIFF" task-x1 --stat)
+
+  assert_contains "$out" "feature.txt" "host-scoped review did not inspect the task branch"
+  assert_contains "$(cat "$git_log")" $'git\x1f-C\x1f'"$case_dir/wt" \
+    "host-scoped review issued no Git command against the target worktree"
+  assert_not_contains "$(cat "$git_log")" $'git\x1f-C\x1f'"$case_dir/project" \
+    "host-scoped review issued a Git command against the primary project checkout"
+  pass "fm-review-diff scopes every host-mode Git command to the target worktree"
+}
+
 test_pr_meta_uses_pr_head_not_stale_local
 test_pr_meta_fetches_pull_head_without_recorded_sha
 test_stale_recorded_pr_head_loses_to_fetched_pull_head
 test_no_pr_meta_uses_local_branch
 test_unreachable_pr_head_falls_back_with_warning
+test_host_mode_scopes_every_git_command_to_worktree

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -747,19 +747,29 @@ SH
 # --- output ordering ----------------------------------------------------------
 
 test_output_ordering_diagnostics_lead() {
-  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line
+  local rec root home fakebin mask out lock_line boot_line wake_line context_line fleet_line next_line
   rec=$(new_world ordering)
   IFS='|' read -r root home fakebin <<EOF
 $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
+  # Force a MISSING diagnostic even when the machine has system node later in
+  # BASE_PATH; bootstrap uses command -v, so mask only that lookup in this case.
   rm -f "$fakebin/node"
+  mask="$home/mask-node.bash"
+  cat > "$mask" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = node ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+SH
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
   lock_line=$(printf '%s\n' "$out" | grep -n '^LOCK$' | head -1 | cut -d: -f1)
   boot_line=$(printf '%s\n' "$out" | grep -n '^BOOTSTRAP$' | head -1 | cut -d: -f1)
@@ -1030,7 +1040,7 @@ EOF
 # --- composition: real scripts run, not reimplemented ------------------------
 
 test_composition_invokes_real_scripts() {
-  local rec root home fakebin out
+  local rec root home fakebin mask out
   rec=$(new_world composition)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -1038,11 +1048,20 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   rm -f "$fakebin/node"
+  mask="$home/mask-node.bash"
+  cat > "$mask" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = node ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+SH
 
   printf 'needs-decision: pick a library\n' > "$home/state/task-z.status"
   append_wake "$home/state" signal task-z.status "needs-decision: pick a library"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -113,7 +113,8 @@ test_opencode_plugin_delivers_exact_nudge_once() {
   local root="$TMP_ROOT/opencode-primary" out status=0
   make_primary "$root"
   cp "$ROOT/bin/fm-sessionstart-nudge.sh" "$ROOT/bin/fm-primary-scope-lib.sh" \
-    "$ROOT/bin/fm-gate-refuse-lib.sh" "$ROOT/bin/fm-operational-input.sh" "$root/bin/"
+    "$ROOT/bin/fm-gate-refuse-lib.sh" "$ROOT/bin/fm-host-root-lib.sh" \
+    "$ROOT/bin/fm-operational-input.sh" "$root/bin/"
   chmod +x "$root/bin/fm-sessionstart-nudge.sh"
   out=$(PLUGIN="$ROOT/.opencode/plugins/fm-primary-sessionstart-nudge.js" \
     WORKTREE="$root" EXPECTED="$NUDGE_LINE" node --input-type=module 2>&1 <<'EOF'

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -158,13 +158,28 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+stopped="${0}.stopped"
+[ "${1:-}" != list-panes ] || exit 0
 case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{pane_current_path}"*)
+    [ ! -e "$stopped" ] || exit 1
+    if [ -n "${FM_FAKE_PANE_SEQUENCE:-}" ] && [ -s "$FM_FAKE_PANE_SEQUENCE" ]; then
+      head -1 "$FM_FAKE_PANE_SEQUENCE"
+      tail -n +2 "$FM_FAKE_PANE_SEQUENCE" > "$FM_FAKE_PANE_SEQUENCE.next"
+      mv "$FM_FAKE_PANE_SEQUENCE.next" "$FM_FAKE_PANE_SEQUENCE"
+    else
+      printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+    fi
+    exit 0
+    ;;
+  *"#{pane_id}"*) [ ! -e "$stopped" ] && printf '%%1\n'; exit $? ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|send-keys) exit 0 ;;
+  new-window) rm -f "$stopped"; exit 0 ;;
+  kill-window) : > "$stopped"; exit 0 ;;
+  has-session|new-session|send-keys) exit 0 ;;
 esac
 exit 0
 SH
@@ -180,8 +195,8 @@ run_spawn() {
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
-    PATH="$fakebin:$PATH" \
+    FM_SPAWN_NO_GUARD=1 FM_WORKTREE_CWD_ATTEMPTS="${FM_WORKTREE_CWD_ATTEMPTS:-2}" FM_WORKTREE_CWD_DELAY=0 \
+    FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" PATH="$fakebin:$PATH" \
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex 2>&1
 }
 
@@ -211,7 +226,18 @@ test_spawn_isolation_abort() {
   expect_code 0 "$status" "spawn into a genuine isolated worktree should succeed"
   assert_contains "$out" "spawned ok-isolated-ff6" "isolated spawn did not report success"
   assert_not_contains "$out" "did not yield an isolated worktree" "isolated spawn wrongly tripped the guard"
-  pass "fm-spawn: aborts unless the resolved worktree is a genuine, isolated worktree"
+
+  # A real Treehouse shell may briefly traverse a non-repository container
+  # directory before entering the linked worktree. Keep polling that transient
+  # cwd instead of treating the first project-external path as final.
+  mkdir -p "$TMP_ROOT/transient-container"
+  printf '%s\n%s\n' "$TMP_ROOT/transient-container" "$TMP_ROOT/spawn-wt" > "$TMP_ROOT/pane-sequence"
+  status=0
+  out=$(FM_FAKE_PANE_SEQUENCE="$TMP_ROOT/pane-sequence" FM_WORKTREE_CWD_ATTEMPTS=3 \
+    run_spawn "$home" transient-isolated-gg7 "$proj" "$TMP_ROOT/spawn-wt" "$fakebin"); status=$?
+  expect_code 0 "$status" "spawn should poll past a transient non-worktree cwd"
+  assert_contains "$out" "spawned transient-isolated-gg7" "transient cwd recovery did not complete the spawn"
+  pass "fm-spawn: requires a genuine isolated worktree and polls past transient container cwd values"
 }
 
 # --- GUARD 1c: fm-spawn tmux window construction ----------------------------

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -83,9 +83,15 @@ exit 0
 SH
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
-# tmux kill-window etc.: succeed silently.
-exit 0
+state="${0%/*}/tmux-live"
+case "${1:-}" in
+  display-message) [ -f "$state" ] ;;
+  list-panes) [ ! -f "$state" ] || printf '%%1|@1|firstmate:fm-task-x1|firstmate:1.0\n' ;;
+  kill-window) [ "${FM_FAKE_TMUX_STOP_FAIL:-0}" = 1 ] || rm -f "$state" ;;
+  *) exit 0 ;;
+esac
 SH
+  : > "$fakebin/tmux-live"
   # Default gh-axi mock: no PR is associated with the branch, and viewing any PR
   # number fails. This keeps the landed-work check hermetic (never reaching the real
   # gh-axi) and represents the common "no GitHub PR" baseline. Tests that need a
@@ -155,7 +161,7 @@ SH
 write_meta() {
   local case_dir=$1 mode=$2 kind=$3
   fm_write_meta "$case_dir/state/task-x1.meta" \
-    "window=fm-task-x1" \
+    "window=firstmate:fm-task-x1" \
     "worktree=$case_dir/wt" \
     "project=$case_dir/project" \
     "kind=$kind" \
@@ -512,6 +518,23 @@ test_local_only_fork_remote_allows() {
   expect_code 0 "$rc" "fork-allow: teardown should succeed when HEAD is on a fork remote"
   ! grep -q REFUSED "$case_dir/stderr" || fail "fork-allow: teardown printed a REFUSED line"
   pass "local-only worktree with HEAD on a fork remote is torn down (fix holds)"
+}
+
+test_teardown_removes_host_root_adapter_state() {
+  local case_dir artifact
+  case_dir=$(make_case host-adapter-state-cleanup)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "host-root adapter cleanup"
+  add_fork_with_pushed_branch "$case_dir"
+  : > "$case_dir/state/task-x1.claude-settings.json"
+  : > "$case_dir/state/task-x1.opencode-turn-end.js"
+
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "host-adapter-state-cleanup: teardown failed"
+  for artifact in task-x1.claude-settings.json task-x1.opencode-turn-end.js; do
+    assert_absent "$case_dir/state/$artifact" "teardown left host-root adapter state $artifact"
+  done
+  pass "teardown removes state-owned Claude and OpenCode host-root adapters"
 }
 
 test_teardown_prompts_tasks_axi_done_when_compatible() {
@@ -1242,6 +1265,29 @@ test_local_only_force_overrides_unpushed() {
   pass "local-only worktree with unpushed work is torn down under --force (escape hatch)"
 }
 
+test_unconfirmed_stop_preserves_worktree() {
+  local case_dir rc tree_log
+  case_dir=$(make_case stop-unconfirmed)
+  write_meta "$case_dir" local-only ship
+  tree_log="$case_dir/treehouse.log"
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_TREEHOUSE_LOG"
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+  set +e
+  FM_FAKE_TMUX_STOP_FAIL=1 FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 FM_TREEHOUSE_LOG="$tree_log" \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "stop-unconfirmed: teardown must fail when endpoint termination cannot be confirmed"
+  assert_grep 'still exists after stop' "$case_dir/stderr" "stop-unconfirmed: refusal did not explain the live endpoint"
+  assert_present "$case_dir/state/task-x1.meta" "stop-unconfirmed: teardown removed recoverable metadata"
+  assert_present "$case_dir/wt" "stop-unconfirmed: teardown recycled the isolated copy"
+  [ ! -s "$tree_log" ] || fail "stop-unconfirmed: teardown invoked treehouse before confirming termination"
+  pass "teardown preserves the isolated copy and task record when worker termination is unconfirmed"
+}
+
 test_herdr_teardown_clears_escalation_marker() {
   local case_dir marker
   case_dir=$(make_case herdr-marker-cleanup)
@@ -1251,14 +1297,28 @@ test_herdr_teardown_clears_escalation_marker() {
   printf '%s\n' 'backend=herdr' >> "$case_dir/state/task-x1.meta"
   cat > "$case_dir/fakebin/herdr" <<'SH'
 #!/usr/bin/env bash
-exit 0
+state="${0%/*}/herdr-live"
+case " $* " in
+  *' status --json '*) printf '%s\n' '{"server":{"running":true}}' ;;
+  *' pane close '*) rm -f "$state" ;;
+  *' pane get '*)
+    if [ -f "$state" ]; then
+      printf '%s\n' '{"result":{"pane":{"pane_id":"pQ"}}}'
+    else
+      printf '%s\n' '{"error":{"code":"pane_not_found"}}' >&2
+      exit 1
+    fi
+    ;;
+  *) exit 0 ;;
+esac
 SH
+  : > "$case_dir/fakebin/herdr-live"
   chmod +x "$case_dir/fakebin/herdr"
   marker="$case_dir/state/.herdr-escalated-default_wG_pQ"
   : > "$marker"
 
   run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
-    || fail "herdr-marker-cleanup: forced teardown failed"
+    || fail "herdr-marker-cleanup: forced teardown failed: $(cat "$case_dir/stderr")"
   [ ! -e "$marker" ] || fail "herdr-marker-cleanup: teardown left the pane's escalation marker behind"
   pass "herdr teardown removes pane-owned escalation dedupe state"
 }
@@ -1353,7 +1413,7 @@ test_herdr_projection_teardown_retires_journal_only_after_confirmed_close() {
 }
 
 test_herdr_projection_teardown_retains_journal_when_close_unconfirmed() {
-  local case_dir log closed restored
+  local case_dir log closed restored status=0
   case_dir=$(make_case herdr-projection-unconfirmed-close)
   write_meta "$case_dir" local-only ship
   configure_herdr_projection_teardown_case "$case_dir"
@@ -1361,17 +1421,23 @@ test_herdr_projection_teardown_retains_journal_when_close_unconfirmed() {
 
   FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_FAKE_HERDR_RESTORED="$restored" FM_FAKE_HERDR_CLOSE_FAIL=1 \
     run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
-    || fail "herdr-projection-unconfirmed-close: teardown should preserve best-effort endpoint semantics"
+    || status=$?
+  [ "$status" -ne 0 ] || fail "herdr-projection-unconfirmed-close: teardown accepted an unconfirmed endpoint stop"
   [ -e "$case_dir/state/task-x1.herdr-presentation" ] \
     || fail "unconfirmed task-pane close incorrectly retired the presentation journal"
-  assert_grep "close could not be confirmed" "$case_dir/stderr" \
-    "unconfirmed projected close did not explain why the journal was retained"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "unconfirmed projected close removed the recovery metadata"
+  assert_present "$case_dir/wt" \
+    "unconfirmed projected close removed the isolated worktree"
+  assert_grep "could not be confirmed absent" "$case_dir/stderr" \
+    "unconfirmed projected close did not explain the destructive-cleanup refusal"
   assert_not_contains "$(cat "$log")" "workspace close" \
     "unconfirmed projected close must not escalate to workspace cleanup"
-  pass "herdr projection teardown retains the stale journal and attempts no workspace cleanup when exact-pane close is unconfirmed"
+  pass "herdr projection teardown retains task state and refuses destructive cleanup when exact-pane close is unconfirmed"
 }
 
 test_local_only_fork_remote_allows
+test_teardown_removes_host_root_adapter_state
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses
@@ -1379,6 +1445,7 @@ test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
+test_unconfirmed_stop_preserves_worktree
 test_herdr_teardown_clears_escalation_marker
 test_herdr_projection_teardown_retires_journal_only_after_confirmed_close
 test_herdr_projection_teardown_retains_journal_when_close_unconfirmed

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1266,9 +1266,13 @@ test_local_only_force_overrides_unpushed() {
 }
 
 test_unconfirmed_stop_preserves_worktree() {
-  local case_dir rc tree_log
+  local case_dir rc tree_log host
   case_dir=$(make_case stop-unconfirmed)
   write_meta "$case_dir" local-only ship
+  host="$case_dir/host"
+  mkdir -p "$host"
+  : > "$host/AGENTS.md"
+  printf 'host_root=%s\n' "$host" >> "$case_dir/state/task-x1.meta"
   tree_log="$case_dir/treehouse.log"
   cat > "$case_dir/fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
@@ -1276,8 +1280,9 @@ printf '%s\n' "$*" >> "$FM_TREEHOUSE_LOG"
 SH
   chmod +x "$case_dir/fakebin/treehouse"
   set +e
-  FM_FAKE_TMUX_STOP_FAIL=1 FM_BACKEND_STOP_ATTEMPTS=1 FM_BACKEND_STOP_DELAY=0 FM_TREEHOUSE_LOG="$tree_log" \
-    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  (cd "$host" && FM_HOST_ROOT="$host" FM_FAKE_TMUX_STOP_FAIL=1 FM_BACKEND_STOP_ATTEMPTS=1 \
+    FM_BACKEND_STOP_DELAY=0 FM_TREEHOUSE_LOG="$tree_log" \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr")
   rc=$?
   set -e
   expect_code 1 "$rc" "stop-unconfirmed: teardown must fail when endpoint termination cannot be confirmed"
@@ -1413,14 +1418,19 @@ test_herdr_projection_teardown_retires_journal_only_after_confirmed_close() {
 }
 
 test_herdr_projection_teardown_retains_journal_when_close_unconfirmed() {
-  local case_dir log closed restored status=0
+  local case_dir log closed restored host status=0
   case_dir=$(make_case herdr-projection-unconfirmed-close)
   write_meta "$case_dir" local-only ship
+  host="$case_dir/host"
+  mkdir -p "$host"
+  : > "$host/AGENTS.md"
+  printf 'host_root=%s\n' "$host" >> "$case_dir/state/task-x1.meta"
   configure_herdr_projection_teardown_case "$case_dir"
   log="$case_dir/herdr.log"; closed="$case_dir/closed"; restored="$case_dir/restored"; : > "$log"
 
-  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_FAKE_HERDR_RESTORED="$restored" FM_FAKE_HERDR_CLOSE_FAIL=1 \
-    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
+  (cd "$host" && FM_HOST_ROOT="$host" FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" \
+    FM_FAKE_HERDR_RESTORED="$restored" FM_FAKE_HERDR_CLOSE_FAIL=1 \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr") \
     || status=$?
   [ "$status" -ne 0 ] || fail "herdr-projection-unconfirmed-close: teardown accepted an unconfirmed endpoint stop"
   [ -e "$case_dir/state/task-x1.herdr-presentation" ] \

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -103,6 +103,7 @@ install_guard_scripts() {
   cp "$ROOT/bin/fm-turnend-guard-grok.sh" "$dir/bin/fm-turnend-guard-grok.sh"
   cp "$ROOT/bin/fm-operational-input.sh" "$dir/bin/fm-operational-input.sh"
   cp "$ROOT/bin/fm-supervision-instructions.sh" "$dir/bin/fm-supervision-instructions.sh"
+  cp "$ROOT/bin/fm-host-root-lib.sh" "$dir/bin/fm-host-root-lib.sh"
   cp "$ROOT/bin/fm-harness.sh" "$dir/bin/fm-harness.sh"
   cp "$ROOT/bin/fm-primary-scope-lib.sh" "$dir/bin/fm-primary-scope-lib.sh"
   cp "$ROOT/bin/fm-supervision-lib.sh" "$dir/bin/fm-supervision-lib.sh"

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -438,14 +438,21 @@ test_watch_restart_rejects_reused_pid() {
 }
 
 test_watch_restart_attaches_to_healthy_peer() {
-  local dir state fakebin out peer identity armpid status i
+  local dir state fakebin out ready peer identity armpid status i
   dir=$(make_case restart-healthy-peer)
   state="$dir/state"
   fakebin="$dir/fakebin"
   out="$dir/restart.out"
+  ready="$dir/peer-ready"
   mark_pr_check_migration_complete "$state"
-  node -e 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 300000)' &
+  node -e 'const fs = require("fs"); process.on("SIGTERM", () => {}); fs.writeFileSync(process.argv[1], "ready"); setTimeout(() => {}, 300000)' "$ready" &
   peer=$!
+  i=0
+  while [ "$i" -lt 50 ] && [ ! -e "$ready" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$ready" ] || fail "TERM-resistant peer did not finish installing its signal handler"
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"

--- a/tests/secondmate-helpers.sh
+++ b/tests/secondmate-helpers.sh
@@ -23,8 +23,19 @@ make_fake_tmux() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+stopped="${0}.stopped"
 case "${1:-}" in
-  has-session|new-session|new-window|send-keys|kill-window)
+  has-session|new-session|send-keys)
+    printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
+    exit 0
+    ;;
+  new-window)
+    rm -f "$stopped"
+    printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
+    exit 0
+    ;;
+  kill-window)
+    : > "$stopped"
     printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
     exit 0
     ;;
@@ -35,10 +46,16 @@ case "${1:-}" in
     exit 0
     ;;
   display-message)
+    [ ! -e "$stopped" ] || exit 1
     case "$*" in
       *'#{cursor_y}'*) printf '0\n' ;;
       *) printf 'firstmate\n' ;;
     esac
+    exit 0
+    ;;
+  list-panes)
+    [ -e "$stopped" ] && exit 0
+    printf '%%1\n'
     exit 0
     ;;
   capture-pane)


### PR DESCRIPTION
## Summary

- add an opt-in `FM_HOST_ROOT` runtime contract that separates the FirstMate code/state root, the physical host instruction root, the target primary clone, and the isolated `FM_TARGET_WORKTREE`
- launch ordinary ship/scout workers from the host root while keeping every target Git, edit, test, build, review, and validation operation scoped to the recorded isolated worktree
- carry the contract through Claude, Codex, OpenCode, Pi, Grok, Kimi, tmux, Herdr, Zellij, Orca, and cmux without changing secondmate isolated-home semantics
- preserve behavior when `FM_HOST_ROOT` is unset and fail closed before destructive cleanup when host ownership, target isolation, endpoint absence, or physical path safety cannot be proven

This is the low-level runtime contract only. Reversible host installation and activation are intentionally deferred to a follow-up so this safety-sensitive change remains reviewable.

## Safety details

- resolves and compares physical paths, rejects host/target overlap, and verifies endpoint cwd before harness launch
- records host ownership with task metadata and durable decision authority
- uses absolute FirstMate command paths and explicit target-scoped worker/promotion instructions
- keeps unknown Orca creation and endpoint-stop races from discarding worktrees
- rejects unsupported host-root `local-only` tasks before fleet mutation
- preserves additive watcher and Kimi completion signaling without rewriting host configuration

## Validation

- `no-mistakes` run `01KYETZS2982GDXVG96QA3AK90`: review, focused test, documentation, canonical lint, and fork push passed with no remaining findings
- `bin/fm-lint.sh` with pinned ShellCheck 0.11.0
- focused host-root, backend, harness, lifecycle, review, decision, teardown, watcher, and secondmate regression coverage
- live Codex 0.145.0 scout through tmux 3.7b and Treehouse 2.0.0 from a separate Second Brain host root
- branch includes upstream `main` through `a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499`

Refs #726


## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

- Run: `01KYETZS2982GDXVG96QA3AK90`
- Head: `4a98d0fd9801e18eec94a236ccc47767fc8c9e7f`
- Outcome: ✅ intent, rebase, review, focused test, documentation, canonical lint, and fork push passed with no remaining findings
- PR and CI were skipped inside the daemon because its service context could not access the authenticated `gh` keyring; this PR was opened from the same authenticated account after the validated push.
