### PR TITLE
feat: add verified Cursor harness adapter

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -84,7 +84,7 @@ The daemon constructs every current injection as the `away-supervisor` kind owne
 The bare `FM_INJECT_MARK` form remains accepted for legacy daemon escalations during rollout.
 U+2063 has no normal keyboard keystroke and survives terminal transport as UTF-8 text.
 This is how firstmate tells a daemon escalation apart from a real message in the same pane.
-The operational prefix travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, pi-signed, grok, and kimi.
+The operational prefix travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, pi-signed, grok, kimi, and cursor.
 
 ## Busy-guard and composer guard
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -167,17 +167,15 @@ Natural language is acceptable if uncertain.
 - pi and pi-signed: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles this through the structural composer reader; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 - kimi: `/<skill>`, for example `/no-mistakes`.
-- cursor: `/<skill>`, for example `/no-mistakes`. Verified end to end: cursor discovers firstmate's user-level skills, the slash-autocomplete popup lists `/no-mistakes` with its description, and a SINGLE Enter submits it. Unlike grok's and codex's popups there is no swallow or settle hazard.
+- cursor: `/<skill>`, for example `/no-mistakes`. Verified end to end: cursor discovers firstmate's user-level skills, the slash-autocomplete popup lists `/no-mistakes` with its description, and a SINGLE Enter submits it. Unlike grok's popup, it does not require a second Enter, but that one Enter still needs Cursor's adapter-wide settle and confirmation handling described in the [cursor section](#cursor-verified-2026-07-26-cursor-agent-20260723-e383d2b).
 
 ## Submission acknowledgement hazards
 
 A send or key action reporting success is not proof that the intended action happened.
 OpenCode can accept and queue an Enter while leaving text visible, Grok can consume Enter in its slash popup without submitting, and Kimi can silently drop a message sent before readiness even though the send returns success.
 The shared symptom is a healthy-looking pane with no work in progress, so each adapter must verify the observable postcondition that is specific to its TUI.
-Cursor adds two further shapes.
-Its composer is not where the terminal cursor is, so a postcondition read anchored to the cursor answers about the wrong row entirely.
-And a zero-settle submit makes cursor accept the message while LEAVING it in the composer, so the verdict reads `pending` and every retried Enter re-sends it - a duplicating failure rather than a swallowed one.
-When verifying a new adapter, establish where its composer actually is before trusting any emptiness verdict about it, and confirm that a failed verdict cannot cause a re-send.
+Cursor adds parked-terminal-cursor and duplicate-Enter hazards; the [cursor section](#cursor-verified-2026-07-26-cursor-agent-20260723-e383d2b) owns their full contract.
+When verifying a new adapter, establish where its composer actually is before trusting any emptiness verdict about it, and confirm that a failed verdict cannot cause a duplicate submission.
 
 ## claude (VERIFIED; busy signature re-verified 2026-07-25 on Claude Code 2.1.220)
 
@@ -418,7 +416,7 @@ For its model and effort axes, see the [launch-profile-axes table](#launch-profi
 | Exit command | `/exit` (or `/quit`); on exit it prints `To resume this session: agent --resume=<chatId>`. |
 | Interrupt | Single `Ctrl+C`, which ends the turn and leaves the session usable. |
 | Skill invocation | `/<skill>`; one Enter submits, with no popup swallow. |
-| Submission settle | Load-bearing, not an optimisation. Any settle at or above 0.1s submits cleanly once; a ZERO settle duplicates the message (see below). |
+| Submission settle | Load-bearing, not an optimisation. Use 1.2s before the single Enter for plain text and slash commands; ZERO duplicated a message and 0.3s later swallowed a plain-text Enter under load. The visible composer can remain stale for more than three seconds after an accepted Enter, so `fm-send` gives recorded Cursor targets 15 observation-only confirmation polls by default (see below). |
 | Autonomy | `--force` (alias `--yolo`, footer shows `Run Everything`); verified to run a shell tool unattended with no approval prompt. |
 | Trust dialog | `⚠ Workspace Trust Required`, offering `[a] Trust this workspace` and `[q] Quit`. Suppressed by `--trust`, which the launch command always passes. |
 | Resume | `cursor-agent --resume=<chatId>`; it restores the conversation but NOT the `--model` pin, so a resumed session falls back to the account default. |
@@ -446,12 +444,17 @@ It also requires the ghost-stripped row to contain the matching `P` or `A` block
 Real input that equals or extends the placeholder text therefore remains pending instead of becoming a false empty.
 Once real text is typed, cursor renders the glyph and the text at normal intensity and drops the placeholder, so pending input is unambiguous.
 
-**A zero-settle submit duplicates the steer, so the settle is a safety requirement.**
+**Cursor submission needs one settled Enter and a longer confirmation window.**
 When the Enter arrives in the same input burst as the typed text, cursor submits the message but does NOT clear it from the composer.
-The submit core then reads a proven `pending`, spends its whole Enter-retry budget, and every one of those retries re-submits the still-present text.
-Measured live: settle 0 gave verdict `pending` and landed one steer four times, while settle 0.1, 0.3 and 0.5 each gave verdict `empty` and exactly one submission.
-Both `fm-send` paths clear that floor with margin - 0.3s for plain text and 1.2s for a slash command - so ordinary steering is correct today, and `tests/fm-send-popup-settle.test.sh` pins both.
-Any future caller reaching `fm_tmux_submit_core` directly must pass a nonzero settle for a cursor target; `fm-spawn`'s zero-settle path is scoped to kimi and never runs for cursor.
+The former generic submit path then read a proven `pending`, spent its whole Enter-retry budget, and re-submitted the still-present text on every retry.
+Measured live: settle 0 gave verdict `pending` and landed one steer four times.
+A later loaded run on the same Cursor version showed the other timing edge: with a 0.3s pre-Enter settle, Cursor left the plain message unsubmitted for the full confirmation window.
+The 1.2s counterfactual submitted once.
+Even after an accepted Enter, Cursor can leave the submitted text painted for more than three seconds before the turn starts, so the generic three-check window can return a false `pending` even though the message was delivered.
+Retrying Enter during that stale interval queues the same text as a follow-up; one live expanded-retry run produced 14 duplicates.
+Both `fm-send` paths now use a 1.2s pre-Enter settle, then send exactly one Enter and give recorded Cursor targets 15 observation-only confirmation polls by default, a six-second window at the default 0.4s interval.
+`tests/fm-send-popup-settle.test.sh` pins the pre-Enter floor and `tests/fm-cursor-harness.test.sh` pins the expanded Cursor confirmation window with one Enter and one typed steer.
+Any future caller reaching `fm_tmux_submit_core` directly for a Cursor target must pass the 1.2s settle and `cursor-single-enter` submit mode; `fm-spawn`'s zero-settle path is scoped to kimi and never runs for cursor.
 Note this is the OPPOSITE hazard from grok's and opencode's: those under-submit, cursor over-submits.
 
 **Its spinner word is not a signature, and the bare stop phrase is not safe.**

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -464,6 +464,7 @@ Like claude's and kimi's, this signature stays out of the shared unrecorded-harn
 That is the preserved-not-relaunched arm, and death detection is unaffected because an exited cursor pane falls back to the login shell and reads `dead`.
 `node` is deliberately not added to the alive patterns: it is far too generic to prove any agent is alive.
 The tmux operator-input boundary accepts `alive`, `ambiguous`, and `unreadable` liveness for structural composer proof, but rejects authoritative `dead` and `missing` states before reporting an empty composer or steering text or keys.
+Text submission rechecks that boundary before every input and before confirming an empty composer throughout settle and retry.
 The raw backend key primitive remains available to spawn and lifecycle mechanics before an agent exists.
 This preserves live Cursor steering while preventing an exited pane's shell prompt from becoming an injection target even when its glyph resembles an agent composer.
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -40,7 +40,8 @@ A harness may draw its own block cursor and park the terminal cursor elsewhere, 
 
 ## Detection
 
-`bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry.
+`bin/fm-harness.sh` prints firstmate's own harness, using one unambiguous verified env marker directly and resolving conflicting verified markers through nearest process ancestry.
+If conflicting markers have no conclusive verified ancestor, detection returns `unknown`.
 Within the Pi family, only the exact launch-boundary marker `FM_PI_HARNESS=pi-signed` alongside `PI_CODING_AGENT=true` selects the signed identity; unmarked shared launcher ancestry remains `pi`.
 `bin/fm-harness.sh crew` resolves the effective crewmate harness from `config/crew-harness` (absent or `default` -> own).
 `bin/fm-harness.sh secondmate` resolves the secondmate-launch harness through the chain `config/secondmate-harness` -> `config/crew-harness` -> own, so an unset `config/secondmate-harness` matches the crew harness.
@@ -131,6 +132,8 @@ The supported launch-profile flags below are verified locally; each row records 
 | cursor | `--model <model>` | none; effort rides in the model name | Verified 2026-07-26 on cursor-agent 2026.07.23-e383d2b. `cursor-agent --help` advertises parameterized bracket overrides (`'claude-opus-4-8[context=1m,effort=high,fast=false]'`), but that syntax - including the help's own literal example - is rejected with exit 1 and the accepted-model list in the error. Effort is a MODEL-NAME suffix instead (`claude-opus-5-thinking-low` .. `-max`, `gpt-5.3-codex-xhigh`), so firstmate picks the tiered model at intake and `fm-spawn` records the requested `effort=` in metadata without emitting any flag. |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
+Cursor dispatch profiles accept the recorded effort vocabulary `low`, `medium`, `high`, `xhigh`, and `max`.
+An effort-bearing Cursor dispatch profile must select a model whose name ends in that effort tier because no separate effort flag is emitted.
 
 ### Model support discovery
 
@@ -438,8 +441,9 @@ Requiring a blank cursor row keeps every already-verified adapter on its existin
 
 **Cursor de-emphasises its whole EMPTY composer, glyph and placeholder alike.**
 The single character under its self-drawn block cursor renders at normal intensity in reverse video, so ghost stripping correctly removes everything else and leaves exactly that one character behind, which would read as real typed input on every idle pane.
-The shared classifier therefore also matches the plain, un-stripped row against `FM_COMPOSER_AGENT_PLACEHOLDER_RE` (`bin/fm-composer-lib.sh`), whose alternatives are anchored to cursor's own `→` glyph so they can neither collide with another harness's composer nor match a shell prompt.
-Trailing context is left open so the busy variant of the same row still matches.
+The shared classifier therefore matches the plain, un-stripped row against `FM_COMPOSER_AGENT_PLACEHOLDER_RE` (`bin/fm-composer-lib.sh`) only when it has the complete idle placeholder or the complete busy placeholder plus `ctrl+c to stop`.
+It also requires the ghost-stripped row to contain the matching `P` or `A` block-cursor remnant, with the busy hint preserved only on the busy shape.
+Real input that equals or extends the placeholder text therefore remains pending instead of becoming a false empty.
 Once real text is typed, cursor renders the glyph and the text at normal intensity and drops the placeholder, so pending input is unambiguous.
 
 **A zero-settle submit duplicates the steer, so the settle is a safety requirement.**
@@ -459,15 +463,12 @@ Like claude's and kimi's, this signature stays out of the shared unrecorded-harn
 `ps -o comm=` reports `cursor-agent` for the foreground process-group leader, but tmux's `#{pane_current_command}` resolves the pane to the bundled `node`, so `fm_backend_tmux_agent_state` returns `ambiguous` for a live cursor pane.
 That is the preserved-not-relaunched arm, and death detection is unaffected because an exited cursor pane falls back to the login shell and reads `dead`.
 `node` is deliberately not added to the alive patterns: it is far too generic to prove any agent is alive.
+The tmux backend accepts `alive`, `ambiguous`, and `unreadable` liveness for structural composer proof, but rejects authoritative `dead` and `missing` states before reporting an empty composer or sending any input.
+This preserves live Cursor steering while preventing an exited pane's shell prompt from becoming an injection target even when its glyph resembles an agent composer.
 
 Cursor has no turn-end hook, so like opencode its wake signal is the crewmate's own status appends plus pane staleness and the busy signature.
 
-**Env-marker precedence hazard, now demonstrated.**
+**Conflicting env markers require ancestry.**
 A cursor tool child launched from a claude terminal was observed carrying an inherited `CLAUDECODE=1` alongside cursor's own `CURSOR_AGENT=1`.
-Detection checks `CLAUDECODE` first, so that ordering would misidentify a cursor session launched from a claude terminal.
-This says nothing about a natively launched harness, and it is the same ordering hazard already recorded in `bin/fm-harness.sh`, but it is now evidence rather than theory.
-
-**Open pre-existing hazard found while verifying this adapter (not introduced by it).**
-After `/exit`, the pane returns to a zsh prompt whose glyph in this fleet's theme is `❯` - the same glyph the shared classifier treats as a genuine empty AGENT composer on a bare row.
-A dead cursor pane therefore classifies as `empty`, which is exactly the dead-shell injection target the classifier exists to prevent.
-This affects claude equally today and is independent of cursor; changing it would alter claude's classification, so it is recorded here for a separate decision rather than fixed in passing.
+When two or more verified markers coexist, `bin/fm-harness.sh` uses the nearest verified process ancestor instead of static marker order.
+It preserves direct marker-only detection when exactly one verified marker is present and returns `unknown` when a conflict has no conclusive verified ancestor.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -465,6 +465,8 @@ That is the preserved-not-relaunched arm, and death detection is unaffected beca
 `node` is deliberately not added to the alive patterns: it is far too generic to prove any agent is alive.
 The tmux operator-input boundary accepts `alive`, `ambiguous`, and `unreadable` liveness for structural composer proof, but rejects authoritative `dead` and `missing` states before reporting an empty composer or steering text or keys.
 Text submission rechecks that boundary before every input and before confirming an empty composer throughout settle and retry.
+Use `FM_HOME=<this-firstmate-home> bin/fm-send.sh <target> --lifecycle-exit /exit` for a supervised Cursor exit.
+Only that explicit, metadata-bound mode accepts dead or missing as the expected postcondition after a verified exit command and successful Enter; ordinary text, including an unflagged `/exit`, stays strict.
 The raw backend key primitive remains available to spawn and lifecycle mechanics before an agent exists.
 This preserves live Cursor steering while preventing an exited pane's shell prompt from becoming an injection target even when its glyph resembles an agent composer.
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, and kimi.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, and cursor.
 user-invocable: false
 metadata:
   internal: true
@@ -34,7 +34,9 @@ The supervision knowledge lives here: busy signature, exit command, interrupt, d
 Never dispatch a crewmate or secondmate on an unverified adapter.
 If `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, tell the captain under `AGENTS.md` section 9 that the requested worker runtime is not verified yet, use firstmate's own verified runtime for current work, and ask only whether to verify the requested runtime before future use.
 Do not pause current work for that future-verification choice, and never launch an unverified adapter.
-If the captain asks for a new harness, propose verifying it first: spawn a trivial supervised task using `fm-spawn`'s raw-launch-command escape hatch, confirm every fact empirically, then record the mechanics in `fm-spawn`, the busy signature in `fm-watch.sh` and `fm-tmux-lib.sh` defaults, any needed `FM_COMPOSER_IDLE_RE` empty-composer override plus any novel bare agent prompt glyph in `bin/fm-composer-lib.sh`'s shared composer classifier (the one fleet-wide owner of the empty/dead-shell/pending decision, so a new harness's own idle composer is not misread as a dead shell), the tmux agent-process liveness classification in `bin/backends/tmux.sh` when the harness can launch a secondmate, and the verified knowledge here.
+If the captain asks for a new harness, propose verifying it first: spawn a trivial supervised task using `fm-spawn`'s raw-launch-command escape hatch, confirm every fact empirically, then record the mechanics in `fm-spawn`, the busy signature in `fm-watch.sh` and `fm-tmux-lib.sh` defaults, any needed `FM_COMPOSER_IDLE_RE` empty-composer override or `FM_COMPOSER_AGENT_PLACEHOLDER_RE` entry plus any novel bare agent prompt glyph in `bin/fm-composer-lib.sh`'s shared composer classifier (the one fleet-wide owner of the empty/dead-shell/pending decision, so a new harness's own idle composer is not misread as a dead shell), the tmux agent-process liveness classification in `bin/backends/tmux.sh` when the harness can launch a secondmate, and the verified knowledge here.
+Establish WHERE the harness keeps its composer before trusting any emptiness verdict about it.
+A harness may draw its own block cursor and park the terminal cursor elsewhere, in which case a cursor-anchored read answers about the wrong row and reports a false `empty` (see the cursor section below).
 
 ## Detection
 
@@ -126,6 +128,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
+| cursor | `--model <model>` | none; effort rides in the model name | Verified 2026-07-26 on cursor-agent 2026.07.23-e383d2b. `cursor-agent --help` advertises parameterized bracket overrides (`'claude-opus-4-8[context=1m,effort=high,fast=false]'`), but that syntax - including the help's own literal example - is rejected with exit 1 and the accepted-model list in the error. Effort is a MODEL-NAME suffix instead (`claude-opus-5-thinking-low` .. `-max`, `gpt-5.3-codex-xhigh`), so firstmate picks the tiered model at intake and `fm-spawn` records the requested `effort=` in metadata without emitting any flag. |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 
@@ -142,6 +145,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | pi / pi-signed | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |
 | kimi | Run `kimi provider list --json`, which lists the current provider and model configuration. |
+| cursor | Run `cursor-agent models`, which lists every model identifier this account may pass to `--model`, effort tier included. |
 
 For an unfamiliar harness or model namespace, establish support and provider identity from that harness's authoritative CLI help, model listing, or current documentation rather than guessing from a name or prefix.
 If those sources do not establish the relationship needed for dispatch, fail loudly and report the unresolved candidate.
@@ -160,12 +164,17 @@ Natural language is acceptable if uncertain.
 - pi and pi-signed: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles this through the structural composer reader; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 - kimi: `/<skill>`, for example `/no-mistakes`.
+- cursor: `/<skill>`, for example `/no-mistakes`. Verified end to end: cursor discovers firstmate's user-level skills, the slash-autocomplete popup lists `/no-mistakes` with its description, and a SINGLE Enter submits it. Unlike grok's and codex's popups there is no swallow or settle hazard.
 
 ## Submission acknowledgement hazards
 
 A send or key action reporting success is not proof that the intended action happened.
 OpenCode can accept and queue an Enter while leaving text visible, Grok can consume Enter in its slash popup without submitting, and Kimi can silently drop a message sent before readiness even though the send returns success.
 The shared symptom is a healthy-looking pane with no work in progress, so each adapter must verify the observable postcondition that is specific to its TUI.
+Cursor adds two further shapes.
+Its composer is not where the terminal cursor is, so a postcondition read anchored to the cursor answers about the wrong row entirely.
+And a zero-settle submit makes cursor accept the message while LEAVING it in the composer, so the verdict reads `pending` and every retried Enter re-sends it - a duplicating failure rather than a swallowed one.
+When verifying a new adapter, establish where its composer actually is before trusting any emptiness verdict about it, and confirm that a failed verdict cannot cause a re-send.
 
 ## claude (VERIFIED; busy signature re-verified 2026-07-25 on Claude Code 2.1.220)
 
@@ -394,3 +403,71 @@ The spinner match covers the full moon-phase glyph set rather than one frame, bu
 Each Kimi crew worktree receives a gitignored `.fm-kimi-turnend` token pointer, and the global hook touches that task's `state/<id>.turn-ended` only when the Stop payload's `cwd`, pointer, and registry entry all agree.
 A guarded silent hook cannot be verified from absence of effect, so prove invocation with an unguarded probe before concluding that the hook did not fire.
 The guarded turn-end signal supplements the pane busy signature, whose locale- and emoji-font-sensitive limits still apply while a turn is running.
+
+## cursor (VERIFIED 2026-07-26, cursor-agent 2026.07.23-e383d2b)
+
+Cursor CLI (`cursor-agent`, also installed as `agent`), launched with a positional prompt that auto-submits: `cursor-agent --force --trust "$(...)"`.
+For its model and effort axes, see the [launch-profile-axes table](#launch-profile-axes); effort is not a flag, it is part of the model name.
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | The right-aligned `ctrl+c to stop` hint in cursor's own composer row, matched anchored as `^[[:space:]]*→.*ctrl\+c to stop[[:space:]]*$`. Present for the whole turn, including while a shell tool runs; absent when idle. |
+| Exit command | `/exit` (or `/quit`); on exit it prints `To resume this session: agent --resume=<chatId>`. |
+| Interrupt | Single `Ctrl+C`, which ends the turn and leaves the session usable. |
+| Skill invocation | `/<skill>`; one Enter submits, with no popup swallow. |
+| Submission settle | Load-bearing, not an optimisation. Any settle at or above 0.1s submits cleanly once; a ZERO settle duplicates the message (see below). |
+| Autonomy | `--force` (alias `--yolo`, footer shows `Run Everything`); verified to run a shell tool unattended with no approval prompt. |
+| Trust dialog | `⚠ Workspace Trust Required`, offering `[a] Trust this workspace` and `[q] Quit`. Suppressed by `--trust`, which the launch command always passes. |
+| Resume | `cursor-agent --resume=<chatId>`; it restores the conversation but NOT the `--model` pin, so a resumed session falls back to the account default. |
+| Environment marker | `CURSOR_AGENT=1`, set for tool child processes. Process ancestry also resolves, because `ps -o comm=` reports `cursor-agent` for the session process. |
+| Composer | BARE (no box), a `→` prompt glyph, and a placeholder that is `Plan, search, build anything` on a fresh session and `Add a follow-up` after any turn. |
+
+**`--force` does not imply `--trust`, and the difference is mode-dependent.**
+In `--print` mode, `-f` alone suppresses the workspace-trust gate.
+In the interactive TUI it does not: `cursor-agent --force` in an untrusted directory still blocks on the trust dialog.
+Every pooled worktree is a fresh path, so an unattended crewmate launched without `--trust` would wedge on that dialog forever.
+This is why `--trust` is in the launch template rather than left to a post-spawn keystroke.
+
+**Cursor does not keep the terminal cursor in its composer.**
+It draws its own block cursor, leaves `#{cursor_flag}` at 0, and parks `#{cursor_y}` on a blank row well below the composer.
+Every previously verified adapter keeps the cursor inside its own composer, so the shared tmux reader's cursor-anchored fallback inspected a blank row and returned `empty` while real unsubmitted text sat in the composer.
+That false-empty is the dangerous direction: it lets the away-mode injector type over live input and lets the submit core report a swallowed Enter as delivered.
+`fm_tmux_composer_state` now falls back to the bottom-most bare `→` row in the visible pane, but only when the cursor row is genuinely blank.
+Both conditions matter.
+Requiring a blank cursor row keeps every already-verified adapter on its existing path, and scanning only for `→` is what preserves the dead-shell rule, because `❯` and `›` are also shell prompt glyphs in this fleet and scanning for those would let dead-shell scrollback masquerade as a live composer.
+
+**Cursor de-emphasises its whole EMPTY composer, glyph and placeholder alike.**
+The single character under its self-drawn block cursor renders at normal intensity in reverse video, so ghost stripping correctly removes everything else and leaves exactly that one character behind, which would read as real typed input on every idle pane.
+The shared classifier therefore also matches the plain, un-stripped row against `FM_COMPOSER_AGENT_PLACEHOLDER_RE` (`bin/fm-composer-lib.sh`), whose alternatives are anchored to cursor's own `→` glyph so they can neither collide with another harness's composer nor match a shell prompt.
+Trailing context is left open so the busy variant of the same row still matches.
+Once real text is typed, cursor renders the glyph and the text at normal intensity and drops the placeholder, so pending input is unambiguous.
+
+**A zero-settle submit duplicates the steer, so the settle is a safety requirement.**
+When the Enter arrives in the same input burst as the typed text, cursor submits the message but does NOT clear it from the composer.
+The submit core then reads a proven `pending`, spends its whole Enter-retry budget, and every one of those retries re-submits the still-present text.
+Measured live: settle 0 gave verdict `pending` and landed one steer four times, while settle 0.1, 0.3 and 0.5 each gave verdict `empty` and exactly one submission.
+Both `fm-send` paths clear that floor with margin - 0.3s for plain text and 1.2s for a slash command - so ordinary steering is correct today, and `tests/fm-send-popup-settle.test.sh` pins both.
+Any future caller reaching `fm_tmux_submit_core` directly must pass a nonzero settle for a cursor target; `fm-spawn`'s zero-settle path is scoped to kimi and never runs for cursor.
+Note this is the OPPOSITE hazard from grok's and opencode's: those under-submit, cursor over-submits.
+
+**Its spinner word is not a signature, and the bare stop phrase is not safe.**
+The spinner word rotates with the phase of the turn (`Working`, `Thinking`, `Running`), so only the composer hint is stable.
+The hint is matched anchored to the composer row rather than as a bare substring, because `ctrl+c to stop` is a phrase ordinary dev servers print, and a crewmate that left such a server in its last visible lines would otherwise look busy forever and mask a real wedge.
+Like claude's and kimi's, this signature stays out of the shared unrecorded-harness default.
+
+**Agent liveness is imprecise but safe.**
+`ps -o comm=` reports `cursor-agent` for the foreground process-group leader, but tmux's `#{pane_current_command}` resolves the pane to the bundled `node`, so `fm_backend_tmux_agent_state` returns `ambiguous` for a live cursor pane.
+That is the preserved-not-relaunched arm, and death detection is unaffected because an exited cursor pane falls back to the login shell and reads `dead`.
+`node` is deliberately not added to the alive patterns: it is far too generic to prove any agent is alive.
+
+Cursor has no turn-end hook, so like opencode its wake signal is the crewmate's own status appends plus pane staleness and the busy signature.
+
+**Env-marker precedence hazard, now demonstrated.**
+A cursor tool child launched from a claude terminal was observed carrying an inherited `CLAUDECODE=1` alongside cursor's own `CURSOR_AGENT=1`.
+Detection checks `CLAUDECODE` first, so that ordering would misidentify a cursor session launched from a claude terminal.
+This says nothing about a natively launched harness, and it is the same ordering hazard already recorded in `bin/fm-harness.sh`, but it is now evidence rather than theory.
+
+**Open pre-existing hazard found while verifying this adapter (not introduced by it).**
+After `/exit`, the pane returns to a zsh prompt whose glyph in this fleet's theme is `❯` - the same glyph the shared classifier treats as a genuine empty AGENT composer on a bare row.
+A dead cursor pane therefore classifies as `empty`, which is exactly the dead-shell injection target the classifier exists to prevent.
+This affects claude equally today and is independent of cursor; changing it would alter claude's classification, so it is recorded here for a separate decision rather than fixed in passing.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -133,7 +133,7 @@ The supported launch-profile flags below are verified locally; each row records 
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 Cursor dispatch profiles accept the recorded effort vocabulary `low`, `medium`, `high`, `xhigh`, and `max`.
-An effort-bearing Cursor dispatch profile must select a model whose name ends in that effort tier because no separate effort flag is emitted.
+Bootstrap validates only that shared vocabulary; intake selects a supported tiered model from `cursor-agent models`, and the selected model name remains the executable source of effort.
 
 ### Model support discovery
 
@@ -463,7 +463,8 @@ Like claude's and kimi's, this signature stays out of the shared unrecorded-harn
 `ps -o comm=` reports `cursor-agent` for the foreground process-group leader, but tmux's `#{pane_current_command}` resolves the pane to the bundled `node`, so `fm_backend_tmux_agent_state` returns `ambiguous` for a live cursor pane.
 That is the preserved-not-relaunched arm, and death detection is unaffected because an exited cursor pane falls back to the login shell and reads `dead`.
 `node` is deliberately not added to the alive patterns: it is far too generic to prove any agent is alive.
-The tmux backend accepts `alive`, `ambiguous`, and `unreadable` liveness for structural composer proof, but rejects authoritative `dead` and `missing` states before reporting an empty composer or sending any input.
+The tmux operator-input boundary accepts `alive`, `ambiguous`, and `unreadable` liveness for structural composer proof, but rejects authoritative `dead` and `missing` states before reporting an empty composer or steering text or keys.
+The raw backend key primitive remains available to spawn and lifecycle mechanics before an agent exists.
 This preserves live Cursor steering while preventing an exited pane's shell prompt from becoming an injection target even when its glyph resembles an agent composer.
 
 Cursor has no turn-end hook, so like opencode its wake signal is the crewmate's own status appends plus pane staleness and the busy signature.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, and `kimi`; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `cursor`; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -13,7 +13,7 @@
 # provider, not the worktree provider, so fm-spawn.sh still drives that part
 # inline with these same send/current-path primitives.
 #
-# The verified composer/busy-detection and verify-and-retry-submit primitives
+# The verified composer/busy-detection and verify-and-confirm-submit primitives
 # already live in bin/fm-tmux-lib.sh, shared with the away-mode daemon
 # (bin/fm-supervise-daemon.sh); this adapter sources that file and wraps its
 # submit core under the backend's naming convention.
@@ -52,8 +52,8 @@ fm_backend_tmux_send_key() {  # <target> <key>
   tmux send-keys -t "$1" "$2"
 }
 
-# fm_backend_tmux_send_text_submit: type <text> into <target> once, then
-# submit with Enter, retried (Enter only, never retyped) until the composer clears.
+# fm_backend_tmux_send_text_submit: type <text> into <target> once, then use the
+# selected submit mode's Enter and confirmation strategy without retyping.
 fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle> [expected-label] [submit-mode]
   fm_tmux_submit_core "$1" "$2" "$3" "$4" "$5" fm_backend_tmux_agent_accepts_input "${7:-ordinary}"
 }

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -55,8 +55,7 @@ fm_backend_tmux_send_key() {  # <target> <key>
 # fm_backend_tmux_send_text_submit: type <text> into <target> once, then
 # submit with Enter, retried (Enter only, never retyped) until the composer clears.
 fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle>
-  fm_backend_tmux_agent_accepts_input "$1" || { printf 'send-failed'; return 0; }
-  fm_tmux_submit_core "$@"
+  fm_tmux_submit_core "$1" "$2" "$3" "$4" "$5" fm_backend_tmux_agent_accepts_input
 }
 
 fm_backend_tmux_composer_state() {  # <target>

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -54,8 +54,8 @@ fm_backend_tmux_send_key() {  # <target> <key>
 
 # fm_backend_tmux_send_text_submit: type <text> into <target> once, then
 # submit with Enter, retried (Enter only, never retyped) until the composer clears.
-fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle>
-  fm_tmux_submit_core "$1" "$2" "$3" "$4" "$5" fm_backend_tmux_agent_accepts_input
+fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle> [expected-label] [submit-mode]
+  fm_tmux_submit_core "$1" "$2" "$3" "$4" "$5" fm_backend_tmux_agent_accepts_input "${7:-ordinary}"
 }
 
 fm_backend_tmux_composer_state() {  # <target>

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -193,7 +193,17 @@ fm_backend_tmux_agent_state() {  # <target>
   }
   comm=${comm#-}
   case "$comm" in
-    *claude*|*codex*|*opencode*|*grok*|*kimi*|pi|pi-signed|pi-launcher|Pi) printf 'alive' ;;
+    # cursor-agent is listed for completeness, but on the verified local setup
+    # tmux does NOT report it: the foreground process GROUP leader is
+    # `cursor-agent`, while `#{pane_current_command}` resolves to the bundled
+    # `node` it spawns, so a live cursor pane lands on the `ambiguous` arm below
+    # (2026-07-26, cursor-agent 2026.07.23-e383d2b, tmux 3.7b). That is the safe
+    # direction - `ambiguous` is preserved rather than relaunched - and a cursor
+    # pane whose agent has EXITED still falls back to the login shell and reads
+    # `dead`, so recovery-grade death detection is unaffected. `node` is
+    # deliberately NOT added to this list: it is far too generic to treat as
+    # proof that any agent is alive.
+    *claude*|*codex*|*opencode*|*grok*|*kimi*|*cursor-agent*|pi|pi-signed|pi-launcher|Pi) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     '') printf 'unreadable' ;;
     *) printf 'ambiguous' ;;

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -15,9 +15,8 @@
 #
 # The verified composer/busy-detection and verify-and-retry-submit primitives
 # already live in bin/fm-tmux-lib.sh, shared with the away-mode daemon
