### PR TITLE
fix: release Codex locks and improve GitHub diagnostics

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, GH_NETWORK, GH_CREDENTIAL_STORE, GH_SANDBOX, GH_AUTH_CHECK, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -23,7 +23,11 @@ When any diagnostic needs captain attention, report the plain consequence and re
   For `quota-axi`, bootstrap requires it because firstmate reads its current output directly before resolving every crew-dispatch profile array; without it, report the missing requirement and do not choose around an unexamined candidate.
 - `MISSING_MANUAL: <tool> (instructions: <url>)` - tell the captain why the tool is required and give them the printed instructions URL, but do not pass the tool to `bin/fm-bootstrap.sh install`; wait for the captain to complete the manual installation, then rerun session start to confirm the dependency is present.
 - `BACKEND_INVALID: <name> (known: <names>)` - the resolved runtime backend has no verified dependency or lifecycle contract, so do not dispatch work until the invalid `FM_BACKEND` or `config/backend` value is corrected to one of the listed backends.
-- `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
+- `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login -h github.com` because the credential is genuinely missing or invalid.
+- `GH_NETWORK` - report that GitHub authentication could not be verified because `api.github.com` is unreachable, and ask the captain to restore DNS/network access before retrying.
+- `GH_CREDENTIAL_STORE` - report that a configured GitHub account exists but its OS credential-store entry is inaccessible; ask the captain to rerun Firstmate where the credential store is available, and suggest `! gh auth login -h github.com` only if the same diagnostic persists there.
+- `GH_SANDBOX` - report that the restricted environment blocks both GitHub API access and the configured credential store; ask the captain to rerun Firstmate outside that sandbox, not to re-authenticate.
+- `GH_AUTH_CHECK` - report that the structured authentication check itself failed and ask the captain to run `! gh auth status -h github.com` outside Firstmate, then resolve the exact diagnostic it prints.
 - `TANGLE: <remediation>` - the primary checkout is stranded on a feature branch instead of its default branch; `AGENTS.md` section 8 explains why this guard exists and what it protects.
   The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree.
   This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -7,6 +7,11 @@
             "type": "command",
             "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-sessionstart-nudge.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.SessionStart[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-sessionstart-nudge.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; exec \"$root/bin/fm-sessionstart-nudge.sh\"'",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-codex-session-lock-hook.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.SessionStart[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-codex-session-lock-hook.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | exec \"$root/bin/fm-codex-session-lock-hook.sh\"'",
+            "timeout": 3
           }
         ]
       }
@@ -35,6 +40,17 @@
             "type": "command",
             "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-turnend-guard.sh\"'",
             "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-codex-session-lock-hook.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.SessionEnd[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-codex-session-lock-hook.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | exec \"$root/bin/fm-codex-session-lock-hook.sh\"'",
+            "timeout": 3
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,7 +469,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `GH_NETWORK:`, `GH_CREDENTIAL_STORE:`, `GH_SANDBOX:`, `GH_AUTH_CHECK:`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 ### Requirements
 
 - A verified primary agent harness: Claude Code, Grok, Pi, `pi-signed`, Codex, or OpenCode.
-- Git and the GitHub CLI, authenticated through `gh auth login`.
+- Git and the GitHub CLI, authenticated through `gh auth login -h github.com`.
 - The CLI and dependencies for your selected runtime backend; tmux is the reference default.
 
 The first mate detects and offers to install supported missing tools after you approve.
@@ -77,7 +77,7 @@ Codex and OpenCode are also verified and supported as primary harnesses; Codex u
 ### Install and launch
 
 ```sh
