### PR TITLE
feat: expand harness supervision and Herdr activity visibility

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -109,6 +109,12 @@ FM_BACKEND_HERDR_SECONDMATE_MARKER=".fm-secondmate-home"
 # spawn can replace one verified agent-free husk under the session lock.
 # No send, capture, Treehouse, or general task-ownership path reads it.
 FM_BACKEND_HERDR_PRESENTATION_JOURNAL_SUFFIX=".herdr-presentation"
+# A Herdr-backed Pi worker keeps its native `agent=pi` identity and receives a
+# task-specific human-facing `name` through Herdr's agent.rename API after Pi
+# registers on the pane.
+# The bounded poll never renames a shell or a different detected harness.
+FM_BACKEND_HERDR_PI_RENAME_POLLS=${FM_BACKEND_HERDR_PI_RENAME_POLLS:-50}
+FM_BACKEND_HERDR_PI_RENAME_POLL_SLEEP=${FM_BACKEND_HERDR_PI_RENAME_POLL_SLEEP:-0.2}
 
 # fm_backend_herdr_workspace_label: the per-firstmate-HOME herdr workspace
 # label (docs/herdr-backend.md "Default task container shape"). The PRIMARY home (no
@@ -133,6 +139,68 @@ fm_backend_herdr_workspace_label() {
     fi
   fi
   printf 'firstmate'
+}
+
+# fm_backend_herdr_pi_worker_name: build the unique human-facing name for one
+# Firstmate-spawned Pi worker.
+# The owner/task prefix keeps the name meaningful in Herdr's agent sidebar, and
+# the exact response-derived pane id makes it unique even if two homes sharing a
+# Herdr session happen to reuse an owner label and task id.
+# The native Herdr identity remains `agent=pi`; this is only AgentInfo.name.
+fm_backend_herdr_pi_worker_name() { # <owner-label> <task-id> <kind> <pane-id>
+  local owner=$1 task=$2 kind=$3 pane=$4 subject
+  if [ "$owner" != firstmate ] \
+     && ! printf '%s\n' "$owner" | grep -Eq '^2ndmate-[A-Za-z0-9._-]+$'; then
+    return 1
+  fi
+  case "$task" in
+    ''|.*|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  case "$pane" in
+    ''|*[!A-Za-z0-9:_-]*) return 1 ;;
+  esac
+  if [ "$kind" = secondmate ]; then
+    subject=$owner
+  else
+    subject="$owner/$task"
+  fi
+  printf 'Pi · %s [%s]' "$subject" "$pane"
+}
+
+# fm_backend_herdr_name_pi_worker: wait only for a native Pi registration, then
+# set its human-facing Herdr name through agent.rename and verify the response.
+# A detected non-Pi identity returns 2 without mutation.
+# An absent/unreadable identity or rename failure returns 1 after a bounded wait.
+fm_backend_herdr_name_pi_worker() { # <target> <human-name>
+  local target=$1 human_name=$2 polls sleep_s attempt=0 out identity current renamed
+  fm_backend_herdr_parse_target "$target" || return 1
+  polls=$FM_BACKEND_HERDR_PI_RENAME_POLLS
+  sleep_s=$FM_BACKEND_HERDR_PI_RENAME_POLL_SLEEP
+  case "$polls" in ''|*[!0-9]*|0) polls=50 ;; esac
+  if ! printf '%s\n' "$sleep_s" | grep -Eq '^[0-9]+([.][0-9]+)?$'; then
+    sleep_s=0.2
+  fi
+  printf '%s\n' "$human_name" \
+    | grep -Eq '^Pi · (firstmate|2ndmate-[A-Za-z0-9._-]+)(/[A-Za-z0-9._-]+)? \[[A-Za-z0-9:_-]+\]$' \
+    || return 1
+  [ "${#human_name}" -le 192 ] || return 1
+  while [ "$attempt" -lt "$polls" ]; do
+    out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" agent get "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || out=
+    identity=$(printf '%s' "$out" | jq -r '.result.agent.agent // empty' 2>/dev/null)
+    current=$(printf '%s' "$out" | jq -r '.result.agent.name // empty' 2>/dev/null)
+    if [ "$identity" = pi ]; then
+      [ "$current" = "$human_name" ] && return 0
+      renamed=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" agent rename "$FM_BACKEND_HERDR_PANE" "$human_name" 2>/dev/null) || return 1
+      printf '%s' "$renamed" | jq -e --arg want "$human_name" '
+        .result.agent.agent == "pi" and .result.agent.name == $want
+      ' >/dev/null 2>&1 || return 1
+      return 0
+    fi
+    [ -z "$identity" ] || return 2
+    attempt=$((attempt + 1))
+    [ "$attempt" -ge "$polls" ] || sleep "$sleep_s"
+  done
+  return 1
 }
 
 # fm_backend_herdr_cli: run `herdr <args...>` scoped to <session>, setting

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -62,6 +62,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-nm-status-lib.sh
+. "$SCRIPT_DIR/fm-nm-status-lib.sh"
 
 ID=${1:-}
 [ -n "$ID" ] || { echo "usage: fm-crew-state.sh <id>" >&2; exit 2; }
