### PR TITLE
feat(bin): add external keepalive to revive a dead primary session

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, FMX, or KEEPALIVE - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -50,3 +50,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Inspect the reason, keep the pending marker under `state/.secondmate-nudge-pending/` intact, and rerun session start after the endpoint or metadata issue is fixed so bootstrap can retry the exact same marked send.
 - `FMX: X mode on ...` / `FMX: X mode off ...` - bootstrap confirmed or removed the local X-mode poll artifacts (`docs/configuration.md` "X mode (.env)").
   Only when a running watcher needs the cadence transition applied immediately, restart the home-scoped watcher through the emitted harness supervision protocol; bootstrap deliberately never restarts the watcher itself.
+- `KEEPALIVE: <problem>` - this home opted into external session revival, but bootstrap could not arm it or its `config/keepalive` value is unrecognized (`docs/session-keepalive.md`).
+  Supervision itself is unaffected, so work may still be dispatched, but a turn that dies with work in flight will not be revived until this is fixed.
+  Report the concrete blocker, correct an unrecognized opt-in value or an unsupported supervisor pane, then rerun session start to confirm the loop is armed.
+  Never work around it by starting the loop with shell `&`; `bin/fm-keepalive.sh` owns its own terminal lifecycle.

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ config/x-mode.env
 config/cmux-socket-password
 config/wedge-alarm
 config/herdr-presentation-spaces
+config/keepalive

--- a/.pi/extensions/lib/fm-operational-input.ts
+++ b/.pi/extensions/lib/fm-operational-input.ts
@@ -13,6 +13,7 @@ export const FIRSTMATE_CURRENT_OPERATIONAL_KINDS = [
   "away-supervisor",
   "from-firstmate",
   "launch-brief",
+  "session-revive",
 ] as const;
 
 export type FirstmateCurrentOperationalKind =

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inhe
 config/herdr-presentation-spaces  optional presence flag for Herdr's default-off disposable single-task visual projection; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Optional presentation spaces"
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
+config/keepalive  opt-in external revival of a primary session whose own turn died with work in flight; LOCAL, gitignored; absent or "off" = off, "on" = armed at session start; see docs/session-keepalive.md
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
@@ -112,6 +113,8 @@ state/               volatile runtime signals; gitignored
   .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
   .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
   .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
+  .keepalive-exhausted  loud give-up report after opt-in session revival hit its attempt cap; read it, reconcile, then remove it
+  .keepalive.* .keepalive-attempts .keepalive-suspect .keepalive-gone .keepalive-terminal  session-keepalive internals; never touch
 .no-mistakes/        local validation state and evidence; gitignored
 ```
 
@@ -136,7 +139,7 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
 1. **Lock** - acquires the per-home session lock first, before anything mutates shared state.
 2. **Bootstrap** - detect-only checks (tool/version problems, GitHub auth, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
    When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
-   Home-local stale Herdr projection cleanup and the five bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, the local secondmate fast-forward sweep, the secondmate liveness sweep, and X-mode artifact writes - run only when this session actually holds the lock from step 1.
+   Home-local stale Herdr projection cleanup and the six bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, the local secondmate fast-forward sweep, the secondmate liveness sweep, X-mode artifact writes, and opt-in session-keepalive arming - run only when this session actually holds the lock from step 1.
    The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous or unreadable targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`).
 3. **Wake queue** - when locked, drains the durable wake queue and prints the raw records prominently as this turn's first work queue; a bounded, clearly labeled historical status-event annotation may follow a valid `signal` record but never replaces it or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
    When the lock could not be acquired and verified, the queue is left untouched because no session mutation is authorized, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
@@ -336,6 +339,7 @@ X mode may require that same live cycle with no fleet work.
 Do not substitute another harness's wait shape, use shell `&`, or create a second cycle when a healthy one already exists.
 For every actionable wake, follow the ordinary-wake continuation in the emitted protocol; use its repair action only when the live cycle is missing or failed.
 No turn ends blind while work is under way, including turns described as holding or waiting.
+A typed session-revival input is internal operational input from the opt-in external keepalive, not a captain message: resume supervision, reconcile from durable records, never repeat work a record already shows finished, and take no new authority from it (`docs/session-keepalive.md`).
 
 At the start of every wake-handling turn, drain the durable wake queue before peeking, reading beyond the reason line, steering, or starting work.
 Session start is the only exception because its one-shot digest already drained while locked or deliberately left the queue untouched in lock-refused read-only mode.
@@ -359,6 +363,7 @@ A forced repair must use the home-scoped owner path emitted by supervision instr
 
 Guard warnings do not replace the contract.
 Queued wakes must be drained before other action, stale liveness must be repaired through the emitted protocol, and the worktree-tangle warning must be resolved without touching unlanded work.
+An exhausted-revival warning means an earlier turn of this session died with work in flight; reconcile that work from durable records, then remove the named report.
 The spawn assertion and generated ship brief must both enforce that project work starts in an isolated disposable worktree, never the primary checkout.
 Harness-aware turn-end guards are structural backstops, not permission to omit the live cycle.
 
