### PR TITLE
feat: fm-xsearch SuperGrok web_search/x_search

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -232,6 +232,7 @@ The checkpoint is deliberately foreground and bounded so Codex regains control r
 | Interrupt | double Escape; known flaky while a long shell command runs, so a wedged pane may need `/exit` and relaunch |
 
 No trust dialog.
+xAI server-side `web_search` / `x_search` are not attached to the default coding agent loop; fleet workers call `bin/fm-xsearch.sh` (or the optional OpenCode custom-tool example) instead — see `docs/xai-server-search.md`.
 Opencode can auto-upgrade itself in the background and the running TUI can exit mid-task, observed live from 1.15.7 to 1.17.3.
 If a pane shows the exit banner, relaunch with `--continue` to resume the session.
 `--prompt` does not auto-submit alongside `--continue`, so send the next instruction via `fm-send` once the TUI is up.
@@ -268,6 +269,9 @@ The follow-up was verified in the interactive TUI; `opencode run` can exit befor
 | Exit command | `/quit` |
 | Interrupt | single Escape |
 
+Pi's Responses path serializes client function tools only; it does not emit xAI built-in `web_search` / `x_search`.
+Fleet X/web server search goes through `bin/fm-xsearch.sh` (see `docs/xai-server-search.md`).
+
 Pi has no permission system, so crewmates are always autonomous.
 Keep the brief as one positional argument.
 Multiple positional args become separate queued messages; `fm-spawn`'s template already does this correctly.
@@ -293,6 +297,7 @@ When a secondmate is launched on Pi, `fm-spawn.sh --secondmate` launches Pi with
 Grok Build TUI (`grok`), a Claude-Code-compatible CLI from xAI.
 Launch with a positional prompt: `grok --always-approve "$(cat <brief>)"`.
 For Grok's supported reasoning-effort values and omission behavior, see the [launch-profile-axes table](#launch-profile-axes).
+For xAI server-side `web_search` / `x_search` (Responses API, SuperGrok OAuth), workers call `bin/fm-xsearch.sh` rather than assuming the TUI attaches those tools — see `docs/xai-server-search.md`.
 
 | Fact | Value |
 |---|---|

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -232,7 +232,7 @@ The checkpoint is deliberately foreground and bounded so Codex regains control r
 | Interrupt | double Escape; known flaky while a long shell command runs, so a wedged pane may need `/exit` and relaunch |
 
 No trust dialog.
-xAI server-side `web_search` / `x_search` are not attached to the default coding agent loop; fleet workers call `bin/fm-xsearch.sh` (or the optional OpenCode custom-tool example) instead — see `docs/xai-server-search.md`.
+xAI server-side `web_search` / `x_search` are not attached to the default coding agent loop; fleet workers call `bin/fm-xsearch.sh` (or the optional OpenCode custom-tool example) instead - see `docs/xai-server-search.md`.
 Opencode can auto-upgrade itself in the background and the running TUI can exit mid-task, observed live from 1.15.7 to 1.17.3.
 If a pane shows the exit banner, relaunch with `--continue` to resume the session.
 `--prompt` does not auto-submit alongside `--continue`, so send the next instruction via `fm-send` once the TUI is up.
@@ -297,7 +297,7 @@ When a secondmate is launched on Pi, `fm-spawn.sh --secondmate` launches Pi with
 Grok Build TUI (`grok`), a Claude-Code-compatible CLI from xAI.
 Launch with a positional prompt: `grok --always-approve "$(cat <brief>)"`.
 For Grok's supported reasoning-effort values and omission behavior, see the [launch-profile-axes table](#launch-profile-axes).
-For xAI server-side `web_search` / `x_search` (Responses API, SuperGrok OAuth), workers call `bin/fm-xsearch.sh` rather than assuming the TUI attaches those tools — see `docs/xai-server-search.md`.
+For xAI server-side `web_search` / `x_search` (Responses API, SuperGrok OAuth), workers call `bin/fm-xsearch.sh` rather than assuming the TUI attaches those tools - see `docs/xai-server-search.md`.
 
 | Fact | Value |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Firstmate's skills live in two separate places with different audiences:
 
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
+- [docs/xai-server-search.md](docs/xai-server-search.md) - xAI server-side `web_search` / `x_search` via SuperGrok OAuth (`bin/fm-xsearch.sh`).
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - current setup and limits for the tmux reference backend.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -125,10 +125,10 @@ family_for_basename() {
     fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
-    fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\
-    fm-subagent-pretool-check.test.sh|\
-    fm-supervision-instructions.test.sh|fm-tmux-submit-busy.test.sh|fm-transition-lib.test.sh|\
-    fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
+     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\
+     fm-subagent-pretool-check.test.sh|\
+     fm-supervision-instructions.test.sh|fm-tmux-submit-busy.test.sh|fm-transition-lib.test.sh|\
+     fm-test-run.test.sh|fm-test-isolation-proof.test.sh|fm-xsearch.test.sh)
       printf '%s\n' pure-contract-unit
       ;;
     fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
@@ -667,6 +667,10 @@ families_for_changed_path() {
     bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
     bin/fm-x-*|bin/fm-check*)
       printf '%s\n' pr-forge
+      ;;
+    bin/fm-xsearch.sh)
+      # xAI Responses search helper (not X-mode). Distinct from bin/fm-x-*.
+      printf '%s\n' pure-contract-unit
       ;;
     bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)

--- a/bin/fm-xsearch.sh
+++ b/bin/fm-xsearch.sh
@@ -317,31 +317,27 @@ handles_json_array() {
 }
 
 build_x_search_tool_json() {
-  local tool handles
-  tool=$(jq -cn '{type:"x_search"}') || return 1
+  local allowed='[]' excluded='[]'
   if [ "${#ALLOWED_HANDLES[@]}" -gt 0 ]; then
-    handles=$(handles_json_array "${ALLOWED_HANDLES[@]}") || return 1
-    tool=$(jq -cn --argjson t "$tool" --argjson h "$handles" \
-      '$t + {allowed_x_handles:$h}') || return 1
+    allowed=$(handles_json_array "${ALLOWED_HANDLES[@]}") || return 1
   fi
   if [ "${#EXCLUDED_HANDLES[@]}" -gt 0 ]; then
-    handles=$(handles_json_array "${EXCLUDED_HANDLES[@]}") || return 1
-    tool=$(jq -cn --argjson t "$tool" --argjson h "$handles" \
-      '$t + {excluded_x_handles:$h}') || return 1
+    excluded=$(handles_json_array "${EXCLUDED_HANDLES[@]}") || return 1
   fi
-  if [ -n "$FROM_DATE" ]; then
-    tool=$(jq -cn --argjson t "$tool" --arg d "$FROM_DATE" '$t + {from_date:$d}') || return 1
-  fi
-  if [ -n "$TO_DATE" ]; then
-    tool=$(jq -cn --argjson t "$tool" --arg d "$TO_DATE" '$t + {to_date:$d}') || return 1
-  fi
-  if [ "$ENABLE_IMAGE" -eq 1 ]; then
-    tool=$(jq -cn --argjson t "$tool" '$t + {enable_image_understanding:true}') || return 1
-  fi
-  if [ "$ENABLE_VIDEO" -eq 1 ]; then
-    tool=$(jq -cn --argjson t "$tool" '$t + {enable_video_understanding:true}') || return 1
-  fi
-  printf '%s\n' "$tool"
+  jq -cn \
+    --argjson allowed "$allowed" \
+    --argjson excluded "$excluded" \
+    --arg from "$FROM_DATE" \
+    --arg to "$TO_DATE" \
+    --arg image "$ENABLE_IMAGE" \
+    --arg video "$ENABLE_VIDEO" \
+    '{type:"x_search"}
+     + (if ($allowed|length) > 0 then {allowed_x_handles:$allowed} else {} end)
+     + (if ($excluded|length) > 0 then {excluded_x_handles:$excluded} else {} end)
+     + (if $from != "" then {from_date:$from} else {} end)
+     + (if $to != "" then {to_date:$to} else {} end)
+     + (if $image == "1" then {enable_image_understanding:true} else {} end)
+     + (if $video == "1" then {enable_video_understanding:true} else {} end)'
 }
 
 build_tools_json() {
@@ -402,6 +398,7 @@ make_tmp() {
 }
 
 AUTH_BEARER=
+REFRESHED_ACCESS=
 
 read_store_xai() {
   local file=$1
@@ -427,51 +424,62 @@ load_oauth_from_store() {
   fi
   if is_uint "$expires" && [ "$expires" -gt 0 ] && [ "$((now + skew))" -ge "$expires" ]; then
     [ -n "$refresh" ] || die "OAuth access expired and no refresh token in $file" 3
-    access=$(refresh_oauth_token "$file" "$refresh") || return 1
-    [ -n "$access" ] || return 1
+    # Called in this shell, not a command substitution: its temp files join
+    # TMP_FILES for the EXIT trap and its die() terminates the script.
+    refresh_oauth_token "$file" "$refresh" || die "OAuth refresh failed for $file" 3
+    access=$REFRESHED_ACCESS
+    REFRESHED_ACCESS=
+    [ -n "$access" ] || die "OAuth refresh returned no access token" 3
   fi
   AUTH_BEARER=$access
   return 0
 }
 
-# Refresh OAuth; print the new access token on stdout. Best-effort write-back to
-# the auth store (mode 600). A write failure still returns the fresh access so
-# the current call can proceed.
+# Refresh OAuth; set REFRESHED_ACCESS to the new access token. Must run in the
+# caller's shell (see load_oauth_from_store) so credential temp files are cleaned
+# by the EXIT trap and refresh failures exit 3 instead of falling through to the
+# next store. Best-effort write-back to the auth store (mode 600); a write
+# failure still yields the fresh access so the current call can proceed.
 refresh_oauth_token() {
-  local file=$1 refresh=$2 form_file resp_file out_file code new_json expires_in access new_refresh expires_ms
+  local file=$1 refresh=$2 form_file resp_file out_file store_dir code new_json expires_in access new_refresh expires_ms
+  REFRESHED_ACCESS=
   command -v curl >/dev/null 2>&1 || die "curl not found"
   make_tmp form_file || die "mktemp failed"
   make_tmp resp_file || die "mktemp failed"
-  # Never log refresh token. Write form body to a 0600 temp file.
-  {
-    printf 'grant_type=refresh_token&client_id='
-    jq -rn --arg v "$CLIENT_ID" '$v|@uri'
-    printf '&refresh_token='
-    jq -rn --arg v "$refresh" '$v|@uri'
-  } > "$form_file" || die "failed to build refresh body"
+  # Never log the refresh token. Write the exact wire body to a 0600 temp file;
+  # -j keeps jq from appending newlines that would corrupt the form fields.
+  jq -jn --arg cid "$CLIENT_ID" --arg refresh "$refresh" \
+    '"grant_type=refresh_token&client_id=" + ($cid|@uri)
+     + "&refresh_token=" + ($refresh|@uri)' \
+    > "$form_file" || die "failed to build refresh body"
 
   code=$(curl -m "$CURL_TIMEOUT" -sS -o "$resp_file" -w '%{http_code}' \
     -X POST \
     -H 'Accept: application/json' \
     -H 'Content-Type: application/x-www-form-urlencoded' \
     --data-binary @"$form_file" \
-    "$TOKEN_URL" 2>/dev/null) || die "OAuth refresh transport failed" 3
+    "$TOKEN_URL" 2>/dev/null) || { rm -f "$form_file"; die "OAuth refresh transport failed" 3; }
+  rm -f "$form_file"
 
   case "$code" in
     2[0-9][0-9]) ;;
-    *) die "OAuth refresh failed (HTTP $code)" 3 ;;
+    *) rm -f "$resp_file"; die "OAuth refresh failed (HTTP $code)" 3 ;;
   esac
 
   access=$(jq -r '.access_token // empty' "$resp_file") || true
