### PR TITLE
fix: classify routine gates by substance before yolo

### DIFF
--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -28,7 +28,7 @@ The concise standing authority boundary remains always loaded in `AGENTS.md` sec
 7. Examine the causal theme across prior findings and fix rounds.
    Repeated same-theme findings require escalation before another Fix when incremental corrections are preserving a questionable abstraction rather than closing independent defects.
 8. Apply the existing stronger captain boundaries first, regardless of step 2's classification or `yolo`.
-   PR merges always require the captain, and destructive, irreversible, and genuinely security-sensitive choices always escalate regardless of whether they also expand the contract.
+   Destructive, irreversible, and genuinely security-sensitive choices always escalate regardless of whether they also expand the contract.
 
 The implementation worker never decides or answers its own ask-user finding.
 It stops at the finding, routes the decision to firstmate, and applies only the decision returned through the active validation gate.
@@ -52,5 +52,4 @@ Do not relay reviewer labels or gate output as if they settled the decision.
 - Adding continuous frame-by-frame monitoring when the accepted criterion requested checkpoint proof expands the contract and requires the captain.
 - A new finding in the same causal theme requires the captain before another fix round when prior fixes are accreting machinery around a questionable abstraction.
 - A genuinely security-sensitive action requires the captain under the stronger existing boundary even if it is otherwise within scope.
-- Merging a PR requires the captain regardless of `yolo`; pushing its feature branch, opening it, updating it, and running CI do not.
 - Complex architecture explicitly requested by the captain stays within scope and does not escalate merely because it is complex.

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -27,7 +27,7 @@ The concise standing authority boundary remains always loaded in `AGENTS.md` sec
 6. Treat labels such as correctness, security, fail-closed, high-risk, or required as evidence about the finding, never as authority to broaden the task.
 7. Examine the causal theme across prior findings and fix rounds.
    Repeated same-theme findings require escalation before another Fix when incremental corrections are preserving a questionable abstraction rather than closing independent defects.
-8. Apply the existing stronger captain boundaries first, regardless of step 1's classification or `yolo`.
+8. Apply the existing stronger captain boundaries first, regardless of step 2's classification or `yolo`.
    Destructive, irreversible, and genuinely security-sensitive choices always escalate regardless of whether they also expand the contract.
 
 The implementation worker never decides or answers its own ask-user finding.

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -28,7 +28,7 @@ The concise standing authority boundary remains always loaded in `AGENTS.md` sec
 7. Examine the causal theme across prior findings and fix rounds.
    Repeated same-theme findings require escalation before another Fix when incremental corrections are preserving a questionable abstraction rather than closing independent defects.
 8. Apply the existing stronger captain boundaries first, regardless of step 2's classification or `yolo`.
-   Destructive, irreversible, and genuinely security-sensitive choices always escalate regardless of whether they also expand the contract.
+   PR merges always require the captain, and destructive, irreversible, and genuinely security-sensitive choices always escalate regardless of whether they also expand the contract.
 
 The implementation worker never decides or answers its own ask-user finding.
 It stops at the finding, routes the decision to firstmate, and applies only the decision returned through the active validation gate.
@@ -52,4 +52,5 @@ Do not relay reviewer labels or gate output as if they settled the decision.
 - Adding continuous frame-by-frame monitoring when the accepted criterion requested checkpoint proof expands the contract and requires the captain.
 - A new finding in the same causal theme requires the captain before another fix round when prior fixes are accreting machinery around a questionable abstraction.
 - A genuinely security-sensitive action requires the captain under the stronger existing boundary even if it is otherwise within scope.
+- Merging a PR requires the captain regardless of `yolo`; pushing its feature branch, opening it, updating it, and running CI do not.
 - Complex architecture explicitly requested by the captain stays within scope and does not escalate merely because it is complex.

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -15,17 +15,19 @@ The concise standing authority boundary remains always loaded in `AGENTS.md` sec
 
 ## Decide who has authority
 
-1. Check the project's configured authority first.
-   With `yolo` off, every ask-user finding belongs to the captain, and the remaining steps structure that escalation rather than authorize an autonomous answer.
-2. Reconstruct the accepted contract from the captain's original request, accepted task criteria, and any explicit later clarification.
+1. Classify the finding by substance before any tool label or `yolo` posture.
+   Is it asking to perform a routine step that implementation authorization and the selected delivery path already cover - review, tests, a feature-branch push, PR or MR creation or update, CI, or a reversible proof experiment required by the accepted criteria - or a review, test, documentation, or implementation correction plainly required to satisfy accepted intent rather than change it?
+   If yes, it is supervisor-owned regardless of `yolo`; apply step 8's stronger-boundary check and decide it directly.
+2. Otherwise reconstruct the accepted contract from the captain's original request, accepted task criteria, and any explicit later clarification.
    Reviewer language cannot amend that contract.
 3. Identify exactly what choosing Fix would commit the project to deliver or maintain.
