### PR TITLE
feat(bin): carry no-agent-co-author rule in every generated brief

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -26,6 +26,8 @@
 #   The flag must be explicit because {TASK} is filled after scaffolding and the
 #   caller-supplied repo string cannot reliably identify this repo. Briefs made
 #   without it carry a loud declaration so an omitted contract cannot be silent.
+#   Every generated brief also carries the no-agent-co-author rule so worker
+#   instructions override any commit-message trailer habit.
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):
@@ -73,6 +75,7 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0
+COAUTHOR_RULE='1. Never add an agent name as a commit co-author.'
 POS=()
 for a in "$@"; do
   case "$a" in
@@ -148,6 +151,13 @@ Do not invent a second delegation system.
 You do not generate your own work.
 Act only on tasks the main firstmate routes to you.
 Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.
+
+# Rules
+1. Never add an agent name as a commit co-author.
+2. Report status by appending one line:
+   `echo "{state}: {one short line}" >> $STATUS_FILE`
+   States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+   Each append wakes firstmate, so report sparingly: only material phase changes, captain decisions, blockers, failures, or work ready for review.
 
 # Requests from the main firstmate
 You are a firstmate in your own home, so an incoming message reaches you in your own chat.
@@ -242,10 +252,11 @@ The worktree is your laboratory - install, run, edit, and make scratch commits f
 The report is the only thing that survives, so anything worth keeping must be in it.
 
 # Rules
-1. Never push to any remote and never open a PR.
-2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
-4. Report status by appending one line:
+$COAUTHOR_RULE
+2. Never push to any remote and never open a PR.
+3. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
+4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+5. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
@@ -351,8 +362,9 @@ If the top-level path is the primary checkout or not the worktree you were launc
 1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
 
 # Rules
+$COAUTHOR_RULE
 $RULE1
-2. Stay inside this worktree; modify nothing outside it.
+3. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -153,11 +153,7 @@ Act only on tasks the main firstmate routes to you.
 Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.
 
 # Rules
-1. Never add an agent name as a commit co-author.
-2. Report status by appending one line:
-   `echo "{state}: {one short line}" >> $STATUS_FILE`
-   States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
-   Each append wakes firstmate, so report sparingly: only material phase changes, captain decisions, blockers, failures, or work ready for review.
+$COAUTHOR_RULE
 
 # Requests from the main firstmate
 You are a firstmate in your own home, so an incoming message reaches you in your own chat.
@@ -266,11 +262,11 @@ $COAUTHOR_RULE
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
-5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions),
+6. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
+7. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
    When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
-7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
+8. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 
@@ -285,7 +281,7 @@ echo "scaffolded: $BRIEF (scout; replace {TASK})"
 exit 0
 fi
 
-# Ship task: shape Setup / Rule 1 / Definition of done by the project's delivery mode.
+# Ship task: shape Setup / Rule 2 / Definition of done by the project's delivery mode.
 # yolo does not affect the brief because the worker never owns approval decisions;
 # firstmate applies the authority contract in AGENTS.md section 7, so discard it.
 read -r MODE _ <<EOF
@@ -295,7 +291,7 @@ EOF
 case "$MODE" in
   direct-PR)
     SETUP2=""
-    RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    RULE1='2. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
@@ -307,7 +303,7 @@ EOF
     ;;
   local-only)
     SETUP2=""