@@ -469,7 +474,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, `FMX:`, or `KEEPALIVE:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -16,7 +16,8 @@
 #                 "NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>",
 #                 "BOOTSTRAP_INFO: nudged fm-<id> with '<message>'",
 #                 "SECONDMATE_LIVENESS: secondmate <id>: skipped: <reason>|respawn failed after <cause>: <reason>",
-#                 "FMX: X mode on ..." or "FMX: X mode off ...".
+#                 "FMX: X mode on ..." or "FMX: X mode off ...",
+#                 "KEEPALIVE: <session-revival arming problem>".
 #          When a RUNNING secondmate worktree is fast-forwarded to firstmate's
 #          own current default-branch commit (a purely LOCAL fast-forward, never
 #          an origin fetch) AND its loaded instruction surface (AGENTS.md, bin/,
@@ -66,9 +67,12 @@
 #          refresh relays any completed fm-fleet-sync.sh output before the
 #          aggregate timeout skip line with timeout and elapsed seconds.
 #          Set FM_FLEET_PRUNE=0 to skip branch pruning during that refresh.
-#          Set FM_BOOTSTRAP_DETECT_ONLY=1 to skip the five MUTATING sweeps
+#          A KEEPALIVE line means the opt-in external session-revival loop
+#          (bin/fm-keepalive.sh, docs/session-keepalive.md) could not be armed or
+#          its config value is unrecognized. A home that has not opted in is silent.
+#          Set FM_BOOTSTRAP_DETECT_ONLY=1 to skip the six MUTATING sweeps
 #          (PR-check migration, secondmate_sync, secondmate_liveness_sweep,
-#          x_mode_setup, fleet_sync) while still printing every read-only detect line
+#          x_mode_setup, keepalive_arm, fleet_sync) while still printing every read-only detect line
 #          above; the TANGLE line switches to advisory-only wording with no
 #          checkout command. Used by
 #          fm-session-start.sh's read-only path when another live session holds
@@ -700,6 +704,36 @@ EOF
   echo "FMX: X mode on - relay poll armed via state/x-watch.check.sh; 30s watcher cadence in config/x-mode.env"
 }
 
+# Arm the opt-in external session keepalive for this home. Off by default: with no
+# config/keepalive value of "on" this is a complete no-op that prints nothing.
+# bin/fm-keepalive.sh owns opt-in resolution, endpoint discovery, its singleton
+# lock, and its non-visible terminal, so this sweep only invokes `start` and
+# reports an actionable failure. Idempotent, because `start` leaves an
+# already-running loop alone; it must run from the primary's own pane so the
+# captured endpoint is the primary session's.
+keepalive_arm() {
+  local keepalive="$SCRIPT_DIR/fm-keepalive.sh" out status
+  [ -x "$keepalive" ] || return 0
+  "$keepalive" config-check
+  status=$?
+  case "$status" in
+    0) ;;
+    2)
+      echo "KEEPALIVE: config/keepalive value is unrecognized (expected on or off); session revival stays off"
+      return 0 ;;
+    *) return 0 ;;
+  esac
+  out=$("$keepalive" start 2>&1)
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "KEEPALIVE: could not arm session revival - $(printf '%s' "$out" | tr '\n' ' ')"
+    return 0
+  fi
+  if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ]; then
+    echo "BOOTSTRAP_INFO: session revival armed - $(printf '%s' "$out" | tr '\n' ' ')"
+  fi
+}
+
 crew_dispatch_validate() {
   local file err
   file="$CONFIG/crew-dispatch.json"
@@ -871,6 +905,7 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
   secondmate_liveness_sweep
   secondmate_sync
   x_mode_setup
+  keepalive_arm
   fleet_sync
 fi
 exit 0

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -13,10 +13,11 @@
 # distinct staleness episode in this FM_HOME (keyed to beacon mtime or absence);
 # later guarded commands in the same episode print a one-line reminder instead.
 # Episode state lives only under state/.guard-watcher-stale-banner (volatile,
-# bounded). Independent alarms (queued wakes, worktree tangle) are never
-# suppressed by that dedup. Normal wake handling (watcher briefly down between a
-# wake and the next supervision resume) stays inside the grace window and stays
-# silent. Always exits 0: the guard warns, it never blocks.
+# bounded). Independent alarms (queued wakes, worktree tangle, an exhausted
+# session revival) are never suppressed by that dedup. Normal wake handling
+# (watcher briefly down between a wake and the next supervision resume) stays
+# inside the grace window and stays silent. Always exits 0: the guard warns, it
+# never blocks.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -113,6 +114,16 @@ fm_guard_clear_stale_banner() {
   rm -f "$STALE_BANNER_MARKER" 2>/dev/null || true
 }
 
+# Session-revival exhaustion is an independent hazard, reported whether or not
+# work is still in flight: an earlier turn of this session died and the opt-in
+# keepalive loop gave up after its attempt cap (bin/fm-keepalive.sh,
+# docs/session-keepalive.md). The report file is the only durable record of that
+# gap, so every guarded command surfaces it until it is read and removed.
+fm_guard_report_keepalive_exhausted() {
+  [ -f "$STATE/.keepalive-exhausted" ] || return 0
+  echo "WARNING: automatic session revival was exhausted - read $STATE/.keepalive-exhausted, reconcile in-flight work, then remove that file." >&2
+}
+
 # Worktree-tangle alarm, checked FIRST and independent of in-flight tasks: the
 # firstmate PRIMARY checkout (FM_ROOT) must stay on its default branch. If a
 # crewmate's branch/commits landed here instead of in its own isolated worktree,
@@ -153,6 +164,7 @@ if [ "$in_flight" -eq 0 ]; then
   # in-flight + stale combination is a fresh episode even if the beacon is still
   # absent with the same key string.
   [ "$READ_ONLY" -eq 1 ] || fm_guard_clear_stale_banner
+  fm_guard_report_keepalive_exhausted
   exit 0
 fi
 
@@ -217,4 +229,5 @@ if "$queue_pending"; then
     echo "WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else." >&2
   fi
 fi
+fm_guard_report_keepalive_exhausted
 exit 0

--- a/bin/fm-keepalive.sh
+++ b/bin/fm-keepalive.sh
@@ -1,0 +1,910 @@
+#!/usr/bin/env bash
+# fm-keepalive.sh - external revival of a PRIMARY firstmate session whose own
+# turn died while fleet work was still in flight.
+#
+# WHY THIS EXISTS. When a crewmate dies the primary notices and relaunches it.
+# When the PRIMARY's own turn dies - a fatal API overload after the harness's
+# internal retries, or any other hard stop - nothing inside that session can
+# start another turn, so in-flight work sits frozen until a human types
+# something. This is a small external loop that watches durable evidence and, on
+# proof that the session is idle-but-lapsed with work riding on it, injects one
+# typed operational input to make the primary resume supervision.
+#
+# It classifies nothing about WHY the turn died and never touches the harness's
+# own retry behavior; it only observes the aftermath.
+#
+# OFF BY DEFAULT. Nothing runs unless the home opts in with config/keepalive
+# containing "on" (local, gitignored; docs/session-keepalive.md owns the contract
+# and docs/configuration.md owns the config reference).
+#
+# AWAY MODE OWNS ITS OWN REVIVAL. While state/.afk exists the away-mode
+# sub-supervisor (bin/fm-supervise-daemon.sh) owns injection into the primary
+# pane, so every verdict here becomes "afk" and nothing is injected. Two
+# injectors racing for one composer would corrupt a turn.
+#
+# DETECTION EVIDENCE (all durable reads; no conversation scraping):
+#   1. state/*.meta          - work in flight; none means nothing to revive.
+#   2. state/.afk            - away mode owns supervision.
+#   3. state/.lock           - the session lock's harness pid. A live harness
+#                              means a dead TURN is revivable; a dead holder
+#                              means the whole session is gone and typing cannot
+#                              revive it; no lock at all fails closed.
+#   4. state/.last-watcher-beat - the watcher liveness beacon shared with
+#                              bin/fm-supervision-lib.sh. A healthy primary
+#                              re-arms supervision every turn, so a stale beacon
+#                              with work in flight is the lapse signal.
+#   5. the primary's busy footer - a long-thinking turn or a foreground tool call
+#                              is busy and is never revived.
+#   6. the primary's composer state - injection happens only into an
+#                              affirmatively empty agent composer, so half-typed
+#                              human input and a dead-shell prompt both defer.
+#   7. state/.keepalive-suspect - the lapse must hold continuously across ticks
+#                              for FM_KEEPALIVE_CONFIRM_SECS before the first
+#                              revival, so a momentary between-turns window
+#                              cannot trigger one.
+#
+# BACKOFF AND CAP. An overloaded API rejects an immediate retry too, so attempt
+# N+1 waits FM_KEEPALIVE_BACKOFF_BASE * 2^(N-1) seconds, capped at
+# FM_KEEPALIVE_BACKOFF_MAX. After FM_KEEPALIVE_MAX_ATTEMPTS the loop stops
+# injecting and writes state/.keepalive-exhausted, which bin/fm-guard.sh surfaces
+# on the next fleet action. Attempt state is durable, so restarting this loop
+# does not reset the cap.
+#
+# AUTHORITY. A revived turn inherits exactly the standing authority it already
+# had. Revival is never approval for a merge, an ask-user finding, or anything
+# destructive, irreversible, or security-sensitive, and the injected body says so.
+#
+# Usage:
+#   fm-keepalive.sh start      Capture the primary pane, then launch the loop in
+#                              a fresh non-visible terminal for the detected
+#                              supervisor backend and record its exact id.
+#                              Idempotent: an already-running loop is left alone.
+#   fm-keepalive.sh run        The foreground loop itself. Normally started by
+#                              `start`, or directly inside a harness-native
+#                              tracked background job. Never use shell `&`.
+#   fm-keepalive.sh stop       Signal the loop, then close the recorded terminal
+#                              by exact id.
+#   fm-keepalive.sh status     Print loop liveness, the current read-only
+#                              verdict, and attempt state. Always exits 0.
+#   fm-keepalive.sh tick       Run exactly one evaluate-and-act pass and print
+#                              its verdict line.
+#   fm-keepalive.sh evaluate   Print the read-only verdict line only.
+#   fm-keepalive.sh config-check
+#                              Silent opt-in probe for callers that arm this loop:
+#                              exit 0 when opted in, 1 when off, 2 when
+#                              config/keepalive holds an unrecognized value.
+#   fm-keepalive.sh --help
+#
+# Verdicts (printed as "<verdict>|<detail>"):
+#   off no-session idle afk healthy agent-gone endpoint-gone busy unsafe
+#   confirming backoff exhausted revived revive-failed
+#
+# Env knobs (defaults in docs/configuration.md):
+#   FM_KEEPALIVE                on|off override for config/keepalive
+#   FM_KEEPALIVE_POLL           seconds between ticks in `run` (default 30)
+#   FM_KEEPALIVE_GRACE          stale-beacon threshold; defaults to FM_GUARD_GRACE
+#   FM_KEEPALIVE_CONFIRM_SECS   continuous lapse required before revival (45)
+#   FM_KEEPALIVE_BACKOFF_BASE   first backoff step in seconds (60)
+#   FM_KEEPALIVE_BACKOFF_MAX    backoff ceiling in seconds (900)
+#   FM_KEEPALIVE_MAX_ATTEMPTS   revival attempts before giving up loudly (5)
+#   FM_KEEPALIVE_GONE_EXIT_SECS continuous endpoint absence before the loop exits
+#                               instead of watching a closed window (600)
+#   FM_KEEPALIVE_SUBMIT_RETRIES Enter-retry attempts after typing once (3)
+#   FM_KEEPALIVE_SUBMIT_SLEEP   seconds between submit checks (0.5)
+#   FM_KEEPALIVE_ENTRY          test seam: command run in the created terminal
+#   FM_SUPERVISOR_TARGET / FM_SUPERVISOR_BACKEND  primary pane overrides, resolved
+#                               by bin/fm-supervisor-target-lib.sh
+#   FM_STATE_OVERRIDE / FM_CONFIG_OVERRIDE  alternate state/config dirs (tests)
+#
+# This file is sourceable: the BASH_SOURCE guard at the foot keeps the CLI from
+# running so tests can drive the pure evaluators directly.
+set -u
+
+FM_KEEPALIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_KEEPALIVE_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+# Shared primitives, each with exactly one owner elsewhere:
+#   fm-tmux-lib.sh          harness busy signatures (fm_busy_lines_match)
+#   fm-backend.sh           per-backend capture/busy/composer/submit dispatch
+#   fm-operational-input.sh the typed operational-input envelope
+#   fm-supervision-lib.sh   in-flight count and watcher-beacon freshness
+#   fm-supervisor-target-lib.sh  primary-pane discovery
+#   fm-session-lock-lib.sh  session-lock harness identity and holder liveness
+# shellcheck source=bin/fm-tmux-lib.sh
+. "$FM_KEEPALIVE_DIR/fm-tmux-lib.sh"
+# shellcheck source=bin/fm-backend.sh
+. "$FM_KEEPALIVE_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-operational-input.sh
+. "$FM_KEEPALIVE_DIR/fm-operational-input.sh"
+# shellcheck source=bin/fm-supervision-lib.sh
+. "$FM_KEEPALIVE_DIR/fm-supervision-lib.sh"
+# shellcheck source=bin/fm-supervisor-target-lib.sh
+. "$FM_KEEPALIVE_DIR/fm-supervisor-target-lib.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$FM_KEEPALIVE_DIR/fm-session-lock-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$FM_KEEPALIVE_DIR/fm-wake-lib.sh"
+# Capability-removal half of the no-mistakes gate boundary: arming or driving this
+# loop types into the captain's primary pane, the same hazard class as fm-send.sh.
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$FM_KEEPALIVE_DIR/fm-gate-refuse-lib.sh"
+
+# Supervisor backends with verified composer/busy/submit primitives for primary
+# injection. Same set as the away-mode daemon; anything else refuses at startup
+# rather than running tmux primitives against a non-tmux pane.
+FM_KEEPALIVE_SUPPORTED_BACKENDS="tmux herdr"
+FM_KEEPALIVE_POLL_DEFAULT=30
+FM_KEEPALIVE_CONFIRM_SECS_DEFAULT=45
+FM_KEEPALIVE_BACKOFF_BASE_DEFAULT=60
+FM_KEEPALIVE_BACKOFF_MAX_DEFAULT=900
+FM_KEEPALIVE_MAX_ATTEMPTS_DEFAULT=5
+FM_KEEPALIVE_GONE_EXIT_SECS_DEFAULT=600
+FM_KEEPALIVE_SUBMIT_RETRIES_DEFAULT=3
+FM_KEEPALIVE_SUBMIT_SLEEP_DEFAULT=0.5
+FM_KEEPALIVE_LOG_MAX_BYTES_DEFAULT=262144
+FM_KEEPALIVE_LOG_KEEP_LINES_DEFAULT=1000
+FM_KEEPALIVE_WS_LABEL="firstmate-keepalive"
+
+fm_keepalive_state() { printf '%s' "${FM_STATE_OVERRIDE:-$FM_HOME/state}"; }
+fm_keepalive_config() { printf '%s' "${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"; }
+
+fm_keepalive_now() { date +%s; }
+
+fm_keepalive_log() {  # <state> <message>
+  local state=$1 log
+  shift
+  log="$state/.keepalive.log"
+  mkdir -p "$state" 2>/dev/null || return 0
+  printf '[%s] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >> "$log" 2>/dev/null || true
+}
+
+fm_keepalive_trim_log() {  # <state>
+  local state=$1 log size tmp
+  log="$state/.keepalive.log"
+  [ -f "$log" ] || return 0
+  size=$(wc -c < "$log" 2>/dev/null) || return 0
+  [ "$size" -ge "${FM_KEEPALIVE_LOG_MAX_BYTES:-$FM_KEEPALIVE_LOG_MAX_BYTES_DEFAULT}" ] || return 0
+  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-keepalive-log.XXXXXX") || return 0
+  if tail -n "${FM_KEEPALIVE_LOG_KEEP_LINES:-$FM_KEEPALIVE_LOG_KEEP_LINES_DEFAULT}" "$log" > "$tmp" 2>/dev/null; then
+    mv -f "$tmp" "$log" 2>/dev/null || rm -f "$tmp"
+  else
+    rm -f "$tmp"
+  fi
+}
+
+# fm_keepalive_positive_int: sanitize one numeric knob. A blank, non-numeric, or
+# negative value uses the default so a typo can never disable a bound.
+fm_keepalive_positive_int() {  # <value> <default>
+  local value=${1-} fallback=$2
+  case "$value" in
+    ''|*[!0-9]*) printf '%s' "$fallback" ;;
+    *) printf '%s' "$value" ;;
+  esac
+}
+
+# fm_keepalive_config_value: the effective opt-in value. FM_KEEPALIVE wins;
+# otherwise the first non-empty, non-comment line of config/keepalive; otherwise
+# empty (absent file = off).
+fm_keepalive_config_value() {  # [config-dir]
+  local config=${1:-$(fm_keepalive_config)} file line
+  if [ -n "${FM_KEEPALIVE:-}" ]; then
+    printf '%s' "$FM_KEEPALIVE"
+    return 0
+  fi
+  file="$config/keepalive"
+  [ -f "$file" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -n "$line" ] || continue
+    case "$line" in '#'*) continue ;; esac
+    printf '%s' "$line"
+    return 0
+  done < "$file"
+  return 0
+}
+
+# fm_keepalive_enabled: 0 = opted in, 1 = off, 2 = present but unrecognized.
+# An unrecognized value never enables the mechanism and never silently passes as
+# off either: bootstrap reports it so the typo gets fixed.
+fm_keepalive_enabled() {  # [config-dir]
+  local value
+  value=$(fm_keepalive_config_value "${1:-}")
+  case "$value" in
+    on) return 0 ;;
+    ''|off) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
+# --- durable episode state --------------------------------------------------
+# .keepalive-suspect     epoch the current continuous lapse was first observed
+# .keepalive-attempts    "<count><TAB><last-attempt-epoch>"
+# .keepalive-gone        epoch the primary endpoint was first observed absent
+# .keepalive-exhausted   the loud give-up report after the attempt cap
+
+FM_KEEPALIVE_TAB=$'\t'
+
+fm_keepalive_attempt_count() {  # <state>
+  local state=$1 record count
+  record=$(cat "$state/.keepalive-attempts" 2>/dev/null || true)
+  count=${record%%"$FM_KEEPALIVE_TAB"*}
+  fm_keepalive_positive_int "$count" 0
+}
+
+fm_keepalive_attempt_epoch() {  # <state>
+  local state=$1 record epoch
+  record=$(cat "$state/.keepalive-attempts" 2>/dev/null || true)
+  case "$record" in
+    *"$FM_KEEPALIVE_TAB"*) epoch=${record##*"$FM_KEEPALIVE_TAB"} ;;
+    *) epoch= ;;
+  esac
+  fm_keepalive_positive_int "$epoch" 0
+}
+
+# fm_keepalive_marker_age: seconds since the epoch recorded INSIDE an episode
+# marker, not since its mtime, so the record survives a copy or a touch and reads
+# the same way the marker is written. A missing or malformed marker reads as
+# ancient, which only ever delays an escalation, never a revival.
+fm_keepalive_marker_age() {  # <marker-path>
+  local marker=$1 recorded now
+  recorded=$(cat "$marker" 2>/dev/null || true)
+  recorded=$(fm_keepalive_positive_int "$recorded" 0)
+  if [ "$recorded" -le 0 ]; then
+    printf '999999'
+    return 0
+  fi
+  now=$(fm_keepalive_now)
+  if [ "$now" -lt "$recorded" ]; then
+    printf '0'
+    return 0
+  fi
+  printf '%s' "$((now - recorded))"
+}
+
+fm_keepalive_record_attempt() {  # <state> <count> <epoch>
+  local state=$1 count=$2 epoch=$3
+  mkdir -p "$state" 2>/dev/null || return 1
+  printf '%s\t%s\n' "$count" "$epoch" > "$state/.keepalive-attempts"
+}
+
+fm_keepalive_clear_episode() {  # <state>
+  local state=$1
+  rm -f "$state/.keepalive-suspect" "$state/.keepalive-attempts" \
+    "$state/.keepalive-gone" 2>/dev/null || true
+}
+
+# fm_keepalive_backoff_delay: seconds required between attempt <count> and the
+# next one. Zero for the very first attempt (the confirm window already gates
+# it); then base * 2^(count-1), capped at the documented ceiling.
+fm_keepalive_backoff_delay() {  # <attempt-count>
+  local count base max delay
+  count=$(fm_keepalive_positive_int "${1-}" 0)
+  base=$(fm_keepalive_positive_int "${FM_KEEPALIVE_BACKOFF_BASE:-}" "$FM_KEEPALIVE_BACKOFF_BASE_DEFAULT")
+  max=$(fm_keepalive_positive_int "${FM_KEEPALIVE_BACKOFF_MAX:-}" "$FM_KEEPALIVE_BACKOFF_MAX_DEFAULT")
+  if [ "$count" -le 0 ]; then
+    printf '0'
+    return 0
+  fi
+  delay=$base
+  while [ "$count" -gt 1 ] && [ "$delay" -lt "$max" ]; do
+    delay=$((delay * 2))
+    count=$((count - 1))
+  done
+  [ "$delay" -gt "$max" ] && delay=$max
+  printf '%s' "$delay"
+}
+
+# --- primary-pane reads -----------------------------------------------------
+# Both wrappers are call sites for the shared primitives, not a second copy of
+# the decision: the native busy state is asked first and a captured tail is
+# matched against the verified harness signatures only when the backend reports
+# unknown, exactly as the watcher, fm-crew-state.sh, and the away-mode daemon do.
+
+fm_keepalive_primary_busy() {  # <backend> <target>
+  local backend=$1 target=$2 native tail40
+  native=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null)
+  case "$native" in
+    busy) return 0 ;;
+  esac
+  tail40=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null) || return 1
+  printf '%s' "$tail40" | grep -v '^[[:space:]]*$' | tail -12 | fm_busy_lines_match
+}
+
+fm_keepalive_composer_state() {  # <backend> <target>
+  local backend=$1 target=$2 verdict
+  verdict=$(fm_backend_composer_state "$backend" "$target" 2>/dev/null)
+  printf '%s' "${verdict:-unknown}"
+}
+
+# fm_keepalive_session_state: what the session lock says about the primary
+# harness process. "live" (a dead turn is revivable), "dead" (the whole session
+# is gone), or "none" (no lock to reason about - fail closed).
+fm_keepalive_session_state() {  # <state>
+  local state=$1 pid
+  pid=$(cat "$state/.lock" 2>/dev/null || true)
+  case "$pid" in
+    ''|*[!0-9]*) printf 'none'; return 0 ;;
+  esac
+  if fm_harness_pid_alive "$pid"; then
+    printf 'live'
+  else
+    printf 'dead'
+  fi
+}
+
+# --- the read-only verdict --------------------------------------------------
+# Prints exactly one "<verdict>|<detail>" line and writes nothing, so a test (or
+# `status`) can ask what the loop would decide without changing state.
+fm_keepalive_evaluate() {  # <state> <backend> <target> [config-dir]
+  local state=$1 backend=$2 target=$3 config=${4:-}
+  local grace in_flight beacon session composer attempts last delay now suspect age confirm max
+
+  fm_keepalive_enabled "$config"
+  case "$?" in
+    1) printf 'off|config/keepalive is not on'; return 0 ;;
+    2) printf 'off|config/keepalive value is unrecognized; treated as off'; return 0 ;;
+  esac
+
+  if [ -e "$state/.afk" ]; then
+    printf 'afk|away mode owns supervision and injection'
+    return 0
+  fi
+
+  grace=$(fm_keepalive_positive_int "${FM_KEEPALIVE_GRACE:-}" "${FM_GUARD_GRACE:-300}")
+  fm_supervision_status "$state" "$grace"
+  in_flight=$FM_SUP_IN_FLIGHT
+  beacon=$FM_SUP_BEACON_DESC
+  if [ "$in_flight" -eq 0 ]; then
+    printf 'idle|no work in flight'
+    return 0
+  fi
+  if [ "$FM_SUP_WATCHER_FRESH" = true ]; then
+    printf 'healthy|supervision beacon %s within %ss with %s task(s) in flight' \
+      "$beacon" "$grace" "$in_flight"
+    return 0
+  fi
+
+  session=$(fm_keepalive_session_state "$state")
+  case "$session" in
+    none)
+      printf 'no-session|no session lock records a primary harness process'
+      return 0 ;;
+    dead)
+      printf 'agent-gone|the session lock holder is no longer a live harness; input cannot revive it'
+      return 0 ;;
+  esac
+
+  if ! fm_backend_target_exists "$backend" "$target"; then
+    printf 'endpoint-gone|%s target %s does not resolve' "$backend" "$target"
+    return 0
+  fi
+  if fm_keepalive_primary_busy "$backend" "$target"; then
+    printf 'busy|the primary is mid-turn'
+    return 0
+  fi
+  composer=$(fm_keepalive_composer_state "$backend" "$target")
+  if [ "$composer" != empty ]; then
+    printf 'unsafe|composer is not confirmed-empty (state=%s)' "$composer"
+    return 0
+  fi
+
+  attempts=$(fm_keepalive_attempt_count "$state")
+  max=$(fm_keepalive_positive_int "${FM_KEEPALIVE_MAX_ATTEMPTS:-}" "$FM_KEEPALIVE_MAX_ATTEMPTS_DEFAULT")
+  if [ "$attempts" -ge "$max" ]; then
+    printf 'exhausted|%s revival attempt(s) did not restore supervision (beacon %s, %s task(s) in flight)' \
+      "$attempts" "$beacon" "$in_flight"
+    return 0
+  fi
+
+  now=$(fm_keepalive_now)
+  confirm=$(fm_keepalive_positive_int "${FM_KEEPALIVE_CONFIRM_SECS:-}" "$FM_KEEPALIVE_CONFIRM_SECS_DEFAULT")
+  suspect=$(cat "$state/.keepalive-suspect" 2>/dev/null || true)
+  suspect=$(fm_keepalive_positive_int "$suspect" 0)
+  if [ "$suspect" -eq 0 ]; then
+    printf 'confirming|first observation of a lapse (beacon %s); confirming for %ss' "$beacon" "$confirm"
+    return 0
+  fi
+  age=$(fm_keepalive_marker_age "$state/.keepalive-suspect")
+  if [ "$age" -lt "$confirm" ]; then
+    printf 'confirming|lapse held %ss of the %ss confirm window (beacon %s)' "$age" "$confirm" "$beacon"
+    return 0
+  fi
+
+  last=$(fm_keepalive_attempt_epoch "$state")
+  delay=$(fm_keepalive_backoff_delay "$attempts")
+  if [ "$attempts" -gt 0 ] && [ "$last" -gt 0 ] && [ $((now - last)) -lt "$delay" ]; then
+    printf 'backoff|attempt %s waits %ss between attempts, %ss elapsed' \
+      "$((attempts + 1))" "$delay" "$((now - last))"
+    return 0
+  fi
+
+  printf 'revive|supervision lapsed %s with %s task(s) in flight; attempt %s of %s' \
+    "$beacon" "$in_flight" "$((attempts + 1))" "$max"
+}
+
+# --- revival ----------------------------------------------------------------
+# The injected body must tell the primary what happened, what to do, and that
+# nothing about its authority changed. Single line, because submission is
+# send-text plus Enter and embedded newlines are ambiguous in a TUI composer.
+fm_keepalive_revive_body() {  # <attempt> <max> <detail>
+  local attempt=$1 max=$2 detail=$3
+  printf '%s' "Automatic session revival ${attempt} of ${max}: the previous turn ended without handing supervision back (${detail}). Resume supervision now - drain queued wakes with bin/fm-wake-drain.sh, reconcile in-flight work from the durable records, and re-arm the supervision cycle for this harness. Do not start new work, and do not re-do work a durable record already shows as finished. This revival grants no authority: merges, ask-user decisions, and anything destructive, irreversible, or security-sensitive keep exactly the approval they had before."
+}
+
+# fm_keepalive_inject: type the revival input once and submit it. Returns 0 only
+# when the backend confirms the submit; an unconfirmed submit leaves the text in
+# the composer, which the next tick reads as a non-empty composer and defers on,
+# so a swallowed Enter can never concatenate two revival inputs.
+fm_keepalive_inject() {  # <backend> <target> <body>
+  local backend=$1 target=$2 body=$3 encoded retries sleep_s verdict
+  body=${body//$'\n'/ - }
+  fm_operational_input_encode session-revive "$body" encoded || return 1
+  retries=$(fm_keepalive_positive_int "${FM_KEEPALIVE_SUBMIT_RETRIES:-}" "$FM_KEEPALIVE_SUBMIT_RETRIES_DEFAULT")
+  sleep_s=${FM_KEEPALIVE_SUBMIT_SLEEP:-$FM_KEEPALIVE_SUBMIT_SLEEP_DEFAULT}
+  verdict=$(fm_backend_send_text_submit "$backend" "$target" "$encoded" "$retries" "$sleep_s" "$sleep_s")
+  [ "$verdict" = empty ]
+}
+
+fm_keepalive_write_exhausted() {  # <state> <detail>
+  local state=$1 detail=$2 marker
+  marker="$state/.keepalive-exhausted"
+  [ -e "$marker" ] && return 0
+  {
+    printf 'fm session revival EXHAUSTED as of %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')"
+    printf '%s\n' "$detail"
+    printf 'The primary session did not resume supervision after the attempt cap.\n'
+    printf 'Nothing was discarded: queued wakes, task records, and crew work all survive.\n'
+  } > "$marker" 2>/dev/null || return 1
+  fm_keepalive_log "$state" "ERROR: revival exhausted - $detail"
+}
+
+# fm_keepalive_tick: evaluate, then perform this verdict's durable bookkeeping
+# and, for a "revive" verdict, the injection. Prints the acted-on verdict line,
+# which is "revived" or "revive-failed" once an injection was attempted.
+fm_keepalive_tick() {  # <state> <backend> <target> [config-dir]
+  local state=$1 backend=$2 target=$3 config=${4:-}
+  local line verdict detail attempts max body now confirm
+  line=$(fm_keepalive_evaluate "$state" "$backend" "$target" "$config")
+  verdict=${line%%|*}
+  detail=${line#*|}
+  case "$verdict" in
+    healthy)
+      if [ -e "$state/.keepalive-suspect" ] || [ -e "$state/.keepalive-attempts" ] \
+        || [ -e "$state/.keepalive-exhausted" ]; then
+        fm_keepalive_log "$state" "recovered: $detail"
+        rm -f "$state/.keepalive-exhausted" 2>/dev/null || true
+      fi
+      fm_keepalive_clear_episode "$state"
+      ;;
+    off|no-session|idle|afk)
+      fm_keepalive_clear_episode "$state"
+      ;;
+    agent-gone|endpoint-gone)
+      # An absent session process or endpoint is confirmed the same way a lapse
+      # is: one continuous confirm window, because a transient `ps` or backend
+      # read failure must not produce a scary report or end the loop. Only a
+      # confirmed absent session process is reported, since nothing can revive it.
+      rm -f "$state/.keepalive-suspect" 2>/dev/null || true
+      if [ -e "$state/.keepalive-gone" ]; then
+        confirm=$(fm_keepalive_positive_int "${FM_KEEPALIVE_CONFIRM_SECS:-}" "$FM_KEEPALIVE_CONFIRM_SECS_DEFAULT")
+        if [ "$verdict" = agent-gone ] && [ "$(fm_keepalive_marker_age "$state/.keepalive-gone")" -ge "$confirm" ]; then
+          fm_keepalive_write_exhausted "$state" "$detail" || true
+        fi
+      else
+        fm_keepalive_now > "$state/.keepalive-gone" 2>/dev/null || true
+      fi
+      ;;
+    busy|unsafe)
+      # The session is alive or its composer is not ours to type into: the
+      # continuous-lapse window restarts, while durable attempt state stays so a
+      # revived-then-re-died turn keeps growing its backoff.
+      rm -f "$state/.keepalive-suspect" "$state/.keepalive-gone" 2>/dev/null || true
+      ;;
+    confirming)
+      rm -f "$state/.keepalive-gone" 2>/dev/null || true
+      [ -e "$state/.keepalive-suspect" ] || fm_keepalive_now > "$state/.keepalive-suspect" 2>/dev/null || true
+      ;;
+    exhausted)
+      fm_keepalive_write_exhausted "$state" "$detail" || true
+      ;;
+    backoff)
+      ;;
+    revive)
+      attempts=$(fm_keepalive_attempt_count "$state")
+      max=$(fm_keepalive_positive_int "${FM_KEEPALIVE_MAX_ATTEMPTS:-}" "$FM_KEEPALIVE_MAX_ATTEMPTS_DEFAULT")
+      attempts=$((attempts + 1))
+      now=$(fm_keepalive_now)
+      fm_keepalive_record_attempt "$state" "$attempts" "$now" || true
+      rm -f "$state/.keepalive-suspect" 2>/dev/null || true
+      body=$(fm_keepalive_revive_body "$attempts" "$max" "$detail")
+      if fm_keepalive_inject "$backend" "$target" "$body"; then
+        fm_keepalive_log "$state" "revived: attempt $attempts of $max - $detail"
+        line="revived|attempt $attempts of $max submitted: $detail"
+      else
+        fm_keepalive_log "$state" "revival attempt $attempts of $max could not confirm a submit - $detail"
+        line="revive-failed|attempt $attempts of $max could not confirm a submit: $detail"
+      fi
+      ;;
+  esac
+  printf '%s' "$line"
+}
+
+# --- loop lifecycle ---------------------------------------------------------
+
+fm_keepalive_lock_path() { printf '%s' "$1/.keepalive.lock"; }
+
+fm_keepalive_lock_pid() {  # <state>
+  cat "$(fm_keepalive_lock_path "$1")/pid" 2>/dev/null || true
+}
+
+# fm_keepalive_live: 0 when the singleton lock is held by a live process whose
+# recorded identity still matches, so a reused pid cannot look like a live loop.
+fm_keepalive_live() {  # <state>
+  local state=$1 lock pid expected actual
+  lock=$(fm_keepalive_lock_path "$state")
+  [ -d "$lock" ] || return 1
+  pid=$(cat "$lock/pid" 2>/dev/null) || return 1
+  fm_pid_alive "$pid" || return 1
+  expected=$(cat "$lock/pid-identity" 2>/dev/null || true)
+  [ -n "$expected" ] || return 0
+  actual=$(fm_pid_identity "$pid" 2>/dev/null) || return 1
+  [ "$actual" = "$expected" ]
+}
+
+fm_keepalive_resolve_endpoint() {  # sets FM_KEEPALIVE_BACKEND / FM_KEEPALIVE_TARGET
+  FM_KEEPALIVE_BACKEND=$(discover_supervisor_backend) || true
+  FM_KEEPALIVE_TARGET=$(discover_supervisor_target) || true
+  if ! fm_backend_list_contains "$FM_KEEPALIVE_SUPPORTED_BACKENDS" "$FM_KEEPALIVE_BACKEND"; then
+    printf 'fm-keepalive: supervisor backend %s has no verified primary-injection primitives (supported: %s)\n' \
+      "$FM_KEEPALIVE_BACKEND" "$FM_KEEPALIVE_SUPPORTED_BACKENDS" >&2
+    return 1
+  fi
+  [ -n "$FM_KEEPALIVE_TARGET" ] || {
+    printf 'fm-keepalive: could not resolve the primary pane; set FM_SUPERVISOR_TARGET\n' >&2
+    return 1
+  }
+}
+
+fm_keepalive_run() {
+  local state config backend target poll gone_exit line verdict gone_age
+  state=$(fm_keepalive_state)
+  config=$(fm_keepalive_config)
+  mkdir -p "$state" 2>/dev/null || {
+    printf 'fm-keepalive: cannot create state directory %s\n' "$state" >&2
+    return 1
+  }
+  if ! fm_keepalive_enabled "$config"; then
+    printf 'fm-keepalive: not opted in (config/keepalive is not on); nothing to run\n' >&2
+    return 1
+  fi
+  fm_keepalive_resolve_endpoint || return 1
+  backend=$FM_KEEPALIVE_BACKEND
+  target=$FM_KEEPALIVE_TARGET
+  if ! fm_backend_target_exists "$backend" "$target"; then
+    printf 'fm-keepalive: primary target %s does not resolve to a %s pane\n' "$target" "$backend" >&2
+    return 1
+  fi
+  local lock
+  lock=$(fm_keepalive_lock_path "$state")
+  if ! fm_lock_try_acquire "$lock"; then
+    printf 'fm-keepalive: already running (lock %s held)\n' "$lock" >&2
+    return 0
+  fi
+  fm_pid_identity "${BASHPID:-$$}" > "$lock/pid-identity" 2>/dev/null || true
+  # shellcheck disable=SC2329 # Invoked indirectly by the signal traps below.
+  fm_keepalive_cleanup() {
+    trap - TERM INT
+    fm_lock_release "$lock" 2>/dev/null || true
+    fm_keepalive_log "$state" "loop stopping"
+    exit 0
+  }
+  trap fm_keepalive_cleanup TERM INT
+
+  poll=$(fm_keepalive_positive_int "${FM_KEEPALIVE_POLL:-}" "$FM_KEEPALIVE_POLL_DEFAULT")
+  gone_exit=$(fm_keepalive_positive_int "${FM_KEEPALIVE_GONE_EXIT_SECS:-}" "$FM_KEEPALIVE_GONE_EXIT_SECS_DEFAULT")
+  fm_keepalive_log "$state" "loop starting (pid $$); backend=$backend target=$target poll=${poll}s"
+  while :; do
+    if ! fm_keepalive_enabled "$config"; then
+      fm_keepalive_log "$state" "standing down: config/keepalive is no longer on"
+      fm_lock_release "$lock" 2>/dev/null || true
+      return 0
+    fi
+    line=$(fm_keepalive_tick "$state" "$backend" "$target" "$config")
+    verdict=${line%%|*}
+    case "$verdict" in
+      revive|revived|revive-failed|exhausted|agent-gone) fm_keepalive_log "$state" "tick: $line" ;;
+    esac
+    # Standing down is correct exactly when there is nothing left to revive: a
+    # confirmed-absent session process can never accept input again, and an
+    # endpoint absent this long is a closed window, not a dead turn. Both leave
+    # their durable records behind for the next session.
+    if [ "$verdict" = agent-gone ] && [ -e "$state/.keepalive-exhausted" ]; then
+      fm_keepalive_log "$state" "standing down: the primary session process is gone"
+      fm_lock_release "$lock" 2>/dev/null || true
+      return 0
+    fi
+    if [ "$verdict" = endpoint-gone ] && [ -e "$state/.keepalive-gone" ]; then
+      gone_age=$(fm_keepalive_marker_age "$state/.keepalive-gone")
+      if [ "$gone_age" -ge "$gone_exit" ]; then
+        fm_keepalive_log "$state" "standing down: primary endpoint absent for ${gone_age}s"
+        fm_lock_release "$lock" 2>/dev/null || true
+        return 0
+      fi
+    fi
+    fm_keepalive_trim_log "$state"
+    sleep "$poll"
+  done
+}
+
+# --- non-visible terminal for the loop --------------------------------------
+# Same shape as the away-mode daemon's launcher (bin/fm-afk-launch.sh, the owner
+# of that rationale): create a terminal that never touches the captain's active
+# tab, capture the PRIMARY pane BEFORE creating it, and pass that pane in so the
+# loop injects into the primary instead of discovering its own new pane. Never
+# shell `&`, which herdr and codex can reap.
+
+fm_keepalive_record_path() { printf '%s' "$1/.keepalive-terminal"; }
+
+fm_keepalive_record_write() {  # <state> <backend> <target> <extra>
+  local state=$1 pending
+  pending=$(mktemp "$state/.keepalive-terminal.pending.XXXXXX") || return 1
+  printf '%s\t%s\t%s\n' "$2" "$3" "$4" > "$pending" || { rm -f "$pending"; return 1; }
+  mv "$pending" "$(fm_keepalive_record_path "$state")" || { rm -f "$pending"; return 1; }
+}
+
+# Exit 0 with the recorded backend/target, 1 when no record exists, 2 when the
+# record is malformed. A malformed record is never guessed at: its caller refuses
+# rather than closing or creating a terminal it cannot identify exactly.
+fm_keepalive_record_read() {  # <state>; sets FM_KEEPALIVE_REC_BACKEND / _TARGET
+  local record
+  FM_KEEPALIVE_REC_BACKEND=""
+  FM_KEEPALIVE_REC_TARGET=""
+  record=$(fm_keepalive_record_path "$1")
+  [ -f "$record" ] || return 1
+  IFS=$'\t' read -r FM_KEEPALIVE_REC_BACKEND FM_KEEPALIVE_REC_TARGET _ < "$record" || return 2
+  [ -n "$FM_KEEPALIVE_REC_BACKEND" ] && [ -n "$FM_KEEPALIVE_REC_TARGET" ] || return 2
+  case "$FM_KEEPALIVE_REC_BACKEND" in
+    tmux|herdr) return 0 ;;
+    *) return 2 ;;
+  esac
+}
+
+fm_keepalive_close_terminal() {  # <backend> <target>
+  local backend=$1 target=$2 session pane
+  case "$backend" in
+    tmux) tmux kill-session -t "$target" 2>/dev/null ;;
+    herdr)
+      fm_backend_source herdr || return 1
+      session=${target%%:*}
+      pane=${target#*:}
+      [ -n "$session" ] && [ -n "$pane" ] && [ "$pane" != "$target" ] || return 1
+      fm_backend_herdr_cli "$session" pane close "$pane" >/dev/null 2>&1
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_keepalive_entry_cmd() {
+  printf '%s' "${FM_KEEPALIVE_ENTRY:-$FM_ROOT/bin/fm-keepalive.sh run}"
+}
+
+fm_keepalive_launch_cmd() {  # <primary-target> <primary-backend>
+  printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %s' \
+    "$FM_HOME" "$1" "$2" "$(fm_keepalive_entry_cmd)"
+}
+
+fm_keepalive_wait_ready() {  # <state>
+  local state=$1 attempt=0
+  [ -z "${FM_KEEPALIVE_ENTRY:-}" ] || return 0
+  while [ "$attempt" -lt 100 ]; do
+    fm_keepalive_live "$state" && return 0
+    sleep 0.05
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+fm_keepalive_create_tmux() {  # <state> <primary-target> <primary-backend>
+  local state=$1 primary_target=$2 primary_backend=$3 session hash nonce
+  hash=$(printf '%s' "$FM_HOME" | cksum | cut -d' ' -f1)
+  nonce="$$-${RANDOM:-0}-$(fm_keepalive_now)"
+  session="fm-keepalive-$hash-$nonce"
+  fm_keepalive_record_write "$state" tmux "$session" "" || return 1
+  if ! tmux new-session -d -s "$session" "$(fm_keepalive_launch_cmd "$primary_target" "$primary_backend")" 2>/dev/null; then
+    rm -f "$(fm_keepalive_record_path "$state")" 2>/dev/null || true
+    printf 'fm-keepalive: could not create the detached tmux session %s\n' "$session" >&2
+    return 1
+  fi
+  if ! fm_keepalive_wait_ready "$state"; then
+    printf 'fm-keepalive: the loop did not start; closing %s\n' "$session" >&2
+    fm_keepalive_close_terminal tmux "$session"
+    rm -f "$(fm_keepalive_record_path "$state")" 2>/dev/null || true
+    return 1
+  fi
+  printf 'fm-keepalive: watching %s from detached tmux session %s\n' "$primary_target" "$session"
+}
+
+fm_keepalive_create_herdr() {  # <state> <primary-target> <primary-backend>
+  local state=$1 primary_target=$2 primary_backend=$3 session out wsid pane label
+  session=${primary_target%%:*}
+  if [ -z "$session" ] || [ "$session" = "$primary_target" ]; then
+    printf 'fm-keepalive: cannot derive a herdr session from primary target %s\n' "$primary_target" >&2
+    return 1
+  fi
+  fm_backend_source herdr || return 1
+  fm_backend_herdr_server_ensure "$session" || {
+    printf 'fm-keepalive: herdr server is not ready for session %s\n' "$session" >&2
+    return 1
+  }
+  label="$FM_KEEPALIVE_WS_LABEL-$$-${RANDOM:-0}-$(fm_keepalive_now)"
+  out=$(fm_backend_herdr_cli "$session" workspace create --cwd "$FM_HOME" --label "$label" --no-focus 2>/dev/null)
+  wsid=$(printf '%s' "$out" | jq -r '.result.workspace.workspace_id // empty' 2>/dev/null)
+  pane=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
+  if [ -z "$wsid" ] || [ -z "$pane" ]; then
+    printf 'fm-keepalive: herdr did not return an exact workspace and pane id\n' >&2
+    return 1
+  fi
+  fm_keepalive_record_write "$state" herdr "$session:$pane" "$wsid" || {
+    fm_keepalive_close_terminal herdr "$session:$pane"
+    return 1
+  }
+  if ! fm_backend_herdr_cli "$session" pane run "$pane" \
+    "$(fm_keepalive_launch_cmd "$primary_target" "$primary_backend")" >/dev/null 2>&1; then
+    printf 'fm-keepalive: could not run the loop in herdr pane %s:%s\n' "$session" "$pane" >&2
+    fm_keepalive_close_terminal herdr "$session:$pane"
+    rm -f "$(fm_keepalive_record_path "$state")" 2>/dev/null || true
+    return 1
+  fi
+  if ! fm_keepalive_wait_ready "$state"; then
+    printf 'fm-keepalive: the loop did not start; closing herdr pane %s:%s\n' "$session" "$pane" >&2
+    fm_keepalive_close_terminal herdr "$session:$pane"
+    rm -f "$(fm_keepalive_record_path "$state")" 2>/dev/null || true
+    return 1
+  fi
+  printf 'fm-keepalive: watching %s from non-visible herdr workspace %s\n' "$primary_target" "$wsid"
+}
+
+fm_keepalive_start() {
+  local state config backend target
+  state=$(fm_keepalive_state)
+  config=$(fm_keepalive_config)
+  mkdir -p "$state" 2>/dev/null || return 1
+  if ! fm_keepalive_enabled "$config"; then
+    printf 'fm-keepalive: not opted in (config/keepalive is not on); nothing started\n' >&2
+    return 1
+  fi
+  if fm_keepalive_live "$state"; then
+    printf 'fm-keepalive: already running (pid %s)\n' "$(fm_keepalive_lock_pid "$state")"
+    return 0
+  fi
+  # A recorded terminal with no live loop is a leak from a crash: close it by its
+  # exact recorded id before creating another one.
+  fm_keepalive_record_read "$state"
+  case "$?" in
+    0)
+      fm_keepalive_close_terminal "$FM_KEEPALIVE_REC_BACKEND" "$FM_KEEPALIVE_REC_TARGET" || true
+      rm -f "$(fm_keepalive_record_path "$state")" 2>/dev/null || true
+      ;;
+    2)
+      printf 'fm-keepalive: the recorded terminal id is malformed; resolve %s before starting\n' \
+        "$(fm_keepalive_record_path "$state")" >&2
+      return 1
+      ;;
+  esac
+  fm_keepalive_resolve_endpoint || return 1
+  backend=$FM_KEEPALIVE_BACKEND
+  target=$FM_KEEPALIVE_TARGET
+  case "$backend" in
+    tmux) fm_keepalive_create_tmux "$state" "$target" "$backend" ;;
+    herdr) fm_keepalive_create_herdr "$state" "$target" "$backend" ;;
+    *)
+      printf 'fm-keepalive: no non-visible launch primitive for backend %s\n' "$backend" >&2
+      return 1 ;;
+  esac
+}
+
+fm_keepalive_stop() {
+  local state pid result=0
+  state=$(fm_keepalive_state)
+  pid=""
+  if fm_keepalive_live "$state"; then
+    pid=$(fm_keepalive_lock_pid "$state")
+    kill -TERM "$pid" 2>/dev/null || result=1
+    local waited=0
+    while [ "$waited" -lt 40 ]; do
+      fm_pid_alive "$pid" || break
+      sleep 0.25
+      waited=$((waited + 1))
+    done
+  fi
+  fm_keepalive_record_read "$state"
+  case "$?" in
+    0)
+      fm_keepalive_close_terminal "$FM_KEEPALIVE_REC_BACKEND" "$FM_KEEPALIVE_REC_TARGET" || result=1
+      rm -f "$(fm_keepalive_record_path "$state")" 2>/dev/null || result=1
+      ;;
+    2)
+      printf 'fm-keepalive: the recorded terminal id is malformed; not guessing which terminal to close\n' >&2
+      result=1
+      ;;
+  esac
+  if [ "$result" -eq 0 ]; then
+    printf 'fm-keepalive: stopped\n'
+  else
+    printf 'fm-keepalive: stop incomplete; the recorded terminal is preserved for retry\n' >&2
+  fi
+  return "$result"
+}
+
+fm_keepalive_status() {
+  local state config backend target
+  state=$(fm_keepalive_state)
+  config=$(fm_keepalive_config)
+  if fm_keepalive_live "$state"; then
+    printf 'loop: running pid %s\n' "$(fm_keepalive_lock_pid "$state")"
+  else
+    printf 'loop: not running\n'
+  fi
+  if fm_keepalive_enabled "$config"; then
+    printf 'config: on\n'
+  else
+    printf 'config: off (value=%s)\n' "$(fm_keepalive_config_value "$config")"
+  fi
+  printf 'attempts: %s (last %s)\n' \
+    "$(fm_keepalive_attempt_count "$state")" "$(fm_keepalive_attempt_epoch "$state")"
+  [ -e "$state/.keepalive-exhausted" ] && printf 'exhausted: %s\n' "$state/.keepalive-exhausted"
+  if fm_keepalive_resolve_endpoint 2>/dev/null; then
+    backend=$FM_KEEPALIVE_BACKEND
+    target=$FM_KEEPALIVE_TARGET
+    printf 'verdict: %s\n' "$(fm_keepalive_evaluate "$state" "$backend" "$target" "$config")"
+  else
+    printf 'verdict: unavailable (no resolvable primary pane)\n'
+  fi
+  return 0
+}
+
+fm_keepalive_usage() {
+  sed -n '/^# Usage:/,/^# This file is sourceable/p' "${BASH_SOURCE[0]}" \
+    | sed '$d' | sed 's/^# \{0,1\}//'
+}
+
+fm_keepalive_main() {
+  local state config backend target
+  # Read-only verbs stay available everywhere; anything that can arm, drive, or
+  # retire the loop refuses from a no-mistakes gate context before acting.
+  case "${1:-status}" in
+    start|run|stop|tick) fm_refuse_if_gate_agent ;;
+  esac
+  case "${1:-status}" in
+    -h|--help|help) fm_keepalive_usage ;;
+    start) fm_keepalive_start ;;
+    run) fm_keepalive_run ;;
+    stop) fm_keepalive_stop ;;
+    status) fm_keepalive_status ;;
+    config-check)
+      fm_keepalive_enabled "$(fm_keepalive_config)"
+      return $?
+      ;;
+    tick|evaluate)
+      state=$(fm_keepalive_state)
+      config=$(fm_keepalive_config)
+      fm_keepalive_resolve_endpoint || return 1
+      backend=$FM_KEEPALIVE_BACKEND
+      target=$FM_KEEPALIVE_TARGET
+      if [ "$1" = tick ]; then
+        fm_keepalive_tick "$state" "$backend" "$target" "$config"
+      else
+        fm_keepalive_evaluate "$state" "$backend" "$target" "$config"
+      fi
+      printf '\n'
+      ;;
+    *) fm_keepalive_usage >&2; return 2 ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  fm_keepalive_main "$@"
+  exit $?
+fi

--- a/bin/fm-operational-input.sh
+++ b/bin/fm-operational-input.sh
@@ -28,7 +28,7 @@ FM_OPERATIONAL_MARK=$'\xE2\x81\xA3'
 FM_OPERATIONAL_PREFIX="${FM_OPERATIONAL_MARK}FIRSTMATE_OP: "
 FM_OPERATIONAL_VERSION=v1
 FM_OPERATIONAL_HEADER_PREFIX="${FM_OPERATIONAL_PREFIX}${FM_OPERATIONAL_VERSION} "
-FM_OPERATIONAL_KINDS='session-start watcher turn-end-guard away-supervisor launch-brief'
+FM_OPERATIONAL_KINDS='session-start watcher turn-end-guard away-supervisor launch-brief session-revive'
 
 # Compatibility name retained for the away-mode owner and its tests.
 # shellcheck disable=SC2034 # Public source-library variable used by callers.
@@ -204,6 +204,7 @@ Usage:
 
 Current construction kinds:
   session-start watcher turn-end-guard away-supervisor from-firstmate launch-brief
+  session-revive
 
 The from-firstmate kind uses its established live-charter-compatible carrier.
 EOF

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -29,9 +29,10 @@
 #                       mutating step runs.
 #   2. bootstrap      - home-local stale Herdr projection cleanup runs only
 #                       when this session actually holds the lock. Detect-only
-#                       diagnostics always run. Bootstrap's five MUTATING sweeps
+#                       diagnostics always run. Bootstrap's six MUTATING sweeps
 #                       (legacy PR-check migration, secondmate fast-forward,
-#                       secondmate liveness, X-mode artifact writes, fleet sync)
+#                       secondmate liveness, X-mode artifact writes, session
+#                       keepalive arming, fleet sync)
 #                       also run only when locked.
 #   3. wake-drain     - mutates the durable wake queue, so it also only runs
 #                       when locked.
@@ -65,7 +66,7 @@
 # tasks-axi and quota-axi tool checks, and tasks-axi availability - none of
 # which mutate shared state and all of which are safe to compute without
 # verified lock ownership.
-# Only projection cleanup, the five bootstrap mutating sweeps, and the
+# Only projection cleanup, the six bootstrap mutating sweeps, and the
 # wake-queue drain are skipped.
 # The context and fleet-state digests
 # below are always read-only, so they run unconditionally in both modes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,11 @@ The daemon injects only into an affirmatively `empty` composer, so both `pending
 Unsupported supervisor backends refuse at daemon startup.
 Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts a configured backend-independent active alert after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
 On an unmarked return, `bin/fm-afk-return.sh` owns ordered shutdown, durable catch-up evidence, and the fail-closed gate that keeps ordinary work behind every live firstmate-actionable blocker.
