### PR TITLE
fix: teach exact keyed status token placement

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -39,6 +39,9 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
+# Optional decision/blocker keys use the wire format owned by bin/fm-classify-lib.sh:
+# the [key=<slug>] token sits between the verb and the colon only
+# (needs-decision [key=route]: ...), never after the colon as trailing prose.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
@@ -172,9 +175,10 @@ This is also how you return the answer to a marked from-firstmate request above.
 A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
 Never append \`working:\` merely to acknowledge receipt or announce that a marked request has started.
 When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
-If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
+If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded: e.g. \`needs-decision [key=<work-slug>]: {summary}\`, \`blocked [key=<work-slug>]: {why}\`, \`$PAUSED_VERB [key=<work-slug>]: {why}\`, \`done [key=<work-slug>]: {outcome}\`, \`failed [key=<work-slug>]: {why}\`.
 When a keyed phase ends without another reportable state, append \`resolved [key=<work-slug>]: {why it is no longer active}\`.
-When a decision you escalated is answered or a blocker clears and your domain resumes, append \`resolved: {how it was decided or unblocked}\` (keyed with \`[key=<slug>]\` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
+When a decision you escalated is answered or a blocker clears and your domain resumes, append \`resolved: {how it was decided or unblocked}\` for a genuine one-off, or \`resolved [key=<work-slug>]: {how}\` when you opened it with a key, so it is durably closed instead of resurfacing behind later unrelated events.
+The \`[key=<work-slug>]\` token always sits between the verb and the colon; a trailing \`[key=...]\` after the colon is note text only and leaves the structured key as default.
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
 
 # Definition of done
@@ -258,7 +262,9 @@ The report is the only thing that survives, so anything worth keeping must be in
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
-   When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
+   When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` so the decision or blocker is durably closed and does not keep resurfacing.
+   For concurrent or multi-item decisions and blockers, put the key token between the verb and the colon on every related event: \`needs-decision [key=<work-slug>]: {summary}\`, \`blocked [key=<work-slug>]: {why}\`, \`$PAUSED_VERB [key=<work-slug>]: {why}\`, \`done [key=<work-slug>]: {outcome}\`, \`failed [key=<work-slug>]: {why}\`, \`resolved [key=<work-slug>]: {how}\`.
+   Omit the token for a genuine one-off (structured key \`default\`); a trailing \`[key=...]\` after the colon is note text only and does not set the structured key.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -370,7 +376,9 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
-   When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
+   When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` so the decision or blocker is durably closed and does not keep resurfacing.
+   For concurrent or multi-item decisions and blockers, put the key token between the verb and the colon on every related event: \`needs-decision [key=<work-slug>]: {summary}\`, \`blocked [key=<work-slug>]: {why}\`, \`$PAUSED_VERB [key=<work-slug>]: {why}\`, \`done [key=<work-slug>]: {outcome}\`, \`failed [key=<work-slug>]: {why}\`, \`resolved [key=<work-slug>]: {how}\`.
+   Omit the token for a genuine one-off (structured key \`default\`); a trailing \`[key=...]\` after the colon is note text only and does not set the structured key.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -413,7 +413,7 @@ assert_keyed_status_protocol_guidance() {
 }
 
 test_keyed_status_protocol_guidance_all_scaffolds() {
-  local home brief
+  local home brief actual
   home="$TMP_ROOT/keyed-status-home"
   mkdir -p "$home/data"
   write_registry "$home"
@@ -452,15 +452,21 @@ test_keyed_status_protocol_guidance_all_scaffolds() {
     "secondmate charter still teaches the ambiguous keyed-with parenthetical"
 
   # Parser contract reinforcement: trailing prose key must not become structured key.
-  # shellcheck source=bin/fm-classify-lib.sh
-  . "$ROOT/bin/fm-classify-lib.sh"
-  [ "$(_fm_decision_key 'needs-decision: summary [key=route]')" = default ] \
+  actual=$(bash -c '. "$1"; _fm_decision_key "$2"' _ \
+    "$ROOT/bin/fm-classify-lib.sh" 'needs-decision: summary [key=route]')
+  [ "$actual" = default ] \
     || fail "trailing prose key was parsed as a structured key"
-  [ "$(_fm_decision_key 'needs-decision [key=route]: summary')" = route ] \
+  actual=$(bash -c '. "$1"; _fm_decision_key "$2"' _ \
+    "$ROOT/bin/fm-classify-lib.sh" 'needs-decision [key=route]: summary')
+  [ "$actual" = route ] \
     || fail "between-verb-and-colon key was not parsed as the structured key"
-  [ "$(_fm_decision_key 'resolved: how [key=route]')" = default ] \
+  actual=$(bash -c '. "$1"; _fm_decision_key "$2"' _ \
+    "$ROOT/bin/fm-classify-lib.sh" 'resolved: how [key=route]')
+  [ "$actual" = default ] \
     || fail "trailing prose key on resolved was parsed as a structured key"
-  [ "$(_fm_decision_key 'resolved [key=route]: how')" = route ] \
+  actual=$(bash -c '. "$1"; _fm_decision_key "$2"' _ \
+    "$ROOT/bin/fm-classify-lib.sh" 'resolved [key=route]: how')
+  [ "$actual" = route ] \
     || fail "between-verb-and-colon resolved key was not parsed"
 
   pass "fm-brief.sh: every scaffold teaches exact keyed status syntax"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -273,8 +273,14 @@ test_secondmate_marked_request_reporting_contract() {
     "secondmate charter lost keyed working syntax for a reportable material phase"
   assert_grep "use the same key on its later \`paused\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event" "$brief" \
     "secondmate charter lost same-key closure for a reportable material phase"
-  assert_grep 'resolved [key=<work-slug>]' "$brief" \
+  assert_grep 'needs-decision [key=<work-slug>]: {summary}' "$brief" \
+    "secondmate charter lost exact needs-decision key placement"
+  assert_grep 'resolved [key=<work-slug>]: {why it is no longer active}' "$brief" \
     "secondmate charter lost resolved closure for a keyed material phase"
+  assert_grep 'between the verb and the colon' "$brief" \
+    "secondmate charter did not state key token placement"
+  assert_grep "trailing \`[key=...]\` after the colon is note text only" "$brief" \
+    "secondmate charter did not reject trailing prose key tokens"
 
   assert_grep 'include that exact token in your parent status reply' "$brief" \
     "secondmate charter lost correlated parent results"
@@ -382,6 +388,84 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# Generated status protocol must teach the exact keyed form owned by
+# bin/fm-classify-lib.sh: [key=<slug>] between verb and colon only.
+# A trailing token after the colon is note prose and must not be taught as a key.
+assert_keyed_status_protocol_guidance() {
+  local brief=$1 label=$2
+  assert_grep 'needs-decision [key=<work-slug>]: {summary}' "$brief" \
+    "$label did not teach needs-decision [key=<work-slug>]: placement"
+  assert_grep 'resolved [key=<work-slug>]: {how}' "$brief" \
+    "$label did not teach resolved [key=<work-slug>]: placement"
+  assert_grep 'blocked [key=<work-slug>]: {why}' "$brief" \
+    "$label did not teach blocked [key=<work-slug>]: placement"
+  assert_grep "trailing \`[key=...]\` after the colon is note text only" "$brief" \
+    "$label did not warn that a trailing prose token is not a structured key"
+  assert_grep 'needs-decision: {summary of options}' "$brief" \
+    "$label dropped the valid unkeyed one-off needs-decision form"
+  assert_grep 'resolved: {how it was decided or unblocked}' "$brief" \
+    "$label dropped the valid unkeyed one-off resolved form"
+  # Reject the ambiguous parenthetical that caused workers to emit trailing keys.
+  assert_no_grep "add the same \`[key=<slug>]\` if you opened it with one" "$brief" \
+    "$label still teaches the ambiguous trailing-key parenthetical"
+  assert_no_grep "keyed with \`[key=<slug>]\` if you opened it with one" "$brief" \
+    "$label still teaches the ambiguous keyed-with parenthetical"
+}
+
+test_keyed_status_protocol_guidance_all_scaffolds() {
+  local home brief
+  home="$TMP_ROOT/keyed-status-home"
+  mkdir -p "$home/data"
+  write_registry "$home"
+
+  FM_HOME="$home" FM_CLASSIFY_PAUSED_VERB=paused \
+    "$ROOT/bin/fm-brief.sh" keyed-ship some-proj >/dev/null 2>&1 \
+    || fail "ship scaffold for keyed status guidance exited non-zero"
+  brief="$home/data/keyed-ship/brief.md"
+  assert_keyed_status_protocol_guidance "$brief" "ship brief"
+
+  FM_HOME="$home" FM_CLASSIFY_PAUSED_VERB=paused \
+    "$ROOT/bin/fm-brief.sh" keyed-scout some-proj --scout >/dev/null 2>&1 \
+    || fail "scout scaffold for keyed status guidance exited non-zero"
+  brief="$home/data/keyed-scout/brief.md"
+  assert_keyed_status_protocol_guidance "$brief" "scout brief"
+
+  FM_HOME="$home" FM_CLASSIFY_PAUSED_VERB=paused \
+    FM_SECONDMATE_CHARTER='Handle routed domain work.' \
+    "$ROOT/bin/fm-brief.sh" keyed-mate --secondmate --no-projects >/dev/null 2>&1 \
+    || fail "secondmate scaffold for keyed status guidance exited non-zero"
+  brief="$home/data/keyed-mate/brief.md"
+  # Secondmate uses a slightly different resolved demo for phase end vs decision close.
+  assert_grep 'needs-decision [key=<work-slug>]: {summary}' "$brief" \
+    "secondmate charter did not teach needs-decision [key=<work-slug>]: placement"
+  assert_grep 'resolved [key=<work-slug>]: {how}' "$brief" \
+    "secondmate charter did not teach resolved [key=<work-slug>]: how for decision close"
+  assert_grep 'blocked [key=<work-slug>]: {why}' "$brief" \
+    "secondmate charter did not teach blocked [key=<work-slug>]: placement"
+  assert_grep "trailing \`[key=...]\` after the colon is note text only" "$brief" \
+    "secondmate charter did not warn that a trailing prose token is not a structured key"
+  assert_grep 'resolved: {how it was decided or unblocked}' "$brief" \
+    "secondmate charter dropped the valid unkeyed one-off resolved form"
+  assert_no_grep "add the same \`[key=<slug>]\` if you opened it with one" "$brief" \
+    "secondmate charter still teaches the ambiguous trailing-key parenthetical"
+  assert_no_grep "keyed with \`[key=<slug>]\` if you opened it with one" "$brief" \
+    "secondmate charter still teaches the ambiguous keyed-with parenthetical"
+
+  # Parser contract reinforcement: trailing prose key must not become structured key.
+  # shellcheck source=bin/fm-classify-lib.sh
+  . "$ROOT/bin/fm-classify-lib.sh"
+  [ "$(_fm_decision_key 'needs-decision: summary [key=route]')" = default ] \
+    || fail "trailing prose key was parsed as a structured key"
+  [ "$(_fm_decision_key 'needs-decision [key=route]: summary')" = route ] \
+    || fail "between-verb-and-colon key was not parsed as the structured key"
+  [ "$(_fm_decision_key 'resolved: how [key=route]')" = default ] \
+    || fail "trailing prose key on resolved was parsed as a structured key"
+  [ "$(_fm_decision_key 'resolved [key=route]: how')" = route ] \
+    || fail "between-verb-and-colon resolved key was not parsed"
+
+  pass "fm-brief.sh: every scaffold teaches exact keyed status syntax"
+}
+
 test_script_parses
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
@@ -397,3 +481,4 @@ test_secondmate_marked_request_reporting_contract
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_keyed_status_protocol_guidance_all_scaffolds


### PR DESCRIPTION
## Intent

Fix the keyed status-event guidance in Firstmate's generated worker instructions so a decision or blocker cannot silently collapse to the default key because [key=<slug>] was placed after the first colon.

Root cause: bin/fm-classify-lib.sh deliberately reads the optional key token from the event prefix before the first colon, so needs-decision: summary [key=route] is unkeyed (default) while needs-decision [key=route]: summary is keyed. Live workers were emitting trailing tokens because the generated brief prose said to reuse keys on later needs-decision/blocked/paused/done/failed/resolved events but did not consistently show exact token placement (parentheticals like "add the same [key=<slug>] if you opened it with one").

Deliberate choices:
- Keep bin/fm-classify-lib.sh as the wire-format owner; do not change the parser to accept trailing tokens (status summaries may legitimately mention [key=...] as text).
- Fix every ordinary ship, scout, and secondmate generated status-protocol variant in bin/fm-brief.sh so they demonstrate the exact form with the token between the verb and colon.
- Preserve the valid unkeyed form for genuine one-off events (structured key default).
- Explicitly teach that a trailing [key=...] after the colon is note text only and does not set the structured key.
- Add focused regression coverage in tests/fm-brief.test.sh proving all scaffolds teach exact syntax and that trailing prose does not become the structured key; remove the old ambiguous parenthetical wording.
- Smallest one-owner correction: worker-facing brief guidance only, not a parser change.

## What Changed

- Update ship, scout, and secondmate briefs to place `[key=<slug>]` between the status verb and colon while preserving valid unkeyed events.
- Clarify that trailing key tokens are note text only and add regression coverage for every scaffold and the existing parser contract.

## Risk Assessment

✅ Low: The change is well-bounded, conforms to the stated intent across ship, scout, and secondmate guidance, preserves parser ownership and unkeyed events, and adds focused regression coverage.

## Testing

Inspected the target change, ran the focused brief regression suite, generated and reviewed all three end-user worker scaffolds, directly demonstrated keyed versus trailing-token classifier behavior, verified the parser stayed unchanged, and found no failures or missing evidence.

<details>
<summary>Evidence: Generated guidance excerpts</summary>

`Generated ship, scout, and secondmate briefs, each showing the key token before the colon, the valid unkeyed form, and the trailing-token warning.`

```text
# Generated worker guidance excerpts