@@ -194,18 +196,10 @@ crew_pane_is_busy() {  # <target>
 # --- no-mistakes run lookup (authoritative when a run matches this branch) --
 
 trim() {
-  local s=${1:-}
-  s="${s#"${s%%[![:space:]]*}"}"
-  s="${s%"${s##*[![:space:]]}"}"
-  printf '%s' "$s"
+  fm_nm_status_trim "${1:-}"
 }
 strip_quotes() {
-  local s
-  s=$(trim "${1:-}")
-  case "$s" in
-    \"*\") s=${s#\"}; s=${s%\"} ;;
-  esac
-  trim "$s"
+  fm_nm_status_strip_quotes "${1:-}"
 }
 
 # Bounded no-mistakes call in the worktree; stdout only, never fails the script.
@@ -226,7 +220,8 @@ nm_run() {  # <args...>
 # Scalar value of a TOON key in the captured run output ($RUN_OUT).
 RUN_OUT=""
 nm_field() {  # <key>
-  printf '%s\n' "$RUN_OUT" | sed -n "s/^[[:space:]]*$1:[[:space:]]*\(.*\)/\1/p" | head -1
+  FM_NM_STATUS_OUT=$RUN_OUT
+  fm_nm_status_field "$1"
 }
 # Finding count from a findings[N]{...} table header; empty when none.
 nm_findings_count() {
@@ -294,12 +289,11 @@ log_reports_ci_ready() {
 }
 
 nm_ci_step_status() {
-  local row rest
-  row=$(printf '%s\n' "$RUN_OUT" | grep -E '^[[:space:]]*ci,[[:space:]]*"?(running|fixing)"?[[:space:]]*,' | head -1)
-  [ -n "$row" ] || return 0
-  row=$(trim "$row")
-  rest=${row#*,}
-  strip_quotes "$(trim "${rest%%,*}")"
+  FM_NM_STATUS_OUT=$RUN_OUT
+  fm_nm_status_parse_step ci
+  case "$FM_NM_STATUS_STEP_STATUS" in
+    running|fixing) printf '%s' "$FM_NM_STATUS_STEP_STATUS" ;;
+  esac
 }
 
 nm_effective_ci_step_status() {
@@ -419,31 +413,16 @@ CREW_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true
 #     advanced outside the run)
 #   - diverged / run head not in this worktree: no match (rewritten branch tip)
 nm_run_head_matches_worktree() {
-  local run_head local_full run_full
+  local run_head
   run_head=$(strip_quotes "$(nm_field head)")
-  [ -n "$run_head" ] || return 1
-  local_full=$(git -C "$WT" rev-parse HEAD 2>/dev/null) || return 1
-  run_full=$(git -C "$WT" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
-  [ "$run_full" = "$local_full" ] && return 0
-  if git -C "$WT" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null; then
-    return 0
-  fi
-  return 1
+  fm_nm_run_head_matches "$WT" "$run_head"
 }
 
 # Coarse runs-list rows are "<status> <branch> <short-sha> ...". 0 if the short
 # sha for this branch row matches the worktree head under the same rules as
 # nm_run_head_matches_worktree (equal, or local is ancestor of run tip).
 nm_coarse_head_matches_worktree() {  # <short-sha>
-  local run_head=$1 local_full run_full
-  [ -n "$run_head" ] || return 1
-  local_full=$(git -C "$WT" rev-parse HEAD 2>/dev/null) || return 1
-  run_full=$(git -C "$WT" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
-  [ "$run_full" = "$local_full" ] && return 0
-  if git -C "$WT" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null; then
-    return 0
-  fi
-  return 1
+  fm_nm_run_head_matches "$WT" "$1"
 }
 
 HAVE_RUN=0

--- a/bin/fm-herdr-nm-visibility-lib.sh
+++ b/bin/fm-herdr-nm-visibility-lib.sh
@@ -40,9 +40,15 @@ FM_NM_VISIBILITY_ACTIVE_TTL_MS=${FM_NM_VISIBILITY_ACTIVE_TTL_MS:-45000}
 FM_NM_VISIBILITY_TERMINAL_TTL_MS=${FM_NM_VISIBILITY_TERMINAL_TTL_MS:-30000}
 FM_NM_VISIBILITY_TIMEOUT=${FM_NM_VISIBILITY_TIMEOUT:-3}
 FM_NM_VISIBILITY_REVIEW_LOG_TAIL=${FM_NM_VISIBILITY_REVIEW_LOG_TAIL:-200}
+FM_NM_VISIBILITY_MAX_TASKS_PER_CYCLE=${FM_NM_VISIBILITY_MAX_TASKS_PER_CYCLE:-1}
 
 _FM_NM_VISIBILITY_CAP_YES="|"
 _FM_NM_VISIBILITY_CAP_NO="|"
+_FM_NM_VISIBILITY_REFRESH_CURSOR=
+
+FM_NM_VISIBILITY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=bin/fm-nm-status-lib.sh
+. "$FM_NM_VISIBILITY_ROOT/bin/fm-nm-status-lib.sh"
 
 fm_nm_visibility_now() {
   if [ -n "${FM_NM_VISIBILITY_NOW:-}" ]; then
@@ -117,49 +123,41 @@ fm_nm_visibility_bounded_no_mistakes() { # <worktree> <args...>
   esac
 }
 
+fm_nm_visibility_bounded_herdr_schema() { # <session>
+  local session=$1 timeout_kind=none
+  fm_nm_visibility_positive_integer "$FM_NM_VISIBILITY_TIMEOUT" || return 1
+  if command -v timeout >/dev/null 2>&1; then
+    timeout_kind=timeout
+  elif command -v gtimeout >/dev/null 2>&1; then
+    timeout_kind=gtimeout
+  elif command -v perl >/dev/null 2>&1; then
+    timeout_kind=perl
+  fi
+  case "$timeout_kind" in
+    timeout) HERDR_SESSION="$session" timeout "$FM_NM_VISIBILITY_TIMEOUT" herdr api schema --json --session "$session" 2>/dev/null ;;
+    gtimeout) HERDR_SESSION="$session" gtimeout "$FM_NM_VISIBILITY_TIMEOUT" herdr api schema --json --session "$session" 2>/dev/null ;;
+    perl)
+      HERDR_SESSION="$session" perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$FM_NM_VISIBILITY_TIMEOUT" herdr api schema --json --session "$session" 2>/dev/null
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 FM_NM_VISIBILITY_STATUS_OUT=
 fm_nm_visibility_status_field() { # <key>
-  printf '%s\n' "$FM_NM_VISIBILITY_STATUS_OUT" \
-    | sed -n "s/^[[:space:]]*$1:[[:space:]]*\(.*\)/\1/p" \
-    | head -1
+  FM_NM_STATUS_OUT=$FM_NM_VISIBILITY_STATUS_OUT
+  fm_nm_status_field "$1"
 }
 
 FM_NM_VISIBILITY_REVIEW_STATUS=
 FM_NM_VISIBILITY_REVIEW_ELAPSED_MS=0
 fm_nm_visibility_parse_review_row() {
-  local row rest status duration
   FM_NM_VISIBILITY_REVIEW_STATUS=
   FM_NM_VISIBILITY_REVIEW_ELAPSED_MS=0
-  row=$(printf '%s\n' "$FM_NM_VISIBILITY_STATUS_OUT" \
-    | grep -E '^[[:space:]]*review,[[:space:]]*' \
-    | head -1)
-  [ -n "$row" ] || return 0
-  row=$(fm_nm_visibility_trim "$row")
-  rest=${row#*,}
-  status=$(fm_nm_visibility_strip_quotes "${rest%%,*}")
-  duration=${row##*,}
-  duration=$(fm_nm_visibility_strip_quotes "$duration")
-  case "$status" in
-    running|fixing|awaiting_approval|fix_review|completed|failed|cancelled|timed-out|timed_out|timeout|pending|skipped)
-      FM_NM_VISIBILITY_REVIEW_STATUS=$status
-      ;;
-    *) return 0 ;;
-  esac
-  case "$duration" in
-    ''|*[!0-9]*) duration=0 ;;
-  esac
-  FM_NM_VISIBILITY_REVIEW_ELAPSED_MS=$duration
-}
-
-fm_nm_visibility_run_head_matches() { # <worktree> <run-head>
-  local worktree=$1 run_head=$2 local_full run_full
-  case "$run_head" in
-    ''|*[!0-9a-fA-F]*) return 1 ;;
-  esac
-  local_full=$(git -C "$worktree" rev-parse HEAD 2>/dev/null) || return 1
-  run_full=$(git -C "$worktree" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
-  [ "$run_full" = "$local_full" ] && return 0
-  git -C "$worktree" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
+  FM_NM_STATUS_OUT=$FM_NM_VISIBILITY_STATUS_OUT
+  fm_nm_status_parse_step review
+  FM_NM_VISIBILITY_REVIEW_STATUS=$FM_NM_STATUS_STEP_STATUS
+  FM_NM_VISIBILITY_REVIEW_ELAPSED_MS=$FM_NM_STATUS_STEP_DURATION_MS
 }
 
 fm_nm_visibility_digits() { # <value>
@@ -291,7 +289,7 @@ fm_nm_visibility_observe() { # <worktree>
   run_head=$(fm_nm_visibility_strip_quotes "$(fm_nm_visibility_status_field head)")
   run_id=$(fm_nm_visibility_strip_quotes "$(fm_nm_visibility_status_field id)")
   [ "$run_branch" = "$branch" ] || return 0
-  fm_nm_visibility_run_head_matches "$worktree" "$run_head" || return 0
+  fm_nm_run_head_matches "$worktree" "$run_head" || return 0
   case "$run_id" in
     ''|*[!A-Za-z0-9_-]*|????????????????????????????????????????????????????????????????*) return 0 ;;
   esac
@@ -356,7 +354,7 @@ fm_nm_visibility_observe() { # <worktree>
       activity=review-timed-out
     fi
   fi
-  if [ -z "$state" ] && [ "$outcome" = failed ] && [ "$FM_NM_VISIBILITY_REVIEW_STATUS" = failed ]; then
+  if [ -z "$state" ] && [ "$outcome" = failed ]; then
     state=failed
     phase=terminal
     activity=review-failed
@@ -504,7 +502,7 @@ fm_nm_visibility_herdr_metadata_capable() { # <session>
   case "$_FM_NM_VISIBILITY_CAP_YES" in *"$key"*) return 0 ;; esac
   case "$_FM_NM_VISIBILITY_CAP_NO" in *"$key"*) return 1 ;; esac
   command -v jq >/dev/null 2>&1 || { _FM_NM_VISIBILITY_CAP_NO="$_FM_NM_VISIBILITY_CAP_NO$session|"; return 1; }
-  schema=$(fm_backend_herdr_cli "$session" api schema --json 2>/dev/null) || {
+  schema=$(fm_nm_visibility_bounded_herdr_schema "$session") || {
     _FM_NM_VISIBILITY_CAP_NO="$_FM_NM_VISIBILITY_CAP_NO$session|"
     return 1
   }
@@ -700,13 +698,35 @@ fm_nm_visibility_refresh_task() { # <state-dir> <task-id>
 }
 
 fm_nm_visibility_refresh_all() { # <state-dir>
-  local state_dir=$1 meta task cache base
+  local state_dir=$1 meta task cache base count=0 max_tasks start_after cursor_seen
   [ -d "$state_dir" ] || return 0
+  max_tasks=$FM_NM_VISIBILITY_MAX_TASKS_PER_CYCLE
+  fm_nm_visibility_positive_integer "$max_tasks" || max_tasks=1
+  start_after=$_FM_NM_VISIBILITY_REFRESH_CURSOR
+  [ -z "$start_after" ] && cursor_seen=1 || cursor_seen=0
   for meta in "$state_dir"/*.meta; do
     [ -e "$meta" ] || continue
     task=$(basename "$meta" .meta)
+    if [ "$cursor_seen" = 0 ]; then
+      [ "$task" = "$start_after" ] && cursor_seen=1
+      continue
+    fi
     fm_nm_visibility_refresh_task "$state_dir" "$task" || true
+    _FM_NM_VISIBILITY_REFRESH_CURSOR=$task
+    count=$((count + 1))
+    [ "$count" -ge "$max_tasks" ] && break
   done
+  if [ "$count" -lt "$max_tasks" ] && [ -n "$start_after" ]; then
+    for meta in "$state_dir"/*.meta; do
+      [ -e "$meta" ] || continue
+      task=$(basename "$meta" .meta)
+      [ "$task" = "$start_after" ] && break
+      fm_nm_visibility_refresh_task "$state_dir" "$task" || true
+      _FM_NM_VISIBILITY_REFRESH_CURSOR=$task
+      count=$((count + 1))
+      [ "$count" -ge "$max_tasks" ] && break
+    done
+  fi
   for cache in "$state_dir"/*"$FM_NM_VISIBILITY_CACHE_SUFFIX"; do
     [ -e "$cache" ] || continue
     base=$(basename "$cache")

--- a/bin/fm-herdr-nm-visibility-lib.sh
+++ b/bin/fm-herdr-nm-visibility-lib.sh
@@ -123,8 +123,9 @@ fm_nm_visibility_bounded_no_mistakes() { # <worktree> <args...>
   esac
 }
 
-fm_nm_visibility_bounded_herdr_schema() { # <session>
+fm_nm_visibility_bounded_herdr() { # <session> <args...>
   local session=$1 timeout_kind=none
+  shift
   fm_nm_visibility_positive_integer "$FM_NM_VISIBILITY_TIMEOUT" || return 1
   if command -v timeout >/dev/null 2>&1; then
     timeout_kind=timeout
@@ -134,10 +135,10 @@ fm_nm_visibility_bounded_herdr_schema() { # <session>
     timeout_kind=perl
   fi
   case "$timeout_kind" in
-    timeout) HERDR_SESSION="$session" timeout "$FM_NM_VISIBILITY_TIMEOUT" herdr api schema --json --session "$session" 2>/dev/null ;;
-    gtimeout) HERDR_SESSION="$session" gtimeout "$FM_NM_VISIBILITY_TIMEOUT" herdr api schema --json --session "$session" 2>/dev/null ;;
+    timeout) HERDR_SESSION="$session" timeout "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@" --session "$session" 2>/dev/null ;;
+    gtimeout) HERDR_SESSION="$session" gtimeout "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@" --session "$session" 2>/dev/null ;;
     perl)
-      HERDR_SESSION="$session" perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$FM_NM_VISIBILITY_TIMEOUT" herdr api schema --json --session "$session" 2>/dev/null
+      HERDR_SESSION="$session" perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@" --session "$session" 2>/dev/null
       ;;
     *) return 1 ;;
   esac
@@ -502,7 +503,7 @@ fm_nm_visibility_herdr_metadata_capable() { # <session>
   case "$_FM_NM_VISIBILITY_CAP_YES" in *"$key"*) return 0 ;; esac
   case "$_FM_NM_VISIBILITY_CAP_NO" in *"$key"*) return 1 ;; esac
   command -v jq >/dev/null 2>&1 || { _FM_NM_VISIBILITY_CAP_NO="$_FM_NM_VISIBILITY_CAP_NO$session|"; return 1; }
-  schema=$(fm_nm_visibility_bounded_herdr_schema "$session") || {
+  schema=$(fm_nm_visibility_bounded_herdr "$session" api schema --json) || {
     _FM_NM_VISIBILITY_CAP_NO="$_FM_NM_VISIBILITY_CAP_NO$session|"
     return 1
   }
@@ -551,7 +552,7 @@ fm_nm_visibility_report() { # <target> <identity> <role> <state> <phase> <elapse
   working_label="worker working · $child_summary"
   blocked_label="worker waiting · $child_summary"
   unknown_label=$child_summary
-  fm_backend_herdr_cli "$session" pane report-metadata "$pane" \
+  fm_nm_visibility_bounded_herdr "$session" pane report-metadata "$pane" \
     --source "$FM_NM_VISIBILITY_SOURCE" \
     --title "$title" \
     --display-agent "$display_agent" \
@@ -573,7 +574,7 @@ fm_nm_visibility_clear() { # <target>
   fm_backend_herdr_parse_target "$target" || return 1
   session=$FM_BACKEND_HERDR_SESSION
   pane=$FM_BACKEND_HERDR_PANE
-  fm_backend_herdr_cli "$session" pane report-metadata "$pane" \
+  fm_nm_visibility_bounded_herdr "$session" pane report-metadata "$pane" \
     --source "$FM_NM_VISIBILITY_SOURCE" \
     --clear-title \
     --clear-display-agent \

--- a/bin/fm-herdr-nm-visibility-lib.sh
+++ b/bin/fm-herdr-nm-visibility-lib.sh
@@ -1,0 +1,640 @@
+#!/usr/bin/env bash
+# Read-only No Mistakes child-activity projection for Herdr-backed Firstmate workers.
+#
+# This file is the authoritative owner of the observation format, privacy filter,
+# Herdr metadata shape, terminal-retention window, and cleanup state machine.
+# The watcher calls fm_nm_visibility_refresh_all once per supervision cycle.
+# Only ship tasks with mode=no-mistakes and backend=herdr are eligible.
+#
+# No Mistakes remains the sole lifecycle and structured-output owner.
+# This observer invokes only `no-mistakes axi status` and the bounded tail form
+# of `no-mistakes axi logs --step review`; it never responds, aborts, starts,
+# resumes, or otherwise controls a run.
+#
+# Herdr 0.7.4 has no nested-agent or child-agent relationship in protocol 16.
+# The supported observational fallback is pane.report_metadata on the owning
+# worker's existing pane.
+# It changes only a source-scoped title, state labels, and five allowlisted tokens.
+# It never creates a pane, reports an agent, changes agent authority, or exposes
+# an independently addressable target.
+#
+# Privacy is allowlist-only.
+# Run ids, roles, states, phases, numeric elapsed time, and fixed activity enums
+# may reach Herdr.
+# Prompt text, agent prose, paths, credentials, commands, pids, raw errors, and
+# raw log lines never do.
+#
+# Active and waiting metadata carries a short renewable TTL.
+# Failed, timed-out, and completed transitions carry a shorter one-shot TTL.
+# A private state/<id>.herdr-nm-activity cache prevents terminal states from
+# being republished forever and is not task metadata, lifecycle authority, a
+# dispatch record, or a fleet member.
+# Expiry is enforced twice: Herdr's TTL removes abandoned metadata by itself,
+# and the next watcher cycle clears this source explicitly and retires the cache.
+
+FM_NM_VISIBILITY_SOURCE=firstmate.no-mistakes
+FM_NM_VISIBILITY_CACHE_SUFFIX=.herdr-nm-activity
+FM_NM_VISIBILITY_ACTIVE_TTL_MS=${FM_NM_VISIBILITY_ACTIVE_TTL_MS:-45000}
+FM_NM_VISIBILITY_TERMINAL_TTL_MS=${FM_NM_VISIBILITY_TERMINAL_TTL_MS:-30000}
+FM_NM_VISIBILITY_TIMEOUT=${FM_NM_VISIBILITY_TIMEOUT:-3}
+
+_FM_NM_VISIBILITY_CAP_YES="|"
+_FM_NM_VISIBILITY_CAP_NO="|"
+
+fm_nm_visibility_now() {
+  if [ -n "${FM_NM_VISIBILITY_NOW:-}" ]; then
+    printf '%s' "$FM_NM_VISIBILITY_NOW"
+  else
+    date +%s
+  fi
+}
+
+fm_nm_visibility_positive_integer() { # <value>
+  case "$1" in
+    ''|*[!0-9]*|0) return 1 ;;
+  esac
+  return 0
+}
+
+fm_nm_visibility_ttl() { # <active|terminal>
+  local value
+  case "$1" in
+    active) value=$FM_NM_VISIBILITY_ACTIVE_TTL_MS ;;
+    terminal) value=$FM_NM_VISIBILITY_TERMINAL_TTL_MS ;;
+    *) return 1 ;;
+  esac
+  fm_nm_visibility_positive_integer "$value" || return 1
+  [ "$value" -le 86400000 ] || return 1
+  printf '%s' "$value"
+}
+
+fm_nm_visibility_trim() {
+  local value=${1:-}
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+fm_nm_visibility_strip_quotes() {
+  local value
+  value=$(fm_nm_visibility_trim "${1:-}")
+  case "$value" in
+    \"*\") value=${value#\"}; value=${value%\"} ;;
+  esac
+  fm_nm_visibility_trim "$value"
+}
+
+fm_nm_visibility_bounded_no_mistakes() { # <worktree> <args...>
+  local worktree=$1 timeout_kind=none
+  shift
+  fm_nm_visibility_positive_integer "$FM_NM_VISIBILITY_TIMEOUT" || return 1
+  if command -v timeout >/dev/null 2>&1; then
+    timeout_kind=timeout
+  elif command -v gtimeout >/dev/null 2>&1; then
+    timeout_kind=gtimeout
+  elif command -v perl >/dev/null 2>&1; then
+    timeout_kind=perl
+  fi
+  case "$timeout_kind" in
+    timeout) ( cd "$worktree" && timeout "$FM_NM_VISIBILITY_TIMEOUT" no-mistakes "$@" ) 2>/dev/null ;;
+    gtimeout) ( cd "$worktree" && gtimeout "$FM_NM_VISIBILITY_TIMEOUT" no-mistakes "$@" ) 2>/dev/null ;;
+    perl)
+      ( cd "$worktree" && perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$FM_NM_VISIBILITY_TIMEOUT" no-mistakes "$@" ) 2>/dev/null
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+FM_NM_VISIBILITY_STATUS_OUT=
+fm_nm_visibility_status_field() { # <key>
+  printf '%s\n' "$FM_NM_VISIBILITY_STATUS_OUT" \
+    | sed -n "s/^[[:space:]]*$1:[[:space:]]*\(.*\)/\1/p" \
+    | head -1
+}
+
+FM_NM_VISIBILITY_REVIEW_STATUS=
+FM_NM_VISIBILITY_REVIEW_ELAPSED_MS=0
+fm_nm_visibility_parse_review_row() {
+  local row rest status duration
+  FM_NM_VISIBILITY_REVIEW_STATUS=
+  FM_NM_VISIBILITY_REVIEW_ELAPSED_MS=0
+  row=$(printf '%s\n' "$FM_NM_VISIBILITY_STATUS_OUT" \
+    | grep -E '^[[:space:]]*review,[[:space:]]*' \
+    | head -1)
+  [ -n "$row" ] || return 0
+  row=$(fm_nm_visibility_trim "$row")
+  rest=${row#*,}
+  status=$(fm_nm_visibility_strip_quotes "${rest%%,*}")
+  duration=${row##*,}
+  duration=$(fm_nm_visibility_strip_quotes "$duration")
+  case "$status" in
+    running|fixing|awaiting_approval|fix_review|completed|failed|cancelled|timed-out|timed_out|timeout|pending|skipped)
+      FM_NM_VISIBILITY_REVIEW_STATUS=$status
+      ;;
+    *) return 0 ;;
+  esac
+  case "$duration" in
+    ''|*[!0-9]*) duration=0 ;;
+  esac
+  FM_NM_VISIBILITY_REVIEW_ELAPSED_MS=$duration
+}
+
+fm_nm_visibility_run_head_matches() { # <worktree> <run-head>
+  local worktree=$1 run_head=$2 local_full run_full
+  case "$run_head" in
+    ''|*[!0-9a-fA-F]*) return 1 ;;
+  esac
+  local_full=$(git -C "$worktree" rev-parse HEAD 2>/dev/null) || return 1
+  run_full=$(git -C "$worktree" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
+  [ "$run_full" = "$local_full" ] && return 0
+  git -C "$worktree" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
+}
+
+FM_NM_VISIBILITY_LOG_ROLE=
+FM_NM_VISIBILITY_LOG_PHASE=
+FM_NM_VISIBILITY_LOG_ACTIVITY=
+fm_nm_visibility_review_log_hints() { # <worktree> <run-id> <initial-role> <initial-phase>
+  local worktree=$1 run_id=$2 line trimmed
+  FM_NM_VISIBILITY_LOG_ROLE=$3
+  FM_NM_VISIBILITY_LOG_PHASE=$4
+  FM_NM_VISIBILITY_LOG_ACTIVITY=
+  while IFS= read -r line; do
+    trimmed=$(fm_nm_visibility_trim "$line")
+    case "$trimmed" in
+      'asking agent to fix identified issues...')
+        FM_NM_VISIBILITY_LOG_ROLE=fixer
+        FM_NM_VISIBILITY_LOG_PHASE=fix
+        FM_NM_VISIBILITY_LOG_ACTIVITY=applying-selected-fixes
+        ;;
+      'reviewing changes...')
+        FM_NM_VISIBILITY_LOG_ROLE=reviewer
+        FM_NM_VISIBILITY_LOG_PHASE=review
+        FM_NM_VISIBILITY_LOG_ACTIVITY=reviewing-changes
+        ;;
+      'committed agent fixes:'*)
+        FM_NM_VISIBILITY_LOG_ROLE=fixer
+        FM_NM_VISIBILITY_LOG_PHASE=fix
+        FM_NM_VISIBILITY_LOG_ACTIVITY=fixes-committed
+        ;;
+      *)
+        if printf '%s\n' "$trimmed" | grep -Eq '^user-fix round starting after round [0-9]+ \([0-9]+ findings? selected\)$'; then
+          FM_NM_VISIBILITY_LOG_ROLE=fixer
+          FM_NM_VISIBILITY_LOG_PHASE=fix
+          FM_NM_VISIBILITY_LOG_ACTIVITY=fix-round-started
+        elif printf '%s\n' "$trimmed" | grep -Eq '^[A-Za-z0-9._-]+ started pid=[0-9]+$'; then
+          FM_NM_VISIBILITY_LOG_ACTIVITY=child-started
+        elif printf '%s\n' "$trimmed" | grep -Eq '^[A-Za-z0-9._-]+ exited pid=[0-9]+ status=success$'; then
+          FM_NM_VISIBILITY_LOG_ACTIVITY=child-finished
+        elif printf '%s\n' "$trimmed" | grep -Eq '^[A-Za-z0-9._-]+ exited pid=[0-9]+ error='; then
+          FM_NM_VISIBILITY_LOG_ACTIVITY=child-failed
+        fi
+        ;;
+    esac
+  done < <(fm_nm_visibility_bounded_no_mistakes "$worktree" axi logs --step review --run "$run_id" || true)
+}
+
+fm_nm_visibility_observation_reset() {
+  FM_NM_VISIBILITY_OBS_PRESENT=0
+  FM_NM_VISIBILITY_OBS_RUN_ID=
+  FM_NM_VISIBILITY_OBS_ROLE=
+  FM_NM_VISIBILITY_OBS_STATE=
+  FM_NM_VISIBILITY_OBS_PHASE=
+  FM_NM_VISIBILITY_OBS_ELAPSED_MS=0
+  FM_NM_VISIBILITY_OBS_ACTIVITY=
+}
+
+fm_nm_visibility_observe() { # <worktree>
+  local worktree=$1 branch run_branch run_head run_id status outcome gate role state phase activity
+  fm_nm_visibility_observation_reset
+  command -v no-mistakes >/dev/null 2>&1 || return 1
+  branch=$(git -C "$worktree" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+  [ -n "$branch" ] || return 1
+  FM_NM_VISIBILITY_STATUS_OUT=$(fm_nm_visibility_bounded_no_mistakes "$worktree" axi status) || return 1
+  [ -n "$FM_NM_VISIBILITY_STATUS_OUT" ] || return 1
+
+  run_branch=$(fm_nm_visibility_strip_quotes "$(fm_nm_visibility_status_field branch)")
+  run_head=$(fm_nm_visibility_strip_quotes "$(fm_nm_visibility_status_field head)")
+  run_id=$(fm_nm_visibility_strip_quotes "$(fm_nm_visibility_status_field id)")
+  [ "$run_branch" = "$branch" ] || return 0
+  fm_nm_visibility_run_head_matches "$worktree" "$run_head" || return 0
+  case "$run_id" in
+    ''|*[!A-Za-z0-9_-]*|????????????????????????????????????????????????????????????????*) return 0 ;;
+  esac
+
+  status=$(fm_nm_visibility_strip_quotes "$(fm_nm_visibility_status_field status)")
+  outcome=$(fm_nm_visibility_strip_quotes "$(fm_nm_visibility_status_field outcome)")
+  gate=$(fm_nm_visibility_strip_quotes "$(fm_nm_visibility_status_field gate)")
+  fm_nm_visibility_parse_review_row
+
+  role=reviewer
+  state=
+  phase=review
+  activity=reviewing
+  case "$FM_NM_VISIBILITY_REVIEW_STATUS" in
+    running)
+      state=working
+      ;;
+    fixing)
+      role=fixer
+      state=working
+      phase=fix
+      activity=applying-fixes
+      ;;
+    awaiting_approval|fix_review)
+      state=waiting-for-captain
+      phase=decision
+      activity=decision-requested
+      ;;
+    failed|cancelled)
+      state=failed
+      phase=terminal
+      activity=review-failed
+      ;;
+    timed-out|timed_out|timeout)
+      state=timed-out
+      phase=terminal
+      activity=review-timed-out
+      ;;
+    completed)
+      state=completed
+      phase=terminal
+      activity=review-completed
+      ;;
+  esac
+
+  if [ -z "$state" ] && [ "$status" = fixing ]; then
+    role=fixer
+    state=working
+    phase=fix
+    activity=applying-fixes
+  fi
+  if [ -z "$state" ] && { [ "$status" = awaiting_approval ] || [ "$status" = fix_review ]; }; then
+    if [ "$gate" = review ] || printf '%s\n' "$FM_NM_VISIBILITY_STATUS_OUT" | grep -Eq '^[[:space:]]*step:[[:space:]]*review[[:space:]]*$'; then
+      state=waiting-for-captain
+      phase=decision
+      activity=decision-requested
+    fi
+  fi
+  if [ "$state" = failed ]; then
+    if printf '%s\n' "$FM_NM_VISIBILITY_STATUS_OUT" | grep -Eiq '^[[:space:]]*error:.*(timed out|timeout)'; then
+      state=timed-out
+      activity=review-timed-out
+    fi
+  fi
+  if [ -z "$state" ] && [ "$outcome" = failed ] && [ "$FM_NM_VISIBILITY_REVIEW_STATUS" = failed ]; then
+    state=failed
+    phase=terminal
+    activity=review-failed
+  fi
+  [ -n "$state" ] || return 0
+
+  case "$state" in
+    working|failed|timed-out)
+      fm_nm_visibility_review_log_hints "$worktree" "$run_id" "$role" "$phase"
+      role=$FM_NM_VISIBILITY_LOG_ROLE
+      phase=$FM_NM_VISIBILITY_LOG_PHASE
+      [ -z "$FM_NM_VISIBILITY_LOG_ACTIVITY" ] || activity=$FM_NM_VISIBILITY_LOG_ACTIVITY
+      ;;
+  esac
+  if [ "$state" = timed-out ]; then
+    activity=review-timed-out
+    phase=terminal
+  elif [ "$state" = failed ]; then
+    activity=review-failed
+    phase=terminal
+  fi
+
+  FM_NM_VISIBILITY_OBS_PRESENT=1
+  FM_NM_VISIBILITY_OBS_RUN_ID=$run_id
+  FM_NM_VISIBILITY_OBS_ROLE=$role
+  FM_NM_VISIBILITY_OBS_STATE=$state
+  FM_NM_VISIBILITY_OBS_PHASE=$phase
+  FM_NM_VISIBILITY_OBS_ELAPSED_MS=$FM_NM_VISIBILITY_REVIEW_ELAPSED_MS
+  FM_NM_VISIBILITY_OBS_ACTIVITY=$activity
+  return 0
+}
+
+fm_nm_visibility_cache_path() { # <state-dir> <task-id>
+  printf '%s/%s%s' "$1" "$2" "$FM_NM_VISIBILITY_CACHE_SUFFIX"
+}
+
+fm_nm_visibility_cache_reset() {
+  FM_NM_VISIBILITY_CACHE_VALID=0
+  FM_NM_VISIBILITY_CACHE_RUN_ID=
+  FM_NM_VISIBILITY_CACHE_ROLE=
+  FM_NM_VISIBILITY_CACHE_STATE=
+  FM_NM_VISIBILITY_CACHE_PHASE=
+  FM_NM_VISIBILITY_CACHE_ELAPSED_MS=0
+  FM_NM_VISIBILITY_CACHE_OBSERVED_EPOCH=0
+  FM_NM_VISIBILITY_CACHE_TERMINAL_UNTIL=0
+}
+
+fm_nm_visibility_cache_load() { # <path>
+  local path=$1 version lines key value seen="|"
+  fm_nm_visibility_cache_reset
+  [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  lines=$(wc -l < "$path" 2>/dev/null | tr -d '[:space:]')
+  [ "$lines" = 8 ] || return 1
+  while IFS='=' read -r key value || [ -n "$key$value" ]; do
+    case "$seen" in *"|$key|"*) return 1 ;; esac
+    seen="$seen$key|"
+    case "$key" in
+      version) version=$value ;;
+      run_id) FM_NM_VISIBILITY_CACHE_RUN_ID=$value ;;
+      role) FM_NM_VISIBILITY_CACHE_ROLE=$value ;;
+      state) FM_NM_VISIBILITY_CACHE_STATE=$value ;;
+      phase) FM_NM_VISIBILITY_CACHE_PHASE=$value ;;
+      elapsed_ms) FM_NM_VISIBILITY_CACHE_ELAPSED_MS=$value ;;
+      observed_epoch) FM_NM_VISIBILITY_CACHE_OBSERVED_EPOCH=$value ;;
+      terminal_until) FM_NM_VISIBILITY_CACHE_TERMINAL_UNTIL=$value ;;
+      *) return 1 ;;
+    esac
+  done < "$path"
+  [ "${version:-}" = 1 ] || return 1
+  case "$FM_NM_VISIBILITY_CACHE_RUN_ID" in ''|*[!A-Za-z0-9_-]*) return 1 ;; esac
+  case "$FM_NM_VISIBILITY_CACHE_ROLE" in reviewer|fixer) ;; *) return 1 ;; esac
+  case "$FM_NM_VISIBILITY_CACHE_STATE" in working|waiting-for-captain|failed|timed-out|completed|retired) ;; *) return 1 ;; esac
+  case "$FM_NM_VISIBILITY_CACHE_PHASE" in review|fix|decision|terminal) ;; *) return 1 ;; esac
+  case "$FM_NM_VISIBILITY_CACHE_ELAPSED_MS" in ''|*[!0-9]*) return 1 ;; esac
+  case "$FM_NM_VISIBILITY_CACHE_OBSERVED_EPOCH" in ''|*[!0-9]*) return 1 ;; esac
+  case "$FM_NM_VISIBILITY_CACHE_TERMINAL_UNTIL" in ''|*[!0-9]*) return 1 ;; esac
+  FM_NM_VISIBILITY_CACHE_VALID=1
+  return 0
+}
+
+fm_nm_visibility_cache_write() { # <path> <run> <role> <state> <phase> <elapsed-ms> <observed-epoch> <terminal-until>
+  local path=$1 run_id=$2 role=$3 state=$4 phase=$5 elapsed=$6 observed=$7 until=$8 tmp
+  case "$run_id" in ''|*[!A-Za-z0-9_-]*) return 1 ;; esac
+  case "$role" in reviewer|fixer) ;; *) return 1 ;; esac
+  case "$state" in working|waiting-for-captain|failed|timed-out|completed|retired) ;; *) return 1 ;; esac
+  case "$phase" in review|fix|decision|terminal) ;; *) return 1 ;; esac
+  case "$elapsed:$observed:$until" in *[!0-9:]*|::*|:*:|*::*) return 1 ;; esac
+  mkdir -p "$(dirname "$path")" || return 1
+  tmp=$(mktemp "${path}.XXXXXX") || return 1
+  chmod 0600 "$tmp" || { rm -f "$tmp"; return 1; }
+  {
+    printf 'version=1\n'
+    printf 'run_id=%s\n' "$run_id"
+    printf 'role=%s\n' "$role"
+    printf 'state=%s\n' "$state"
+    printf 'phase=%s\n' "$phase"
+    printf 'elapsed_ms=%s\n' "$elapsed"
+    printf 'observed_epoch=%s\n' "$observed"
+    printf 'terminal_until=%s\n' "$until"
+  } > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv -f "$tmp" "$path"
+}
+
+fm_nm_visibility_format_elapsed() { # <milliseconds>
+  local milliseconds=$1 seconds hours minutes
+  case "$milliseconds" in ''|*[!0-9]*) milliseconds=0 ;; esac
+  seconds=$((milliseconds / 1000))
+  if [ "$seconds" -lt 1 ]; then
+    printf '<1s'
+  elif [ "$seconds" -lt 60 ]; then
+    printf '%ss' "$seconds"
+  elif [ "$seconds" -lt 3600 ]; then
+    minutes=$((seconds / 60))
+    seconds=$((seconds % 60))
+    if [ "$seconds" -eq 0 ]; then printf '%sm' "$minutes"; else printf '%sm%ss' "$minutes" "$seconds"; fi
+  else
+    hours=$((seconds / 3600))
+    minutes=$(((seconds % 3600) / 60))
+    if [ "$minutes" -eq 0 ]; then printf '%sh' "$hours"; else printf '%sh%sm' "$hours" "$minutes"; fi
+  fi
+}
+
+fm_nm_visibility_activity_label() { # <activity-enum>
+  case "$1" in
+    reviewing) printf 'reviewing' ;;
+    reviewing-changes) printf 'reviewing changes' ;;
+    applying-fixes) printf 'applying fixes' ;;
+    applying-selected-fixes) printf 'applying selected fixes' ;;
+    fix-round-started) printf 'fix round started' ;;
+    fixes-committed) printf 'fixes committed' ;;
+    child-started) printf 'child started' ;;
+    child-finished) printf 'child finished' ;;
+    child-failed) printf 'child failed' ;;
+    decision-requested) printf 'decision requested' ;;
+    review-failed) printf 'review failed' ;;
+    review-timed-out) printf 'review timed out' ;;
+    review-completed) printf 'review completed' ;;
+    *) printf 'activity updated' ;;
+  esac
+}
+
+fm_nm_visibility_herdr_metadata_capable() { # <session>
+  local session=$1 key schema
+  key="|$session|"
+  case "$_FM_NM_VISIBILITY_CAP_YES" in *"$key"*) return 0 ;; esac
+  case "$_FM_NM_VISIBILITY_CAP_NO" in *"$key"*) return 1 ;; esac
+  command -v jq >/dev/null 2>&1 || { _FM_NM_VISIBILITY_CAP_NO="$_FM_NM_VISIBILITY_CAP_NO$session|"; return 1; }
+  schema=$(fm_backend_herdr_cli "$session" api schema --json 2>/dev/null) || {
+    _FM_NM_VISIBILITY_CAP_NO="$_FM_NM_VISIBILITY_CAP_NO$session|"
+    return 1
+  }
+  if printf '%s' "$schema" | jq -e '
+    any(.schemas.request.oneOf[]?; .properties.method.const == "pane.report_metadata")
+    and (.schemas.request["$defs"].PaneReportMetadataParams.required | index("pane_id") != null)
+    and (.schemas.request["$defs"].PaneReportMetadataParams.required | index("source") != null)
+    and (.schemas.request["$defs"].PaneReportMetadataParams.properties.title.type != null)
+    and (.schemas.request["$defs"].PaneReportMetadataParams.properties.state_labels.type == "object")
+    and (.schemas.request["$defs"].PaneReportMetadataParams.properties.tokens.type == "object")
+    and (.schemas.request["$defs"].PaneReportMetadataParams.properties.ttl_ms.maximum >= 86400000)
+  ' >/dev/null 2>&1; then
+    _FM_NM_VISIBILITY_CAP_YES="$_FM_NM_VISIBILITY_CAP_YES$session|"
+    return 0
+  fi
+  _FM_NM_VISIBILITY_CAP_NO="$_FM_NM_VISIBILITY_CAP_NO$session|"
+  return 1
+}
+
+fm_nm_visibility_report() { # <target> <identity> <role> <state> <phase> <elapsed-ms> <activity> <active|terminal>
+  local target=$1 identity=$2 role=$3 state=$4 phase=$5 elapsed_ms=$6 activity=$7 ttl_kind=$8
+  local session pane ttl elapsed activity_label title child_summary display_agent idle_label working_label blocked_label unknown_label
+  if printf '%s\n' "$identity" | grep -Eq '^task [A-Za-z0-9._-]{1,64}$'; then
+    :
+  elif printf '%s\n' "$identity" | grep -Eq '^Pi · (firstmate|2ndmate-[A-Za-z0-9._-]+)(/[A-Za-z0-9._-]+)? \[[A-Za-z0-9:_-]+\]$'; then
+    :
+  else
+    return 1
+  fi
+  [ "${#identity}" -le 192 ] || return 1
+  case "$role" in reviewer|fixer) ;; *) return 1 ;; esac
+  case "$state" in working|waiting-for-captain|failed|timed-out|completed) ;; *) return 1 ;; esac
+  case "$phase" in review|fix|decision|terminal) ;; *) return 1 ;; esac
+  case "$activity" in reviewing|reviewing-changes|applying-fixes|applying-selected-fixes|fix-round-started|fixes-committed|child-started|child-finished|child-failed|decision-requested|review-failed|review-timed-out|review-completed) ;; *) return 1 ;; esac
+  case "$elapsed_ms" in ''|*[!0-9]*) return 1 ;; esac
+  ttl=$(fm_nm_visibility_ttl "$ttl_kind") || return 1
+  fm_backend_herdr_parse_target "$target" || return 1
+  session=$FM_BACKEND_HERDR_SESSION
+  pane=$FM_BACKEND_HERDR_PANE
+  elapsed=$(fm_nm_visibility_format_elapsed "$elapsed_ms")
+  activity_label=$(fm_nm_visibility_activity_label "$activity")
+  title="$identity · No Mistakes $role · $state · $elapsed · $activity_label"
+  child_summary="No Mistakes $role $state · $elapsed"
+  display_agent="$identity · $child_summary · $activity_label"
+  idle_label="worker idle · $child_summary"
+  working_label="worker working · $child_summary"
+  blocked_label="worker waiting · $child_summary"
+  unknown_label=$child_summary
+  fm_backend_herdr_cli "$session" pane report-metadata "$pane" \
+    --source "$FM_NM_VISIBILITY_SOURCE" \
+    --title "$title" \
+    --display-agent "$display_agent" \
+    --state-label "idle=$idle_label" \
+    --state-label "working=$working_label" \
+    --state-label "blocked=$blocked_label" \
+    --state-label "unknown=$unknown_label" \
+    --token "nm_role=$role" \
+    --token "nm_state=$state" \
+    --token "nm_phase=$phase" \
+    --token "nm_elapsed=$elapsed" \
+    --token "nm_activity=$activity" \
+    --token "nm_summary=$role $state · $elapsed · $activity_label" \
+    --ttl-ms "$ttl" >/dev/null 2>&1
+}
+
+fm_nm_visibility_clear() { # <target>
+  local target=$1 session pane
+  fm_backend_herdr_parse_target "$target" || return 1
+  session=$FM_BACKEND_HERDR_SESSION
+  pane=$FM_BACKEND_HERDR_PANE
+  fm_backend_herdr_cli "$session" pane report-metadata "$pane" \
+    --source "$FM_NM_VISIBILITY_SOURCE" \
+    --clear-title \
+    --clear-display-agent \
+    --clear-state-labels \
+    --clear-token nm_role \
+    --clear-token nm_state \
+    --clear-token nm_phase \
+    --clear-token nm_elapsed \
+    --clear-token nm_activity \
+    --clear-token nm_summary >/dev/null 2>&1
+}
+
+fm_nm_visibility_effective_elapsed() { # <now> <observed-ms> <cache-valid>
+  local now=$1 observed_ms=$2 cache_valid=$3 delta
+  case "$observed_ms" in ''|*[!0-9]*) observed_ms=0 ;; esac
+  if [ "$observed_ms" -gt 0 ] || [ "$cache_valid" != 1 ]; then
+    printf '%s' "$observed_ms"
+    return 0
+  fi
+  delta=$((now - FM_NM_VISIBILITY_CACHE_OBSERVED_EPOCH))
+  [ "$delta" -lt 0 ] && delta=0
+  printf '%s' $((FM_NM_VISIBILITY_CACHE_ELAPSED_MS + delta * 1000))
+}
+
+fm_nm_visibility_retire_if_due() { # <target> <cache-path> <now>
+  local target=$1 cache=$2 now=$3 active_ttl active_deadline
+  [ "$FM_NM_VISIBILITY_CACHE_VALID" = 1 ] || return 0
+  case "$FM_NM_VISIBILITY_CACHE_STATE" in
+    failed|timed-out|completed)
+      if [ "$now" -ge "$FM_NM_VISIBILITY_CACHE_TERMINAL_UNTIL" ]; then
+        fm_nm_visibility_clear "$target" || return 1
+        fm_nm_visibility_cache_write "$cache" "$FM_NM_VISIBILITY_CACHE_RUN_ID" \
+          "$FM_NM_VISIBILITY_CACHE_ROLE" retired terminal \
+          "$FM_NM_VISIBILITY_CACHE_ELAPSED_MS" "$now" 0
+      fi
+      ;;
+    working|waiting-for-captain)
+      active_ttl=$(fm_nm_visibility_ttl active) || return 1
+      active_deadline=$((FM_NM_VISIBILITY_CACHE_OBSERVED_EPOCH + (active_ttl + 999) / 1000))
+      if [ "$now" -ge "$active_deadline" ]; then
+        fm_nm_visibility_clear "$target" || true
+        rm -f "$cache"
+      fi
+      ;;
+  esac
+}
+
+fm_nm_visibility_refresh_task() { # <state-dir> <task-id>
+  local state_dir=$1 task_id=$2 meta backend mode kind harness worktree target session pane owner identity cache now cache_valid=0
+  local role state phase elapsed activity ttl until prior_role
+  case "$task_id" in ''|.*|*[!A-Za-z0-9._-]*) return 0 ;; esac
+  meta="$state_dir/$task_id.meta"
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 0
+  backend=$(fm_backend_of_meta "$meta")
+  [ "$backend" = herdr ] || return 0
+  mode=$(fm_meta_get "$meta" mode)
+  kind=$(fm_meta_get "$meta" kind)
+  [ "$mode" = no-mistakes ] && { [ -z "$kind" ] || [ "$kind" = ship ]; } || return 0
+  harness=$(fm_meta_get "$meta" harness)
+  worktree=$(fm_meta_get "$meta" worktree)
+  target=$(fm_backend_target_of_meta "$meta")
+  [ -d "$worktree" ] && [ -n "$target" ] || return 0
+  fm_backend_source herdr >/dev/null 2>&1 || return 0
+  fm_backend_herdr_parse_target "$target" || return 0
+  session=$FM_BACKEND_HERDR_SESSION
+  pane=$FM_BACKEND_HERDR_PANE
+  identity="task $task_id"
+  if [ "$harness" = pi ]; then
+    owner=$(fm_backend_herdr_workspace_label)
+    identity=$(fm_backend_herdr_pi_worker_name "$owner" "$task_id" "$kind" "$pane") || identity="task $task_id"
+  fi
+  cache=$(fm_nm_visibility_cache_path "$state_dir" "$task_id")
+  if fm_nm_visibility_cache_load "$cache"; then cache_valid=1; else rm -f "$cache"; fi
+  if ! fm_nm_visibility_herdr_metadata_capable "$session"; then
+    rm -f "$cache"
+    return 0
+  fi
+  now=$(fm_nm_visibility_now)
+  case "$now" in ''|*[!0-9]*) return 0 ;; esac
+
+  if ! fm_nm_visibility_observe "$worktree"; then
+    fm_nm_visibility_retire_if_due "$target" "$cache" "$now" || true
+    return 0
+  fi
+  if [ "$FM_NM_VISIBILITY_OBS_PRESENT" != 1 ]; then
+    fm_nm_visibility_retire_if_due "$target" "$cache" "$now" || true
+    return 0
+  fi
+
+  role=$FM_NM_VISIBILITY_OBS_ROLE
+  state=$FM_NM_VISIBILITY_OBS_STATE
+  phase=$FM_NM_VISIBILITY_OBS_PHASE
+  activity=$FM_NM_VISIBILITY_OBS_ACTIVITY
+  elapsed=$(fm_nm_visibility_effective_elapsed "$now" "$FM_NM_VISIBILITY_OBS_ELAPSED_MS" "$cache_valid")
+  case "$state" in
+    working|waiting-for-captain)
+      fm_nm_visibility_report "$target" "$identity" "$role" "$state" "$phase" "$elapsed" "$activity" active || return 0
+      fm_nm_visibility_cache_write "$cache" "$FM_NM_VISIBILITY_OBS_RUN_ID" "$role" "$state" "$phase" "$elapsed" "$now" 0 || true
+      ;;
+    failed|timed-out|completed)
+      [ "$cache_valid" = 1 ] || return 0
+      [ "$FM_NM_VISIBILITY_CACHE_RUN_ID" = "$FM_NM_VISIBILITY_OBS_RUN_ID" ] || return 0
+      case "$FM_NM_VISIBILITY_CACHE_STATE" in
+        retired) return 0 ;;
+        failed|timed-out|completed)
+          fm_nm_visibility_retire_if_due "$target" "$cache" "$now" || true
+          return 0
+          ;;
+        working|waiting-for-captain) ;;
+        *) return 0 ;;
+      esac
+      prior_role=$FM_NM_VISIBILITY_CACHE_ROLE
+      [ "$state" = completed ] && role=$prior_role
+      ttl=$(fm_nm_visibility_ttl terminal) || return 0
+      until=$((now + (ttl + 999) / 1000))
+      fm_nm_visibility_report "$target" "$identity" "$role" "$state" terminal "$elapsed" "$activity" terminal || return 0
+      fm_nm_visibility_cache_write "$cache" "$FM_NM_VISIBILITY_OBS_RUN_ID" "$role" "$state" terminal "$elapsed" "$now" "$until" || true
+      ;;
+  esac
+}
+
+fm_nm_visibility_refresh_all() { # <state-dir>
+  local state_dir=$1 meta task cache base
+  [ -d "$state_dir" ] || return 0
+  for meta in "$state_dir"/*.meta; do
+    [ -e "$meta" ] || continue
+    task=$(basename "$meta" .meta)
+    fm_nm_visibility_refresh_task "$state_dir" "$task" || true
+  done
+  for cache in "$state_dir"/*"$FM_NM_VISIBILITY_CACHE_SUFFIX"; do
+    [ -e "$cache" ] || continue
+    base=$(basename "$cache")
+    task=${base%"$FM_NM_VISIBILITY_CACHE_SUFFIX"}
+    [ -f "$state_dir/$task.meta" ] || rm -f "$cache"
+  done
+  return 0
+}

--- a/bin/fm-herdr-nm-visibility-lib.sh
+++ b/bin/fm-herdr-nm-visibility-lib.sh
@@ -71,6 +71,15 @@ fm_nm_visibility_ttl() { # <active|terminal>
   printf '%s' "$value"
 }
 
+fm_nm_visibility_review_log_tail() {
+  local value=$FM_NM_VISIBILITY_REVIEW_LOG_TAIL
+  if fm_nm_visibility_positive_integer "$value" && [ "$value" -le 10000 ]; then
+    printf '%s' "$value"
+  else
+    printf '%s' 200
+  fi
+}
+
 fm_nm_visibility_trim() {
   local value=${1:-}
   value="${value#"${value%%[![:space:]]*}"}"
@@ -217,7 +226,8 @@ FM_NM_VISIBILITY_LOG_ROLE=
 FM_NM_VISIBILITY_LOG_PHASE=
 FM_NM_VISIBILITY_LOG_ACTIVITY=
 fm_nm_visibility_review_log_hints() { # <worktree> <run-id> <initial-role> <initial-phase>
-  local worktree=$1 run_id=$2 line trimmed
+  local worktree=$1 run_id=$2 line trimmed tail_lines
+  tail_lines=$(fm_nm_visibility_review_log_tail)
   FM_NM_VISIBILITY_LOG_ROLE=$3
   FM_NM_VISIBILITY_LOG_PHASE=$4
   FM_NM_VISIBILITY_LOG_ACTIVITY=
@@ -255,7 +265,7 @@ fm_nm_visibility_review_log_hints() { # <worktree> <run-id> <initial-role> <init
         fi
         ;;
     esac
-  done < <(fm_nm_visibility_bounded_no_mistakes "$worktree" axi logs --step review --run "$run_id" 2>/dev/null | tail -n "$FM_NM_VISIBILITY_REVIEW_LOG_TAIL" || true)
+  done < <(fm_nm_visibility_bounded_no_mistakes "$worktree" axi logs --step review --run "$run_id" 2>/dev/null | tail -n "$tail_lines" || true)
 }
 
 fm_nm_visibility_observation_reset() {
@@ -578,10 +588,10 @@ fm_nm_visibility_clear() { # <target>
     --clear-token nm_summary >/dev/null 2>&1
 }
 
-fm_nm_visibility_effective_elapsed() { # <now> <observed-ms> <cache-valid>
-  local now=$1 observed_ms=$2 cache_valid=$3 delta
+fm_nm_visibility_effective_elapsed() { # <now> <observed-ms> <cache-usable-for-this-run>
+  local now=$1 observed_ms=$2 cache_usable=$3 delta
   case "$observed_ms" in ''|*[!0-9]*) observed_ms=0 ;; esac
-  if [ "$observed_ms" -gt 0 ] || [ "$cache_valid" != 1 ]; then
+  if [ "$observed_ms" -gt 0 ] || [ "$cache_usable" != 1 ]; then
     printf '%s' "$observed_ms"
     return 0
   fi
@@ -615,7 +625,7 @@ fm_nm_visibility_retire_if_due() { # <target> <cache-path> <now>
 
 fm_nm_visibility_refresh_task() { # <state-dir> <task-id>
   local state_dir=$1 task_id=$2 meta backend mode kind harness worktree target session pane owner identity cache now cache_valid=0
-  local role state phase elapsed activity ttl until prior_role
+  local role state phase elapsed activity ttl until prior_role cache_same_run=0
   case "$task_id" in ''|.*|*[!A-Za-z0-9._-]*) return 0 ;; esac
   meta="$state_dir/$task_id.meta"
   [ -f "$meta" ] && [ ! -L "$meta" ] || return 0
@@ -659,15 +669,17 @@ fm_nm_visibility_refresh_task() { # <state-dir> <task-id>
   state=$FM_NM_VISIBILITY_OBS_STATE
   phase=$FM_NM_VISIBILITY_OBS_PHASE
   activity=$FM_NM_VISIBILITY_OBS_ACTIVITY
-  elapsed=$(fm_nm_visibility_effective_elapsed "$now" "$FM_NM_VISIBILITY_OBS_ELAPSED_MS" "$cache_valid")
+  if [ "$cache_valid" = 1 ] && [ "$FM_NM_VISIBILITY_CACHE_RUN_ID" = "$FM_NM_VISIBILITY_OBS_RUN_ID" ]; then
+    cache_same_run=1
+  fi
+  elapsed=$(fm_nm_visibility_effective_elapsed "$now" "$FM_NM_VISIBILITY_OBS_ELAPSED_MS" "$cache_same_run")
   case "$state" in
     working|waiting-for-captain)
       fm_nm_visibility_report "$target" "$identity" "$role" "$state" "$phase" "$elapsed" "$activity" active || return 0
       fm_nm_visibility_cache_write "$cache" "$FM_NM_VISIBILITY_OBS_RUN_ID" "$role" "$state" "$phase" "$elapsed" "$now" 0 || true
       ;;
     failed|timed-out|completed)
-      [ "$cache_valid" = 1 ] || return 0
-      [ "$FM_NM_VISIBILITY_CACHE_RUN_ID" = "$FM_NM_VISIBILITY_OBS_RUN_ID" ] || return 0
+      [ "$cache_same_run" = 1 ] || return 0
       case "$FM_NM_VISIBILITY_CACHE_STATE" in
         retired) return 0 ;;
         failed|timed-out|completed)

--- a/bin/fm-herdr-nm-visibility-lib.sh
+++ b/bin/fm-herdr-nm-visibility-lib.sh
@@ -14,7 +14,9 @@
 # Herdr 0.7.4 has no nested-agent or child-agent relationship in protocol 16.
 # The supported observational fallback is pane.report_metadata on the owning
 # worker's existing pane.
-# It changes only a source-scoped title, state labels, and five allowlisted tokens.
+# It changes only a source-scoped title, a display-agent label, state labels, and
+# six allowlisted tokens: nm_role, nm_state, nm_phase, nm_elapsed, nm_activity,
+# and nm_summary.
 # It never creates a pane, reports an agent, changes agent authority, or exposes
 # an independently addressable target.
 #
@@ -37,6 +39,7 @@ FM_NM_VISIBILITY_CACHE_SUFFIX=.herdr-nm-activity
 FM_NM_VISIBILITY_ACTIVE_TTL_MS=${FM_NM_VISIBILITY_ACTIVE_TTL_MS:-45000}
 FM_NM_VISIBILITY_TERMINAL_TTL_MS=${FM_NM_VISIBILITY_TERMINAL_TTL_MS:-30000}
 FM_NM_VISIBILITY_TIMEOUT=${FM_NM_VISIBILITY_TIMEOUT:-3}
+FM_NM_VISIBILITY_REVIEW_LOG_TAIL=${FM_NM_VISIBILITY_REVIEW_LOG_TAIL:-200}
 
 _FM_NM_VISIBILITY_CAP_YES="|"
 _FM_NM_VISIBILITY_CAP_NO="|"
@@ -150,6 +153,66 @@ fm_nm_visibility_run_head_matches() { # <worktree> <run-head>
   git -C "$worktree" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
 }
 
+fm_nm_visibility_digits() { # <value>
+  case "$1" in ''|*[!0-9]*) return 1 ;; esac
+  return 0
+}
+
+fm_nm_visibility_ident() { # <value>  matches ^[A-Za-z0-9._-]+$
+  case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
+  return 0
+}
+
+fm_nm_visibility_is_fix_round() { # <trimmed>
+  local rest round count
+  case "$1" in
+    'user-fix round starting after round '*' finding selected)') ;;
+    'user-fix round starting after round '*' findings selected)') ;;
+    *) return 1 ;;
+  esac
+  rest=${1#user-fix round starting after round }
+  round=${rest%% *}
+  fm_nm_visibility_digits "$round" || return 1
+  rest=${rest#* }
+  case "$rest" in '('*) ;; *) return 1 ;; esac
+  count=${rest#(}
+  count=${count%% *}
+  fm_nm_visibility_digits "$count"
+}
+
+fm_nm_visibility_is_child_started() { # <trimmed>
+  local name pid
+  case "$1" in *' started pid='*) ;; *) return 1 ;; esac
+  name=${1%% started pid=*}
+  pid=${1##* started pid=}
+  fm_nm_visibility_ident "$name" || return 1
+  fm_nm_visibility_digits "$pid" || return 1
+  [ "$1" = "$name started pid=$pid" ]
+}
+
+fm_nm_visibility_is_child_finished() { # <trimmed>
+  local name rest pid
+  case "$1" in *' exited pid='*' status=success') ;; *) return 1 ;; esac
+  name=${1%% exited pid=*}
+  rest=${1##* exited pid=}
+  pid=${rest%% *}
+  fm_nm_visibility_ident "$name" || return 1
+  fm_nm_visibility_digits "$pid" || return 1
+  [ "$1" = "$name exited pid=$pid status=success" ]
+}
+
+fm_nm_visibility_is_child_failed() { # <trimmed>
+  local name rest pid
+  case "$1" in *' exited pid='*' error='*) ;; *) return 1 ;; esac
+  name=${1%% exited pid=*}
+  rest=${1##* exited pid=}
+  pid=${rest%% *}
+  fm_nm_visibility_ident "$name" || return 1
+  fm_nm_visibility_digits "$pid" || return 1
+  case "$rest" in "$pid error="*) ;; *) return 1 ;; esac
+  return 0
+}
+
 FM_NM_VISIBILITY_LOG_ROLE=
 FM_NM_VISIBILITY_LOG_PHASE=
 FM_NM_VISIBILITY_LOG_ACTIVITY=
@@ -159,7 +222,9 @@ fm_nm_visibility_review_log_hints() { # <worktree> <run-id> <initial-role> <init
   FM_NM_VISIBILITY_LOG_PHASE=$4
   FM_NM_VISIBILITY_LOG_ACTIVITY=
   while IFS= read -r line; do
-    trimmed=$(fm_nm_visibility_trim "$line")
+    trimmed=$line
+    trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
     case "$trimmed" in
       'asking agent to fix identified issues...')
         FM_NM_VISIBILITY_LOG_ROLE=fixer
@@ -177,20 +242,20 @@ fm_nm_visibility_review_log_hints() { # <worktree> <run-id> <initial-role> <init
         FM_NM_VISIBILITY_LOG_ACTIVITY=fixes-committed
         ;;
       *)
-        if printf '%s\n' "$trimmed" | grep -Eq '^user-fix round starting after round [0-9]+ \([0-9]+ findings? selected\)$'; then
+        if fm_nm_visibility_is_fix_round "$trimmed"; then
           FM_NM_VISIBILITY_LOG_ROLE=fixer
           FM_NM_VISIBILITY_LOG_PHASE=fix
           FM_NM_VISIBILITY_LOG_ACTIVITY=fix-round-started
-        elif printf '%s\n' "$trimmed" | grep -Eq '^[A-Za-z0-9._-]+ started pid=[0-9]+$'; then
+        elif fm_nm_visibility_is_child_started "$trimmed"; then
           FM_NM_VISIBILITY_LOG_ACTIVITY=child-started
-        elif printf '%s\n' "$trimmed" | grep -Eq '^[A-Za-z0-9._-]+ exited pid=[0-9]+ status=success$'; then
+        elif fm_nm_visibility_is_child_finished "$trimmed"; then
           FM_NM_VISIBILITY_LOG_ACTIVITY=child-finished
-        elif printf '%s\n' "$trimmed" | grep -Eq '^[A-Za-z0-9._-]+ exited pid=[0-9]+ error='; then
+        elif fm_nm_visibility_is_child_failed "$trimmed"; then
           FM_NM_VISIBILITY_LOG_ACTIVITY=child-failed
         fi
         ;;
     esac
-  done < <(fm_nm_visibility_bounded_no_mistakes "$worktree" axi logs --step review --run "$run_id" || true)
+  done < <(fm_nm_visibility_bounded_no_mistakes "$worktree" axi logs --step review --run "$run_id" 2>/dev/null | tail -n "$FM_NM_VISIBILITY_REVIEW_LOG_TAIL" || true)
 }
 
 fm_nm_visibility_observation_reset() {

--- a/bin/fm-herdr-nm-visibility-lib.sh
+++ b/bin/fm-herdr-nm-visibility-lib.sh
@@ -114,8 +114,8 @@ fm_nm_visibility_bounded_no_mistakes() { # <worktree> <args...>
     timeout_kind=perl
   fi
   case "$timeout_kind" in
-    timeout) ( cd "$worktree" && timeout "$FM_NM_VISIBILITY_TIMEOUT" no-mistakes "$@" ) 2>/dev/null ;;
-    gtimeout) ( cd "$worktree" && gtimeout "$FM_NM_VISIBILITY_TIMEOUT" no-mistakes "$@" ) 2>/dev/null ;;
+    timeout) ( cd "$worktree" && timeout --kill-after=1 "$FM_NM_VISIBILITY_TIMEOUT" no-mistakes "$@" ) 2>/dev/null ;;
+    gtimeout) ( cd "$worktree" && gtimeout --kill-after=1 "$FM_NM_VISIBILITY_TIMEOUT" no-mistakes "$@" ) 2>/dev/null ;;
     perl)
       ( cd "$worktree" && perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$FM_NM_VISIBILITY_TIMEOUT" no-mistakes "$@" ) 2>/dev/null
       ;;
@@ -135,8 +135,8 @@ fm_nm_visibility_bounded_herdr() { # <session> <args...>
     timeout_kind=perl
   fi
   case "$timeout_kind" in
-    timeout) HERDR_SESSION="$session" timeout "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@" --session "$session" 2>/dev/null ;;
-    gtimeout) HERDR_SESSION="$session" gtimeout "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@" --session "$session" 2>/dev/null ;;
+    timeout) HERDR_SESSION="$session" timeout --kill-after=1 "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@" --session "$session" 2>/dev/null ;;
+    gtimeout) HERDR_SESSION="$session" gtimeout --kill-after=1 "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@" --session "$session" 2>/dev/null ;;
     perl)
       HERDR_SESSION="$session" perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@" --session "$session" 2>/dev/null
       ;;

--- a/bin/fm-herdr-version.sh
+++ b/bin/fm-herdr-version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+FM_HERDR_CI_VERSION=0.7.4
+FM_HERDR_CI_TAG="v${FM_HERDR_CI_VERSION}"

--- a/bin/fm-herdr-version.sh
+++ b/bin/fm-herdr-version.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 FM_HERDR_CI_VERSION=0.7.4
+# shellcheck disable=SC2034 # Sourced release-tag contract used by fm-install-herdr.sh.
 FM_HERDR_CI_TAG="v${FM_HERDR_CI_VERSION}"

--- a/bin/fm-install-herdr.sh
+++ b/bin/fm-install-herdr.sh
@@ -15,9 +15,10 @@
 # at or above the required floor (16 for the real-Herdr family).
 set -eu
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Exact pin - change only with a re-verified real-Herdr matrix.
-FM_HERDR_CI_VERSION=0.7.4
-FM_HERDR_CI_TAG="v${FM_HERDR_CI_VERSION}"
+# shellcheck source=bin/fm-herdr-version.sh
+. "$ROOT/bin/fm-herdr-version.sh"
 FM_HERDR_CI_MIN_PROTOCOL=16
 # Bounded download ceiling (bytes). The largest official 0.7.4 asset is under 20 MiB.
 FM_HERDR_CI_MAX_BYTES=25000000

--- a/bin/fm-nm-status-lib.sh
+++ b/bin/fm-nm-status-lib.sh
@@ -41,6 +41,7 @@ fm_nm_status_parse_step() { # <step>
   duration=$(fm_nm_status_strip_quotes "$duration")
   case "$status" in
     running|fixing|awaiting_approval|fix_review|completed|failed|cancelled|timed-out|timed_out|timeout|pending|skipped)
+      # shellcheck disable=SC2034 # Parsed output consumed by sourcing callers.
       FM_NM_STATUS_STEP_STATUS=$status
       ;;
     *) return 0 ;;
@@ -48,6 +49,7 @@ fm_nm_status_parse_step() { # <step>
   case "$duration" in
     ''|*[!0-9]*) duration=0 ;;
   esac
+  # shellcheck disable=SC2034 # Parsed output consumed by sourcing callers.
   FM_NM_STATUS_STEP_DURATION_MS=$duration
 }
 

--- a/bin/fm-nm-status-lib.sh
+++ b/bin/fm-nm-status-lib.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+FM_NM_STATUS_OUT=${FM_NM_STATUS_OUT:-}
+FM_NM_STATUS_STEP_STATUS=
+FM_NM_STATUS_STEP_DURATION_MS=0
+
+fm_nm_status_trim() {
+  local value=${1:-}
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+fm_nm_status_strip_quotes() {
+  local value
+  value=$(fm_nm_status_trim "${1:-}")
+  case "$value" in
+    \"*\") value=${value#\"}; value=${value%\"} ;;
+  esac
+  fm_nm_status_trim "$value"
+}
+
+fm_nm_status_field() { # <key>
+  printf '%s\n' "$FM_NM_STATUS_OUT" \
+    | sed -n "s/^[[:space:]]*$1:[[:space:]]*\(.*\)/\1/p" \
+    | head -1
+}
+
+fm_nm_status_parse_step() { # <step>
+  local step=$1 row rest status duration
+  FM_NM_STATUS_STEP_STATUS=
+  FM_NM_STATUS_STEP_DURATION_MS=0
+  row=$(printf '%s\n' "$FM_NM_STATUS_OUT" \
+    | grep -E "^[[:space:]]*$step,[[:space:]]*" \
+    | head -1)
+  [ -n "$row" ] || return 0
+  row=$(fm_nm_status_trim "$row")
+  rest=${row#*,}
+  status=$(fm_nm_status_strip_quotes "${rest%%,*}")
+  duration=${row##*,}
+  duration=$(fm_nm_status_strip_quotes "$duration")
+  case "$status" in
+    running|fixing|awaiting_approval|fix_review|completed|failed|cancelled|timed-out|timed_out|timeout|pending|skipped)
+      FM_NM_STATUS_STEP_STATUS=$status
+      ;;
+    *) return 0 ;;
+  esac
+  case "$duration" in
+    ''|*[!0-9]*) duration=0 ;;
+  esac
+  FM_NM_STATUS_STEP_DURATION_MS=$duration
+}
+
+fm_nm_run_head_matches() { # <worktree> <run-head>
+  local worktree=$1 run_head=$2 local_full run_full
+  case "$run_head" in
+    ''|*[!0-9a-fA-F]*) return 1 ;;
+  esac
+  local_full=$(git -C "$worktree" rev-parse HEAD 2>/dev/null) || return 1
+  run_full=$(git -C "$worktree" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
+  [ "$run_full" = "$local_full" ] && return 0
+  git -C "$worktree" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
+}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1517,6 +1517,22 @@ if [ "$HARNESS" = kimi ]; then
     exit 1
   fi
 fi
+# Herdr's default agent sidebar groups every task in this home's shared
+# workspace under the same prominent workspace label.
+# For Pi, wait for the native Pi registration and assign a unique task-specific
+# human-facing AgentInfo.name through Herdr's display-only naming API.
+# The pane id suffix keeps names unique across homes that share a Herdr session;
+# the tab/workspace topology and native `agent=pi` identity are unchanged.
+if [ "$BACKEND" = herdr ] && [ "$HARNESS" = pi ]; then
+  HERDR_PI_OWNER=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_workspace_label)
+  if HERDR_PI_NAME=$(fm_backend_herdr_pi_worker_name "$HERDR_PI_OWNER" "$ID" "$KIND" "$HERDR_PANE_ID"); then
+    if ! fm_backend_herdr_name_pi_worker "$T" "$HERDR_PI_NAME"; then
+      echo "warning: Herdr could not apply the task-specific Pi worker name for $ID; the worker is running under its ordinary tab" >&2
+    fi
+  else
+    echo "warning: Herdr could not derive a safe task-specific Pi worker name for $ID; the worker is running under its ordinary tab" >&2
+  fi
+fi
 if [ "$KIND" = secondmate ]; then
   if ! fm_config_reread_discard_pending "$PROJ_ABS" "$ID" "$FM_HOME"; then
     if fm_config_reread_quarantine_pending "$PROJ_ABS" "$ID" "$FM_HOME"; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1037,7 +1037,8 @@ cleanup_firstmate_home_children() {
     remove_pr_poll_artifacts "$sub_state" "$child_id" || return 1
     rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" \
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
-      "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token"
+      "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
+      "$sub_state/$child_id.herdr-nm-activity"
   done
 }
 
@@ -1228,7 +1229,7 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
-  "$STATE/$ID.kimi-turnend-token"
+  "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.herdr-nm-activity"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -623,6 +623,7 @@ families_for_changed_path() {
       printf '%s\n' real-herdr-gated
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit
+      printf '%s\n' watcher-wake-lock
       ;;
     bin/fm-herdr-session-cleanup.sh)
       printf '%s\n' session-bootstrap
@@ -680,6 +681,7 @@ families_for_changed_path() {
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit
       printf '%s\n' real-herdr-gated
+      printf '%s\n' watcher-wake-lock
       ;;
     bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -131,7 +131,7 @@ family_for_basename() {
     fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
       printf '%s\n' pure-contract-unit
       ;;
-    fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
+    fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-herdr-nm-visibility.test.sh|fm-pi-watch-extension.test.sh|\
     fm-supervision-events.test.sh|fm-turnend-guard.test.sh|fm-wake-daemon-lifecycle-e2e.test.sh|\
     fm-wake-queue.test.sh|fm-watch-checkpoint.test.sh|fm-watch-triage.test.sh|\
     fm-watcher-lock.test.sh)
@@ -140,7 +140,7 @@ family_for_basename() {
     fm-afk-inject-herdr-e2e.test.sh|fm-afk-launch.test.sh|fm-backend-autodetect-smoke.test.sh|\
     fm-backend-herdr-eventwait-smoke.test.sh|fm-backend-herdr-presentation-e2e.test.sh|\
     fm-backend-herdr-prune-safety-e2e.test.sh|fm-backend-herdr-respawn-idem-e2e.test.sh|\
-    fm-herdr-session-cleanup-e2e.test.sh|\
+    fm-herdr-session-cleanup-e2e.test.sh|fm-herdr-nm-visibility-e2e.test.sh|\
     fm-backend-herdr-smoke.test.sh|fm-backend-herdr-workspace-per-home-e2e.test.sh)
       printf '%s\n' real-herdr-gated
       ;;
@@ -615,6 +615,10 @@ families_for_changed_path() {
     bin/fm-test-run.sh|bin/fm-test-isolation-proof.sh)
       printf '%s\n' pure-contract-unit
       ;;
+    bin/fm-herdr-nm-visibility-lib.sh)
+      printf '%s\n' watcher-wake-lock
+      printf '%s\n' real-herdr-gated
+      ;;
     bin/backends/herdr*|bin/fm-herdr-lab.sh|tests/herdr-test-safety.sh)
       printf '%s\n' real-herdr-gated
       printf '%s\n' backend-dispatch
@@ -664,11 +668,20 @@ families_for_changed_path() {
     bin/fm-gate-refuse*|bin/fm-lock*)
       printf '%s\n' session-bootstrap
       ;;
-    bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
+    bin/fm-teardown.sh)
+      printf '%s\n' pr-forge
+      printf '%s\n' watcher-wake-lock
+      ;;
+    bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-review-diff.sh|\
     bin/fm-x-*|bin/fm-check*)
       printf '%s\n' pr-forge
       ;;
-    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
+    bin/fm-spawn.sh)
+      printf '%s\n' backend-dispatch
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' real-herdr-gated
+      ;;
+    bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -615,7 +615,7 @@ families_for_changed_path() {
     bin/fm-test-run.sh|bin/fm-test-isolation-proof.sh)
       printf '%s\n' pure-contract-unit
       ;;
-    bin/fm-herdr-nm-visibility-lib.sh)
+    bin/fm-herdr-nm-visibility-lib.sh|bin/fm-nm-status-lib.sh)
       printf '%s\n' watcher-wake-lock
       printf '%s\n' real-herdr-gated
       ;;

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -55,6 +55,12 @@ mkdir -p "$STATE"
 # without sourcing the entire watcher graph.
 # shellcheck source=bin/fm-push-transition-lib.sh
 . "$SCRIPT_DIR/fm-push-transition-lib.sh"
+# Herdr-only, read-only projection of active No Mistakes reviewer/fixer activity
+# onto each owning worker's existing pane.
+# The library owns capability fallback, privacy filtering, TTL cleanup, and its
+# non-authoritative cache; this watcher only supplies the regular refresh tick.
+# shellcheck source=bin/fm-herdr-nm-visibility-lib.sh
+. "$SCRIPT_DIR/fm-herdr-nm-visibility-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-x-lib.sh
@@ -1012,6 +1018,13 @@ EOF
       triage_log "absorbed heartbeat (no captain-relevant change)"
     fi
   fi
+
+  # Refresh observational Herdr metadata only after every actionable wake path
+  # had its chance to exit, so a slow read-only status call can never delay a
+  # captain-relevant notification.
+  # This is a no-op for every non-Herdr task, non-ship task, and delivery mode
+  # other than no-mistakes, and it never emits a wake or controls a child run.
+  fm_nm_visibility_refresh_all "$STATE" || true
 
   # Terminal wait: a bounded native-event wait for push-capable homes (herdr),
   # else the blind poll sleep. See event_wait_or_sleep.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -53,6 +53,71 @@ Existing task operations use recorded endpoint ids and do not move a live task w
 The per-home workspace is reused while it has task tabs.
 Closing its last tab can remove the workspace, and the next spawn recreates it.
 
+## Firstmate worker identity and No Mistakes child activity
+
+Herdr 0.7.4's stock expanded agent row is `[["state_icon", "workspace", "tab"], ["agent"]]`.
+That is why several Pi workers in Firstmate's shared workspace all show the prominent label `firstmate`, a dim task tab on the right, and the generic `pi` label below.
+The protocol has no per-pane override for the built-in `workspace` token, and its schema has no nested-agent or child-agent relation.
+`agent.start` would create an independently interactive terminal, so Firstmate deliberately does not use it for No Mistakes visibility.
+
+Every new Herdr-backed Pi worker now receives a unique task-specific Herdr agent name after native Pi detection, such as `Pi · firstmate/review-a [w1:p2]`.
+The owner/task prefix is human-readable, and the response-derived pane suffix keeps the name distinct even if two homes sharing a session reuse an owner label and task id.
+Firstmate verifies `agent=pi` before calling `agent rename`, leaves that canonical identity unchanged, and never renames the shared workspace or the `fm-<id>` task tab.
+A shell, an unreadable pane, or a non-Pi agent is never renamed.
+
+To put that task-specific Pi name in the prominent first position rather than Herdr's shared workspace label, add this supported Herdr sidebar override to the operator's normal Herdr config:
+
+```toml
+[ui.sidebar.agents.rows_by_agent]
+pi = [["state_icon", "agent", "tab"], ["state_text", "$nm_summary"]]
+```
+
+Firstmate never edits or reloads the operator's Herdr config automatically.
+The override uses only Herdr's documented canonical `pi` row selector, built-in `agent` and `tab` values, and the custom metadata token `$nm_summary`.
+When no review is active, the optional custom token is elided and the second row still shows Pi's native state text.
+
+While the owning Herdr worker has an attributable active No Mistakes review or fix round, the watcher reports source-scoped `pane.report_metadata` on that worker's existing pane.
+The default sidebar's `agent` row becomes a bounded summary beginning with the task identity and including the child role, state, elapsed time, and last allowlisted structural activity.
+The recommended Pi row above keeps the same task identity prominent and adds the concise `$nm_summary` row.
+Tokens also expose `nm_role`, `nm_state`, `nm_phase`, `nm_elapsed`, and `nm_activity` for other supported custom layouts.
+Waiting for the captain, failure, timeout, and completion are distinct states.
+Completion, failure, and timeout are transient one-shot presentations, while active and waiting presentations use a renewable short TTL.
+Herdr's TTL removes abandoned metadata on its own, and the next watcher cycle explicitly clears this source and retires its private non-authoritative cache.
+
+This surface is observational only.
+It creates no pane, agent, Firstmate task, dispatch target, or fleet record, and it has no send, focus, interrupt, kill, resume, or control action.
+No Mistakes remains the sole owner of child processes, run lifecycle, and structured output.
+Only strict run ids, fixed role/state/phase/activity values, and numeric elapsed time reach Herdr.
+Prompt text, findings, paths, credentials, environment values, command lines, pids, raw errors, agent prose, and raw log lines are never copied.
+If the exact `pane.report_metadata` schema is unavailable, the feature performs no No Mistakes query or Herdr mutation and existing task behavior remains unchanged.
+Non-Herdr tasks never enter this path.
+
+### Isolated 0.7.4 evidence (2026-07-22)
+
+The guarded named-session test used Herdr 0.7.4, protocol 16, without changing the running default session.
+The exact command was:
+
+```sh
+HERDR_LAB_HELPER=/Users/lorenzlat/lorenz-agent-workspace/bin/fm-herdr-lab.sh \
+  bash tests/fm-herdr-nm-visibility-e2e.test.sh
+```
+
+The exact result was:
+
+```text
+ok - real Herdr lab: task-specific Pi names are distinct while both owners remain native Pi agents in one shared workspace
+ok - real Herdr lab: Herdr accepts the Pi sidebar layout that makes the task-specific agent name prominent
+ok - real Herdr lab: owning Pi row exposes bounded reviewer role/state/phase/elapsed/activity without a child agent
+ok - real Herdr lab: completed activity cleans up deterministically and leaves the named owner intact
+ok - real Herdr lab: source TTL removes abandoned activity without removing the task-specific owner name
+ok - real Herdr lab validation completed on Herdr 0.7.4 protocol 16
+```
+
+The accepted row layout and live AgentInfo values resolve visually as a task-specific first row such as `Pi · firstmate/review-a [w1:p2] · fm-review-a`, followed by state and No Mistakes summary text while activity exists.
+The same lab proved two such rows retained different names and pane ids inside one exact `firstmate` workspace, and that terminal cleanup restored the underlying task name rather than the generic `pi` label.
+`herdr api schema --json` exposed `pane.report_metadata` with title, display-agent, state-label, token, and TTL fields, but no nested-agent field or relationship.
+`agent rename` returned the unchanged canonical `agent: pi` plus the new task-specific `name`, and Herdr rejected a duplicate name with `agent_name_taken`.
+
 ## Optional presentation spaces
 
 Create local gitignored `config/herdr-presentation-spaces` to request a disposable one-task workspace for each new crewmate or scout.
@@ -278,6 +343,8 @@ tests/fm-backend-herdr-presentation-e2e.test.sh
 tests/fm-backend-herdr-eventwait-smoke.test.sh
 tests/fm-herdr-session-cleanup.test.sh
 tests/fm-herdr-session-cleanup-e2e.test.sh
+tests/fm-herdr-nm-visibility.test.sh
+tests/fm-herdr-nm-visibility-e2e.test.sh
 tests/fm-afk-inject-herdr-e2e.test.sh
 tests/fm-afk-pi-herdr-return-e2e.test.sh
 ```

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -92,31 +92,7 @@ Prompt text, findings, paths, credentials, environment values, command lines, pi
 If the exact `pane.report_metadata` schema is unavailable, the feature performs no No Mistakes query or Herdr mutation and existing task behavior remains unchanged.
 Non-Herdr tasks never enter this path.
 
-### Isolated 0.7.4 evidence (2026-07-22)
-
-The guarded named-session test used Herdr 0.7.4, protocol 16, without changing the running default session.
-The exact command was:
-
-```sh
-HERDR_LAB_HELPER=/Users/lorenzlat/lorenz-agent-workspace/bin/fm-herdr-lab.sh \
-  bash tests/fm-herdr-nm-visibility-e2e.test.sh
-```
-
-The exact result was:
-
-```text
-ok - real Herdr lab: task-specific Pi names are distinct while both owners remain native Pi agents in one shared workspace
-ok - real Herdr lab: Herdr accepts the Pi sidebar layout that makes the task-specific agent name prominent
-ok - real Herdr lab: owning Pi row exposes bounded reviewer role/state/phase/elapsed/activity without a child agent
-ok - real Herdr lab: completed activity cleans up deterministically and leaves the named owner intact
-ok - real Herdr lab: source TTL removes abandoned activity without removing the task-specific owner name
-ok - real Herdr lab validation completed on Herdr 0.7.4 protocol 16
-```
-
-The accepted row layout and live AgentInfo values resolve visually as a task-specific first row such as `Pi · firstmate/review-a [w1:p2] · fm-review-a`, followed by state and No Mistakes summary text while activity exists.
-The same lab proved two such rows retained different names and pane ids inside one exact `firstmate` workspace, and that terminal cleanup restored the underlying task name rather than the generic `pi` label.
-`herdr api schema --json` exposed `pane.report_metadata` with title, display-agent, state-label, token, and TTL fields, but no nested-agent field or relationship.
-`agent rename` returned the unchanged canonical `agent: pi` plus the new task-specific `name`, and Herdr rejected a duplicate name with `agent_name_taken`.
+[`verification/runtime-backends.md`](verification/runtime-backends.md#pi-worker-identity-and-no-mistakes-activity) records the versioned schema, identity, layout, privacy, and cleanup evidence for this feature.
 
 ## Optional presentation spaces
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -130,6 +130,38 @@ ok - real Herdr lab validation completed on Herdr 0.7.4 with the default-session
 
 The suite also covers lost or failed move responses, active-tab refusal, restart husks, missing and duplicate tokens, manual renames, concurrent cleanup, and exact focus restoration.
 
+### Pi worker identity and No Mistakes activity
+
+The guarded named-session suite ran on 2026-07-22 against Herdr 0.7.4 protocol 16:
+
+```sh
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
+  tests/fm-herdr-nm-visibility-e2e.test.sh
+```
+
+Observed output:
+
+```text
+ok - real Herdr lab: task-specific Pi names are distinct while both owners remain native Pi agents in one shared workspace
+ok - real Herdr lab: Herdr accepts the Pi sidebar layout that makes the task-specific agent name prominent
+ok - real Herdr lab: owning Pi row exposes bounded reviewer role/state/phase/elapsed/activity without a child agent
+ok - real Herdr lab: completed activity cleans up deterministically and leaves the named owner intact
+ok - real Herdr lab: source TTL removes abandoned activity without removing the task-specific owner name
+ok - real Herdr lab validation completed on Herdr 0.7.4 protocol 16
+```
+
+The accepted row layout and live AgentInfo values resolved visually as a task-specific first row such as `Pi · firstmate/review-a [w1:p2] · fm-review-a`, followed by state and No Mistakes summary text while activity existed.
+Two such rows retained different names and pane ids inside one exact `firstmate` workspace, and terminal cleanup restored the underlying task name rather than the generic `pi` label.
+`herdr api schema --json` exposed `pane.report_metadata` with title, display-agent, state-label, token, and TTL fields, but no nested-agent field or relationship.
+`agent rename` returned the unchanged canonical `agent: pi` plus the new task-specific `name`, and Herdr rejected a duplicate name with `agent_name_taken`.
+
+The focused privacy, attribution, capability-fallback, lifecycle, and cleanup regressions are:
+
+```sh
+tests/fm-herdr-nm-visibility.test.sh
+tests/fm-herdr-nm-visibility-e2e.test.sh
+```
+
 The mandatory projection suite ran again on 2026-07-24 against Herdr 0.7.5 protocol 16:
 
 ```sh

--- a/tests/fm-herdr-nm-visibility-e2e.test.sh
+++ b/tests/fm-herdr-nm-visibility-e2e.test.sh
@@ -6,6 +6,8 @@ set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+# shellcheck source=bin/fm-herdr-version.sh
+. "$ROOT/bin/fm-herdr-version.sh"
 
 fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
@@ -26,7 +28,7 @@ trap cleanup EXIT HUP INT TERM
 STATUS=$("$HERDR_LAB_HELPER" run "$SESSION" status --json) || fail "could not read isolated Herdr status"
 HERDR_VERSION=$(printf '%s' "$STATUS" | jq -r '.client.version // empty')
 HERDR_PROTOCOL=$(printf '%s' "$STATUS" | jq -r '.client.protocol // empty')
-[ "$HERDR_VERSION" = 0.7.4 ] || fail "expected Herdr 0.7.4, got ${HERDR_VERSION:-empty}"
+[ "$HERDR_VERSION" = "$FM_HERDR_CI_VERSION" ] || fail "expected Herdr $FM_HERDR_CI_VERSION, got ${HERDR_VERSION:-empty}"
 [ "$HERDR_PROTOCOL" -ge 16 ] 2>/dev/null || fail "expected Herdr protocol 16 or newer, got ${HERDR_PROTOCOL:-empty}"
 
 CREATE=$("$HERDR_LAB_HELPER" run "$SESSION" workspace create --cwd "$TMP_ROOT" --label firstmate --no-focus) \

--- a/tests/fm-herdr-nm-visibility-e2e.test.sh
+++ b/tests/fm-herdr-nm-visibility-e2e.test.sh
@@ -63,7 +63,9 @@ fm_backend_herdr_cli() {
 NAME_A=$(fm_backend_herdr_pi_worker_name firstmate review-a ship "$PANE_A") || fail "could not derive first Pi name"
 NAME_B=$(fm_backend_herdr_pi_worker_name firstmate review-b ship "$PANE_B") || fail "could not derive second Pi name"
 [ "$NAME_A" != "$NAME_B" ] || fail "distinct task panes derived the same Pi name"
+# shellcheck disable=SC2034 # Read by the dynamically sourced Herdr backend.
 FM_BACKEND_HERDR_PI_RENAME_POLLS=1
+# shellcheck disable=SC2034 # Read by the dynamically sourced Herdr backend.
 FM_BACKEND_HERDR_PI_RENAME_POLL_SLEEP=0
 fm_backend_herdr_name_pi_worker "$SESSION:$PANE_A" "$NAME_A" || fail "could not rename first native Pi owner"
 fm_backend_herdr_name_pi_worker "$SESSION:$PANE_B" "$NAME_B" || fail "could not rename second native Pi owner"

--- a/tests/fm-herdr-nm-visibility-e2e.test.sh
+++ b/tests/fm-herdr-nm-visibility-e2e.test.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Real-Herdr 0.7.4 evidence for owning-pane No Mistakes metadata, deterministic
+# TTL cleanup, distinct task-specific Pi names, and shared-workspace retention.
+# Every real Herdr operation is routed through the guarded named-session helper.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+
+fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+
+command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+[ -x "$HERDR_LAB_HELPER" ] || { echo "skip: Herdr lab helper not executable at $HERDR_LAB_HELPER"; exit 0; }
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-herdr-nm-visibility-e2e.XXXXXX")
+SESSION=$($HERDR_LAB_HELPER name herdr-no-mistakes-review-visibility)
+cleanup() {
+  "$HERDR_LAB_HELPER" teardown "$SESSION" >/dev/null 2>&1 || true
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+"$HERDR_LAB_HELPER" provision "$SESSION" || fail "could not provision isolated Herdr lab session"
+
+STATUS=$("$HERDR_LAB_HELPER" run "$SESSION" status --json) || fail "could not read isolated Herdr status"
+HERDR_VERSION=$(printf '%s' "$STATUS" | jq -r '.client.version // empty')
+HERDR_PROTOCOL=$(printf '%s' "$STATUS" | jq -r '.client.protocol // empty')
+[ "$HERDR_VERSION" = 0.7.4 ] || fail "expected Herdr 0.7.4, got ${HERDR_VERSION:-empty}"
+[ "$HERDR_PROTOCOL" -ge 16 ] 2>/dev/null || fail "expected Herdr protocol 16 or newer, got ${HERDR_PROTOCOL:-empty}"
+
+CREATE=$("$HERDR_LAB_HELPER" run "$SESSION" workspace create --cwd "$TMP_ROOT" --label firstmate --no-focus) \
+  || fail "could not create shared firstmate workspace"
+WORKSPACE=$(printf '%s' "$CREATE" | jq -r '.result.workspace.workspace_id // empty')
+TAB_A=$("$HERDR_LAB_HELPER" run "$SESSION" tab create --workspace "$WORKSPACE" --cwd "$TMP_ROOT" --label fm-review-a --no-focus) \
+  || fail "could not create first task tab"
+TAB_B=$("$HERDR_LAB_HELPER" run "$SESSION" tab create --workspace "$WORKSPACE" --cwd "$TMP_ROOT" --label fm-review-b --no-focus) \
+  || fail "could not create second task tab"
+PANE_A=$(printf '%s' "$TAB_A" | jq -r '.result.root_pane.pane_id // empty')
+PANE_B=$(printf '%s' "$TAB_B" | jq -r '.result.root_pane.pane_id // empty')
+[ -n "$PANE_A" ] && [ -n "$PANE_B" ] || fail "task tabs did not return pane ids"
+
+"$HERDR_LAB_HELPER" run "$SESSION" pane report-agent "$PANE_A" --source firstmate.e2e --agent pi --state working --seq 1 >/dev/null \
+  || fail "could not register first simulated owner"
+"$HERDR_LAB_HELPER" run "$SESSION" pane report-agent "$PANE_B" --source firstmate.e2e --agent pi --state idle --seq 1 >/dev/null \
+  || fail "could not register second simulated owner"
+
+# Route production adapter calls through the same lab helper.
+# shellcheck source=bin/fm-backend.sh
+. "$ROOT/bin/fm-backend.sh"
+fm_backend_source herdr
+fm_backend_herdr_cli() {
+  local ignored_session=$1
+  shift
+  [ "$ignored_session" = "$SESSION" ] || return 1
+  "$HERDR_LAB_HELPER" run "$SESSION" "$@"
+}
+# shellcheck source=bin/fm-herdr-nm-visibility-lib.sh
+. "$ROOT/bin/fm-herdr-nm-visibility-lib.sh"
+
+NAME_A=$(fm_backend_herdr_pi_worker_name firstmate review-a ship "$PANE_A") || fail "could not derive first Pi name"
+NAME_B=$(fm_backend_herdr_pi_worker_name firstmate review-b ship "$PANE_B") || fail "could not derive second Pi name"
+[ "$NAME_A" != "$NAME_B" ] || fail "distinct task panes derived the same Pi name"
+FM_BACKEND_HERDR_PI_RENAME_POLLS=1
+FM_BACKEND_HERDR_PI_RENAME_POLL_SLEEP=0
+fm_backend_herdr_name_pi_worker "$SESSION:$PANE_A" "$NAME_A" || fail "could not rename first native Pi owner"
+fm_backend_herdr_name_pi_worker "$SESSION:$PANE_B" "$NAME_B" || fail "could not rename second native Pi owner"
+
+AGENTS=$("$HERDR_LAB_HELPER" run "$SESSION" agent list) || fail "could not list renamed agents"
+printf '%s' "$AGENTS" | jq -e --arg ws "$WORKSPACE" --arg a "$NAME_A" --arg b "$NAME_B" '
+  [.result.agents[]? | select(.workspace_id == $ws and (.name == $a or .name == $b))]
+  | length == 2
+    and (map(.agent) | all(. == "pi"))
+    and (map(.pane_id) | unique | length == 2)
+' >/dev/null || fail "Pi names were not distinct inside the one shared workspace"
+pass "real Herdr lab: task-specific Pi names are distinct while both owners remain native Pi agents in one shared workspace"
+
+# Herdr's stock first row is workspace+tab.
+# The supported visual override moves the renamed `agent` field into the
+# prominent first position for Pi and adds the source-scoped No Mistakes summary
+# on row two.
+SIDEBAR_CONFIG="$TMP_ROOT/herdr-sidebar.toml"
+cat > "$SIDEBAR_CONFIG" <<'EOF'
+[ui.sidebar.agents.rows_by_agent]
+pi = [["state_icon", "agent", "tab"], ["state_text", "$nm_summary"]]
+EOF
+HERDR_CONFIG_PATH="$SIDEBAR_CONFIG" "$HERDR_LAB_HELPER" run "$SESSION" config check >/dev/null \
+  || fail "Herdr rejected the documented Firstmate Pi sidebar rows"
+pass "real Herdr lab: Herdr accepts the Pi sidebar layout that makes the task-specific agent name prominent"
+
+WORKTREE="$TMP_ROOT/worktree"
+STATE_DIR="$TMP_ROOT/state"
+FAKEBIN="$TMP_ROOT/fakebin"
+mkdir -p "$WORKTREE" "$STATE_DIR" "$FAKEBIN"
+git -C "$WORKTREE" init -q
+git -C "$WORKTREE" -c user.name=Firstmate -c user.email=firstmate@example.invalid commit -q --allow-empty -m initial
+git -C "$WORKTREE" checkout -qb fm/review-a
+HEAD_SHA=$(git -C "$WORKTREE" rev-parse HEAD)
+cat > "$FAKEBIN/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  "axi status") printf '%s\n' "${FM_FAKE_AXI_STATUS:-}" ;;
+  "axi logs") printf '%s\n' "${FM_FAKE_REVIEW_LOG:-}" ;;
+esac
+SH
+chmod +x "$FAKEBIN/no-mistakes"
+PATH="$FAKEBIN:$PATH"
+export PATH
+cat > "$STATE_DIR/review-a.meta" <<EOF
+window=$SESSION:$PANE_A
+worktree=$WORKTREE
+project=/project
+harness=pi
+kind=ship
+mode=no-mistakes
+backend=herdr
+herdr_session=$SESSION
+herdr_workspace_id=$WORKSPACE
+herdr_tab_id=$(printf '%s' "$TAB_A" | jq -r '.result.tab.tab_id')
+herdr_pane_id=$PANE_A
+EOF
+
+FM_FAKE_AXI_STATUS=$(cat <<EOF
+run:
+  id: "01REALHERDRVISIBILITY"
+  branch: fm/review-a
+  status: running
+  head: $HEAD_SHA
+  findings: none
+  steps[2]{step,status,findings,duration_ms}:
+    intent,completed,0,10
+    review,running,0,12000
+EOF
+)
+FM_FAKE_REVIEW_LOG=$(cat <<'EOF'
+reviewing changes...
+pi started pid=12345
+"SECRET_PROMPT must never render"
+EOF
+)
+FM_NM_VISIBILITY_NOW=1000
+FM_NM_VISIBILITY_ACTIVE_TTL_MS=45000
+FM_NM_VISIBILITY_TERMINAL_TTL_MS=30000
+export FM_FAKE_AXI_STATUS FM_FAKE_REVIEW_LOG FM_NM_VISIBILITY_NOW
+export FM_NM_VISIBILITY_ACTIVE_TTL_MS FM_NM_VISIBILITY_TERMINAL_TTL_MS
+fm_nm_visibility_refresh_task "$STATE_DIR" review-a || fail "active reviewer refresh failed"
+
+ACTIVE=$("$HERDR_LAB_HELPER" run "$SESSION" agent get "$PANE_A") || fail "could not read active reviewer metadata"
+printf '%s' "$ACTIVE" | jq -e --arg name "$NAME_A" '
+  .result.agent.agent == "pi"
+  and .result.agent.name == $name
+  and (.result.agent.display_agent | startswith($name + " · No Mistakes reviewer working · 12s"))
+  and .result.agent.tokens.nm_role == "reviewer"
+  and .result.agent.tokens.nm_state == "working"
+  and .result.agent.tokens.nm_phase == "review"
+  and .result.agent.tokens.nm_elapsed == "12s"
+  and .result.agent.tokens.nm_activity == "child-started"
+  and (.result.agent.tokens.nm_summary | contains("reviewer working"))
+  and ([.result.agent | tostring] | all(contains("SECRET_PROMPT") | not))
+' >/dev/null || fail "active reviewer metadata was incomplete, displaced the owner name, or leaked private text"
+pass "real Herdr lab: owning Pi row exposes bounded reviewer role/state/phase/elapsed/activity without a child agent"
+
+# Transition the same observed review to completed, then advance the deterministic
+# clock past its terminal TTL and require explicit source cleanup.
+FM_FAKE_AXI_STATUS=$(cat <<EOF
+run:
+  id: "01REALHERDRVISIBILITY"
+  branch: fm/review-a
+  status: running
+  head: $HEAD_SHA
+  findings: none
+  steps[3]{step,status,findings,duration_ms}:
+    intent,completed,0,10
+    review,completed,0,18000
+    test,running,0,1000
+EOF
+)
+FM_NM_VISIBILITY_NOW=1010
+export FM_FAKE_AXI_STATUS FM_NM_VISIBILITY_NOW
+fm_nm_visibility_refresh_task "$STATE_DIR" review-a || fail "completed reviewer refresh failed"
+COMPLETED=$("$HERDR_LAB_HELPER" run "$SESSION" agent get "$PANE_A") || fail "could not read completed reviewer metadata"
+printf '%s' "$COMPLETED" | jq -e '
+  .result.agent.tokens.nm_state == "completed"
+  and .result.agent.tokens.nm_activity == "review-completed"
+' >/dev/null || fail "completed reviewer transition was not represented"
+
+FM_NM_VISIBILITY_NOW=1041
+export FM_NM_VISIBILITY_NOW
+fm_nm_visibility_refresh_task "$STATE_DIR" review-a || fail "reviewer cleanup refresh failed"
+CLEAN=$("$HERDR_LAB_HELPER" run "$SESSION" agent get "$PANE_A") || fail "could not read cleaned owner"
+printf '%s' "$CLEAN" | jq -e --arg name "$NAME_A" '
+  .result.agent as $agent
+  | $agent.agent == "pi"
+  and $agent.name == $name
+  and ($agent.display_agent == null)
+  and ($agent.title == null)
+  and (($agent.state_labels // {}) | length == 0)
+  and (["nm_role", "nm_state", "nm_phase", "nm_elapsed", "nm_activity", "nm_summary"]
+       | all(. as $key | ($agent.tokens[$key] == null)))
+' >/dev/null || fail "terminal reviewer metadata did not cleanly retire while preserving the owner name"
+pass "real Herdr lab: completed activity cleans up deterministically and leaves the named owner intact"
+
+# Native TTL is the crash/abandonment cleanup backstop.
+FM_NM_VISIBILITY_ACTIVE_TTL_MS=150
+export FM_NM_VISIBILITY_ACTIVE_TTL_MS
+fm_nm_visibility_report "$SESSION:$PANE_A" "$NAME_A" reviewer working review 2000 reviewing active \
+  || fail "short-TTL metadata report failed"
+sleep 0.4
+EXPIRED=$("$HERDR_LAB_HELPER" run "$SESSION" agent get "$PANE_A") || fail "could not read TTL-expired owner"
+printf '%s' "$EXPIRED" | jq -e --arg name "$NAME_A" '
+  .result.agent.name == $name
+  and (.result.agent.display_agent == null)
+  and (.result.agent.tokens.nm_summary == null)
+' >/dev/null || fail "Herdr TTL did not remove abandoned review metadata"
+pass "real Herdr lab: source TTL removes abandoned activity without removing the task-specific owner name"
+
+printf 'ok - real Herdr lab validation completed on Herdr %s protocol %s\n' "$HERDR_VERSION" "$HERDR_PROTOCOL"

--- a/tests/fm-herdr-nm-visibility.test.sh
+++ b/tests/fm-herdr-nm-visibility.test.sh
@@ -325,7 +325,9 @@ test_pi_worker_name_is_unique_and_verified() {
   reset_case
   name=$(fm_backend_herdr_pi_worker_name firstmate review-task ship w1:p2) || fail "could not derive Pi worker name"
   [ "$name" = 'Pi · firstmate/review-task [w1:p2]' ] || fail "unexpected Pi worker name: $name"
+  # shellcheck disable=SC2034 # Read by the dynamically sourced Herdr backend.
   FM_BACKEND_HERDR_PI_RENAME_POLLS=1
+  # shellcheck disable=SC2034 # Read by the dynamically sourced Herdr backend.
   FM_BACKEND_HERDR_PI_RENAME_POLL_SLEEP=0
   fm_backend_herdr_name_pi_worker fmtest:w1:p2 "$name" || fail "Pi worker rename failed"
   calls=$(cat "$HERDR_LOG")
@@ -342,7 +344,9 @@ test_pi_worker_name_refuses_non_pi_identity() {
   name=$(fm_backend_herdr_pi_worker_name firstmate review-task ship w1:p2)
   FM_FAKE_AGENT_IDENTITY=claude
   export FM_FAKE_AGENT_IDENTITY
+  # shellcheck disable=SC2034 # Read by the dynamically sourced Herdr backend.
   FM_BACKEND_HERDR_PI_RENAME_POLLS=1
+  # shellcheck disable=SC2034 # Read by the dynamically sourced Herdr backend.
   FM_BACKEND_HERDR_PI_RENAME_POLL_SLEEP=0
   fm_backend_herdr_name_pi_worker fmtest:w1:p2 "$name" >/dev/null 2>&1
   status=$?

--- a/tests/fm-herdr-nm-visibility.test.sh
+++ b/tests/fm-herdr-nm-visibility.test.sh
@@ -33,6 +33,12 @@ case "${1:-} ${2:-}" in
 esac
 SH
 chmod +x "$FAKEBIN/no-mistakes"
+cat > "$FAKEBIN/herdr" <<'SH'
+#!/usr/bin/env bash
+trap '' TERM
+while :; do sleep 1; done
+SH
+chmod +x "$FAKEBIN/herdr"
 PATH="$FAKEBIN:$PATH"
 export PATH FM_FAKE_NM_LOG="$NM_LOG"
 
@@ -442,7 +448,7 @@ test_refresh_cycle_is_bounded_and_fair() {
 }
 
 test_metadata_report_and_clear_use_bounded_herdr() {
-  local calls helper_source
+  local calls helper_source no_mistakes_source
   reset_case
   FM_FAKE_AXI_STATUS=$(status_with_review running 1000)
   fm_nm_visibility_refresh_task "$STATE" review-task
@@ -452,9 +458,30 @@ test_metadata_report_and_clear_use_bounded_herdr() {
   assert_contains "$calls" $'\x1f''--clear-title'$'\x1f''--clear-display-agent' "metadata clear bypassed bounded Herdr execution"
   assert_not_contains "$(sed -n '/^fm_nm_visibility_report()/,/^}/p; /^fm_nm_visibility_clear()/,/^}/p' "$ROOT/bin/fm-herdr-nm-visibility-lib.sh")" 'fm_backend_herdr_cli' "visibility mutation calls the unbounded backend helper"
   helper_source=$(sed -n '/^fm_nm_visibility_bounded_herdr()/,/^}/p' "$ROOT/bin/fm-herdr-nm-visibility-lib.sh")
-  assert_contains "$helper_source" 'timeout "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@"' "bounded Herdr helper lacks timeout execution"
+  no_mistakes_source=$(sed -n '/^fm_nm_visibility_bounded_no_mistakes()/,/^}/p' "$ROOT/bin/fm-herdr-nm-visibility-lib.sh")
+  assert_contains "$helper_source" 'timeout --kill-after=1 "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@"' "bounded Herdr helper lacks KILL escalation"
+  assert_contains "$helper_source" 'gtimeout --kill-after=1 "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@"' "bounded Herdr helper lacks gtimeout KILL escalation"
+  assert_contains "$no_mistakes_source" 'timeout --kill-after=1 "$FM_NM_VISIBILITY_TIMEOUT" no-mistakes "$@"' "bounded No Mistakes helper lacks KILL escalation"
+  assert_contains "$no_mistakes_source" 'gtimeout --kill-after=1 "$FM_NM_VISIBILITY_TIMEOUT" no-mistakes "$@"' "bounded No Mistakes helper lacks gtimeout KILL escalation"
   assert_contains "$helper_source" 'kill "TERM", -$pid' "bounded Herdr helper lacks process-group fallback termination"
   pass "metadata reports and clears share bounded Herdr execution"
+}
+
+test_term_ignoring_herdr_is_killed() {
+  local started elapsed
+  started=$(date +%s)
+  if (
+    unset -f fm_nm_visibility_bounded_herdr
+    # shellcheck source=bin/fm-herdr-nm-visibility-lib.sh
+    . "$ROOT/bin/fm-herdr-nm-visibility-lib.sh"
+    FM_NM_VISIBILITY_TIMEOUT=1
+    fm_nm_visibility_bounded_herdr fmtest status --json
+  ); then
+    fail "TERM-ignoring Herdr command unexpectedly succeeded"
+  fi
+  elapsed=$(($(date +%s) - started))
+  [ "$elapsed" -le 4 ] || fail "TERM-ignoring Herdr command exceeded bounded KILL escalation"
+  pass "TERM-ignoring Herdr subprocess is killed within the watcher budget"
 }
 
 test_active_reviewer_is_visible_and_bounded
@@ -474,4 +501,5 @@ test_zero_elapsed_does_not_cross_run_cache
 test_invalid_log_tail_falls_back_and_preserves_hints
 test_top_level_failure_without_review_failure_is_visible
 test_metadata_report_and_clear_use_bounded_herdr
+test_term_ignoring_herdr_is_killed
 test_refresh_cycle_is_bounded_and_fair

--- a/tests/fm-herdr-nm-visibility.test.sh
+++ b/tests/fm-herdr-nm-visibility.test.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# Deterministic behavior tests for the read-only No Mistakes activity projection
+# and task-specific Pi worker naming on Herdr.
+# Static source assertions below intentionally match literal shell variables.
+# shellcheck disable=SC2016
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-herdr-nm-visibility)
+HOME_DIR="$TMP_ROOT/home"
+STATE="$HOME_DIR/state"
+WORKTREE="$TMP_ROOT/worktree"
+FAKEBIN="$TMP_ROOT/fakebin"
+HERDR_LOG="$TMP_ROOT/herdr.log"
+NM_LOG="$TMP_ROOT/no-mistakes.log"
+mkdir -p "$STATE" "$FAKEBIN" "$WORKTREE"
+fm_git_identity
+fm_git_init_commit "$WORKTREE"
+git -C "$WORKTREE" checkout -qb fm/review-task
+HEAD_SHA=$(git -C "$WORKTREE" rev-parse HEAD)
+
+cat > "$FAKEBIN/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "${FM_FAKE_NM_LOG:?}"
+case "${1:-} ${2:-}" in
+  "axi status") printf '%s\n' "${FM_FAKE_AXI_STATUS:-}" ;;
+  "axi logs") printf '%s\n' "${FM_FAKE_REVIEW_LOG:-}" ;;
+esac
+SH
+chmod +x "$FAKEBIN/no-mistakes"
+PATH="$FAKEBIN:$PATH"
+export PATH FM_FAKE_NM_LOG="$NM_LOG"
+
+# shellcheck source=bin/fm-backend.sh
+. "$ROOT/bin/fm-backend.sh"
+fm_backend_source herdr
+# shellcheck source=bin/fm-herdr-nm-visibility-lib.sh
+. "$ROOT/bin/fm-herdr-nm-visibility-lib.sh"
+
+FM_FAKE_METADATA_CAPABLE=1
+FM_FAKE_AGENT_IDENTITY=pi
+export FM_FAKE_METADATA_CAPABLE FM_FAKE_AGENT_IDENTITY
+
+# Every fake Herdr call is unit-separated so assertions cannot confuse argument
+# boundaries with spaces inside human-facing labels.
+fm_backend_herdr_cli() {
+  local session=$1 arg name
+  shift
+  {
+    printf 'session=%s' "$session"
+    for arg in "$@"; do printf '\x1f%s' "$arg"; done
+    printf '\n'
+  } >> "$HERDR_LOG"
+  case "${1:-} ${2:-}" in
+    "agent get") printf '{"result":{"agent":{"agent":"%s","agent_status":"working"}}}\n' "$FM_FAKE_AGENT_IDENTITY" ;;
+    "agent rename")
+      name=${4:-}
+      printf '{"result":{"agent":{"agent":"pi","name":"%s"}}}\n' "$name"
+      ;;
+    *) printf '{}\n' ;;
+  esac
+}
+
+fm_nm_visibility_herdr_metadata_capable() {
+  [ "$FM_FAKE_METADATA_CAPABLE" = 1 ]
+}
+
+write_meta() { # [backend] [harness]
+  local backend=${1:-herdr} harness=${2:-pi}
+  fm_write_meta "$STATE/review-task.meta" \
+    'window=fmtest:w1:p2' \
+    "worktree=$WORKTREE" \
+    'project=/project' \
+    "harness=$harness" \
+    'kind=ship' \
+    'mode=no-mistakes' \
+    "backend=$backend" \
+    'herdr_session=fmtest' \
+    'herdr_workspace_id=w1' \
+    'herdr_tab_id=w1:t2' \
+    'herdr_pane_id=w1:p2'
+}
+
+status_with_review() { # <review-status> <duration-ms> [top-status] [outcome] [error]
+  local review=$1 duration=$2 top=${3:-running} outcome=${4:-} error=${5:-}
+  cat <<EOF
+run:
+  id: "01VISIBILITYRUN"
+  branch: fm/review-task
+  status: $top
+  head: $HEAD_SHA
+  findings: none
+  steps[3]{step,status,findings,duration_ms}:
+    intent,completed,0,10
+    review,$review,0,$duration
+    test,pending,0,0
+EOF
+  [ -z "$outcome" ] || printf 'outcome: %s\n' "$outcome"
+  [ -z "$error" ] || printf 'error: "%s"\n' "$error"
+}
+
+status_waiting_for_captain() {
+  cat <<EOF
+run:
+  id: "01VISIBILITYRUN"
+  branch: fm/review-task
+  status: awaiting_approval
+  awaiting_agent: parked 25s
+  head: $HEAD_SHA
+  findings[1]{id,severity,file,line,action,description}:
+    r1,error,secret.go,,ask-user,contains TOP_SECRET_PROMPT
+  steps[3]{step,status,findings,duration_ms}:
+    intent,completed,0,10
+    review,fix_review,1,25000
+    test,pending,0,0
+gate: review
+EOF
+}
+
+reset_case() {
+  : > "$HERDR_LOG"
+  : > "$NM_LOG"
+  rm -f "$STATE/review-task.herdr-nm-activity"
+  write_meta
+  FM_FAKE_METADATA_CAPABLE=1
+  FM_FAKE_AGENT_IDENTITY=pi
+  FM_FAKE_AXI_STATUS=
+  FM_FAKE_REVIEW_LOG=
+  FM_NM_VISIBILITY_NOW=1000
+  FM_NM_VISIBILITY_ACTIVE_TTL_MS=45000
+  FM_NM_VISIBILITY_TERMINAL_TTL_MS=30000
+  export FM_FAKE_METADATA_CAPABLE FM_FAKE_AGENT_IDENTITY FM_FAKE_AXI_STATUS FM_FAKE_REVIEW_LOG
+  export FM_NM_VISIBILITY_NOW FM_NM_VISIBILITY_ACTIVE_TTL_MS FM_NM_VISIBILITY_TERMINAL_TTL_MS
+}
+
+assert_observational_only() {
+  local calls=$1
+  assert_not_contains "$calls" $'\x1f''agent'$'\x1f''send' "visibility attempted to steer an agent"
+  assert_not_contains "$calls" $'\x1f''pane'$'\x1f''send-text' "visibility attempted to type into a pane"
+  assert_not_contains "$calls" $'\x1f''pane'$'\x1f''send-keys' "visibility attempted to send a key"
+  assert_not_contains "$calls" $'\x1f''pane'$'\x1f''close' "visibility attempted to close a pane"
+  assert_not_contains "$calls" $'\x1f''agent'$'\x1f''start' "visibility attempted to start an agent"
+  assert_not_contains "$calls" $'\x1f''agent'$'\x1f''rename' "review visibility attempted to rename the owner"
+}
+
+test_active_reviewer_is_visible_and_bounded() {
+  local calls cache
+  reset_case
+  FM_FAKE_AXI_STATUS=$(status_with_review running 12000)
+  FM_FAKE_REVIEW_LOG=$(cat <<'EOF'
+step: review
+  reviewing changes...
+  claude started pid=4242
+  "PROMPT_TEXT=do not expose me"
+EOF
+)
+  export FM_FAKE_AXI_STATUS FM_FAKE_REVIEW_LOG
+
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  calls=$(cat "$HERDR_LOG")
+  cache=$(cat "$STATE/review-task.herdr-nm-activity")
+  assert_contains "$calls" $'\x1f''pane'$'\x1f''report-metadata'$'\x1f''w1:p2' "active reviewer did not use owning-pane metadata"
+  assert_contains "$calls" $'\x1f''--display-agent'$'\x1f''Pi · firstmate/review-task [w1:p2] · No Mistakes reviewer working · 12s · child started' "active reviewer display omitted identity, role, state, elapsed time, or activity"
+  assert_contains "$calls" $'\x1f''--token'$'\x1f''nm_role=reviewer' "active reviewer role token missing"
+  assert_contains "$calls" $'\x1f''--token'$'\x1f''nm_phase=review' "active reviewer phase token missing"
+  assert_contains "$calls" $'\x1f''--ttl-ms'$'\x1f''45000' "active reviewer metadata lacks bounded TTL"
+  assert_contains "$cache" 'state=working' "active reviewer cache state mismatch"
+  assert_not_contains "$calls$cache" '4242' "review visibility exposed a child pid"
+  assert_not_contains "$calls$cache" 'PROMPT_TEXT' "review visibility exposed prompt text"
+  assert_observational_only "$calls"
+  pass "active reviewer exposes safe role/state/phase/elapsed/activity metadata on the owning pane"
+}
+
+test_active_fixer_is_distinct() {
+  local calls
+  reset_case
+  FM_FAKE_AXI_STATUS=$(status_with_review fixing 61000 fixing)
+  FM_FAKE_REVIEW_LOG=$'user-fix round starting after round 2 (4 findings selected)\nasking agent to fix identified issues...\nclaude started pid=99'
+  export FM_FAKE_AXI_STATUS FM_FAKE_REVIEW_LOG
+
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  calls=$(cat "$HERDR_LOG")
+  assert_contains "$calls" $'\x1f''nm_role=fixer' "fixer role token missing"
+  assert_contains "$calls" $'\x1f''nm_phase=fix' "fixer phase token missing"
+  assert_contains "$calls" 'No Mistakes fixer working · 1m1s · child started' "fixer summary omitted state, elapsed time, or activity"
+  pass "active fixer is represented separately from a reviewer"
+}
+
+test_waiting_for_captain_is_accurate() {
+  local calls
+  reset_case
+  FM_FAKE_AXI_STATUS=$(status_waiting_for_captain)
+  FM_FAKE_REVIEW_LOG='TOP_SECRET_REVIEWER_PROSE'
+  export FM_FAKE_AXI_STATUS FM_FAKE_REVIEW_LOG
+
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  calls=$(cat "$HERDR_LOG")
+  assert_contains "$calls" $'\x1f''nm_state=waiting-for-captain' "captain wait state token missing"
+  assert_contains "$calls" $'\x1f''nm_phase=decision' "captain wait phase token missing"
+  assert_contains "$calls" 'decision requested' "captain wait activity missing"
+  assert_not_contains "$calls" 'TOP_SECRET' "captain wait exposed finding or reviewer text"
+  pass "waiting-for-captain is represented without exposing the decision prompt"
+}
+
+prime_active_cache() {
+  FM_FAKE_AXI_STATUS=$(status_with_review running 5000)
+  FM_FAKE_REVIEW_LOG='reviewing changes...'
+  export FM_FAKE_AXI_STATUS FM_FAKE_REVIEW_LOG
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  : > "$HERDR_LOG"
+}
+
+test_failed_transition_is_one_shot() {
+  local calls
+  reset_case
+  prime_active_cache
+  FM_NM_VISIBILITY_NOW=1010
+  FM_FAKE_AXI_STATUS=$(status_with_review failed 20000 failed failed 'review agent exited unsuccessfully; API_KEY=secret')
+  FM_FAKE_REVIEW_LOG=$'claude exited pid=777 error=claude exited: exit status 1: SECRET_COMMAND --token abc'
+  export FM_NM_VISIBILITY_NOW FM_FAKE_AXI_STATUS FM_FAKE_REVIEW_LOG
+
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  calls=$(cat "$HERDR_LOG")
+  assert_contains "$calls" $'\x1f''nm_state=failed' "failed reviewer state token missing"
+  assert_contains "$calls" $'\x1f''--ttl-ms'$'\x1f''30000' "failed reviewer did not use terminal TTL"
+  assert_not_contains "$calls" 'API_KEY' "failed reviewer exposed raw error text"
+  assert_not_contains "$calls" 'SECRET_COMMAND' "failed reviewer exposed a complete command"
+  assert_not_contains "$calls" '777' "failed reviewer exposed a pid"
+  pass "failed reviewer transition is accurate, bounded, and redacted"
+}
+
+test_timed_out_transition_is_distinct() {
+  local calls
+  reset_case
+  prime_active_cache
+  FM_NM_VISIBILITY_NOW=1010
+  FM_FAKE_AXI_STATUS=$(status_with_review failed 30000 failed failed 'review agent timed out while running SECRET --credential value')
+  FM_FAKE_REVIEW_LOG='agent prose containing credentials must not escape'
+  export FM_NM_VISIBILITY_NOW FM_FAKE_AXI_STATUS FM_FAKE_REVIEW_LOG
+
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  calls=$(cat "$HERDR_LOG")
+  assert_contains "$calls" $'\x1f''nm_state=timed-out' "timed-out reviewer state token missing"
+  assert_contains "$calls" 'review timed out' "timed-out reviewer activity missing"
+  assert_not_contains "$calls" 'SECRET' "timed-out reviewer exposed raw timeout context"
+  assert_not_contains "$calls" 'credential' "timed-out reviewer exposed a credential marker"
+  pass "timed-out reviewer is distinct from generic failure and remains private"
+}
+
+test_completed_transition_cleans_up_deterministically() {
+  local calls before after cache
+  reset_case
+  prime_active_cache
+  FM_NM_VISIBILITY_NOW=1010
+  FM_FAKE_AXI_STATUS=$(status_with_review completed 18000 running)
+  FM_FAKE_REVIEW_LOG='reviewer final prose must not escape'
+  export FM_NM_VISIBILITY_NOW FM_FAKE_AXI_STATUS FM_FAKE_REVIEW_LOG
+
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  calls=$(cat "$HERDR_LOG")
+  assert_contains "$calls" $'\x1f''nm_state=completed' "completed reviewer state token missing"
+  assert_contains "$calls" $'\x1f''--ttl-ms'$'\x1f''30000' "completed reviewer did not use terminal TTL"
+
+  FM_NM_VISIBILITY_NOW=1041
+  export FM_NM_VISIBILITY_NOW
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  calls=$(cat "$HERDR_LOG")
+  assert_contains "$calls" $'\x1f''--clear-title'$'\x1f''--clear-display-agent'$'\x1f''--clear-state-labels' "expired completed reviewer was not explicitly cleared"
+  assert_contains "$calls" $'\x1f''--clear-token'$'\x1f''nm_summary' "expired completed reviewer summary token was not cleared"
+  cache=$(cat "$STATE/review-task.herdr-nm-activity")
+  assert_contains "$cache" 'state=retired' "completed reviewer cache was not retired"
+  before=$(wc -l < "$HERDR_LOG" | tr -d '[:space:]')
+  FM_NM_VISIBILITY_NOW=1100
+  export FM_NM_VISIBILITY_NOW
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  after=$(wc -l < "$HERDR_LOG" | tr -d '[:space:]')
+  [ "$before" = "$after" ] || fail "retired completed reviewer was republished"
+  pass "completed reviewer is shown once, cleared after its TTL, and never accumulates"
+}
+
+test_unsupported_capability_falls_back_without_side_effects() {
+  reset_case
+  FM_FAKE_METADATA_CAPABLE=0
+  FM_FAKE_AXI_STATUS=$(status_with_review running 12000)
+  export FM_FAKE_METADATA_CAPABLE FM_FAKE_AXI_STATUS
+
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  [ ! -s "$HERDR_LOG" ] || fail "unsupported metadata capability still called Herdr"
+  [ ! -s "$NM_LOG" ] || fail "unsupported metadata capability still queried No Mistakes"
+  [ ! -e "$STATE/review-task.herdr-nm-activity" ] || fail "unsupported metadata capability created a cache"
+  pass "unsupported Herdr metadata capability degrades to a silent no-op"
+}
+
+test_non_herdr_backend_is_unchanged() {
+  reset_case
+  write_meta tmux pi
+  FM_FAKE_AXI_STATUS=$(status_with_review running 12000)
+  export FM_FAKE_AXI_STATUS
+
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  [ ! -s "$HERDR_LOG" ] || fail "non-Herdr task called Herdr visibility"
+  [ ! -s "$NM_LOG" ] || fail "non-Herdr task queried No Mistakes visibility"
+  pass "non-Herdr backends retain their existing behavior"
+}
+
+test_pi_worker_name_is_unique_and_verified() {
+  local name calls
+  reset_case
+  name=$(fm_backend_herdr_pi_worker_name firstmate review-task ship w1:p2) || fail "could not derive Pi worker name"
+  [ "$name" = 'Pi · firstmate/review-task [w1:p2]' ] || fail "unexpected Pi worker name: $name"
+  FM_BACKEND_HERDR_PI_RENAME_POLLS=1
+  FM_BACKEND_HERDR_PI_RENAME_POLL_SLEEP=0
+  fm_backend_herdr_name_pi_worker fmtest:w1:p2 "$name" || fail "Pi worker rename failed"
+  calls=$(cat "$HERDR_LOG")
+  assert_contains "$calls" $'\x1f''agent'$'\x1f''get'$'\x1f''w1:p2' "Pi worker rename did not verify native identity"
+  assert_contains "$calls" $'\x1f''agent'$'\x1f''rename'$'\x1f''w1:p2'$'\x1f''Pi · firstmate/review-task [w1:p2]' "Pi worker rename did not apply the task-specific name"
+  assert_not_contains "$calls" $'\x1f''workspace'$'\x1f''rename' "Pi worker naming changed the shared workspace"
+  assert_not_contains "$calls" $'\x1f''tab'$'\x1f''rename' "Pi worker naming changed the task tab"
+  pass "Pi worker naming preserves native identity and shared workspace/tab topology"
+}
+
+test_pi_worker_name_refuses_non_pi_identity() {
+  local name calls status
+  reset_case
+  name=$(fm_backend_herdr_pi_worker_name firstmate review-task ship w1:p2)
+  FM_FAKE_AGENT_IDENTITY=claude
+  export FM_FAKE_AGENT_IDENTITY
+  FM_BACKEND_HERDR_PI_RENAME_POLLS=1
+  FM_BACKEND_HERDR_PI_RENAME_POLL_SLEEP=0
+  fm_backend_herdr_name_pi_worker fmtest:w1:p2 "$name" >/dev/null 2>&1
+  status=$?
+  [ "$status" = 2 ] || fail "non-Pi identity should return 2 without mutation, got $status"
+  calls=$(cat "$HERDR_LOG")
+  assert_not_contains "$calls" $'\x1f''agent'$'\x1f''rename' "non-Pi identity was renamed"
+  pass "Pi worker naming never renames a shell or another harness"
+}
+
+test_spawn_applies_pi_name_after_launch_only_on_herdr() {
+  local source enter_line condition_line rename_line success_line
+  source=$(cat "$ROOT/bin/fm-spawn.sh")
+  assert_contains "$source" 'if [ "$BACKEND" = herdr ] && [ "$HARNESS" = pi ]; then' "spawn lost the Herdr+Pi-only naming condition"
+  enter_line=$(grep -nF 'spawn_send_key "$T" Enter' "$ROOT/bin/fm-spawn.sh" | tail -1 | cut -d: -f1)
+  condition_line=$(grep -nF 'if [ "$BACKEND" = herdr ] && [ "$HARNESS" = pi ]; then' "$ROOT/bin/fm-spawn.sh" | tail -1 | cut -d: -f1)
+  rename_line=$(grep -nF 'fm_backend_herdr_name_pi_worker "$T" "$HERDR_PI_NAME"' "$ROOT/bin/fm-spawn.sh" | tail -1 | cut -d: -f1)
+  success_line=$(grep -nF 'echo "spawned $ID harness=' "$ROOT/bin/fm-spawn.sh" | tail -1 | cut -d: -f1)
+  [ "$enter_line" -lt "$condition_line" ] || fail "Pi naming ran before the worker launch was submitted"
+  [ "$condition_line" -lt "$rename_line" ] || fail "Pi naming call escaped its Herdr+Pi condition"
+  [ "$rename_line" -lt "$success_line" ] || fail "spawn reported success before attempting the Pi name"
+  pass "new Herdr-backed Pi workers receive their task name after launch and before spawn success"
+}
+
+test_cleanup_removes_only_the_private_visibility_cache() {
+  local source
+  source=$(cat "$ROOT/bin/fm-teardown.sh")
+  assert_contains "$source" '"$STATE/$ID.herdr-nm-activity"' "ordinary cleanup does not remove the No Mistakes visibility cache"
+  assert_contains "$source" '"$sub_state/$child_id.herdr-nm-activity"' "secondmate-child cleanup does not remove the visibility cache"
+  assert_not_contains "$source" 'pane report-metadata' "cleanup gained Herdr metadata mutation instead of relying on pane close and TTL"
+  pass "task cleanup removes the private visibility cache without adding reviewer lifecycle control"
+}
+
+test_watcher_owns_the_regular_observation_tick() {
+  local source
+  source=$(cat "$ROOT/bin/fm-watch.sh")
+  assert_contains "$source" '. "$SCRIPT_DIR/fm-herdr-nm-visibility-lib.sh"' "watcher does not load the visibility owner"
+  assert_contains "$source" 'fm_nm_visibility_refresh_all "$STATE" || true' "watcher does not refresh review visibility"
+  assert_not_contains "$(cat "$ROOT/bin/fm-herdr-nm-visibility-lib.sh")" 'no-mistakes axi respond' "visibility owner can respond to a No Mistakes gate"
+  assert_not_contains "$(cat "$ROOT/bin/fm-herdr-nm-visibility-lib.sh")" 'no-mistakes axi abort' "visibility owner can abort a No Mistakes run"
+  pass "the existing watcher refreshes observation without acquiring No Mistakes lifecycle control"
+}
+
+test_active_reviewer_is_visible_and_bounded
+test_active_fixer_is_distinct
+test_waiting_for_captain_is_accurate
+test_failed_transition_is_one_shot
+test_timed_out_transition_is_distinct
+test_completed_transition_cleans_up_deterministically
+test_unsupported_capability_falls_back_without_side_effects
+test_non_herdr_backend_is_unchanged
+test_pi_worker_name_is_unique_and_verified
+test_pi_worker_name_refuses_non_pi_identity
+test_spawn_applies_pi_name_after_launch_only_on_herdr
+test_cleanup_removes_only_the_private_visibility_cache
+test_watcher_owns_the_regular_observation_tick

--- a/tests/fm-herdr-nm-visibility.test.sh
+++ b/tests/fm-herdr-nm-visibility.test.sh
@@ -66,6 +66,12 @@ fm_backend_herdr_cli() {
   esac
 }
 
+fm_nm_visibility_bounded_herdr() {
+  local session=$1
+  shift
+  fm_backend_herdr_cli "$session" "$@"
+}
+
 fm_nm_visibility_herdr_metadata_capable() {
   [ "$FM_FAKE_METADATA_CAPABLE" = 1 ]
 }
@@ -435,6 +441,22 @@ test_refresh_cycle_is_bounded_and_fair() {
   pass "refresh cycle bounds aggregate work and fairly defers tasks"
 }
 
+test_metadata_report_and_clear_use_bounded_herdr() {
+  local calls helper_source
+  reset_case
+  FM_FAKE_AXI_STATUS=$(status_with_review running 1000)
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  fm_nm_visibility_clear fmtest:w1:p2
+  calls=$(cat "$HERDR_LOG")
+  assert_contains "$calls" $'\x1f''--ttl-ms'$'\x1f''45000' "active metadata report bypassed bounded Herdr execution"
+  assert_contains "$calls" $'\x1f''--clear-title'$'\x1f''--clear-display-agent' "metadata clear bypassed bounded Herdr execution"
+  assert_not_contains "$(sed -n '/^fm_nm_visibility_report()/,/^}/p; /^fm_nm_visibility_clear()/,/^}/p' "$ROOT/bin/fm-herdr-nm-visibility-lib.sh")" 'fm_backend_herdr_cli' "visibility mutation calls the unbounded backend helper"
+  helper_source=$(sed -n '/^fm_nm_visibility_bounded_herdr()/,/^}/p' "$ROOT/bin/fm-herdr-nm-visibility-lib.sh")
+  assert_contains "$helper_source" 'timeout "$FM_NM_VISIBILITY_TIMEOUT" herdr "$@"' "bounded Herdr helper lacks timeout execution"
+  assert_contains "$helper_source" 'kill "TERM", -$pid' "bounded Herdr helper lacks process-group fallback termination"
+  pass "metadata reports and clears share bounded Herdr execution"
+}
+
 test_active_reviewer_is_visible_and_bounded
 test_active_fixer_is_distinct
 test_waiting_for_captain_is_accurate
@@ -451,4 +473,5 @@ test_watcher_owns_the_regular_observation_tick
 test_zero_elapsed_does_not_cross_run_cache
 test_invalid_log_tail_falls_back_and_preserves_hints
 test_top_level_failure_without_review_failure_is_visible
+test_metadata_report_and_clear_use_bounded_herdr
 test_refresh_cycle_is_bounded_and_fair

--- a/tests/fm-herdr-nm-visibility.test.sh
+++ b/tests/fm-herdr-nm-visibility.test.sh
@@ -373,6 +373,68 @@ test_watcher_owns_the_regular_observation_tick() {
   pass "the existing watcher refreshes observation without acquiring No Mistakes lifecycle control"
 }
 
+test_zero_elapsed_does_not_cross_run_cache() {
+  reset_case
+  FM_NM_VISIBILITY_NOW=100
+  FM_FAKE_AXI_STATUS=$(status_with_review running 12000)
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  FM_NM_VISIBILITY_NOW=110
+  FM_FAKE_AXI_STATUS=$(status_with_review running 0 | sed 's/01VISIBILITYRUN/01VISIBILITYRUNB/')
+  fm_nm_visibility_refresh_task "$STATE" review-task
+  assert_contains "$(cat "$STATE/review-task.herdr-nm-activity")" 'elapsed_ms=0' "new run inherited prior elapsed cache"
+  pass "zero elapsed starts fresh when the observed run changes"
+}
+
+test_invalid_log_tail_falls_back_and_preserves_hints() {
+  local bad
+  for bad in invalid -4; do
+    reset_case
+    FM_NM_VISIBILITY_REVIEW_LOG_TAIL=$bad
+    FM_FAKE_AXI_STATUS=$(status_with_review running 5000)
+    FM_FAKE_REVIEW_LOG='asking agent to fix identified issues...'
+    fm_nm_visibility_refresh_task "$STATE" review-task
+    assert_contains "$(cat "$STATE/review-task.herdr-nm-activity")" 'role=fixer' "invalid log tail lost parsed role hint"
+    assert_contains "$(cat "$STATE/review-task.herdr-nm-activity")" 'phase=fix' "invalid log tail lost parsed phase hint"
+  done
+  FM_NM_VISIBILITY_REVIEW_LOG_TAIL=200
+  pass "invalid and negative log tails use the safe default without losing hints"
+}
+
+test_top_level_failure_without_review_failure_is_visible() {
+  local review
+  for review in pending skipped absent; do
+    reset_case
+    FM_FAKE_AXI_STATUS=$(status_with_review running 1000)
+    fm_nm_visibility_refresh_task "$STATE" review-task
+    if [ "$review" = absent ]; then
+      FM_FAKE_AXI_STATUS=$(status_with_review pending 0 failed failed | grep -v 'review,pending')
+    else
+      FM_FAKE_AXI_STATUS=$(status_with_review "$review" 0 failed failed)
+    fi
+    fm_nm_visibility_refresh_task "$STATE" review-task
+    assert_contains "$(cat "$STATE/review-task.herdr-nm-activity")" 'state=failed' "top-level failure was hidden for review=$review"
+  done
+  pass "top-level failure remains visible without terminal review detail"
+}
+
+test_refresh_cycle_is_bounded_and_fair() {
+  local seen
+  reset_case
+  cp "$STATE/review-task.meta" "$STATE/review-task-b.meta"
+  cp "$STATE/review-task.meta" "$STATE/review-task-c.meta"
+  fm_nm_visibility_refresh_task() { printf '%s\n' "$2" >> "$NM_LOG"; }
+  FM_NM_VISIBILITY_MAX_TASKS_PER_CYCLE=1
+  _FM_NM_VISIBILITY_REFRESH_CURSOR=
+  : > "$NM_LOG"
+  fm_nm_visibility_refresh_all "$STATE"
+  fm_nm_visibility_refresh_all "$STATE"
+  fm_nm_visibility_refresh_all "$STATE"
+  seen=$(sort -u "$NM_LOG" | wc -l | tr -d ' ')
+  [ "$seen" = 3 ] || fail "bounded refresh did not fairly visit all tasks"
+  [ "$(wc -l < "$NM_LOG" | tr -d ' ')" = 3 ] || fail "refresh exceeded one task per cycle"
+  pass "refresh cycle bounds aggregate work and fairly defers tasks"
+}
+
 test_active_reviewer_is_visible_and_bounded
 test_active_fixer_is_distinct
 test_waiting_for_captain_is_accurate
@@ -386,3 +448,7 @@ test_pi_worker_name_refuses_non_pi_identity
 test_spawn_applies_pi_name_after_launch_only_on_herdr
 test_cleanup_removes_only_the_private_visibility_cache
 test_watcher_owns_the_regular_observation_tick
+test_zero_elapsed_does_not_cross_run_cache
+test_invalid_log_tail_falls_back_and_preserves_hints
+test_top_level_failure_without_review_failure_is_visible
+test_refresh_cycle_is_bounded_and_fair

--- a/tests/fm-install-herdr.test.sh
+++ b/tests/fm-install-herdr.test.sh
@@ -8,11 +8,13 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 HERDR_INSTALL="$ROOT/bin/fm-install-herdr.sh"
+HERDR_VERSION_OWNER="$ROOT/bin/fm-herdr-version.sh"
 TREEHOUSE_INSTALL="$ROOT/bin/fm-install-treehouse.sh"
 CLEANUP="$ROOT/bin/fm-herdr-ci-cleanup.sh"
 CI="$ROOT/.github/workflows/ci.yml"
 
 assert_present "$HERDR_INSTALL" "bin/fm-install-herdr.sh is missing"
+assert_present "$HERDR_VERSION_OWNER" "bin/fm-herdr-version.sh is missing"
 assert_present "$TREEHOUSE_INSTALL" "bin/fm-install-treehouse.sh is missing"
 assert_present "$CLEANUP" "bin/fm-herdr-ci-cleanup.sh is missing"
 [ -x "$HERDR_INSTALL" ] || fail "fm-install-herdr.sh must be executable"
@@ -20,8 +22,10 @@ assert_present "$CLEANUP" "bin/fm-herdr-ci-cleanup.sh is missing"
 [ -x "$CLEANUP" ] || fail "fm-herdr-ci-cleanup.sh must be executable"
 
 test_herdr_installer_pins_exact_version_and_checksums() {
-  assert_grep 'FM_HERDR_CI_VERSION=0.7.4' "$HERDR_INSTALL" \
-    "Herdr installer must pin suite-verified 0.7.4"
+  assert_grep 'FM_HERDR_CI_VERSION=0.7.4' "$HERDR_VERSION_OWNER" \
+    "Herdr version owner must pin suite-verified 0.7.4"
+  assert_grep 'fm-herdr-version.sh' "$HERDR_INSTALL" \
+    "Herdr installer must consume the shared version owner"
   assert_grep 'FM_HERDR_CI_MIN_PROTOCOL=16' "$HERDR_INSTALL" \
     "Herdr installer must require protocol floor 16"
   assert_grep 'ogulcancelik/herdr' "$HERDR_INSTALL" \

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -101,6 +101,8 @@ init_changed_fixture_repo() {
     fm-captain-translation-contract.test.sh \
     fm-cd-pretool-check.test.sh \
     fm-daemon.test.sh \
+    fm-herdr-nm-visibility.test.sh \
+    fm-herdr-nm-visibility-e2e.test.sh \
     fm-backend-herdr-smoke.test.sh \
     fm-secondmate-safety.test.sh \
     fm-session-start.test.sh \
@@ -118,6 +120,7 @@ init_changed_fixture_repo() {
   done
   : >"$repo/tests/lib.sh"
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
+  : >"$repo/bin/fm-nm-status-lib.sh"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/unmapped-source.sh"
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
@@ -161,6 +164,13 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-afk-return.test.sh" "supervisor target selects afk coverage"
   git -C "$repo" add bin/fm-supervisor-target-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm supervisor-change
+
+  printf '\n' >>"$repo/bin/fm-nm-status-lib.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-herdr-nm-visibility.test.sh" "No Mistakes status parser selects visibility coverage"
+  assert_contains "$listed" "tests/fm-herdr-nm-visibility-e2e.test.sh" "No Mistakes status parser selects real Herdr coverage"
+  git -C "$repo" add bin/fm-nm-status-lib.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm nm-status-change
 
   printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
   printf '\n' >>"$repo/.claude/settings.json"


### PR DESCRIPTION
## Intent

The developer wanted Firstmate/Herdr to expose active No Mistakes reviewers and fixers as bounded, privacy-safe, read-only activity associated with their owning worker, with accurate lifecycle states, deterministic cleanup, unsupported-capability fallback, focused tests, and user documentation—without creating controllable panes, duplicate workers, or changing No Mistakes lifecycle ownership. They also required every Firstmate-spawned Pi worker in the shared Herdr workspace to have a distinct task-specific prominent identity, verified empirically and visually using only the isolated Herdr lab helper. The implementation had to preserve non-Herdr behavior, existing mainline and task changes, all review fixes and conflict resolutions, follow Firstmate contract ownership rules, and pass relevant tests and shell lint. Finally, they wanted the preserved commit history validated and delivered through No Mistakes using supported recovery/rerun flows with unchanged approved configuration, no reset and no --yes, including captain-approved regression coverage and design corrections, then pushed to a fork with a PR and green CI; the latest instruction required confirming the reviewer was temporarily routed to Codex before proceeding.

## What Changed

- Expose bounded, read-only No Mistakes reviewer and fixer activity in Herdr, with capability fallback, lifecycle-aware status, and deterministic stale-projection cleanup.
- Add verified Kimi worker support and harden cross-harness submission, composer detection, operational-input handling, and watcher continuity.
- Refine Pi Calm rendering, task dispatch and decision-authority contracts, plus supporting documentation and regression coverage.

## Risk Assessment

✅ Low: The latest fix adds bounded KILL escalation to all preferred Herdr and No Mistakes timeout paths, preserves the process-group fallback, and introduces focused coverage without creating a new material source risk.

## Testing

Startup and dependency checks, focused lifecycle/privacy/fallback tests, a real isolated Herdr 0.7.4 flow, test-runner regression coverage, and related backend/state/ownership/teardown integrations all passed. The lab helper exposes Herdr’s real metadata API and validates the sidebar configuration but provides no rendered UI capture surface, so visual evidence is represented by the real-Herdr transcript rather than a screenshot.

<details>
<summary>Evidence: Real Herdr end-to-end evidence</summary>

`Real Herdr 0.7.4 transcript demonstrating distinct Pi identities, prominent sidebar configuration acceptance, privacy-safe reviewer activity, lifecycle cleanup, and TTL expiry.`

```text
ok - real Herdr lab: task-specific Pi names are distinct while both owners remain native Pi agents in one shared workspace
ok - real Herdr lab: Herdr accepts the Pi sidebar layout that makes the task-specific agent name prominent
ok - real Herdr lab: owning Pi row exposes bounded reviewer role/state/phase/elapsed/activity without a child agent
ok - real Herdr lab: completed activity cleans up deterministically and leaves the named owner intact
ok - real Herdr lab: source TTL removes abandoned activity without removing the task-specific owner name
ok - real Herdr lab validation completed on Herdr 0.7.4 protocol 16
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-herdr-nm-visibility-lib.sh:508` - The capability probe invokes `herdr api schema` without any timeout. Because this runs synchronously in the sole supervision watcher, a stalled Herdr CLI can freeze all subsequent task monitoring and notifications indefinitely. Apply a bounded invocation or cache the result outside the watcher’s critical loop.
- ⚠️ `bin/fm-herdr-nm-visibility-lib.sh:708` - Visibility refresh processes eligible tasks serially, with each active task potentially spending up to 3 seconds on status and another 3 seconds on logs. The watcher therefore gains roughly six seconds of latency per active No Mistakes task before it can observe the next event; use a global cycle budget, stagger refreshes, or move observation off the supervision-critical path.

🔧 Fix: Bound Herdr refreshes and centralize No Mistakes parsing
2 issues (1 error, 1 warning) still open:
- 🚨 `bin/fm-herdr-nm-visibility-lib.sh:554` - The cycle now limits task count, but each selected task still calls `pane report-metadata` synchronously without a timeout; the cleanup path does the same. A stalled Herdr mutation can therefore freeze the sole watcher indefinitely, so aggregate refresh latency is not actually bounded. Route both report and clear operations through a bounded Herdr helper.
- ⚠️ `bin/fm-herdr-nm-visibility-lib.sh:723` - The one-task default counts every `.meta` file against the refresh budget, including non-Herdr and non-No-Mistakes tasks that immediately no-op. With enough fleet records, an active eligible task may not be revisited within its 45-second TTL, causing its metadata to expire and flicker despite continuing activity. Budget only eligible tasks and define how renewal should behave when eligible tasks themselves exceed the TTL capacity.

🔧 Fix: Bound all Herdr visibility metadata operations
1 error still open:
- 🚨 `bin/fm-herdr-nm-visibility-lib.sh:129` - The `timeout` and `gtimeout` branches send only TERM. If a stalled Herdr process ignores or cannot handle TERM, `timeout` continues waiting indefinitely, so report/clear operations can still freeze the watcher. Add a bounded KILL escalation (for example `--kill-after`) comparable to the Perl fallback.

🔧 Fix: Escalate visibility timeouts to bounded KILL
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-session-start.sh`
- `bin/fm-test-run.sh tests/fm-herdr-nm-visibility.test.sh tests/fm-install-herdr.test.sh --json /var/folders/n8/_ljjh36x6h19cpnycv43r5gm0000gn/T/no-mistakes-evidence/01KYG2GK2B30NAYMN2CEV69C2B/focused-tests.json`
- `bash tests/fm-herdr-nm-visibility-e2e.test.sh 2>&1 | tee /var/folders/n8/_ljjh36x6h19cpnycv43r5gm0000gn/T/no-mistakes-evidence/01KYG2GK2B30NAYMN2CEV69C2B/herdr-e2e-transcript.txt`
- <code>`bin/fm-test-run.sh --list --changed --base a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499` (reproduced missing mapping, then passed after fix)</code>
- `bin/fm-test-run.sh tests/fm-test-run.test.sh`
- `bin/fm-test-run.sh tests/fm-backend-herdr.test.sh tests/fm-backend.test.sh tests/fm-crew-state.test.sh tests/fm-nm-test-contract.test.sh tests/fm-no-mistakes-ownership.test.sh tests/fm-teardown.test.sh tests/fm-watch-checkpoint.test.sh --json /var/folders/n8/_ljjh36x6h19cpnycv43r5gm0000gn/T/no-mistakes-evidence/01KYG2GK2B30NAYMN2CEV69C2B/integration-tests.json`
- `git diff --check`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Captain: annotate intentional sourced globals for ShellCheck
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