-gh auth login
+gh auth login -h github.com
 git clone https://github.com/kunchenguid/firstmate
 cd firstmate
 ```

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -872,6 +872,7 @@ EOF
     token_available=1
   fi
   network_error=0
+  [ "$state" = timeout ] && network_error=1
   case "$error" in
     *"api.github.com"*"lookup"*|*"lookup api.github.com"*|*"dial tcp"*|*"Could not resolve host"*|*"could not resolve host"*|*"no such host"*|*"Network is unreachable"*|*"network is unreachable"*|*"connection refused"*|*"Connection refused"*|*"i/o timeout"*|*"Client.Timeout"*|*"error connecting to api.github.com"*)
       network_error=1

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -6,7 +6,12 @@
 #          exits 0.
 #          Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)",
-#                 "MISSING_MANUAL: <tool> (instructions: <url>)", "NEEDS_GH_AUTH",
+#                 "MISSING_MANUAL: <tool> (instructions: <url>)",
+#                 "NEEDS_GH_AUTH: missing or invalid GitHub authentication - run gh auth login -h github.com",
+#                 "GH_NETWORK: GitHub API unreachable - check network and DNS access to api.github.com, then rerun",
+#                 "GH_CREDENTIAL_STORE: configured GitHub credential is inaccessible - rerun Firstmate where the OS credential store is available; if it still fails, run gh auth login -h github.com",
+#                 "GH_SANDBOX: restricted environment blocks api.github.com and the configured GitHub credential store - rerun Firstmate outside that sandbox",
+#                 "GH_AUTH_CHECK: unable to inspect GitHub authentication - run gh auth status -h github.com outside Firstmate and resolve its diagnostic",
 #                 "BACKEND_INVALID: <name> (known: <names>)",
 #                 "CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>",
 #                 "FLEET_SYNC: <repo>: skipped|recovered|STUCK: <detail>",
@@ -844,7 +849,48 @@ fi
 if command -v tasks-axi >/dev/null 2>&1 && ! fm_tasks_axi_compatible; then
   echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
 fi
-gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
+
+# GitHub CLI's plain `auth status` exit code collapses bad credentials, DNS or
+# network failure, and an inaccessible OS credential store. Its structured
+# status keeps those causes separate without exposing the token. A second
+# `auth token` probe uses only the exit code and discards all credential bytes.
+github_auth_diagnostic() {
+  local record state login token_source error token_available network_error
+  record=$(gh auth status -h github.com --json hosts \
+    --jq '.hosts["github.com"] // [] | (map(select(.active == true)) + .) | .[0] // {} | [.state // "", .login // "", .tokenSource // "", .error // ""] | @tsv' \
+    2>/dev/null) || {
+    echo "GH_AUTH_CHECK: unable to inspect GitHub authentication - run gh auth status -h github.com outside Firstmate and resolve its diagnostic"
+    return
+  }
+  IFS="$(printf '\t')" read -r state login token_source error <<EOF
+$record
+EOF
+  [ "$state" = success ] && return
+
+  token_available=0
+  if [ -n "$login" ] && gh auth token -h github.com -u "$login" >/dev/null 2>&1; then
+    token_available=1
+  fi
+  network_error=0
+  case "$error" in
+    *"api.github.com"*"lookup"*|*"lookup api.github.com"*|*"dial tcp"*|*"Could not resolve host"*|*"could not resolve host"*|*"no such host"*|*"Network is unreachable"*|*"network is unreachable"*|*"connection refused"*|*"Connection refused"*|*"i/o timeout"*|*"Client.Timeout"*|*"error connecting to api.github.com"*)
+      network_error=1
+      ;;
+  esac
+
+  if [ "$network_error" -eq 1 ]; then
+    if [ -n "$login" ] && [ "$token_source" = default ] && [ "$token_available" -eq 0 ]; then
+      echo "GH_SANDBOX: restricted environment blocks api.github.com and the configured GitHub credential store - rerun Firstmate outside that sandbox"
+    else
+      echo "GH_NETWORK: GitHub API unreachable - check network and DNS access to api.github.com, then rerun"
+    fi
+  elif [ -n "$login" ] && [ "$token_available" -eq 0 ]; then
+    echo "GH_CREDENTIAL_STORE: configured GitHub credential is inaccessible - rerun Firstmate where the OS credential store is available; if it still fails, run gh auth login -h github.com"
+  else
+    echo "NEEDS_GH_AUTH: missing or invalid GitHub authentication - run gh auth login -h github.com"
+  fi
+}
+github_auth_diagnostic
 # Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its
 # default branch, not a feature branch (see fm-tangle-lib.sh). Scoped to the
 # primary only; detached-HEAD worktrees and secondmate homes never trip it.

--- a/bin/fm-codex-session-lock-hook.sh
+++ b/bin/fm-codex-session-lock-hook.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Codex SessionStart/SessionEnd adapter for the per-home session lock.
+# Usage: <Codex hook JSON> | fm-codex-session-lock-hook.sh
+#
+# SessionStart claims the lock before the first model turn so a visible Codex
+# ancestry PID is retained when available. A later PID-isolated tool call from
+# the same thread preserves that owner instead of replacing it with a transient
+# fallback PID. Failure to claim stays silent because fm-session-start.sh owns
+# the complete read-only diagnostic.
+#
+# SessionEnd removes only a regular lock whose Codex thread marker exactly
+# matches the ending session. The comparison and removal run under the same
+# acquisition lock as fm-lock.sh. A missing, malformed, unreadable, symlinked,
+# differently owned, or concurrently busy lock is left untouched. Codex allows
+# at most three seconds for SessionEnd hooks, so this adapter never waits for a
+# busy acquisition lock and never delays a clean /quit.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+LOCK="$STATE/.lock"
+PAYLOAD=$(cat 2>/dev/null || true)
+
+command -v jq >/dev/null 2>&1 || exit 0
+EVENT=$(printf '%s' "$PAYLOAD" | jq -r '.hook_event_name // empty' 2>/dev/null) || exit 0
+SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null) || exit 0
+[ -n "$SESSION_ID" ] || exit 0
+case "$SESSION_ID" in *[!A-Za-z0-9._:-]*) exit 0 ;; esac
+if [ -n "${CODEX_THREAD_ID:-}" ] && [ "$CODEX_THREAD_ID" != "$SESSION_ID" ]; then
+  exit 0
+fi
+export CODEX_THREAD_ID="$SESSION_ID"
+
+if [ "$EVENT" = SessionStart ]; then
+  "$SCRIPT_DIR/fm-lock.sh" >/dev/null 2>&1 || true
+  exit 0
+fi
+[ "$EVENT" = SessionEnd ] || exit 0
+[ -e "$LOCK" ] || [ -L "$LOCK" ] || exit 0
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+CLAIM_LOCK="$STATE/.lock.acquire"
+if ! fm_lock_try_acquire "$CLAIM_LOCK"; then
+  exit 0
+fi
+release_claim_lock() {
+  fm_lock_release "$CLAIM_LOCK"
+}
+trap release_claim_lock EXIT
+trap 'exit 0' HUP INT TERM
+
+[ -f "$LOCK" ] && [ ! -L "$LOCK" ] || exit 0
+OWNER=$(cat "$LOCK" 2>/dev/null) || exit 0
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
+MARKER=$(fm_codex_owner_marker "$OWNER" 2>/dev/null || true)
+[ -n "$(fm_codex_owner_kind "$OWNER" 2>/dev/null || true)" ] || exit 0
+[ "$MARKER" = "$SESSION_ID" ] || exit 0
+rm -f "$LOCK" 2>/dev/null || true

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -30,8 +30,7 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # and kimi are markerless, so a foreign marker retained in a terminal
+  # Opencode and kimi are markerless, so a foreign marker retained in a terminal
   # multiplexer's stored environment can silently misidentify one of them before
   # ancestry is consulted. This is a precedence hazard, not evidence that
   # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
@@ -40,14 +39,14 @@ detect_own() {
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
     return
   fi
-  # Codex exposes a stable per-session marker to tool processes. This is
-  # required in PID-isolated tool sandboxes where Codex is not visible in the
-  # child process ancestry.
-  [ -n "${CODEX_THREAD_ID:-}" ] && { echo codex; return; }
   # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # Codex exposes a stable per-session marker to tool processes. This is
+  # required in PID-isolated tool sandboxes where Codex is not visible in the
+  # child process ancestry.
+  [ -n "${CODEX_THREAD_ID:-}" ] && { echo codex; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -40,6 +40,10 @@ detect_own() {
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
     return
   fi
+  # Codex exposes a stable per-session marker to tool processes. This is
+  # required in PID-isolated tool sandboxes where Codex is not visible in the
+  # child process ancestry.
+  [ -n "${CODEX_THREAD_ID:-}" ] && { echo codex; return; }
   # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# Acquire or inspect the per-home firstmate session lock.
-# Writes the harness (agent) process PID found by walking the shell's ancestry,
-# which lives as long as the firstmate session - unlike the transient subshell
-# PID of any one tool call, which is dead moments after it is written.
+# Acquire or inspect the per-home Firstmate session lock.
+# Writes a verified harness process PID, which lives as long as the session.
+# Codex adds its stable thread marker and whether the PID was verified from
+# ancestry or is a PID-isolated fallback. A same-thread Codex tool keeps the
+# existing owner record, while a different thread can reclaim only a verified
+# harness PID that is provably dead. Legacy and fallback Codex owners remain
+# fail-closed until the matching SessionEnd hook releases them.
 # Usage: fm-lock.sh           acquire; exit 1 unless ownership is verified
 #        fm-lock.sh status    print holder and liveness; always exits 0
 set -u
@@ -17,23 +20,37 @@ mkdir -p "$STATE" 2>/dev/null || {
   exit 1
 }
 
-# Harness identity (FM_HARNESS_RE, ancestry walk, holder liveness) is owned by
-# the shared session-lock lib so the Claude Stop auto-arm applies the exact
-# same identity contract.
+# Harness identity, owner format, ancestry, and holder liveness are shared with
+# the Claude Stop auto-arm and the Codex SessionEnd release hook.
 # shellcheck source=bin/fm-session-lock-lib.sh
 . "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
-if [ "${1:-}" = "status" ]; then
+if [ "${1:-}" = status ]; then
   if [ ! -f "$LOCK" ]; then echo "lock: free"; exit 0; fi
   old=$(cat "$LOCK" 2>/dev/null) || {
     echo "lock: unreadable"
     exit 0
   }
-  if fm_harness_pid_alive "$old"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
+  fm_session_lock_holder_state "$old"
+  holder_status=$?
+  case "$holder_status" in
+    0)
+      case "$old" in
+        *'|codex:'*) echo "lock: held by live Codex session owner $old" ;;
+        *) echo "lock: held by live harness pid $old" ;;
+      esac
+      ;;
+    1) echo "lock: stale (owner $old dead or not a harness)" ;;
+    2) echo "lock: held by unverifiable Codex session owner $old" ;;
+    *) echo "lock: invalid owner record; manual inspection required" ;;
+  esac
   exit 0
 fi
 
-me=$(fm_harness_ancestry_pid) || { echo "error: cannot locate harness process in ancestry" >&2; exit 1; }
+owner=$(fm_session_lock_owner) || {
+  echo "error: cannot locate harness process in ancestry" >&2
+  exit 1
+}
 probe=$(mktemp "$STATE/.lock-write.XXXXXX" 2>/dev/null) || {
   echo "error: cannot write session lock; operate read-only until resolved" >&2
   exit 1
@@ -66,12 +83,30 @@ if [ -e "$LOCK" ] || [ -L "$LOCK" ]; then
     echo "error: session lock is unreadable; operate read-only until resolved" >&2
     exit 1
   }
-  if [ "$old" != "$me" ] && fm_harness_pid_alive "$old"; then
-    echo "error: another live firstmate session holds the lock (pid $old); operate read-only until resolved" >&2
-    exit 1
+  old_marker=$(fm_codex_owner_marker "$old" 2>/dev/null || true)
+  owner_marker=$(fm_codex_owner_marker "$owner" 2>/dev/null || true)
+  if [ -n "$old_marker" ] && [ "$old_marker" = "$owner_marker" ]; then
+    owner=$old
+  elif [ "$old" != "$owner" ]; then
+    fm_session_lock_holder_state "$old"
+    holder_status=$?
+    case "$holder_status" in
+      0)
+        echo "error: another live firstmate session holds the lock (owner $old); operate read-only until resolved" >&2
+        exit 1
+        ;;
+      2)
+        echo "error: cannot verify whether another Codex session holds the lock (owner $old); operate read-only until resolved" >&2
+        exit 1
+        ;;
+      3)
+        echo "error: session lock has an invalid owner record; operate read-only until resolved" >&2
+        exit 1
+        ;;
+    esac
   fi
 fi
-if ! { printf '%s\n' "$me" > "$LOCK"; } 2>/dev/null; then
+if ! { printf '%s\n' "$owner" > "$LOCK"; } 2>/dev/null; then
   echo "error: cannot write session lock; operate read-only until resolved" >&2
   exit 1
 fi
@@ -79,9 +114,12 @@ written=$(cat "$LOCK" 2>/dev/null) || {
   echo "error: cannot verify session lock ownership; operate read-only until resolved" >&2
   exit 1
 }
-if [ ! -f "$LOCK" ] || [ -L "$LOCK" ] || [ "$written" != "$me" ]; then
+if [ ! -f "$LOCK" ] || [ -L "$LOCK" ] || [ "$written" != "$owner" ]; then
   echo "error: session lock ownership verification failed; operate read-only until resolved" >&2
   exit 1
 fi
 release_claim_lock
-echo "lock acquired: harness pid $me"
+case "$owner" in
+  *'|codex:'*) echo "lock acquired: Codex session owner $owner" ;;
+  *) echo "lock acquired: harness pid $owner" ;;
+esac

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -1,23 +1,31 @@
 #!/usr/bin/env bash
 # Shared session-lock harness identity.
 #
-# ONE owner of the "which verified-harness process holds this home's session
-# lock, and does the current process descend from that same harness?" decision.
+# ONE owner of the "which verified-harness session holds this home's session
+# lock, and does the current process belong to that same session?" decision.
 # bin/fm-lock.sh uses it to acquire and inspect state/.lock;
 # bin/fm-claude-stop-autoarm.sh uses it to prove a Stop hook fires inside the
 # lock-owning primary session before it may arm or rewake.
+# Codex owners use one of these formats:
+#   <pid>|codex:<thread-id>|harness
+#   <pid>|codex:<thread-id>|fallback
+# `harness` means the PID was verified from ancestry and can prove liveness.
+# `fallback` means PID isolation hid the harness, so only the thread marker can
+# prove same-session ownership and a different thread must treat it as
+# unverifiable until Codex's SessionEnd hook releases it.
+# The legacy two-field Codex owner remains readable and fail-closed.
 # This file is sourced by scripts and has no side effects on source.
 
 # Known harness command names; extend when a new adapter is verified.
 FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
 
-# Walk the current process ancestry (up to 8 hops) and print the first pid whose
-# command looks like a verified harness. The harness pid lives as long as the
-# session, unlike the transient subshell pid of any one tool call.
-fm_harness_ancestry_pid() {
+# Walk the current process ancestry (up to 8 hops) and print the first PID whose
+# command looks like a verified harness.
+# This function never falls back to a tool PID.
+fm_verified_harness_ancestry_pid() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
     if printf '%s' "$(basename "$comm")" | grep -qE "$FM_HARNESS_RE"; then
       echo "$pid"; return 0
@@ -27,9 +35,26 @@ fm_harness_ancestry_pid() {
       *node*|*python*) printf '%s' "$args" | grep -qE "$FM_HARNESS_RE" && { echo "$pid"; return 0; } ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
+    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
   done
   return 1
+}
+
+# Print the current owner record.
+# Codex keeps working when its tool sandbox hides the harness PID: the fallback
+# record is deliberately not reclaimable by a different thread, but the same
+# thread can keep using it and SessionEnd can release it deterministically.
+fm_session_lock_owner() {
+  local pid
+  if [ -n "${CODEX_THREAD_ID:-}" ]; then
+    if pid=$(fm_verified_harness_ancestry_pid); then
+      printf '%s|codex:%s|harness\n' "$pid" "$CODEX_THREAD_ID"
+    else
+      printf '%s|codex:%s|fallback\n' "$$" "$CODEX_THREAD_ID"
+    fi
+    return 0
+  fi
+  fm_verified_harness_ancestry_pid
 }
 
 # True if $1 is a live process that looks like a verified harness.
@@ -49,16 +74,75 @@ fm_harness_pid_alive() {
   esac
 }
 
+# Print a Codex owner marker, or fail for a numeric/non-Codex owner.
+fm_codex_owner_marker() {
+  local owner=$1 pid rest marker suffix
+  pid=${owner%%|*}
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  rest=${owner#*|}
+  case "$rest" in codex:*) rest=${rest#codex:} ;; *) return 1 ;; esac
+  marker=${rest%%|*}
+  case "$marker" in ''|*[!A-Za-z0-9._:-]*) return 1 ;; esac
+  if [ "$rest" != "$marker" ]; then
+    suffix=${rest#*|}
+    case "$suffix" in harness|fallback) ;; *) return 1 ;; esac
+  fi
+  printf '%s\n' "$marker"
+}
+
+fm_codex_owner_kind() {
+  local owner=$1 rest marker suffix
+  fm_codex_owner_marker "$owner" >/dev/null || return 1
+  rest=${owner#*|codex:}
+  marker=${rest%%|*}
+  if [ "$rest" = "$marker" ]; then
+    printf '%s\n' legacy
+    return 0
+  fi
+  suffix=${rest#*|}
+  printf '%s\n' "$suffix"
+}
+
+# Return 0 when owner $1 is live or belongs to the current Codex thread, 1 when
+# it is provably stale, 2 when another Codex thread cannot verify it, and 3 for
+# an invalid owner record.
+fm_session_lock_holder_state() {
+  local owner=$1 pid marker kind
+  case "$owner" in
+    *'|codex:'*)
+      pid=${owner%%|*}
+      case "$pid" in ''|*[!0-9]*) return 3 ;; esac
+      marker=$(fm_codex_owner_marker "$owner") || return 3
+      [ -n "$marker" ] || return 3
+      if [ -n "${CODEX_THREAD_ID:-}" ] && [ "$CODEX_THREAD_ID" = "$marker" ]; then
+        return 0
+      fi
+      kind=$(fm_codex_owner_kind "$owner") || return 3
+      if [ "$kind" = harness ]; then
+        fm_harness_pid_alive "$pid"
+        return $?
+      fi
+      return 2
+      ;;
+    *)
+      case "$owner" in ''|*[!0-9]*) return 3 ;; esac
+      fm_harness_pid_alive "$owner"
+      ;;
+  esac
+}
+
 # True when state dir $1 holds a session lock whose pid is the harness ancestor
 # of the current process: this script runs inside the session that owns the
 # home's fleet lock. A missing lock, a lock held by another live harness, or an
 # ancestry that cannot be resolved all fail closed.
 fm_session_lock_owned_by_self() {
-  local state=$1 lock_pid my_pid
-  lock_pid=$(cat "$state/.lock" 2>/dev/null || true)
-  case "$lock_pid" in
-    ''|*[!0-9]*) return 1 ;;
-  esac
-  my_pid=$(fm_harness_ancestry_pid) || return 1
-  [ "$my_pid" = "$lock_pid" ]
+  local state=$1 owner marker my_pid
+  owner=$(cat "$state/.lock" 2>/dev/null || true)
+  if marker=$(fm_codex_owner_marker "$owner"); then
+    [ -n "${CODEX_THREAD_ID:-}" ] && [ "$CODEX_THREAD_ID" = "$marker" ]
+    return $?
+  fi
+  case "$owner" in ''|*[!0-9]*) return 1 ;; esac
+  my_pid=$(fm_verified_harness_ancestry_pid) || return 1
+  [ "$my_pid" = "$owner" ]
 }

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -46,7 +46,7 @@ fm_verified_harness_ancestry_pid() {
 # thread can keep using it and SessionEnd can release it deterministically.
 fm_session_lock_owner() {
   local pid
-  if [ -n "${CODEX_THREAD_ID:-}" ]; then
+  if [ "${GROK_AGENT:-}" != "1" ] && [ -n "${CODEX_THREAD_ID:-}" ]; then
     if pid=$(fm_verified_harness_ancestry_pid); then
       printf '%s|codex:%s|harness\n' "$pid" "$CODEX_THREAD_ID"
     else

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,6 +251,7 @@ On session start the first mate detects what its required toolchain is missing o
 It installs automatically supported tools only after you say go; manual-only tools remain for you to install from the printed instructions.
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
 The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
+Bootstrap reports missing or invalid GitHub authentication separately from API network/DNS failure, inaccessible OS credential storage, and a restricted environment that blocks both surfaces.
 This section is the single owner of that universal toolchain list; backend guides' prerequisites point here and add only their backend-specific tools.
 In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-aware array dispatch.
 The per-backend delta is required only for the backend resolved from `FM_BACKEND`, then `config/backend`, then runtime auto-detection, then default `tmux`, so a home is never told to install a tool an inactive backend or feature would need.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -250,7 +250,7 @@ Secondmate homes inherit this file from the primary, so a secondmate's own crewm
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.
 It installs automatically supported tools only after you say go; manual-only tools remain for you to install from the printed instructions.
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
-The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
+The universal toolchain is node, git, gh with GitHub auth via `gh auth login -h github.com`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
 Bootstrap reports missing or invalid GitHub authentication separately from API network/DNS failure, inaccessible OS credential storage, and a restricted environment that blocks both surfaces.
 This section is the single owner of that universal toolchain list; backend guides' prerequisites point here and add only their backend-specific tools.
 In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-aware array dispatch.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -28,7 +28,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
-| `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
+| `fm-session-lock-lib.sh` | Shared session-lock harness/thread identity, Codex PID-isolation owner format, ancestry walk, and holder liveness for fm-lock.sh and lifecycle hooks |
+| `fm-codex-session-lock-hook.sh` | Codex SessionStart owner claim and exact-marker SessionEnd release for the per-home session lock |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -1,7 +1,7 @@
 # Native session-start nudge
 
 AGENTS.md section 3 is the authoritative behavioral contract for session start.
