### PR TITLE
feat(watcher): add off-by-default Bridge inbox check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ config/startup-memory-budget     primary-authoritative per-home startup-memory b
 config/herdr-presentation-spaces  optional presence flag for Herdr's default-off disposable single-task visual projection; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Optional presentation spaces"
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
-config/bridge-vessel  optional Bridge inbox vessel name(s), space-separated; LOCAL, gitignored; read only when FM_BRIDGE_VESSEL is unset, and absent with that variable also unset disables Bridge inbox scanning entirely (docs/configuration.md "Bridge inbox check")
+config/bridge-vessel  optional Bridge inbox vessel name(s), space-separated; LOCAL, gitignored; read only when FM_BRIDGE_VESSEL is unset or empty, and absent with that variable also unset or empty disables Bridge inbox scanning entirely (docs/configuration.md "Bridge inbox check")
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ config/startup-memory-budget     primary-authoritative per-home startup-memory b
 config/herdr-presentation-spaces  optional presence flag for Herdr's default-off disposable single-task visual projection; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Optional presentation spaces"
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
+config/bridge-vessel  optional Bridge inbox vessel name(s), space-separated; LOCAL, gitignored; read only when FM_BRIDGE_VESSEL is unset, and absent with that variable also unset disables Bridge inbox scanning entirely (docs/configuration.md "Bridge inbox check")
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
@@ -113,7 +114,7 @@ state/               volatile runtime signals; gitignored
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
   .claude-autoarm.lock .claude-autoarm-epoch .turnend-claude-blocks   Claude Stop auto-arm single-flight, epoch, and guard-budget records; never touch
-  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
+  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak .bridge-*   watcher internals; never touch
   .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
   .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
   .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
@@ -365,7 +366,7 @@ Handle actionable wakes as follows:
 
 1. For `signal:`, read the listed event lines first, then reconcile current state only where action depends on it.
 2. For `stale:`, inspect the recorded endpoint and load `stuck-crewmate-recovery` for a stopped, looping, confused, or unresponsive worker; a deep-inspection reason also requires current-state and validation-log inspection.
-3. For `check:`, act on the named poll result, including merges, X-mode events, and process-to-event source results.
+3. For `check:`, act on the named poll result, including merges, Bridge inbox traffic, X-mode events, and process-to-event source results.
 4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.

--- a/bin/fm-bounded-process-lib.sh
+++ b/bin/fm-bounded-process-lib.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Shared owner of bounded child execution.
+#
+# Every timed read in this tree runs through run_bounded_process, so the
+# fallback's signal hardening - the same handler on ALRM and on HUP/INT/TERM,
+# tearing the child's process group down instead of orphaning it - can never be
+# half-present in a second copy. The function execs, so callers that need to
+# keep running invoke it inside a subshell.
+#
+# FM_CHECK_OWNED_GROUP=1 keeps the child in the caller's own process group for a
+# caller that already owns and tears down that group; the default gives the
+# child its own. FM_CHECK_FORCE_FALLBACK=1 selects the perl path even where
+# timeout or gtimeout exists, so the fallback stays testable everywhere.
+
+run_bounded_process() {  # <timeout-seconds> <command> [args...]
+  local t=$1
+  shift
+  if [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v timeout >/dev/null 2>&1; then
+    exec timeout "$t" "$@"
+  elif [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v gtimeout >/dev/null 2>&1; then
+    exec gtimeout "$t" "$@"
+  else
+    # shellcheck disable=SC2016  # single quotes are deliberate: Perl expands its own variables.
+    exec perl -e 'my $t = shift; my $owned = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0) unless $owned; exec @ARGV } my $group = $owned ? getpgrp(0) : $pid; my $stop = sub { $SIG{HUP} = $SIG{INT} = $SIG{TERM} = "IGNORE"; kill "TERM", -$group; select undef, undef, undef, 0.2; kill "KILL", -$group; waitpid $pid, 0; exit 124 }; local $SIG{ALRM} = $stop; local $SIG{HUP} = $stop; local $SIG{INT} = $stop; local $SIG{TERM} = $stop; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$t" "${FM_CHECK_OWNED_GROUP:-0}" "$@"
+  fi
+}

--- a/bin/fm-bridge-inbox-lib.sh
+++ b/bin/fm-bridge-inbox-lib.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 # Shared read-only Bridge inbox detection and durable wake publication.
 #
-# Source after bin/fm-wake-lib.sh, which owns fm_wake_append.
+# Source after bin/fm-wake-lib.sh, which owns fm_wake_append, and from a caller
+# that owns run_bounded_process (bin/fm-watch.sh) - every Bridge read goes
+# through that one bounded-process helper rather than a private copy, so the
+# child's process group is torn down with the watcher on HUP/INT/TERM too.
 #
 # bridge_inbox_surface
 #   Compares every watched vessel's fetched inbox tree against its own surfaced
-#   marker, appends ONE durable check wake covering the vessels whose pending
-#   mail is new, and publishes their markers only after that append succeeded.
-#   Prints one actionable reason only when it durably appended a new wake, so a
-#   crash between detection and enqueue re-detects instead of losing the mail.
+#   marker and, for each vessel whose pending mail is new, appends a durable
+#   check wake keyed on that vessel alone, publishing that vessel's marker only
+#   after its own append succeeded. The queue keeps the last record per kind and
+#   key, so a shared key would let a vessel enqueued later collapse an earlier
+#   vessel's still-undrained record while that vessel's marker already claims it
+#   was surfaced; per-vessel keys are what make each vessel independent in the
+#   drained output too. Prints one actionable reason naming every vessel
+#   surfaced this cycle, and only for vessels whose append succeeded, so a crash
+#   between detection and enqueue re-detects instead of losing the mail.
 #
 # bridge_inbox_fetch
 #   Refreshes the shared clone's origin/main ref. Every read below resolves
@@ -24,15 +32,17 @@ FM_BRIDGE_LIB_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_BRIDGE_LIB_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_BRIDGE_LIB_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-${STATE:-$FM_HOME/state}}"
 BRIDGE_CHECK_TIMEOUT=${FM_CHECK_TIMEOUT:-${CHECK_TIMEOUT:-30}}
-BRIDGE_ROOT=${FM_BRIDGE_ROOT:-$FM_HOME/projects/coditan-bridge}
+BRIDGE_CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+BRIDGE_ROOT=${FM_BRIDGE_ROOT:-${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}/coditan-bridge}
 BRIDGE_URGENT_CHECK_INTERVAL=${FM_BRIDGE_URGENT_CHECK_INTERVAL:-30}
 
+# read reports failure at EOF on a final line with no newline, having already
+# assigned it, so the vessel is taken from the variable rather than the status.
+BRIDGE_VESSEL_RAW=
 if [ -n "${FM_BRIDGE_VESSEL:-}" ]; then
   BRIDGE_VESSEL_RAW=$FM_BRIDGE_VESSEL
-elif [ -f "$FM_HOME/config/bridge-vessel" ]; then
-  IFS= read -r BRIDGE_VESSEL_RAW < "$FM_HOME/config/bridge-vessel" || BRIDGE_VESSEL_RAW=
-else
-  BRIDGE_VESSEL_RAW=
+elif [ -f "$BRIDGE_CONFIG/bridge-vessel" ]; then
+  IFS= read -r BRIDGE_VESSEL_RAW < "$BRIDGE_CONFIG/bridge-vessel" || true
 fi
 
 # BRIDGE_VESSEL keeps the first/primary value so a pre-existing single-vessel
@@ -43,39 +53,33 @@ read -r -a BRIDGE_VESSELS <<< "$BRIDGE_VESSEL_RAW"
 BRIDGE_VESSEL=${BRIDGE_VESSELS[0]:-}
 
 bridge_run_bounded() {
-  if [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v timeout >/dev/null 2>&1; then
-    timeout "$BRIDGE_CHECK_TIMEOUT" "$@" 2>/dev/null || true
-  elif [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "$BRIDGE_CHECK_TIMEOUT" "$@" 2>/dev/null || true
-  else
-    # shellcheck disable=SC2016
-    perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$BRIDGE_CHECK_TIMEOUT" "$@" 2>/dev/null || true
-  fi
+  ( run_bounded_process "$BRIDGE_CHECK_TIMEOUT" "$@" ) 2>/dev/null || true
 }
 
-bridge_pending_priority_scan() {
-  local inbox="inbox/$BRIDGE_VESSEL/new" f priority rank=-1
-  while IFS= read -r -d '' f; do
-    case "$f" in *.json) ;; *) continue ;; esac
-    priority=$(git -C "$BRIDGE_ROOT" show "origin/main:$inbox/$f" 2>/dev/null | jq -r '.priority // "normal"' 2>/dev/null || echo normal)
-    case "$priority" in
-      immediate) rank=3 ;;
-      high) [ "$rank" -lt 2 ] && rank=2 ;;
-      normal) [ "$rank" -lt 1 ] && rank=1 ;;
-      low) [ "$rank" -lt 0 ] && rank=0 ;;
-      *) [ "$rank" -lt 1 ] && rank=1 ;;
-    esac
-  done < <(git -C "$BRIDGE_ROOT" ls-tree -z --name-only "origin/main:$inbox" 2>/dev/null)
-  case "$rank" in 3) echo immediate ;; 2) echo high ;; 1) echo normal ;; 0) echo low ;; *) echo none ;; esac
-}
-export -f bridge_pending_priority_scan
+# A whole scan, not a single git call, is what has to stay inside one bounded
+# read, so each scan runs as a child shell. Their programs are passed inline
+# with the clone and vessel as positional arguments, so nothing about this
+# default-off feature is exported into the environment of every other process
+# the watcher spawns.
+# shellcheck disable=SC2016  # single quotes are deliberate: the child shell expands these.
+BRIDGE_SIGNATURE_SCAN='sig=$(git -C "$1" rev-parse "origin/main:inbox/$2/new" 2>/dev/null || true); printf "%s" "${sig:-empty}"'
 
-bridge_inbox_signature_scan() {
-  local inbox="inbox/$BRIDGE_VESSEL/new" sig
-  sig=$(git -C "$BRIDGE_ROOT" rev-parse "origin/main:$inbox" 2>/dev/null || true)
-  printf '%s' "${sig:-empty}"
-}
-export -f bridge_inbox_signature_scan
+# shellcheck disable=SC2016
+BRIDGE_PRIORITY_SCAN='
+root=$1; inbox="inbox/$2/new"; rank=-1
+while IFS= read -r -d "" f; do
+  case "$f" in *.json) ;; *) continue ;; esac
+  priority=$(git -C "$root" show "origin/main:$inbox/$f" 2>/dev/null | jq -r ".priority // \"normal\"" 2>/dev/null || echo normal)
+  case "$priority" in
+    immediate) rank=3 ;;
+    high) [ "$rank" -lt 2 ] && rank=2 ;;
+    normal) [ "$rank" -lt 1 ] && rank=1 ;;
+    low) [ "$rank" -lt 0 ] && rank=0 ;;
+    *) [ "$rank" -lt 1 ] && rank=1 ;;
+  esac
+done < <(git -C "$root" ls-tree -z --name-only "origin/main:$inbox" 2>/dev/null)
+case "$rank" in 3) echo immediate ;; 2) echo high ;; 1) echo normal ;; 0) echo low ;; *) echo none ;; esac
+'
 
 # The fetched inbox tree object id is the whole change signal: it advances on a
 # new, edited, or acknowledged envelope and on nothing else. "timeout" is a
@@ -83,7 +87,7 @@ export -f bridge_inbox_signature_scan
 # for an empty inbox.
 bridge_inbox_signature() {
   local vessel=${1:-$BRIDGE_VESSEL} out
-  out=$(BRIDGE_ROOT="$BRIDGE_ROOT" BRIDGE_VESSEL="$vessel" bridge_run_bounded bash -c 'bridge_inbox_signature_scan')
+  out=$(bridge_run_bounded bash -c "$BRIDGE_SIGNATURE_SCAN" _ "$BRIDGE_ROOT" "$vessel")
   printf '%s' "${out:-timeout}"
 }
 
