### PR TITLE
fix: transport large fleet snapshots without argv overflow

### DIFF
--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -174,6 +174,90 @@ esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; exit 1; }
 
+SNAPSHOT_TMP_DIR=
+SNAPSHOT_TMP_FILES=
+SNAPSHOT_TMP_COUNTER=0
+SNAPSHOT_TMP_CLEANUP_ARMED=0
+SNAPSHOT_MADE_FILE=
+snapshot_rm() {
+  if [ -x /bin/rm ]; then
+    /bin/rm "$@"
+  else
+    rm "$@"
+  fi
+}
+
+snapshot_cleanup_tmp() {
+  local file
+  if [ -n "$SNAPSHOT_TMP_DIR" ]; then
+    snapshot_rm -rf "$SNAPSHOT_TMP_DIR"
+  fi
+  if [ -n "$SNAPSHOT_TMP_FILES" ]; then
+    while IFS= read -r file; do
+      [ -n "$file" ] && snapshot_rm -f "$file"
+    done <<EOF
+$SNAPSHOT_TMP_FILES
+EOF
+  fi
+}
+
+snapshot_arm_tmp_cleanup() {
+  [ "$SNAPSHOT_TMP_CLEANUP_ARMED" = 1 ] && return 0
+  trap 'snapshot_cleanup_tmp' EXIT
+  trap 'snapshot_cleanup_tmp; exit 130' INT
+  trap 'snapshot_cleanup_tmp; exit 143' TERM
+  trap 'snapshot_cleanup_tmp; exit 129' HUP
+  SNAPSHOT_TMP_CLEANUP_ARMED=1
+}
+
+snapshot_make_file() {
+  local file tmpbase try
+  snapshot_arm_tmp_cleanup
+  if command -v mktemp >/dev/null 2>&1; then
+    if [ -z "$SNAPSHOT_TMP_DIR" ]; then
+      SNAPSHOT_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-fleet-snapshot.XXXXXX") || return 1
+    fi
+    file=$(mktemp "$SNAPSHOT_TMP_DIR/json.XXXXXX") || return 1
+    SNAPSHOT_MADE_FILE=$file
+    return 0
+  fi
+
+  tmpbase=${TMPDIR:-/tmp}
+  try=0
+  while [ "$try" -lt 100 ]; do
+    SNAPSHOT_TMP_COUNTER=$((SNAPSHOT_TMP_COUNTER + 1))
+    file="$tmpbase/fm-fleet-snapshot.$$.$SNAPSHOT_TMP_COUNTER"
+    if ( set -C; : > "$file" ) 2>/dev/null; then
+      if [ -n "$SNAPSHOT_TMP_FILES" ]; then
+        SNAPSHOT_TMP_FILES="$SNAPSHOT_TMP_FILES
+$file"
+      else
+        SNAPSHOT_TMP_FILES=$file
+      fi
+      SNAPSHOT_MADE_FILE=$file
+      return 0
+    fi
+    try=$((try + 1))
+  done
+  return 1
+}
+
+snapshot_json_file() {  # <out-var> <json>
+  local out_var=$1 file
+  shift
+  snapshot_make_file || return 1
+  file=$SNAPSHOT_MADE_FILE
+  printf '%s' "$1" > "$file" || return 1
+  printf -v "$out_var" '%s' "$file"
+}
+
+snapshot_new_file() {  # <out-var>
+  local out_var=$1 file
+  snapshot_make_file || return 1
+  file=$SNAPSHOT_MADE_FILE
+  printf -v "$out_var" '%s' "$file"
+}
+
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
@@ -563,10 +647,13 @@ task_json_lines() {
 # used by secondmate_home_summary_json, without inventing live task rows.
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
-main_inventory_json() {  # <backlog-json> <tasks-json>
+main_inventory_json() {  # <backlog-json-file> <tasks-json-file>
   jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+    --slurpfile backlog_doc "$1" \
+    --slurpfile tasks_doc "$2" '
+    ($backlog_doc[0]) as $backlog
+    | ($tasks_doc[0]) as $tasks
+    |
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
@@ -591,7 +678,7 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # validated parent read needs.
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
-secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
+secondmate_home_summary_json() {  # <backlog-json-file> <tasks-json-file>
   jq -n \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
@@ -599,8 +686,11 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+    --slurpfile backlog_doc "$1" \
+    --slurpfile tasks_doc "$2" '
+    ($backlog_doc[0]) as $backlog
+    | ($tasks_doc[0]) as $tasks
+    |
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
@@ -1010,8 +1100,15 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
     '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:true,observed_at:$observed,freshness:"fresh",reason:null,lines:$lines,bytes:$bytes,event_note_seen:$seen,contradiction:$contradiction}'
 }
 
-parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+parent_evidence_reconciliation_json() {  # <summary-json-file> <activities-json-file> <decisions-json-file>
+  jq -n \
+    --slurpfile summary_doc "$1" \
+    --slurpfile activities_doc "$2" \
+    --slurpfile decisions_doc "$3" '
+    ($summary_doc[0]) as $summary
+    | ($activities_doc[0]) as $activities
+    | ($decisions_doc[0]) as $decisions
+    |
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
@@ -1070,13 +1167,19 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
        inconclusive:any(($activity_results + $decision_results)[]; .verdict == "inconclusive")}'
 }
 
-secondmate_current_json() {  # <parent-tasks-json>
-  local tasks=$1 registry union rows total_registered total shown truncated
+secondmate_current_json() {  # <parent-tasks-json-file>
+  local tasks_file=$1 registry registry_file union rows total_registered total shown truncated
   local row id home registered registry_error task status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
-  local records='[]' seen_homes=''
+  local activity_scan_file activities_file decisions_file summary_file reconciliation_file terminal_file records_file seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
+  snapshot_json_file registry_file "$registry" || return 1
+  union=$(jq -n \
+    --slurpfile registry_doc "$registry_file" \
+    --slurpfile tasks_doc "$tasks_file" '
+    ($registry_doc[0]) as $registry
+    | ($tasks_doc[0]) as $tasks
+    |
     ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
@@ -1096,6 +1199,7 @@ secondmate_current_json() {  # <parent-tasks-json>
   rows=$(printf '%s' "$union" | jq -c --argjson cap "$FM_SNAPSHOT_SECONDMATES" '(if $cap == 0 then .records else .records[:$cap] end)[]')
   shown=$(printf '%s\n' "$rows" | grep -c . || true)
   truncated=$((total - shown))
+  snapshot_new_file records_file || return 1
 
   while IFS= read -r row; do
     [ -n "$row" ] || continue
@@ -1110,6 +1214,9 @@ secondmate_current_json() {  # <parent-tasks-json>
     activity_scan=$(bounded_parent_activities_json "$status_file")
     activities=$(printf '%s' "$activity_scan" | jq -c '.records')
     decisions=$(printf '%s' "$task" | jq -c '.hints.open_decisions // []')
+    snapshot_json_file activity_scan_file "$activity_scan" || return 1
+    snapshot_json_file activities_file "$activities" || return 1
+    snapshot_json_file decisions_file "$decisions" || return 1
     event_epoch=$(file_mtime_epoch "$status_file")
     event_age=null
     if [ -n "$event_epoch" ]; then
@@ -1184,12 +1291,14 @@ secondmate_current_json() {  # <parent-tasks-json>
     fi
 
     if [ -z "$reason" ]; then
+      snapshot_json_file summary_file "$summary" || return 1
       state=$(printf '%s' "$summary" | jq -r '.state')
       current_reason=
       if [ "$summary_valid" != true ]; then
         current_reason="structured home state invalid: $(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')"
       fi
-      reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
+      reconciliation=$(parent_evidence_reconciliation_json "$summary_file" "$activities_file" "$decisions_file")
+      snapshot_json_file reconciliation_file "$reconciliation" || return 1
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
       terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r --arg note "$event_note" '
         any(.activities[]; .verdict == "contradicts" and .summary == $note)')
@@ -1199,13 +1308,25 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
+      snapshot_json_file terminal_file "$terminal" || return 1
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
       record=$(jq -n \
         --arg id "$id" --arg home "$home" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
+        --slurpfile summary_doc "$summary_file" \
+        --slurpfile decisions_doc "$decisions_file" \
+        --slurpfile activities_doc "$activities_file" \
+        --slurpfile activity_scan_doc "$activity_scan_file" \
+        --slurpfile reconciliation_doc "$reconciliation_file" \
+        --slurpfile terminal_doc "$terminal_file" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
+        ($summary_doc[0]) as $summary
+        | ($decisions_doc[0]) as $decisions
+        | ($activities_doc[0]) as $activities
+        | ($activity_scan_doc[0]) as $activity_scan
+        | ($reconciliation_doc[0]) as $reconciliation
+        | ($terminal_doc[0]) as $terminal
+        |
         {id:$id,home:$home,registered:$registered,
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
@@ -1230,11 +1351,20 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
+      snapshot_json_file terminal_file "$terminal" || return 1
       record=$(jq -n \
         --arg id "$id" --arg home "$home" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" '
+        --argjson registered "$registered" --argjson event_age "$event_age" \
+        --slurpfile activities_doc "$activities_file" \
+        --slurpfile activity_scan_doc "$activity_scan_file" \
+        --slurpfile decisions_doc "$decisions_file" \
+        --slurpfile terminal_doc "$terminal_file" '
+        ($activities_doc[0]) as $activities
+        | ($activity_scan_doc[0]) as $activity_scan
+        | ($decisions_doc[0]) as $decisions
+        | ($terminal_doc[0]) as $terminal
+        |
         {id:$id,home:($home | if . == "" then null else . end),registered:$registered,
          current:{state:"unknown",reason:$reason},invalidity:null,
          provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
@@ -1243,22 +1373,24 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    printf '%s\n' "$record" >> "$records_file" || return 1
   done <<EOF
 $rows
 EOF
   jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+    --slurpfile registry_doc "$registry_file" \
+    --slurpfile records "$records_file" \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    '{registry:$registry_doc[0],records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
-secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
+secondmate_landed_from_current_json() {  # <secondmate-current-json-file>
+  jq -n --slurpfile current_doc "$1" '
+    ($current_doc[0]) as $current
+    |
     {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
@@ -1291,21 +1423,39 @@ scout_report_lines() {
 }
 
 BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" >&2; exit 1; }
+snapshot_json_file BACKLOG_JSON_FILE "$BACKLOG_JSON" \
+  || { echo "fm-fleet-snapshot: temporary backlog transport failed" >&2; exit 1; }
+unset BACKLOG_JSON
 TASKS_JSON=$(task_json_lines) || { echo "fm-fleet-snapshot: task snapshot failed" >&2; exit 1; }
+snapshot_json_file TASKS_JSON_FILE "$TASKS_JSON" \
+  || { echo "fm-fleet-snapshot: temporary task transport failed" >&2; exit 1; }
+unset TASKS_JSON
 
 if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
-  secondmate_home_summary_json "$BACKLOG_JSON" "$TASKS_JSON" \
+  secondmate_home_summary_json "$BACKLOG_JSON_FILE" "$TASKS_JSON_FILE" \
     || { echo "fm-fleet-snapshot: secondmate home summary failed" >&2; exit 1; }
   exit 0
 fi
 
 SCOUT_REPORTS_JSON=$(scout_report_lines)
-MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON" "$TASKS_JSON") \
+snapshot_json_file SCOUT_REPORTS_JSON_FILE "$SCOUT_REPORTS_JSON" \
+  || { echo "fm-fleet-snapshot: temporary scout-report transport failed" >&2; exit 1; }
+unset SCOUT_REPORTS_JSON
+MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON_FILE" "$TASKS_JSON_FILE") \
   || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
-SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
+snapshot_json_file MAIN_INVENTORY_JSON_FILE "$MAIN_INVENTORY_JSON" \
+  || { echo "fm-fleet-snapshot: temporary main-inventory transport failed" >&2; exit 1; }
+unset MAIN_INVENTORY_JSON
+SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON_FILE") \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
-SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
+snapshot_json_file SECONDMATE_CURRENT_JSON_FILE "$SECONDMATE_CURRENT_JSON" \
+  || { echo "fm-fleet-snapshot: temporary secondmate-current transport failed" >&2; exit 1; }
+unset SECONDMATE_CURRENT_JSON
+SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON_FILE") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
+snapshot_json_file SECONDMATE_LANDED_JSON_FILE "$SECONDMATE_LANDED_JSON" \
+  || { echo "fm-fleet-snapshot: temporary secondmate-landed transport failed" >&2; exit 1; }
+unset SECONDMATE_LANDED_JSON
 
 jq -n \
   --arg generated "$SNAPSHOT_NOW" \
@@ -1315,13 +1465,19 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  --slurpfile backlog_doc "$BACKLOG_JSON_FILE" \
+  --slurpfile tasks_doc "$TASKS_JSON_FILE" \
+  --slurpfile main_inventory_doc "$MAIN_INVENTORY_JSON_FILE" \
+  --slurpfile scout_reports_doc "$SCOUT_REPORTS_JSON_FILE" \
+  --slurpfile secondmate_current_doc "$SECONDMATE_CURRENT_JSON_FILE" \
+  --slurpfile secondmate_landed_doc "$SECONDMATE_LANDED_JSON_FILE" \
+  '($backlog_doc[0]) as $backlog
+   | ($tasks_doc[0]) as $tasks
+   | ($main_inventory_doc[0]) as $main_inventory
+   | ($scout_reports_doc[0]) as $scout_reports
+   | ($secondmate_current_doc[0]) as $secondmate_current
+   | ($secondmate_landed_doc[0]) as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -188,10 +188,14 @@ snapshot_rm() {
 }
 
 snapshot_cleanup_tmp() {
-  local file
+  local file tmpbase
   if [ -n "$SNAPSHOT_TMP_DIR" ]; then
     snapshot_rm -rf "$SNAPSHOT_TMP_DIR"
   fi
+  tmpbase=${TMPDIR:-/tmp}
+  for file in "$tmpbase"/fm-fleet-snapshot."$$".*; do
+    [ -e "$file" ] && snapshot_rm -f "$file"
+  done
   if [ -n "$SNAPSHOT_TMP_FILES" ]; then
     while IFS= read -r file; do
       [ -n "$file" ] && snapshot_rm -f "$file"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -227,7 +227,7 @@ snapshot_make_file() {
   while [ "$try" -lt 100 ]; do
     SNAPSHOT_TMP_COUNTER=$((SNAPSHOT_TMP_COUNTER + 1))
     file="$tmpbase/fm-fleet-snapshot.$$.$SNAPSHOT_TMP_COUNTER"
-    if ( set -C; : > "$file" ) 2>/dev/null; then
+    if ( umask 077; set -C; : > "$file" ) 2>/dev/null; then
       if [ -n "$SNAPSHOT_TMP_FILES" ]; then
         SNAPSHOT_TMP_FILES="$SNAPSHOT_TMP_FILES
 $file"

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -165,6 +165,52 @@ run() {  # <home> <fakebin> <args...>
   PATH="$fakebin:$PATH" FM_HOME="$home" FM_BEARINGS_NOW=2026-07-11T18:00:00Z NET_LOG="$home/net.log" "$BEARINGS" "$@"
 }
 
+test_large_inventory_uses_file_backed_snapshot_transport() {
+  local home fakebin canonical bearings payload count i id
+  home=$(make_home large-argv-transport)
+  fakebin=$(make_fakebin "$home")
+  count=48
+  payload=$(awk 'BEGIN { for (i = 0; i < 4096; i++) printf "x" }')
+  {
+    printf '## In flight\n'
+    i=1
+    while [ "$i" -le "$count" ]; do
+      id=$(printf 'ship-%03d' "$i")
+      mkdir -p "$home/projects/$id"
+      printf -- '- [ ] %s - Large task %03d (repo: firstmate) (kind: ship) (since 2026-07-27)\n' "$id" "$i"
+      fm_write_meta "$home/state/$id.meta" \
+        "window=firstmate:fm-$id" \
+        "worktree=$home/projects/$id" \
+        "project=firstmate" \
+        "harness=codex" \
+        "kind=ship" \
+        "mode=ship"
+      printf 'working: %s %s\n' "$id" "$payload" > "$home/state/$id.status"
+      i=$((i + 1))
+    done
+    printf '\n## Queued\n\n## Done\n'
+  } > "$home/data/backlog.md"
+
+  canonical=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$ROOT/bin/fm-fleet-snapshot.sh" --json)
+  [ "${#canonical}" -gt 131072 ] || fail "large fixture did not exceed a single argv-safe JSON string"
+  printf '%s' "$canonical" | jq -e --argjson count "$count" '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.tasks | length) == $count
+      and .main_inventory.valid == true
+      and ([.tasks[].id] | .[0] == "ship-001" and .[-1] == "ship-048")
+      and (.tasks[] | select(.id == "ship-048") | (.hints.last_event_text | length) > 4096)
+  ' >/dev/null || fail "large canonical snapshot did not preserve deterministic structured output"
+
+  bearings=$(run "$home" "$fakebin" --json --all-in-flight)
+  printf '%s' "$bearings" | jq -e --argjson count "$count" '
+    .schema == "fm-bearings.v1"
+      and (.in_flight | length) == $count
+      and ([.in_flight[].id] | .[0] == "ship-001" and .[-1] == "ship-048")
+      and ([.omitted[].surface] | any(test("in_flight showing")) | not)
+  ' >/dev/null || fail "large Bearings projection did not report every in-flight task: $bearings"
+  pass "large fleet snapshot transport uses file-backed JSON instead of argv-sized jq args"
+}
+
 # End-to-end Domain Alpha regression fixture.
 # The parent event claims Phase 7 started, while the registered home has no child
 # metadata, every sample-rollout item is Done, and only an external legal hold remains.
@@ -1892,6 +1938,7 @@ test_chat_contract_four_sections() {
 
 test_domain_alpha_stale_parent_event_does_not_become_current_work
 test_gnu_stat_uses_file_formats_without_bsd_fallback_pollution
+test_large_inventory_uses_file_backed_snapshot_transport
 test_parent_activity_evidence_is_bounded_and_disclosed
 test_active_child_overrides_old_parent_event
 test_structured_child_decision_reaches_captains_call

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -211,6 +211,49 @@ test_large_inventory_uses_file_backed_snapshot_transport() {
   pass "large fleet snapshot transport uses file-backed JSON instead of argv-sized jq args"
 }
 
+test_no_mktemp_fallback_cleans_file_backed_snapshot_transport() {
+  local home fakebin tmpdir bashenv canonical leftovers
+  home=$(make_home no-mktemp-transport-cleanup)
+  fakebin=$(make_fakebin "$home")
+  tmpdir="$home/tmp"
+  mkdir -p "$tmpdir" "$home/projects/task-one"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] task-one - Exercise fallback transport cleanup (repo: firstmate) (kind: ship)
+
+## Queued
+
+## Done
+EOF
+  fm_write_meta "$home/state/task-one.meta" \
+    "window=firstmate:fm-task-one" \
+    "worktree=$home/projects/task-one" \
+    "project=firstmate" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship"
+  printf 'working: fallback cleanup\n' > "$home/state/task-one.status"
+  bashenv="$home/hide-mktemp.bashenv"
+  cat > "$bashenv" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = mktemp ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+SH
+
+  canonical=$(PATH="$fakebin:$PATH" BASH_ENV="$bashenv" TMPDIR="$tmpdir" FM_HOME="$home" "$ROOT/bin/fm-fleet-snapshot.sh" --json)
+  printf '%s' "$canonical" | jq -e '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.tasks | length) == 1
+      and .tasks[0].id == "task-one"
+  ' >/dev/null || fail "no-mktemp fallback did not produce a valid canonical snapshot"
+  leftovers=$(find "$tmpdir" -maxdepth 1 -type f -name 'fm-fleet-snapshot.*' | wc -l | tr -d ' ')
+  [ "$leftovers" = 0 ] || fail "no-mktemp fallback left transport files behind: $leftovers"
+  pass "no-mktemp fallback cleans file-backed snapshot transport"
+}
+
 # End-to-end Domain Alpha regression fixture.
 # The parent event claims Phase 7 started, while the registered home has no child
 # metadata, every sample-rollout item is Done, and only an external legal hold remains.
@@ -1939,6 +1982,7 @@ test_chat_contract_four_sections() {
 test_domain_alpha_stale_parent_event_does_not_become_current_work
 test_gnu_stat_uses_file_formats_without_bsd_fallback_pollution
 test_large_inventory_uses_file_backed_snapshot_transport
+test_no_mktemp_fallback_cleans_file_backed_snapshot_transport
 test_parent_activity_evidence_is_bounded_and_disclosed
 test_active_child_overrides_old_parent_event
 test_structured_child_decision_reaches_captains_call


### PR DESCRIPTION
## Intent

Repair the Firstmate fleet snapshot transport defect that made /bearings and bin/fm-fleet-snapshot.sh --json fail at current fleet size with /bin/jq: Argument list too long around bin/fm-fleet-snapshot.sh line 567. Preserve the existing snapshot and Bearings schemas, deterministic ordering, bounds, omission disclosures, secondmate behavior, and local-only defaults while changing only the JSON transport boundary so large structured blobs are passed via stdin or safely managed files instead of argv-sized --argjson strings. Include a regression above the observed fleet size that exercises both bin/fm-fleet-snapshot.sh --json and bin/fm-bearings-snapshot.sh on large synthetic inventory, and keep the work narrowly scoped without redesigning Bearings presentation or fleet lifecycle state. Local implementation committed 441310a uses file-backed jq slurps for large snapshot sections, retains a no-mktemp fallback for the existing Perl timeout test environment, and adds the large synthetic inventory regression to tests/fm-bearings-snapshot.test.sh.

## What Changed
- Reworks fleet snapshot JSON assembly to pass large structured sections through stdin/file-backed jq slurps instead of argv-sized `--argjson` values.
- Adds safely managed snapshot transport files, including private no-`mktemp` fallback creation and cleanup.
- Adds a large synthetic inventory regression covering both `bin/fm-fleet-snapshot.sh --json` and Bearings snapshot generation above the observed fleet size.

## Risk Assessment

✅ Low: The change is narrowly scoped to moving large jq JSON transport from argv to file-backed slurps, preserves the visible schemas and ordering logic, and the prior fallback temp-file permission issue is fixed with private creation permissions.

## Testing

After inspecting the branch diff and targeted test coverage, I ran the focused Bearings snapshot test file, then captured manual CLI transcripts showing a 1.18 MB fleet snapshot and 48-item Bearings projection completing in deterministic order without argv failure, plus the no-mktemp fallback producing valid JSON with zero leftover transport files; the worktree remained clean.

<details>
<summary>Evidence: Large fleet CLI transcript</summary>

```text
$ FM_HOME=/tmp/no-mistakes-evidence/01KYGQZ9FWWJYG1F5GHZQQ9JZB/manual-large-fm-home PATH=/tmp/no-mistakes-evidence/01KYGQZ9FWWJYG1F5GHZQQ9JZB/fakebin:$PATH bin/fm-fleet-snapshot.sh --json | jq summary
{
  "schema": "fm-fleet-snapshot.v1",
  "task_count": 48,
  "main_inventory_valid": true,
  "first_task": "ship-001",
  "last_task": "ship-048",
  "largest_status_chars": 4114,
  "json_bytes": 1186412
}

$ FM_HOME=/tmp/no-mistakes-evidence/01KYGQZ9FWWJYG1F5GHZQQ9JZB/manual-large-fm-home PATH=/tmp/no-mistakes-evidence/01KYGQZ9FWWJYG1F5GHZQQ9JZB/fakebin:$PATH bin/fm-bearings-snapshot.sh --json --all-in-flight | jq summary
{
  "schema": "fm-bearings.v1",
  "in_flight_count": 48,
  "first_in_flight": "ship-001",
  "last_in_flight": "ship-048",
  "omitted_surfaces": [
    "backlog item bodies",
    "task paths",
    "watch/steer actions",
    "healthy endpoint detail",
    "full scout-report inventory",
    "superseded queued items",
    "live PR discovery + checks"
  ]
}
```
</details>
<details>
<summary>Evidence: Fleet large summary</summary>

```text
{
  "schema": "fm-fleet-snapshot.v1",
  "task_count": 48,
  "main_inventory_valid": true,
  "first_task": "ship-001",
  "last_task": "ship-048",
  "largest_status_chars": 4114,
  "json_bytes": 1186412
}
```
</details>
<details>
<summary>Evidence: Bearings large summary</summary>

```text
{
  "schema": "fm-bearings.v1",
  "in_flight_count": 48,
  "first_in_flight": "ship-001",
  "last_in_flight": "ship-048",
  "omitted_surfaces": [
    "backlog item bodies",
    "task paths",
    "watch/steer actions",
    "healthy endpoint detail",
    "full scout-report inventory",
    "superseded queued items",
    "live PR discovery + checks"
  ]
}
```
</details>
<details>
<summary>Evidence: No-mktemp fallback cleanup transcript</summary>

```text
$ BASH_ENV=<hide mktemp> TMPDIR=/tmp/no-mistakes-evidence/01KYGQZ9FWWJYG1F5GHZQQ9JZB/manual-no-mktemp-tmp FM_HOME=/tmp/no-mistakes-evidence/01KYGQZ9FWWJYG1F5GHZQQ9JZB/manual-no-mktemp-fm-home bin/fm-fleet-snapshot.sh --json | jq summary
{
  "schema": "fm-fleet-snapshot.v1",
  "task_count": 1,
  "first_task": "task-one",
  "main_inventory_valid": true
}
transport_leftover_files=0
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (19m38s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-fleet-snapshot.sh:230` - The no-mktemp fallback creates snapshot transport files directly under TMPDIR with the caller&#39;s default umask. On common umask 022 this makes files like /tmp/fm-fleet-snapshot.$pid.$n world-readable while the process runs, even though they contain full fleet state, paths, and status text. The new transport boundary should create these fallback files with private permissions, for example by wrapping the noclobber creation/write path in umask 077 or creating a private fallback directory first.

🔧 Fix: Harden fallback snapshot temp permissions
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-fleet-snapshot.sh:216` - Manual no-mktemp fallback verification produced valid snapshot JSON, but left two fallback transport files in TMPDIR after `fm-fleet-snapshot.sh --json` exited. That does not fully satisfy the stated requirement for safely managed file-backed JSON transport on the no-mktemp fallback path.
- `./tests/fm-bearings-snapshot.test.sh`
- `/tmp/no-mistakes-evidence/01KYGQZ9FWWJYG1F5GHZQQ9JZB/run-large-fixture.sh "$PWD"`
- `/tmp/no-mistakes-evidence/01KYGQZ9FWWJYG1F5GHZQQ9JZB/run-no-mktemp-fallback.sh "$PWD"`
- `git status --short`

🔧 Fix: Clean no-mktemp snapshot transport files
✅ Re-checked - no issues remain.
- `git status --short && git rev-parse HEAD && git diff --stat a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499..HEAD`
- `bash tests/fm-bearings-snapshot.test.sh`
- <code>manual large synthetic `FM_HOME` evidence: ran `bin/fm-fleet-snapshot.sh --json` and `bin/fm-bearings-snapshot.sh --json --all-in-flight` with 48 in-flight tasks containing 4 KiB status payloads</code>
- <code>manual no-`mktemp` fallback evidence: ran `bin/fm-fleet-snapshot.sh --json` with `BASH_ENV` hiding `mktemp`, then checked `find &#34;$TMPDIR&#34; -name &#39;fm-fleet-snapshot.*&#39;` returned zero leftovers</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