-The tracked native adapters inject one instruction and never run the digest, acquire the lock, perform bootstrap work, drain notifications, or arm supervision themselves.
+The tracked native nudge adapters inject one instruction and never run the digest, acquire the lock, perform bootstrap work, drain notifications, or arm supervision themselves.
 The payload starts with U+2063 and the stable `FIRSTMATE_OP: ` label, carries the current `session-start` protocol kind, and retains exactly ``Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.`` as its body.
 The Ahoy skill owns the rule that this marked operational input is never a captain-authored session boundary, including its narrow legacy compatibility cases.
 
@@ -26,6 +26,10 @@ Every path exits 0, including malformed state and adapter errors, because a Clau
 | Pi / pi-signed | `.pi/extensions/fm-primary-turnend-guard.ts` handles `session_start` reasons `startup`, `new`, and `resume`, then injects the wrapper output with `pi.sendMessage`. | The custom message reaches model context without racing an initial positional prompt. |
 | Grok | `.grok/hooks/fm-primary-sessionstart-nudge.json` registers a project `SessionStart` hook and invokes the wrapper through inline-defaulted `${GROK_WORKSPACE_ROOT:-}`. | The project hook runs when the checkout is trusted, but Grok currently discards hook stdout from model context, so this path is intentionally fail-open. |
 