+
+Those mechanisms all run inside the primary's own turns, so none of them can start a turn after the primary's turn itself dies with work in flight.
+The opt-in external keepalive (`bin/fm-keepalive.sh`) closes that one gap from outside the session: it proves the session process is alive but its supervision beacon has lapsed with an idle, affirmatively empty composer, then injects one `session-revive` operational input through the same typed protocol and submit primitives the sub-supervisor uses.
+Its revival duty is exclusive with away mode - while `state/.afk` exists the daemon owns injection - and it stops at a documented backoff ceiling and attempt cap, after which `bin/fm-guard.sh` surfaces the durable exhaustion report.
+[session-keepalive.md](session-keepalive.md) owns that contract, its detection evidence, and its authority boundary.
 `fm-send.sh` selects a pre-Enter popup-settle for slash commands and for codex `$...` skill invocations using metadata-routed target `harness=` values, then adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that post-submit pause.
 
 ## Runtime session backends
@@ -130,7 +135,7 @@ Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-
 
 Firstmate's own no-mistakes gate runs agents inside a checkout that also contains the fleet-captain identity in `AGENTS.md`, so gate execution needs an authority boundary separate from ordinary crewmate worktree isolation.
 The tracked `.no-mistakes.yaml` sets `disable_project_settings: true`; no-mistakes honors that setting only from the trusted default-branch copy, so a pushed branch cannot enable its own project instructions during validation.
