### PR TITLE
fix(herdr): recognize opencode's left-only heavy-vertical composer shape (afk wedge 2026-07-19)

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -114,9 +114,9 @@ catch-up if present), a tmux status-line flash when applicable, and a configurab
 So a guard false-positive becomes a visible stall, never an unbounded silent no-op.
 
 **Verify the primary harness's composer shape before relying on afk injection.**
-The composer guard admits only the four structural shapes `fm_backend_herdr_composer_state` and its tmux equivalent recognize: bordered, bare (`❯`/`›`), Pi-separator, and opencode-left-bar.
-A primary harness whose composer shape is outside that set reads `unknown` on every tick, so afk injection defers forever and the wedge alarm is the only signal - exactly the 2026-07-07 claude, 2026-07-08 codex, 2026-07-14 Pi, and 2026-07-19 opencode incidents.
-Before the captain relies on afk injection on herdr (or tmux), verify the primary harness's idle composer reads `empty` from `fm_backend_composer_state "<backend>" "<target>"` (or the tmux equivalent); record the verified shape in `.agents/skills/harness-adapters/SKILL.md` and add a regression fixture in `tests/fm-backend-herdr.test.sh` so a future opencode-shape change cannot silently re-wedge.
+On herdr, the composer guard admits only the four structural shapes `fm_backend_herdr_composer_state` recognizes: bordered, bare (`❯`/`›`), Pi-separator, and opencode-left-bar.
+A primary harness whose herdr composer shape is outside that set reads `unknown` on every tick, so afk injection defers forever and the wedge alarm is the only signal - exactly the 2026-07-07 claude, 2026-07-08 codex, 2026-07-14 Pi, and 2026-07-19 opencode incidents.
+Before the captain relies on afk injection, verify the primary harness's idle composer reads `empty` from `fm_backend_composer_state "<backend>" "<target>"`; record the verified shape in `.agents/skills/harness-adapters/SKILL.md` and add a regression fixture for the affected backend so a future harness-shape change cannot silently re-wedge.
 
 ## Submit model
 

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -113,6 +113,11 @@ catch-up if present), a tmux status-line flash when applicable, and a configurab
 `docs/wedge-alarm.md` owns the alert channel setup, and `docs/verification/supervision.md` "Wedge-alarm channels" owns active evidence.
 So a guard false-positive becomes a visible stall, never an unbounded silent no-op.
 