+Codex also registers a separate `SessionStart` and `SessionEnd` lifecycle adapter in `.codex/hooks.json` for the per-home lock.
+The start records the stable Codex thread marker and retains a verified harness PID when ancestry is visible, while PID-isolated tools preserve the same owner rather than replacing it with a transient PID.
+The end releases only a regular lock with the exact matching thread marker on clean `/quit` or `/exit`; other threads, malformed records, symlinks, and ambiguous release races remain fail-closed.
+
 The OpenCode nudge runs only on `session.created`.
 The watcher-arm and turn-end plugins run later on `session.idle`, and the guard lets the watcher coordinator act first, so the plugins do not race for one lifecycle event.
 
@@ -37,6 +41,8 @@ That alternative expands trust and writes outside this repository, so Firstmate 
 `tests/fm-sessionstart-nudge.test.sh` proves wrapper silence for both gate signals, an unmarked linked worktree, a missing state directory, and an already-owned lock.
 It proves exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output for a plain primary and a marked linked secondmate primary.
 It also verifies every tracked transport registration listed above.
+`tests/fm-codex-session-lock.test.sh` proves Codex lifecycle registration, same-thread preservation, verified stale recovery, live-session exclusion, PID-isolated fail-closed behavior, and exact-marker release.
+`FM_CODEX_LOCK_LIVE_E2E=1 tests/fm-codex-session-lock-live-e2e.test.sh` verifies that a real Codex `/quit` fires `SessionEnd` and releases the per-home lock without a provider request.
 `tests/fm-captain-translation-contract.test.sh` proves Ahoy's current marker rule, narrow legacy compatibility exclusions, genuine captain-message near misses, and the shared marker on supported user-role operational injections.
 `tests/fm-pi-primary-live-e2e.test.sh` and `tests/fm-opencode-primary-live-e2e.test.sh` exercise native startup paths with first-message and later-message Ahoy regressions.
 `tests/fm-turnend-guard.test.sh`, `tests/fm-pi-watch-extension.test.sh`, and `tests/fm-daemon.test.sh` cover marked guard, monitoring, and away-mode delivery.

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -12,8 +12,9 @@ It sources `bin/fm-gate-refuse-lib.sh` and stays silent for a no-mistakes gate a
 It shares `bin/fm-primary-scope-lib.sh` with `bin/fm-turnend-guard.sh`, so the hooks use one primary-detection owner.
 The Shared Predicate section of [`turnend-guard.md`](turnend-guard.md#shared-predicate) owns marker validation, plain-checkout detection, and required Firstmate-shaped paths.
 
-Before printing, the wrapper reads `state/.lock` and walks at most eight parents from its own pid, matching `bin/fm-lock.sh` and Pi's `lockOwnership()` ancestry depth.
-If the lock names a live pid in that ancestry, session start already ran in this harness session and the wrapper stays silent.
+Before printing, the wrapper reads `state/.lock` and applies the shared ownership predicate from `bin/fm-session-lock-lib.sh`.
+Numeric owners use an at-most-eight-parent ancestry walk, matching Pi's `lockOwnership()` depth, while Codex owners use the exact stable thread marker so PID-isolated tools still recognize the same session.
+If that predicate proves the current harness session owns the lock, session start already ran and the wrapper stays silent.
 Every path exits 0, including malformed state and adapter errors, because a Claude SessionStart exit 2 blocks session initialization.
 
 ## Harness transports

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -40,7 +40,6 @@ If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot s
 
 - Claude registers two `Stop` hooks in `.claude/settings.json`, both anchored through `CLAUDE_PROJECT_DIR`: `bin/fm-turnend-guard.sh --claude`, and `bin/fm-claude-stop-autoarm.sh` with `asyncRewake: true` and `timeout: 28800`.
 - Codex registers a `Stop` hook in `.codex/hooks.json`, anchors the executable to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and passes the original payload to the shared guard.
-- Codex separately registers `SessionStart` and `SessionEnd` lock lifecycle hooks; the start retains a verified harness PID when visible, and the end releases only the exact matching thread marker on clean `/quit` or `/exit`.
 - OpenCode listens for `session.idle` in `.opencode/plugins/fm-primary-turnend-guard.js`, lets the watcher coordinator act first, and calls `client.session.promptAsync` once when the guard returns 2.
 - Pi listens for `agent_settled` in `.pi/extensions/fm-primary-turnend-guard.ts`, runs once per logical agent run, and calls `pi.sendUserMessage(..., { deliverAs: "followUp" })` once when the guard returns 2.
 - Grok registers a `Stop` hook in `.grok/hooks/fm-primary-turnend-guard.json` and uses `bin/fm-turnend-guard-grok.sh` to resume the reported session once when the shared guard returns 2.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -40,6 +40,7 @@ If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot s
 
 - Claude registers two `Stop` hooks in `.claude/settings.json`, both anchored through `CLAUDE_PROJECT_DIR`: `bin/fm-turnend-guard.sh --claude`, and `bin/fm-claude-stop-autoarm.sh` with `asyncRewake: true` and `timeout: 28800`.
 - Codex registers a `Stop` hook in `.codex/hooks.json`, anchors the executable to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and passes the original payload to the shared guard.
+- Codex separately registers `SessionStart` and `SessionEnd` lock lifecycle hooks; the start retains a verified harness PID when visible, and the end releases only the exact matching thread marker on clean `/quit` or `/exit`.
 - OpenCode listens for `session.idle` in `.opencode/plugins/fm-primary-turnend-guard.js`, lets the watcher coordinator act first, and calls `client.session.promptAsync` once when the guard returns 2.
 - Pi listens for `agent_settled` in `.pi/extensions/fm-primary-turnend-guard.ts`, runs once per logical agent run, and calls `pi.sendUserMessage(..., { deliverAs: "followUp" })` once when the guard returns 2.
 - Grok registers a `Stop` hook in `.grok/hooks/fm-primary-turnend-guard.json` and uses `bin/fm-turnend-guard-grok.sh` to resume the reported session once when the shared guard returns 2.

--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -8,6 +8,10 @@
 # Empirical harness evidence lives in docs/arm-pretool-check.md.
 set -u
 
+# Matrix roots are this disposable checkout. A supervisor's separate FM_HOME
+# would make absolute blessed setup paths compare against the wrong home.
+unset FM_HOME 2>/dev/null || true
+
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -48,6 +48,7 @@ if [ "${1:-}" = auth ] && [ "${2:-}" = status ]; then
     missing) printf '\t\t\t\n' ;;
     invalid) printf 'error\tfake-user\tkeyring\tHTTP 401: Bad credentials\n' ;;
     network) printf 'error\tfake-user\tkeyring\tdial tcp: lookup api.github.com: no such host\n' ;;