-  [ -n "$access" ] || die "OAuth refresh response missing access_token" 3
+  [ -n "$access" ] || { rm -f "$resp_file"; die "OAuth refresh response missing access_token" 3; }
   new_refresh=$(jq -r '.refresh_token // empty' "$resp_file") || true
   [ -n "$new_refresh" ] || new_refresh=$refresh
   expires_in=$(jq -r '.expires_in // empty' "$resp_file") || true
+  rm -f "$resp_file"
   if ! is_uint "${expires_in:-}"; then
     expires_in=$DEFAULT_TOKEN_LIFETIME_S
   fi
-  expires_ms=$(( $(now_ms) + expires_in * 1000 - REFRESH_SKEW_MS ))
-  [ "$expires_ms" -gt 0 ] || expires_ms=$(( $(now_ms) + expires_in * 1000 ))
+  # Absolute expiry, as OpenCode/Pi define the field. The refresh skew belongs
+  # only to the read-side comparison in load_oauth_from_store.
+  expires_ms=$(( $(now_ms) + expires_in * 1000 ))
+
+  REFRESHED_ACCESS=$access
 
   new_json=$(jq -c \
     --arg access "$access" \
@@ -480,29 +488,23 @@ refresh_oauth_token() {
     '.xai.type = "oauth"
      | .xai.access = $access
      | .xai.refresh = $refresh
-     | .xai.expires = $expires' "$file") || {
-    printf '%s\n' "$access"
-    return 0
-  }
+     | .xai.expires = $expires' "$file") || return 0
 
-  make_tmp out_file || {
-    printf '%s\n' "$access"
+  # Stage inside the store's own directory so the replace is a same-filesystem
+  # rename; a cross-device copy could truncate the shared credential file.
+  store_dir=$(dirname -- "$file")
+  out_file=$(mktemp "$store_dir/.fm-xsearch-auth.XXXXXX" 2>/dev/null) || {
+    echo "fm-xsearch: warning: could not write refreshed token to $file" >&2
     return 0
   }
-  printf '%s\n' "$new_json" > "$out_file" || {
-    printf '%s\n' "$access"
+  TMP_FILES+=("$out_file")
+  chmod 600 "$out_file" 2>/dev/null || true
+  if printf '%s\n' "$new_json" > "$out_file" 2>/dev/null &&
+     mv -f "$out_file" "$file" 2>/dev/null; then
     return 0
-  }
-  chmod 600 "$out_file" || true
-  if ! mv -f "$out_file" "$file" 2>/dev/null; then
-    if ! cat "$out_file" > "$file" 2>/dev/null; then
-      echo "fm-xsearch: warning: could not write refreshed token to $file" >&2
-    else
-      chmod 600 "$file" 2>/dev/null || true
-    fi
-    rm -f "$out_file"
   fi
-  printf '%s\n' "$access"
+  rm -f "$out_file"
+  echo "fm-xsearch: warning: could not write refreshed token to $file" >&2
   return 0
 }
 

--- a/bin/fm-xsearch.sh
+++ b/bin/fm-xsearch.sh
@@ -1,0 +1,632 @@
+#!/usr/bin/env bash
+# Call xAI server-side web_search and/or x_search via the Responses API.
+#
+# Usage:
+#   fm-xsearch.sh [options] <prompt>
+#   fm-xsearch.sh [options] --prompt-file <path>
+#   fm-xsearch.sh [options] -
+#
+# This is firstmate's fleet path for Grok X Search and Web Search. It is NOT the
+# X Developer API and NOT firstmate X-mode (public @mentions). Auth is SuperGrok
+# OAuth from an existing OpenCode or Pi store, or an explicit XAI_API_KEY. Tokens
+# are never printed.
+#
+# Server tools only work on POST https://api.x.ai/v1/responses (chat completions
+# rejects type x_search). Default model is grok-4.5. Calls are metered; prefer a
+# low --max-tool-calls and tight prompts.
+#
+# Auth resolution (first match wins):
+#   1. XAI_API_KEY environment variable
+#   2. FM_XAI_AUTH_FILE when set (OpenCode/Pi-shaped JSON with an "xai" entry)
+#   3. OpenCode store: ${XDG_DATA_HOME:-$HOME/.local/share}/opencode/auth.json
+#   4. Pi store: $HOME/.pi/agent/auth.json
+#
+# OAuth access tokens near expiry are refreshed against auth.x.ai and written
+# back to the same store (mode 600) when the store is writable.
+#
+# Options:
+#   --tool <x_search|web_search|both>   tools to attach (default: both)
+#   --model <id>                        Responses model (default: grok-4.5)
+#   --max-tool-calls <n>                cap server tool rounds (default: 3)
+#   --allowed-handle <handle>           x_search allowlist (repeatable, max 20)
+#   --excluded-handle <handle>          x_search denylist (repeatable, max 20)
+#   --from-date <YYYY-MM-DD>            x_search lower bound (inclusive)
+#   --to-date <YYYY-MM-DD>              x_search upper bound (inclusive)
+#   --enable-image-understanding        opt-in x_search image analysis (costly)
+#   --enable-video-understanding        opt-in x_search video analysis (costly)
+#   --prompt-file <path>                read prompt from file instead of argv
+#   --json                              print the full API JSON response
+#   --dry-run                           build and print the request body; no auth
+#                                       refresh and no network call
+#   -h, --help                          show this help
+#
+# Exit codes:
+#   0 success
+#   1 transport or unexpected failure
+#   2 usage error
+#   3 no usable auth
+#   4 API non-2xx (stderr has HTTP code; body only with --json on stdout empty)
+#
+# Env overrides (tests / advanced):
+#   FM_XAI_AUTH_FILE       force one auth.json path
+#   FM_XAI_BASE_URL        API base (default https://api.x.ai/v1)
+#   FM_XAI_TOKEN_URL       OAuth token URL (default https://auth.x.ai/oauth2/token)
+#   FM_XAI_CLIENT_ID       OAuth client id (OpenCode/Pi shared default)
+#   FM_XAI_REFRESH_SKEW_MS refresh this many ms before expires (default 300000)
+#   FM_XAI_CURL_TIMEOUT    curl -m seconds (default 120)
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+DEFAULT_MODEL=grok-4.5
+DEFAULT_MAX_TOOL_CALLS=3
+DEFAULT_BASE_URL=https://api.x.ai/v1
+DEFAULT_TOKEN_URL=https://auth.x.ai/oauth2/token
+DEFAULT_CLIENT_ID=b1a00492-073a-47ea-816f-4c329264a828
+DEFAULT_REFRESH_SKEW_MS=300000
+DEFAULT_CURL_TIMEOUT=120
+DEFAULT_TOKEN_LIFETIME_S=3600
+
+TOOL=both
+MODEL=$DEFAULT_MODEL
+MAX_TOOL_CALLS=$DEFAULT_MAX_TOOL_CALLS
+PROMPT_FILE=
+PROMPT=
+JSON_OUT=0
+DRY_RUN=0
+ENABLE_IMAGE=0
+ENABLE_VIDEO=0
+ALLOWED_HANDLES=()
+EXCLUDED_HANDLES=()
+
+usage() {
+  cat <<'EOF'
+usage: fm-xsearch.sh [options] <prompt>
+       fm-xsearch.sh [options] --prompt-file <path>
+       fm-xsearch.sh [options] -
+
+Call xAI server-side web_search and/or x_search on /v1/responses using SuperGrok
+OAuth (OpenCode or Pi store) or XAI_API_KEY. Not the X Developer API. Not X-mode.
+
+Options:
+  --tool <x_search|web_search|both>   tools to attach (default: both)
+  --model <id>                        model id (default: grok-4.5)
+  --max-tool-calls <n>                server tool-call cap (default: 3)
+  --allowed-handle <handle>           x_search allowlist handle (repeatable)
+  --excluded-handle <handle>          x_search denylist handle (repeatable)
+  --from-date <YYYY-MM-DD>            x_search from_date
+  --to-date <YYYY-MM-DD>              x_search to_date
+  --enable-image-understanding        enable x_search image understanding
+  --enable-video-understanding        enable x_search video understanding
+  --prompt-file <path>                read prompt text from a file
+  --json                              emit full API JSON on stdout
+  --dry-run                           print request JSON only; no network
+  -h, --help                          show this help
+EOF
+}
+
+die_usage() {
+  echo "fm-xsearch: $1" >&2
+  usage >&2
+  exit 2
+}
+
+die() {
+  echo "fm-xsearch: $1" >&2
+  exit "${2:-1}"
+}
+
+is_uint() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+is_iso_date() {
+  case "$1" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_safe_handle() {
+  case "$1" in
+    ''|*[!A-Za-z0-9_]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+now_ms() {
+  # Portable epoch milliseconds. GNU date's %N is nanoseconds; take the first
+  # three digits. Do not use %s%3N — some builds paste full nanoseconds and
+  # produce a value far larger than real epoch-ms.
+  local s n
+  s=$(date +%s) || return 1
+  n=$(date +%N 2>/dev/null || true)
+  case "$n" in
+    [0-9][0-9][0-9]*)
+      printf '%s%s\n' "$s" "${n:0:3}"
+      ;;
+    *)
+      printf '%s000\n' "$s"
+      ;;
+  esac
+}
+
+opencode_auth_path() {
+  local base
+  base="${XDG_DATA_HOME:-$HOME/.local/share}"
+  printf '%s\n' "$base/opencode/auth.json"
+}
+
+pi_auth_path() {
+  printf '%s\n' "$HOME/.pi/agent/auth.json"
+}
+
+# Parse argv -----------------------------------------------------------------
+
+FROM_DATE=
+TO_DATE=
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --tool)
+      [ $# -ge 2 ] || die_usage "--tool requires a value"
+      TOOL=$2
+      shift 2
+      ;;
+    --model)
+      [ $# -ge 2 ] || die_usage "--model requires a value"
+      MODEL=$2
+      shift 2
+      ;;
+    --max-tool-calls)
+      [ $# -ge 2 ] || die_usage "--max-tool-calls requires a value"
+      MAX_TOOL_CALLS=$2
+      shift 2
+      ;;
+    --allowed-handle)
+      [ $# -ge 2 ] || die_usage "--allowed-handle requires a value"
+      ALLOWED_HANDLES+=("$2")
+      shift 2
+      ;;
+    --excluded-handle)
+      [ $# -ge 2 ] || die_usage "--excluded-handle requires a value"
+      EXCLUDED_HANDLES+=("$2")
+      shift 2
+      ;;
+    --from-date)
+      [ $# -ge 2 ] || die_usage "--from-date requires a value"
+      FROM_DATE=$2
+      shift 2
+      ;;
+    --to-date)
+      [ $# -ge 2 ] || die_usage "--to-date requires a value"
+      TO_DATE=$2
+      shift 2
+      ;;
+    --enable-image-understanding)
+      ENABLE_IMAGE=1
+      shift
+      ;;
+    --enable-video-understanding)
+      ENABLE_VIDEO=1
+      shift
+      ;;
+    --prompt-file)
+      [ $# -ge 2 ] || die_usage "--prompt-file requires a path"
+      PROMPT_FILE=$2
+      shift 2
+      ;;
+    --json)
+      JSON_OUT=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -)
+      PROMPT_FILE=-
+      shift
+      break
+      ;;
+    -*)
+      die_usage "unknown option: $1"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+case "$TOOL" in
+  x_search|web_search|both) ;;
+  *) die_usage "--tool must be x_search, web_search, or both" ;;
+esac
+
+is_uint "$MAX_TOOL_CALLS" || die_usage "--max-tool-calls must be a non-negative integer"
+[ "$MAX_TOOL_CALLS" -ge 1 ] || die_usage "--max-tool-calls must be >= 1"
+[ "${#ALLOWED_HANDLES[@]}" -le 20 ] || die_usage "at most 20 --allowed-handle values"
+[ "${#EXCLUDED_HANDLES[@]}" -le 20 ] || die_usage "at most 20 --excluded-handle values"
+if [ "${#ALLOWED_HANDLES[@]}" -gt 0 ] && [ "${#EXCLUDED_HANDLES[@]}" -gt 0 ]; then
+  die_usage "cannot combine --allowed-handle and --excluded-handle"
+fi
+
+for h in "${ALLOWED_HANDLES[@]:-}"; do
+  [ -n "$h" ] || continue
+  is_safe_handle "$h" || die_usage "unsafe --allowed-handle: $h"
+done
+for h in "${EXCLUDED_HANDLES[@]:-}"; do
+  [ -n "$h" ] || continue
+  is_safe_handle "$h" || die_usage "unsafe --excluded-handle: $h"
+done
+
+if [ -n "$FROM_DATE" ]; then
+  is_iso_date "$FROM_DATE" || die_usage "--from-date must be YYYY-MM-DD"
+fi
+if [ -n "$TO_DATE" ]; then
+  is_iso_date "$TO_DATE" || die_usage "--to-date must be YYYY-MM-DD"
+fi
+
+if [ -n "$PROMPT_FILE" ]; then
+  [ $# -eq 0 ] || die_usage "prompt text and --prompt-file/- are mutually exclusive"
+  if [ "$PROMPT_FILE" = - ]; then
+    PROMPT=$(cat) || die "failed to read prompt from stdin"
+  else
+    [ -f "$PROMPT_FILE" ] || die_usage "prompt file not found: $PROMPT_FILE"
+    PROMPT=$(cat -- "$PROMPT_FILE") || die "failed to read prompt file"
+  fi
+else
+  [ $# -ge 1 ] || die_usage "prompt required"
+  PROMPT=$*
+fi
+
+[ -n "${PROMPT//[[:space:]]/}" ] || die_usage "prompt must be non-empty"
+
+command -v jq >/dev/null 2>&1 || die "jq not found"
+
+BASE_URL=${FM_XAI_BASE_URL:-$DEFAULT_BASE_URL}
+TOKEN_URL=${FM_XAI_TOKEN_URL:-$DEFAULT_TOKEN_URL}
+CLIENT_ID=${FM_XAI_CLIENT_ID:-$DEFAULT_CLIENT_ID}
+REFRESH_SKEW_MS=${FM_XAI_REFRESH_SKEW_MS:-$DEFAULT_REFRESH_SKEW_MS}
+CURL_TIMEOUT=${FM_XAI_CURL_TIMEOUT:-$DEFAULT_CURL_TIMEOUT}
+is_uint "$REFRESH_SKEW_MS" || die "FM_XAI_REFRESH_SKEW_MS must be an integer"
+is_uint "$CURL_TIMEOUT" || die "FM_XAI_CURL_TIMEOUT must be an integer"
+
+# Build tools JSON -----------------------------------------------------------
+
+handles_json_array() {
+  # Encode argv handles as a JSON string array (raw lines are not JSON).
+  if [ "$#" -eq 0 ]; then
+    printf '%s\n' '[]'
+    return 0
+  fi
+  jq -cn --args '$ARGS.positional' -- "$@"
+}
+
+build_x_search_tool_json() {
+  local tool handles
+  tool=$(jq -cn '{type:"x_search"}') || return 1
+  if [ "${#ALLOWED_HANDLES[@]}" -gt 0 ]; then
+    handles=$(handles_json_array "${ALLOWED_HANDLES[@]}") || return 1
+    tool=$(jq -cn --argjson t "$tool" --argjson h "$handles" \
+      '$t + {allowed_x_handles:$h}') || return 1
+  fi
+  if [ "${#EXCLUDED_HANDLES[@]}" -gt 0 ]; then
+    handles=$(handles_json_array "${EXCLUDED_HANDLES[@]}") || return 1
+    tool=$(jq -cn --argjson t "$tool" --argjson h "$handles" \
+      '$t + {excluded_x_handles:$h}') || return 1
+  fi
+  if [ -n "$FROM_DATE" ]; then
+    tool=$(jq -cn --argjson t "$tool" --arg d "$FROM_DATE" '$t + {from_date:$d}') || return 1
+  fi
+  if [ -n "$TO_DATE" ]; then
+    tool=$(jq -cn --argjson t "$tool" --arg d "$TO_DATE" '$t + {to_date:$d}') || return 1
+  fi
+  if [ "$ENABLE_IMAGE" -eq 1 ]; then
+    tool=$(jq -cn --argjson t "$tool" '$t + {enable_image_understanding:true}') || return 1
+  fi
+  if [ "$ENABLE_VIDEO" -eq 1 ]; then
+    tool=$(jq -cn --argjson t "$tool" '$t + {enable_video_understanding:true}') || return 1
+  fi
+  printf '%s\n' "$tool"
+}
+
+build_tools_json() {
+  local parts=() t
+  case "$TOOL" in
+    web_search)
+      parts+=('{"type":"web_search"}')
+      ;;
+    x_search)
+      t=$(build_x_search_tool_json) || return 1
+      parts+=("$t")
+      ;;
+    both)
+      parts+=('{"type":"web_search"}')
+      t=$(build_x_search_tool_json) || return 1
+      parts+=("$t")
+      ;;
+  esac
+  printf '%s\n' "${parts[@]}" | jq -cs '.'
+}
+
+TOOLS_JSON=$(build_tools_json) || die "failed to build tools JSON"
+
+REQUEST_JSON=$(jq -cn \
+  --arg model "$MODEL" \
+  --arg prompt "$PROMPT" \
+  --argjson tools "$TOOLS_JSON" \
+  --argjson max "$MAX_TOOL_CALLS" \
+  '{
+    model: $model,
+    input: [{role:"user", content:$prompt}],
+    tools: $tools,
+    max_tool_calls: $max
+  }') || die "failed to build request JSON"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '%s\n' "$REQUEST_JSON"
+  exit 0
+fi
+
+# Auth -----------------------------------------------------------------------
+
+TMP_FILES=()
+# shellcheck disable=SC2329 # Invoked via EXIT trap.
+cleanup_tmp() {
+  if [ "${#TMP_FILES[@]}" -gt 0 ]; then
+    rm -f "${TMP_FILES[@]}"
+  fi
+}
+trap cleanup_tmp EXIT
+
+make_tmp() {
+  local var=$1 f
+  f=$(mktemp "${TMPDIR:-/tmp}/fm-xsearch.XXXXXX") || return 1
+  chmod 600 "$f" || return 1
+  TMP_FILES+=("$f")
+  printf -v "$var" '%s' "$f"
+}
+
+AUTH_BEARER=
+
+read_store_xai() {
+  local file=$1
+  [ -f "$file" ] || return 1
+  jq -e '.xai and (.xai|type=="object")' "$file" >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# Sets AUTH_BEARER and optionally AUTH_STORE / AUTH_KIND from a store file.
+load_oauth_from_store() {
+  local file=$1 typ access refresh expires now skew
+  typ=$(jq -r '.xai.type // empty' "$file") || return 1
+  [ "$typ" = oauth ] || return 1
+  access=$(jq -r '.xai.access // empty' "$file") || return 1
+  refresh=$(jq -r '.xai.refresh // empty' "$file") || return 1
+  expires=$(jq -r '.xai.expires // 0' "$file") || return 1
+  [ -n "$access" ] || return 1
+  now=$(now_ms)
+  skew=$REFRESH_SKEW_MS
+  # expires may be ms (OpenCode/Pi) ; if it looks like seconds (< 1e12), scale.
+  if is_uint "$expires" && [ "$expires" -gt 0 ] && [ "$expires" -lt 1000000000000 ]; then
+    expires=$((expires * 1000))
+  fi
+  if is_uint "$expires" && [ "$expires" -gt 0 ] && [ "$((now + skew))" -ge "$expires" ]; then
+    [ -n "$refresh" ] || die "OAuth access expired and no refresh token in $file" 3
+    access=$(refresh_oauth_token "$file" "$refresh") || return 1
+    [ -n "$access" ] || return 1
+  fi
+  AUTH_BEARER=$access
+  return 0
+}
+
+# Refresh OAuth; print the new access token on stdout. Best-effort write-back to
+# the auth store (mode 600). A write failure still returns the fresh access so
+# the current call can proceed.
+refresh_oauth_token() {
+  local file=$1 refresh=$2 form_file resp_file out_file code new_json expires_in access new_refresh expires_ms
+  command -v curl >/dev/null 2>&1 || die "curl not found"
+  make_tmp form_file || die "mktemp failed"
+  make_tmp resp_file || die "mktemp failed"
+  # Never log refresh token. Write form body to a 0600 temp file.
+  {
+    printf 'grant_type=refresh_token&client_id='
+    jq -rn --arg v "$CLIENT_ID" '$v|@uri'
+    printf '&refresh_token='
+    jq -rn --arg v "$refresh" '$v|@uri'
+  } > "$form_file" || die "failed to build refresh body"
+
+  code=$(curl -m "$CURL_TIMEOUT" -sS -o "$resp_file" -w '%{http_code}' \
+    -X POST \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    --data-binary @"$form_file" \
+    "$TOKEN_URL" 2>/dev/null) || die "OAuth refresh transport failed" 3
+
+  case "$code" in
+    2[0-9][0-9]) ;;
+    *) die "OAuth refresh failed (HTTP $code)" 3 ;;
+  esac
+
+  access=$(jq -r '.access_token // empty' "$resp_file") || true
+  [ -n "$access" ] || die "OAuth refresh response missing access_token" 3
+  new_refresh=$(jq -r '.refresh_token // empty' "$resp_file") || true
+  [ -n "$new_refresh" ] || new_refresh=$refresh
+  expires_in=$(jq -r '.expires_in // empty' "$resp_file") || true
+  if ! is_uint "${expires_in:-}"; then
+    expires_in=$DEFAULT_TOKEN_LIFETIME_S
+  fi
+  expires_ms=$(( $(now_ms) + expires_in * 1000 - REFRESH_SKEW_MS ))
+  [ "$expires_ms" -gt 0 ] || expires_ms=$(( $(now_ms) + expires_in * 1000 ))
+
+  new_json=$(jq -c \
+    --arg access "$access" \
+    --arg refresh "$new_refresh" \
+    --argjson expires "$expires_ms" \
+    '.xai.type = "oauth"
+     | .xai.access = $access
+     | .xai.refresh = $refresh
+     | .xai.expires = $expires' "$file") || {
+    printf '%s\n' "$access"
+    return 0
+  }
+
+  make_tmp out_file || {
+    printf '%s\n' "$access"
+    return 0
+  }
+  printf '%s\n' "$new_json" > "$out_file" || {
+    printf '%s\n' "$access"
+    return 0
+  }
+  chmod 600 "$out_file" || true
+  if ! mv -f "$out_file" "$file" 2>/dev/null; then
+    if ! cat "$out_file" > "$file" 2>/dev/null; then
+      echo "fm-xsearch: warning: could not write refreshed token to $file" >&2
+    else
+      chmod 600 "$file" 2>/dev/null || true
+    fi
+    rm -f "$out_file"
+  fi
+  printf '%s\n' "$access"
+  return 0
+}
+
+resolve_auth() {
+  if [ -n "${XAI_API_KEY:-}" ]; then
+    AUTH_BEARER=$XAI_API_KEY
+    return 0
+  fi
+  if [ -n "${FM_XAI_AUTH_FILE:-}" ]; then
+    read_store_xai "$FM_XAI_AUTH_FILE" || die "FM_XAI_AUTH_FILE has no usable xai entry: $FM_XAI_AUTH_FILE" 3
+    load_oauth_from_store "$FM_XAI_AUTH_FILE" || die "cannot load OAuth from $FM_XAI_AUTH_FILE" 3
+    return 0
+  fi
+  local oc pi
+  oc=$(opencode_auth_path)
+  pi=$(pi_auth_path)
+  if read_store_xai "$oc" && load_oauth_from_store "$oc"; then
+    return 0
+  fi
+  if read_store_xai "$pi" && load_oauth_from_store "$pi"; then
+    return 0
+  fi
+  die "no xAI auth: set XAI_API_KEY or sign in via OpenCode/Pi SuperGrok OAuth" 3
+}
+
+resolve_auth
+command -v curl >/dev/null 2>&1 || die "curl not found"
+
+make_tmp AUTH_HEADER_FILE || die "mktemp failed"
+# Authorization header via file so the token never appears on the process argv.
+{
+  printf 'Authorization: Bearer '
+  # shellcheck disable=SC2059
+  printf '%s\n' "$AUTH_BEARER"
+} > "$AUTH_HEADER_FILE" || die "failed to write auth header"
+# Clear shell copy promptly; curl reads the file.
+AUTH_BEARER=
+
+make_tmp RESPONSE_BODY_FILE || die "mktemp failed"
+make_tmp REQ_FILE || die "mktemp failed"
+printf '%s\n' "$REQUEST_JSON" > "$REQ_FILE" || die "failed to write request body"
+
+HTTP_CODE=$(curl -m "$CURL_TIMEOUT" -sS -o "$RESPONSE_BODY_FILE" -w '%{http_code}' \
+  -X POST \
+  -H @"$AUTH_HEADER_FILE" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  --data-binary @"$REQ_FILE" \
+  "$BASE_URL/responses" 2>/dev/null) || die "request to xAI /responses failed"
+
+case "$HTTP_CODE" in
+  2[0-9][0-9]) ;;
+  *)
+    echo "fm-xsearch: xAI returned HTTP $HTTP_CODE" >&2
+    if [ "$JSON_OUT" -eq 1 ] && [ -s "$RESPONSE_BODY_FILE" ]; then
+      cat "$RESPONSE_BODY_FILE"
+      echo
+    fi
+    exit 4
+    ;;
+esac
+
+if [ "$JSON_OUT" -eq 1 ]; then
+  cat "$RESPONSE_BODY_FILE"
+  echo
+  exit 0
+fi
+
+# Human-oriented summary: assistant text + tool usage counters (no secrets).
+TEXT=$(jq -r '
+  def texts:
+    if type == "array" then
+      [.[]
+        | if type == "object" then
+            if .type == "message" then
+              (.content // [])
+              | if type == "array" then
+                  [.[] | select(.type == "output_text" or .type == "text") | (.text // .)]
+                else [] end
+            elif .type == "output_text" or .type == "text" then
+              [(.text // .)]
+            else [] end
+          elif type == "string" then [.]
+          else [] end]
+      | add // []
+    else [] end;
+  (.output | texts | map(select(type=="string" and length>0)) | join("\n"))
+  // .output_text // .text // empty
+' "$RESPONSE_BODY_FILE" 2>/dev/null || true)
+
+if [ -z "$TEXT" ]; then
+  TEXT=$(jq -r '
+    [ .. | objects | select(has("text")) | .text | select(type=="string" and length>0) ] | last // empty
+  ' "$RESPONSE_BODY_FILE" 2>/dev/null || true)
+fi
+
+USAGE=$(jq -c '
+  {
+    web_search_calls: (
+      .usage.server_side_tool_usage_details.web_search_calls
+      // .server_side_tool_usage_details.web_search_calls
+      // .usage.web_search_calls
+      // 0
+    ),
+    x_search_calls: (
+      .usage.server_side_tool_usage_details.x_search_calls
+      // .server_side_tool_usage_details.x_search_calls
+      // .usage.x_search_calls
+      // 0
+    ),
+    num_server_side_tools_used: (
+      .usage.num_server_side_tools_used
+      // .num_server_side_tools_used
+      // 0
+    ),
+    input_tokens: (.usage.input_tokens // .usage.prompt_tokens // null),
+    output_tokens: (.usage.output_tokens // .usage.completion_tokens // null)
+  }
+' "$RESPONSE_BODY_FILE" 2>/dev/null || printf '%s\n' '{}')
+
+if [ -n "$TEXT" ]; then
+  printf '%s\n' "$TEXT"
+else
+  echo "fm-xsearch: response contained no assistant text (use --json for raw body)" >&2
+fi
+printf 'fm-xsearch: usage %s\n' "$USAGE" >&2
+exit 0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -357,6 +357,12 @@ In dry-run, `fm-x-dismiss.sh` records `{request_id, endpoint:"dismiss"}` to the 
 The live answer and follow-up bodies intentionally stay the same shape, including optional `image`; the relay distinguishes them by endpoint, and dismiss stays `{request_id}`.
 These paths need `jq` to build the JSON payload, but they run before token and network checks, so they need neither `FMX_PAIRING_TOKEN` nor `curl`.
 
+## xAI server-side search (web_search / x_search)
+
+Fleet Grok X Search and Web Search use `bin/fm-xsearch.sh` against the xAI Responses API with existing SuperGrok OAuth (OpenCode or Pi auth stores) or an optional `XAI_API_KEY`.
+This is separate from X-mode above and does not use the X Developer API.
+[docs/xai-server-search.md](xai-server-search.md) is the single owner of auth resolution, CLI flags, cost guardrails, and OpenCode tool attachment.
+
 ## Environment variables
 
 Runtime tuning via environment variables (defaults shown):

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -322,6 +322,14 @@
     {
       "path": "skills/stow/SKILL.md",
       "audience": "public-product"
+    },
+    {
+      "path": "docs/xai-server-search.md",
+      "audience": "operator-current"
+    },
+    {
+      "path": "docs/examples/opencode-xai-search-tool.ts",
+      "audience": "operator-example"
     }
   ]
 }

--- a/docs/examples/opencode-xai-search-tool.ts
+++ b/docs/examples/opencode-xai-search-tool.ts
@@ -1,0 +1,59 @@
+// Copy to ~/.config/opencode/tools/xai-search.ts (global) or
+// <project>/.opencode/tools/xai-search.ts (project-local).
+// Requires firstmate's bin/fm-xsearch.sh on PATH, or set FM_XSEARCH to its path.
+// Auth: existing SuperGrok OAuth in OpenCode/Pi auth.json, or XAI_API_KEY.
+// See docs/xai-server-search.md.
+import { tool } from "@opencode-ai/plugin"
+
+function resolveXsearch(): string {
+  return process.env.FM_XSEARCH || "fm-xsearch.sh"
+}
+
+export default tool({
+  description:
+    "Search X (Twitter) and/or the web via xAI server-side tools (Responses API). Uses SuperGrok OAuth or XAI_API_KEY. Not the X Developer API.",
+  args: {
+    prompt: tool.schema.string().describe("Search question or instruction for Grok"),
+    tool: tool.schema
+      .enum(["x_search", "web_search", "both"])
+      .optional()
+      .describe("Which server tools to attach (default both)"),
+    maxToolCalls: tool.schema
+      .number()
+      .optional()
+      .describe("Cap server tool rounds (default 3)"),
+    allowedHandle: tool.schema
+      .string()
+      .optional()
+      .describe("Optional single X handle allowlist for x_search"),
+  },
+  async execute(args) {
+    const bin = resolveXsearch()
+    const argv = [bin, "--tool", args.tool || "both"]
+    if (args.maxToolCalls != null) {
+      argv.push("--max-tool-calls", String(args.maxToolCalls))
+    }
+    if (args.allowedHandle) {
+      argv.push("--allowed-handle", args.allowedHandle)
+    }
+    argv.push("--prompt-file", "-")
+    const proc = Bun.spawn(argv, {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    proc.stdin.write(args.prompt)
+    proc.stdin.end()
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+    const code = await proc.exited
+    if (code !== 0) {
+      return `fm-xsearch failed (exit ${code}): ${stderr.trim() || stdout.trim() || "no output"}`
+    }
+    const usage = stderr
+      .split("\n")
+      .filter((line) => line.startsWith("fm-xsearch: usage "))
+      .join("\n")
+    return usage ? `${stdout.trim()}\n\n${usage}` : stdout.trim()
+  },
+})

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -93,3 +93,4 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-x-dismiss.sh`        | Dismiss a skipped X-mode mention at the relay without replying                       |
 | `fm-x-link.sh`           | Link a spawned task to its originating X-mode mention in task meta                   |
 | `fm-x-followup.sh`       | Detect, post, and cap completion follow-ups for an X-mode-linked task                |
+| `fm-xsearch.sh`          | Call xAI server-side web_search / x_search on /v1/responses via SuperGrok OAuth or XAI_API_KEY ([docs/xai-server-search.md](xai-server-search.md)) |

--- a/docs/xai-server-search.md
+++ b/docs/xai-server-search.md
@@ -1,0 +1,87 @@
+# xAI server-side search (web_search / x_search)
+
+Fleet workers call xAI's built-in **Web Search** and **X Search** through `bin/fm-xsearch.sh`.
+This is the xAI Responses API path under SuperGrok OAuth (or an optional console API key).
+It is **not** the X Developer API and **not** firstmate X-mode (public `@myfirstmate` mentions).
+
+## When to use it
+
+- Need live posts or trends from X (Twitter) with Grok's `x_search`.
+- Need xAI-hosted web search (`web_search`) rather than a local `webfetch` / Exa tool.
+- Any harness (OpenCode, Pi, Grok CLI, Claude, Codex) can shell out to the helper; Pi's default agent loop does not attach these built-in tools today.
+
+Default coding harnesses still use their local tools until a worker explicitly runs this helper (or an OpenCode custom tool that wraps it).
+
+## Auth
+
+No firstmate secret plumbing and nothing to commit.
+
+Resolution order inside `bin/fm-xsearch.sh`:
+
+1. `XAI_API_KEY` in the environment (optional pay-as-you-go console key).
+2. `FM_XAI_AUTH_FILE` when set (OpenCode/Pi-shaped JSON with an `xai` OAuth entry).
+3. OpenCode store: `${XDG_DATA_HOME:-$HOME/.local/share}/opencode/auth.json`.
+4. Pi store: `~/.pi/agent/auth.json`.
+
+SuperGrok / X Premium OAuth already used by OpenCode or Pi is enough.
+The access token is sent as `Authorization: Bearer` to `https://api.x.ai/v1`.
+Near-expiry OAuth tokens are refreshed against `https://auth.x.ai/oauth2/token` and written back to the same store (mode `600`) when possible.
+
+Sign in once with OpenCode `/connect` → xAI (SuperGrok) or the equivalent Pi login.
+You do not need a separate `XAI_API_KEY` for OAuth.
+
+## API shape
+
+- Endpoint: `POST /v1/responses` only.
+- Chat completions rejects `type: x_search` (HTTP 422).
+- Prefer a Responses-capable model such as `grok-4.5` (the helper default).
+- Tools are request-level: `[{ "type": "web_search" }]`, `[{ "type": "x_search" }]`, or both.
+
+## CLI
+
+Authoritative flags and exit codes live in the script header and `--help`.
+
+```sh
+# Both tools (default), print assistant text + usage counters on stderr
+bin/fm-xsearch.sh 'What are people saying on X about firstmate?'
+
+# X Search only, bounded handles and dates
+bin/fm-xsearch.sh --tool x_search \
+  --allowed-handle elonmusk \
+  --from-date 2026-07-01 \
+  --max-tool-calls 2 \
+  'Latest status posts'
+
+# Dry-run: print the JSON body only (no auth, no network)
+bin/fm-xsearch.sh --dry-run --tool web_search 'ping'
+
+# Full API JSON
+bin/fm-xsearch.sh --json --tool both 'summarize recent coverage'
+```
+
+Prompt text can come from argv, `--prompt-file`, or stdin (`-`).
+Tokens are never printed.
+
+## Cost and guardrails
+
+xAI prices `web_search` and `x_search` per invocation (see current [tools pricing](https://docs.x.ai/developers/pricing#tools-pricing)), plus ordinary token usage.
+Multi-hop answers can issue several tool calls per user question.
+The helper defaults to `--max-tool-calls 3`.
+Image and video understanding on `x_search` are opt-in flags and cost more.
+Confirm in the xAI console whether SuperGrok Heavy absorbs tool usage or shows separate tool line items before wide fleet rollout.
+
+## OpenCode attachment
+
+OpenCode's bundled `@ai-sdk/xai` understands `xai.web_search` / `xai.x_search`, but the default coding agent loop does not attach those provider tools for fleet turns.
+Practical options:
+
+1. **Preferred for any harness:** call `bin/fm-xsearch.sh` from the worker shell when live X/web search is required.
+2. **OpenCode custom tool:** add a small tool under `~/.config/opencode/tools/` (or a project's `.opencode/tools/`) that shells out to this script.
+   See [custom tools](https://opencode.ai/docs/custom-tools/) and the copyable example at [docs/examples/opencode-xai-search-tool.ts](examples/opencode-xai-search-tool.ts).
+
+## Related
+
+- Script inventory: [scripts.md](scripts.md)
+- X-mode (public mentions, different subsystem): [configuration.md](configuration.md#x-mode-env)
+- xAI docs: [tools overview](https://docs.x.ai/developers/tools/overview), [X Search](https://docs.x.ai/developers/tools/x-search), [Web Search](https://docs.x.ai/developers/tools/web-search)
+- Behavior tests: `tests/fm-xsearch.test.sh`

--- a/docs/xai-server-search.md
+++ b/docs/xai-server-search.md
@@ -27,7 +27,7 @@ SuperGrok / X Premium OAuth already used by OpenCode or Pi is enough.
 The access token is sent as `Authorization: Bearer` to `https://api.x.ai/v1`.
 Near-expiry OAuth tokens are refreshed against `https://auth.x.ai/oauth2/token` and written back to the same store (mode `600`) when possible.
 
-Sign in once with OpenCode `/connect` → xAI (SuperGrok) or the equivalent Pi login.
+Sign in once with OpenCode `/connect` -> xAI (SuperGrok) or the equivalent Pi login.
 You do not need a separate `XAI_API_KEY` for OAuth.
 
 ## API shape

--- a/tests/fm-xsearch.test.sh
+++ b/tests/fm-xsearch.test.sh
@@ -28,11 +28,14 @@ while [ $# -gt 0 ]; do
     -o) ofile=$2; shift 2 ;;
     -X) method=$2; shift 2 ;;
     --data|--data-binary)
+      # Sentinel-guarded capture: command substitution strips trailing newlines,
+      # which would hide a malformed wire body from every assertion below.
       case "$2" in
-        @-) data=$(cat) ;;
-        @*) data=$(cat -- "${2#@}") ;;
-        *) data=$2 ;;
+        @-) data=$(cat; printf X) ;;
+        @*) data=$(cat -- "${2#@}"; printf X) ;;
+        *) data=$2X ;;
       esac
+      data=${data%X}
       shift 2
       ;;
     -H)
@@ -63,12 +66,14 @@ if [ -n "${FAKE_CURL_LOG:-}" ]; then
     Authorization:\ Bearer\ *) auth_kind=bearer ;;
     Authorization:*) auth_kind=other ;;
   esac
+  # Escape newlines so the log stays line-oriented AND a stray newline inside a
+  # request body is visible to an exact-match assertion instead of vanishing.
   {
     echo "method=$method"
     echo "url=$url"
     echo "auth_kind=$auth_kind"
     echo "content_type=$content_type"
-    echo "data=$data"
+    echo "data=${data//$'\n'/\\n}"
   } >> "$FAKE_CURL_LOG"
 fi
 case "$url" in
@@ -251,14 +256,18 @@ test_oauth_store_via_fm_xai_auth_file() {
 }
 
 test_oauth_refresh_when_expired() {
-  local home fakebin log store out rc new_access
+  local home fakebin log store tmpdir out rc new_access now_s leaked
   home="$TMP_ROOT/oauth-refresh"; mkdir -p "$home"
   fakebin=$(make_fake_curl "$home")
   log="$home/curl.log"
   store="$home/auth.json"
-  write_oauth_store "$store" 'old-access' 'refresh-token-ccc' 1
-  out=$(HOME="$home" PATH="$fakebin:$BASE_PATH" \
+  tmpdir="$home/tmp"; mkdir -p "$tmpdir"
+  # A refresh token with reserved characters proves the body is form-encoded.
+  write_oauth_store "$store" 'old-access' 'refresh+token/ccc=' 1
+  now_s=$(date +%s)
+  out=$(HOME="$home" PATH="$fakebin:$BASE_PATH" TMPDIR="$tmpdir" \
     FM_XAI_AUTH_FILE="$store" \
+    FM_XAI_CLIENT_ID='test-client-9' \
     FAKE_CURL_LOG="$log" \
     FAKE_TOKEN_CODE=200 \
     FAKE_TOKEN_BODY='{"access_token":"new-access-ddd","refresh_token":"refresh-token-eee","expires_in":3600}' \
@@ -269,11 +278,44 @@ test_oauth_refresh_when_expired() {
   printf '%s' "$out" | grep -q 'hello from x search' || fail "text after refresh: $out"
   grep -q 'oauth2/token' "$log" || fail "expected token refresh call"
   grep -q 'responses' "$log" || fail "expected responses call after refresh"
+  # Exact wire body: no stray newlines, correct percent-encoding, no bare token.
+  grep -Fqx \
+    'data=grant_type=refresh_token&client_id=test-client-9&refresh_token=refresh%2Btoken%2Fccc%3D' \
+    "$log" || fail "refresh form body malformed: $(grep '^data=' "$log")"
+  grep -Fq 'content_type=Content-Type: application/x-www-form-urlencoded' "$log" \
+    || fail "refresh missing form content type"
   new_access=$(jq -r '.xai.access' "$store")
   [ "$new_access" = 'new-access-ddd' ] || fail "store not updated: $(cat "$store")"
   jq -e '.other.key == "keep-me"' "$store" >/dev/null || fail "sibling providers clobbered"
   jq -e '.xai.refresh == "refresh-token-eee"' "$store" >/dev/null || fail "refresh token not rotated"
+  # Absolute expiry: expires_in with no refresh-skew subtracted.
+  jq -e --argjson floor "$(( (now_s + 3500) * 1000 ))" '.xai.expires > $floor' "$store" \
+    >/dev/null || fail "expiry written with skew subtracted: $(jq -r '.xai.expires' "$store")"
+  # Credential-bearing temp files must not survive the run.
+  leaked=$(find "$tmpdir" "$home" -maxdepth 1 \
+    \( -name 'fm-xsearch.*' -o -name '.fm-xsearch-auth.*' \) 2>/dev/null)
+  [ -z "$leaked" ] || fail "temp credentials leaked: $leaked"
   pass "fm-xsearch refreshes expired OAuth and writes store back"
+}
+
+test_refresh_failure_exits_3_without_fallthrough() {
+  local home fakebin log store rc err
+  home="$TMP_ROOT/refresh-fail"; mkdir -p "$home/xdg/opencode" "$home/.pi/agent"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  store="$home/xdg/opencode/auth.json"
+  write_oauth_store "$store" 'stale-access' 'stale-refresh' 1
+  write_oauth_store "$home/.pi/agent/auth.json" 'pi-access' 'pi-refresh' 9999999999999
+  err=$(HOME="$home" XDG_DATA_HOME="$home/xdg" PATH="$fakebin:$BASE_PATH" \
+    FAKE_CURL_LOG="$log" \
+    FAKE_TOKEN_CODE=401 \
+    FAKE_TOKEN_BODY='{"error":"invalid_grant"}' \
+    FAKE_RESP_BODY="$(sample_response)" \
+    run_xsearch 'refresh should fail' 2>&1 >/dev/null); rc=$?
+  expect_code 3 "$rc" "refresh failure exit"
+  printf '%s' "$err" | grep -q 'HTTP 401' || fail "expected refresh HTTP code: $err"
+  grep -q 'url=.*responses' "$log" && fail "refresh failure fell through to /responses"
+  pass "fm-xsearch surfaces refresh failure as exit 3"
 }
 
 test_opencode_default_store_path() {
@@ -363,6 +405,7 @@ test_no_auth_exits_3
 test_api_key_env_posts_responses
 test_oauth_store_via_fm_xai_auth_file
 test_oauth_refresh_when_expired
+test_refresh_failure_exits_3_without_fallthrough
 test_opencode_default_store_path
 test_pi_default_store_path
 test_api_error_exit_4

--- a/tests/fm-xsearch.test.sh
+++ b/tests/fm-xsearch.test.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-xsearch.sh: xAI Responses web_search / x_search
+# client using SuperGrok OAuth stores or XAI_API_KEY.
+#
+# Network is stubbed with a fakebin curl. Real jq is used. No live tokens and no
+# secrets are committed. Covers dry-run body shape, auth resolution, OAuth
+# refresh write-back, tool filters, and API error mapping.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+JQ_DIR=$(command -v jq 2>/dev/null) && JQ_DIR=$(dirname "$JQ_DIR") || JQ_DIR=
+[ -n "$JQ_DIR" ] && BASE_PATH="$JQ_DIR:$BASE_PATH"
+# date +%s%3N and mktemp need coreutils/busybox on PATH
+TMP_ROOT=$(fm_test_tmproot fm-xsearch-tests)
+
+make_fake_curl() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+ofile="" method=GET url="" data="" auth="" content_type=""
+argv=$*
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) ofile=$2; shift 2 ;;
+    -X) method=$2; shift 2 ;;
+    --data|--data-binary)
+      case "$2" in
+        @-) data=$(cat) ;;
+        @*) data=$(cat -- "${2#@}") ;;
+        *) data=$2 ;;
+      esac
+      shift 2
+      ;;
+    -H)
+      case "$2" in
+        @*)
+          while IFS= read -r header; do
+            case "$header" in
+              Authorization:*) auth=$header ;;
+              Content-Type:*) content_type=$header ;;
+            esac
+          done < "${2#@}"
+          ;;
+        Authorization:*) auth=$2 ;;
+        Content-Type:*) content_type=$2 ;;
+      esac
+      shift 2
+      ;;
+    -m|-w) shift 2 ;;
+    -s|-sS) shift ;;
+    http://*|https://*) url=$1; shift ;;
+    *) shift ;;
+  esac
+done
+if [ -n "${FAKE_CURL_LOG:-}" ]; then
+  # Never log Authorization values in full for accidental capture in CI logs.
+  auth_kind=none
+  case "$auth" in
+    Authorization:\ Bearer\ *) auth_kind=bearer ;;
+    Authorization:*) auth_kind=other ;;
+  esac
+  {
+    echo "method=$method"
+    echo "url=$url"
+    echo "auth_kind=$auth_kind"
+    echo "content_type=$content_type"
+    echo "data=$data"
+  } >> "$FAKE_CURL_LOG"
+fi
+case "$url" in
+  */oauth2/token)
+    [ -n "$ofile" ] && printf '%s' "${FAKE_TOKEN_BODY:-}" > "$ofile"
+    printf '%s' "${FAKE_TOKEN_CODE:-200}"
+    ;;
+  */responses)
+    [ -n "$ofile" ] && printf '%s' "${FAKE_RESP_BODY:-}" > "$ofile"
+    printf '%s' "${FAKE_RESP_CODE:-200}"
+    ;;
+  *)
+    [ -n "$ofile" ] && printf '%s' '{"error":"unknown url"}' > "$ofile"
+    printf '%s' "${FAKE_UNKNOWN_CODE:-500}"
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/curl"
+  printf '%s\n' "$fakebin"
+}
+
+sample_response() {
+  cat <<'JSON'
+{
+  "id": "resp_test",
+  "output": [
+    {
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {"type": "output_text", "text": "hello from x search"}
+      ]
+    }
+  ],
+  "usage": {
+    "input_tokens": 10,
+    "output_tokens": 5,
+    "num_server_side_tools_used": 2,
+    "server_side_tool_usage_details": {
+      "web_search_calls": 1,
+      "x_search_calls": 1
+    }
+  }
+}
+JSON
+}
+
+write_oauth_store() {
+  local path=$1 access=$2 refresh=$3 expires=$4
+  mkdir -p "$(dirname "$path")"
+  jq -cn \
+    --arg access "$access" \
+    --arg refresh "$refresh" \
+    --argjson expires "$expires" \
+    '{xai:{type:"oauth",access:$access,refresh:$refresh,expires:$expires},other:{type:"api",key:"keep-me"}}' \
+    > "$path"
+  chmod 600 "$path"
+}
+
+run_xsearch() {
+  env -u XAI_API_KEY "$ROOT/bin/fm-xsearch.sh" "$@"
+}
+
+# ---------------------------------------------------------------------------
+
+test_help_exits_zero() {
+  local out rc
+  out=$("$ROOT/bin/fm-xsearch.sh" --help 2>&1); rc=$?
+  expect_code 0 "$rc" "help exit"
+  printf '%s' "$out" | grep -q 'x_search' || fail "help should mention x_search"
+  pass "fm-xsearch --help"
+}
+
+test_usage_requires_prompt() {
+  local rc
+  "$ROOT/bin/fm-xsearch.sh" --dry-run >/dev/null 2>&1; rc=$?
+  expect_code 2 "$rc" "missing prompt"
+  pass "fm-xsearch refuses missing prompt"
+}
+
+test_dry_run_both_tools_default() {
+  local out
+  out=$("$ROOT/bin/fm-xsearch.sh" --dry-run 'what is trending on x about grok')
+  printf '%s' "$out" | jq -e '
+    .model == "grok-4.5"
+    and .max_tool_calls == 3
+    and (.tools | length) == 2
+    and (.tools | map(.type) | index("web_search") != null)
+    and (.tools | map(.type) | index("x_search") != null)
+    and .input[0].content == "what is trending on x about grok"
+  ' >/dev/null || fail "dry-run body shape: $out"
+  pass "fm-xsearch dry-run default both tools"
+}
+
+test_dry_run_x_search_filters() {
+  local out
+  out=$("$ROOT/bin/fm-xsearch.sh" --dry-run --tool x_search \
+    --allowed-handle elonmusk --allowed-handle xai \
+    --from-date 2026-01-01 --to-date 2026-01-31 \
+    --max-tool-calls 2 \
+    --model grok-4.5 \
+    'status of xAI')
+  printf '%s' "$out" | jq -e '
+    .max_tool_calls == 2
+    and (.tools | length) == 1
+    and .tools[0].type == "x_search"
+    and (.tools[0].allowed_x_handles | length) == 2
+    and .tools[0].from_date == "2026-01-01"
+    and .tools[0].to_date == "2026-01-31"
+    and (.tools[0] | has("enable_image_understanding") | not)
+  ' >/dev/null || fail "filter body: $out"
+  pass "fm-xsearch dry-run x_search filters"
+}
+
+test_dry_run_rejects_mixed_handle_filters() {
+  local rc
+  "$ROOT/bin/fm-xsearch.sh" --dry-run --tool x_search \
+    --allowed-handle a --excluded-handle b 'q' >/dev/null 2>&1
+  rc=$?
+  expect_code 2 "$rc" "mixed handles"
+  pass "fm-xsearch rejects mixed allow/exclude handles"
+}
+
+test_no_auth_exits_3() {
+  local home fakebin rc err
+  home="$TMP_ROOT/no-auth"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  err=$(HOME="$home" XDG_DATA_HOME="$home/xdg" PATH="$fakebin:$BASE_PATH" \
+    run_xsearch --tool web_search 'hi' 2>&1 >/dev/null); rc=$?
+  expect_code 3 "$rc" "no auth exit"
+  printf '%s' "$err" | grep -qi 'no xAI auth' || fail "expected no-auth message: $err"
+  pass "fm-xsearch exits 3 without auth"
+}
+
+test_api_key_env_posts_responses() {
+  local home fakebin log out err rc
+  home="$TMP_ROOT/api-key"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  out=$(HOME="$home" XDG_DATA_HOME="$home/xdg" PATH="$fakebin:$BASE_PATH" \
+    XAI_API_KEY='test-key-not-real' \
+    FAKE_CURL_LOG="$log" \
+    FAKE_RESP_CODE=200 \
+    FAKE_RESP_BODY="$(sample_response)" \
+    "$ROOT/bin/fm-xsearch.sh" --tool web_search 'hello world' 2>"$home/err"); rc=$?
+  err=$(cat "$home/err")
+  expect_code 0 "$rc" "api key path"
+  printf '%s' "$out" | grep -q 'hello from x search' || fail "missing text: $out"
+  printf '%s' "$err" | grep -q 'x_search_calls' || fail "missing usage on stderr: $err"
+  grep -q 'url=https://api.x.ai/v1/responses' "$log" || fail "did not POST /responses: $(cat "$log")"
+  grep -q 'auth_kind=bearer' "$log" || fail "missing bearer auth"
+  # Ensure the raw key never appears in stdout/stderr.
+  printf '%s\n%s\n' "$out" "$err" | grep -q 'test-key-not-real' && fail "api key leaked to output"
+  pass "fm-xsearch XAI_API_KEY posts /responses"
+}
+
+test_oauth_store_via_fm_xai_auth_file() {
+  local home fakebin log store out rc
+  home="$TMP_ROOT/oauth-file"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  store="$home/auth.json"
+  # Far-future expiry so no refresh.
+  write_oauth_store "$store" 'access-token-aaa' 'refresh-token-bbb' 9999999999999
+  out=$(HOME="$home" PATH="$fakebin:$BASE_PATH" \
+    FM_XAI_AUTH_FILE="$store" \
+    FAKE_CURL_LOG="$log" \
+    FAKE_RESP_CODE=200 \
+    FAKE_RESP_BODY="$(sample_response)" \
+    run_xsearch --json --tool x_search 'query' 2>/dev/null); rc=$?
+  expect_code 0 "$rc" "oauth file"
+  printf '%s' "$out" | jq -e '.id == "resp_test"' >/dev/null || fail "json out: $out"
+  grep -q 'auth_kind=bearer' "$log" || fail "oauth bearer missing"
+  # No token URL hit when unexpired.
+  if grep -q 'oauth2/token' "$log"; then
+    fail "unexpected refresh for unexpired token"
+  fi
+  pass "fm-xsearch loads OAuth from FM_XAI_AUTH_FILE"
+}
+
+test_oauth_refresh_when_expired() {
+  local home fakebin log store out rc new_access
+  home="$TMP_ROOT/oauth-refresh"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  store="$home/auth.json"
+  write_oauth_store "$store" 'old-access' 'refresh-token-ccc' 1
+  out=$(HOME="$home" PATH="$fakebin:$BASE_PATH" \
+    FM_XAI_AUTH_FILE="$store" \
+    FAKE_CURL_LOG="$log" \
+    FAKE_TOKEN_CODE=200 \
+    FAKE_TOKEN_BODY='{"access_token":"new-access-ddd","refresh_token":"refresh-token-eee","expires_in":3600}' \
+    FAKE_RESP_CODE=200 \
+    FAKE_RESP_BODY="$(sample_response)" \
+    run_xsearch --tool both 'refresh me' 2>/dev/null); rc=$?
+  expect_code 0 "$rc" "refresh path"
+  printf '%s' "$out" | grep -q 'hello from x search' || fail "text after refresh: $out"
+  grep -q 'oauth2/token' "$log" || fail "expected token refresh call"
+  grep -q 'responses' "$log" || fail "expected responses call after refresh"
+  new_access=$(jq -r '.xai.access' "$store")
+  [ "$new_access" = 'new-access-ddd' ] || fail "store not updated: $(cat "$store")"
+  jq -e '.other.key == "keep-me"' "$store" >/dev/null || fail "sibling providers clobbered"
+  jq -e '.xai.refresh == "refresh-token-eee"' "$store" >/dev/null || fail "refresh token not rotated"
+  pass "fm-xsearch refreshes expired OAuth and writes store back"
+}
+
+test_opencode_default_store_path() {
+  local home fakebin store out rc
+  home="$TMP_ROOT/oc-default"; mkdir -p "$home/xdg/opencode"
+  fakebin=$(make_fake_curl "$home")
+  store="$home/xdg/opencode/auth.json"
+  write_oauth_store "$store" 'oc-access' 'oc-refresh' 9999999999999
+  out=$(HOME="$home" XDG_DATA_HOME="$home/xdg" PATH="$fakebin:$BASE_PATH" \
+    FAKE_RESP_BODY="$(sample_response)" \
+    run_xsearch 'from opencode store' 2>/dev/null); rc=$?
+  expect_code 0 "$rc" "opencode default store"
+  printf '%s' "$out" | grep -q 'hello from x search' || fail "oc store text: $out"
+  pass "fm-xsearch reads OpenCode default auth path"
+}
+
+test_pi_default_store_path() {
+  local home fakebin store out rc
+  home="$TMP_ROOT/pi-default"; mkdir -p "$home/.pi/agent"
+  fakebin=$(make_fake_curl "$home")
+  store="$home/.pi/agent/auth.json"
+  write_oauth_store "$store" 'pi-access' 'pi-refresh' 9999999999999
+  out=$(HOME="$home" XDG_DATA_HOME="$home/empty-xdg" PATH="$fakebin:$BASE_PATH" \
+    FAKE_RESP_BODY="$(sample_response)" \
+    run_xsearch 'from pi store' 2>/dev/null); rc=$?
+  expect_code 0 "$rc" "pi default store"
+  printf '%s' "$out" | grep -q 'hello from x search' || fail "pi store text: $out"
+  pass "fm-xsearch reads Pi default auth path"
+}
+
+test_api_error_exit_4() {
+  local home fakebin rc err
+  home="$TMP_ROOT/api-err"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  err=$(HOME="$home" PATH="$fakebin:$BASE_PATH" \
+    XAI_API_KEY='k' \
+    FAKE_RESP_CODE=422 \
+    FAKE_RESP_BODY='{"error":"bad"}' \
+    "$ROOT/bin/fm-xsearch.sh" 'nope' 2>&1 >/dev/null); rc=$?
+  expect_code 4 "$rc" "api error"
+  printf '%s' "$err" | grep -q 'HTTP 422' || fail "expected 422 message: $err"
+  pass "fm-xsearch maps API errors to exit 4"
+}
+
+test_prompt_file_and_stdin() {
+  local home fakebin out rc pf
+  home="$TMP_ROOT/prompt-file"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  pf="$home/prompt.txt"
+  printf 'file prompt body' > "$pf"
+  out=$(HOME="$home" PATH="$fakebin:$BASE_PATH" XAI_API_KEY='k' \
+    FAKE_RESP_BODY="$(sample_response)" \
+    "$ROOT/bin/fm-xsearch.sh" --dry-run --prompt-file "$pf")
+  printf '%s' "$out" | jq -e '.input[0].content == "file prompt body"' >/dev/null \
+    || fail "prompt-file: $out"
+  out=$(printf 'stdin prompt' | HOME="$home" PATH="$fakebin:$BASE_PATH" XAI_API_KEY='k' \
+    "$ROOT/bin/fm-xsearch.sh" --dry-run -)
+  printf '%s' "$out" | jq -e '.input[0].content == "stdin prompt"' >/dev/null \
+    || fail "stdin prompt: $out"
+  pass "fm-xsearch --prompt-file and stdin"
+}
+
+test_custom_base_url() {
+  local home fakebin log rc
+  home="$TMP_ROOT/base-url"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  HOME="$home" PATH="$fakebin:$BASE_PATH" XAI_API_KEY='k' \
+    FM_XAI_BASE_URL='https://example.test/v1' \
+    FAKE_CURL_LOG="$log" \
+    FAKE_RESP_BODY="$(sample_response)" \
+    "$ROOT/bin/fm-xsearch.sh" 'ping' >/dev/null 2>&1
+  rc=$?
+  expect_code 0 "$rc" "custom base"
+  grep -q 'url=https://example.test/v1/responses' "$log" || fail "base url not used: $(cat "$log")"
+  pass "fm-xsearch honors FM_XAI_BASE_URL"
+}
+
+# ---------------------------------------------------------------------------
+
+test_help_exits_zero
+test_usage_requires_prompt
+test_dry_run_both_tools_default
+test_dry_run_x_search_filters
+test_dry_run_rejects_mixed_handle_filters
+test_no_auth_exits_3
+test_api_key_env_posts_responses
+test_oauth_store_via_fm_xai_auth_file
+test_oauth_refresh_when_expired
+test_opencode_default_store_path
+test_pi_default_store_path
+test_api_error_exit_4
+test_prompt_file_and_stdin
+test_custom_base_url
+
+echo "all fm-xsearch tests passed"