-# (bin/fm-supervise-daemon.sh); this adapter sources that file and re-exports
-# its submit core under the backend's naming convention rather than
-# duplicating it, so the two consumers cannot drift apart.
+# (bin/fm-supervise-daemon.sh); this adapter sources that file and wraps its
+# submit core under the backend's naming convention.
 # shellcheck source=bin/fm-tmux-lib.sh
 . "$FM_BACKEND_LIB_DIR/fm-tmux-lib.sh"
 
@@ -38,6 +37,13 @@ fm_backend_tmux_capture() {  # <target> <lines>
   tmux capture-pane -p -t "$1" -S -"$2"
 }
 
+fm_backend_tmux_agent_accepts_input() {  # <target>
+  case "$(fm_backend_tmux_agent_state "$1")" in
+    dead|missing) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 # fm_backend_tmux_send_key: one named key. Mirrors fm-send.sh's --key path:
 # `tmux display-message -p -t "$T" '#{pane_id}' >/dev/null`, then
 # `tmux send-keys -t "$T" "$2"`.
@@ -47,11 +53,16 @@ fm_backend_tmux_send_key() {  # <target> <key>
 }
 
 # fm_backend_tmux_send_text_submit: type <text> into <target> once, then
-# submit with Enter, retried (Enter only, never retyped) until the composer
-# clears. Re-exports fm_tmux_submit_core (bin/fm-tmux-lib.sh) verbatim; see
-# that file for the composer-verification contract and echoed verdicts.
+# submit with Enter, retried (Enter only, never retyped) until the composer clears.
 fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle>
+  fm_backend_tmux_agent_accepts_input "$1" || { printf 'send-failed'; return 0; }
   fm_tmux_submit_core "$@"
+}
+
+fm_backend_tmux_composer_state() {  # <target>
+  fm_backend_tmux_agent_accepts_input "$1" \
+    || { printf 'unknown'; return 0; }
+  fm_tmux_composer_state "$1"
 }
 
 # fm_backend_tmux_container_ensure: reuse the current tmux session when

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -799,7 +799,7 @@ fm_backend_busy_state() {  # <backend> <target>
 # caller other than the send path (the away-mode daemon's supervisor-pane
 # pending-input guard, bin/fm-supervise-daemon.sh) can ask the same question
 # without duplicating per-backend composer-reading logic. tmux and herdr both
-# expose a named classifier already (fm_tmux_composer_state,
+# expose a named classifier already (fm_backend_tmux_composer_state,
 # fm_backend_herdr_composer_state), as do orca and cmux
 # (fm_backend_orca_composer_state, fm_backend_cmux_composer_state); zellij's
 # submit path uses an internal content-diff approach with no separately named
@@ -810,7 +810,7 @@ fm_backend_composer_state() {  # <backend> <target> -> empty|pending|pending-unp
   shift
   fm_backend_source "$backend" || { printf 'unknown'; return 0; }
   case "$backend" in
-    tmux) fm_tmux_composer_state "$@" ;;
+    tmux) fm_backend_tmux_composer_state "$@" ;;
     herdr) fm_backend_herdr_composer_state "$@" ;;
     orca) fm_backend_orca_composer_state "$@" ;;
     cmux) fm_backend_cmux_composer_state "$@" ;;

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -730,8 +730,8 @@ fm_backend_send_operator_key() {  # <backend> <target> <key> [expected-label]
   fm_backend_send_key "$@"
 }
 