+    timeout) printf 'timeout\tfake-user\tkeyring\tcontext deadline exceeded\n' ;;
     credential-store) printf 'error\tfake-user\tdefault\tconfigured credential unavailable\n' ;;
     sandbox) printf 'error\tfake-user\tdefault\tdial tcp: lookup api.github.com: connection refused\n' ;;
     inspect-failure) exit 1 ;;
@@ -328,6 +329,7 @@ success^
 missing^NEEDS_GH_AUTH: missing or invalid GitHub authentication - run gh auth login -h github.com
 invalid^NEEDS_GH_AUTH: missing or invalid GitHub authentication - run gh auth login -h github.com
 network^GH_NETWORK: GitHub API unreachable - check network and DNS access to api.github.com, then rerun
+timeout^GH_NETWORK: GitHub API unreachable - check network and DNS access to api.github.com, then rerun
 credential-store^GH_CREDENTIAL_STORE: configured GitHub credential is inaccessible - rerun Firstmate where the OS credential store is available; if it still fails, run gh auth login -h github.com
 sandbox^GH_SANDBOX: restricted environment blocks api.github.com and the configured GitHub credential store - rerun Firstmate outside that sandbox
 inspect-failure^GH_AUTH_CHECK: unable to inspect GitHub authentication - run gh auth status -h github.com outside Firstmate and resolve its diagnostic

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -41,8 +41,25 @@ make_fake_toolchain() {
   fm_fake_exit0 "$fakebin" tmux node gh-axi chrome-devtools-axi lavish-axi
   cat > "$fakebin/gh" <<'SH'
 #!/usr/bin/env bash
+mode=${FM_FAKE_GH_MODE:-success}
 if [ "${1:-}" = auth ] && [ "${2:-}" = status ]; then
+  case "$mode" in
+    success) printf 'success\tfake-user\tkeyring\t\n' ;;
+    missing) printf '\t\t\t\n' ;;
+    invalid) printf 'error\tfake-user\tkeyring\tHTTP 401: Bad credentials\n' ;;
+    network) printf 'error\tfake-user\tkeyring\tdial tcp: lookup api.github.com: no such host\n' ;;
+    credential-store) printf 'error\tfake-user\tdefault\tconfigured credential unavailable\n' ;;
+    sandbox) printf 'error\tfake-user\tdefault\tdial tcp: lookup api.github.com: connection refused\n' ;;
+    inspect-failure) exit 1 ;;
+    *) exit 2 ;;
+  esac
   exit 0
+fi
+if [ "${1:-}" = auth ] && [ "${2:-}" = token ]; then
+  case "$mode" in
+    missing|credential-store|sandbox) exit 1 ;;
+    *) exit 0 ;;
+  esac
 fi
 exit 0
 SH
@@ -291,6 +308,33 @@ ROWS
   pass "bootstrap reports treehouse lease + tasks-axi/quota-axi bootstrap contracts"
 }
 
