### PR TITLE
feat: add release batching protocol

### DIFF
--- a/.agents/skills/release-batching-protocol/SKILL.md
+++ b/.agents/skills/release-batching-protocol/SKILL.md
@@ -2,7 +2,7 @@
 name: release-batching-protocol
 description: >-
   Agent-only policy for Firstmate risk-class parallel certification and release batching.
-  Use before deciding that multiple ship lanes may certify or release together, when risk class affects queued-work re-evaluation, and before batching captain-facing release status.
+  Use before initial intake, dispatch, or spawn decisions that may let multiple ship lanes proceed; when risk class affects queued-work re-evaluation; before deciding that multiple ship lanes may certify or release together; and before batching captain-facing release status.
 user-invocable: false
 metadata:
   internal: true

--- a/.agents/skills/release-batching-protocol/SKILL.md
+++ b/.agents/skills/release-batching-protocol/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: release-batching-protocol
+description: >-
+  Agent-only policy for Firstmate risk-class parallel certification and release batching.
+  Use before deciding that multiple ship lanes may certify or release together, when risk class affects queued-work re-evaluation, and before batching captain-facing release status.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# release-batching-protocol
+
+This skill is the single owner of Firstmate's risk-class parallel certification and release-batching policy.
+It applies across every supported primary harness and runtime backend because it constrains shared dispatch, queue re-evaluation, validation, release, and captain-facing status behavior before backend-specific mechanics run.
+It never expands project-write, cleanup, merge, production, destructive, irreversible, security-sensitive, no-mistakes ownership, or approval authority.
+
+## Evidence Inputs
+
+Classify from current durable evidence, not conversational memory.
+Use the task brief, current backlog dependencies and time gates, relevant reports, task metadata, current `bin/fm-crew-state.sh` output when validation state matters, the selected delivery mode, configured `yolo` posture, and current PR or branch evidence from the forge or guarded local helpers.
+If the evidence does not establish independence and the class would affect whether work proceeds in parallel, treat the lane as serialized or escalate the uncertainty when production, destructive, irreversible, or security-sensitive consequences are possible.
+
+## Low-Risk Certification Lanes
+
+Independent low-risk certification may run in parallel for UI, documentation, tooling, lint rules, labels, and templates.
+A low-risk lane is independent only when it has no semantic dependency on another active lane, no shared mutable external state, no incompatible migration or rollout sequence, and a selected delivery path that can reconcile ordinary rebase or conflict work.
+Same-file overlap alone is not a blocker.
+File overlap becomes a blocker only when the edits encode a real semantic dependency, mutate a shared generated artifact, compete for one external resource, or make one lane's validation result stale.
+Parallel certification means each lane still runs its own selected delivery path, tests, review gates, PR or ready-branch checks, and current-code validation evidence.
+
+## Serialized Classes
+
+Migrations remain isolated and serialized.
+Authentication, billing, runtime state machines, and deployment infrastructure remain isolated and serialized.
+Security-sensitive changes are never batched for speed.
+Unrelated migrations are never batched for speed.
+Production migration remains singular.
+Container cutover remains singular.
+Production release remains singular unless the captain gives explicit release authority for that concrete production action.
+Dark-feature activation is not authorized by parallel certification or release batching.
+Destructive or irreversible action is not authorized by parallel certification or release batching.
+If a lane mixes low-risk work with any serialized class, classify the whole lane by the serialized class until the risky work is split out or complete.
+
+## Dispatch And Queue Re-Evaluation
+
+At intake, classify the requested ship work before using concurrency as a reason to spawn, hold, or route multiple lanes.
+At backlog re-evaluation, apply the same classification to every queued item whose dependencies and time gates have cleared.
+Dispatch all eligible independent low-risk lanes that can proceed without shared mutable external state.
+Do not hold an eligible low-risk lane only because another low-risk lane touches the same file.
+Hold or serialize a lane when it depends on an active high-risk lane, modifies the same migration or rollout sequence, changes the same production or deployment resource, or could make another lane's validation evidence obsolete.
+Keep the blocker durable in the backlog rather than relying on the next agent to remember the reason.
+
+## Validation And Release
+
+Parallel certification does not combine validation runs.
+Each lane's worker remains responsible for its own no-mistakes run, direct-PR checks, or local-only ready branch under the selected delivery path.
+Firstmate may treat multiple independent low-risk lanes as concurrently releaseable only after each lane is independently ready under its own delivery path and approval posture.
+Release batching is an administrative grouping of already-ready low-risk lanes.
+It never replaces per-task `bin/fm-pr-check.sh`, `bin/fm-pr-merge.sh`, `bin/fm-merge-local.sh`, `bin/fm-teardown.sh`, or the guarded fleet-sync path.
+Run those helpers per task so merge metadata, landed-work proof, cleanup refusal, and clone refresh behavior remain intact.
+If one merge, local landing, or sync could invalidate another lane's validation basis, re-check that lane before landing it.
+Never merge a red PR, never infer approval from batching, and never use batching to bypass an ask-user, captain approval, security, destructive, irreversible, or production boundary.
+
+## Captain-Facing Status
+
+Batch non-urgent ready updates only when the grouping reflects independent low-risk lanes that are ready under their own delivery paths.
+Describe the concrete outcome and consequence, not the internal risk-class mechanics.
+When approval is still required, present the ready lanes together but ask for the same approval that each lane would have required individually.
+When `yolo` authorizes routine green low-risk merges, report the finished PR URLs or local-main outcomes after each helper completes.
+Never phrase certification batching as feature activation, production release, migration execution, deployment cutover, or approval for destructive, irreversible, or security-sensitive work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,7 @@ Load `diagnostic-reasoning` before scoping a reported bug and before acting on a
 
 Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts.
 Serialize only for a true semantic dependency, shared mutable external state, incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, and genuine blockers remain durable.