-# fm_backend_send_text_submit: type text once, then submit and verify,
-# retrying only the submission (never retyping). Echoes the backend's
+# fm_backend_send_text_submit: type text once, then submit and verify with the
+# backend's selected confirmation strategy, never retyping. Echoes the
 # proof-carrying verdict; callers require exact empty for confirmed delivery.
 fm_backend_send_text_submit() {  # <backend> <target> <text> <retries> <enter-sleep> <settle> [expected-label] [submit-mode]
   local backend=$1

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -733,7 +733,7 @@ fm_backend_send_operator_key() {  # <backend> <target> <key> [expected-label]
 # fm_backend_send_text_submit: type text once, then submit and verify,
 # retrying only the submission (never retyping). Echoes the backend's
 # proof-carrying verdict; callers require exact empty for confirmed delivery.
-fm_backend_send_text_submit() {  # <backend> <target> <text> <retries> <enter-sleep> <settle> [expected-label]
+fm_backend_send_text_submit() {  # <backend> <target> <text> <retries> <enter-sleep> <settle> [expected-label] [submit-mode]
   local backend=$1
   shift
   fm_backend_source "$backend" || return 1

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -721,6 +721,15 @@ fm_backend_send_key() {  # <backend> <target> <key> [expected-label]
   esac
 }
 
+fm_backend_send_operator_key() {  # <backend> <target> <key> [expected-label]
+  local backend=$1 target=$2
+  if [ "$backend" = tmux ]; then
+    fm_backend_source "$backend" || return 1
+    fm_backend_tmux_agent_accepts_input "$target" || return 1
+  fi
+  fm_backend_send_key "$@"
+}
+
 # fm_backend_send_text_submit: type text once, then submit and verify,
 # retrying only the submission (never retyping). Echoes the backend's
 # proof-carrying verdict; callers require exact empty for confirmed delivery.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -437,7 +437,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
     case "$harness" in
-      claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+      claude|codex|opencode|pi|pi-signed|grok|kimi|cursor) ;;
       *)
         case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
         ;;

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -722,7 +722,7 @@ crew_dispatch_validate() {
   fi
   err=$(jq -r '
     def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","cursor"] | index($h);
-    def effort_ok($h; $m; $e):
+    def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
@@ -730,11 +730,7 @@ crew_dispatch_validate() {
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "cursor" then
-        ((["low","medium","high","xhigh","max"] | index($e))
-          and (if ($m | type) == "string"
-               then ($m | endswith("-" + $e))
-               else false
-               end))
+        (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false
       else true
       end;
@@ -751,10 +747,10 @@ crew_dispatch_validate() {
       or ($items | any(has("effort") and (((.effort | type) != "string") or (.effort | length) == 0)));
     def bad_efforts:
       configured_profiles
-      | map({h: .harness, m: .model, e: .effort})
+      | map({h: .harness, e: .effort})
       | map(select(.e != null))
       | map(select((.h | type) == "string" and verified(.h)))
-      | map(select(. as $p | effort_ok($p.h; $p.m; $p.e) | not))
+      | map(select(. as $p | effort_ok($p.h; $p.e) | not))
       | map("\(.h):\(.e)")
       | unique;
     if type != "object" then "top-level value must be an object"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -721,14 +721,20 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi"] | index($h);
-    def effort_ok($h; $e):
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","cursor"] | index($h);
+    def effort_ok($h; $m; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "cursor" then
+        ((["low","medium","high","xhigh","max"] | index($e))
+          and (if ($m | type) == "string"
+               then ($m | endswith("-" + $e))
+               else false
+               end))
       elif $h == "opencode" or $h == "kimi" then false
       else true
       end;
@@ -745,10 +751,10 @@ crew_dispatch_validate() {
       or ($items | any(has("effort") and (((.effort | type) != "string") or (.effort | length) == 0)));
     def bad_efforts:
       configured_profiles
-      | map({h: .harness, e: .effort})
+      | map({h: .harness, m: .model, e: .effort})
       | map(select(.e != null))
       | map(select((.h | type) == "string" and verified(.h)))
-      | map(select(. as $p | effort_ok($p.h; $p.e) | not))
+      | map(select(. as $p | effort_ok($p.h; $p.m; $p.e) | not))
       | map("\(.h):\(.e)")
       | unique;
     if type != "object" then "top-level value must be an object"

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -181,17 +181,31 @@ fm_composer_strip_ghost() {
 # the glyph and the placeholder, so the only content left is the single
 # character sitting under that block cursor, and every idle pane would read as
 # real typed input. The plain, un-stripped row is therefore matched against this
-# pattern too. Each alternative is anchored to its own harness's agent glyph, so
-# it can neither collide with another harness's composer nor match a shell
-# prompt, and the trailing context is left open so the busy variant of the same
-# row (cursor-agent appends a right-aligned `ctrl+c to stop`) still matches.
+# pattern too, but only when it has the exact idle or busy shape and the
+# ghost-stripped content is the expected cursor remnant. Each alternative is
+# anchored to its own harness's agent glyph, so it can neither collide with
+# another harness's composer nor match a shell prompt.
 # This is a UNION with the caller's own idle_re, not a replacement, because the
 # per-adapter idle regexes are backend-specific while this rule is harness-specific.
-FM_COMPOSER_AGENT_PLACEHOLDER_RE=${FM_COMPOSER_AGENT_PLACEHOLDER_RE-'^→[[:space:]]+(Plan, search, build anything|Add a follow-up)([[:space:]]|$)'}
+FM_COMPOSER_AGENT_PLACEHOLDER_RE=${FM_COMPOSER_AGENT_PLACEHOLDER_RE-'^→[[:space:]]+(Plan, search, build anything|Add a follow-up)([[:space:]]+ctrl\+c to stop)?$'}
 
-fm_composer_placeholder_matches() {  # <plain-content>
+fm_composer_placeholder_matches() {  # <plain-content> <ghost-stripped-content>
+  local plain=$1 stripped=$2 remnant
   [ -n "${FM_COMPOSER_AGENT_PLACEHOLDER_RE:-}" ] || return 1
-  printf '%s' "$1" | grep -qE "$FM_COMPOSER_AGENT_PLACEHOLDER_RE"
+  printf '%s' "$plain" | grep -qE "$FM_COMPOSER_AGENT_PLACEHOLDER_RE" || return 1
+  case "$plain" in
+    '→ '*Plan,\ search,\ build\ anything*) remnant=P ;;
+    '→ '*Add\ a\ follow-up*) remnant=A ;;
+    *) return 1 ;;
+  esac
+  case "$plain" in
+    *ctrl+c\ to\ stop)
+      printf '%s' "$stripped" | grep -qE "^${remnant}[[:space:]]+ctrl\\+c to stop$"
+      ;;
+    *)
+      [ "$stripped" = "$remnant" ]
+      ;;
+  esac
 }
 
 fm_composer_idle_matches() {
@@ -208,7 +222,7 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
   plain_content=${5:-$content}
   # A harness that de-emphasises its whole empty composer leaves only its block
   # cursor behind after ghost stripping, so judge the plain row first.
-  if fm_composer_placeholder_matches "$plain_content"; then
+  if fm_composer_placeholder_matches "$plain_content" "$content"; then
     printf 'empty'; return 0
   fi
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -19,8 +19,8 @@
 # container - a bordered composer box, where the harness draws its own prompt
 # glyph (e.g. claude's older `| > ... |`). On a bare, unstructured row it is a
 # dead-shell prompt and is NEVER "empty"; it classifies as `unknown` (not a safe
-# injection target). The AGENT prompt glyphs `❯` (claude) and `›` (codex) are a
-# genuine empty agent composer either way, bordered or bare.
+# injection target). The AGENT prompt glyphs `❯` (claude), `›` (codex) and `→`
+# (cursor-agent) are a genuine empty agent composer either way, bordered or bare.
 #
 # GHOST/PLACEHOLDER TEXT is the other half of this owner (task
 # afk-herdr-false-pending): a harness fills an otherwise-empty composer with
@@ -171,6 +171,29 @@ fm_composer_strip_ghost() {
 #              "Type a message...") that reads as empty; matched both before and
 #              after a leading prompt glyph is stripped, so a pattern written
 #              with or without the glyph both land.
+#   [plain_content] the same row BEFORE ghost stripping, used for the shared
+#              agent-placeholder rule below and for the bare-row glyph decision.
+#
+# FM_COMPOSER_AGENT_PLACEHOLDER_RE is the fleet-wide pattern for a harness that
+# de-emphasises its ENTIRE empty composer - agent glyph and placeholder alike -
+# and then draws its own block cursor in reverse video on top of it, which is
+# how cursor-agent renders an idle composer. Ghost stripping correctly removes
+# the glyph and the placeholder, so the only content left is the single
+# character sitting under that block cursor, and every idle pane would read as
+# real typed input. The plain, un-stripped row is therefore matched against this
+# pattern too. Each alternative is anchored to its own harness's agent glyph, so
+# it can neither collide with another harness's composer nor match a shell
+# prompt, and the trailing context is left open so the busy variant of the same
+# row (cursor-agent appends a right-aligned `ctrl+c to stop`) still matches.
+# This is a UNION with the caller's own idle_re, not a replacement, because the
+# per-adapter idle regexes are backend-specific while this rule is harness-specific.
+FM_COMPOSER_AGENT_PLACEHOLDER_RE=${FM_COMPOSER_AGENT_PLACEHOLDER_RE-'^→[[:space:]]+(Plan, search, build anything|Add a follow-up)([[:space:]]|$)'}
+
+fm_composer_placeholder_matches() {  # <plain-content>
+  [ -n "${FM_COMPOSER_AGENT_PLACEHOLDER_RE:-}" ] || return 1
+  printf '%s' "$1" | grep -qE "$FM_COMPOSER_AGENT_PLACEHOLDER_RE"
+}
+
 fm_composer_idle_matches() {
   local content=$1 idle_re=$2 idle_case=$3
   [ -n "$idle_re" ] || return 1
@@ -183,15 +206,20 @@ fm_composer_idle_matches() {
 fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [plain_content]
   local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content
   plain_content=${5:-$content}
+  # A harness that de-emphasises its whole empty composer leaves only its block
+  # cursor behind after ghost stripping, so judge the plain row first.
+  if fm_composer_placeholder_matches "$plain_content"; then
+    printf 'empty'; return 0
+  fi
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
-      '❯'|'›') printf 'empty'; return 0 ;;
+      '❯'|'›'|'→') printf 'empty'; return 0 ;;
       *) printf 'unknown'; return 0 ;;
     esac
   fi
   # A bare prompt glyph on its own row.
   case "$content" in
-    '❯'|'›')
+    '❯'|'›'|'→')
       # Agent prompt glyph: a genuine empty agent composer, bordered or bare.
       printf 'empty'; return 0 ;;
     '>'|'$'|'%'|'#')
@@ -208,8 +236,8 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
   fi
   # Strip a leading prompt glyph, then re-judge the remainder.
   case "$content" in
-    '❯ '*|'› '*|'> '*|'$ '*|'% '*|'# '*) content=${content#??} ;;
-    '❯'*|'›'*|'>'*|'$'*|'%'*|'#'*) content=${content#?} ;;
+    '❯ '*|'› '*|'→ '*|'> '*|'$ '*|'% '*|'# '*) content=${content#??} ;;
+    '❯'*|'›'*|'→'*|'>'*|'$'*|'%'*|'#'*) content=${content#?} ;;
   esac
   content="${content#"${content%%[![:space:]]*}"}"
   content="${content%"${content##*[![:space:]]}"}"

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -30,16 +30,23 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # and kimi are markerless, so a foreign marker retained in a terminal
+  # Only claude, pi, grok, and cursor set verified markers of their own; codex,
+  # opencode, and kimi are markerless, so a foreign marker retained in a terminal
   # multiplexer's stored environment can silently misidentify one of them before
-  # ancestry is consulted. This is a precedence hazard, not evidence that
-  # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
+  # ancestry is consulted. That precedence hazard is now DEMONSTRATED rather than
+  # theoretical: a cursor-agent tool child launched from a claude terminal was
+  # observed carrying an inherited CLAUDECODE=1 alongside cursor's own
+  # CURSOR_AGENT=1 (2026-07-26). It remains ordering-only - it says nothing about
+  # a natively launched harness - but it is why every marker below is checked
+  # against its OWN harness's variable rather than trusted as exclusive.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
     return
   fi
+  # cursor-agent sets CURSOR_AGENT=1 for its tool child processes (verified,
+  # cursor-agent 2026.07.23-e383d2b).
+  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
@@ -49,6 +56,9 @@ detect_own() {
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     case "$(basename -- "$comm")" in
+      # cursor-agent is matched before the generic patterns purely for
+      # readability; its name shares no substring with another adapter.
+      *cursor-agent*) echo cursor; return ;;
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
@@ -60,6 +70,7 @@ detect_own() {
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
+          *cursor-agent*) echo cursor; return ;;
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -18,7 +18,8 @@
 # harness only, no model/effort. Only the first non-empty, non-comment line is parsed.
 # Model/effort come ONLY from this file - config/crew-harness stays a bare adapter
 # name and is never parsed for a model.
-# Detection layers: verified environment markers first, then process ancestry.
+# Detection layers: one verified environment marker wins directly; conflicting
+# verified markers are resolved by nearest process ancestry or fail closed.
 # Record each newly verified env marker here.
 set -u
 
@@ -27,31 +28,7 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
-detect_own() {
-  # Layer 1: environment markers for verified harnesses.
-  # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Only claude, pi, grok, and cursor set verified markers of their own; codex,
-  # opencode, and kimi are markerless, so a foreign marker retained in a terminal
-  # multiplexer's stored environment can silently misidentify one of them before
-  # ancestry is consulted. That precedence hazard is now DEMONSTRATED rather than
-  # theoretical: a cursor-agent tool child launched from a claude terminal was
-  # observed carrying an inherited CLAUDECODE=1 alongside cursor's own
-  # CURSOR_AGENT=1 (2026-07-26). It remains ordering-only - it says nothing about
-  # a natively launched harness - but it is why every marker below is checked
-  # against its OWN harness's variable rather than trusted as exclusive.
-  [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
-  if [ "${PI_CODING_AGENT:-}" = "true" ]; then
-    if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
-    return
-  fi
-  # cursor-agent sets CURSOR_AGENT=1 for its tool child processes (verified,
-  # cursor-agent 2026.07.23-e383d2b).
-  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
-  # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
-  # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
-  # is unambiguous when firstmate runs natively on grok.
-  [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
-  # Layer 2: walk the parent chain and match the command name.
+detect_ancestry() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
@@ -84,6 +61,43 @@ detect_own() {
     fi
   done
   echo unknown
+}
+
+detect_own() {
+  local marker_count=0 marker_harness= ancestry
+  if [ "${CLAUDECODE:-}" = "1" ]; then
+    marker_count=$((marker_count + 1))
+    marker_harness=claude
+  fi
+  if [ "${PI_CODING_AGENT:-}" = "true" ]; then
+    marker_count=$((marker_count + 1))
+    if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then
+      marker_harness=pi-signed
+    else
+      marker_harness=pi
+    fi
+  fi
+  # cursor-agent sets CURSOR_AGENT=1 for its tool child processes (verified,
+  # cursor-agent 2026.07.23-e383d2b).
+  if [ "${CURSOR_AGENT:-}" = "1" ]; then
+    marker_count=$((marker_count + 1))
+    marker_harness=cursor
+  fi
+  # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
+  if [ "${GROK_AGENT:-}" = "1" ]; then
+    marker_count=$((marker_count + 1))
+    marker_harness=grok
+  fi
+  if [ "$marker_count" -eq 1 ]; then
+    echo "$marker_harness"
+    return
+  fi
+  ancestry=$(detect_ancestry)
+  if [ "$marker_count" -gt 1 ] && [ "$ancestry" = unknown ]; then
+    echo unknown
+    return
+  fi
+  echo "$ancestry"
 }
 
 # Resolve the effective crewmate harness: config/crew-harness (a bare adapter

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -64,7 +64,7 @@ detect_ancestry() {
 }
 
 detect_own() {
-  local marker_count=0 marker_harness= ancestry
+  local marker_count=0 marker_harness='' ancestry
   if [ "${CLAUDECODE:-}" = "1" ]; then
     marker_count=$((marker_count + 1))
     marker_harness=claude

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -12,13 +12,16 @@
 # Orca currently supports Enter and C-c only, and rejects Escape.
 #
 # Text submission is verified: the line is typed ONCE, then Enter is sent and
-# retried (Enter only, never retyped) until the target backend confirms a
-# submit or reports an inconclusive send. If a swallowed Enter is positively
-# confirmed, fm-send exits NON-ZERO so the caller knows the steer did not land
-# instead of silently leaving an unsubmitted instruction.
+# normally retried (Enter only, never retyped) until the target backend confirms
+# a submit or reports an inconclusive send. Cursor sends exactly one Enter and
+# uses observation-only confirmation polls because another Enter can duplicate
+# an already-accepted steer. If a swallowed Enter is positively confirmed,
+# fm-send exits NON-ZERO so the caller knows the steer did not land instead of
+# silently leaving an unsubmitted instruction.
 # Submission dispatches through the target's recorded backend; the tmux adapter
 # shares its composer/submit core with the away-mode daemon via bin/fm-tmux-lib.sh.
-# Tune with FM_SEND_RETRIES (default 3) / FM_SEND_SLEEP (0.4).
+# Tune with FM_SEND_RETRIES (default 3; Cursor uses 15 confirmation polls
+# after its single Enter) / FM_SEND_SLEEP (0.4).
 # Slash commands, and codex `$...` skill invocations resolved through harness
 # meta, get a longer pre-Enter settle so completion popups do not swallow Enter.
 #
@@ -281,10 +284,34 @@ else
       ;;
     *) settle=0.3 ;;
   esac
-  retries=${FM_SEND_RETRIES:-3}
+  # Cursor needs the same 1.2-second input settle for plain text as for slash
+  # commands. A live 0.3-second run left the first Enter unaccepted for the full
+  # confirmation window; the 1.2-second counterfactual submitted once.
+  [ "$TARGET_HARNESS" != cursor ] || settle=1.2
+  # Cursor can accept the first Enter while leaving the submitted text painted
+  # in its composer for more than three seconds before the turn starts. The
+  # normal three checks then return a false `pending` even though the steer was
+  # delivered. Keep the caller override authoritative, but give recorded Cursor
+  # targets a six-second default confirmation window (15 * 0.4s). Cursor's
+  # submit mode sends exactly one Enter and only polls after it: another Enter
+  # while the stale text remains visible queues a duplicate follow-up.
+  if [ -n "${FM_SEND_RETRIES+x}" ]; then
+    retries=$FM_SEND_RETRIES
+  elif [ "$TARGET_HARNESS" = cursor ]; then
+    retries=15
+  else
+    retries=3
+  fi
   sleep_s=${FM_SEND_SLEEP:-0.4}
   submit_mode=ordinary
   [ "$LIFECYCLE_EXIT" = 0 ] || submit_mode=lifecycle-exit
+  if [ "$TARGET_HARNESS" = cursor ] && [ "$TARGET_BACKEND" = tmux ]; then
+    if [ "$LIFECYCLE_EXIT" = 0 ]; then
+      submit_mode=cursor-single-enter
+    else
+      submit_mode=cursor-lifecycle-exit
+    fi
+  fi
   # Type once, submit, verify. Only exact empty confirms delivery; every other
   # verdict preserves the loud refusal boundary.
   if ! verdict=$(fm_backend_send_text_submit "$TARGET_BACKEND" "$T" "$MESSAGE" "$retries" "$sleep_s" "$settle" "$EXPECTED_LABEL" "$submit_mode"); then

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -220,7 +220,7 @@ fi
 # error with the attempted resolution attached.
 
 if [ "${1:-}" = "--key" ]; then
-  if ! fm_backend_send_key "$TARGET_BACKEND" "$T" "$2" "$EXPECTED_LABEL"; then
+  if ! fm_backend_send_operator_key "$TARGET_BACKEND" "$T" "$2" "$EXPECTED_LABEL"; then
     echo "error: key '$2' not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
     exit 1
   fi

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -7,6 +7,7 @@
 #   tmux window search, because a "successful" send to the wrong endpoint is
 #   worse than a loud failure.
 # Special keys instead of text: fm-send.sh <target> --key Enter
+# Authorized lifecycle exit: fm-send.sh <target> --lifecycle-exit <verified-exit-command>
 # Key support is backend-specific: tmux/herdr support Escape, Enter, and C-c;
 # Orca currently supports Enter and C-c only, and rejects Escape.
 #
@@ -193,6 +194,20 @@ shift
 
 fm_backend_validate "$TARGET_BACKEND" || exit 1
 
+LIFECYCLE_EXIT=0
+if [ "${1:-}" = --lifecycle-exit ]; then
+  LIFECYCLE_EXIT=1
+  shift
+  if [ "$#" -ne 1 ] || [ -z "$TARGET_META" ] || [ -z "$TARGET_HARNESS" ] || [ "$TARGET_BACKEND" != tmux ]; then
+    echo "error: --lifecycle-exit requires one verified exit command for a metadata-routed tmux harness" >&2
+    exit 1
+  fi
+  case "$TARGET_HARNESS:$1" in
+    claude:/exit|codex:/quit|opencode:/exit|pi:/quit|grok:/exit|kimi:/exit|cursor:/exit|cursor:/quit) ;;
+    *) echo "error: '$1' is not the verified lifecycle-exit command for harness '$TARGET_HARNESS'" >&2; exit 1 ;;
+  esac
+fi
+
 # Classify a from-firstmate -> secondmate request. Only a task selector resolved
 # through this home's meta whose authoritative kind is secondmate is marked: the
 # secondmate then routes its reply via the status path (see fm-marker-lib.sh).
@@ -202,7 +217,7 @@ MARK_FROM_FIRSTMATE=0
 PENDING_REPLY_CORR=
 PENDING_REPLY_CREATED=0
 TARGET_TASK_ID=
-if [ -n "$TARGET_SELECTOR" ] && [ -n "$TARGET_META" ] && [ "$(fm_meta_get "$TARGET_META" kind)" = secondmate ]; then
+if [ "$LIFECYCLE_EXIT" = 0 ] && [ -n "$TARGET_SELECTOR" ] && [ -n "$TARGET_META" ] && [ "$(fm_meta_get "$TARGET_META" kind)" = secondmate ]; then
   MARK_FROM_FIRSTMATE=1
   TARGET_TASK_ID=$(fm_send_id_from_meta "$TARGET_META")
 fi
@@ -268,9 +283,11 @@ else
   esac
   retries=${FM_SEND_RETRIES:-3}
   sleep_s=${FM_SEND_SLEEP:-0.4}
+  submit_mode=ordinary
+  [ "$LIFECYCLE_EXIT" = 0 ] || submit_mode=lifecycle-exit
   # Type once, submit, verify. Only exact empty confirms delivery; every other
   # verdict preserves the loud refusal boundary.
-  if ! verdict=$(fm_backend_send_text_submit "$TARGET_BACKEND" "$T" "$MESSAGE" "$retries" "$sleep_s" "$settle" "$EXPECTED_LABEL"); then
+  if ! verdict=$(fm_backend_send_text_submit "$TARGET_BACKEND" "$T" "$MESSAGE" "$retries" "$sleep_s" "$settle" "$EXPECTED_LABEL" "$submit_mode"); then
     if [ "$PENDING_REPLY_CREATED" = 1 ] && [ -n "$PENDING_REPLY_CORR" ]; then
       fm_pending_reply_discard_undelivered "$STATE" "$PENDING_REPLY_CORR" || true
     fi

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -9,7 +9,9 @@
 # This file is sourced by scripts and has no side effects on source.
 
 # Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+# `cursor-agent` is spelled in full rather than as a bare `cursor`, so an
+# unrelated process merely mentioning a cursor cannot be read as a harness.
+FM_HARNESS_RE='claude|codex|opencode|grok|kimi|cursor-agent|^pi$|^pi-signed$'
 
 # Walk the current process ancestry (up to 16 hops) and print a harness pid.
 # For every harness except Claude, the first match wins (innermost pid), which

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -59,7 +59,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|cursor)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. pi-signed launches that exact executable name from PATH and
@@ -409,7 +409,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -474,6 +474,16 @@ launch_template() {
     # only an absolute brief pointer after the TUI readiness gate below.
     # Its turn-end signal is a globally configured Stop hook plus a guarded
     # per-task worktree token, so no launch placeholder belongs here.
+    # cursor (Cursor CLI, `cursor-agent`): a positional prompt starts and
+    # auto-submits the supervised interactive session, the same shape as claude
+    # and grok. --force (alias --yolo, footer "Run Everything") auto-approves
+    # every tool call; verified to run a shell command unattended. --trust is
+    # SEPARATELY required: unlike --print mode, where -f alone suppresses the
+    # workspace-trust gate, the interactive TUI still blocks on a "Workspace
+    # Trust Required" dialog under --force alone, and every pooled worktree is a
+    # fresh path, so an unattended crewmate would wedge on that dialog forever
+    # without it. cursor has no reasoning-effort flag, so no __EFFORTFLAG__ here.
+    cursor) printf '%s' 'cursor-agent --force --trust __MODELFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
     *) return 1 ;;
   esac
@@ -598,7 +608,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi)
+    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -642,6 +652,18 @@ effort_flag_for_harness() {
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
     # kimi likewise has no reasoning-effort flag; the requested axis stays in
     # task metadata but never reaches the launch command.
+    # cursor has no effort flag either, and its case is worth stating exactly
+    # because its --help ADVERTISES one: parameterized bracket overrides such as
+    # 'claude-opus-4-8[context=1m,effort=high,fast=false]'. That documented
+    # syntax - including the help's own literal example - is rejected with exit 1
+    # by cursor-agent 2026.07.23-e383d2b, so it must not be synthesized here.
+    # cursor carries reasoning effort in the MODEL NAME instead
+    # (claude-opus-5-thinking-low .. -max, gpt-5.3-codex-xhigh, ...), and firstmate
+    # picks that concrete model at intake. fm-spawn deliberately does not derive a
+    # suffix from --effort, because the tier vocabulary is per-family and
+    # incomplete: composer-2.5 has no tiers, gpt-5.2 has no -medium, gpt-5.5 spells
+    # it -extra-high, and gemini-3.6-flash spells it -minimal, so a synthesized
+    # suffix would be exactly the known-bad launch value this function avoids.
   esac
 }
 

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1138,8 +1138,7 @@ inject_msg() {  # <message> [state]
   # submit. An unconfirmed/unknown pane does NOT count as delivered, so the
   # buffer is preserved (strict) rather than cleared.
   # Dispatches through fm_backend_send_text_submit (bin/fm-backend.sh): for
-  # backend=tmux this calls fm_backend_tmux_send_text_submit, a verbatim
-  # re-export of fm_tmux_submit_core - byte-identical to calling it directly.
+  # backend=tmux this calls fm_backend_tmux_send_text_submit.
   retries=${FM_INJECT_CONFIRM_RETRIES:-$INJECT_CONFIRM_RETRIES_DEFAULT}
   sleep_s=${FM_INJECT_CONFIRM_SLEEP:-$INJECT_CONFIRM_SLEEP_DEFAULT}
   verdict=$(fm_backend_send_text_submit "$backend" "$target" "$msg" "$retries" "$sleep_s" "$sleep_s")

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -420,12 +420,23 @@ fm_pane_is_busy() {  # <target> [harness]
 # `empty` so the caller does not re-send), while an idle pane keeps `pending` as
 # a genuine swallow. Pending-unproven receives the same Enter retry budget but
 # never reaches this exception.
-fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep>
-  local target=$1 retries=$2 sleep_s=$3 i=0 state
+fm_tmux_submit_input_allowed() {
+  local target=$1 input_check=${2:-}
+  [ -z "$input_check" ] || "$input_check" "$target"
+}
+
+fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep> [input-check]
+  local target=$1 retries=$2 sleep_s=$3 input_check=${4:-} i=0 state
   while :; do
+    fm_tmux_submit_input_allowed "$target" "$input_check" \
+      || { printf 'send-failed'; return 0; }
     tmux send-keys -t "$target" Enter 2>/dev/null || true
     sleep "$sleep_s"
     state=$(fm_tmux_composer_state "$target")
+    if [ "$state" = empty ]; then
+      fm_tmux_submit_input_allowed "$target" "$input_check" \
+        || { printf 'send-failed'; return 0; }
+    fi
     case "$state" in
       pending|pending-unproven) ;;
       *) printf '%s' "$state"; return 0 ;;
@@ -443,15 +454,21 @@ fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep>
   # Treat it as submitted so the caller does not re-send.
   # On an idle pane, keep reporting pending - a genuine swallow.
   if fm_pane_is_busy "$target"; then
-    printf 'empty'
+    if fm_tmux_submit_input_allowed "$target" "$input_check"; then
+      printf 'empty'
+    else
+      printf 'send-failed'
+    fi
   else
     printf 'pending'
   fi
 }
 
-fm_tmux_submit_core() {  # <target> <text> <retries> <enter-sleep> <settle>
-  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5
+fm_tmux_submit_core() {  # <target> <text> <retries> <enter-sleep> <settle> [input-check]
+  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 input_check=${6:-}
+  fm_tmux_submit_input_allowed "$target" "$input_check" \
+    || { printf 'send-failed'; return 0; }
   tmux send-keys -t "$target" -l "$text" 2>/dev/null || { printf 'send-failed'; return 0; }
   sleep "$settle"
-  fm_tmux_submit_enter_core "$target" "$retries" "$sleep_s"
+  fm_tmux_submit_enter_core "$target" "$retries" "$sleep_s" "$input_check"
 }

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -425,20 +425,35 @@ fm_tmux_submit_input_allowed() {
   [ -z "$input_check" ] || "$input_check" "$target"
 }
 
-fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep> [input-check]
-  local target=$1 retries=$2 sleep_s=$3 input_check=${4:-} i=0 state
+fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep> [input-check] [submit-mode]
+  local target=$1 retries=$2 sleep_s=$3 input_check=${4:-} submit_mode=${5:-ordinary}
+  local i=0 state submitted=0
   while :; do
     fm_tmux_submit_input_allowed "$target" "$input_check" \
       || { printf 'send-failed'; return 0; }
-    tmux send-keys -t "$target" Enter 2>/dev/null || true
+    if tmux send-keys -t "$target" Enter 2>/dev/null; then
+      submitted=1
+    fi
     sleep "$sleep_s"
     state=$(fm_tmux_composer_state "$target")
-    if [ "$state" = empty ]; then
-      fm_tmux_submit_input_allowed "$target" "$input_check" \
-        || { printf 'send-failed'; return 0; }
+    if ! fm_tmux_submit_input_allowed "$target" "$input_check"; then
+      if [ "$submit_mode" = lifecycle-exit ] && [ "$submitted" = 1 ]; then
+        printf 'empty'
+      else
+        printf 'send-failed'
+      fi
+      return 0
     fi
     case "$state" in
       pending|pending-unproven) ;;
+      empty)
+        if [ "$submit_mode" = lifecycle-exit ] && [ "$submitted" != 1 ]; then
+          printf 'send-failed'
+        else
+          printf 'empty'
+        fi
+        return 0
+        ;;
       *) printf '%s' "$state"; return 0 ;;
     esac
     i=$((i + 1))