+test_github_access_diagnostics() {
+  local case_dir fakebin mode expected out
+  case_dir="$TMP_ROOT/github-access"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  while IFS='^' read -r mode expected; do
+    [ -n "$mode" ] || continue
+    out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+      FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_GH_MODE="$mode" "$ROOT/bin/fm-bootstrap.sh")
+    if [ "$mode" = success ]; then
+      [ -z "$out" ] || fail "authenticated GitHub access should stay silent, got: $out"
+    else
+      [ "$out" = "$expected" ] || fail "$mode: expected '$expected', got: '$out'"
+    fi
+  done <<'ROWS'
+success^
+missing^NEEDS_GH_AUTH: missing or invalid GitHub authentication - run gh auth login -h github.com
+invalid^NEEDS_GH_AUTH: missing or invalid GitHub authentication - run gh auth login -h github.com
+network^GH_NETWORK: GitHub API unreachable - check network and DNS access to api.github.com, then rerun
+credential-store^GH_CREDENTIAL_STORE: configured GitHub credential is inaccessible - rerun Firstmate where the OS credential store is available; if it still fails, run gh auth login -h github.com
+sandbox^GH_SANDBOX: restricted environment blocks api.github.com and the configured GitHub credential store - rerun Firstmate outside that sandbox
+inspect-failure^GH_AUTH_CHECK: unable to inspect GitHub authentication - run gh auth status -h github.com outside Firstmate and resolve its diagnostic
+ROWS
+  pass "bootstrap distinguishes authenticated, invalid, network, credential-store, and sandbox GitHub states without live access"
+}
+
 test_no_mistakes_min_version() {
   local label version mode case_dir fakebin out missing n
   missing='MISSING: no-mistakes (install: curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh)'
@@ -349,15 +393,24 @@ SH
 }
 
 test_orca_backend_gates_orca_tool_only_when_selected() {
-  local case_dir fakebin out missing_orca
+  local case_dir fakebin out missing_orca bash_env
   missing_orca="MISSING: orca (install: brew install orca  # or the platform's package manager)"
+  bash_env="$TMP_ROOT/no-orca.bash"
+  cat > "$bash_env" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = orca ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+SH
 
   case_dir="$TMP_ROOT/orca-backend-selected"
   mkdir -p "$case_dir/home/config"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   printf '%s\n' orca > "$case_dir/home/config/backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   [ "$out" = "$missing_orca" ] || fail "backend=orca should require only the Orca-specific missing tool, got: $out"
 
@@ -365,7 +418,7 @@ test_orca_backend_gates_orca_tool_only_when_selected() {
   mkdir -p "$case_dir/home/config"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   assert_not_contains "$out" "MISSING: orca" "bootstrap should not require orca unless backend=orca is selected"
   pass "bootstrap: backend=orca gates the Orca CLI without requiring it on the default backend"
@@ -804,6 +857,7 @@ ROWS
 }
 
 test_bootstrap_reporting
+test_github_access_diagnostics
 test_no_mistakes_min_version
 test_git_is_required_with_supported_install_instruction
 test_orca_backend_gates_orca_tool_only_when_selected

--- a/tests/fm-claude-stop-autoarm.test.sh
+++ b/tests/fm-claude-stop-autoarm.test.sh
@@ -11,6 +11,10 @@
 # shellcheck disable=SC2016 # single quotes are deliberate: $FM_HOME expands inside the fake harness child, and grep needles are literal strings
 set -u
 
+# These are Claude fixtures. An ambient Codex thread marker would otherwise
+# override their fake ancestry and change the lock owner format under test.
+unset CODEX_THREAD_ID 2>/dev/null || true
+
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 

--- a/tests/fm-codex-session-lock-live-e2e.test.sh
+++ b/tests/fm-codex-session-lock-live-e2e.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Opt-in live Codex TUI regression for the native /quit -> SessionEnd lock
+# lifecycle. It sends /quit before any model turn and uses no provider request.
+set -u
+
+if [ "${FM_CODEX_LOCK_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_CODEX_LOCK_LIVE_E2E=1 to run the Codex /quit lock regression"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+command -v codex >/dev/null 2>&1 || fail "codex not found"
+command -v script >/dev/null 2>&1 || fail "script not found"
+command -v timeout >/dev/null 2>&1 || fail "timeout not found"
+
+LAB="$ROOT/.codex-session-lock-live-e2e.$$"
+HOME_DIR="$LAB/fmhome"
+TRANSCRIPT="$LAB/codex.typescript"
+CODEX_VERSION=$(codex --version)
+
+cleanup() {
+  rm -rf "$LAB"
+}
+trap cleanup EXIT
+mkdir -p "$HOME_DIR/state"
+
+# `script` supplies the PTY required by Codex's TUI. The leading unset prevents
+# the parent test session's thread marker from being mistaken for the nested
+# session; Codex publishes the nested marker to its own lifecycle hooks.
+printf '/quit\r' \
+  | timeout 30 env -u CODEX_THREAD_ID FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$ROOT" \
+      script -qfec "codex --dangerously-bypass-hook-trust -C '$ROOT'" "$TRANSCRIPT" \
+      >/dev/null 2>&1 \
+  || fail "Codex /quit session did not close cleanly: $(tail -20 "$TRANSCRIPT" 2>/dev/null)"
+
+[ ! -e "$HOME_DIR/state/.lock" ] \
+  || fail "Codex /quit left the session lock behind: $(cat "$HOME_DIR/state/.lock" 2>/dev/null)"
+grep -F '/quit' "$TRANSCRIPT" >/dev/null \
+  || fail "Codex PTY transcript did not contain the real /quit command"
+
+printf 'ok - %s live /quit fired SessionEnd and released the per-home lock\n' "$CODEX_VERSION"

--- a/tests/fm-codex-session-lock.test.sh
+++ b/tests/fm-codex-session-lock.test.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Focused behavior tests for Codex marker-owned session locks and the native
+# SessionStart/SessionEnd lifecycle adapter.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LOCK="$ROOT/bin/fm-lock.sh"
+HOOK="$ROOT/bin/fm-codex-session-lock-hook.sh"
+TMP_ROOT=$(fm_test_tmproot fm-codex-session-lock-tests)
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+
+make_home() {
+  local home="$TMP_ROOT/$1"
+  mkdir -p "$home/state"
+  printf '%s\n' "$home"
+}
+
+make_hidden_ps() {
+  local dir=$1
+  mkdir -p "$dir"
+  cat > "$dir/ps" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$dir/ps"
+}
+
+make_live_owner_ps() {
+  local dir=$1
+  mkdir -p "$dir"
+  cat > "$dir/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+pid=
+previous=
+for argument in "$@"; do
+  [ "$previous" = -p ] && pid=$argument
+  previous=$argument
+done
+[ "$pid" = "${FM_FAKE_LIVE_PID:-}" ] || exit 1
+case "$*" in
+  *"comm="*) printf '%s\n' codex ;;
+  *"args="*) printf '%s\n' codex ;;
+  *"ppid="*) printf '%s\n' 1 ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$dir/ps"
+}
+
+run_lock() {
+  local home=$1 thread=$2 fakebin=$3
+  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    FM_HOME="$home" CODEX_THREAD_ID="$thread" PATH="$fakebin:$BASE_PATH" \
+    bash "$LOCK"
+}
+
+run_hook() {
+  local home=$1 event=$2 session=$3
+  printf '{"hook_event_name":"%s","session_id":"%s","cwd":"%s"}\n' \
+    "$event" "$session" "$ROOT" \
+    | FM_HOME="$home" CODEX_THREAD_ID="$session" bash "$HOOK"
+}
+
+test_hook_registration() {
+  local command
+  jq -e '.hooks.SessionEnd | length == 1' "$ROOT/.codex/hooks.json" >/dev/null \
+    || fail "Codex SessionEnd hook is not registered exactly once"
+  command=$(jq -r '.hooks.SessionEnd[0].hooks[0].command' "$ROOT/.codex/hooks.json")
+  # shellcheck disable=SC2016 # The command must retain this literal shell expression.
+  assert_contains "$command" 'root=$(pwd -P)' "Codex SessionEnd hook is not pwd-anchored"
+  assert_contains "$command" 'fm-codex-session-lock-hook.sh' "Codex SessionEnd hook does not invoke the lock adapter"
+  jq -e '.hooks.SessionEnd[0].hooks[0].timeout == 3' "$ROOT/.codex/hooks.json" >/dev/null \
+    || fail "Codex SessionEnd hook must respect Codex's three-second maximum"
+  jq -e '[.hooks.SessionStart[]?.hooks[] | select(.command | contains("fm-codex-session-lock-hook.sh"))] | length == 1' \
+    "$ROOT/.codex/hooks.json" >/dev/null \
+    || fail "Codex SessionStart does not retain a verified harness owner before the first turn"
+  pass "Codex registers one bounded SessionEnd release and one SessionStart owner claim"
+}
+
+test_clean_session_end_releases_matching_lock() {
+  local home
+  home=$(make_home clean-exit)
+  printf '%s\n' '999999|codex:thread-clean|fallback' > "$home/state/.lock"
+  run_hook "$home" SessionEnd thread-clean
+  [ ! -e "$home/state/.lock" ] || fail "matching SessionEnd left the Codex session lock behind"
+  pass "matching Codex SessionEnd releases the lock used by /quit"
+}
+
+test_session_start_retains_verified_harness_owner() {
+  local home fakecodex owner
+  home=$(make_home start-owner)
+  fakecodex="$home/codex"
+  ln -s /bin/bash "$fakecodex"
+  # shellcheck disable=SC2016 # FM_HOOK_PATH expands inside the fake Codex process.
+  FM_HOOK_PATH="$HOOK" FM_HOME="$home" CODEX_THREAD_ID=thread-start \
+    "$fakecodex" -c 'printf '\''{"hook_event_name":"SessionStart","session_id":"thread-start"}\n'\'' | bash "$FM_HOOK_PATH"'
+  owner=$(cat "$home/state/.lock")
+  case "$owner" in
+    *'|codex:thread-start|harness') ;;
+    *) fail "SessionStart did not retain the visible Codex harness PID: $owner" ;;
+  esac
+  pass "Codex SessionStart retains a verified harness PID when ancestry is visible"
+}
+
+test_same_thread_preserves_existing_owner() {
+  local home fakebin before out
+  home=$(make_home same-thread)
+  fakebin="$home/fakebin"
+  make_hidden_ps "$fakebin"
+  before='8123|codex:thread-same|fallback'
+  printf '%s\n' "$before" > "$home/state/.lock"
+  out=$(run_lock "$home" thread-same "$fakebin") || fail "same Codex thread could not reacquire its lock: $out"
+  [ "$(cat "$home/state/.lock")" = "$before" ] || fail "same thread replaced the stable owner with a transient tool PID"
+  assert_contains "$out" "$before" "same-thread acquisition did not report the preserved owner"
+  pass "same Codex thread preserves its existing owner across PID-isolated tool calls"
+}
+
+test_dead_verified_owner_is_reclaimed() {
+  local home fakebin out owner
+  home=$(make_home dead-owner)
+  fakebin="$home/fakebin"
+  make_hidden_ps "$fakebin"
+  printf '%s\n' '99999999|codex:thread-dead|harness' > "$home/state/.lock"
+  out=$(run_lock "$home" thread-new "$fakebin") || fail "provably dead Codex owner was not reclaimed: $out"
+  owner=$(cat "$home/state/.lock")
+  case "$owner" in
+    *'|codex:thread-new|fallback') ;;
+    *) fail "dead owner recovery wrote unexpected owner: $owner" ;;
+  esac
+  pass "a verified Codex harness PID that is provably dead is reclaimed"
+}
+
+test_different_live_thread_is_excluded() {
+  local home fakebin sleeper out status owner
+  home=$(make_home live-other)
+  fakebin="$home/fakebin"
+  sleep 60 &
+  sleeper=$!
+  make_live_owner_ps "$fakebin"
+  owner="$sleeper|codex:thread-live|harness"
+  printf '%s\n' "$owner" > "$home/state/.lock"
+  status=0
+  out=$(FM_FAKE_LIVE_PID="$sleeper" run_lock "$home" thread-other "$fakebin" 2>&1) || status=$?
+  kill "$sleeper" 2>/dev/null || true
+  wait "$sleeper" 2>/dev/null || true
+  expect_code 1 "$status" "different live Codex thread must be excluded"
+  assert_contains "$out" "another live firstmate session holds the lock" "live-thread refusal was not explicit"
+  [ "$(cat "$home/state/.lock")" = "$owner" ] || fail "different thread replaced the live Codex owner"
+  pass "a different live Codex thread remains excluded"
+}
+
+test_different_fallback_thread_stays_fail_closed() {
+  local home fakebin out status owner
+  home=$(make_home fallback-other)
+  fakebin="$home/fakebin"
+  make_hidden_ps "$fakebin"
+  owner='17|codex:thread-hidden|fallback'
+  printf '%s\n' "$owner" > "$home/state/.lock"
+  status=0
+  out=$(run_lock "$home" thread-other "$fakebin" 2>&1) || status=$?
+  expect_code 1 "$status" "different thread must not reclaim a PID-isolated fallback owner"
+  assert_contains "$out" "cannot verify whether another Codex session holds the lock" "fallback refusal lost its fail-closed reason"
+  [ "$(cat "$home/state/.lock")" = "$owner" ] || fail "different thread replaced the unverifiable fallback owner"
+  pass "a different thread cannot weaken the PID-isolated fallback boundary"
+}
+
+test_session_end_disconfirming_cases_leave_lock() {
+  local home owner
+  home=$(make_home release-disconfirming)
+  for owner in \
+    '4321' \
+    '4321|codex:thread-other|harness' \
+    '4321|codex:thread-clean|unknown' \
+    '4321|unexpected|codex:thread-clean|harness' \
+    'not-an-owner'; do
+    printf '%s\n' "$owner" > "$home/state/.lock"
+    run_hook "$home" SessionEnd thread-clean
+    [ "$(cat "$home/state/.lock")" = "$owner" ] || fail "SessionEnd removed or changed disconfirming owner '$owner'"
+  done
+  rm -f "$home/state/.lock"
+  ln -s "$home/state/missing-target" "$home/state/.lock"
+  run_hook "$home" SessionEnd thread-clean
+  [ -L "$home/state/.lock" ] || fail "SessionEnd followed or removed a symlinked lock"
+  pass "SessionEnd leaves numeric, different, malformed, and symlinked owners untouched"
+}
+
+test_hook_registration
+test_clean_session_end_releases_matching_lock
+test_session_start_retains_verified_harness_owner
+test_same_thread_preserves_existing_owner
+test_dead_verified_owner_is_reclaimed
+test_different_live_thread_is_excluded
+test_different_fallback_thread_stays_fail_closed
+test_session_end_disconfirming_cases_leave_lock

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -2,6 +2,10 @@
 # Behavior tests for the verified Kimi Code CLI crewmate adapter.
 set -u
 
