### PR TITLE
feat(pi): add bare skill command aliases

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -97,7 +97,7 @@ Do not substitute another harness's wait shape when resuming supervision.
 Claude's Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns tokenless re-arm around `bin/fm-watch-arm.sh`, and Grok uses tracked background-notify cycles around `bin/fm-watch-arm.sh`.
 Codex uses bounded foreground checkpoints through `bin/fm-watch-checkpoint.sh` because Codex cannot reason while a foreground tool call is running.
 OpenCode uses `.opencode/plugins/fm-primary-watch-arm.js`, which coordinates with the turn-end guard plugin and wakes the TUI with `client.session.promptAsync`.
-Pi uses the tracked `.pi/extensions/fm-primary-turnend-guard.ts` plus the tracked `.pi/extensions/fm-primary-pi-watch.ts`, both project-local extensions Pi auto-discovers once trusted.
+Pi uses the tracked project-local primary extensions that Pi auto-discovers once trusted; `docs/supervision-protocols/pi.md` owns the required Pi supervision launch set, while `docs/pi-skill-aliases.md` owns the Pi-only Firstmate skill alias mechanism.
 When changing any primary watcher adapter, update `docs/supervision-protocols/`, `docs/turnend-guard.md` if a shared idle or turn-end hook changed, and the relevant concise fact below.
 
 ## Launch profile axes
@@ -285,8 +285,8 @@ The firstmate PRIMARY's own `.pi/extensions/fm-primary-turnend-guard.ts` listens
 Without `deliverAs: "followUp"`, Pi rejects the send while the agent is still processing.
 Pi's primary watcher protocol also requires the tracked `.pi/extensions/fm-primary-pi-watch.ts` extension, same trust-once discovery as the turn-end guard.
 The model arms through `fm_watch_arm_pi`, never a foreground bash arm; the watcher tool result and clean-exit fallback are owned by `docs/supervision-protocols/pi.md`.
-`bin/fm-session-start.sh` reports when the live Pi session has not loaded both the turn-end guard and watcher extensions, and points at plain `pi` after project trust as the fix, with `-e` as a trust-free fallback.
-When a secondmate is launched on Pi, `fm-spawn.sh --secondmate` launches Pi with both `-e .pi/extensions/fm-primary-turnend-guard.ts` and `-e .pi/extensions/fm-primary-pi-watch.ts`, both already present in the secondmate home's git worktree.
+`bin/fm-session-start.sh` reports when the live Pi session has not loaded the required project extensions, and points at plain `pi` after project trust as the fix, with `-e` as a trust-free fallback.
+When a secondmate is launched on Pi, `fm-spawn.sh --secondmate` launches Pi with `-e` flags for the secondmate home's tracked turn-end guard, watcher, and skill-alias extensions already present in that git worktree.
 
 ## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99; exit paths re-verified 2026-07-19 on grok 0.2.103)
 