-Independently, `fm-spawn.sh`, `fm-send.sh`, and `fm-teardown.sh` source `bin/fm-gate-refuse-lib.sh` and exit with status 3 before fleet mutation when the gate environment marker is present or the current checkout matches the default no-mistakes gate-repository topology.
+Independently, `fm-spawn.sh`, `fm-send.sh`, `fm-teardown.sh`, and `fm-keepalive.sh`'s arming, driving, and retiring verbs source `bin/fm-gate-refuse-lib.sh` and exit with status 3 before fleet mutation when the gate environment marker is present or the current checkout matches the default no-mistakes gate-repository topology.
 A normal primary checkout or crewmate worktree has neither signal and remains unaffected.
 The helper's header owns the exact signal detection, relocated-home limitation, test-harness bypass, and relationship to no-mistakes' HEAD-continuity guard.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,16 @@ An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisel
 A missing or failing channel logs and falls through to the next, never crashing the daemon.
 See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
 
+## Session keepalive (config/keepalive)
+
+The external session keepalive revives a PRIMARY firstmate session whose own turn died while fleet work was still in flight; [`session-keepalive.md`](session-keepalive.md) owns its detection evidence, injected input, backoff, cap, away-mode division of duty, and authority boundary.
+It ships inert and changes nothing until the home opts in by putting `on` in the local, gitignored `config/keepalive` file under the effective firstmate home.
+An absent file, an empty file, or `off` keeps it off, while any other value is reported as a `KEEPALIVE:` session-start diagnostic and never treated as `on`.
+When the value is `on`, the locked session-start bootstrap sweep runs `bin/fm-keepalive.sh start` from the primary's own pane so the captured endpoint is the primary session's; arming is idempotent and a home that has not opted in stays silent.
+The loop stands down on its next tick when the value stops being `on`, so opting out needs no process hunting.
+It supports the same `tmux` and `herdr` supervisor panes as away-mode injection and refuses any other supervisor backend at startup.
+This file is not inherited by secondmate homes: a secondmate is idle by default and its parent, not an injected turn, owns routing work to it.
+
 ## Gate defaults (.no-mistakes.yaml)
 
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
@@ -465,6 +475,18 @@ FM_CRASH_BACKOFF=60                # seconds to wait after crossing the crash th
 FM_CRASH_NORMAL_SLEEP=5            # seconds to wait after an isolated watcher crash
 FM_LOG_MAX_BYTES=1048576           # daemon log size that triggers trimming
 FM_LOG_KEEP_LINES=2000             # daemon log lines kept when trimming