@@ -454,7 +469,8 @@ fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep> [input-check]
   # Treat it as submitted so the caller does not re-send.
   # On an idle pane, keep reporting pending - a genuine swallow.
   if fm_pane_is_busy "$target"; then
-    if fm_tmux_submit_input_allowed "$target" "$input_check"; then
+    if fm_tmux_submit_input_allowed "$target" "$input_check" \
+      && { [ "$submit_mode" != lifecycle-exit ] || [ "$submitted" = 1 ]; }; then
       printf 'empty'
     else
       printf 'send-failed'
@@ -464,11 +480,12 @@ fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep> [input-check]
   fi
 }
 
-fm_tmux_submit_core() {  # <target> <text> <retries> <enter-sleep> <settle> [input-check]
+fm_tmux_submit_core() {  # <target> <text> <retries> <enter-sleep> <settle> [input-check] [submit-mode]
   local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 input_check=${6:-}
+  local submit_mode=${7:-ordinary}
   fm_tmux_submit_input_allowed "$target" "$input_check" \
     || { printf 'send-failed'; return 0; }
   tmux send-keys -t "$target" -l "$text" 2>/dev/null || { printf 'send-failed'; return 0; }
   sleep "$settle"
-  fm_tmux_submit_enter_core "$target" "$retries" "$sleep_s" "$input_check"
+  fm_tmux_submit_enter_core "$target" "$retries" "$sleep_s" "$input_check" "$submit_mode"
 }

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -76,6 +76,19 @@
 # busy signals on their own.
 # The full moon-phase set remains locale- and emoji-font-sensitive because Kimi
 # exposes no stable ASCII busy token.
+# cursor-agent's own spinner WORD rotates with the phase of the turn (`Working`,
+# `Thinking`, `Running`), so it is not a signature. The stable signal is the
+# right-aligned `ctrl+c to stop` hint cursor-agent renders in its composer row
+# for the whole turn, including while a shell tool runs, and never renders when
+# idle. That hint is matched ONLY as the tail of cursor-agent's own composer
+# row, because `ctrl+c to stop` as a bare substring is a phrase ordinary dev
+# servers print ("Press Ctrl+C to stop"), and a crewmate that leaves such a
+# server in its last visible lines would then look busy forever and mask a real
+# wedge. Anchoring to the `→` composer glyph plus the end of the line removes
+# that. The glyph is a plain arrow rather than a braille or emoji frame, so it
+# carries none of Kimi's emoji-font sensitivity, and the hint itself is ASCII.
+# Like claude's and kimi's, this signature stays OUT of the shared default
+# because it is not safe to apply to arbitrary unrecorded harness output.
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
 FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
@@ -83,6 +96,7 @@ FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
 FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
 FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
+FM_TMUX_CURSOR_BUSY_REGEX_DEFAULT='^[[:space:]]*→.*ctrl\+c to stop[[:space:]]*$'
 
 fm_busy_lines_match() {  # [harness]
   local harness=${1:-} lines regex
@@ -97,6 +111,7 @@ fm_busy_lines_match() {  # [harness]
       pi|pi-signed) regex=$FM_TMUX_PI_BUSY_REGEX_DEFAULT ;;
       grok) regex=$FM_TMUX_GROK_BUSY_REGEX_DEFAULT ;;
       kimi) regex=$FM_TMUX_KIMI_BUSY_REGEX_DEFAULT ;;
+      cursor) regex=$FM_TMUX_CURSOR_BUSY_REGEX_DEFAULT ;;
       '') regex=$FM_TMUX_BUSY_REGEX_DEFAULT ;;
       *)
         # A supplied harness must never borrow another harness's signature.
@@ -309,7 +324,7 @@ EOF
 # busy-queued Enter conversion.
 fm_tmux_composer_state() {  # <target> -> empty|pending|pending-unproven|unknown
   local target=$1 cy raw pane plain box box_status top bottom geometry_ambiguous
-  local row row_raw state unknown_seen=0
+  local row row_raw state unknown_seen=0 composer_row
   cy=$(tmux display-message -p -t "$target" '#{cursor_y}' 2>/dev/null) || { printf 'unknown'; return 0; }
   case "$cy" in ''|*[!0-9]*) printf 'unknown'; return 0 ;; esac
   pane=$(tmux capture-pane -e -p -t "$target" -S 0 -E - 2>/dev/null) || { printf 'unknown'; return 0; }
@@ -354,6 +369,25 @@ fm_tmux_composer_state() {  # <target> -> empty|pending|pending-unproven|unknown
   if fm_tmux_row_has_composer_edge "$(printf '%s\n' "$raw" | fm_composer_strip_ansi)"; then
     printf 'unknown'
     return 0
+  fi
+  # A harness need not keep the terminal cursor in its composer. cursor-agent
+  # draws its own block cursor, leaves #{cursor_flag} at 0, and parks
+  # #{cursor_y} on a blank row well below its bare composer, so the cursor row
+  # carries no composer at all and reads "empty" while real text sits
+  # unsubmitted - the exact false-empty that lets the away-mode injector type
+  # over live input and lets the submit core report a swallowed Enter as
+  # delivered. When the cursor row is genuinely BLANK there is no cursor-anchored
+  # answer to trust, so fall back to the bottom-most bare agent-composer row in
+  # the visible pane. Only `→` is scanned for: `❯` and `›` are also shell prompt
+  # glyphs in this fleet, so scanning for those would let dead-shell scrollback
+  # masquerade as a live composer. Requiring a blank cursor row also keeps every
+  # already-verified harness on its existing path, because claude, codex,
+  # opencode, pi, grok and kimi all keep the cursor inside their own composer.
+  if [ -z "$(printf '%s\n' "$raw" | fm_composer_strip_ansi | tr -d '[:space:]')" ]; then
+    composer_row=$(printf '%s\n' "$plain" | grep -nE '^[[:space:]]*→' | tail -1 | cut -d: -f1)
+    if [ -n "$composer_row" ]; then
+      raw=$(printf '%s\n' "$pane" | sed -n "${composer_row}p")
+    fi
   fi
   fm_tmux_composer_row_state "$raw" 0
 }

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -2,7 +2,7 @@
 # fm-tmux-lib.sh — shared tmux pane primitives for firstmate.
 #
 # ONE source of truth for: busy detection, composer-empty (pending-input)
-# detection, and a verify-and-retry-Enter submit. Sourced by both the away-mode
+# detection, and a verify-and-confirm-Enter submit. Sourced by both the away-mode
 # daemon (bin/fm-supervise-daemon.sh) and bin/fm-send.sh so the composer/submit
 # logic cannot drift between the two.
 #
