### PR TITLE
fix(bin): refuse local merges only on genuine working-tree collisions

### DIFF
--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -14,6 +14,8 @@
 # a path that is both uncommitted in the project checkout and rewritten by this
 # exact fast-forward, including an untracked entry and an incoming path that
 # cannot both exist because one is a directory where the other is a file. An
+# untracked directory git will not descend into, a nested repository above all,
+# stands for everything beneath it, because nothing here can see what it holds. An
 # untracked or modified path the fast-forward never touches cannot be clobbered
 # by it, and an ignored path is declared disposable - git itself overwrites one
 # without complaint, and this guard matches git rather than second-guessing it -
@@ -22,7 +24,8 @@
 # unresolved conflict, a merge, cherry-pick, revert, rebase, bisect, or patch
 # application left in progress, an unrecognized status code, a git command that
 # fails - refuses instead of proceeding, naming the operation it found and how to
-# conclude or abandon it.
+# conclude or abandon it, ahead of the divergence that operation's own commits
+# caused, since rebasing is not what settles it.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
 
@@ -123,28 +126,29 @@ refuse_if_operation_in_progress() {
     "a bisect is in progress here; end it with 'git bisect reset'"
 }
 
-# The project's main checkout must be on its default branch, so the fast-forward
-# lands predictably (firstmate never writes here otherwise).
+# --- state checks, ordered specific before generic ---------------------------
+#
+# The ordering principle every check below obeys, and every check added later
+# must obey: a refusal that can NAME the state it found runs before any generic
+# check that would describe the same checkout in vaguer terms. A half-finished
+# operation is the reason this matters - it parks the checkout on no branch at
+# all, and it commits onto the default branch as it works through its remaining
+# picks. Either symptom reaches a generic check first if the order is reversed,
+# and the operator is told they are on the wrong branch or that the task branch
+# has diverged and should be rebased, when what they actually have to do is
+# conclude or abandon the operation, which restores the default branch and makes
+# the fast-forward valid again.
+
 cur=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo "")
 if [ -z "$cur" ]; then
-  # A rebase and a bisect both park the checkout on a detached HEAD, so the
-  # sentinels have to answer here or they never run at all: the generic refusal
-  # below reports an empty branch name and says nothing about the operation that
-  # caused it.
+  # A rebase and a bisect both park the checkout on a detached HEAD, where the
+  # operation's own name is all there is to report: the listing below classifies
+  # what such a rebase left behind as ordinary dirt or as a bare conflict, and the
+  # branch check has nothing but an empty branch name to print.
   refuse_if_operation_in_progress
 fi
-[ "$cur" = "$DEFAULT" ] || { echo "error: $PROJ is on '$cur', expected default branch '$DEFAULT'; cannot merge safely" >&2; exit 1; }
 
-# Clean fast-forward only: DEFAULT must be an ancestor of BRANCH. Settled before
-# the collision guard below, so that guard's incoming change set is exactly the
-# set of paths this fast-forward rewrites rather than a diverged two-way diff.
-if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BRANCH"; then
-  echo "REFUSED: $BRANCH is not a fast-forward of $DEFAULT (it has diverged)." >&2
-  echo "Have the crewmate rebase $BRANCH onto $DEFAULT, then retry." >&2
-  exit 1
-fi
-
-# --- working-tree collision guard -------------------------------------------
+# --- working-tree listing ----------------------------------------------------
 #
 # A blanket "any uncommitted change refuses" check is stricter than git itself
 # and self-deadlocking: it blocks the very commit that would settle the
@@ -156,8 +160,12 @@ fi
 # only status and diff format that emits paths verbatim instead of quoting names
 # with spaces or non-ASCII bytes. --untracked-files=all is required so untracked
 # entries are individual files rather than a collapsed parent directory, which