+# Kimi identity cases supply their own harness marker or ancestry. Do not let
+# the surrounding Codex session win detect_own() before those fixtures run.
+unset CODEX_THREAD_ID 2>/dev/null || true
+
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -36,6 +36,9 @@
 #      flags still win.
 set -u
 
+# Harness identity cases below provide their own markers and mocked ancestry.
+unset CODEX_THREAD_ID GROK_AGENT 2>/dev/null || true
+
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 # shellcheck source=/dev/null
@@ -174,7 +177,7 @@ SH
   [ "$got" = pi ] || fail "unrelated pi-signed-helper ancestry resolved '$got', expected pi"
 
   got=$(PATH="$fakebin:$BASE_PATH" bash -c \
-    '. "$0/bin/fm-session-lock-lib.sh"; fm_harness_ancestry_pid' "$ROOT")
+    '. "$0/bin/fm-session-lock-lib.sh"; fm_verified_harness_ancestry_pid' "$ROOT")
   [ "$got" = 100 ] || fail "session-lock ancestry selected '$got', expected the inner Pi engine pid 100"
   PATH="$fakebin:$BASE_PATH" bash -c \
     '. "$0/bin/fm-session-lock-lib.sh"; kill() { return 0; }; fm_harness_pid_alive 200' "$ROOT" \

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -315,6 +315,9 @@ SH
   chmod +x "$fakebin/tmux"
   cat > "$fakebin/gh" <<'SH'
 #!/usr/bin/env bash
+if [ "${1:-} ${2:-}" = "auth status" ]; then
+  printf 'success\tfake-user\tkeyring\t\n'
+fi
 exit 0
 SH
   chmod +x "$fakebin/gh"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -454,6 +454,14 @@ SH
   pass "session start accepts Codex's PID-isolated process marker"
 }
 
+test_grok_marker_precedes_inherited_codex_marker() {
+  local out
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT GROK_AGENT=1 CODEX_THREAD_ID=inherited-codex-thread \
+    FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-harness.sh")
+  [ "$out" = grok ] || fail "Grok marker should override an inherited Codex marker, got: $out"
+  pass "Grok marker takes precedence over an inherited Codex marker"
+}
+
 # prepare_session_start_secondmate <name>: a throwaway main home and Pi
 # secondmate home wired to the real spawn implementation through the fixture
 # root. Echoes root|home|fakebin|mate|log|spawned.
@@ -1418,6 +1426,7 @@ EOF
 
 test_context_digest_absent_empty_present
 test_session_start_accepts_codex_pid_isolated_marker
+test_grok_marker_precedes_inherited_codex_marker
 test_lock_refusal_read_only_path
 test_lock_write_failure_read_only_path
 test_session_lock_concurrent_single_winner

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -455,11 +455,24 @@ SH
 }
 
 test_grok_marker_precedes_inherited_codex_marker() {
-  local out
+  local rec root home fakebin out owner
   out=$(env -u CLAUDECODE -u PI_CODING_AGENT GROK_AGENT=1 CODEX_THREAD_ID=inherited-codex-thread \
     FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-harness.sh")
   [ "$out" = grok ] || fail "Grok marker should override an inherited Codex marker, got: $out"
-  pass "Grok marker takes precedence over an inherited Codex marker"
+
+  rec=$(new_world grok-inherited-codex-marker)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_ps_harness "$fakebin" grok
+  env -u CLAUDECODE -u PI_CODING_AGENT GROK_AGENT=1 CODEX_THREAD_ID=inherited-codex-thread \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" FM_FAKE_HARNESS=grok \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" >/dev/null
+  owner=$(cat "$home/state/.lock")
+  case "$owner" in
+    ''|*[!0-9]*) fail "Grok lock owner should be a harness PID, got: $owner" ;;
+  esac
+  pass "Grok marker takes precedence over an inherited Codex marker in detection and lock ownership"
 }
 
 # prepare_session_start_secondmate <name>: a throwaway main home and Pi

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -20,6 +20,11 @@
 #     does not reimplement their logic
 set -u
 
+# The suite supplies harness identity explicitly per case. Do not let the
+# surrounding Codex session turn direct fm-lock.sh cases into same-thread
+# acquisitions.
+unset CODEX_THREAD_ID 2>/dev/null || true
+
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 # shellcheck source=tests/wake-helpers.sh
@@ -406,21 +411,47 @@ SH
 # Drop every harness env marker from bin/fm-harness.sh detect_own so the
 # surrounding interactive shell cannot leak past the suite's fake ps harness.
 # Markers today: CLAUDECODE (claude), PI_CODING_AGENT plus FM_PI_HARNESS
-# (Pi family), GROK_AGENT (grok).
-# codex and opencode have no env markers (ancestry only). Without this, a local
-# claude/pi/grok session fails cases that pin a different fake harness while CI
-# (no ambient markers) still passes.
+# (Pi family), CODEX_THREAD_ID (codex), and GROK_AGENT (grok).
+# Without this, a local claude/pi/codex/grok session fails cases that pin a
+# different fake harness while CI (no ambient markers) still passes.
 run_session_start() {
   local home=$1 root=$2 path=$3 pi_harness=${4:-}
   if [ -n "$pi_harness" ]; then
-    env -u CLAUDECODE -u GROK_AGENT PI_CODING_AGENT=true FM_PI_HARNESS="$pi_harness" \
+    env -u CLAUDECODE -u CODEX_THREAD_ID -u GROK_AGENT \
+      PI_CODING_AGENT=true FM_PI_HARNESS="$pi_harness" \
       FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
       "$SESSION_START"
   else
-    env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS \
+      -u CODEX_THREAD_ID -u GROK_AGENT \
       FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
       "$SESSION_START"
   fi
+}
+
+test_session_start_accepts_codex_pid_isolated_marker() {
+  local rec root home fakebin out status
+  rec=$(new_world codex-pid-isolated)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  # No harness is visible through the fake ancestry. The Codex marker is the
+  # only available identity, matching the PID-isolated tool-sandbox failure.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+
+  status=0
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$root" CODEX_THREAD_ID=codex-test-thread \
+    PATH="$fakebin:$BASE_PATH" "$SESSION_START") || status=$?
+
+  expect_code 0 "$status" "Codex marker should allow session start without visible ancestry"
+  assert_contains "$out" "lock acquired: Codex session owner" "Codex marker lock acquisition was not reported"
+  assert_contains "$out" "codex:codex-test-thread" "Codex thread marker was not persisted in the lock owner"
+  pass "session start accepts Codex's PID-isolated process marker"
 }
 
 # prepare_session_start_secondmate <name>: a throwaway main home and Pi
@@ -1386,6 +1417,7 @@ EOF
 }
 
 test_context_digest_absent_empty_present
+test_session_start_accepts_codex_pid_isolated_marker
 test_lock_refusal_read_only_path
 test_lock_write_failure_read_only_path
 test_session_lock_concurrent_single_winner


### PR DESCRIPTION
## Intent