@@ -408,10 +408,15 @@ fm_pane_is_busy() {  # <target> [harness]
 }
 
 # fm_tmux_submit_core: type <text> into <target> ONCE, then submit with Enter,
-# verifying the composer cleared. Retries Enter ONLY — never retypes, because a
+# verifying the composer cleared. Retries Enter ONLY - never retypes, because a
 # swallowed Enter leaves our text in the composer and retyping would duplicate
 # it. Echoes the final proof-carrying verdict on stdout so callers can require
 # exact `empty` before treating submission as confirmed.
+# Cursor is the deliberate exception to Enter retrying. After a correctly
+# settled Enter, its visible composer can retain the submitted text for more
+# than three seconds while the TUI has already accepted it. A second Enter then
+# queues the same text as a follow-up. `cursor-single-enter` therefore sends one
+# Enter and spends the retry budget on observation-only polls.
 # Busy-queued Enter (opencode 1.18.4): the harness accepts Enter while mid-turn
 # and queues it for after the current turn, but keeps the typed text visible in
 # the composer. Once the Enter-retry budget is spent and a structurally proven
@@ -431,39 +436,64 @@ fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep> [input-check] 
   while :; do
     fm_tmux_submit_input_allowed "$target" "$input_check" \
       || { printf 'send-failed'; return 0; }
-    if tmux send-keys -t "$target" Enter 2>/dev/null; then
-      submitted=1
+    if [ "$i" -eq 0 ] \
+      || { [ "$submit_mode" != cursor-single-enter ] && [ "$submit_mode" != cursor-lifecycle-exit ]; }; then
+      if tmux send-keys -t "$target" Enter 2>/dev/null; then
+        submitted=1
+      fi
     fi
     sleep "$sleep_s"
     state=$(fm_tmux_composer_state "$target")
     if ! fm_tmux_submit_input_allowed "$target" "$input_check"; then
-      if [ "$submit_mode" = lifecycle-exit ] && [ "$submitted" = 1 ]; then
-        printf 'empty'
-      else
-        printf 'send-failed'
-      fi
+      case "$submit_mode:$submitted" in
+        lifecycle-exit:1|cursor-lifecycle-exit:1) printf 'empty' ;;
+        *) printf 'send-failed' ;;
+      esac
       return 0
     fi
     case "$state" in
       pending|pending-unproven) ;;
       empty)
-        if [ "$submit_mode" = lifecycle-exit ] && [ "$submitted" != 1 ]; then
-          printf 'send-failed'
-        else
-          printf 'empty'
-        fi
-        return 0
+        case "$submit_mode:$submitted" in
+          cursor-lifecycle-exit:1)
+            # Cursor lifecycle success is process death, not merely a cleared
+            # composer. Keep polling without another Enter.
+            ;;
+          lifecycle-exit:0|cursor-lifecycle-exit:0|cursor-single-enter:0)
+            printf 'send-failed'
+            return 0
+            ;;
+          *)
+            printf 'empty'
+            return 0
+            ;;
+        esac
         ;;
       *) printf '%s' "$state"; return 0 ;;
     esac
     i=$((i + 1))
     [ "$i" -lt "$retries" ] || break
   done
+  if [ "$submit_mode" = cursor-lifecycle-exit ]; then
+    printf 'send-failed'
+    return 0
+  fi
   if [ "$state" != pending ]; then
     printf '%s' "$state"
     return 0
   fi
   # Retries exhausted, composer still shows proven pending.
+  # Cursor's scoped busy hint is a safe positive acknowledgement after its one
+  # Enter. It is intentionally not part of the generic fallback below.
+  if [ "$submit_mode" = cursor-single-enter ]; then
+    if [ "$submitted" = 1 ] && fm_pane_is_busy "$target" cursor \
+      && fm_tmux_submit_input_allowed "$target" "$input_check"; then
+      printf 'empty'
+    else
+      printf 'pending'
+    fi
+    return 0
+  fi
   # If the pane is busy (agent mid-turn), the harness accepted the Enter
   # and queued the message for processing when the current turn ends.
   # Treat it as submitted so the caller does not re-send.

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -106,7 +106,9 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # grok: "Ctrl+c:cancel". Claude's current spinner signature is matched only for
 # a recorded Claude task because an ellipsis followed by elapsed time is not a
 # safe shared signature for arbitrary harness output. Kimi's moon-plus-middot
-# spinner signature is likewise matched only for a recorded Kimi task.
+# spinner signature is likewise matched only for a recorded Kimi task, as is
+# cursor's composer-anchored "ctrl+c to stop" hint, whose bare substring is a
+# phrase ordinary dev servers print.
 BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,7 +148,7 @@ The session-start bootstrap step keeps valid dispatch configuration silent unles
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and kimi while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, grok, pi, opencode, kimi, and cursor while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,7 +179,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, pi-signed, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
+claude, codex, opencode, pi, pi-signed, grok, kimi, and cursor are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the narrower set supported for the primary session.
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -73,7 +73,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, then assert watcher liveness |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
 | `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |
-| `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |
+| `fm-send.sh`             | Send one verified literal line, authorized tmux lifecycle exit, or supported key through the target's recorded backend |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, composer capture, and verified submit |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2392,7 +2392,7 @@ test_dispatch_composer_state_routes_by_backend() {
     _FM_BACKEND_HERDR_SOURCED=1
     _FM_BACKEND_ORCA_SOURCED=1
     _FM_BACKEND_ZELLIJ_SOURCED=1
-    fm_tmux_composer_state() { [ "$1" = "sess:win" ] || fail "tmux composer_state got wrong target: $1"; printf 'pending'; }
+    fm_backend_tmux_composer_state() { [ "$1" = "sess:win" ] || fail "tmux composer_state got wrong target: $1"; printf 'pending'; }
     fm_backend_herdr_composer_state() { [ "$1" = "default:w1:p2" ] || fail "herdr composer_state got wrong target: $1"; printf 'empty'; }
     fm_backend_orca_composer_state() { [ "$1" = "term-1" ] || fail "orca composer_state got wrong target: $1"; printf 'empty'; }
     [ "$(fm_backend_composer_state tmux sess:win)" = pending ] || fail "composer_state did not dispatch to the tmux classifier"

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -648,7 +648,12 @@ set -u
 case "${1:-}" in
   send-keys) exit 0 ;;
   display-message)
-    for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
+    for a in "$@"; do
+      case "$a" in
+        *cursor_y*) printf '1\n'; exit 0 ;;
+        *pane_current_command*) printf 'codex\n'; exit 0 ;;
+      esac
+    done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane)
     start= end=
@@ -665,7 +670,7 @@ case "${1:-}" in
       printf '╭────╮\n│    │\n╰────╯\n'
     fi
     exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows) printf 'win\n'; exit 0 ;;
 esac
 exit 0
 SH
@@ -682,10 +687,15 @@ run_send_case() {  # <bin-root> <fakebin> <log> <home> -- <send args...>
     "$bin/bin/fm-send.sh" "$@" >/dev/null 2>&1
 }
 
