### PR TITLE
fix(bin): stop task workers inheriting the primary home and pooled slots

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -30,7 +30,8 @@ When any diagnostic needs captain attention, report the plain consequence and re
 - `ISOLATION: task <id> collapsed onto the primary checkout - agent process <pid> is running in <path> ...` - a restore or resume put that task's live agent inside the primary checkout instead of its own worktree, so anything it writes lands in the shared checkout.
   The finding comes from the agent process itself, not a pane reading, so treat it as proven.
   Stop that worker before it writes anything further, load `stuck-crewmate-recovery` to reconcile its recorded work, and relaunch it in an isolated worktree; never dispose of a worktree or steer the task while this line stands.
-- `ISOLATION: task <id> is running as a worker of home <path>, not this home ...` - a live agent declared for a different home is acting against this home's records, which is the home-inheritance defect itself.
+- `ISOLATION: task <id> is running as a worker of home <path>, not the home that owns it ...` - a live agent declared for a different home is acting against this home's records, which is the home-inheritance defect itself.
+  A secondmate legitimately declares its own home and never trips this line, so a reported mismatch is always a genuine one.
   Stop that worker, then reconcile ownership from the home that actually launched it rather than adopting it here.
 - `ISOLATION: task <id> is not in its recorded worktree - agent process <pid> is running in <path> ...` - the task's recorded worktree is stale relative to where its agent actually is.
   Reconcile the record before any teardown or steer; disposal paths already refuse the slot, and forcing past that would risk another task's work.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, ISOLATION, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -27,6 +27,13 @@ When any diagnostic needs captain attention, report the plain consequence and re
 - `TANGLE: <remediation>` - the primary checkout is stranded on a feature branch instead of its default branch; `AGENTS.md` section 8 explains why this guard exists and what it protects.
   The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree.
   This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.
+- `ISOLATION: task <id> collapsed onto the primary checkout - agent process <pid> is running in <path> ...` - a restore or resume put that task's live agent inside the primary checkout instead of its own worktree, so anything it writes lands in the shared checkout.
+  The finding comes from the agent process itself, not a pane reading, so treat it as proven.
+  Stop that worker before it writes anything further, load `stuck-crewmate-recovery` to reconcile its recorded work, and relaunch it in an isolated worktree; never dispose of a worktree or steer the task while this line stands.
+- `ISOLATION: task <id> is running as a worker of home <path>, not this home ...` - a live agent declared for a different home is acting against this home's records, which is the home-inheritance defect itself.
+  Stop that worker, then reconcile ownership from the home that actually launched it rather than adopting it here.
+- `ISOLATION: task <id> is not in its recorded worktree - agent process <pid> is running in <path> ...` - the task's recorded worktree is stale relative to where its agent actually is.
+  Reconcile the record before any teardown or steer; disposal paths already refuse the slot, and forcing past that would risk another task's work.
 - `CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>` - the optional dispatch profile file exists but failed low-cost bootstrap validation; stop profile-based dispatch, report the actionable error, and require correction of the malformed schema, unverified harness name, or invalid harness/effort pair rather than falling back around it or selecting a bad profile.
 - `FLEET_SYNC: <repo>: skipped: <reason>` - a benign one-off skip (offline, no origin, local-only); bootstrap continued, investigate only if it blocks work.
   A skip can also report the bounded fleet-refresh timeout (`FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT`, or a fleet-size-aware default with a 20 second floor); a timeout never blocks startup.

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -175,6 +175,7 @@ When safe, teardown kills the direct tmux window, removes the `data/secondmates.
 Removing a leased home releases its durable treehouse lease via `treehouse return`, so the pool slot is freed for reuse rather than left leased forever.
 A plain-clone home with no pool slot is simply removed.
 If `treehouse return` fails for a leased home, teardown stops with state intact rather than raw-removing the directory and hiding a held lease.
+Teardown also stops with state intact when another task still holds that pooled slot, and `--force` does not waive that gate, so reconcile the other holder and retry instead of escalating (`docs/worker-isolation.md`).
 
 With `--force`, teardown is the explicit discard path.
 It kills child windows, discards child work and state inside the secondmate home, removes the route, releases the lease, and removes the retired secondmate home.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ If the session lock cannot be acquired and verified, report its exact diagnostic
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
 
 1. **Lock** - acquires the per-home session lock first, before anything mutates shared state.
-2. **Bootstrap** - detect-only checks (tool/version problems, GitHub auth, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
+2. **Bootstrap** - detect-only checks (tool/version problems, GitHub auth, the worktree-tangle check, the read-only worker-isolation sweep, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
    When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
    Home-local stale Herdr projection cleanup and the five bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, the local secondmate fast-forward sweep, the secondmate liveness sweep, and X-mode artifact writes - run only when this session actually holds the lock from step 1.
    The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous or unreadable targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,7 +469,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `ISOLATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/bin/fm-agent-cwd-lib.sh