+When deciding whether multiple ship lanes may certify or release together, load `release-batching-protocol`; it owns risk classes, batching boundaries, and non-expanded authority.
 Write the task-specific brief under section 11 before spawning.
 
 ### Dispatch and supervision handoff
@@ -302,6 +303,7 @@ Judge validation by the current-code-matched run step through `bin/fm-crew-state
 Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed or cancelled is failed.
 A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership; steer it back to the gate response flow.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.
+Parallel certification stays per lane; use `release-batching-protocol` before treating multiple lanes as concurrently ready.
 
 ### PR ready, landing, and teardown
 
@@ -309,6 +311,7 @@ For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
+Release batching never replaces the per-task PR check, merge, local landing, cleanup, or fleet-sync helpers.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
 
 Tear down a ship task only after landing is confirmed.
@@ -429,6 +432,7 @@ Mention cost as a courtesy when unusually much work is running, but never block 
 `data/backlog.md` is the durable queue.
 It tracks work items only, never agents; persistent secondmates never appear as backlog items.
 Work routed to a secondmate is recorded in that secondmate home's own backlog, not the main backlog.
+When queued-work re-evaluation depends on risk class, load `release-batching-protocol` before dispatching or grouping multiple ship lanes.
 When a main-side thread such as a pending captain decision or relay reminder is worth durable tracking, file it as its own work item; use `tasks-axi hold <id> --reason "<reason>" --kind captain` for a captain-gated thread.
 Unresolved decisions discovered by investigations or visual reviews follow `decision-hold-lifecycle`, which owns their mandatory backlog lifecycle.
 Update the backlog on every dispatch, completion, and decision for a work item.
@@ -481,6 +485,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `release-batching-protocol` - load before deciding that multiple ship lanes may certify or release together, when risk class affects queued-work re-evaluation, or before batching captain-facing release status.
 
 ## 14. X mode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,7 +250,7 @@ Load `diagnostic-reasoning` before scoping a reported bug and before acting on a
 
 Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts.
 Serialize only for a true semantic dependency, shared mutable external state, incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, and genuine blockers remain durable.
-When deciding whether multiple ship lanes may certify or release together, load `release-batching-protocol`; it owns risk classes, batching boundaries, and non-expanded authority.
+Before initial intake, dispatch, or spawn decisions that may let multiple ship lanes proceed, load `release-batching-protocol`; it owns risk classes, batching boundaries, and non-expanded authority.
 Write the task-specific brief under section 11 before spawning.
 
 ### Dispatch and supervision handoff
@@ -485,7 +485,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
-- `release-batching-protocol` - load before deciding that multiple ship lanes may certify or release together, when risk class affects queued-work re-evaluation, or before batching captain-facing release status.
+- `release-batching-protocol` - load before initial intake, dispatch, or spawn decisions that may let multiple ship lanes proceed; when risk class affects queued-work re-evaluation; before deciding that multiple ship lanes may certify or release together; and before batching captain-facing release status.
 
 ## 14. X mode
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,6 +192,9 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.
+Parallel certification and release batching are shared Firstmate lifecycle decisions, not primary-runtime or backend-specific behavior.
+The [`release-batching-protocol` skill](../.agents/skills/release-batching-protocol/SKILL.md) owns risk classes, serialization classes, and non-expanded authority.
+`tests/fm-instruction-owners.test.sh` pins that policy and its concise AGENTS.md load points.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
 The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state; a well-formed GitLab merge request URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) is refused too, explicitly, rather than sent to the wrong forge.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -156,6 +156,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/release-batching-protocol/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/secondmate-provisioning/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/tests/fm-instruction-owners.test.sh
+++ b/tests/fm-instruction-owners.test.sh
@@ -40,9 +40,9 @@ test_new_skill_metadata_and_triggers() {
     "project-management skill metadata lost its precise load trigger"
   assert_grep '`project-management` - load before adding, creating, removing, or initializing a project.' "$ROOT/AGENTS.md" \
     "AGENTS.md lost the project-management trigger"
-  assert_grep 'Use before deciding that multiple ship lanes may certify or release together' "$RELEASE_BATCHING" \
+  assert_grep 'Use before initial intake, dispatch, or spawn decisions that may let multiple ship lanes proceed' "$RELEASE_BATCHING" \
     "release-batching skill metadata lost its precise load trigger"
-  assert_grep '`release-batching-protocol` - load before deciding that multiple ship lanes may certify or release together' "$ROOT/AGENTS.md" \
+  assert_grep '`release-batching-protocol` - load before initial intake, dispatch, or spawn decisions that may let multiple ship lanes proceed' "$ROOT/AGENTS.md" \
     "AGENTS.md lost the release-batching trigger"
   pass "new internal skills have one precise AGENTS.md trigger each"
 }
@@ -304,11 +304,11 @@ test_release_batching_policy_serializes_high_risk_and_preserves_authority() {
 
 test_release_batching_load_points_cover_lifecycle_and_status() {
   for phrase in \
-    'When deciding whether multiple ship lanes may certify or release together, load `release-batching-protocol`' \
+    'Before initial intake, dispatch, or spawn decisions that may let multiple ship lanes proceed, load `release-batching-protocol`' \
     'Parallel certification stays per lane; use `release-batching-protocol` before treating multiple lanes as concurrently ready.' \
     'Release batching never replaces the per-task PR check, merge, local landing, cleanup, or fleet-sync helpers.' \
     'When queued-work re-evaluation depends on risk class, load `release-batching-protocol` before dispatching or grouping multiple ship lanes.' \
-    '`release-batching-protocol` - load before deciding that multiple ship lanes may certify or release together'; do
+    '`release-batching-protocol` - load before initial intake, dispatch, or spawn decisions that may let multiple ship lanes proceed'; do
     assert_grep "$phrase" "$AGENTS" "AGENTS.md lost release-batching lifecycle load point '$phrase'"
   done
   assert_grep 'Batch non-urgent ready updates only when the grouping reflects independent low-risk lanes' "$RELEASE_BATCHING" \

--- a/tests/fm-instruction-owners.test.sh
+++ b/tests/fm-instruction-owners.test.sh
@@ -13,14 +13,16 @@ HARNESS="$ROOT/.agents/skills/harness-adapters/SKILL.md"
 CODING="$ROOT/.agents/skills/firstmate-coding-guidelines/SKILL.md"
 RECOVERY="$ROOT/.agents/skills/stuck-crewmate-recovery/SKILL.md"
 SECONDMATE="$ROOT/.agents/skills/secondmate-provisioning/SKILL.md"
+RELEASE_BATCHING="$ROOT/.agents/skills/release-batching-protocol/SKILL.md"
 CONFIG="$ROOT/docs/configuration.md"
+ARCH="$ROOT/docs/architecture.md"
 AGENTS="$ROOT/AGENTS.md"
 BRIEF="$ROOT/bin/fm-brief.sh"
 BOOTSTRAP="$ROOT/bin/fm-bootstrap.sh"
 
 test_new_skill_metadata_and_triggers() {
   local skill name count
-  for pair in "diagnostic-reasoning:$DIAG" "project-management:$PROJECT"; do
+  for pair in "diagnostic-reasoning:$DIAG" "project-management:$PROJECT" "release-batching-protocol:$RELEASE_BATCHING"; do
     name=${pair%%:*}
     skill=${pair#*:}
     assert_present "$skill" "$name skill is missing"
@@ -38,6 +40,10 @@ test_new_skill_metadata_and_triggers() {
     "project-management skill metadata lost its precise load trigger"
   assert_grep '`project-management` - load before adding, creating, removing, or initializing a project.' "$ROOT/AGENTS.md" \
     "AGENTS.md lost the project-management trigger"
+  assert_grep 'Use before deciding that multiple ship lanes may certify or release together' "$RELEASE_BATCHING" \
+    "release-batching skill metadata lost its precise load trigger"
+  assert_grep '`release-batching-protocol` - load before deciding that multiple ship lanes may certify or release together' "$ROOT/AGENTS.md" \
+    "AGENTS.md lost the release-batching trigger"
   pass "new internal skills have one precise AGENTS.md trigger each"
 }
 
@@ -257,6 +263,63 @@ test_intake_reuses_evidence_and_parallelizes_safe_work() {
   pass "intake reuses evidence, reserves scouts for uncertainty, and parallelizes safe work"
 }
 
+test_release_batching_policy_allows_low_risk_parallel_lanes() {
+  local phrase
+  assert_grep "single owner of Firstmate's risk-class parallel certification and release-batching policy" "$RELEASE_BATCHING" \
+    "release-batching skill does not declare single ownership"
+  assert_grep "applies across every supported primary harness and runtime backend" "$RELEASE_BATCHING" \
+    "release-batching policy must be shared Firstmate behavior"
+  for phrase in \
+    'Independent low-risk certification may run in parallel for UI, documentation, tooling, lint rules, labels, and templates.' \
+    'no semantic dependency on another active lane' \
+    'no shared mutable external state' \
+    'no incompatible migration or rollout sequence' \
+    'Same-file overlap alone is not a blocker.' \
+    'Dispatch all eligible independent low-risk lanes' \
+    'Do not hold an eligible low-risk lane only because another low-risk lane touches the same file.' \
+    'Firstmate may treat multiple independent low-risk lanes as concurrently releaseable only after each lane is independently ready'; do
+    assert_grep "$phrase" "$RELEASE_BATCHING" "release-batching low-risk contract lost '$phrase'"
+  done
+  pass "release-batching owner permits independent low-risk certification and release lanes"
+}
+
+test_release_batching_policy_serializes_high_risk_and_preserves_authority() {
+  local phrase
+  for phrase in \
+    'Migrations remain isolated and serialized.' \
+    'Authentication, billing, runtime state machines, and deployment infrastructure remain isolated and serialized.' \
+    'Security-sensitive changes are never batched for speed.' \
+    'Unrelated migrations are never batched for speed.' \
+    'Production migration remains singular.' \
+    'Container cutover remains singular.' \
+    'Production release remains singular unless the captain gives explicit release authority for that concrete production action.' \
+    'Dark-feature activation is not authorized by parallel certification or release batching.' \
+    'Destructive or irreversible action is not authorized by parallel certification or release batching.' \
+    'It never replaces per-task `bin/fm-pr-check.sh`, `bin/fm-pr-merge.sh`, `bin/fm-merge-local.sh`, `bin/fm-teardown.sh`, or the guarded fleet-sync path.' \
+    'Never merge a red PR, never infer approval from batching, and never use batching to bypass an ask-user, captain approval, security, destructive, irreversible, or production boundary.'; do
+    assert_grep "$phrase" "$RELEASE_BATCHING" "release-batching serialized-class contract lost '$phrase'"
+  done
+  pass "release-batching owner serializes high-risk classes and preserves authority"
+}
+
+test_release_batching_load_points_cover_lifecycle_and_status() {
+  for phrase in \
+    'When deciding whether multiple ship lanes may certify or release together, load `release-batching-protocol`' \
+    'Parallel certification stays per lane; use `release-batching-protocol` before treating multiple lanes as concurrently ready.' \
+    'Release batching never replaces the per-task PR check, merge, local landing, cleanup, or fleet-sync helpers.' \
+    'When queued-work re-evaluation depends on risk class, load `release-batching-protocol` before dispatching or grouping multiple ship lanes.' \
+    '`release-batching-protocol` - load before deciding that multiple ship lanes may certify or release together'; do
+    assert_grep "$phrase" "$AGENTS" "AGENTS.md lost release-batching lifecycle load point '$phrase'"
+  done
+  assert_grep 'Batch non-urgent ready updates only when the grouping reflects independent low-risk lanes' "$RELEASE_BATCHING" \
+    "release-batching captain-facing status semantics are missing"
+  assert_grep 'Never phrase certification batching as feature activation, production release, migration execution, deployment cutover' "$RELEASE_BATCHING" \
+    "release-batching status semantics lost dark/production wording boundary"
+  assert_grep "The [\`release-batching-protocol\` skill](../.agents/skills/release-batching-protocol/SKILL.md) owns risk classes" "$ARCH" \
+    "architecture docs do not point to the release-batching owner"
+  pass "release-batching load points cover dispatch, validation, release, queue re-evaluation, and status"
+}
+
 test_compressed_agents_retains_authority_and_supervision_safety() {
   for phrase in \
     'A lock-refused session must not spawn, steer, merge, drain the wake queue' \
@@ -296,4 +359,7 @@ test_secondmate_registry_contract_stays_concise
 test_state_startup_and_ordinary_recovery_placement
 test_compressed_agents_owner_map
 test_intake_reuses_evidence_and_parallelizes_safe_work
+test_release_batching_policy_allows_low_risk_parallel_lanes
+test_release_batching_policy_serializes_high_risk_and_preserves_authority
+test_release_batching_load_points_cover_lifecycle_and_status
 test_compressed_agents_retains_authority_and_supervision_safety


### PR DESCRIPTION
## Intent

Implement the captain-authorized risk-class parallel certification and release-batching protocol in Firstmate shared tracked material. The accepted policy allows independent low-risk certification and concurrent release handling for UI, documentation, tooling, lint rules, labels, and templates, while migrations, authentication, billing, runtime state machines, deployment infrastructure, production migration, container cutover, unrelated migrations, and security-sensitive changes remain serialized. Parallel certification must not authorize dark-feature activation, production release, destructive or irreversible action, bypass existing merge authority, or make same-file overlap alone a blocker. The implementation should choose one authoritative policy owner, keep AGENTS guidance concise, cover dispatch, queue re-evaluation, validation release, and captain-facing status semantics across all supported runtimes and backends, add focused regressions, update maintained documentation only where its audience owner requires it, and preserve all approval, security, cleanup, project-write, and production boundaries.

## What Changed
- Added an authoritative release batching protocol skill that defines when Firstmate work can certify or release in parallel, while keeping high-risk classes like migrations, auth, billing, runtime state machines, deployment infrastructure, production migration, container cutover, and security-sensitive work serialized.
- Updated shared agent guidance, architecture documentation, and documentation audience ownership so dispatch, queue re-evaluation, validation release decisions, and captain-facing status semantics route through the new protocol.
- Expanded instruction-owner regression coverage for the release batching protocol and its concise AGENTS.md trigger stub.

## Risk Assessment

✅ Low: The change is well-bounded to agent-runtime policy text, concise load pointers, documentation inventory, and static owner regressions, and it now covers the required intake/dispatch/spawn trigger while preserving serialized classes and authority boundaries.

## Testing

Focused instruction-owner regressions, documentation-audience checks, and a reviewer-facing transcript demonstrate that the new single-owner policy allows independent low-risk parallel certification, serializes the forbidden high-risk classes, preserves approval/release boundaries, and is loaded at intake, validation/release, queue re-evaluation, and status points.

<details>
<summary>Evidence: Release batching policy evidence</summary>

```text
Release batching protocol evidence
==================================