@@ -108,7 +112,7 @@ bridge_pending_priority() {
   fi
   if [ "$sig" = timeout ]; then printf '%s' "${cached_priority:-none}"; return; fi
   if [ -n "$cached_sig" ] && [ "$sig" = "$cached_sig" ]; then printf '%s' "${cached_priority:-none}"; return; fi
-  out=$(BRIDGE_ROOT="$BRIDGE_ROOT" BRIDGE_VESSEL="$vessel" bridge_run_bounded bash -c 'bridge_pending_priority_scan')
+  out=$(bridge_run_bounded bash -c "$BRIDGE_PRIORITY_SCAN" _ "$BRIDGE_ROOT" "$vessel")
   if [ -z "$out" ]; then printf '%s' "${cached_priority:-none}"; return; fi
   printf '%s\t%s\n' "$sig" "$out" > "$cache" 2>/dev/null || true
   printf '%s' "$out"
@@ -140,8 +144,7 @@ bridge_inbox_fetch() {
 }
 
 bridge_inbox_surface() {
-  local vessel marker sig surfaced vessel_out out="" reason="" i
-  local marker_paths=() marker_sigs=()
+  local vessel marker sig surfaced vessel_out out=""
 
   [ "${#BRIDGE_VESSELS[@]}" -gt 0 ] || return 0
   [ -d "$BRIDGE_ROOT/.git" ] || return 0
@@ -154,9 +157,9 @@ bridge_inbox_surface() {
     [ "$sig" != "$surfaced" ] || continue
     vessel_out=$(bridge_inbox_check "$vessel" "$sig")
     if [ -n "$vessel_out" ]; then
+      fm_wake_append check "bridge-inbox:$vessel" "check: bridge-inbox: $vessel_out" || return "$?"
+      printf '%s' "$sig" > "$marker" 2>/dev/null || true
       out="${out:+$out; }$vessel_out"
-      marker_paths[${#marker_paths[@]}]=$marker
-      marker_sigs[${#marker_sigs[@]}]=$sig
     else
       # An acknowledged inbox drops its marker so the same envelopes surface
       # again if Bridge re-delivers them byte-identically later.
@@ -165,12 +168,5 @@ bridge_inbox_surface() {
   done
 
   [ -n "$out" ] || return 0
-  reason="check: bridge-inbox: $out"
-  fm_wake_append check bridge-inbox "$reason" || return "$?"
-  i=0
-  while [ "$i" -lt "${#marker_paths[@]}" ]; do
-    printf '%s' "${marker_sigs[$i]}" > "${marker_paths[$i]}" 2>/dev/null || true
-    i=$((i + 1))
-  done
-  printf '%s\n' "$reason"
+  printf 'check: bridge-inbox: %s\n' "$out"
 }

--- a/bin/fm-bridge-inbox-lib.sh
+++ b/bin/fm-bridge-inbox-lib.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # Shared read-only Bridge inbox detection and durable wake publication.
 #
-# Source after bin/fm-wake-lib.sh, which owns fm_wake_append, and from a caller
-# that owns run_bounded_process (bin/fm-watch.sh) - every Bridge read goes
-# through that one bounded-process helper rather than a private copy, so the
-# child's process group is torn down with the watcher on HUP/INT/TERM too.
+# Source after bin/fm-wake-lib.sh, which owns fm_wake_append. The bounded-child
+# helper every Bridge read goes through is required here directly rather than
+# expected from the caller, because a missing one would otherwise degrade into
+# every read timing out and every vessel being skipped in silence.
 #
 # bridge_inbox_surface
 #   Compares every watched vessel's fetched inbox tree against its own surfaced
@@ -28,6 +28,8 @@
 # or otherwise write an envelope: acknowledgement stays with the Bridge tooling.
 
 FM_BRIDGE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-bounded-process-lib.sh
+. "$FM_BRIDGE_LIB_DIR/fm-bounded-process-lib.sh"
 FM_BRIDGE_LIB_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_BRIDGE_LIB_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_BRIDGE_LIB_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-${STATE:-$FM_HOME/state}}"
@@ -35,6 +37,9 @@ BRIDGE_CHECK_TIMEOUT=${FM_CHECK_TIMEOUT:-${CHECK_TIMEOUT:-30}}
 BRIDGE_CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 BRIDGE_ROOT=${FM_BRIDGE_ROOT:-${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}/coditan-bridge}
 BRIDGE_URGENT_CHECK_INTERVAL=${FM_BRIDGE_URGENT_CHECK_INTERVAL:-30}
+case "$BRIDGE_URGENT_CHECK_INTERVAL" in
+  ''|*[!0-9]*) BRIDGE_URGENT_CHECK_INTERVAL=30 ;;
+esac
 
 # read reports failure at EOF on a final line with no newline, having already
 # assigned it, so the vessel is taken from the variable rather than the status.

--- a/bin/fm-bridge-inbox-lib.sh
+++ b/bin/fm-bridge-inbox-lib.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Shared read-only Bridge inbox detection and durable wake publication.
+#
+# Source after bin/fm-wake-lib.sh, which owns fm_wake_append.
+#
+# bridge_inbox_surface
+#   Compares every watched vessel's fetched inbox tree against its own surfaced
+#   marker, appends ONE durable check wake covering the vessels whose pending
+#   mail is new, and publishes their markers only after that append succeeded.
+#   Prints one actionable reason only when it durably appended a new wake, so a
+#   crash between detection and enqueue re-detects instead of losing the mail.
+#
+# bridge_inbox_fetch
+#   Refreshes the shared clone's origin/main ref. Every read below resolves
+#   against that fetched ref rather than the working tree, so a stale or dirty
+#   local checkout can neither invent nor mask pending mail, and the checkout is
+#   never mutated.
+#
+# All Bridge reads are bounded by FM_CHECK_TIMEOUT and never acknowledge, move,
+# or otherwise write an envelope: acknowledgement stays with the Bridge tooling.
+
+FM_BRIDGE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_BRIDGE_LIB_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_BRIDGE_LIB_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_BRIDGE_LIB_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-${STATE:-$FM_HOME/state}}"
+BRIDGE_CHECK_TIMEOUT=${FM_CHECK_TIMEOUT:-${CHECK_TIMEOUT:-30}}
+BRIDGE_ROOT=${FM_BRIDGE_ROOT:-$FM_HOME/projects/coditan-bridge}
+BRIDGE_URGENT_CHECK_INTERVAL=${FM_BRIDGE_URGENT_CHECK_INTERVAL:-30}
+
+if [ -n "${FM_BRIDGE_VESSEL:-}" ]; then
+  BRIDGE_VESSEL_RAW=$FM_BRIDGE_VESSEL
+elif [ -f "$FM_HOME/config/bridge-vessel" ]; then
+  IFS= read -r BRIDGE_VESSEL_RAW < "$FM_HOME/config/bridge-vessel" || BRIDGE_VESSEL_RAW=
+else
+  BRIDGE_VESSEL_RAW=
+fi
+
+# BRIDGE_VESSEL keeps the first/primary value so a pre-existing single-vessel
+# configuration reads exactly as before, while the ordered array carries the
+# optional space-separated multi-vessel list.
+BRIDGE_VESSELS=()
+read -r -a BRIDGE_VESSELS <<< "$BRIDGE_VESSEL_RAW"
+BRIDGE_VESSEL=${BRIDGE_VESSELS[0]:-}
+
+bridge_run_bounded() {
+  if [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v timeout >/dev/null 2>&1; then
+    timeout "$BRIDGE_CHECK_TIMEOUT" "$@" 2>/dev/null || true
+  elif [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$BRIDGE_CHECK_TIMEOUT" "$@" 2>/dev/null || true
+  else
+    # shellcheck disable=SC2016
+    perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$BRIDGE_CHECK_TIMEOUT" "$@" 2>/dev/null || true
+  fi
+}
+
+bridge_pending_priority_scan() {
+  local inbox="inbox/$BRIDGE_VESSEL/new" f priority rank=-1
+  while IFS= read -r -d '' f; do
+    case "$f" in *.json) ;; *) continue ;; esac
+    priority=$(git -C "$BRIDGE_ROOT" show "origin/main:$inbox/$f" 2>/dev/null | jq -r '.priority // "normal"' 2>/dev/null || echo normal)
+    case "$priority" in
+      immediate) rank=3 ;;
+      high) [ "$rank" -lt 2 ] && rank=2 ;;
+      normal) [ "$rank" -lt 1 ] && rank=1 ;;
+      low) [ "$rank" -lt 0 ] && rank=0 ;;
+      *) [ "$rank" -lt 1 ] && rank=1 ;;
+    esac
+  done < <(git -C "$BRIDGE_ROOT" ls-tree -z --name-only "origin/main:$inbox" 2>/dev/null)
+  case "$rank" in 3) echo immediate ;; 2) echo high ;; 1) echo normal ;; 0) echo low ;; *) echo none ;; esac
+}
+export -f bridge_pending_priority_scan
+
+bridge_inbox_signature_scan() {
+  local inbox="inbox/$BRIDGE_VESSEL/new" sig
+  sig=$(git -C "$BRIDGE_ROOT" rev-parse "origin/main:$inbox" 2>/dev/null || true)
+  printf '%s' "${sig:-empty}"
+}
+export -f bridge_inbox_signature_scan
+
+# The fetched inbox tree object id is the whole change signal: it advances on a
+# new, edited, or acknowledged envelope and on nothing else. "timeout" is a
+# distinct third value so a bounded read that never completed is never mistaken
+# for an empty inbox.
+bridge_inbox_signature() {
+  local vessel=${1:-$BRIDGE_VESSEL} out
+  out=$(BRIDGE_ROOT="$BRIDGE_ROOT" BRIDGE_VESSEL="$vessel" bridge_run_bounded bash -c 'bridge_inbox_signature_scan')
+  printf '%s' "${out:-timeout}"
+}
+
+# The primary vessel keeps the historical unsuffixed state filenames.
+bridge_state_suffix() {
+  local vessel=$1
+  [ "$vessel" = "$BRIDGE_VESSEL" ] && return 0
+  printf -- '-%s' "$(printf '%s' "$vessel" | tr -c 'A-Za-z0-9_.-' '_')"
+}
+
+# Reading every envelope costs one git show plus one jq per file, so the derived
+# priority is cached against the tree signature that produced it and re-read only
+# when that signature moves.
+bridge_pending_priority() {
+  local sig=${1:-} vessel=${2:-$BRIDGE_VESSEL} cache cached_sig="" cached_priority="" out
+  [ -n "$vessel" ] || { printf '%s' none; return; }
+  [ -d "$BRIDGE_ROOT/.git" ] || { printf '%s' none; return; }
+  cache="$STATE/.bridge-priority-cache$(bridge_state_suffix "$vessel")"
+  [ -n "$sig" ] || sig=$(bridge_inbox_signature "$vessel")
+  if [ -f "$cache" ]; then
+    IFS=$'\t' read -r cached_sig cached_priority < "$cache" 2>/dev/null || true
+  fi
+  if [ "$sig" = timeout ]; then printf '%s' "${cached_priority:-none}"; return; fi
+  if [ -n "$cached_sig" ] && [ "$sig" = "$cached_sig" ]; then printf '%s' "${cached_priority:-none}"; return; fi
+  out=$(BRIDGE_ROOT="$BRIDGE_ROOT" BRIDGE_VESSEL="$vessel" bridge_run_bounded bash -c 'bridge_pending_priority_scan')
+  if [ -z "$out" ]; then printf '%s' "${cached_priority:-none}"; return; fi
+  printf '%s\t%s\n' "$sig" "$out" > "$cache" 2>/dev/null || true
+  printf '%s' "$out"
+}
+
+# Urgent mail in ANY watched vessel tightens the one shared fetch-and-check
+# cadence; it never changes the watcher's own CHECK_INTERVAL for other polls.
+bridge_check_interval() {
+  local vessel
+  for vessel in "${BRIDGE_VESSELS[@]}"; do
+    case "$(bridge_pending_priority "" "$vessel")" in
+      high|immediate) echo "$BRIDGE_URGENT_CHECK_INTERVAL"; return ;;
+    esac
+  done
+  echo "${CHECK_INTERVAL:-300}"
+}
+
+bridge_inbox_check() {
+  local vessel=$1 sig=${2:-}
+  local inbox="inbox/$vessel/new" highest count
+  highest=$(bridge_pending_priority "$sig" "$vessel")
+  [ "$highest" != none ] || return 0
+  count=$(bridge_run_bounded git -C "$BRIDGE_ROOT" ls-tree --name-only "origin/main:$inbox" | awk '/[.]json$/' | wc -l | tr -d '[:space:]')
+  printf 'bridge-inbox %s pending=%s highest=%s\n' "$vessel" "${count:-0}" "$highest"
+}
+
+bridge_inbox_fetch() {
+  bridge_run_bounded git -C "$BRIDGE_ROOT" fetch --quiet origin main >/dev/null
+}
+
+bridge_inbox_surface() {
+  local vessel marker sig surfaced vessel_out out="" reason="" i
+  local marker_paths=() marker_sigs=()
+
+  [ "${#BRIDGE_VESSELS[@]}" -gt 0 ] || return 0
+  [ -d "$BRIDGE_ROOT/.git" ] || return 0
+
+  for vessel in "${BRIDGE_VESSELS[@]}"; do
+    marker="$STATE/.bridge-surfaced$(bridge_state_suffix "$vessel")"
+    sig=$(bridge_inbox_signature "$vessel")
+    surfaced=$(cat "$marker" 2>/dev/null || true)
+    [ "$sig" != timeout ] || continue
+    [ "$sig" != "$surfaced" ] || continue
+    vessel_out=$(bridge_inbox_check "$vessel" "$sig")
+    if [ -n "$vessel_out" ]; then
+      out="${out:+$out; }$vessel_out"
+      marker_paths[${#marker_paths[@]}]=$marker
+      marker_sigs[${#marker_sigs[@]}]=$sig
+    else
+      # An acknowledged inbox drops its marker so the same envelopes surface
+      # again if Bridge re-delivers them byte-identically later.
+      rm -f "$marker" 2>/dev/null || true
+    fi
+  done
+
+  [ -n "$out" ] || return 0
+  reason="check: bridge-inbox: $out"
+  fm_wake_append check bridge-inbox "$reason" || return "$?"
+  i=0
+  while [ "$i" -lt "${#marker_paths[@]}" ]; do
+    printf '%s' "${marker_sigs[$i]}" > "${marker_paths[$i]}" 2>/dev/null || true
+    i=$((i + 1))
+  done
+  printf '%s\n' "$reason"
+}

--- a/bin/fm-test-isolation-proof.sh
+++ b/bin/fm-test-isolation-proof.sh
@@ -424,7 +424,8 @@ for script in "${CANDIDATES[@]}"; do
     export TMP="$work/tmp"
     # Clear ambient fleet overrides so candidates cannot share a live home.
     unset FM_HOME FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_ROOT_OVERRIDE \
-      FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND 2>/dev/null || true
+      FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND \
+      FM_BRIDGE_VESSEL FM_BRIDGE_ROOT FM_BRIDGE_URGENT_CHECK_INTERVAL 2>/dev/null || true
     cd "$ROOT" || exit 1
     begin_ms=$(now_ms)
     bash "$script" >"$work/out/stdout" 2>"$work/out/stderr"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1365,7 +1365,8 @@ else
       export TMPDIR="$work/tmp"
       export TMP="$work/tmp"
       unset FM_HOME FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_ROOT_OVERRIDE \
-        FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND 2>/dev/null || true
+        FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND \
+        FM_BRIDGE_VESSEL FM_BRIDGE_ROOT FM_BRIDGE_URGENT_CHECK_INTERVAL 2>/dev/null || true
       cd "$ROOT" || exit 1
       begin_ms=$(now_ms)
       bash "$script" >"$work/output" 2>&1

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -133,8 +133,8 @@ family_for_basename() {
       ;;
     fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
     fm-supervision-events.test.sh|fm-turnend-guard.test.sh|fm-wake-daemon-lifecycle-e2e.test.sh|\
-    fm-wake-queue.test.sh|fm-watch-checkpoint.test.sh|fm-watch-triage.test.sh|\
-    fm-watcher-lock.test.sh)
+    fm-wake-queue.test.sh|fm-watch-bridge-inbox.test.sh|fm-watch-checkpoint.test.sh|\
+    fm-watch-triage.test.sh|fm-watcher-lock.test.sh)
       printf '%s\n' watcher-wake-lock
       ;;
     fm-afk-inject-herdr-e2e.test.sh|fm-afk-launch.test.sh|fm-backend-autodetect-smoke.test.sh|\

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -51,6 +51,11 @@
 #   check: rejected unauthenticated PR poll retirement receipts: <paths>
 #                          invalid pending retirements were preserved without
 #                          running a check or removing poll artifacts
+#   check: bridge-inbox: bridge-inbox <vessel> pending=<n> highest=<priority>[; ...]
+#                          a watched Bridge vessel's fetched inbox tree carries
+#                          pending mail this watcher has not surfaced yet; read
+#                          only, on its own cadence, and silent while the tree is
+#                          unchanged (bin/fm-bridge-inbox-lib.sh)
 #   heartbeat              fleet-scan backstop found an unsurfaced captain-relevant
 #                          status, unless afk is active
 # For normal supervision, resume the session-start primary-harness protocol
@@ -113,6 +118,10 @@ HEARTBEAT=${FM_HEARTBEAT:-600}        # base seconds between heartbeat scans
 HEARTBEAT_MAX=${FM_HEARTBEAT_MAX:-7200}  # heartbeat backoff cap
 CHECK_INTERVAL=${FM_CHECK_INTERVAL:-300}  # seconds between *.check.sh sweeps
 CHECK_TIMEOUT=${FM_CHECK_TIMEOUT:-30}     # seconds allowed per *.check.sh
+# Read-only Bridge inbox detection and enqueue-before-marker deduplication.
+# Sourced AFTER CHECK_TIMEOUT so it inherits this cycle's bounded-read budget.
+# shellcheck source=bin/fm-bridge-inbox-lib.sh
+. "$SCRIPT_DIR/fm-bridge-inbox-lib.sh"
 SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trailing
                                       # signals (a status write, then the same turn's
                                       # turn-end hook) coalesce into one wake
@@ -858,6 +867,27 @@ while :; do
       wake "$reason"
     fi
     touch "$STATE/.last-check"
+  fi
+
+  # Read-only Bridge inbox poll, on its own cadence. Discovery fetches the
+  # shared clone and re-derives the interval no more often than the urgent
+  # interval, caching it so the cheap cycles in between never spawn a scan.
+  # A home with no configured vessel, or no Bridge clone, does neither.
+  if [ "${#BRIDGE_VESSELS[@]}" -eq 0 ] || [ ! -d "$BRIDGE_ROOT/.git" ]; then
+    bridge_interval=$CHECK_INTERVAL
+  elif [ "$(age_of "$STATE/.last-bridge-discovery")" -ge "$BRIDGE_URGENT_CHECK_INTERVAL" ]; then
+    bridge_inbox_fetch
+    bridge_interval=$(bridge_check_interval)
+    printf '%s' "$bridge_interval" > "$STATE/.bridge-interval-cache" 2>/dev/null || true
+    touch "$STATE/.last-bridge-discovery"
+  else
+    bridge_interval=$(cat "$STATE/.bridge-interval-cache" 2>/dev/null)
+    [ -n "$bridge_interval" ] || bridge_interval=$CHECK_INTERVAL
+  fi
+  if [ "$(age_of "$STATE/.last-bridge-check")" -ge "$bridge_interval" ]; then
+    reason=$(bridge_inbox_surface) || exit 1
+    touch "$STATE/.last-bridge-check"
+    [ -z "$reason" ] || wake "$reason"
   fi
 
   # On the first changed signal, linger one grace period and re-scan before

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -55,7 +55,9 @@
 #                          a watched Bridge vessel's fetched inbox tree carries
 #                          pending mail this watcher has not surfaced yet; read
 #                          only, on its own cadence, and silent while the tree is
-#                          unchanged (bin/fm-bridge-inbox-lib.sh)
+#                          unchanged. The reason names every vessel surfaced this
+#                          cycle, and each of them queues its own durable record
+#                          (bin/fm-bridge-inbox-lib.sh)
 #   heartbeat              fleet-scan backstop found an unsurfaced captain-relevant
 #                          status, unless afk is active
 # For normal supervision, resume the session-start primary-harness protocol
@@ -517,17 +519,27 @@ procevent_surface_queued() {
   wake "$reason"
 }
 
+# The one bounded-child implementation in this tree: every timed read the
+# watcher makes runs through it, so the fallback's signal hardening (the same
+# handler on ALRM and on HUP/INT/TERM, tearing down the child's process group
+# instead of orphaning it) can never be half-present in a second copy.
+run_bounded_process() {  # <timeout-seconds> <command> [args...]
+  local t=$1
+  shift
+  if [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v timeout >/dev/null 2>&1; then
+    exec timeout "$t" "$@"
+  elif [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v gtimeout >/dev/null 2>&1; then
+    exec gtimeout "$t" "$@"
+  else
+    # shellcheck disable=SC2016  # single quotes are deliberate: Perl expands its own variables.
+    exec perl -e 'my $t = shift; my $owned = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0) unless $owned; exec @ARGV } my $group = $owned ? getpgrp(0) : $pid; my $stop = sub { $SIG{HUP} = $SIG{INT} = $SIG{TERM} = "IGNORE"; kill "TERM", -$group; select undef, undef, undef, 0.2; kill "KILL", -$group; waitpid $pid, 0; exit 124 }; local $SIG{ALRM} = $stop; local $SIG{HUP} = $stop; local $SIG{INT} = $stop; local $SIG{TERM} = $stop; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$t" "${FM_CHECK_OWNED_GROUP:-0}" "$@"
+  fi
+}
+
 run_check_process() {
   local c=$1
   shift
-  if [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v timeout >/dev/null 2>&1; then
-    exec timeout "$CHECK_TIMEOUT" bash "$c" "$@"
-  elif [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v gtimeout >/dev/null 2>&1; then
-    exec gtimeout "$CHECK_TIMEOUT" bash "$c" "$@"
-  else
-    # shellcheck disable=SC2016  # single quotes are deliberate: Perl expands its own variables.
-    exec perl -e 'my $t = shift; my $owned = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0) unless $owned; exec @ARGV } my $group = $owned ? getpgrp(0) : $pid; my $stop = sub { $SIG{HUP} = $SIG{INT} = $SIG{TERM} = "IGNORE"; kill "TERM", -$group; select undef, undef, undef, 0.2; kill "KILL", -$group; waitpid $pid, 0; exit 124 }; local $SIG{ALRM} = $stop; local $SIG{HUP} = $stop; local $SIG{INT} = $stop; local $SIG{TERM} = $stop; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$CHECK_TIMEOUT" "${FM_CHECK_OWNED_GROUP:-0}" bash "$c" "$@"
-  fi
+  run_bounded_process "$CHECK_TIMEOUT" bash "$c" "$@"
 }
 
 run_check() {
@@ -869,25 +881,32 @@ while :; do
     touch "$STATE/.last-check"
   fi
 
-  # Read-only Bridge inbox poll, on its own cadence. Discovery fetches the
-  # shared clone and re-derives the interval no more often than the urgent
-  # interval, caching it so the cheap cycles in between never spawn a scan.
-  # A home with no configured vessel, or no Bridge clone, does neither.
-  if [ "${#BRIDGE_VESSELS[@]}" -eq 0 ] || [ ! -d "$BRIDGE_ROOT/.git" ]; then
-    bridge_interval=$CHECK_INTERVAL
-  elif [ "$(age_of "$STATE/.last-bridge-discovery")" -ge "$BRIDGE_URGENT_CHECK_INTERVAL" ]; then
-    bridge_inbox_fetch
-    bridge_interval=$(bridge_check_interval)
-    printf '%s' "$bridge_interval" > "$STATE/.bridge-interval-cache" 2>/dev/null || true
-    touch "$STATE/.last-bridge-discovery"
-  else
-    bridge_interval=$(cat "$STATE/.bridge-interval-cache" 2>/dev/null)
-    [ -n "$bridge_interval" ] || bridge_interval=$CHECK_INTERVAL
-  fi
-  if [ "$(age_of "$STATE/.last-bridge-check")" -ge "$bridge_interval" ]; then
-    reason=$(bridge_inbox_surface) || exit 1
-    touch "$STATE/.last-bridge-check"
-    [ -z "$reason" ] || wake "$reason"
+  # Read-only Bridge inbox poll, on its own cadence. A home with no configured
+  # vessel, or no Bridge clone, skips the whole block: no fetch, no scan, and no
+  # Bridge state file. Discovery fetches the shared clone and re-derives the
+  # interval, caching it so the cheap cycles in between never spawn a scan. The
+  # urgent interval only ever TIGHTENS that cadence: discovery runs on whichever
+  # of it and the interval in force is smaller, because this fetch is the only
+  # thing that advances origin/main, and gating it on the urgent interval alone
+  # would let a widened urgent knob freeze detection on a ref that never moves.
+  if [ "${#BRIDGE_VESSELS[@]}" -gt 0 ] && [ -d "$BRIDGE_ROOT/.git" ]; then
+    bridge_interval=$(cat "$STATE/.bridge-interval-cache" 2>/dev/null || true)
+    case "$bridge_interval" in
+      ''|*[!0-9]*) bridge_interval=$CHECK_INTERVAL ;;
+    esac
+    bridge_discovery_interval=$BRIDGE_URGENT_CHECK_INTERVAL
+    [ "$bridge_discovery_interval" -le "$bridge_interval" ] || bridge_discovery_interval=$bridge_interval
+    if [ "$(age_of "$STATE/.last-bridge-discovery")" -ge "$bridge_discovery_interval" ]; then
+      bridge_inbox_fetch
+      bridge_interval=$(bridge_check_interval)
+      printf '%s' "$bridge_interval" > "$STATE/.bridge-interval-cache" 2>/dev/null || true
+      touch "$STATE/.last-bridge-discovery"
+    fi
+    if [ "$(age_of "$STATE/.last-bridge-check")" -ge "$bridge_interval" ]; then
+      reason=$(bridge_inbox_surface) || exit 1
+      touch "$STATE/.last-bridge-check"
+      [ -z "$reason" ] || wake "$reason"
+    fi
   fi
 
   # On the first changed signal, linger one grace period and re-scan before

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -82,6 +82,9 @@ mkdir -p "$STATE"
 . "$SCRIPT_DIR/fm-x-lib.sh"
 # shellcheck source=bin/fm-check-lib.sh
 . "$SCRIPT_DIR/fm-check-lib.sh"
+# Every timed read this watcher makes is bounded by the one shared helper here.
+# shellcheck source=bin/fm-bounded-process-lib.sh
+. "$SCRIPT_DIR/fm-bounded-process-lib.sh"
 # Parent-owned secondmate missed-report guards: durable pending-reply
 # expectations created by fm-send on marked secondmate requests. The tick is
 # cheap when no records exist and never scrapes secondmate conversation.
@@ -517,23 +520,6 @@ procevent_surface_queued() {
   reason="check: process-event result captured:$PROCEVENT_SURFACED"
   FM_WAKE_POST_OUTPUT_ACTION=procevent_surface_after_output
   wake "$reason"
-}
-
-# The one bounded-child implementation in this tree: every timed read the
-# watcher makes runs through it, so the fallback's signal hardening (the same
-# handler on ALRM and on HUP/INT/TERM, tearing down the child's process group
-# instead of orphaning it) can never be half-present in a second copy.
-run_bounded_process() {  # <timeout-seconds> <command> [args...]
-  local t=$1
-  shift
-  if [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v timeout >/dev/null 2>&1; then
-    exec timeout "$t" "$@"
-  elif [ "${FM_CHECK_FORCE_FALLBACK:-0}" != 1 ] && command -v gtimeout >/dev/null 2>&1; then
-    exec gtimeout "$t" "$@"
-  else
-    # shellcheck disable=SC2016  # single quotes are deliberate: Perl expands its own variables.
-    exec perl -e 'my $t = shift; my $owned = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0) unless $owned; exec @ARGV } my $group = $owned ? getpgrp(0) : $pid; my $stop = sub { $SIG{HUP} = $SIG{INT} = $SIG{TERM} = "IGNORE"; kill "TERM", -$group; select undef, undef, undef, 0.2; kill "KILL", -$group; waitpid $pid, 0; exit 124 }; local $SIG{ALRM} = $stop; local $SIG{HUP} = $stop; local $SIG{INT} = $stop; local $SIG{TERM} = $stop; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$t" "${FM_CHECK_OWNED_GROUP:-0}" "$@"
-  fi
 }
 
 run_check_process() {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -316,9 +316,11 @@ The check is read-only: it fetches the Bridge clone's `origin/main` and reads `i
 When neither is set the feature is silent and disabled: the watcher performs no fetch and no scan at all.
 A pre-existing single-vessel value keeps working unchanged, as a one-element list.
 `FM_BRIDGE_ROOT` selects the shared clone that every listed vessel reads from, and a home without that clone is treated exactly like an unconfigured one.
+The vessel list, the clone path, and the urgent interval are each resolved once at watcher start, so writing `config/bridge-vessel` or changing any `FM_BRIDGE_*` value while a watcher is already running takes effect only after that home-scoped watcher restarts, exactly like the `FM_CHECK_INTERVAL` transition below.
 
 A vessel wakes once per change to its pending mail rather than once per poll, and each vessel is independent, so one vessel's wake never suppresses or is suppressed by another's.
 `FM_BRIDGE_URGENT_CHECK_INTERVAL` tightens the shared Bridge fetch-and-check cadence whenever any one vessel's highest pending priority is `high` or `immediate`; it changes only the Bridge poll, never `FM_CHECK_INTERVAL` for the watcher's other slow checks.
+Reading an envelope's priority needs `jq`, which is not a universal toolchain requirement (see "Toolchain" above): without it every envelope counts as `normal`, so vessels still wake on new mail but the urgent cadence never engages.
 Every fetch and read is bounded by `FM_CHECK_TIMEOUT`.
 The wake reason is listed with the watcher's other reasons in `bin/fm-watch.sh`'s header.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -306,6 +306,22 @@ The locked bootstrap inheritance pass uses the same per-home changed-set and rer
 That live discovery starts from `state/*.meta` records with `kind=secondmate`; `data/secondmates.md` only backfills `home=` for older or incomplete meta records.
 Skipped items, such as a destination checkout that does not yet gitignore the item, are visible warnings but not hard failures.
 
+## Bridge inbox check (config/bridge-vessel / FM_BRIDGE_*)
+
+`bin/fm-watch.sh` can turn pending Bridge envelopes into durable `check:` wakes.
+The check is read-only: it fetches the Bridge clone's `origin/main` and reads `inbox/<vessel>/new/` from that fetched ref, never acknowledging, moving, or otherwise mutating an envelope, and never touching the clone's working tree.
+`bin/fm-bridge-inbox-lib.sh`'s header owns the exact detection, caching, and wake-publication mechanics.
+
+`FM_BRIDGE_VESSEL` selects one or more space-separated vessels, each watched independently, and falls through to the effective home's `config/bridge-vessel` when unset or empty.
+When neither is set the feature is silent and disabled: the watcher performs no fetch and no scan at all.
+A pre-existing single-vessel value keeps working unchanged, as a one-element list.
+`FM_BRIDGE_ROOT` selects the shared clone that every listed vessel reads from, and a home without that clone is treated exactly like an unconfigured one.
+
+A vessel wakes once per change to its pending mail rather than once per poll, and each vessel is independent, so one vessel's wake never suppresses or is suppressed by another's.
+`FM_BRIDGE_URGENT_CHECK_INTERVAL` tightens the shared Bridge fetch-and-check cadence whenever any one vessel's highest pending priority is `high` or `immediate`; it changes only the Bridge poll, never `FM_CHECK_INTERVAL` for the watcher's other slow checks.
+Every fetch and read is bounded by `FM_CHECK_TIMEOUT`.
+The wake reason is listed with the watcher's other reasons in `bin/fm-watch.sh`'s header.
+
 ## X mode (.env)
 
 X mode lets a firstmate instance answer public `@myfirstmate` mentions and act on normal reversible mention requests through firstmate's normal lifecycle.
@@ -487,6 +503,9 @@ FM_HEARTBEAT=600        # base seconds between heartbeat scans; no-change heartb
 FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
 FM_CHECK_INTERVAL=300   # seconds between slow checks (authenticated merge polls, custom checks, or X-mode dispatch)
 FM_CHECK_TIMEOUT=30     # seconds allowed per slow check script
+FM_BRIDGE_VESSEL=       # optional override for config/bridge-vessel; one or more space-separated vessels; absent disables Bridge inbox scanning
+FM_BRIDGE_ROOT=$FM_HOME/projects/coditan-bridge   # Bridge clone whose fetched origin/main ref the watcher reads
+FM_BRIDGE_URGENT_CHECK_INTERVAL=30   # Bridge-only cadence while any watched vessel's highest pending priority is high or immediate
 FM_PROCEVENT_MAX_OUTPUT_BYTES=1048576   # bound on one captured process-to-event result
 FM_PROCEVENT_CLAIM_ROOT=                # machine-wide source claim root; default $XDG_STATE_HOME/firstmate/procevent-claims
 FM_CODEX_WATCH_CHECKPOINT=180   # seconds per foreground watcher checkpoint in Codex primary supervision

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -59,6 +59,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
 | `fm-watch.sh`            | Singleton-safe always-on watcher: absorb benign wakes, queue and exit on actionable ones |
 | `fm-bridge-inbox-lib.sh` | Read-only Bridge inbox signatures, cadence, and enqueue-before-marker wake publication |
+| `fm-bounded-process-lib.sh` | Single timeout/gtimeout/perl bounded-child runner with process-group teardown on signals |
 | `fm-afk-start.sh`        | Run the common sourceable away-mode daemon entry in the foreground                      |
 | `fm-afk-launch.sh`       | Own away-mode entry, exit, rollback, and any backend terminal lifecycle                 |
 | `fm-afk-return.sh`       | Own deterministic return shutdown, catch-up evidence, and the firstmate-actionable blocker gate |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -58,6 +58,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with loud cycle endings and bounded lifecycle ledger |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
 | `fm-watch.sh`            | Singleton-safe always-on watcher: absorb benign wakes, queue and exit on actionable ones |
+| `fm-bridge-inbox-lib.sh` | Read-only Bridge inbox signatures, cadence, and enqueue-before-marker wake publication |
 | `fm-afk-start.sh`        | Run the common sourceable away-mode daemon entry in the foreground                      |
 | `fm-afk-launch.sh`       | Own away-mode entry, exit, rollback, and any backend terminal lifecycle                 |
 | `fm-afk-return.sh`       | Own deterministic return shutdown, catch-up evidence, and the firstmate-actionable blocker gate |

--- a/tests/fm-watch-bridge-inbox.test.sh
+++ b/tests/fm-watch-bridge-inbox.test.sh
@@ -473,6 +473,27 @@ test_library_carries_its_own_bounded_reader() {
   pass "the library sources the bounded-child helper it needs instead of expecting it from a caller"
 }
 
+# bin/fm-bounded-process-lib.sh is the one bounded-child owner every timed read
+# in this tree goes through, so its bound is asserted directly rather than only
+# through a caller. The perl path is exercised explicitly because it is the
+# fallback whose signal hardening has no other coverage, and a machine with
+# timeout installed would otherwise never reach it.
+test_bounded_process_lib_bounds_a_runaway_child() {
+  local bounded_lib path rc
+  bounded_lib="$ROOT/bin/fm-bounded-process-lib.sh"
+  for path in default fallback; do
+    rc=0
+    (
+      [ "$path" = fallback ] && export FM_CHECK_FORCE_FALLBACK=1
+      # shellcheck disable=SC2016
+      bash -c '. "$1"; run_bounded_process 1 sleep 30' _ "$bounded_lib"
+    ) >/dev/null 2>&1 || rc=$?
+    [ "$rc" -eq 124 ] \
+      || fail "bin/fm-bounded-process-lib.sh ($path path) did not bound a runaway child: exit $rc"
+  done
+  pass "the shared bounded-child helper stops a runaway child on both the timeout and perl paths"
+}
+
 test_multi_vessel_cadence_reflects_any_vessel() {
   local home interval
   home=$(make_home multi-cadence captain)
@@ -641,6 +662,7 @@ test_multi_vessel_wakes_survive_an_undrained_queue
 test_priority_tightens_only_bridge_cadence
 test_non_numeric_urgent_interval_falls_back_to_the_default
 test_library_carries_its_own_bounded_reader
+test_bounded_process_lib_bounds_a_runaway_child
 test_multi_vessel_cadence_reflects_any_vessel
 test_cache_skips_rescan_when_unchanged
 test_inplace_edit_invalidates_cache

--- a/tests/fm-watch-bridge-inbox.test.sh
+++ b/tests/fm-watch-bridge-inbox.test.sh
@@ -6,9 +6,10 @@
 # envelope producing exactly one durable check wake per inbox-tree signature;
 # silence for an empty, unchanged, or acknowledged inbox; per-vessel independence
 # in a multi-vessel list, including in an undrained queue; the urgent cadence
-# tightening only the Bridge poll and never freezing the fetch that advances
-# origin/main; the signature-keyed priority cache; and reads resolving against
-# the fetched origin/main rather than a stale working tree.
+# tightening only the Bridge poll, never freezing the fetch that advances
+# origin/main, and falling back to its default when set to a non-number; the
+# signature-keyed priority cache; and reads resolving against the fetched
+# origin/main rather than a stale working tree.
 #
 # Each case drives a real fm-watch.sh subprocess against a throwaway Bridge
 # clone, so the assertions are on observable watcher output plus durable state,
@@ -19,6 +20,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 WATCH="$ROOT/bin/fm-watch.sh"
+LIB="$ROOT/bin/fm-bridge-inbox-lib.sh"
 DRAIN="$ROOT/bin/fm-wake-drain.sh"
 TMP_ROOT=$(fm_test_tmproot fm-watch-bridge-inbox)
 fm_git_identity
@@ -428,6 +430,49 @@ test_priority_tightens_only_bridge_cadence() {
   pass "high-priority Bridge traffic tightens only the Bridge poll interval"
 }
 
+test_non_numeric_urgent_interval_falls_back_to_the_default() {
+  local home resolved interval
+  home=$(make_home bad-urgent)
+  write_envelope "$home" flash immediate
+
+  resolved=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" FM_BRIDGE_URGENT_CHECK_INTERVAL=30s \
+      bash -c '. "$1"; printf "%s" "$BRIDGE_URGENT_CHECK_INTERVAL"' _ "$WATCH"
+  )
+  [ "$resolved" = 30 ] || \
+    fail "a non-numeric FM_BRIDGE_URGENT_CHECK_INTERVAL reached the interval comparisons: '$resolved'"
+
+  # Every consumer of the interval must see a number, or the arithmetic tests it
+  # feeds error out on each poll cycle instead of tightening the cadence.
+  interval=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" FM_CHECK_INTERVAL=300 FM_BRIDGE_URGENT_CHECK_INTERVAL=30s \
+      bash -c '. "$1"; bridge_check_interval' _ "$WATCH" 2>/dev/null
+  )
+  [ "$interval" = 30 ] || \
+    fail "urgent tightening did not fall back to the documented default: $interval"
+  pass "a non-numeric urgent interval falls back to the documented default rather than propagating"
+}
+
+test_library_carries_its_own_bounded_reader() {
+  local home sig
+  # Sourced on its own, without the watcher: a bounded-child helper expected
+  # from the caller instead of required here would leave every read reporting a
+  # timeout and every vessel silently skipped.
+  home=$(make_home standalone-lib)
+  write_envelope "$home" solo normal
+
+  sig=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" bash -c '. "$1"; bridge_inbox_signature' _ "$LIB"
+  )
+  case "$sig" in
+    timeout|empty|'') fail "the library sourced on its own could not complete a bounded Bridge read: '$sig'" ;;
+  esac
+  pass "the library sources the bounded-child helper it needs instead of expecting it from a caller"
+}
+
 test_multi_vessel_cadence_reflects_any_vessel() {
   local home interval
   home=$(make_home multi-cadence captain)
@@ -594,6 +639,8 @@ test_bridge_inbox_surfaces_each_signature_once
 test_multi_vessel_each_surfaces_independently
 test_multi_vessel_wakes_survive_an_undrained_queue
 test_priority_tightens_only_bridge_cadence
+test_non_numeric_urgent_interval_falls_back_to_the_default
+test_library_carries_its_own_bounded_reader
 test_multi_vessel_cadence_reflects_any_vessel
 test_cache_skips_rescan_when_unchanged
 test_inplace_edit_invalidates_cache

--- a/tests/fm-watch-bridge-inbox.test.sh
+++ b/tests/fm-watch-bridge-inbox.test.sh
@@ -5,9 +5,10 @@
 # Covered contract: vessel resolution and the disabled default; a pending
 # envelope producing exactly one durable check wake per inbox-tree signature;
 # silence for an empty, unchanged, or acknowledged inbox; per-vessel independence
-# in a multi-vessel list; the urgent cadence tightening only the Bridge poll; the
-# signature-keyed priority cache; and reads resolving against the fetched
-# origin/main rather than a stale working tree.
+# in a multi-vessel list, including in an undrained queue; the urgent cadence
+# tightening only the Bridge poll and never freezing the fetch that advances
+# origin/main; the signature-keyed priority cache; and reads resolving against
+# the fetched origin/main rather than a stale working tree.
 #
 # Each case drives a real fm-watch.sh subprocess against a throwaway Bridge
 # clone, so the assertions are on observable watcher output plus durable state,
@@ -18,6 +19,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 WATCH="$ROOT/bin/fm-watch.sh"
+DRAIN="$ROOT/bin/fm-wake-drain.sh"
 TMP_ROOT=$(fm_test_tmproot fm-watch-bridge-inbox)
 fm_git_identity
 
@@ -106,6 +108,21 @@ count_lines() { wc -l < "$1" | tr -d '[:space:]'; }
 # Bridge can print. Trailing arguments are appended last and therefore override
 # these defaults.
 
+# Wait up to <limit> 0.1s ticks for <pid> to exit; 0 if it exited, 1 on expiry.
+# A regressed check would otherwise loop forever and block the whole suite,
+# which applies no per-test timeout, instead of failing with a diagnostic.
+wait_exit() {  # <pid> [limit]
+  local pid=$1 limit=${2:-600} i=0
+  while [ "$i" -lt "$limit" ]; do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.1
+    i=$((i + 1))
+  done
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  return 1
+}
+
 # Run the watcher until it exits on its own; the caller expects a wake.
 watch_until_wake() {  # <home> <out> [extra env assignments...]
   local home=$1 out=$2 pid
@@ -113,6 +130,7 @@ watch_until_wake() {  # <home> <out> [extra env assignments...]
   env FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 \
     FM_BRIDGE_URGENT_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$@" "$WATCH" > "$out" &
   pid=$!
+  wait_exit "$pid" || fail "the watcher never produced a Bridge wake"
   wait "$pid"
 }
 
@@ -154,7 +172,35 @@ test_vessel_resolution_precedence() {
       bash -c '. "$1"; printf "%s" "$BRIDGE_VESSEL"' _ "$WATCH"
   )
   [ "$resolved" = tugboat ] || fail "an empty FM_BRIDGE_VESSEL shadowed config/bridge-vessel: $resolved"
-  pass "Bridge vessel resolution prefers a non-empty env value and falls back to per-home config"
+
+  # A caller reading another home redirects config the same way every other
+  # config reader in bin/ is redirected.
+  mkdir -p "$home/alt-config"
+  printf '%s\n' dinghy > "$home/alt-config/bridge-vessel"
+  resolved=$(
+    # shellcheck disable=SC2016
+    env -u FM_BRIDGE_VESSEL FM_HOME="$home" FM_CONFIG_OVERRIDE="$home/alt-config" \
+      bash -c '. "$1"; printf "%s" "$BRIDGE_VESSEL"' _ "$WATCH"
+  )
+  [ "$resolved" = dinghy ] || fail "FM_CONFIG_OVERRIDE was ignored when reading bridge-vessel: $resolved"
+  pass "Bridge vessel resolution prefers a non-empty env value and falls back to the effective home's config"
+}
+
+test_vessel_config_without_trailing_newline_resolves() {
+  local home resolved
+  home=$(make_home vessel-no-newline)
+  mkdir -p "$home/config"
+  # An editor with no final EOL, or printf/echo -n, writes the file this way.
+  printf tugboat > "$home/config/bridge-vessel"
+
+  resolved=$(
+    # shellcheck disable=SC2016
+    env -u FM_BRIDGE_VESSEL FM_HOME="$home" \
+      bash -c '. "$1"; printf "%s" "$BRIDGE_VESSEL"' _ "$WATCH"
+  )
+  [ "$resolved" = tugboat ] || \
+    fail "config/bridge-vessel without a trailing newline silently disabled the check: '$resolved'"
+  pass "a config/bridge-vessel written without a final newline still resolves its vessel"
 }
 
 test_multi_vessel_list_resolves_into_array() {
@@ -242,8 +288,8 @@ test_bridge_inbox_surfaces_each_signature_once() {
   watch_until_wake "$home" "$out" || fail "watcher failed while checking a pending Bridge envelope"
   assert_contains "$(cat "$out")" "check: bridge-inbox: bridge-inbox coditan pending=1 highest=high" \
     "pending Bridge envelope did not produce an actionable check wake"
-  assert_contains "$(cat "$home/state/.wake-queue")" $'\tcheck\tbridge-inbox\t' \
-    "Bridge check wake was not queued durably"
+  assert_contains "$(cat "$home/state/.wake-queue")" $'\tcheck\tbridge-inbox:coditan\t' \
+    "Bridge check wake was not queued durably under its own vessel key"
   first_marker=$(cat "$home/state/.bridge-surfaced")
   [ -n "$first_marker" ] || fail "first surfaced inbox signature was not recorded"
 
@@ -323,6 +369,34 @@ test_multi_vessel_each_surfaces_independently() {
   assert_present "$home/state/.bridge-surfaced-captain" \
     "the secondary vessel's surfaced marker was not recorded"
   pass "each configured vessel surfaces its own pending mail independently of the others"
+}
+
+test_multi_vessel_wakes_survive_an_undrained_queue() {
+  local home out drained
+  home=$(make_home multi-undrained captain)
+  out="$home/watch.out"
+
+  # The primary vessel's wake is queued and its marker advances, and only then
+  # does the secondary vessel get mail. The queue keeps one record per kind and
+  # key, so a key shared between vessels would drop the primary's still-pending
+  # mail here for good: its marker already claims the mail was surfaced.
+  write_envelope "$home" first high coditan
+  watch_until_wake "$home" "$out" 'FM_BRIDGE_VESSEL=coditan captain' \
+    || fail "watcher failed while checking the primary vessel's pending envelope"
+
+  write_envelope "$home" second normal captain
+  : > "$out"
+  watch_until_wake "$home" "$out" 'FM_BRIDGE_VESSEL=coditan captain' \
+    || fail "watcher failed while checking the secondary vessel's pending envelope"
+
+  drained="$home/drain.out"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" "$DRAIN" > "$drained" \
+    || fail "draining the queued Bridge wakes failed"
+  assert_contains "$(cat "$drained")" "bridge-inbox coditan pending=1 highest=high" \
+    "the primary vessel's undrained wake was collapsed by the secondary vessel's later wake"
+  assert_contains "$(cat "$drained")" "bridge-inbox captain pending=1 highest=normal" \
+    "the secondary vessel's wake was not drained"
+  pass "a vessel queued before the queue drains is still named once a later vessel queues its own wake"
 }
 
 test_priority_tightens_only_bridge_cadence() {
@@ -446,6 +520,43 @@ test_discovery_gated_by_urgent_interval() {
   pass "repeated loop cycles do not keep spawning Bridge scans within the urgent window"
 }
 
+test_wide_urgent_interval_does_not_freeze_detection() {
+  local home out peer pid i=0
+  # The discovery fetch is the only thing that advances the watcher's own
+  # origin/main, so an urgent interval WIDER than the interval actually in force
+  # must not gate it: gating on the urgent interval alone leaves the ref frozen
+  # at the value it had when the watcher started, and mail that arrives later is
+  # never seen. Bridge delivers from its own clone, so this envelope is pushed
+  # from a peer: a push made from the watcher's clone would advance that clone's
+  # remote-tracking ref by itself and hide a frozen fetch.
+  home=$(make_home wide-urgent)
+  out="$home/watch.out"
+  peer="$home/bridge-peer"
+  git clone -q "$home/bridge-origin.git" "$peer"
+
+  env FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 \
+    FM_BRIDGE_URGENT_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+
+  while [ ! -e "$home/state/.last-bridge-discovery" ]; do
+    [ "$i" -lt 300 ] || { kill "$pid" 2>/dev/null || true; fail "the first Bridge discovery never ran"; }
+    sleep 0.1
+    i=$((i + 1))
+  done
+
+  printf '{"schema":"bridge-envelope.v1","id":"late","priority":"normal","state":"new"}\n' \
+    > "$peer/inbox/coditan/new/late.json"
+  git -C "$peer" add inbox/coditan/new/late.json
+  git -C "$peer" commit -qm "add late"
+  git -C "$peer" push -q origin main
+  wait_exit "$pid" \
+    || fail "a wide FM_BRIDGE_URGENT_CHECK_INTERVAL froze Bridge detection: mail arriving after the first discovery was never seen"
+  wait "$pid" || fail "watcher failed while detecting mail under a wide urgent interval"
+  assert_contains "$(cat "$out")" "check: bridge-inbox: bridge-inbox coditan pending=1 highest=normal" \
+    "mail arriving after the first discovery did not produce a wake"
+  pass "a wide urgent interval only tightens the Bridge cadence and never stops refreshing origin/main"
+}
+
 test_acked_on_origin_ignores_stale_working_tree() {
   local home bridge peer out
   home=$(make_home stale-working-tree)
@@ -474,15 +585,18 @@ test_acked_on_origin_ignores_stale_working_tree() {
 }
 
 test_vessel_resolution_precedence
+test_vessel_config_without_trailing_newline_resolves
 test_multi_vessel_list_resolves_into_array
 test_unconfigured_home_skips_bridge_scan
 test_missing_bridge_clone_skips_scan
 test_empty_inbox_is_silent
 test_bridge_inbox_surfaces_each_signature_once
 test_multi_vessel_each_surfaces_independently
+test_multi_vessel_wakes_survive_an_undrained_queue
 test_priority_tightens_only_bridge_cadence
 test_multi_vessel_cadence_reflects_any_vessel
 test_cache_skips_rescan_when_unchanged
 test_inplace_edit_invalidates_cache
 test_discovery_gated_by_urgent_interval
+test_wide_urgent_interval_does_not_freeze_detection
 test_acked_on_origin_ignores_stale_working_tree

--- a/tests/fm-watch-bridge-inbox.test.sh
+++ b/tests/fm-watch-bridge-inbox.test.sh
@@ -1,0 +1,488 @@
+#!/usr/bin/env bash
+# tests/fm-watch-bridge-inbox.test.sh - the watcher's read-only Bridge inbox
+# check (bin/fm-bridge-inbox-lib.sh, driven from bin/fm-watch.sh).
+#
+# Covered contract: vessel resolution and the disabled default; a pending
+# envelope producing exactly one durable check wake per inbox-tree signature;
+# silence for an empty, unchanged, or acknowledged inbox; per-vessel independence
+# in a multi-vessel list; the urgent cadence tightening only the Bridge poll; the
+# signature-keyed priority cache; and reads resolving against the fetched
+# origin/main rather than a stale working tree.
+#
+# Each case drives a real fm-watch.sh subprocess against a throwaway Bridge
+# clone, so the assertions are on observable watcher output plus durable state,
+# never on internals.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+WATCH="$ROOT/bin/fm-watch.sh"
+TMP_ROOT=$(fm_test_tmproot fm-watch-bridge-inbox)
+fm_git_identity
+
+# Existing Bridge fixtures explicitly opt into the historical vessel name; cases
+# that exercise the multi-vessel list or the disabled path override it.
+export FM_BRIDGE_VESSEL=coditan
+# An operator's own shell commonly exports FM_BRIDGE_ROOT for a live vessel, and
+# it outranks FM_HOME in the library's resolution, so an inherited value would
+# silently point every fixture below at that real clone. A misdirected root reads
+# as "Bridge is unconfigured", which means the cases that WAIT for a wake would
+# hang rather than fail. Drop it.
+unset FM_BRIDGE_ROOT
+
+# A home with its own bare Bridge origin and a clone under projects/. Extra
+# arguments name additional vessels beside the default "coditan".
+make_home() {
+  local name=$1 home bridge origin vessel
+  shift
+  home="$TMP_ROOT/$name"
+  bridge="$home/projects/coditan-bridge"
+  origin="$home/bridge-origin.git"
+  mkdir -p "$home/state" "$bridge/inbox/coditan/new"
+  for vessel in "$@"; do
+    mkdir -p "$bridge/inbox/$vessel/new"
+  done
+  git init -q --bare "$origin"
+  git -C "$bridge" init -q -b main
+  touch "$bridge/inbox/coditan/new/.gitkeep"
+  for vessel in "$@"; do
+    touch "$bridge/inbox/$vessel/new/.gitkeep"
+  done
+  git -C "$bridge" add inbox
+  git -C "$bridge" commit -qm init
+  git -C "$bridge" remote add origin "$origin"
+  git -C "$bridge" push -qu origin main
+  git --git-dir="$origin" symbolic-ref HEAD refs/heads/main
+  printf '%s\n' "$home"
+}
+
+write_envelope() {
+  local home=$1 name=$2 priority=$3 vessel=${4:-coditan}
+  printf '{"schema":"bridge-envelope.v1","id":"%s","priority":"%s","state":"new"}\n' \
+    "$name" "$priority" > "$home/projects/coditan-bridge/inbox/$vessel/new/$name.json"
+  git -C "$home/projects/coditan-bridge" add "inbox/$vessel/new/$name.json"
+  git -C "$home/projects/coditan-bridge" commit -qm "add $name"
+  git -C "$home/projects/coditan-bridge" push -qu origin main
+}
+
+# A timeout shim that counts every bounded Bridge read, so "did not scan" is
+# asserted on evidence rather than on silence alone.
+counting_timeout() {
+  local dir=$1 counter=$2 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  : > "$counter"
+  cat > "$fakebin/timeout" <<EOF
+#!/usr/bin/env bash
+echo x >> "$counter"
+exec /usr/bin/timeout "\$@"
+EOF
+  chmod +x "$fakebin/timeout"
+  printf '%s\n' "$fakebin"
+}
+
+# A jq shim that counts envelope reads while still reporting the real priority,
+# so cache hits and misses are countable.
+counting_jq() {
+  local dir=$1 counter=$2 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  : > "$counter"
+  cat > "$fakebin/jq" <<EOF
+#!/usr/bin/env bash
+echo x >> "$counter"
+priority=\$(grep -o '"priority":"[a-z]*"' | head -1 | cut -d'"' -f4)
+printf '%s\n' "\${priority:-normal}"
+EOF
+  chmod +x "$fakebin/jq"
+  printf '%s\n' "$fakebin"
+}
+
+count_lines() { wc -l < "$1" | tr -d '[:space:]'; }
+
+# Both helpers keep the Bridge poll due on every cycle: the urgent interval
+# gates discovery and FM_CHECK_INTERVAL is what the non-urgent cadence returns,
+# so zeroing both makes a silent run prove the check RAN and said nothing rather
+# than prove only that it was not yet due. The heartbeat is parked so nothing but
+# Bridge can print. Trailing arguments are appended last and therefore override
+# these defaults.
+
+# Run the watcher until it exits on its own; the caller expects a wake.
+watch_until_wake() {  # <home> <out> [extra env assignments...]
+  local home=$1 out=$2 pid
+  shift 2
+  env FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 \
+    FM_BRIDGE_URGENT_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$@" "$WATCH" > "$out" &
+  pid=$!
+  wait "$pid"
+}
+
+# Run the watcher for a few cycles and stop it; the caller expects silence.
+watch_briefly() {  # <home> <out> <seconds> [extra env assignments...]
+  local home=$1 out=$2 seconds=$3 pid
+  shift 3
+  env FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 \
+    FM_BRIDGE_URGENT_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$@" "$WATCH" > "$out" 2>&1 &
+  pid=$!
+  sleep "$seconds"
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+test_vessel_resolution_precedence() {
+  local home resolved
+  home=$(make_home vessel-resolution)
+  mkdir -p "$home/config"
+  printf '%s\n' tugboat > "$home/config/bridge-vessel"
+
+  resolved=$(
+    # shellcheck disable=SC2016  # $1/$BRIDGE_VESSEL belong to the inner bash -c process.
+    FM_HOME="$home" FM_BRIDGE_VESSEL=override \
+      bash -c '. "$1"; printf "%s" "$BRIDGE_VESSEL"' _ "$WATCH"
+  )
+  [ "$resolved" = override ] || fail "FM_BRIDGE_VESSEL did not override config/bridge-vessel: $resolved"
+
+  resolved=$(
+    # shellcheck disable=SC2016
+    env -u FM_BRIDGE_VESSEL FM_HOME="$home" \
+      bash -c '. "$1"; printf "%s" "$BRIDGE_VESSEL"' _ "$WATCH"
+  )
+  [ "$resolved" = tugboat ] || fail "config/bridge-vessel was not used without an env override: $resolved"
+
+  resolved=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" FM_BRIDGE_VESSEL='' \
+      bash -c '. "$1"; printf "%s" "$BRIDGE_VESSEL"' _ "$WATCH"
+  )
+  [ "$resolved" = tugboat ] || fail "an empty FM_BRIDGE_VESSEL shadowed config/bridge-vessel: $resolved"
+  pass "Bridge vessel resolution prefers a non-empty env value and falls back to per-home config"
+}
+
+test_multi_vessel_list_resolves_into_array() {
+  local home resolved
+  home=$(make_home multi-vessel-list)
+
+  resolved=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" FM_BRIDGE_VESSEL="coditan captain" \
+      bash -c '. "$1"; printf "%s" "$BRIDGE_VESSEL"' _ "$WATCH"
+  )
+  [ "$resolved" = coditan ] || fail "BRIDGE_VESSEL did not keep the first vessel for single-vessel compatibility: $resolved"
+
+  resolved=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" FM_BRIDGE_VESSEL="coditan captain" \
+      bash -c '. "$1"; printf "%s %s (%s)" "${BRIDGE_VESSELS[0]}" "${BRIDGE_VESSELS[1]}" "${#BRIDGE_VESSELS[@]}"' _ "$WATCH"
+  )
+  [ "$resolved" = "coditan captain (2)" ] || fail "space-separated vessels did not resolve in order: $resolved"
+
+  resolved=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" FM_BRIDGE_VESSEL=coditan \
+      bash -c '. "$1"; printf "%s" "${#BRIDGE_VESSELS[@]}"' _ "$WATCH"
+  )
+  [ "$resolved" = 1 ] || fail "a single-vessel value did not resolve to exactly one watched vessel: $resolved"
+  pass "a space-separated FM_BRIDGE_VESSEL resolves into an ordered vessel list, with BRIDGE_VESSEL as the first"
+}
+
+test_unconfigured_home_skips_bridge_scan() {
+  local home fakebin counter out
+  home=$(make_home unconfigured)
+  counter="$home/timeout-calls"
+  fakebin=$(counting_timeout "$home" "$counter")
+  out="$home/watch.out"
+
+  # Neither the environment variable nor config/bridge-vessel: the feature is off.
+  ( unset FM_BRIDGE_VESSEL; watch_briefly "$home" "$out" 2 "PATH=$fakebin:$PATH" )
+
+  assert_absent "$home/config/bridge-vessel" "the unconfigured fixture grew a vessel config file"
+  [ ! -s "$out" ] || fail "unconfigured Bridge watcher did not stay silent: $(cat "$out")"
+  assert_absent "$home/state/.wake-queue" "unconfigured Bridge watcher created a wake"
+  [ "$(count_lines "$counter")" = 0 ] || \
+    fail "unconfigured Bridge watcher still spawned a bounded scan"
+  pass "a home with neither FM_BRIDGE_VESSEL nor config/bridge-vessel performs no Bridge scan and emits no wake"
+}
+
+test_missing_bridge_clone_skips_scan() {
+  local home fakebin counter out
+  home="$TMP_ROOT/missing"
+  mkdir -p "$home/state"
+  counter="$home/timeout-calls"
+  fakebin=$(counting_timeout "$home" "$counter")
+  out="$home/watch.out"
+
+  watch_briefly "$home" "$out" 3 "PATH=$fakebin:$PATH"
+
+  [ ! -s "$out" ] || fail "missing Bridge clone did not stay silent: $(cat "$out")"
+  assert_absent "$home/state/.wake-queue" "missing Bridge clone created a wake"
+  [ "$(count_lines "$counter")" = 0 ] || \
+    fail "missing Bridge clone still spawned a bounded scan"
+  pass "a configured vessel without a Bridge clone short-circuits without spawning a scan"
+}
+
+test_empty_inbox_is_silent() {
+  local home out
+  home=$(make_home empty)
+  out="$home/watch.out"
+
+  watch_briefly "$home" "$out" 2
+
+  [ ! -s "$out" ] || fail "empty Bridge inbox did not stay silent: $(cat "$out")"
+  assert_absent "$home/state/.wake-queue" "empty Bridge inbox created a wake"
+  assert_absent "$home/state/.bridge-surfaced" "empty Bridge inbox recorded a surfaced marker"
+  pass "an empty Bridge inbox is scanned and absorbed silently"
+}
+
+test_bridge_inbox_surfaces_each_signature_once() {
+  local home bridge out first_marker second_marker
+  home=$(make_home pending)
+  bridge="$home/projects/coditan-bridge"
+  out="$home/watch.out"
+  write_envelope "$home" urgent high
+
+  watch_until_wake "$home" "$out" || fail "watcher failed while checking a pending Bridge envelope"
+  assert_contains "$(cat "$out")" "check: bridge-inbox: bridge-inbox coditan pending=1 highest=high" \
+    "pending Bridge envelope did not produce an actionable check wake"
+  assert_contains "$(cat "$home/state/.wake-queue")" $'\tcheck\tbridge-inbox\t' \
+    "Bridge check wake was not queued durably"
+  first_marker=$(cat "$home/state/.bridge-surfaced")
+  [ -n "$first_marker" ] || fail "first surfaced inbox signature was not recorded"
+
+  # Unchanged pending inbox: still pending, but already surfaced.
+  : > "$out"
+  rm -f "$home/state/.wake-queue"
+  watch_briefly "$home" "$out" 2
+  [ ! -s "$out" ] || fail "unchanged Bridge inbox signature re-fired a wake: $(cat "$out")"
+  assert_absent "$home/state/.wake-queue" "unchanged Bridge inbox signature created a wake"
+  [ "$(cat "$home/state/.bridge-surfaced")" = "$first_marker" ] || \
+    fail "absorbing an unchanged inbox altered the surfaced marker"
+
+  # New mail moves the tree signature, so it surfaces again.
+  write_envelope "$home" second normal
+  : > "$out"
+  watch_until_wake "$home" "$out" || fail "watcher failed after the Bridge inbox signature changed"
+  assert_contains "$(cat "$out")" "check: bridge-inbox: bridge-inbox coditan pending=2 highest=high" \
+    "changed Bridge inbox signature did not produce a new wake"
+  second_marker=$(cat "$home/state/.bridge-surfaced")
+  [ "$second_marker" != "$first_marker" ] || fail "changed inbox did not advance the surfaced marker"
+
+  # Acknowledged on origin: silent again, and the marker is dropped.
+  git -C "$bridge" rm -q inbox/coditan/new/urgent.json inbox/coditan/new/second.json
+  git -C "$bridge" commit -qm "ack envelopes"
+  git -C "$bridge" push -qu origin main
+  : > "$out"
+  rm -f "$home/state/.wake-queue"
+  watch_briefly "$home" "$out" 2
+  [ ! -s "$out" ] || fail "acked Bridge inbox did not stay silent: $(cat "$out")"
+  assert_absent "$home/state/.wake-queue" "acked Bridge inbox created a wake"
+  assert_absent "$home/state/.bridge-surfaced" "acked inbox did not clear the surfaced marker"
+
+  # Byte-identical re-delivery restores the earlier tree, which the dropped
+  # marker must not suppress.
+  write_envelope "$home" urgent high
+  write_envelope "$home" second normal
+  : > "$out"
+  watch_until_wake "$home" "$out" || fail "watcher failed after a byte-identical Bridge re-delivery"
+  assert_contains "$(cat "$out")" "check: bridge-inbox: bridge-inbox coditan pending=2 highest=high" \
+    "byte-identical re-delivered inbox did not produce a new wake"
+  [ "$(cat "$home/state/.bridge-surfaced")" = "$second_marker" ] || \
+    fail "re-delivered inbox did not record its surfaced signature"
+  pass "Bridge inbox wakes once per pending signature, clears on ack, and re-fires on re-delivery"
+}
+
+test_multi_vessel_each_surfaces_independently() {
+  local home out
+  home=$(make_home multi-independent captain)
+  out="$home/watch.out"
+  write_envelope "$home" urgent high coditan
+
+  watch_until_wake "$home" "$out" 'FM_BRIDGE_VESSEL=coditan captain' \
+    || fail "watcher failed while checking the primary vessel's pending envelope"
+  assert_contains "$(cat "$out")" "check: bridge-inbox: bridge-inbox coditan pending=1 highest=high" \
+    "primary vessel envelope did not produce a wake"
+  assert_not_contains "$(cat "$out")" "captain pending" \
+    "the secondary vessel with no mail was reported as pending"
+  assert_present "$home/state/.bridge-surfaced" \
+    "the primary vessel did not keep its historical unsuffixed surfaced marker"
+  assert_absent "$home/state/.bridge-surfaced-captain" \
+    "the secondary vessel surfaced a marker despite having no mail"
+
+  : > "$out"
+  rm -f "$home/state/.wake-queue"
+  watch_briefly "$home" "$out" 2 'FM_BRIDGE_VESSEL=coditan captain'
+  [ ! -s "$out" ] || fail "an unchanged primary vessel inbox re-fired a wake: $(cat "$out")"
+  assert_absent "$home/state/.wake-queue" "an unchanged primary vessel inbox created a wake"
+
+  write_envelope "$home" second normal captain
+  : > "$out"
+  watch_until_wake "$home" "$out" 'FM_BRIDGE_VESSEL=coditan captain' \
+    || fail "watcher failed while checking the secondary vessel's pending envelope"
+  assert_contains "$(cat "$out")" "check: bridge-inbox: bridge-inbox captain pending=1 highest=normal" \
+    "secondary vessel envelope did not produce its own wake"
+  assert_not_contains "$(cat "$out")" "coditan pending" \
+    "an unchanged primary vessel was re-surfaced alongside the secondary vessel's new mail"
+  assert_present "$home/state/.bridge-surfaced-captain" \
+    "the secondary vessel's surfaced marker was not recorded"
+  pass "each configured vessel surfaces its own pending mail independently of the others"
+}
+
+test_priority_tightens_only_bridge_cadence() {
+  local home interval
+  home=$(make_home cadence)
+
+  interval=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" FM_CHECK_INTERVAL=300 FM_BRIDGE_URGENT_CHECK_INTERVAL=30 \
+      bash -c '. "$1"; bridge_check_interval' _ "$WATCH"
+  )
+  [ "$interval" = 300 ] || fail "empty-inbox Bridge cadence was $interval, expected 300"
+
+  write_envelope "$home" routine normal
+  interval=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" FM_CHECK_INTERVAL=300 FM_BRIDGE_URGENT_CHECK_INTERVAL=30 \
+      bash -c '. "$1"; bridge_check_interval' _ "$WATCH"
+  )
+  [ "$interval" = 300 ] || fail "normal envelope cadence was $interval, expected 300"
+
+  write_envelope "$home" flash immediate
+  interval=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" FM_CHECK_INTERVAL=300 FM_BRIDGE_URGENT_CHECK_INTERVAL=30 \
+      bash -c '. "$1"; bridge_check_interval' _ "$WATCH"
+  )
+  [ "$interval" = 30 ] || fail "immediate envelope cadence was $interval, expected 30"
+  pass "high-priority Bridge traffic tightens only the Bridge poll interval"
+}
+
+test_multi_vessel_cadence_reflects_any_vessel() {
+  local home interval
+  home=$(make_home multi-cadence captain)
+  write_envelope "$home" routine normal coditan
+  interval=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" FM_BRIDGE_VESSEL="coditan captain" FM_CHECK_INTERVAL=300 \
+      FM_BRIDGE_URGENT_CHECK_INTERVAL=30 \
+      bash -c '. "$1"; bridge_check_interval' _ "$WATCH"
+  )
+  [ "$interval" = 300 ] || fail "cadence with only normal-priority mail was $interval, expected 300"
+
+  write_envelope "$home" flash immediate captain
+  interval=$(
+    # shellcheck disable=SC2016
+    FM_HOME="$home" FM_BRIDGE_VESSEL="coditan captain" FM_CHECK_INTERVAL=300 \
+      FM_BRIDGE_URGENT_CHECK_INTERVAL=30 \
+      bash -c '. "$1"; bridge_check_interval' _ "$WATCH"
+  )
+  [ "$interval" = 30 ] || \
+    fail "cadence with the secondary vessel at immediate priority was $interval, expected 30"
+  pass "the shared Bridge cadence tightens when any watched vessel is high or immediate priority"
+}
+
+test_cache_skips_rescan_when_unchanged() {
+  local home fakebin counter out calls
+  home=$(make_home cache)
+  counter="$home/jq-calls"
+  fakebin=$(counting_jq "$home" "$counter")
+  write_envelope "$home" first normal
+
+  # shellcheck disable=SC2016
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" bash -c '. "$1"; bridge_pending_priority' _ "$WATCH")
+  [ "$out" = normal ] || fail "first priority read was $out, expected normal"
+  # shellcheck disable=SC2016
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" bash -c '. "$1"; bridge_pending_priority' _ "$WATCH")
+  [ "$out" = normal ] || fail "cached priority read was $out, expected normal"
+  calls=$(count_lines "$counter")
+  [ "$calls" = 1 ] || fail "unchanged inbox re-ran the priority scan ($calls envelope reads, expected 1)"
+
+  write_envelope "$home" second immediate
+  # shellcheck disable=SC2016
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" bash -c '. "$1"; bridge_pending_priority' _ "$WATCH")
+  [ "$out" = immediate ] || fail "priority after new arrival was $out, expected immediate"
+  calls=$(count_lines "$counter")
+  [ "$calls" = 3 ] || fail "new arrival did not trigger a rescan (1 old + 2 new reads: got $calls, expected 3)"
+  pass "an unchanged Bridge inbox reuses the cached priority; new arrivals trigger a rescan"
+}
+
+test_inplace_edit_invalidates_cache() {
+  local home fakebin counter out calls
+  home=$(make_home inplace)
+  counter="$home/jq-calls"
+  fakebin=$(counting_jq "$home" "$counter")
+  write_envelope "$home" first normal
+
+  # shellcheck disable=SC2016
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" bash -c '. "$1"; bridge_pending_priority' _ "$WATCH")
+  [ "$out" = normal ] || fail "first priority read was $out, expected normal"
+
+  write_envelope "$home" first immediate
+  # shellcheck disable=SC2016
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" bash -c '. "$1"; bridge_pending_priority' _ "$WATCH")
+  [ "$out" = immediate ] || \
+    fail "priority after an in-place edit was $out, expected immediate (the cache did not invalidate)"
+  calls=$(count_lines "$counter")
+  [ "$calls" = 2 ] || \
+    fail "an in-place edit under an unchanged filename did not trigger a rescan ($calls reads, expected 2)"
+  pass "an in-place envelope edit under an unchanged filename invalidates the cached priority"
+}
+
+test_discovery_gated_by_urgent_interval() {
+  local home fakebin counter out calls
+  # An empty inbox keeps the watcher looping, so the scan count reflects the
+  # discovery gate rather than an early exit on a wake.
+  home=$(make_home discovery)
+  counter="$home/timeout-calls"
+  fakebin=$(counting_timeout "$home" "$counter")
+  out="$home/watch.out"
+
+  # A wide urgent interval means exactly one discovery, no matter how many poll
+  # cycles elapse; without the gate every 1s cycle would fetch and rescan.
+  watch_briefly "$home" "$out" 4 "PATH=$fakebin:$PATH" \
+    FM_BRIDGE_URGENT_CHECK_INTERVAL=999999 FM_CHECK_INTERVAL=999999
+
+  calls=$(count_lines "$counter")
+  [ "$calls" -le 5 ] || \
+    fail "repeated unchanged loop cycles kept spawning bounded scans ($calls calls across several ticks)"
+  assert_present "$home/state/.last-bridge-discovery" "the Bridge discovery cadence marker was never written"
+  pass "repeated loop cycles do not keep spawning Bridge scans within the urgent window"
+}
+
+test_acked_on_origin_ignores_stale_working_tree() {
+  local home bridge peer out
+  home=$(make_home stale-working-tree)
+  bridge="$home/projects/coditan-bridge"
+  peer="$home/bridge-peer"
+  write_envelope "$home" acked normal
+
+  # Acknowledge from a peer clone so the local Bridge working tree keeps the
+  # envelope file that origin/main no longer carries.
+  git clone -q "$home/bridge-origin.git" "$peer"
+  git -C "$peer" rm -q inbox/coditan/new/acked.json
+  git -C "$peer" commit -qm "ack envelope"
+  git -C "$peer" push -qu origin main
+  assert_present "$bridge/inbox/coditan/new/acked.json" \
+    "the stale-working-tree fixture did not retain the locally pending envelope"
+
+  out="$home/watch.out"
+  watch_briefly "$home" "$out" 3
+
+  [ ! -s "$out" ] || fail "an origin-acked envelope in a stale working tree caused a false wake: $(cat "$out")"
+  assert_absent "$home/state/.wake-queue" \
+    "an origin-acked envelope in a stale working tree created a wake"
+  assert_present "$bridge/inbox/coditan/new/acked.json" \
+    "the watcher fetch mutated the stale Bridge working tree"
+  pass "an origin ack clears the check without mutating a stale local working tree"
+}
+
+test_vessel_resolution_precedence
+test_multi_vessel_list_resolves_into_array
+test_unconfigured_home_skips_bridge_scan
+test_missing_bridge_clone_skips_scan
+test_empty_inbox_is_silent
+test_bridge_inbox_surfaces_each_signature_once
+test_multi_vessel_each_surfaces_independently
+test_priority_tightens_only_bridge_cadence
+test_multi_vessel_cadence_reflects_any_vessel
+test_cache_skips_rescan_when_unchanged
+test_inplace_edit_invalidates_cache
+test_discovery_gated_by_urgent_interval
+test_acked_on_origin_ignores_stale_working_tree


### PR DESCRIPTION
## Intent

Contribute the Bridge inbox check feature from the Freudator86/firstmate fork upstream to kunchenguid/firstmate, with test coverage added, so it stops being permanent fork-only drift.

Background: the native Bridge inbox check (FM_BRIDGE_VESSEL / config/bridge-vessel, the check logic driven from bin/fm-watch.sh, and the docs/configuration.md section) exists on our fork's own main but was never PR'd upstream. Core changes are supposed to flow through the contribution fork and an upstream PR rather than living forever as fork-local divergence.

Deliberate decisions made while doing the work, which a reviewer reading only the diff would not know:

1. The branch is based on origin/main (kunchenguid/firstmate, a5fe1bc), NOT on the fork's main, because the fork already contains the feature and a branch cut from it would produce an empty diff. The feature was ported forward onto current upstream code.

2. ONLY the Bridge inbox check is in scope. The fork is 53 commits ahead of upstream and carries much other drift. Two closely related fork features were deliberately EXCLUDED and are not missing by accident: bin/fm-bridge-relay.sh plus its tests (a separate guarded relay path for envelope traffic, not the inbox check), and the fast Bridge frequency monitor (bin/fm-frequency-monitor.sh, bin/fm-frequency-monitor-service.sh, their tests and the systemd unit). Other unshipped fork drift was reported separately rather than bundled in.

3. On the fork, bridge_inbox_surface takes a lock and a fetch parameter. Both exist only to serialize the watcher against that fast frequency monitor. Since the monitor is not part of this contribution, shipping the lock would mean upstream carrying a lock guarding a process that does not exist in the tree, so the lock and the now-unused fetch parameter were deliberately dropped. Upstream runs exactly one watcher process through the existing watcher singleton lock. This is a considered simplification, not an omission.

4. The detection logic was kept in a separate sourced library, bin/fm-bridge-inbox-lib.sh, rather than inlined into bin/fm-watch.sh: fm-watch.sh already delegates to fm-check-lib, fm-pr-lib, fm-x-lib and fm-pending-reply-lib, and the separation keeps 170 lines out of an already large watcher and lets the tests source the library directly.

5. FM_BRIDGE_ROOT deliberately keeps the fork's default of $FM_HOME/projects/coditan-bridge. That is a specific repo name, which may look surprising upstream, but changing it would silently break every existing instance on fast-forward. It is overridable and the whole feature is off by default, so compatibility was chosen over a more neutral default.

6. The premise that the feature had zero tests turned out to be wrong: the fork does carry tests/fm-watch-bridge-inbox.test.sh. Those tests were used as the starting point rather than writing from scratch, then adapted to upstream's tests/lib.sh helpers (fm_test_tmproot has a different signature upstream, plus fm_git_identity and fm_fakebin), and strengthened: two cases the fork lacks were added (the missing-clone short circuit and an empty-inbox marker assertion) and the discovery-gate case was fixed, because the fork's version exits on a wake before the gate it claims to test is ever exercised. The tests were verified to bite by two mutations: dropping the surfaced-marker write and reading HEAD: instead of origin/main: each produced a distinct failure.

7. Knowledge placement follows .agents/skills/firstmate-coding-guidelines/SKILL.md. docs/configuration.md owns the schema (config file, env vars, on/off semantics, operator-visible wake behavior) and deliberately does NOT restate the detection, caching, or wake-publication mechanics; those are owned by bin/fm-bridge-inbox-lib.sh's own header, and the wake reason string is owned by bin/fm-watch.sh's header. AGENTS.md growth was kept to one config row, one word added to an existing state-internals line, and two words in an existing check-wake line, per that skill's size discipline.

Known pre-existing failure, not caused by this change: tests/fm-watcher-lock.test.sh fails at 'restart did not attach to the verified healthy peer' in this environment. It was reproduced on a pristine clone of origin/main with none of these changes applied, so it is environmental.

## What Changed

- Adds a read-only Bridge inbox poll to `bin/fm-watch.sh`, backed by a new `bin/fm-bridge-inbox-lib.sh`: it fetches the shared Bridge clone's `origin/main`, reads `inbox/<vessel>/new/` from that ref, and queues a `check: bridge-inbox: ...` wake per vessel whose pending mail changed, staying silent while the tree is unchanged. The feature is off unless `FM_BRIDGE_VESSEL` or `config/bridge-vessel` names a vessel and the clone exists; it runs on its own cached cadence, which `FM_BRIDGE_URGENT_CHECK_INTERVAL` only ever tightens (discovery uses the smaller of the two so a widened knob cannot freeze the ref).
- Extracts the watcher's inline `timeout`/`gtimeout`/`perl` triad into `bin/fm-bounded-process-lib.sh` so the check scripts and the Bridge reads share one bounded-child runner with process-group teardown on signals; the Bridge lib requires it rather than carrying its own copy.
- Adds `tests/fm-watch-bridge-inbox.test.sh` (18 cases, including the missing-clone short circuit, empty-inbox marker, and the discovery gate), clears the three new `FM_BRIDGE_*` variables in both test-isolation env sanitizers, and documents the schema in `docs/configuration.md`, `docs/scripts.md`, and one `AGENTS.md` config row.

Test, Lint, and Push passed. `tests/fm-watcher-lock.test.sh` and `tests/fm-turnend-guard.test.sh` fail identically on a clean extraction of base `a5fe1bc`, so both are pre-existing and environmental.

## Rebase onto current base

The branch was cut from `a5fe1bc` and had been conflicting since. It is now rebased onto `cd73e75`, the current `main`, which is 41 commits ahead of that old base. The pre-rebase head was `c449da4`.

Every conflict was decided against what the code does now, not against what it did when the branch was cut. A resolution that only clears the markers can restore stale behaviour under the appearance of a clean rebase, and one of these hunks was exactly that trap. Each conflict and the side taken:

**`.gitignore` - took the base side whole; the branch's line is now dead.**
The branch added `config/bridge-vessel` to the name-by-name ignore list. `e595611` (#1261) has since replaced that entire list with a `config/` directory ignore, and `tests/fm-gitignore-config.test.sh` asserts precisely that ("must ignore `config/` as a directory, not by exact filename"). Re-adding an enumerated entry, or keeping both sides, would have reverted that fix and failed its test. Nothing is lost: `config/bridge-vessel` is already covered by `config/`. One consequence for the reader - the operator transcript further down predates this and still shows `.gitignore:21:config/bridge-vessel` as the `git check-ignore` hit; the current hit is `config/`, and the file is still ignored.

**`AGENTS.md` check-wake list - merged both, took neither side whole.**
The branch rewrote item 3 to "merges, Bridge inbox traffic, and X-mode events". The base had independently rewritten the same line to "merges, X-mode events, and process-to-event source results". Taking the branch side would have silently deleted that new process-event item. The line now reads "merges, Bridge inbox traffic, X-mode events, and process-to-event source results".

**`docs/configuration.md` environment block - kept both additions.**
The base inserted `FM_PROCEVENT_*` and the branch inserted `FM_BRIDGE_*` at the same point after `FM_CHECK_TIMEOUT`. The two are independent. The `FM_BRIDGE_*` rows now sit directly under `FM_CHECK_TIMEOUT` so the check-cadence knobs stay grouped, with the `FM_PROCEVENT_*` rows unchanged below them.

**`bin/fm-watch.sh` - kept both, and re-verified the extraction against current code.**
The base added `procevent_surfaced_marker` / `procevent_surface_after_output` / `procevent_surface_queued` in the exact place this branch extracts the inline `timeout`/`gtimeout`/`perl` triad into `run_bounded_process`, so the same region conflicted twice: once for the extraction, once for the later move of that function into `bin/fm-bounded-process-lib.sh`. All three process-event functions are kept untouched, and the extraction and then the move are applied on top of them.

The branch's claim that the extraction is behaviour-preserving was re-checked against the base's *current* `run_check_process`, not against the older one it was originally written from. The `exec perl -e '...'` program is byte-identical on both sides (555 bytes each) once `"$CHECK_TIMEOUT"` -> `"$t"` and `bash "$c" "$@"` -> `"$@"` are applied, and the `timeout`/`gtimeout` branches differ only by that same parameterization. The shared check path is still provably unchanged.

Three things merged without conflict but were verified rather than assumed, because the watcher moved substantially over those 41 commits:

- The Bridge poll still sits between the slow-check sweep and the signal scan, and still calls `wake` and `age_of`. `wake` now lives in `bin/fm-push-transition-lib.sh`, which `bin/fm-watch.sh` sources, and still exits the cycle; `age_of` is unchanged.
- `fm_wake_append`'s `(kind, key, payload)` signature is unchanged, so the per-vessel enqueue-before-marker publication still holds. `procevent_surface_queued` filters queued keys on `procevent:*`, so the `bridge-inbox:<vessel>` keys pass through it untouched.
- `tests/lib.sh` drift since the old base is confined to `fm_write_secondmate_meta`, which this suite does not use, and the two `docs/configuration.md` cross-references added by the last commit ("Toolchain" above, the `FM_CHECK_INTERVAL` transition below) both still resolve.

### One test added during the rebase

`tests/fm-watch-bridge-inbox.test.sh` gains `test_bounded_process_lib_bounds_a_runaway_child`, taking it from 18 cases to 19. No existing assertion was weakened or removed.

`bin/fm-bounded-process-lib.sh` is a new shared script that no test named, and `bin/fm-test-run.sh` fails closed on an unmapped `bin/` path: `--changed` dies with `no changed-test mapping for source path: bin/fm-bounded-process-lib.sh` (exit 2). That guard is a contract `tests/fm-test-run.test.sh` asserts deliberately, and it would hit every later branch that touches this file. It is pre-existing on the branch rather than caused by the rebase - it reproduces on the pre-rebase head - but it should not ship.

The new case covers the script through its behaviour rather than by asserting a source line: `run_bounded_process` must stop a runaway child at the requested bound and exit 124, on the `timeout` path and on the `perl` fallback whose signal hardening had no coverage at all, since a machine with `timeout` installed never reaches it otherwise. Proven to bite - with the bound removed from the helper, the case fails with `did not bound a runaway child: exit 0`. `--changed` now resolves.

### Verification after the rebase

No conflict markers remain anywhere in the tree.

**CI on this head: 9 of 10 checks green, and the tenth was cancelled rather than failed.**

`Behavior portable serial` shows as not-green, but its log ends with `FM_TEST_SUMMARY total=70 failed=0 skipped_gate=13 duration_ms=1203725`, followed by `##[error]The operation was canceled.` Every one of that lane's 70 scripts ran and passed; the job was then killed by the workflow's own `timeout-minutes: 20` about sixteen seconds after the suite finished, during artifact upload. There is not a single `not ok` line in the job log.

This is not caused by this branch, and the base can be checked directly: the same job on `cd73e75` itself - upstream `main`'s own CI run `30737553289`, with none of these changes - was cancelled by the same cap at 20m16s, and got *less* far than this branch does. It reached 68 of 70 scripts and never printed a summary line at all, so the lane did not even complete there. This branch's run completes it, at 20m15s.

The lane has been creeping into its cap on `main`: 18m40s at `1e24757`, 19m13s at `8c21b10`, then over the cap at `cd73e75`. The workflow comment still sizes that cap against a "measured serial remainder is ~13 min wall". Nothing in this PR needs a decision about it, and fixing it is out of scope for a rebase, but it does mean no PR against this base can currently show a fully green serial lane until the lane is sped back up or the cap is raised. Happy to carry that as its own change if that would help.

Run locally against the rebased branch, before the push:

- `bin/fm-lint.sh`: clean (pinned ShellCheck 0.11.0).
- `tests/fm-watch-bridge-inbox.test.sh`: 19/19.
- `bin/fm-test-run.sh --lane portable-parallel-2`: 13 scripts, 0 failed.
- `bin/fm-test-run.sh --lane portable-parallel-1`: 11 scripts, the only failure being `tests/fm-test-run.test.sh`, which fails identically on a pristine checkout of the base `cd73e75` in this environment. Its coverage-guard case sorts inputs with `LC_ALL=C` but then runs `comm` in the ambient locale, so any non-C default trips `comm: file 2 is not in sorted order`. Under `LC_ALL=C` both that case and `bin/fm-test-run.sh --check-coverage` pass with these changes (`FM_TEST_COVERAGE ok total=105`). Environmental and pre-existing; CI runs it green on the base.
- `bin/fm-test-run.sh --lane portable-serial`: 70 scripts, 5 failed locally - all five environmental, and all five green in CI. Each was re-run on a pristine checkout of the base `cd73e75` in the same environment and fails there with the identical assertion: `fm-busy-adapter-wiring` and `fm-calm-pi-extension` both die in Node with `ERR_UNKNOWN_FILE_EXTENSION` (this box runs Node 20.20.2); `fm-pi-watch-extension` fails "must surface an external healthy watcher as an owned-wake failure" on a host that has a real watcher running; `fm-session-start` fails "MISSING diagnostic did not appear at all"; and `fm-turnend-guard` fails "Pi guard must inject once for no-tool and multi-tool logical runs".
- The whole `watcher-wake-lock` family, which is where this change lives, was run: `fm-watch-bridge-inbox`, `fm-watch-triage`, `fm-watcher-lock`, `fm-wake-queue`, `fm-daemon`, `fm-watch-checkpoint`, `fm-supervision-events` and `fm-wake-daemon-lifecycle-e2e` all pass. The family's only two failures are the pre-existing `fm-pi-watch-extension` and `fm-turnend-guard` above.

One correction to the "Known pre-existing failure" note earlier in this body: `tests/fm-watcher-lock.test.sh` no longer fails. It passes on the rebased branch (101s, exit 0). `tests/fm-turnend-guard.test.sh` is still failing, still pre-existing, but now on a different assertion than the one recorded at the old base.

## Risk Assessment

✅ Low: Both round-2 findings are closed with tests that bite the pre-fix behaviour, the `run_bounded_process` extraction is byte-identical to the code it replaces so the shared check path is provably unchanged, and the only residual is an inaccurate absolute claim in a new file's header comment.

## Testing

I drove the real watcher end to end against a real Bridge clone and captured the operator transcript: with no config/bridge-vessel the feature is completely silent and writes no state/.bridge-* files even while mail waits on origin; after enabling the vessel it emits `check: bridge-inbox: bridge-inbox coditan pending=1 highest=high`, queues a durable per-vessel record that fm-wake-drain.sh hands to the captain, stays silent while the inbox is unchanged, re-fires with an updated count and priority on new immediate mail, goes quiet again after an origin-side ack without ever mutating the stale local working tree, and keeps two configured vessels independent in an undrained queue. The new 18-case suite passes, and I proved it actually bites by mutating two lines on pristine copies of the target commit (dropping the surfaced-marker write, and reading local HEAD instead of the fetched origin/main), each producing a distinct failure. The watcher family plus the tests covering the bounded-process extraction, the runner family assignment, and the docs/AGENTS rows all pass. Two suites fail, both reproduced identically on a clean extraction of base a5fe1bc and therefore not caused by this change: fm-watcher-lock (the one the author documented) and fm-turnend-guard. No screenshots apply — this change has no UI surface; its entire end-user surface is watcher stdout, the durable wake queue, and state files, all captured in the CLI transcript.

<details>
<summary>Evidence: Operator walkthrough: Bridge inbox check end to end (real fm-watch.sh + real Bridge clone)</summary>

<code>=== 1. Off by default: no config/bridge-vessel, no FM_BRIDGE_VESSEL ===&#10;watcher output (6s, mail waiting on origin):&#10;[end of watcher output]&#10;Bridge state files created while disabled:&#10;$ ls -1a .../state | grep bridge || echo &#39;(none - the watcher never scanned)&#39;&#10;(none - the watcher never scanned)&#10;wake queue: (absent/empty)&#10;&#10;=== 2. Operator enables the check for vessel &#39;coditan&#39; ===&#10;$ printf &#39;coditan\n&#39; &gt; .../config/bridge-vessel&#10;$ git check-ignore -v config/bridge-vessel&#10;.gitignore:21:config/bridge-vessel config/bridge-vessel&#10;&#10;=== 3. Watcher surfaces the pending envelope as an actionable check wake ===&#10;watcher stdout:&#10;check: bridge-inbox: bridge-inbox coditan pending=1 highest=high&#10;&#10;durable wake queue (state/.wake-queue):&#10;1785120240 1 check bridge-inbox:coditan check: bridge-inbox: bridge-inbox coditan pending=1 highest=high&#10;&#10;state/.bridge-surfaced marker: 795aba94164fa30f7028ae3e61565db6ab17076a&#10;origin/main inbox tree: 795aba94164fa30f7028ae3e61565db6ab17076a&#10;&#10;=== 4. What the captain sees on the next turn (bin/fm-wake-drain.sh) ===&#10;1785120240 1 check bridge-inbox:coditan check: bridge-inbox: bridge-inbox coditan pending=1 highest=high&#10;&#10;=== 5. Unchanged inbox: still pending, but already surfaced -&gt; silent ===&#10;watcher output (8s):&#10;[end of watcher output]&#10;wake queue: (empty)&#10;&#10;=== 6. New immediate-priority mail arrives -&gt; a fresh wake with the new count/priority ===&#10;Bridge delivered escalation (priority=immediate) to inbox/coditan/new/ on origin/main&#10;check: bridge-inbox: bridge-inbox coditan pending=2 highest=immediate&#10;&#10;=== 7. Bridge acknowledges everything on origin; the local clone is still stale ===&#10;local working tree still holds the acked envelopes:&#10;.gitkeep escalation.json hello-while-unconfigured.json&#10;watcher output (8s):&#10;[end of watcher output]&#10;wake queue: (empty)&#10;surfaced marker after ack: (cleared)&#10;local working tree untouched by the watcher:&#10;.gitkeep escalation.json hello-while-unconfigured.json&#10;$ git status --porcelain&#10;&#10;=== 8. Multi-vessel: &#39;coditan tugboat&#39;, each vessel independent ===&#10;Bridge delivered for-coditan (priority=normal) to inbox/coditan/new/ on origin/main&#10;check: bridge-inbox: bridge-inbox coditan pending=1 highest=normal&#10;Bridge delivered for-tugboat (priority=immediate) to inbox/tugboat/new/ on origin/main&#10;check: bridge-inbox: bridge-inbox tugboat pending=1 highest=immediate&#10;&#10;undrained queue holds one record per vessel:&#10;1785120362 3 check bridge-inbox:coditan check: bridge-inbox: bridge-inbox coditan pending=1 highest=normal&#10;1785120366 4 check bridge-inbox:tugboat check: bridge-inbox: bridge-inbox tugboat pending=1 highest=immediate&#10;&#10;=== 9. Both vessels reach the captain from one drain ===&#10;1785120362 3 check bridge-inbox:coditan check: bridge-inbox: bridge-inbox coditan pending=1 highest=normal&#10;1785120366 4 check bridge-inbox:tugboat check: bridge-inbox: bridge-inbox tugboat pending=1 highest=immediate&#10;&#10;=== 10. Bridge state files the watcher owns ===&#10;.bridge-interval-cache&#10;.bridge-priority-cache&#10;.bridge-priority-cache-tugboat&#10;.bridge-surfaced&#10;.bridge-surfaced-tugboat&#10;.last-bridge-check&#10;.last-bridge-discovery</code>

```text

^[[1m=== 1. Off by default: no config/bridge-vessel, no FM_BRIDGE_VESSEL ===^[[0m
$ ls /tmp/no-mistakes-evidence/01KYGK9BE5MEFSGXM05CNVSP1E/lab/home/config
watcher output (6s, mail waiting on origin):
[end of watcher output]
Bridge state files created while disabled:
$ ls -1a /tmp/no-mistakes-evidence/01KYGK9BE5MEFSGXM05CNVSP1E/lab/home/state | grep bridge || echo '(none - the watcher never scanned)'
(none - the watcher never scanned)
wake queue: (absent/empty)

^[[1m=== 2. Operator enables the check for vessel 'coditan' ===^[[0m
$ printf 'coditan\n' > /tmp/no-mistakes-evidence/01KYGK9BE5MEFSGXM05CNVSP1E/lab/home/config/bridge-vessel
$ cat /tmp/no-mistakes-evidence/01KYGK9BE5MEFSGXM05CNVSP1E/lab/home/config/bridge-vessel
coditan
$ git -C /home/captain/.no-mistakes/worktrees/595f2100ea41/01KYGK9BE5MEFSGXM05CNVSP1E check-ignore -v config/bridge-vessel
.gitignore:21:config/bridge-vessel	config/bridge-vessel

^[[1m=== 3. Watcher surfaces the pending envelope as an actionable check wake ===^[[0m
watcher stdout:
check: bridge-inbox: bridge-inbox coditan pending=1 highest=high

durable wake queue (state/.wake-queue):
1785120344	1	check	bridge-inbox:coditan	check: bridge-inbox: bridge-inbox coditan pending=1 highest=high

state/.bridge-surfaced marker: 795aba94164fa30f7028ae3e61565db6ab17076a
origin/main inbox tree:         795aba94164fa30f7028ae3e61565db6ab17076a

^[[1m=== 4. What the captain sees on the next turn (bin/fm-wake-drain.sh) ===^[[0m
1785120344	1	check	bridge-inbox:coditan	check: bridge-inbox: bridge-inbox coditan pending=1 highest=high

^[[1m=== 5. Unchanged inbox: still pending, but already surfaced -> silent ===^[[0m
watcher output (8s):
[end of watcher output]
wake queue: (empty)

^[[1m=== 6. New immediate-priority mail arrives -> a fresh wake with the new count/priority ===^[[0m
Bridge delivered escalation (priority=immediate) to inbox/coditan/new/ on origin/main
check: bridge-inbox: bridge-inbox coditan pending=2 highest=immediate
durable record:
1785120353	2	check	bridge-inbox:coditan	check: bridge-inbox: bridge-inbox coditan pending=2 highest=immediate

^[[1m=== 7. Bridge acknowledges everything on origin; the local clone is still dirty/stale ===^[[0m
Bridge acknowledged hello-while-unconfigured for coditan on origin/main
Bridge acknowledged escalation for coditan on origin/main
local working tree still holds the acked envelopes:
$ ls -1a /tmp/no-mistakes-evidence/01KYGK9BE5MEFSGXM05CNVSP1E/lab/home/projects/coditan-bridge/inbox/coditan/new
.
..
.gitkeep
escalation.json
hello-while-unconfigured.json
watcher output (8s):
[end of watcher output]
wake queue: (empty)
surfaced marker after ack: (cleared)
local working tree untouched by the watcher:
$ ls -1a /tmp/no-mistakes-evidence/01KYGK9BE5MEFSGXM05CNVSP1E/lab/home/projects/coditan-bridge/inbox/coditan/new
.
..
.gitkeep
escalation.json
hello-while-unconfigured.json
$ git -C /tmp/no-mistakes-evidence/01KYGK9BE5MEFSGXM05CNVSP1E/lab/home/projects/coditan-bridge status --porcelain

^[[1m=== 8. Multi-vessel: 'coditan tugboat', each vessel independent ===^[[0m
$ printf 'coditan tugboat\n' > /tmp/no-mistakes-evidence/01KYGK9BE5MEFSGXM05CNVSP1E/lab/home/config/bridge-vessel
Bridge delivered for-coditan (priority=normal) to inbox/coditan/new/ on origin/main
check: bridge-inbox: bridge-inbox coditan pending=1 highest=normal
Bridge delivered for-tugboat (priority=immediate) to inbox/tugboat/new/ on origin/main
check: bridge-inbox: bridge-inbox tugboat pending=1 highest=immediate

undrained queue holds one record per vessel:
1785120362	3	check	bridge-inbox:coditan	check: bridge-inbox: bridge-inbox coditan pending=1 highest=normal
1785120366	4	check	bridge-inbox:tugboat	check: bridge-inbox: bridge-inbox tugboat pending=1 highest=immediate


^[[1m=== 9. Both vessels reach the captain from one drain ===^[[0m
1785120362	3	check	bridge-inbox:coditan	check: bridge-inbox: bridge-inbox coditan pending=1 highest=normal
1785120366	4	check	bridge-inbox:tugboat	check: bridge-inbox: bridge-inbox tugboat pending=1 highest=immediate

^[[1m=== 10. Bridge state files the watcher owns ===^[[0m
$ ls -1a /tmp/no-mistakes-evidence/01KYGK9BE5MEFSGXM05CNVSP1E/lab/home/state | grep bridge
.bridge-interval-cache
.bridge-priority-cache
.bridge-priority-cache-tugboat
.bridge-surfaced
.bridge-surfaced-tugboat
.last-bridge-check
.last-bridge-discovery
```
</details>
<details>
<summary>Evidence: Mutation check: the new tests catch both injected defects</summary>

<code>=== Mutant A: per-vessel surfaced-marker write removed ===&#10;fm_wake_append check &#34;bridge-inbox:$vessel&#34; &#34;check: bridge-inbox: $vessel_out&#34; || return &#34;$?&#34;&#10;: # MUTATED: surfaced-marker write dropped&#10;-&gt; suite exit 1&#10;not ok - first surfaced inbox signature was not recorded&#10;&#10;=== Mutant B: inbox tree read from local HEAD instead of the fetched origin/main ===&#10;BRIDGE_SIGNATURE_SCAN=&#39;sig=$(git -C &#34;$1&#34; rev-parse &#34;HEAD:inbox/$2/new&#34; 2&gt;/dev/null || true); printf &#34;%s&#34; &#34;${sig:-empty}&#34;&#39;&#10;-&gt; suite exit 1&#10;not ok - a wide FM_BRIDGE_URGENT_CHECK_INTERVAL froze Bridge detection: mail arriving after the first discovery was never seen&#10;&#10;=== Unmutated worktree: suite exit 0, 18/18 ok ===</code>

```text
Mutation check: do tests/fm-watch-bridge-inbox.test.sh assertions actually bite?
Each mutant is a pristine copy of 26b88d7 with one line changed; the suite is unmodified.

=== Mutant A: bin/fm-bridge-inbox-lib.sh - per-vessel surfaced-marker write removed ===
    surfaced=$(cat "$marker" 2>/dev/null || true)
    [ "$sig" != timeout ] || continue
    [ "$sig" != "$surfaced" ] || continue
    vessel_out=$(bridge_inbox_check "$vessel" "$sig")
    if [ -n "$vessel_out" ]; then
      fm_wake_append check "bridge-inbox:$vessel" "check: bridge-inbox: $vessel_out" || return "$?"
      : # MUTATED: surfaced-marker write dropped
      out="${out:+$out; }$vessel_out"
    else
      # An acknowledged inbox drops its marker so the same envelopes surface
      # again if Bridge re-delivers them byte-identically later.
      rm -f "$marker" 2>/dev/null || true
    fi
-> suite exit 1
not ok - first surfaced inbox signature was not recorded

=== Mutant B: inbox tree read from local HEAD instead of the fetched origin/main ===
BRIDGE_SIGNATURE_SCAN='sig=$(git -C "$1" rev-parse "HEAD:inbox/$2/new" 2>/dev/null || true); printf "%s" "${sig:-empty}"'
-> suite exit 1
not ok - a wide FM_BRIDGE_URGENT_CHECK_INTERVAL froze Bridge detection: mail arriving after the first discovery was never seen

=== Unmutated worktree: suite exit 0, 18/18 ok (see bridge-inbox-tests.txt) ===
```
</details>
<details>
<summary>Evidence: tests/fm-watch-bridge-inbox.test.sh output</summary>

<code>ok - Bridge vessel resolution prefers a non-empty env value and falls back to the effective home&#39;s config&#10;ok - a config/bridge-vessel written without a final newline still resolves its vessel&#10;ok - a space-separated FM_BRIDGE_VESSEL resolves into an ordered vessel list, with BRIDGE_VESSEL as the first&#10;ok - a home with neither FM_BRIDGE_VESSEL nor config/bridge-vessel performs no Bridge scan and emits no wake&#10;ok - a configured vessel without a Bridge clone short-circuits without spawning a scan&#10;ok - an empty Bridge inbox is scanned and absorbed silently&#10;ok - Bridge inbox wakes once per pending signature, clears on ack, and re-fires on re-delivery&#10;ok - each configured vessel surfaces its own pending mail independently of the others&#10;ok - a vessel queued before the queue drains is still named once a later vessel queues its own wake&#10;ok - high-priority Bridge traffic tightens only the Bridge poll interval&#10;ok - a non-numeric urgent interval falls back to the documented default rather than propagating&#10;ok - the library sources the bounded-child helper it needs instead of expecting it from a caller&#10;ok - the shared Bridge cadence tightens when any watched vessel is high or immediate priority&#10;ok - an unchanged Bridge inbox reuses the cached priority; new arrivals trigger a rescan&#10;ok - an in-place envelope edit under an unchanged filename invalidates the cached priority&#10;ok - repeated loop cycles do not keep spawning Bridge scans within the urgent window&#10;ok - a wide urgent interval only tightens the Bridge cadence and never stops refreshing origin/main&#10;ok - an origin ack clears the check without mutating a stale local working tree</code>

```text
ok - Bridge vessel resolution prefers a non-empty env value and falls back to the effective home's config
ok - a config/bridge-vessel written without a final newline still resolves its vessel
ok - a space-separated FM_BRIDGE_VESSEL resolves into an ordered vessel list, with BRIDGE_VESSEL as the first
ok - a home with neither FM_BRIDGE_VESSEL nor config/bridge-vessel performs no Bridge scan and emits no wake
ok - a configured vessel without a Bridge clone short-circuits without spawning a scan
ok - an empty Bridge inbox is scanned and absorbed silently
ok - Bridge inbox wakes once per pending signature, clears on ack, and re-fires on re-delivery
ok - each configured vessel surfaces its own pending mail independently of the others
ok - a vessel queued before the queue drains is still named once a later vessel queues its own wake
ok - high-priority Bridge traffic tightens only the Bridge poll interval
ok - a non-numeric urgent interval falls back to the documented default rather than propagating
ok - the library sources the bounded-child helper it needs instead of expecting it from a caller
ok - the shared Bridge cadence tightens when any watched vessel is high or immediate priority
ok - an unchanged Bridge inbox reuses the cached priority; new arrivals trigger a rescan
ok - an in-place envelope edit under an unchanged filename invalidates the cached priority
ok - repeated loop cycles do not keep spawning Bridge scans within the urgent window
ok - a wide urgent interval only tightens the Bridge cadence and never stops refreshing origin/main
ok - an origin ack clears the check without mutating a stale local working tree
```
</details>
<details>
<summary>Evidence: Walkthrough script used to produce the operator transcript</summary>

```text
#!/usr/bin/env bash
# Manual operator walkthrough of the Bridge inbox check, run against the real
# bin/fm-watch.sh from the worktree with a real Bridge git clone.
set -u

ROOT=$1
LAB=$2
rm -rf "$LAB"
HOME_DIR="$LAB/home"
BRIDGE="$HOME_DIR/projects/coditan-bridge"
ORIGIN="$LAB/coditan-bridge.git"
PEER="$LAB/bridge-peer"   # stands in for the Bridge tooling on the other side
mkdir -p "$HOME_DIR/state" "$HOME_DIR/config"

export GIT_AUTHOR_NAME=demo GIT_AUTHOR_EMAIL=demo@example.com
export GIT_COMMITTER_NAME=demo GIT_COMMITTER_EMAIL=demo@example.com
export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null

say() { printf '\n\033[1m=== %s ===\033[0m\n' "$*"; }
run() { printf '$ %s\n' "$*"; eval "$@"; }

# ---- Bridge side: an origin, the operator's shared clone, and Bridge tooling's peer
git init -q --bare "$ORIGIN"
git --git-dir="$ORIGIN" symbolic-ref HEAD refs/heads/main
git init -q -b main "$BRIDGE" 2>/dev/null
mkdir -p "$BRIDGE/inbox/coditan/new" "$BRIDGE/inbox/tugboat/new"
touch "$BRIDGE/inbox/coditan/new/.gitkeep" "$BRIDGE/inbox/tugboat/new/.gitkeep"
git -C "$BRIDGE" add inbox >/dev/null
git -C "$BRIDGE" commit -qm "init bridge inboxes"
git -C "$BRIDGE" remote add origin "$ORIGIN"
git -C "$BRIDGE" push -qu origin main
git clone -q "$ORIGIN" "$PEER"

# Delivery lands in the shared clone and is published to origin/main, so the
# local working tree genuinely carries the envelope - that is what makes the
# later origin-side ack a real stale-working-tree case.
deliver() {  # <vessel> <id> <priority>
  printf '{"schema":"bridge-envelope.v1","id":"%s","priority":"%s","state":"new"}\n' \
    "$2" "$3" > "$BRIDGE/inbox/$1/new/$2.json"
  git -C "$BRIDGE" add "inbox/$1/new/$2.json" >/dev/null
  git -C "$BRIDGE" commit -qm "deliver $2 to $1"
  git -C "$BRIDGE" push -q origin main
  echo "Bridge delivered $2 (priority=$3) to inbox/$1/new/ on origin/main"
}

ack() {  # <vessel> <id> - acknowledged by the Bridge tooling on the other side
  git -C "$PEER" fetch -q origin main && git -C "$PEER" reset -q --hard origin/main
  git -C "$PEER" rm -q "inbox/$1/new/$2.json"
  git -C "$PEER" commit -qm "ack $2" >/dev/null
  git -C "$PEER" push -q origin main
  echo "Bridge acknowledged $2 for $1 on origin/main"
}

# The watcher, run the way an armed firstmate home runs it. It exits by design
# on the first actionable wake; a silent run is stopped after a few cycles.
watch_until_wake() {
  local out=$1 pid i=0
  shift
  env FM_HOME="$HOME_DIR" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=5 \
    FM_BRIDGE_URGENT_CHECK_INTERVAL=2 FM_HEARTBEAT=999999 "$@" \
    "$ROOT/bin/fm-watch.sh" > "$out" 2>&1 &
  pid=$!
  while [ $i -lt 300 ]; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; i=$((i+1)); done
  kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
}

watch_briefly() {
  local out=$1 secs=$2 pid
  shift 2
  env FM_HOME="$HOME_DIR" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=5 \
    FM_BRIDGE_URGENT_CHECK_INTERVAL=2 FM_HEARTBEAT=999999 "$@" \
    "$ROOT/bin/fm-watch.sh" > "$out" 2>&1 &
  pid=$!
  sleep "$secs"
  kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
}

say "1. Off by default: no config/bridge-vessel, no FM_BRIDGE_VESSEL"
run "ls $HOME_DIR/config"
deliver coditan hello-while-unconfigured high >/dev/null
watch_briefly "$LAB/off.out" 6
echo "watcher output (6s, mail waiting on origin):"
cat "$LAB/off.out"; echo "[end of watcher output]"
echo "Bridge state files created while disabled:"
run "ls -1a $HOME_DIR/state | grep bridge || echo '(none - the watcher never scanned)'"
echo "wake queue: $( [ -s "$HOME_DIR/state/.wake-queue" ] && cat "$HOME_DIR/state/.wake-queue" || echo '(absent/empty)')"

say "2. Operator enables the check for vessel 'coditan'"
run "printf 'coditan\\n' > $HOME_DIR/config/bridge-vessel"
run "cat $HOME_DIR/config/bridge-vessel"
run "git -C $ROOT check-ignore -v config/bridge-vessel"

say "3. Watcher surfaces the pending envelope as an actionable check wake"
watch_until_wake "$LAB/wake1.out"
echo "watcher stdout:"; cat "$LAB/wake1.out"
echo
echo "durable wake queue (state/.wake-queue):"
cat "$HOME_DIR/state/.wake-queue"
echo
echo "state/.bridge-surfaced marker: $(cat "$HOME_DIR/state/.bridge-surfaced")"
echo "origin/main inbox tree:         $(git -C "$BRIDGE" rev-parse origin/main:inbox/coditan/new)"

say "4. What the captain sees on the next turn (bin/fm-wake-drain.sh)"
env FM_HOME="$HOME_DIR" "$ROOT/bin/fm-wake-drain.sh"

say "5. Unchanged inbox: still pending, but already surfaced -> silent"
watch_briefly "$LAB/quiet.out" 8
echo "watcher output (8s):"; cat "$LAB/quiet.out"; echo "[end of watcher output]"
echo "wake queue: $( [ -s "$HOME_DIR/state/.wake-queue" ] && cat "$HOME_DIR/state/.wake-queue" || echo '(empty)')"

say "6. New immediate-priority mail arrives -> a fresh wake with the new count/priority"
deliver coditan escalation immediate
watch_until_wake "$LAB/wake2.out"
cat "$LAB/wake2.out"
echo "durable record:"; cat "$HOME_DIR/state/.wake-queue"

say "7. Bridge acknowledges everything on origin; the local clone is still dirty/stale"
ack coditan hello-while-unconfigured
ack coditan escalation
echo "local working tree still holds the acked envelopes:"
run "ls -1a $BRIDGE/inbox/coditan/new"
rm -f "$HOME_DIR/state/.wake-queue"
watch_briefly "$LAB/acked.out" 8
echo "watcher output (8s):"; cat "$LAB/acked.out"; echo "[end of watcher output]"
echo "wake queue: $( [ -s "$HOME_DIR/state/.wake-queue" ] && cat "$HOME_DIR/state/.wake-queue" || echo '(empty)')"
echo "surfaced marker after ack: $( [ -f "$HOME_DIR/state/.bridge-surfaced" ] && cat "$HOME_DIR/state/.bridge-surfaced" || echo '(cleared)')"
echo "local working tree untouched by the watcher:"
run "ls -1a $BRIDGE/inbox/coditan/new"
run "git -C $BRIDGE status --porcelain"

say "8. Multi-vessel: 'coditan tugboat', each vessel independent"
# The operator resyncs the shared clone after the acks above (the watcher never
# does this itself), so further deliveries fast-forward.
git -C "$BRIDGE" fetch -q origin main && git -C "$BRIDGE" reset -q --hard origin/main
run "printf 'coditan tugboat\\n' > $HOME_DIR/config/bridge-vessel"
rm -f "$HOME_DIR/state/.bridge-surfaced"* "$HOME_DIR/state/.bridge-priority-cache"* \
      "$HOME_DIR/state/.last-bridge-check" "$HOME_DIR/state/.last-bridge-discovery" \
      "$HOME_DIR/state/.bridge-interval-cache" "$HOME_DIR/state/.wake-queue"
deliver coditan for-coditan normal
watch_until_wake "$LAB/multi1.out"
cat "$LAB/multi1.out"
# The queue is deliberately NOT drained here: the second vessel's wake must not
# collapse the first vessel's still-undrained record.
deliver tugboat for-tugboat immediate
watch_until_wake "$LAB/multi2.out"
cat "$LAB/multi2.out"
echo
echo "undrained queue holds one record per vessel:"
cat "$HOME_DIR/state/.wake-queue"
echo
say "9. Both vessels reach the captain from one drain"
env FM_HOME="$HOME_DIR" "$ROOT/bin/fm-wake-drain.sh"

say "10. Bridge state files the watcher owns"
run "ls -1a $HOME_DIR/state | grep bridge"
```
</details>
- Outcome: ⚠️ 2 infos across 1 run (17m42s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `bin/fm-bridge-inbox-lib.sh:33` - `IFS= read -r BRIDGE_VESSEL_RAW &lt; &#34;$FM_HOME/config/bridge-vessel&#34; || BRIDGE_VESSEL_RAW=` discards a valid value. `read` returns 1 at EOF but still assigns the partial line, so a config file written without a trailing newline (`printf &#39;coditan&#39; &gt;`, `echo -n`, an editor with no final EOL) leaves BRIDGE_VESSEL_RAW empty, BRIDGE_VESSELS empty, and the Bridge inbox check silently disabled with no error anywhere. Verified: `IFS= read -r v &lt; &lt;(printf &#34;tugboat&#34;) || v=` yields an empty `v`, while the `\n` form yields `tugboat`. The tests only ever write the file via `printf &#39;%s\n&#39;`, so they cannot catch this. Use `|| true` (read already assigns &#34;&#34; for a genuinely empty file), or `|| [ -n &#34;$BRIDGE_VESSEL_RAW&#34; ]`.
- ⚠️ `bin/fm-test-run.sh:1349` - The per-test env sanitizers (`bin/fm-test-run.sh:1349` and `bin/fm-test-isolation-proof.sh:430`) unset FM_HOME/FM_STATE_OVERRIDE/FM_DATA_OVERRIDE/FM_ROOT_OVERRIDE/FM_PROJECTS_OVERRIDE/FM_CONFIG_OVERRIDE/FM_BACKEND, but this change adds three new ambient inputs that are not cleared: FM_BRIDGE_VESSEL, FM_BRIDGE_ROOT, FM_BRIDGE_URGENT_CHECK_INTERVAL. The new test defends itself (it pins FM_BRIDGE_VESSEL and unsets FM_BRIDGE_ROOT, and its own comment notes an inherited root would make waiting cases hang), but the sibling watcher tests in the same family (fm-watch-triage, fm-watcher-lock, fm-daemon, fm-wake-queue, fm-watch-checkpoint) do not. An operator running the suite from a Bridge-configured shell gives every one of those watcher runs a live BRIDGE_ROOT: the watcher then fetches a real remote and can exit with an unexpected `check: bridge-inbox:` wake, failing tests that assert silence or a different reason. Add the three variables to both unset lists.
- ⚠️ `bin/fm-watch.sh:785` - The discovery branch gates the `git fetch` on `age_of .last-bridge-discovery &gt;= BRIDGE_URGENT_CHECK_INTERVAL`, unconditionally — not only while a vessel is at high/immediate priority. Two consequences. (a) With the defaults (POLL=15, urgent=30, check=300) a configured home runs a network `git fetch` every 30s forever, ten times more often than the documented non-urgent cadence; docs/configuration.md:298 states the variable &#34;tightens the shared Bridge fetch-and-check cadence whenever any one vessel&#39;s highest pending priority is high or immediate&#34;, which does not describe the implemented fetch behaviour. (b) Because it is the only refresh point for `origin/main`, raising it above the effective bridge interval to reduce that load (e.g. FM_BRIDGE_URGENT_CHECK_INTERVAL=3600 with FM_CHECK_INTERVAL=300) means the ref is fetched once at watcher start and never again: `bridge_inbox_surface` then reads a frozen ref and new mail is never detected, silently. Consider gating the fetch on `min(urgent, bridge_interval)`, or reconciling the docs with the always-urgent fetch.
- ⚠️ `bin/fm-bridge-inbox-lib.sh:169` - `fm_wake_append check bridge-inbox &#34;$reason&#34;` uses one dedupe key for all vessels, while every other check site keys on its own source (`fm_wake_append check &#34;$c&#34;`). `fm_wake_print_deduped` keeps only the last row per kind+key, and each bridge wake lists only the vessels whose signature changed since their own marker. So with a multi-vessel list: vessel A gets mail, a wake is queued and A&#39;s marker is written; before the queue is drained, vessel B gets mail and queues a second wake naming only B; the drain then prints only B&#39;s line. A&#39;s marker is already advanced, so A&#39;s pending mail is never named in a wake again until its tree changes. The single-vessel case is unaffected because its payload is cumulative. Keying per vessel (e.g. `bridge-inbox:$vessel`, one append per vessel) would preserve the per-vessel guarantee, but that changes the one-wake-covers-all-vessels shape the library header documents.
- ⚠️ `bin/fm-bridge-inbox-lib.sh:52` - `bridge_run_bounded` re-implements the timeout/gtimeout/perl triad that `run_check_process` (bin/fm-watch.sh:438) already owns, but its perl fallback traps only SIGALRM. The existing implementation deliberately installs the same `$stop` handler on HUP/INT/TERM so the bounded child&#39;s process group is torn down when the watcher itself is signalled. Since the fallback puts the child in its own process group (`setpgrp(0, 0)`) and is the default path wherever neither timeout nor gtimeout exists (stock macOS without coreutils), killing the watcher mid-read leaves the bounded `git fetch`/`ls-tree` orphaned and running. Reuse or parameterise the existing helper rather than carrying a weaker copy.
- ⚠️ `bin/fm-bridge-inbox-lib.sh:71` - `export -f bridge_pending_priority_scan` / `bridge_inbox_signature_scan` are the first uses of `export -f` anywhere in bin/ (previously tests-only), and because the library is sourced unconditionally by fm-watch.sh both functions land as BASH_FUNC_* entries in the environment of every process the watcher spawns — check scripts, pr-poll, backend queries — for a feature that is off by default. `bridge_inbox_signature_scan` does not need this at all: it is a single `git rev-parse`, so `bridge_run_bounded git -C &#34;$BRIDGE_ROOT&#34; rev-parse &#34;origin/main:$inbox&#34;` is equivalent. The priority loop does need a child shell, but can be passed inline as `bash -c &#39;&lt;script&gt;&#39; _ &#34;$root&#34; &#34;$vessel&#34;` instead of exporting into the global environment.
- ⚠️ `tests/fm-watch-bridge-inbox.test.sh:116` - `watch_until_wake` ends in a bare `wait &#34;$pid&#34;` with no bound. If the Bridge check regresses and never produces a wake, the watcher loops forever and the test blocks indefinitely instead of failing — and bin/fm-test-run.sh applies no per-test timeout, so the whole suite/CI hangs with no diagnostic. The file&#39;s own comment at line 30 already identifies this hazard for a misdirected FM_BRIDGE_ROOT. The sibling watcher test uses a bounded poll (`wait_live &lt;pid&gt; &lt;limit&gt;` in tests/fm-watch-triage.test.sh:43); mirror that and `fail` on expiry.
- ℹ️ `bin/fm-bridge-inbox-lib.sh:32` - The library honours FM_ROOT_OVERRIDE and FM_STATE_OVERRIDE but reads `$FM_HOME/config/bridge-vessel` directly. Every other config reader in bin/ (fm-harness.sh, fm-guard.sh, fm-spawn.sh, fm-bootstrap.sh, fm-backend.sh, fm-supervise-daemon.sh:672, and 11 more) uses `${FM_CONFIG_OVERRIDE:-$FM_HOME/config}`, and both fm-test-run.sh and fm-test-isolation-proof.sh treat FM_CONFIG_OVERRIDE as an isolation boundary. A caller that redirects config (fm-fleet-snapshot.sh:205 passes FM_CONFIG_OVERRIDE when reading another home) would silently get the wrong vessel file. Same class for BRIDGE_ROOT vs `${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}`.
- ℹ️ `AGENTS.md:75` - The new row says config/bridge-vessel is &#34;read only when FM_BRIDGE_VESSEL is unset&#34;. The implementation falls back on unset *or empty* (`[ -n &#34;${FM_BRIDGE_VESSEL:-}&#34; ]` at bin/fm-bridge-inbox-lib.sh:30), docs/configuration.md:291 says &#34;unset or empty&#34;, and tests/fm-watch-bridge-inbox.test.sh:151 asserts the empty case explicitly. Align the AGENTS.md wording with the two other sources.
- ℹ️ `bin/fm-watch.sh:794` - When no vessel is configured the block still falls through to the second `if`, forks a subshell for `bridge_inbox_surface` (which returns immediately) and touches `state/.last-bridge-check` every CHECK_INTERVAL — so every upstream home that never enables the feature grows a `.bridge-*` state file. docs/configuration.md:292 describes the disabled path as &#34;the watcher performs no fetch and no scan at all&#34;. Collapsing the disabled case into a single early skip over the whole block would match the documented wording and drop the recurring fork and state write.

🔧 Fix: fix(bridge): harden inbox config read, cadence, and per-vessel wakes
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-bridge-inbox-lib.sh:37` - `BRIDGE_URGENT_CHECK_INTERVAL=${FM_BRIDGE_URGENT_CHECK_INTERVAL:-30}` accepts any string, while the value it is now compared against is validated one line apart (bin/fm-watch.sh:801-803 rejects a non-numeric cached interval). A plausible typo such as FM_BRIDGE_URGENT_CHECK_INTERVAL=30s then hits three unguarded numeric contexts: `[ &#34;$bridge_discovery_interval&#34; -le &#34;$bridge_interval&#34; ]` (bin/fm-watch.sh:805) errors to the watcher&#39;s stderr on every poll cycle (4x/min at the default POLL=15) and falls through to the `||` branch; `bridge_check_interval` echoes the bad value verbatim (bin/fm-bridge-inbox-lib.sh:127) into `bridge_interval`, so `[ ... -ge &#34;$bridge_interval&#34; ]` at bin/fm-watch.sh:812 also errors and skips the Bridge check for that cycle; and the bad value is persisted to `.bridge-interval-cache`, where the next cycle&#39;s validation silently replaces it with CHECK_INTERVAL. Net effect: urgent tightening never applies and the operator gets no diagnostic beyond repeated `integer expression expected` noise. Apply the same `case &#34;$x&#34; in &#39;&#39;|*[!0-9]*) x=30 ;; esac` guard where the variable is defaulted, so every consumer sees a number.
- ℹ️ `bin/fm-bridge-inbox-lib.sh:56` - `bridge_run_bounded` calls `run_bounded_process`, which is defined in the consumer (bin/fm-watch.sh:444) rather than in a library this file sources - an inversion of the pattern used by bin/fm-push-transition-lib.sh, which sources its four dependencies itself. The consolidation onto one bounded-child implementation is the right call and the header documents the requirement, but the failure mode is silent: the call is wrapped in `( ... ) 2&gt;/dev/null || true`, so a missing helper yields empty output, `bridge_inbox_signature` returns the literal `timeout`, and `bridge_inbox_surface` skips every vessel forever with no error. Today there is exactly one consumer so this is latent, but a second one (or a future reordering) would silently disable the feature. Either fail loudly when the helper is absent, or move `run_bounded_process` into a small sourced lib the bridge lib can require for itself.

🔧 Fix: fix(bridge): validate urgent interval, require bounded-process lib
1 info still open:
- ℹ️ `bin/fm-bounded-process-lib.sh:3` - The header states &#34;Every timed read in this tree runs through run_bounded_process, so the fallback&#39;s signal hardening ... can never be half-present in a second copy.&#34; Three other private copies exist today: `gh_bounded` at bin/fm-bearings-snapshot.sh:193 and `run_timed` at bin/fm-fleet-snapshot.sh:747 both carry a perl fallback with only `local $SIG{ALRM}` and no HUP/INT/TERM handler - precisely the half-present hardening the header says cannot exist - and bin/fm-watch-checkpoint.sh:77 has its own inline timeout/gtimeout/perl triad. The scoped comment left in bin/fm-watch.sh:71 (&#34;Every timed read this watcher makes&#34;) is accurate; only the promoted tree-wide claim is not. In a tree where a header is the designated owner of a contract, an absolute claim like this stops the next maintainer from looking. Migrating the other three callers is out of scope per the intent&#39;s scoping constraint, so correct the wording instead: say this is the shared helper the watcher and the Bridge check use, and name the remaining private copies as not yet migrated.

</details>

<details>
<summary>⚠️ **Test** - 2 infos</summary>

- ℹ️ `tests/fm-turnend-guard.test.sh` - tests/fm-turnend-guard.test.sh fails on &#39;Pi guard must inject once for no-tool and multi-tool logical runs: expected exit 0, got 1&#39;. Not caused by this change: reproduced with the identical failure on a clean extraction of base a5fe1bc. Noting it because the author&#39;s known-failure list only mentions fm-watcher-lock.test.sh.
- ℹ️ `tests/fm-watcher-lock.test.sh` - tests/fm-watcher-lock.test.sh fails on &#39;restart did not attach to the verified healthy peer&#39;, matching the environmental failure the author documented. Confirmed pre-existing: same failure on a clean extraction of base a5fe1bc.
- <code>`bash tests/fm-watch-bridge-inbox.test.sh` — 18/18 ok</code>
- <code>Manual operator walkthrough driving the real `bin/fm-watch.sh` and `bin/fm-wake-drain.sh` against a real Bridge origin/clone/peer: off-by-default, enable via `config/bridge-vessel`, wake on pending mail, drain, silence while unchanged, re-fire on new immediate mail, origin-side ack, and a two-vessel list (`/tmp/no-mistakes-evidence/01KYGK9BE5MEFSGXM05CNVSP1E/demo-bridge-inbox.sh`)</code>
- <code>Mutation check on pristine copies of 26b88d7: dropped the per-vessel surfaced-marker write in `bin/fm-bridge-inbox-lib.sh` → `not ok - first surfaced inbox signature was not recorded`</code>
- <code>Mutation check: `rev-parse &#34;origin/main:inbox/$2/new&#34;` → `rev-parse &#34;HEAD:inbox/$2/new&#34;` → `not ok - a wide FM_BRIDGE_URGENT_CHECK_INTERVAL froze Bridge detection`</code>
- <code>`bash tests/fm-watch-triage.test.sh`, `bash tests/fm-watch-checkpoint.test.sh`, `bash tests/fm-wake-queue.test.sh`, `bash tests/fm-daemon.test.sh`, `bash tests/fm-supervision-events.test.sh` — watcher family, all pass</code>
- <code>`bash tests/fm-pr-check-security.test.sh` — covers the bounded-check timeout path refactored into `bin/fm-bounded-process-lib.sh`, passes</code>
- <code>`bash tests/fm-test-run.test.sh`, `bash tests/fm-test-isolation-proof.test.sh`, `bash tests/fm-documentation-audiences.test.sh`, `bash tests/fm-instruction-owners.test.sh` — cover the runner family assignment, the FM_BRIDGE_* unset list, and the docs/AGENTS.md rows; all pass</code>
- <code>`bash tests/fm-watcher-lock.test.sh` and `bash tests/fm-turnend-guard.test.sh` on the change and on a clean `git archive a5fe1bc` extraction — identical failures on both, confirming they are pre-existing</code>

</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `docs/architecture.md:12` - docs/architecture.md:12 enumerates actionable wake kinds as &#34;authenticated check output such as PR merge polling or an X-mode mention&#34;. The Bridge inbox wake is a new actionable wake that is not check-script output. The list is phrased as an open &#34;such as&#34; set and docs/configuration.md owns the Bridge schema, so I left it alone rather than duplicating the feature into a second prose surface — but a maintainer may want the taxonomy sentence widened to say the watcher also has native polls of its own.
- ℹ️ `docs/fm-test-isolation-proof.md:33` - docs/fm-test-isolation-proof.md records &#34;Ambient FM_HOME / FM_*_OVERRIDE cleared for each worker&#34;. bin/fm-test-isolation-proof.sh now also clears FM_BRIDGE_VESSEL / FM_BRIDGE_ROOT / FM_BRIDGE_URGENT_CHECK_INTERVAL, which do not match that FM_*_OVERRIDE shorthand. That page is an archived, dated Phase 2 proof record, so editing it would falsify the evidence; left as-is deliberately.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