+# external session keepalive (bin/fm-keepalive.sh); opt-in via config/keepalive
+FM_KEEPALIVE=                      # on|off override for config/keepalive, mainly for tests
+FM_KEEPALIVE_POLL=30               # seconds between keepalive evaluation passes
+FM_KEEPALIVE_GRACE=                # stale-beacon threshold for the lapse signal; defaults to FM_GUARD_GRACE
+FM_KEEPALIVE_CONFIRM_SECS=45       # continuous lapse required before the first revival attempt
+FM_KEEPALIVE_BACKOFF_BASE=60       # first backoff step; attempt N+1 waits base * 2^(N-1)
+FM_KEEPALIVE_BACKOFF_MAX=900       # documented backoff ceiling
+FM_KEEPALIVE_MAX_ATTEMPTS=5        # revival attempts before writing state/.keepalive-exhausted
+FM_KEEPALIVE_GONE_EXIT_SECS=600    # continuous primary-endpoint absence before the loop stands down
+FM_KEEPALIVE_SUBMIT_RETRIES=3      # Enter-retry attempts after typing the revival input once
+FM_KEEPALIVE_SUBMIT_SLEEP=0.5      # seconds between keepalive submit checks
+FM_KEEPALIVE_ENTRY=                # test seam: command run in the created non-visible terminal
 ```
 
 `fm-teardown.sh` retries only Git's `Unable to create '...index.lock': File exists` return failure up to `FM_TREEHOUSE_RETURN_LOCK_RETRIES` times.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -260,6 +260,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/session-keepalive.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/sessionstart-nudge.md",
       "audience": "operator-current"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -26,7 +26,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
-| `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
+| `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, stale watcher liveness, and an exhausted session revival |
+| `fm-keepalive.sh`        | Opt-in external revival of a primary session whose own turn died with work in flight (docs/session-keepalive.md) |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |

--- a/docs/session-keepalive.md
+++ b/docs/session-keepalive.md
@@ -1,0 +1,90 @@
+# Session keepalive
+
+External revival of a PRIMARY firstmate session whose own turn died while fleet work was still in flight.
+This page is the contract owner: the detection evidence, the injected input, the backoff and cap, the away-mode division of duty, and the authority boundary.
+`bin/fm-keepalive.sh`'s header and `--help` own the exact flags, state-file names, and mechanics.
+
+## The gap it closes
+
+When a crewmate dies, the primary notices and relaunches it.
+When the primary's own turn dies - a fatal API overload after the harness's internal retries, or any other hard stop - nothing inside that session can start another turn.
+In-flight work then sits frozen until a human types something, which overnight can mean hours.
+
+The keepalive is a small loop outside the session that watches durable records and, on proof that the session is alive but idle with lapsed supervision, injects one typed input so the primary resumes supervision itself.
+It never classifies why a turn died and never changes the harness's own retry behavior.
+
+## Opt in
+
+The mechanism ships inert.
+Put `on` in the local, gitignored `config/keepalive` file under the effective firstmate home to enable it; an absent file, an empty file, or `off` keeps it off.
+An unrecognized value is never treated as `on`: session start reports a `KEEPALIVE:` diagnostic so the typo gets fixed, and revival stays off until it does.
+See [configuration.md](configuration.md#session-keepalive-configkeepalive) for the file and every environment knob.
+
+Once opted in, the locked session-start bootstrap sweep arms the loop from the primary's own pane, so the endpoint it captures is the primary session's.
+Arming is idempotent: an already-running loop is left alone, and a recorded-but-dead terminal from a crash is closed by its exact id first.
+Removing the opt-in value makes the running loop stand down cleanly on its next tick.
+
+## Detection evidence
+
+Revival happens only when every one of these holds.
+A false revival is worse than none - it interrupts a live turn and can duplicate actions - so each condition is proven from a durable record or a real endpoint read, never from elapsed time alone.
+
+| Evidence | Requirement for revival |
+| --- | --- |
+| `state/*.meta` | At least one task is in flight. No work means nothing to revive, and the loop stays silent. |
+| `state/.afk` | Absent. Away mode owns injection into the primary pane, so away mode also owns revival. |
+| `state/.lock` | Present and its recorded harness process is still alive. A live harness with a dead turn is revivable; a dead holder means the whole session is gone and typing cannot revive it. |
+| `state/.last-watcher-beat` | Missing or older than the stale-beacon threshold. A healthy primary re-arms supervision every turn, so a stale beacon with work in flight is the lapse signal. |
+| The primary's busy footer | Absent. A long-thinking turn or a foreground tool call reads as busy and is never revived. |
+| The primary's composer | Affirmatively empty. Half-typed human input reads as pending and a bare shell prompt reads as unknown; both defer, so nothing is ever typed over a person's input or into a dead shell. |
+| `state/.keepalive-suspect` | The lapse has held continuously through the confirm window. A momentary between-turns gap cannot trigger a revival. |
+
+Any condition that breaks resets the continuous-lapse window, while the durable attempt count survives, so a session that is revived and then dies again keeps growing its backoff instead of restarting it.
+
+The verdict for one pass is printable without changing anything: `bin/fm-keepalive.sh evaluate` prints `<verdict>|<detail>`, and `bin/fm-keepalive.sh status` adds loop liveness, the opt-in value, and attempt state.
+The verdicts are `off`, `no-session`, `idle`, `afk`, `healthy`, `agent-gone`, `endpoint-gone`, `busy`, `unsafe`, `confirming`, `backoff`, `exhausted`, `revived`, and `revive-failed`.
+
+## The injected input
+
+The revival input is constructed through the shared operational-input protocol (`bin/fm-operational-input.sh`) as the typed `session-revive` kind, so the primary recognizes it structurally as internal rather than as a captain message, exactly like an away-mode escalation.
+Its body states what happened, tells the primary to resume supervision - drain queued wakes, reconcile in-flight work from durable records, re-arm the supervision cycle - and explicitly tells it not to start new work or repeat work a record already shows as finished.
+
+Injection uses the same submit primitive as the away-mode daemon: type once, then retry only Enter.
+An unconfirmed submit leaves the text in the composer, which the next pass reads as a non-empty composer and defers on, so two revival inputs can never be concatenated into one corrupted turn.
+
+## Backoff, cap, and giving up
+
+An overloaded API rejects an immediate retry too, so revival attempts are spaced exponentially: the first attempt fires as soon as the confirm window closes, and attempt N+1 waits `FM_KEEPALIVE_BACKOFF_BASE * 2^(N-1)` seconds, capped at the `FM_KEEPALIVE_BACKOFF_MAX` ceiling.
+With the defaults that is 60s, 120s, 240s, 480s, then the 900s ceiling.
+There is never a tight retry loop: the loop's own poll interval bounds how often it even looks.
+
+After `FM_KEEPALIVE_MAX_ATTEMPTS` attempts (default 5) the loop stops injecting and writes `state/.keepalive-exhausted` with the evidence.
+`bin/fm-guard.sh` surfaces that report on every guarded command until it is read and removed, so the gap becomes visible on the very next fleet action rather than staying silent.
+The same report is written when the session lock's harness process is confirmed gone for the length of the confirm window, because input cannot revive a session that no longer exists; the loop then stands down instead of watching a closed session forever, and so does a primary endpoint that stays absent past `FM_KEEPALIVE_GONE_EXIT_SECS`.
+A single unreadable process or endpoint check is never enough for either: both need the same continuous confirmation a lapse does.
+Nothing is discarded in either case: queued wakes, task metadata, status events, and crew work all survive, and a session that recovers on its own clears the episode and logs the recovery.
+
+## Away mode owns its own revival
+
+Two injectors competing for one composer would corrupt a turn, so the duty is split by mode and never shared.
+
+- Away mode on (`state/.afk` present): the sub-supervisor daemon owns the primary pane.
+  It already injects batched escalations into an idle-empty composer, which starts a turn, and its wedge alarm owns the active out-of-band alert when delivery cannot be confirmed.
+  The keepalive loop reports the `afk` verdict and injects nothing.
+- Away mode off: the keepalive loop owns revival, and its exhaustion report is what surfaces the failure to the next turn.
+
+Entering or leaving away mode needs no keepalive action; the flag alone moves the duty.
+
+## Authority
+
+A revived turn inherits exactly the standing authority it already had.
+Revival is not approval for anything: merges, ask-user findings, and destructive, irreversible, or security-sensitive choices keep the same captain boundaries they had before the turn died, and the injected body says so in the input itself.
+Away mode does not expand that authority either, and neither does an exhausted revival.
+
+## Supported endpoints
+
+Revival needs verified composer, busy, and submit primitives for the primary's own pane, so it supports the same supervisor backends as away-mode injection: `tmux` and `herdr`.
+Any other supervisor backend refuses loudly at startup instead of running tmux primitives against a pane that is not a tmux pane.
+`FM_SUPERVISOR_TARGET` and `FM_SUPERVISOR_BACKEND` override the discovered primary pane, resolved by the same owner the away-mode daemon uses.
+
+Active empirical evidence for this mechanism is in [verification/supervision.md](verification/supervision.md#session-keepalive-revival).

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -161,3 +161,51 @@ Observed output:
 ```
 
 The safe command-channel contract is covered without a notification by `tests/fm-daemon.test.sh`: the summary reaches both `$1` and stdin, every channel is process-group bounded, and a failed channel falls through.
+
+## Session keepalive revival
+
+The external revival path ran against a real primary session on 2026-07-26 with Claude Code 2.1.220 on tmux, in a throwaway `FM_HOME` that contained only one in-flight task record, a session lock naming the live harness pid, and `config/keepalive` set to `on`.
+Operator behavior and the detection contract stay in [session-keepalive.md](../session-keepalive.md).
+
+Arming, with the primary pane passed explicitly:
+
+```sh
+FM_HOME="$H" FM_SUPERVISOR_TARGET=%30 FM_SUPERVISOR_BACKEND=tmux bin/fm-keepalive.sh start
+```
+
+Observed output, plus the recorded terminal id and the loop's own log with default knobs (45s confirm window, 30s poll):
+
+```
+fm-keepalive: watching %30 from detached tmux session fm-keepalive-3625860978-508-109-1785080690
+loop: running pid 632
+config: on
+verdict: confirming|lapse held 0s of the 45s confirm window (beacon never)
+
+[2026-07-26T08:44:50-0700] loop starting (pid 632); backend=tmux target=%30 poll=30s
+[2026-07-26T08:45:51-0700] revived: attempt 1 of 5 - supervision lapsed never with 1 task(s) in flight; attempt 1 of 5
+```
+
+The pane received exactly one typed input and started a real turn:
+
+```
+❯ FIRSTMATE_OP: v1 session-revive: Automatic session revival 1 of 5: the previous turn ended without handing supervision back (...).
+  Resume supervision now - drain queued wakes with bin/fm-wake-drain.sh, reconcile in-flight work from the durable records, and re-arm the supervision cycle for this harness. ...
+✻ Cogitated for 8s
+```
+
+That evidence session was a bare Claude Code session in the throwaway home, so it had no `AGENTS.md` and treated the input as untrusted conversation content rather than internal operational input.
+Transport, detection, and submit confirmation are therefore what this record covers; recognition of the `session-revive` kind is an instruction contract in `AGENTS.md` section 8, asserted statically by `tests/fm-keepalive.test.sh`.
+
+Two safety refusals were observed against the same real session:
+
+```sh
+# a mid-turn primary, with claude's "esc to interrupt" footer present
+FM_HOME="$H" FM_SUPERVISOR_TARGET=%30 FM_SUPERVISOR_BACKEND=tmux bin/fm-keepalive.sh tick
+busy|the primary is mid-turn
+
+# the same command while claude's first-run trust dialog held the composer
+unsafe|composer is not confirmed-empty (state=pending)
+```
+
+Neither typed anything, and the busy pass also cleared the continuous-lapse window.
+Backoff spacing, the attempt cap with its durable give-up report, away mode's exclusive ownership of revival duty, and an unconfirmed submit are covered deterministically by `tests/fm-keepalive.test.sh`.

--- a/tests/fm-keepalive.test.sh
+++ b/tests/fm-keepalive.test.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# tests/fm-keepalive.test.sh - external session-revival contract: opt-in gating,
+# the detection matrix that separates a dead turn from a busy or genuinely idle
+# primary, the typed revival envelope, exponential backoff, the attempt cap and
+# its loud give-up, and away mode's exclusive ownership of revival duty.
+#
+# The fake tmux in tests/wake-helpers.sh (make_supercase) supplies composer,
+# busy, and submit behavior, so these cases drive the real injection path without
+# a terminal.
+set -u
+
+# shellcheck source=tests/wake-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+
+KEEPALIVE="$ROOT/bin/fm-keepalive.sh"
+# Source the pure evaluators and the tick once; the CLI is skipped under sourcing
+# via the script's BASH_SOURCE guard.
+if [ -z "${FM_TEST_KEEPALIVE_SOURCED:-}" ]; then
+  export FM_TEST_KEEPALIVE_SOURCED=1
+  # shellcheck source=bin/fm-keepalive.sh
+  . "$KEEPALIVE"
+fi
+
+TMP_ROOT=$(fm_test_tmproot fm-keepalive-tests)
+
+# Build a case with work in flight, a recorded session process, an absent (stale)
+# watcher beacon, and the opt-in value: the dead-turn shape the detection cases
+# start from. The case dir doubles as the config dir, so config/keepalive is
+# "<dir>/keepalive".
+make_keepalive_case() {  # <name>
+  local name=$1 dir state
+  dir=$(make_supercase "$name")
+  state="$dir/state"
+  fm_write_meta "$state/t1.meta" "window=fm-t1" "worktree=/tmp/t1" "harness=claude"
+  printf 'working: building\n' > "$state/t1.status"
+  printf '4242\n' > "$state/.lock"
+  printf 'on\n' > "$dir/keepalive"
+  : > "$dir/pane.txt"
+  printf '%s\n' "$dir"
+}
+
+# The session-lock liveness read is stubbed per case: this test process is a plain
+# bash, so a real fm_harness_pid_alive read would depend on the runner's own
+# command line instead of the case's recorded lock.
+harness_alive_stub_live() { fm_harness_pid_alive() { [ -n "${1:-}" ]; }; }
+harness_alive_stub_dead() { fm_harness_pid_alive() { return 1; }; }
+
+# evaluate_case <dir>: the read-only verdict, with the fake tmux on PATH and a
+# live recorded session process. Callers prefix their own FM_KEEPALIVE_* env
+# assignments, which apply for the duration of the call.
+evaluate_case() {  # <dir>
+  local dir=$1
+  (
+    harness_alive_stub_live
+    PATH="$dir/fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" \
+      fm_keepalive_evaluate "$dir/state" tmux fakepane "$dir"
+  )
+}
+
+# tick_case <dir> [live|dead]: one full evaluate-and-act pass. Everything typed
+# into the fake primary pane lands in <dir>/sent.log.
+tick_case() {  # <dir> [live|dead]
+  local dir=$1
+  local session=${2:-live}
+  (
+    if [ "$session" = dead ]; then harness_alive_stub_dead; else harness_alive_stub_live; fi
+    PATH="$dir/fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" \
+      FM_FAKE_TMUX_SENT="$dir/sent.log" \
+      fm_keepalive_tick "$dir/state" tmux fakepane "$dir"
+  )
+}
+
+# Backdate an episode marker's recorded epoch so a window counts as elapsed.
+backdate_marker() {  # <path> <seconds-ago>
+  printf '%s\n' "$(( $(date +%s) - $2 ))" > "$1"
+}
+
+test_off_by_default_and_value_gated() {
+  local dir out status
+  dir=$(make_keepalive_case off-default)
+  rm -f "$dir/keepalive"
+
+  out=$(evaluate_case "$dir")
+  assert_contains "$out" "off|" "an absent config/keepalive must read as off"
+
+  printf 'off\n' > "$dir/keepalive"
+  out=$(evaluate_case "$dir")
+  assert_contains "$out" "off|" "an explicit off must read as off"
+
+  printf 'maybe\n' > "$dir/keepalive"
+  out=$(evaluate_case "$dir")
+  assert_contains "$out" "unrecognized" "an unrecognized value must be reported, never treated as on"
+  status=0
+  fm_keepalive_enabled "$dir" || status=$?
+  [ "$status" -eq 2 ] || fail "an unrecognized value must exit 2 for the arming caller, got $status"
+
+  printf '# comment\n\non\n' > "$dir/keepalive"
+  fm_keepalive_enabled "$dir" || fail "a commented config with on must enable revival"
+  assert_absent "$dir/state/.keepalive-attempts" "an off config must not create attempt state"
+  pass "session revival is off by default and only an explicit on enables it"
+}
+
+test_idle_home_with_no_work_stays_silent() {
+  local dir out
+  dir=$(make_keepalive_case idle-no-work)
+  rm -f "$dir/state/t1.meta"
+
+  out=$(evaluate_case "$dir")
+  assert_contains "$out" "idle|no work in flight" "no in-flight work must produce the idle verdict"
+
+  out=$(tick_case "$dir")
+  assert_contains "$out" "idle|" "the idle tick must not act"
+  assert_absent "$dir/state/.keepalive-suspect" "an idle home must not open a lapse window"
+  assert_absent "$dir/sent.log" "an idle home must never be typed into"
+  pass "a home with no work in flight is left alone"
+}
+
+test_busy_primary_is_not_dead() {
+  local dir out
+  dir=$(make_keepalive_case busy-not-dead)
+  # A claude turn mid-flight: its verified busy footer in the captured tail.
+  printf 'thinking about it\n  Pondering... (12s - esc to interrupt)\n' > "$dir/pane.txt"
+  backdate_marker "$dir/state/.keepalive-suspect" 600
+
+  out=$(evaluate_case "$dir")
+  assert_contains "$out" "busy|" "a mid-turn primary must never be classified dead"
+
+  out=$(tick_case "$dir")
+  assert_contains "$out" "busy|" "the busy tick must not inject"
+  assert_absent "$dir/sent.log" "a busy primary must never be typed into"
+  assert_absent "$dir/state/.keepalive-suspect" "a busy primary must reset the continuous-lapse window"
+  pass "a busy primary is never revived and resets the lapse window"
+}
+
+test_pending_composer_defers() {
+  local dir out
+  dir=$(make_keepalive_case pending-composer)
+  printf 'let me check whether\n' > "$dir/pane.txt"
+  backdate_marker "$dir/state/.keepalive-suspect" 600
+
+  out=$(tick_case "$dir")
+  assert_contains "$out" "unsafe|" "unsubmitted composer content must defer"
+  assert_absent "$dir/sent.log" "a composer with real content must never be typed over"
+  pass "half-typed input in the primary composer defers revival"
+}
+
+test_healthy_beacon_is_not_dead() {
+  local dir out
+  dir=$(make_keepalive_case healthy-beacon)
+  touch "$dir/state/.last-watcher-beat"
+  printf '%s\t%s\n' 2 "$(date +%s)" > "$dir/state/.keepalive-attempts"
+  fm_keepalive_write_exhausted "$dir/state" "earlier episode" >/dev/null
+
+  out=$(tick_case "$dir")
+  assert_contains "$out" "healthy|" "a fresh supervision beacon must read healthy"
+  assert_absent "$dir/state/.keepalive-attempts" "recovery must clear durable attempt state"
+  assert_absent "$dir/state/.keepalive-exhausted" "recovery must clear the exhaustion report"
+  assert_grep "recovered:" "$dir/state/.keepalive.log" "recovery must be logged"
+  pass "a session that resumes supervision clears its revival episode"
+}
+
+test_dead_session_process_is_reported_not_revived() {
+  local dir out
+  dir=$(make_keepalive_case dead-session)
+
+  out=$(tick_case "$dir" dead)
+  assert_contains "$out" "agent-gone|" "a dead session process must be reported, not revived"
+  assert_present "$dir/state/.keepalive-gone" "an absent session process must open its confirm window"
+  assert_absent "$dir/state/.keepalive-exhausted" "one unreadable process check must not be enough"
+
+  backdate_marker "$dir/state/.keepalive-gone" 999
+  out=$(tick_case "$dir" dead)
+  assert_contains "$out" "agent-gone|" "a confirmed-dead session must keep reporting agent-gone"
+  assert_present "$dir/state/.keepalive-exhausted" "a confirmed-dead session must write the give-up report"
+  assert_absent "$dir/sent.log" "a dead session process must never be typed into"
+  pass "a session whose process is gone is reported instead of revived"
+}
+
+test_dead_with_work_revives_once_confirmed() {
+  local dir out sent
+  dir=$(make_keepalive_case dead-with-work)
+  sent="$dir/sent.log"
+
+  # First pass: the lapse is real but unconfirmed, so nothing is typed.
+  out=$(tick_case "$dir")
+  assert_contains "$out" "confirming|" "a first-seen lapse must confirm before revival"
+  assert_present "$dir/state/.keepalive-suspect" "the confirm window must be recorded durably"
+  assert_absent "$sent" "an unconfirmed lapse must not type anything"
+
+  # Same evidence, confirm window elapsed: now it is a confirmed dead turn.
+  backdate_marker "$dir/state/.keepalive-suspect" 600
+  out=$(tick_case "$dir")
+  assert_contains "$out" "revived|attempt 1 of" "a confirmed dead turn with work in flight must be revived"
+  assert_grep 'FIRSTMATE_OP: v1 session-revive: ' "$sent" \
+    "the revival input lacks the exact typed session-revive envelope"
+  assert_grep 'Resume supervision now' "$sent" \
+    "the revival input does not tell the primary to resume supervision"
+  assert_grep 'Do not start new work' "$sent" \
+    "the revival input does not forbid starting new work"
+  assert_grep 'grants no authority' "$sent" \
+    "the revival input does not state that authority is unchanged"
+  [ "$(grep -c '\[ENTER\]' "$sent")" -eq 1 ] \
+    || fail "expected exactly one submitted revival input"
+  [ "$(fm_keepalive_attempt_count "$dir/state")" -eq 1 ] \
+    || fail "the revival attempt was not recorded durably"
+  assert_absent "$dir/state/.keepalive-suspect" "a revival must close the confirm window it consumed"
+  pass "a confirmed dead turn with work in flight is revived exactly once"
+}
+
+test_backoff_sequence_and_ceiling() {
+  local dir out expected attempts
+  dir=$(make_keepalive_case backoff)
+
+  # base 60 doubling to a 900s ceiling: 0, 60, 120, 240, 480, 900, 900...
+  for expected in 0:0 1:60 2:120 3:240 4:480 5:900 9:900; do
+    attempts=${expected%%:*}
+    out=$(FM_KEEPALIVE_BACKOFF_BASE=60 FM_KEEPALIVE_BACKOFF_MAX=900 \
+      fm_keepalive_backoff_delay "$attempts")
+    [ "$out" = "${expected#*:}" ] \
+      || fail "attempt after $attempts tries must wait ${expected#*:}s, got ${out}s"
+  done
+
+  # An attempt inside its backoff window is refused with the backoff verdict.
+  backdate_marker "$dir/state/.keepalive-suspect" 600
+  printf '%s\t%s\n' 2 "$(date +%s)" > "$dir/state/.keepalive-attempts"
+  out=$(FM_KEEPALIVE_BACKOFF_BASE=60 FM_KEEPALIVE_BACKOFF_MAX=900 evaluate_case "$dir")
+  assert_contains "$out" "backoff|attempt 3 waits 120s" \
+    "a revival inside its backoff window must be refused"
+
+  # Once that window has elapsed the same evidence revives again.
+  printf '%s\t%s\n' 2 "$(( $(date +%s) - 200 ))" > "$dir/state/.keepalive-attempts"
+  out=$(FM_KEEPALIVE_BACKOFF_BASE=60 FM_KEEPALIVE_BACKOFF_MAX=900 evaluate_case "$dir")
+  assert_contains "$out" "revive|" "a revival past its backoff window must proceed"
+  assert_contains "$out" "attempt 3 of" "the next attempt must continue the durable count"
+  pass "revival attempts back off exponentially up to the documented ceiling"
+}
+
+test_attempt_cap_gives_up_loudly() {
+  local dir out guard
+  dir=$(make_keepalive_case attempt-cap)
+  backdate_marker "$dir/state/.keepalive-suspect" 600
+  printf '%s\t%s\n' 5 "$(( $(date +%s) - 5000 ))" > "$dir/state/.keepalive-attempts"
+
+  out=$(FM_KEEPALIVE_MAX_ATTEMPTS=5 tick_case "$dir")
+  assert_contains "$out" "exhausted|" "the attempt cap must stop revival"
+  assert_absent "$dir/sent.log" "an exhausted episode must not type anything"
+  assert_present "$dir/state/.keepalive-exhausted" "the attempt cap must write the give-up report"
+  assert_grep "revival EXHAUSTED" "$dir/state/.keepalive-exhausted" \
+    "the report must name the exhausted revival"
+  assert_grep "Nothing was discarded" "$dir/state/.keepalive-exhausted" \
+    "the report must state that nothing was lost"
+
+  # The guard is what surfaces that report on the next fleet action.
+  guard=$(FM_STATE_OVERRIDE="$dir/state" FM_ROOT_OVERRIDE="$dir" "$ROOT/bin/fm-guard.sh" 2>&1)
+  assert_contains "$guard" "automatic session revival was exhausted" \
+    "fm-guard.sh must surface the exhaustion report"
+  pass "revival gives up loudly at its attempt cap instead of looping forever"
+}
+
+test_afk_owns_revival_duty() {
+  local dir out
+  dir=$(make_keepalive_case afk-owns)
+  backdate_marker "$dir/state/.keepalive-suspect" 600
+  touch "$dir/state/.afk"
+
+  out=$(tick_case "$dir")
+  assert_contains "$out" "afk|away mode owns supervision" \
+    "away mode must own revival duty exclusively"
+  assert_absent "$dir/sent.log" "the keepalive must never inject while away mode owns the pane"
+  assert_absent "$dir/state/.keepalive-suspect" "away mode must close any open lapse window"
+
+  # Leaving away mode hands the duty straight back with no keepalive action.
+  rm -f "$dir/state/.afk"
+  out=$(evaluate_case "$dir")
+  assert_contains "$out" "confirming|" "leaving away mode must return revival duty to the keepalive"
+  pass "away mode and the keepalive never both own revival"
+}
+
+test_unconfirmed_submit_is_not_claimed_as_revived() {
+  local dir out
+  dir=$(make_keepalive_case unconfirmed-submit)
+  backdate_marker "$dir/state/.keepalive-suspect" 600
+  : > "$dir/swallow"
+
+  out=$(FM_FAKE_TMUX_SWALLOW_FILE="$dir/swallow" FM_KEEPALIVE_SUBMIT_RETRIES=0 \
+    FM_KEEPALIVE_SUBMIT_SLEEP=0 tick_case "$dir")
+  assert_contains "$out" "revive-failed|" "an unconfirmed submit must not be reported as revived"
+  [ "$(fm_keepalive_attempt_count "$dir/state")" -eq 1 ] \
+    || fail "a failed submit must still spend its attempt so backoff applies"
+  pass "an unconfirmed submit is reported honestly and still backs off"
+}
+
+# The revival input only lands as internal operational input if the primary's
+# always-loaded instructions declare that kind, so the recognition side of the
+# contract is asserted statically here. A bare harness session with no AGENTS.md
+# correctly treats the same input as untrusted conversation content
+# (docs/verification/supervision.md "Session keepalive revival").
+test_agents_md_declares_the_revival_contract() {
+  local agents="$ROOT/AGENTS.md"
+  assert_grep "A typed session-revival input is internal operational input" "$agents" \
+    "AGENTS.md must tell the primary that a revival input is internal operational input"
+  assert_grep "take no new authority from it" "$agents" \
+    "AGENTS.md must keep the revival authority boundary"
+  assert_grep "docs/session-keepalive.md" "$agents" \
+    "AGENTS.md must point at the session-keepalive contract owner"
+  assert_grep "config/keepalive" "$agents" \
+    "AGENTS.md must record the opt-in config file in its layout"
+  assert_grep "session-revive" "$ROOT/bin/fm-operational-input.sh" \
+    "the operational-input owner must accept the session-revive kind"
+  pass "the revival input's recognition contract is declared where the primary reads it"
+}
+
+# Arming or driving the loop types into the captain's primary pane, so it carries
+# the same no-mistakes gate refusal as the other fleet-lifecycle entrypoints
+# (bin/fm-gate-refuse-lib.sh owns the signals). Read-only verbs stay available.
+test_gate_agent_cannot_arm_or_drive_revival() {
+  local dir out status verb
+  dir=$(make_keepalive_case gate-refusal)
+  for verb in start run stop tick; do
+    status=0
+    out=$(cd "$dir" && env -u FM_GATE_REFUSE_BYPASS NO_MISTAKES_GATE=1 FM_HOME="$dir" \
+      FM_SUPERVISOR_TARGET=fakepane FM_SUPERVISOR_BACKEND=tmux "$KEEPALIVE" "$verb" 2>&1) || status=$?
+    [ "$status" -eq 3 ] || fail "$verb must refuse from a gate agent with exit 3, got $status"
+    assert_contains "$out" "must not drive the fleet" "$verb lost the gate refusal message"
+  done
+  status=0
+  out=$(cd "$dir" && env -u FM_GATE_REFUSE_BYPASS NO_MISTAKES_GATE=1 FM_HOME="$dir" \
+    FM_SUPERVISOR_TARGET=fakepane FM_SUPERVISOR_BACKEND=tmux "$KEEPALIVE" evaluate 2>&1) || status=$?
+  [ "$status" -ne 3 ] || fail "the read-only verdict must stay available to a gate agent"
+  pass "a no-mistakes gate agent cannot arm, drive, or retire session revival"
+}
+
+test_unsupported_supervisor_backend_refuses() {
+  local out status
+  out=$(FM_SUPERVISOR_BACKEND=zellij FM_SUPERVISOR_TARGET=whatever \
+    FM_KEEPALIVE=on FM_STATE_OVERRIDE="$TMP_ROOT/refuse-state" "$KEEPALIVE" evaluate 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "an unsupported supervisor backend must refuse"
+  assert_contains "$out" "no verified primary-injection primitives" \
+    "the refusal must name the missing verified primitives"
+  pass "an unsupported supervisor pane refuses instead of guessing primitives"
+}
+
+test_off_by_default_and_value_gated
+test_idle_home_with_no_work_stays_silent
+test_busy_primary_is_not_dead
+test_pending_composer_defers
+test_healthy_beacon_is_not_dead
+test_dead_session_process_is_reported_not_revived
+test_dead_with_work_revives_once_confirmed
+test_backoff_sequence_and_ceiling
+test_attempt_cap_gives_up_loudly
+test_afk_owns_revival_duty
+test_unconfirmed_submit_is_not_claimed_as_revived
+test_agents_md_declares_the_revival_contract
+test_gate_agent_cannot_arm_or_drive_revival
+test_unsupported_supervisor_backend_refuses

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -253,7 +253,7 @@ test_source_graph_boundaries_keep_every_owner() {
     grep -q '^[[:space:]]*# shellcheck source=bin/' "$file" || continue
     production_context_tests="${production_context_tests}$(basename "$file")|"
   done
-  [ "$production_context_tests" = 'fm-backend-herdr.test.sh|fm-daemon.test.sh|fm-pending-reply.test.sh|fm-secondmate-sync.test.sh|' ] \
+  [ "$production_context_tests" = 'fm-backend-herdr.test.sh|fm-daemon.test.sh|fm-keepalive.test.sh|fm-pending-reply.test.sh|fm-secondmate-sync.test.sh|' ] \
     || fail "only callback/variable interop tests may retain production source context: $production_context_tests"
   pass "dispatcher, adapters, production owner, and tests have explicit lint boundaries"
 }

--- a/tests/fm-operational-input.test.sh
+++ b/tests/fm-operational-input.test.sh
@@ -28,7 +28,7 @@ test_current_generic_matrix() {
   [ "$prefix_hex" = e281a346495253544d4154455f4f503a20 ] \
     || fail "current operational prefix lost the landed U+2063 FIRSTMATE_OP bytes: $prefix_hex"
 
-  for kind in session-start watcher turn-end-guard away-supervisor launch-brief; do
+  for kind in session-start watcher turn-end-guard away-supervisor launch-brief session-revive; do
     body="CURRENT_BODY_FOR_${kind}"
     fm_operational_input_encode "$kind" "$body" encoded \
       || fail "could not encode current $kind fixture"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -6,7 +6,7 @@
 # Coverage:
 #   - absent-file markers vs empty-but-present files in the context digest
 #   - the lock-refusal read-only path: banner leads, every mutating step is
-#     skipped (including bootstrap's five mutating sweeps, verified by their
+#     skipped (including bootstrap's six mutating sweeps, verified by their
 #     ABSENCE), the digest still completes
 #   - output section ordering: diagnostics/banners lead, bulk file dumps follow
 #   - context-aware next-step guidance for read-only, AFK, X mode, and normal


### PR DESCRIPTION
## Intent

The captain asked (2026-07-26) for an external keep-alive that revives the PRIMARY firstmate session when its own turn dies mid-work. The prompt was API 529 overload errors killing a turn with fleet work still in flight and nobody able to restart it: when a crewmate dies the primary relaunches it, but when the primary's own turn dies nothing inside that session can start another turn, so work freezes until a human types something - potentially overnight.

Deliberate decisions made while building it, so the diff does not read as surprising:
- REUSE, not a second mechanism. The away-mode daemon already injects into the primary pane, so revival goes through the same owners: bin/fm-operational-input.sh for the typed envelope (a new session-revive kind added to FM_OPERATIONAL_KINDS and mirrored in the Pi TS kind list), bin/fm-backend.sh's composer/busy/submit primitives, bin/fm-supervisor-target-lib.sh for pane discovery, bin/fm-supervision-lib.sh for the in-flight count and watcher beacon, and bin/fm-session-lock-lib.sh for harness liveness. The non-visible-terminal launch mirrors bin/fm-afk-launch.sh's proven tmux/herdr primitives (a second consumer of the same backend calls, deliberately not a refactor of away mode's delicate lifecycle code).
- DETECTION is durable evidence, never a timeout: in-flight state/*.meta, absence of state/.afk, a live harness pid in state/.lock, a stale state/.last-watcher-beat, no harness busy footer, an affirmatively empty composer, and a continuous confirm window recorded in state/.keepalive-suspect. False revivals were treated as worse than none, so busy / pending-composer / dead-shell / no-session / idle all defer and print a verdict instead.
- BACKOFF base 60s doubling to a documented 900s ceiling, five-attempt cap, durable attempt record so restarting the loop does not reset the cap. On exhaustion it writes state/.keepalive-exhausted and bin/fm-guard.sh surfaces that on the next fleet action - deliberately NOT reusing away mode's config/wedge-alarm channels, because that alarm has one owner in the daemon and duplicating its channel logic would violate the repo's one-owner rule.
- AWAY MODE keeps exclusive revival duty while state/.afk exists (documented in both directions) so two injectors never compete for one composer. Extending the daemon was considered and rejected: the daemon only runs in away mode, and the gap being closed is precisely normal mode.
- OFF BY DEFAULT via local gitignored config/keepalive=on, armed by a new sixth locked bootstrap sweep that reports only KEEPALIVE: problems; an unrecognized value is reported and never treated as on.
- AUTHORITY is explicitly unchanged by a revival, stated in the injected body itself, in docs/session-keepalive.md, and in AGENTS.md section 8.
- The arming/driving/retiring verbs carry the shared no-mistakes gate refusal because they type into the captain's primary pane; read-only verdict verbs stay available.
- Deliberately OUT of scope per the captain: no attempt to catch or classify the 529 inside the dying turn and no change to the harness's own retry behavior.

Knowledge placement follows .agents/skills/firstmate-coding-guidelines: docs/session-keepalive.md is the new operator-current contract owner (classified in docs/documentation-audiences.json), docs/configuration.md owns the config and env reference, docs/architecture.md gets a short maintainer paragraph, docs/verification/supervision.md records the live evidence, and AGENTS.md gains only three short inline lines plus list entries.

Evidence: the mechanism was verified end to end on 2026-07-26 against a real Claude Code 2.1.220 primary session in a throwaway FM_HOME on tmux - armed with bin/fm-keepalive.sh start, revived after the default 45s confirm plus 30s poll, one typed session-revive input submitted and a real turn started; the same real session returned busy while mid-turn and unsafe while its trust dialog held the composer, typing nothing in either case. tests/fm-keepalive.test.sh covers busy-not-dead, idle-with-no-work, dead-with-work, the backoff sequence and ceiling, the attempt cap and its guard surfacing, afk ownership, opt-in gating, an unconfirmed submit, the gate refusal, and the AGENTS.md recognition contract. Two pre-existing suite failures on main (tests/fm-session-start.test.sh BASHPID under /bin/bash 3.2 and tests/fm-tangle-guard.test.sh via the known fm-brief.sh 3.2 parse bug, issue 1069 / PR 1074) reproduce unchanged on a clean clone of main and are not from this change.

## What Changed

- Add `bin/fm-keepalive.sh`, a new external daemon that detects a dead primary session (in-flight work, no `.afk`, live harness pid, stale watcher beacon, no busy footer, empty composer, sustained confirm window) and types a `session-revive` operational input to restart the turn, backing off from 60s to a 900s ceiling with a five-attempt cap recorded durably in `state/.keepalive-suspect`/`state/.keepalive-exhausted`.
- Wire `session-revive` into `bin/fm-operational-input.sh` (and the mirrored Pi TS kind list in `.pi/extensions/lib/fm-operational-input.ts`), and reuse existing backend/pane-discovery/supervision/lock primitives (`bin/fm-backend.sh`, `bin/fm-supervisor-target-lib.sh`, `bin/fm-supervision-lib.sh`, `bin/fm-session-lock-lib.sh`) rather than introducing a second injection path.
- Add a locked, opt-in bootstrap sweep in `bin/fm-bootstrap.sh` gated by `config/keepalive=on`, surface exhaustion via `bin/fm-guard.sh`, and defer entirely while `state/.afk` exists so away mode retains exclusive revival duty.
- Add `tests/fm-keepalive.test.sh` (14 cases covering detection, backoff, cap, afk deferral, opt-in gating, and gate refusal) and document the mechanism in `docs/session-keepalive.md`, `docs/configuration.md`, `docs/architecture.md`, `docs/verification/supervision.md`, and `AGENTS.md`.

## Risk Assessment

✅ Low: The change is a self-contained, opt-in, off-by-default mechanism that reuses existing verified primitives (fm-backend.sh, fm-operational-input.sh, fm-supervision-lib.sh, fm-session-lock-lib.sh, fm-gate-refuse-lib.sh) rather than duplicating logic; detection is durable-evidence-based with fail-closed defaults, backoff/cap/exhaustion are bounded and logged, away-mode exclusivity is enforced via the .afk check, gate refusal is wired for the arming/driving/retiring verbs, and the extensive test suite (14 cases) covers the claimed scenarios — verified against the actual diff with no contradictions of the stated intent found.

## Testing

All targeted shell tests for the fm-session-keepalive change pass, including the specific case that verifies fm-guard.sh surfaces the 'revival EXHAUSTED' report and the case verifying keepalive is off by default; no regressions in adjacent operational-input or bootstrap tests, and the worktree is clean afterward.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-keepalive.test.sh (14/14 pass)`
- `bash tests/fm-operational-input.test.sh (7/7 pass, verifies session-revive kind added to FM_OPERATIONAL_KINDS)`
- `bash tests/fm-bootstrap.test.sh (opt-in keepalive sweep path, pass)`
- `bash tests/fm-guard-stale-banner.test.sh (unaffected regression check, pass)`
- `git status --porcelain (clean, no stray test artifacts)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