### PR DESCRIPTION
## Summary

- Add `bin/fm-xsearch.sh` so fleet workers can call xAI server-side `web_search` / `x_search` on `POST /v1/responses` using SuperGrok OAuth (OpenCode/Pi auth stores) or optional `XAI_API_KEY`.
- Not the X Developer API and not firstmate X-mode. Tokens never logged; refresh write-back keeps sibling providers and uses atomic same-dir store replace.
- Hermetic tests (`tests/fm-xsearch.test.sh`), operator docs (`docs/xai-server-search.md`), scripts/configuration/README pointers, harness-adapters notes, and optional OpenCode custom-tool example.

## Validation

- no-mistakes cleared intent → rebase → review → test → document → lint (push failed on upstream write; fork PR path authorized).
- Review fixes hardened OAuth refresh body, temp credential cleanup, store write atomicity, expiry skew, and refresh failure surfacing.
- Captain approved hermetic-only coverage; scout already proved live OAuth tool calls on `/v1/responses`.

## Test plan

- [x] `bin/fm-test-run.sh tests/fm-xsearch.test.sh`
- [x] `bin/fm-lint.sh` on touched shell
- [x] `bin/fm-doc-audience-check.sh`
- [ ] CI green on this PR

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

_Fork PR path: no-mistakes completed intent→lint; upstream push 403 for willchen95; branch pushed to willchen95/firstmate and PR opened against kunchenguid/firstmate._