Skill metadata and trigger:
---
name: release-batching-protocol
description: >-
  Agent-only policy for Firstmate risk-class parallel certification and release batching.
  Use before initial intake, dispatch, or spawn decisions that may let multiple ship lanes proceed; when risk class affects queued-work re-evaluation; before deciding that multiple ship lanes may certify or release together; and before batching captain-facing release status.
user-invocable: false
metadata:
  internal: true
---

# release-batching-protocol

This skill is the single owner of Firstmate's risk-class parallel certification and release-batching policy.
It applies across every supported primary harness and runtime backend because it constrains shared dispatch, queue re-evaluation, validation, release, and captain-facing status behavior before backend-specific mechanics run.

AGENTS.md load points:
253:Before initial intake, dispatch, or spawn decisions that may let multiple ship lanes proceed, load `release-batching-protocol`; it owns risk classes, batching boundaries, and non-expanded authority.
306:Parallel certification stays per lane; use `release-batching-protocol` before treating multiple lanes as concurrently ready.
314:Release batching never replaces the per-task PR check, merge, local landing, cleanup, or fleet-sync helpers.
435:When queued-work re-evaluation depends on risk class, load `release-batching-protocol` before dispatching or grouping multiple ship lanes.
488:- `release-batching-protocol` - load before initial intake, dispatch, or spawn decisions that may let multiple ship lanes proceed; when risk class affects queued-work re-evaluation; before deciding that multiple ship lanes may certify or release together; and before batching captain-facing release status.