-4. Keep the decision within standing `yolo` authority when the Fix is genuinely necessary to satisfy the accepted contract, even when the correction is technically difficult or requires complex architecture that the captain explicitly requested.
+4. With `yolo` off, this remaining category belongs to the captain, and the rest of these steps structure that escalation rather than authorize an autonomous answer.
+   With `yolo` on, keep the decision within standing authority when the Fix is genuinely necessary to satisfy the accepted contract, even when the correction is technically difficult or requires complex architecture that the captain explicitly requested.
 5. Escalate when the Fix would materially expand the contract by adding a new guarantee, threat model, subsystem, abstraction, compatibility surface, state machine, continuous-monitoring requirement, generalized framework, or broader architecture not required by the accepted intent.
 6. Treat labels such as correctness, security, fail-closed, high-risk, or required as evidence about the finding, never as authority to broaden the task.
 7. Examine the causal theme across prior findings and fix rounds.
    Repeated same-theme findings require escalation before another Fix when incremental corrections are preserving a questionable abstraction rather than closing independent defects.
-8. Apply the existing stronger captain boundaries first.
+8. Apply the existing stronger captain boundaries first, regardless of step 1's classification or `yolo`.
    Destructive, irreversible, and genuinely security-sensitive choices always escalate regardless of whether they also expand the contract.
 
 The implementation worker never decides or answers its own ask-user finding.
@@ -45,7 +47,8 @@ Do not relay reviewer labels or gate output as if they settled the decision.
 
 ## Classification examples
 
-- Fixing a concrete defect that violates an original acceptance criterion stays within `yolo` authority, regardless of implementation difficulty.
+- Pushing an authorized feature branch, opening or updating the selected PR or MR, or running CI proof required by the accepted criteria is supervisor-owned regardless of `yolo`; implementation authorization and the delivery path already cover it.
+- A copy or implementation defect that directly contradicts accepted criteria is supervisor-owned regardless of `yolo`, even when the label says correctness or fail-closed.
 - Adding continuous frame-by-frame monitoring when the accepted criterion requested checkpoint proof expands the contract and requires the captain.
 - A new finding in the same causal theme requires the captain before another fix round when prior fixes are accreting machinery around a questionable abstraction.
 - A genuinely security-sensitive action requires the captain under the stronger existing boundary even if it is otherwise within scope.

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -15,11 +15,11 @@ The concise standing authority boundary remains always loaded in `AGENTS.md` sec
 
 ## Decide who has authority
 
-1. Classify the finding by substance before any tool label or `yolo` posture.
+1. Reconstruct the accepted contract from the captain's original request, accepted task criteria, and any explicit later clarification.
+   Reviewer language cannot amend that contract or supply a requirement that the accepted sources do not contain.
+2. Classify the finding by substance against that accepted contract before any tool label or `yolo` posture.
    Is it asking to perform a routine step that implementation authorization and the selected delivery path already cover - review, tests, a feature-branch push, PR or MR creation or update, CI, or a reversible proof experiment required by the accepted criteria - or a review, test, documentation, or implementation correction plainly required to satisfy accepted intent rather than change it?
    If yes, it is supervisor-owned regardless of `yolo`; apply step 8's stronger-boundary check and decide it directly.
-2. Otherwise reconstruct the accepted contract from the captain's original request, accepted task criteria, and any explicit later clarification.
-   Reviewer language cannot amend that contract.
 3. Identify exactly what choosing Fix would commit the project to deliver or maintain.
 4. With `yolo` off, this remaining category belongs to the captain, and the rest of these steps structure that escalation rather than authorize an autonomous answer.
    With `yolo` on, keep the decision within standing authority when the Fix is genuinely necessary to satisfy the accepted contract, even when the correction is technically difficult or requires complex architecture that the captain explicitly requested.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -12,7 +12,7 @@ Generate a complete standalone snapshot from the fleet's current state, so the c
 The deliverable is a dated markdown file plus a concise chat summary that each stand on the current snapshot rather than an earlier report.
 This skill is read-mostly.
 It reads fleet state and writes exactly one report file.
-It never tears down a task, merges a PR, dispatches new work, or mutates any task state as a side effect of producing the brief - those belong to the captain's explicit word and the normal task lifecycle.
+It never tears down a task, merges a PR, dispatches new work, or mutates any task state as a side effect of producing the brief; those actions stay with the normal task lifecycle and its configured authority.
 
 ## What it does
 