-    RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
+    RULE1="2. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
     DOD=$(cat <<EOF
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
@@ -321,7 +317,7 @@ EOF
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
-    RULE1='1. Never push to the default branch. Never merge a PR.'
+    RULE1='2. Never push to the default branch. Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done
 The task is complete only when committed on your branch.
@@ -333,7 +329,7 @@ Follow the guidance no-mistakes itself provides for the mechanics: it loads when
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
+- ask-user findings are never yours to answer: escalate to firstmate (rule 7) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
@@ -365,8 +361,8 @@ If the top-level path is the primary checkout or not the worktree you were launc
 $COAUTHOR_RULE
 $RULE1
 3. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
-4. Report status by appending one line:
+4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+5. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
@@ -379,11 +375,11 @@ $RULE1
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
-5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
+6. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
+7. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
    When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
-7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
+8. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -26,8 +26,6 @@
 #   The flag must be explicit because {TASK} is filled after scaffolding and the
 #   caller-supplied repo string cannot reliably identify this repo. Briefs made
 #   without it carry a loud declaration so an omitted contract cannot be silent.
-#   Every generated brief also carries the no-agent-co-author rule so worker
-#   instructions override any commit-message trailer habit.
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):
@@ -37,6 +35,9 @@
 #                captain approves, firstmate merges to local main
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
+# Every scaffold - ship, scout, and secondmate charter - opens its Rules section
+# with the no-agent-co-author rule, so the brief the worker is following states it
+# and overrides any commit-message trailer habit of the harness.
 # Every scaffold's status protocol distinguishes the configured
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -65,6 +65,7 @@ test_ship_modes_generate_clean_briefs() {
     brief="$home/data/$id/brief.md"
     assert_present "$brief" "$id: brief was not scaffolded"
     assert_grep "# Definition of done" "$brief" "$id: brief missing Definition of done section"
+    assert_grep "Never add an agent name as a commit co-author." "$brief" "$id: brief missing the no-agent-co-author rule"
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
@@ -370,6 +371,7 @@ test_scout_and_secondmate_scaffold() {
   brief="$BRIEF_HOME/data/brief-scout-q6/brief.md"
   assert_present "$brief" "scout brief was not scaffolded"
   assert_grep "SCOUT task" "$brief" "scout brief must declare itself a scout task"
+  assert_grep "Never add an agent name as a commit co-author." "$brief" "scout brief must carry the no-agent-co-author rule"
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
 
   FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
@@ -377,6 +379,7 @@ test_scout_and_secondmate_scaffold() {
     || fail "fm-brief.sh secondmate scaffold exited non-zero"
   brief="$BRIEF_HOME/data/brief-sm-q6/brief.md"
   assert_present "$brief" "secondmate charter was not scaffolded"
+  assert_grep "Never add an agent name as a commit co-author." "$brief" "secondmate charter must carry the no-agent-co-author rule"
   assert_grep "persistent second mate" "$brief" \
     "secondmate charter must declare its role"
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"


### PR DESCRIPTION
## Intent

Validate and ship the brief scaffold change that makes every generated brief carry the no-agent-co-author rule, including ship, scout, and secondmate variants where applicable, while preserving the existing brief tests and shipping the committed branch through review, test, document, lint, push, PR, and CI to the captain's fork for a cross-fork PR into kunchenguid/firstmate.

## What Changed

- `bin/fm-brief.sh` now defines a single `COAUTHOR_RULE` string ("Never add an agent name as a commit co-author.") and emits it as the first entry of the Rules section in all three scaffold families: ship briefs (all delivery modes), scout briefs, and the secondmate charter, which gains a `# Rules` section for it.
- Renumbered the existing ship and scout rules from 1-7 to 2-8 to make room, including the per-mode `RULE1` strings, and updated the in-brief `(rule 6)` ask-user escalation cross-reference to `(rule 7)` plus the header comment describing the scaffold.
- `tests/fm-brief.test.sh` asserts the rule text is present in ship-mode briefs, scout briefs, and the secondmate charter; the full 15-test brief suite passes.

## Risk Assessment

✅ Low: The change is a bounded edit to generated brief text — one shared rule string added to three brief variants with consistent renumbering and an updated cross-reference — with no logic, control-flow, or downstream-parser impact, and test coverage added for all three variants.

## Testing

Ran the targeted brief suite (all 15 checks pass, including the three new co-author assertions) and then verified the intent on the real product artifact by scaffolding all seven brief variants — three ship delivery modes, herdr-lab, scout, and both secondmate forms — and reading the generated brief.md files. Every variant carries "Never add an agent name as a commit co-author." as rule 1, numbering is contiguous 1-8 in ship and scout briefs, and the in-brief "(rule 7)" ask-user cross-reference resolves to the correct needs-decision rule. Regenerating the same briefs from base commit a5fe1bc confirms the rule was genuinely absent before and that every subsequent rule shifted by exactly one, so the captured before/after is a real behavioral delta rather than a green-test claim. Three adjacent suites that consume brief text (ask-user authority, secondmate safety, instruction owners) also pass. No screenshot or rendered-UI artifact applies here: the change has no UI surface — the end-user experience is the generated markdown brief a crewmate reads, so the brief text itself is the correct product-level evidence and is captured verbatim. Worktree left clean.

<details>
<summary>Evidence: Before/after of the generated brief Rules section (base a5fe1bc vs 1e9e3ea)</summary>

<code>### ship-nomistakes&#10;--- BEFORE ---&#10;# Rules&#10;1. Never push to the default branch. Never merge a PR.&#10;2. Stay inside this worktree; modify nothing outside it.&#10;3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.&#10;4. Report status by appending one line:&#10;5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.&#10;6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),&#10;7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving&#10;--- AFTER ----&#10;# Rules&#10;1. Never add an agent name as a commit co-author.&#10;2. Never push to the default branch. Never merge a PR.&#10;3. Stay inside this worktree; modify nothing outside it.&#10;4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.&#10;5. Report status by appending one line:&#10;6. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.&#10;7. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),&#10;8. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving&#10;&#10;### scout-task&#10;--- BEFORE ---&#10;# Rules&#10;1. Never push to any remote and never open a PR.&#10;2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.&#10;3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.&#10;4. Report status by appending one line:&#10;5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.&#10;6. If a decision belongs to a human (product choices, destructive actions),&#10;7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving&#10;--- AFTER ----&#10;# Rules&#10;1. Never add an agent name as a commit co-author.&#10;2. Never push to any remote and never open a PR.&#10;3. Stay inside this worktree; the only files you may write outside it are the report and the status file below.&#10;4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.&#10;5. Report status by appending one line:&#10;6. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.&#10;7. If a decision belongs to a human (product choices, destructive actions),&#10;8. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving&#10;&#10;### sm-alpha (secondmate charter)&#10;--- BEFORE ---&#10;(no &#39;# Rules&#39; section in this brief)&#10;--- AFTER ----&#10;# Rules&#10;1. Never add an agent name as a commit co-author.&#10;&#10;co-author rule presence:&#10;ship-nomistakes before=absent after=present&#10;scout-task before=absent after=present&#10;sm-alpha before=absent after=present</code>

```text
Generated brief "# Rules" section — BEFORE (base a5fe1bc) vs AFTER (1e9e3ea)
Command: fm-brief.sh <id> <repo> [--scout | --secondmate --no-projects]

### ship-nomistakes
--- BEFORE ---
# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
--- AFTER ----
# Rules
1. Never add an agent name as a commit co-author.
2. Never push to the default branch. Never merge a PR.
3. Stay inside this worktree; modify nothing outside it.
4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
5. Report status by appending one line:
6. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
7. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
8. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving

### scout-task
--- BEFORE ---
# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
--- AFTER ----
# Rules
1. Never add an agent name as a commit co-author.
2. Never push to any remote and never open a PR.
3. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
5. Report status by appending one line:
6. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
7. If a decision belongs to a human (product choices, destructive actions),
8. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving

### sm-alpha
--- BEFORE ---
(no '# Rules' section in this brief)
--- AFTER ----
# Rules
1. Never add an agent name as a commit co-author.

co-author rule presence:
  ship-nomistakes  before=absent  after=present
  scout-task       before=absent  after=present
  sm-alpha         before=absent  after=present
```
</details>
<details>
<summary>Evidence: Full Rules section of all 7 generated brief variants</summary>

```text
====================================================================
  ship-nomistakes  ->  data/ship-nomistakes/brief.md
====================================================================
# Rules
1. Never add an agent name as a commit co-author.
2. Never push to the default branch. Never merge a PR.
3. Stay inside this worktree; modify nothing outside it.
4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
5. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KYFQS3Q5JVKQVKR0EGV6FYJS/fmhome/state/ship-nomistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
6. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
7. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
8. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.


====================================================================
  ship-directpr  ->  data/ship-directpr/brief.md
====================================================================
# Rules
1. Never add an agent name as a commit co-author.
2. Never push to the default branch (push only your `fm/ship-directpr` branch). Never merge a PR.
3. Stay inside this worktree; modify nothing outside it.
4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
5. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KYFQS3Q5JVKQVKR0EGV6FYJS/fmhome/state/ship-directpr.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
6. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
7. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
8. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.


====================================================================
  ship-localonly  ->  data/ship-localonly/brief.md
====================================================================
# Rules
1. Never add an agent name as a commit co-author.
2. Never push to any remote and never open a PR. Work only on your `fm/ship-localonly` branch; firstmate handles the merge into local `main`.
3. Stay inside this worktree; modify nothing outside it.
4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
5. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KYFQS3Q5JVKQVKR0EGV6FYJS/fmhome/state/ship-localonly.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
6. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
7. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
8. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.


====================================================================
  ship-herdr  ->  data/ship-herdr/brief.md
====================================================================
# Rules
1. Never add an agent name as a commit co-author.
2. Never push to the default branch. Never merge a PR.
3. Stay inside this worktree; modify nothing outside it.
4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
5. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KYFQS3Q5JVKQVKR0EGV6FYJS/fmhome/state/ship-herdr.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
6. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
7. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
8. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.


====================================================================
  scout-task  ->  data/scout-task/brief.md
====================================================================
# Rules
1. Never add an agent name as a commit co-author.
2. Never push to any remote and never open a PR.
3. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
5. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KYFQS3Q5JVKQVKR0EGV6FYJS/fmhome/state/scout-task.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
6. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
7. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
8. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.


====================================================================
  sm-alpha  ->  data/sm-alpha/brief.md
====================================================================
# Rules
1. Never add an agent name as a commit co-author.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.


====================================================================
  sm-noproj  ->  data/sm-noproj/brief.md
====================================================================
# Rules
1. Never add an agent name as a commit co-author.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.
```
</details>
- Evidence: Generated briefs (real fm-brief.sh output tree: ship x3, herdr-lab, scout, secondmate x2) (local file: <code>/tmp/no-mistakes-evidence/01KYFQS3Q5JVKQVKR0EGV6FYJS/fmhome/data</code>)
<details>
<summary>Evidence: Targeted test runs</summary>

```text
$ bash tests/fm-brief.test.sh
ok - fm-brief.sh: bash -n succeeds
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs

$ rule numbering audit over generated briefs
ship-nomistakes numbering: [1 2 3 4 5 6 7 8] xrefs: [rule 7]
ship-directpr numbering: [1 2 3 4 5 6 7 8] xrefs: []
ship-localonly numbering: [1 2 3 4 5 6 7 8] xrefs: []
ship-herdr numbering: [1 2 3 4 5 6 7 8] xrefs: [rule 7]
scout-task numbering: [1 2 3 4 5 6 7 8] xrefs: []
sm-alpha numbering: [1]
sm-noproj numbering: [1]

$ bash tests/fm-ask-user-authority.test.sh -> all ok
$ bash tests/fm-secondmate-safety.test.sh -> all ok
$ bash tests/fm-instruction-owners.test.sh -> all ok
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-brief.sh:366` - The ship brief&#39;s Rules list is now mis-numbered. $COAUTHOR_RULE emits &#39;1.&#39; (line 365) and $RULE1 still emits &#39;1.&#39; in all three delivery modes (lines 298, 310, 324), so the generated brief has two rule 1s; line 367 was bumped to &#39;3.&#39; while line 368 was left at &#39;3.&#39;, so there is no rule 2 and two rule 3s. Rendered order is 1, 1, 3, 3, 4, 5, 6, 7. Fix by making the three RULE1 strings start with &#39;2.&#39; and shifting lines 367-388 to 3-8 -- and note that the &#39;(rule 6)&#39; cross-reference at line 336 points at the needs-decision rule, which becomes rule 7 after the shift, so it must be updated in the same pass. The stale comment at line 288 (&#39;shape Setup / Rule 1 / ...&#39;) should also say rule 2.
- 🚨 `bin/fm-brief.sh:269` - The scout brief now has two rules numbered &#39;5.&#39;: the status-reporting rule was renumbered 4 -&gt; 5 (line 259) but the pre-existing &#39;5. If you hit the same obstacle twice&#39; (line 269) was not shifted. Rendered order is 1, 2, 3, 4, 5, 5, 6, 7. Bump lines 269, 270 and 273 to 6, 7 and 8.
- ⚠️ `bin/fm-brief.sh:157` - The new secondmate &#39;# Rules&#39; section adds a status-reporting rule (rule 2) on top of the co-author rule, but the charter already specifies status reporting in the &#39;# Escalation to main firstmate&#39; section (lines 174-188) in more detail (paused-vs-blocked semantics, corr= correlation, keyed phases, no receipt &#39;working:&#39; lines). The new rule is a shorter, partially conflicting restatement that goes beyond the stated goal of carrying the no-agent-co-author rule. Consider limiting the new section to the co-author rule alone.
- ℹ️ `bin/fm-brief.sh:156` - The secondmate heredoc hardcodes the co-author rule text instead of interpolating $COAUTHOR_RULE (the heredoc is unquoted, so the variable would expand). Editing the variable would silently leave the secondmate charter behind, and all three tests assert the same literal string. Use $COAUTHOR_RULE here for a single source of truth.

🔧 Fix: fix brief rule numbering and secondmate co-author rule
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` — full brief suite, 15/15 pass including the 3 new co-author assertions</code>
- <code>Manual end-to-end scaffold of all 7 generation paths: `bin/fm-brief.sh ship-nomistakes some-proj`, `... ship-directpr direct-proj`, `... ship-localonly local-proj`, `... ship-herdr some-proj --herdr-lab`, `... scout-task some-proj --scout`, `... sm-alpha --secondmate direct-proj`, `... sm-noproj --secondmate --no-projects`</code>
- <code>Rule-numbering audit of each generated `brief.md`: confirmed contiguous `1 2 3 4 5 6 7 8` with no gaps/duplicates, and that the in-brief `(rule 7)` ask-user cross-reference resolves to the needs-decision rule</code>
- <code>Baseline regeneration from base commit `a5fe1bc` (temp copy of `bin/` so sourced sibling libs resolve) to prove the co-author rule was absent before and numbering shifted by exactly one</code>
- <code>`bash tests/fm-ask-user-authority.test.sh` — covers the renumbered `rule 6`→`rule 7` escalation reference</code>
- <code>`bash tests/fm-secondmate-safety.test.sh` — covers the secondmate charter that gained a new `# Rules` section</code>
- <code>`bash tests/fm-instruction-owners.test.sh` — covers instruction/ownership wording across briefs</code>
- <code>`git status --porcelain` — worktree clean, no transient test artifacts left behind</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-brief.sh:76` - The no-agent-co-author sentence now exists in three places: AGENTS.md:44 (captain-facing prime-directive scope for firstmate&#39;s own repo), .agents/skills/firstmate-coding-guidelines/SKILL.md:96 (contributor style rule), and the generated brief literal in bin/fm-brief.sh (worker instruction for every project). I deliberately did not add a fourth copy to AGENTS.md section 11 or CONTRIBUTING.md, because section 11 already delegates generated-variant facts to the script and its help, which I updated. The first two copies predate this change and serve genuinely different audiences, so consolidating them is out of scope here; flagging the judgment call so a reviewer can confirm the placement rather than expecting synchronized prose.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