## ship

42:   For concurrent or multi-item decisions and blockers, put the key token between the verb and the colon on every related event: `needs-decision [key=<work-slug>]: {summary}`, `blocked [key=<work-slug>]: {why}`, `paused [key=<work-slug>]: {why}`, `done [key=<work-slug>]: {outcome}`, `failed [key=<work-slug>]: {why}`, `resolved [key=<work-slug>]: {how}`.
43:   Omit the token for a genuine one-off (structured key `default`); a trailing `[key=...]` after the colon is note text only and does not set the structured key.

## scout

35:   For concurrent or multi-item decisions and blockers, put the key token between the verb and the colon on every related event: `needs-decision [key=<work-slug>]: {summary}`, `blocked [key=<work-slug>]: {why}`, `paused [key=<work-slug>]: {why}`, `done [key=<work-slug>]: {outcome}`, `failed [key=<work-slug>]: {why}`, `resolved [key=<work-slug>]: {how}`.
36:   Omit the token for a genuine one-off (structured key `default`); a trailing `[key=...]` after the colon is note text only and does not set the structured key.

## secondmate

44:If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded: e.g. `needs-decision [key=<work-slug>]: {summary}`, `blocked [key=<work-slug>]: {why}`, `paused [key=<work-slug>]: {why}`, `done [key=<work-slug>]: {outcome}`, `failed [key=<work-slug>]: {why}`.
47:The `[key=<work-slug>]` token always sits between the verb and the colon; a trailing `[key=...]` after the colon is note text only and leaves the structured key as default.
```
</details>
<details>
<summary>Evidence: Classifier behavior transcript</summary>

<code>Keyed input produced `route`; trailing and unkeyed inputs both produced `default`.</code>

```text
Wire-format behavior observed through bin/fm-classify-lib.sh