+++ b/bin/fm-agent-cwd-lib.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# bin/fm-agent-cwd-lib.sh - the ONE owner of "where is this agent actually
+# running?".
+#
+# METHOD OF RECORD (owner ruling 2026-07-25): the AGENT PROCESS's own cwd, read
+# from /proc/<pid>/cwd, is the isolation check of record. A session provider's
+# pane/surface cwd field is a cheap HINT and never evidence.
+#
+# Why: a backend's pane cwd can name a completely different process. Observed
+# live - a herdr pane listing reported a worker's cwd as the PRIMARY checkout
+# while /proc/<pid>/cwd showed the worker correctly inside its own treehouse
+# worktree; the pane field had picked up firstmate's own process because both
+# share the workspace. A pane read is also frozen at pane-creation time on
+# several providers, which is why fm-spawn.sh's worktree-settle poll needs the
+# live foreground process rather than the pane record.
+#
+# Resolution order, most authoritative first:
+#   1. the declared agent process - the root-most live process carrying this
+#      task's FM_AGENT_TASK marker (bin/fm-worker-isolation-lib.sh). Backend
+#      independent, and the only source that survives a restore that re-parents
+#      or relabels panes.
+#   2. the backend's pane/shell pid, then the deepest descendant of it (the
+#      foreground process), read through /proc. Only tmux exposes a verified
+#      per-pane pid; herdr, zellij, cmux, and orca do not, so they fall through.
+#   3. nothing - the caller may use its own pane-cwd hint, LABELLED as a hint.
+#
+# Every reader prints one tab-separated verdict record so no call site invents
+# its own shape:
+#     <source>\t<pid>\t<cwd>
+# with source one of:
+#   proc       - authoritative, read from the named process
+#   unknown    - no authoritative reading is available here (pid and cwd empty)
+#
+# On a host without procfs (macOS) step 1 is unavailable and step 2 falls back
+# to `lsof -d cwd`; when neither works the verdict is `unknown` rather than a
+# pane value silently promoted to evidence.
+#
+# docs/worker-isolation.md owns how this mechanism fits with the other three,
+# and docs/verification/worker-isolation.md owns the per-provider evidence.
+#
+# This file is sourced by scripts and has no side effects on source.
+
+_FM_AGENT_CWD_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# FM_HARNESS_RE and the harness-identity contract have one owner.
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$_FM_AGENT_CWD_LIB_DIR/fm-session-lock-lib.sh"
+
+FM_AGENT_CWD_MAX_DESCEND=16
+
+fm_agent_pid_is_numeric() {  # <pid>
+  case "${1:-}" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  return 0
+}
+
+# fm_agent_ppid <pid>: the parent pid, from procfs where available and `ps`
+# otherwise. /proc/<pid>/status is preferred over /proc/<pid>/stat because a
+# process comm containing spaces or parentheses makes stat field offsets unsafe.
+fm_agent_ppid() {
+  local pid=$1 ppid
+  fm_agent_pid_is_numeric "$pid" || return 1
+  if [ -r "/proc/$pid/status" ]; then
+    ppid=$(awk '/^PPid:/ {print $2; exit}' "/proc/$pid/status" 2>/dev/null)
+  else
+    ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+  fi
+  fm_agent_pid_is_numeric "$ppid" || return 1
+  printf '%s' "$ppid"
+}
+
+# fm_agent_proc_cwd <pid>: the process's real working directory. procfs first;
+# `lsof -d cwd` is the documented fallback for hosts without /proc. Returns 1
+# rather than guessing when neither can answer.
+fm_agent_proc_cwd() {
+  local pid=$1 cwd
+  fm_agent_pid_is_numeric "$pid" || return 1
+  if [ -L "/proc/$pid/cwd" ]; then
+    cwd=$(readlink "/proc/$pid/cwd" 2>/dev/null) || cwd=
+    case "$cwd" in
+      /*) printf '%s' "$cwd"; return 0 ;;
+    esac
+    return 1
+  fi
+  command -v lsof >/dev/null 2>&1 || return 1
+  cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
+  case "$cwd" in
+    /*) printf '%s' "$cwd"; return 0 ;;
+  esac
+  return 1
+}
+
+# fm_agent_environ <pid>: the process environment as newline-separated
+# assignments, or 1 when it cannot be read.
+#
+# The mode bits on /proc/<pid>/environ are not sufficient permission: the kernel
+# additionally requires ptrace read access, so a same-uid but privileged process
+# passes `-r` and still fails EACCES at open. The redirect therefore has to be
+# allowed to fail quietly. Silencing it needs the group form: redirections are
+# applied left to right, so a trailing `2>/dev/null` on the same command is set
+# up only AFTER the input redirect has already failed and printed to stderr.
+fm_agent_environ() {
+  local pid=$1 dump
+  fm_agent_pid_is_numeric "$pid" || return 1
+  [ -r "/proc/$pid/environ" ] || return 1
+  dump=$( { tr '\0' '\n' < "/proc/$pid/environ"; } 2>/dev/null ) || return 1
+  [ -n "$dump" ] || return 1
+  printf '%s' "$dump"
+}
+
+# fm_agent_proc_env <pid> <var>: one environment value of a live process, or 1
+# when procfs is unavailable, the process is gone, or the variable is unset.
+fm_agent_proc_env() {
+  local pid=$1 var=$2 value
+  [ -n "$var" ] || return 1
+  value=$(fm_agent_environ "$pid" | sed -n "s/^$var=//p" | head -1)
+  [ -n "$value" ] || return 1
+  printf '%s' "$value"
+}
+
+# fm_agent_pids_for_task <task-id>: every live process whose environment
+# declares this task, newline separated. Only the launch command itself carries
+# the marker, so the set is the agent plus its descendants.
+fm_agent_pids_for_task() {
+  local id=$1 entry pid found=1
+  [ -n "$id" ] || return 1
+  [ -d /proc ] || return 1
+  for entry in /proc/[0-9]*; do
+    [ -d "$entry" ] || continue
+    pid=${entry#/proc/}
+    fm_agent_environ "$pid" | grep -qxF "FM_AGENT_TASK=$id" || continue
+    printf '%s\n' "$pid"
+    found=0
+  done
+  return "$found"
+}
+
+# fm_agent_pid_for_task <task-id>: the ROOT-most declared process for the task -
+# the launched agent itself rather than one of its tool subprocesses, which is
+# the process whose cwd answers "is this worker isolated?". The root is the
+# match whose own parent is not also a match.
+fm_agent_pid_for_task() {
+  local id=$1 matches pid ppid
+  matches=$(fm_agent_pids_for_task "$id") || return 1
+  [ -n "$matches" ] || return 1
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    ppid=$(fm_agent_ppid "$pid") || ppid=
+    if [ -n "$ppid" ] && printf '%s\n' "$matches" | grep -qxF "$ppid"; then
+      continue
+    fi
+    printf '%s' "$pid"
+    return 0
+  done <<EOF
+$matches
+EOF
+  # Every match claims a matching parent (a cycle cannot happen, but a race
+  # between the scan and a reap can): fall back to the lowest pid seen rather
+  # than reporting nothing.
+  printf '%s' "$(printf '%s\n' "$matches" | sort -n | head -1)"
+}
+
+# fm_agent_backend_shell_pid <backend> <target>: the backend's pane/shell pid.
+#
+# Provider matrix (verified surfaces, docs/worker-isolation.md owns the record):
+#   tmux    #{pane_pid} is a real per-pane shell pid.
+#   herdr   the pane API exposes foreground_cwd but no process id.
+#   zellij  no per-pane pid is exposed at all (docs/zellij-backend.md).
+#   cmux    the control socket exposes no per-surface process id.
+#   orca    the terminal endpoint exposes no process id.
+# A provider with no pid is not a failure of this function; it means the caller
+# has only a hint for tasks that also lack the declared-agent marker.
+fm_agent_backend_shell_pid() {
+  local backend=$1 target=$2 pid
+  case "$backend" in
+    tmux)
+      command -v tmux >/dev/null 2>&1 || return 1
+      pid=$(tmux display-message -p -t "$target" '#{pane_pid}' 2>/dev/null | tr -d '[:space:]')
+      fm_agent_pid_is_numeric "$pid" || return 1
+      printf '%s' "$pid"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# fm_agent_foreground_pid <pid>: the deepest descendant of <pid> - the process
+# actually running in the foreground of that shell. This is what makes a tmux
+# reading track `treehouse get`'s subshell, exactly as herdr's foreground_cwd
+# does; the pane shell's own cwd never moves.
+fm_agent_foreground_pid() {
+  local root=$1 table child current depth=0
+  fm_agent_pid_is_numeric "$root" || return 1
+  table=$(ps -eo pid=,ppid= 2>/dev/null) || return 1
+  current=$root
+  while [ "$depth" -lt "$FM_AGENT_CWD_MAX_DESCEND" ]; do
+    child=$(printf '%s\n' "$table" | awk -v p="$current" '$2 == p {print $1}' | sort -n | tail -1)
+    fm_agent_pid_is_numeric "$child" || break
+    current=$child
+    depth=$((depth + 1))
+  done
+  printf '%s' "$current"
+}
+
+# fm_agent_harness_pid_below <pid>: the deepest descendant of <pid> whose
+# command names a verified harness, using the shared FM_HARNESS_RE identity.
+# Preferred over the plain foreground process once an agent is running, because
+# a transient tool subprocess can sit below the agent with an unrelated cwd.
+fm_agent_harness_pid_below() {
+  local root=$1 table pid comm args best='' queue next
+  fm_agent_pid_is_numeric "$root" || return 1
+  table=$(ps -eo pid=,ppid= 2>/dev/null) || return 1
+  queue=$root
+  local depth=0
+  while [ -n "$queue" ] && [ "$depth" -lt "$FM_AGENT_CWD_MAX_DESCEND" ]; do
+    next=
+    for pid in $queue; do
+      comm=$(ps -o comm= -p "$pid" 2>/dev/null) || comm=
+      args=$(ps -o args= -p "$pid" 2>/dev/null) || args=
+      if [ -n "$comm" ] \
+        && printf '%s' "$(basename "$comm") $args" | grep -qE "$FM_HARNESS_RE"; then
+        best=$pid
+      fi
+      next="$next $(printf '%s\n' "$table" | awk -v p="$pid" '$2 == p {print $1}' | tr '\n' ' ')"
+    done
+    queue=$next
+    depth=$((depth + 1))
+  done
+  [ -n "$best" ] || return 1
+  printf '%s' "$best"
+}
+
+# fm_agent_cwd_verdict <task-id> [backend] [target]
+# Print the tab-separated verdict record documented in this file's header.
+# Never falls back to a pane value: a caller that wants a hint must ask its
+# backend for one and label it as a hint.
+fm_agent_cwd_verdict() {
+  local id=${1:-} backend=${2:-} target=${3:-} pid cwd shell_pid
+  if [ -n "$id" ] && pid=$(fm_agent_pid_for_task "$id"); then
+    if cwd=$(fm_agent_proc_cwd "$pid"); then
+      printf 'proc\t%s\t%s' "$pid" "$cwd"
+      return 0
+    fi
+  fi
+  if [ -n "$backend" ] && [ -n "$target" ] \
+    && shell_pid=$(fm_agent_backend_shell_pid "$backend" "$target"); then
+    pid=$(fm_agent_harness_pid_below "$shell_pid" 2>/dev/null) \
+      || pid=$(fm_agent_foreground_pid "$shell_pid" 2>/dev/null) \
+      || pid=$shell_pid
+    if cwd=$(fm_agent_proc_cwd "$pid"); then
+      printf 'proc\t%s\t%s' "$pid" "$cwd"
+      return 0
+    fi
+  fi
+  printf 'unknown\t\t'
+}
+
+# fm_agent_verdict_field <record> <source|pid|cwd>
+fm_agent_verdict_field() {
+  local record=$1 field=$2
+  case "$field" in
+    source) printf '%s' "${record%%$'\t'*}" ;;
+    pid) record=${record#*$'\t'}; printf '%s' "${record%%$'\t'*}" ;;
+    cwd) printf '%s' "${record##*$'\t'}" ;;
+    *) return 1 ;;
+  esac
+}
+
+# fm_agent_canonical_dir <path>: physical path of an existing directory, or 1.
+fm_agent_canonical_dir() {
+  local path=${1:-}
+  [ -n "$path" ] || return 1
+  [ -d "$path" ] || return 1
+  ( cd "$path" 2>/dev/null && pwd -P )
+}
+
+# fm_agent_path_within <ancestor> <path>: 0 when <path> is <ancestor> or lives
+# under it. Both arguments must already be physical paths.
+fm_agent_path_within() {
+  local ancestor=${1:-} path=${2:-}
+  [ -n "$ancestor" ] && [ -n "$path" ] || return 1
+  [ "$ancestor" = "$path" ] && return 0
+  case "$path" in
+    "$ancestor"/*) return 0 ;;
+  esac
+  return 1
+}

--- a/bin/fm-agent-cwd-lib.sh
+++ b/bin/fm-agent-cwd-lib.sh
@@ -118,12 +118,44 @@ fm_agent_proc_env() {
   printf '%s' "$value"
 }
 
-# fm_agent_pids_for_task <task-id>: every live process whose environment
-# declares this task, newline separated. Only the launch command itself carries
-# the marker, so the set is the agent plus its descendants.
+# fm_agent_task_pid_index: one `<task-id>\t<pid>` line per live process that
+# declares a task, built from a SINGLE walk of /proc.
+#
+# Reading one process's environment costs several processes of its own, so a
+# caller that asks about MANY tasks builds this index once and hands it back to
+# the lookups below. Asking per task instead is O(tasks x processes), which the
+# resume sweep pays on the session-start critical path - and the incident it
+# exists for had 17 concurrent tasks.
+# Returns 1 when procfs is unavailable or no live process declares a task.
+fm_agent_task_pid_index() {
+  local entry pid task found=1
+  [ -d /proc ] || return 1
+  for entry in /proc/[0-9]*; do
+    [ -d "$entry" ] || continue
+    pid=${entry#/proc/}
+    task=$(fm_agent_proc_env "$pid" FM_AGENT_TASK) || continue
+    printf '%s\t%s\n' "$task" "$pid"
+    found=0
+  done
+  return "$found"
+}
+
+# fm_agent_pids_for_task <task-id> [pid-index]: every live process whose
+# environment declares this task, newline separated. Only the launch command
+# itself carries the marker, so the set is the agent plus its descendants.
+# A supplied <pid-index> (fm_agent_task_pid_index) is consulted instead of
+# walking /proc again; an empty one is a real answer - no process declares a
+# task - not a missing argument.
 fm_agent_pids_for_task() {
-  local id=$1 entry pid found=1
+  local id=$1 index pids entry pid found=1
   [ -n "$id" ] || return 1
+  if [ "$#" -ge 2 ]; then
+    index=$2
+    pids=$(printf '%s\n' "$index" | awk -F'\t' -v t="$id" '$1 == t {print $2}')
+    [ -n "$pids" ] || return 1
+    printf '%s\n' "$pids"
+    return 0
+  fi
   [ -d /proc ] || return 1
   for entry in /proc/[0-9]*; do
     [ -d "$entry" ] || continue
@@ -135,13 +167,17 @@ fm_agent_pids_for_task() {
   return "$found"
 }
 
-# fm_agent_pid_for_task <task-id>: the ROOT-most declared process for the task -
-# the launched agent itself rather than one of its tool subprocesses, which is
-# the process whose cwd answers "is this worker isolated?". The root is the
-# match whose own parent is not also a match.
+# fm_agent_pid_for_task <task-id> [pid-index]: the ROOT-most declared process
+# for the task - the launched agent itself rather than one of its tool
+# subprocesses, which is the process whose cwd answers "is this worker
+# isolated?". The root is the match whose own parent is not also a match.
 fm_agent_pid_for_task() {
   local id=$1 matches pid ppid
-  matches=$(fm_agent_pids_for_task "$id") || return 1
+  if [ "$#" -ge 2 ]; then
+    matches=$(fm_agent_pids_for_task "$id" "$2") || return 1
+  else
+    matches=$(fm_agent_pids_for_task "$id") || return 1
+  fi
   [ -n "$matches" ] || return 1
   while IFS= read -r pid; do
     [ -n "$pid" ] || continue
@@ -160,6 +196,33 @@ EOF
   printf '%s' "$(printf '%s\n' "$matches" | sort -n | head -1)"
 }
 
+# fm_agent_tmux_window_id <target>: the STABLE window id behind a tmux target.
+#
+# A `@<n>` target is already stable and passes straight through. A
+# `<session>:<name>` target is resolved by EXACT enumeration and is never handed
+# to tmux for resolution, because `display-message -t <unknown-name>` silently
+# falls back to the ACTIVE CLIENT's window. A task whose window name was lost or
+# auto-renamed would then answer with firstmate's OWN pane pid, whose cwd is the
+# primary checkout - a healthy worker reported as a collapse, which is the exact
+# false-violation class this library exists to eliminate. bin/fm-spawn.sh pins
+# the window name and targets the id for the same reason.
+# No exact match returns 1, so the caller reports `unknown` rather than another
+# window's evidence.
+fm_agent_tmux_window_id() {  # <target>
+  local target=${1:-} session window wid
+  case "$target" in
+    '') return 1 ;;
+    @*) printf '%s' "$target"; return 0 ;;
+    *:*) session=${target%%:*}; window=${target#*:} ;;
+    *) return 1 ;;
+  esac
+  [ -n "$session" ] && [ -n "$window" ] || return 1
+  wid=$(tmux list-windows -t "=$session" -F '#{window_id} #{window_name}' 2>/dev/null \
+    | awk -v w="$window" '{ id = $1; $1 = ""; sub(/^ /, ""); if ($0 == w) { print id; exit } }')
+  [ -n "$wid" ] || return 1
+  printf '%s' "$wid"
+}
+
 # fm_agent_backend_shell_pid <backend> <target>: the backend's pane/shell pid.
 #
 # Provider matrix (verified surfaces, docs/worker-isolation.md owns the record):
@@ -171,11 +234,12 @@ EOF
 # A provider with no pid is not a failure of this function; it means the caller
 # has only a hint for tasks that also lack the declared-agent marker.
 fm_agent_backend_shell_pid() {
-  local backend=$1 target=$2 pid
+  local backend=$1 target=$2 pid wid
   case "$backend" in
     tmux)
       command -v tmux >/dev/null 2>&1 || return 1
-      pid=$(tmux display-message -p -t "$target" '#{pane_pid}' 2>/dev/null | tr -d '[:space:]')
+      wid=$(fm_agent_tmux_window_id "$target") || return 1
+      pid=$(tmux display-message -p -t "$wid" '#{pane_pid}' 2>/dev/null | tr -d '[:space:]')
       fm_agent_pid_is_numeric "$pid" || return 1
       printf '%s' "$pid"
       ;;
@@ -229,13 +293,22 @@ fm_agent_harness_pid_below() {
   printf '%s' "$best"
 }
 
-# fm_agent_cwd_verdict <task-id> [backend] [target]
+# fm_agent_cwd_verdict <task-id> [backend] [target] [pid-index]
 # Print the tab-separated verdict record documented in this file's header.
 # Never falls back to a pane value: a caller that wants a hint must ask its
 # backend for one and label it as a hint.
+# A caller looping over many tasks passes one fm_agent_task_pid_index so the
+# declared-agent lookup costs a single /proc walk for the whole loop.
 fm_agent_cwd_verdict() {
-  local id=${1:-} backend=${2:-} target=${3:-} pid cwd shell_pid
-  if [ -n "$id" ] && pid=$(fm_agent_pid_for_task "$id"); then
+  local id=${1:-} backend=${2:-} target=${3:-} pid='' cwd shell_pid
+  if [ -n "$id" ]; then
+    if [ "$#" -ge 4 ]; then
+      pid=$(fm_agent_pid_for_task "$id" "$4") || pid=
+    else
+      pid=$(fm_agent_pid_for_task "$id") || pid=
+    fi
+  fi
+  if [ -n "$pid" ]; then
     if cwd=$(fm_agent_proc_cwd "$pid"); then
       printf 'proc\t%s\t%s' "$pid" "$cwd"
       return 0

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -12,6 +12,7 @@
 #                 "FLEET_SYNC: <repo>: skipped|recovered|STUCK: <detail>",
 #                 "PR_CHECK_MIGRATION: <private remediation>",
 #                 "TANGLE: <remediation>",
+#                 "ISOLATION: task <id> <collapse or ownership finding>",
 #                 "SECONDMATE_SYNC: secondmate <id>: skipped: <reason>",
 #                 "NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>",
 #                 "BOOTSTRAP_INFO: nudged fm-<id> with '<message>'",
@@ -41,6 +42,11 @@
 #          failed names whether the endpoint was missing or agent-less.
 #          Already-live and successfully relaunched secondmates are silent
 #          unless FM_BOOTSTRAP_VERBOSE_FACTS=1 requests BOOTSTRAP_INFO facts.
+#          An ISOLATION line means a task's live agent process is provably not
+#          in its recorded worktree - a restore that collapsed the worktree onto
+#          the primary checkout, or an agent declared for another home. It is
+#          read-only, runs in detect-only mode too, and reports only from an
+#          authoritative process reading, never from a pane path.
 #          A TANGLE line means the firstmate primary checkout (FM_ROOT) is stranded
 #          on a feature branch instead of its default branch - a crewmate's work
 #          landed in the primary instead of its own worktree; restore it per the line.
@@ -848,6 +854,11 @@ gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
 # Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its
 # default branch, not a feature branch (see fm-tangle-lib.sh). Scoped to the
 # primary only; detached-HEAD worktrees and secondmate homes never trip it.
+# Worker-isolation sweep: the spawn-time assertion does not survive a restore,
+# so every session re-establishes it from live process evidence. Read-only, so
+# it runs in detect-only mode too. bin/fm-isolation-sweep.sh owns the evidence
+# discipline and the exact ISOLATION line shapes.
+"$SCRIPT_DIR/fm-isolation-sweep.sh" 2>/dev/null || true
 tangle_branch=$(fm_primary_tangle_branch "$FM_ROOT" 2>/dev/null || true)
 if [ -n "$tangle_branch" ]; then
   tangle_default=$(fm_default_branch "$FM_ROOT" 2>/dev/null || echo main)

--- a/bin/fm-isolation-sweep.sh
+++ b/bin/fm-isolation-sweep.sh
@@ -51,6 +51,13 @@ esac
 HOME_REAL=$(fm_agent_canonical_dir "$FM_HOME") || HOME_REAL=$FM_HOME
 ROOT_REAL=$(fm_agent_canonical_dir "$FM_ROOT") || ROOT_REAL=$FM_ROOT
 
+# One /proc walk for the whole sweep, reused for every task below. Asking per
+# task instead costs a full walk each time - O(tasks x processes) of forked
+# environment reads on the session-start critical path, and the incident this
+# sweep exists for had 17 concurrent tasks. An empty index is a real answer (no
+# live process declares a task), not a missing one.
+PID_INDEX=$(fm_agent_task_pid_index) || PID_INDEX=
+
 for meta in "$STATE"/*.meta; do
   [ -f "$meta" ] || continue
   id=$(basename "$meta" .meta)
@@ -59,7 +66,7 @@ for meta in "$STATE"/*.meta; do
   backend=$(fm_backend_of_meta "$meta")
   target=$(fm_backend_target_of_meta "$meta")
 
-  record=$(fm_agent_cwd_verdict "$id" "$backend" "$target")
+  record=$(fm_agent_cwd_verdict "$id" "$backend" "$target" "$PID_INDEX")
   source=$(fm_agent_verdict_field "$record" source)
   if [ "$source" != proc ]; then
     if [ "${FM_ISOLATION_VERBOSE:-0}" = 1 ]; then
@@ -73,11 +80,26 @@ for meta in "$STATE"/*.meta; do
 
   # A resumed agent that carries a declared owning home from another home is the
   # inheritance defect itself, not merely a misplaced cwd.
+  #
+  # The home a record EXPECTS is not always this one. A secondmate is
+  # deliberately launched with FM_AGENT_OWNER_HOME set to its OWN home while its
+  # record lives in the launching primary's state directory, because it is the
+  # primary of that home and only there (bin/fm-worker-isolation-lib.sh).
+  # Comparing it against this home would report every healthy secondmate in the
+  # fleet as a foreign worker on every session start, so the expected owner is
+  # taken from the record itself.
+  kind=$(fm_meta_get "$meta" kind)
+  expected_home=$HOME_REAL
+  if [ "$kind" = secondmate ]; then
+    expected_declared=$(fm_meta_get "$meta" home)
+    [ -n "$expected_declared" ] || expected_declared=$recorded
+    expected_home=$(fm_agent_canonical_dir "$expected_declared") || expected_home=$expected_declared
+  fi
   declared_home=$(fm_agent_proc_env "$pid" FM_AGENT_OWNER_HOME 2>/dev/null || true)
   if [ -n "$declared_home" ]; then
     declared_real=$(fm_agent_canonical_dir "$declared_home") || declared_real=$declared_home
-    if [ "$declared_real" != "$HOME_REAL" ]; then
-      echo "ISOLATION: task $id is running as a worker of home $declared_real, not this home ($HOME_REAL); stop it before it acts on this home's records"
+    if [ "$declared_real" != "$expected_home" ]; then
+      echo "ISOLATION: task $id is running as a worker of home $declared_real, not the home that owns it ($expected_home); stop it before it acts on that home's records"
       continue
     fi
   fi

--- a/bin/fm-isolation-sweep.sh
+++ b/bin/fm-isolation-sweep.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# fm-isolation-sweep.sh - re-assert task-worker isolation for a whole home,
+# after a restart, restore, or resume.
+#
+# Spawn asserts isolation once, at launch. That assertion does not survive a
+# restore: after the 2026-07-24 reboot a session provider restored every pane by
+# resuming its recorded agent session but resolved each working directory back
+# to the repository the worktree was derived from, collapsing 17 of 17 isolated
+# worktrees onto their origin - four of them into the firstmate PRIMARY
+# checkout. Isolation therefore has to be re-established from live evidence on
+# every resume, not assumed from the launch that happened before the reboot.
+#
+# This sweep is READ-ONLY and always exits 0. It prints one actionable
+# `ISOLATION:` line per task whose live agent process is provably not where its
+# record says it is, so bin/fm-bootstrap.sh can surface it in the session-start
+# digest exactly like TANGLE.
+#
+# Evidence discipline (bin/fm-agent-cwd-lib.sh owns the method of record): a
+# collapse is reported only from an AUTHORITATIVE /proc reading of the agent
+# process. A provider's pane cwd is never promoted to evidence here, because a
+# pane field naming the wrong process is precisely what produced a false
+# isolation violation on 2026-07-25. A task with no authoritative reading is
+# reported only under FM_ISOLATION_VERBOSE=1, as a BOOTSTRAP_INFO fact.
+#
+# docs/worker-isolation.md owns how this mechanism fits with the other three.
+#
+# Usage: fm-isolation-sweep.sh
+#   FM_ISOLATION_VERBOSE=1  also print BOOTSTRAP_INFO facts for tasks whose
+#                           isolation could not be proved either way.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-agent-cwd-lib.sh
+. "$SCRIPT_DIR/fm-agent-cwd-lib.sh"
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+
+case "${1:-}" in
+  -h|--help)
+    sed -n '2,29p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+esac
+
+[ -d "$STATE" ] || exit 0
+
+HOME_REAL=$(fm_agent_canonical_dir "$FM_HOME") || HOME_REAL=$FM_HOME
+ROOT_REAL=$(fm_agent_canonical_dir "$FM_ROOT") || ROOT_REAL=$FM_ROOT
+
+for meta in "$STATE"/*.meta; do
+  [ -f "$meta" ] || continue
+  id=$(basename "$meta" .meta)
+  recorded=$(fm_meta_get "$meta" worktree)
+  [ -n "$recorded" ] || continue
+  backend=$(fm_backend_of_meta "$meta")
+  target=$(fm_backend_target_of_meta "$meta")
+
+  record=$(fm_agent_cwd_verdict "$id" "$backend" "$target")
+  source=$(fm_agent_verdict_field "$record" source)
+  if [ "$source" != proc ]; then
+    if [ "${FM_ISOLATION_VERBOSE:-0}" = 1 ]; then
+      echo "BOOTSTRAP_INFO: isolation for $id is unproven: no live agent process could be identified, and a pane path is only a hint"
+    fi
+    continue
+  fi
+  pid=$(fm_agent_verdict_field "$record" pid)
+  cwd=$(fm_agent_verdict_field "$record" cwd)
+  cwd_real=$(fm_agent_canonical_dir "$cwd") || cwd_real=$cwd
+
+  # A resumed agent that carries a declared owning home from another home is the
+  # inheritance defect itself, not merely a misplaced cwd.
+  declared_home=$(fm_agent_proc_env "$pid" FM_AGENT_OWNER_HOME 2>/dev/null || true)
+  if [ -n "$declared_home" ]; then
+    declared_real=$(fm_agent_canonical_dir "$declared_home") || declared_real=$declared_home
+    if [ "$declared_real" != "$HOME_REAL" ]; then
+      echo "ISOLATION: task $id is running as a worker of home $declared_real, not this home ($HOME_REAL); stop it before it acts on this home's records"
+      continue
+    fi
+  fi
+
+  recorded_real=$(fm_agent_canonical_dir "$recorded") || recorded_real=$recorded
+  if fm_agent_path_within "$recorded_real" "$cwd_real"; then
+    if [ "${FM_ISOLATION_VERBOSE:-0}" = 1 ]; then
+      echo "BOOTSTRAP_INFO: isolation for $id proved from agent process $pid in $cwd_real"
+    fi
+    continue
+  fi
+
+  if fm_agent_path_within "$ROOT_REAL" "$cwd_real" || fm_agent_path_within "$HOME_REAL" "$cwd_real"; then
+    echo "ISOLATION: task $id collapsed onto the primary checkout - agent process $pid is running in $cwd_real instead of its worktree $recorded_real; stop that worker before it writes, then relaunch it in an isolated worktree"
+    continue
+  fi
+  echo "ISOLATION: task $id is not in its recorded worktree - agent process $pid is running in $cwd_real instead of $recorded_real; reconcile the record before any disposal or steer"
+done
+
+exit 0

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -5,9 +5,27 @@
 # PID of any one tool call, which is dead moments after it is written.
 # Usage: fm-lock.sh           acquire; exit 1 unless ownership is verified
 #        fm-lock.sh status    print holder and liveness; always exits 0
+#
+# This script is the ONLY writer of state/.lock. The owner record is never
+# hand-edited, and acquisition never displaces a live holder: an existing lock
+# naming another live harness refuses, and a declared task worker
+# (bin/fm-worker-isolation-lib.sh) refuses acquisition before touching the
+# record at all, while its read-only `status` inspection stays available.
+# A task child that inherited a primary's FM_HOME would otherwise resolve THIS
+# home's state directory and take the primary's own session ownership - the
+# 2026-07-24 incident where a suspended-then-resumed primary came back locked
+# out of its own home and stopped monitoring.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-worker-isolation-lib.sh
+. "$SCRIPT_DIR/fm-worker-isolation-lib.sh"
+# Refuse acquisition before any state directory is resolved or created, so a
+# task worker cannot even publish a probe file into the home it inherited.
+# Read-only `status` keeps its documented always-exit-0 contract.
+if [ "${1:-}" != status ]; then
+  fm_worker_refuse_primary_operation "session lock acquisition" || exit 1
+fi
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"

--- a/bin/fm-primary-scope-lib.sh
+++ b/bin/fm-primary-scope-lib.sh
@@ -3,6 +3,11 @@
 # in a genuine firstmate primary home.
 # This file is sourced by hook entrypoints and has no side effects on source.
 
+_FM_PRIMARY_SCOPE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The declared-agent-role contract has one owner; this predicate only consumes it.
+# shellcheck source=bin/fm-worker-isolation-lib.sh
+. "$_FM_PRIMARY_SCOPE_LIB_DIR/fm-worker-isolation-lib.sh"
+
 # Return 0 when $1 carries a genuine secondmate-home marker.
 fm_root_is_secondmate_home() {
   local marker="$1/.fm-secondmate-home" id LC_ALL=C
@@ -20,8 +25,12 @@ fm_root_is_secondmate_home() {
 # Return 0 when $1 is a genuine primary root whose effective state dir is $2.
 # A valid secondmate marker force-includes a linked secondmate home.
 # Otherwise only a plain checkout is primary, never a linked task worktree.
+# A declared task worker is never primary anywhere, whatever root and state it
+# was handed: an inherited FM_HOME or FM_ROOT_OVERRIDE would otherwise let a
+# worker launched inside a primary checkout fire that home's hooks.
 fm_primary_scope_matches() {
   local root=$1 state=$2 git_dir git_common_dir
+  fm_worker_is_task_worker && return 1
   if ! fm_root_is_secondmate_home "$root"; then
     git_dir=$(git -C "$root" rev-parse --git-dir 2>/dev/null) || return 1
     git_common_dir=$(git -C "$root" rev-parse --git-common-dir 2>/dev/null) || return 1

--- a/bin/fm-slot-owner-lib.sh
+++ b/bin/fm-slot-owner-lib.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# bin/fm-slot-owner-lib.sh - the ONE owner of "may this pooled worktree slot be
+# released?".
+#
+# A task's recorded `worktree=` is a HISTORICAL record of a slot the task once
+# used, never proof that the task still owns it. Pooled slots are reused: a
+# census on 2026-07-24 found ten treehouse slots recorded by more than one task,
+# up to six each, and on 2026-07-25 the hazard fired - tearing down one task
+# released a lease that a still-live quarantined-paused task also recorded, and
+# the pool reissued that exact slot to a new spawn.
+#
+# So disposal is gated on POSITIVE evidence of a conflict, in three independent
+# forms, any one of which retains the lease:
+#
+#   1. another task recorded in the same home names the same physical slot -
+#      the observed incident, and it needs no cooperation from the occupant;
+#   2. the slot's ownership stamp names a different task or home - the metadata
+#      being trusted is positively stale because the slot was reissued;
+#   3. a live agent declared for a DIFFERENT task is running inside the slot
+#      (bin/fm-agent-cwd-lib.sh's authoritative process cwd).
+#
+# Retain means the lease is not returned to the pool: firstmate finishes the
+# rest of the teardown (records and endpoint) and leaves the directory on disk,
+# so the slot can never be reissued out from under its other holder. That is
+# the records-and-panes-only policy that kept the 2026-07-25 collision harmless,
+# made deterministic. It is NOT a work-preservation check and therefore is NOT
+# waived by --force: --force is the captain's authority to discard THIS task's
+# work, never authority to release another task's slot.
+#
+# Absence of evidence is not evidence: a slot with no stamp (every task spawned
+# before stamping existed) and no conflicting reference still disposes normally.
+#
+# The stamp lives in the worktree's PRIVATE git directory, never in the working
+# tree, so it can never dirty a status check or leak into a commit. Writing is
+# refused for anything that is not a linked worktree, so a primary checkout can
+# never be stamped as a disposable slot.
+#
+# docs/worker-isolation.md owns how this mechanism fits with the other three.
+#
+# This file is sourced by scripts and has no side effects on source.
+
+_FM_SLOT_OWNER_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-agent-cwd-lib.sh
+. "$_FM_SLOT_OWNER_LIB_DIR/fm-agent-cwd-lib.sh"
+
+FM_SLOT_OWNER_STAMP_NAME=fm-slot-owner
+
+# fm_slot_stamp_path <worktree>: the stamp path for a LINKED worktree, or 1 for
+# a plain checkout (whose git dir is shared and must never be stamped).
+fm_slot_stamp_path() {
+  local wt=$1 git_dir common_dir
+  [ -n "$wt" ] && [ -d "$wt" ] || return 1
+  git_dir=$(git -C "$wt" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+  common_dir=$(git -C "$wt" rev-parse --git-common-dir 2>/dev/null) || return 1
+  [ -n "$git_dir" ] && [ -n "$common_dir" ] || return 1
+  # --git-common-dir can be relative to the worktree; resolve both physically
+  # rather than depending on a git new enough for --path-format=absolute.
+  case "$common_dir" in
+    /*) ;;
+    *) common_dir="$wt/$common_dir" ;;
+  esac
+  git_dir=$(fm_agent_canonical_dir "$git_dir") || return 1
+  common_dir=$(fm_agent_canonical_dir "$common_dir") || return 1
+  [ "$git_dir" != "$common_dir" ] || return 1
+  printf '%s/%s' "$git_dir" "$FM_SLOT_OWNER_STAMP_NAME"
+}
+
+# fm_slot_stamp_write <worktree> <task-id> <home>: record current ownership of
+# the slot. Best-effort by design - a slot that cannot be stamped simply has no
+# stamp evidence later, which is the pre-existing behavior.
+fm_slot_stamp_write() {
+  local wt=$1 id=$2 home=$3 path
+  [ -n "$id" ] && [ -n "$home" ] || return 1
+  path=$(fm_slot_stamp_path "$wt") || return 1
+  printf 'task=%s\nhome=%s\n' "$id" "$home" > "$path" 2>/dev/null || return 1
+}
+
+# fm_slot_stamp_field <worktree> <task|home>: the stamped value, or 1.
+fm_slot_stamp_field() {
+  local wt=$1 field=$2 path value
+  path=$(fm_slot_stamp_path "$wt") || return 1
+  [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  value=$(sed -n "s/^$field=//p" "$path" 2>/dev/null | head -1)
+  [ -n "$value" ] || return 1
+  printf '%s' "$value"
+}
+
+# fm_slot_stamp_clear <worktree>: drop the stamp once the slot is released.
+fm_slot_stamp_clear() {
+  local wt=$1 path
+  path=$(fm_slot_stamp_path "$wt") || return 0
+  rm -f "$path" 2>/dev/null || true
+}
+
+# fm_slot_meta_worktree <meta-file>: the recorded worktree path, or empty.
+fm_slot_meta_worktree() {
+  local meta=$1
+  [ -f "$meta" ] || return 0
+  grep '^worktree=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+# fm_slot_same_path <a> <b>: physical comparison where both paths exist, exact
+# string comparison otherwise, so a recorded slot whose directory is already
+# gone is still recognized as the same reference.
+fm_slot_same_path() {
+  local a=${1:-} b=${2:-} ra rb
+  [ -n "$a" ] && [ -n "$b" ] || return 1
+  [ "$a" = "$b" ] && return 0
+  ra=$(fm_agent_canonical_dir "$a") || return 1
+  rb=$(fm_agent_canonical_dir "$b") || return 1
+  [ "$ra" = "$rb" ]
+}
+
+# fm_slot_meta_referencing_tasks <state-dir> <task-id> <worktree>: other task
+# ids in this home whose metadata names the same slot, newline separated.
+fm_slot_meta_referencing_tasks() {
+  local state=$1 self=$2 wt=$3 meta id other found=1
+  [ -d "$state" ] || return 1
+  for meta in "$state"/*.meta; do
+    [ -f "$meta" ] || continue
+    id=$(basename "$meta" .meta)
+    [ "$id" != "$self" ] || continue
+    other=$(fm_slot_meta_worktree "$meta")
+    [ -n "$other" ] || continue
+    fm_slot_same_path "$other" "$wt" || continue
+    printf '%s\n' "$id"
+    found=0
+  done
+  return "$found"
+}
+
+# fm_slot_live_occupant_tasks <worktree> <task-id>: other tasks whose declared
+# live agent process is running inside the slot right now, newline separated
+# and deduplicated. Requires procfs; a host without it simply contributes no
+# evidence from this source.
+fm_slot_live_occupant_tasks() {
+  local wt=$1 self=$2 wt_real entry pid task cwd hits
+  wt_real=$(fm_agent_canonical_dir "$wt") || return 1
+  [ -d /proc ] || return 1
+  hits=
+  for entry in /proc/[0-9]*; do
+    [ -d "$entry" ] || continue
+    pid=${entry#/proc/}
+    task=$(fm_agent_proc_env "$pid" FM_AGENT_TASK) || continue
+    [ -n "$task" ] || continue
+    [ "$task" != "$self" ] || continue
+    cwd=$(fm_agent_proc_cwd "$pid") || continue
+    cwd=$(fm_agent_canonical_dir "$cwd") || continue
+    fm_agent_path_within "$wt_real" "$cwd" || continue
+    hits="$hits$task"$'\n'
+  done
+  [ -n "$hits" ] || return 1
+  printf '%s' "$hits" | LC_ALL=C sort -u
+}
+
+# fm_slot_join_ids <newline-separated>: comma-joined single line.
+fm_slot_join_ids() {
+  printf '%s' "$1" | LC_ALL=C sort -u | tr '\n' ',' | sed 's/,$//'
+}
+
+# fm_slot_disposal_verdict <state-dir> <task-id> <worktree> <home>
+# Print exactly `dispose` or `retain: <reason>`.
+fm_slot_disposal_verdict() {
+  local state=$1 self=$2 wt=$3 home=$4 stamp_task stamp_home refs occupants
+  if [ -z "$wt" ] || [ ! -d "$wt" ]; then
+    printf 'dispose'
+    return 0
+  fi
+  if refs=$(fm_slot_meta_referencing_tasks "$state" "$self" "$wt"); then
+    printf 'retain: slot is also recorded by task(s) %s in this home' "$(fm_slot_join_ids "$refs")"
+    return 0
+  fi
+  if stamp_task=$(fm_slot_stamp_field "$wt" task); then
+    if [ "$stamp_task" != "$self" ]; then
+      printf 'retain: slot ownership stamp names task %s, not %s' "$stamp_task" "$self"
+      return 0
+    fi
+    if stamp_home=$(fm_slot_stamp_field "$wt" home); then
+      if [ -n "$home" ] && ! fm_slot_same_path "$stamp_home" "$home"; then
+        printf 'retain: slot ownership stamp names home %s, not %s' "$stamp_home" "$home"
+        return 0
+      fi
+    fi
+  fi
+  if occupants=$(fm_slot_live_occupant_tasks "$wt" "$self"); then
+    printf 'retain: a live agent for task(s) %s is running in the slot' "$(fm_slot_join_ids "$occupants")"
+    return 0
+  fi
+  printf 'dispose'
+}

--- a/bin/fm-slot-owner-lib.sh
+++ b/bin/fm-slot-owner-lib.sh
@@ -30,6 +30,14 @@
 # Absence of evidence is not evidence: a slot with no stamp (every task spawned
 # before stamping existed) and no conflicting reference still disposes normally.
 #
+# Retention must not be a one-way door either. A task that retains on rule 1
+# gives up its own stamp as it goes (fm_slot_stamp_relinquish), so the holder
+# left behind can still release the slot once nothing references it. A stamp
+# naming someone ELSE is never cleared, because that stamp is what stops a stale
+# task from disposing of a slot whose real occupant is merely paused.
+# docs/worker-isolation.md owns the operator reclaim path for a slot that was
+# already leaked before this rule existed.
+#
 # The stamp lives in the worktree's PRIVATE git directory, never in the working
 # tree, so it can never dirty a status check or leak into a commit. Writing is
 # refused for anything that is not a linked worktree, so a primary checkout can
@@ -44,6 +52,11 @@ _FM_SLOT_OWNER_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$_FM_SLOT_OWNER_LIB_DIR/fm-agent-cwd-lib.sh"
 
 FM_SLOT_OWNER_STAMP_NAME=fm-slot-owner
+
+# The exact prefix of the rule-1 (metadata reference) retain verdict. One owner,
+# because fm_slot_stamp_relinquish keys the only stamp clear that is safe off
+# this specific reason.
+FM_SLOT_RETAIN_META_PREFIX='retain: slot is also recorded by task(s) '
 
 # fm_slot_stamp_path <worktree>: the stamp path for a LINKED worktree, or 1 for
 # a plain checkout (whose git dir is shared and must never be stamped).
@@ -167,7 +180,7 @@ fm_slot_disposal_verdict() {
     return 0
   fi
   if refs=$(fm_slot_meta_referencing_tasks "$state" "$self" "$wt"); then
-    printf 'retain: slot is also recorded by task(s) %s in this home' "$(fm_slot_join_ids "$refs")"
+    printf '%s%s in this home' "$FM_SLOT_RETAIN_META_PREFIX" "$(fm_slot_join_ids "$refs")"
     return 0
   fi
   if stamp_task=$(fm_slot_stamp_field "$wt" task); then
@@ -187,4 +200,43 @@ fm_slot_disposal_verdict() {
     return 0
   fi
   printf 'dispose'
+}
+
+# fm_slot_stamp_relinquish <worktree> <task-id> <verdict>
+# Give up THIS task's claim on a slot it is retaining, so a retained lease can
+# still be released later by whoever is left holding it.
+#
+# Without this the gate is a one-way door. Task B stamps a slot, paused task A's
+# stale metadata also names it, B tears down and retains on rule 1, and B's
+# metadata is then removed. When A finally tears down, no reference is left to
+# justify the retention - but the stamp still names B, so rule 2 retains forever
+# and the pool has silently lost a slot that nothing references.
+#
+# The clear is deliberately NARROW, and the narrowness is the whole safety
+# argument:
+#   - retained by ANOTHER TASK'S METADATA while the stamp names SELF: this is
+#     the true owner handing the slot back to the other holder, so its stamp
+#     must not outlive it;
+#   - retained because the stamp names a DIFFERENT task: PRESERVE it. The stamp
+#     is positive evidence the slot was reissued to someone else, and clearing
+#     it would let a later teardown of the stale task dispose of a slot whose
+#     real occupant merely has no live process at that moment (paused or exited
+#     work), destroying preserved work - strictly worse than the leak above;
+#   - retained by a live occupant: PRESERVE it, for the same reason.
+# Metadata references stay checked first and stay authoritative in
+# fm_slot_disposal_verdict; that ordering is what protects a live-but-paused
+# task from having its slot reissued, and nothing here weakens it.
+#
+# Always succeeds: a slot with no stamp, or one stamped for someone else, simply
+# keeps whatever evidence it has.
+fm_slot_stamp_relinquish() {  # <worktree> <task-id> <verdict>
+  local wt=$1 self=$2 verdict=$3 stamp_task
+  case "$verdict" in
+    "$FM_SLOT_RETAIN_META_PREFIX"*) ;;
+    *) return 0 ;;
+  esac
+  stamp_task=$(fm_slot_stamp_field "$wt" task) || return 0
+  [ "$stamp_task" = "$self" ] || return 0
+  fm_slot_stamp_clear "$wt"
+  return 0
 }

--- a/bin/fm-slot-owner-lib.sh
+++ b/bin/fm-slot-owner-lib.sh
@@ -30,11 +30,14 @@
 # Absence of evidence is not evidence: a slot with no stamp (every task spawned
 # before stamping existed) and no conflicting reference still disposes normally.
 #
-# Retention must not be a one-way door either. A task that retains on rule 1
-# gives up its own stamp as it goes (fm_slot_stamp_relinquish), so the holder
-# left behind can still release the slot once nothing references it. A stamp
-# naming someone ELSE is never cleared, because that stamp is what stops a stale
-# task from disposing of a slot whose real occupant is merely paused.
+# Retention must not be a one-way door either. A task that retains on rule 1 AND
+# still completes its own teardown gives up its own stamp as it goes
+# (fm_slot_stamp_relinquish), so the holder left behind can still release the
+# slot once nothing references it. A caller that refuses outright keeps every
+# record and therefore keeps the stamp too, because a refused operation changes
+# nothing. A stamp naming someone ELSE is never cleared either, because that
+# stamp is what stops a stale task from disposing of a slot whose real occupant
+# is merely paused.
 # docs/worker-isolation.md owns the operator reclaim path for a slot that was
 # already leaked before this rule existed.
 #
@@ -205,6 +208,12 @@ fm_slot_disposal_verdict() {
 # fm_slot_stamp_relinquish <worktree> <task-id> <verdict>
 # Give up THIS task's claim on a slot it is retaining, so a retained lease can
 # still be released later by whoever is left holding it.
+#
+# Only a caller that PROCEEDS past the gate and goes on to delete this task's
+# own records may ask for this. A caller that refuses outright and preserves
+# every record must not: nothing was torn down, ownership did not change, and
+# erasing the stamp there would strip the rule-2 evidence that stops a stale
+# sibling from later disposing of a slot still holding this task's paused work.
 #
 # Without this the gate is a one-way door. Task B stamps a slot, paused task A's
 # stale metadata also names it, B tears down and retains on rule 1, and B's

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -83,7 +83,15 @@
 #   Before a secondmate launch, the home is locally fast-forwarded to the primary
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
-#   git worktree root distinct from the primary project checkout.
+#   git worktree root distinct from the primary project checkout, from this
+#   home, and from the firstmate repo.
+#   EVERY launch carries an explicit home declaration so no task child inherits
+#   the launching home's operational environment; bin/fm-worker-isolation-lib.sh
+#   owns the variables, per-role values, and the refusals that depend on them.
+#   The worktree-settle poll reads the live process cwd through /proc where the
+#   provider exposes a pane process id, falling back to the provider's pane cwd
+#   only as a hint (bin/fm-agent-cwd-lib.sh), and the resolved slot is stamped
+#   with its current owner for teardown (bin/fm-slot-owner-lib.sh).
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -140,6 +148,16 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-worker-isolation-lib.sh
+. "$SCRIPT_DIR/fm-worker-isolation-lib.sh"
+# shellcheck source=bin/fm-agent-cwd-lib.sh
+. "$SCRIPT_DIR/fm-agent-cwd-lib.sh"
+# shellcheck source=bin/fm-slot-owner-lib.sh
+. "$SCRIPT_DIR/fm-slot-owner-lib.sh"
+# A task worker never dispatches: it has no home of its own to spawn from, and
+# spawning from an inherited one would create a direct report the real primary
+# never records (bin/fm-worker-isolation-lib.sh).
+fm_worker_refuse_primary_operation "spawn" || exit 1
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
 # a direct report (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
@@ -833,7 +851,7 @@ real_path_or_raw() {  # <path>
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
 validate_spawn_worktree() {  # <source> <inspect-target>
-  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
+  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real guarded guarded_real
   wt_real=
   if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
     wt_real=
@@ -848,6 +866,16 @@ validate_spawn_worktree() {  # <source> <inspect-target>
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
+  # Home isolation, not just project isolation: a task worktree that resolves
+  # to this home or to the firstmate repo would put a worker inside the
+  # operational home whatever its project argument said.
+  for guarded in "$FM_HOME" "$FM_ROOT"; do
+    guarded_real=$(real_path_or_raw "$guarded")
+    if [ "$wt_real" = "$guarded_real" ]; then
+      echo "error: $source resolved to the active operational home '$guarded_real'; refusing to launch a task worker inside the home it would otherwise own. Inspect target $inspect_target" >&2
+      exit 1
+    fi
+  done
 }
 
 herdr_projection_meta_field_exact() {  # <meta> <key>
@@ -1155,6 +1183,21 @@ spawn_current_path() {  # <target>
     cmux) fm_backend_cmux_current_path "$1" "$W" ;;
   esac
 }
+# The method of record for "where did this pane actually go" is the live
+# process's own cwd, read through /proc; the provider's pane cwd is a HINT used
+# only where no per-pane process id is exposed. bin/fm-agent-cwd-lib.sh owns
+# that resolution and the per-provider matrix. Reading the pane instead can name
+# an entirely different process - a herdr pane listing once reported a worker's
+# cwd as the primary checkout while /proc showed it correctly isolated.
+spawn_settle_path() {  # <target>
+  local target=$1 record
+  record=$(fm_agent_cwd_verdict "" "$BACKEND" "$target")
+  if [ "$(fm_agent_verdict_field "$record" source)" = proc ]; then
+    fm_agent_verdict_field "$record" cwd
+    return 0
+  fi
+  spawn_current_path "$target" || true
+}
 spawn_send_literal() {  # <target> <text>
   case "$BACKEND" in
     tmux) fm_backend_tmux_send_literal "$1" "$2" ;;
@@ -1228,7 +1271,10 @@ kimi_spawn_fail() {  # <detail>
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+  # Wait for the treehouse subshell: the live process's cwd moves from the
+  # project to the worktree. spawn_settle_path prefers /proc over the pane
+  # field, so this poll is proof rather than a hint wherever the provider
+  # exposes a per-pane process id.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
   # automatic-rename slips through), display-message -t <bad-name> falls back to the
   # active client's window, which would misread firstmate's OWN pane path as the
@@ -1250,7 +1296,7 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
   candidate=""
   for _ in $(seq 1 60); do
-    p=$(spawn_current_path "$WT_TARGET" || true)
+    p=$(spawn_settle_path "$WT_TARGET" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
       if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
@@ -1418,6 +1464,13 @@ $("$FM_ROOT/bin/fm-project-mode.sh" "$PROJ_NAME")
 EOF
 fi
 
+# Stamp CURRENT ownership into the slot's private git directory before the
+# metadata that points at it exists. `worktree=` alone is a historical record of
+# a slot once used, so teardown needs a live statement of who holds it now
+# (bin/fm-slot-owner-lib.sh). Best-effort: a slot that cannot be stamped simply
+# contributes no stamp evidence later.
+fm_slot_stamp_write "$WT" "$ID" "$(real_path_or_raw "$FM_HOME")" 2>/dev/null || true
+
 META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
 {
@@ -1477,10 +1530,26 @@ LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
+# Home declaration for EVERY task child, not just secondmates. A pane inherits
+# this process's exported operational-home environment, so a crewmate launched
+# without an explicit declaration resolves the PRIMARY's state directory in
+# every firstmate script it runs - the 2026-07-24 incident where an audit worker
+# took the primary's own session ownership. bin/fm-worker-isolation-lib.sh owns
+# the variable set, the per-role values, and the downstream refusals; a
+# secondmate keeps a concrete FM_HOME because it IS the primary of that home,
+# while a crewmate or scout gets no home at all.
 if [ "$KIND" = secondmate ]; then
-  sq_home=$(shell_quote "$PROJ_ABS")
-  LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"
+  WORKER_HOME=$PROJ_ABS
+  WORKER_ROLE=secondmate
+else
+  WORKER_HOME=$(real_path_or_raw "$FM_HOME")
+  WORKER_ROLE=crewmate
 fi
+WORKER_ENV_PREFIX=$(fm_worker_launch_env_prefix "$WORKER_ROLE" "$ID" "$WORKER_HOME") || {
+  echo "error: could not build the home declaration for $ID; refusing to launch a task child that would inherit this home" >&2
+  exit 1
+}
+LAUNCH="$WORKER_ENV_PREFIX$LAUNCH"
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -52,6 +52,17 @@
 # leased home releases its durable treehouse lease so the pool slot is freed,
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
+# Worktree disposal never trusts the task's recorded worktree= as proof of
+# CURRENT ownership: pooled slots are reused, and a slot recorded by a
+# still-live, paused, or quarantined task must never be reissued. Before any
+# slot is released, bin/fm-slot-owner-lib.sh must find no conflicting reference.
+# A conflict RETIRES the lease instead of returning it: the directory is left
+# untouched on disk, the rest of the teardown (endpoint and records) still runs,
+# and the completion line says the slot was retained. This gate is not waived by
+# --force, which grants authority over this task's work only, never over another
+# task's slot. A conflicting SECONDMATE home or Orca worktree refuses outright
+# instead, because skipping their removal would strand a registry entry or an
+# Orca-owned worktree.
 # Usage: fm-teardown.sh <task-id> [--force]
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
@@ -106,6 +117,13 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-slot-owner-lib.sh
+. "$SCRIPT_DIR/fm-slot-owner-lib.sh"
+# shellcheck source=bin/fm-worker-isolation-lib.sh
+. "$SCRIPT_DIR/fm-worker-isolation-lib.sh"
+# A task worker never tears down: an inherited home would let it dispose of a
+# sibling's slot and state (bin/fm-worker-isolation-lib.sh).
+fm_worker_refuse_primary_operation "teardown" || exit 1
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   echo "error: invalid teardown request" >&2
   exit 2
@@ -762,6 +780,29 @@ firstmate_home_has_treehouse_slot() {
   worktree_registered_for_project "$FM_ROOT" "$home"
 }
 
+# Slot-release gate. `worktree=` is a historical record of a slot once used, not
+# proof of current ownership, so bin/fm-slot-owner-lib.sh decides whether the
+# lease may go back to the pool. A retained lease leaves the directory on disk
+# and untouched - no branch delete, no hook-file removal, no return - so the
+# slot can never be reissued while another task still holds it.
+# Leaving this task's turn-end pointer behind in a retained slot is safe and
+# deliberate: the pointer only fires when it agrees with a matching entry in the
+# firstmate-owned hook registry, and teardown still removes THIS task's registry
+# entry, so the orphaned pointer is inert. Deleting it would mean writing into a
+# directory whose current occupant is another task.
+# NOT waived by --force: --force is the captain's authority to discard THIS
+# task's work, never authority to release another task's slot.
+TEARDOWN_SLOT_RETAINED=0
+slot_release_allowed() {  # <state-dir> <task-id> <worktree> <home> <label>
+  local state=$1 id=$2 wt=$3 home=$4 label=$5 verdict
+  verdict=$(fm_slot_disposal_verdict "$state" "$id" "$wt" "$home")
+  [ "$verdict" = dispose ] && return 0
+  TEARDOWN_SLOT_RETAINED=1
+  echo "teardown: $label $wt lease RETAINED, not returned to the pool: ${verdict#retain: }" >&2
+  echo "teardown: the directory is left untouched on disk so the slot cannot be reissued while another task still references it; --force does not waive this gate." >&2
+  return 1
+}
+
 validate_removal_target() {
   local target=$1 label=$2 abs_target abs_home abs_root
   [ -n "$target" ] || return 0
@@ -928,6 +969,8 @@ remove_firstmate_home() {
       echo "error: treehouse command not found; cannot return $label $abs_home_path" >&2
       return 1
     }
+    slot_release_allowed "$STATE" "${expected_id:-$ID}" "$abs_home_path" "$FM_HOME" "$label" || return 1
+    fm_slot_stamp_clear "$abs_home_path"
     teardown_treehouse_return "$abs_home_path" "$FM_ROOT" "$label" || {
       echo "error: treehouse return failed for $label $abs_home_path; lease may still be held" >&2
       return 1
@@ -1015,21 +1058,24 @@ cleanup_firstmate_home_children() {
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
-      validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
-        "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
-      if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
-        if teardown_treehouse_return "$child_wt" "$child_proj" "child worktree"; then
-          :
-        else
-          child_return_rc=$?
-          if [ "$child_return_rc" -eq "$TEARDOWN_TREEHOUSE_LOCK_REFUSED" ]; then
-            return "$child_return_rc"
+      if slot_release_allowed "$sub_state" "$child_id" "$child_wt" "$home" "child worktree"; then
+        validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
+        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
+          "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
+        fm_slot_stamp_clear "$child_wt"
+        if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
+          if teardown_treehouse_return "$child_wt" "$child_proj" "child worktree"; then
+            :
+          else
+            child_return_rc=$?
+            if [ "$child_return_rc" -eq "$TEARDOWN_TREEHOUSE_LOCK_REFUSED" ]; then
+              return "$child_return_rc"
+            fi
+            safe_rm_rf_child_worktree "$child_wt" "$child_proj"
           fi
+        else
           safe_rm_rf_child_worktree "$child_wt" "$child_proj"
         fi
-      else
-        safe_rm_rf_child_worktree "$child_wt" "$child_proj"
       fi
     fi
     remove_grok_turnend_auth "$sub_state" "$child_id"
@@ -1121,6 +1167,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
     ORCA_PATH_MATCH_VERIFIED=1
   fi
   if [ -d "$WT" ]; then
+    slot_release_allowed "$STATE" "$ID" "$WT" "$FM_HOME" "orca worktree" || exit 1
     branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
     if [ "$branch" != "HEAD" ]; then
       if git -C "$WT" checkout --detach -q 2>/dev/null; then
@@ -1129,31 +1176,40 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
     fi
     rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
       "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
+    fm_slot_stamp_clear "$WT"
   fi
   [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
   fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
 elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
-  branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
-  if [ "$branch" != "HEAD" ]; then
-    if git -C "$WT" checkout --detach -q 2>/dev/null; then
-      git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
+  # Ownership gate first: a retained lease leaves the slot completely untouched,
+  # so the branch delete and hook-file removal below never reach another task's
+  # live or paused occupant. The rest of teardown still runs - the lease is
+  # retired rather than returned, which is exactly the records-and-panes-only
+  # policy that kept the 2026-07-25 slot collision harmless.
+  if slot_release_allowed "$STATE" "$ID" "$WT" "$FM_HOME" "worktree"; then
+    branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
+    if [ "$branch" != "HEAD" ]; then
+      if git -C "$WT" checkout --detach -q 2>/dev/null; then
+        git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
+      fi
     fi
+    # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
+    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+      "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
+    fm_slot_stamp_clear "$WT"
+    # Kills remaining processes in the worktree (including the agent), resets, returns
+    # to pool. treehouse resolves the pool from the working directory, so run it from
+    # the project. teardown_treehouse_return tolerates transient and stale git locks
+    # left by a killed crew process; see the script header for retry and stale-lock proof.
+    post_lock_cleanup_check=
+    if [ "$FORCE" != "--force" ] && [ "$KIND" != scout ] && [ "$KIND" != secondmate ]; then
+      post_lock_cleanup_check=validate_worktree_teardown_safety
+    fi
+    teardown_treehouse_return "$WT" "$PROJ" "worktree" "$post_lock_cleanup_check" || {
+      echo "error: treehouse return failed for worktree $WT; teardown aborted" >&2
+      exit 1
+    }
   fi
-  # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
-    "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
-  # Kills remaining processes in the worktree (including the agent), resets, returns
-  # to pool. treehouse resolves the pool from the working directory, so run it from
-  # the project. teardown_treehouse_return tolerates transient and stale git locks
-  # left by a killed crew process; see the script header for retry and stale-lock proof.
-  post_lock_cleanup_check=
-  if [ "$FORCE" != "--force" ] && [ "$KIND" != scout ] && [ "$KIND" != secondmate ]; then
-    post_lock_cleanup_check=validate_worktree_teardown_safety
-  fi
-  teardown_treehouse_return "$WT" "$PROJ" "worktree" "$post_lock_cleanup_check" || {
-    echo "error: treehouse return failed for worktree $WT; teardown aborted" >&2
-    exit 1
-  }
 fi
 
 HERDR_PRESENTATION_JOURNAL="$STATE/$ID.herdr-presentation"
@@ -1232,5 +1288,9 @@ rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi
-echo "teardown $ID complete (window $T, worktree $WT)"
+if [ "$TEARDOWN_SLOT_RETAINED" = 1 ]; then
+  echo "teardown $ID complete (window $T, worktree $WT retained on disk - its lease was retired, not returned)"
+else
+  echo "teardown $ID complete (window $T, worktree $WT)"
+fi
 backlog_refresh_reminder

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -58,14 +58,16 @@
 # slot is released, bin/fm-slot-owner-lib.sh must find no conflicting reference.
 # A conflict RETIRES the lease instead of returning it: the directory is left
 # untouched on disk, the rest of the teardown (endpoint and records) still runs,
-# and the completion line says the slot was retained. A retiring task also gives
-# up its OWN ownership stamp so the holder left behind can still release the
-# slot once nothing references it; docs/worker-isolation.md owns the operator
-# reclaim path for a slot that no record names at all. This gate is not waived by
+# and the completion line says the slot was retained. A task that retires a lease
+# and still completes gives up its OWN ownership stamp so the holder left behind
+# can still release the slot once nothing references it;
+# docs/worker-isolation.md owns the operator reclaim path for a slot that no
+# record names at all. This gate is not waived by
 # --force, which grants authority over this task's work only, never over another
 # task's slot. A conflicting SECONDMATE home or Orca worktree refuses outright
 # instead, because skipping their removal would strand a registry entry or an
-# Orca-owned worktree.
+# Orca-owned worktree; a refusal keeps every record for the task and therefore
+# keeps its ownership stamp too.
 # Usage: fm-teardown.sh <task-id> [--force]
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
@@ -795,19 +797,39 @@ firstmate_home_has_treehouse_slot() {
 # directory whose current occupant is another task.
 # NOT waived by --force: --force is the captain's authority to discard THIS
 # task's work, never authority to release another task's slot.
+#
+# The last argument states what THIS caller does when the gate says retain, and
+# every caller must state it rather than inherit a default:
+#   retire  teardown continues past the gate and still deletes this task's own
+#           records, so the task must also hand over its own ownership stamp -
+#           otherwise the stamp outlives every reference to it and the slot can
+#           never be released again.
+#   refuse  teardown aborts and deliberately preserves every record for this
+#           task. A refused operation mutates NOTHING: the stamp stays, because
+#           ownership did not change and it is the rule-2 evidence that stops a
+#           stale sibling from later disposing of a slot that still holds this
+#           task's paused work.
 TEARDOWN_SLOT_RETAINED=0
-slot_release_allowed() {  # <state-dir> <task-id> <worktree> <home> <label>
-  local state=$1 id=$2 wt=$3 home=$4 label=$5 verdict
+slot_release_allowed() {  # <state-dir> <task-id> <worktree> <home> <label> <retire|refuse>
+  local state=$1 id=$2 wt=$3 home=$4 label=$5 disposition=$6 verdict
+  case "$disposition" in
+    retire|refuse) ;;
+    *)
+      echo "error: slot gate for $label $wt was asked for an unknown disposition '$disposition'" >&2
+      return 1
+      ;;
+  esac
   verdict=$(fm_slot_disposal_verdict "$state" "$id" "$wt" "$home")
   [ "$verdict" = dispose ] && return 0
   TEARDOWN_SLOT_RETAINED=1
-  # Hand this task's own claim over as it goes, so the holder left behind can
-  # still release the slot. bin/fm-slot-owner-lib.sh owns exactly when that is
-  # safe - never when the stamp names someone else.
-  fm_slot_stamp_relinquish "$wt" "$id" "$verdict"
   echo "teardown: $label $wt lease RETAINED, not returned to the pool: ${verdict#retain: }" >&2
   echo "teardown: the directory is left untouched on disk so the slot cannot be reissued while another task still references it; --force does not waive this gate." >&2
-  echo "teardown: once nothing references the slot, tearing down its remaining holder releases it; docs/worker-isolation.md owns the operator reclaim path for a slot no record names at all." >&2
+  if [ "$disposition" = retire ]; then
+    fm_slot_stamp_relinquish "$wt" "$id" "$verdict"
+    echo "teardown: once nothing references the slot, tearing down its remaining holder releases it; docs/worker-isolation.md owns the operator reclaim path for a slot no record names at all." >&2
+  else
+    echo "teardown: refusing to continue for $label $wt and leaving every record for $id in place; reconcile the other holder, then retry." >&2
+  fi
   return 1
 }
 
@@ -982,7 +1004,7 @@ remove_firstmate_home() {  # <home> <label> [expected-id] [state-dir] [home-scop
       echo "error: treehouse command not found; cannot return $label $abs_home_path" >&2
       return 1
     }
-    slot_release_allowed "$state_scope" "${expected_id:-$ID}" "$abs_home_path" "$home_scope" "$label" || return 1
+    slot_release_allowed "$state_scope" "${expected_id:-$ID}" "$abs_home_path" "$home_scope" "$label" refuse || return 1
     fm_slot_stamp_clear "$abs_home_path"
     teardown_treehouse_return "$abs_home_path" "$FM_ROOT" "$label" || {
       echo "error: treehouse return failed for $label $abs_home_path; lease may still be held" >&2
@@ -1076,7 +1098,7 @@ cleanup_firstmate_home_children() {
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
-      if slot_release_allowed "$sub_state" "$child_id" "$child_wt" "$home" "child worktree"; then
+      if slot_release_allowed "$sub_state" "$child_id" "$child_wt" "$home" "child worktree" retire; then
         validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
         rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
           "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
@@ -1185,7 +1207,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
     ORCA_PATH_MATCH_VERIFIED=1
   fi
   if [ -d "$WT" ]; then
-    slot_release_allowed "$STATE" "$ID" "$WT" "$FM_HOME" "orca worktree" || exit 1
+    slot_release_allowed "$STATE" "$ID" "$WT" "$FM_HOME" "orca worktree" refuse || exit 1
     branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
     if [ "$branch" != "HEAD" ]; then
       if git -C "$WT" checkout --detach -q 2>/dev/null; then
@@ -1204,7 +1226,7 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   # live or paused occupant. The rest of teardown still runs - the lease is
   # retired rather than returned, which is exactly the records-and-panes-only
   # policy that kept the 2026-07-25 slot collision harmless.
-  if slot_release_allowed "$STATE" "$ID" "$WT" "$FM_HOME" "worktree"; then
+  if slot_release_allowed "$STATE" "$ID" "$WT" "$FM_HOME" "worktree" retire; then
     branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
     if [ "$branch" != "HEAD" ]; then
       if git -C "$WT" checkout --detach -q 2>/dev/null; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -58,7 +58,10 @@
 # slot is released, bin/fm-slot-owner-lib.sh must find no conflicting reference.
 # A conflict RETIRES the lease instead of returning it: the directory is left
 # untouched on disk, the rest of the teardown (endpoint and records) still runs,
-# and the completion line says the slot was retained. This gate is not waived by
+# and the completion line says the slot was retained. A retiring task also gives
+# up its OWN ownership stamp so the holder left behind can still release the
+# slot once nothing references it; docs/worker-isolation.md owns the operator
+# reclaim path for a slot that no record names at all. This gate is not waived by
 # --force, which grants authority over this task's work only, never over another
 # task's slot. A conflicting SECONDMATE home or Orca worktree refuses outright
 # instead, because skipping their removal would strand a registry entry or an
@@ -798,8 +801,13 @@ slot_release_allowed() {  # <state-dir> <task-id> <worktree> <home> <label>
   verdict=$(fm_slot_disposal_verdict "$state" "$id" "$wt" "$home")
   [ "$verdict" = dispose ] && return 0
   TEARDOWN_SLOT_RETAINED=1
+  # Hand this task's own claim over as it goes, so the holder left behind can
+  # still release the slot. bin/fm-slot-owner-lib.sh owns exactly when that is
+  # safe - never when the stamp names someone else.
+  fm_slot_stamp_relinquish "$wt" "$id" "$verdict"
   echo "teardown: $label $wt lease RETAINED, not returned to the pool: ${verdict#retain: }" >&2
   echo "teardown: the directory is left untouched on disk so the slot cannot be reissued while another task still references it; --force does not waive this gate." >&2
+  echo "teardown: once nothing references the slot, tearing down its remaining holder releases it; docs/worker-isolation.md owns the operator reclaim path for a slot no record names at all." >&2
   return 1
 }
 
@@ -958,8 +966,13 @@ EOF
   printf '%s\n' "$abs_home_path"
 }
 
-remove_firstmate_home() {
-  local home=$1 label=$2 expected_id=${3:-} abs_home_path
+# The slot scope is a PARAMETER, not this run's globals: a nested child
+# secondmate home was recorded and stamped by its own parent secondmate's home,
+# so judging it against the primary's state directory and FM_HOME would compare
+# against a home that never owned it and retain every time. Callers pass the
+# scope that actually stamped the home being removed.
+remove_firstmate_home() {  # <home> <label> [expected-id] [state-dir] [home-scope]
+  local home=$1 label=$2 expected_id=${3:-} state_scope=${4:-$STATE} home_scope=${5:-$FM_HOME} abs_home_path
   [ -n "$home" ] || return 0
   [ -e "$home" ] || return 0
   abs_home_path=$(validate_firstmate_home_for_removal "$home" "$label" "$expected_id") || return 1
@@ -969,7 +982,7 @@ remove_firstmate_home() {
       echo "error: treehouse command not found; cannot return $label $abs_home_path" >&2
       return 1
     }
-    slot_release_allowed "$STATE" "${expected_id:-$ID}" "$abs_home_path" "$FM_HOME" "$label" || return 1
+    slot_release_allowed "$state_scope" "${expected_id:-$ID}" "$abs_home_path" "$home_scope" "$label" || return 1
     fm_slot_stamp_clear "$abs_home_path"
     teardown_treehouse_return "$abs_home_path" "$FM_ROOT" "$label" || {
       echo "error: treehouse return failed for $label $abs_home_path; lease may still be held" >&2
@@ -1047,8 +1060,13 @@ cleanup_firstmate_home_children() {
       child_home=$(meta_value "$child_meta" home)
       [ -n "$child_home" ] || child_home=$child_wt
       if [ -n "$child_home" ] && [ -d "$child_home" ]; then
-        cleanup_firstmate_home_children "$child_home"
-        remove_firstmate_home "$child_home" "child firstmate home" "$child_id"
+        cleanup_firstmate_home_children "$child_home" || return $?
+        # This child home belongs to the home being cleaned, not to the primary:
+        # pass that scope, and refuse rather than fall through to the record
+        # deletion below, which would strand the home, its state, and its
+        # backlog on disk after their routing entry was already cleared.
+        remove_firstmate_home "$child_home" "child firstmate home" "$child_id" \
+          "$sub_state" "$home" || return 1
       fi
     elif [ "$child_backend" = orca ]; then
       if [ -n "$child_wt" ] && [ -d "$child_wt" ]; then

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -151,7 +151,7 @@ family_for_basename() {
       ;;
     fm-bootstrap.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
     fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-tangle-guard.test.sh|\
-    fm-update.test.sh)
+    fm-update.test.sh|fm-worker-isolation.test.sh)
       printf '%s\n' session-bootstrap
       ;;
     fm-afk-pi-herdr-return-e2e.test.sh|\

--- a/bin/fm-worker-isolation-lib.sh
+++ b/bin/fm-worker-isolation-lib.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# bin/fm-worker-isolation-lib.sh - the ONE owner of the launched-agent home
+# declaration contract.
+#
+# A firstmate script resolves its operational home from ambient environment
+# (FM_HOME, then the FM_*_OVERRIDE family, then its own FM_ROOT). That
+# resolution is correct for a firstmate primary and catastrophic for a task
+# child: a crewmate, scout, or audit agent launched from a primary's pane
+# inherits that primary's exported FM_HOME, so every firstmate script it runs -
+# including bin/fm-lock.sh - resolves the PRIMARY's state directory. A worker
+# that then runs session start acquires the primary's session-owner record and
+# the real primary is locked out of its own home (incident 2026-07-24).
+#
+# The fix is a DECLARATION, not a guess: every task child is launched with an
+# explicit home environment, and declares which home owns it and in what role.
+# Nothing downstream has to infer ownership from cwd, pane, or process tree.
+#
+#   FM_AGENT_ROLE        crewmate | secondmate  (the declared role)
+#   FM_AGENT_TASK        the owning task or secondmate id
+#   FM_AGENT_OWNER_HOME  absolute path of the home that launched this agent
+#
+# `crewmate` covers every ship/scout/audit task child. Such an agent is never a
+# firstmate primary anywhere, so it must never own a home, acquire a session
+# lock, or fire a primary-home hook - see fm_worker_refuse_primary_operation and
+# bin/fm-primary-scope-lib.sh.
+#
+# `secondmate` is a primary IN ITS OWN HOME and only there, so it keeps a
+# concrete FM_HOME while every inheritable override is cleared. Its own
+# crewmates are launched by its own bin/fm-spawn.sh and get the crewmate
+# treatment against the secondmate's home, which is what keeps a secondmate
+# child from ever reaching the primary's home.
+#
+# The markers are also the backend-independent identity key that
+# bin/fm-agent-cwd-lib.sh uses to find the real agent process, so a launch that
+# omits them costs authoritative cwd proof as well as home isolation.
+#
+# docs/worker-isolation.md owns how this mechanism fits with the other three.
+#
+# This file is sourced by scripts and hook entrypoints and has no side effects
+# on source.
+
+# Every operational-home variable a firstmate script reads. Extend here, not at
+# a call site, when a new home override is introduced.
+FM_WORKER_ISOLATION_HOME_VARS="FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE"
+
+fm_worker_shell_quote() {  # <text>
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+# fm_worker_launch_env_prefix <role> <task-id> <owner-home>
+# Print the exact env-assignment prefix a launch command must carry, with one
+# trailing space, so a caller composes `<prefix><launch command>`. Refuses an
+# unknown role, an empty id, or a non-absolute home rather than emitting a
+# partial prefix that would leave the child inheriting a home.
+fm_worker_launch_env_prefix() {
+  local role=$1 id=$2 home=$3 var
+  case "$role" in
+    crewmate|secondmate) ;;
+    *) echo "error: unknown agent role '$role'; expected crewmate or secondmate" >&2; return 1 ;;
+  esac
+  [ -n "$id" ] || { echo "error: agent role $role requires a task id" >&2; return 1; }
+  case "$home" in
+    /*) ;;
+    *) echo "error: agent role $role requires an absolute owning home, got '${home:-<empty>}'" >&2; return 1 ;;
+  esac
+  for var in $FM_WORKER_ISOLATION_HOME_VARS; do
+    if [ "$var" = FM_HOME ] && [ "$role" = secondmate ]; then
+      printf 'FM_HOME=%s ' "$(fm_worker_shell_quote "$home")"
+    else
+      printf '%s= ' "$var"
+    fi
+  done
+  printf 'FM_AGENT_ROLE=%s ' "$role"
+  printf 'FM_AGENT_TASK=%s ' "$(fm_worker_shell_quote "$id")"
+  printf 'FM_AGENT_OWNER_HOME=%s ' "$(fm_worker_shell_quote "$home")"
+}
+
+# fm_worker_declared_role: the current process's declared role, or empty when
+# it declares none (a primary firstmate, or a pre-declaration legacy agent).
+fm_worker_declared_role() {
+  case "${FM_AGENT_ROLE:-}" in
+    crewmate|secondmate) printf '%s' "$FM_AGENT_ROLE" ;;
+  esac
+}
+
+# fm_worker_is_task_worker: 0 when this process is a declared task child that
+# must never act as a firstmate primary in any home.
+fm_worker_is_task_worker() {
+  [ "${FM_AGENT_ROLE:-}" = crewmate ]
+}
+
+# fm_worker_owning_home: the home that declared this agent, or empty.
+fm_worker_owning_home() {
+  printf '%s' "${FM_AGENT_OWNER_HOME:-}"
+}
+
+# fm_worker_refuse_primary_operation <operation>
+# Fail closed with one actionable line when a declared task worker attempts an
+# operation only a home's primary may perform. Silent and successful for every
+# other process, so a call site can guard unconditionally.
+fm_worker_refuse_primary_operation() {
+  local operation=$1
+  fm_worker_is_task_worker || return 0
+  echo "error: $operation refused: this process is task worker '${FM_AGENT_TASK:-unnamed}' launched by ${FM_AGENT_OWNER_HOME:-an unrecorded home}; a task worker never owns a firstmate operational home" >&2
+  return 1
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,7 @@ On an unmarked return, `bin/fm-afk-return.sh` owns ordered shutdown, durable cat
 ## Runtime session backends
 
 The runtime backend is the session-provider layer below firstmate's scripts.
-It owns task endpoint creation, bounded capture, text/key sends, current-path reads for spawn-time worktree discovery when the backend does not create the worktree itself, live-window fallback lookup, agent-process liveness probes where verified, and endpoint teardown.
+It owns task endpoint creation, bounded capture, text/key sends, current-path reads that back spawn-time worktree discovery when the backend does not create the worktree itself and no authoritative agent-process reading is available, live-window fallback lookup, agent-process liveness probes where verified, and endpoint teardown.
 `bin/fm-backend.sh` centralizes backend selection, `state/<id>.meta` helpers, selector resolution, and operation dispatch; `bin/backends/tmux.sh` is the verified reference adapter ([`docs/tmux-backend.md`](tmux-backend.md)), and `bin/backends/herdr.sh` (P2), `bin/backends/zellij.sh` (P3), `bin/backends/orca.sh` (P4), and `bin/backends/cmux.sh` (P5) are experimental task-spawn adapters.
 New spawns select a backend from `--backend`, then `FM_BACKEND`, then local `config/backend`, then runtime auto-detection from `$TMUX`, `HERDR_ENV=1`, or cmux runtime signals, then default `tmux`.
 Runtime auto-detection is innermost-first: `$TMUX` wins over `HERDR_ENV=1`, which wins over cmux's primary `CMUX_WORKSPACE_ID` marker and documented fallback signals; auto-detected herdr or cmux prints a one-time opt-out notice, auto-detected tmux stays silent, and zellij and orca are never auto-detected (only explicit selection).
@@ -114,7 +114,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
-For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout, from the active operational home, and from the firstmate repo root.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.
@@ -125,6 +125,9 @@ Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.
 `fm-guard.sh` prints the repair command on the next mutable fleet action, while `bin/fm-session-start.sh` reports the same condition through bootstrap as a `TANGLE:` line at session start.
 If another live session holds the fleet lock, both surfaces keep the alarm but switch to read-only wording with no repair command.
 Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>`, then stop with a blocked status if it landed in the primary checkout.
+
+That spawn-time assertion is not by itself a durable property: a restored session can resume a recorded agent while resolving its working directory back to the repository the worktree came from, a launched agent can inherit the launching home's environment, and one pooled slot can end up recorded by more than one task.
+[`worker-isolation.md`](worker-isolation.md) owns the four mechanisms that keep a launched agent out of the home and the slot it does not own: the launch-time home declaration, the agent-process working-directory method of record, the pooled-slot ownership gate, and the session-start `ISOLATION:` re-assertion.
 
 ## No-mistakes gate authority boundary
 
@@ -195,6 +198,7 @@ The firstmate repo itself is the exception: its `.no-mistakes/` directory is loc
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
 The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state; a well-formed GitLab merge request URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) is refused too, explicitly, rather than sent to the wrong forge.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
+Releasing the worktree is separately gated on live ownership evidence, so a pooled slot another task still holds is never returned and `--force` does not waive that gate; [`worker-isolation.md`](worker-isolation.md) owns the gate and what each disposal path does when it fires.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
 
 ## Optional X mode

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -385,6 +385,7 @@ FM_BACKEND_CMUX_IDLE_RE='^Type a message\.\.\.$'  # cmux-only: empty-composer pl
 CMUX_SOCKET_PASSWORD=   # cmux-only: socket password fallback when config/cmux-socket-password is absent (docs/cmux-backend.md)
 FM_SESSION_START_STATUS_TAIL=5   # state/*.status lines printed per task in the session-start digest
 FM_BOOTSTRAP_DETECT_ONLY=0   # internal/read-only session-start mode: skip bootstrap's mutating sweeps and print advisory TANGLE wording
+FM_ISOLATION_VERBOSE=0   # session-start worker-isolation sweep: also emit BOOTSTRAP_INFO facts for per-task isolation outcomes, not only actionable ISOLATION lines (docs/worker-isolation.md)
 FM_GUARD_READ_ONLY=0    # internal/read-only guard mode: keep alarms but suppress drain, supervision repair, and checkout repair commands
 FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the guarded operation WILL still run.'   # banner continuation line; fm-send.sh overrides it to name the requested message specifically
 FM_POLL=15              # seconds between watcher poll cycles

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -100,6 +100,10 @@
     {
       "source": "docs/codex-app-backend.md",
       "target": "docs/verification/runtime-backends.md"
+    },
+    {
+      "source": "docs/worker-isolation.md",
+      "target": "docs/verification/worker-isolation.md"
     }
   ],
   "surfaces": [
@@ -308,12 +312,20 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/verification/worker-isolation.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/watcher-continuity.md",
       "audience": "operator-current"
     },
     {
       "path": "docs/wedge-alarm.md",
       "audience": "operator-current"
+    },
+    {
+      "path": "docs/worker-isolation.md",
+      "audience": "maintainer-architecture"
     },
     {
       "path": "docs/zellij-backend.md",

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -28,6 +28,10 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
+| `fm-worker-isolation-lib.sh` | Shared launched-agent home declaration: per-role launch environment and the task-worker refusals it enables (docs/worker-isolation.md) |
+| `fm-agent-cwd-lib.sh`    | Shared authoritative agent-process working directory, with the per-provider process-id matrix (docs/worker-isolation.md) |
+| `fm-slot-owner-lib.sh`   | Shared pooled-worktree slot ownership evidence and the release-or-retain verdict (docs/worker-isolation.md) |
+| `fm-isolation-sweep.sh`  | Re-assert task-worker isolation after a restart or restore; prints `ISOLATION:` findings |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -127,7 +127,7 @@ It costs one line and removes the failure mode where a rename or a rollback sile
 The shipped hook fires only in a genuine firstmate primary home, using the shared predicate `fm_primary_scope_matches` from `bin/fm-primary-scope-lib.sh`.
 This is the same predicate `bin/fm-sessionstart-nudge.sh` and `bin/fm-turnend-guard.sh` use, so the three tracked primary-scoped hooks cannot drift apart.
 
-A home is in scope when it has `AGENTS.md`, a `bin/` directory, an existing state directory, and either a plain checkout where git-dir equals git-common-dir or a valid `.fm-secondmate-home` marker.
+The [Shared Predicate section of `turnend-guard.md`](turnend-guard.md#shared-predicate) owns the exact in-scope rule, including the declared-task-worker exclusion.
 A marked secondmate home is in scope on purpose: it operates its own fleet and must dispatch through it for the same durability reasons.
 
 A crewmate's disposable task worktree is a linked git worktree, which is the shape `bin/fm-spawn.sh` always hands out, so it is out of scope.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -19,6 +19,7 @@ The guard remains a backstop; [`watcher-continuity.md`](watcher-continuity.md) o
 ## Shared predicate
 
 The guard first calls the shared primary scope.
+A declared task worker is never in scope, whatever root and state directory it was handed, so an agent that inherited or was restored into a primary's home cannot fire that home's hooks; [`worker-isolation.md`](worker-isolation.md) owns that declaration.
 A secondmate home runs its own primary Firstmate session, so a genuine `.fm-secondmate-home` marker includes it whether the home is a linked worktree or plain clone.
 The marker must be a regular non-symlink file whose whitespace-stripped first line is a non-empty identifier containing only letters, digits, dots, underscores, and dashes.
 An unmarked checkout or invalid marker falls through to the git-dir check.

--- a/docs/verification/worker-isolation.md
+++ b/docs/verification/worker-isolation.md
@@ -1,0 +1,129 @@
+# Worker isolation verification
+
+Audience: maintainer verification.
+
+This record contains reusable evidence for the guarantees in [`docs/worker-isolation.md`](../worker-isolation.md).
+Host for every capture below: Linux 6.18 (WSL2), tmux 3.6, verified 2026-07-26.
+Exact task chronology, branch names, temporary homes, and delivery transcripts remain in private reports or PR evidence.
+
+## Launched-agent home declaration
+
+```sh
+. bin/fm-worker-isolation-lib.sh
+fm_worker_launch_env_prefix crewmate demo-task /home/cap/firstmate; echo
+fm_worker_launch_env_prefix secondmate dom-x /home/cap/homes/dom; echo
+```
+
+Observed output, one trailing space per assignment included:
+
+```text
+FM_HOME= FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_AGENT_ROLE=crewmate FM_AGENT_TASK='demo-task' FM_AGENT_OWNER_HOME='/home/cap/firstmate' 
+FM_HOME='/home/cap/homes/dom' FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_AGENT_ROLE=secondmate FM_AGENT_TASK='dom-x' FM_AGENT_OWNER_HOME='/home/cap/homes/dom' 
+```
+
+A crewmate carries no home at all; a secondmate carries only its own.
+
+The declaration refuses rather than emitting a partial prefix:
+
+```sh
+fm_worker_launch_env_prefix auditor t /home/cap/firstmate; echo "rc=$?"
+fm_worker_launch_env_prefix crewmate '' /home/cap/firstmate; echo "rc=$?"
+fm_worker_launch_env_prefix crewmate t relative/home; echo "rc=$?"
+```
+
+```text
+error: unknown agent role 'auditor'; expected crewmate or secondmate
+rc=1
+error: agent role crewmate requires a task id
+rc=1
+error: agent role crewmate requires an absolute owning home, got 'relative/home'
+rc=1
+```
+
+## Harness axis: every verified harness launches with the declaration
+
+Captured by driving `bin/fm-spawn.sh` against the fake-provider fixture used by `tests/fm-worker-isolation.test.sh`, which records the literal launch command the provider is asked to run.
+The operating home and repository root are elided as `<HOME>` and `<ROOT>`.
+
+```text
+claude:   FM_HOME= FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_AGENT_ROLE=crewmate FM_AGENT_TASK='ev-claude' FM_AGENT_OWNER_HOME='<HOME>' CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('<ROOT>/bin/fm-operational-input.sh' encode launch-brief < '<HOME>/data/ev-claude/brief.md')"
+codex:    FM_HOME= FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_AGENT_ROLE=crewmate FM_AGENT_TASK='ev-codex' FM_AGENT_OWNER_HOME='<HOME>' codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '<HOME>/state/ev-codex.turn-ended'\"]" "$('<ROOT>/bin/fm-operational-input.sh' encode launch-brief < '<HOME>/data/ev-codex/brief.md')"
+opencode: FM_HOME= FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_AGENT_ROLE=crewmate FM_AGENT_TASK='ev-opencode' FM_AGENT_OWNER_HOME='<HOME>' OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --prompt "$('<ROOT>/bin/fm-operational-input.sh' encode launch-brief < '<HOME>/data/ev-opencode/brief.md')"
+pi:       FM_HOME= FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_AGENT_ROLE=crewmate FM_AGENT_TASK='ev-pi' FM_AGENT_OWNER_HOME='<HOME>' pi -e '<HOME>/state/ev-pi.pi-ext.ts' "$('<ROOT>/bin/fm-operational-input.sh' encode launch-brief < '<HOME>/data/ev-pi/brief.md')"
+grok:     FM_HOME= FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_AGENT_ROLE=crewmate FM_AGENT_TASK='ev-grok' FM_AGENT_OWNER_HOME='<HOME>' grok --always-approve "$('<ROOT>/bin/fm-operational-input.sh' encode launch-brief < '<HOME>/data/ev-grok/brief.md')"
+```
+
+The declaration precedes each adapter's own environment and flags, so an adapter cannot opt out of it.
+Kimi is launched bare and then sent a readiness-gated pointer, so its declaration is asserted in `tests/fm-kimi-harness.test.sh` alongside that adapter's delivery gates rather than here.
+
+## Provider axis: per-pane process id
+
+```sh
+tmux new-session -d -s fmiso2 -n w -c /tmp
+. bin/fm-agent-cwd-lib.sh
+for b in tmux herdr zellij cmux orca; do
+  if p=$(fm_agent_backend_shell_pid "$b" 'fmiso2:w' 2>/dev/null); then
+    printf '%-7s exposes pid=%s\n' "$b" "$p"
+  else
+    printf '%-7s no per-pane process id\n' "$b"
+  fi
+done
+```
+
+Observed output against a real live pane:
+
+```text
+tmux    exposes pid=776113
+herdr   no per-pane process id
+zellij  no per-pane process id
+cmux    no per-pane process id
+orca    no per-pane process id
+```
+
+A provider with no process id reports `unknown` rather than degrading to its pane path:
+
+```sh
+. bin/fm-agent-cwd-lib.sh && fm_agent_cwd_verdict '' herdr 'ses:pane' | cat -A
+```
+
+```text
+unknown^I^I
+```
+
+## tmux: the process reading tracks the live foreground, the pane field does not have to
+
+```sh
+tmux new-session -d -s fmiso -n w -c /tmp
+PP=$(tmux display-message -p -t fmiso:w '#{pane_pid}')
+tmux send-keys -t fmiso:w 'cd /usr && sleep 60' Enter
+. bin/fm-agent-cwd-lib.sh
+FG=$(fm_agent_foreground_pid "$PP")
+```
+
+Observed:
+
+```text
+pane_pid=641003
+pane_current_path=/tmp
+proc_cwd_of_pane_pid=/tmp
+after cd+sleep:
+  pane_current_path=/usr
+  shell /proc cwd=/usr
+  foreground_pid=641185  fg /proc cwd=/usr
+```
+
+The descent to the foreground process is what makes a tmux reading follow a `treehouse get` subshell during the spawn worktree-settle poll, rather than reporting the pane shell's own directory.
+
+## Reading another process's environment
+
+`/proc/<pid>/environ` mode bits are not sufficient permission: the kernel additionally requires ptrace read access, so a same-uid but privileged process passes a readability test and still fails `EACCES` at open.
+Before this was handled, a whole-host scan printed lines like the following into a read-only sweep's output, where they would have been surfaced as if they were findings:
+
+```text
+bin/fm-agent-cwd-lib.sh: line 114: /proc/462/environ: Permission denied
+```
+
+Redirections are applied left to right, so a trailing `2>/dev/null` on the same command is established only after the input redirect has already failed and written to stderr.
+The group form is what suppresses it, and `fm_agent_environ` is the single reader that applies it.
+
+Regression: `tests/fm-worker-isolation.test.sh`'s isolated-worker sweep case captures the sweep with stderr folded into stdout and requires it to be completely empty, so an unreadable `/proc` entry anywhere on the host fails the suite.

--- a/docs/worker-isolation.md
+++ b/docs/worker-isolation.md
@@ -1,0 +1,128 @@
+# Worker isolation
+
+Audience: maintainer architecture.
+
+This document is the authoritative contract for keeping a launched agent out of the home and the pooled slot it does not own.
+The four shared libraries below each own one mechanism; their script headers own the exact functions, arguments, and record shapes, and this document owns how they fit together and why the boundaries sit where they do.
+[`docs/verification/worker-isolation.md`](verification/worker-isolation.md) owns the dated empirical evidence.
+
+## What it guarantees
+
+- A task child never resolves, acquires, or acts against the operational home that launched it, and a secondmate resolves only its own home.
+- "Where is this agent actually running?" is answered from the agent process itself, never from a session provider's pane field.
+- A pooled worktree slot is never released while any other task still references it, including a paused or quarantined one.
+
+## Why it exists
+
+Three defects were observed live, not hypothesized.
+Each one defeated a guard that looked sufficient until it was tested against real fleet behavior.
+
+**A worker inherited the primary's home (2026-07-24).**
+An audit agent launched from a primary's pane inherited that primary's exported `FM_HOME`.
+Every firstmate script it then ran resolved the primary's state directory, and running session start took the primary's own session-owner record.
+The real primary was suspended and resumed, came back locked out of its own home, and stopped monitoring.
+The lesson is that ownership cannot be inferred downstream from cwd, pane, or process tree; it has to be declared at launch.
+
+**The spawn-time isolation assertion did not survive a restore (2026-07-24).**
+After a reboot the session provider restored every pane by resuming its recorded agent session, but resolved each working directory back to the repository the worktree was derived from.
+All 17 isolated worktrees collapsed onto their origin, four of them into the firstmate primary checkout.
+No writes occurred before they were retired, verified from pre-reboot mtimes.
+The lesson is that an assertion made once at launch is not a property that holds afterwards; isolation has to be re-established from live evidence on every resume.
+
+**Recorded `worktree=` is not proof of ownership (2026-07-24, fired 2026-07-25).**
+A census found ten pooled slots recorded by more than one task, up to six each.
+The hazard then fired: tearing down one task released a lease that a still-live quarantined-paused task also recorded, and the pool reissued that exact slot to a new spawn.
+No work was lost, because a task's work lives on its branch and because teardown had been run records-and-panes-only.
+The lesson is that disposal has to be gated on live evidence about the slot, and that the records-and-panes-only policy which made the collision harmless should be the deterministic default rather than a manual choice.
+
+A fourth finding corrected the method used to investigate the others.
+A pane listing reported a worker's cwd as the primary checkout while `/proc/<pid>/cwd` showed it correctly isolated, because the pane field had picked up a different process sharing the workspace.
+A pane read is therefore a hint and never evidence.
+
+## The four mechanisms
+
+### Declared agent identity
+
+`bin/fm-worker-isolation-lib.sh` owns the launch-time declaration.
+`bin/fm-spawn.sh` prepends it to every launch command, so the declaration is part of the command the provider runs rather than state the child has to look up.
+
+Two roles exist.
+A `crewmate` covers every ship, scout, and audit child; it is never a primary anywhere, so it is launched with every operational-home variable cleared.
+A `secondmate` is the primary of its own home and only there, so it keeps a concrete `FM_HOME` while every inheritable override is cleared.
+A secondmate's own crewmates are launched by that home's own `bin/fm-spawn.sh` and get the crewmate treatment against the secondmate's home, which is what stops a secondmate's child from ever reaching the primary.
+
+The declaration is a refusal point, not a best effort: an unknown role, an empty id, or a non-absolute home fails rather than emitting a partial prefix, because a partial prefix is exactly the inheritance the mechanism exists to prevent.
+
+Three enforcement points consume the declaration.
+`bin/fm-lock.sh` refuses acquisition before it resolves or creates a state directory, so a worker cannot even publish a probe file into a home it inherited, while read-only `status` stays available.
+`bin/fm-primary-scope-lib.sh` reports a declared worker as non-primary whatever root and state it was handed, which keeps every tracked project-local startup and turn-end adapter inert for workers.
+`bin/fm-spawn.sh` and `bin/fm-teardown.sh` refuse outright, because a worker acting on an inherited home would create or destroy direct reports the real primary never recorded.
+
+### The method of record for an agent's working directory
+
+`bin/fm-agent-cwd-lib.sh` owns the answer and its per-provider limits.
+Resolution is most-authoritative-first: the root-most live process carrying the task's declaration marker, then the provider's pane process id descended to the running agent, then `unknown`.
+It never falls back to a pane value, so a caller that wants a hint has to ask its provider for one and label it as a hint.
+
+The declaration marker matters here beyond home isolation: it is the provider-independent identity key, and it is the only source that survives a restore which re-parents or relabels panes.
+
+Per-provider process id availability:
+
+| Provider | Per-pane process id | Consequence |
+|---|---|---|
+| tmux | `#{pane_pid}`, a real shell pid | Authoritative reading available even for an agent with no declaration marker. |
+| herdr | none; the pane API exposes `foreground_cwd` only | Authoritative reading requires the declaration marker. |
+| zellij | none exposed at all | Same. |
+| cmux | none on the control socket | Same. |
+| orca | none on the terminal endpoint | Same. |
+
+A provider with no process id is not a failure of the library.
+It means a task that also lacks the declaration marker has only a hint, which is reported as `unknown` rather than promoted to evidence.
+
+Reading another process's environment needs care that is easy to get wrong.
+The mode bits on `/proc/<pid>/environ` are not sufficient permission, because the kernel additionally requires ptrace read access; a same-uid but privileged process passes a readability test and still fails at open.
+The failing redirect has to be silenced with the group form, since redirections are applied left to right and a trailing `2>/dev/null` on the same command is set up only after the input redirect has already printed to stderr.
+Getting this wrong turns unrelated host processes into stderr noise on a read-only sweep.
+
+### Pooled-slot ownership
+
+`bin/fm-slot-owner-lib.sh` owns the release-or-retain verdict.
+Disposal is gated on positive evidence of a conflict in three independent forms, any one of which retains the lease: another task recorded in the same home naming the same physical slot, an ownership stamp naming a different task or home, or a live agent declared for a different task running inside the slot.
+
+The stamp is written by `bin/fm-spawn.sh` into the worktree's private git directory, never into the working tree, so it can never dirty a status check or reach a commit.
+Writing is refused for anything that is not a linked worktree, so a primary checkout can never be marked as a disposable slot.
+
+Two boundaries are deliberate.
+Absence of evidence is not evidence: a slot with no stamp and no conflicting reference disposes normally, which is what keeps every task spawned before stamping existed working unchanged.
+`--force` does not waive the gate: it is the captain's authority to discard *this* task's work, never authority to release another task's slot.
+
+Retaining means the lease is retired rather than returned.
+`bin/fm-teardown.sh` leaves the directory completely untouched - no branch delete, no hook-file removal, no pool return - and still completes the rest of the teardown, reporting the retained slot on its completion line.
+A conflicting secondmate home or Orca worktree refuses outright instead, because silently skipping their removal would strand a registry entry or an Orca-owned worktree.
+
+### Restore-time re-assertion
+
+`bin/fm-isolation-sweep.sh` re-establishes at session start what spawn could only assert at launch.
+It is read-only, always exits 0, and prints one `ISOLATION:` line per task whose live agent is provably not where its record says it is.
+`bin/fm-bootstrap.sh` runs it in the same place as the worktree-tangle check and surfaces those lines in the session-start digest; the `bootstrap-diagnostics` skill owns what the agent does about each shape.
+
+It reports only from an authoritative process reading.
+A task with no such reading is silent by default and reported as an unproven `BOOTSTRAP_INFO` fact under `FM_ISOLATION_VERBOSE=1`, because reporting a violation from a pane path is precisely the false positive that corrected the method in the first place.
+
+## Extension points
+
+- A new operational-home variable belongs in `FM_WORKER_ISOLATION_HOME_VARS` in `bin/fm-worker-isolation-lib.sh`, not at a call site, or task children will inherit it.
+- A new runtime provider that exposes a per-pane process id belongs in `fm_agent_backend_shell_pid` and in the matrix above; one that does not needs no change, because the declaration marker already covers it.
+- A new verified harness needs no isolation-specific work, because the declaration is prepended to whatever launch command the adapter builds; the regression suite asserts that for every verified harness so an adapter cannot quietly opt out.
+
+## Regression coverage
+
+`tests/fm-worker-isolation.test.sh` covers all four mechanisms: the declaration's exact bytes and its refusals, the launch declaration for every verified harness, each consuming refusal, the process-cwd method of record against a deliberately lying pane path, the provider matrix, all three slot-conflict forms plus the clean-disposal case, teardown retiring a contested lease under `--force`, and the four sweep outcomes.
+Kimi's launch declaration is asserted in `tests/fm-kimi-harness.test.sh`, which owns that adapter's readiness and delivery gates.
+
+## Maintaining this file
+
+Keep this file to stable ownership, mechanism boundaries, and the safety rationale a future maintainer needs before changing one of the four libraries.
+Exact functions, arguments, flags, and record shapes belong in each script's own header and `--help`, not here.
+Dated commands and captured output belong in [`docs/verification/worker-isolation.md`](verification/worker-isolation.md).
+Task chronology and delivery proof belong in private task reports or PR evidence.

--- a/docs/worker-isolation.md
+++ b/docs/worker-isolation.md
@@ -108,8 +108,11 @@ Retaining means the lease is retired rather than returned.
 A conflicting secondmate home or Orca worktree refuses outright instead, because silently skipping their removal would strand a registry entry or an Orca-owned worktree.
 
 Retention is not a one-way door.
-A task that retains because another task's metadata still names the slot gives up its own ownership stamp on the way out, so the holder left behind can release the slot normally once nothing else references it.
-That clear is deliberately narrow: a stamp naming a *different* task is always preserved, because it is the evidence that stops a stale task from disposing of a slot whose real occupant is merely paused or between processes, and destroying preserved work would be strictly worse than leaking a slot.
+A task that retains because another task's metadata still names the slot *and then completes its own teardown* gives up its own ownership stamp on the way out, so the holder left behind can release the slot normally once nothing else references it.
+That clear is deliberately narrow in two directions.
+A stamp naming a *different* task is always preserved, because it is the evidence that stops a stale task from disposing of a slot whose real occupant is merely paused or between processes, and destroying preserved work would be strictly worse than leaking a slot.
+A caller that refuses outright preserves the stamp too, because a refused operation mutates nothing: its records all stay, ownership did not change, and stripping the evidence there would set up exactly that same destructive sequence once those records are reconciled away.
+Each call site therefore states which of the two it is, so a new caller cannot silently inherit the wrong behaviour.
 The live-occupant check stays a blocking condition and is never weakened to compensate.
 
 #### Reclaiming an already-leaked slot

--- a/docs/worker-isolation.md
+++ b/docs/worker-isolation.md
@@ -79,6 +79,13 @@ Per-provider process id availability:
 A provider with no process id is not a failure of the library.
 It means a task that also lacks the declaration marker has only a hint, which is reported as `unknown` rather than promoted to evidence.
 
+A tmux target is resolved to its stable window id by exact enumeration before any pane is read.
+`display-message` given a window name it cannot find silently answers for the *active client's* window instead, so a task whose window name was lost or auto-renamed would hand back firstmate's own pane, whose working directory is the primary checkout - a healthy worker reported as collapsed.
+No exact match reports `unknown`, which is why a caller must never re-derive the pane pid from a name itself.
+
+A caller that asks about many tasks passes one process index built from a single `/proc` walk.
+Asking per task instead re-walks every process for every task, and the resume sweep runs on the session-start critical path over a home that has held seventeen concurrent tasks.
+
 Reading another process's environment needs care that is easy to get wrong.
 The mode bits on `/proc/<pid>/environ` are not sufficient permission, because the kernel additionally requires ptrace read access; a same-uid but privileged process passes a readability test and still fails at open.
 The failing redirect has to be silenced with the group form, since redirections are applied left to right and a trailing `2>/dev/null` on the same command is set up only after the input redirect has already printed to stderr.
@@ -100,6 +107,24 @@ Retaining means the lease is retired rather than returned.
 `bin/fm-teardown.sh` leaves the directory completely untouched - no branch delete, no hook-file removal, no pool return - and still completes the rest of the teardown, reporting the retained slot on its completion line.
 A conflicting secondmate home or Orca worktree refuses outright instead, because silently skipping their removal would strand a registry entry or an Orca-owned worktree.
 
+Retention is not a one-way door.
+A task that retains because another task's metadata still names the slot gives up its own ownership stamp on the way out, so the holder left behind can release the slot normally once nothing else references it.
+That clear is deliberately narrow: a stamp naming a *different* task is always preserved, because it is the evidence that stops a stale task from disposing of a slot whose real occupant is merely paused or between processes, and destroying preserved work would be strictly worse than leaking a slot.
+The live-occupant check stays a blocking condition and is never weakened to compensate.
+
+#### Reclaiming an already-leaked slot
+
+A slot leaked before that rule existed has no record left to release it: no metadata in any home names it, and its stamp names a task that no longer exists.
+Reclaim it by hand, in this order, and stop at the first step that fails.
+
+1. Confirm nothing records the slot: `grep -l "worktree=<slot>" <home>/state/*.meta` across every home, including secondmate homes, must find nothing.
+2. Confirm nothing lives in it: no process under `/proc` declaring `FM_AGENT_TASK` may have that slot as its `cwd`, and `git -C <slot> status` must show no work worth keeping.
+3. Read the stamp at `$(git -C <slot> rev-parse --absolute-git-dir)/fm-slot-owner` and confirm the task it names is gone from every home's state directory.
+4. Delete that stamp file, then return the slot from its project with `cd <project> && treehouse return --force <slot>`.
+
+`--force` on `bin/fm-teardown.sh` is deliberately not a shortcut for this.
+It is the captain's authority to discard *this* task's work, never authority to release another task's slot, so the gate stays in place and the reclaim stays a deliberate, evidence-checked operator act.
+
 ### Restore-time re-assertion
 
 `bin/fm-isolation-sweep.sh` re-establishes at session start what spawn could only assert at launch.
@@ -109,6 +134,10 @@ It is read-only, always exits 0, and prints one `ISOLATION:` line per task whose
 It reports only from an authoritative process reading.
 A task with no such reading is silent by default and reported as an unproven `BOOTSTRAP_INFO` fact under `FM_ISOLATION_VERBOSE=1`, because reporting a violation from a pane path is precisely the false positive that corrected the method in the first place.
 
+Which home a record expects is read from the record, never assumed to be the home running the sweep.
+A secondmate declares its own home while its record lives in the launching primary's state directory, so comparing every declaration against this home would report every healthy secondmate in the fleet as a foreign worker on every session start.
+A sweep that cries wolf on a normal fleet is worse than no sweep, because the `bootstrap-diagnostics` skill tells the agent to treat these lines as proven.
+
 ## Extension points
 
 - A new operational-home variable belongs in `FM_WORKER_ISOLATION_HOME_VARS` in `bin/fm-worker-isolation-lib.sh`, not at a call site, or task children will inherit it.
@@ -117,7 +146,7 @@ A task with no such reading is silent by default and reported as an unproven `BO
 
 ## Regression coverage
 
-`tests/fm-worker-isolation.test.sh` covers all four mechanisms: the declaration's exact bytes and its refusals, the launch declaration for every verified harness, each consuming refusal, the process-cwd method of record against a deliberately lying pane path, the provider matrix, all three slot-conflict forms plus the clean-disposal case, teardown retiring a contested lease under `--force`, and the four sweep outcomes.
+`tests/fm-worker-isolation.test.sh` covers all four mechanisms: the declaration's exact bytes and its refusals, the launch declaration for every verified harness, each consuming refusal, the process-cwd method of record against a deliberately lying pane path, the provider matrix, the stable-window-id resolution and its refusal to answer from a lost window name, all three slot-conflict forms plus the clean-disposal case, teardown retiring a contested lease under `--force`, the contested-then-released and still-blocked stamp sequences, and the sweep outcomes including a healthy secondmate staying silent.
 Kimi's launch declaration is asserted in `tests/fm-kimi-harness.test.sh`, which owns that adapter's readiness and delivery gates.
 
 ## Maintaining this file

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -813,7 +813,7 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
 # lease the way the pooled-worktree path does, because silently skipping the
 # removal would strand an Orca-owned worktree behind a cleared record.
 test_scout_teardown_refuses_orca_worktree_referenced_by_another_task() {
-  local proj wt data state config id out rc neutral
+  local proj wt data state config id out rc neutral stamp
   id="orcacontestedz9"
   proj="$TMP_ROOT/contested-project"
   wt="$TMP_ROOT/contested-wt"
@@ -837,6 +837,10 @@ test_scout_teardown_refuses_orca_worktree_referenced_by_another_task() {
   orca_case contested
   printf '{"ok":true,"result":{"worktree":{"id":"wt-contested","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  # shellcheck source=/dev/null
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_write "$wt" "$id" "$neutral" ) \
+    || fail "the contested Orca slot fixture could not be stamped"
   set +e
   out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
     FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
@@ -851,6 +855,13 @@ test_scout_teardown_refuses_orca_worktree_referenced_by_another_task() {
   assert_present "$wt" "a contested Orca worktree was deleted"
   assert_present "$state/$id.meta" "a refused Orca teardown should preserve its own metadata"
   assert_present "$state/paused-$id.meta" "a refused Orca teardown cleared the other holder's record"
+  # A refused operation mutates nothing: the ownership stamp is the rule-2
+  # evidence that stops a stale sibling disposing of this still-owned slot.
+  # shellcheck source=/dev/null
+  stamp=$( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_field "$wt" task || printf 'none' )
+  [ "$stamp" = "$id" ] \
+    || fail "a refused Orca teardown erased its own ownership stamp: $stamp"
   pass "fm-teardown.sh backend=orca: refuses a worktree still recorded by another task"
 }
 

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -807,6 +807,53 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   pass "fm-teardown.sh backend=orca: scout report gate then helper-backed worktree removal"
 }
 
+# Pooled slots are reused, so a recorded worktree= is a historical reference and
+# not proof of current ownership (bin/fm-slot-owner-lib.sh, docs/worker-isolation.md).
+# On the Orca path a contested slot refuses OUTRIGHT rather than retiring the
+# lease the way the pooled-worktree path does, because silently skipping the
+# removal would strand an Orca-owned worktree behind a cleared record.
+test_scout_teardown_refuses_orca_worktree_referenced_by_another_task() {
+  local proj wt data state config id out rc neutral
+  id="orcacontestedz9"
+  proj="$TMP_ROOT/contested-project"
+  wt="$TMP_ROOT/contested-wt"
+  data="$TMP_ROOT/contested-data"
+  state="$TMP_ROOT/contested-state"
+  config="$TMP_ROOT/contested-config"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  mkdir -p "$data/$id" "$state" "$config"
+  printf 'report\n' > "$data/$id/report.md"
+  touch "$state/.last-watcher-beat"
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "terminal=term-contested" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
+    "backend=orca" "orca_worktree_id=wt-contested" \
+    "decisions_reviewed=1" "decision_keys="
+  # A still-recorded paused task naming the same slot - the 2026-07-25 shape.
+  fm_write_meta "$state/paused-$id.meta" \
+    "window=fm-paused-$id" "terminal=term-paused" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
+    "backend=orca" "orca_worktree_id=wt-paused"
+  orca_case contested
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-contested","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "Orca teardown should refuse a worktree another task still records"$'\n'"$out"
+  assert_contains "$out" "lease RETAINED" "the Orca refusal did not report the retained lease"
+  assert_contains "$out" "paused-$id" "the Orca refusal did not name the other holder"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
+    "a contested Orca worktree was removed anyway"
+  assert_present "$wt" "a contested Orca worktree was deleted"
+  assert_present "$state/$id.meta" "a refused Orca teardown should preserve its own metadata"
+  assert_present "$state/paused-$id.meta" "a refused Orca teardown cleared the other holder's record"
+  pass "fm-teardown.sh backend=orca: refuses a worktree still recorded by another task"
+}
+
 test_scout_teardown_refuses_orca_id_path_mismatch() {
   local proj wt other_wt data state config id out rc neutral
   id="orcascoutmismatchz5"
@@ -1314,6 +1361,7 @@ test_peek_send_and_crew_state_route_through_orca_meta
 test_peek_and_crew_state_fail_closed_on_orca_error_json
 test_target_exists_rejects_orca_error_json
 test_scout_teardown_removes_orca_worktree_via_helper
+test_scout_teardown_refuses_orca_worktree_referenced_by_another_task
 test_scout_teardown_refuses_orca_id_path_mismatch
 test_teardown_removes_orca_worktree_when_path_missing
 test_teardown_preserves_metadata_when_orca_remove_error_json

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1520,6 +1520,7 @@ test_interactive_terminal_e2e() {
   cp \
     "$ROOT/bin/fm-sessionstart-nudge.sh" \
     "$ROOT/bin/fm-primary-scope-lib.sh" \
+    "$ROOT/bin/fm-worker-isolation-lib.sh" \
     "$ROOT/bin/fm-gate-refuse-lib.sh" \
     "$ROOT/bin/fm-operational-input.sh" \
     "$project/bin/"

--- a/tests/fm-claude-stop-autoarm.test.sh
+++ b/tests/fm-claude-stop-autoarm.test.sh
@@ -27,6 +27,7 @@ install_autoarm_scripts() {
   mkdir -p "$dir/bin"
   cp "$ROOT/bin/fm-claude-stop-autoarm.sh" "$dir/bin/fm-claude-stop-autoarm.sh"
   cp "$ROOT/bin/fm-primary-scope-lib.sh" "$dir/bin/fm-primary-scope-lib.sh"
+  cp "$ROOT/bin/fm-worker-isolation-lib.sh" "$dir/bin/fm-worker-isolation-lib.sh"
   cp "$ROOT/bin/fm-supervision-lib.sh" "$dir/bin/fm-supervision-lib.sh"
   cp "$ROOT/bin/fm-wake-lib.sh" "$dir/bin/fm-wake-lib.sh"
   cp "$ROOT/bin/fm-session-lock-lib.sh" "$dir/bin/fm-session-lock-lib.sh"

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -65,6 +65,13 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.
   ln -s "$ROOT/bin/fm-pr-lib.sh" "$fake/bin/fm-pr-lib.sh"
+  # Slot-ownership and task-worker isolation: teardown sources both before any
+  # disposal, and fm-slot-owner-lib.sh pulls in the agent-cwd library and its own
+  # harness-identity dependency.
+  ln -s "$ROOT/bin/fm-slot-owner-lib.sh" "$fake/bin/fm-slot-owner-lib.sh"
+  ln -s "$ROOT/bin/fm-agent-cwd-lib.sh" "$fake/bin/fm-agent-cwd-lib.sh"
+  ln -s "$ROOT/bin/fm-session-lock-lib.sh" "$fake/bin/fm-session-lock-lib.sh"
+  ln -s "$ROOT/bin/fm-worker-isolation-lib.sh" "$fake/bin/fm-worker-isolation-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -165,6 +172,12 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.
   ln -s "$ROOT/bin/fm-pr-lib.sh" "$fake/bin/fm-pr-lib.sh"
+  # Slot-ownership and task-worker isolation, with the same transitive
+  # dependencies make_fake_root links.
+  ln -s "$ROOT/bin/fm-slot-owner-lib.sh" "$fake/bin/fm-slot-owner-lib.sh"
+  ln -s "$ROOT/bin/fm-agent-cwd-lib.sh" "$fake/bin/fm-agent-cwd-lib.sh"
+  ln -s "$ROOT/bin/fm-session-lock-lib.sh" "$fake/bin/fm-session-lock-lib.sh"
+  ln -s "$ROOT/bin/fm-worker-isolation-lib.sh" "$fake/bin/fm-worker-isolation-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
 exit 0

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -205,8 +205,8 @@ test_kimi_launch_then_send_is_verified() {
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
 
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "'$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
-    || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
+  [ "$launch" = "$(fm_worker_env_prefix crewmate "$id" "$(cd "$HOME_DIR" && pwd -P)")'$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
+    || fail "kimi launch did not use the home declaration, absolute binary, model, and --auto only: $launch"
   assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
   assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
   assert_not_contains "$launch" "__TURNEND__" "kimi launch retained a turn-end placeholder"
@@ -458,7 +458,7 @@ test_kimi_falls_back_to_expanded_home_binary() {
   rc=$?
   expect_code 0 "$rc" "Kimi HOME fallback spawn should succeed"
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "'$fallback' --auto" ] \
+  [ "$launch" = "$(fm_worker_env_prefix crewmate "$id" "$(cd "$HOME_DIR" && pwd -P)")'$fallback' --auto" ] \
     || fail "Kimi fallback did not expand HOME into an absolute executable: $launch"
   pass "fm-spawn: Kimi fallback expands the active HOME"
 }

--- a/tests/fm-opencode-primary-live-e2e.test.sh
+++ b/tests/fm-opencode-primary-live-e2e.test.sh
@@ -160,6 +160,7 @@ run_ahoy_transcript_regressions() {
   cp \
     "$ROOT/bin/fm-sessionstart-nudge.sh" \
     "$ROOT/bin/fm-primary-scope-lib.sh" \
+    "$ROOT/bin/fm-worker-isolation-lib.sh" \
     "$ROOT/bin/fm-gate-refuse-lib.sh" \
     "$ROOT/bin/fm-operational-input.sh" \
     "$AHOY_PROJECT/bin/"

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -180,6 +180,7 @@ run_native_ahoy_regressions() {
   cp \
     "$ROOT/bin/fm-sessionstart-nudge.sh" \
     "$ROOT/bin/fm-primary-scope-lib.sh" \
+    "$ROOT/bin/fm-worker-isolation-lib.sh" \
     "$ROOT/bin/fm-gate-refuse-lib.sh" \
     "$ROOT/bin/fm-operational-input.sh" \
     "$AHOY_PROJECT/bin/"

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -1322,7 +1322,7 @@ EOF
 # lease: continuing would clear the routing entry and metadata while leaving the
 # home - and the secondmate's own state and backlog inside it - on disk unowned.
 test_secondmate_teardown_refuses_home_referenced_by_another_task() {
-  local home subhome subhome_abs fakebin log lease fmroot rc err
+  local home subhome subhome_abs fakebin log lease fmroot rc err stamp
   home="$TMP_ROOT/teardown-contested-home"
   subhome="$TMP_ROOT/teardown-contested-subhome"
   fmroot="$TMP_ROOT/teardown-contested-fmroot"
@@ -1354,6 +1354,10 @@ mode=no-mistakes
 yolo=off
 EOF
   printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
+  # shellcheck source=/dev/null
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_write "$subhome" domain "$home" ) \
+    || fail "the contested secondmate home fixture could not be stamped"
   fakebin=$(make_fake_tmux "$TMP_ROOT/teardown-contested-fake")
   log="$TMP_ROOT/teardown-contested-fake/tmux.log"
   lease="$TMP_ROOT/teardown-contested-fake/lease"
@@ -1375,6 +1379,13 @@ EOF
   [ -e "$home/state/domain.meta" ] || fail "a refused secondmate teardown cleared its own metadata"
   grep -F -- '- domain ' "$home/data/secondmates.md" >/dev/null \
     || fail "a refused secondmate teardown removed the routing entry"
+  # A refused operation mutates nothing: the ownership stamp is the rule-2
+  # evidence that stops a stale sibling disposing of this still-owned home.
+  # shellcheck source=/dev/null
+  stamp=$( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_field "$subhome" task || printf 'none' )
+  [ "$stamp" = domain ] \
+    || fail "a refused secondmate teardown erased its own ownership stamp: $stamp"
   pass "secondmate teardown refuses a home still recorded by another task"
 }
 

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -1316,6 +1316,68 @@ EOF
   pass "secondmate teardown retires empty homes and releases routing"
 }
 
+# A leased secondmate home sits in the same reusable pool as a task worktree, so
+# its lease is gated by the same ownership evidence (bin/fm-slot-owner-lib.sh,
+# docs/worker-isolation.md). Here the refusal is outright rather than a retired
+# lease: continuing would clear the routing entry and metadata while leaving the
+# home - and the secondmate's own state and backlog inside it - on disk unowned.
+test_secondmate_teardown_refuses_home_referenced_by_another_task() {
+  local home subhome subhome_abs fakebin log lease fmroot rc err
+  home="$TMP_ROOT/teardown-contested-home"
+  subhome="$TMP_ROOT/teardown-contested-subhome"
+  fmroot="$TMP_ROOT/teardown-contested-fmroot"
+  err="$TMP_ROOT/teardown-contested.err"
+  make_firstmate_git_root "$fmroot"
+  git -C "$fmroot" worktree add --quiet --detach "$subhome" HEAD
+  mkdir -p "$home/state" "$home/data" "$subhome/state"
+  printf 'domain\n' > "$subhome/.fm-secondmate-home"
+  subhome_abs=$(cd "$subhome" && pwd -P)
+  cat > "$home/state/domain.meta" <<EOF
+window=firstmate:fm-domain
+worktree=$subhome
+project=$subhome
+harness=echo
+kind=secondmate
+mode=secondmate
+yolo=off
+home=$subhome
+projects=alpha
+EOF
+  # A second recorded task naming the same pooled slot - the 2026-07-25 shape.
+  cat > "$home/state/paused-domain.meta" <<EOF
+window=firstmate:fm-paused-domain
+worktree=$subhome
+project=$subhome
+harness=echo
+kind=ship
+mode=no-mistakes
+yolo=off
+EOF
+  printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/teardown-contested-fake")
+  log="$TMP_ROOT/teardown-contested-fake/tmux.log"
+  lease="$TMP_ROOT/teardown-contested-fake/lease"
+  printf 'domain\n' > "$lease"
+  set +e
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$fmroot" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/teardown-contested-fake/pane.txt" \
+    FM_FAKE_TREEHOUSE_LEASE_FILE="$lease" \
+    "$ROOT/bin/fm-teardown.sh" domain >/dev/null 2>"$err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "secondmate teardown should refuse a home another task still records"
+  grep -F "lease RETAINED" "$err" >/dev/null || fail "the refusal did not report the retained lease"$'\n'"$(cat "$err")"
+  grep -F "paused-domain" "$err" >/dev/null || fail "the refusal did not name the other holder"
+  grep -F "treehouse return --force $subhome_abs" "$log" >/dev/null \
+    && fail "a contested secondmate home lease was returned to the pool"
+  [ -d "$subhome" ] || fail "a contested secondmate home was removed"
+  [ -e "$lease" ] || fail "a contested secondmate home lease was released"
+  [ -e "$home/state/domain.meta" ] || fail "a refused secondmate teardown cleared its own metadata"
+  grep -F -- '- domain ' "$home/data/secondmates.md" >/dev/null \
+    || fail "a refused secondmate teardown removed the routing entry"
+  pass "secondmate teardown refuses a home still recorded by another task"
+}
+
 test_secondmate_teardown_refuses_failed_leased_home_return() {
   local home subhome subhome_abs fakebin log fmroot err rc
   home="$TMP_ROOT/teardown-return-fail-home"
@@ -2205,6 +2267,7 @@ test_secondmate_spawn_requires_seeded_matching_home
 test_secondmate_spawn_refuses_operational_dirs_outside_subhome
 test_fm_send_refuses_bare_window_without_home_meta
 test_secondmate_teardown_retires_empty_home
+test_secondmate_teardown_refuses_home_referenced_by_another_task
 test_secondmate_teardown_refuses_failed_leased_home_return
 test_secondmate_teardown_removes_plain_clone_home_without_treehouse_return
 test_secondmate_force_teardown_discards_child_work

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -1378,6 +1378,70 @@ EOF
   pass "secondmate teardown refuses a home still recorded by another task"
 }
 
+# A NESTED child secondmate home was recorded and stamped by its own parent
+# secondmate, so its ownership evidence names the parent's state directory and
+# the parent's home - never the primary's. Judging it against the primary's
+# scope compares against a home that never owned it, retains every time, and
+# blocks the whole force teardown; the child's records would then be the only
+# thing that could be cleared, stranding the home, its state, and its backlog.
+test_secondmate_force_teardown_scopes_a_nested_child_home_to_its_parent() {
+  # Named primary_home, not home: bin/fm-slot-owner-lib.sh is sourced below and
+  # carries its own `home` local, which makes shellcheck read the two as one.
+  local primary_home subhome nested nested_abs fakebin log fmroot
+  primary_home="$TMP_ROOT/nested-scope-home"
+  subhome="$TMP_ROOT/nested-scope-subhome"
+  nested="$TMP_ROOT/nested-scope-child"
+  fmroot="$TMP_ROOT/nested-scope-fmroot"
+  make_firstmate_git_root "$fmroot"
+  git -C "$fmroot" worktree add --quiet --detach "$subhome" HEAD
+  git -C "$fmroot" worktree add --quiet --detach "$nested" HEAD
+  mkdir -p "$primary_home/state" "$primary_home/data" "$subhome/state" "$nested/state"
+  printf 'domain\n' > "$subhome/.fm-secondmate-home"
+  printf 'child\n' > "$nested/.fm-secondmate-home"
+  nested_abs=$(cd "$nested" && pwd -P)
+  cat > "$primary_home/state/domain.meta" <<EOF
+window=firstmate:fm-domain
+worktree=$subhome
+project=$subhome
+harness=echo
+kind=secondmate
+mode=secondmate
+yolo=off
+home=$subhome
+projects=alpha
+EOF
+  cat > "$subhome/state/child.meta" <<EOF
+window=firstmate:fm-child
+worktree=$nested
+project=$nested
+harness=echo
+kind=secondmate
+mode=secondmate
+yolo=off
+home=$nested
+projects=alpha
+EOF
+  printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$primary_home/data/secondmates.md"
+  # Stamped the way each home's own spawn stamps it: the child by the parent
+  # secondmate's home, the parent by the primary's.
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_write "$nested" child "$subhome" \
+    && fm_slot_stamp_write "$subhome" domain "$primary_home" ) \
+    || fail "the nested home fixture could not be stamped"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/nested-scope-fake")
+  log="$TMP_ROOT/nested-scope-fake/tmux.log"
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$fmroot" FM_HOME="$primary_home" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/nested-scope-fake/pane.txt" \
+    "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>/dev/null \
+    || fail "force teardown refused a nested child home its own parent owned"
+  grep -F "treehouse return --force $nested_abs" "$log" >/dev/null \
+    || fail "the nested child home lease was never returned to the pool"
+  [ ! -d "$nested" ] || fail "force teardown left the nested child home on disk"
+  [ ! -e "$subhome" ] || fail "force teardown left the parent secondmate home on disk"
+  [ ! -e "$primary_home/state/domain.meta" ] || fail "force teardown did not clear parent meta"
+  pass "a nested child secondmate home is judged against its own parent's scope, not the primary's"
+}
+
 test_secondmate_teardown_refuses_failed_leased_home_return() {
   local home subhome subhome_abs fakebin log fmroot err rc
   home="$TMP_ROOT/teardown-return-fail-home"
@@ -2268,6 +2332,7 @@ test_secondmate_spawn_refuses_operational_dirs_outside_subhome
 test_fm_send_refuses_bare_window_without_home_meta
 test_secondmate_teardown_retires_empty_home
 test_secondmate_teardown_refuses_home_referenced_by_another_task
+test_secondmate_force_teardown_scopes_a_nested_child_home_to_its_parent
 test_secondmate_teardown_refuses_failed_leased_home_return
 test_secondmate_teardown_removes_plain_clone_home_without_treehouse_return
 test_secondmate_force_teardown_discards_child_work

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -113,6 +113,7 @@ test_opencode_plugin_delivers_exact_nudge_once() {
   local root="$TMP_ROOT/opencode-primary" out status=0
   make_primary "$root"
   cp "$ROOT/bin/fm-sessionstart-nudge.sh" "$ROOT/bin/fm-primary-scope-lib.sh" \
+    "$ROOT/bin/fm-worker-isolation-lib.sh" \
     "$ROOT/bin/fm-gate-refuse-lib.sh" "$ROOT/bin/fm-operational-input.sh" "$root/bin/"
   chmod +x "$root/bin/fm-sessionstart-nudge.sh"
   out=$(PLUGIN="$ROOT/.opencode/plugins/fm-primary-sessionstart-nudge.js" \

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -118,7 +118,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="$(fm_worker_env_prefix crewmate "$id" "$(cd "$HOME_DIR" && pwd -P)")CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -204,7 +204,8 @@ test_active_dispatch_profile_allows_raw_launch_command() {
   assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default
   launch=$(cat "$LAUNCH_LOG")
-  [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
+  [ "$launch" = "$(fm_worker_env_prefix crewmate "$id" "$(cd "$HOME_DIR" && pwd -P)")custom-agent --flag" ] \
+    || fail "raw launch command changed"$'\n'"actual: $launch"
   pass "active crew-dispatch profile allows the raw launch-command escape hatch"
 }
 

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -105,6 +105,7 @@ install_guard_scripts() {
   cp "$ROOT/bin/fm-supervision-instructions.sh" "$dir/bin/fm-supervision-instructions.sh"
   cp "$ROOT/bin/fm-harness.sh" "$dir/bin/fm-harness.sh"
   cp "$ROOT/bin/fm-primary-scope-lib.sh" "$dir/bin/fm-primary-scope-lib.sh"
+  cp "$ROOT/bin/fm-worker-isolation-lib.sh" "$dir/bin/fm-worker-isolation-lib.sh"
   cp "$ROOT/bin/fm-supervision-lib.sh" "$dir/bin/fm-supervision-lib.sh"
   cp "$ROOT/bin/fm-wake-lib.sh" "$dir/bin/fm-wake-lib.sh"
   mkdir -p "$dir/docs"

--- a/tests/fm-worker-isolation.test.sh
+++ b/tests/fm-worker-isolation.test.sh
@@ -671,7 +671,7 @@ test_a_stamp_naming_another_task_survives_a_retain_and_still_blocks() {
 }
 
 test_teardown_retires_a_contested_lease_even_with_force() {
-  local rec fakebin out status
+  local rec fakebin out status stamp
   rec=$(make_slot_world slot-teardown)
   read_slot_world "$rec"
   fakebin=$(fm_fakebin "$WORLD/fake")
@@ -689,6 +689,9 @@ SH
   fm_write_meta "$WORLD/home/state/quarantined-e6.meta" \
     "window=firstmate:fm-quarantined-e6" "worktree=$WT_DIR" "project=$PROJ_DIR" \
     "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_write "$WT_DIR" task-e6 "$WORLD/home" ) \
+    || fail "the contested-slot fixture could not be stamped"
 
   out=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$WORLD/home" \
     FM_STATE_OVERRIDE="$WORLD/home/state" FM_DATA_OVERRIDE="$WORLD/home/data" \
@@ -708,6 +711,12 @@ SH
     || fail "teardown moved a contested worktree off its branch"
   assert_absent "$WORLD/home/state/task-e6.meta" "teardown did not clear its own records"
   assert_present "$WORLD/home/state/quarantined-e6.meta" "teardown cleared the other holder's record"
+  # This path DID complete and delete its own records, so its stamp must not
+  # outlive it, or the slot could never be released again.
+  stamp=$( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_field "$WT_DIR" task || printf 'none' )
+  [ "$stamp" = none ] \
+    || fail "a completed teardown left its own ownership stamp behind: $stamp"
   pass "teardown retires a contested lease, leaves the slot untouched, and --force does not waive it"
 }
 

--- a/tests/fm-worker-isolation.test.sh
+++ b/tests/fm-worker-isolation.test.sh
@@ -1,0 +1,637 @@
+#!/usr/bin/env bash
+# Regression tests for task-worker isolation: the launched-agent home
+# declaration, the refusals that depend on it, /proc as the method of record for
+# an agent's working directory, pooled-slot ownership, and the resume-time
+# re-assertion sweep.
+#
+# The defects these pin (all observed live, 2026-07-24/25):
+#   - an audit worker inherited the primary's FM_HOME and took the primary's own
+#     session-owner record, locking the real primary out of its home;
+#   - a restore resumed every recorded agent session but resolved 17 of 17
+#     worktrees back onto their origin repository, four into the primary
+#     checkout, so the spawn-time isolation assertion did not survive;
+#   - ten pooled slots were recorded by more than one task, and releasing one
+#     task's lease reissued a slot a still-live paused task also held;
+#   - a pane cwd field named the wrong process and reported an isolated worker
+#     as living in the primary checkout.
+#
+# Kimi's launch declaration is asserted in tests/fm-kimi-harness.test.sh, which
+# owns that adapter's readiness and delivery gates; the five adapters that need
+# no readiness gate are driven end to end here.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+LOCK="$ROOT/bin/fm-lock.sh"
+SWEEP="$ROOT/bin/fm-isolation-sweep.sh"
+NUDGE="$ROOT/bin/fm-sessionstart-nudge.sh"
+TMP_ROOT=$(fm_test_tmproot fm-worker-isolation)
+
+# Fixture agents are real long-lived processes, and the code under test finds
+# them by scanning /proc for a declaration marker. Two hygiene rules follow.
+#
+# Every fixture id carries RUN_TAG, so a process leaked by an earlier run - a
+# run killed outright, before its trap could fire - can never be mistaken for
+# this run's agent. Without it a stale `sleep` answers a later lookup and the
+# suite fails for a reason that is not in the diff.
+#
+# Every fixture process also carries FM_AGENT_TEST_RUN, so cleanup can find them
+# all by marker rather than by bookkeeping. Recorded pids alone are not enough:
+# a fixture started inside a command substitution registers its pid in a
+# subshell that is already gone, and a parent/child fixture leaves the child
+# behind when only the parent is signalled.
+RUN_TAG=$$
+BG_PIDS=()
+worker_isolation_cleanup() {
+  local pid entry marker
+  for pid in "${BG_PIDS[@]:-}"; do
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null
+  done
+  for entry in /proc/[0-9]*; do
+    [ -d "$entry" ] || continue
+    pid=${entry#/proc/}
+    marker=$( { tr '\0' '\n' < "$entry/environ"; } 2>/dev/null \
+      | sed -n 's/^FM_AGENT_TEST_RUN=//p' | head -1)
+    [ "$marker" = "$RUN_TAG" ] || continue
+    kill -9 "$pid" 2>/dev/null
+  done
+  fm_test_cleanup
+}
+trap worker_isolation_cleanup EXIT
+
+# start_declared_agent <cwd> <task-id> <home> [role]: start a live process that
+# carries the declaration bin/fm-spawn.sh injects, from <cwd>. Echoes its pid.
+# The agent's own descriptors are detached from this function's stdout: a
+# long-lived background process that inherits the write end of a caller's
+# command substitution keeps that substitution blocked until the process exits.
+start_declared_agent() {
+  local cwd=$1 id=$2 home=$3 role=${4:-crewmate} pid
+  ( cd "$cwd" \
+    && FM_AGENT_ROLE="$role" FM_AGENT_TASK="$id" FM_AGENT_OWNER_HOME="$home" \
+       FM_AGENT_TEST_RUN="$RUN_TAG" \
+       exec sleep 300 ) >/dev/null 2>&1 </dev/null &
+  pid=$!
+  BG_PIDS+=("$pid")
+  # Wait for the exec'd process to actually be in place before it is inspected.
+  local i=0
+  while [ "$i" -lt 50 ]; do
+    [ -e "/proc/$pid/cwd" ] && break
+    sleep 0.05
+    i=$((i + 1))
+  done
+  printf '%s\n' "$pid"
+}
+
+require_procfs() {
+  [ -d /proc ] && [ -L "/proc/$$/cwd" ]
+}
+
+# --- A. the home declaration itself -----------------------------------------
+
+test_crewmate_declaration_clears_every_inherited_home() {
+  local prefix
+  prefix=$( . "$ROOT/bin/fm-worker-isolation-lib.sh" \
+    && fm_worker_launch_env_prefix crewmate task-a1 /home/cap/firstmate )
+  [ "$prefix" = "FM_HOME= FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_AGENT_ROLE=crewmate FM_AGENT_TASK='task-a1' FM_AGENT_OWNER_HOME='/home/cap/firstmate' " ] \
+    || fail "crewmate declaration changed: $prefix"
+  pass "a crewmate declaration clears every operational-home variable and names its owner"
+}
+
+test_secondmate_declaration_pins_only_its_own_home() {
+  local prefix
+  prefix=$( . "$ROOT/bin/fm-worker-isolation-lib.sh" \
+    && fm_worker_launch_env_prefix secondmate dom-b2 /home/cap/homes/dom )
+  [ "$prefix" = "FM_HOME='/home/cap/homes/dom' FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_AGENT_ROLE=secondmate FM_AGENT_TASK='dom-b2' FM_AGENT_OWNER_HOME='/home/cap/homes/dom' " ] \
+    || fail "secondmate declaration changed: $prefix"
+  pass "a secondmate declaration pins its own home and clears every inherited override"
+}
+
+test_declaration_refuses_rather_than_emitting_a_partial_prefix() {
+  local out status
+  out=$( . "$ROOT/bin/fm-worker-isolation-lib.sh" \
+    && fm_worker_launch_env_prefix auditor task-a3 /home/cap/firstmate 2>&1 )
+  status=$?
+  expect_code 1 "$status" "an unknown role must refuse"
+  assert_contains "$out" "unknown agent role" "unknown role refusal lost its reason"
+
+  out=$( . "$ROOT/bin/fm-worker-isolation-lib.sh" \
+    && fm_worker_launch_env_prefix crewmate '' /home/cap/firstmate 2>&1 )
+  status=$?
+  expect_code 1 "$status" "an empty task id must refuse"
+
+  out=$( . "$ROOT/bin/fm-worker-isolation-lib.sh" \
+    && fm_worker_launch_env_prefix crewmate task-a3 relative/home 2>&1 )
+  status=$?
+  expect_code 1 "$status" "a relative owning home must refuse"
+  assert_contains "$out" "absolute owning home" "relative-home refusal lost its reason"
+  pass "an unbuildable declaration refuses instead of emitting a partial prefix"
+}
+
+# --- B. every verified harness launches with the declaration ----------------
+
+make_launch_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{pane_pid}"*) printf '%s\n' "${FM_FAKE_PANE_PID:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  send-keys)
+    prev=
+    for arg in "$@"; do
+      if [ "$prev" = -l ]; then printf '%s\n' "$arg" >> "$FM_FAKE_LAUNCH_LOG"; break; fi
+      prev=$arg
+    done
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+make_launch_case() {
+  local name=$1 id=$2 case_dir home proj wt fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_launch_fakebin "$case_dir/fake")
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  touch "$home/state/.last-watcher-beat"
+  : > "$case_dir/launch.log"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
+}
+
+read_launch_record() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR <<EOF
+$1
+EOF
+}
+
+test_every_verified_harness_launches_with_its_home_declaration() {
+  local harness id rec out status launch expected home_real
+  for harness in claude codex opencode pi grok; do
+    id="declared-$harness-b1"
+    rec=$(make_launch_case "launch-$harness" "$id")
+    read_launch_record "$rec"
+    out=$(HOME="$HOME_DIR" GROK_HOME="$HOME_DIR/.grok" \
+      FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+      FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+      FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+      FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$WT_DIR" \
+      FM_FAKE_LAUNCH_LOG="$CASE_DIR/launch.log" \
+      PATH="$FAKEBIN_DIR:$PATH" \
+      "$SPAWN" "$id" "$PROJ_DIR" --harness "$harness" 2>&1)
+    status=$?
+    expect_code 0 "$status" "$harness spawn should succeed"$'\n'"$out"
+    launch=$(cat "$CASE_DIR/launch.log")
+    home_real=$(cd "$HOME_DIR" && pwd -P)
+    expected=$(fm_worker_env_prefix crewmate "$id" "$home_real")
+    case "$launch" in
+      "$expected"*) : ;;
+      *) fail "$harness launch did not begin with the home declaration"$'\n'"expected prefix: $expected"$'\n'"actual: $launch" ;;
+    esac
+    assert_contains "$launch" "FM_HOME= " "$harness launch let the worker inherit FM_HOME"
+  done
+  pass "claude, codex, opencode, pi, and grok all launch with the crewmate home declaration"
+}
+
+test_secondmate_child_receives_only_its_own_home() {
+  local expected
+  expected=$(fm_worker_env_prefix secondmate dom-b5 /homes/dom)
+  case "$expected" in
+    "FM_HOME='/homes/dom' "*) : ;;
+    *) fail "secondmate declaration did not pin its own home first: $expected" ;;
+  esac
+  assert_not_contains "$expected" "FM_ROOT_OVERRIDE='" \
+    "secondmate declaration passed an inherited root override through"
+  pass "a secondmate child receives its own home and no inherited override"
+}
+
+# --- C. a declared worker is inert and refused -------------------------------
+
+make_primary_home() {
+  local dir=$1
+  mkdir -p "$dir/bin" "$dir/state" "$dir/data" "$dir/config"
+  fm_git_init_commit "$dir"
+  printf '# agents\n' > "$dir/AGENTS.md"
+  printf '%s\n' "$dir"
+}
+
+test_declared_worker_is_never_a_primary_scope_match() {
+  # Named primary_home, not home: the sourced libraries carry their own `home`
+  # local, and reusing the name here makes shellcheck read the two as one.
+  local primary_home out
+  primary_home=$(make_primary_home "$TMP_ROOT/scope-home")
+  out=$( . "$ROOT/bin/fm-primary-scope-lib.sh" \
+    && fm_primary_scope_matches "$primary_home" "$primary_home/state" && printf 'primary' || printf 'not-primary' )
+  [ "$out" = primary ] || fail "the fixture is not recognized as a genuine primary at all"
+  out=$( export FM_AGENT_ROLE=crewmate FM_AGENT_TASK=w1 FM_AGENT_OWNER_HOME="$primary_home"
+    . "$ROOT/bin/fm-primary-scope-lib.sh" \
+    && fm_primary_scope_matches "$primary_home" "$primary_home/state" && printf 'primary' || printf 'not-primary' )
+  [ "$out" = not-primary ] \
+    || fail "a declared crewmate matched primary scope inside a genuine primary checkout"
+  pass "a declared crewmate is never a primary-scope match, even in a real primary checkout"
+}
+
+test_project_local_startup_adapter_stays_inert_for_a_worker() {
+  local out
+  out=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$ROOT" \
+    FM_AGENT_ROLE=crewmate FM_AGENT_TASK=w2 FM_AGENT_OWNER_HOME="$ROOT" \
+    "$NUDGE" 2>&1)
+  [ -z "$out" ] || fail "the session-start nudge fired for a declared task worker: $out"
+  pass "the tracked session-start adapter stays inert for a declared task worker"
+}
+
+test_worker_cannot_take_the_session_owner_record() {
+  local home before out status
+  home=$(make_primary_home "$TMP_ROOT/lock-home")
+  printf '424242\n' > "$home/state/.lock"
+  before=$(cat "$home/state/.lock")
+
+  out=$(FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+    FM_AGENT_ROLE=crewmate FM_AGENT_TASK=w3 FM_AGENT_OWNER_HOME="$home" \
+    "$LOCK" 2>&1)
+  status=$?
+  expect_code 1 "$status" "a declared task worker must not acquire the session lock"
+  assert_contains "$out" "task worker" "the lock refusal did not name the worker declaration"
+  [ "$(cat "$home/state/.lock")" = "$before" ] \
+    || fail "the session owner record was rewritten by a task worker"
+
+  out=$(FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+    FM_AGENT_ROLE=crewmate FM_AGENT_TASK=w3 FM_AGENT_OWNER_HOME="$home" \
+    "$LOCK" status 2>&1)
+  status=$?
+  expect_code 0 "$status" "read-only lock status must stay available to a worker"
+  pass "a declared task worker is refused the session owner record and never rewrites it"
+}
+
+test_worker_cannot_spawn_or_tear_down() {
+  local home out status
+  home=$(make_primary_home "$TMP_ROOT/refuse-home")
+  out=$(FM_ROOT_OVERRIDE="$home" FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
+    FM_AGENT_ROLE=crewmate FM_AGENT_TASK=w4 FM_AGENT_OWNER_HOME="$home" \
+    "$SPAWN" some-task "$home" 2>&1)
+  status=$?
+  expect_code 1 "$status" "a declared task worker must not spawn"
+  assert_contains "$out" "spawn refused" "the spawn refusal did not name the operation"
+
+  out=$(FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+    FM_AGENT_ROLE=crewmate FM_AGENT_TASK=w4 FM_AGENT_OWNER_HOME="$home" \
+    "$TEARDOWN" some-task 2>&1)
+  status=$?
+  expect_code 1 "$status" "a declared task worker must not tear down"
+  assert_contains "$out" "teardown refused" "the teardown refusal did not name the operation"
+  pass "a declared task worker is refused both dispatch and teardown"
+}
+
+# --- D. /proc is the method of record ---------------------------------------
+
+test_proc_cwd_is_read_from_the_live_process() {
+  local dir pid cwd
+  require_procfs || { pass "skip: this host has no readable procfs for cwd proof"; return 0; }
+  dir="$TMP_ROOT/proc-cwd"
+  mkdir -p "$dir"
+  pid=$(start_declared_agent "$dir" "proc-d1-$RUN_TAG" "$TMP_ROOT/proc-home")
+  cwd=$( . "$ROOT/bin/fm-agent-cwd-lib.sh" && fm_agent_proc_cwd "$pid" )
+  [ "$cwd" = "$(cd "$dir" && pwd -P)" ] \
+    || fail "the process cwd was not read from /proc: $cwd"
+  pass "an agent's working directory is read from the live process, not a record"
+}
+
+test_declared_agent_lookup_returns_the_root_most_process() {
+  # Named root_pid, not root: the sourced library carries its own `root` local.
+  local dir out root_pid child id
+  require_procfs || { pass "skip: this host has no readable procfs for declaration lookup"; return 0; }
+  dir="$TMP_ROOT/proc-root"
+  id="proc-d2-$RUN_TAG"
+  mkdir -p "$dir"
+  ( cd "$dir" && FM_AGENT_ROLE=crewmate FM_AGENT_TASK="$id" \
+      FM_AGENT_OWNER_HOME="$TMP_ROOT/proc-home" FM_AGENT_TEST_RUN="$RUN_TAG" \
+      sh -c 'sleep 300' ) >/dev/null 2>&1 </dev/null &
+  root_pid=$!
+  BG_PIDS+=("$root_pid")
+  sleep 0.5
+  out=$( . "$ROOT/bin/fm-agent-cwd-lib.sh" && fm_agent_pid_for_task "$id" )
+  [ -n "$out" ] || fail "the declared agent process was not found at all"
+  child=$( . "$ROOT/bin/fm-agent-cwd-lib.sh" && fm_agent_pids_for_task "$id" | wc -l )
+  [ "$child" -ge 2 ] || fail "the fixture did not produce a declared parent and child"
+  [ "$out" = "$root_pid" ] \
+    || fail "the lookup returned $out, not the root-most declared process $root_pid"
+  pass "the declared-agent lookup returns the agent itself, not one of its subprocesses"
+}
+
+test_provider_process_id_matrix_is_explicit() {
+  local out
+  out=$( . "$ROOT/bin/fm-agent-cwd-lib.sh"
+    for backend in herdr zellij cmux orca unknown; do
+      if fm_agent_backend_shell_pid "$backend" "session:pane" >/dev/null 2>&1; then
+        printf '%s-exposes-a-pid\n' "$backend"
+      fi
+    done )
+  [ -z "$out" ] || fail "a provider with no verified per-pane process id claimed one: $out"
+  out=$( . "$ROOT/bin/fm-agent-cwd-lib.sh" \
+    && fm_agent_cwd_verdict '' herdr 'ses:pane' )
+  case "$out" in
+    unknown*) : ;;
+    *) fail "a provider without a process id must report unknown, not a pane value: $out" ;;
+  esac
+  pass "providers with no verified per-pane process id report unknown instead of a pane value"
+}
+
+test_spawn_settles_on_proc_evidence_over_a_lying_pane_path() {
+  local rec id out status lying pid
+  require_procfs || { pass "skip: this host has no readable procfs for spawn settle proof"; return 0; }
+  id="settle-proc-d4-$RUN_TAG"
+  rec=$(make_launch_case settle-proc "$id")
+  read_launch_record "$rec"
+  lying="$CASE_DIR/other-real-checkout"
+  fm_git_init_commit "$lying"
+  pid=$(start_declared_agent "$WT_DIR" "$id-shell" "$HOME_DIR")
+
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH="$lying" FM_FAKE_PANE_PID="$pid" \
+    FM_FAKE_LAUNCH_LOG="$CASE_DIR/launch.log" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" --harness claude 2>&1)
+  status=$?
+  expect_code 0 "$status" "spawn should settle on the process evidence"$'\n'"$out"
+  assert_grep "worktree=$(cd "$WT_DIR" && pwd -P)" "$HOME_DIR/state/$id.meta" \
+    "spawn did not record the worktree proved by the agent process"
+  assert_no_grep "worktree=$lying" "$HOME_DIR/state/$id.meta" \
+    "spawn recorded the lying pane path as the worktree"
+  pass "spawn settles on the process's own working directory, not a pane field that names another process"
+}
+
+# --- E. pooled-slot ownership -----------------------------------------------
+
+make_slot_world() {
+  local name=$1 world proj wt other
+  world="$TMP_ROOT/$name"
+  proj="$world/project"
+  wt="$world/wt"
+  other="$world/wt-other"
+  mkdir -p "$world/home/state" "$world/home/data" "$world/home/config"
+  fm_git_worktree "$proj" "$wt" "slot-$name"
+  git -C "$proj" worktree add --quiet -b "slot-$name-other" "$other"
+  printf '%s\n' "$world|$proj|$wt|$other"
+}
+
+read_slot_world() {
+  IFS='|' read -r WORLD PROJ_DIR WT_DIR OTHER_WT <<EOF
+$1
+EOF
+}
+
+slot_verdict() {  # <state> <id> <wt> <home>
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" && fm_slot_disposal_verdict "$@" )
+}
+
+test_slot_stamp_records_ownership_and_never_stamps_a_plain_checkout() {
+  local rec task
+  rec=$(make_slot_world slot-stamp)
+  read_slot_world "$rec"
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_write "$WT_DIR" task-e1 "$WORLD/home" ) \
+    || fail "a linked worktree could not be stamped"
+  task=$( . "$ROOT/bin/fm-slot-owner-lib.sh" && fm_slot_stamp_field "$WT_DIR" task )
+  [ "$task" = task-e1 ] || fail "the slot stamp did not record its task: $task"
+  [ -z "$(git -C "$WT_DIR" status --porcelain)" ] \
+    || fail "the slot stamp dirtied the working tree"
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_write "$PROJ_DIR" task-e1 "$WORLD/home" ) 2>/dev/null \
+    && fail "a plain checkout was stamped as a disposable slot"
+  pass "slot ownership is stamped invisibly in a linked worktree and refused for a plain checkout"
+}
+
+test_clean_ownership_disposes() {
+  local rec verdict
+  rec=$(make_slot_world slot-clean)
+  read_slot_world "$rec"
+  fm_write_meta "$WORLD/home/state/task-e2.meta" \
+    "window=firstmate:fm-task-e2" "worktree=$WT_DIR" "project=$PROJ_DIR" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  # A busy home is the normal case: another task holding a DIFFERENT slot must
+  # not retain this one, or the gate would leak every lease it ever inspects.
+  fm_write_meta "$WORLD/home/state/neighbour-e2.meta" \
+    "window=firstmate:fm-neighbour-e2" "worktree=$OTHER_WT" "project=$PROJ_DIR" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_write "$WT_DIR" task-e2 "$WORLD/home" )
+  verdict=$(slot_verdict "$WORLD/home/state" task-e2 "$WT_DIR" "$WORLD/home")
+  [ "$verdict" = dispose ] || fail "clean ownership did not dispose: $verdict"
+  pass "a slot this task alone records and stamps disposes normally"
+}
+
+test_a_second_recorded_task_retains_the_slot() {
+  local rec verdict
+  rec=$(make_slot_world slot-shared)
+  read_slot_world "$rec"
+  fm_write_meta "$WORLD/home/state/task-e3.meta" \
+    "window=firstmate:fm-task-e3" "worktree=$WT_DIR" "project=$PROJ_DIR" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  fm_write_meta "$WORLD/home/state/paused-e3.meta" \
+    "window=firstmate:fm-paused-e3" "worktree=$WT_DIR" "project=$PROJ_DIR" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  verdict=$(slot_verdict "$WORLD/home/state" task-e3 "$WT_DIR" "$WORLD/home")
+  case "$verdict" in
+    "retain: slot is also recorded by task(s) paused-e3"*) : ;;
+    *) fail "a slot recorded by a second task did not retain: $verdict" ;;
+  esac
+  pass "a slot still recorded by another task - live, paused, or quarantined - retains its lease"
+}
+
+test_a_stamp_naming_another_task_retains_the_slot() {
+  local rec verdict
+  rec=$(make_slot_world slot-stale)
+  read_slot_world "$rec"
+  fm_write_meta "$WORLD/home/state/task-e4.meta" \
+    "window=firstmate:fm-task-e4" "worktree=$WT_DIR" "project=$PROJ_DIR" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_write "$WT_DIR" reissued-e4 "$WORLD/home" )
+  verdict=$(slot_verdict "$WORLD/home/state" task-e4 "$WT_DIR" "$WORLD/home")
+  case "$verdict" in
+    "retain: slot ownership stamp names task reissued-e4"*) : ;;
+    *) fail "stale metadata pointing at a reissued slot did not retain: $verdict" ;;
+  esac
+  pass "metadata pointing at a slot that was reissued is recognized as stale and retains the lease"
+}
+
+test_a_live_agent_of_another_task_retains_the_slot() {
+  local rec verdict occupant
+  require_procfs || { pass "skip: this host has no readable procfs for occupancy proof"; return 0; }
+  rec=$(make_slot_world slot-occupied)
+  read_slot_world "$rec"
+  occupant="occupant-e5-$RUN_TAG"
+  fm_write_meta "$WORLD/home/state/task-e5.meta" \
+    "window=firstmate:fm-task-e5" "worktree=$WT_DIR" "project=$PROJ_DIR" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  start_declared_agent "$WT_DIR" "$occupant" "$WORLD/home" >/dev/null
+  verdict=$(slot_verdict "$WORLD/home/state" task-e5 "$WT_DIR" "$WORLD/home")
+  case "$verdict" in
+    "retain: a live agent for task(s) $occupant"*) : ;;
+    *) fail "a slot occupied by another task's live agent did not retain: $verdict" ;;
+  esac
+  pass "a slot occupied by another task's live agent retains its lease"
+}
+
+test_teardown_retires_a_contested_lease_even_with_force() {
+  local rec fakebin out status
+  rec=$(make_slot_world slot-teardown)
+  read_slot_world "$rec"
+  fakebin=$(fm_fakebin "$WORLD/fake")
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_FAKE_TREEHOUSE_LOG"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+  fm_fake_exit0 "$fakebin" tmux gh-axi gh
+  : > "$WORLD/treehouse.log"
+  fm_write_meta "$WORLD/home/state/task-e6.meta" \
+    "window=firstmate:fm-task-e6" "worktree=$WT_DIR" "project=$PROJ_DIR" \
+    "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off"
+  fm_write_meta "$WORLD/home/state/quarantined-e6.meta" \
+    "window=firstmate:fm-quarantined-e6" "worktree=$WT_DIR" "project=$PROJ_DIR" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+
+  out=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$WORLD/home" \
+    FM_STATE_OVERRIDE="$WORLD/home/state" FM_DATA_OVERRIDE="$WORLD/home/data" \
+    FM_CONFIG_OVERRIDE="$WORLD/home/config" \
+    FM_FAKE_TREEHOUSE_LOG="$WORLD/treehouse.log" \
+    PATH="$fakebin:$PATH" \
+    "$TEARDOWN" task-e6 --force 2>&1)
+  status=$?
+  expect_code 0 "$status" "teardown should complete while retiring the contested lease"$'\n'"$out"
+  assert_contains "$out" "lease RETAINED" "teardown did not report the retained lease"
+  assert_contains "$out" "quarantined-e6" "teardown did not name the other holder"
+  assert_contains "$out" "retained on disk" "the completion line did not report the retained slot"
+  [ ! -s "$WORLD/treehouse.log" ] \
+    || fail "teardown returned a contested slot to the pool: $(cat "$WORLD/treehouse.log")"
+  assert_present "$WT_DIR" "teardown removed a contested worktree"
+  [ "$(git -C "$WT_DIR" rev-parse --abbrev-ref HEAD)" = "slot-slot-teardown" ] \
+    || fail "teardown moved a contested worktree off its branch"
+  assert_absent "$WORLD/home/state/task-e6.meta" "teardown did not clear its own records"
+  assert_present "$WORLD/home/state/quarantined-e6.meta" "teardown cleared the other holder's record"
+  pass "teardown retires a contested lease, leaves the slot untouched, and --force does not waive it"
+}
+
+# --- F. restore-time re-assertion -------------------------------------------
+
+make_sweep_home() {
+  local name=$1 world
+  world="$TMP_ROOT/$name"
+  mkdir -p "$world/home/state" "$world/home/data" "$world/home/config"
+  fm_git_worktree "$world/project" "$world/wt" "sweep-$name"
+  printf '%s\n' "$world"
+}
+
+run_sweep() {  # <world>
+  FM_ROOT_OVERRIDE="$1/project" FM_HOME="$1/home" \
+    FM_STATE_OVERRIDE="$1/home/state" "$SWEEP" 2>&1
+}
+
+test_sweep_reports_a_worktree_that_collapsed_onto_the_primary_checkout() {
+  local world out id
+  require_procfs || { pass "skip: this host has no readable procfs for the resume sweep"; return 0; }
+  world=$(make_sweep_home sweep-collapsed)
+  id="task-f1-$RUN_TAG"
+  fm_write_meta "$world/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "worktree=$world/wt" "project=$world/project" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  start_declared_agent "$world/project" "$id" "$world/home" >/dev/null
+  out=$(run_sweep "$world")
+  assert_contains "$out" "ISOLATION: task $id collapsed onto the primary checkout" \
+    "the resume sweep did not report a collapsed worktree"
+  pass "the resume sweep re-asserts isolation and reports a worktree that collapsed onto the primary checkout"
+}
+
+test_sweep_is_silent_for_a_correctly_isolated_worker() {
+  local world out id
+  require_procfs || { pass "skip: this host has no readable procfs for the resume sweep"; return 0; }
+  world=$(make_sweep_home sweep-isolated)
+  id="task-f2-$RUN_TAG"
+  fm_write_meta "$world/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "worktree=$world/wt" "project=$world/project" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  start_declared_agent "$world/wt" "$id" "$world/home" >/dev/null
+  # Captured with stderr folded in: the sweep scans every process on the host,
+  # and a /proc entry it may not read must stay silent rather than surfacing a
+  # permission error as if it were a finding.
+  out=$(run_sweep "$world")
+  [ -z "$out" ] || fail "the resume sweep reported a correctly isolated worker: $out"
+  pass "the resume sweep stays silent for a worker that is genuinely in its worktree"
+}
+
+test_sweep_never_promotes_a_pane_path_to_evidence() {
+  local world out
+  world=$(make_sweep_home sweep-hint)
+  fm_write_meta "$world/home/state/task-f3.meta" \
+    "window=firstmate:fm-task-f3" "worktree=$world/wt" "project=$world/project" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  out=$(run_sweep "$world")
+  [ -z "$out" ] || fail "the resume sweep reported a violation with no live process to prove it: $out"
+  out=$(FM_ISOLATION_VERBOSE=1 run_sweep "$world")
+  assert_contains "$out" "BOOTSTRAP_INFO: isolation for task-f3 is unproven" \
+    "an unprovable task was not reported as unproven under verbose facts"
+  pass "an unprovable task is never reported as a violation from a pane path alone"
+}
+
+test_sweep_reports_an_agent_declared_for_another_home() {
+  local world out id
+  require_procfs || { pass "skip: this host has no readable procfs for the resume sweep"; return 0; }
+  world=$(make_sweep_home sweep-foreign)
+  id="task-f4-$RUN_TAG"
+  fm_write_meta "$world/home/state/$id.meta" \
+    "window=firstmate:fm-$id" "worktree=$world/wt" "project=$world/project" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  mkdir -p "$world/other-home"
+  start_declared_agent "$world/wt" "$id" "$world/other-home" >/dev/null
+  out=$(run_sweep "$world")
+  assert_contains "$out" "ISOLATION: task $id is running as a worker of home" \
+    "the resume sweep did not report an agent declared for another home"
+  pass "the resume sweep reports an agent that declares another home as its owner"
+}
+
+test_crewmate_declaration_clears_every_inherited_home
+test_secondmate_declaration_pins_only_its_own_home
+test_declaration_refuses_rather_than_emitting_a_partial_prefix
+test_every_verified_harness_launches_with_its_home_declaration
+test_secondmate_child_receives_only_its_own_home
+test_declared_worker_is_never_a_primary_scope_match
+test_project_local_startup_adapter_stays_inert_for_a_worker
+test_worker_cannot_take_the_session_owner_record
+test_worker_cannot_spawn_or_tear_down
+test_proc_cwd_is_read_from_the_live_process
+test_declared_agent_lookup_returns_the_root_most_process
+test_provider_process_id_matrix_is_explicit
+test_spawn_settles_on_proc_evidence_over_a_lying_pane_path
+test_slot_stamp_records_ownership_and_never_stamps_a_plain_checkout
+test_clean_ownership_disposes
+test_a_second_recorded_task_retains_the_slot
+test_a_stamp_naming_another_task_retains_the_slot
+test_a_live_agent_of_another_task_retains_the_slot
+test_teardown_retires_a_contested_lease_even_with_force
+test_sweep_reports_a_worktree_that_collapsed_onto_the_primary_checkout
+test_sweep_is_silent_for_a_correctly_isolated_worker
+test_sweep_never_promotes_a_pane_path_to_evidence
+test_sweep_reports_an_agent_declared_for_another_home
+
+echo "# all fm-worker-isolation tests passed"

--- a/tests/fm-worker-isolation.test.sh
+++ b/tests/fm-worker-isolation.test.sh
@@ -143,6 +143,15 @@ case "$*" in
   *"#{pane_pid}"*) printf '%s\n' "${FM_FAKE_PANE_PID:-}"; exit 0 ;;
 esac
 case "${1:-}" in
+  # The stable-window-id enumeration. The duplicate-name check spawn runs first
+  # asks for '#{window_name}' alone and must still answer nothing, or spawn
+  # would refuse the launch as a duplicate.
+  list-windows)
+    case "$*" in
+      *"#{window_id}"*) printf '%s %s\n' "${FM_FAKE_WINDOW_ID:-@1}" "${FM_FAKE_WINDOW_NAME:-}" ;;
+    esac
+    exit 0
+    ;;
   display-message) printf 'firstmate\n'; exit 0 ;;
   send-keys)
     prev=
@@ -352,6 +361,100 @@ test_provider_process_id_matrix_is_explicit() {
   pass "providers with no verified per-pane process id report unknown instead of a pane value"
 }
 
+make_window_id_fakebin() {  # <dir>
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  list-windows)
+    case "$*" in
+      *"#{window_id}"*) printf '@7 fm-live\n' ;;
+    esac
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      # The one honest answer: the pane of the window actually asked for.
+      *"-t @7 "*) printf '4242\n' ;;
+      # What real tmux does with a target it cannot resolve - it answers for the
+      # ACTIVE CLIENT's window, which is firstmate's own pane.
+      *) printf '9999\n' ;;
+    esac
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  printf '%s\n' "$fakebin"
+}
+
+# agent_cwd_call <fakebin> <function> [args...]: call one bin/fm-agent-cwd-lib.sh
+# function with <fakebin> ahead of PATH, in a child shell so the fake provider
+# never leaks into the rest of the suite.
+agent_cwd_call() {
+  local fakebin=$1
+  shift
+  PATH="$fakebin:$PATH" bash -c '. "$1/bin/fm-agent-cwd-lib.sh" || exit 1; shift; "$@"' \
+    _ "$ROOT" "$@"
+}
+
+test_tmux_pane_pid_comes_from_the_stable_window_id() {
+  local fakebin out
+  fakebin=$(make_window_id_fakebin "$TMP_ROOT/window-id")
+  out=$(agent_cwd_call "$fakebin" fm_agent_backend_shell_pid tmux 'firstmate:fm-live')
+  [ "$out" = 4242 ] \
+    || fail "the pane pid was not read through the window's stable id: $out"
+  pass "a tmux pane pid is read through the window's stable id, not its name"
+}
+
+test_a_lost_window_name_never_answers_with_firstmates_own_pane() {
+  local fakebin out status
+  fakebin=$(make_window_id_fakebin "$TMP_ROOT/window-lost")
+  out=$(agent_cwd_call "$fakebin" fm_agent_backend_shell_pid tmux 'firstmate:fm-renamed-away')
+  status=$?
+  expect_code 1 "$status" "a window name that resolves to nothing must not yield a pid"
+  [ -z "$out" ] || fail "a lost window name answered with another window's pane pid: $out"
+  out=$(agent_cwd_call "$fakebin" fm_agent_cwd_verdict '' tmux 'firstmate:fm-renamed-away')
+  case "$out" in
+    unknown*) : ;;
+    *) fail "a lost window name produced a verdict instead of unknown: $out" ;;
+  esac
+  pass "a lost or renamed window reports unknown instead of firstmate's own pane"
+}
+
+test_one_proc_walk_answers_every_task_in_a_sweep() {
+  local dir dir_real index one two out
+  require_procfs || { pass "skip: this host has no readable procfs for the process index"; return 0; }
+  dir="$TMP_ROOT/proc-index"
+  mkdir -p "$dir"
+  dir_real=$(cd "$dir" && pwd -P)
+  one="index-one-d6-$RUN_TAG"
+  two="index-two-d6-$RUN_TAG"
+  start_declared_agent "$dir" "$one" "$TMP_ROOT/proc-home" >/dev/null
+  start_declared_agent "$dir" "$two" "$TMP_ROOT/proc-home" >/dev/null
+  index=$( . "$ROOT/bin/fm-agent-cwd-lib.sh" && fm_agent_task_pid_index )
+  assert_contains "$index" "$one" "the single process walk missed a declared task"
+  assert_contains "$index" "$two" "the single process walk missed a declared task"
+  out=$( . "$ROOT/bin/fm-agent-cwd-lib.sh" \
+    && fm_agent_cwd_verdict "$two" '' '' "$index" )
+  case "$out" in
+    proc*"$dir_real") : ;;
+    *) fail "a verdict taken from the shared index did not prove the process cwd: $out" ;;
+  esac
+  # An index with no entry for the task is a real answer, not a missing
+  # argument: it must not silently fall back to a fresh walk that finds one.
+  out=$( . "$ROOT/bin/fm-agent-cwd-lib.sh" \
+    && fm_agent_cwd_verdict "$two" '' '' '' )
+  case "$out" in
+    unknown*) : ;;
+    *) fail "an empty shared index was treated as no index at all: $out" ;;
+  esac
+  pass "one /proc walk answers every task in a sweep, and an empty index is a real answer"
+}
+
 test_spawn_settles_on_proc_evidence_over_a_lying_pane_path() {
   local rec id out status lying pid
   require_procfs || { pass "skip: this host has no readable procfs for spawn settle proof"; return 0; }
@@ -367,6 +470,7 @@ test_spawn_settles_on_proc_evidence_over_a_lying_pane_path() {
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_PANE_PATH="$lying" FM_FAKE_PANE_PID="$pid" \
+    FM_FAKE_WINDOW_NAME="fm-$id" \
     FM_FAKE_LAUNCH_LOG="$CASE_DIR/launch.log" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" --harness claude 2>&1)
@@ -492,6 +596,80 @@ test_a_live_agent_of_another_task_retains_the_slot() {
   pass "a slot occupied by another task's live agent retains its lease"
 }
 
+test_a_relinquished_slot_is_releasable_by_its_remaining_holder() {
+  # The exact reported leak sequence. B is the stamped true owner and paused A's
+  # stale metadata also names the slot, so B retains and its own metadata goes.
+  # If B's stamp outlived it, A's later teardown would retain on the stamp with
+  # nothing left referencing the slot, and the pool would lose it forever.
+  local rec verdict stamp
+  rec=$(make_slot_world slot-relinquish)
+  read_slot_world "$rec"
+  fm_write_meta "$WORLD/home/state/owner-e7.meta" \
+    "window=firstmate:fm-owner-e7" "worktree=$WT_DIR" "project=$PROJ_DIR" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  fm_write_meta "$WORLD/home/state/paused-e7.meta" \
+    "window=firstmate:fm-paused-e7" "worktree=$WT_DIR" "project=$PROJ_DIR" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_write "$WT_DIR" owner-e7 "$WORLD/home" )
+
+  verdict=$(slot_verdict "$WORLD/home/state" owner-e7 "$WT_DIR" "$WORLD/home")
+  case "$verdict" in
+    "retain: slot is also recorded by task(s) paused-e7"*) : ;;
+    *) fail "the stamped owner did not retain against the paused task's record: $verdict" ;;
+  esac
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_relinquish "$WT_DIR" owner-e7 "$verdict" )
+  stamp=$( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_field "$WT_DIR" task || printf 'none' )
+  [ "$stamp" = none ] \
+    || fail "the retiring owner's own stamp outlived it and still names $stamp"
+  rm -f "$WORLD/home/state/owner-e7.meta"
+
+  verdict=$(slot_verdict "$WORLD/home/state" paused-e7 "$WT_DIR" "$WORLD/home")
+  [ "$verdict" = dispose ] \
+    || fail "the last holder could not release a slot nothing else references: $verdict"
+  pass "a retiring owner gives up its own stamp so the remaining holder can still release the slot"
+}
+
+test_a_stamp_naming_another_task_survives_a_retain_and_still_blocks() {
+  # The complementary case, and the reason the clear above is narrow. Here the
+  # stamp names a THIRD task, so it is positive evidence the slot was reissued.
+  # Clearing it would let the stale task dispose of a slot whose real occupant
+  # merely has no live process right now - destroying preserved work.
+  local rec verdict stamp
+  rec=$(make_slot_world slot-preserve)
+  read_slot_world "$rec"
+  fm_write_meta "$WORLD/home/state/stale-e8.meta" \
+    "window=firstmate:fm-stale-e8" "worktree=$WT_DIR" "project=$PROJ_DIR" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  fm_write_meta "$WORLD/home/state/other-e8.meta" \
+    "window=firstmate:fm-other-e8" "worktree=$WT_DIR" "project=$PROJ_DIR" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off"
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_write "$WT_DIR" reissued-e8 "$WORLD/home" )
+
+  verdict=$(slot_verdict "$WORLD/home/state" stale-e8 "$WT_DIR" "$WORLD/home")
+  case "$verdict" in
+    "retain: slot is also recorded by task(s) other-e8"*) : ;;
+    *) fail "the metadata conflict was not the retain reason under test: $verdict" ;;
+  esac
+  ( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_relinquish "$WT_DIR" stale-e8 "$verdict" )
+  stamp=$( . "$ROOT/bin/fm-slot-owner-lib.sh" \
+    && fm_slot_stamp_field "$WT_DIR" task || printf 'none' )
+  [ "$stamp" = reissued-e8 ] \
+    || fail "a stamp naming another task was cleared on retain: $stamp"
+  rm -f "$WORLD/home/state/stale-e8.meta" "$WORLD/home/state/other-e8.meta"
+
+  verdict=$(slot_verdict "$WORLD/home/state" stale-e8 "$WT_DIR" "$WORLD/home")
+  case "$verdict" in
+    "retain: slot ownership stamp names task reissued-e8"*) : ;;
+    *) fail "a preserved stamp stopped blocking disposal for a stale task: $verdict" ;;
+  esac
+  pass "a stamp naming another task survives a retain and still blocks that slot's disposal"
+}
+
 test_teardown_retires_a_contested_lease_even_with_force() {
   local rec fakebin out status
   rec=$(make_slot_world slot-teardown)
@@ -610,6 +788,39 @@ test_sweep_reports_an_agent_declared_for_another_home() {
   pass "the resume sweep reports an agent that declares another home as its owner"
 }
 
+test_sweep_is_silent_for_a_healthy_secondmate() {
+  # A secondmate is deliberately launched declaring its OWN home while its
+  # record lives in the launching primary's state directory. Judging that
+  # declaration against the sweeping home would print an actionable, wrong
+  # "stop this worker" line on every session start in any fleet that has one.
+  local world out id sub_home
+  require_procfs || { pass "skip: this host has no readable procfs for the resume sweep"; return 0; }
+  world=$(make_sweep_home sweep-secondmate)
+  id="dom-f5-$RUN_TAG"
+  sub_home="$world/secondmate-home"
+  mkdir -p "$sub_home/state"
+  fm_write_secondmate_meta "$world/home/state/$id.meta" "$sub_home" "firstmate:fm-$id"
+  start_declared_agent "$sub_home" "$id" "$sub_home" secondmate >/dev/null
+  out=$(run_sweep "$world")
+  [ -z "$out" ] || fail "the resume sweep reported a healthy live secondmate: $out"
+  pass "the resume sweep stays silent for a secondmate that declares its own home"
+}
+
+test_sweep_still_reports_a_secondmate_running_for_a_foreign_home() {
+  local world out id sub_home
+  require_procfs || { pass "skip: this host has no readable procfs for the resume sweep"; return 0; }
+  world=$(make_sweep_home sweep-secondmate-foreign)
+  id="dom-f6-$RUN_TAG"
+  sub_home="$world/secondmate-home"
+  mkdir -p "$sub_home/state" "$world/other-home"
+  fm_write_secondmate_meta "$world/home/state/$id.meta" "$sub_home" "firstmate:fm-$id"
+  start_declared_agent "$sub_home" "$id" "$world/other-home" secondmate >/dev/null
+  out=$(run_sweep "$world")
+  assert_contains "$out" "ISOLATION: task $id is running as a worker of home" \
+    "the resume sweep excused a secondmate declaring a home its record does not name"
+  pass "the resume sweep still reports a secondmate whose declared home is not the one it owns"
+}
+
 test_crewmate_declaration_clears_every_inherited_home
 test_secondmate_declaration_pins_only_its_own_home
 test_declaration_refuses_rather_than_emitting_a_partial_prefix
@@ -622,16 +833,23 @@ test_worker_cannot_spawn_or_tear_down
 test_proc_cwd_is_read_from_the_live_process
 test_declared_agent_lookup_returns_the_root_most_process
 test_provider_process_id_matrix_is_explicit
+test_tmux_pane_pid_comes_from_the_stable_window_id
+test_a_lost_window_name_never_answers_with_firstmates_own_pane
+test_one_proc_walk_answers_every_task_in_a_sweep
 test_spawn_settles_on_proc_evidence_over_a_lying_pane_path
 test_slot_stamp_records_ownership_and_never_stamps_a_plain_checkout
 test_clean_ownership_disposes
 test_a_second_recorded_task_retains_the_slot
 test_a_stamp_naming_another_task_retains_the_slot
 test_a_live_agent_of_another_task_retains_the_slot
+test_a_relinquished_slot_is_releasable_by_its_remaining_holder
+test_a_stamp_naming_another_task_survives_a_retain_and_still_blocks
 test_teardown_retires_a_contested_lease_even_with_force
 test_sweep_reports_a_worktree_that_collapsed_onto_the_primary_checkout
 test_sweep_is_silent_for_a_correctly_isolated_worker
 test_sweep_never_promotes_a_pane_path_to_evidence
 test_sweep_reports_an_agent_declared_for_another_home
+test_sweep_is_silent_for_a_healthy_secondmate
+test_sweep_still_reports_a_secondmate_running_for_a_foreign_home
 
 echo "# all fm-worker-isolation tests passed"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -169,6 +169,17 @@ fm_write_secondmate_meta() {
     "projects=$projects"
 }
 
+# --- launched-agent home declaration ----------------------------------------
+
+# fm_worker_env_prefix <role> <task-id> <home>: the exact home declaration
+# bin/fm-spawn.sh prepends to every launch command. Composed from the one owner
+# (bin/fm-worker-isolation-lib.sh) so a test pinning a HARNESS TEMPLATE does not
+# also re-pin the declaration; tests/fm-worker-isolation.test.sh pins the
+# declaration's own bytes.
+fm_worker_env_prefix() {
+  ( . "$ROOT/bin/fm-worker-isolation-lib.sh" && fm_worker_launch_env_prefix "$@" )
+}
+
 # --- common assertions ------------------------------------------------------
 
 # assert_contains <haystack> <needle> <msg>


### PR DESCRIPTION
## What

Task workers could inherit the operational home that launched them, be trusted from a stale record about where they were running, and release a pooled worktree slot another task still held. Three defects were observed live and drive this change.

1. **Home inheritance.** An audit worker inherited the launching primary's exported `FM_HOME`, so every firstmate script it ran resolved that primary's state directory. It took the primary's own session-owner record, and the real primary came back from a suspend/resume locked out of its home with monitoring stopped.
2. **Restore did not preserve isolation.** After a reboot the session provider restored every pane by resuming its recorded agent session but resolved each working directory back to the repository the worktree was derived from, collapsing 17 of 17 isolated worktrees onto their origin, four into the primary checkout. A spawn-time assertion does not survive a restore.
3. **`worktree=` is not ownership.** Ten pooled slots were recorded by more than one task. The hazard fired: tearing down one task released a lease a still-live quarantined-paused task also recorded, and the pool reissued that slot to a new spawn.

A fourth finding corrected the investigation method itself: a pane listing reported a worker's cwd as the primary checkout while `/proc` showed it correctly isolated, so `/proc/<agent-pid>/cwd` is the check of record and pane cwd is only a hint.

## How

Four mechanisms, one owner each, documented in `docs/worker-isolation.md`.

- **`bin/fm-worker-isolation-lib.sh`** declares the owning home at launch, so ownership is never inferred downstream from cwd, pane, or process tree. A crewmate carries no home; a secondmate carries only its own. `fm-lock`, `fm-primary-scope-lib`, `fm-spawn`, and `fm-teardown` consume the declaration and refuse, which also keeps project-local startup and turn-end adapters inert for workers.
- **`bin/fm-agent-cwd-lib.sh`** makes the agent process's own cwd authoritative. A pane field can name a different process, so it stays a hint; a provider with no per-pane process id reports `unknown` rather than degrading to a pane path. tmux targets resolve to a stable window id first, because `display-message` given an unknown window name silently answers for the active client's window.
- **`bin/fm-slot-owner-lib.sh`** gates slot release on positive evidence of a conflict. A contested lease is retired, not returned, and `--force` does not waive it: `--force` is authority over this task's work, never another task's slot.
- **`bin/fm-isolation-sweep.sh`** re-establishes isolation at session start, surfacing `ISOLATION:` findings beside the existing `TANGLE:` check.

## Verification

`tests/fm-worker-isolation.test.sh` (30 checks) covers the declaration for every verified harness, each consuming refusal, the process-cwd method of record against a deliberately lying pane path, the per-provider matrix, all slot-conflict forms, and the sweep outcomes. Orca and secondmate-home refusals are covered in the suites that own those fixtures.

`bin/fm-lint.sh`, `bin/fm-doc-audience-check.sh`, and the CI test-partition coverage guard are clean.

Two suites fail identically on base `a5fe1bc` and are unrelated to this change: `fm-session-start.test.sh` (Herdr husk emits an unexpected `SECONDMATE_LIVENESS:` line) and `fm-calm-pi-extension.test.sh` (a Pi version pin wanting 0.81.1/0.82.0 against an installed 0.82.1).

## Note

Opened from a fork because the author lacks write access to this repository. CI may need maintainer approval to run.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

Run `01KYG7DCY2VTZX20CN8WH89KSF` on this branch, gates in order:

| Step | Result |
|---|---|
| intent | completed |
| rebase | completed |
| review | completed after two fix rounds, 7 findings resolved |
| test | completed, 90 suites run, 88 pass |
| document | completed, 2 informational findings |
| lint | completed clean (`bin/fm-lint.sh`) |
| push | **failed: HTTP 403, no write access to this repository** |

Every validation gate passed. The pipeline's own `push` step could not publish because the author lacks write access here, so the validated branch was pushed to the author's fork and this PR was raised from it by hand. The commits are exactly the ones the pipeline produced, unchanged:

```
d1834ab no-mistakes(document): fix stale isolation, primary-scope, and teardown documentation
326f95c no-mistakes(test): link newly sourced teardown libs in fm-gotmp fake root
7e83139 no-mistakes(review): keep refused teardowns from clearing the slot stamp
fc15161 no-mistakes(review): fix worker-isolation sweep, slot-lease, and teardown scope defects
7ac5b34 fix(bin): stop task workers inheriting the primary home and pooled slots
```