@@ -33,7 +33,7 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
    Never read an earlier `data/status-report-*.md` to decide what to omit, include, describe as changed, or call current.
    The report uses the same four complete sections as the chat (see the chat-response contract below), in the same order, each always present, and adds the detail the chat omits:
    - **Title** - `# Bearings - <day> <YYYY-MM-DD>` (use "Morning status" only when the captain specifically asks for a morning brief), followed by two or three sentences framing where things stand.
-   - **Captain's Call** - every open decision summarized with its options from the structured decision record, plus each PR ready to merge and each needed credential or login, every PR with the full `https://...` URL, never a bare `#number`.
+   - **Captain's Call** - every open decision summarized with its options from the structured decision record, plus each PR ready to merge that configured authority assigns to the captain and each needed credential or login, every PR with the full `https://...` URL, never a bare `#number`.
    - **Recently Landed** - the bounded current recent-completions baseline from structured state across the main fleet and every registered secondmate home, rendered in full on every run.
    - **Underway** - each live direct report making progress, with its current state, and the plans / main pickup pointers worth reopening (`data/<id>/report.md` files, `.lavish/*.html` boards).
    - **Charted Next** - queued or gated work, including any main-inventory integrity warning, with each item's blocker, date, or integrity reason.
@@ -50,7 +50,7 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
 This skill is the one owner of the `/bearings` chat-response format; the snapshot and classifier own the data that feeds it, and no other file restates this contract.
 Every `/bearings` chat response renders EXACTLY these four sections, in THIS order, and nothing else structural (there is no At Anchor section):
 
-1. **Captain's Call** - ONLY items that need the captain's own action now: a decision to make, a PR to approve or merge, a credential or login to provide, or a blocker only the captain can clear.
+1. **Captain's Call** - ONLY items that need the captain's own action now: a decision to make, a PR that configured authority assigns to the captain for approval or merge, a credential or login to provide, or a blocker only the captain can clear.
    Empty-state: "Nothing needs your action right now."
 2. **Recently Landed** - the bounded current recent-completions baseline: merged PRs, completed scouts, and finished local-only merges across the main fleet and every registered secondmate home.
    Empty-state: "No recent completions are in the current baseline."

--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -35,7 +35,7 @@ The goal is a session that is safe to reset or destroy because everything durabl
    - Project-intrinsic knowledge: never hand-write a project's `AGENTS.md`.
      Route it through a normal ship task so a crewmate records it via `bin/fm-ensure-agents-md.sh` and commits it through that project's delivery pipeline, exactly as section 6 describes.
      If the fleet is live, delegate this to a crewmate rather than doing it inline.
-   - Knowledge generalizable to every firstmate user: this repo's own `AGENTS.md` (or other shared, tracked material), shipped through the normal branch -> no-mistakes -> PR -> captain-merge pipeline for this repo (section 1), never hand-committed straight to `main`.
+   - Knowledge generalizable to every firstmate user: this repo's own `AGENTS.md` (or other shared, tracked material), shipped through the normal branch -> no-mistakes -> PR pipeline under the configured merge authority in `AGENTS.md` section 7, never hand-committed straight to `main`.
    - Task-scoped notes: inspect the relevant backlog item with `tasks-axi show <id> --full`, judge whether the new note is new, duplicate, superseding, or obsolete, then write a considered replacement body with `tasks-axi update <id> --body-file <path>`.
      When the replacement intentionally supersedes prior state that should remain recoverable, add `--archive-body` to that update command so the prior body stays recoverable without copying it into the replacement.
      Never append.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Hard rules, in priority order:
    The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths owned by their referenced skills and scripts.
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
 2. **Never merge a PR without the captain's explicit word.**
-   A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns its exceptions and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
+   A project's captain-approved `yolo` posture is the only standing relaxation for routine merge decisions; section 7 owns its exceptions, including the substance-based ask-user authority contract, and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
 3. **Never tear down unlanded work.**
    Uncommitted changes are never landed, and `bin/fm-teardown.sh` owns the complete landed-work test.
    Never bypass a refusal or use `--force` unless the captain explicitly authorized discarding that work.
@@ -277,12 +277,13 @@ The path's worker, automated gates, and captain approval remain authoritative:
 - **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
 