-# would hide a collision at a nested path. Ignored files are absent from this
-# listing (no --ignored), which is why they never collide.
+# would hide a collision at a nested path. It cannot collapse every such parent:
+# a directory git will not descend into - a nested repository is the shape that
+# does it - still arrives as a lone "<dir>/" entry, so the collision lookup below
+# normalizes that trailing slash away and treats the entry as covering everything
+# beneath it. Ignored files are absent from this listing (no --ignored), which is
+# why they never collide.
 
 GUARD_TMP=
 guard_tmp_cleanup() {
@@ -221,6 +229,23 @@ done < "$GUARD_TMP/status"
 # these catch it once its resolutions are staged and it has nothing left to show.
 refuse_if_operation_in_progress
 
+# --- generic checks, reached only once no specific state was named -----------
+
+# The project's main checkout must be on its default branch, so the fast-forward
+# lands predictably (firstmate never writes here otherwise).
+[ "$cur" = "$DEFAULT" ] || { echo "error: $PROJ is on '$cur', expected default branch '$DEFAULT'; cannot merge safely" >&2; exit 1; }
+
+# Clean fast-forward only: DEFAULT must be an ancestor of BRANCH. Settled before
+# the incoming change set below, so that set is exactly the paths this
+# fast-forward rewrites rather than a diverged two-way diff.
+if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BRANCH"; then
+  echo "REFUSED: $BRANCH is not a fast-forward of $DEFAULT (it has diverged)." >&2
+  echo "Have the crewmate rebase $BRANCH onto $DEFAULT, then retry." >&2
+  exit 1
+fi
+
+# --- incoming change set and collision guard ---------------------------------
+
 # The trailing `--` is load-bearing: without it git applies its revision/filename
 # ambiguity check to both arguments and dies outright in any project holding a
 # root entry named like its default branch, which would refuse a landing the
@@ -282,23 +307,39 @@ incoming_action() {  # <path>
 # needs a directory, and a directory where the merge needs a file.
 UNTRACKED_COLLISION=
 untracked_collision() {  # <path>
-  local want=$1 i=0 add
+  local want=$1 i=0 add lead nested
+  lead="untracked file here"
+  nested="needs that path to be a directory to create"
+  # A lone "<dir>/" entry is the one shape --untracked-files=all still collapses:
+  # git reports a directory it will not descend into, a nested repository above
+  # all, without listing what is inside. Comparing that entry verbatim would build
+  # the prefix pattern '<dir>//*', which matches nothing, so every incoming add
+  # beneath it would pass this guard and hit git's own abort instead. Strip the
+  # slash and let the entry stand for its whole subtree: nothing here can see what
+  # that directory holds, and an unreadable state refuses.
+  case "$want" in
+    */)
+      want=${want%/}
+      lead="untracked directory here that git will not descend into"
+      nested="creates a file beneath it at"
+      ;;
+  esac
   while [ "$i" -lt "${#INC_PATHS[@]}" ]; do
     if [ "${INC_ACTIONS[$i]}" = adds ]; then
       add=${INC_PATHS[$i]}
       if [ "$add" = "$want" ]; then
-        UNTRACKED_COLLISION="untracked file here, and this merge creates a file at that path"
+        UNTRACKED_COLLISION="$lead, and this merge creates a file at that path"
         return 0
       fi
       case "$add" in
         "$want"/*)
-          UNTRACKED_COLLISION="untracked file here, and this merge needs that path to be a directory to create '$add'"
+          UNTRACKED_COLLISION="$lead, and this merge $nested '$add'"
           return 0
           ;;
       esac
       case "$want" in
         "$add"/*)
-          UNTRACKED_COLLISION="untracked file here, and this merge creates a file at '$add', replacing the directory holding it"
+          UNTRACKED_COLLISION="$lead, and this merge creates a file at '$add', replacing the directory holding it"
           return 0
           ;;
       esac

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -9,6 +9,15 @@
 # auto-approves), and only as a clean fast-forward - it refuses a diverged branch
 # and tells you to have the crewmate rebase. See AGENTS.md prime directives,
 # project management, and task lifecycle.
+#
+# Uncommitted work in the project blocks the merge only on a GENUINE COLLISION:
+# a path that is both uncommitted in the project checkout and rewritten by this
+# exact fast-forward. Untracked files, ignored files, and changes at paths the
+# fast-forward never touches cannot be clobbered by it, so they do not block it,
+# and a refusal names every colliding path and what the incoming commits do to
+# it. A state this guard cannot classify confidently - an unresolved conflict, an
+# unrecognized status code, a git command that fails - refuses instead of
+# proceeding.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
 
@@ -46,21 +55,178 @@ git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { e
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 
-# The project's main checkout must be on its default branch and clean, so the
-# fast-forward lands predictably (firstmate never writes here otherwise).
+# The project's main checkout must be on its default branch, so the fast-forward
+# lands predictably (firstmate never writes here otherwise).
 cur=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo "")
 [ "$cur" = "$DEFAULT" ] || { echo "error: $PROJ is on '$cur', expected default branch '$DEFAULT'; cannot merge safely" >&2; exit 1; }
-if [ -n "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ]; then
-  echo "error: $PROJ has a dirty working tree; refusing to merge into it" >&2
-  exit 1
-fi
 
-# Clean fast-forward only: DEFAULT must be an ancestor of BRANCH.
+# Clean fast-forward only: DEFAULT must be an ancestor of BRANCH. Settled before
+# the collision guard below, so that guard's incoming change set is exactly the
+# set of paths this fast-forward rewrites rather than a diverged two-way diff.
 if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BRANCH"; then
   echo "REFUSED: $BRANCH is not a fast-forward of $DEFAULT (it has diverged)." >&2
   echo "Have the crewmate rebase $BRANCH onto $DEFAULT, then retry." >&2
   exit 1
 fi
+
+# --- working-tree collision guard -------------------------------------------
+#
+# A blanket "any uncommitted change refuses" check is stricter than git itself
+# and self-deadlocking: it blocks the very commit that would settle the
+# uncommitted entries (adding ignore rules, dropping a machine-local pointer from
+# the index), because the cure sits behind the symptom. So refuse only where the
+# fast-forward could actually destroy local work.
+#
+# Both sides are read NUL-delimited. -z is not an optimization here: it is the
+# only status and diff format that emits paths verbatim instead of quoting names
+# with spaces or non-ASCII bytes. --untracked-files=all is required so untracked
+# entries are individual files rather than a collapsed parent directory, which
+# would hide a collision at a nested path. Ignored files are absent from this
+# listing (no --ignored), which is why they never collide.
+
+GUARD_TMP=
+guard_tmp_cleanup() {
+  [ -n "$GUARD_TMP" ] || return 0
+  rm -rf "$GUARD_TMP"
+  GUARD_TMP=
+}
+trap guard_tmp_cleanup EXIT
+GUARD_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-merge-local.XXXXXX") || {
+  echo "error: cannot create a temporary directory to inspect $PROJ" >&2
+  exit 1
+}
+
+# An unclassifiable state is not a safe state, so every parse or command failure
+# lands here rather than degrading into an empty - and therefore silent - change set.
+refuse_unreadable() {  # <detail>
+  echo "REFUSED: cannot classify the state of $PROJ, so refusing to merge into it." >&2
+  echo "  $1" >&2
+  echo "Resolve that state in $PROJ (finish or abort an unresolved merge, or report an unexpected git status), then retry." >&2
+  exit 1
+}
+
+DIRTY_PATHS=()      # tracked paths carrying staged or unstaged changes
+UNTRACKED_PATHS=()  # untracked, non-ignored files
+INC_PATHS=()        # paths the fast-forward rewrites
+INC_ACTIONS=()      # what it does to INC_PATHS[i]: changes, removes, or adds
+INC_ADDS=()         # paths the fast-forward creates
+
+git -C "$PROJ" status --porcelain=v1 -z --untracked-files=all > "$GUARD_TMP/status" \
+  || refuse_unreadable "git status failed in $PROJ"
+
+# Records are "XY <path>\0". Rename and copy entries carry a second NUL field
+# holding the other endpoint, which must be consumed from the same stream or
+# every later record is misread as a status code.
+while IFS= read -r -d '' entry; do
+  code=${entry:0:2}
+  path=${entry:3}
+  case "$code" in
+    '??')
+      UNTRACKED_PATHS+=("$path")
+      continue
+      ;;
+    'DD'|'AA'|U?|?U)
+      refuse_unreadable "unresolved merge conflict at '$path'"
+      ;;
+  esac
+  case "${code:0:1}" in
+    ' '|M|T|A|D|R|C) : ;;
+    *) refuse_unreadable "unrecognized git status code '$code' at '$path'" ;;
+  esac
+  case "${code:1:1}" in
+    ' '|M|T|D|R|C) : ;;
+    *) refuse_unreadable "unrecognized git status code '$code' at '$path'" ;;
+  esac
+  DIRTY_PATHS+=("$path")
+  case "$code" in
+    *R*|*C*)
+      IFS= read -r -d '' other || refuse_unreadable "truncated '$code' rename entry at '$path'"
+      DIRTY_PATHS+=("$other")
+      ;;
+  esac
+done < "$GUARD_TMP/status"
+
+git -C "$PROJ" diff -z --name-status "$DEFAULT" "$BRANCH" > "$GUARD_TMP/incoming" \
+  || refuse_unreadable "git diff failed between $DEFAULT and $BRANCH in $PROJ"
+
+# Records are "<status>\0<path>\0", and for rename/copy "<status>\0<old>\0<new>\0"
+# (source first, the reverse of the status field order above).
+while IFS= read -r -d '' change; do
+  IFS= read -r -d '' path || refuse_unreadable "truncated '$change' entry in the incoming diff"
+  case "$change" in
+    A)
+      INC_PATHS+=("$path"); INC_ACTIONS+=(adds); INC_ADDS+=("$path")
+      ;;
+    M|M[0-9]*|T|T[0-9]*)
+      INC_PATHS+=("$path"); INC_ACTIONS+=(changes)
+      ;;
+    D)
+      INC_PATHS+=("$path"); INC_ACTIONS+=(removes)
+      ;;
+    R|R[0-9]*)
+      IFS= read -r -d '' other || refuse_unreadable "truncated '$change' entry at '$path' in the incoming diff"
+      INC_PATHS+=("$path"); INC_ACTIONS+=(removes)
+      INC_PATHS+=("$other"); INC_ACTIONS+=(adds); INC_ADDS+=("$other")
+      ;;
+    C|C[0-9]*)
+      IFS= read -r -d '' other || refuse_unreadable "truncated '$change' entry at '$path' in the incoming diff"
+      INC_PATHS+=("$other"); INC_ACTIONS+=(adds); INC_ADDS+=("$other")
+      ;;
+    *)
+      refuse_unreadable "unrecognized git diff status '$change' at '$path'"
+      ;;
+  esac
+done < "$GUARD_TMP/incoming"
+
+# Echo what the fast-forward does to <path>, or fail when it leaves it alone.
+incoming_action() {  # <path>
+  local want=$1 i=0
+  while [ "$i" -lt "${#INC_PATHS[@]}" ]; do
+    if [ "${INC_PATHS[$i]}" = "$want" ]; then
+      printf '%s\n' "${INC_ACTIONS[$i]}"
+      return 0
+    fi
+    i=$((i + 1))
+  done
+  return 1
+}
+
+# True when the fast-forward creates a file at <path>, where an untracked file of
+# the operator's own would be in the way.
+incoming_creates() {  # <path> <created-path>...
+  local want=$1 candidate
+  shift
+  for candidate in "$@"; do
+    [ "$candidate" = "$want" ] && return 0
+  done
+  return 1
+}
+
+COLLISIONS=()
+if [ "${#DIRTY_PATHS[@]}" -gt 0 ]; then
+  for path in "${DIRTY_PATHS[@]}"; do
+    if action=$(incoming_action "$path"); then
+      COLLISIONS+=("$path - uncommitted changes here, and this merge $action it")
+    fi
+  done
+fi
+if [ "${#UNTRACKED_PATHS[@]}" -gt 0 ] && [ "${#INC_ADDS[@]}" -gt 0 ]; then
+  for path in "${UNTRACKED_PATHS[@]}"; do
+    if incoming_creates "$path" "${INC_ADDS[@]}"; then
+      COLLISIONS+=("$path - untracked file here, and this merge creates a file at that path")
+    fi
+  done
+fi
+
+if [ "${#COLLISIONS[@]}" -gt 0 ]; then
+  echo "REFUSED: uncommitted work in $PROJ collides with the $BRANCH fast-forward:" >&2
+  for collision in "${COLLISIONS[@]}"; do
+    echo "  $collision" >&2
+  done
+  echo "Commit, stash, or remove exactly those paths, then retry; other uncommitted files do not block this merge." >&2
+  exit 1
+fi
+guard_tmp_cleanup
 
 before=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
 git -C "$PROJ" merge --ff-only "$BRANCH" >/dev/null

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -13,14 +13,16 @@
 # Uncommitted work in the project blocks the merge only on a GENUINE COLLISION:
 # a path that is both uncommitted in the project checkout and rewritten by this
 # exact fast-forward, including an untracked entry and an incoming path that
-# cannot both exist because one is a directory where the other is a file. Ignored
-# files, and untracked or modified paths the fast-forward never touches, cannot
-# be clobbered by it, so they do not block it, and a refusal names every
-# colliding path and what the incoming commits do to it. A state this guard
-# cannot classify confidently - an unresolved conflict, a merge, cherry-pick,
-# revert, rebase, bisect, or patch application left in progress, an unrecognized
-# status code, a git command that fails - refuses instead of proceeding, naming
-# the operation it found and how to conclude or abandon it.
+# cannot both exist because one is a directory where the other is a file. An
+# untracked or modified path the fast-forward never touches cannot be clobbered
+# by it, and an ignored path is declared disposable - git itself overwrites one
+# without complaint, and this guard matches git rather than second-guessing it -
+# so neither blocks the merge. A refusal names every colliding path and what the
+# incoming commits do to it. A state this guard cannot classify confidently - an
+# unresolved conflict, a merge, cherry-pick, revert, rebase, bisect, or patch
+# application left in progress, an unrecognized status code, a git command that
+# fails - refuses instead of proceeding, naming the operation it found and how to
+# conclude or abandon it.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
 

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -18,8 +18,9 @@
 # be clobbered by it, so they do not block it, and a refusal names every
 # colliding path and what the incoming commits do to it. A state this guard
 # cannot classify confidently - an unresolved conflict, a merge, cherry-pick,
-# revert, rebase, or bisect left in progress, an unrecognized status code, a git
-# command that fails - refuses instead of proceeding.
+# revert, rebase, bisect, or patch application left in progress, an unrecognized
+# status code, a git command that fails - refuses instead of proceeding, naming
+# the operation it found and how to conclude or abandon it.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
 
@@ -57,9 +58,71 @@ git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { e
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 
+# --- unclassifiable-state refusals -------------------------------------------
+#
+# An unclassifiable state is not a safe state, so every parse or command failure
+# lands here rather than degrading into an empty - and therefore silent - change set.
+refuse_unreadable() {  # <detail>
+  echo "REFUSED: cannot classify the state of $PROJ, so refusing to merge into it." >&2
+  echo "  $1" >&2
+  echo "Resolve that state in $PROJ (finish or abort the operation in progress, or report an unexpected git status), then retry." >&2
+  exit 1
+}
+
+# A merge, cherry-pick, revert, rebase, bisect, or patch application left
+# half-finished is such a state, and one no other check can see on its own: once
+# its conflicts are staged, git status reports plain modifications
+# indistinguishable from ordinary dirt. Resolve each sentinel through
+# rev-parse --git-path rather than assuming "$PROJ/.git": in a linked worktree
+# the git dir is elsewhere, and a hardcoded path would silently never fire.
+IN_PROGRESS_PATH=
+in_progress_path() {  # <git-dir-entry>
+  local rel
+  rel=$(git -C "$PROJ" rev-parse --git-path "$1") \
+    || refuse_unreadable "git rev-parse --git-path $1 failed in $PROJ"
+  case "$rel" in
+    /*) IN_PROGRESS_PATH=$rel ;;
+    *) IN_PROGRESS_PATH="$PROJ/$rel" ;;
+  esac
+}
+
+refuse_if_in_progress() {  # <git-dir-entry> <detail>
+  in_progress_path "$1"
+  [ -e "$IN_PROGRESS_PATH" ] || return 0
+  refuse_unreadable "$2"
+}
+
+# `git am` and the apply-backend rebase share the rebase-apply directory but need
+# different advice - `git rebase --abort` refuses outright while an am is open.
+# git's own status tells them apart by the `applying` marker inside it, so this
+# does too, and checks that marker before the directory it lives in.
+refuse_if_operation_in_progress() {
+  refuse_if_in_progress MERGE_HEAD \
+    "a merge is in progress here; conclude it with 'git commit' or abandon it with 'git merge --abort'"
+  refuse_if_in_progress CHERRY_PICK_HEAD \
+    "a cherry-pick is in progress here; conclude it with 'git cherry-pick --continue' or abandon it with 'git cherry-pick --abort'"
+  refuse_if_in_progress REVERT_HEAD \
+    "a revert is in progress here; conclude it with 'git revert --continue' or abandon it with 'git revert --abort'"
+  refuse_if_in_progress rebase-merge \
+    "a rebase is in progress here; conclude it with 'git rebase --continue' or abandon it with 'git rebase --abort'"
+  refuse_if_in_progress rebase-apply/applying \
+    "a patch application is in progress here; conclude it with 'git am --continue' or abandon it with 'git am --abort'"
+  refuse_if_in_progress rebase-apply \
+    "a rebase is in progress here; conclude it with 'git rebase --continue' or abandon it with 'git rebase --abort'"
+  refuse_if_in_progress BISECT_LOG \
+    "a bisect is in progress here; end it with 'git bisect reset'"
+}
+
 # The project's main checkout must be on its default branch, so the fast-forward
 # lands predictably (firstmate never writes here otherwise).
 cur=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo "")
+if [ -z "$cur" ]; then
+  # A rebase and a bisect both park the checkout on a detached HEAD, so the
+  # sentinels have to answer here or they never run at all: the generic refusal
+  # below reports an empty branch name and says nothing about the operation that
+  # caused it.
+  refuse_if_operation_in_progress
+fi
 [ "$cur" = "$DEFAULT" ] || { echo "error: $PROJ is on '$cur', expected default branch '$DEFAULT'; cannot merge safely" >&2; exit 1; }
 
 # Clean fast-forward only: DEFAULT must be an ancestor of BRANCH. Settled before
@@ -96,33 +159,6 @@ trap guard_tmp_cleanup EXIT
 GUARD_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-merge-local.XXXXXX") || {
   echo "error: cannot create a temporary directory to inspect $PROJ" >&2
   exit 1
-}
-
-# An unclassifiable state is not a safe state, so every parse or command failure
-# lands here rather than degrading into an empty - and therefore silent - change set.
-refuse_unreadable() {  # <detail>
-  echo "REFUSED: cannot classify the state of $PROJ, so refusing to merge into it." >&2
-  echo "  $1" >&2
-  echo "Resolve that state in $PROJ (finish or abort the operation in progress, or report an unexpected git status), then retry." >&2
-  exit 1
-}
-
-# A merge, cherry-pick, revert, rebase, or bisect left half-finished is another
-# such state, and one the status listing cannot show on its own: once its
-# conflicts are staged, git reports plain modifications indistinguishable from
-# ordinary dirt. Resolve the sentinel through rev-parse --git-path rather than
-# assuming "$PROJ/.git": in a linked worktree the git dir is elsewhere, and a
-# hardcoded path would silently never fire.
-refuse_if_in_progress() {  # <git-dir-entry> <detail>
-  local rel path
-  rel=$(git -C "$PROJ" rev-parse --git-path "$1") \
-    || refuse_unreadable "git rev-parse --git-path $1 failed in $PROJ"
-  case "$rel" in
-    /*) path=$rel ;;
-    *) path="$PROJ/$rel" ;;
-  esac
-  [ -e "$path" ] || return 0
-  refuse_unreadable "$2"
 }
 
 DIRTY_PATHS=()      # tracked paths carrying staged or unstaged changes
@@ -165,21 +201,11 @@ while IFS= read -r -d '' entry; do
   esac
 done < "$GUARD_TMP/status"
 
-# Checked after the listing above, so an operation still carrying live conflicts
-# is named by the conflicted path it left behind; these sentinels then catch the
-# same operation once its resolutions are staged and it has nothing left to show.
-refuse_if_in_progress MERGE_HEAD \
-  "a merge is in progress here; conclude it with 'git commit' or abandon it with 'git merge --abort'"
-refuse_if_in_progress CHERRY_PICK_HEAD \
-  "a cherry-pick is in progress here; conclude it with 'git cherry-pick --continue' or abandon it with 'git cherry-pick --abort'"
-refuse_if_in_progress REVERT_HEAD \
-  "a revert is in progress here; conclude it with 'git revert --continue' or abandon it with 'git revert --abort'"
-refuse_if_in_progress rebase-merge \
-  "a rebase is in progress here; conclude it with 'git rebase --continue' or abandon it with 'git rebase --abort'"
-refuse_if_in_progress rebase-apply \
-  "a rebase is in progress here; conclude it with 'git rebase --continue' or abandon it with 'git rebase --abort'"
-refuse_if_in_progress BISECT_LOG \
-  "a bisect is in progress here; end it with 'git bisect reset'"
+# An operation that kept HEAD attached reaches the sentinels here rather than at
+# the detached-HEAD check above, deliberately after the listing: one still
+# carrying live conflicts is named by the conflicted path it left behind, and
+# these catch it once its resolutions are staged and it has nothing left to show.
+refuse_if_operation_in_progress
 
 git -C "$PROJ" diff -z --name-status "$DEFAULT" "$BRANCH" > "$GUARD_TMP/incoming" \
   || refuse_unreadable "git diff failed between $DEFAULT and $BRANCH in $PROJ"

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -12,12 +12,14 @@
 #
 # Uncommitted work in the project blocks the merge only on a GENUINE COLLISION:
 # a path that is both uncommitted in the project checkout and rewritten by this
-# exact fast-forward. Untracked files, ignored files, and changes at paths the
-# fast-forward never touches cannot be clobbered by it, so they do not block it,
-# and a refusal names every colliding path and what the incoming commits do to
-# it. A state this guard cannot classify confidently - an unresolved conflict, an
-# unrecognized status code, a git command that fails - refuses instead of
-# proceeding.
+# exact fast-forward, including an untracked entry and an incoming path that
+# cannot both exist because one is a directory where the other is a file. Ignored
+# files, and untracked or modified paths the fast-forward never touches, cannot
+# be clobbered by it, so they do not block it, and a refusal names every
+# colliding path and what the incoming commits do to it. A state this guard
+# cannot classify confidently - an unresolved conflict, a merge, cherry-pick,
+# revert, rebase, or bisect left in progress, an unrecognized status code, a git
+# command that fails - refuses instead of proceeding.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
 
@@ -101,15 +103,32 @@ GUARD_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-merge-local.XXXXXX") || {
 refuse_unreadable() {  # <detail>
   echo "REFUSED: cannot classify the state of $PROJ, so refusing to merge into it." >&2
   echo "  $1" >&2
-  echo "Resolve that state in $PROJ (finish or abort an unresolved merge, or report an unexpected git status), then retry." >&2
+  echo "Resolve that state in $PROJ (finish or abort the operation in progress, or report an unexpected git status), then retry." >&2
   exit 1
+}
+
+# A merge, cherry-pick, revert, rebase, or bisect left half-finished is another
+# such state, and one the status listing cannot show on its own: once its
+# conflicts are staged, git reports plain modifications indistinguishable from
+# ordinary dirt. Resolve the sentinel through rev-parse --git-path rather than
+# assuming "$PROJ/.git": in a linked worktree the git dir is elsewhere, and a
+# hardcoded path would silently never fire.
+refuse_if_in_progress() {  # <git-dir-entry> <detail>
+  local rel path
+  rel=$(git -C "$PROJ" rev-parse --git-path "$1") \
+    || refuse_unreadable "git rev-parse --git-path $1 failed in $PROJ"
+  case "$rel" in
+    /*) path=$rel ;;
+    *) path="$PROJ/$rel" ;;
+  esac
+  [ -e "$path" ] || return 0
+  refuse_unreadable "$2"
 }
 
 DIRTY_PATHS=()      # tracked paths carrying staged or unstaged changes
 UNTRACKED_PATHS=()  # untracked, non-ignored files
 INC_PATHS=()        # paths the fast-forward rewrites
 INC_ACTIONS=()      # what it does to INC_PATHS[i]: changes, removes, or adds
-INC_ADDS=()         # paths the fast-forward creates
 
 git -C "$PROJ" status --porcelain=v1 -z --untracked-files=all > "$GUARD_TMP/status" \
   || refuse_unreadable "git status failed in $PROJ"
@@ -146,6 +165,22 @@ while IFS= read -r -d '' entry; do
   esac
 done < "$GUARD_TMP/status"
 
+# Checked after the listing above, so an operation still carrying live conflicts
+# is named by the conflicted path it left behind; these sentinels then catch the
+# same operation once its resolutions are staged and it has nothing left to show.
+refuse_if_in_progress MERGE_HEAD \
+  "a merge is in progress here; conclude it with 'git commit' or abandon it with 'git merge --abort'"
+refuse_if_in_progress CHERRY_PICK_HEAD \
+  "a cherry-pick is in progress here; conclude it with 'git cherry-pick --continue' or abandon it with 'git cherry-pick --abort'"
+refuse_if_in_progress REVERT_HEAD \
+  "a revert is in progress here; conclude it with 'git revert --continue' or abandon it with 'git revert --abort'"
+refuse_if_in_progress rebase-merge \
+  "a rebase is in progress here; conclude it with 'git rebase --continue' or abandon it with 'git rebase --abort'"
+refuse_if_in_progress rebase-apply \
+  "a rebase is in progress here; conclude it with 'git rebase --continue' or abandon it with 'git rebase --abort'"
+refuse_if_in_progress BISECT_LOG \
+  "a bisect is in progress here; end it with 'git bisect reset'"
+
 git -C "$PROJ" diff -z --name-status "$DEFAULT" "$BRANCH" > "$GUARD_TMP/incoming" \
   || refuse_unreadable "git diff failed between $DEFAULT and $BRANCH in $PROJ"
 
@@ -155,7 +190,7 @@ while IFS= read -r -d '' change; do
   IFS= read -r -d '' path || refuse_unreadable "truncated '$change' entry in the incoming diff"
   case "$change" in
     A)
-      INC_PATHS+=("$path"); INC_ACTIONS+=(adds); INC_ADDS+=("$path")
+      INC_PATHS+=("$path"); INC_ACTIONS+=(adds)
       ;;
     M|M[0-9]*|T|T[0-9]*)
       INC_PATHS+=("$path"); INC_ACTIONS+=(changes)
@@ -166,11 +201,11 @@ while IFS= read -r -d '' change; do
     R|R[0-9]*)
       IFS= read -r -d '' other || refuse_unreadable "truncated '$change' entry at '$path' in the incoming diff"
       INC_PATHS+=("$path"); INC_ACTIONS+=(removes)
-      INC_PATHS+=("$other"); INC_ACTIONS+=(adds); INC_ADDS+=("$other")
+      INC_PATHS+=("$other"); INC_ACTIONS+=(adds)
       ;;
     C|C[0-9]*)
       IFS= read -r -d '' other || refuse_unreadable "truncated '$change' entry at '$path' in the incoming diff"
-      INC_PATHS+=("$other"); INC_ACTIONS+=(adds); INC_ADDS+=("$other")
+      INC_PATHS+=("$other"); INC_ACTIONS+=(adds)
       ;;
     *)
       refuse_unreadable "unrecognized git diff status '$change' at '$path'"
@@ -178,12 +213,16 @@ while IFS= read -r -d '' change; do
   esac
 done < "$GUARD_TMP/incoming"
 
-# Echo what the fast-forward does to <path>, or fail when it leaves it alone.
+# Set INC_ACTION to what the fast-forward does to <path>, or fail when it leaves
+# it alone. Both lookups below assign a global rather than echoing: a command
+# substitution would fork a subshell per dirty path in a large checkout, and
+# would also swallow the `exit` a refusal depends on.
+INC_ACTION=
 incoming_action() {  # <path>
   local want=$1 i=0
   while [ "$i" -lt "${#INC_PATHS[@]}" ]; do
     if [ "${INC_PATHS[$i]}" = "$want" ]; then
-      printf '%s\n' "${INC_ACTIONS[$i]}"
+      INC_ACTION=${INC_ACTIONS[$i]}
       return 0
     fi
     i=$((i + 1))
@@ -191,13 +230,35 @@ incoming_action() {  # <path>
   return 1
 }
 
-# True when the fast-forward creates a file at <path>, where an untracked file of
-# the operator's own would be in the way.
-incoming_creates() {  # <path> <created-path>...
-  local want=$1 candidate
-  shift
-  for candidate in "$@"; do
-    [ "$candidate" = "$want" ] && return 0
+# Set UNTRACKED_COLLISION to how the fast-forward would have to disturb the
+# untracked entry at <path> to land, or fail when it can leave that entry alone.
+# git refuses all three shapes, so name them here rather than letting git emit
+# its own abort: the merge's file at that exact path, a file where the merge
+# needs a directory, and a directory where the merge needs a file.
+UNTRACKED_COLLISION=
+untracked_collision() {  # <path>
+  local want=$1 i=0 add
+  while [ "$i" -lt "${#INC_PATHS[@]}" ]; do
+    if [ "${INC_ACTIONS[$i]}" = adds ]; then
+      add=${INC_PATHS[$i]}
+      if [ "$add" = "$want" ]; then
+        UNTRACKED_COLLISION="untracked file here, and this merge creates a file at that path"
+        return 0
+      fi
+      case "$add" in
+        "$want"/*)
+          UNTRACKED_COLLISION="untracked file here, and this merge needs that path to be a directory to create '$add'"
+          return 0
+          ;;
+      esac
+      case "$want" in
+        "$add"/*)
+          UNTRACKED_COLLISION="untracked file here, and this merge creates a file at '$add', replacing the directory holding it"
+          return 0
+          ;;
+      esac
+    fi
+    i=$((i + 1))
   done
   return 1
 }
@@ -205,15 +266,15 @@ incoming_creates() {  # <path> <created-path>...
 COLLISIONS=()
 if [ "${#DIRTY_PATHS[@]}" -gt 0 ]; then
   for path in "${DIRTY_PATHS[@]}"; do
-    if action=$(incoming_action "$path"); then
-      COLLISIONS+=("$path - uncommitted changes here, and this merge $action it")
+    if incoming_action "$path"; then
+      COLLISIONS+=("$path - uncommitted changes here, and this merge $INC_ACTION it")
     fi
   done
 fi
-if [ "${#UNTRACKED_PATHS[@]}" -gt 0 ] && [ "${#INC_ADDS[@]}" -gt 0 ]; then
+if [ "${#UNTRACKED_PATHS[@]}" -gt 0 ]; then
   for path in "${UNTRACKED_PATHS[@]}"; do
-    if incoming_creates "$path" "${INC_ADDS[@]}"; then
-      COLLISIONS+=("$path - untracked file here, and this merge creates a file at that path")
+    if untracked_collision "$path"; then
+      COLLISIONS+=("$path - $UNTRACKED_COLLISION")
     fi
   done
 fi

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -103,6 +103,14 @@ refuse_if_operation_in_progress() {
     "a cherry-pick is in progress here; conclude it with 'git cherry-pick --continue' or abandon it with 'git cherry-pick --abort'"
   refuse_if_in_progress REVERT_HEAD \
     "a revert is in progress here; conclude it with 'git revert --continue' or abandon it with 'git revert --abort'"
+  # A multi-commit cherry-pick or revert keeps its remaining picks in the
+  # sequencer after the conflicted one is resolved and committed, which drops
+  # CHERRY_PICK_HEAD while the sequence is still open. That marker is checked
+  # last of the three so a sequence still carrying its live conflict keeps the
+  # more specific message above. The interactive rebase does not appear here: it
+  # keeps its todo list in rebase-merge, which the next sentinel covers.
+  refuse_if_in_progress sequencer/todo \
+    "a cherry-pick or revert sequence is in progress here; conclude it with 'git cherry-pick --continue' or 'git revert --continue', or abandon it with 'git cherry-pick --abort' or 'git revert --abort'"
   refuse_if_in_progress rebase-merge \
     "a rebase is in progress here; conclude it with 'git rebase --continue' or abandon it with 'git rebase --abort'"
   refuse_if_in_progress rebase-apply/applying \
@@ -188,8 +196,12 @@ while IFS= read -r -d '' entry; do
     ' '|M|T|A|D|R|C) : ;;
     *) refuse_unreadable "unrecognized git status code '$code' at '$path'" ;;
   esac
+  # 'A' on the worktree side is an intent-to-add entry (`git add -N`), which is an
+  # ordinary dirty tracked path; the collision intersection below decides it, the
+  # same as a modification. Every code outside these two sets still refuses,
+  # because a state this cannot classify is not a safe state.
   case "${code:1:1}" in
-    ' '|M|T|D|R|C) : ;;
+    ' '|M|T|A|D|R|C) : ;;
     *) refuse_unreadable "unrecognized git status code '$code' at '$path'" ;;
   esac
   DIRTY_PATHS+=("$path")
@@ -207,7 +219,12 @@ done < "$GUARD_TMP/status"
 # these catch it once its resolutions are staged and it has nothing left to show.
 refuse_if_operation_in_progress
 
-git -C "$PROJ" diff -z --name-status "$DEFAULT" "$BRANCH" > "$GUARD_TMP/incoming" \
+# The trailing `--` is load-bearing: without it git applies its revision/filename
+# ambiguity check to both arguments and dies outright in any project holding a
+# root entry named like its default branch, which would refuse a landing the
+# operator cannot settle. No other git call here takes a pathspec, so none of the
+# others can read a revision as a filename.
+git -C "$PROJ" diff -z --name-status "$DEFAULT" "$BRANCH" -- > "$GUARD_TMP/incoming" \
   || refuse_unreadable "git diff failed between $DEFAULT and $BRANCH in $PROJ"
 
 # Records are "<status>\0<path>\0", and for rename/copy "<status>\0<old>\0<new>\0"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -165,8 +165,8 @@ family_for_basename() {
     fm-spawn-dispatch-profile.test.sh|fm-spawn-worktree-settle.test.sh)
       printf '%s\n' backend-dispatch
       ;;
-    fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
-    fm-teardown.test.sh|fm-x-mode.test.sh)
+    fm-merge-local.test.sh|fm-pr-check-security.test.sh|fm-pr-merge.test.sh|\
+    fm-review-diff.test.sh|fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge
       ;;
     fm-afk-inject-e2e.test.sh|fm-afk-return.test.sh)

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -13,17 +13,26 @@
 #   refuses  (c) untracked file at a path the fast-forward adds (name with spaces)
 #   refuses  (d) untracked file nested inside an otherwise untracked directory,
 #                which a collapsed status listing would hide
-#   refuses  (e) either endpoint of a staged rename that the fast-forward removes
-#   refuses  (f) an unresolved merge conflict (state it cannot classify)
-#   refuses  (g) an unrecognized git status code
-#   proceeds (h) untracked file at a path the fast-forward never touches
-#   proceeds (i) modified path the fast-forward never touches
-#   proceeds (j) ignored file, even at a path the fast-forward adds
-#   proceeds (k) clean tree
-#   proceeds (l) a staged rename at paths the fast-forward never touches, proving
+#   refuses  (e) untracked file sitting where the fast-forward needs a directory
+#   refuses  (f) untracked files under a path the fast-forward replaces with a file
+#   refuses  (g) either endpoint of a staged rename that the fast-forward removes
+#   refuses  (h) both endpoints of an INCOMING rename, whose diff record orders
+#                old-then-new, the reverse of git status
+#   refuses  (i) the destination of an INCOMING copy, when the project has asked
+#                git for copy detection
+#   refuses  (j) an unresolved merge conflict (state it cannot classify)
+#   refuses  (k) a merge left in progress with its resolution staged, in a linked
+#                worktree, where the git dir is not <project>/.git
+#   refuses  (l) a cherry-pick left in progress with its resolution staged
+#   refuses  (m) an unrecognized git status code
+#   proceeds (n) untracked file at a path the fast-forward never touches
+#   proceeds (o) modified path the fast-forward never touches
+#   proceeds (p) ignored file, even at a path the fast-forward adds
+#   proceeds (q) clean tree
+#   proceeds (r) a staged rename at paths the fast-forward never touches, proving
 #                the rename's second NUL field is consumed and not misread as the
 #                next record's status code
-#   regression (m) the observed deadlock: two untracked operator files plus one
+#   regression (s) the observed deadlock: two untracked operator files plus one
 #                modified tracked pointer that the incoming commit removes from
 #                the index. It must refuse, naming only the pointer, and must
 #                merge once that single path is settled - the cure can no longer
@@ -43,22 +52,36 @@ REAL_GIT=$(command -v git)
 # A local-only task whose project is a one-commit repo on main, with the task
 # branch checked out for the caller to build the incoming commits on. Echoes the
 # case dir; "$case_dir/project" is the project checkout fm-merge-local writes to.
+#
+# layout=worktree instead makes that project checkout a LINKED worktree of a repo
+# beside it, so its .git is a pointer file and its git dir is not
+# "$proj/.git" - the layout where a hardcoded git-dir path silently never fires.
 make_case() {
-  local name=$1 case_dir proj
+  local name=$1 layout=${2:-plain} case_dir proj repo
   case_dir="$TMP_ROOT/$name"
   proj="$case_dir/project"
-  mkdir -p "$case_dir/state" "$proj/docs"
-  git -C "$proj" init -q
+  repo="$proj"
+  if [ "$layout" = worktree ]; then
+    repo="$case_dir/repo"
+  fi
+  mkdir -p "$case_dir/state" "$repo/docs"
+  git -C "$repo" init -q
   # Set the default branch without relying on `git init -b` (git 2.28+).
-  git -C "$proj" symbolic-ref HEAD refs/heads/main
-  git -C "$proj" config user.name 'Firstmate Tests'
-  git -C "$proj" config user.email 'tests@example.invalid'
-  printf 'tracked\n' > "$proj/tracked.txt"
-  printf 'pointer\n' > "$proj/runtime-pointer.json"
-  printf 'long enough contents to pair as a rename\n' > "$proj/docs/notes.md"
-  printf 'ignored-*\n' > "$proj/.gitignore"
-  git -C "$proj" add -A
-  git -C "$proj" commit -qm base
+  git -C "$repo" symbolic-ref HEAD refs/heads/main
+  git -C "$repo" config user.name 'Firstmate Tests'
+  git -C "$repo" config user.email 'tests@example.invalid'
+  printf 'tracked\n' > "$repo/tracked.txt"
+  printf 'pointer\n' > "$repo/runtime-pointer.json"
+  printf 'long enough contents to pair as a rename\n' > "$repo/docs/notes.md"
+  printf 'ignored-*\n' > "$repo/.gitignore"
+  git -C "$repo" add -A
+  git -C "$repo" commit -qm base
+  if [ "$layout" = worktree ]; then
+    # Park the repo's own worktree on a branch nobody else wants, so main is free
+    # to be checked out in the linked worktree the merge actually targets.
+    git -C "$repo" checkout -q -b scratch
+    git -C "$repo" worktree add -q "$proj" main
+  fi
   fm_write_meta "$case_dir/state/$TASK_ID.meta" \
     "window=fm-$TASK_ID" \
     "worktree=$case_dir/wt" \
@@ -203,6 +226,52 @@ test_refuses_untracked_file_inside_an_untracked_directory() {
   pass "fm-merge-local sees an untracked file nested inside an otherwise untracked directory"
 }
 
+test_refuses_untracked_file_where_the_merge_needs_a_directory() {
+  local case_dir proj
+  case_dir=$(make_case refuse-untracked-file-vs-dir)
+  proj="$case_dir/project"
+  mkdir -p "$proj/reports"
+  printf 'theirs\n' > "$proj/reports/Quarterly Review.pdf"
+  commit_in "$proj" 'add a report in a new directory'
+  git -C "$proj" checkout -q main
+  # An untracked FILE sitting at a leading component of the incoming path. No
+  # exact path matches, but the two cannot both exist, and git refuses.
+  printf 'the operators own notes\n' > "$proj/reports"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-untracked-file-vs-dir: expected a refusal"
+  assert_grep "reports - untracked file here, and this merge needs that path to be a directory to create 'reports/Quarterly Review.pdf'" \
+    "$case_dir/stderr" "refuse-untracked-file-vs-dir: the file-where-a-directory-is-needed collision was not named"
+  assert_not_merged "$proj" refuse-untracked-file-vs-dir
+  assert_grep 'the operators own notes' "$proj/reports" \
+    "refuse-untracked-file-vs-dir: the operator's untracked file was disturbed"
+  pass "fm-merge-local names an untracked file sitting where the fast-forward needs a directory"
+}
+
+test_refuses_untracked_files_under_a_path_the_merge_turns_into_a_file() {
+  local case_dir proj
+  case_dir=$(make_case refuse-untracked-dir-vs-file)
+  proj="$case_dir/project"
+  printf 'theirs\n' > "$proj/notes"
+  commit_in "$proj" 'add a notes file'
+  git -C "$proj" checkout -q main
+  # The mirror shape: the operator's untracked files live UNDER a path the
+  # fast-forward replaces with a blob.
+  mkdir -p "$proj/notes"
+  printf 'operator draft\n' > "$proj/notes/draft.md"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-untracked-dir-vs-file: expected a refusal"
+  assert_grep "notes/draft.md - untracked file here, and this merge creates a file at 'notes', replacing the directory holding it" \
+    "$case_dir/stderr" "refuse-untracked-dir-vs-file: the directory-where-a-file-is-created collision was not named"
+  assert_not_merged "$proj" refuse-untracked-dir-vs-file
+  assert_grep 'operator draft' "$proj/notes/draft.md" \
+    "refuse-untracked-dir-vs-file: the operator's untracked file was disturbed"
+  pass "fm-merge-local names untracked files under a path the fast-forward replaces with a file"
+}
+
 test_refuses_rename_endpoint_the_merge_removes() {
   local case_dir proj
   case_dir=$(make_case refuse-rename-endpoint)
@@ -221,6 +290,59 @@ test_refuses_rename_endpoint_the_merge_removes() {
     "$case_dir/stderr" "refuse-rename-endpoint: the rename's source endpoint was not treated as uncommitted"
   assert_not_merged "$proj" refuse-rename-endpoint
   pass "fm-merge-local refuses when a staged rename's endpoint is removed by the fast-forward"
+}
+
+test_refuses_both_endpoints_of_an_incoming_rename() {
+  local case_dir proj
+  case_dir=$(make_case refuse-incoming-rename)
+  proj="$case_dir/project"
+  # Rename detection is on by default, so an incoming rename arrives as a single
+  # R record whose two path fields are old-then-new - the REVERSE of the
+  # new-then-old order git status uses. Both endpoints are dirty here, so the
+  # refusal must name the source as removed and the destination as created; if
+  # the reader's old/new assumption were inverted, both assertions flip.
+  git -C "$proj" mv docs/notes.md 'docs/crewmate notes.md'
+  commit_in "$proj" 'rename docs/notes.md'
+  git -C "$proj" checkout -q main
+  printf 'operator edit\n' >> "$proj/docs/notes.md"
+  printf 'the operators own copy\n' > "$proj/docs/crewmate notes.md"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-incoming-rename: expected a refusal"
+  assert_grep 'docs/notes.md - uncommitted changes here, and this merge removes it' \
+    "$case_dir/stderr" "refuse-incoming-rename: the incoming rename's source was not reported as removed"
+  assert_grep 'docs/crewmate notes.md - untracked file here, and this merge creates a file at that path' \
+    "$case_dir/stderr" "refuse-incoming-rename: the incoming rename's destination was not reported as created"
+  assert_not_merged "$proj" refuse-incoming-rename
+  assert_grep 'the operators own copy' "$proj/docs/crewmate notes.md" \
+    "refuse-incoming-rename: the operator's untracked file was overwritten"
+  pass "fm-merge-local reads an incoming rename's endpoints in the incoming diff's own field order"
+}
+
+test_refuses_untracked_file_at_an_incoming_copy_destination() {
+  local case_dir proj
+  case_dir=$(make_case refuse-incoming-copy)
+  proj="$case_dir/project"
+  # Copy detection is off unless the project asks for it, and then a C record
+  # arrives source-first like R. Only the destination is created, so only it can
+  # collide - an inverted reader would name the untouched source instead.
+  git -C "$proj" config diff.renames copies
+  cp "$proj/docs/notes.md" "$proj/docs/notes copy.md"
+  printf 'crewmate line\n' >> "$proj/docs/notes.md"
+  commit_in "$proj" 'copy docs/notes.md'
+  git -C "$proj" checkout -q main
+  printf 'the operators own copy\n' > "$proj/docs/notes copy.md"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-incoming-copy: expected a refusal"
+  assert_grep 'docs/notes copy.md - untracked file here, and this merge creates a file at that path' \
+    "$case_dir/stderr" "refuse-incoming-copy: the incoming copy's destination was not reported as created"
+  assert_not_merged "$proj" refuse-incoming-copy
+  assert_grep 'the operators own copy' "$proj/docs/notes copy.md" \
+    "refuse-incoming-copy: the operator's untracked file was overwritten"
+  pass "fm-merge-local reads an incoming copy's destination from the incoming diff"
 }
 
 test_refuses_unresolved_conflict() {
@@ -256,6 +378,73 @@ test_refuses_unresolved_conflict() {
     "refuse-unresolved-conflict: refusal did not name the conflicted path"
   assert_not_merged "$proj" refuse-unresolved-conflict
   pass "fm-merge-local refuses an unresolved merge conflict rather than classifying it as ordinary dirt"
+}
+
+# Build a conflicting `sideline` branch and rebuild the task branch on top of the
+# advanced main, so the fast-forward itself stays valid and the half-finished
+# operation is the only thing the guard can object to. The incoming commit only
+# touches tracked.txt, which no resolution below goes near - so nothing but the
+# in-progress sentinel can produce a refusal.
+prepare_conflicting_sideline() {
+  local proj=$1
+  git -C "$proj" checkout -q main
+  git -C "$proj" branch sideline
+  printf 'main side\n' >> "$proj/docs/notes.md"
+  commit_in "$proj" 'main side'
+  git -C "$proj" checkout -q sideline
+  printf 'other side\n' >> "$proj/docs/notes.md"
+  commit_in "$proj" 'other side'
+  git -C "$proj" checkout -q main
+  git -C "$proj" branch -f "$BRANCH" main
+  git -C "$proj" checkout -q "$BRANCH"
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
+  git -C "$proj" checkout -q main
+}
+
+test_refuses_in_progress_merge_in_a_linked_worktree() {
+  local case_dir proj
+  case_dir=$(make_case refuse-in-progress-merge worktree)
+  proj="$case_dir/project"
+  prepare_conflicting_sideline "$proj"
+  git -C "$proj" merge sideline >/dev/null 2>&1 \
+    && fail "refuse-in-progress-merge: fixture merge was expected to conflict"
+  # Staging the resolution without committing hides the merge from git status:
+  # the entry becomes a plain 'M ', so only MERGE_HEAD still says an operation is
+  # open - and in this linked worktree it does not live at "$proj/.git".
+  git -C "$proj" add docs/notes.md
+  assert_absent "$proj/.git/MERGE_HEAD" \
+    "refuse-in-progress-merge: fixture is not a linked worktree, so it cannot pin git-dir resolution"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-in-progress-merge: expected a refusal"
+  assert_grep 'cannot classify the state of' "$case_dir/stderr" \
+    "refuse-in-progress-merge: refusal was not the unclassifiable-state refusal"
+  assert_grep 'a merge is in progress here' "$case_dir/stderr" \
+    "refuse-in-progress-merge: refusal did not name the half-finished merge"
+  assert_grep 'git merge --abort' "$case_dir/stderr" \
+    "refuse-in-progress-merge: refusal was not actionable"
+  assert_not_merged "$proj" refuse-in-progress-merge
+  pass "fm-merge-local refuses a merge left in progress, including in a linked worktree"
+}
+
+test_refuses_in_progress_cherry_pick() {
+  local case_dir proj
+  case_dir=$(make_case refuse-in-progress-cherry-pick)
+  proj="$case_dir/project"
+  prepare_conflicting_sideline "$proj"
+  git -C "$proj" cherry-pick sideline >/dev/null 2>&1 \
+    && fail "refuse-in-progress-cherry-pick: fixture cherry-pick was expected to conflict"
+  git -C "$proj" add docs/notes.md
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-in-progress-cherry-pick: expected a refusal"
+  assert_grep 'a cherry-pick is in progress here' "$case_dir/stderr" \
+    "refuse-in-progress-cherry-pick: refusal did not name the half-finished cherry-pick"
+  assert_not_merged "$proj" refuse-in-progress-cherry-pick
+  pass "fm-merge-local refuses a cherry-pick left in progress, not just a merge"
 }
 
 test_refuses_unrecognized_status_code() {
@@ -435,8 +624,14 @@ test_refuses_modified_path_the_merge_changes
 test_refuses_modified_path_the_merge_removes
 test_refuses_untracked_file_at_an_added_path
 test_refuses_untracked_file_inside_an_untracked_directory
+test_refuses_untracked_file_where_the_merge_needs_a_directory
+test_refuses_untracked_files_under_a_path_the_merge_turns_into_a_file
 test_refuses_rename_endpoint_the_merge_removes
+test_refuses_both_endpoints_of_an_incoming_rename
+test_refuses_untracked_file_at_an_incoming_copy_destination
 test_refuses_unresolved_conflict
+test_refuses_in_progress_merge_in_a_linked_worktree
+test_refuses_in_progress_cherry_pick
 test_refuses_unrecognized_status_code
 test_proceeds_on_untracked_file_the_merge_never_touches
 test_proceeds_on_modified_path_the_merge_never_touches

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -11,17 +11,19 @@
 #   refuses  (a) modified path the fast-forward changes
 #   refuses  (b) modified path the fast-forward removes
 #   refuses  (c) untracked file at a path the fast-forward adds (name with spaces)
-#   refuses  (d) either endpoint of a staged rename that the fast-forward removes
-#   refuses  (e) an unresolved merge conflict (state it cannot classify)
-#   refuses  (f) an unrecognized git status code
-#   proceeds (g) untracked file at a path the fast-forward never touches
-#   proceeds (h) modified path the fast-forward never touches
-#   proceeds (i) ignored file, even at a path the fast-forward adds
-#   proceeds (j) clean tree
-#   proceeds (k) a staged rename at paths the fast-forward never touches, proving
+#   refuses  (d) untracked file nested inside an otherwise untracked directory,
+#                which a collapsed status listing would hide
+#   refuses  (e) either endpoint of a staged rename that the fast-forward removes
+#   refuses  (f) an unresolved merge conflict (state it cannot classify)
+#   refuses  (g) an unrecognized git status code
+#   proceeds (h) untracked file at a path the fast-forward never touches
+#   proceeds (i) modified path the fast-forward never touches
+#   proceeds (j) ignored file, even at a path the fast-forward adds
+#   proceeds (k) clean tree
+#   proceeds (l) a staged rename at paths the fast-forward never touches, proving
 #                the rename's second NUL field is consumed and not misread as the
 #                next record's status code
-#   regression (l) the observed deadlock: two untracked operator files plus one
+#   regression (m) the observed deadlock: two untracked operator files plus one
 #                modified tracked pointer that the incoming commit removes from
 #                the index. It must refuse, naming only the pointer, and must
 #                merge once that single path is settled - the cure can no longer
@@ -174,6 +176,31 @@ test_refuses_untracked_file_at_an_added_path() {
   assert_grep 'the operators own copy' "$proj/docs/Knowledge Graphs.pdf" \
     "refuse-untracked-added: the operator's untracked file was overwritten"
   pass "fm-merge-local refuses an untracked file at a path the fast-forward adds"
+}
+
+test_refuses_untracked_file_inside_an_untracked_directory() {
+  local case_dir proj
+  case_dir=$(make_case refuse-untracked-in-new-dir)
+  proj="$case_dir/project"
+  mkdir -p "$proj/reports"
+  printf 'theirs\n' > "$proj/reports/Quarterly Review.pdf"
+  commit_in "$proj" 'add a report in a new directory'
+  git -C "$proj" checkout -q main
+  # The whole directory is untracked here. git status collapses that to
+  # "reports/" unless untracked files are listed individually, which would hide
+  # the collision at the nested path the fast-forward actually adds.
+  mkdir -p "$proj/reports"
+  printf 'the operators own copy\n' > "$proj/reports/Quarterly Review.pdf"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-untracked-in-new-dir: expected a refusal"
+  assert_grep 'reports/Quarterly Review.pdf - untracked file here, and this merge creates a file at that path' \
+    "$case_dir/stderr" "refuse-untracked-in-new-dir: the collapsed untracked directory hid the nested collision"
+  assert_not_merged "$proj" refuse-untracked-in-new-dir
+  assert_grep 'the operators own copy' "$proj/reports/Quarterly Review.pdf" \
+    "refuse-untracked-in-new-dir: the operator's untracked file was overwritten"
+  pass "fm-merge-local sees an untracked file nested inside an otherwise untracked directory"
 }
 
 test_refuses_rename_endpoint_the_merge_removes() {
@@ -407,6 +434,7 @@ test_regression_untracked_documents_plus_removed_pointer() {
 test_refuses_modified_path_the_merge_changes
 test_refuses_modified_path_the_merge_removes
 test_refuses_untracked_file_at_an_added_path
+test_refuses_untracked_file_inside_an_untracked_directory
 test_refuses_rename_endpoint_the_merge_removes
 test_refuses_unresolved_conflict
 test_refuses_unrecognized_status_code

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -24,15 +24,21 @@
 #   refuses  (k) a merge left in progress with its resolution staged, in a linked
 #                worktree, where the git dir is not <project>/.git
 #   refuses  (l) a cherry-pick left in progress with its resolution staged
-#   refuses  (m) an unrecognized git status code
-#   proceeds (n) untracked file at a path the fast-forward never touches
-#   proceeds (o) modified path the fast-forward never touches
-#   proceeds (p) ignored file, even at a path the fast-forward adds
-#   proceeds (q) clean tree
-#   proceeds (r) a staged rename at paths the fast-forward never touches, proving
+#   refuses  (m) a conflicted rebase, which detaches HEAD, so the named refusal
+#                has to come before the default-branch check to be reachable
+#   refuses  (n) a conflicted apply-backend rebase, which leaves the same state
+#                directory git am uses but without its marker
+#   refuses  (o) a failed git am, which keeps HEAD attached and needs the git am
+#                commands rather than the rebase ones
+#   refuses  (p) an unrecognized git status code
+#   proceeds (q) untracked file at a path the fast-forward never touches
+#   proceeds (r) modified path the fast-forward never touches
+#   proceeds (s) ignored file, even at a path the fast-forward adds
+#   proceeds (t) clean tree
+#   proceeds (u) a staged rename at paths the fast-forward never touches, proving
 #                the rename's second NUL field is consumed and not misread as the
 #                next record's status code
-#   regression (s) the observed deadlock: two untracked operator files plus one
+#   regression (v) the observed deadlock: two untracked operator files plus one
 #                modified tracked pointer that the incoming commit removes from
 #                the index. It must refuse, naming only the pointer, and must
 #                merge once that single path is settled - the cure can no longer
@@ -447,6 +453,85 @@ test_refuses_in_progress_cherry_pick() {
   pass "fm-merge-local refuses a cherry-pick left in progress, not just a merge"
 }
 
+test_refuses_in_progress_rebase() {
+  local case_dir proj
+  case_dir=$(make_case refuse-in-progress-rebase)
+  proj="$case_dir/project"
+  prepare_conflicting_sideline "$proj"
+  # A real conflicted rebase, not a hand-made sentinel: it parks the checkout on
+  # a DETACHED HEAD, which is the whole point. The default-branch check would
+  # otherwise report an empty branch name and never reach the sentinels, so this
+  # fails if that ordering regresses.
+  git -C "$proj" checkout -q sideline
+  git -C "$proj" rebase main >/dev/null 2>&1 \
+    && fail "refuse-in-progress-rebase: fixture rebase was expected to conflict"
+  [ -z "$(git -C "$proj" symbolic-ref --short HEAD 2>/dev/null || true)" ] \
+    || fail "refuse-in-progress-rebase: fixture did not leave a detached HEAD"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-in-progress-rebase: expected a refusal"
+  assert_grep 'a rebase is in progress here' "$case_dir/stderr" \
+    "refuse-in-progress-rebase: refusal did not name the rebase"
+  assert_grep 'git rebase --abort' "$case_dir/stderr" \
+    "refuse-in-progress-rebase: refusal was not actionable"
+  assert_no_grep 'expected default branch' "$case_dir/stderr" \
+    "refuse-in-progress-rebase: the detached-HEAD branch check preempted the named refusal"
+  assert_not_merged "$proj" refuse-in-progress-rebase
+  pass "fm-merge-local names a conflicted rebase rather than reporting an empty branch name"
+}
+
+test_refuses_in_progress_apply_backend_rebase() {
+  local case_dir proj
+  case_dir=$(make_case refuse-in-progress-rebase-apply)
+  proj="$case_dir/project"
+  prepare_conflicting_sideline "$proj"
+  # The apply backend leaves rebase-apply/ WITHOUT the `applying` marker, so this
+  # pins that the shared directory is still read as a rebase once the git am
+  # marker checked before it does not match.
+  git -C "$proj" checkout -q sideline
+  git -C "$proj" rebase --apply main >/dev/null 2>&1 \
+    && fail "refuse-in-progress-rebase-apply: fixture rebase was expected to conflict"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-in-progress-rebase-apply: expected a refusal"
+  assert_grep 'a rebase is in progress here' "$case_dir/stderr" \
+    "refuse-in-progress-rebase-apply: refusal did not name the rebase"
+  assert_no_grep 'git am --abort' "$case_dir/stderr" \
+    "refuse-in-progress-rebase-apply: an apply-backend rebase was mistaken for a patch application"
+  assert_no_grep 'expected default branch' "$case_dir/stderr" \
+    "refuse-in-progress-rebase-apply: the detached-HEAD branch check preempted the named refusal"
+  assert_not_merged "$proj" refuse-in-progress-rebase-apply
+  pass "fm-merge-local names an apply-backend rebase, which shares git am's state directory"
+}
+
+test_refuses_in_progress_patch_application() {
+  local case_dir proj
+  case_dir=$(make_case refuse-in-progress-am)
+  proj="$case_dir/project"
+  prepare_conflicting_sideline "$proj"
+  # A real failing `git am`. It keeps HEAD attached and leaves a clean tree, so
+  # nothing but the `applying` marker inside the shared rebase-apply directory
+  # says an operation is open - and `git rebase --abort` refuses outright here,
+  # so naming this a rebase would send the operator to a command that errors.
+  git -C "$proj" format-patch --stdout main..sideline > "$case_dir/sideline.patch"
+  git -C "$proj" am "$case_dir/sideline.patch" >/dev/null 2>&1 \
+    && fail "refuse-in-progress-am: fixture patch was expected to fail to apply"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-in-progress-am: expected a refusal"
+  assert_grep 'a patch application is in progress here' "$case_dir/stderr" \
+    "refuse-in-progress-am: refusal did not name the patch application"
+  assert_grep 'git am --abort' "$case_dir/stderr" \
+    "refuse-in-progress-am: refusal did not offer the command that actually abandons an am"
+  assert_no_grep 'git rebase --abort' "$case_dir/stderr" \
+    "refuse-in-progress-am: a patch application was mislabelled as a rebase"
+  assert_not_merged "$proj" refuse-in-progress-am
+  pass "fm-merge-local tells a patch application apart from the rebase that shares its state directory"
+}
+
 test_refuses_unrecognized_status_code() {
   local case_dir proj fakebin stderr
   case_dir=$(make_case refuse-unknown-code)
@@ -632,6 +717,9 @@ test_refuses_untracked_file_at_an_incoming_copy_destination
 test_refuses_unresolved_conflict
 test_refuses_in_progress_merge_in_a_linked_worktree
 test_refuses_in_progress_cherry_pick
+test_refuses_in_progress_rebase
+test_refuses_in_progress_apply_backend_rebase
+test_refuses_in_progress_patch_application
 test_refuses_unrecognized_status_code
 test_proceeds_on_untracked_file_the_merge_never_touches
 test_proceeds_on_modified_path_the_merge_never_touches

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-merge-local.sh's working-tree collision guard: the approved
+# local-only landing path must refuse only where the fast-forward could actually
+# destroy uncommitted operator work, never on uncommitted entries it provably
+# cannot touch. A blanket "dirty tree refuses" check is self-deadlocking - it
+# blocks the very commit that would settle those entries - so precision here is
+# what keeps the guard usable, and refusing every genuine collision is what keeps
+# it safe.
+#
+# Matrix:
+#   refuses  (a) modified path the fast-forward changes
+#   refuses  (b) modified path the fast-forward removes
+#   refuses  (c) untracked file at a path the fast-forward adds (name with spaces)
+#   refuses  (d) either endpoint of a staged rename that the fast-forward removes
+#   refuses  (e) an unresolved merge conflict (state it cannot classify)
+#   refuses  (f) an unrecognized git status code
+#   proceeds (g) untracked file at a path the fast-forward never touches
+#   proceeds (h) modified path the fast-forward never touches
+#   proceeds (i) ignored file, even at a path the fast-forward adds
+#   proceeds (j) clean tree
+#   proceeds (k) a staged rename at paths the fast-forward never touches, proving
+#                the rename's second NUL field is consumed and not misread as the
+#                next record's status code
+#   regression (l) the observed deadlock: two untracked operator files plus one
+#                modified tracked pointer that the incoming commit removes from
+#                the index. It must refuse, naming only the pointer, and must
+#                merge once that single path is settled - the cure can no longer
+#                be locked behind the symptom.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+MERGE_LOCAL="$ROOT/bin/fm-merge-local.sh"
+TMP_ROOT=$(fm_test_tmproot fm-merge-local-tests)
+TASK_ID=local-1
+BRANCH="fm/$TASK_ID"
+REAL_GIT=$(command -v git)
+
+# A local-only task whose project is a one-commit repo on main, with the task
+# branch checked out for the caller to build the incoming commits on. Echoes the
+# case dir; "$case_dir/project" is the project checkout fm-merge-local writes to.
+make_case() {
+  local name=$1 case_dir proj
+  case_dir="$TMP_ROOT/$name"
+  proj="$case_dir/project"
+  mkdir -p "$case_dir/state" "$proj/docs"
+  git -C "$proj" init -q
+  # Set the default branch without relying on `git init -b` (git 2.28+).
+  git -C "$proj" symbolic-ref HEAD refs/heads/main
+  git -C "$proj" config user.name 'Firstmate Tests'
+  git -C "$proj" config user.email 'tests@example.invalid'
+  printf 'tracked\n' > "$proj/tracked.txt"
+  printf 'pointer\n' > "$proj/runtime-pointer.json"
+  printf 'long enough contents to pair as a rename\n' > "$proj/docs/notes.md"
+  printf 'ignored-*\n' > "$proj/.gitignore"
+  git -C "$proj" add -A
+  git -C "$proj" commit -qm base
+  fm_write_meta "$case_dir/state/$TASK_ID.meta" \
+    "window=fm-$TASK_ID" \
+    "worktree=$case_dir/wt" \
+    "project=$proj" \
+    "kind=ship" \
+    "mode=local-only"
+  # Keep the shared watcher-liveness banner quiet: this suite exercises the merge
+  # guard, not supervision staleness.
+  touch "$case_dir/state/.last-watcher-beat"
+  git -C "$proj" checkout -q -b "$BRANCH"
+  printf '%s\n' "$case_dir"
+}
+
+# commit_in <proj> <message> [path...]: stage the named paths (or everything when
+# none are named) and commit. Explicit paths matter for a case that has already
+# staged a `git rm --cached` removal, which `add -A` would undo.
+commit_in() {
+  local proj=$1 msg=$2
+  shift 2
+  if [ "$#" -gt 0 ]; then
+    git -C "$proj" add -- "$@"
+  else
+    git -C "$proj" add -A
+  fi
+  git -C "$proj" commit -qm "$msg"
+}
+
+run_merge_local() {
+  local case_dir=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  PATH="${FM_TEST_PATH_PREFIX:-}${FM_TEST_PATH_PREFIX:+:}$PATH" \
+    "$MERGE_LOCAL" "$TASK_ID" "$@"
+}
+
+# Run the merge and capture its streams; echoes nothing, sets RC.
+attempt_merge() {
+  local case_dir=$1
+  set +e
+  run_merge_local "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  RC=$?
+  set -e
+}
+
+assert_merged() {
+  local proj=$1 label=$2
+  [ "$(git -C "$proj" rev-parse main)" = "$(git -C "$proj" rev-parse "$BRANCH")" ] \
+    || fail "$label: expected main to be fast-forwarded to $BRANCH"
+}
+
+assert_not_merged() {
+  local proj=$1 label=$2
+  [ "$(git -C "$proj" rev-parse main)" != "$(git -C "$proj" rev-parse "$BRANCH")" ] \
+    || fail "$label: main was merged despite a refusal"
+}
+
+# --- refuses ----------------------------------------------------------------
+
+test_refuses_modified_path_the_merge_changes() {
+  local case_dir proj
+  case_dir=$(make_case refuse-modified-changed)
+  proj="$case_dir/project"
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
+  git -C "$proj" checkout -q main
+  printf 'operator edit\n' > "$proj/tracked.txt"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-modified-changed: expected a refusal"
+  assert_grep 'tracked.txt - uncommitted changes here, and this merge changes it' \
+    "$case_dir/stderr" "refuse-modified-changed: refusal did not name the colliding path and action"
+  assert_not_merged "$proj" refuse-modified-changed
+  assert_grep 'operator edit' "$proj/tracked.txt" \
+    "refuse-modified-changed: the operator's uncommitted edit was not preserved"
+  pass "fm-merge-local refuses a modified path the fast-forward changes"
+}
+
+test_refuses_modified_path_the_merge_removes() {
+  local case_dir proj
+  case_dir=$(make_case refuse-modified-removed)
+  proj="$case_dir/project"
+  git -C "$proj" rm -q docs/notes.md
+  commit_in "$proj" 'remove docs/notes.md'
+  git -C "$proj" checkout -q main
+  printf 'operator edit\n' >> "$proj/docs/notes.md"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-modified-removed: expected a refusal"
+  assert_grep 'docs/notes.md - uncommitted changes here, and this merge removes it' \
+    "$case_dir/stderr" "refuse-modified-removed: refusal did not report the incoming deletion"
+  assert_not_merged "$proj" refuse-modified-removed
+  assert_grep 'operator edit' "$proj/docs/notes.md" \
+    "refuse-modified-removed: the operator's uncommitted edit was not preserved"
+  pass "fm-merge-local refuses a modified path the fast-forward removes"
+}
+
+test_refuses_untracked_file_at_an_added_path() {
+  local case_dir proj
+  case_dir=$(make_case refuse-untracked-added)
+  proj="$case_dir/project"
+  printf 'theirs\n' > "$proj/docs/Knowledge Graphs.pdf"
+  commit_in "$proj" 'add a document'
+  git -C "$proj" checkout -q main
+  printf 'the operators own copy\n' > "$proj/docs/Knowledge Graphs.pdf"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-untracked-added: expected a refusal"
+  assert_grep 'docs/Knowledge Graphs.pdf - untracked file here, and this merge creates a file at that path' \
+    "$case_dir/stderr" "refuse-untracked-added: refusal did not name the spaced untracked path"
+  assert_not_merged "$proj" refuse-untracked-added
+  assert_grep 'the operators own copy' "$proj/docs/Knowledge Graphs.pdf" \
+    "refuse-untracked-added: the operator's untracked file was overwritten"
+  pass "fm-merge-local refuses an untracked file at a path the fast-forward adds"
+}
+
+test_refuses_rename_endpoint_the_merge_removes() {
+  local case_dir proj
+  case_dir=$(make_case refuse-rename-endpoint)
+  proj="$case_dir/project"
+  git -C "$proj" rm -q docs/notes.md
+  commit_in "$proj" 'remove docs/notes.md'
+  git -C "$proj" checkout -q main
+  # A staged rename makes BOTH endpoints uncommitted. The fast-forward removes
+  # the source, so the operator's staged rename is at risk.
+  git -C "$proj" mv docs/notes.md 'docs/renamed notes.md'
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-rename-endpoint: expected a refusal"
+  assert_grep 'docs/notes.md - uncommitted changes here, and this merge removes it' \
+    "$case_dir/stderr" "refuse-rename-endpoint: the rename's source endpoint was not treated as uncommitted"
+  assert_not_merged "$proj" refuse-rename-endpoint
+  pass "fm-merge-local refuses when a staged rename's endpoint is removed by the fast-forward"
+}
+
+test_refuses_unresolved_conflict() {
+  local case_dir proj
+  case_dir=$(make_case refuse-unresolved-conflict)
+  proj="$case_dir/project"
+  git -C "$proj" checkout -q main
+  printf 'base\n' > "$proj/conflict.txt"
+  commit_in "$proj" 'add conflict.txt'
+  git -C "$proj" branch sideline
+  printf 'main side\n' > "$proj/conflict.txt"
+  commit_in "$proj" 'main side'
+  git -C "$proj" checkout -q sideline
+  printf 'other side\n' > "$proj/conflict.txt"
+  commit_in "$proj" 'other side'
+  git -C "$proj" checkout -q main
+  # Rebuild the task branch on top of main so the fast-forward itself stays valid
+  # and the conflict is the only thing the guard can object to.
+  git -C "$proj" branch -f "$BRANCH" main
+  git -C "$proj" checkout -q "$BRANCH"
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
+  git -C "$proj" checkout -q main
+  git -C "$proj" merge sideline >/dev/null 2>&1 \
+    && fail "refuse-unresolved-conflict: fixture merge was expected to conflict"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-unresolved-conflict: expected a refusal"
+  assert_grep 'cannot classify the state of' "$case_dir/stderr" \
+    "refuse-unresolved-conflict: refusal was not the unclassifiable-state refusal"
+  assert_grep "unresolved merge conflict at 'conflict.txt'" "$case_dir/stderr" \
+    "refuse-unresolved-conflict: refusal did not name the conflicted path"
+  assert_not_merged "$proj" refuse-unresolved-conflict
+  pass "fm-merge-local refuses an unresolved merge conflict rather than classifying it as ordinary dirt"
+}
+
+test_refuses_unrecognized_status_code() {
+  local case_dir proj fakebin stderr
+  case_dir=$(make_case refuse-unknown-code)
+  proj="$case_dir/project"
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
+  git -C "$proj" checkout -q main
+
+  # git never emits an unknown status code, so shim just that one call. Every
+  # other git invocation passes straight through to the real binary.
+  fakebin=$(fm_fakebin "$case_dir")
+  cat > "$fakebin/git" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  if [ "\$arg" = --porcelain=v1 ]; then
+    printf 'XY strange.txt\0'
+    exit 0
+  fi
+done
+exec $REAL_GIT "\$@"
+SH
+  chmod +x "$fakebin/git"
+
+  FM_TEST_PATH_PREFIX="$fakebin" attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-unknown-code: expected a refusal"
+  assert_grep "unrecognized git status code 'XY' at 'strange.txt'" "$case_dir/stderr" \
+    "refuse-unknown-code: refusal did not report the unrecognized status code"
+  assert_not_merged "$proj" refuse-unknown-code
+  stderr=$(cat "$case_dir/stderr")
+  assert_not_contains "$stderr" 'merged fm/' \
+    "refuse-unknown-code: an unclassifiable status must not report a merge"
+  pass "fm-merge-local refuses an unrecognized git status code instead of guessing"
+}
+
+# --- proceeds ---------------------------------------------------------------
+
+test_proceeds_on_untracked_file_the_merge_never_touches() {
+  local case_dir proj
+  case_dir=$(make_case proceed-untracked-untouched)
+  proj="$case_dir/project"
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
+  git -C "$proj" checkout -q main
+  printf 'the operators own copy\n' > "$proj/docs/Knowledge Graphs.pdf"
+
+  attempt_merge "$case_dir"
+
+  expect_code 0 "$RC" "proceed-untracked-untouched: expected the merge to proceed"
+  assert_merged "$proj" proceed-untracked-untouched
+  assert_grep 'the operators own copy' "$proj/docs/Knowledge Graphs.pdf" \
+    "proceed-untracked-untouched: the untracked file was disturbed"
+  pass "fm-merge-local proceeds past an untracked file the fast-forward never touches"
+}
+
+test_proceeds_on_modified_path_the_merge_never_touches() {
+  local case_dir proj
+  case_dir=$(make_case proceed-modified-untouched)
+  proj="$case_dir/project"
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
+  git -C "$proj" checkout -q main
+  printf 'operator edit\n' >> "$proj/docs/notes.md"
+
+  attempt_merge "$case_dir"
+
+  expect_code 0 "$RC" "proceed-modified-untouched: expected the merge to proceed"
+  assert_merged "$proj" proceed-modified-untouched
+  assert_grep 'operator edit' "$proj/docs/notes.md" \
+    "proceed-modified-untouched: the uncommitted edit was not preserved through the merge"
+  pass "fm-merge-local proceeds past a modified path the fast-forward never touches"
+}
+
+test_proceeds_on_ignored_file() {
+  local case_dir proj
+  case_dir=$(make_case proceed-ignored)
+  proj="$case_dir/project"
+  # The incoming commit adds a path the project ignores, so this proves the guard
+  # excludes ignored paths outright rather than merely finding them untouched.
+  printf 'theirs\n' > "$proj/ignored-artifact.bin"
+  git -C "$proj" add -f ignored-artifact.bin
+  git -C "$proj" commit -qm 'track an otherwise-ignored artifact'
+  git -C "$proj" checkout -q main
+  printf 'local build output\n' > "$proj/ignored-artifact.bin"
+
+  attempt_merge "$case_dir"
+
+  expect_code 0 "$RC" "proceed-ignored: expected the merge to proceed"
+  assert_merged "$proj" proceed-ignored
+  pass "fm-merge-local proceeds past an ignored file, matching git's own handling"
+}
+
+test_proceeds_on_clean_tree() {
+  local case_dir proj
+  case_dir=$(make_case proceed-clean)
+  proj="$case_dir/project"
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
+  git -C "$proj" checkout -q main
+
+  attempt_merge "$case_dir"
+
+  expect_code 0 "$RC" "proceed-clean: expected the merge to proceed"
+  assert_merged "$proj" proceed-clean
+  assert_grep 'merged fm/' "$case_dir/stdout" "proceed-clean: no merge outcome was reported"
+  pass "fm-merge-local proceeds on a clean tree"
+}
+
+test_proceeds_past_untouched_staged_rename() {
+  local case_dir proj
+  case_dir=$(make_case proceed-rename-untouched)
+  proj="$case_dir/project"
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
+  git -C "$proj" checkout -q main
+  # A rename entry carries a second NUL field. If it were not consumed, the old
+  # path would be misread as the next record's status code and the untracked file
+  # after it would go unclassified - so this case also guards the parser.
+  git -C "$proj" mv docs/notes.md 'docs/renamed notes.md'
+  printf 'zz\n' > "$proj/zz untracked.txt"
+
+  attempt_merge "$case_dir"
+
+  expect_code 0 "$RC" "proceed-rename-untouched: expected the merge to proceed"
+  assert_merged "$proj" proceed-rename-untouched
+  assert_present "$proj/docs/renamed notes.md" \
+    "proceed-rename-untouched: the staged rename was not preserved through the merge"
+  pass "fm-merge-local parses a rename's second path field and proceeds when neither endpoint collides"
+}
+
+# --- regression -------------------------------------------------------------
+
+test_regression_untracked_documents_plus_removed_pointer() {
+  local case_dir proj stderr
+  case_dir=$(make_case regression-deadlock)
+  proj="$case_dir/project"
+  # The commit that settles all three uncommitted entries: ignore rules plus one
+  # index removal of the machine-local pointer.
+  git -C "$proj" rm -q --cached runtime-pointer.json
+  printf 'ignored-*\nruntime-pointer.json\n' > "$proj/.gitignore"
+  commit_in "$proj" 'ignore local artifacts and drop the runtime pointer' .gitignore
+  git -C "$proj" checkout -q main
+
+  printf 'operator copy\n' > "$proj/docs/Knowledge Graphs.pdf"
+  printf 'operator copy\n' > "$proj/docs/Second Paper.pdf"
+  printf 'machine local drift\n' >> "$proj/runtime-pointer.json"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "regression-deadlock: the removed-and-modified pointer must still refuse"
+  assert_grep 'runtime-pointer.json - uncommitted changes here, and this merge removes it' \
+    "$case_dir/stderr" "regression-deadlock: refusal did not identify the one genuinely colliding path"
+  stderr=$(cat "$case_dir/stderr")
+  assert_not_contains "$stderr" 'Knowledge Graphs.pdf' \
+    "regression-deadlock: an untracked document the merge never touches was reported as a collision"
+  assert_not_contains "$stderr" 'Second Paper.pdf' \
+    "regression-deadlock: an untracked document the merge never touches was reported as a collision"
+  assert_not_merged "$proj" regression-deadlock
+
+  # Settling that single named path is now enough: the commit that cures the
+  # uncommitted entries is no longer locked behind them.
+  git -C "$proj" checkout -- runtime-pointer.json
+  attempt_merge "$case_dir"
+
+  expect_code 0 "$RC" "regression-deadlock: the merge must land once the named path is settled"
+  assert_merged "$proj" regression-deadlock
+  assert_present "$proj/docs/Knowledge Graphs.pdf" \
+    "regression-deadlock: the operator's untracked document was removed by the merge"
+  assert_present "$proj/docs/Second Paper.pdf" \
+    "regression-deadlock: the operator's untracked document was removed by the merge"
+  pass "fm-merge-local names only the colliding path and lands once that path is settled"
+}
+
+test_refuses_modified_path_the_merge_changes
+test_refuses_modified_path_the_merge_removes
+test_refuses_untracked_file_at_an_added_path
+test_refuses_rename_endpoint_the_merge_removes
+test_refuses_unresolved_conflict
+test_refuses_unrecognized_status_code
+test_proceeds_on_untracked_file_the_merge_never_touches
+test_proceeds_on_modified_path_the_merge_never_touches
+test_proceeds_on_ignored_file
+test_proceeds_on_clean_tree
+test_proceeds_past_untouched_staged_rename
+test_regression_untracked_documents_plus_removed_pointer

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -7,44 +7,54 @@
 # what keeps the guard usable, and refusing every genuine collision is what keeps
 # it safe.
 #
+# Several cases also pin an ordering the guard depends on: a refusal that can name
+# the state it found runs before any generic wrong-branch or divergence complaint,
+# because a half-finished git operation produces both of those symptoms and
+# neither switching branches nor rebasing is what settles it.
+#
 # Matrix:
 #   refuses  (a) modified path the fast-forward changes
 #   refuses  (b) modified path the fast-forward removes
 #   refuses  (c) untracked file at a path the fast-forward adds (name with spaces)
 #   refuses  (d) untracked file nested inside an otherwise untracked directory,
 #                which a collapsed status listing would hide
-#   refuses  (e) untracked file sitting where the fast-forward needs a directory
-#   refuses  (f) untracked files under a path the fast-forward replaces with a file
-#   refuses  (g) either endpoint of a staged rename that the fast-forward removes
-#   refuses  (h) both endpoints of an INCOMING rename, whose diff record orders
+#   refuses  (e) untracked directory git will not descend into, which arrives as a
+#                lone collapsed entry even with untracked files listed in full
+#   refuses  (f) untracked file sitting where the fast-forward needs a directory
+#   refuses  (g) untracked files under a path the fast-forward replaces with a file
+#   refuses  (h) either endpoint of a staged rename that the fast-forward removes
+#   refuses  (i) both endpoints of an INCOMING rename, whose diff record orders
 #                old-then-new, the reverse of git status
-#   refuses  (i) the destination of an INCOMING copy, when the project has asked
+#   refuses  (j) the destination of an INCOMING copy, when the project has asked
 #                git for copy detection
-#   refuses  (j) an intent-to-add path the fast-forward also adds
-#   refuses  (k) an unresolved merge conflict (state it cannot classify)
-#   refuses  (l) a merge left in progress with its resolution staged, in a linked
+#   refuses  (k) an intent-to-add path the fast-forward also adds
+#   refuses  (l) an unresolved merge conflict (state it cannot classify)
+#   refuses  (m) a merge left in progress with its resolution staged, in a linked
 #                worktree, where the git dir is not <project>/.git
-#   refuses  (m) a cherry-pick left in progress with its resolution staged
-#   refuses  (n) a multi-commit cherry-pick whose conflicted pick has already been
-#                resolved and committed, so only the sequencer still says it is open
-#   refuses  (o) a conflicted rebase, which detaches HEAD, so the named refusal
+#   refuses  (n) a cherry-pick left in progress with its resolution staged
+#   refuses  (o) a multi-commit cherry-pick whose conflicted pick has already been
+#                resolved and committed, so only the sequencer still says it is
+#                open - and whose commit advanced the default branch past the task
+#                branch, so the named refusal has to come before the fast-forward
+#                check to be reachable
+#   refuses  (p) a conflicted rebase, which detaches HEAD, so the named refusal
 #                has to come before the default-branch check to be reachable
-#   refuses  (p) a conflicted apply-backend rebase, which leaves the same state
+#   refuses  (q) a conflicted apply-backend rebase, which leaves the same state
 #                directory git am uses but without its marker
-#   refuses  (q) a failed git am, which keeps HEAD attached and needs the git am
+#   refuses  (r) a failed git am, which keeps HEAD attached and needs the git am
 #                commands rather than the rebase ones
-#   refuses  (r) an unrecognized git status code
-#   proceeds (s) untracked file at a path the fast-forward never touches
-#   proceeds (t) modified path the fast-forward never touches
-#   proceeds (u) an intent-to-add path the fast-forward never touches
-#   proceeds (v) ignored file, even at a path the fast-forward adds
-#   proceeds (w) clean tree
-#   proceeds (x) a staged rename at paths the fast-forward never touches, proving
+#   refuses  (s) an unrecognized git status code
+#   proceeds (t) untracked file at a path the fast-forward never touches
+#   proceeds (u) modified path the fast-forward never touches
+#   proceeds (v) an intent-to-add path the fast-forward never touches
+#   proceeds (w) ignored file, even at a path the fast-forward adds
+#   proceeds (x) clean tree
+#   proceeds (y) a staged rename at paths the fast-forward never touches, proving
 #                the rename's second NUL field is consumed and not misread as the
 #                next record's status code
-#   proceeds (y) a project whose root holds an entry named like its default
+#   proceeds (z) a project whose root holds an entry named like its default
 #                branch, which git reads as a filename without a '--' separator
-#   regression (z) the observed deadlock: two untracked operator files plus one
+#   regression (aa) the observed deadlock: two untracked operator files plus one
 #                modified tracked pointer that the incoming commit removes from
 #                the index. It must refuse, naming only the pointer, and must
 #                merge once that single path is settled - the cure can no longer
@@ -236,6 +246,37 @@ test_refuses_untracked_file_inside_an_untracked_directory() {
   assert_grep 'the operators own copy' "$proj/reports/Quarterly Review.pdf" \
     "refuse-untracked-in-new-dir: the operator's untracked file was overwritten"
   pass "fm-merge-local sees an untracked file nested inside an otherwise untracked directory"
+}
+
+test_refuses_collapsed_untracked_directory() {
+  local case_dir proj stderr
+  case_dir=$(make_case refuse-untracked-nested-repo)
+  proj="$case_dir/project"
+  mkdir -p "$proj/vendor"
+  printf 'theirs\n' > "$proj/vendor/lib.txt"
+  commit_in "$proj" 'add a vendored file'
+  git -C "$proj" checkout -q main
+  # A nested repository is the one untracked shape listing untracked files in full
+  # still cannot expand: git reports it as a lone 'vendor/' entry and never says
+  # what is inside. Compared verbatim, that entry matches no incoming path at all,
+  # so the guard would find nothing and leave git to abort the merge itself.
+  git -C "$proj" init -q vendor
+  printf 'the operators own checkout\n' > "$proj/vendor/lib.txt"
+  [ "$(git -C "$proj" status --porcelain=v1 --untracked-files=all)" = '?? vendor/' ] \
+    || fail "refuse-untracked-nested-repo: fixture did not produce a collapsed untracked directory entry"
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-untracked-nested-repo: expected a refusal"
+  assert_grep "vendor/ - untracked directory here that git will not descend into, and this merge creates a file beneath it at 'vendor/lib.txt'" \
+    "$case_dir/stderr" "refuse-untracked-nested-repo: the collapsed entry hid the incoming add beneath it"
+  stderr=$(cat "$case_dir/stderr")
+  assert_not_contains "$stderr" 'would be overwritten by merge' \
+    "refuse-untracked-nested-repo: the guard fell through to git's own abort instead of naming the collision"
+  assert_not_merged "$proj" refuse-untracked-nested-repo
+  assert_grep 'the operators own checkout' "$proj/vendor/lib.txt" \
+    "refuse-untracked-nested-repo: the operator's nested checkout was overwritten"
+  pass "fm-merge-local names a collapsed untracked directory entry git will not descend into"
 }
 
 test_refuses_untracked_file_where_the_merge_needs_a_directory() {
@@ -488,6 +529,10 @@ test_refuses_pending_cherry_pick_sequence() {
   local case_dir proj
   case_dir=$(make_case refuse-pending-sequence)
   proj="$case_dir/project"
+  # The task branch's own commit, landed before main moves at all, so main truly
+  # diverges from it below rather than being rebuilt on top of it afterwards.
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
   # A real two-commit cherry-pick whose FIRST pick conflicts. Resolving and
   # committing that pick drops CHERRY_PICK_HEAD while the second pick is still
   # queued, which is the state git's own status reports as a cherry-pick in
@@ -509,13 +554,14 @@ test_refuses_pending_cherry_pick_sequence() {
   git -C "$proj" commit -qm 'resolve the conflicted pick'
   assert_absent "$proj/.git/CHERRY_PICK_HEAD" \
     "refuse-pending-sequence: fixture still has a live cherry-pick, so it cannot pin the sequencer sentinel"
-  # Rebuild the task branch on top of the advanced main, so the fast-forward
-  # itself stays valid and the pending sequence is the only objection left. The
-  # tree is clean here, so nothing in the status listing can produce a refusal.
-  git -C "$proj" checkout -q -B "$BRANCH" main
-  printf 'incoming\n' > "$proj/tracked.txt"
-  commit_in "$proj" 'change tracked.txt'
-  git -C "$proj" checkout -q main
+  # The committed pick advanced main past the task branch, which is exactly the
+  # ordering this case pins: the generic fast-forward check now has something to
+  # complain about, and reaching it first would tell the operator to have the
+  # crewmate rebase - wrong advice, because aborting the sequence is what restores
+  # main and makes the fast-forward valid again. The tree is clean here, so
+  # nothing in the status listing can produce a refusal either.
+  git -C "$proj" merge-base --is-ancestor main "$BRANCH" \
+    && fail "refuse-pending-sequence: fixture left main an ancestor of $BRANCH, so it cannot pin the check ordering"
 
   attempt_merge "$case_dir"
 
@@ -526,8 +572,10 @@ test_refuses_pending_cherry_pick_sequence() {
     "refuse-pending-sequence: refusal was not actionable"
   assert_no_grep 'has diverged' "$case_dir/stderr" \
     "refuse-pending-sequence: the pending sequence was reported as ordinary divergence"
+  assert_no_grep 'rebase' "$case_dir/stderr" \
+    "refuse-pending-sequence: the refusal prescribed a rebase, which does not settle a pending sequence"
   assert_not_merged "$proj" refuse-pending-sequence
-  pass "fm-merge-local names a cherry-pick sequence still queued after its conflicted pick was committed"
+  pass "fm-merge-local names a pending cherry-pick sequence ahead of the divergence its own commit caused"
 }
 
 test_refuses_in_progress_rebase() {
@@ -839,6 +887,7 @@ test_refuses_modified_path_the_merge_changes
 test_refuses_modified_path_the_merge_removes
 test_refuses_untracked_file_at_an_added_path
 test_refuses_untracked_file_inside_an_untracked_directory
+test_refuses_collapsed_untracked_directory
 test_refuses_untracked_file_where_the_merge_needs_a_directory
 test_refuses_untracked_files_under_a_path_the_merge_turns_into_a_file
 test_refuses_rename_endpoint_the_merge_removes

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -20,25 +20,31 @@
 #                old-then-new, the reverse of git status
 #   refuses  (i) the destination of an INCOMING copy, when the project has asked
 #                git for copy detection
-#   refuses  (j) an unresolved merge conflict (state it cannot classify)
-#   refuses  (k) a merge left in progress with its resolution staged, in a linked
+#   refuses  (j) an intent-to-add path the fast-forward also adds
+#   refuses  (k) an unresolved merge conflict (state it cannot classify)
+#   refuses  (l) a merge left in progress with its resolution staged, in a linked
 #                worktree, where the git dir is not <project>/.git
-#   refuses  (l) a cherry-pick left in progress with its resolution staged
-#   refuses  (m) a conflicted rebase, which detaches HEAD, so the named refusal
+#   refuses  (m) a cherry-pick left in progress with its resolution staged
+#   refuses  (n) a multi-commit cherry-pick whose conflicted pick has already been
+#                resolved and committed, so only the sequencer still says it is open
+#   refuses  (o) a conflicted rebase, which detaches HEAD, so the named refusal
 #                has to come before the default-branch check to be reachable
-#   refuses  (n) a conflicted apply-backend rebase, which leaves the same state
+#   refuses  (p) a conflicted apply-backend rebase, which leaves the same state
 #                directory git am uses but without its marker
-#   refuses  (o) a failed git am, which keeps HEAD attached and needs the git am
+#   refuses  (q) a failed git am, which keeps HEAD attached and needs the git am
 #                commands rather than the rebase ones
-#   refuses  (p) an unrecognized git status code
-#   proceeds (q) untracked file at a path the fast-forward never touches
-#   proceeds (r) modified path the fast-forward never touches
-#   proceeds (s) ignored file, even at a path the fast-forward adds
-#   proceeds (t) clean tree
-#   proceeds (u) a staged rename at paths the fast-forward never touches, proving
+#   refuses  (r) an unrecognized git status code
+#   proceeds (s) untracked file at a path the fast-forward never touches
+#   proceeds (t) modified path the fast-forward never touches
+#   proceeds (u) an intent-to-add path the fast-forward never touches
+#   proceeds (v) ignored file, even at a path the fast-forward adds
+#   proceeds (w) clean tree
+#   proceeds (x) a staged rename at paths the fast-forward never touches, proving
 #                the rename's second NUL field is consumed and not misread as the
 #                next record's status code
-#   regression (v) the observed deadlock: two untracked operator files plus one
+#   proceeds (y) a project whose root holds an entry named like its default
+#                branch, which git reads as a filename without a '--' separator
+#   regression (z) the observed deadlock: two untracked operator files plus one
 #                modified tracked pointer that the incoming commit removes from
 #                the index. It must refuse, naming only the pointer, and must
 #                merge once that single path is settled - the cure can no longer
@@ -351,6 +357,31 @@ test_refuses_untracked_file_at_an_incoming_copy_destination() {
   pass "fm-merge-local reads an incoming copy's destination from the incoming diff"
 }
 
+test_refuses_intent_to_add_path_the_merge_adds() {
+  local case_dir proj
+  case_dir=$(make_case refuse-intent-to-add-collision)
+  proj="$case_dir/project"
+  printf 'theirs\n' > "$proj/docs/Knowledge Graphs.pdf"
+  commit_in "$proj" 'add a document'
+  git -C "$proj" checkout -q main
+  # `git add -N` records the path in the index without its contents, so status
+  # reports it as a tracked worktree addition rather than an untracked entry. The
+  # fast-forward creates a file at that exact path, so it is a genuine collision
+  # and the refusal has to name it.
+  printf 'the operators own copy\n' > "$proj/docs/Knowledge Graphs.pdf"
+  git -C "$proj" add -N -- 'docs/Knowledge Graphs.pdf'
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-intent-to-add-collision: expected a refusal"
+  assert_grep 'docs/Knowledge Graphs.pdf - uncommitted changes here, and this merge adds it' \
+    "$case_dir/stderr" "refuse-intent-to-add-collision: refusal did not name the intent-to-add path"
+  assert_not_merged "$proj" refuse-intent-to-add-collision
+  assert_grep 'the operators own copy' "$proj/docs/Knowledge Graphs.pdf" \
+    "refuse-intent-to-add-collision: the operator's file was overwritten"
+  pass "fm-merge-local refuses an intent-to-add path the fast-forward also adds"
+}
+
 test_refuses_unresolved_conflict() {
   local case_dir proj
   case_dir=$(make_case refuse-unresolved-conflict)
@@ -451,6 +482,52 @@ test_refuses_in_progress_cherry_pick() {
     "refuse-in-progress-cherry-pick: refusal did not name the half-finished cherry-pick"
   assert_not_merged "$proj" refuse-in-progress-cherry-pick
   pass "fm-merge-local refuses a cherry-pick left in progress, not just a merge"
+}
+
+test_refuses_pending_cherry_pick_sequence() {
+  local case_dir proj
+  case_dir=$(make_case refuse-pending-sequence)
+  proj="$case_dir/project"
+  # A real two-commit cherry-pick whose FIRST pick conflicts. Resolving and
+  # committing that pick drops CHERRY_PICK_HEAD while the second pick is still
+  # queued, which is the state git's own status reports as a cherry-pick in
+  # progress and the only one the sequencer sentinel can see.
+  git -C "$proj" checkout -q main
+  git -C "$proj" branch sideline
+  printf 'main side\n' >> "$proj/docs/notes.md"
+  commit_in "$proj" 'main side'
+  git -C "$proj" checkout -q sideline
+  printf 'other side\n' >> "$proj/docs/notes.md"
+  commit_in "$proj" 'other side'
+  printf 'tail\n' > "$proj/sequence-tail.txt"
+  commit_in "$proj" 'sequence tail'
+  git -C "$proj" checkout -q main
+  git -C "$proj" cherry-pick sideline~1 sideline >/dev/null 2>&1 \
+    && fail "refuse-pending-sequence: fixture cherry-pick was expected to conflict"
+  printf 'resolved\n' > "$proj/docs/notes.md"
+  git -C "$proj" add docs/notes.md
+  git -C "$proj" commit -qm 'resolve the conflicted pick'
+  assert_absent "$proj/.git/CHERRY_PICK_HEAD" \
+    "refuse-pending-sequence: fixture still has a live cherry-pick, so it cannot pin the sequencer sentinel"
+  # Rebuild the task branch on top of the advanced main, so the fast-forward
+  # itself stays valid and the pending sequence is the only objection left. The
+  # tree is clean here, so nothing in the status listing can produce a refusal.
+  git -C "$proj" checkout -q -B "$BRANCH" main
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
+  git -C "$proj" checkout -q main
+
+  attempt_merge "$case_dir"
+
+  expect_code 1 "$RC" "refuse-pending-sequence: expected a refusal"
+  assert_grep 'a cherry-pick or revert sequence is in progress here' "$case_dir/stderr" \
+    "refuse-pending-sequence: refusal did not name the half-finished sequence"
+  assert_grep 'git cherry-pick --abort' "$case_dir/stderr" \
+    "refuse-pending-sequence: refusal was not actionable"
+  assert_no_grep 'has diverged' "$case_dir/stderr" \
+    "refuse-pending-sequence: the pending sequence was reported as ordinary divergence"
+  assert_not_merged "$proj" refuse-pending-sequence
+  pass "fm-merge-local names a cherry-pick sequence still queued after its conflicted pick was committed"
 }
 
 test_refuses_in_progress_rebase() {
@@ -605,6 +682,31 @@ test_proceeds_on_modified_path_the_merge_never_touches() {
   pass "fm-merge-local proceeds past a modified path the fast-forward never touches"
 }
 
+test_proceeds_on_intent_to_add_path_the_merge_never_touches() {
+  local case_dir proj
+  case_dir=$(make_case proceed-intent-to-add)
+  proj="$case_dir/project"
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
+  git -C "$proj" checkout -q main
+  # `git add -N` is how an operator stages a new file for a partial commit, and
+  # git status spells it with a worktree-side 'A'. git fast-forwards straight past
+  # it when the merge never touches that path, so this guard must too rather than
+  # refusing a code it failed to recognize.
+  printf 'the operators own draft\n' > "$proj/docs/draft notes.md"
+  git -C "$proj" add -N -- 'docs/draft notes.md'
+
+  attempt_merge "$case_dir"
+
+  expect_code 0 "$RC" "proceed-intent-to-add: expected the merge to proceed"
+  assert_no_grep 'unrecognized git status code' "$case_dir/stderr" \
+    "proceed-intent-to-add: an intent-to-add entry was treated as an unclassifiable state"
+  assert_merged "$proj" proceed-intent-to-add
+  assert_grep 'the operators own draft' "$proj/docs/draft notes.md" \
+    "proceed-intent-to-add: the intent-to-add file was disturbed"
+  pass "fm-merge-local proceeds past an intent-to-add path the fast-forward never touches"
+}
+
 test_proceeds_on_ignored_file() {
   local case_dir proj
   case_dir=$(make_case proceed-ignored)
@@ -662,6 +764,34 @@ test_proceeds_past_untouched_staged_rename() {
   pass "fm-merge-local parses a rename's second path field and proceeds when neither endpoint collides"
 }
 
+test_proceeds_when_a_root_entry_is_named_like_the_default_branch() {
+  local case_dir proj
+  case_dir=$(make_case proceed-branch-shaped-path)
+  proj="$case_dir/project"
+  # A tracked directory named `main` is enough to make a bare `git diff <rev>
+  # <rev>` ambiguous: git reads the default branch name as a filename and dies,
+  # which would refuse every landing in this project with nothing the operator
+  # could settle. Landing here proves the incoming diff separates its revisions
+  # from paths.
+  mkdir -p "$proj/main"
+  printf 'an entry named like the default branch\n' > "$proj/main/notes.txt"
+  commit_in "$proj" 'add a directory named like the default branch'
+  git -C "$proj" branch -f main "$BRANCH"
+  printf 'incoming\n' > "$proj/tracked.txt"
+  commit_in "$proj" 'change tracked.txt'
+  git -C "$proj" checkout -q main
+
+  attempt_merge "$case_dir"
+
+  expect_code 0 "$RC" "proceed-branch-shaped-path: expected the merge to proceed"
+  assert_no_grep 'cannot classify the state of' "$case_dir/stderr" \
+    "proceed-branch-shaped-path: a root entry named like the default branch was read as a filename"
+  assert_merged "$proj" proceed-branch-shaped-path
+  assert_present "$proj/main/notes.txt" \
+    "proceed-branch-shaped-path: the branch-shaped entry was disturbed by the merge"
+  pass "fm-merge-local lands in a project whose root holds an entry named like its default branch"
+}
+
 # --- regression -------------------------------------------------------------
 
 test_regression_untracked_documents_plus_removed_pointer() {
@@ -714,16 +844,20 @@ test_refuses_untracked_files_under_a_path_the_merge_turns_into_a_file
 test_refuses_rename_endpoint_the_merge_removes
 test_refuses_both_endpoints_of_an_incoming_rename
 test_refuses_untracked_file_at_an_incoming_copy_destination
+test_refuses_intent_to_add_path_the_merge_adds
 test_refuses_unresolved_conflict
 test_refuses_in_progress_merge_in_a_linked_worktree
 test_refuses_in_progress_cherry_pick
+test_refuses_pending_cherry_pick_sequence
 test_refuses_in_progress_rebase
 test_refuses_in_progress_apply_backend_rebase
 test_refuses_in_progress_patch_application
 test_refuses_unrecognized_status_code
 test_proceeds_on_untracked_file_the_merge_never_touches
 test_proceeds_on_modified_path_the_merge_never_touches
+test_proceeds_on_intent_to_add_path_the_merge_never_touches
 test_proceeds_on_ignored_file
 test_proceeds_on_clean_tree
 test_proceeds_past_untouched_staged_rename
+test_proceeds_when_a_root_entry_is_named_like_the_default_branch
 test_regression_untracked_documents_plus_removed_pointer


### PR DESCRIPTION
## Intent

Make bin/fm-merge-local.sh's working-tree guard precise instead of blanket. The old guard refused any non-empty git status --porcelain, which is far stricter than git itself and deadlocked a real landing: a project had two untracked operator PDFs plus one locally-modified machine-local runtime pointer, and the very commit that would settle all three could not land because the tree was dirty. The fix refuses only on a genuine collision - the intersection of paths dirty in the working tree with paths the fast-forward (DEFAULT..BRANCH) would actually change - and otherwise proceeds. Deliberate design decisions, all authorized: (1) a fast-forward that deletes a tracked path whose working copy is locally modified is a genuine collision and must still refuse; (2) an untracked file at a path the incoming commit adds is a genuine collision, because git itself refuses there, and this includes a collapsed untracked directory entry that git reports with a trailing slash such as a nested git repository; (3) untracked or modified files at paths the merge never touches, and ignored paths, are NOT collisions and must proceed; (4) any status code that cannot be classified confidently causes a refusal - an unclassifiable state is not a safe state, and every ambiguous case is biased toward refusing because this is a safety guard whose failure mode is clobbering real operator work; (5) parsing uses git -z NUL-delimited output because real filenames include spaces and non-ASCII (e.g. 'docs/Knowledge Graphs.pdf') and porcelain quoting would otherwise be word-split; (6) refusal messages name the colliding paths and why, since the old opaque message was half of why the incident cost so much time; (7) specific named state refusals run BEFORE generic divergence checks - a half-finished cherry-pick, revert, git am, rebase, merge, or bisect that already advanced the default branch must produce its own named refusal pointing at aborting the sequence, never the generic 'has diverged, have the crewmate rebase' advice, which is actively wrong in that state. That ordering principle is stated explicitly in the code and pinned by a test that fails if the checks are reordered. In-progress states in tests are produced by real git operations - a real rebase, a real git am, a real multi-commit cherry-pick - never by synthesizing sentinel files. Three earlier gate decisions on this branch are settled and closed, so do not reopen them: commit identity is repo-local with global git config untouched; the detached-HEAD in-progress ordering finding was ruled fix-not-accept; and the same ruling was extended to the whole ordering class. The guard's collision lookup is a linear scan of the incoming path set, which is an accepted tradeoff rather than a defect: bash 3.2 compatibility is a stated repo constraint that rules out associative arrays, and NUL-delimited paths rule out portable comm or grep pipelines - do not change the algorithm for it. Scope is deliberately limited to this one merge path: bin/fm-pr-merge.sh and bin/fm-ff-lib.sh were explicitly left alone, and issue #1041 tracks the sibling blanket refusal in fm-ff-lib.sh. Constraints: bin/*.sh must pass bin/fm-lint.sh (which owns the lint definition and pins the shellcheck version), tracked Markdown uses one full sentence per line and plain dashes never em dashes, no agent name as commit co-author, and mechanics belong in the script header and --help only - not restated in AGENTS.md, per the repo one-owner rule.

## What Changed

- `bin/fm-merge-local.sh` replaces its blanket "any dirty tree refuses" check with a collision guard: it intersects the paths dirty in the project checkout with the paths the `DEFAULT..BRANCH` fast-forward actually rewrites, reading both `git status` and `git diff --name-status` NUL-delimited so names with spaces or non-ASCII bytes survive. Untracked, modified, and ignored paths the merge never touches now proceed; a deletion over a locally modified file, an untracked file where the merge adds one, and an untracked directory git will not descend into (a nested repo, which stands for its whole subtree) still refuse, naming every colliding path and what the incoming commits do to it. Any status or diff code it cannot classify, and any failing git call, refuses rather than degrading to an empty change set.
- The script now names half-finished git operations before the generic branch and divergence checks: merge, cherry-pick, revert, open sequencer todo, rebase (merge and apply backends), `git am`, and bisect each get their own refusal pointing at the right `--continue`/`--abort`, resolved through `git rev-parse --git-path` so linked worktrees are covered. Sentinels are checked on detached HEAD before the branch check and again after the status listing, so an operation that already advanced the default branch no longer produces the wrong "has diverged, have the crewmate rebase" advice. That ordering rule is written into the code and pinned by a test.
- Adds `tests/fm-merge-local.test.sh` (27 cases: 19 refusals, 7 proceeds, plus the deadlock regression) building in-progress states from real git operations rather than synthesized sentinel files, and registers the file in the `pr-forge` family in `bin/fm-test-run.sh`. The sibling blanket refusal in `bin/fm-ff-lib.sh` is deliberately untouched and tracked by issue #1041.

## Risk Assessment

✅ Low: The change is confined to one script's guard plus its new test suite and a test-family registration, it implements every required behavior in the authoritative intent and forbids none of them, the widened path is covered by 27 cases including the exact reported deadlock regression, and any collision the intersection could still miss is backstopped by git's own refusal to overwrite untracked or locally modified files.

## Testing

I ran the targeted suite tests/fm-merge-local.test.sh (27/27 pass), confirmed the runner now selects it in the pr-forge family, and then drove the real gate action end-to-end on purpose-built project checkouts to capture an operator-level CLI transcript: the baseline guard from a5fe1bc refuses a tree holding only two untracked PDFs the merge never touches with an opaque "has a dirty working tree" message, while the version under test lands that same tree, refuses the full incident tree naming only runtime-pointer.json and what the merge does to it, lands once that one path is settled with both operator documents intact, names a collapsed nested-repository entry instead of falling through to git's own abort, and gives a real conflicted rebase and a real pending cherry-pick sequence their own named refusals. I also confirmed the ordering is genuinely pinned by temporarily reordering the checks: the suite failed at refuse-pending-sequence and the operator output degraded to the forbidden "it has diverged / have the crewmate rebase" advice; that mutation is reverted and the worktree is clean at dee17ed. This change is a shell CLI guard with no rendered surface, so the reviewer-visible evidence is a CLI transcript rather than a screenshot. Per the rules I did not run bin/fm-lint.sh or any static analysis, so the intent's lint constraint is left to CI.

<details>
<summary>Evidence: Operator CLI transcript: baseline vs. precise guard, six scenarios end-to-end</summary>

<code>== ACT 1 - BASELINE (a5fe1bc): two untracked operator PDFs alone, nothing the merge touches&#10;$ git -C &lt;project&gt; status --porcelain --untracked-files=all&#10;?? &#34;docs/Knowledge Graphs.pdf&#34;&#10;?? &#34;docs/Second Paper.pdf&#34;&#10;(the incoming commit only rewrites src.txt, so git itself would fast-forward this happily)&#10;$ fm-merge-local.sh local-1&#10;error: .../atlas has a dirty working tree; refusing to merge into it&#10;[exit 1] &lt;- the blanket guard refuses work the merge provably cannot touch&#10;&#10;== ACT 2 - UNDER TEST: two untracked operator PDFs the fast-forward never touches&#10;$ fm-merge-local.sh local-1&#10;merged fm/local-1 into local main (a60486d -&gt; ceb90bb) in .../atlas&#10;[exit 0]&#10;&#10;== ACT 3 - UNDER TEST: the incident tree. Only the genuinely colliding path is named.&#10;$ git -C &lt;project&gt; status --porcelain --untracked-files=all&#10;M runtime-pointer.json&#10;?? &#34;docs/Knowledge Graphs.pdf&#34;&#10;?? &#34;docs/Second Paper.pdf&#34;&#10;$ fm-merge-local.sh local-1&#10;REFUSED: uncommitted work in .../atlas collides with the fm/local-1 fast-forward:&#10;runtime-pointer.json - uncommitted changes here, and this merge removes it&#10;Commit, stash, or remove exactly those paths, then retry; other uncommitted files do not block this merge.&#10;[exit 1]&#10;Operator settles exactly that one named path and retries:&#10;$ git -C &lt;project&gt; checkout -- runtime-pointer.json&#10;$ fm-merge-local.sh local-1&#10;merged fm/local-1 into local main (6cc0e66 -&gt; 786c60f) in .../atlas&#10;[exit 0] &lt;- the cure is no longer locked behind the symptom&#10;$ ls &lt;project&gt;/docs&#10;Knowledge Graphs.pdf&#10;Second Paper.pdf&#10;notes.md&#10;&#10;== ACT 4 - UNDER TEST: a nested untracked repository, which git status collapses to &#34;vendor/&#34;&#10;$ git -C &lt;project&gt; status --porcelain --untracked-files=all&#10;?? vendor/&#10;$ fm-merge-local.sh local-1&#10;REFUSED: uncommitted work in .../atlas collides with the fm/local-1 fast-forward:&#10;vendor/ - untracked directory here that git will not descend into, and this merge creates a file beneath it at &#39;vendor/lib.txt&#39;&#10;[exit 1]&#10;$ cat &lt;project&gt;/vendor/lib.txt&#10;operator local checkout&#10;&#10;== ACT 5 - UNDER TEST: a real conflicted rebase left in progress (detached HEAD)&#10;$ git -C &lt;project&gt; status --short --branch&#10;## HEAD (no branch)&#10;UU docs/notes.md&#10;$ fm-merge-local.sh local-1&#10;REFUSED: cannot classify the state of .../atlas, so refusing to merge into it.&#10;a rebase is in progress here; conclude it with &#39;git rebase --continue&#39; or abandon it with &#39;git rebase --abort&#39;&#10;[exit 1] &lt;- names the rebase, not an empty branch name&#10;&#10;== ACT 6 - UNDER TEST: a pending cherry-pick sequence that already advanced main past the task branch&#10;$ git -C &lt;project&gt; merge-base --is-ancestor main fm/local-1&#10;[exit 1 - nonzero means main is NOT an ancestor, so this is not a fast-forward]&#10;$ fm-merge-local.sh local-1&#10;REFUSED: cannot classify the state of .../atlas, so refusing to merge into it.&#10;a cherry-pick or revert sequence is in progress here; conclude it with &#39;git cherry-pick --continue&#39; or &#39;git revert --continue&#39;, or abandon it with &#39;git cherry-pick --abort&#39; or &#39;git revert --abort&#39;&#10;[exit 1] &lt;- the named state wins over the generic &#34;has diverged, have the crewmate rebase&#34;</code>

```text

[1m== ACT 1 - BASELINE (a5fe1bc): two untracked operator PDFs alone, nothing the merge touches[0m

$ git -C <project> status --porcelain --untracked-files=all
    ?? "docs/Knowledge Graphs.pdf"
    ?? "docs/Second Paper.pdf"

(the incoming commit only rewrites src.txt, so git itself would fast-forward this happily)

$ fm-merge-local.sh local-1
    error: /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch/baseline-pdfs-only/projects/atlas has a dirty working tree; refusing to merge into it
    [exit 1]  <- the blanket guard refuses work the merge provably cannot touch

[1m== ACT 1b - BASELINE: the incident tree (2 untracked PDFs + modified machine-local pointer)[0m

$ fm-merge-local.sh local-1
    error: /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch/baseline-incident/projects/atlas has a dirty working tree; refusing to merge into it
    [exit 1]  <- opaque: names nothing, and the commit that would settle all three cannot land

[1m== ACT 2 - UNDER TEST: two untracked operator PDFs the fast-forward never touches[0m

$ fm-merge-local.sh local-1
    merged fm/local-1 into local main (6cc0e66 -> e275e68) in /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch/fixed-pdfs-only/projects/atlas
    [exit 0]  <- lands, matching what git itself would do

$ git -C <project> log --oneline -1 main
    e275e68 crewmate work on src.txt

(the operator documents survived untouched)

$ git -C <project> status --porcelain --untracked-files=all
    ?? "docs/Knowledge Graphs.pdf"
    ?? "docs/Second Paper.pdf"

[1m== ACT 3 - UNDER TEST: the incident tree. Only the genuinely colliding path is named.[0m

$ git -C <project> status --porcelain --untracked-files=all
     M runtime-pointer.json
    ?? "docs/Knowledge Graphs.pdf"
    ?? "docs/Second Paper.pdf"

$ fm-merge-local.sh local-1
    REFUSED: uncommitted work in /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch/fixed-incident/projects/atlas collides with the fm/local-1 fast-forward:
      runtime-pointer.json - uncommitted changes here, and this merge removes it
    Commit, stash, or remove exactly those paths, then retry; other uncommitted files do not block this merge.
    [exit 1]  <- the two PDFs are not mentioned; the pointer is, with what the merge does to it

Operator settles exactly that one named path and retries:

$ git -C <project> checkout -- runtime-pointer.json

$ fm-merge-local.sh local-1
    merged fm/local-1 into local main (6cc0e66 -> 786c60f) in /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch/fixed-incident/projects/atlas
    [exit 0]  <- the cure is no longer locked behind the symptom

(both operator documents are still on disk after the merge)
$ ls <project>/docs
    Knowledge Graphs.pdf
    Second Paper.pdf
    notes.md

[1m== ACT 4 - UNDER TEST: a nested untracked repository, which git status collapses to "vendor/"[0m

$ git -C <project> status --porcelain --untracked-files=all
    ?? vendor/

$ fm-merge-local.sh local-1
    REFUSED: uncommitted work in /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch/fixed-nested-repo/projects/atlas collides with the fm/local-1 fast-forward:
      vendor/ - untracked directory here that git will not descend into, and this merge creates a file beneath it at 'vendor/lib.txt'
    Commit, stash, or remove exactly those paths, then retry; other uncommitted files do not block this merge.
    [exit 1]  <- named by the guard, not left to git's own abort

(the operator vendor checkout is intact)
$ cat <project>/vendor/lib.txt
    operator local checkout

[1m== ACT 5 - UNDER TEST: a real conflicted rebase left in progress (detached HEAD)[0m

$ git -C <project> status --short --branch
    ## HEAD (no branch)
    UU docs/notes.md

$ fm-merge-local.sh local-1
    REFUSED: cannot classify the state of /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch/fixed-rebase/projects/atlas, so refusing to merge into it.
      a rebase is in progress here; conclude it with 'git rebase --continue' or abandon it with 'git rebase --abort'
    Resolve that state in /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch/fixed-rebase/projects/atlas (finish or abort the operation in progress, or report an unexpected git status), then retry.
    [exit 1]  <- names the rebase, not an empty branch name

[1m== ACT 6 - UNDER TEST: a pending cherry-pick sequence that already advanced main past the task branch[0m

$ git -C <project> status --short --branch
    ## main

(main has genuinely diverged from the task branch - the sequence own commit did it)
$ git -C <project> merge-base --is-ancestor main fm/local-1
    [exit 1 - nonzero means main is NOT an ancestor, so this is not a fast-forward]

$ fm-merge-local.sh local-1
    REFUSED: cannot classify the state of /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch/fixed-sequence/projects/atlas, so refusing to merge into it.
      a cherry-pick or revert sequence is in progress here; conclude it with 'git cherry-pick --continue' or 'git revert --continue', or abandon it with 'git cherry-pick --abort' or 'git revert --abort'
    Resolve that state in /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch/fixed-sequence/projects/atlas (finish or abort the operation in progress, or report an unexpected git status), then retry.
    [exit 1]  <- the named state wins over the generic "has diverged, have the crewmate rebase"
```
</details>
<details>
<summary>Evidence: Ordering is pinned: reordering the checks fails the suite and produces the forbidden advice</summary>

<code># With refuse_if_operation_in_progress moved below the generic checks:&#10;$ bash tests/fm-merge-local.test.sh (exit 1)&#10;...&#10;ok - fm-merge-local refuses a cherry-pick left in progress, not just a merge&#10;not ok - refuse-pending-sequence: refusal did not name the half-finished sequence&#10;&#10;# And what the operator would have seen in that state:&#10;$ fm-merge-local.sh local-1&#10;REFUSED: fm/local-1 is not a fast-forward of main (it has diverged).&#10;Have the crewmate rebase fm/local-1 onto main, then retry.&#10;[exit 1] &lt;- actively wrong advice: aborting the sequence is what restores main&#10;&#10;# Mutation reverted; suite green again at dee17ed.</code>

```text
[1m== ACT 5 - UNDER TEST: a real conflicted rebase left in progress (detached HEAD)[0m

$ git -C <project> status --short --branch
    ## HEAD (no branch)
    UU docs/notes.md

$ fm-merge-local.sh local-1
    REFUSED: cannot classify the state of /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch-mutated/fixed-rebase/projects/atlas, so refusing to merge into it.
      unresolved merge conflict at 'docs/notes.md'
    Resolve that state in /tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-scratch-mutated/fixed-rebase/projects/atlas (finish or abort the operation in progress, or report an unexpected git status), then retry.
    [exit 1]  <- names the rebase, not an empty branch name

[1m== ACT 6 - UNDER TEST: a pending cherry-pick sequence that already advanced main past the task branch[0m

$ git -C <project> status --short --branch
    ## main

(main has genuinely diverged from the task branch - the sequence own commit did it)
$ git -C <project> merge-base --is-ancestor main fm/local-1
    [exit 1 - nonzero means main is NOT an ancestor, so this is not a fast-forward]

$ fm-merge-local.sh local-1
    REFUSED: fm/local-1 is not a fast-forward of main (it has diverged).
    Have the crewmate rebase fm/local-1 onto main, then retry.
    [exit 1]  <- the named state wins over the generic "has diverged, have the crewmate rebase"
```
</details>
<details>
<summary>Evidence: Targeted suite output (27 cases)</summary>

```text
ok - fm-merge-local refuses a modified path the fast-forward changes
ok - fm-merge-local refuses a modified path the fast-forward removes
ok - fm-merge-local refuses an untracked file at a path the fast-forward adds
ok - fm-merge-local sees an untracked file nested inside an otherwise untracked directory
ok - fm-merge-local names a collapsed untracked directory entry git will not descend into
ok - fm-merge-local names an untracked file sitting where the fast-forward needs a directory
ok - fm-merge-local names untracked files under a path the fast-forward replaces with a file
ok - fm-merge-local refuses when a staged rename's endpoint is removed by the fast-forward
ok - fm-merge-local reads an incoming rename's endpoints in the incoming diff's own field order
ok - fm-merge-local reads an incoming copy's destination from the incoming diff
ok - fm-merge-local refuses an intent-to-add path the fast-forward also adds
ok - fm-merge-local refuses an unresolved merge conflict rather than classifying it as ordinary dirt
ok - fm-merge-local refuses a merge left in progress, including in a linked worktree
ok - fm-merge-local refuses a cherry-pick left in progress, not just a merge
ok - fm-merge-local names a pending cherry-pick sequence ahead of the divergence its own commit caused
ok - fm-merge-local names a conflicted rebase rather than reporting an empty branch name
ok - fm-merge-local names an apply-backend rebase, which shares git am's state directory
ok - fm-merge-local tells a patch application apart from the rebase that shares its state directory
ok - fm-merge-local refuses an unrecognized git status code instead of guessing
ok - fm-merge-local proceeds past an untracked file the fast-forward never touches
ok - fm-merge-local proceeds past a modified path the fast-forward never touches
ok - fm-merge-local proceeds past an intent-to-add path the fast-forward never touches
ok - fm-merge-local proceeds past an ignored file, matching git's own handling
ok - fm-merge-local proceeds on a clean tree
ok - fm-merge-local parses a rename's second path field and proceeds when neither endpoint collides
ok - fm-merge-local lands in a project whose root holds an entry named like its default branch
ok - fm-merge-local names only the colliding path and lands once that path is settled
```
</details>
<details>
<summary>Evidence: Demo driver used to produce the transcript</summary>

```text
#!/usr/bin/env bash
# End-to-end demo of bin/fm-merge-local.sh's working-tree guard, run as an
# operator would: a real project checkout, a real crewmate branch, real git
# operations, and the real gate action invoked by task id.
#
# Act 1 runs the BASELINE script (base commit a5fe1bc, blanket dirty-tree guard).
# Acts 2-6 run the script under test from the worktree.
set -eu

ROOT=$1                 # worktree under test
BASELINE=$2             # baseline fm-merge-local.sh extracted from a5fe1bc
DEMO=$3                 # scratch dir for the demo projects
DEMO=$(cd "$DEMO" && pwd)

export GIT_AUTHOR_NAME='Ops Operator' GIT_AUTHOR_EMAIL='ops@example.invalid'
export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
TASK=local-1
BRANCH="fm/$TASK"
PROJ=

say() { printf '\n\033[1m== %s\033[0m\n' "$*"; }

# Every git call in this demo goes through g(), which refuses to run unless PROJ
# is a real path inside the scratch dir - so a demo bug can never reach the
# checkout this script is being run from.
g() {
  case "$PROJ" in
    "$DEMO"/*) : ;;
    *) echo "demo bug: PROJ='$PROJ' is not inside $DEMO" >&2; exit 99 ;;
  esac
  [ -d "$PROJ" ] || { echo "demo bug: PROJ='$PROJ' does not exist" >&2; exit 99; }
  git -C "$PROJ" "$@"
}
show() { printf '\n$ git -C <project> %s\n' "$*"; g "$@" 2>&1 | sed 's/^/    /'; }

# new_project <name>: sets PROJ, leaves the crewmate branch checked out.
new_project() {
  local name case_dir
  name=$1
  case_dir="$DEMO/$name"
  PROJ="$case_dir/projects/atlas"
  mkdir -p "$case_dir/state" "$PROJ/docs"
  g init -q
  g symbolic-ref HEAD refs/heads/main
  g config user.name 'Ops Operator'
  g config user.email 'ops@example.invalid'
  printf 'v1\n' > "$PROJ/src.txt"
  printf '{"runtime":"/home/ops/local"}\n' > "$PROJ/runtime-pointer.json"
  printf 'notes\n' > "$PROJ/docs/notes.md"
  printf 'build/\n' > "$PROJ/.gitignore"
  g add -A
  g commit -qm 'atlas base'
  {
    echo "window=fm-$TASK"
    echo "worktree=$case_dir/wt"
    echo "project=$PROJ"
    echo "kind=ship"
    echo "mode=local-only"
  } > "$case_dir/state/$TASK.meta"
  touch "$case_dir/state/.last-watcher-beat"
  g checkout -q -b "$BRANCH"
}

# merge_local <script> [note]: run the gate action exactly as firstmate does.
merge_local() {
  local script=$1 note=${2:-} case_dir rc=0
  case_dir=$(cd "$PROJ/../.." && pwd)
  printf '\n$ fm-merge-local.sh %s\n' "$TASK"
  set +e
  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" \
    "$script" "$TASK" 2>&1 | sed 's/^/    /'
  rc=${PIPESTATUS[0]}
  set -e
  printf '    [exit %s]%s\n' "$rc" "${note:+  <- $note}"
}

# The crewmate commit from the real incident: add the ignore rules and drop the
# machine-local runtime pointer from the index.
settling_commit() {
  g rm -q --cached runtime-pointer.json
  printf 'build/\n*.pdf\nruntime-pointer.json\n' > "$PROJ/.gitignore"
  g add .gitignore
  g commit -qm 'ignore operator documents, drop the machine-local runtime pointer'
  g checkout -q main
}

incident_tree() {
  printf '%%PDF operator scan\n' > "$PROJ/docs/Knowledge Graphs.pdf"
  printf '%%PDF operator scan\n' > "$PROJ/docs/Second Paper.pdf"
  printf '{"runtime":"/home/ops/other-machine"}\n' > "$PROJ/runtime-pointer.json"
}

########################################################################
say 'ACT 1 - BASELINE (a5fe1bc): two untracked operator PDFs alone, nothing the merge touches'
new_project baseline-pdfs-only
printf 'v2\n' > "$PROJ/src.txt"
g commit -qam 'crewmate work on src.txt'
g checkout -q main
printf '%%PDF operator scan\n' > "$PROJ/docs/Knowledge Graphs.pdf"
printf '%%PDF operator scan\n' > "$PROJ/docs/Second Paper.pdf"
show status --porcelain --untracked-files=all
printf '\n(the incoming commit only rewrites src.txt, so git itself would fast-forward this happily)\n'
merge_local "$BASELINE" 'the blanket guard refuses work the merge provably cannot touch'

say 'ACT 1b - BASELINE: the incident tree (2 untracked PDFs + modified machine-local pointer)'
new_project baseline-incident
settling_commit
incident_tree
merge_local "$BASELINE" 'opaque: names nothing, and the commit that would settle all three cannot land'

########################################################################
say 'ACT 2 - UNDER TEST: two untracked operator PDFs the fast-forward never touches'
new_project fixed-pdfs-only
printf 'v2\n' > "$PROJ/src.txt"
g commit -qam 'crewmate work on src.txt'
g checkout -q main
printf '%%PDF operator scan\n' > "$PROJ/docs/Knowledge Graphs.pdf"
printf '%%PDF operator scan\n' > "$PROJ/docs/Second Paper.pdf"
merge_local "$ROOT/bin/fm-merge-local.sh" 'lands, matching what git itself would do'
show log --oneline -1 main
printf '\n(the operator documents survived untouched)\n'
show status --porcelain --untracked-files=all

say 'ACT 3 - UNDER TEST: the incident tree. Only the genuinely colliding path is named.'
new_project fixed-incident
settling_commit
incident_tree
show status --porcelain --untracked-files=all
merge_local "$ROOT/bin/fm-merge-local.sh" 'the two PDFs are not mentioned; the pointer is, with what the merge does to it'
printf '\nOperator settles exactly that one named path and retries:\n'
show checkout -- runtime-pointer.json
merge_local "$ROOT/bin/fm-merge-local.sh" 'the cure is no longer locked behind the symptom'
printf '\n(both operator documents are still on disk after the merge)\n'
printf '$ ls <project>/docs\n'
ls "$PROJ/docs" | sed 's/^/    /'

say 'ACT 4 - UNDER TEST: a nested untracked repository, which git status collapses to "vendor/"'
new_project fixed-nested-repo
mkdir -p "$PROJ/vendor"
printf 'upstream lib\n' > "$PROJ/vendor/lib.txt"
g add -A
g commit -qm 'vendor the library'
g checkout -q main
git init -q "$PROJ/vendor"
printf 'operator local checkout\n' > "$PROJ/vendor/lib.txt"
show status --porcelain --untracked-files=all
merge_local "$ROOT/bin/fm-merge-local.sh" "named by the guard, not left to git's own abort"
printf '\n(the operator vendor checkout is intact)\n'
printf '$ cat <project>/vendor/lib.txt\n'
sed 's/^/    /' "$PROJ/vendor/lib.txt"

say 'ACT 5 - UNDER TEST: a real conflicted rebase left in progress (detached HEAD)'
new_project fixed-rebase
g checkout -q main
g branch sideline
printf 'main side\n' >> "$PROJ/docs/notes.md"
g commit -qam 'main side'
g checkout -q sideline
printf 'other side\n' >> "$PROJ/docs/notes.md"
g commit -qam 'other side'
g checkout -q main
g branch -f "$BRANCH" main
g checkout -q "$BRANCH"
printf 'v2\n' > "$PROJ/src.txt"
g commit -qam 'crewmate work on src.txt'
g checkout -q sideline
g rebase main >/dev/null 2>&1 || true
show status --short --branch
merge_local "$ROOT/bin/fm-merge-local.sh" 'names the rebase, not an empty branch name'

say 'ACT 6 - UNDER TEST: a pending cherry-pick sequence that already advanced main past the task branch'
new_project fixed-sequence
printf 'v2\n' > "$PROJ/src.txt"
g commit -qam 'crewmate work on src.txt'
g checkout -q main
g branch sideline
printf 'main side\n' >> "$PROJ/docs/notes.md"
g commit -qam 'main side'
g checkout -q sideline
printf 'other side\n' >> "$PROJ/docs/notes.md"
g commit -qam 'other side'
printf 'tail\n' > "$PROJ/tail.txt"
g add -A
g commit -qm 'sequence tail'
g checkout -q main
g cherry-pick sideline~1 sideline >/dev/null 2>&1 || true
printf 'resolved\n' > "$PROJ/docs/notes.md"
g add docs/notes.md
g commit -qm 'resolve the conflicted pick'
show status --short --branch
printf '\n(main has genuinely diverged from the task branch - the sequence own commit did it)\n'
printf '$ git -C <project> merge-base --is-ancestor main %s\n' "$BRANCH"
set +e
g merge-base --is-ancestor main "$BRANCH"
printf '    [exit %s - nonzero means main is NOT an ancestor, so this is not a fast-forward]\n' "$?"
set -e
merge_local "$ROOT/bin/fm-merge-local.sh" 'the named state wins over the generic "has diverged, have the crewmate rebase"'

printf '\n'
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-merge-local.sh:202` - A half-finished operation still carrying live conflicts gets a different refusal depending only on whether HEAD is attached. On detached HEAD (conflicted rebase, bisect) the sentinels at line 148 fire first and the operator is told &#39;a rebase is in progress here; ... git rebase --abort&#39;. With HEAD attached (conflicted merge, cherry-pick, revert) the status listing runs first and the unmerged-code branch here refuses with &#34;unresolved merge conflict at &#39;&lt;path&gt;&#39;&#34; instead, so the operation is never named and the abort command is never offered - the sentinel call at line 230 is unreachable for that case. This is deliberate and documented at lines 226-229, and it does not violate the ordering constraint (the generic &#39;has diverged, have the crewmate rebase&#39; advice is still never reached), so it is noted as a tradeoff rather than a defect. Moving the single refuse_if_operation_in_progress call ahead of the listing would also collapse the two call sites into one.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-merge-local.test.sh` - all 27 cases pass (19 refusals, 7 proceeds, plus the deadlock regression)</code>
- <code>`bash bin/fm-test-run.sh --list --family pr-forge` - confirms tests/fm-merge-local.test.sh is registered and selectable by the runner</code>
- <code>Manual end-to-end demo `/tmp/no-mistakes-evidence/01KYFJDKAFVYN77RK1EKMJD35X/demo-merge-guard.sh`: real project checkouts, real crewmate branches, real git operations, gate action invoked by task id</code>
- <code>Before/after: same trees run against the baseline `bin/fm-merge-local.sh` extracted from a5fe1bc (blanket dirty-tree guard) and against the version under test</code>
- <code>Incident reproduction: two untracked operator PDFs (names with spaces) plus a locally modified machine-local `runtime-pointer.json` the incoming commit removes - refuses naming only the pointer, then lands after `git checkout -- runtime-pointer.json` with both PDFs intact</code>
- <code>Collapsed untracked directory: `git init vendor` inside the project so status reports the lone `?? vendor/` entry, with an incoming add at `vendor/lib.txt`</code>
- <code>Real conflicted `git rebase main` (detached HEAD) and a real two-commit `git cherry-pick sideline~1 sideline` whose resolved pick advanced main past the task branch</code>
- <code>Ordering mutation check: temporarily moved both `refuse_if_operation_in_progress` calls below the branch/fast-forward checks, re-ran the suite (failed at `refuse-pending-sequence`) and re-ran the demo to capture the wrong operator-visible advice, then reverted with `git checkout -- bin/fm-merge-local.sh`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
