### PR TITLE
feat(fm-spawn): auto-inject scout role note for firstmate-repo scouts

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -78,8 +78,11 @@
 #   (fm-config-inherit-lib.sh). A successful launch clears pending inherited
 #   config reread generations because the new agent reads the converged files.
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
-#   see AGENTS.md task lifecycle); --secondmate records kind=secondmate and launches in a
-#   provisioned firstmate home; the default is kind=ship.
+#   see AGENTS.md task lifecycle). Scout spawns whose project is this firstmate repo
+#   or one of its git worktrees receive an automatic role disclaimer in the delivered
+#   brief unless the source brief already contains ROLE NOTE:.
+#   --secondmate records kind=secondmate and launches in a provisioned firstmate home;
+#   the default is kind=ship.
 #   Before a secondmate launch, the home is locally fast-forwarded to the primary
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
@@ -824,6 +827,45 @@ real_path_or_raw() {  # <path>
   fi
 }
 
+# A firstmate-repo scout otherwise reads this repo's AGENTS.md and can mistake
+# itself for the supervising firstmate. Keep the correction structural instead of
+# relying on every caller to hand-write the same role note.
+git_common_dir_real() {  # <git-worktree-or-repo>
+  local repo=$1 common common_abs
+  common=$(git -C "$repo" rev-parse --git-common-dir 2>/dev/null) || return 1
+  case "$common" in
+    /*) common_abs=$common ;;
+    *) common_abs=$repo/$common ;;
+  esac
+  cd "$common_abs" 2>/dev/null && pwd -P
+}
+
+project_is_firstmate_checkout() {  # <project-real-path>
+  local project=$1 root_common project_common
+  root_common=$(git_common_dir_real "$FM_ROOT") || return 1
+  project_common=$(git_common_dir_real "$project") || return 1
+  [ "$project_common" = "$root_common" ]
+}
+
+prepare_delivered_brief() {
+  local delivered
+  DELIVERED_BRIEF=$BRIEF_REAL
+  DELIVERED_BRIEF_REAL=$BRIEF_REAL
+  if [ "$KIND" = scout ] \
+    && project_is_firstmate_checkout "$PROJ_ABS_REAL" \
+    && ! grep -F 'ROLE NOTE:' "$BRIEF_REAL" >/dev/null; then
+    delivered="$BRIEF_DIR_REAL/brief.with-scout-role-note.md"
+    {
+      printf '%s\n' "ROLE NOTE: You are a scout, not the firstmate supervisor. This repo's AGENTS.md does not apply to you. Do not run bin/fm-session-start.sh, arm watchers, or touch state/. Your brief is your only job."
+      printf '\n'
+      cat "$BRIEF_REAL"
+    } > "$delivered"
+    DELIVERED_BRIEF=$delivered
+    DELIVERED_BRIEF_REAL=$delivered
+  fi
+}
+prepare_delivered_brief
+
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
 # left it (same session-name / new-window sequence, see bin/backends/tmux.sh);
 # a herdr spawn goes through the version-gated, workspace-per-HOME,
@@ -1461,7 +1503,7 @@ META_WINDOW=$T
 } > "$STATE/$ID.meta"
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
-sq_brief=$(shell_quote "$BRIEF")
+sq_brief=$(shell_quote "$DELIVERED_BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
@@ -1498,7 +1540,7 @@ if [ "$HARNESS" = kimi ]; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"
     exit 1
   fi
-  KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
+  KIMI_POINTER="Read the brief at $DELIVERED_BRIEF_REAL and follow it exactly."
   KIMI_SUBMIT_RETRIES=${FM_KIMI_SUBMIT_RETRIES:-3}
   KIMI_SUBMIT_SLEEP=${FM_KIMI_SUBMIT_SLEEP:-${FM_KIMI_POLL_INTERVAL:-0.5}}
   KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}

--- a/tests/fm-spawn-scout-role.test.sh
+++ b/tests/fm-spawn-scout-role.test.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh's automatic role disclaimer on firstmate-repo scouts.
+#
+# These tests use a fake firstmate repo and fake tmux/treehouse binaries so they
+# pin the delivered brief path without creating a real terminal or task window.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-scout-role)
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+install_fake_firstmate_bins() {
+  local root=$1
+  mkdir -p "$root/bin"
+  cat > "$root/bin/fm-project-mode.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'direct-PR off\n'
+SH
+  chmod +x "$root/bin/fm-project-mode.sh"
+}
+
+make_case() {
+  local name=$1 relation=$2 id=$3 note=${4:-plain}
+  local case_dir home fm_root firstmate_project project_repo project agent fakebin launchlog
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  fm_root="$case_dir/firstmate-root"
+  firstmate_project="$case_dir/firstmate-project"
+  project_repo="$case_dir/other-project"
+  project=
+  agent=
+  launchlog="$case_dir/launch.log"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  touch "$home/state/.last-watcher-beat"
+
+  case "$relation" in
+    firstmate-root)
+      fm_git_init_commit "$fm_root"
+      agent="$case_dir/agent-wt"
+      git -C "$fm_root" worktree add --quiet -b "agent-$name" "$agent"
+      project="$fm_root"
+      ;;
+    firstmate-worktree)
+      fm_git_worktree "$fm_root" "$firstmate_project" "project-$name"
+      agent="$case_dir/agent-wt"
+      git -C "$fm_root" worktree add --quiet -b "agent-$name" "$agent"
+      project="$firstmate_project"
+      ;;
+    other-project)
+      fm_git_init_commit "$fm_root"
+      fm_git_worktree "$project_repo" "$firstmate_project" "project-$name"
+      agent="$case_dir/agent-wt"
+      git -C "$project_repo" worktree add --quiet -b "agent-$name" "$agent"
+      project="$firstmate_project"
+      ;;
+    *) fail "unknown relation $relation" ;;
+  esac
+  install_fake_firstmate_bins "$fm_root"
+
+  if [ "$note" = role-note ]; then
+    printf 'ROLE NOTE: existing scout role note.\n\nbrief for %s\n' "$id" > "$home/data/$id/brief.md"
+  else
+    printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  fi
+  printf '%s\n' "$case_dir|$home|$fm_root|$project|$agent|$fakebin|$launchlog"
+}
+
+read_case_record() {
+  IFS='|' read -r _CASE_DIR HOME_DIR FM_ROOT_DIR PROJECT_DIR AGENT_WT FAKEBIN_DIR LAUNCH_LOG <<EOF
+$1
+EOF
+}
+
+run_spawn() {
+  local id=$1 kind=${2:-scout}
+  : > "$LAUNCH_LOG"
+  if [ "$kind" = scout ]; then
+    FM_ROOT_OVERRIDE="$FM_ROOT_DIR" FM_HOME="$HOME_DIR" \
+      FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+      FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$AGENT_WT" TMUX="fake,1,0" \
+      FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" PATH="$FAKEBIN_DIR:$PATH" \
+      "$SPAWN" "$id" "$PROJECT_DIR" --scout --harness claude 2>&1
+  else
+    FM_ROOT_OVERRIDE="$FM_ROOT_DIR" FM_HOME="$HOME_DIR" \
+      FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+      FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$AGENT_WT" TMUX="fake,1,0" \
+      FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" PATH="$FAKEBIN_DIR:$PATH" \
+      "$SPAWN" "$id" "$PROJECT_DIR" --harness claude 2>&1
+  fi
+}
+
+last_typed_launch() {
+  tail -n 1 "$LAUNCH_LOG"
+}
+
+test_firstmate_root_scout_gets_generated_role_brief() {
+  local rec id out status generated launch
+  id=scout-role-root-z1
+  rec=$(make_case firstmate-root firstmate-root "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$id" scout)
+  status=$?
+  expect_code 0 "$status" "firstmate-root scout spawn should succeed"
+  generated="$HOME_DIR/data/$id/brief.with-scout-role-note.md"
+  assert_present "$generated" "firstmate-root scout should get a generated delivered brief"
+  assert_grep "ROLE NOTE: You are a scout, not the firstmate supervisor." "$generated" \
+    "generated brief is missing the scout role note"
+  assert_grep "Do not run bin/fm-session-start.sh, arm watchers, or touch state/." "$generated" \
+    "generated brief is missing the operational refusals"
+  assert_grep "brief for $id" "$generated" "generated brief did not preserve the source brief body"
+  assert_no_grep "ROLE NOTE:" "$HOME_DIR/data/$id/brief.md" "source brief should not be rewritten"
+  launch=$(last_typed_launch)
+  assert_contains "$launch" "$generated" "launch did not use the generated role-note brief"
+  pass "firstmate-root scout receives the automatic role disclaimer"
+}
+
+test_firstmate_worktree_existing_role_note_is_not_duplicated() {
+  local rec id out status generated launch
+  id=scout-role-existing-z2
+  rec=$(make_case firstmate-worktree firstmate-worktree "$id" role-note)
+  read_case_record "$rec"
+
+  out=$(run_spawn "$id" scout)
+  status=$?
+  expect_code 0 "$status" "firstmate-worktree scout with ROLE NOTE should succeed"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  generated="$HOME_DIR/data/$id/brief.with-scout-role-note.md"
+  assert_absent "$generated" "existing ROLE NOTE should not create a generated duplicate brief"
+  launch=$(last_typed_launch)
+  assert_contains "$launch" "$HOME_DIR/data/$id/brief.md" "launch should use the source brief with its existing role note"
+  pass "existing ROLE NOTE prevents duplicate scout-role injection"
+}
+
+test_firstmate_ship_uses_source_brief() {
+  local rec id out status generated launch
+  id=scout-role-ship-z3
+  rec=$(make_case firstmate-ship firstmate-root "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$id" ship)
+  status=$?
+  expect_code 0 "$status" "firstmate ship spawn should succeed"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  generated="$HOME_DIR/data/$id/brief.with-scout-role-note.md"
+  assert_absent "$generated" "non-scout firstmate spawn should not create a generated role brief"
+  launch=$(last_typed_launch)
+  assert_contains "$launch" "$HOME_DIR/data/$id/brief.md" "non-scout launch should use the source brief"
+  pass "non-scout firstmate spawns keep the source brief"
+}
+
+test_non_firstmate_scout_uses_source_brief() {
+  local rec id out status generated launch
+  id=scout-role-other-z4
+  rec=$(make_case other-project other-project "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$id" scout)
+  status=$?
+  expect_code 0 "$status" "non-firstmate scout spawn should succeed"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  generated="$HOME_DIR/data/$id/brief.with-scout-role-note.md"
+  assert_absent "$generated" "non-firstmate scout should not create a generated role brief"
+  launch=$(last_typed_launch)
+  assert_contains "$launch" "$HOME_DIR/data/$id/brief.md" "non-firstmate scout launch should use the source brief"
+  pass "non-firstmate scout spawns keep the source brief"
+}
+
+test_firstmate_root_scout_gets_generated_role_brief
+test_firstmate_worktree_existing_role_note_is_not_duplicated
+test_firstmate_ship_uses_source_brief
+test_non_firstmate_scout_uses_source_brief
+
+echo "# all fm-spawn-scout-role tests passed"


### PR DESCRIPTION
## Intent

Mission fm-scout-role-guard: for firstmate-repo scout spawns, make bin/fm-spawn.sh structurally add the proven scout role disclaimer so callers no longer have to hand-write it. The behavior must only apply when kind=scout and the project directory belongs to the firstmate repo or one of its git worktrees; non-scout spawns and scouts for other projects must keep the original source brief. The disclaimer should say the worker is a scout, the repo AGENTS.md does not apply, it must not run bin/fm-session-start.sh, arm watchers, or touch state/, and its brief is its only job. If the source brief already contains ROLE NOTE:, do not duplicate it. Add tests in the repo's shell test style.

## What Changed

Origin: addresses the 2026-07-25 learnings entry for the firstmate-repo scout identity-confusion trap.

- `bin/fm-spawn.sh` now structurally prepends a scout `ROLE NOTE:` disclaimer to the delivered brief when `kind=scout` and the project directory is the firstmate repo or one of its git worktrees, so callers no longer hand-write it. Detection compares the resolved `git rev-parse --git-common-dir` of the project against `FM_ROOT` (new `git_common_dir_real` / `project_is_firstmate_checkout` helpers), and `prepare_delivered_brief` writes the augmented brief to `brief.with-scout-role-note.md`; the note tells the worker it is a scout, that the repo AGENTS.md does not apply, and not to run `bin/fm-session-start.sh`, arm watchers, or touch `state/`.
- Non-scout spawns, scouts for other projects, and briefs that already contain `ROLE NOTE:` keep the original source brief unchanged. Brief delivery (`sq_brief`) and the Kimi pointer now reference `DELIVERED_BRIEF`/`DELIVERED_BRIEF_REAL` instead of the raw brief path.
- Adds `tests/fm-spawn-scout-role.test.sh` covering the four cases: firstmate-root scout gets the note, an existing `ROLE NOTE:` is not duplicated, non-scout ships keep the source brief, and non-firstmate scouts keep the source brief.

## Risk Assessment

✅ Low: The change is a well-bounded, structurally-gated brief augmentation that correctly targets only firstmate-repo scouts, consistently updates every delivery path, is set -e-safe, and ships matching shell tests, with only a trivial redundant-variable observation.

## Testing

Ran the new `tests/fm-spawn-scout-role.test.sh` both directly and through `bin/fm-test-run.sh` (all cases pass), then produced product-level evidence by driving the real `fm-spawn.sh` across five scenarios and capturing the actual delivered-brief content plus the exact brief path launched into the worker pane; the transcript confirms the role disclaimer is injected only for firstmate-repo scouts (root and worktree), is never duplicated when the source already has ROLE NOTE:, and is absent for non-scout and non-firstmate spawns. This is a CLI/backend change with no rendered UI surface, so the reviewer-visible artifact is a CLI transcript rather than a screenshot. Worktree left clean.

<details>
<summary>Evidence: Delivered-brief transcript across 5 spawn scenarios (real fm-spawn.sh)</summary>

<code>SCENARIO 1 firstmate-root scout -&gt; generated brief.with-scout-role-note.md:&#10;&#34;ROLE NOTE: You are a scout, not the firstmate supervisor. This repo&#39;s AGENTS.md does not apply to you. Do not run bin/fm-session-start.sh, arm watchers, or touch state/. Your brief is your only job.&#34; + source body; launched with the generated brief.&#10;SCENARIO 2 firstmate-worktree scout -&gt; same disclaimer prepended; launched with generated brief.&#10;SCENARIO 3 scout whose source already has &#39;ROLE NOTE:&#39; -&gt; no generated brief; source brief delivered unchanged.&#10;SCENARIO 4 firstmate ship (non-scout) -&gt; no generated brief; source brief delivered.&#10;SCENARIO 5 non-firstmate scout -&gt; no generated brief; source brief delivered.</code>

```text
==================================================================
SCENARIO: 1-firstmate-root-scout   (relation=firstmate-root, kind=scout, source_note=plain)
==================================================================
-> Generated delivered brief EXISTS: data/s-root-1/brief.with-scout-role-note.md
------ delivered brief content ------
ROLE NOTE: You are a scout, not the firstmate supervisor. This repo's AGENTS.md does not apply to you. Do not run bin/fm-session-start.sh, arm watchers, or touch state/. Your brief is your only job.

brief for s-root-1
------ end delivered brief ------
-> Brief path actually typed into the worker pane:
     CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/tmp/tmp.9Hko32xo2Z/1-firstmate-root-scout/fm-root/bin/fm-operational-input.sh' encode launch-brief < '/tmp/tmp.9Hko32xo2Z/1-firstmate-root-scout/home/data/s-root-1/brief.with-scout-role-note.md')"

==================================================================
SCENARIO: 2-firstmate-worktree-scout   (relation=firstmate-worktree, kind=scout, source_note=plain)
==================================================================
-> Generated delivered brief EXISTS: data/s-wt-2/brief.with-scout-role-note.md
------ delivered brief content ------
ROLE NOTE: You are a scout, not the firstmate supervisor. This repo's AGENTS.md does not apply to you. Do not run bin/fm-session-start.sh, arm watchers, or touch state/. Your brief is your only job.

brief for s-wt-2
------ end delivered brief ------
-> Brief path actually typed into the worker pane:
     CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/tmp/tmp.9Hko32xo2Z/2-firstmate-worktree-scout/fm-root/bin/fm-operational-input.sh' encode launch-brief < '/tmp/tmp.9Hko32xo2Z/2-firstmate-worktree-scout/home/data/s-wt-2/brief.with-scout-role-note.md')"

==================================================================
SCENARIO: 3-existing-role-note-scout   (relation=firstmate-worktree, kind=scout, source_note=role-note)
==================================================================
-> No generated brief. Source brief delivered unchanged:
------ source brief content ------
ROLE NOTE: existing scout role note.

brief for s-existing-3
------ end source brief ------
-> Brief path actually typed into the worker pane:
     CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/tmp/tmp.9Hko32xo2Z/3-existing-role-note-scout/fm-root/bin/fm-operational-input.sh' encode launch-brief < '/tmp/tmp.9Hko32xo2Z/3-existing-role-note-scout/home/data/s-existing-3/brief.md')"

==================================================================
SCENARIO: 4-firstmate-ship   (relation=firstmate-root, kind=ship, source_note=plain)
==================================================================
-> No generated brief. Source brief delivered unchanged:
------ source brief content ------
brief for s-ship-4
------ end source brief ------
-> Brief path actually typed into the worker pane:
     CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/tmp/tmp.9Hko32xo2Z/4-firstmate-ship/fm-root/bin/fm-operational-input.sh' encode launch-brief < '/tmp/tmp.9Hko32xo2Z/4-firstmate-ship/home/data/s-ship-4/brief.md')"

==================================================================
SCENARIO: 5-non-firstmate-scout   (relation=other-project, kind=scout, source_note=plain)
==================================================================
-> No generated brief. Source brief delivered unchanged:
------ source brief content ------
brief for s-other-5
------ end source brief ------
-> Brief path actually typed into the worker pane:
     CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/tmp/tmp.9Hko32xo2Z/5-non-firstmate-scout/fm-root/bin/fm-operational-input.sh' encode launch-brief < '/tmp/tmp.9Hko32xo2Z/5-non-firstmate-scout/home/data/s-other-5/brief.md')"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-spawn.sh:852` - DELIVERED_BRIEF and DELIVERED_BRIEF_REAL are always set to the same value (both to BRIEF_REAL, or both to the generated `delivered` path, which is itself already under BRIEF_DIR_REAL/pwd -P-resolved). Unlike the BRIEF vs BRIEF_REAL pair — where BRIEF may retain a symlinked component and BRIEF_REAL is canonicalized — these two never diverge, so maintaining both is redundant. Could collapse to a single DELIVERED_BRIEF used at both line 1506 and line 1543. Purely non-functional; no behavior change.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-scout-role.test.sh` — all 4 cases pass (firstmate-root scout gets note, existing ROLE NOTE not duplicated, non-scout ship keeps source, non-firstmate scout keeps source)</code>
- <code>`bash bin/fm-test-run.sh tests/fm-spawn-scout-role.test.sh` — passes through the official runner (exit=0, 0 failed)</code>
- <code>Manual end-to-end drive of `bin/fm-spawn.sh` across 5 scenarios (firstmate-root scout, firstmate-worktree scout, existing-ROLE-NOTE scout, firstmate ship, non-firstmate scout) capturing the delivered brief content and the launch command typed into the worker pane</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