-strip_send_preflight() {  # <log>
+strip_send_safety_probes() {  # <log>
   local preflight
   preflight=$'tmux\x1fdisplay-message\x1f-p\x1f-t\x1fsess:win\x1f#{pane_id}'
-  awk -v preflight="$preflight" '$0 != preflight { print }' "$1"
+  awk -v preflight="$preflight" '
+    $0 == preflight { next }
+    index($0, "\x1flist-windows\x1f") { next }
+    index($0, "\x1f#{pane_current_command}") { next }
+    { print }
+  ' "$1"
 }
 
 test_send_conformance_old_vs_new() {
@@ -704,8 +714,8 @@ test_send_conformance_old_vs_new() {
   expect_code "$rc_old" "$rc_new" "fm-send --key: old vs new exit code"
   assert_contains "$(cat "$log_new")" $'\x1f''display-message'$'\x1f''-p'$'\x1f''-t'$'\x1f''sess:win'$'\x1f''#{pane_id}' \
     "fm-send --key did not verify the explicit tmux target before sending"
-  strip_send_preflight "$log_old" > "$filtered_old"
-  strip_send_preflight "$log_new" > "$filtered_new"
+  strip_send_safety_probes "$log_old" > "$filtered_old"
+  strip_send_safety_probes "$log_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-key.txt" 2>&1 \
     || fail "fm-send --key: tmux command log differs old vs new"$'\n'"$(cat "$TMP_ROOT/send-diff-key.txt")"
   assert_contains "$(cat "$log_new")" $'\x1f''Escape' "fm-send --key did not send the named key"
@@ -716,8 +726,8 @@ test_send_conformance_old_vs_new() {
   run_send_case "$ROOT" "$fb" "$log_new" "$home" -- "sess:win" hello captain
   rc_new=$?
   expect_code "$rc_old" "$rc_new" "fm-send plain text: old vs new exit code"
-  strip_send_preflight "$log_old" > "$filtered_old"
-  strip_send_preflight "$log_new" > "$filtered_new"
+  strip_send_safety_probes "$log_old" > "$filtered_old"
+  strip_send_safety_probes "$log_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-plain.txt" 2>&1 \
     || fail "fm-send plain text: tmux command log differs old vs new"$'\n'"$(cat "$TMP_ROOT/send-diff-plain.txt")"
   assert_contains "$(cat "$log_new")" $'\x1f''send-keys'$'\x1f''-t'$'\x1f''sess:win'$'\x1f''-l'$'\x1f''hello captain' \
@@ -732,8 +742,8 @@ test_send_conformance_old_vs_new() {
   run_send_case "$ROOT" "$fb" "$log_new" "$home" -- "sess:win" /some-skill
   rc_new=$?
   expect_code "$rc_old" "$rc_new" "fm-send /skill: old vs new exit code"
-  strip_send_preflight "$log_old" > "$filtered_old"
-  strip_send_preflight "$log_new" > "$filtered_new"
+  strip_send_safety_probes "$log_old" > "$filtered_old"
+  strip_send_safety_probes "$log_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-slash.txt" 2>&1 \
     || fail "fm-send /skill: tmux command log differs old vs new"$'\n'"$(cat "$TMP_ROOT/send-diff-slash.txt")"
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -785,6 +785,11 @@ pi-signed max effort is accepted^{"rules":[{"when":"signed coding","use":{"harne
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
 kimi model profile is accepted^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3"}}]}^empty^
 unsupported kimi effort is flagged^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: kimi:high
+cursor model effort is accepted^{"rules":[{"when":"cursor work","use":{"harness":"cursor","model":"claude-opus-5-thinking-xhigh","effort":"xhigh"}}]}^empty^
+cursor max model effort is accepted^{"default":{"harness":"cursor","model":"claude-opus-5-thinking-max","effort":"max"}}^empty^
+unsupported cursor effort is flagged^{"rules":[{"when":"cursor work","use":{"harness":"cursor","model":"claude-opus-5-thinking","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: cursor:ultra
+cursor effort without tiered model is flagged^{"rules":[{"when":"cursor work","use":{"harness":"cursor","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: cursor:high
+cursor effort mismatching model tier is flagged^{"rules":[{"when":"cursor work","use":{"harness":"cursor","model":"claude-opus-5-thinking-high","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: cursor:xhigh
 array use with quota-balanced is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}],"select":"quota-balanced"}]}^empty^
 array use without select is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}]}]}^empty^
 one-element array use is accepted^{"rules":[{"when":"focused feature","use":[{"harness":"claude"}]}]}^empty^

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -785,11 +785,11 @@ pi-signed max effort is accepted^{"rules":[{"when":"signed coding","use":{"harne
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
 kimi model profile is accepted^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3"}}]}^empty^
 unsupported kimi effort is flagged^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: kimi:high
-cursor model effort is accepted^{"rules":[{"when":"cursor work","use":{"harness":"cursor","model":"claude-opus-5-thinking-xhigh","effort":"xhigh"}}]}^empty^
-cursor max model effort is accepted^{"default":{"harness":"cursor","model":"claude-opus-5-thinking-max","effort":"max"}}^empty^
+cursor aliased model effort is accepted^{"rules":[{"when":"cursor work","use":{"harness":"cursor","model":"gpt-5.5-extra-high","effort":"xhigh"}}]}^empty^
+cursor minimal model effort is accepted^{"default":{"harness":"cursor","model":"gemini-3.6-flash-minimal","effort":"low"}}^empty^
 unsupported cursor effort is flagged^{"rules":[{"when":"cursor work","use":{"harness":"cursor","model":"claude-opus-5-thinking","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: cursor:ultra
-cursor effort without tiered model is flagged^{"rules":[{"when":"cursor work","use":{"harness":"cursor","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: cursor:high
-cursor effort mismatching model tier is flagged^{"rules":[{"when":"cursor work","use":{"harness":"cursor","model":"claude-opus-5-thinking-high","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: cursor:xhigh
+cursor effort without a model is accepted^{"rules":[{"when":"cursor work","use":{"harness":"cursor","effort":"high"}}]}^empty^
+cursor effort does not infer model-family spelling^{"rules":[{"when":"cursor work","use":{"harness":"cursor","model":"claude-opus-5-thinking-high","effort":"xhigh"}}]}^empty^
 array use with quota-balanced is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}],"select":"quota-balanced"}]}^empty^
 array use without select is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}]}]}^empty^
 one-element array use is accepted^{"rules":[{"when":"focused feature","use":[{"harness":"claude"}]}]}^empty^

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -433,7 +433,7 @@ test_backend_input_boundary_rejects_dead_and_missing_agents() {
 }
 
 test_submit_rechecks_liveness_during_settle() {
-  local dir fb pane log comm sleep_count verdict
+  local dir fb pane log comm sleep_count verdict home err rc
   dir="$TMP_ROOT/submit-liveness"; mkdir -p "$dir"
   fb=$(make_fake_tmux "$dir")
   pane="$dir/pane.txt"
@@ -477,6 +477,49 @@ SH
   [ "$verdict" = send-failed ] || fail "Cursor crash during Enter settle returned '$verdict'"
   [ "$(grep -Fc -- 'send-keys -t sess:win Enter' "$log")" -eq 1 ] \
     || fail "Cursor crash during Enter settle did not stop after one Enter"
+
+  home="$dir/home"
+  err="$dir/send.err"
+  mkdir -p "$home/state"
+  fm_write_meta "$home/state/exit.meta" "window=sess:win" "kind=ship" "harness=cursor"
+
+  printf 'node\n' > "$comm"
+  : > "$log"
+  : > "$sleep_count"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" \
+    FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 FM_FAKE_WINDOWS=win \
+    FM_FAKE_COMM_FILE="$comm" FM_FAKE_SEND_LOG="$log" \
+    FM_FAKE_SLEEP_COUNT="$sleep_count" FM_FAKE_EXIT_ON_SLEEP=2 \
+    FM_SEND_SETTLE=0 FM_GATE_REFUSE_BYPASS=1 \
+    "$ROOT/bin/fm-send.sh" exit --lifecycle-exit /exit >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -eq 0 ] || fail "authorized Cursor lifecycle exit failed: $(tail -1 "$err")"
+  grep -F -- 'send-keys -t sess:win -l /exit' "$log" >/dev/null \
+    || fail "authorized Cursor lifecycle exit never typed /exit"
+  [ "$(grep -Fc -- 'send-keys -t sess:win Enter' "$log")" -eq 1 ] \
+    || fail "authorized Cursor lifecycle exit did not submit exactly once"
+
+  printf 'node\n' > "$comm"
+  : > "$log"
+  : > "$sleep_count"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" \
+    FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 FM_FAKE_WINDOWS=win \
+    FM_FAKE_COMM_FILE="$comm" FM_FAKE_SEND_LOG="$log" \
+    FM_FAKE_SLEEP_COUNT="$sleep_count" FM_FAKE_EXIT_ON_SLEEP=2 \
+    FM_SEND_SETTLE=0 FM_GATE_REFUSE_BYPASS=1 \
+    "$ROOT/bin/fm-send.sh" exit /exit >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "ordinary /exit text inferred lifecycle authorization"
+
+  printf 'zsh\n' > "$comm"
+  : > "$log"
+  : > "$sleep_count"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" \
+    FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 FM_FAKE_WINDOWS=win \
+    FM_FAKE_COMM_FILE="$comm" FM_FAKE_SEND_LOG="$log" \
+    FM_FAKE_SLEEP_COUNT="$sleep_count" FM_FAKE_EXIT_ON_SLEEP=2 \
+    FM_SEND_SETTLE=0 FM_GATE_REFUSE_BYPASS=1 \
+    "$ROOT/bin/fm-send.sh" exit --lifecycle-exit /exit >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "authorized lifecycle exit relaxed the pre-submit dead-agent check"
+  [ ! -s "$log" ] || fail "authorized lifecycle exit sent input to an already-dead agent"
   pass "tmux submit rechecks Cursor liveness during settle and confirmation"
 }
 

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -77,7 +77,14 @@ case "${1:-}" in
     for a in "$@"; do
       case "$a" in
         *cursor_y*) printf '%s\n' "${FM_FAKE_CY:-0}"; exit 0 ;;
-        *pane_current_command*) printf '%s\n' "${FM_FAKE_COMM:-node}"; exit 0 ;;
+        *pane_current_command*)
+          if [ -n "${FM_FAKE_COMM_FILE:-}" ]; then
+            cat "$FM_FAKE_COMM_FILE"
+          else
+            printf '%s\n' "${FM_FAKE_COMM:-node}"
+          fi
+          exit 0
+          ;;
       esac
     done
     printf 'fakepane\n'; exit 0 ;;
@@ -425,6 +432,54 @@ test_backend_input_boundary_rejects_dead_and_missing_agents() {
   pass "tmux input boundary rejects dead and missing agents but preserves live cursor steering"
 }
 
+test_submit_rechecks_liveness_during_settle() {
+  local dir fb pane log comm sleep_count verdict
+  dir="$TMP_ROOT/submit-liveness"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  pane="$dir/pane.txt"
+  log="$dir/send.log"
+  comm="$dir/comm"
+  sleep_count="$dir/sleep-count"
+  make_pane_file "$pane" '❯'
+  cat > "$fb/sleep" <<'SH'
+#!/usr/bin/env bash
+count=0
+[ ! -f "$FM_FAKE_SLEEP_COUNT" ] || count=$(cat "$FM_FAKE_SLEEP_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" > "$FM_FAKE_SLEEP_COUNT"
+if [ "$count" -eq "$FM_FAKE_EXIT_ON_SLEEP" ]; then
+  printf 'zsh\n' > "$FM_FAKE_COMM_FILE"
+fi
+SH
+  chmod +x "$fb/sleep"
+
+  printf 'node\n' > "$comm"
+  : > "$log"
+  : > "$sleep_count"
+  verdict=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    FM_FAKE_WINDOWS=win FM_FAKE_COMM_FILE="$comm" FM_FAKE_SEND_LOG="$log" \
+    FM_FAKE_SLEEP_COUNT="$sleep_count" FM_FAKE_EXIT_ON_SLEEP=1 \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_send_text_submit tmux sess:win steer 3 0 0' "$ROOT")
+  [ "$verdict" = send-failed ] || fail "Cursor exit during initial settle returned '$verdict'"
+  grep -F -- 'send-keys -t sess:win -l steer' "$log" >/dev/null \
+    || fail "Cursor settle-exit case never received its literal text"
+  if grep -F -- 'send-keys -t sess:win Enter' "$log" >/dev/null; then
+    fail "Cursor exit during initial settle received Enter at its shell"
+  fi
+
+  printf 'node\n' > "$comm"
+  : > "$log"
+  : > "$sleep_count"
+  verdict=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    FM_FAKE_WINDOWS=win FM_FAKE_COMM_FILE="$comm" FM_FAKE_SEND_LOG="$log" \
+    FM_FAKE_SLEEP_COUNT="$sleep_count" FM_FAKE_EXIT_ON_SLEEP=2 \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_send_text_submit tmux sess:win steer 3 0 0' "$ROOT")
+  [ "$verdict" = send-failed ] || fail "Cursor crash during Enter settle returned '$verdict'"
+  [ "$(grep -Fc -- 'send-keys -t sess:win Enter' "$log")" -eq 1 ] \
+    || fail "Cursor crash during Enter settle did not stop after one Enter"
+  pass "tmux submit rechecks Cursor liveness during settle and confirmation"
+}
+
 test_busy_signature_matches_only_the_composer_anchored_hint
 test_busy_signature_is_not_shared_across_harnesses
 test_busy_signature_survives_tool_execution_rendering
@@ -440,5 +495,6 @@ test_conflicting_markers_use_nearest_ancestry
 test_cursor_is_an_accepted_configured_crew_harness
 test_agent_liveness_states
 test_backend_input_boundary_rejects_dead_and_missing_agents
+test_submit_rechecks_liveness_during_settle
 
 echo "# all fm-cursor-harness tests passed"

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -498,6 +498,23 @@ SH
   [ "$(grep -Fc -- 'send-keys -t sess:win Enter' "$log")" -eq 1 ] \
     || fail "authorized Cursor lifecycle exit did not submit exactly once"
 
+  # Clearing the composer is not enough to prove `/exit` worked. Cursor can
+  # accept the bytes as ordinary message text (for example after pending input)
+  # and leave the agent alive. Cursor lifecycle mode must wait for the
+  # authoritative dead/missing postcondition and fail if it never arrives.
+  printf 'node\n' > "$comm"
+  : > "$log"
+  : > "$sleep_count"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" \
+    FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 FM_FAKE_WINDOWS=win \
+    FM_FAKE_COMM_FILE="$comm" FM_FAKE_SEND_LOG="$log" \
+    FM_FAKE_SLEEP_COUNT="$sleep_count" FM_FAKE_EXIT_ON_SLEEP=99 \
+    FM_SEND_SLEEP=0 FM_SEND_SETTLE=0 FM_GATE_REFUSE_BYPASS=1 \
+    "$ROOT/bin/fm-send.sh" exit --lifecycle-exit /exit >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "Cursor lifecycle exit accepted an empty composer while the agent stayed alive"
+  [ "$(grep -Fc -- 'send-keys -t sess:win Enter' "$log")" -eq 1 ] \
+    || fail "Cursor lifecycle exit retried Enter while waiting for process death"
+
   printf 'node\n' > "$comm"
   : > "$log"
   : > "$sleep_count"
@@ -523,6 +540,54 @@ SH
   pass "tmux submit rechecks Cursor liveness during settle and confirmation"
 }
 
+test_fm_send_waits_for_cursor_delayed_submit_ack() {
+  local dir fb pane idle_pane log sleep_count home err rc
+  dir="$TMP_ROOT/delayed-submit-ack"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  pane="$dir/pane.txt"
+  idle_pane="$dir/idle-pane.txt"
+  log="$dir/send.log"
+  sleep_count="$dir/sleep-count"
+  home="$dir/home"
+  err="$dir/send.err"
+  mkdir -p "$home/state"
+  fm_write_meta "$home/state/delayed.meta" "window=sess:win" "kind=ship" "harness=cursor"
+
+  # Live cursor-agent 2026.07.23-e383d2b accepted one correctly settled Enter
+  # while leaving the submitted text painted for more than three seconds. The
+  # old three-check default returned `pending` before the turn started. Model
+  # that delayed redraw by keeping the real text visible through six post-Enter
+  # checks, then exposing the verified idle placeholder.
+  make_pane_file "$pane" "$ARROW steer"
+  make_pane_file "$idle_pane" "$(idle_composer_row A 'dd a follow-up')"
+  cat > "$fb/sleep" <<'SH'
+#!/usr/bin/env bash
+count=0
+[ ! -f "$FM_FAKE_SLEEP_COUNT" ] || count=$(cat "$FM_FAKE_SLEEP_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" > "$FM_FAKE_SLEEP_COUNT"
+if [ "$count" -eq "$FM_FAKE_ACK_ON_SLEEP" ]; then
+  cp "$FM_FAKE_IDLE_PANE" "$FM_FAKE_STYLED"
+fi
+SH
+  chmod +x "$fb/sleep"
+
+  : > "$log"
+  : > "$sleep_count"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" \
+    FM_FAKE_STYLED="$pane" FM_FAKE_IDLE_PANE="$idle_pane" FM_FAKE_CY=10 \
+    FM_FAKE_WINDOWS=win FM_FAKE_COMM=node FM_FAKE_SEND_LOG="$log" \
+    FM_FAKE_SLEEP_COUNT="$sleep_count" FM_FAKE_ACK_ON_SLEEP=8 \
+    FM_SEND_SETTLE=0 \
+    "$ROOT/bin/fm-send.sh" delayed steer >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -eq 0 ] || fail "Cursor delayed submit acknowledgement failed: $(tail -1 "$err")"
+  [ "$(grep -Fc -- 'send-keys -t sess:win -l steer' "$log")" -eq 1 ] \
+    || fail "Cursor delayed acknowledgement retyped the steer"
+  [ "$(grep -Fc -- 'send-keys -t sess:win Enter' "$log")" -eq 1 ] \
+    || fail "Cursor delayed acknowledgement retried Enter instead of polling"
+  pass "fm-send waits through Cursor's delayed submit acknowledgement with one Enter and one typed steer"
+}
+
 test_busy_signature_matches_only_the_composer_anchored_hint
 test_busy_signature_is_not_shared_across_harnesses
 test_busy_signature_survives_tool_execution_rendering
@@ -539,5 +604,6 @@ test_cursor_is_an_accepted_configured_crew_harness
 test_agent_liveness_states
 test_backend_input_boundary_rejects_dead_and_missing_agents
 test_submit_rechecks_liveness_during_settle
+test_fm_send_waits_for_cursor_delayed_submit_ack
 
 echo "# all fm-cursor-harness tests passed"

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# Behavior tests for the verified Cursor CLI (`cursor-agent`) crewmate adapter.
+#
+# Fixtures reproduce the rendering observed live on cursor-agent
+# 2026.07.23-e383d2b under tmux 3.7b. Two of cursor's properties are unlike every
+# previously verified adapter and are what these tests exist to pin:
+#
+#   1. Its composer is BARE (no box) and it draws its OWN block cursor, leaving
+#      the terminal cursor parked on a blank row well below the composer. A
+#      cursor-anchored read therefore inspects a blank row and reports "empty"
+#      while real text sits unsubmitted - the false-empty that lets the away-mode
+#      injector type over live input and lets the submit core report a swallowed
+#      Enter as delivered.
+#   2. Its whole EMPTY composer is de-emphasised - agent glyph and placeholder
+#      alike - with the self-drawn block cursor rendering one placeholder
+#      character at normal intensity in reverse video. Ghost stripping correctly
+#      removes everything else, so that single leftover character would read as
+#      real typed input on every idle pane.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LIB="$ROOT/bin/fm-tmux-lib.sh"
+TMUX_BACKEND="$ROOT/bin/backends/tmux.sh"
+HARNESS="$ROOT/bin/fm-harness.sh"
+
+# shellcheck source=/dev/null
+. "$LIB"
+
+TMP_ROOT=$(fm_test_tmproot fm-cursor-harness)
+
+ARROW=$(printf '\xe2\x86\x92')   # U+2192, cursor-agent's composer glyph
+
+# The live idle composer row: a background band, a DIM glyph, one reverse-video
+# block-cursor character at normal intensity, then the DIM remainder of the
+# placeholder.
+idle_composer_row() {  # <placeholder-first-char> <placeholder-rest>
+  printf '\033[48;2;21;21;21m \033[2m%s \033[0;7m\033[48;2;21;21;21m%s\033[0;2m\033[48;2;21;21;21m%s\033[0m\033[49m' \
+    "$ARROW" "$1" "$2"
+}
+
+# A full visible pane whose composer sits well above the parked terminal cursor.
+make_pane_file() {  # <file> <composer-row-styled> [extra-trailing-blank-rows]
+  local file=$1 composer=$2 blanks=${3:-6} i
+  {
+    printf '  Cursor Agent\n'
+    printf '  v2026.07.23-e383d2b\n'
+    printf '\n'
+    printf '  1. One is where everything starts.\n'
+    printf '\n'
+    printf '%s\n' "$composer"
+    printf '\n'
+    printf '  Opus 5 300K Low                     Run Everything\n'
+    printf '  /tmp/repo %s main\n' '·'
+    i=0
+    while [ "$i" -lt "$blanks" ]; do printf '\n'; i=$((i + 1)); done
+  } > "$file"
+}
+
+# A fake tmux serving one styled pane file, with the terminal cursor parked on a
+# blank row (FM_FAKE_CY), exactly as cursor-agent leaves it.
+make_fake_tmux() {  # <dir>
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  display-message)
+    for a in "$@"; do
+      case "$a" in
+        *cursor_y*) printf '%s\n' "${FM_FAKE_CY:-0}"; exit 0 ;;
+        *pane_current_command*) printf '%s\n' "${FM_FAKE_COMM:-node}"; exit 0 ;;
+      esac
+    done
+    printf 'fakepane\n'; exit 0 ;;
+  capture-pane)
+    has_e=0
+    start= end= prev=
+    for a in "$@"; do
+      [ "$a" = "-e" ] && has_e=1
+      case "$prev" in
+        -S) start=$a ;;
+        -E) end=$a ;;
+      esac
+      prev=$a
+    done
+    f="${FM_FAKE_STYLED:-/dev/null}"
+    if [ -n "$start" ] && [ "$start" = "$end" ]; then
+      # Single-row read at the parked cursor row.
+      LC_ALL=C sed -n "$((start + 1))p" "$f" 2>/dev/null
+      exit 0
+    fi
+    if [ "$has_e" = 1 ]; then
+      cat "$f" 2>/dev/null
+    else
+      LC_ALL=C awk '{gsub(/\033\[[0-9;:]*m/, ""); print}' "$f" 2>/dev/null
+    fi
+    exit 0 ;;
+  list-windows) printf '%s\n' "${FM_FAKE_WINDOWS:-fakepane}"; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fb/tmux"
+  printf '%s\n' "$fb"
+}
+
+# --- busy signature ---------------------------------------------------------
+
+test_busy_signature_matches_only_the_composer_anchored_hint() {
+  local busy_row idle_row devserver
+  busy_row="  $ARROW Add a follow-up                            ctrl+c to stop"
+  idle_row="  $ARROW Add a follow-up"
+  # A dev server's own hint: the same words, NOT in cursor's composer row.
+  devserver="  Press Ctrl+C to stop"
+
+  printf '%s\n' "$busy_row" | fm_busy_lines_match cursor \
+    || fail "cursor busy composer row was not recognised as busy"
+  printf '%s\n' "$idle_row" | fm_busy_lines_match cursor \
+    && fail "cursor idle composer row was wrongly recognised as busy"
+  printf '%s\n' "$devserver" | fm_busy_lines_match cursor \
+    && fail "a dev server's 'Press Ctrl+C to stop' must not read as a busy cursor turn"
+  pass "cursor busy signature matches its composer-anchored hint, not the bare phrase"
+}
+
+test_busy_signature_is_not_shared_across_harnesses() {
+  local busy_row
+  busy_row="  $ARROW Add a follow-up                            ctrl+c to stop"
+  # Like claude's and kimi's, cursor's signature stays out of the shared default,
+  # so an unrecorded harness never borrows it.
+  printf '%s\n' "$busy_row" | fm_busy_lines_match '' \
+    && fail "cursor's signature must not be in the shared unrecorded-harness default"
+  printf '%s\n' "$busy_row" | fm_busy_lines_match grok \
+    && fail "grok must not borrow cursor's busy signature"
+  # And cursor must not borrow anyone else's.
+  printf '%s\n' '  esc to interrupt' | fm_busy_lines_match cursor \
+    && fail "cursor must not borrow claude/codex's busy signature"
+  pass "cursor's busy signature is neither borrowed nor lent"
+}
+
+test_busy_signature_survives_tool_execution_rendering() {
+  local busy_row
+  # During a shell tool the spinner WORD changes (Working -> Running) while the
+  # composer hint is unchanged, which is why the word is never the signature.
+  busy_row="  $ARROW Add a follow-up                            ctrl+c to stop"
+  printf ' %s Running  114 tokens\n%s\n' "$(printf '\xe2\xa0\xa0\xe2\xa0\x9b')" "$busy_row" \
+    | fm_busy_lines_match cursor \
+    || fail "cursor busy signature lost during tool execution"
+  printf ' %s Running  114 tokens\n' "$(printf '\xe2\xa0\xa0\xe2\xa0\x9b')" \
+    | fm_busy_lines_match cursor \
+    && fail "the rotating spinner word must not be treated as the signature"
+  pass "cursor busy signature holds across tool execution and ignores the spinner word"
+}
+
+# --- composer classification ------------------------------------------------
+
+test_parked_cursor_idle_composer_reads_empty() {
+  local dir fb pane state
+  dir="$TMP_ROOT/idle"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  pane="$dir/pane.txt"
+  make_pane_file "$pane" "$(idle_composer_row A 'dd a follow-up')"
+  # Row 5 is the composer; the terminal cursor is parked on blank row 10.
+  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    fm_tmux_composer_state "fakepane")
+  [ "$state" = empty ] || fail "idle cursor composer read '$state', expected empty"
+  pass "an idle cursor composer reads empty despite its self-drawn block cursor"
+}
+
+test_parked_cursor_fresh_launch_placeholder_reads_empty() {
+  local dir fb pane state
+  dir="$TMP_ROOT/idle-fresh"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  pane="$dir/pane.txt"
+  # The other placeholder cursor-agent shows, on a never-used session.
+  make_pane_file "$pane" "$(idle_composer_row P 'lan, search, build anything')"
+  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    fm_tmux_composer_state "fakepane")
+  [ "$state" = empty ] || fail "fresh-launch cursor composer read '$state', expected empty"
+  pass "a fresh-launch cursor composer placeholder reads empty"
+}
+
+test_parked_cursor_pending_text_is_not_missed() {
+  local dir fb pane state
+  dir="$TMP_ROOT/pending"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  pane="$dir/pane.txt"
+  # Real typed text: cursor-agent renders the glyph and the text at NORMAL
+  # intensity, and the placeholder is gone.
+  make_pane_file "$pane" "  $ARROW unsubmitted instruction"
+  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    fm_tmux_composer_state "fakepane")
+  [ "$state" = pending ] || fail "unsubmitted cursor text read '$state', expected pending"
+  PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    fm_pane_input_pending "fakepane" \
+    || fail "unsubmitted cursor text was not treated as pending input"
+  pass "unsubmitted text in a parked-cursor composer is never read as empty"
+}
+
+test_busy_cursor_composer_still_reads_empty() {
+  local dir fb pane state
+  dir="$TMP_ROOT/busy-composer"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  pane="$dir/pane.txt"
+  # Mid-turn the placeholder row gains a right-aligned stop hint; it is still an
+  # empty composer, so a queued steer must not be deferred forever.
+  make_pane_file "$pane" \
+    "$(idle_composer_row A 'dd a follow-up')                    ctrl+c to stop"
+  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    fm_tmux_composer_state "fakepane")
+  [ "$state" = empty ] || fail "busy cursor composer read '$state', expected empty"
+  pass "a busy cursor composer row still reads empty"
+}
+
+test_blank_cursor_row_without_a_cursor_composer_is_unchanged() {
+  local dir fb pane state
+  dir="$TMP_ROOT/no-composer"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  pane="$dir/pane.txt"
+  # No cursor-agent composer anywhere: the bare-row fallback must behave exactly
+  # as it did before, so no already-verified adapter changes behaviour.
+  make_pane_file "$pane" "  ordinary agent output line"
+  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    fm_tmux_composer_state "fakepane")
+  [ "$state" = empty ] || fail "blank cursor row without a cursor composer read '$state'"
+  pass "a blank cursor row with no cursor composer keeps the pre-existing verdict"
+}
+
+test_bare_arrow_glyph_is_an_agent_composer_not_a_dead_shell() {
+  local state
+  # Bare `→` is cursor's own prompt glyph, so it is a genuine empty agent
+  # composer - unlike the shell glyphs, which stay `unknown` on a bare row.
+  state=$(fm_composer_classify_content 0 "$ARROW")
+  [ "$state" = empty ] || fail "bare cursor glyph read '$state', expected empty"
+  state=$(fm_composer_classify_content 0 '$')
+  [ "$state" = unknown ] || fail "dead-shell rule regressed: bare '\$' read '$state'"
+  state=$(fm_composer_classify_content 0 '>')
+  [ "$state" = unknown ] || fail "dead-shell rule regressed: bare '>' read '$state'"
+  pass "the bare cursor glyph is an agent composer while shell glyphs stay unknown"
+}
+
+test_placeholder_rule_does_not_swallow_real_text() {
+  local state
+  # The placeholder rule is anchored to the glyph and the exact placeholder, so
+  # text that merely mentions it is still pending.
+  state=$(fm_composer_classify_content 0 "$ARROW please add a follow-up test")
+  [ "$state" = pending ] || fail "real text mentioning the placeholder read '$state'"
+  pass "the cursor placeholder rule does not swallow real typed text"
+}
+
+# --- harness detection ------------------------------------------------------
+
+test_env_marker_detects_cursor() {
+  local out
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT CURSOR_AGENT=1 "$HARNESS")
+  [ "$out" = cursor ] || fail "CURSOR_AGENT=1 detected as '$out', expected cursor"
+  pass "fm-harness detects cursor from its CURSOR_AGENT marker"
+}
+
+test_cursor_is_an_accepted_configured_crew_harness() {
+  local dir out
+  dir="$TMP_ROOT/crew-config"; mkdir -p "$dir/config"
+  printf 'cursor\n' > "$dir/config/crew-harness"
+  out=$(FM_CONFIG_OVERRIDE="$dir/config" "$HARNESS" crew)
+  [ "$out" = cursor ] || fail "configured crew harness resolved to '$out', expected cursor"
+  out=$(FM_CONFIG_OVERRIDE="$dir/config" "$HARNESS" secondmate)
+  [ "$out" = cursor ] || fail "secondmate fallback resolved to '$out', expected cursor"
+  pass "cursor resolves as a configured crewmate and secondmate harness"
+}
+
+# --- tmux agent liveness ----------------------------------------------------
+
+test_agent_liveness_states() {
+  local dir fb state
+  dir="$TMP_ROOT/liveness"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+
+  agent_state() {  # <fake-pane-current-command>
+    PATH="$fb:$PATH" FM_BACKEND_LIB_DIR="$ROOT/bin" FM_FAKE_WINDOWS=win FM_FAKE_COMM="$1" \
+      bash -c '. "$0"; fm_backend_tmux_agent_state "sess:win"' "$TMUX_BACKEND"
+  }
+
+  state=$(agent_state 'cursor-agent')
+  [ "$state" = alive ] || fail "a reported cursor-agent command read '$state', expected alive"
+
+  # The verified local reality: tmux resolves the pane to the bundled `node`, so
+  # a live cursor pane is `ambiguous` - preserved, never relaunched.
+  state=$(agent_state 'node')
+  [ "$state" = ambiguous ] || fail "a live cursor pane reporting node read '$state', expected ambiguous"
+
+  # Death detection is unaffected: an exited cursor pane falls back to the shell.
+  state=$(agent_state 'zsh')
+  [ "$state" = dead ] || fail "an exited cursor pane read '$state', expected dead"
+  pass "cursor pane liveness: alive when named, ambiguous as node, dead on the shell"
+}
+
+test_busy_signature_matches_only_the_composer_anchored_hint
+test_busy_signature_is_not_shared_across_harnesses
+test_busy_signature_survives_tool_execution_rendering
+test_parked_cursor_idle_composer_reads_empty
+test_parked_cursor_fresh_launch_placeholder_reads_empty
+test_parked_cursor_pending_text_is_not_missed
+test_busy_cursor_composer_still_reads_empty
+test_blank_cursor_row_without_a_cursor_composer_is_unchanged
+test_bare_arrow_glyph_is_an_agent_composer_not_a_dead_shell
+test_placeholder_rule_does_not_swallow_real_text
+test_env_marker_detects_cursor
+test_cursor_is_an_accepted_configured_crew_harness
+test_agent_liveness_states
+
+echo "# all fm-cursor-harness tests passed"

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -396,6 +396,32 @@ test_backend_input_boundary_rejects_dead_and_missing_agents() {
     bash -c '. "$0/bin/fm-backend.sh"; fm_backend_send_text_submit tmux sess:win steer 1 0 0' "$ROOT")
   [ "$verdict" = send-failed ] || fail "missing cursor target steer returned '$verdict'"
   [ ! -s "$log" ] || fail "missing cursor target received tmux input"
+
+  if PATH="$fb:$PATH" FM_FAKE_WINDOWS=win FM_FAKE_COMM=zsh FM_FAKE_SEND_LOG="$log" \
+      bash -c '. "$0/bin/fm-backend.sh"; fm_backend_send_operator_key tmux sess:win Enter' "$ROOT"; then
+    fail "dead cursor shell accepted an operator key"
+  fi
+  [ ! -s "$log" ] || fail "dead cursor shell received an operator key"
+
+  if PATH="$fb:$PATH" FM_FAKE_WINDOWS=other FM_FAKE_COMM=node FM_FAKE_SEND_LOG="$log" \
+      bash -c '. "$0/bin/fm-backend.sh"; fm_backend_send_operator_key tmux sess:win Enter' "$ROOT"; then
+    fail "missing cursor target accepted an operator key"
+  fi
+  [ ! -s "$log" ] || fail "missing cursor target received an operator key"
+
+  PATH="$fb:$PATH" FM_FAKE_WINDOWS=win FM_FAKE_COMM=node FM_FAKE_SEND_LOG="$log" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_send_operator_key tmux sess:win Enter' "$ROOT" \
+    || fail "live ambiguous cursor target refused an operator key"
+  grep -F -- 'send-keys -t sess:win Enter' "$log" >/dev/null \
+    || fail "live ambiguous cursor operator key never reached tmux"
+
+  : > "$log"
+  PATH="$fb:$PATH" FM_BACKEND_LIB_DIR="$ROOT/bin" \
+    FM_FAKE_WINDOWS=win FM_FAKE_COMM=zsh FM_FAKE_SEND_LOG="$log" \
+    bash -c '. "$0/bin/backends/tmux.sh"; fm_backend_tmux_send_key sess:win Enter' "$ROOT" \
+    || fail "raw tmux key primitive refused a lifecycle key"
+  grep -F -- 'send-keys -t sess:win Enter' "$log" >/dev/null \
+    || fail "raw tmux lifecycle key never reached tmux"
   pass "tmux input boundary rejects dead and missing agents but preserves live cursor steering"
 }
 

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -29,6 +29,7 @@ HARNESS="$ROOT/bin/fm-harness.sh"
 . "$LIB"
 
 TMP_ROOT=$(fm_test_tmproot fm-cursor-harness)
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 
 ARROW=$(printf '\xe2\x86\x92')   # U+2192, cursor-agent's composer glyph
 
@@ -67,6 +68,11 @@ make_fake_tmux() {  # <dir>
 #!/usr/bin/env bash
 set -u
 case "${1:-}" in
+  send-keys)
+    if [ -n "${FM_FAKE_SEND_LOG:-}" ]; then
+      printf '%s\n' "$*" >> "$FM_FAKE_SEND_LOG"
+    fi
+    exit 0 ;;
   display-message)
     for a in "$@"; do
       case "$a" in