Input (keyed): needs-decision [key=route]: choose route A or B
Structured key: route
Open decision record: route	needs-decision	choose route A or B

Input (trailing-token): needs-decision: choose route A or B [key=route]
Structured key: default
Open decision record: default	needs-decision	choose route A or B [key=route]

Input (unkeyed): needs-decision: choose route A or B
Structured key: default
Open decision record: default	needs-decision	choose route A or B
```
</details>
<details>
<summary>Evidence: Brief generation transcript</summary>

`CLI output confirming all three worker briefs were scaffolded.`

```text
scaffolded: /var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T/no-mistakes-evidence/01KYHEC96G32ZSSCVPQRRY23GA/generated-home/data/evidence-ship/brief.md (ship, mode=no-mistakes; replace {TASK})
scaffolded: /var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T/no-mistakes-evidence/01KYHEC96G32ZSSCVPQRRY23GA/generated-home/data/evidence-scout/brief.md (scout; replace {TASK})
scaffolded: /var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T/no-mistakes-evidence/01KYHEC96G32ZSSCVPQRRY23GA/generated-home/data/evidence-secondmate/brief.md (secondmate charter)
```
</details>
<details>
<summary>Evidence: Generated ship brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of example-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-ship`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T/no-mistakes-evidence/01KYHEC96G32ZSSCVPQRRY23GA/generated-home/state/evidence-ship.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` so the decision or blocker is durably closed and does not keep resurfacing.
   For concurrent or multi-item decisions and blockers, put the key token between the verb and the colon on every related event: `needs-decision [key=<work-slug>]: {summary}`, `blocked [key=<work-slug>]: {why}`, `paused [key=<work-slug>]: {why}`, `done [key=<work-slug>]: {outcome}`, `failed [key=<work-slug>]: {why}`, `resolved [key=<work-slug>]: {how}`.
   Omit the token for a genuine one-off (structured key `default`); a trailing `[key=...]` after the colon is note text only and does not set the structured key.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/james/.no-mistakes/worktrees/03f7a29d4e35/01KYHEC96G32ZSSCVPQRRY23GA/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/james/.no-mistakes/worktrees/03f7a29d4e35/01KYHEC96G32ZSSCVPQRRY23GA/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated scout brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of example-project, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T/no-mistakes-evidence/01KYHEC96G32ZSSCVPQRRY23GA/generated-home/state/evidence-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` so the decision or blocker is durably closed and does not keep resurfacing.
   For concurrent or multi-item decisions and blockers, put the key token between the verb and the colon on every related event: `needs-decision [key=<work-slug>]: {summary}`, `blocked [key=<work-slug>]: {why}`, `paused [key=<work-slug>]: {why}`, `done [key=<work-slug>]: {outcome}`, `failed [key=<work-slug>]: {why}`, `resolved [key=<work-slug>]: {how}`.
   Omit the token for a genuine one-off (structured key `default`); a trailing `[key=...]` after the colon is note text only and does not set the structured key.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T/no-mistakes-evidence/01KYHEC96G32ZSSCVPQRRY23GA/generated-home/data/evidence-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/Users/james/.no-mistakes/worktrees/03f7a29d4e35/01KYHEC96G32ZSSCVPQRRY23GA/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Generated secondmate brief</summary>

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
Handle routed domain work.

