### PR TITLE
fix(bin): restore Bash 3.2 parsing of ship brief scaffolding

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -325,7 +325,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass the authority check performed by firstmate and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -131,7 +131,7 @@ test_primary_and_secondmate_instruction_generation() {
     "generated implementation brief lets the worker own an ask-user decision"
   assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$ship" \
     "generated implementation brief bypasses the primary authority owner"
-  assert_grep "silently bypass firstmate's authority check and any required captain escalation" "$ship" \
+  assert_grep "silently bypass the authority check performed by firstmate and any required captain escalation" "$ship" \
     "generated implementation brief permits silent ask-user auto-resolution"
   assert_no_grep 'the captain, not you, owns the ask-user decisions' "$ship" \
     "generated implementation brief retained conflicting captain-only wording"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -36,6 +36,21 @@ test_help_includes_entire_header() {
   pass "fm-brief.sh: --help renders the complete header"
 }
 
+# CI may run a newer Bash whose lexer accepts apostrophes in these heredoc
+# bodies, while macOS Bash 3.2 cannot find the command substitution's closing
+# parenthesis. Pin the source-level compatibility invariant independently of
+# the Bash version executing this test.
+test_ship_dod_heredocs_have_no_apostrophes() {
+  local offenders
+  offenders=$(awk '
+    /DOD=\$\(cat <<EOF/ { in_dod=1; next }
+    in_dod && /^EOF$/ { in_dod=0; next }
+    in_dod && index($0, sprintf("%c", 39)) { print NR ":" $0 }
+  ' "$ROOT/bin/fm-brief.sh")
+  [ -z "$offenders" ] || fail "fm-brief.sh ship Definition-of-done heredocs contain Bash 3.2-breaking apostrophes: $offenders"
+  pass "fm-brief.sh: ship Definition-of-done heredocs avoid apostrophes"
+}
+
 # Registry with one project per delivery mode, so each ship-mode DOD branch is
 # exercised. A project absent from the registry defaults to no-mistakes.
 write_registry() {
@@ -384,6 +399,7 @@ test_scout_and_secondmate_scaffold() {
 
 test_script_parses
 test_help_includes_entire_header
+test_ship_dod_heredocs_have_no_apostrophes
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording


### PR DESCRIPTION
## Intent

Restore macOS Bash 3.2 compatibility in Firstmate ship brief scaffolding so the captain-approved Artemis follow-on work can be dispatched. The no-mistakes Definition-of-done heredoc is built inside command substitution, and an apostrophe in its prose prevents Bash 3.2 from finding the closing parenthesis. Rephrase that sentence without changing the brief's authority semantics, add version-independent regression coverage that forbids apostrophes in all ship Definition-of-done heredoc bodies, and preserve every generated brief safety contract. The focused fm-brief tests and repository lint already pass locally.

## What Changed

- Reword the `--yes` warning line in the no-mistakes Definition-of-done heredoc in `bin/fm-brief.sh` to drop the apostrophe (`firstmate's` → `performed by firstmate`), which had prevented macOS Bash 3.2 from finding the closing parenthesis of the enclosing command substitution — the authority semantics of the generated brief are unchanged.
- Add a version-independent regression test `test_ship_dod_heredocs_have_no_apostrophes` to `tests/fm-brief.test.sh` that scans every ship Definition-of-done heredoc body for apostrophes via awk, so the Bash 3.2 breakage is caught regardless of the Bash version running the suite.

Verified via `/bin/bash -n` under Bash 3.2.57 (now parses OK) and the full `tests/fm-brief.test.sh` suite (16/16 pass, including the new detector, which flags the pre-fix apostrophe and is clean on the fix).

## Risk Assessment

✅ Low: A minimal, well-bounded fix that rephrases one sentence to drop a Bash 3.2-breaking apostrophe while preserving authority semantics, plus a correct version-independent regression test covering all DOD heredoc bodies.

## Testing

On the exact target platform (macOS Bash 3.2.57), I confirmed the pre-fix script fails `bash -n` on the apostrophe and the fixed script parses cleanly; ran the full fm-brief suite (16/16 pass including the new regression test); proved the new pure-awk apostrophe detector flags the old line and clears on the fix (version-independent); and generated a real brief showing the reworded authority sentence and every safety-contract line preserved. This is a CLI/text-generation change with no rendered UI surface, so the reviewer-visible artifact is the generated brief markdown and CLI transcripts rather than a screenshot. Everything passes with no findings.

<details>
<summary>Evidence: Generated ship brief (real fm-brief.sh output) showing reworded authority line + preserved safety contract</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of artemis-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/brief-demo-1`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/b0/frc2r_1s5l77zdf6_xrlqfdw0000gn/T/tmp.6ZpA7c321f/state/brief-demo-1.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/willronchetti/.no-mistakes/worktrees/97538b09da8a/01KYF804P4STJJXY08AJWHDMKH/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/willronchetti/.no-mistakes/worktrees/97538b09da8a/01KYF804P4STJJXY08AJWHDMKH/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass the authority check performed by firstmate and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Baseline vs fix parse under Bash 3.2.57</summary>

```text
PRE-FIX: /tmp/fm-brief-prefix.sh: line 314: unexpected EOF while looking for matching `)' => PARSE FAILED
FIXED: bin/fm-brief.sh => PARSE OK
```
</details>
<details>
<summary>Evidence: Regression detector: flags old apostrophe, empty on fix</summary>

```text
PRE-FIX -> 328:- Avoid `--yes`: it would silently bypass firstmate's authority check ... (test would FAIL)
FIXED -> (empty; test PASSES)
```
</details>
<details>
<summary>Evidence: fm-brief.test.sh under Bash 3.2 (16/16 ok)</summary>

```text
ok - fm-brief.sh: bash -n succeeds
ok - fm-brief.sh: ship Definition-of-done heredocs avoid apostrophes
ok - fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression
... (16 ok, EXIT=0)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`/bin/bash -n bin/fm-brief.sh` under Bash 3.2.57 → PARSE OK (fixed)</code>
- <code>`/bin/bash -n` on HEAD~1 fm-brief.sh → fails with `unexpected EOF while looking for matching )` (baseline bug confirmed)</code>
- <code>`/bin/bash tests/fm-brief.test.sh` → 16/16 pass, incl. new `test_ship_dod_heredocs_have_no_apostrophes`</code>
- `Ran the new test's awk detector against pre-fix vs fixed script: flags old apostrophe line 328, empty on fix (proves the test has teeth and is Bash-version-independent)`
- <code>Generated a real brief via `FM_HOME=... bin/fm-brief.sh brief-demo-1 artemis-proj` and confirmed reworded authority line + escalation/authority-contract/`no-mistakes axi respond`/`--yes` safety lines all render intact</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