Low-risk allowed lanes:
## Low-Risk Certification Lanes

Independent low-risk certification may run in parallel for UI, documentation, tooling, lint rules, labels, and templates.
A low-risk lane is independent only when it has no semantic dependency on another active lane, no shared mutable external state, no incompatible migration or rollout sequence, and a selected delivery path that can reconcile ordinary rebase or conflict work.
Same-file overlap alone is not a blocker.
File overlap becomes a blocker only when the edits encode a real semantic dependency, mutate a shared generated artifact, compete for one external resource, or make one lane's validation result stale.
Parallel certification means each lane still runs its own selected delivery path, tests, review gates, PR or ready-branch checks, and current-code validation evidence.


Serialized classes and forbidden authority expansion:
## Serialized Classes

Migrations remain isolated and serialized.
Authentication, billing, runtime state machines, and deployment infrastructure remain isolated and serialized.
Security-sensitive changes are never batched for speed.
Unrelated migrations are never batched for speed.
Production migration remains singular.
Container cutover remains singular.
Production release remains singular unless the captain gives explicit release authority for that concrete production action.
Dark-feature activation is not authorized by parallel certification or release batching.
Destructive or irreversible action is not authorized by parallel certification or release batching.
If a lane mixes low-risk work with any serialized class, classify the whole lane by the serialized class until the risky work is split out or complete.


