### PR TITLE
feat(skills): add doc-review-lenses skill and per-initiative memlog convention

### DIFF
--- a/.agents/skills/doc-review-lenses/SKILL.md
+++ b/.agents/skills/doc-review-lenses/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: doc-review-lenses
+description: >-
+  Agent-only procedure for reviewing planning artifacts, SPECs, scout reports, Linear Documents, ticket descriptions, and memlog-derived artifacts through named document lenses before those documents are treated as decision-ready or worker-ready.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# doc-review-lenses
+
+Load this before reviewing a planning artifact, SPEC, scout report, Linear Document, ticket description, story shard, or memlog-derived artifact through named document lenses.
+It complements no-mistakes for document quality and planning integrity.
+It does not replace no-mistakes, code review, project-docs, Linear workflow, or the captain's decision authority.
+
+## Inputs
+
+Read the target artifact in full before finding issues.
+Also read any cited SPEC, memlog, report, ticket, PR, or project document that the target depends on for its claims.
+If the artifact is large, split the review by section but keep one consolidated findings list.
+If the target claims to be rendered from a memlog, read the memlog first and verify that every rendered decision, non-goal, ticket, and acceptance criterion can be traced to a current entry.
+
+## Lenses
+
+Use every required lens unless the caller explicitly scopes a narrower review.
+Tag each finding with exactly one primary lens.
+
+- `adversarial` tests whether a reasonable critic could reject the artifact's assumptions, scope, authority, or unstated tradeoffs.
+- `edge-case` tests unusual projects, absent integrations, missing credentials, concurrent work, privacy boundaries, or failure modes that the artifact does not cover.
+- `verification-gap` tests whether success signals, evidence, acceptance criteria, and rerender proofs are concrete enough to validate.
+- `structure` tests ownership, ordering, duplication, rendering boundaries, dependency flow, and whether a worker could act without guessing.
+- `prose` tests ambiguity, stale wording, captain-facing translation, excessive ceremony, and sentences that obscure the operational consequence.
+
+## Finding format
+
+Return a compact findings table followed by any safe self-resolutions already applied or recommended.
+Use this schema for every finding:
+
+- `id`: stable local identifier such as `DRL-001`.
+- `lens`: one of the required lens tags.
+- `severity`: `minor`, `moderate`, or `major`.
+- `evidence`: exact source location or quote.
+- `risk`: what can go wrong if this remains as written.
+- `route`: `self-resolve`, `captain-ticket`, `defer`, or `dismiss`.
+- `recommended action`: the concrete edit, ticket, or reason to leave it alone.
+
+## Routing findings
+
+Do not turn every unresolved captain-facing finding into a decision hold or ticket.
+Firstmate self-resolves smaller document revisions when the overall project direction already answers them.
+Use `self-resolve` for clarification, missing cross-references, local inconsistency, incomplete verification wording, stale phrasing, and limited scope choices that stay inside the approved initiative direction.
+Use `captain-ticket` only for large directional commitments such as product scope expansion, architecture or workflow commitments that constrain future work, security or privacy posture, irreversible or costly external commitments, or a conflict between approved sources that cannot be resolved from the existing direction.
+When `captain-ticket` is required, create or request a Linear issue assigned to the captain and summarize the decision needed in plain language.
+Use the decision-hold lifecycle only when the unresolved decision must be tracked locally rather than as a Linear issue, or when another firstmate contract specifically requires that lifecycle before completion.
+Use `defer` only when the artifact can remain useful without the answer and the deferred question has a named destination.
+Use `dismiss` only when the issue is invalidated by a cited source or is below the artifact's intended rigor.
+
+## Memlog interaction checks
+
+A memlog is source material for one initiative's planning render, not a general memory bucket.
+It never replaces `/stow`, because `/stow` routes session knowledge to the most specific durable owner and may decide that a fact belongs in captain preferences, learnings, backlog, a project `AGENTS.md`, or shared tracked material instead.
+It never replaces graphify, because graphify indexes and queries a corpus but does not own decisions or rendering authority.
+If graphify is run over a corpus that includes rendered SPECs or memlogs, treat its output as navigation evidence only and trace decisions back to the memlog before changing tickets or briefs.
+If `/stow` finds a session decision for an active initiative with a memlog, the stow sweep may add or cite the memlog entry, then still route any broader reusable learning to the normal knowledge owner.
+
+## Done criteria
+
+The review is done only after the findings list names the lenses used, each finding has a route, and any `captain-ticket` or local decision tracking destination is explicit.
+For a memlog-derived artifact, the review is done only after the report says whether the render is traceable from current memlog entries.
+Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` if any unresolved decision remains outside a Linear ticket.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
   captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
+  <initiative>/.memlog.md  optional append-only per-initiative decision source for SPECs, tickets, and worker-brief rationale; graphify and /stow never replace it (section 6)
   projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)
   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
@@ -212,12 +213,15 @@ Route durable knowledge to its most specific owner:
 - Captain preferences shared across secondmate domains belong in the primary home's `data/captain-shared.md` under the `secondmate-provisioning` contract.
 - Fleet-local operational facts belong in curated, home-local `data/learnings.md`.
 - Task-scoped notes belong with the backlog item, and investigation findings belong in the scout report.
+- Per-initiative decisions for long-lived planning, SPEC, documentation, or ticket-sharding work belong in append-only `data/<initiative>/.memlog.md` when later artifacts must be re-rendered from them.
 - Knowledge useful to almost every contributor to one project belongs in that project's committed `AGENTS.md`.
 - Knowledge general to every firstmate user belongs in this repo's shared tracked surface.
 
 Firstmate never writes a project's `AGENTS.md` directly.
 A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.
 Keep fleet delivery posture and captain-private strategy out of project memory.
+When a memlog exists, it records dated decisions with why, supersedes, and rendered targets, and rendered SPECs, tickets, and worker briefs cite the current memlog entries rather than restating rationale from memory.
+A memlog does not replace `/stow`, `data/learnings.md`, `data/captain.md`, backlog notes, or graphify output: `/stow` still routes session knowledge to the most specific owner, and graphify may index memlogs or rendered artifacts but is never decision authority.
 When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
 
 ## 7. Task lifecycle
@@ -471,6 +475,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `doc-review-lenses` - load before reviewing planning artifacts, SPECs, scout reports, Linear Documents, ticket descriptions, story shards, or memlog-derived artifacts through named document lenses.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -132,6 +132,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/doc-review-lenses/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/firstmate-codexapp/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

Implement ONM-1036 for firstmate: add an internal doc-review-lenses skill for planning artifacts with lens-tagged findings and the captain's amended routing split, document a per-initiative append-only memlog convention in AGENTS.md with explicit graphify and /stow boundaries, prove it on the live fm-doc-lenses-memlog initiative with rendered private SPEC/tickets, and validate with no-mistakes for a PR that the captain will merge.

## What Changed

- Add the internal, agent-only `doc-review-lenses` skill (`.agents/skills/doc-review-lenses/SKILL.md`) defining five named review lenses (`adversarial`, `edge-case`, `verification-gap`, `structure`, `prose`), a lens-tagged finding schema, and a routing split between firstmate `self-resolve` and captain-ticket decisions for planning artifacts, SPECs, and memlog-derived documents.
- Document a per-initiative append-only `data/<initiative>/.memlog.md` convention in `AGENTS.md`, including its knowledge-routing entry and explicit boundaries that it never replaces `/stow`, `data/learnings.md`/`captain.md`, backlog notes, or graphify authority, plus the internal-skill trigger line for `doc-review-lenses`.
- Register the new skill in `docs/documentation-audiences.json` under the `agent-runtime` audience so it is inventoried and link-checked (`fm-doc-audience-check.sh` passes with all 56 surfaces classified).

## Risk Assessment

✅ Low: Documentation-only addition (a new internal skill, an AGENTS.md convention, and its inventory entry) with all cross-references, section pointers, frontmatter conventions, and the doc-audience inventory verified consistent and intent-conformant.

## Testing

Ran the smallest set of structural gates that govern the three tracked surfaces this change ships (doc-audience-check script, fm-documentation-audiences, fm-instruction-owners, fm-stow-contract) — all pass, confirming the new skill is registered/linkable, the AGENTS.md additions honor the one-trigger and no-em-dash contracts, and the /stow boundary is intact. Since these are agent-facing documentation surfaces with no local markdown renderer available, I built a rendered HTML view of the new SKILL.md and the AGENTS.md diff and captured a headless-Chromium screenshot as reviewer-visible evidence; it clearly shows the five lens tags, the amended self-resolve/captain-ticket/defer/dismiss routing split, and the memlog convention's explicit graphify and /stow boundaries. The only intent element not demonstrable here is the live fm-doc-lenses-memlog initiative's private SPEC/tickets, which live in gitignored fleet-local data/ and are correctly absent from the tracked change. No test or product failures; worktree left clean.

- Evidence: Rendered view: new doc-review-lenses skill + AGENTS.md memlog convention (local file: <code>/tmp/no-mistakes-evidence/01KYF3RCJ74220QPM23FCZ333E/onm-1036-rendered.png</code>)
<details>
<summary>Evidence: Self-contained rendered HTML source for the screenshot</summary>

```text
<!DOCTYPE html><html><head><meta charset="utf-8">
<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
<style>
:root{color-scheme:dark}
body{margin:0;background:#0d1117;color:#c9d1d9;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:15px;line-height:1.55}
.wrap{max-width:1180px;margin:0 auto;padding:28px 32px 60px}
h1.page{font-size:22px;color:#f0f6fc;border-bottom:1px solid #30363d;padding-bottom:12px;margin:0 0 6px}
.sub{color:#8b949e;font-size:13px;margin:0 0 26px}
.grid{display:grid;grid-template-columns:1fr 1fr;gap:26px;align-items:start}
@media(max-width:1000px){.grid{grid-template-columns:1fr}}
.card{background:#161b22;border:1px solid #30363d;border-radius:10px;overflow:hidden;min-width:0}
.card>h2{margin:0;font-size:13px;font-weight:600;letter-spacing:.02em;color:#e6edf3;background:#1f2733;padding:11px 16px;border-bottom:1px solid #30363d}
.card>h2 .tag{float:right;font-weight:500;color:#7ee787;font-size:11px}
.card>h2 .tag.new{color:#7ee787}
.body{padding:8px 20px 20px}
.body h1{font-size:19px;color:#f0f6fc;border-bottom:1px solid #21262d;padding-bottom:6px}
.body h2{font-size:16px;color:#f0f6fc;margin-top:20px}
.body code{background:#2d333b;padding:.15em .4em;border-radius:5px;font-size:12.5px;color:#e6edf3}
.body pre{background:#010409;padding:12px;border-radius:6px;overflow:auto}
.body ul{padding-left:20px}
.body li{margin:3px 0}
.diffwrap{padding:10px 0 4px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12.5px}
.dl{padding:1px 16px;white-space:pre-wrap;word-break:break-word}
.dl.meta{color:#8b949e}
.dl.hunk{color:#a5d6ff;background:#0d2136}
.dl.add{color:#aff5b4;background:#0f2f1a}
.dl.del{color:#ffb4b4;background:#331616}
.dl.ctx{color:#8b949e}
</style></head><body><div class="wrap">
<h1 class="page">ONM-1036 &mdash; doc-review-lenses skill + per-initiative memlog convention</h1>
<p class="sub">Rendered view of the two agent-facing surfaces this change ships. Left: the new internal skill (lens-tagged findings + amended self-resolve / captain-ticket routing split). Right: the append-only memlog convention added to AGENTS.md with explicit graphify and /stow boundaries.</p>
<div class="grid">
  <div class="card">
    <h2>.agents/skills/doc-review-lenses/SKILL.md<span class="tag new">NEW FILE</span></h2>
    <div class="body" id="skill"></div>
  </div>
  <div class="card">
    <h2>AGENTS.md<span class="tag new">+ memlog convention</span></h2>
    <div class="diffwrap"><div class="dl meta">diff --git a/AGENTS.md b/AGENTS.md</div>
<div class="dl meta">index 382413e..07ebe0e 100644</div>
<div class="dl meta">--- a/AGENTS.md</div>
<div class="dl meta">+++ b/AGENTS.md</div>
<div class="dl hunk">@@ -78,6 +78,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole</div>
<div class="dl ctx">   captain.md         this home&#x27;s domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update</div>
<div class="dl ctx">   captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning</div>
<div class="dl ctx">   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store</div>
<div class="dl add">+  &lt;initiative&gt;/.memlog.md  optional append-only per-initiative decision source for SPECs, tickets, and worker-brief rationale; graphify and /stow never replace it (section 6)</div>
<div class="dl ctx">   projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)</div>
<div class="dl ctx">   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)</div>
<div class="dl ctx">   &lt;id&gt;/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate</div>
<div class="dl hunk">@@ -212,12 +213,15 @@ Route durable knowledge to its most specific owner:</div>
<div class="dl ctx"> - Captain preferences shared across secondmate domains belong in the primary home&#x27;s `data/captain-shared.md` under the `secondmate-provisioning` contract.</div>
<div class="dl ctx"> - Fleet-local operational facts belong in curated, home-local `data/learnings.md`.</div>
<div class="dl ctx"> - Task-scoped notes belong with the backlog item, and investigation findings belong in the scout report.</div>
<div class="dl add">+- Per-initiative decisions for long-lived planning, SPEC, documentation, or ticket-sharding work belong in append-only `data/&lt;initiative&gt;/.memlog.md` when later artifacts must be re-rendered from them.</div>
<div class="dl ctx"> - Knowledge useful to almost every contributor to one project belongs in that project&#x27;s committed `AGENTS.md`.</div>
<div class="dl ctx"> - Knowledge general to every firstmate user belongs in this repo&#x27;s shared tracked surface.</div>
<div class="dl ctx"> </div>
<div class="dl ctx"> Firstmate never writes a project&#x27;s `AGENTS.md` directly.</div>
<div class="dl ctx"> A crewmate creates or updates it lazily through the project&#x27;s selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.</div>
<div class="dl ctx"> Keep fleet delivery posture and captain-private strategy out of project memory.</div>
<div class="dl add">+When a memlog exists, it records dated decisions with why, supersedes, and rendered targets, and rendered SPECs, tickets, and worker briefs cite the current memlog entries rather than restating rationale from memory.</div>
<div class="dl add">+A memlog does not replace `/stow`, `data/learnings.md`, `data/captain.md`, backlog notes, or graphify output: `/stow` still routes session knowledge to the most specific owner, and graphify may index memlogs or rendered artifacts but is never decision authority.</div>
<div class="dl ctx"> When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.</div>
<div class="dl ctx"> </div>
<div class="dl ctx"> ## 7. Task lifecycle</div>
<div class="dl hunk">@@ -471,6 +475,7 @@ These skills are not captain-invocable; load them only at their precise triggers</div>
<div class="dl ctx"> </div>
<div class="dl ctx"> - `bootstrap-diagnostics` - load whenever the session-start digest&#x27;s bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.</div>
<div class="dl ctx"> - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.</div>
<div class="dl add">+- `doc-review-lenses` - load before reviewing planning artifacts, SPECs, scout reports, Linear Documents, ticket descriptions, story shards, or memlog-derived artifacts through named document lenses.</div>
<div class="dl ctx"> - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project&#x27;s `yolo` posture.</div>
<div class="dl ctx"> - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.</div>
<div class="dl ctx"> - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.</div></div>
  </div>
</div>
</div>
<script>
const md = "---\nname: doc-review-lenses\ndescription: >-\n  Agent-only procedure for reviewing planning artifacts, SPECs, scout reports, Linear Documents, ticket descriptions, and memlog-derived artifacts through named document lenses before those documents are treated as decision-ready or worker-ready.\nuser-invocable: false\nmetadata:\n  internal: true\n---\n\n# doc-review-lenses\n\nLoad this before reviewing a planning artifact, SPEC, scout report, Linear Document, ticket description, story shard, or memlog-derived artifact through named document lenses.\nIt complements no-mistakes for document quality and planning integrity.\nIt does not replace no-mistakes, code review, project-docs, Linear workflow, or the captain's decision authority.\n\n## Inputs\n\nRead the target artifact in full before finding issues.\nAlso read any cited SPEC, memlog, report, ticket, PR, or project document that the target depends on for its claims.\nIf the artifact is large, split the review by section but keep one consolidated findings list.\nIf the target claims to be rendered from a memlog, read the memlog first and verify that every rendered decision, non-goal, ticket, and acceptance criterion can be traced to a current entry.\n\n## Lenses\n\nUse every required lens unless the caller explicitly scopes a narrower review.\nTag each finding with exactly one primary lens.\n\n- `adversarial` tests whether a reasonable critic could reject the artifact's assumptions, scope, authority, or unstated tradeoffs.\n- `edge-case` tests unusual projects, absent integrations, missing credentials, concurrent work, privacy boundaries, or failure modes that the artifact does not cover.\n- `verification-gap` tests whether success signals, evidence, acceptance criteria, and rerender proofs are concrete enough to validate.\n- `structure` tests ownership, ordering, duplication, rendering boundaries, dependency flow, and whether a worker could act without guessing.\n- `prose` tests ambiguity, stale wording, captain-facing translation, excessive ceremony, and sentences that obscure the operational consequence.\n\n## Finding format\n\nReturn a compact findings table followed by any safe self-resolutions already applied or recommended.\nUse this schema for every finding:\n\n- `id`: stable local identifier such as `DRL-001`.\n- `lens`: one of the required lens tags.\n- `severity`: `minor`, `moderate`, or `major`.\n- `evidence`: exact source location or quote.\n- `risk`: what can go wrong if this remains as written.\n- `route`: `self-resolve`, `captain-ticket`, `defer`, or `dismiss`.\n- `recommended action`: the concrete edit, ticket, or reason to leave it alone.\n\n## Routing findings\n\nDo not turn every unresolved captain-facing finding into a decision hold or ticket.\nFirstmate self-resolves smaller document revisions when the overall project direction already answers them.\nUse `self-resolve` for clarification, missing cross-references, local inconsistency, incomplete verification wording, stale phrasing, and limited scope choices that stay inside the approved initiative direction.\nUse `captain-ticket` only for large directional commitments such as product scope expansion, architecture or workflow commitments that constrain future work, security or privacy posture, irreversible or costly external commitments, or a conflict between approved sources that cannot be resolved from the existing direction.\nWhen `captain-ticket` is required, create or request a Linear issue assigned to the captain and summarize the decision needed in plain language.\nUse the decision-hold lifecycle only when the unresolved decision must be tracked locally rather than as a Linear issue, or when another firstmate contract specifically requires that lifecycle before completion.\nUse `defer` only when the artifact can remain useful without the answer and the deferred question has a named destination.\nUse `dismiss` only when the issue is invalidated by a cited source or is below the artifact's intended rigor.\n\n## Memlog interaction checks\n\nA memlog is source material for one initiative's planning render, not a general memory bucket.\nIt never replaces `/stow`, because `/stow` routes session knowledge to the most specific durable owner and may decide that a fact belongs in captain preferences, learnings, backlog, a project `AGENTS.md`, or shared tracked material instead.\nIt never replaces graphify, because graphify indexes and queries a corpus but does not own decisions or rendering authority.\nIf graphify is run over a corpus that includes rendered SPECs or memlogs, treat its output as navigation evidence only and trace decisions back to the memlog before changing tickets or briefs.\nIf `/stow` finds a session decision for an active initiative with a memlog, the stow sweep may add or cite the memlog entry, then still route any broader reusable learning to the normal knowledge owner.\n\n## Done criteria\n\nThe review is done only after the findings list names the lenses used, each finding has a route, and any `captain-ticket` or local decision tracking destination is explicit.\nFor a memlog-derived artifact, the review is done only after the report says whether the render is traceable from current memlog entries.\nBefore treating an investigation or visual review as complete, load `decision-hold-lifecycle` if any unresolved decision remains outside a Linear ticket.\n";
function render(){document.getElementById('skill').innerHTML = marked.parse(md);}
if(window.marked){render()}else{window.addEventListener('load',render)}
</script>
</body></html>
```
</details>
<details>
<summary>Evidence: Raw new SKILL.md (doc-review-lenses)</summary>

```text
---
name: doc-review-lenses
description: >-
  Agent-only procedure for reviewing planning artifacts, SPECs, scout reports, Linear Documents, ticket descriptions, and memlog-derived artifacts through named document lenses before those documents are treated as decision-ready or worker-ready.
user-invocable: false
metadata:
  internal: true
---

# doc-review-lenses

Load this before reviewing a planning artifact, SPEC, scout report, Linear Document, ticket description, story shard, or memlog-derived artifact through named document lenses.
It complements no-mistakes for document quality and planning integrity.
It does not replace no-mistakes, code review, project-docs, Linear workflow, or the captain's decision authority.

## Inputs

Read the target artifact in full before finding issues.
Also read any cited SPEC, memlog, report, ticket, PR, or project document that the target depends on for its claims.
If the artifact is large, split the review by section but keep one consolidated findings list.
If the target claims to be rendered from a memlog, read the memlog first and verify that every rendered decision, non-goal, ticket, and acceptance criterion can be traced to a current entry.

## Lenses

Use every required lens unless the caller explicitly scopes a narrower review.
Tag each finding with exactly one primary lens.

- `adversarial` tests whether a reasonable critic could reject the artifact's assumptions, scope, authority, or unstated tradeoffs.
- `edge-case` tests unusual projects, absent integrations, missing credentials, concurrent work, privacy boundaries, or failure modes that the artifact does not cover.
- `verification-gap` tests whether success signals, evidence, acceptance criteria, and rerender proofs are concrete enough to validate.
- `structure` tests ownership, ordering, duplication, rendering boundaries, dependency flow, and whether a worker could act without guessing.
- `prose` tests ambiguity, stale wording, captain-facing translation, excessive ceremony, and sentences that obscure the operational consequence.

## Finding format

Return a compact findings table followed by any safe self-resolutions already applied or recommended.
Use this schema for every finding:

- `id`: stable local identifier such as `DRL-001`.
- `lens`: one of the required lens tags.
- `severity`: `minor`, `moderate`, or `major`.
- `evidence`: exact source location or quote.
- `risk`: what can go wrong if this remains as written.
- `route`: `self-resolve`, `captain-ticket`, `defer`, or `dismiss`.
- `recommended action`: the concrete edit, ticket, or reason to leave it alone.

## Routing findings

Do not turn every unresolved captain-facing finding into a decision hold or ticket.
Firstmate self-resolves smaller document revisions when the overall project direction already answers them.
Use `self-resolve` for clarification, missing cross-references, local inconsistency, incomplete verification wording, stale phrasing, and limited scope choices that stay inside the approved initiative direction.
Use `captain-ticket` only for large directional commitments such as product scope expansion, architecture or workflow commitments that constrain future work, security or privacy posture, irreversible or costly external commitments, or a conflict between approved sources that cannot be resolved from the existing direction.
When `captain-ticket` is required, create or request a Linear issue assigned to the captain and summarize the decision needed in plain language.
Use the decision-hold lifecycle only when the unresolved decision must be tracked locally rather than as a Linear issue, or when another firstmate contract specifically requires that lifecycle before completion.
Use `defer` only when the artifact can remain useful without the answer and the deferred question has a named destination.
Use `dismiss` only when the issue is invalidated by a cited source or is below the artifact's intended rigor.

## Memlog interaction checks

A memlog is source material for one initiative's planning render, not a general memory bucket.
It never replaces `/stow`, because `/stow` routes session knowledge to the most specific durable owner and may decide that a fact belongs in captain preferences, learnings, backlog, a project `AGENTS.md`, or shared tracked material instead.
It never replaces graphify, because graphify indexes and queries a corpus but does not own decisions or rendering authority.
If graphify is run over a corpus that includes rendered SPECs or memlogs, treat its output as navigation evidence only and trace decisions back to the memlog before changing tickets or briefs.
If `/stow` finds a session decision for an active initiative with a memlog, the stow sweep may add or cite the memlog entry, then still route any broader reusable learning to the normal knowledge owner.

## Done criteria

The review is done only after the findings list names the lenses used, each finding has a route, and any `captain-ticket` or local decision tracking destination is explicit.
For a memlog-derived artifact, the review is done only after the report says whether the render is traceable from current memlog entries.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` if any unresolved decision remains outside a Linear ticket.
```
</details>
<details>
<summary>Evidence: AGENTS.md memlog-convention diff</summary>

```text
diff --git a/AGENTS.md b/AGENTS.md
index 382413e..07ebe0e 100644
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
   captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
+  <initiative>/.memlog.md  optional append-only per-initiative decision source for SPECs, tickets, and worker-brief rationale; graphify and /stow never replace it (section 6)
   projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)
   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
@@ -212,12 +213,15 @@ Route durable knowledge to its most specific owner:
 - Captain preferences shared across secondmate domains belong in the primary home's `data/captain-shared.md` under the `secondmate-provisioning` contract.
 - Fleet-local operational facts belong in curated, home-local `data/learnings.md`.
 - Task-scoped notes belong with the backlog item, and investigation findings belong in the scout report.
+- Per-initiative decisions for long-lived planning, SPEC, documentation, or ticket-sharding work belong in append-only `data/<initiative>/.memlog.md` when later artifacts must be re-rendered from them.
 - Knowledge useful to almost every contributor to one project belongs in that project's committed `AGENTS.md`.
 - Knowledge general to every firstmate user belongs in this repo's shared tracked surface.
 
 Firstmate never writes a project's `AGENTS.md` directly.
 A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.
 Keep fleet delivery posture and captain-private strategy out of project memory.
+When a memlog exists, it records dated decisions with why, supersedes, and rendered targets, and rendered SPECs, tickets, and worker briefs cite the current memlog entries rather than restating rationale from memory.
+A memlog does not replace `/stow`, `data/learnings.md`, `data/captain.md`, backlog notes, or graphify output: `/stow` still routes session knowledge to the most specific owner, and graphify may index memlogs or rendered artifacts but is never decision authority.
 When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
 
 ## 7. Task lifecycle
@@ -471,6 +475,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `doc-review-lenses` - load before reviewing planning artifacts, SPECs, scout reports, Linear Documents, ticket descriptions, story shards, or memlog-derived artifacts through named document lenses.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
```
</details>
<details>
<summary>Evidence: Audience-inventory gate result</summary>

```text
fm-doc-audience-check: ok surfaces=56 local_links=150
```
</details>
- Outcome: ⚠️ 1 info across 1 run (6m9s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ The intent&#39;s &#39;prove it on the live fm-doc-lenses-memlog initiative with rendered private SPEC/tickets&#39; refers to fleet-local, gitignored data/&lt;initiative&gt;/ artifacts that are intentionally not part of the tracked change and are absent from this worktree. That proof-of-use cannot be demonstrated from the tracked diff; the shippable change (skill + AGENTS.md convention + inventory entry) is fully validated. Flagging so the reviewer knows the live-initiative portion was not (and cannot be) exercised here.
- <code>`bash bin/fm-doc-audience-check.sh` — passes: 56 surfaces classified exactly once, 150 local links resolve (validates the new SKILL.md path + inventory entry)</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` — all 5 cases pass (inventory classification, fail-safe mutations, required owner pointers, local-link resolution, no-mistakes document schema)</code>
- <code>`bash tests/fm-instruction-owners.test.sh` — all 11 cases pass, including the AGENTS.md em-dash prohibition and one-precise-trigger-per-internal-skill contract that the new AGENTS.md lines must satisfy</code>
- <code>`bash tests/fm-stow-contract.test.sh` — passes; confirms the /stow boundary the memlog convention references is intact</code>
- `Rendered both shipped surfaces (new SKILL.md via marked.js + AGENTS.md diff) to HTML and captured a headless-Chromium screenshot showing the five lenses, the route split, and the memlog convention with graphify/stow boundaries`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
