### PR TITLE
feat(skills): add /fleet-help fleet navigator skill

### DIFF
--- a/.agents/skills/fleet-help/SKILL.md
+++ b/.agents/skills/fleet-help/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: fleet-help
+description: >-
+  Explain what the firstmate fleet can do and recommend the next captain action from live read-only sources.
+  Use when the captain invokes /fleet-help, asks what firstmate or the fleet can do, asks what is in flight, blocked, awaiting them, or asks what should happen next.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# fleet-help
+
+Guide the captain through firstmate's real capabilities and current fleet state.
+This is a navigator, not a workflow runner.
+It must preserve firstmate autonomy by guiding the captain in plain language without adding approval gates, personas, BMAD installs, or a second decision ceremony.
+
+## Boundaries
+
+- This skill is read-only over fleet state.
+- Do not spawn workers, steer workers, dispatch queued work, merge PRs, update Linear, update the backlog, write reports, arm supervision, or mutate `state/` or `data/` as a side effect of help.
+- If the best next step is actionable, say what the captain can ask for and stop.
+- If the captain follows up with an implementation, merge, dispatch, project-management, secondmate, X-mode, or self-update request, leave this skill and use the normal owner for that request.
+- Do not install BMAD, copy BMAD personas, or present named role menus.
+- Apply `AGENTS.md` section 9 for captain-facing language and never relay raw command output as the answer.
+
+## Sources to read
+
+1. Read [`fleet-catalog.json`](fleet-catalog.json) from this skill directory.
+   This catalog is the machine-readable inventory for user-invocable internal skills and script-owned lifecycle operations.
+   Treat it as the source for capability mode instead of reconstructing a hardcoded capability list from memory.
+2. Gather current fleet state with `bin/fm-bearings-snapshot.sh --json`.
+   This is the preferred bounded local read because it already projects backlog, task state, secondmates, decision holds, landed work, report pointers, recorded PRs, and queue gates without writing a report.
+   Add `--include-prs` only when the captain explicitly asks for live PR enrichment or asks what is awaiting review and local records are insufficient.
+3. If `bin/fm-bearings-snapshot.sh` is unavailable, fall back to `bin/fm-fleet-snapshot.sh --json`.
+   Do not parse `state/*.status` directly because those files are append-only event history, not current state.
+4. If the snapshot reports unavailable or partial sources, disclose the consequence in plain language and avoid recommending actions that depend on the missing source.
+5. If the captain asks a general capability question and no current-state answer is needed, the catalog alone is enough.
+
+## Capability mode
+
+Use this mode for questions like "what can the fleet do", "what can I ask firstmate for", or "how do I use the crew".
+
+1. Read the catalog and group entries by the captain's likely intent, such as delivery, investigation, quality, fleet management, tracking, documentation, integration, and built-in slash skills.
+2. Mention only capabilities that exist in the catalog or in the live snapshot.
+3. For each relevant capability, give a short plain-English description and one sample captain prompt from the catalog.
+4. Prefer a compact curated answer over dumping the whole catalog.
+5. If the captain's question is broad, include a short "best next prompt" suggestion at the end.
+6. Keep the handoff explicit: "If you want that, say ..." rather than starting it.
+
+## Current-state and next-step mode
+
+Use this mode for questions like "what is in flight", "what is blocked", "what is awaiting me", "what should happen next", or "where should I point the fleet".
+
+1. Gather the snapshot before answering unless a fresh snapshot is already visible in the current conversation.
+2. Classify the snapshot into captain-relevant buckets:
+   - Needs the captain now: open decisions, merge-ready PRs, credential or login blockers, and blockers that only the captain can clear.
+   - Underway: live work progressing on its own.
+   - Blocked or gated: queued work whose blockers, dates, or integrity warnings are not captain actions yet.
+   - Recently finished: landed work and completed scout reports that help choose follow-up work.
+3. Recommend exactly one next action when the evidence supports it.
+4. Prefer captain-held decisions and review-ready PRs over new work.
+5. Prefer real blockers or failed work over routine queued work.
+6. If nothing needs the captain, say that clearly and suggest the next sensible fleet request only when it would be useful.
+7. Include exact phrasing the captain can use for the recommended follow-up.
+8. Never present an action-free queued item as something the captain must decide.
+9. Never infer current worker state from the last historical event line.
+
+## Answer shape
+
+For a broad `/fleet-help`, use this concise structure:
+
+1. **What the fleet can do** - two to five grouped bullets from the catalog.
+2. **What is live now** - the current state summary from the snapshot, or "I did not need a live snapshot for this question" when capability-only.
+3. **Best next ask** - one recommended captain prompt, or "Nothing needs your action right now" when appropriate.
+
+For a narrow question, answer only the requested part and keep the same boundaries.
+Always include full PR URLs when mentioning PRs.
+When the catalog and live state disagree, trust live state for current work and the catalog for capability names.
+
+## Maintenance contract
+
+The `generated_skills` section of `fleet-catalog.json` must match every internal user-invocable skill under `.agents/skills/`.
+The test suite owns that sync check so `/fleet-help` does not advertise missing built-ins or omit installed ones.
+The `lifecycle_operations` section is hand-authored because those capabilities are owned by scripts, skills, and fleet contracts rather than slash skills.