--- a/.pi/extensions/fm-primary-skill-aliases.ts
+++ b/.pi/extensions/fm-primary-skill-aliases.ts
@@ -1,0 +1,198 @@
+// Firstmate's Pi-only bare command aliases for user-invocable Firstmate skills.
+//
+// Pi's native skill command form remains /skill:<name>. This extension registers
+// the historical Firstmate bare names as Pi extension commands. Pi's extension
+// command API does not re-enter prompt expansion from sendUserMessage(), so the
+// handler first verifies that Pi registered the native skill command, then sends
+// the same skill block shape built from Pi's loaded skill metadata exactly once.
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { stripFrontmatter } from "@earendil-works/pi-coding-agent";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  SlashCommandInfo,
+} from "@earendil-works/pi-coding-agent";
+
+type Alias = {
+  alias: string;
+  skill: string;
+  description: string;
+};
+
+type LockOwnership = "owned" | "missing" | "other";
+
+type LoadedSkill = {
+  name: string;
+  filePath: string;
+  baseDir: string;
+};
+
+const aliases: Alias[] = [
+  {
+    alias: "ahoy",
+    skill: "ahoy",
+    description: "Invoke Firstmate Ahoy through Pi's native /skill:ahoy path.",
+  },
+  {
+    alias: "bearings",
+    skill: "bearings",
+    description: "Invoke Firstmate Bearings through Pi's native /skill:bearings path.",
+  },
+  {
+    alias: "afk",
+    skill: "afk",
+    description: "Invoke Firstmate away mode through Pi's native /skill:afk path.",
+  },
+  {
+    alias: "stow",
+    skill: "stow",
+    description: "Invoke Firstmate Stow through Pi's native /skill:stow path.",
+  },
+  {
+    alias: "updatefirstmate",
+    skill: "updatefirstmate",
+    description: "Invoke Firstmate self-update through Pi's native /skill:updatefirstmate path.",
+  },
+];
+
+const extensionFile = fileURLToPath(import.meta.url);
+const extensionDir = dirname(extensionFile);
+const root = resolve(extensionDir, "../..");
+const fmHome = process.env.FM_HOME || process.env.FM_ROOT_OVERRIDE || root;
+const state = process.env.FM_STATE_OVERRIDE || `${fmHome}/state`;
+const marker = `${state}/.pi-skill-aliases-extension-loaded`;
+const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
+
+function parentPid(pid: string): string {
+  const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
+  if (result.status !== 0) return "";
+  return result.stdout.trim();
+}
+
+function pidAlive(pid: string): boolean {
+  try {
+    process.kill(Number(pid), 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function lockOwnership(): LockOwnership {
+  let lockPid = "";
+  try {
+    lockPid = readFileSync(`${state}/.lock`, "utf8").trim();
+  } catch {
+    return "missing";
+  }
+  if (!/^[0-9]+$/.test(lockPid) || lockPid === "1") return "other";
+  let pid = String(process.pid);
+  for (let i = 0; i < 8; i += 1) {
+    if (pid === lockPid) return "owned";
+    pid = parentPid(pid);
+    if (!pid || pid === "1") break;
+  }
+  return pidAlive(lockPid) ? "other" : "missing";
+}
+
+function markLoaded(): void {
+  if (!existsSync(state) || lockOwnership() === "other") return;
+  writeFileSync(marker, `${extensionVersion}\n${process.pid}\n`);
+}
+
+function commandBase(name: string): string {
+  return name.replace(/:[0-9]+$/, "");
+}
+
+function samePath(a: string | undefined, b: string): boolean {
+  if (!a) return false;
+  return resolve(a) === resolve(b);
+}
+
+function formatCommand(command: SlashCommandInfo): string {
+  return `${command.source}:${command.name} (${command.sourceInfo.path})`;
+}
+
+export default function (pi: ExtensionAPI) {
+  const isThisExtensionCommand = (command: SlashCommandInfo, alias: string): boolean => (
+    command.source === "extension" &&
+    commandBase(command.name) === alias &&
+    samePath(command.sourceInfo.path, extensionFile)
+  );
+
+  const commandCollisions = (alias: string): SlashCommandInfo[] => (
+    pi.getCommands()
+      .filter((command) => commandBase(command.name) === alias)
+      .filter((command) => !isThisExtensionCommand(command, alias))
+      .sort((a, b) => formatCommand(a).localeCompare(formatCommand(b)))
+  );
+
+  const hasNativeSkillCommand = (skill: string): boolean => (
+    pi.getCommands().some((command) => command.name === `skill:${skill}` && command.source === "skill")
+  );
+
+  const loadedSkill = (ctx: ExtensionCommandContext, skillName: string): LoadedSkill | undefined => (
+    ctx.getSystemPromptOptions().skills?.find((skill) => skill.name === skillName)
+  );
+
+  const expandedSkillMessage = (
+    skill: LoadedSkill,
+    args: string,
+  ): string => {
+    const content = readFileSync(skill.filePath, "utf-8");
+    const body = stripFrontmatter(content).trim();
+    const skillBlock = `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${skill.baseDir}.\n\n${body}\n</skill>`;
+    return args.length > 0 ? `${skillBlock}\n\n${args}` : skillBlock;
+  };
+
+  for (const alias of aliases) {
+    pi.registerCommand(alias.alias, {
+      description: alias.description,
+      handler: async (args, ctx) => {
+        const collisions = commandCollisions(alias.alias);
+        if (collisions.length > 0) {
+          ctx.ui.notify(
+            `Firstmate /${alias.alias} refused because another Pi command already owns that name: ${collisions.map(formatCommand).join("; ")}. Use /skill:${alias.skill} for the Firstmate skill.`,
+            "error",
+          );
+          return;
+        }
+
+        const skill = loadedSkill(ctx, alias.skill);
+        if (!hasNativeSkillCommand(alias.skill) || !skill) {
+          ctx.ui.notify(
+            `Firstmate /${alias.alias} refused because Pi has not registered /skill:${alias.skill}. Ensure project skills are trusted and enableSkillCommands is true, or invoke the skill after Pi reports it in command discovery.`,
+            "error",
+          );
+          return;
+        }
+
+        let message = "";
+        try {
+          message = expandedSkillMessage(skill, args);
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
+          ctx.ui.notify(
+            `Firstmate /${alias.alias} could not load /skill:${alias.skill}: ${detail}`,
+            "error",
+          );
+          return;
+        }
+
+        if (ctx.isIdle()) {
+          pi.sendUserMessage(message);
+        } else {
+          pi.sendUserMessage(message, { deliverAs: "steer" });
+        }
+      },
+    });
+  }
+
+  pi.on("session_start", () => {
+    markLoaded();
+  });
+}

--- a/.pi/extensions/fm-primary-skill-aliases.ts
+++ b/.pi/extensions/fm-primary-skill-aliases.ts
@@ -14,6 +14,8 @@ import { stripFrontmatter } from "@earendil-works/pi-coding-agent";
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
+  ExtensionContext,
+  InputEvent,
   SlashCommandInfo,
 } from "@earendil-works/pi-coding-agent";
 
@@ -117,6 +119,13 @@ function formatCommand(command: SlashCommandInfo): string {
   return `${command.source}:${command.name} (${command.sourceInfo.path})`;
 }
 
+function parseAliasInvocation(text: string): Alias | undefined {
+  if (!text.startsWith("/")) return undefined;
+  const spaceIndex = text.indexOf(" ");
+  const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+  return aliases.find((alias) => alias.alias === commandName);
+}
+
 export default function (pi: ExtensionAPI) {
   const isThisExtensionCommand = (command: SlashCommandInfo, alias: string): boolean => (
     command.source === "extension" &&
@@ -149,18 +158,21 @@ export default function (pi: ExtensionAPI) {
     return args.length > 0 ? `${skillBlock}\n\n${args}` : skillBlock;
   };
 
+  const refuseCollisions = (alias: Alias, ctx: ExtensionContext): boolean => {
+    const collisions = commandCollisions(alias.alias);
+    if (collisions.length === 0) return false;
+    ctx.ui.notify(
+      `Firstmate /${alias.alias} refused because another Pi command already owns that name: ${collisions.map(formatCommand).join("; ")}. Use /skill:${alias.skill} for the Firstmate skill.`,
+      "error",
+    );
+    return true;
+  };
+
   for (const alias of aliases) {
     pi.registerCommand(alias.alias, {
       description: alias.description,
       handler: async (args, ctx) => {
-        const collisions = commandCollisions(alias.alias);
-        if (collisions.length > 0) {
-          ctx.ui.notify(
-            `Firstmate /${alias.alias} refused because another Pi command already owns that name: ${collisions.map(formatCommand).join("; ")}. Use /skill:${alias.skill} for the Firstmate skill.`,
-            "error",
-          );
-          return;
-        }
+        if (refuseCollisions(alias, ctx)) return;
 
         const skill = loadedSkill(ctx, alias.skill);
         if (!hasNativeSkillCommand(alias.skill) || !skill) {
@@ -191,6 +203,14 @@ export default function (pi: ExtensionAPI) {
       },
     });
   }
+
+  pi.on("input", (event: InputEvent, ctx: ExtensionContext) => {
+    const alias = parseAliasInvocation(event.text);
+    if (alias && refuseCollisions(alias, ctx)) {
+      return { action: "handled" };
+    }
+    return { action: "continue" };
+  });
 
   pi.on("session_start", () => {
     markLoaded();

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Backend-specific setup is linked in [Documentation](#documentation).
 ### Recommended harnesses
 
 **Claude Code, Grok, and Pi are equal co-primary recommendations** for running the primary firstmate session.
-Claude Code uses a tracked Stop hook for tokenless watcher re-arm and rewake, Grok uses background-notify wake cycles, and Pi uses its tracked primary watcher extension.
+Claude Code uses a tracked Stop hook for tokenless watcher re-arm and rewake, Grok uses background-notify wake cycles, and Pi uses tracked primary extensions.
 All three have verified turn-end guard paths when launched with their documented setup.
 Pick whichever one matches your subscription and workflow.
 
@@ -163,7 +163,9 @@ Full architecture - the supervision engine, worktree isolation, secondmates, dis
 ## Built-in skills
 
 Firstmate ships these user-invocable built-in skills.
-Claude and grok use the slash form shown here; codex uses the same names with `$`, such as `$afk`.
+Claude, Grok, and Pi use the slash form shown here; Pi also keeps native `/skill:<name>` commands discoverable.
+Codex uses the same names with `$`, such as `$afk`.
+The Pi alias mechanism is owned by [docs/pi-skill-aliases.md](docs/pi-skill-aliases.md).
 
 | Skill              | What it does                                                                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -197,6 +199,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/orca-backend.md](docs/orca-backend.md) - current setup and limits for the experimental Orca backend.
 - [docs/cmux-backend.md](docs/cmux-backend.md) - current setup, socket security, and limits for the experimental cmux backend.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - the current blocked Codex App backend boundary and rollout contract.
+- [docs/pi-skill-aliases.md](docs/pi-skill-aliases.md) - maintainer contract for Pi bare Firstmate skill aliases and unchanged non-Pi harness axes.
 - [docs/verification/runtime-backends.md](docs/verification/runtime-backends.md) - active maintainer verification for runtime backend guarantees.
 - [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - maintainer verification for GitLab merge watching on arbitrary instances.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's current "no turn ends blind" backstop, scope, loop safety, and compatibility limits.

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -314,14 +314,18 @@ X_MODE_PRESENT=0
 if [ "$PRIMARY_HARNESS" = pi ]; then
   PI_EXT="$FM_ROOT/.pi/extensions/fm-primary-pi-watch.ts"
   PI_TURNEND_EXT="$FM_ROOT/.pi/extensions/fm-primary-turnend-guard.ts"
+  PI_ALIAS_EXT="$FM_ROOT/.pi/extensions/fm-primary-skill-aliases.ts"
   PI_WATCH_MARKER="$STATE/.pi-watch-extension-loaded"
   PI_TURNEND_MARKER="$STATE/.pi-turnend-extension-loaded"
+  PI_ALIAS_MARKER="$STATE/.pi-skill-aliases-extension-loaded"
   PI_LOCK="$STATE/.lock"
   PI_WATCH_VERSION=$(hash_file "$PI_EXT" || printf '')
   PI_TURNEND_VERSION=$(hash_file "$PI_TURNEND_EXT" || printf '')
+  PI_ALIAS_VERSION=$(hash_file "$PI_ALIAS_EXT" || printf '')
   if ! pi_extension_loaded "$PI_WATCH_MARKER" "$PI_WATCH_VERSION" "$PI_LOCK" \
-    || ! pi_extension_loaded "$PI_TURNEND_MARKER" "$PI_TURNEND_VERSION" "$PI_LOCK"; then
-    printf 'PI_WATCH_EXTENSION: not loaded - approve Pi project trust once per clone, then restart plain pi so %s and %s auto-load for turn-end guard and background wake coverage; use -e %s -e %s only if project hooks are not trusted\n' "$PI_TURNEND_EXT" "$PI_EXT" "$PI_TURNEND_EXT" "$PI_EXT"
+    || ! pi_extension_loaded "$PI_TURNEND_MARKER" "$PI_TURNEND_VERSION" "$PI_LOCK" \
+    || ! pi_extension_loaded "$PI_ALIAS_MARKER" "$PI_ALIAS_VERSION" "$PI_LOCK"; then
+    printf 'PI_WATCH_EXTENSION: not loaded - approve Pi project trust once per clone, then restart plain pi so %s, %s, and %s auto-load for turn-end guard, background wake coverage, and Firstmate skill aliases; use -e %s -e %s -e %s only if project hooks are not trusted\n' "$PI_TURNEND_EXT" "$PI_EXT" "$PI_ALIAS_EXT" "$PI_TURNEND_EXT" "$PI_EXT" "$PI_ALIAS_EXT"
   fi
 fi
 "$SCRIPT_DIR/fm-supervision-instructions.sh" \

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -100,6 +100,7 @@
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
+#     __PIALIASES__ absolute path to .pi/extensions/fm-primary-skill-aliases.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
@@ -436,7 +437,7 @@ launch_template() {
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     pi)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ -e __PIALIASES__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
@@ -1466,6 +1467,7 @@ sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
+sq_pialiases=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-skill-aliases.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
@@ -1476,6 +1478,7 @@ LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
+LAUNCH=${LAUNCH//__PIALIASES__/$sq_pialiases}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -89,6 +89,7 @@ esac
 checkpoint_seconds=${FM_CODEX_WATCH_CHECKPOINT:-180}
 pi_ext="$FM_ROOT/.pi/extensions/fm-primary-pi-watch.ts"
 pi_turnend_ext="$FM_ROOT/.pi/extensions/fm-primary-turnend-guard.ts"
+pi_alias_ext="$FM_ROOT/.pi/extensions/fm-primary-skill-aliases.ts"
 x_mode_env="$CONFIG/x-mode.env"
 
 shell_quote() {
@@ -108,6 +109,7 @@ render_snippet() {
   while IFS= read -r line || [ -n "$line" ]; do
     line=${line//__FM_PI_EXT__/$pi_ext}
     line=${line//__FM_PI_TURNEND_EXT__/$pi_turnend_ext}
+    line=${line//__FM_PI_ALIAS_EXT__/$pi_alias_ext}
     line=${line//__FM_X_MODE_ENV_SH__/$x_mode_env_sh}
     line=${line//__FM_X_MODE_ENV__/$x_mode_env}
     printf '%s\n' "$line"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -124,7 +124,7 @@ family_for_basename() {
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
-    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
+    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|fm-pi-skill-aliases.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-tmux-submit-busy.test.sh|fm-transition-lib.test.sh|\
@@ -692,6 +692,10 @@ families_for_changed_path() {
       ;;
     .agents/skills/*/SKILL.md)
       printf '%s\n' pure-contract-unit
+      ;;
+    .pi/extensions/fm-primary-skill-aliases.ts)
+      printf '%s\n' "__script__:fm-pi-skill-aliases.test.sh"
+      printf '%s\n' "__script__:fm-pi-primary-types.test.sh"
       ;;
     .github/workflows/ci.yml|.no-mistakes.yaml)
       printf '%s\n' pure-contract-unit

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,7 @@ The default path remains local-only; live GitHub enrichment exists only behind t
 Optional X mode integrates with the watcher only after explicit opt-in; [configuration.md](configuration.md#x-mode-env) owns its generated-artifact and dispatch mechanics.
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
-That block owns the live wait shape for the running primary harness: Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
+That block owns the live wait shape for the running primary harness: Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses tracked primary extensions, and OpenCode uses its TUI plugin.
 `bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints an honest `started`, `attached`, or nonzero `FAILED` status.
 On `attached` it stays live across identity-matched successors, and an unexplained clean child close either attaches to a verified healthy successor or becomes the typed nonzero `watcher: FAILED - cycle ended without an actionable reason` result.
 The arm layer records one bounded lifecycle row per observed cycle in `state/.watch-cycle-exits.log`; `state/.watch-triage.log` remains exclusively the absorbed-wake debug log.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,7 +181,7 @@ Launch mechanics, including the verified command templates, live in [`bin/fm-spa
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
-Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
+Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its tracked primary extensions, and OpenCode uses its TUI plugin.
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.
 When it is absent or contains `default`, crewmates mirror the firstmate's own harness.
 `config/secondmate-harness` is a separate local, gitignored file containing the adapter the primary uses to launch secondmate agents, optionally followed by model and effort tokens on the same line.
@@ -200,7 +200,7 @@ For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install`, drops a pe
 Kimi continues to use the captain's normal Kimi home, including the existing config, skills, and memory; Firstmate does not create an isolated Kimi home.
 The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, or surprising or when either tool requirement is unavailable.
 Its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
-For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
+For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts`, `.pi/extensions/fm-primary-turnend-guard.ts`, and `.pi/extensions/fm-primary-skill-aliases.ts`, all already present from the secondmate home's git worktree.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -256,6 +256,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/pi-skill-aliases.md",
+      "audience": "maintainer-architecture"
+    },
+    {
       "path": "docs/scripts.md",
       "audience": "operator-current"
     },

--- a/docs/pi-skill-aliases.md
+++ b/docs/pi-skill-aliases.md
@@ -1,0 +1,60 @@
+# Pi skill aliases
+
+This page owns the maintainer contract for Firstmate's Pi-only bare aliases for user-invocable Firstmate skills.
+Public current behavior is summarized in the README, and active evidence is recorded in [`docs/verification/supervision.md`](verification/supervision.md#pi-skill-aliases).
+
+## Scope
+
+The tracked extension is [`.pi/extensions/fm-primary-skill-aliases.ts`](../.pi/extensions/fm-primary-skill-aliases.ts).
+It registers exactly these Pi extension commands:
+
+- `/ahoy` for `/skill:ahoy`.
+- `/bearings` for `/skill:bearings`.
+- `/afk` for `/skill:afk`.
+- `/stow` for `/skill:stow`.
+- `/updatefirstmate` for `/skill:updatefirstmate`.
+
+Pi's native `/skill:<name>` commands remain enabled and discoverable.
+The alias layer does not add prompt templates, does not duplicate skill bodies into tracked prose, does not edit installed Pi files, and does not change global Pi configuration.
+
+## Dispatch
+
+Pi checks extension commands before `input` handlers and before native `/skill:<name>` expansion.
+Pi's public extension command API does not expose a supported recursive prompt-expansion call, and `pi.sendUserMessage()` deliberately sends extension-originated messages with command and template expansion disabled.
+The alias handler therefore uses Pi's supported extension command path for discovery and dispatch, then mirrors the installed Pi skill expansion shape from Pi's loaded skill metadata.
+
+For each invocation, the handler first requires `pi.getCommands()` to contain the matching `skill:<name>` command with source `skill`.
+It also requires `ctx.getSystemPromptOptions().skills` to contain the loaded skill metadata for that name.
+It reads the current loaded `SKILL.md`, strips frontmatter with Pi's exported `stripFrontmatter`, builds Pi's installed `<skill name="..." location="...">` block shape, and appends the handler argument string exactly as received.
+When Pi is idle, the extension sends that expanded user message once with no delivery option.
+When Pi is busy, it sends the same expanded user message once with `{ deliverAs: "steer" }`.
+
+The sent message starts with a skill XML block, not a slash command.
+That prevents recursive alias handling, duplicate command delivery, and slash-command injection from arguments that themselves begin with `/`.
+Ahoy's Bearings fallback, AFK enter and return boundaries, Stow's knowledge routing, and Updatefirstmate's authority limits remain owned by the corresponding `.agents/skills/*/SKILL.md` bodies because the extension reads those bodies at dispatch time.
+
+## Collisions
+
+Firstmate treats the unsuffixed base command name as the collision key, so `ahoy` and `ahoy:1` collide.
+At dispatch time the alias refuses if `pi.getCommands()` reports any same-base command not owned by this exact extension file.
+The refusal sends a Pi UI error and points the operator at the native `/skill:<name>` command.
+
+If Pi detects duplicate extension command names, it assigns numeric invocation suffixes in load order.
+Any suffixed same-base command still counts as a collision, so Firstmate refuses instead of treating `/ahoy:1` or `/ahoy:2` as a safe alias.
+If a same-base prompt or skill command exists, Firstmate refuses the bare alias rather than silently overriding that command.
+
+## Other Harnesses
+
+This implementation is Pi-only because the missing behavior is specific to Pi's command registry.
+Claude already exposes the shared Firstmate skills through `.claude/skills -> .agents/skills` and uses slash skill invocation.
+Grok uses the same slash form for user-level skills, while its tracked project hooks are supervision hooks rather than skill aliases.
+Codex uses `$<skill>` for skill invocation, and slash skill syntax is intentionally not accepted there.
+OpenCode has no separate verified Firstmate bare-alias gap beyond its normal prompt and command behavior.
+Kimi uses slash skill invocation for crew instructions and has only the separate guarded global turn-end hook path.
+Runtime backends such as tmux, Herdr, Zellij, Orca, and cmux transport harness input and do not own skill command syntax.
+
+## Verification
+
+`tests/fm-pi-skill-aliases.test.sh` is the focused regression suite for this mechanism.
+It covers static extension scope, deterministic handler dispatch and argument preservation, collision refusal, missing native command refusal, Pi RPC command discovery for aliases and native skill commands, and a real Pi RPC provider-context proof that bare `/ahoy` reaches skill-expanded context once.
+`tests/fm-pi-primary-types.test.sh` includes the alias extension in the tracked Pi extension typecheck when a local TypeScript compiler is available.

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -2,7 +2,7 @@ Mode: Pi extension background wake.
 
 When this session owns supervision and away mode is not active:
 1. Drain first with `bin/fm-wake-drain.sh`.
-2. Confirm the Pi primary auto-loaded both project extensions (plain `pi`, after approving project trust once per clone); if not, restart with `-e __FM_PI_TURNEND_EXT__ -e __FM_PI_EXT__` as a trust-free fallback.
+2. Confirm the Pi primary auto-loaded the project extensions for turn-end guard, background wakes, and Firstmate skill aliases (plain `pi`, after approving project trust once per clone); if not, restart with `-e __FM_PI_TURNEND_EXT__ -e __FM_PI_EXT__ -e __FM_PI_ALIAS_EXT__` as a trust-free fallback.
 3. First cycle only: make the one required `fm_watch_arm_pi` call.
    Use `/fm-watch-arm-pi` only as a human-entered fallback.
    Never run `bin/fm-watch-arm.sh` through Pi's bash tool because that foreground arm can wedge the agent and bypasses extension-owned cleanup.
@@ -11,11 +11,12 @@ When this session owns supervision and away mode is not active:
 6. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
 7. Ordinary work, turn completion, and ordinary signal, stale, check, heartbeat, or other wake handling: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
 8. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.
-9. Missing, failed, or unhealthy cycle only: if a later notification explicitly reports one of those repair conditions, drain queued wakes, inspect the failure text, call `fm_watch_arm_pi`, and restart Pi with both extensions loaded if needed.
+9. Missing, failed, or unhealthy cycle only: if a later notification explicitly reports one of those repair conditions, drain queued wakes, inspect the failure text, call `fm_watch_arm_pi`, and restart Pi with the required project extensions loaded if needed.
    A redundant call while the extension owns an arm child or scheduled retry is an ownership-based `watcher: unchanged` no-op, not an independent health claim.
 10. Never use shell `&` for watcher supervision.
    The arm mechanism above is extension-owned, not a model tool call, but a manual recovery probe that backgrounds, pipes, or bundles the arm is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, wired into the turn-end guard extension at `__FM_PI_TURNEND_EXT__`).
 
 The turn-end guard extension lives at `__FM_PI_TURNEND_EXT__`.
 The watcher extension lives at `__FM_PI_EXT__`.
-Both are tracked, project-local `.pi/extensions/*.ts` files that Pi auto-discovers once the project is trusted; `bin/fm-session-start.sh` reports when the running Pi session has not loaded both required extensions.
+The Firstmate skill alias extension lives at `__FM_PI_ALIAS_EXT__`.
+All three are tracked, project-local `.pi/extensions/*.ts` files that Pi auto-discovers once the project is trusted; `bin/fm-session-start.sh` reports when the running Pi session has not loaded the required extensions.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -59,6 +59,28 @@ The Ahoy first-message boundary was reverified on 2026-07-22 with Pi 0.81.1 and 
 Marked current operational input and the two exact legacy compatibility shapes selected Bearings, while genuine near-miss captain messages remained real boundaries.
 The detailed reconciliation and task chronology stay in the private audit report and PR evidence.
 
+## Pi skill aliases
+
+The Pi-only bare Firstmate skill aliases were verified on 2026-07-26 with Pi 0.82.1.
+The mechanism owner is [`docs/pi-skill-aliases.md`](../pi-skill-aliases.md).
+
+Command:
+
+```sh
+pi --version
+bash tests/fm-pi-skill-aliases.test.sh
+```
+
+Observed output:
+
+```text
+0.82.1
+ok - Pi skill alias extension is tracked, narrow, and dispatches expanded skill content once
+ok - Pi alias handlers preserve args, refuse collisions, and avoid ordinary-chat fallthrough
+ok - Pi RPC command discovery lists bare aliases and native skill commands
+ok - Pi RPC bare /ahoy dispatch enters skill-expanded context once
+```
+
 ## Turn-end guard
 
 The direct and passive mechanisms were validated across all five harnesses on 2026-07-08 through 2026-07-12, with Claude's replacement Stop-owned path revalidated on 2026-07-24.

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -24,7 +24,7 @@ test_existing_launch_templates_are_byte_pinned() {
   assert_source_line "        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
   assert_source_line "        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c \"notify=[\\\"bash\\\",\\\"-c\\\",\\\"touch __TURNEND__\\\"]\" \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
   assert_source_line "    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\\''{\"permission\":{\"*\":\"allow\"}}'\\'' opencode __MODELFLAG__--prompt \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"' ;;"
-  assert_source_line "        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
+  assert_source_line "        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ -e __PIALIASES__ \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
   assert_source_line "        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ \"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"'"
   assert_source_line "    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__\"\$(__OPINPUT__ encode launch-brief < __BRIEF__)\"' ;;"
   pass "fm-spawn: the five pre-existing adapters' launch templates stay byte-pinned"

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -124,7 +124,7 @@ run_ahoy_case() {
       pi --print --approve --no-session --no-context-files --no-extensions \
         --no-skills --skill .agents/skills --tools read \
         --model openai-codex/gpt-5.6-sol --thinking low \
-        "$preceding" "/ahoy"
+        "$preceding" "/skill:ahoy"
   ) || status=$?
   [ "$status" -eq 0 ] || fail "Pi Ahoy $label case exited $status: $out"
   case "$expected" in
@@ -221,7 +221,7 @@ run_native_ahoy_regressions() {
         -e .pi/extensions/fm-primary-turnend-guard.ts \
         --no-skills --skill .agents/skills \
         --model openai-codex/gpt-5.6-sol --thinking low \
-        "/ahoy"
+        "/skill:ahoy"
   )
   printf '%s\n' "$first_out" | grep -Fq "AHOY_BEARINGS_BRANCH" \
     || fail "Pi native first-message Ahoy did not take Bearings: $first_out"
@@ -234,7 +234,7 @@ run_native_ahoy_regressions() {
         -e .pi/extensions/fm-primary-turnend-guard.ts \
         --no-skills --skill .agents/skills \
         --model openai-codex/gpt-5.6-sol --thinking low \
-        "Respond exactly PRIOR_BOUNDARY_ACK." "/ahoy"
+        "Respond exactly PRIOR_BOUNDARY_ACK." "/skill:ahoy"
   )
   printf '%s\n' "$later_out" | grep -Fq "PRIOR_BOUNDARY_ACK" \
     || fail "Pi native later-message setup did not preserve the genuine captain boundary: $later_out"

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -29,6 +29,7 @@ mkdir -p "$TMP_ROOT/lib" "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/nod
 cp "$ROOT/.pi/extensions/fm-calm.ts" "$TMP_ROOT/fm-calm.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
+cp "$ROOT/.pi/extensions/fm-primary-skill-aliases.ts" "$TMP_ROOT/fm-primary-skill-aliases.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-assistant-layout.ts" "$TMP_ROOT/lib/fm-calm-assistant-layout.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-operational-user-layout.ts" "$TMP_ROOT/lib/fm-calm-operational-user-layout.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$TMP_ROOT/lib/fm-calm-visibility.ts"

--- a/tests/fm-pi-skill-aliases.test.sh
+++ b/tests/fm-pi-skill-aliases.test.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Tests for Firstmate's Pi-only bare aliases for user-invocable skills.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-pi-skill-aliases)
+ALIAS_EXT="$ROOT/.pi/extensions/fm-primary-skill-aliases.ts"
+ALIAS_NAMES="ahoy bearings afk stow updatefirstmate"
+export NODE_NO_WARNINGS=1
+
+test_static_extension_contract() {
+  local text
+  assert_present "$ALIAS_EXT" "tracked Pi skill alias extension is missing"
+  text=$(cat "$ALIAS_EXT")
+  for name in $ALIAS_NAMES; do
+    assert_contains "$text" "alias: \"$name\"" "Pi alias extension does not define /$name"
+    assert_contains "$text" "skill: \"$name\"" "Pi alias extension does not map /$name to /skill:$name"
+    assert_contains "$text" "pi.registerCommand(alias.alias" "Pi alias extension does not use Pi's command registration path"
+  done
+  assert_contains "$text" "pi.sendUserMessage(message" "Pi alias extension does not redispatch through Pi user-message processing"
+  assert_contains "$text" "stripFrontmatter" "Pi alias extension does not build Pi-equivalent skill expansion from the loaded SKILL.md"
+  assert_contains "$text" "hasNativeSkillCommand" "Pi alias extension does not require the native skill command before dispatch"
+  assert_contains "$text" "getSystemPromptOptions().skills" "Pi alias extension does not use Pi's loaded skill metadata"
+  assert_contains "$text" "commandCollisions" "Pi alias extension does not check command collisions"
+  assert_contains "$text" "deliverAs: \"steer\"" "Pi alias extension does not handle busy Pi sessions deterministically"
+  assert_contains "$text" ".pi-skill-aliases-extension-loaded" "Pi alias extension does not write a loaded marker"
+  assert_contains "$text" 'createHash("sha256").update(readFileSync(extensionFile)).digest("hex")' "Pi alias extension does not self-hash its own content"
+  assert_not_contains "$text" ".agents/skills/ahoy/SKILL.md" "Pi alias extension duplicates a skill body path"
+  pass "Pi skill alias extension is tracked, narrow, and dispatches expanded skill content once"
+}
+
+test_handler_dispatch_and_collision_contract() {
+  local fixture plugin out status=0
+  fixture="$TMP_ROOT/handler-plugin"
+  plugin="$fixture/.pi/extensions/fm-primary-skill-aliases.ts"
+  mkdir -p "$fixture/.pi/extensions" "$fixture/node_modules/@earendil-works/pi-coding-agent"
+  cp "$ALIAS_EXT" "$plugin"
+  cat > "$fixture/node_modules/@earendil-works/pi-coding-agent/package.json" <<'JSON'
+{"name":"@earendil-works/pi-coding-agent","type":"module","exports":"./index.js"}
+JSON
+  cat > "$fixture/node_modules/@earendil-works/pi-coding-agent/index.js" <<'JS'
+export function stripFrontmatter(content) {
+  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+}
+JS
+
+  out=$(PLUGIN="$plugin" TEST_TMP="$TMP_ROOT" node --input-type=module <<'JS'
+import { mkdirSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const pluginPath = process.env.PLUGIN;
+const mod = await import(pathToFileURL(pluginPath).href);
+const aliases = ["ahoy", "bearings", "afk", "stow", "updatefirstmate"];
+let extraCommands = [];
+let availableSkills = new Set(aliases);
+const registeredCommands = [];
+const handlers = new Map();
+const sent = [];
+const notices = [];
+const skillRoot = `${process.env.TEST_TMP}/handler-skills`;
+const loadedSkills = aliases.map((name) => {
+  const baseDir = `${skillRoot}/${name}`;
+  const filePath = `${baseDir}/SKILL.md`;
+  mkdirSync(baseDir, { recursive: true });
+  writeFileSync(filePath, `---\nname: ${name}\ndescription: ${name} test skill\n---\n\n# ${name}\n\n${name.toUpperCase()}_BODY_SENTINEL\n`);
+  return { name, filePath, baseDir };
+});
+
+const sourceInfo = (path, source = "test") => ({
+  path,
+  source,
+  scope: "temporary",
+  origin: "top-level",
+});
+
+const pi = {
+  on() {},
+  registerCommand(name, options) {
+    handlers.set(name, options.handler);
+    registeredCommands.push({
+      name,
+      description: options.description,
+      source: "extension",
+      sourceInfo: sourceInfo(pluginPath, "cli"),
+    });
+  },
+  getCommands() {
+    const skillCommands = [...availableSkills].map((name) => ({
+      name: `skill:${name}`,
+      source: "skill",
+      sourceInfo: sourceInfo(`/skills/${name}/SKILL.md`, "path"),
+    }));
+    return [...registeredCommands, ...extraCommands, ...skillCommands];
+  },
+  sendUserMessage(message, options) {
+    sent.push({ message, options: options ?? null });
+  },
+};
+
+await mod.default(pi);
+
+if (registeredCommands.map((c) => c.name).join(" ") !== aliases.join(" ")) {
+  throw new Error(`registered aliases mismatch: ${registeredCommands.map((c) => c.name).join(" ")}`);
+}
+
+const ctx = (idle) => ({
+  isIdle: () => idle,
+  getSystemPromptOptions: () => ({ skills: loadedSkills }),
+  ui: { notify: (message, type) => notices.push({ message, type }) },
+});
+const idleCtx = ctx(true);
+const busyCtx = ctx(false);
+
+for (const name of aliases) {
+  const args = `ARG_${name}  /literal-${name}`;
+  await handlers.get(name)(args, idleCtx);
+  const last = sent.at(-1);
+  if (!last.message.includes(`<skill name="${name}"`)) {
+    throw new Error(`${name} did not expand its matching skill block: ${JSON.stringify(last)}`);
+  }
+  if (!last.message.includes(`${name.toUpperCase()}_BODY_SENTINEL`)) {
+    throw new Error(`${name} skill body was not loaded: ${JSON.stringify(last)}`);
+  }
+  if (!last.message.endsWith(`\n\n${args}`)) {
+    throw new Error(`${name} args were not preserved exactly: ${JSON.stringify(last)}`);
+  }
+  if (last.message.includes(`/skill:${name}`)) {
+    throw new Error(`${name} leaked a literal native command instead of expanded content: ${JSON.stringify(last)}`);
+  }
+  if (last.options !== null) {
+    throw new Error(`${name} idle dispatch unexpectedly used delivery options`);
+  }
+}
+
+await handlers.get("ahoy")("alpha  beta\n/stow --not-a-command", idleCtx);
+if (!sent.at(-1).message.includes('<skill name="ahoy"')) {
+  throw new Error(`ahoy did not expand a skill block: ${JSON.stringify(sent.at(-1))}`);
+}
+if (!sent.at(-1).message.includes("AHOY_BODY_SENTINEL")) {
+  throw new Error(`ahoy skill body was not loaded: ${JSON.stringify(sent.at(-1))}`);
+}
+if (!sent.at(-1).message.endsWith("\n\nalpha  beta\n/stow --not-a-command")) {
+  throw new Error(`ahoy args were not preserved exactly: ${JSON.stringify(sent.at(-1))}`);
+}
+if (sent.at(-1).message.includes("/skill:ahoy")) {
+  throw new Error(`ahoy leaked a literal native command instead of expanded content: ${JSON.stringify(sent.at(-1))}`);
+}
+if (sent.at(-1).options !== null) {
+  throw new Error("idle dispatch unexpectedly used delivery options");
+}
+
+await handlers.get("bearings")("fleet please", busyCtx);
+if (!sent.at(-1).message.includes('<skill name="bearings"') || !sent.at(-1).message.endsWith("\n\nfleet please")) {
+  throw new Error(`bearings args were not forwarded: ${JSON.stringify(sent.at(-1))}`);
+}
+if (sent.at(-1).options?.deliverAs !== "steer") {
+  throw new Error(`busy dispatch did not use steer delivery: ${JSON.stringify(sent.at(-1))}`);
+}
+
+await handlers.get("stow")("", idleCtx);
+if (!sent.at(-1).message.includes('<skill name="stow"') || !sent.at(-1).message.endsWith("</skill>")) {
+  throw new Error(`empty args should not add trailing argument text: ${JSON.stringify(sent.at(-1))}`);
+}
+
+const beforeCollisionSends = sent.length;
+extraCommands = [{
+  name: "afk",
+  source: "prompt",
+  sourceInfo: sourceInfo("/tmp/afk.md", "project"),
+}];
+await handlers.get("afk")("now", idleCtx);
+if (sent.length !== beforeCollisionSends) throw new Error("collision did not refuse dispatch");
+if (!notices.at(-1)?.message.includes("Use /skill:afk")) {
+  throw new Error(`collision notice did not point at the native skill: ${JSON.stringify(notices.at(-1))}`);
+}
+
+extraCommands = [{
+  name: "stow:1",
+  source: "extension",
+  sourceInfo: sourceInfo("/tmp/other.ts", "cli"),
+}];
+await handlers.get("stow")("again", idleCtx);
+if (sent.length !== beforeCollisionSends) throw new Error("suffixed collision did not refuse dispatch");
+
+extraCommands = [];
+availableSkills = new Set(aliases.filter((name) => name !== "updatefirstmate"));
+await handlers.get("updatefirstmate")("", idleCtx);
+if (sent.length !== beforeCollisionSends) throw new Error("missing native skill command fell through to chat");
+if (!notices.at(-1)?.message.includes("has not registered /skill:updatefirstmate")) {
+  throw new Error(`missing skill notice was not explicit: ${JSON.stringify(notices.at(-1))}`);
+}
+
+console.log("ok");
+JS
+  ) || status=$?
+  [ "$status" -eq 0 ] || fail "Pi alias handler contract failed: $out"
+  assert_contains "$out" "ok" "Pi alias handler contract did not complete"
+  pass "Pi alias handlers preserve args, refuse collisions, and avoid ordinary-chat fallthrough"
+}
+
+test_rpc_command_discovery_lists_aliases_and_native_skills() {
+  local out status=0 name
+  if ! command -v pi >/dev/null 2>&1; then
+    echo "skip: pi not found for RPC command discovery"
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "skip: jq not found for RPC command discovery"
+    return 0
+  fi
+
+  out=$(
+    cd "$ROOT" &&
+      printf '{"type":"get_commands"}\n' |
+        timeout 15s env PI_OFFLINE=1 pi --mode rpc --no-session --approve \
+          --no-context-files --no-prompt-templates --no-extensions \
+          -e .pi/extensions/fm-primary-skill-aliases.ts \
+          --no-skills --skill .agents/skills --offline
+  ) || status=$?
+  [ "$status" -eq 0 ] || fail "Pi RPC get_commands failed: $out"
+
+  for name in $ALIAS_NAMES; do
+    printf '%s\n' "$out" | jq -e --arg name "$name" --arg path "$ALIAS_EXT" '
+      select(.type == "response" and .command == "get_commands")
+      | .data.commands[]
+      | select(.name == $name and .source == "extension" and (.sourceInfo.path | endswith($path)))
+    ' >/dev/null || fail "Pi RPC command discovery did not list /$name as a Firstmate extension alias"
+
+    printf '%s\n' "$out" | jq -e --arg name "skill:$name" '
+      select(.type == "response" and .command == "get_commands")
+      | .data.commands[]
+      | select(.name == $name and .source == "skill")
+    ' >/dev/null || fail "Pi RPC command discovery did not keep /skill:$name discoverable"
+  done
+
+  pass "Pi RPC command discovery lists bare aliases and native skill commands"
+}
+
+test_rpc_bare_ahoy_enters_skill_expanded_context_once() {
+  local project proof provider out prompt status=0 line_count
+  if ! command -v pi >/dev/null 2>&1; then
+    echo "skip: pi not found for RPC alias dispatch E2E"
+    return 0
+  fi
+
+  project="$TMP_ROOT/rpc-ahoy-project"
+  proof="$TMP_ROOT/rpc-ahoy-prompts.jsonl"
+  provider="$project/alias-proof-provider.ts"
+  mkdir -p "$project/.agents/skills/ahoy"
+  fm_git_init_commit "$project"
+
+  cat > "$project/.agents/skills/ahoy/SKILL.md" <<'MD'
+---
+name: ahoy
+description: Test-only Ahoy alias dispatch sentinel.
+---
+
+# Ahoy Alias Dispatch Sentinel
+
+The native skill expansion must include `ALIAS_AHOY_SKILL_SENTINEL`.
+MD
+
+  cat > "$provider" <<'TS'
+import { appendFileSync } from "node:fs";
+import {
+  createFauxCore,
+  fauxAssistantMessage,
+  fauxText,
+} from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI): void {
+  const faux = createFauxCore({
+    api: "firstmate-alias-e2e-api",
+    provider: "firstmate-alias-e2e",
+    models: [{
+      id: "deterministic",
+      name: "Firstmate alias E2E",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 4096,
+      maxTokens: 128,
+    }],
+    tokenSize: { min: 1, max: 1 },
+  });
+  faux.setResponses([
+    fauxAssistantMessage([fauxText("ALIAS_E2E_FINAL")]),
+  ]);
+  pi.registerProvider("firstmate-alias-e2e", {
+    baseUrl: "http://127.0.0.1/unused",
+    apiKey: "test-only",
+    api: faux.api,
+    models: faux.models,
+    streamSimple: faux.streamSimple,
+  });
+  pi.on("session_start", async (_event, ctx) => {
+    const model = ctx.modelRegistry.find("firstmate-alias-e2e", "deterministic");
+    if (!model || !(await pi.setModel(model))) {
+      throw new Error("Firstmate alias E2E model unavailable");
+    }
+  });
+  pi.on("context", (event) => {
+    appendFileSync(process.env.FM_PI_ALIAS_PROOF!, `${JSON.stringify({ messages: event.messages })}\n`);
+  });
+}
+TS
+
+  out=$(
+    cd "$project" &&
+      printf '{"type":"prompt","message":"/ahoy ARG_EXACT /stow --literal"}\n' |
+        timeout 25s env FM_PI_ALIAS_PROOF="$proof" PI_OFFLINE=1 pi --mode rpc --no-session --approve \
+          --no-context-files --no-prompt-templates --no-extensions \
+          -e "$ALIAS_EXT" -e "$provider" \
+          --no-skills --skill .agents/skills --offline
+  ) || status=$?
+  [ "$status" -eq 0 ] || fail "Pi RPC bare /ahoy dispatch E2E failed: $out"
+  assert_contains "$out" "ALIAS_E2E_FINAL" "deterministic Pi provider did not complete the alias-dispatched turn"
+  assert_present "$proof" "Pi alias E2E did not record provider context"
+
+  line_count=$(wc -l < "$proof" | tr -d ' ')
+  [ "$line_count" = 1 ] || fail "bare /ahoy produced $line_count provider contexts instead of one"
+  prompt=$(cat "$proof")
+  assert_contains "$prompt" "ALIAS_AHOY_SKILL_SENTINEL" "bare /ahoy did not enter skill-expanded provider context"
+  assert_contains "$prompt" "ARG_EXACT /stow --literal" "bare /ahoy did not preserve command arguments"
+  assert_not_contains "$prompt" "/skill:ahoy" "bare /ahoy leaked a literal native skill command into provider context"
+  assert_not_contains "$prompt" "/ahoy ARG_EXACT" "bare /ahoy fell through as ordinary chat"
+
+  pass "Pi RPC bare /ahoy dispatch enters skill-expanded context once"
+}
+
+test_static_extension_contract
+test_handler_dispatch_and_collision_contract
+test_rpc_command_discovery_lists_aliases_and_native_skills
+test_rpc_bare_ahoy_enters_skill_expanded_context_once

--- a/tests/fm-pi-skill-aliases.test.sh
+++ b/tests/fm-pi-skill-aliases.test.sh
@@ -57,6 +57,7 @@ let extraCommands = [];
 let availableSkills = new Set(aliases);
 const registeredCommands = [];
 const handlers = new Map();
+const inputHandlers = [];
 const sent = [];
 const notices = [];
 const skillRoot = `${process.env.TEST_TMP}/handler-skills`;
@@ -76,7 +77,9 @@ const sourceInfo = (path, source = "test") => ({
 });
 
 const pi = {
-  on() {},
+  on(event, handler) {
+    if (event === "input") inputHandlers.push(handler);
+  },
   registerCommand(name, options) {
     handlers.set(name, options.handler);
     registeredCommands.push({
@@ -183,6 +186,26 @@ extraCommands = [{
 }];
 await handlers.get("stow")("again", idleCtx);
 if (sent.length !== beforeCollisionSends) throw new Error("suffixed collision did not refuse dispatch");
+
+const inputResult = await inputHandlers.at(-1)(
+  { type: "input", text: "/stow EXACT  args\n/afk --literal", source: "rpc" },
+  idleCtx,
+);
+if (inputResult?.action !== "handled") {
+  throw new Error(`suffixed collision input was not handled: ${JSON.stringify(inputResult)}`);
+}
+if (sent.length !== beforeCollisionSends) throw new Error("suffixed collision input fell through to dispatch");
+if (!notices.at(-1)?.message.includes("Use /skill:stow")) {
+  throw new Error(`suffixed collision input notice did not point at the native skill: ${JSON.stringify(notices.at(-1))}`);
+}
+
+const nonAliasInputResult = await inputHandlers.at(-1)(
+  { type: "input", text: "/not-firstmate hello", source: "rpc" },
+  idleCtx,
+);
+if (nonAliasInputResult?.action !== "continue") {
+  throw new Error(`non-alias input should continue: ${JSON.stringify(nonAliasInputResult)}`);
+}
 
 extraCommands = [];
 availableSkills = new Set(aliases.filter((name) => name !== "updatefirstmate"));

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -105,12 +105,14 @@ test_tracked_extension_present_and_self_hashing() {
 test_spawn_template_mentions_pi_watch_placeholder() {
   local text
   text=$(cat "$ROOT/bin/fm-spawn.sh")
-  assert_contains "$text" "-e __PITURNEND__ -e __PIWATCH__" "Pi secondmate launch template does not include both primary extensions"
+  assert_contains "$text" "-e __PITURNEND__ -e __PIWATCH__ -e __PIALIASES__" "Pi secondmate launch template does not include the required primary extensions"
   assert_contains "$text" "\$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts" "fm-spawn does not point the Pi secondmate watch placeholder at the tracked extension"
+  assert_contains "$text" "\$PROJ_ABS/.pi/extensions/fm-primary-skill-aliases.ts" "fm-spawn does not point the Pi secondmate alias placeholder at the tracked extension"
   assert_not_contains "$text" "fm-pi-watch-extension.sh" "fm-spawn should no longer generate the Pi watch extension before launch"
   assert_contains "$text" "__PITURNEND__" "fm-spawn does not replace the Pi turn-end guard extension placeholder"
   assert_contains "$text" "__PIWATCH__" "fm-spawn does not replace the Pi watch extension placeholder"
-  pass "Pi secondmate launch wiring includes both tracked primary extensions"
+  assert_contains "$text" "__PIALIASES__" "fm-spawn does not replace the Pi skill alias extension placeholder"
+  pass "Pi secondmate launch wiring includes the tracked primary extensions"
 }
 
 test_pi_extension_reports_external_healthy_watcher() {
@@ -1199,7 +1201,7 @@ const hooks = await mod.FmPrimaryWatchArm({
 const event = { event: { type: "session.idle", properties: { sessionID: "session-test" } } };
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, "999999\n");
 await hooks.event(event);
-await new Promise((resolve) => setTimeout(resolve, 120));
+await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
 if (existsSync(process.env.FM_ARM_LOG)) {
   console.error("watch arm ran without owning the session lock");
   process.exit(1);
@@ -1922,13 +1924,14 @@ EOF
 }
 
 test_opencode_healthy_arm_output_does_not_suppress_guard() {
-  local arm_plugin guard_plugin repo home log guard_log out status
+  local arm_plugin guard_plugin repo home log guard_log release out status
   arm_plugin="$ROOT/.opencode/plugins/fm-primary-watch-arm.js"
   guard_plugin="$ROOT/.opencode/plugins/fm-primary-turnend-guard.js"
   repo="$TMP_ROOT/opencode-external-healthy-root"
   home="$TMP_ROOT/opencode-external-healthy-home"
   log="$TMP_ROOT/opencode-external-healthy-arm.log"
   guard_log="$TMP_ROOT/opencode-external-healthy-guard.log"
+  release="$TMP_ROOT/opencode-external-healthy.release"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
@@ -1937,15 +1940,21 @@ test_opencode_healthy_arm_output_does_not_suppress_guard() {
 #!/usr/bin/env bash
 printf 'args=%s\n' "$*" >> "${FM_ARM_LOG:?}"
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
+i=0
+while [ "$i" -lt 100 ] && [ ! -e "$FM_RELEASE_FILE" ]; do
+  sleep 0.02
+  i=$((i + 1))
+done
 SH
   cat > "$repo/bin/fm-turnend-guard.sh" <<'SH'
 #!/usr/bin/env bash
+cat >/dev/null
 printf 'guard\n' >> "${FM_GUARD_LOG:?}"
 printf 'guard ran after external healthy watcher\n' >&2
 exit 2
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh" "$repo/bin/fm-turnend-guard.sh"
-  out=$(ARM_PLUGIN="$arm_plugin" GUARD_PLUGIN="$guard_plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_GUARD_LOG="$guard_log" node 2>&1 <<'EOF'
+  out=$(ARM_PLUGIN="$arm_plugin" GUARD_PLUGIN="$guard_plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_GUARD_LOG="$guard_log" FM_RELEASE_FILE="$release" node 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1990,9 +1999,11 @@ if (!promptBody.includes("TURN WOULD END BLIND")) {
   console.error(`missing blind-turn prompt: ${promptBody}`);
   process.exit(1);
 }
+writeFileSync(process.env.FM_RELEASE_FILE, "release\n");
 EOF
 )
   status=$?
+  [ "$status" -eq 0 ] || fail "OpenCode external-healthy test exited $status: $out"
   expect_code 0 "$status" "OpenCode watch plugin must not treat external healthy output as an owned arm"
   [ -z "$out" ] || fail "OpenCode external-healthy test printed output: $out"
   pass "OpenCode healthy arm output does not suppress the turn-end guard"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -525,6 +525,12 @@ install_pi_watch_extension_fixture() {
   cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$root/.pi/extensions/fm-primary-pi-watch.ts"
 }
 
+install_pi_alias_extension_fixture() {
+  local root=$1
+  mkdir -p "$root/.pi/extensions"
+  cp "$ROOT/.pi/extensions/fm-primary-skill-aliases.ts" "$root/.pi/extensions/fm-primary-skill-aliases.ts"
+}
+
 write_pi_watch_loaded_marker() {
   local home=$1 root=$2 pid=$3 version
   version=$(hash_file_for_test "$root/.pi/extensions/fm-primary-pi-watch.ts")
@@ -537,10 +543,17 @@ write_pi_turnend_loaded_marker() {
   printf '%s\n%s\n' "$version" "$pid" > "$home/state/.pi-turnend-extension-loaded"
 }
 
+write_pi_alias_loaded_marker() {
+  local home=$1 root=$2 pid=$3 version
+  version=$(hash_file_for_test "$root/.pi/extensions/fm-primary-skill-aliases.ts")
+  printf '%s\n%s\n' "$version" "$pid" > "$home/state/.pi-skill-aliases-extension-loaded"
+}
+
 write_pi_loaded_markers() {
   local home=$1 root=$2 pid=$3
   write_pi_watch_loaded_marker "$home" "$root" "$pid"
   write_pi_turnend_loaded_marker "$home" "$root" "$pid"
+  write_pi_alias_loaded_marker "$home" "$root" "$pid"
 }
 
 # --- context digest: absent vs empty vs present -----------------------------
@@ -1240,7 +1253,7 @@ EOF
   assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: pi" "pi supervision block missing"
   assert_contains "$out" "Mode: Pi extension background wake." "pi snippet missing from session start"
   assert_contains "$out" "PI_WATCH_EXTENSION: not loaded" "pi extension load diagnostic missing"
-  assert_contains "$out" "restart plain pi so $root/.pi/extensions/fm-primary-turnend-guard.ts and $root/.pi/extensions/fm-primary-pi-watch.ts auto-load" "pi extension load diagnostic omits the turn-end guard extension"
+  assert_contains "$out" "restart plain pi so $root/.pi/extensions/fm-primary-turnend-guard.ts, $root/.pi/extensions/fm-primary-pi-watch.ts, and $root/.pi/extensions/fm-primary-skill-aliases.ts auto-load" "pi extension load diagnostic omits the required Pi extensions"
 
   wake_line=$(printf '%s\n' "$out" | grep -n '^WAKE QUEUE$' | head -1 | cut -d: -f1)
   sup_line=$(printf '%s\n' "$out" | grep -n '^SUPERVISION OPERATING INSTRUCTIONS' | head -1 | cut -d: -f1)
@@ -1264,9 +1277,11 @@ EOF
   make_fake_ps_pi_holder "$fakebin" "$holder_pid"
   install_pi_turnend_extension_fixture "$root"
   install_pi_watch_extension_fixture "$root"
+  install_pi_alias_extension_fixture "$root"
   marker="$home/state/.pi-watch-extension-loaded"
   printf 'stale-extension-version\n%s\n' "$holder_pid" > "$marker"
   write_pi_turnend_loaded_marker "$home" "$root" "$holder_pid"
+  write_pi_alias_loaded_marker "$home" "$root" "$holder_pid"
   touch -t 203001010000 "$marker" 2>/dev/null || touch "$marker"
 
   out=$(FM_FAKE_HARNESS=pi run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
@@ -1291,6 +1306,7 @@ EOF
   make_fake_ps_pi_holder "$fakebin" "$holder_pid"
   install_pi_turnend_extension_fixture "$root"
   install_pi_watch_extension_fixture "$root"
+  install_pi_alias_extension_fixture "$root"
 
   write_pi_loaded_markers "$home" "$root" "$holder_pid"
 
@@ -1316,8 +1332,10 @@ EOF
   make_fake_ps_pi_holder "$fakebin" "$holder_pid"
   install_pi_turnend_extension_fixture "$root"
   install_pi_watch_extension_fixture "$root"
+  install_pi_alias_extension_fixture "$root"
 
   write_pi_watch_loaded_marker "$home" "$root" "$holder_pid"
+  write_pi_alias_loaded_marker "$home" "$root" "$holder_pid"
 
   out=$(FM_FAKE_HARNESS=pi run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
   kill "$holder_pid" 2>/dev/null || true
@@ -1341,10 +1359,12 @@ EOF
   make_fake_ps_pi_holder "$fakebin" "$holder_pid"
   install_pi_turnend_extension_fixture "$root"
   install_pi_watch_extension_fixture "$root"
+  install_pi_alias_extension_fixture "$root"
   marker="$home/state/.pi-watch-extension-loaded"
   version=$(hash_file_for_test "$root/.pi/extensions/fm-primary-pi-watch.ts")
   printf '%s\n999999\n' "$version" > "$marker"
   write_pi_turnend_loaded_marker "$home" "$root" "$holder_pid"
+  write_pi_alias_loaded_marker "$home" "$root" "$holder_pid"
 
   out=$(FM_FAKE_HARNESS=pi run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
   kill "$holder_pid" 2>/dev/null || true

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -108,6 +108,7 @@ init_changed_fixture_repo() {
     fm-backend.test.sh \
     fm-pr-merge.test.sh \
     fm-pi-watch-extension.test.sh \
+    fm-pi-skill-aliases.test.sh \
     fm-afk-return.test.sh \
     fm-bearings-snapshot.test.sh \
     fm-backend-cmux.test.sh \
@@ -123,11 +124,13 @@ init_changed_fixture_repo() {
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
     >>"$repo/tests/fm-cd-pretool-check.test.sh"
   printf '# .pi/extensions/fm-primary-pi-watch.ts\n' >>"$repo/tests/fm-pi-watch-extension.test.sh"
+  printf '# .pi/extensions/fm-primary-skill-aliases.ts\n' >>"$repo/tests/fm-pi-skill-aliases.test.sh"
   mkdir -p "$repo/.agents/skills/example" "$repo/.claude" "$repo/.pi/extensions" "$repo/src"
   : >"$repo/.agents/skills/example/SKILL.md"
   : >"$repo/.claude/settings.json"
   : >"$repo/.pi/extensions/fm-primary-pi-watch.ts"
   : >"$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  : >"$repo/.pi/extensions/fm-primary-skill-aliases.ts"
   : >"$repo/src/unmapped.ts"
   git -C "$repo" init -q
   git -C "$repo" add .
@@ -166,10 +169,12 @@ test_changed_dependency_selection_and_unmapped_failure() {
   printf '\n' >>"$repo/.claude/settings.json"
   printf '\n' >>"$repo/.pi/extensions/fm-primary-pi-watch.ts"
   printf '\n' >>"$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  printf '\n' >>"$repo/.pi/extensions/fm-primary-skill-aliases.ts"
   listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
   assert_contains "$listed" "tests/fm-captain-translation-contract.test.sh" "skill source selects pure contract coverage"
   assert_contains "$listed" "tests/fm-cd-pretool-check.test.sh" "Claude and Pi source selects hook coverage"
   assert_contains "$listed" "tests/fm-pi-watch-extension.test.sh" "Pi source selects watcher coverage"
+  assert_contains "$listed" "tests/fm-pi-skill-aliases.test.sh" "Pi alias source selects alias coverage"
   git -C "$repo" add .agents .claude .pi
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm non-bin-source-change
 


### PR DESCRIPTION
## Intent

Implement the captain-approved Pi bare-command parity for Firstmate's user-invocable skills, using a Pi-only tracked extension alias layer for exactly /ahoy, /bearings, /afk, /stow, and /updatefirstmate while preserving native /skill:<name> commands. The aliases must use Pi's supported extension command/dispatch path, preserve arguments exactly, avoid recursive alias handling, duplicate delivery, ordinary-chat fallthrough, and command-injection ambiguity, and refuse deterministic same-base command collisions without silently overriding non-Firstmate commands. The implementation must preserve existing skill authority boundaries including Ahoy's Bearings fallback, AFK enter/return semantics, Stow routing, and Updatefirstmate constraints by loading the current skill bodies at dispatch time. Keep all non-Pi harness syntax unchanged, document why those axes are unchanged, update public Pi-facing command docs with one maintainer owner for the mechanism, replace misleading pi --print /ahoy inference coverage with actual command-dispatch proof, and add focused Pi RPC command-discovery, dispatch, argument-forwarding, native command discoverability, and provider-context E2E coverage. Prior local evidence already passed with task-local ShellCheck 0.11.0 via bin/fm-install-shellcheck.sh, and the Pi type owner was inspected but skipped because tsc is not installed and this repository defines no TypeScript compiler version to install.

## What Changed
- Added a Pi-only tracked extension alias layer for bare `/ahoy`, `/bearings`, `/afk`, `/stow`, and `/updatefirstmate` commands while preserving native `/skill:<name>` dispatch and guarding same-base command collisions.
- Updated Pi launch/session/test-run wiring so the alias extension is loaded for Pi harness flows without changing non-Pi harness command syntax.
- Documented the Pi alias behavior and added focused coverage for command discovery, dispatch, argument forwarding, native command discoverability, provider context, and collision handling.

## Risk Assessment

✅ Low: The updated change is well-bounded to a Pi-only alias extension plus matching docs and focused coverage, and the prior collision fallthrough and pinned-test issues are now addressed in source.

## Testing

Exercised the focused Pi alias tests, adjacent changed-test/docs/session/watcher/non-Pi harness regression suites, confirmed the Pi type test skip matches the known missing `tsc` setup, and captured Pi RPC evidence showing all five aliases plus native `/skill:*` commands discoverable and bare `/ahoy` delivered once as expanded skill context with arguments preserved.

<details>
<summary>Evidence: Focused Pi alias test transcript</summary>

```text
ok - Pi skill alias extension is tracked, narrow, and dispatches expanded skill content once
ok - Pi alias handlers preserve args, refuse collisions, and avoid ordinary-chat fallthrough
ok - Pi RPC command discovery lists bare aliases and native skill commands
ok - Pi RPC bare /ahoy dispatch enters skill-expanded context once
```
</details>
<details>
<summary>Evidence: Pi RPC command discovery summary</summary>

`{"aliases":["ahoy","bearings","afk","stow","updatefirstmate"],"native":["skill:afk","skill:ahoy","skill:bearings","skill:stow","skill:updatefirstmate"]}`

```text
{"aliases":["ahoy","bearings","afk","stow","updatefirstmate"],"native":["skill:afk","skill:ahoy","skill:bearings","skill:stow","skill:updatefirstmate"]}
```
</details>
<details>
<summary>Evidence: Bare /ahoy provider-context proof summary</summary>

`{"containsSentinel":true,"containsArgs":true,"leaksNativeCommand":false,"ordinaryChatFallthrough":false}`

```text
{"containsSentinel":true,"containsArgs":true,"leaksNativeCommand":false,"ordinaryChatFallthrough":false}
```
</details>
<details>
<summary>Evidence: Manual Pi RPC prompt response JSONL</summary>

```text
{"type":"response","command":"prompt","success":true}
{"type":"agent_start"}
{"type":"turn_start"}
{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"<skill name=\"ahoy\" location=\"/tmp/no-mistakes-evidence/01KYGR5M8EEGD3HZFRW37KF52P/manual-pi-alias-proof/project/.agents/skills/ahoy/SKILL.md\">\nReferences are relative to /tmp/no-mistakes-evidence/01KYGR5M8EEGD3HZFRW37KF52P/manual-pi-alias-proof/project/.agents/skills/ahoy.\n\n# Ahoy Manual Alias Dispatch Sentinel\n\nThe expanded skill context must contain MANUAL_ALIAS_AHOY_SKILL_SENTINEL.\n</skill>\n\nARG_ONE  two /stow --literal"}],"timestamp":1785122121439}}
{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"<skill name=\"ahoy\" location=\"/tmp/no-mistakes-evidence/01KYGR5M8EEGD3HZFRW37KF52P/manual-pi-alias-proof/project/.agents/skills/ahoy/SKILL.md\">\nReferences are relative to /tmp/no-mistakes-evidence/01KYGR5M8EEGD3HZFRW37KF52P/manual-pi-alias-proof/project/.agents/skills/ahoy.\n\n# Ahoy Manual Alias Dispatch Sentinel\n\nThe expanded skill context must contain MANUAL_ALIAS_AHOY_SKILL_SENTINEL.\n</skill>\n\nARG_ONE  two /stow --literal"}],"timestamp":1785122121439}}
{"type":"message_start","message":{"role":"assistant","content":[],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}}
{"type":"message_update","assistantMessageEvent":{"type":"text_start","contentIndex":0,"partial":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}},"message":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}}
{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"MANU","partial":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}},"message":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}}
{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"AL_A","partial":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}},"message":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}}
{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"LIAS","partial":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}},"message":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}}
{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"_FIN","partial":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}},"message":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}}
{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"AL","partial":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}},"message":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}}
{"type":"message_update","assistantMessageEvent":{"type":"text_end","contentIndex":0,"content":"MANUAL_ALIAS_FINAL","partial":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}},"message":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}}
{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}}
{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342},"toolResults":[]}
{"type":"agent_end","messages":[{"role":"user","content":[{"type":"text","text":"<skill name=\"ahoy\" location=\"/tmp/no-mistakes-evidence/01KYGR5M8EEGD3HZFRW37KF52P/manual-pi-alias-proof/project/.agents/skills/ahoy/SKILL.md\">\nReferences are relative to /tmp/no-mistakes-evidence/01KYGR5M8EEGD3HZFRW37KF52P/manual-pi-alias-proof/project/.agents/skills/ahoy.\n\n# Ahoy Manual Alias Dispatch Sentinel\n\nThe expanded skill context must contain MANUAL_ALIAS_AHOY_SKILL_SENTINEL.\n</skill>\n\nARG_ONE  two /stow --literal"}],"timestamp":1785122121439},{"role":"assistant","content":[{"type":"text","text":"MANUAL_ALIAS_FINAL"}],"api":"manual-alias-proof-api","provider":"manual-alias-proof","model":"deterministic","usage":{"input":1643,"output":5,"cacheRead":0,"cacheWrite":1643,"totalTokens":3291,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785122121342}],"willRetry":false}
{"type":"agent_settled"}
```
</details>
<details>
<summary>Evidence: Pi provider context JSONL</summary>

```text
{"messages":[{"role":"user","content":[{"type":"text","text":"<skill name=\"ahoy\" location=\"/tmp/no-mistakes-evidence/01KYGR5M8EEGD3HZFRW37KF52P/manual-pi-alias-proof/project/.agents/skills/ahoy/SKILL.md\">\nReferences are relative to /tmp/no-mistakes-evidence/01KYGR5M8EEGD3HZFRW37KF52P/manual-pi-alias-proof/project/.agents/skills/ahoy.\n\n# Ahoy Manual Alias Dispatch Sentinel\n\nThe expanded skill context must contain MANUAL_ALIAS_AHOY_SKILL_SENTINEL.\n</skill>\n\nARG_ONE  two /stow --literal"}],"timestamp":1785122121439}]}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `.pi/extensions/fm-primary-skill-aliases.ts:153` - Intent requires the aliases to “refuse deterministic same-base command collisions” and avoid “ordinary-chat fallthrough,” but the collision check only runs inside the registered alias handler. Pi suffixes duplicate extension command names (for example `/ahoy:1`, `/ahoy:2`), so when another extension registers the same base name there is no bare `/ahoy` handler to run this refusal; bare `/ahoy` can fall through instead of producing the Firstmate error. Decide whether duplicate extension-command collisions must be handled before dispatch or accepted as out of scope.
- ⚠️ `bin/fm-spawn.sh:440` - The Pi secondmate launch template now includes `-e __PIALIASES__`, but the existing byte-pinned launch-template test in `tests/fm-kimi-harness.test.sh` still expects the old two-extension Pi line. That unchanged assertion will fail once this source line changes; update the pinned expectation to include the alias extension.

🔧 Fix: Guard Pi alias collision fallthrough
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-pi-skill-aliases.test.sh`
- <code>`bash tests/fm-pi-primary-types.test.sh` (skipped: `tsc` not found)</code>
- `bash tests/fm-test-run.test.sh`
- `bash tests/fm-documentation-audiences.test.sh`
- `bash tests/fm-session-start.test.sh`
- `bash tests/fm-pi-watch-extension.test.sh`
- `bash tests/fm-supervision-instructions.test.sh`
- `bash tests/fm-kimi-harness.test.sh`
- <code>`bash tests/fm-pi-primary-live-e2e.test.sh` (skipped: `FM_PI_LIVE_E2E` not set)</code>
- <code>Manual Pi RPC `get_commands` proof captured to `/tmp/no-mistakes-evidence/01KYGR5M8EEGD3HZFRW37KF52P/manual-pi-alias-proof/get-commands.jsonl`</code>
- <code>Manual deterministic-provider Pi RPC prompt proof for `/ahoy ARG_ONE two /stow --literal` captured to `/tmp/no-mistakes-evidence/01KYGR5M8EEGD3HZFRW37KF52P/manual-pi-alias-proof/provider-context.jsonl`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