+**Verify the primary harness's composer shape before relying on afk injection.**
+The composer guard admits only the four structural shapes `fm_backend_herdr_composer_state` and its tmux equivalent recognize: bordered, bare (`❯`/`›`), Pi-separator, and opencode-left-bar.
+A primary harness whose composer shape is outside that set reads `unknown` on every tick, so afk injection defers forever and the wedge alarm is the only signal - exactly the 2026-07-07 claude, 2026-07-08 codex, 2026-07-14 Pi, and 2026-07-19 opencode incidents.
+Before the captain relies on afk injection on herdr (or tmux), verify the primary harness's idle composer reads `empty` from `fm_backend_composer_state "<backend>" "<target>"` (or the tmux equivalent); record the verified shape in `.agents/skills/harness-adapters/SKILL.md` and add a regression fixture in `tests/fm-backend-herdr.test.sh` so a future opencode-shape change cannot silently re-wedge.
+
 ## Submit model
 
 The digest is typed **once** (`send-keys -l` on tmux, `pane send-text` on

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -230,6 +230,7 @@ The checkpoint is deliberately foreground and bounded so Codex regains control r
 | Busy-pane signature | `esc interrupt` (dotted spinner footer; note no "to") |
 | Exit command | `/exit` |
 | Interrupt | double Escape; known flaky while a long shell command runs, so a wedged pane may need `/exit` and relaunch |
+| Idle-composer shape (herdr) | A left-only heavy-vertical (`┃`, U+2503) run with NO right border and NO prompt glyph; the trailing `Build · <model>` row inside the box is chrome (verified 2026-07-19, opencode 1.17.x under herdr 0.7.x; see docs/herdr-backend.md "Incident (2026-07-19)") |
 
 No trust dialog.
 Opencode can auto-upgrade itself in the background and the running TUI can exit mid-task, observed live from 1.15.7 to 1.17.3.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2113,7 +2113,7 @@ EOF
         raw_match=$FM_BACKEND_HERDR_OPENCODE_CONTENT
         found=1
         ;;
-      opencode:*)
+      opencode:*|:*)
         # A working opencode cannot authorize injection, and the lower
         # opencode run proves any generic row above is not current.
         found=0

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1760,7 +1760,7 @@ fm_backend_herdr_strip_ansi() {  # <text>
 # fm_backend_herdr_composer_state: classify the composer's own row as
 # empty|pending|unknown, scanning a generous tail-window capture of <target>.
 # herdr's CLI exposes no cursor-row primitive (unlike tmux's #{cursor_y}), so
-# this locates the composer structurally, recognizing THREE shapes and keeping
+# this locates the composer structurally, recognizing FOUR shapes and keeping
 # whichever match comes LAST (scanning forward), so a shape earlier in
 # scrollback/a popup can never outrank the real (bottom-anchored) composer:
 #
@@ -1798,6 +1798,18 @@ fm_backend_herdr_strip_ansi() {  # <text>
 #              pair remains unknown. This identity + structure conjunction is
 #              what makes a blank Pi row safe without weakening dead-shell or
 #              ambiguous-pane refusal.
+#   opencode-left-bar - opencode's TUI composer is a run of rows whose trimmed
+#              plain text starts with the heavy vertical `┃` (U+2503), with NO
+#              right border and NO prompt glyph (verified real opencode 1.17.x
+#              under herdr 0.7.x, docs/herdr-backend.md "Incident (2026-07-19)").
+#              opencode paints a status chrome row (`┃  Build · <model>`) as
+#              the LAST row of the run, which the finder excludes before
+#              classification. This shape is accepted ONLY when Herdr's native
+#              `agent get` identifies the target as opencode and reports it
+#              idle, done, or blocked. A working opencode keeps the existing
+#              unknown verdict, preserving the never-inject-into-busy-pane
+#              contract; a non-opencode identity, an over-tall candidate, or a
+#              run with no content rows remains unknown.
 #
 #   empty   - blank, a bare prompt glyph, known ghost/placeholder text
 #             ("Type a message...", verified grok 0.2.82's empty-composer
@@ -1836,6 +1848,10 @@ FM_BACKEND_HERDR_BARE_PROMPT_RE=${FM_BACKEND_HERDR_BARE_PROMPT_RE:-'^[❯›]'}
 # structural candidate so two unrelated transcript rules with an arbitrarily
 # large region between them can never be promoted into a composer.
 FM_BACKEND_HERDR_PI_COMPOSER_MAX_LINES=${FM_BACKEND_HERDR_PI_COMPOSER_MAX_LINES:-8}
+# opencode's composer is a run of rows whose trimmed plain text starts with the
+# heavy vertical `┃` (U+2503) - a left-only border with no right border and no
+# prompt glyph. Bound the structural candidate the same way Pi is bounded.
+FM_BACKEND_HERDR_OPENCODE_COMPOSER_MAX_LINES=${FM_BACKEND_HERDR_OPENCODE_COMPOSER_MAX_LINES:-8}
 
 fm_backend_herdr_pi_separator_row() {  # <plain-row>
   local row=$1
@@ -1890,6 +1906,117 @@ fm_backend_herdr_pi_composer_find() {  # <ansi-capture>
   done <<EOF
 $cap
 EOF
+}
+
+# An opencode composer row's TRIMMED plain text starts with the heavy vertical
+# `┃` (U+2503). opencode's TUI draws its composer with a LEFT-ONLY heavy vertical
+# border - no right border, no prompt glyph - so a composer row is either
+# exactly `┃` (an empty input line) or `┃ <text>` (typed input or status chrome).
+# See docs/herdr-backend.md "Incident (2026-07-19)" for the byte-level capture.
+fm_backend_herdr_opencode_composer_row() {  # <plain-row>
+  local row=$1
+  row="${row#"${row%%[![:space:]]*}"}"
+  row="${row%"${row##*[![:space:]]}"}"
+  case "$row" in
+    ┃|┃\ *) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# opencode paints a status chrome row INSIDE the composer box - `<left bar>
+# Build · <model>` - which survives the shared ghost stripper (the "Build" run's
+# truecolor foreground is too bright for the dark-foreground cutoff, so the
+# shared owner keeps it as real content). Recognize the chrome signature - a
+# leading `┃` plus the U+00B7 middot separator - so the composer finder can
+# exclude the status row before content classification. The signature is
+# narrow enough that ordinary user input ("hello world") never matches.
+fm_backend_herdr_opencode_status_row() {  # <plain-row>
+  local row=$1
+  row="${row#"${row%%[![:space:]]*}"}"
+  row="${row%"${row##*[![:space:]]}"}"
+  case "$row" in
+    ┃\ *·*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Drop the last line of a (possibly multi-line, possibly empty) string. Used by
+# the opencode finder to strip the trailing status chrome row from a composer
+# run without forking sed.
+fm_backend_herdr_opencode_drop_last_line() {  # <string>
+  local s=$1
+  case "$s" in
+    *$'\n'*) printf '%s' "${s%$'\n'*}" ;;
+    *) printf '' ;;
+  esac
+}
+
+# Locate the bottom-most run of consecutive opencode composer rows (left-only
+# `┃` border) and return globals parallel to fm_backend_herdr_pi_composer_find:
+# pair-found flag, opening line, bottom composer line, last composer line seen
+# even when no valid pair formed, and the raw composer CONTENT with the trailing
+# status chrome row already removed. The globals let the caller compare this
+# shape's screen position with generic bordered/bare candidates without losing
+# empty composer content through command substitution. An over-tall run is
+# reported as not found but still sets LAST_COMPOSER_LINE so a stale generic
+# row above it cannot be promoted.
+fm_backend_herdr_opencode_composer_find() {  # <ansi-capture>
+  local cap=$1 line plain row=0
+  local in_run=0 run_start=0 run_lines=0 candidate="" last_plain=""
+  local best_start=0 best_end=0 best_content="" best_lines=0 max
+  max=$FM_BACKEND_HERDR_OPENCODE_COMPOSER_MAX_LINES
+  case "$max" in ''|*[!0-9]*|0) max=8 ;; esac
+  FM_BACKEND_HERDR_OPENCODE_PAIR_FOUND=0
+  FM_BACKEND_HERDR_OPENCODE_PAIR_OPEN_LINE=0
+  FM_BACKEND_HERDR_OPENCODE_PAIR_LINE=0
+  FM_BACKEND_HERDR_OPENCODE_LAST_COMPOSER_LINE=0
+  FM_BACKEND_HERDR_OPENCODE_CONTENT=""
+  while IFS= read -r line; do
+    row=$((row + 1))
+    plain=$(fm_backend_herdr_strip_ansi "$line")
+    if fm_backend_herdr_opencode_composer_row "$plain"; then
+      if [ "$in_run" -eq 0 ]; then
+        in_run=1
+        run_start=$row
+        run_lines=0
+        candidate=""
+      fi
+      run_lines=$((run_lines + 1))
+      FM_BACKEND_HERDR_OPENCODE_LAST_COMPOSER_LINE=$row
+      [ -z "$candidate" ] || candidate="${candidate}"$'\n'
+      candidate="${candidate}${line}"
+      last_plain=$plain
+      continue
+    fi
+    if [ "$in_run" -eq 1 ]; then
+      # The status chrome row, when present, is the LAST row of the run; drop
+      # it before forwarding the candidate.
+      if fm_backend_herdr_opencode_status_row "$last_plain"; then
+        candidate=$(fm_backend_herdr_opencode_drop_last_line "$candidate")
+      fi
+      best_start=$run_start
+      best_end=$((row - 1))
+      best_content=$candidate
+      best_lines=$run_lines
+      in_run=0
+    fi
+  done < <(printf '%s\n' "$cap")
+  # A run that runs to the bottom of the capture (no terminator after it).
+  if [ "$in_run" -eq 1 ]; then
+    if fm_backend_herdr_opencode_status_row "$last_plain"; then
+      candidate=$(fm_backend_herdr_opencode_drop_last_line "$candidate")
+    fi
+    best_start=$run_start
+    best_end=$row
+    best_content=$candidate
+    best_lines=$run_lines
+  fi
+  [ "$best_end" -gt 0 ] || return 0
+  [ "$best_lines" -le "$max" ] || return 0
+  FM_BACKEND_HERDR_OPENCODE_PAIR_FOUND=1
+  FM_BACKEND_HERDR_OPENCODE_PAIR_OPEN_LINE=$best_start
+  FM_BACKEND_HERDR_OPENCODE_PAIR_LINE=$best_end
+  FM_BACKEND_HERDR_OPENCODE_CONTENT=$best_content
 }
 
 fm_backend_herdr_agent_identity_raw() {  # <session> <pane> -> <agent>\t<status>
@@ -1968,6 +2095,37 @@ EOF
     # not provide the complete Pi composer structure required for injection.
     found=0
   fi
+  # opencode has no right border and no prompt glyph. Compare its bottom-most
+  # left-only `┃` run with the last generic match so an earlier bordered
+  # transcript row can never suppress the live opencode composer. Identity is
+  # consulted only when a lower opencode run could change the verdict.
+  fm_backend_herdr_opencode_composer_find "$cap"
+  if [ "$FM_BACKEND_HERDR_OPENCODE_PAIR_FOUND" -eq 1 ] \
+     && [ "$FM_BACKEND_HERDR_OPENCODE_PAIR_LINE" -gt "$generic_line" ] \
+     && [ "$generic_line" -lt "$FM_BACKEND_HERDR_OPENCODE_PAIR_OPEN_LINE" ]; then
+    identity=$(fm_backend_herdr_agent_identity_raw "$session" "$pane" 2>/dev/null || true)
+    IFS=$'\t' read -r agent agent_status <<EOF
+$identity
+EOF
+    case "$agent:$agent_status" in
+      opencode:idle|opencode:done|opencode:blocked)
+        shape=opencode-left-bar
+        raw_match=$FM_BACKEND_HERDR_OPENCODE_CONTENT
+        found=1
+        ;;
+      opencode:*)
+        # A working opencode cannot authorize injection, and the lower
+        # opencode run proves any generic row above is not current.
+        found=0
+        ;;
+      *) : ;; # A known non-opencode agent keeps its established verdict.
+    esac
+  elif [ "$FM_BACKEND_HERDR_OPENCODE_PAIR_FOUND" -eq 0 ] \
+       && [ "$FM_BACKEND_HERDR_OPENCODE_LAST_COMPOSER_LINE" -gt "$generic_line" ]; then
+    # A lower unmatched opencode-composer row proves the generic row is stale,
+    # but the run did not form a valid opencode composer (e.g. over-tall).
+    found=0
+  fi
   [ "$found" -eq 1 ] || { printf 'unknown'; return 0; }
   # Content: extract the real typed text from the raw row with the shared,
   # fleet-wide ghost stripper (bin/fm-composer-lib.sh), which drops dim/faint AND
@@ -1980,7 +2138,7 @@ EOF
   stripped=$(printf '%s\n' "$raw_match" | fm_composer_strip_ghost)
   stripped="${stripped#"${stripped%%[![:space:]]*}"}"
   stripped="${stripped%"${stripped##*[![:space:]]}"}"
-  if [ "$shape" = bordered ]; then
+  if [ "$shape" = bordered ] || [ "$shape" = opencode-left-bar ]; then
     bordered=1
     stripped=${stripped//│/}
     stripped=${stripped//┃/}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -375,6 +375,7 @@ FM_BACKEND_HERDR_COMPOSER_LINES=20  # herdr-only: tail lines scanned by composer
 FM_BACKEND_HERDR_IDLE_RE='^Type a message\.\.\.$'  # herdr-only: empty-composer placeholder regex after shared ghost extraction plus border and prompt stripping
 FM_BACKEND_HERDR_BARE_PROMPT_RE='^[❯›]'  # herdr-only: verified agent glyphs recognized as an UNBORDERED (bare) composer row, e.g. Claude's ❯ or Codex's ›; shell glyphs remain unknown rather than empty, and de-emphasised ghost/placeholder text reads empty through shared fm_composer_strip_ghost (docs/herdr-backend.md "Composer and injection safety")
 FM_BACKEND_HERDR_PI_COMPOSER_MAX_LINES=8  # herdr-only: maximum rows admitted between Pi's native-identity-corroborated separator pair; taller or ambiguous candidates stay unknown (docs/herdr-backend.md "Composer and injection safety")
+FM_BACKEND_HERDR_OPENCODE_COMPOSER_MAX_LINES=8  # herdr-only: maximum rows admitted in opencode's native-identity-corroborated left-only heavy-vertical run; taller or ambiguous candidates stay unknown (docs/herdr-backend.md "Incident (2026-07-19)")
 FM_BACKEND_HERDR_SUBMIT_POLLS=6  # herdr-only: agent-state samples spread across each Enter attempt's budget when confirming a submit (docs/herdr-backend.md "Current transport behavior")
 FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP=0.6  # herdr-only: minimum per-Enter confirmation budget before polling agent-state after an idle baseline
 FM_BACKEND_ORCA_COMPOSER_LINES=200  # orca-only: terminal-read lines scanned to locate the composer row for submit verification

--- a/docs/examples/wedge-alarm
+++ b/docs/examples/wedge-alarm
@@ -25,9 +25,10 @@ command: curl -fsS -H "Title: firstmate wedge alarm" -d "$1" https://ntfy.sh/rep
 # OS-level alert channel on Linux" and the durable state/.subsuper-inject-wedged
 # marker is the only signal - nothing surfaces it until bin/fm-afk-return.sh
 # runs on the captain's return. A `command:` directive gives the alarm a real
-# channel. logger(1) ships on every Linux distribution and writes the summary
-# to syslog, so `journalctl -t firstmate-fm-wedge` (or /var/log/messages) shows
-# the wedge without any external service. Add ntfy or another push channel on a
-# second line if the captain is ever away from the host itself.
+# channel. On a system with logger(1) and a local system log, this writes the
+# summary under the `firstmate-fm-wedge` tag; inspect it with
+# `journalctl -t firstmate-fm-wedge` on systemd-journald systems or the host's
+# configured syslog destination. Add ntfy or another push channel on a second
+# line if the captain is ever away from the host itself.
 # command: logger -t firstmate-fm-wedge
 # command: curl -fsS -H "Title: firstmate wedge alarm" -d "$1" https://ntfy.sh/replace-with-your-topic

--- a/docs/examples/wedge-alarm
+++ b/docs/examples/wedge-alarm
@@ -20,3 +20,14 @@
 # happens overnight reaches you even away from the machine.
 osascript
 command: curl -fsS -H "Title: firstmate wedge alarm" -d "$1" https://ntfy.sh/replace-with-your-topic
+
+# Example: a Linux home. Without a configured channel, the alarm logs "no
+# OS-level alert channel on Linux" and the durable state/.subsuper-inject-wedged
+# marker is the only signal - nothing surfaces it until bin/fm-afk-return.sh
+# runs on the captain's return. A `command:` directive gives the alarm a real
+# channel. logger(1) ships on every Linux distribution and writes the summary
+# to syslog, so `journalctl -t firstmate-fm-wedge` (or /var/log/messages) shows
+# the wedge without any external service. Add ntfy or another push channel on a
+# second line if the captain is ever away from the host itself.
+# command: logger -t firstmate-fm-wedge
+# command: curl -fsS -H "Title: firstmate wedge alarm" -d "$1" https://ntfy.sh/replace-with-your-topic

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -182,8 +182,9 @@ A human-blocked permission dialog has no busy banner and still surfaces.
 ## Composer and injection safety
 
 Herdr has no direct cursor-row primitive.
-The adapter locates the bottom-most recognized bordered row, Claude `❯` row, Codex `›` row, or a Pi separator region admitted only when native identity is exactly Pi and state is idle, done, or blocked.
-A working Pi, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains pending or unknown.
+The adapter locates the bottom-most recognized bordered row, Claude `❯` row, Codex `›` row, a Pi separator region admitted only when native identity is exactly Pi and state is idle, done, or blocked, or an opencode left-only heavy-vertical (`┃`, U+2503) run admitted only when native identity is exactly opencode and state is idle, done, or blocked.
+A working Pi or opencode, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains pending or unknown.
+The opencode run's trailing `Build · <model>` status chrome row is excluded before classification; the never-inject-into-busy-pane contract holds for every shape.
 
 ANSI capture preserves de-emphasized placeholder style.
 `bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input.
@@ -198,6 +199,15 @@ The separate routed-request carrier uses `[fm-from-firstmate]` plus U+2063.
 U+2063 survives Herdr terminal input as text, unlike the legacy ASCII control separator that could erase the visible routing label.
 `bin/fm-operational-input.sh` owns current operational construction and parsing, and the AFK skill owns legacy away-input compatibility.
 No Herdr-specific copy of that protocol exists.
+
+## Incident (2026-07-19): opencode-on-Herdr away escalation stayed non-injectable for ~3.9 hours
+
+The away-mode daemon buffered a captain-relevant escalation and attempted injection on every housekeeping tick (~every 14-16 s) for ~3.9 hours.
+All 988 inject attempts returned `composer_state=unknown` because opencode's TUI renders its composer with a left-only heavy-vertical (`┃`, U+2503) border, no right border, and no prompt glyph - a shape the structural classifier did not recognize.
+The full byte-level investigation is recorded at `data/afk-wedge-diag-2026-07-19/report.md`.
+The fix adds opencode's left-only `┃` run as a fourth identity-gated structural shape, admitted only when native `agent get` reports `agent=opencode` with status `idle`, `done`, or `blocked`; a working opencode keeps the never-inject-into-busy-pane contract.
+The wedge alarm mechanism was healthy throughout; the captain was not paged because the Linux home had no `config/wedge-alarm` directive, so the alarm fired into a silent channel.
+`docs/examples/wedge-alarm` now ships a Linux `command:logger -t firstmate-fm-wedge` starting point.
 
 ## Restart and liveness behavior
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1962,7 +1962,7 @@ test_composer_state_opencode_left_bar_requires_safe_native_identity() {
         printf '{"result":{"agent":{"agent":"claude","agent_status":"idle"}}}\n' > "$resp/2.out"
         ;;
       unreadable)
-        printf 'transcript line above the composer\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83  Build \xc2\xb7 GLM-5.2 Z.AI\n' > "$resp/1.out"
+        printf '\xe2\x94\x82 stale bordered transcript row \xe2\x94\x82\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83  Build \xc2\xb7 GLM-5.2 Z.AI\n' > "$resp/1.out"
         printf '1\n' > "$resp/2.exit"
         ;;
       over-tall)

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1895,6 +1895,93 @@ test_composer_state_pi_separator_requires_safe_native_identity() {
   pass "fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets"
 }
 
+# --- composer_state: opencode left-only `┃` border composer ---------------
+# Regression coverage for the away-mode injection wedge on 2026-07-19
+# (docs/herdr-backend.md "Incident (2026-07-19)"): real opencode 1.17.x under
+# herdr renders its composer with a left-only heavy vertical (U+2503) border,
+# no right border, and no prompt glyph; a `Build · <model>` status row sits
+# inside the box as chrome. The fixtures below capture that shape verbatim
+# (character-for-character) from the captain's live idle pane
+# (data/afk-wedge-diag-2026-07-19/report.md "Evidence C"). Before the fix
+# these reads returned `unknown`, so the away-mode injector refused for 988
+# ticks across ~3.9 hours and the captain was not paged until they returned.
+
+test_composer_state_opencode_left_bar_idle_is_empty() {
+  local dir log resp fb out calls
+  dir="$TMP_ROOT/composer-opencode-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # Verbatim tail of a real idle opencode pane (scout report Evidence C,
+  # rows 14-18); the leading transcript row confirms the structural scan does
+  # not promote a stale non-composer row.
+  printf 'transcript line above the composer\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83  Build \xc2\xb7 GLM-5.2 Z.AI\n  \xe2\x95\xb9\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"opencode","agent_status":"idle"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  [ "$out" = empty ] || fail "an idle native opencode left-bar composer should read empty, got '$out'"
+  calls=$(grep -c $'\x1f''agent'$'\x1f''get' "$log")
+  [ "$calls" -eq 1 ] || fail "opencode recognition must corroborate identity exactly once, made $calls agent calls"
+  pass "fm_backend_herdr_composer_state: a native idle opencode left-bar composer reads empty"
+}
+
+test_composer_state_opencode_left_bar_busy_is_unknown() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-opencode-busy"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # The same opencode shape but the pane is busy (scout report Counterfactual B).
+  # The identity gate must refuse so the never-inject-into-busy-pane contract holds.
+  printf 'transcript line above the composer\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83  Build \xc2\xb7 GLM-5.2 Z.AI\n  \xe2\x95\xb9\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\n  \xe2\x96\xa0\xe2\x96\xa0\xe2\xac\x9d\xe2\xac\x9d  esc interrupt   310.1K (31%%)\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"opencode","agent_status":"working"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  [ "$out" = unknown ] || fail "a working opencode pane must remain unknown so injection cannot interrupt a turn, got '$out'"
+  pass "fm_backend_herdr_composer_state: a busy opencode pane keeps the never-inject-into-busy-pane contract"
+}
+
+test_composer_state_opencode_left_bar_real_text_is_pending() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-opencode-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # Real user-typed text in the composer (a `┃  hello world` row above the
+  # status chrome row). The status row must be excluded as chrome; the
+  # remaining real text must read pending, not empty.
+  printf 'transcript line above the composer\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83  hello world\n  \xe2\x94\x83  Build \xc2\xb7 GLM-5.2 Z.AI\n  \xe2\x95\xb9\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\xe2\x96\x80\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"opencode","agent_status":"idle"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  [ "$out" = pending ] || fail "real opencode composer text should read pending, got '$out'"
+  pass "fm_backend_herdr_composer_state: real opencode composer text remains pending while status chrome is treated as empty"
+}
+
+test_composer_state_opencode_left_bar_requires_safe_native_identity() {
+  local dir log resp fb out case_id
+  for case_id in non-opencode unreadable over-tall; do
+    dir="$TMP_ROOT/composer-opencode-$case_id"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+    case "$case_id" in
+      non-opencode)
+        printf 'transcript line above the composer\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83  Build \xc2\xb7 GLM-5.2 Z.AI\n' > "$resp/1.out"
+        printf '{"result":{"agent":{"agent":"claude","agent_status":"idle"}}}\n' > "$resp/2.out"
+        ;;
+      unreadable)
+        printf 'transcript line above the composer\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83\n  \xe2\x94\x83  Build \xc2\xb7 GLM-5.2 Z.AI\n' > "$resp/1.out"
+        printf '1\n' > "$resp/2.exit"
+        ;;
+      over-tall)
+        {
+          printf 'transcript line above the composer\n'
+          for _ in 1 2 3 4 5 6 7 8 9; do printf '  \xe2\x94\x83\n'; done
+          printf '  \xe2\x94\x83  Build \xc2\xb7 GLM-5.2 Z.AI\n'
+        } > "$resp/1.out"
+        printf '{"result":{"agent":{"agent":"opencode","agent_status":"idle"}}}\n' > "$resp/2.out"
+        ;;
+    esac
+    fb=$(make_herdr_fakebin "$dir")
+    out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+    [ "$out" = unknown ] || fail "unsafe opencode left-bar case '$case_id' must remain unknown, got '$out'"
+  done
+  pass "fm_backend_herdr_composer_state: opencode left-bar never authorizes a non-opencode identity, an unreadable identity, or an over-tall run"
+}
+
 # --- composer_state: unbordered (bare) composer rows -------------------------
 # Regression coverage for the away-mode redelivery-loop incident
 # (docs/herdr-backend.md "Incident (2026-07-07)"): real claude and codex
@@ -3057,6 +3144,10 @@ test_composer_state_pi_separator_idle_is_empty
 test_composer_state_pi_separator_real_text_is_pending
 test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown
 test_composer_state_pi_separator_requires_safe_native_identity
+test_composer_state_opencode_left_bar_idle_is_empty
+test_composer_state_opencode_left_bar_busy_is_unknown
+test_composer_state_opencode_left_bar_real_text_is_pending
+test_composer_state_opencode_left_bar_requires_safe_native_identity
 test_composer_state_claude_unbordered_prompt_is_empty
 test_composer_state_claude_unbordered_prompt_is_pending
 test_composer_state_bare_prompt_below_stale_bordered_banner_wins


### PR DESCRIPTION
## Intent

Fix the 2026-07-19 afk-mode injection wedge: opencode-on-herdr away-mode injections were refused for ~3.9 hours because the herdr composer classifier did not recognize opencode's left-only heavy-vertical composer shape. R1 adds opencode-left-bar as a fourth identity-gated structural shape in bin/backends/herdr.sh::fm_backend_herdr_composer_state. R2 expands docs/examples/wedge-alarm with a Linux syslog example. R5 documents the shape in docs/herdr-backend.md, harness-adapters/SKILL.md, and afk/SKILL.md. Four new regression tests in tests/fm-backend-herdr.test.sh pin idle-reads-empty, busy-refuses, real-text-reads-pending, and non-opencode-or-unreadable-or-over-tall refusal. This is upstream contribution work - PR from Restillence/firstmate to kunchenguid/firstmate:main.

## What Changed

- Recognize OpenCode’s identity-gated, left-only heavy-vertical Herdr composer and safely classify empty or pending input while refusing unsafe states.
- Add regression coverage for idle, busy, pending-text, non-OpenCode, unreadable, and over-tall composer cases.
- Document the OpenCode composer shape, AFK verification guidance, and Linux syslog wedge-alarm configuration.

## Risk Assessment

✅ Low: The unreadable-identity path now fails closed even with a stale generic composer match, and the regression fixture exercises that sequence; no other material source risks were found.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (18m49s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/backends/herdr.sh:1029` - Required criterion “non-opencode-or-unreadable-or-over-tall refusal” is not durable when a stale generic composer match precedes the opencode run. If `agent get` is unreadable, `agent:status` becomes `:`, but the `*)` arm preserves `found=1` from that stale generic row; it can therefore return `empty` and permit injection despite unreadable identity. Clear `found` for `:*` at this identity gate, matching the sibling Pi path, and extend the unreadable fixture with a stale generic row.

🔧 Fix: Reject unreadable OpenCode identity despite stale composer matches
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo \"tmux is required for e2e tests\" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo \"== $t ==\"; bash \"$t\" || rc=1; done; exit \"$rc\"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

  comment_count: 0 — use --comments to see full comments