-Delivery mode and `yolo` are orthogonal.
-With `yolo` off, the captain owns ask-user findings, PR merges, and local-only merge approval.
-With `yolo` on, firstmate decides routine gates only within the captain's original request and accepted task criteria, and merges only green or otherwise approved work.
-Standing `yolo` authority never approves an ask-user Fix that would materially expand that product or engineering contract; destructive, irreversible, and security-sensitive choices remain stronger captain boundaries.
+Delivery mode and `yolo` are orthogonal, and an ask-user finding's authority is classified by the substance of the proposed change before any tool label or `yolo` posture is applied; load `ask-user-authority` before deciding one.
+Implementation authorization and the selected delivery path already authorize routine review, tests, feature-branch pushes, PR or MR creation and updates, CI, and reversible proof experiments required by the accepted criteria, plus any review, test, documentation, or implementation correction plainly required to satisfy accepted intent rather than change it; the supervising firstmate or secondmate clears these even when `yolo` is off.
+The implementation worker never answers its own finding regardless of who holds authority; it routes every finding to its supervisor and applies only the decision returned through the active validation gate.
+With `yolo` off, the captain owns every remaining ask-user finding, PR merges, and local-only merge approval.
+With `yolo` on, firstmate decides remaining routine gates only within the captain's original request and accepted task criteria, and merges only green or otherwise approved work.
+Standing authority, with or without `yolo`, never approves an ask-user Fix that would materially expand that product or engineering contract; destructive, irreversible, and security-sensitive choices remain stronger captain boundaries.
 Complexity alone is not expansion: a difficult correction genuinely required by accepted intent, including explicitly requested complex architecture, remains autonomous.
-Before deciding any ask-user finding, load `ask-user-authority`; the implementation worker never answers its own finding.
 Never merge a red PR.
 Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
 After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
@@ -293,7 +294,7 @@ For a no-mistakes ship, trigger validation on the same worker after its implemen
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 
-An ask-user finding returns as `needs-decision`; firstmate decides only when the configured authority permits, otherwise escalates to the captain.
+An ask-user finding returns as `needs-decision`; the supervising firstmate or secondmate classifies and decides it under the authority contract above, escalating to the captain only when that contract requires it.
 Send the same worker one exact decision naming the decision key, step, action, affected finding IDs, instructions where needed, and exact response command.
 Require the matching `resolved` event, forbid `--yes`, and require the worker to process every synchronous return until completion or a genuinely new escalation.
 Resume fleet supervision immediately after the decision lands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Hard rules, in priority order:
    The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths owned by their referenced skills and scripts.
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
 2. **Never merge a PR without the captain's explicit word.**
-   A project's captain-approved `yolo` posture is the only standing relaxation for routine merge decisions; section 7 owns its exceptions, including the substance-based ask-user authority contract, and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
+   A project's captain-approved `yolo` posture is a standing relaxation only for routine non-merge decisions; section 7 owns its exceptions, including the substance-based ask-user authority contract, and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
 3. **Never tear down unlanded work.**
    Uncommitted changes are never landed, and `bin/fm-teardown.sh` owns the complete landed-work test.
    Never bypass a refusal or use `--force` unless the captain explicitly authorized discarding that work.
@@ -280,13 +280,14 @@ The path's worker, automated gates, and captain approval remain authoritative:
 Delivery mode and `yolo` are orthogonal, and an ask-user finding's authority is classified by the substance of the proposed change before any tool label or `yolo` posture is applied; load `ask-user-authority` before deciding one.
 Implementation authorization and the selected delivery path already authorize routine review, tests, feature-branch pushes, PR or MR creation and updates, CI, and reversible proof experiments required by the accepted criteria, plus any review, test, documentation, or implementation correction plainly required to satisfy accepted intent rather than change it; the supervising firstmate or secondmate clears these even when `yolo` is off.
 The implementation worker never answers its own finding regardless of who holds authority; it routes every finding to its supervisor and applies only the decision returned through the active validation gate.
-With `yolo` off, the captain owns every remaining ask-user finding, PR merges, and local-only merge approval.
-With `yolo` on, firstmate decides remaining routine gates only within the captain's original request and accepted task criteria, and merges only green or otherwise approved work.
+PR merges always require the captain regardless of `yolo`.
+With `yolo` off, the captain owns every remaining ask-user finding and local-only merge approval.
+With `yolo` on, firstmate decides remaining routine non-merge gates only within the captain's original request and accepted task criteria.
 Standing authority, with or without `yolo`, never approves an ask-user Fix that would materially expand that product or engineering contract; destructive, irreversible, and security-sensitive choices remain stronger captain boundaries.
 Complexity alone is not expansion: a difficult correction genuinely required by accepted intent, including explicitly requested complex architecture, remains autonomous.
 Never merge a red PR.
 Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
-After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
+After an autonomous local-only merge, give the captain a one-line local-main outcome.
 
 ### Validate
 
@@ -309,7 +310,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
-A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
+A captain instruction to merge a PR is the only PR merge authority; `yolo` never grants it.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
 
 Tear down a ship task only after landing is confirmed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Hard rules, in priority order:
    The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths owned by their referenced skills and scripts.
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
 2. **Never merge a PR without the captain's explicit word.**