Dispatch and queue re-evaluation:
## Dispatch And Queue Re-Evaluation

At intake, classify the requested ship work before using concurrency as a reason to spawn, hold, or route multiple lanes.
At backlog re-evaluation, apply the same classification to every queued item whose dependencies and time gates have cleared.
Dispatch all eligible independent low-risk lanes that can proceed without shared mutable external state.
Do not hold an eligible low-risk lane only because another low-risk lane touches the same file.
Hold or serialize a lane when it depends on an active high-risk lane, modifies the same migration or rollout sequence, changes the same production or deployment resource, or could make another lane's validation evidence obsolete.
Keep the blocker durable in the backlog rather than relying on the next agent to remember the reason.


Validation and release:
## Validation And Release

Parallel certification does not combine validation runs.
Each lane's worker remains responsible for its own no-mistakes run, direct-PR checks, or local-only ready branch under the selected delivery path.
Firstmate may treat multiple independent low-risk lanes as concurrently releaseable only after each lane is independently ready under its own delivery path and approval posture.
Release batching is an administrative grouping of already-ready low-risk lanes.
It never replaces per-task `bin/fm-pr-check.sh`, `bin/fm-pr-merge.sh`, `bin/fm-merge-local.sh`, `bin/fm-teardown.sh`, or the guarded fleet-sync path.
Run those helpers per task so merge metadata, landed-work proof, cleanup refusal, and clone refresh behavior remain intact.
If one merge, local landing, or sync could invalidate another lane's validation basis, re-check that lane before landing it.
Never merge a red PR, never infer approval from batching, and never use batching to bypass an ask-user, captain approval, security, destructive, irreversible, or production boundary.


