### PR TITLE
fix(bin): restore fm-brief scaffold parsing

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -325,7 +325,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass the firstmate authority check and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -131,7 +131,7 @@ test_primary_and_secondmate_instruction_generation() {
     "generated implementation brief lets the worker own an ask-user decision"
   assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$ship" \
     "generated implementation brief bypasses the primary authority owner"
-  assert_grep "silently bypass firstmate's authority check and any required captain escalation" "$ship" \
+  assert_grep "silently bypass the firstmate authority check and any required captain escalation" "$ship" \
     "generated implementation brief permits silent ask-user auto-resolution"
   assert_no_grep 'the captain, not you, owns the ask-user decisions' "$ship" \
     "generated implementation brief retained conflicting captain-only wording"


### PR DESCRIPTION
## Intent

Restore Firstmate task dispatch after the current fm-brief scaffold regressed into a shell syntax error. Preserve the newly accepted ask-user authority wording while removing the apostrophe that breaks Bash parsing inside the no-mistakes definition-of-done heredoc command substitution. The supported scaffold must pass bash -n, its behavior test, and the repository lint unchanged otherwise.

## What Changed

- Replace the apostrophe in the generated no-mistakes authority guidance so `fm-brief.sh` parses correctly and task briefs can be scaffolded again.
- Align the ask-user authority behavior test with the preserved generated wording.

## Risk Assessment

✅ Low: The two-line change is tightly scoped: the apostrophe-free generated wording preserves the ask-user authority boundary, and the fixed-string behavior-test expectation now matches it exactly.

## Testing

Reproduced the base syntax failure, verified the target through Bash parsing and its dedicated behavior suite, and generated a real no-mistakes ship brief retaining the ask-user authority wording without the breaking apostrophe; evidence was captured and the worktree is clean, but repository lint was intentionally not run because this task forbids linters.

<details>
<summary>Evidence: Baseline vs target Bash syntax transcript</summary>

```text
$ git show <base>:bin/fm-brief.sh | /bin/bash -n
/bin/bash: line 314: unexpected EOF while looking for matching `)'
/bin/bash: line 388: syntax error: unexpected end of file
base exit: 2

$ /bin/bash -n bin/fm-brief.sh
target exit: 0
```
</details>
<details>
<summary>Evidence: End-to-end fm-brief scaffold transcript</summary>

```text
$ FM_HOME=<evidence-home> bin/fm-brief.sh apostrophe-regression-demo demo-project
warn: no registry at /var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYH0TVRY2BRY8WDKHYPXMS4M/fm-brief-e2e-home/data/projects.md; defaulting demo-project to no-mistakes off
scaffolded: /var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYH0TVRY2BRY8WDKHYPXMS4M/fm-brief-e2e-home/data/apostrophe-regression-demo/brief.md (ship, mode=no-mistakes; replace {TASK})

$ Generated brief: ask-user authority and no-mistakes definition-of-done excerpt
# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass the firstmate authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

$ Forbidden parser-breaking wording check
PASS: parser-breaking apostrophe wording is absent

$ Preserved authority wording checks
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
- Avoid `--yes`: it would silently bypass the firstmate authority check and any required captain escalation.
PASS: generated brief preserves the accepted ask-user authority contract
```
</details>
<details>
<summary>Evidence: Generated no-mistakes ship brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/apostrophe-regression-demo`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/wz/856vlf5n4nl6fn086x3f23zm0000gn/T/no-mistakes-evidence/01KYH0TVRY2BRY8WDKHYPXMS4M/fm-brief-e2e-home/state/apostrophe-regression-demo.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/gavin/.no-mistakes/worktrees/f04eccabf018/01KYH0TVRY2BRY8WDKHYPXMS4M/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/gavin/.no-mistakes/worktrees/f04eccabf018/01KYH0TVRY2BRY8WDKHYPXMS4M/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass the firstmate authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (1m57s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-brief.sh:328` - The authoritative criterion requires that “the supported scaffold must pass … its behavior test,” but this hunk changes the generated text to “silently bypass the firstmate authority check…” while `tests/fm-ask-user-authority.test.sh:134` still requires “silently bypass firstmate&#39;s authority check…”. Once scaffolding succeeds, that literal assertion cannot match; update the behavior-test expectation alongside this change.

🔧 Fix: Align authority behavior test with generated wording
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `bin/fm-brief.sh:328` - Repository lint remains unverified because this validation task explicitly forbids running linters. A later lint-authorized gate must run `bin/fm-lint.sh` to demonstrate that final acceptance criterion.
- `git diff --unified=12 a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499..5dbb254198ab81f00bdda0e0d603bb687e60169b -- bin/fm-brief.sh tests/fm-brief.test.sh`
- <code>`git show a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499:bin/fm-brief.sh | /bin/bash -n` (reproduced base failure, exit 2)</code>
- `/bin/bash -n bin/fm-brief.sh`
- `/bin/bash tests/fm-brief.test.sh`
- <code>`FM_HOME=&lt;evidence-home&gt; bin/fm-brief.sh apostrophe-regression-demo demo-project` followed by inspection and exact authority-wording checks</code>
- <code>`git status --short` plus evidence-file presence checks</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
