### PR TITLE
fix(bin): stop the turn-end guard blocking during watcher arm confirmation

### DIFF
--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -139,6 +139,15 @@ if fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
   budget_reset
   exit 0
 fi
+# An arm that has forked its watcher but not yet confirmed the lock is doing
+# exactly what this guard asks for, so blocking the turn on it is a false alarm.
+# Observed live 2026-07-25: four consecutive turns were blocked this way, each
+# time with a healthy watcher moments later, because the hook fired inside that
+# confirmation window. A stale marker times out, so a real lapse still alarms.
+if fm_arm_in_flight "$STATE"; then
+  budget_reset
+  exit 0
+fi
 
 block_stop() {
   local afk x_mode reason rule

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -70,6 +70,25 @@ fm_path_age() {
   echo $(( $(date +%s) - m ))
 }
 
+# Marker bin/fm-watch-arm.sh holds while it has forked a watcher but has not yet
+# confirmed that watcher owns the lock. That confirmation window is real work,
+# not a lapse: the arm polls for up to FM_ARM_CONFIRM_TIMEOUT seconds, and until
+# the fresh watcher acquires the lock a strict lock-identity check
+# (fm_watcher_healthy) correctly reports no live watcher. A caller that would
+# raise a "supervision is off" alarm must consult this first, or it reports an
+# in-progress arm as a lapse - the false alarm this exists to end.
+# The arm removes the marker on every terminal outcome, and the TTL bounds one
+# orphaned by a killed arm, so a genuinely absent watcher still alarms.
+FM_ARM_INFLIGHT_NAME=.watch-arm-inflight
+
+fm_arm_in_flight() {
+  local state=$1 ttl=${2:-$(( ${FM_ARM_CONFIRM_TIMEOUT:-10} + 5 ))} arm_marker arm_age
+  arm_marker="$state/$FM_ARM_INFLIGHT_NAME"
+  [ -e "$arm_marker" ] || return 1
+  arm_age=$(fm_path_age "$arm_marker")
+  [ "$arm_age" -le "$ttl" ]
+}
+
 fm_watcher_lock_matches_pid() {
   local state=$1 watch_path=$2 pid=$3 home=${4:-$FM_HOME} lockdir lock_home lock_path lock_identity current_identity
   lockdir="$state/.watch.lock"

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -69,6 +69,15 @@ BEAT="$STATE/.last-watcher-beat"
 GRACE=${FM_GUARD_GRACE:-300}
 # How long to wait for a freshly forked watcher to acquire the lock and beat.
 CONFIRM_TIMEOUT=${FM_ARM_CONFIRM_TIMEOUT:-10}
+# Held only across that confirmation window so a concurrent alarm (the Stop-hook
+# guard, bin/fm-turnend-guard.sh) can tell "an arm is in progress" apart from
+# "supervision lapsed"; see fm_arm_in_flight in bin/fm-wake-lib.sh.
+ARM_INFLIGHT="$STATE/$FM_ARM_INFLIGHT_NAME"
+
+clear_arm_inflight() {
+  rm -f "$ARM_INFLIGHT" 2>/dev/null || true
+}
+
 # Poll interval while attached to an existing healthy watcher.
 ATTACH_POLL=${FM_ARM_ATTACH_POLL:-0.5}
 CYCLE_LOG="$STATE/.watch-cycle-exits.log"
@@ -364,6 +373,7 @@ fi
 child=
 child_out=
 cleanup_child() {
+  clear_arm_inflight
   if [ -n "$child" ] && fm_pid_alive "$child"; then
     kill -TERM "$child" 2>/dev/null || true
   fi
@@ -393,6 +403,7 @@ child_out=$(mktemp "$STATE/.watch-arm-output.XXXXXX") || {
   echo "watcher: FAILED - no live watcher with a fresh beacon"
   exit 1
 }
+: > "$ARM_INFLIGHT" 2>/dev/null || true
 "$WATCH" >"$child_out" &
 child=$!
 cycle_begin "$child" started
@@ -400,6 +411,7 @@ child_done=0
 
 owned_child_finished() {
   local rc=$1 signal reason_type status
+  clear_arm_inflight
   signal=$(cycle_signal_name "$rc")
   if [ "$rc" -eq 0 ] && watch_output_has_wake "$child_out"; then
     reason_type=$(watch_output_reason_type "$child_out")
@@ -459,6 +471,7 @@ while :; do
     if [ "$HEALTHY_PID" = "$child" ]; then
       cycle_refresh_lock_before
       cycle_mark_predecessor_successor "started:$child"
+      clear_arm_inflight
       echo "watcher: started pid=$child (beacon fresh)"
       wait "$child"
       rc=$?

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -32,6 +32,14 @@ Otherwise it calls `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] 
 A stale beacon blocks even when a watcher pid is live.
 A fresh leftover beacon blocks when the lock is missing, dead, or identity-mismatched.
 
+`bin/fm-watch-arm.sh` forks its watcher and only then polls, for up to `FM_ARM_CONFIRM_TIMEOUT` seconds (default 10), for that child to acquire the lock and beat.
+Inside that confirmation window the lock is legitimately unowned, so `fm_watcher_healthy` correctly reports no live watcher even though supervision is being armed correctly.
+Because AGENTS.md section 8 requires arming as the last act of a turn, the turn-end hook can fire inside that window, so the guard must distinguish an arm in progress from a genuine lapse.
+`bin/fm-watch-arm.sh` writes `state/.watch-arm-inflight` immediately before forking the watcher and removes it on every terminal outcome, including the signal-trap cleanup path.
+`fm_arm_in_flight <state-dir> [ttl]` in `bin/fm-wake-lib.sh` owns the read side, and the guard consults it only after `fm_watcher_healthy` has already failed, so it never weakens the identity-matched check.
+The default TTL of `FM_ARM_CONFIRM_TIMEOUT` plus 5 seconds bounds a marker orphaned by a killed arm, so a genuinely absent watcher still blocks rather than trading a false alarm for a missed one.
+`bin/fm-guard.sh` needs no equivalent change because it is beacon-based, so its grace window already absorbs this window.
+
 `FM_STATE_OVERRIDE` wins over `FM_HOME/state`, and `FM_HOME` wins over repository-root `state/`.
 `FM_GUARD_GRACE` controls beacon freshness and defaults to 300 seconds.
 If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot safely read loop-guard fields.
@@ -83,7 +91,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 ## Regression coverage
 
-`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, and Grok resume permission and recursion safety.
+`tests/fm-turnend-guard.test.sh` covers the predicate, the arm-confirmation in-flight marker in both directions, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, and Grok resume permission and recursion safety.
 `tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -230,6 +230,38 @@ test_hook_blocks_when_fresh_beacon_has_no_live_lock() {
   pass "fm-turnend-guard: blocks when a fresh beacon has no live watcher lock"
 }
 
+# bin/fm-watch-arm.sh forks its watcher and only then polls, for up to
+# FM_ARM_CONFIRM_TIMEOUT seconds, for that watcher to take the lock. The hook
+# firing inside that window sees no lock owner and used to block the turn even
+# though supervision was being armed correctly - four consecutive false blocks in
+# one session on 2026-07-25. The in-flight marker is what distinguishes the two.
+test_hook_allows_while_an_arm_is_in_flight() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-arm-inflight")
+  : > "$dir/state/task1.meta"
+  touch "$dir/state/.last-watcher-beat"
+  : > "$dir/state/.watch-arm-inflight"
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 0 "$status" "hook must not block while an arm is confirming its watcher"
+  [ -z "$out" ] || fail "hook produced output while an arm was in flight: $out"
+  pass "fm-turnend-guard: silent while bin/fm-watch-arm.sh is confirming a fresh watcher"
+}
+
+# The marker only ever suppresses the alarm for the confirmation window. An arm
+# killed mid-confirmation leaves it behind, so a stale one must not buy permanent
+# silence - otherwise this fix would trade a false alarm for a missed one.
+test_hook_blocks_when_arm_marker_is_stale() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-arm-stale")
+  : > "$dir/state/task1.meta"
+  touch "$dir/state/.last-watcher-beat"
+  touch -t 202001010000 "$dir/state/.watch-arm-inflight"
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 2 "$status" "hook must still block when the arm marker is stale"
+  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
+  pass "fm-turnend-guard: an orphaned arm marker times out and the alarm returns"
+}
+
 test_hook_blocks_when_dead_lock_has_fresh_beacon() {
   local dir dead out status
   dir=$(make_primary_dir "$TMP_ROOT/hook-dead-lock-fresh")
@@ -952,6 +984,22 @@ test_hook_claude_mode_reblocks_x_mode_without_tasks() {
   pass "fm-turnend-guard --claude: X-mode-only homes re-block when auto-arm recovery is absent"
 }
 
+# Claude is the primary that blocks on this hook in production, so the
+# arm-confirmation window must also be silent in the cooperative mode - and it
+# must not consume one of Claude's bounded re-blocks to get there.
+test_hook_claude_mode_allows_while_an_arm_is_in_flight() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-claude-arm-inflight")
+  : > "$dir/state/task1.meta"
+  touch "$dir/state/.last-watcher-beat"
+  : > "$dir/state/.watch-arm-inflight"
+  out=$(FM_CLAUDE_AUTOARM_SYNC_WAIT_MS=200 run_hook_claude "$dir" true); status=$?
+  expect_code 0 "$status" "--claude mode must not block while an arm is confirming its watcher"
+  [ -z "$out" ] || fail "--claude arm-in-flight allow produced output: $out"
+  [ -f "$dir/state/.turnend-claude-blocks" ] && fail "--claude arm-in-flight allow must not consume a re-block"
+  pass "fm-turnend-guard --claude: silent while bin/fm-watch-arm.sh is confirming a fresh watcher"
+}
+
 test_hook_claude_mode_allows_when_autoarm_owner_alive() {
   local dir pid out status
   dir=$(make_primary_dir "$TMP_ROOT/hook-claude-owner")
@@ -1086,6 +1134,8 @@ test_grok_hook_invokes_adapter() {
   pass ".grok primary hook: Stop hook invokes the grok adapter"
 }
 
+test_hook_allows_while_an_arm_is_in_flight
+test_hook_blocks_when_arm_marker_is_stale
 test_predicate_healthy_no_inflight
 test_predicate_unhealthy_no_beacon
 test_predicate_unhealthy_stale_beacon
@@ -1129,6 +1179,7 @@ test_pi_extension_retries_after_followup_delivery_failure
 test_grok_hook_invokes_adapter
 test_hook_claude_mode_reblocks_stop_hook_active_when_unhealthy
 test_hook_claude_mode_reblocks_x_mode_without_tasks
+test_hook_claude_mode_allows_while_an_arm_is_in_flight
 test_hook_claude_mode_allows_when_autoarm_owner_alive
 test_hook_claude_mode_allows_on_fresh_rewake_epoch
 test_hook_claude_mode_stale_rewake_epoch_blocks


### PR DESCRIPTION
## Intent

Land an already-written turn-end guard fix upstream as a contribution PR from a fork.

The bug: bin/fm-turnend-guard.sh is a Stop-hook backstop that blocks a turn from ending while work is in flight and no identity-matched watcher holds the home lock with a fresh beacon. bin/fm-watch-arm.sh forks the watcher and only then polls, for up to FM_ARM_CONFIRM_TIMEOUT seconds (default 10), for that child to acquire the lock and beat. Inside that confirmation window the lock is legitimately unowned, so fm_watcher_healthy correctly returns false. Because AGENTS.md section 8 requires arming the watcher as the last act of a turn, the Stop hook routinely fires inside that window and blocks a turn whose supervision is in fact being armed correctly. Observed live on 2026-07-25: four consecutive turns blocked, each followed seconds later by a foreground arm reporting a healthy watcher on a fresh pid.

The chosen fix, deliberately: a marker, not a weakened predicate. bin/fm-watch-arm.sh writes state/.watch-arm-inflight immediately before forking the watcher and clears it on every terminal outcome, including the signal-trap cleanup path. fm_arm_in_flight in bin/fm-wake-lib.sh owns the read side. The guard consults it ONLY after fm_watcher_healthy has already failed, so the identity-matched lock and fresh-beacon check is never relaxed. A TTL of FM_ARM_CONFIRM_TIMEOUT + 5 seconds bounds a marker orphaned by a killed arm, so a genuine supervision lapse still blocks rather than trading a false alarm for a missed one. bin/fm-guard.sh is intentionally left unchanged because it is beacon-based and its grace window already absorbs this gap.

Scope decisions the reviewer should know: the change is deliberately limited to the turn-end guard, its read-side helper, the arm marker, and the tests. bin/fm-watch.sh stale and re-arm behavior is intentionally NOT touched - separate work owns it and would collide. Regression coverage is colocated in tests/fm-turnend-guard.test.sh, three cases, all mutation-verified to fail without the fix: a fresh marker must not block in the default cross-harness mode, a fresh marker must not block in --claude cooperative mode and must not consume one of Claude's bounded re-blocks, and a stale marker must still block. The locals in fm_arm_in_flight are named arm_marker and arm_age rather than marker and age because bin/fm-lint.sh runs shellcheck with --external-sources, and a plain 'marker' collides with a test-local of the same name in tests/fm-afk-launch.test.sh and produces a false SC2031.

Repo conventions applied: one sentence per line in tracked Markdown, plain dashes, no agent commit co-author, shellcheck-clean bin scripts via bin/fm-lint.sh, tests colocated in the existing tests/<subject>.test.sh runner. docs/turnend-guard.md is the authoritative owner of this contract, so the mechanism is documented there in the Shared predicate section as current behavior; incident chronology stays in the PR, not in the doc.

Delivery: origin is the upstream kunchenguid/firstmate and we have no push rights there. The branch must be pushed to the Nikita-Guzenko/firstmate fork and the PR opened against kunchenguid/firstmate:main. The PR body must explain the race concretely - what the guard did, why an arm in progress tripped it, and how the fix distinguishes the two. Nothing under .no-mistakes/ may be committed; that path stays gitignored in this repo and CI rejects tracked .no-mistakes paths.

## What Changed

- `bin/fm-watch-arm.sh` now writes `state/.watch-arm-inflight` immediately before forking the watcher and clears it on every terminal outcome, including the signal-trap cleanup path, marking the window where the home lock is legitimately unowned while the child acquires it.
- `bin/fm-wake-lib.sh` gains `fm_arm_in_flight`, the read side that treats the marker as valid only within a `FM_ARM_CONFIRM_TIMEOUT + 5`s TTL so an orphaned marker from a killed arm still lets a genuine supervision lapse block.
- `bin/fm-turnend-guard.sh` consults `fm_arm_in_flight` only after `fm_watcher_healthy` has already failed, so the identity-matched lock and fresh-beacon check is never relaxed; `docs/turnend-guard.md` documents the mechanism and `tests/fm-turnend-guard.test.sh` adds three mutation-verified cases (fresh marker allows in default and `--claude` modes without consuming a re-block, stale marker still blocks).

## Risk Assessment

✅ Low: Well-bounded, marker-based fix that only relaxes the turn-end guard after the strict identity check already failed, clears the marker on every terminal path, bounds orphans via a fail-safe TTL, and is covered by three mutation-verified regression tests matching the stated intent.

## Testing

Baseline `bash tests/fm-turnend-guard.test.sh` aborted at an environment-broken Pi extension test (node v22 refuses to import the `.ts` extension file — ERR_UNKNOWN_FILE_EXTENSION), which is pre-existing and independent of this bash-only change; that abort also prevented the new `--claude` arm test (declared later) from running. Excluding the two node-`.ts`-import Pi tests, the suite passes 51/0 including all three new arm-marker regression cases. I also drove the real Stop hook directly to capture a CLI transcript showing the actual end-user surface: a fresh arm-inflight marker allows the turn to end silently, a stale marker still blocks with the exact required watcher-repair reason, and the no-marker path is unchanged; a mutation test against the base-commit guard confirms the false block returns without the fix. This is a CLI/hook change with no rendered UI, so the reviewer-visible evidence is the hook transcript rather than a screenshot.

<details>
<summary>Evidence: Real Stop-hook transcript (3 scenarios)</summary>

`Scenario A arm in-flight: exit=0 silent (allow). Scenario B stale marker: exit=2 with 'TURN WOULD END BLIND - SUPERVISION IS OFF' + 'repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task'. Scenario C no marker: exit=2 (unchanged).`

```text
=== REAL Stop-hook transcript: bin/fm-turnend-guard.sh, work in flight, fresh beacon, no live lock ===

--- Scenario A: arm IN FLIGHT (fresh marker) — should ALLOW turn end, silent ---
exit=0  output=[]
RESULT: turn allowed to end silently (false alarm avoided) ✔

--- Scenario B: STALE arm marker (orphaned by killed arm) — should still BLOCK ---
exit=2
output:
    ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    ●  TURN WOULD END BLIND - SUPERVISION IS OFF
    ●  1 task(s) in flight, but no live watcher holds this home lock (last beat: 0s ago).
    ●  repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task, never shell &.
    ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
RESULT: real supervision lapse still blocks ✔

--- Scenario C: NO marker at all — baseline block preserved ---
exit=2 (2=block)  RESULT: unchanged strict behavior ✔
```
</details>
<details>
<summary>Evidence: Mutation verification (fix reverted)</summary>

`Base-commit guard + fresh arm-inflight marker → exit=2: without the fix the guard blocks a correctly-armed turn (the bug this change removes).`

```text
=== MUTATION TEST: fix reverted (base-commit guard), fresh arm-inflight marker present ===
exit=2 (expect 2 = false block returns without the fix)
CONFIRMED: without the fix the guard blocks a correctly-armed turn — the bug the fix removes ✔
```
</details>
<details>
<summary>Evidence: Suite run minus env-broken Pi tests (51 ok / 0 fail)</summary>

```text
ok - fm-turnend-guard: silent while bin/fm-watch-arm.sh is confirming a fresh watcher
ok - fm-turnend-guard: an orphaned arm marker times out and the alarm returns
ok - fm_supervision_unhealthy: false with no state/*.meta at all
ok - fm_supervision_unhealthy: true with in-flight task and no beacon ever
ok - fm_supervision_unhealthy: true with in-flight task and a beacon far outside the grace window
ok - fm_supervision_unhealthy: false with in-flight task and a fresh beacon
ok - fm_supervision_status: FM_SUP_QUEUE_PENDING tracks state/.wake-queue
ok - fm_supervision_needed: X-mode relay poll needs supervision without changing the task predicate
ok - fm-turnend-guard: silent no-op with nothing in flight
ok - fm-turnend-guard: blocks when a fresh beacon has no live watcher lock
ok - fm-turnend-guard: blocks on a dead watcher lock even when the beacon is fresh
ok - fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon
ok - fm-turnend-guard: blocks on a live watcher lock with an ancient beacon
ok - fm-turnend-guard: blocks with the exact required reason in the primary when unhealthy
ok - fm-turnend-guard: blocks from active FM_HOME state, not only repo-root state
ok - fm-turnend-guard: X-mode repair reason sources the cadence config
ok - fm-turnend-guard: ignores stale repo-root state when FM_HOME is set
ok - fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state
ok - fm-turnend-guard: stop_hook_active=true always allows the stop (never blocks twice in one turn)
ok - fm-turnend-guard: blocks a blind turn end in a secondmate's own home (.fm-secondmate-home no longer excludes it)
ok - fm-turnend-guard: idle-by-default - silent in a secondmate home with nothing in flight
ok - fm-turnend-guard: stop_hook_active=true allows the stop in a secondmate home (never blocks twice in one turn)
ok - fm-turnend-guard: secondmate deferred-death recovery - silent while watched, forces re-arm once the watcher exits
ok - fm-turnend-guard: inert in a secondmate's own child worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: blocks a blind turn end in a treehouse-leased LINKED secondmate home (marker force-include)
ok - fm-turnend-guard: an invalid (empty) marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: a non-ASCII marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: inert in a crewmate/scout task worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: fails open (never blocks) when jq is missing
ok - fm-turnend-guard: silent no-op on empty stdin
ok - fm-turnend-guard: runs well under the generous timing margin (0s)
ok - fm-turnend-guard-grok: forces one explicitly marked same-session resume when the shared predicate blocks
ok - fm-turnend-guard-grok: loop guard prevents a nested resume loop
ok - .claude/settings.json: Stop hook uses CLAUDE_PROJECT_DIR-anchored --claude guard command
ok - .codex/hooks.json: Stop hook invokes the shared primary guard
ok - .codex/hooks.json: Stop hook uses hook process root when payload cwd is outside
ok - .codex/hooks.json: Stop hook ignores nested git root guard scripts
ok - .opencode primary plugin: session.idle forces one follow-up through the shared guard
ok - .opencode primary plugin: guard path is anchored to worktree, not directory
ok - .pi primary extension: agent_settled forces one follow-up through the shared guard
ok - .grok primary hook: Stop hook invokes the grok adapter
ok - fm-turnend-guard --claude: re-blocks a loop-guarded stop while unhealthy and unclaimed (incident regression)
ok - fm-turnend-guard --claude: X-mode-only homes re-block when auto-arm recovery is absent
ok - fm-turnend-guard --claude: silent while bin/fm-watch-arm.sh is confirming a fresh watcher
ok - fm-turnend-guard --claude: allows the stop when the Stop auto-arm owner holds this home
ok - fm-turnend-guard --claude: fresh rewake epoch prevents a duplicate continuation for the same event
ok - fm-turnend-guard --claude: stale rewake epoch does not allow a blind stop
ok - fm-turnend-guard --claude: re-block budget stays below the 8-block cap and resets after degraded allow
ok - fm-turnend-guard --claude: any allow resets the consecutive-block budget
ok - fm-turnend-guard --claude: bounded claim wait avoids a token-consuming forced continuation
ok - fm-turnend-guard --claude: secondmate home re-blocks unclaimed and allows auto-arm-claimed stops
```
</details>
- Outcome: ⚠️ 1 info across 1 run (4m24s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ tests/fm-turnend-guard.test.sh aborts at test_pi_extension_injects_once_per_logical_agent_run because node v22.22.1 cannot import a .ts extension file (ERR_UNKNOWN_FILE_EXTENSION). This is an environment/toolchain limitation in the .pi extension tests, pre-existing and unrelated to this bash-only change (the guard, read-side helper, arm marker, and their three new tests all pass). Because fail() exits the suite, the later new --claude arm test does not run under a plain full-suite invocation in this environment; it passes when run.
- <code>`bash tests/fm-turnend-guard.test.sh` — full run; the only failure is the env-broken `test_pi_extension_injects_once_per_logical_agent_run` (node v22 cannot import a `.ts` extension: ERR_UNKNOWN_FILE_EXTENSION), pre-existing and unrelated to this bash-only change</code>
- <code>Re-ran the suite with the two node-`.ts`-import Pi tests neutralized: 51 ok / 0 not-ok, including all three new tests (`test_hook_allows_while_an_arm_is_in_flight`, `test_hook_blocks_when_arm_marker_is_stale`, `test_hook_claude_mode_allows_while_an_arm_is_in_flight`)</code>
- `Real Stop-hook transcript against bin/fm-turnend-guard.sh with work in flight + fresh beacon + no live lock: fresh marker → exit 0 silent (allow); stale marker → exit 2 with 'TURN WOULD END BLIND' + required bin/fm-watch-arm.sh reason (block); no marker → exit 2 (unchanged)`
- <code>Mutation test: replaced guard with base-commit `git show a5fe1bc:bin/fm-turnend-guard.sh` (no fm_arm_in_flight consult) and confirmed a fresh marker still blocks (exit 2) — proving the fix is what removes the false alarm</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: lint passes clean with ShellCheck 0.11.0, no source changes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