@@ -103,6 +109,29 @@ esac
 exit 1
 SH
   chmod +x "$fb/tmux"
+  cat > "$fb/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field=
+pid=
+prev=
+for arg in "$@"; do
+  [ "$prev" = -o ] && field=$arg
+  [ "$prev" = -p ] && pid=$arg
+  prev=$arg
+done
+case "${FM_FAKE_ANCESTRY:-unknown}:$field:$pid" in
+  cursor:comm=:4242) printf '/opt/cursor/bin/cursor-agent\n' ;;
+  claude:comm=:4242) printf '/opt/claude/bin/claude\n' ;;
+  unknown:comm=:*) printf '/bin/bash\n' ;;
+  *:comm=:*) printf '/bin/bash\n' ;;
+  unknown:ppid=:*) printf '1\n' ;;
+  *:ppid=:4242) printf '1\n' ;;
+  *:ppid=:*) printf '4242\n' ;;
+  *:args=:*) printf '/bin/bash\n' ;;
+esac
+SH
+  chmod +x "$fb/ps"
   printf '%s\n' "$fb"
 }
 
@@ -241,12 +270,20 @@ test_bare_arrow_glyph_is_an_agent_composer_not_a_dead_shell() {
 }
 
 test_placeholder_rule_does_not_swallow_real_text() {
-  local state
-  # The placeholder rule is anchored to the glyph and the exact placeholder, so
-  # text that merely mentions it is still pending.
-  state=$(fm_composer_classify_content 0 "$ARROW please add a follow-up test")
-  [ "$state" = pending ] || fail "real text mentioning the placeholder read '$state'"
-  pass "the cursor placeholder rule does not swallow real typed text"
+  local content state
+  for content in \
+    "$ARROW Add a follow-up test" \
+    "$ARROW Add a follow-up" \
+    "$ARROW Plan, search, build anything now" \
+    "$ARROW Plan, search, build anything"; do
+    state=$(fm_composer_classify_content 0 "$content")
+    [ "$state" = pending ] \
+      || fail "real text matching or extending a placeholder read '$state': $content"
+  done
+  state=$(fm_composer_classify_content 0 B '' sensitive "$ARROW Add a follow-up")
+  [ "$state" = pending ] \
+    || fail "placeholder shape with the wrong ghost-stripped remnant read '$state'"
+  pass "cursor placeholders require exact shape, styling, and block-cursor remnant"
 }
 
 # --- harness detection ------------------------------------------------------
@@ -256,6 +293,30 @@ test_env_marker_detects_cursor() {
   out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT CURSOR_AGENT=1 "$HARNESS")
   [ "$out" = cursor ] || fail "CURSOR_AGENT=1 detected as '$out', expected cursor"
   pass "fm-harness detects cursor from its CURSOR_AGENT marker"
+}
+
+test_conflicting_markers_use_nearest_ancestry() {
+  local dir fb out
+  dir="$TMP_ROOT/marker-conflict"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+
+  out=$(env -u PI_CODING_AGENT -u GROK_AGENT \
+    PATH="$fb:$BASE_PATH" FM_FAKE_ANCESTRY=cursor CLAUDECODE=1 CURSOR_AGENT=1 "$HARNESS")
+  [ "$out" = cursor ] || fail "nearest cursor ancestry resolved as '$out'"
+  out=$(env -u PI_CODING_AGENT -u GROK_AGENT \
+    PATH="$fb:$BASE_PATH" FM_FAKE_ANCESTRY=claude CLAUDECODE=1 CURSOR_AGENT=1 "$HARNESS")
+  [ "$out" = claude ] || fail "nearest claude ancestry resolved as '$out'"
+  out=$(env -u PI_CODING_AGENT -u GROK_AGENT \
+    PATH="$fb:$BASE_PATH" FM_FAKE_ANCESTRY=unknown CLAUDECODE=1 CURSOR_AGENT=1 "$HARNESS")
+  [ "$out" = unknown ] || fail "inconclusive conflicting markers resolved as '$out'"
+
+  out=$(env -u PI_CODING_AGENT -u GROK_AGENT -u CURSOR_AGENT \
+    PATH="$fb:$BASE_PATH" FM_FAKE_ANCESTRY=cursor CLAUDECODE=1 "$HARNESS")
+  [ "$out" = claude ] || fail "unambiguous claude marker resolved as '$out'"
+  out=$(env -u PI_CODING_AGENT -u GROK_AGENT -u CLAUDECODE \
+    PATH="$fb:$BASE_PATH" FM_FAKE_ANCESTRY=claude CURSOR_AGENT=1 "$HARNESS")
+  [ "$out" = cursor ] || fail "unambiguous cursor marker resolved as '$out'"
+  pass "conflicting markers use nearest ancestry and fail closed when inconclusive"
 }
 
 test_cursor_is_an_accepted_configured_crew_harness() {
@@ -295,6 +356,49 @@ test_agent_liveness_states() {
   pass "cursor pane liveness: alive when named, ambiguous as node, dead on the shell"
 }
 
+test_backend_input_boundary_rejects_dead_and_missing_agents() {
+  local dir fb pane log state verdict
+  dir="$TMP_ROOT/input-boundary"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  pane="$dir/pane.txt"
+  log="$dir/send.log"
+  make_pane_file "$pane" "$(idle_composer_row A 'dd a follow-up')"
+  : > "$log"
+
+  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    FM_FAKE_WINDOWS=win FM_FAKE_COMM=node \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_composer_state tmux sess:win' "$ROOT")
+  [ "$state" = empty ] || fail "live ambiguous cursor composer read '$state'"
+  verdict=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    FM_FAKE_WINDOWS=win FM_FAKE_COMM=node FM_FAKE_SEND_LOG="$log" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_send_text_submit tmux sess:win steer 1 0 0' "$ROOT")
+  [ "$verdict" = empty ] || fail "live ambiguous cursor steer returned '$verdict'"
+  [ -s "$log" ] || fail "live ambiguous cursor steer never reached tmux"
+
+  : > "$log"
+  make_pane_file "$pane" '❯'
+  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    FM_FAKE_WINDOWS=win FM_FAKE_COMM=zsh \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_composer_state tmux sess:win' "$ROOT")
+  [ "$state" = unknown ] || fail "dead cursor shell composer read '$state'"
+  verdict=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    FM_FAKE_WINDOWS=win FM_FAKE_COMM=zsh FM_FAKE_SEND_LOG="$log" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_send_text_submit tmux sess:win steer 1 0 0' "$ROOT")
+  [ "$verdict" = send-failed ] || fail "dead cursor shell steer returned '$verdict'"
+  [ ! -s "$log" ] || fail "dead cursor shell received tmux input"
+
+  state=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    FM_FAKE_WINDOWS=other FM_FAKE_COMM=node \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_composer_state tmux sess:win' "$ROOT")
+  [ "$state" = unknown ] || fail "missing cursor target composer read '$state'"
+  verdict=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$pane" FM_FAKE_CY=10 \
+    FM_FAKE_WINDOWS=other FM_FAKE_COMM=node FM_FAKE_SEND_LOG="$log" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_send_text_submit tmux sess:win steer 1 0 0' "$ROOT")
+  [ "$verdict" = send-failed ] || fail "missing cursor target steer returned '$verdict'"
+  [ ! -s "$log" ] || fail "missing cursor target received tmux input"
+  pass "tmux input boundary rejects dead and missing agents but preserves live cursor steering"
+}
+
 test_busy_signature_matches_only_the_composer_anchored_hint
 test_busy_signature_is_not_shared_across_harnesses
 test_busy_signature_survives_tool_execution_rendering
@@ -306,7 +410,9 @@ test_blank_cursor_row_without_a_cursor_composer_is_unchanged
 test_bare_arrow_glyph_is_an_agent_composer_not_a_dead_shell
 test_placeholder_rule_does_not_swallow_real_text
 test_env_marker_detects_cursor
+test_conflicting_markers_use_nearest_ancestry
 test_cursor_is_an_accepted_configured_crew_harness
 test_agent_liveness_states
+test_backend_input_boundary_rejects_dead_and_missing_agents
 
 echo "# all fm-cursor-harness tests passed"

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1504,12 +1504,14 @@ test_fm_send_exits_nonzero_on_confirmed_swallow() {
   fakebin="$dir/fakebin"; err="$dir/send.err"
   # Clean submit -> exit 0.
   PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$dir/state" FM_FAKE_COMPOSER="$dir/composer" \
+    FM_FAKE_TMUX_WINDOW=win \
     FM_SEND_SLEEP=0.05 "$ROOT/bin/fm-send.sh" sess:win 'route this work' >/dev/null 2>"$err" \
     || fail "fm-send exited non-zero on a clean submit: $(cat "$err")"
   # Persistent swallow -> exit non-zero with a clear message.
   printf '╭─────╮\n│ >   │\n╰─────╯\n' > "$dir/composer"
   touch "$dir/.swallow"
   if PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$dir/state" FM_FAKE_COMPOSER="$dir/composer" \
+    FM_FAKE_TMUX_WINDOW=win \
     FM_FAKE_SWALLOW="$dir/.swallow" FM_FAKE_PERSIST_SWALLOW=1 FM_SEND_SLEEP=0.05 \
     "$ROOT/bin/fm-send.sh" sess:win 'fix findings 1 and 3, skip 2' >/dev/null 2>"$err"; then
     fail "fm-send exited zero despite a swallowed Enter (silent unsubmitted instruction)"
@@ -1523,6 +1525,7 @@ test_fm_send_exits_nonzero_on_initial_send_failure() {
   dir=$(make_bordered_case send-type-failure)
   fakebin="$dir/fakebin"; err="$dir/send.err"
   if PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$dir/state" FM_FAKE_COMPOSER="$dir/composer" \
+    FM_FAKE_TMUX_WINDOW=win \
     FM_FAKE_SEND_FAIL=1 FM_SEND_SLEEP=0.05 \
     "$ROOT/bin/fm-send.sh" sess:win 'route this work' >/dev/null 2>"$err"; then
     fail "fm-send exited zero despite initial tmux send-keys failure"
@@ -1537,6 +1540,7 @@ test_fm_send_exits_nonzero_on_unproven_submit() {
   fakebin="$dir/fakebin"; err="$dir/send.err"
   touch "$dir/.swallow"
   if PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$dir/state" FM_FAKE_COMPOSER="$dir/composer" \
+    FM_FAKE_TMUX_WINDOW=win \
     FM_FAKE_SWALLOW="$dir/.swallow" FM_FAKE_PERSIST_SWALLOW=1 FM_SEND_SLEEP=0.05 \
     "$ROOT/bin/fm-send.sh" sess:win '修复' >/dev/null 2>"$err"; then
     fail "fm-send exited zero when submit proof remained pending-unproven"

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -224,9 +224,15 @@ case "${1:-}" in
     printf 'send-keys target=%s literal=%s arg=%s\n' "$target" "$literal" "${1:-}" >> "$FM_TMUX_LOG"
     exit 0 ;;
   display-message)
-    for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
+    for a in "$@"; do
+      case "$a" in
+        *cursor_y*) printf '1\n'; exit 0 ;;
+        *pane_current_command*) printf 'node\n'; exit 0 ;;
+      esac
+    done
     printf '%%1\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
+  list-windows) printf 'fm-lane-ok\n'; exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -71,10 +71,13 @@ fake_cursor_y() {
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "$FM_FAKE_PANE_PATH"; exit 0 ;;
   *"#{cursor_y}"*) fake_cursor_y; exit 0 ;;
+  *"#{pane_current_command}"*) printf 'kimi\n'; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows)
+    [ -z "$state" ] || printf '%s\n' "$FM_FAKE_TASK_WINDOW"
+    exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
   send-keys)
     prev=