--- a/.agents/skills/fleet-help/fleet-catalog.json
+++ b/.agents/skills/fleet-help/fleet-catalog.json
@@ -1,0 +1,293 @@
+{
+  "schema": "fleet-help-catalog.v1",
+  "description": "Read-mostly capability catalog for the internal /fleet-help navigator.",
+  "generated_skills": [
+    {
+      "id": "afk",
+      "command": "/afk",
+      "display": "Away-mode supervision",
+      "source": ".agents/skills/afk/SKILL.md",
+      "summary": "Step away while the fleet keeps supervising routine notifications and escalates only captain-relevant events.",
+      "sample_prompts": [
+        "/afk",
+        "I am going afk for an hour."
+      ]
+    },
+    {
+      "id": "ahoy",
+      "command": "/ahoy",
+      "display": "Visible-session recap",
+      "source": ".agents/skills/ahoy/SKILL.md",
+      "summary": "Recap visible session events since the prior real captain message and surface visibly unanswered captain decisions.",
+      "sample_prompts": [
+        "/ahoy",
+        "What happened since my last message?"
+      ]
+    },
+    {
+      "id": "bearings",
+      "command": "/bearings",
+      "display": "Current fleet status report",
+      "source": ".agents/skills/bearings/SKILL.md",
+      "summary": "Generate a standalone current-status report from bounded local fleet and registered-secondmate state.",
+      "sample_prompts": [
+        "/bearings",
+        "Give me a morning status report."
+      ]
+    },
+    {
+      "id": "fleet-help",
+      "command": "/fleet-help",
+      "display": "Fleet capability and next-step navigator",
+      "source": ".agents/skills/fleet-help/SKILL.md",
+      "summary": "Explain what the fleet can do and recommend the next captain action from live read-only sources.",
+      "sample_prompts": [
+        "/fleet-help what can the fleet do?",
+        "/fleet-help what should happen next?"
+      ]
+    },
+    {
+      "id": "stow",
+      "command": "/stow",
+      "display": "Session knowledge sweep",
+      "source": ".agents/skills/stow/SKILL.md",
+      "summary": "Sweep the session for uncaptured durable knowledge, route each finding to its disk home, and report reset safety.",
+      "sample_prompts": [
+        "/stow",
+        "Stow what you learned before reset."
+      ]
+    },
+    {
+      "id": "updatefirstmate",
+      "command": "/updatefirstmate",
+      "display": "Firstmate self-update",
+      "source": ".agents/skills/updatefirstmate/SKILL.md",
+      "summary": "Fast-forward firstmate and registered secondmates to the latest origin state, then refresh loaded instructions.",
+      "sample_prompts": [
+        "/updatefirstmate",
+        "Update firstmate to the latest version."
+      ]
+    }
+  ],
+  "lifecycle_operations": [
+    {
+      "id": "ship-task",
+      "display": "Ship a project change",
+      "category": "delivery",
+      "summary": "Firstmate can turn an approved coding request into an isolated worker task that implements, validates, opens a PR, and waits for captain merge approval unless routine authority already applies.",
+      "reads": [
+        "data/projects.md",
+        "data/backlog.md",
+        "state/*.meta",
+        "project delivery posture"
+      ],
+      "owners": [
+        "AGENTS.md section 7",
+        "bin/fm-brief.sh",
+        "bin/fm-spawn.sh",
+        "no-mistakes"
+      ],
+      "mutates_when_requested_outside_help": [
+        "data/backlog.md",
+        "state/",
+        "project worktree",
+        "PR branch"
+      ],
+      "sample_prompts": [
+        "Fix the login redirect bug in pm-tools and ship a PR.",
+        "Build ONM-1234 with no-mistakes and stop at a PR for me to merge."
+      ]
+    },
+    {
+      "id": "scout-investigation",
+      "display": "Scout or investigate before changing code",
+      "category": "investigation",
+      "summary": "Firstmate can commission a read-only or scratch investigation that produces a report before any implementation is authorized.",
+      "reads": [
+        "existing reports",
+        "project code",
+        "data/backlog.md"
+      ],
+      "owners": [
+        "AGENTS.md section 7",
+        "bin/fm-brief.sh",
+        ".agents/skills/decision-hold-lifecycle/SKILL.md"
+      ],
+      "mutates_when_requested_outside_help": [
+        "data/<id>/report.md",
+        "data/backlog.md"
+      ],
+      "sample_prompts": [
+        "Scout why the document list feels slow and report options.",
+        "Investigate this regression first; do not change code yet."
+      ]
+    },
+    {
+      "id": "bug-diagnosis",
+      "display": "Diagnose a reported bug",
+      "category": "investigation",
+      "summary": "Firstmate can reproduce an end-user symptom, separate cause from masking conditions, and then either report findings or promote the scout into a fix when the captain authorizes implementation.",
+      "reads": [
+        "bug report",
+        "project history",
+        "tests",
+        "diagnostic report"
+      ],
+      "owners": [
+        ".agents/skills/diagnostic-reasoning/SKILL.md",
+        "bin/fm-promote.sh"
+      ],
+      "mutates_when_requested_outside_help": [
+        "data/<id>/report.md",
+        "project worktree after promotion"
+      ],
+      "sample_prompts": [
+        "Diagnose why fresh issues disappear from the project view.",
+        "Reproduce this browser error, find the cause, then ask before fixing."
+      ]
+    },
+    {
+      "id": "review-or-validate",
+      "display": "Review or validate work",
+      "category": "quality",
+      "summary": "Firstmate can run no-mistakes on a committed branch, coordinate review findings, tests, docs, lint, PR creation, and CI without adding a separate manual approval gate.",
+      "reads": [
+        "branch diff",
+        "no-mistakes state",
+        "CI status"
+      ],
+      "owners": [
+        "no-mistakes",
+        ".agents/skills/ask-user-authority/SKILL.md"
+      ],
+      "mutates_when_requested_outside_help": [
+        "validation branch",
+        "PR",
+        "Linear comments when configured"
+      ],
+      "sample_prompts": [
+        "Run no-mistakes on this branch and open the PR.",
+        "Review this plan for verification gaps only."
+      ]
+    },
+    {
+      "id": "project-management",
+      "display": "Add, create, initialize, or remove projects",
+      "category": "fleet-management",
+      "summary": "Firstmate can manage registered projects, delivery mode, project initialization, and outward-facing repository consent through the project-management contract.",
+      "reads": [
+        "data/projects.md",
+        "project clone state",
+        "GitHub auth"
+      ],
+      "owners": [
+        ".agents/skills/project-management/SKILL.md",
+        "bin/fm-project-mode.sh"
+      ],
+      "mutates_when_requested_outside_help": [
+        "data/projects.md",
+        "projects/ clones",
+        "remote repository only after consent"
+      ],
+      "sample_prompts": [
+        "Add this repo to the fleet as direct-PR.",
+        "Create a private GitHub repo for this new project."
+      ]
+    },
+    {
+      "id": "secondmate-routing",
+      "display": "Route a domain to a persistent second mate",
+      "category": "fleet-management",
+      "summary": "Firstmate can create, sync, hand work to, recover, or retire a persistent second mate for a defined scope while the main home remains the captain's point of contact.",
+      "reads": [
+        "data/secondmates.md",
+        "registered secondmate homes",
+        "pending replies"
+      ],
+      "owners": [
+        ".agents/skills/secondmate-provisioning/SKILL.md",
+        "bin/fm-backlog-handoff.sh"
+      ],
+      "mutates_when_requested_outside_help": [
+        "data/secondmates.md",
+        "secondmate home",
+        "pending reply records"
+      ],
+      "sample_prompts": [
+        "Set up a second mate for pm-tools QA work.",
+        "Route this frontend maintenance stream to the existing second mate if it fits."
+      ]
+    },
+    {
+      "id": "linear-backed-work",
+      "display": "Keep Linear aligned with work",
+      "category": "tracking",
+      "summary": "For projects that use Linear, firstmate can find or create the issue, post progress, link commits and PRs, and move the ticket at delivery milestones.",
+      "reads": [
+        "project tracker anchors",
+        "Linear issue state",
+        "PR URL"
+      ],
+      "owners": [
+        "linear-workflow",
+        "project-tracker.md when present"
+      ],
+      "mutates_when_requested_outside_help": [
+        "Linear issue comments",
+        "Linear issue status"
+      ],
+      "sample_prompts": [
+        "Build ONM-1034 and keep the ticket updated.",
+        "Create Linear issues from this approved breakdown."
+      ]
+    },
+    {
+      "id": "documentation-updates",
+      "display": "Keep project docs current",
+      "category": "documentation",
+      "summary": "When a change ships, firstmate can include relevant README, architecture, runbook, or external-document updates through the project's doc discipline.",
+      "reads": [
+        "project-docs.md",
+        "README.md",
+        "architecture docs",
+        "Linear Documents when configured"
+      ],
+      "owners": [
+        "project-docs",
+        "project documentation map"
+      ],
+      "mutates_when_requested_outside_help": [
+        "project docs",
+        "external docs when configured"
+      ],
+      "sample_prompts": [
+        "Ship the fix and update the affected docs.",
+        "Sync the runbook after this deployment change."
+      ]
+    },
+    {
+      "id": "x-mode",
+      "display": "Answer eligible public mentions through X mode",
+      "category": "integration",
+      "summary": "When X mode is explicitly opted in, firstmate can classify eligible mentions, reply or dismiss, link spawned work, and post milestone follow-ups within the X-mode safety boundary.",
+      "reads": [
+        ".env pairing token presence",
+        "state/x-inbox",
+        "state/x-context"
+      ],
+      "owners": [
+        ".agents/skills/fmx-respond/SKILL.md",
+        "docs/configuration.md"
+      ],
+      "mutates_when_requested_outside_help": [
+        "public replies",
+        "X-mode state artifacts",
+        "fleet work only after eligible classification"
+      ],
+      "sample_prompts": [
+        "What can X mode safely handle?",
+        "Opt me out of X mode."
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
 | `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, falling back to Bearings when invoked as the session's first real captain message |
 | `/bearings`        | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
+| `/fleet-help`      | Explain what the fleet can do and recommend the next captain action from live read-only sources such as the capability catalog, backlog projection, current task state, secondmates, decisions, and PR records |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -144,6 +144,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/fleet-help/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/fmx-respond/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/tests/fm-fleet-help.test.sh
+++ b/tests/fm-fleet-help.test.sh
@@ -15,6 +15,7 @@ test_fleet_help_metadata_and_readme() {
   assert_grep 'user-invocable: true' "$SKILL" "fleet-help skill is not user-invocable"
   assert_grep '  internal: true' "$SKILL" "fleet-help skill is not internal"
   assert_absent "$ROOT/skills/fleet-help" "fleet-help must not exist in the public installer-facing skills directory"
+  # shellcheck disable=SC2016  # single quotes are deliberate: a literal needle string, not an expansion
   assert_grep '| `/fleet-help`' "$README" "README built-in skills table does not list /fleet-help"
   pass "fleet-help is internal, user-invocable, and documented with built-in skills"
 }
@@ -24,6 +25,7 @@ test_fleet_help_is_read_only_navigator() {
     "fleet-help does not declare the navigator boundary"
   assert_grep 'This skill is read-only over fleet state.' "$SKILL" \
     "fleet-help does not declare read-only state access"
+  # shellcheck disable=SC2016  # single quotes are deliberate: a literal needle string, not an expansion
   assert_grep 'Do not spawn workers, steer workers, dispatch queued work, merge PRs, update Linear, update the backlog, write reports, arm supervision, or mutate `state/` or `data/` as a side effect of help.' "$SKILL" \
     "fleet-help lost the no-mutation and no-dispatch boundary"
   assert_grep 'If the best next step is actionable, say what the captain can ask for and stop.' "$SKILL" \
@@ -34,12 +36,14 @@ test_fleet_help_is_read_only_navigator() {
 }
 
 test_fleet_help_reads_live_sources_not_status_logs() {
+  # shellcheck disable=SC2016  # single quotes are deliberate: a literal needle string, not an expansion
   assert_grep '[`fleet-catalog.json`](fleet-catalog.json)' "$SKILL" \
     "fleet-help does not point to its machine-readable catalog"
   assert_grep 'bin/fm-bearings-snapshot.sh --json' "$SKILL" \
     "fleet-help does not use the bounded bearings snapshot"
   assert_grep 'bin/fm-fleet-snapshot.sh --json' "$SKILL" \
     "fleet-help does not define the canonical snapshot fallback"
+  # shellcheck disable=SC2016  # single quotes are deliberate: a literal needle string, not an expansion
   assert_grep 'Do not parse `state/*.status` directly because those files are append-only event history, not current state.' "$SKILL" \
     "fleet-help must not infer current state from raw status logs"
   pass "fleet-help uses live structured sources instead of raw status history"

--- a/tests/fm-fleet-help.test.sh
+++ b/tests/fm-fleet-help.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Static contract tests for the internal /fleet-help navigator skill.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SKILL="$ROOT/.agents/skills/fleet-help/SKILL.md"
+CATALOG="$ROOT/.agents/skills/fleet-help/fleet-catalog.json"
+README="$ROOT/README.md"
+
+test_fleet_help_metadata_and_readme() {
+  assert_present "$SKILL" "fleet-help skill is missing"
+  assert_grep 'name: fleet-help' "$SKILL" "fleet-help skill metadata has the wrong name"
+  assert_grep 'user-invocable: true' "$SKILL" "fleet-help skill is not user-invocable"
+  assert_grep '  internal: true' "$SKILL" "fleet-help skill is not internal"
+  assert_absent "$ROOT/skills/fleet-help" "fleet-help must not exist in the public installer-facing skills directory"
+  assert_grep '| `/fleet-help`' "$README" "README built-in skills table does not list /fleet-help"
+  pass "fleet-help is internal, user-invocable, and documented with built-in skills"
+}
+
+test_fleet_help_is_read_only_navigator() {
+  assert_grep 'This is a navigator, not a workflow runner.' "$SKILL" \
+    "fleet-help does not declare the navigator boundary"
+  assert_grep 'This skill is read-only over fleet state.' "$SKILL" \
+    "fleet-help does not declare read-only state access"
+  assert_grep 'Do not spawn workers, steer workers, dispatch queued work, merge PRs, update Linear, update the backlog, write reports, arm supervision, or mutate `state/` or `data/` as a side effect of help.' "$SKILL" \
+    "fleet-help lost the no-mutation and no-dispatch boundary"
+  assert_grep 'If the best next step is actionable, say what the captain can ask for and stop.' "$SKILL" \
+    "fleet-help does not stop before acting on recommendations"
+  assert_grep 'Do not install BMAD, copy BMAD personas, or present named role menus.' "$SKILL" \
+    "fleet-help does not preserve the no-BMAD and no-persona boundary"
+  pass "fleet-help is a read-only guide rather than a runner"
+}
+
+test_fleet_help_reads_live_sources_not_status_logs() {
+  assert_grep '[`fleet-catalog.json`](fleet-catalog.json)' "$SKILL" \
+    "fleet-help does not point to its machine-readable catalog"
+  assert_grep 'bin/fm-bearings-snapshot.sh --json' "$SKILL" \
+    "fleet-help does not use the bounded bearings snapshot"
+  assert_grep 'bin/fm-fleet-snapshot.sh --json' "$SKILL" \
+    "fleet-help does not define the canonical snapshot fallback"
+  assert_grep 'Do not parse `state/*.status` directly because those files are append-only event history, not current state.' "$SKILL" \
+    "fleet-help must not infer current state from raw status logs"
+  pass "fleet-help uses live structured sources instead of raw status history"
+}
+
+test_fleet_catalog_generated_skills_match_user_invocable_internal_skills() {
+  local expected actual skill id
+  assert_present "$CATALOG" "fleet-help catalog is missing"
+  jq -e '.schema == "fleet-help-catalog.v1"' "$CATALOG" >/dev/null \
+    || fail "fleet-help catalog has the wrong schema or invalid JSON"
+
+  expected=$(
+    for skill in "$ROOT"/.agents/skills/*/SKILL.md; do
+      id=$(basename "$(dirname "$skill")")
+      if awk '
+        /^---$/ { markers += 1; next }
+        markers == 1 && /^user-invocable: true$/ { user = 1 }
+        markers == 1 && /^  internal: true$/ { internal = 1 }
+        END { exit !(user && internal) }
+      ' "$skill"; then
+        printf '%s\n' "$id"
+      fi
+    done | LC_ALL=C sort
+  )
+  actual=$(jq -r '.generated_skills[].id' "$CATALOG" | LC_ALL=C sort)
+  [ "$actual" = "$expected" ] || fail "fleet-help generated skill catalog is out of sync"$'\n'"expected:"$'\n'"$expected"$'\n'"actual:"$'\n'"$actual"
+  pass "fleet-help generated skill catalog matches internal user-invocable skills"
+}
+
+test_fleet_catalog_covers_script_owned_operations() {
+  jq -e '
+    (.lifecycle_operations | length) >= 8 and
+    all(.lifecycle_operations[];
+      (.id | type) == "string" and
+      (.display | type) == "string" and
+      (.summary | type) == "string" and
+      (.owners | type) == "array" and
+      (.sample_prompts | type) == "array" and
+      (.sample_prompts | length) > 0 and
+      (.mutates_when_requested_outside_help | type) == "array") and
+    ([.lifecycle_operations[].id] | index("ship-task")) and
+    ([.lifecycle_operations[].id] | index("scout-investigation")) and
+    ([.lifecycle_operations[].id] | index("linear-backed-work")) and
+    ([.lifecycle_operations[].id] | index("secondmate-routing"))
+  ' "$CATALOG" >/dev/null || fail "fleet-help catalog does not cover the required script-owned operations"
+  pass "fleet-help catalog includes hand-authored lifecycle operations"
+}
+
+test_fleet_help_metadata_and_readme
+test_fleet_help_is_read_only_navigator
+test_fleet_help_reads_live_sources_not_status_logs
+test_fleet_catalog_generated_skills_match_user_invocable_internal_skills
+test_fleet_catalog_covers_script_owned_operations


### PR DESCRIPTION
## Intent

Build ONM-1034 for the firstmate repo: add an internal, user-invocable /fleet-help navigator skill on branch onm-1034-fleet-help. The skill should answer what the fleet can do, what is in flight or blocked or awaiting the captain, and what should happen next by reading live read-only sources such as the capability catalog, fm-bearings/fleet snapshot, backlog projection, task state, secondmates, decision holds, and PR records. Preserve firstmate autonomy: /fleet-help guides the captain, adds no approval gates or personas, installs no BMAD tooling, never spawns or messages workers, never mutates state/backlog/Linear/reports, and stops after suggesting exact follow-up wording. Include a small machine-readable catalog in the firstmate-internal skill tier, keep the generated skill section in sync via a test, document the built-in skill in README, and ship through no-mistakes with a PR for captain merge.

## What Changed

- Add the firstmate-internal, user-invocable `/fleet-help` navigator skill (`SKILL.md` + machine-readable `fleet-catalog.json`) that answers what the fleet can do and what is in flight, blocked, or awaiting the captain by reading live read-only sources (capability catalog, `fm-bearings`/fleet snapshot, backlog projection, task state, secondmates, decision holds, PR records); it only suggests exact follow-up wording and never spawns/messages workers or mutates state, backlog, Linear, or reports.
- Register the built-in skill: add its row to the README skills table and a `/fleet-help` entry to `docs/documentation-audiences.json`.
- Add `tests/fm-fleet-help.test.sh` covering skill metadata/README presence, read-only navigator boundaries, live-source usage, `generated_skills`↔`skills` catalog sync, and lifecycle-operation coverage.

## Risk Assessment

✅ Low: Additive documentation/skill authoring plus a contract test with no runtime code paths; all referenced scripts, flags, and owner files exist, the catalog exactly matches the internal user-invocable skills, and every stated intent constraint is satisfied.

## Testing

Ran the smallest relevant set: the new fm-fleet-help contract suite plus the documentation-audiences suite (both green, 10 assertions), then exercised the skill's actual end-user data path by running bin/fm-bearings-snapshot.sh --json and confirming it produces the exact live buckets /fleet-help classifies. I proved the "keep the catalog in sync via a test" intent is enforced with a mutation test (removing a skill from the catalog makes the sync assertion fail, restore makes it pass) and captured the README built-in-skills table showing the /fleet-help row. No rendered UI exists for this change — it is an agent-facing markdown navigator skill plus a machine-readable catalog — so the reviewer-visible evidence is the CLI snapshot transcript, the README table row, and the test transcript rather than a screenshot. Worktree left clean; all evidence written under the dedicated evidence directory.

<details>
<summary>Evidence: Live bearings snapshot (the read-only source /fleet-help consumes)</summary>

<code>{&#10;&#34;schema&#34;: &#34;fm-bearings.v1&#34;,&#10;&#34;prs&#34;: &#34;not_requested (run: /bearings include PRs)&#34;,&#10;&#34;in_flight&#34;: [], &#34;secondmates&#34;: [], &#34;decisions_open&#34;: [],&#10;&#34;landed&#34;: [], &#34;gates&#34;: [], &#34;reports&#34;: [], &#34;recorded_prs&#34;: []&#10;}</code>

```text
{
  "schema": "fm-bearings.v1",
  "home": "cab07976cc95/01KYF3MHHAKKVKRN1173TJHF8W",
  "generated": "2026-07-26T11:44:58Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [],
  "secondmates": [],
  "decisions_open": [],
  "landed": [],
  "gates": [],
  "reports": [],
  "recorded_prs": [],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>
<details>
<summary>Evidence: fleet-help + documentation-audiences test run (all green)</summary>

<code>ok - fleet-help is internal, user-invocable, and documented with built-in skills&#10;ok - fleet-help is a read-only guide rather than a runner&#10;ok - fleet-help uses live structured sources instead of raw status history&#10;ok - fleet-help generated skill catalog matches internal user-invocable skills&#10;ok - fleet-help catalog includes hand-authored lifecycle operations&#10;FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0</code>

```text
FM_TEST_BEGIN 2026-07-26T11:44:59Z tests/fm-fleet-help.test.sh family=unclassified expected_gate_skip=none
ok - fleet-help is internal, user-invocable, and documented with built-in skills
ok - fleet-help is a read-only guide rather than a runner
ok - fleet-help uses live structured sources instead of raw status history
ok - fleet-help generated skill catalog matches internal user-invocable skills
ok - fleet-help catalog includes hand-authored lifecycle operations
FM_TEST_END 2026-07-26T11:45:00Z tests/fm-fleet-help.test.sh exit=0 duration_ms=713 gate_skip=false
FM_TEST_BEGIN 2026-07-26T11:45:00Z tests/fm-documentation-audiences.test.sh family=pure-contract-unit expected_gate_skip=none
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
ok - no-mistakes uses the supported trusted document.instructions schema
FM_TEST_END 2026-07-26T11:45:02Z tests/fm-documentation-audiences.test.sh exit=0 duration_ms=2280 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=3345
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=2280 failed=0
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=713 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-documentation-audiences.test.sh duration_ms=2280
FM_TEST_SLOWEST rank=2 script=tests/fm-fleet-help.test.sh duration_ms=713
```
</details>
<details>
<summary>Evidence: README built-in skills table showing the /fleet-help row</summary>

<code>| `/fleet-help` | Explain what the fleet can do and recommend the next captain action from live read-only sources such as the capability catalog, backlog projection, current task state, secondmates, decisions, and PR records |</code>

```text
170:| `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
171:| `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, falling back to Bearings when invoked as the session's first real captain message |
172:| `/bearings`        | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
173:| `/fleet-help`      | Explain what the fleet can do and recommend the next captain action from live read-only sources such as the capability catalog, backlog projection, current task state, secondmates, decisions, and PR records |
174:| `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
```
</details>
<details>
<summary>Evidence: Catalog sync guard is real (mutation test)</summary>

```text
After `jq del(.generated_skills[]|select(.id=="bearings"))`:
not ok - fleet-help generated skill catalog is out of sync (exit=1)
After `git checkout` restore:
ok - fleet-help generated skill catalog matches internal user-invocable skills (exit=0)
git status --porcelain: clean
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-fleet-help.test.sh tests/fm-documentation-audiences.test.sh` — all 10 assertions pass (metadata/README, read-only navigator boundaries, live-source usage, generated_skills↔skills sync, lifecycle-operations coverage, docs-audience inventory)</code>
- <code>`bin/fm-bearings-snapshot.sh --json` — live read-only source runs and emits the projected buckets the skill consumes (in_flight, secondmates, decisions_open, landed, gates, reports, recorded_prs, prs)</code>
- <code>Mutation test: `jq del(generated_skills[id==bearings])` then re-ran the sync test → `not ok - ... out of sync` (exit 1); `git checkout` restored → green again, worktree clean</code>
- <code>`grep -nE &#39;/fleet-help&#39; README.md` — confirmed the built-in skills table row is rendered alongside the other slash skills</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