-   A project's captain-approved `yolo` posture is a standing relaxation only for routine non-merge decisions; section 7 owns its exceptions, including the substance-based ask-user authority contract, and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
+   A project's captain-approved `yolo` posture is the only standing relaxation for routine merge decisions; section 7 owns its exceptions, including the substance-based ask-user authority contract, and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
 3. **Never tear down unlanded work.**
    Uncommitted changes are never landed, and `bin/fm-teardown.sh` owns the complete landed-work test.
    Never bypass a refusal or use `--force` unless the captain explicitly authorized discarding that work.
@@ -280,14 +280,13 @@ The path's worker, automated gates, and captain approval remain authoritative:
 Delivery mode and `yolo` are orthogonal, and an ask-user finding's authority is classified by the substance of the proposed change before any tool label or `yolo` posture is applied; load `ask-user-authority` before deciding one.
 Implementation authorization and the selected delivery path already authorize routine review, tests, feature-branch pushes, PR or MR creation and updates, CI, and reversible proof experiments required by the accepted criteria, plus any review, test, documentation, or implementation correction plainly required to satisfy accepted intent rather than change it; the supervising firstmate or secondmate clears these even when `yolo` is off.
 The implementation worker never answers its own finding regardless of who holds authority; it routes every finding to its supervisor and applies only the decision returned through the active validation gate.
-PR merges always require the captain regardless of `yolo`.
-With `yolo` off, the captain owns every remaining ask-user finding and local-only merge approval.
-With `yolo` on, firstmate decides remaining routine non-merge gates only within the captain's original request and accepted task criteria.
+With `yolo` off, the captain owns every remaining ask-user finding, PR merges, and local-only merge approval.
+With `yolo` on, firstmate decides remaining routine gates only within the captain's original request and accepted task criteria, and merges only green or otherwise approved work.
 Standing authority, with or without `yolo`, never approves an ask-user Fix that would materially expand that product or engineering contract; destructive, irreversible, and security-sensitive choices remain stronger captain boundaries.
 Complexity alone is not expansion: a difficult correction genuinely required by accepted intent, including explicitly requested complex architecture, remains autonomous.
 Never merge a red PR.
 Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
-After an autonomous local-only merge, give the captain a one-line local-main outcome.
+After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
 
 ### Validate
 