Ship two related Firstmate reliability fixes based on reproduced end-user failures. Make clean Codex /quit release the per-home session lock through supported native lifecycle integration while preserving fail-closed exclusion of live sessions, same-thread behavior, verified stale recovery, and PID-isolated compatibility. Distinguish genuine GitHub authentication failure from API network or DNS failure, inaccessible credential storage, and combined sandbox isolation without leaking credentials or requiring live GitHub in tests. Update authoritative headers and help plus narrowly relevant docs under the one-owner rule, keep scripts shellcheck-clean, and validate with focused real and deterministic regressions. Include the approved follow-up decisions: structured GitHub CLI state=timeout maps to GH_NETWORK with regression coverage, GROK_AGENT takes precedence over inherited CODEX_THREAD_ID with regression coverage, and publication uses the KarlvonPoncet/firstmate fork while the PR targets kunchenguid/firstmate.

## What Changed

- Release per-home Codex session locks through native SessionStart and SessionEnd hooks while preserving same-thread access, live-session exclusion, stale recovery, and PID-isolated fail-closed behavior.
- Classify GitHub authentication checks into invalid credentials, network or DNS failures, inaccessible credential storage, combined sandbox isolation, and generic inspection failures.
- Preserve Grok identity when `GROK_AGENT` and an inherited Codex thread marker coexist, with focused deterministic and live regressions plus updated operator documentation.

## Risk Assessment

✅ Low: The follow-up now enforces Grok-over-Codex marker precedence at the shared session-lock owner boundary with deterministic regression coverage, and the complete branch remains well-bounded with no other substantiated source or intent-conformance defects.

## Testing

No baseline commands were supplied; focused lock, bootstrap, and session-start regressions passed, and a real Codex CLI 0.145.0 PTY session confirmed that clean /quit fires SessionEnd and removes the per-home lock. The first live attempt was blocked by the runner's unsupported TERM=dumb setting, then passed unchanged with TERM=xterm-256color. CLI logs were captured instead of screenshots because the changed user surfaces are terminal lifecycle and diagnostic output, not rendered UI.

<details>
<summary>Evidence: Real Codex /quit lifecycle evidence</summary>

`ok - codex-cli 0.145.0 live /quit fired SessionEnd and released the per-home lock`

```text
ok - codex-cli 0.145.0 live /quit fired SessionEnd and released the per-home lock
```
</details>
<details>
<summary>Evidence: Codex lock regression evidence</summary>

`Covers matching release, same-thread preservation, stale recovery, live-session exclusion, PID-isolated fail-closed behavior, and malformed/symlinked lock preservation.`

```text
ok - Codex registers one bounded SessionEnd release and one SessionStart owner claim
ok - matching Codex SessionEnd releases the lock used by /quit
ok - Codex SessionStart retains a verified harness PID when ancestry is visible
ok - same Codex thread preserves its existing owner across PID-isolated tool calls
ok - a verified Codex harness PID that is provably dead is reclaimed
ok - a different live Codex thread remains excluded
ok - a different thread cannot weaken the PID-isolated fallback boundary
ok - SessionEnd leaves numeric, different, malformed, and symlinked owners untouched
```
</details>
<details>
<summary>Evidence: GitHub diagnostic regression evidence</summary>

`Covers deterministic missing/invalid auth, network/DNS, structured timeout, inaccessible credential storage, combined sandbox isolation, and inspection failure without live GitHub.`

```text
ok - bootstrap reports treehouse lease + tasks-axi/quota-axi bootstrap contracts
ok - bootstrap distinguishes authenticated, invalid, network, credential-store, and sandbox GitHub states without live access
ok - bootstrap enforces no-mistakes minimum version
ok - bootstrap requires git with an install instruction
ok - bootstrap: backend=orca gates the Orca CLI without requiring it on the default backend
ok - bootstrap: session-provider backends require their own CLI + jq + treehouse, never tmux
ok - bootstrap: a session-provider backend gates its own CLI, never a false tmux requirement
ok - bootstrap: Herdr manual-install guidance is never executed as a shell command
ok - bootstrap: the bundled cmux CLI satisfies the active backend dependency
ok - bootstrap: unknown resolved backends fail closed with an actionable diagnostic
ok - bootstrap: JSON-emitting backends require jq (their genuine dep), never tmux
ok - bootstrap: the treehouse lease check follows the resolved backend's worktree provider
ok - bootstrap computes a fleet-size-aware default timeout and preserves partial fleet-sync output
ok - bootstrap keeps the quick 20s default for small fleets
ok - bootstrap preserves FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT as an explicit override
ok - bootstrap treats a blank timeout override as unset
ok - bootstrap computes the timeout before launching fleet sync
ok - bootstrap keeps routine tasks-axi, harness, dispatch, and already-live liveness confirmations silent
ok - bootstrap routine contract runs under system /bin/bash
ok - bootstrap diagnostics trigger excludes benign lines and keeps actionable prefixes
ok - bootstrap surfaces active crew-dispatch rules only as verbose BOOTSTRAP_INFO
ok - bootstrap validates crew-dispatch.json and reports malformed or unverified configs
```
</details>
<details>
<summary>Evidence: Session-start regression evidence</summary>

`Includes PID-isolated Codex ownership and GROK_AGENT precedence over inherited CODEX_THREAD_ID.`

```text
ok - context digest distinguishes ABSENT, empty-but-present, and populated files
ok - session start accepts Codex's PID-isolated process marker
ok - Grok marker takes precedence over an inherited Codex marker in detection and lock ownership
ok - a lock refusal prints a loud read-only banner, skips every mutating step, and still completes the digest
ok - session start stays read-only when lock ownership cannot be published
ok - concurrent session-lock acquisition admits exactly one live harness
ok - digest sections are ordered diagnostics-first, bulk-context-last
ok - session start: configured and auto-detected Herdr homes never require tmux
ok - session start: an absent recorded tmux window relaunches its Pi secondmate exactly once
ok - session start: an existing ambiguous Pi process prevents duplicate recovery
ok - session start: transient tmux unreadability never licenses a relaunch
ok - session start: the proven bare-shell recovery path remains intact
ok - session start: a confirmed Herdr husk is closed and relaunched
ok - status tail is bounded to the configured line count, with the full log path always printed
ok - orphan status logs are printed once with bounded tails
ok - tmux endpoint liveness is reported per task: alive for a live window, dead for a gone one
ok - herdr endpoint liveness is reported per task: alive for a live pane, dead for a gone one
ok - fm-session-start.sh composes the real fm-lock.sh, fm-bootstrap.sh, and fm-wake-drain.sh output verbatim
ok - compatible tasks-axi backlog rendering is compact, bounded, and preserves recovery metadata
ok - manual backlog rendering prints only title lines with hold and blocker metadata
ok - unavailable or incompatible tasks-axi falls back to compact manual backlog rendering
ok - an empty fleet reports (none) for in-flight tasks and an absent AFK flag
ok - session start emits X-mode cadence guidance in the harness supervision block
ok - next step delegates watcher ownership to the AFK daemon
ok - session start emits exactly one detected harness block and reports Pi extension load state
ok - session start rejects stale Pi loaded markers
ok - session start accepts current Pi markers written before lock acquisition
ok - session start rejects Pi sessions missing the turn-end guard marker
ok - session start rejects Pi loaded markers from previous sessions
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-session-lock-lib.sh:49` - Intent requires &#34;GROK_AGENT takes precedence over inherited CODEX_THREAD_ID&#34;, but `fm_session_lock_owner` still treats any non-empty `CODEX_THREAD_ID` as Codex without checking `GROK_AGENT`. A Grok session inheriting a Codex marker is correctly identified as Grok by `fm-harness.sh`, then `fm-lock.sh` writes a Codex owner anyway; same-session checks subsequently trust the inherited Codex thread and Grok has no Codex SessionEnd release. Enforce the precedence at the shared lock-owner boundary, not only in harness-name detection, and cover the resulting owner record in the Grok regression.

🔧 Fix: Honor Grok precedence in session lock ownership
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-codex-session-lock.test.sh`
- `bash tests/fm-bootstrap.test.sh`
- `bash tests/fm-session-start.test.sh`
- `TERM=xterm-256color FM_CODEX_LOCK_LIVE_E2E=1 bash tests/fm-codex-session-lock-live-e2e.test.sh`
- <code>`git remote -v` verified upstream fetch and fork push destinations</code>
- <code>`git status --short` verified testing left no working-tree artifacts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Validate lint with pinned ShellCheck 0.11.0
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