# Routing scope
Handle routed domain work.

# Project clones
None. This is a project-less domain: its subject is the firstmate repo this home lives in, so it needs no separate clones under `projects/`; its crews take pooled worktrees of that firstmate repo.

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T/no-mistakes-evidence/01KYHEC96G32ZSSCVPQRRY23GA/generated-home/state/evidence-secondmate.status'`
States: working, needs-decision, blocked, paused, done, failed.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded: e.g. `needs-decision [key=<work-slug>]: {summary}`, `blocked [key=<work-slug>]: {why}`, `paused [key=<work-slug>]: {why}`, `done [key=<work-slug>]: {outcome}`, `failed [key=<work-slug>]: {why}`.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
When a decision you escalated is answered or a blocker clears and your domain resumes, append `resolved: {how it was decided or unblocked}` for a genuine one-off, or `resolved [key=<work-slug>]: {how}` when you opened it with a key, so it is durably closed instead of resurfacing behind later unrelated events.
The `[key=<work-slug>]` token always sits between the verb and the colon; a trailing `[key=...]` after the colon is note text only and leaves the structured key as default.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the committed target diff with `git diff a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499..734743d41c25bb9f8a229497337cdbc33702dfe2 -- bin/fm-brief.sh tests/fm-brief.test.sh`.</code>
- <code>Ran `bash tests/fm-brief.test.sh`.</code>
- <code>Generated real ship, scout, and secondmate surfaces with `bin/fm-brief.sh` using isolated `FM_HOME` evidence data.</code>
- <code>Sourced `bin/fm-classify-lib.sh` under Bash and exercised `_fm_decision_key` plus `status_open_decisions` against keyed, trailing-token, and genuine unkeyed status events.</code>
- <code>Ran `git diff --quiet a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499..734743d41c25bb9f8a229497337cdbc33702dfe2 -- bin/fm-classify-lib.sh` to verify the parser was not changed.</code>
- <code>Checked all evidence files were present and non-empty, then confirmed `git status --short` remained clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