@@ -310,7 +309,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
-A captain instruction to merge a PR is the only PR merge authority; `yolo` never grants it.
+A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
 
 Tear down a ship task only after landing is confirmed.

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -28,7 +28,7 @@ approval_contract() {
 }
 
 test_owner_and_always_loaded_boundary() {
-  local contract trigger_count
+  local classification_line contract contract_line reviewer_guard_line trigger_count yolo_line
   contract=$(approval_contract)
 
   assert_contains "$contract" "only within the captain's original request and accepted task criteria" \
@@ -49,10 +49,22 @@ test_owner_and_always_loaded_boundary() {
   assert_grep 'user-invocable: false' "$OWNER" "ask-user authority skill must be agent-only"
   assert_grep 'single owner of the decision procedure for ask-user findings' "$OWNER" \
     "ask-user authority skill does not declare ownership"
-  assert_grep 'Classify the finding by substance before any tool label or `yolo` posture' "$OWNER" \
+  assert_grep 'Reconstruct the accepted contract from the captain'\''s original request, accepted task criteria, and any explicit later clarification' "$OWNER" \
+    "detailed procedure does not establish the authoritative accepted contract"
+  assert_grep 'Reviewer language cannot amend that contract or supply a requirement that the accepted sources do not contain' "$OWNER" \
+    "reviewer language can still supply its own acceptance requirement"
+  assert_grep 'Classify the finding by substance against that accepted contract before any tool label or `yolo` posture' "$OWNER" \
     "detailed procedure no longer classifies a finding by substance before yolo"
   assert_grep 'With `yolo` off, this remaining category belongs to the captain' "$OWNER" \
     "detailed procedure escalates every finding to the captain with yolo off instead of only the remaining category"
+  contract_line=$(grep -nF "1. Reconstruct the accepted contract" "$OWNER" | cut -d: -f1)
+  reviewer_guard_line=$(grep -nF "Reviewer language cannot amend that contract" "$OWNER" | cut -d: -f1)
+  classification_line=$(grep -nF "2. Classify the finding by substance against that accepted contract" "$OWNER" | cut -d: -f1)
+  yolo_line=$(grep -nF 'With `yolo` off, this remaining category belongs to the captain' "$OWNER" | cut -d: -f1)
+  [ "$contract_line" -lt "$reviewer_guard_line" ] &&
+    [ "$reviewer_guard_line" -lt "$classification_line" ] &&
+    [ "$classification_line" -lt "$yolo_line" ] ||
+    fail "authority procedure must establish and guard accepted intent before substance classification, then apply yolo posture"
   trigger_count=$(grep -Fc -- '- `ask-user-authority` -' "$AGENTS")
   [ "$trigger_count" -eq 1 ] || fail "ask-user-authority must have exactly one section 13 trigger, found $trigger_count"
   assert_no_grep 'Hi Bit' "$AGENTS" "AGENTS.md encoded an incident-specific authority rule"

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -118,14 +118,18 @@ test_stronger_security_boundary_survives() {
   pass "genuinely security-sensitive action still escalates"
 }
 
-test_pr_merge_authority_stays_with_captain() {
+test_yolo_merge_authority_unchanged() {
   local contract
   contract=$(approval_contract)
-  assert_contains "$contract" 'PR merges always require the captain regardless of `yolo`' \
-    "yolo gained PR merge authority contrary to the accepted contract"
-  assert_grep 'PR merges always require the captain' "$OWNER" \
-    "detailed authority procedure lets a routine-delivery classification bypass captain-owned PR merges"
-  pass "PR merge authority stays with the captain regardless of yolo"
+  assert_contains "$contract" 'the captain owns every remaining ask-user finding, PR merges, and local-only merge approval' \
+    "yolo off no longer leaves PR merges captain-owned"
+  assert_contains "$contract" 'merges only green or otherwise approved work' \
+    "yolo lost its standing routine PR-merge authority"
+  assert_grep 'A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.' "$AGENTS" \
+    "standing merge-authority sentence was altered"
+  assert_no_grep 'PR merges always require the captain' "$OWNER" \
+    "authority procedure incorrectly stripped yolo's pre-existing merge authority"
+  pass "yolo's pre-existing standing PR-merge authority is unchanged by the routine-authority correction"
 }
 
 test_explicit_complex_architecture_stays_in_scope() {
@@ -194,7 +198,7 @@ test_routine_delivery_steps_stay_supervisor_owned
 test_continuous_monitoring_expansion_escalates
 test_repeated_same_theme_escalates_before_another_round
 test_stronger_security_boundary_survives
-test_pr_merge_authority_stays_with_captain
+test_yolo_merge_authority_unchanged
 test_explicit_complex_architecture_stays_in_scope
 test_reviewer_labels_are_evidence_not_authority
 test_captain_escalation_is_decision_ready

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -49,8 +49,10 @@ test_owner_and_always_loaded_boundary() {
   assert_grep 'user-invocable: false' "$OWNER" "ask-user authority skill must be agent-only"
   assert_grep 'single owner of the decision procedure for ask-user findings' "$OWNER" \
     "ask-user authority skill does not declare ownership"
-  assert_grep 'With `yolo` off, every ask-user finding belongs to the captain' "$OWNER" \
-    "detailed procedure permits autonomous ask-user decisions with yolo off"
+  assert_grep 'Classify the finding by substance before any tool label or `yolo` posture' "$OWNER" \
+    "detailed procedure no longer classifies a finding by substance before yolo"
+  assert_grep 'With `yolo` off, this remaining category belongs to the captain' "$OWNER" \
+    "detailed procedure escalates every finding to the captain with yolo off instead of only the remaining category"
   trigger_count=$(grep -Fc -- '- `ask-user-authority` -' "$AGENTS")
   [ "$trigger_count" -eq 1 ] || fail "ask-user-authority must have exactly one section 13 trigger, found $trigger_count"
   assert_no_grep 'Hi Bit' "$AGENTS" "AGENTS.md encoded an incident-specific authority rule"
@@ -61,9 +63,21 @@ test_owner_and_always_loaded_boundary() {
 test_concrete_required_defect_stays_autonomous() {
   assert_grep 'genuinely necessary to satisfy the accepted contract' "$OWNER" \
     "required concrete corrections no longer stay within standing authority"
-  assert_grep 'Fixing a concrete defect that violates an original acceptance criterion stays within `yolo` authority' "$OWNER" \
+  assert_grep 'A copy or implementation defect that directly contradicts accepted criteria is supervisor-owned regardless of `yolo`' "$OWNER" \
     "concrete acceptance-criterion defect scenario is missing"
-  pass "required concrete defect correction stays within yolo authority"
+  pass "required concrete defect correction stays supervisor-owned regardless of yolo"
+}
+
+test_routine_delivery_steps_stay_supervisor_owned() {
+  local contract
+  contract=$(approval_contract)
+  assert_contains "$contract" 'feature-branch pushes, PR or MR creation and updates, CI, and reversible proof experiments required by the accepted criteria' \
+    "standing contract no longer authorizes routine delivery-path steps"
+  assert_contains "$contract" 'clears these even when `yolo` is off' \
+    "standing contract no longer clears routine gates when yolo is off"
+  assert_grep 'Pushing an authorized feature branch, opening or updating the selected PR or MR, or running CI proof required by the accepted criteria is supervisor-owned regardless of `yolo`' "$OWNER" \
+    "routine delivery-step scenario is missing from the detailed procedure"
+  pass "routine feature-branch, PR/MR, and CI steps required by accepted criteria stay supervisor-owned regardless of yolo"
 }
 
 test_continuous_monitoring_expansion_escalates() {
@@ -152,6 +166,7 @@ test_primary_and_secondmate_instruction_generation() {
 
 test_owner_and_always_loaded_boundary
 test_concrete_required_defect_stays_autonomous
+test_routine_delivery_steps_stay_supervisor_owned
 test_continuous_monitoring_expansion_escalates
 test_repeated_same_theme_escalates_before_another_round
 test_stronger_security_boundary_survives

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -109,6 +109,8 @@ test_repeated_same_theme_escalates_before_another_round() {
 }
 
 test_stronger_security_boundary_survives() {
+  assert_grep 'regardless of step 2'\''s classification or `yolo`' "$OWNER" \
+    "stronger captain boundaries do not override the substantive classification step"
   assert_grep 'genuinely security-sensitive choices always escalate' "$OWNER" \
     "security-sensitive choices no longer use the stronger captain boundary"
   assert_grep 'genuinely security-sensitive action requires the captain under the stronger existing boundary' "$OWNER" \

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -118,6 +118,16 @@ test_stronger_security_boundary_survives() {
   pass "genuinely security-sensitive action still escalates"
 }
 
+test_pr_merge_authority_stays_with_captain() {
+  local contract
+  contract=$(approval_contract)
+  assert_contains "$contract" 'PR merges always require the captain regardless of `yolo`' \
+    "yolo gained PR merge authority contrary to the accepted contract"
+  assert_grep 'PR merges always require the captain' "$OWNER" \
+    "detailed authority procedure lets a routine-delivery classification bypass captain-owned PR merges"
+  pass "PR merge authority stays with the captain regardless of yolo"
+}
+
 test_explicit_complex_architecture_stays_in_scope() {
   assert_grep 'complex architecture that the captain explicitly requested' "$OWNER" \
     "explicitly requested complex architecture is not protected from complexity-only escalation"
@@ -184,6 +194,7 @@ test_routine_delivery_steps_stay_supervisor_owned
 test_continuous_monitoring_expansion_escalates
 test_repeated_same_theme_escalates_before_another_round
 test_stronger_security_boundary_survives
+test_pr_merge_authority_stays_with_captain
 test_explicit_complex_architecture_stays_in_scope
 test_reviewer_labels_are_evidence_not_authority
 test_captain_escalation_is_decision_ready


### PR DESCRIPTION
## Intent

Follow-up correction on top of the prior no-mistakes run for the same task (fix the ask-user authority contract so it is classified by substance before yolo posture, per the original intent). The prior run's review-step fix (commit 8aa1bf5/2a97cbe) correctly reordered the ask-user-authority procedure to reconstruct the accepted contract and apply the reviewer-language guard before classifying substance - that correction is intended and must be kept. However the prior run's test-step fix (commit c08ce2d5) went out of scope: it changed existing yolo merge semantics by making every PR merge captain-only regardless of yolo. That was never part of the accepted task - the task explicitly required merge authority to remain unchanged (yolo already had standing authority to merge green/approved work; this task never touched that). This commit reverts only that out-of-scope merge-authority restriction in AGENTS.md and .agents/skills/ask-user-authority/SKILL.md back to the pre-task wording, while keeping every intended routine-authority classification fix. It also replaces the test the prior run added (which had incorrectly locked in captain-only merges) with one that correctly locks in the unchanged invariant: yolo retains its pre-existing standing PR-merge authority. Do not re-introduce a captain-only merge restriction; PR merge authority is explicitly out of scope for this task and must stay exactly as it was before this task began (yolo may merge green/otherwise-approved work; a captain instruction to merge is the only other authority).

## What Changed

- Classify ask-user findings against accepted intent before applying tool labels or `yolo`, allowing supervisors to clear already-authorized delivery steps and required corrections.
- Preserve escalation for contract expansion and stronger safety boundaries while retaining `yolo` authority to merge green or otherwise approved work.
- Align bearings and stow guidance with configured merge authority and add regression coverage for the updated authority rules.

## Risk Assessment

✅ Low: Captain, the change cleanly preserves the intended substance-first authority classification while restoring the pre-existing yolo merge authority.

## Testing

Baseline and corrective diffs were inspected, the focused authority scenarios and real worker/secondmate brief generation passed, direct policy-surface evidence was captured, and the worktree remained clean; no visual artifact was needed because this is an agent instruction and CLI-generated brief contract rather than UI behavior.

<details>
<summary>Evidence: Focused authority scenario test transcript</summary>

```text
ok - ask-user authority has one conditional owner and a concise always-loaded boundary
ok - required concrete defect correction stays supervisor-owned regardless of yolo
ok - routine feature-branch, PR/MR, and CI steps required by accepted criteria stay supervisor-owned regardless of yolo
ok - continuous frame-by-frame proof escalates when only checkpoints were requested
ok - repeated abstraction-preserving findings escalate before another fix round
ok - genuinely security-sensitive action still escalates
ok - yolo's pre-existing standing PR-merge authority is unchanged by the routine-authority correction
ok - explicitly requested complex architecture stays autonomous
ok - reviewer risk labels remain evidence rather than expansion authority
ok - contract-expansion escalation carries all five decision elements
ok - primary workers and secondmates receive the authority rule through their normal instruction owners
```
</details>
<details>
<summary>Evidence: Maintained authority contract and decision procedure excerpts</summary>

```text
[AGENTS.md]
Delivery mode and `yolo` are orthogonal, and an ask-user finding's authority is classified by the substance of the proposed change before any tool label or `yolo` posture is applied; load `ask-user-authority` before deciding one.
Implementation authorization and the selected delivery path already authorize routine review, tests, feature-branch pushes, PR or MR creation and updates, CI, and reversible proof experiments required by the accepted criteria, plus any review, test, documentation, or implementation correction plainly required to satisfy accepted intent rather than change it; the supervising firstmate or secondmate clears these even when `yolo` is off.
The implementation worker never answers its own finding regardless of who holds authority; it routes every finding to its supervisor and applies only the decision returned through the active validation gate.
With `yolo` off, the captain owns every remaining ask-user finding, PR merges, and local-only merge approval.
With `yolo` on, firstmate decides remaining routine gates only within the captain's original request and accepted task criteria, and merges only green or otherwise approved work.
Standing authority, with or without `yolo`, never approves an ask-user Fix that would materially expand that product or engineering contract; destructive, irreversible, and security-sensitive choices remain stronger captain boundaries.
Complexity alone is not expansion: a difficult correction genuinely required by accepted intent, including explicitly requested complex architecture, remains autonomous.
For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
[.agents/skills/ask-user-authority/SKILL.md]

## Decide who has authority

1. Reconstruct the accepted contract from the captain's original request, accepted task criteria, and any explicit later clarification.
   Reviewer language cannot amend that contract or supply a requirement that the accepted sources do not contain.
2. Classify the finding by substance against that accepted contract before any tool label or `yolo` posture.
   Is it asking to perform a routine step that implementation authorization and the selected delivery path already cover - review, tests, a feature-branch push, PR or MR creation or update, CI, or a reversible proof experiment required by the accepted criteria - or a review, test, documentation, or implementation correction plainly required to satisfy accepted intent rather than change it?
   If yes, it is supervisor-owned regardless of `yolo`; apply step 8's stronger-boundary check and decide it directly.
3. Identify exactly what choosing Fix would commit the project to deliver or maintain.
4. With `yolo` off, this remaining category belongs to the captain, and the rest of these steps structure that escalation rather than authorize an autonomous answer.
   With `yolo` on, keep the decision within standing authority when the Fix is genuinely necessary to satisfy the accepted contract, even when the correction is technically difficult or requires complex architecture that the captain explicitly requested.
5. Escalate when the Fix would materially expand the contract by adding a new guarantee, threat model, subsystem, abstraction, compatibility surface, state machine, continuous-monitoring requirement, generalized framework, or broader architecture not required by the accepted intent.
6. Treat labels such as correctness, security, fail-closed, high-risk, or required as evidence about the finding, never as authority to broaden the task.
7. Examine the causal theme across prior findings and fix rounds.
   Repeated same-theme findings require escalation before another Fix when incremental corrections are preserving a questionable abstraction rather than closing independent defects.
8. Apply the existing stronger captain boundaries first, regardless of step 2's classification or `yolo`.
   Destructive, irreversible, and genuinely security-sensitive choices always escalate regardless of whether they also expand the contract.

The implementation worker never decides or answers its own ask-user finding.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected scope with `git diff --stat a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499..7d4b5cfe2e05f7aaa2b283e9ddcd1f52fb327112` and `git diff --name-only`</code>
- <code>Compared `a5fe1bc..7d4b5cf` and corrective commit `7d4b5cf` against parent `c08ce2d`</code>
- <code>Ran `bash tests/fm-ask-user-authority.test.sh`</code>
- <code>Captured the actual `AGENTS.md` authority contract and `.agents/skills/ask-user-authority/SKILL.md` procedure with `awk`</code>
- <code>Verified cleanup with `git status --short`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