Captain-facing status:
## Captain-Facing Status

Batch non-urgent ready updates only when the grouping reflects independent low-risk lanes that are ready under their own delivery paths.
Describe the concrete outcome and consequence, not the internal risk-class mechanics.
When approval is still required, present the ready lanes together but ask for the same approval that each lane would have required individually.
When `yolo` authorizes routine green low-risk merges, report the finished PR URLs or local-main outcomes after each helper completes.
Never phrase certification batching as feature activation, production release, migration execution, deployment cutover, or approval for destructive, irreversible, or security-sensitive work.

Maintained documentation owner pointer:
docs/documentation-audiences.json:159:      "path": ".agents/skills/release-batching-protocol/SKILL.md",
docs/architecture.md:196:The [`release-batching-protocol` skill](../.agents/skills/release-batching-protocol/SKILL.md) owns risk classes, serialization classes, and non-expanded authority.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `AGENTS.md:253` - Intent requires the protocol to &#34;cover dispatch,&#34; and serialized classes like authentication, billing, runtime state machines, deployment infrastructure, production migration, and container cutover must remain serialized. The changed dispatch stub only says to load `release-batching-protocol` when deciding whether lanes may &#34;certify or release together,&#34; so initial multi-lane dispatch can still proceed under the existing broad parallel-dispatch rule without loading the serialized-class policy; add dispatch/spawn/intake to the load trigger and regression coverage.

🔧 Fix: Cover release batching dispatch triggers
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./tests/fm-instruction-owners.test.sh`
- `./tests/fm-documentation-audiences.test.sh`
- `./bin/fm-doc-audience-check.sh`
- <code>Captured reviewer-visible policy transcript from `AGENTS.md`, `.agents/skills/release-batching-protocol/SKILL.md`, `docs/architecture.md`, and `docs/documentation-audiences.json` into `/tmp/no-mistakes-evidence/01KYGS98SSRSW2Q27SEBABF7AA/release-batching-policy-evidence.txt`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Confirm lint passes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
