### PR TITLE
chore(ci): bump pinned Treehouse to v2.1.0

### DIFF
--- a/bin/fm-install-treehouse.sh
+++ b/bin/fm-install-treehouse.sh
@@ -9,12 +9,12 @@
 # Usage:
 #   fm-install-treehouse.sh <destination-directory>
 #
-# Pins Treehouse v2.0.1, the version exercised by the local real-Herdr suite.
+# Pins Treehouse v2.1.0, the version exercised by the local real-Herdr suite.
 set -eu
 
-FM_TREEHOUSE_CI_VERSION=2.0.1
+FM_TREEHOUSE_CI_VERSION=2.1.0
 FM_TREEHOUSE_CI_TAG="v${FM_TREEHOUSE_CI_VERSION}"
-# Bounded download ceiling (bytes). Official 2.0.1 archives are under 8 MiB.
+# Bounded download ceiling (bytes). Official 2.1.0 archives are under 8 MiB.
 FM_TREEHOUSE_CI_MAX_BYTES=15000000
 FM_TREEHOUSE_CI_REPO=kunchenguid/treehouse
 
@@ -30,19 +30,19 @@ arch=$(uname -m)
 case "${os}-${arch}" in
   Linux-x86_64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-linux-amd64.tar.gz
-    SHA256=1d5a32751ab921670103fd201ddb2b91b47338cb13976f45642b827cf8976af2
+    SHA256=ff030255663bb5d384309cdf1b3a0bd62006e0ac978340d292039697cb70c225
     ;;
   Linux-aarch64|Linux-arm64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-linux-arm64.tar.gz
-    SHA256=eaccc9c5b98125df8bd77425598eeecee66cb0371db4eb1cf75f0d813c18fab9
+    SHA256=d4e37ad11d50fb6381c060d34e7372e944e01af78b0c6707c6d0ff966c7c2c44
     ;;
   Darwin-arm64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-darwin-arm64.tar.gz
-    SHA256=7ee5078f3d1f33c01196548797fce65408e459d53530b77d4ba56e074fa1c1a2
+    SHA256=a2e9bcba88d643a828062f3425dcf601886372fc2aca87b542b36fc8bbf2c992
     ;;
   Darwin-x86_64)
     ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-darwin-amd64.tar.gz
-    SHA256=1cf44580a5837f995e1d3bb74f4fbd3112b642acd20406087d9735a8106112fd
+    SHA256=8eb2eb3b63f409a316bd9c19af5d3035e5b72f6feffc98f0fac658e1ed33a397
     ;;
   *)
     die "unsupported platform ${os}-${arch}; official Treehouse assets are linux/darwin amd64 and arm64"
@@ -68,7 +68,7 @@ fi
 [ "$ACTUAL_SHA256" = "$SHA256" ] || die "checksum mismatch for $ARCHIVE (expected $SHA256, got $ACTUAL_SHA256)"
 
 tar -xzf "$TMP/$ARCHIVE" -C "$TMP"
-# Archive layout: a single `treehouse` binary at the archive root (verified for v2.0.1).
+# Archive layout: a single `treehouse` binary at the archive root (verified for v2.1.0).
 if [ -f "$TMP/treehouse" ]; then
   BIN="$TMP/treehouse"
 elif [ -f "$TMP/treehouse-v${FM_TREEHOUSE_CI_VERSION}/treehouse" ]; then
@@ -82,7 +82,7 @@ mkdir -p "$DESTINATION"
 install -m 0755 "$BIN" "$DESTINATION/treehouse"
 
 installed_version=$("$DESTINATION/treehouse" --version 2>/dev/null | tr -d '[:space:]')
-# treehouse prints "v2.0.1" (leading v) on --version.
+# treehouse prints "v2.1.0" (leading v) on --version.
 case "$installed_version" in
   "v${FM_TREEHOUSE_CI_VERSION}"|"${FM_TREEHOUSE_CI_VERSION}") ;;
   *)

--- a/tests/fm-install-herdr.test.sh
+++ b/tests/fm-install-herdr.test.sh
@@ -42,13 +42,13 @@ test_herdr_installer_pins_exact_version_and_checksums() {
 }
 
 test_treehouse_installer_pins_exact_version_and_checksums() {
-  assert_grep 'FM_TREEHOUSE_CI_VERSION=2.0.1' "$TREEHOUSE_INSTALL" \
-    "Treehouse installer must pin the suite-verified 2.0.1 release"
+  assert_grep 'FM_TREEHOUSE_CI_VERSION=2.1.0' "$TREEHOUSE_INSTALL" \
+    "Treehouse installer must pin the suite-verified 2.1.0 release"
   assert_grep 'kunchenguid/treehouse' "$TREEHOUSE_INSTALL" \
     "Treehouse installer must use the official GitHub release source"
   assert_grep 'linux-amd64.tar.gz' "$TREEHOUSE_INSTALL" \
     "Treehouse installer must name the Linux amd64 archive"
-  assert_grep '1d5a32751ab921670103fd201ddb2b91b47338cb13976f45642b827cf8976af2' "$TREEHOUSE_INSTALL" \
+  assert_grep 'ff030255663bb5d384309cdf1b3a0bd62006e0ac978340d292039697cb70c225' "$TREEHOUSE_INSTALL" \
     "Treehouse installer must pin the Linux amd64 SHA-256"
   assert_grep '--max-filesize' "$TREEHOUSE_INSTALL" \
     "Treehouse installer must bound the download size"


### PR DESCRIPTION
Bump the pinned Treehouse CI build in `bin/fm-install-treehouse.sh` from v2.0.1 to v2.1.0, keeping the existing pin-and-checksum discipline.

- `FM_TREEHOUSE_CI_VERSION` 2.0.1 -> 2.1.0
- All four per-platform SHA-256 pins swapped to values re-derived and verified against the upstream `v2.1.0/checksums.txt`
- Stale 2.0.1 comment strings refreshed for internal consistency
- `tests/fm-install-herdr.test.sh` assertions updated to the new version and SHA so the pin guard stays in sync

Validated through the no-mistakes pipeline (review, test, document, lint all passed).

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)