@@ -180,6 +183,7 @@ run_spawn() {
     FM_FAKE_KIMI_SWALLOWED="$case_dir/kimi.swallowed" \
     FM_FAKE_KIMI_SWALLOW_FIRST="${FM_FAKE_KIMI_SWALLOW_FIRST:-no}" \
     FM_FAKE_TMUX_CALL_LOG="$case_dir/tmux-calls.log" \
+    FM_FAKE_TASK_WINDOW="fm-$id" \
     FM_FAKE_BRIEF_REAL="$(cd "$home/data/$id" && pwd -P)/brief.md" \
     FM_KIMI_READY_POLLS=2 FM_KIMI_DELIVERY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
     PATH="$fakebin:$BASE_PATH" \

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -59,10 +59,17 @@ case "${1:-}" in
     fi
     exit 0 ;;
   display-message)
-    for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
+    for a in "$@"; do
+      case "$a" in
+        *cursor_y*) printf '1\n'; exit 0 ;;
+        *pane_current_command*) printf 'node\n'; exit 0 ;;
+      esac
+    done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows)
+    printf '%s\n' fm-build fm-hibit fm-resolved fm-escalated fm-domain fm-other
+    exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -920,6 +920,11 @@ if [ -n "${FM_FAKE_TMUX_LOG:-}" ]; then
   printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
 fi
 case "$*" in
+  *list-windows*)
+    state_dir=${FM_STATE_OVERRIDE:-${FM_HOME:?}/state}
+    sed -n 's/^window=[^:]*://p' "$state_dir"/*.meta 2>/dev/null
+    exit 0
+    ;;
   *display-message*'#{pane_current_command}'*) printf '%s\n' codex; exit 0 ;;
   *display-message*'#{pane_id}'*) printf '%s\n' '%1'; exit 0 ;;
   *display-message*'#{cursor_y}'*) printf '%s\n' 0; exit 0 ;;

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -138,7 +138,9 @@ phase_send() {
   : > "$PANE"
   # The meta window (firstmate:fm-design) must win over a foreign same-named
   # window returned by list-windows.
-  PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" FM_FAKE_TMUX_WINDOW="other-session:fm-design" \
+  PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" \
+    FM_FAKE_TMUX_WINDOW="other-session:fm-design" \
+    FM_FAKE_TMUX_SESSION_WINDOWS="fm-design" \
     FM_FAKE_TMUX_LOG="$LOG" FM_FAKE_TMUX_CAPTURE="$PANE" \
     "$ROOT/bin/fm-send.sh" fm-design 'route this work' >/dev/null 2>&1 \
     || fail "fm-send failed for a bare firstmate window with home metadata"

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -299,7 +299,8 @@ if [ -n "${FM_FAKE_TMUX_LOG:-}" ]; then
 fi
 case "$*" in
   list-windows*)
-    sed -n 's/^window=[^:]*://p' "${FM_HOME:?}"/state/*.meta
+    state_dir=${FM_STATE_OVERRIDE:-${FM_HOME:?}/state}
+    sed -n 's/^window=[^:]*://p' "$state_dir"/*.meta
     exit 0
     ;;
   *display-message*'#{pane_current_command}'*) printf '%s\n' codex; exit 0 ;;

--- a/tests/fm-send-popup-settle.test.sh
+++ b/tests/fm-send-popup-settle.test.sh
@@ -14,7 +14,8 @@
 #   $... to claude  -> 0.3  (NOT codex: `$` commonly starts plain text "$5", "$HOME")
 #   $... explicit   -> 0.3  (session:window target has no meta -> harness unknown
 #                            -> non-codex safe default)
-#   plain text      -> 0.3  (fast path)
+#   plain text      -> 0.3  (fast path, except Cursor)
+#   Cursor text     -> 1.2  (its input settle is load-bearing for every message)
 #
 # The popup-settle is the FIRST sleep recorded: fm_tmux_submit_core types the text,
 # then `sleep "$settle"`, then the Enter-retry loop (sleep 0.4 each) and finally
@@ -143,11 +144,9 @@ first_settle 1.2 'codex /command -> long settle (slash unchanged)' codex '/help'
 first_settle 0.3 'codex plain text -> fast path' codex 'just a normal steer'
 
 # Cursor makes the settle load-bearing rather than an optimisation. Verified live
-# on cursor-agent 2026.07.23-e383d2b: with a ZERO settle the Enter arrives in the
-# same input burst as the typed text, cursor submits the message but leaves it
-# sitting in the composer, so the verdict reads `pending` and each retried Enter
-# RE-SUBMITS it - one steer landed four times. Any settle at or above 0.1 gives a
-# clean single submission and an `empty` verdict. Both fm-send paths clear that
-# floor with margin, which is what these two cases pin.
-first_settle 0.3 'cursor plain text -> fast path is still a nonzero settle' cursor 'just a normal steer'
+# on cursor-agent 2026.07.23-e383d2b: zero settle duplicated a steer, and a later
+# loaded run left a plain message unaccepted after the 0.3-second fast settle.
+# The 1.2-second counterfactual submitted once and confirmed cleanly, so every
+# Cursor message uses the longer settle.
+first_settle 1.2 'cursor plain text -> long safety settle' cursor 'just a normal steer'
 first_settle 1.2 'cursor /command -> long settle' cursor '/no-mistakes'

--- a/tests/fm-send-popup-settle.test.sh
+++ b/tests/fm-send-popup-settle.test.sh
@@ -50,10 +50,15 @@ set -u
 case "${1:-}" in
   send-keys) exit 0 ;;
   display-message)
-    for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
+    for a in "$@"; do
+      case "$a" in
+        *cursor_y*) printf '1\n'; exit 0 ;;
+        *pane_current_command*) printf 'node\n'; exit 0 ;;
+      esac
+    done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows) printf 'win\n'; exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-send-popup-settle.test.sh
+++ b/tests/fm-send-popup-settle.test.sh
@@ -136,3 +136,13 @@ first_settle 1.2 'codex /command -> long settle (slash unchanged)' codex '/help'
 
 # Plain text to codex takes the fast path - the codex scope is `$`-prefixed only.
 first_settle 0.3 'codex plain text -> fast path' codex 'just a normal steer'
+
+# Cursor makes the settle load-bearing rather than an optimisation. Verified live
+# on cursor-agent 2026.07.23-e383d2b: with a ZERO settle the Enter arrives in the
+# same input burst as the typed text, cursor submits the message but leaves it
+# sitting in the composer, so the verdict reads `pending` and each retried Enter
+# RE-SUBMITS it - one steer landed four times. Any settle at or above 0.1 gives a
+# clean single submission and an `empty` verdict. Both fm-send paths clear that
+# floor with margin, which is what these two cases pin.
+first_settle 0.3 'cursor plain text -> fast path is still a nonzero settle' cursor 'just a normal steer'
+first_settle 1.2 'cursor /command -> long settle' cursor '/no-mistakes'

--- a/tests/fm-send-secondmate-marker.test.sh
+++ b/tests/fm-send-secondmate-marker.test.sh
@@ -53,10 +53,15 @@ case "${1:-}" in
     fi
     exit 0 ;;
   display-message)
-    for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
+    for a in "$@"; do
+      case "$a" in
+        *cursor_y*) printf '1\n'; exit 0 ;;
+        *pane_current_command*) printf 'node\n'; exit 0 ;;
+      esac
+    done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows) printf '%s\n' fm-domain fm-build win window; exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-send-settle.test.sh
+++ b/tests/fm-send-settle.test.sh
@@ -36,10 +36,15 @@ set -u
 case "${1:-}" in
   send-keys) exit 0 ;;
   display-message)
-    for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
+    for a in "$@"; do
+      case "$a" in
+        *cursor_y*) printf '1\n'; exit 0 ;;
+        *pane_current_command*) printf 'node\n'; exit 0 ;;
+      esac
+    done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows) printf 'win\n'; exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -178,7 +178,24 @@ test_recorded_dead_agent_refuses_before_steering() {
   [ "$rc" -ne 0 ] || fail "recorded dead agent should refuse steering"
   assert_contains "$(cat "$err")" "text not sent" "dead-agent refusal should be explicit"
   [ ! -s "$log" ] || fail "recorded dead agent still received tmux input"$'\n'"$(cat "$log")"
-  pass "fm-send strict: recorded dead agents refuse before steering"
+
+  : > "$log"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_COMM=zsh FM_SEND_SETTLE=0 \
+    "$SEND" fm-dead-agent --key Enter >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "recorded dead agent should refuse key steering"
+  assert_contains "$(cat "$err")" "key 'Enter' not sent" "dead-agent key refusal should be explicit"
+  [ ! -s "$log" ] || fail "recorded dead agent still received a tmux key"$'\n'"$(cat "$log")"
+
+  fm_write_meta "$home/state/missing-agent.meta" "window=sess:fm-missing-agent" "kind=ship" "harness=cursor"
+  : > "$log"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_COMM=node FM_SEND_SETTLE=0 \
+    "$SEND" fm-missing-agent --key Enter >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "missing agent should refuse key steering"
+  assert_contains "$(cat "$err")" "key 'Enter' not sent" "missing-agent key refusal should be explicit"
+  [ ! -s "$log" ] || fail "missing agent still received a tmux key"$'\n'"$(cat "$log")"
+  pass "fm-send strict: dead and missing agents refuse before steering"
 }
 
 test_exact_lane_id_send_still_works

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -36,10 +36,12 @@ case "${1:-}" in
   display-message)
     target=
     cursor=0
+    current=0
     while [ $# -gt 0 ]; do
       case "$1" in
         -t) target=$2; shift 2 ;;
         *cursor_y*) cursor=1; shift ;;
+        *pane_current_command*) current=1; shift ;;
         *) shift ;;
       esac
     done
@@ -47,13 +49,14 @@ case "${1:-}" in
       exit 1
     fi
     [ "$cursor" = 1 ] && { printf '1\n'; exit 0; }
+    [ "$current" = 1 ] && { printf '%s\n' "${FM_FAKE_TMUX_COMM:-node}"; exit 0; }
     printf '%%1\n'
     exit 0 ;;
   capture-pane)
     printf '╭────╮\n│    │\n╰────╯\n'
     exit 0 ;;
   list-windows)
-    printf 'foreign:%s\n' "${FM_FAKE_TMUX_WINDOW:-fm-lost}"
+    printf '%s\n' fm-mpf-lane-m8 fm-lane-ok fm-dead-agent "${FM_FAKE_TMUX_WINDOW:-fm-lost}"
     exit 0 ;;
 esac
 exit 0
@@ -163,9 +166,25 @@ test_healthy_fm_id_send_still_works() {
   pass "fm-send strict: healthy fm-<id> sends still type once and submit"
 }
 
+test_recorded_dead_agent_refuses_before_steering() {
+  local dir fb home err log rc
+  dir="$TMP_ROOT/dead-agent"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home deadagent); err="$dir/send.err"; log="$dir/tmux.log"; : > "$log"
+  fm_write_meta "$home/state/dead-agent.meta" "window=sess:fm-dead-agent" "kind=ship" "harness=cursor"
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_COMM=zsh FM_SEND_SETTLE=0 \
+    "$SEND" fm-dead-agent "do not run in the shell" >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "recorded dead agent should refuse steering"
+  assert_contains "$(cat "$err")" "text not sent" "dead-agent refusal should be explicit"
+  [ ! -s "$log" ] || fail "recorded dead agent still received tmux input"$'\n'"$(cat "$log")"
+  pass "fm-send strict: recorded dead agents refuse before steering"
+}
+
 test_exact_lane_id_send_still_works
 test_unset_fm_home_fails
 test_unresolvable_target_does_not_tmux_fallback
 test_prefixless_herdr_pane_id_fails
 test_unmatched_single_colon_target_must_exist
 test_healthy_fm_id_send_still_works
+test_recorded_dead_agent_refuses_before_steering

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -482,6 +482,49 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   pass "opencode receives --model and omits the unsupported effort axis"
 }
 
+test_cursor_threads_model_and_omits_every_effort_form() {
+  local rec id out status launch
+  id=profile-cursor-z16
+  rec=$(make_spawn_case profile-cursor cursor "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model claude-opus-5-thinking-xhigh --effort xhigh)
+  status=$?
+  expect_code 0 "$status" "cursor spawn with model and recorded-only effort should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" cursor claude-opus-5-thinking-xhigh xhigh
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "cursor-agent --force --trust --model 'claude-opus-5-thinking-xhigh'" \
+    "cursor launch did not thread the model through the verified autonomy and trust flags"
+  # cursor's --help advertises parameterized bracket overrides, but
+  # cursor-agent 2026.07.23-e383d2b rejects them (exit 1) - effort travels in the
+  # model NAME. Nothing effort-shaped may be synthesized onto the launch.
+  assert_not_contains "$launch" "[effort=" "cursor launch must not synthesize a rejected bracket override"
+  assert_not_contains "$launch" "--effort" "cursor launch must not pass claude's effort flag"
+  assert_not_contains "$launch" "--reasoning-effort" "cursor launch must not pass grok's effort flag"
+  assert_not_contains "$launch" "--thinking" "cursor launch must not pass pi's thinking flag"
+  assert_not_contains "$launch" "model_reasoning_effort" "cursor launch must not pass codex's effort config"
+  pass "cursor receives --model and omits every effort form, including the rejected bracket syntax"
+}
+
+test_cursor_always_passes_trust_because_force_alone_blocks() {
+  local rec id out status launch
+  id=profile-cursor-trust-z17
+  rec=$(make_spawn_case profile-cursor-trust cursor "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "cursor spawn without a model should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  # Every pooled worktree is a fresh path, and the interactive TUI blocks on its
+  # "Workspace Trust Required" dialog under --force alone (unlike --print mode),
+  # so an unattended crewmate wedges forever without --trust.
+  assert_contains "$launch" "--force" "cursor launch lost its autonomy flag"
+  assert_contains "$launch" "--trust" "cursor launch lost the trust flag that unblocks a fresh worktree"
+  assert_not_contains "$launch" "--model" "cursor launch must omit --model when none was chosen"
+  pass "cursor launch always carries both --force and --trust"
+}
+
 test_pi_threads_model_and_max_effort() {
   local rec id out status launch
   id=profile-pi-z8
@@ -672,6 +715,8 @@ test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
+test_cursor_threads_model_and_omits_every_effort_form
+test_cursor_always_passes_trust_because_force_alone_blocks
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata

--- a/tests/secondmate-helpers.sh
+++ b/tests/secondmate-helpers.sh
@@ -29,6 +29,13 @@ case "${1:-}" in
     exit 0
     ;;
   list-windows)
+    case "$*" in
+      *'-F #{window_name}'*)
+        [ -z "${FM_FAKE_TMUX_SESSION_WINDOWS:-}" ] \
+          || printf '%s\n' "$FM_FAKE_TMUX_SESSION_WINDOWS"
+        exit 0
+        ;;
+    esac
     if [ -n "${FM_FAKE_TMUX_WINDOW:-}" ]; then
       printf '%s\n' "$FM_FAKE_TMUX_WINDOW"
     fi
@@ -37,6 +44,7 @@ case "${1:-}" in
   display-message)
     case "$*" in
       *'#{cursor_y}'*) printf '0\n' ;;
+      *'#{pane_current_command}'*) printf 'codex\n' ;;
       *) printf 'firstmate\n' ;;
     esac
     exit 0

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -130,13 +130,17 @@ case "${1:-}" in
     _print=0
     # Return cursor_y when the format asks for it (pane_input_pending).
     for _a in "$@"; do
-      case "$_a" in *cursor_y*) printf '%s\n' "${FM_FAKE_TMUX_CURSOR_Y:-0}"; exit 0 ;; esac
+      case "$_a" in
+        *cursor_y*) printf '%s\n' "${FM_FAKE_TMUX_CURSOR_Y:-0}"; exit 0 ;;
+        *pane_current_command*) printf '%s\n' "${FM_FAKE_TMUX_CURRENT_COMMAND:-node}"; exit 0 ;;
+      esac
       [ "$_a" = "-p" ] && _print=1
     done
     [ "$_print" = 1 ] && printf 'fakepane\n'
     exit 0 ;;
   list-windows)
-    [ -n "${FM_FAKE_TMUX_WINDOW:-}" ] && printf '%s\n' "$FM_FAKE_TMUX_WINDOW"
+    [ "${FM_FAKE_TMUX_PANE_ALIVE:-1}" = "1" ] || exit 1
+    printf '%s\n' "${FM_FAKE_TMUX_WINDOW:-0}"
     exit 0 ;;
   capture-pane)
     # Honor a single-line band capture (-S N -E M, both non-negative) for the
@@ -219,12 +223,17 @@ write_composer() {
 case "${1:-}" in
   display-message)
     print=0
-    for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
+    for a in "$@"; do
+      case "$a" in
+        *cursor_y*) printf '1\n'; exit 0 ;;
+        *pane_current_command*) printf '%s\n' "${FM_FAKE_TMUX_CURRENT_COMMAND:-node}"; exit 0 ;;
+      esac
+    done
     for a in "$@"; do [ "$a" = "-p" ] && print=1; done
     [ "$print" = 1 ] && printf 'fakepane\n'
     exit 0 ;;
   capture-pane) cat "$COMPOSER" 2>/dev/null; exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows) printf '%s\n' "${FM_FAKE_TMUX_WINDOW:-0}"; exit 0 ;;
   send-keys)
     shift
     text=""; is_enter=0; lit=0


### PR DESCRIPTION
## Intent

Verify cursor-agent as a fully dispatchable Firstmate crewmate harness adapter, preserving all existing validated pipeline commits and accepted captain decisions. This exact head 1766edb64643c05340de45ff03137625955016b6 has already passed review, live E2E tests, documentation, and lint, so those four steps are intentionally skipped in this recovery run. Push the existing branch to the configured pietgk/firstmate fork with origin unchanged, then have no-mistakes open the required signed PR against kunchenguid/firstmate upstream and monitor CI.

## What Changed

- Add Cursor as a verified crewmate and secondmate harness with marker detection, dispatch validation, trusted autonomous launches, and model forwarding.
- Harden tmux composer detection and submission for Cursor’s parked cursor, delayed acknowledgements, single-Enter behavior, liveness checks, and authorized lifecycle exits.
- Document the Cursor adapter contract and add regression coverage for detection, spawning, busy state, composer classification, and steering.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
