### PR TITLE
feat(bin): add AGY crewmate runtime

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, and kimi.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, and agy.
 user-invocable: false
 metadata:
   internal: true
@@ -124,6 +124,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
+| agy | `--model <model>` | `--effort <low\|medium\|high>` | Verified 2026-07-27 on Antigravity CLI 1.1.7. |
 
 ### Model support discovery
 
@@ -138,6 +139,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | pi / pi-signed | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |
 | kimi | Run `kimi provider list --json`, which lists the current provider and model configuration. |
+| agy | Run `agy models`, which lists the current authenticated Google models. |
 
 For an unfamiliar harness or model namespace, establish support and provider identity from that harness's authoritative CLI help, model listing, or current documentation rather than guessing from a name or prefix.
 If those sources do not establish the relationship needed for dispatch, fail loudly and report the unresolved candidate.
@@ -156,6 +158,7 @@ Natural language is acceptable if uncertain.
 - pi and pi-signed: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles this through the structural composer reader; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 - kimi: `/<skill>`, for example `/no-mistakes`.
+- agy: no separate verified skill invocation exists; use a natural-language validation instruction.
 
 ## Submission acknowledgement hazards
 
@@ -349,6 +352,40 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## agy (VERIFIED 2026-07-27, Antigravity CLI 1.1.7; ordinary crewmate/scout only)
+
+AGY launches as `agy --dangerously-skip-permissions --mode accept-edits --model <model> --effort <low|medium|high> --prompt-interactive <encoded-brief>`.
+`--dangerously-skip-permissions` and `--mode accept-edits` ran read, command, and write tools unattended.
+Its child/tool-process marker is `ANTIGRAVITY_AGENT=1`.
+The busy footer is `esc to cancel` or `esc to cancel generation`.
+The idle footer is `? for shortcuts` and the accept-edits composer is a `>` row between horizontal rules with dim `Accept-edits mode: file edits auto-approved (shift+tab to cycle)` placeholder text.
+Send Escape to interrupt and `/exit` to leave the TUI.
+Resume with `agy --conversation <UUID>` or cwd-scoped `agy --continue`.
+A fresh isolated worktree can show `Do you trust the contents of this project?`; accept the dialog with Enter, then verify the brief is processing.
+Do not pre-seed or edit `~/.gemini/antigravity-cli/settings.json`.
+AGY 1.1.7 exposes no verified user-facing lifecycle hook, so ordinary pane monitoring remains the wake path.
+AGY is not a primary or secondmate runtime.
+
+Verification evidence from 2026-07-27:
+
+```sh
+/usr/bin/agy -p "Reply with exactly AGY_OK and nothing else." \
+  --model gemini-3.1-pro-high --effort high --print-timeout 2m
+```
+
+```text
+AGY_OK
+```
+
+```sh
+agy --help
+```
+
+```text
+--effort Reasoning effort for the current CLI session (low|medium|high)
+--prompt-interactive Run an initial prompt interactively and continue the session
+```
 
 ## kimi (VERIFIED 2026-07-25, kimi 0.29.1)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, and `kimi`; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and ordinary-crewmate/scout-only `agy`; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1898,8 +1898,8 @@ fm_backend_herdr_agent_identity_raw() {  # <session> <pane> -> <agent>\t<status>
   printf '%s' "$out" | jq -r '[.result.agent.agent // "", .result.agent.agent_status // ""] | @tsv' 2>/dev/null
 }
 
-fm_backend_herdr_composer_state() {  # <target> -> empty|pending|unknown
-  local target=$1 session pane cap line trimmed found=0 shape="" raw_match="" bordered=0 stripped
+fm_backend_herdr_composer_state() {  # <target> [harness] -> empty|pending|unknown
+  local target=$1 harness=${2:-} session pane cap line trimmed found=0 shape="" raw_match="" bordered=0 stripped
   local identity agent agent_status row=0 generic_line=0
   fm_backend_herdr_parse_target "$target" || { printf 'unknown'; return 0; }
   session=$FM_BACKEND_HERDR_SESSION
@@ -1938,7 +1938,18 @@ fm_backend_herdr_composer_state() {  # <target> -> empty|pending|unknown
   # row can never suppress the live Pi composer. Identity is consulted only when
   # a lower separator pair could change the verdict.
   fm_backend_herdr_pi_composer_find "$cap"
-  if [ "$FM_BACKEND_HERDR_PI_PAIR_FOUND" -eq 1 ] \
+  if [ "$harness" = agy ] \
+     && [ "$FM_BACKEND_HERDR_PI_PAIR_FOUND" -eq 1 ] \
+     && [ "$FM_BACKEND_HERDR_PI_PAIR_VALID" -eq 1 ] \
+     && [ "$FM_BACKEND_HERDR_PI_PAIR_LINE" -gt "$generic_line" ] \
+     && [ "$generic_line" -lt "$FM_BACKEND_HERDR_PI_PAIR_OPEN_LINE" ]; then
+    # AGY's accept-edits composer is one or more rows between complete rules.
+    # Only a recorded AGY target reaches this branch, so this generic-looking
+    # structure cannot authorize injection into another harness or a shell.
+    shape=separated
+    raw_match=$FM_BACKEND_HERDR_PI_CONTENT
+    found=1
+  elif [ "$FM_BACKEND_HERDR_PI_PAIR_FOUND" -eq 1 ] \
      && [ "$FM_BACKEND_HERDR_PI_PAIR_LINE" -gt "$generic_line" ] \
      && [ "$generic_line" -lt "$FM_BACKEND_HERDR_PI_PAIR_OPEN_LINE" ]; then
     identity=$(fm_backend_herdr_agent_identity_raw "$session" "$pane" 2>/dev/null || true)
@@ -2061,8 +2072,8 @@ EOF
 # submit vocabulary. Empty means confirmed submitted for every backend; how
 # each backend confirms it is an internal decision, and herdr's is no longer
 # literally "the composer read empty".
-fm_backend_herdr_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle>
-  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 i=0 verdict baseline confirm_sleep
+fm_backend_herdr_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle> [expected-label] [harness]
+  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 harness=${7:-} i=0 verdict baseline confirm_sleep
   fm_backend_herdr_parse_target "$target" || { printf 'unknown'; return 0; }
   fm_backend_herdr_send_literal "$target" "$text" || { printf 'send-failed'; return 0; }
   sleep "$settle"
@@ -2076,7 +2087,7 @@ fm_backend_herdr_send_text_submit() {  # <target> <text> <retries> <enter-sleep>
         "$confirm_sleep" "$FM_BACKEND_HERDR_SUBMIT_POLLS")
     else
       sleep "$sleep_s"
-      verdict=$(fm_backend_herdr_composer_state "$target")
+      verdict=$(fm_backend_herdr_composer_state "$target" "$harness")
     fi
     case "$verdict" in
       busy) printf 'empty'; return 0 ;;

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -50,8 +50,8 @@ fm_backend_tmux_send_key() {  # <target> <key>
 # submit with Enter, retried (Enter only, never retyped) until the composer
 # clears. Re-exports fm_tmux_submit_core (bin/fm-tmux-lib.sh) verbatim; see
 # that file for the composer-verification contract and echoed verdicts.
-fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle>
-  fm_tmux_submit_core "$@"
+fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle> [expected-label] [harness]
+  fm_tmux_submit_core "$1" "$2" "$3" "$4" "$5" "${7:-}"
 }
 
 # fm_backend_tmux_container_ensure: reuse the current tmux session when
@@ -181,7 +181,7 @@ fm_backend_tmux_agent_state() {  # <target>
   }
   comm=${comm#-}
   case "$comm" in
-    *claude*|*codex*|*opencode*|*grok*|*kimi*|pi|pi-signed|pi-launcher|Pi) printf 'alive' ;;
+    *claude*|*codex*|*opencode*|*grok*|*kimi*|*agy*|pi|pi-signed|pi-launcher|Pi) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     '') printf 'unreadable' ;;
     *) printf 'ambiguous' ;;

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -553,7 +553,7 @@ fm_backend_send_key() {  # <backend> <target> <key> [expected-label]
 # fm_backend_send_text_submit: type text once, then submit and verify,
 # retrying only the submission (never retyping). Echoes the backend's
 # proof-carrying verdict; callers require exact empty for confirmed delivery.
-fm_backend_send_text_submit() {  # <backend> <target> <text> <retries> <enter-sleep> <settle> [expected-label]
+fm_backend_send_text_submit() {  # <backend> <target> <text> <retries> <enter-sleep> <settle> [expected-label] [harness]
   local backend=$1
   shift
   fm_backend_source "$backend" || return 1
@@ -633,7 +633,7 @@ fm_backend_busy_state() {  # <backend> <target>
 # submit path uses an internal content-diff approach with no separately named
 # classifier, so it reports unknown here - callers fall back to their own
 # policy, exactly as an unknown fm_backend_busy_state already does.
-fm_backend_composer_state() {  # <backend> <target> -> empty|pending|pending-unproven|unknown
+fm_backend_composer_state() {  # <backend> <target> [harness] -> empty|pending|pending-unproven|unknown
   local backend=$1
   shift
   fm_backend_source "$backend" || { printf 'unknown'; return 0; }

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -436,7 +436,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
     case "$harness" in
-      claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+      claude|codex|opencode|pi|pi-signed|grok|kimi|agy) ;;
       *)
         case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
         ;;
@@ -495,6 +495,7 @@ install_cmd() {
 manual_install_url() {
   case "$1" in
     herdr) echo "https://herdr.dev" ;;
+    agy) echo "https://antigravity.google" ;;
     *) return 1 ;;
   esac
 }
@@ -713,7 +714,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","agy"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -721,6 +722,7 @@ crew_dispatch_validate() {
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "agy" then (["low","medium","high"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false
       else true
       end;
@@ -863,6 +865,9 @@ if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] && [ -n "$crew" ] && [ "$crew" != 
   echo "BOOTSTRAP_INFO: crew harness override active: $crew"
 fi
 crew_dispatch_validate
+if [ "$crew" = agy ] && ! command -v agy >/dev/null 2>&1; then
+  missing_tool_diagnostic agy
+fi
 if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] \
   && ! fm_backlog_backend_manual "$CONFIG" && fm_tasks_axi_compatible; then
   echo "BOOTSTRAP_INFO: tasks-axi available"

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -72,7 +72,7 @@ fm_composer_strip_ansi() {
 #     38:2::r:g:b) whose perceived luminance (0.299R + 0.587G + 0.114B) is below
 #     FM_COMPOSER_GHOST_LUMA_MAX (default 128): how grok renders its placeholder
 #     and hint text. A reset (SGR 0), a default-foreground (SGR 39), any base
-#     foreground colour (30-37 / 90-97), or a lighter 38;2 foreground ends the
+#     foreground colour (30-37 / 91-97), or a lighter 38;2 foreground ends the
 #     dark-foreground run. This assumes a DARK terminal theme, the firstmate
 #     fleet reality, where real typed input is bright and only de-emphasised UI
 #     is dark; the SGR-2 signal above stays theme-independent. A 256-colour
@@ -80,6 +80,7 @@ fm_composer_strip_ansi() {
 #     no fleet harness uses it for ghost text, so it is kept (real text wins:
 #     under-stripping merely defers, which the max-defer alarm surfaces, while
 #     over-stripping would inject over real input).
+#   - SGR 90 dark gray: AGY's accept-edits placeholder is rendered this way.
 # The dim/faint and dark-foreground states are tracked together as "de-emphasis";
 # codes are processed left to right within a sequence, so "ESC[0;2m" reads as dim.
 # LC_ALL=C makes awk walk bytes, so multibyte glyphs (e.g. ❯) and de-emphasised
@@ -145,7 +146,8 @@ fm_composer_strip_ghost() {
                 else if (code == "22") dim = 0
                 else if (code == "39") darkfg = 0
                 else if (code + 0 >= 30 && code + 0 <= 37) darkfg = 0
-                else if (code + 0 >= 90 && code + 0 <= 97) darkfg = 0
+                else if (code == "90") darkfg = 1
+                else if (code + 0 >= 91 && code + 0 <= 97) darkfg = 0
               }
             }
             if (j <= n) { i = j + 1; continue }

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|agy|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -30,8 +30,8 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # and kimi are markerless, so a foreign marker retained in a terminal
+  # Claude, Pi, Grok, and AGY set verified markers of their own; Codex, OpenCode,
+  # and Kimi are markerless, so a foreign marker retained in a terminal
   # multiplexer's stored environment can silently misidentify one of them before
   # ancestry is consulted. This is a precedence hazard, not evidence that
   # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
@@ -44,6 +44,9 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # AGY exports ANTIGRAVITY_AGENT=1 to its child/tool processes (verified,
+  # Antigravity CLI 1.1.7).
+  [ "${ANTIGRAVITY_AGENT:-}" = "1" ] && { echo agy; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -53,6 +56,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      agy) echo agy; return ;;
       kimi) echo kimi; return ;;
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;
@@ -64,6 +68,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *agy*) echo agy; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -270,7 +270,7 @@ else
   sleep_s=${FM_SEND_SLEEP:-0.4}
   # Type once, submit, verify. Only exact empty confirms delivery; every other
   # verdict preserves the loud refusal boundary.
-  if ! verdict=$(fm_backend_send_text_submit "$TARGET_BACKEND" "$T" "$MESSAGE" "$retries" "$sleep_s" "$settle" "$EXPECTED_LABEL"); then
+  if ! verdict=$(fm_backend_send_text_submit "$TARGET_BACKEND" "$T" "$MESSAGE" "$retries" "$sleep_s" "$settle" "$EXPECTED_LABEL" "$TARGET_HARNESS"); then
     if [ "$PENDING_REPLY_CREATED" = 1 ] && [ -n "$PENDING_REPLY_CORR" ]; then
       fm_pending_reply_discard_undelivered "$STATE" "$PENDING_REPLY_CORR" || true
     fi

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -9,7 +9,7 @@
 # This file is sourced by scripts and has no side effects on source.
 
 # Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+FM_HARNESS_RE='claude|codex|opencode|grok|kimi|agy|^pi$|^pi-signed$'
 
 # Walk the current process ancestry (up to 8 hops) and print the first pid whose
 # command looks like a verified harness. The harness pid lives as long as the

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -59,7 +59,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|agy)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. pi-signed launches that exact executable name from PATH and
@@ -102,6 +102,7 @@
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
+#     __AGYBIN__    resolved absolute Antigravity CLI executable
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -389,7 +390,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|agy)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -455,6 +456,9 @@ launch_template() {
     # Its turn-end signal is a globally configured Stop hook plus a guarded
     # per-task worktree token, so no launch placeholder belongs here.
     kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
+    # AGY accepts an encoded interactive brief. Its trust dialog is handled
+    # after spawn; never pre-seed AGY's managed settings or invent a hook.
+    agy) printf '%s' '__AGYBIN__ --dangerously-skip-permissions --mode accept-edits __MODELFLAG____EFFORTFLAG__--prompt-interactive "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -529,6 +533,11 @@ if [ "$KIND" = secondmate ] && [ -z "$ARG3" ]; then
   fi
 fi
 
+if [ "$KIND" = secondmate ] && [ "$HARNESS" = agy ]; then
+  echo "error: agy is verified for crewmate and scout launches only, not secondmates" >&2
+  exit 1
+fi
+
 secondmate_registry_value() {
   local id=$1 key=$2 reg line value
   reg="$DATA/secondmates.md"
@@ -548,6 +557,22 @@ shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
   printf "'"
+}
+
+resolve_agy_binary() {
+  local candidate dir
+  candidate=$(command -v agy 2>/dev/null || true)
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    case "$candidate" in
+      /*) printf '%s\n' "$candidate"; return 0 ;;
+      *)
+        dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || dir=
+        [ -n "$dir" ] && { printf '%s/%s\n' "$dir" "$(basename "$candidate")"; return 0; }
+        ;;
+    esac
+  fi
+  echo "error: agy executable not found in PATH" >&2
+  return 1
 }
 
 resolve_kimi_binary() {
@@ -578,7 +603,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi)
+    claude|codex|opencode|pi|pi-signed|grok|kimi|agy)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -617,6 +642,11 @@ effort_flag_for_harness() {
         low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
       esac
       ;;
+    agy)
+      case "$effort" in
+        low|medium|high) printf -- '--effort %s ' "$(shell_quote "$effort")" ;;
+      esac
+      ;;
     # opencode's interactive `opencode --prompt` launch has a verified --model
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
@@ -626,6 +656,10 @@ effort_flag_for_harness() {
 }
 
 case "$LAUNCH" in
+  *__AGYBIN__*)
+    AGY_BIN=$(resolve_agy_binary) || exit 1
+    LAUNCH=${LAUNCH//__AGYBIN__/$(shell_quote "$AGY_BIN")}
+    ;;
   *__KIMIBIN__*)
     KIMI_BIN=$(resolve_kimi_binary) || exit 1
     LAUNCH=${LAUNCH//__KIMIBIN__/$(shell_quote "$KIMI_BIN")}
@@ -1517,7 +1551,7 @@ if [ "$HARNESS" = kimi ]; then
   KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}
   KIMI_SUBMIT_VERDICT=$(fm_backend_send_text_submit \
     "$BACKEND" "$T" "$KIMI_POINTER" "$KIMI_SUBMIT_RETRIES" \
-    "$KIMI_SUBMIT_SLEEP" "$KIMI_SUBMIT_SETTLE" "$W") || {
+    "$KIMI_SUBMIT_SLEEP" "$KIMI_SUBMIT_SETTLE" "$W" "$HARNESS") || {
     kimi_spawn_fail "kimi brief pointer could not be submitted"
     exit 1
   }

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -117,7 +117,7 @@ now_ms() {
 # unclassified so new tests are still runnable and visible in summaries.
 family_for_basename() {
   case "$1" in
-    fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|fm-brief.test.sh|\
+    fm-agy-harness.test.sh|fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|fm-brief.test.sh|\
     fm-calm-pi-extension.test.sh|fm-captain-translation-contract.test.sh|fm-cd-pretool-check.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -82,6 +82,7 @@ FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
 FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
+FM_TMUX_AGY_BUSY_REGEX_DEFAULT='esc to cancel( generation)?'
 FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
 
 fm_busy_lines_match() {  # [harness]
@@ -96,6 +97,7 @@ fm_busy_lines_match() {  # [harness]
       opencode) regex=$FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT ;;
       pi|pi-signed) regex=$FM_TMUX_PI_BUSY_REGEX_DEFAULT ;;
       grok) regex=$FM_TMUX_GROK_BUSY_REGEX_DEFAULT ;;
+      agy) regex=$FM_TMUX_AGY_BUSY_REGEX_DEFAULT ;;
       kimi) regex=$FM_TMUX_KIMI_BUSY_REGEX_DEFAULT ;;
       '') regex=$FM_TMUX_BUSY_REGEX_DEFAULT ;;
       *)
@@ -296,6 +298,33 @@ EOF
   return 1
 }
 
+# fm_tmux_find_agy_composer: locate AGY's complete horizontal-rule composer
+# around the cursor. This shape is accepted only for a metadata-routed AGY task,
+# so transcript separators or a dead shell in another harness cannot become an
+# injection target. Prints the zero-based opening and closing rule rows.
+fm_tmux_find_agy_composer() {  # <cursor-y> <plain-visible-pane>
+  local cy=$1 pane=$2 line row=0 top=-1 content_rows=0 trimmed
+  while IFS= read -r line; do
+    trimmed="${line#"${line%%[![:space:]]*}"}"
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+    if [ "${#trimmed}" -ge 8 ] && [ -z "${trimmed//─/}" ]; then
+      if [ "$top" -ge 0 ] && [ "$content_rows" -gt 0 ] \
+         && [ "$top" -lt "$cy" ] && [ "$cy" -le "$row" ]; then
+        printf '%s %s' "$top" "$row"
+        return 0
+      fi
+      top=$row
+      content_rows=0
+    elif [ "$top" -ge 0 ]; then
+      content_rows=$((content_rows + 1))
+    fi
+    row=$((row + 1))
+  done <<EOF
+$pane
+EOF
+  return 1
+}
+
 # fm_tmux_composer_state classification contract:
 # A row is structural only when its first or last non-whitespace character is a
 # composer edge. A complete box has matching border families and bounded top and
@@ -307,14 +336,29 @@ EOF
 # requires positive proof: a genuinely empty composer, an all-empty unambiguous
 # box, an empty non-bordered fallback row, or the submit core's proven
 # busy-queued Enter conversion.
-fm_tmux_composer_state() {  # <target> -> empty|pending|pending-unproven|unknown
-  local target=$1 cy raw pane plain box box_status top bottom geometry_ambiguous
+fm_tmux_composer_state() {  # <target> [harness] -> empty|pending|pending-unproven|unknown
+  local target=$1 harness=${2:-} cy raw pane plain box box_status top bottom geometry_ambiguous
   local row row_raw state unknown_seen=0
   cy=$(tmux display-message -p -t "$target" '#{cursor_y}' 2>/dev/null) || { printf 'unknown'; return 0; }
   case "$cy" in ''|*[!0-9]*) printf 'unknown'; return 0 ;; esac
   pane=$(tmux capture-pane -e -p -t "$target" -S 0 -E - 2>/dev/null) || { printf 'unknown'; return 0; }
   plain=$(printf '%s\n' "$pane" | fm_composer_strip_ansi)
-  if box=$(fm_tmux_find_composer_box "$cy" "$plain"); then
+  if [ "$harness" = agy ] && box=$(fm_tmux_find_agy_composer "$cy" "$plain"); then
+    top=${box%% *}
+    bottom=${box#* }
+    row=$((top + 1))
+    while [ "$row" -lt "$bottom" ]; do
+      row_raw=$(printf '%s\n' "$pane" | sed -n "$((row + 1))p")
+      state=$(fm_tmux_composer_row_state "$row_raw" 1 0)
+      case "$state" in
+        pending) printf 'pending'; return 0 ;;
+        unknown) printf 'unknown'; return 0 ;;
+      esac
+      row=$((row + 1))
+    done
+    printf 'empty'
+    return 0
+  elif box=$(fm_tmux_find_composer_box "$cy" "$plain"); then
     top=${box%% *}
     box=${box#* }
     bottom=${box%% *}
@@ -386,12 +430,12 @@ fm_pane_is_busy() {  # <target> [harness]
 # `empty` so the caller does not re-send), while an idle pane keeps `pending` as
 # a genuine swallow. Pending-unproven receives the same Enter retry budget but
 # never reaches this exception.
-fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep>
-  local target=$1 retries=$2 sleep_s=$3 i=0 state
+fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep> [harness]
+  local target=$1 retries=$2 sleep_s=$3 harness=${4:-} i=0 state
   while :; do
     tmux send-keys -t "$target" Enter 2>/dev/null || true
     sleep "$sleep_s"
-    state=$(fm_tmux_composer_state "$target")
+    state=$(fm_tmux_composer_state "$target" "$harness")
     case "$state" in
       pending|pending-unproven) ;;
       *) printf '%s' "$state"; return 0 ;;
@@ -408,16 +452,16 @@ fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep>
   # and queued the message for processing when the current turn ends.
   # Treat it as submitted so the caller does not re-send.
   # On an idle pane, keep reporting pending - a genuine swallow.
-  if fm_pane_is_busy "$target"; then
+  if fm_pane_is_busy "$target" "$harness"; then
     printf 'empty'
   else
     printf 'pending'
   fi
 }
 
-fm_tmux_submit_core() {  # <target> <text> <retries> <enter-sleep> <settle>
-  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5
+fm_tmux_submit_core() {  # <target> <text> <retries> <enter-sleep> <settle> [harness]
+  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 harness=${6:-}
   tmux send-keys -t "$target" -l "$text" 2>/dev/null || { printf 'send-failed'; return 0; }
   sleep "$settle"
-  fm_tmux_submit_enter_core "$target" "$retries" "$sleep_s"
+  fm_tmux_submit_enter_core "$target" "$retries" "$sleep_s" "$harness"
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,7 +148,7 @@ The session-start bootstrap step keeps valid dispatch configuration silent unles
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and kimi while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, grok, pi, opencode, kimi, and agy while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,7 +174,9 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, pi-signed, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
+claude, codex, opencode, pi, pi-signed, grok, and kimi are empirically verified for crewmate and secondmate launches.
+AGY is empirically verified for ordinary crewmate and scout launches only, not primary or secondmate use.
+[README requirements](../README.md#requirements) own the set supported for the primary session.
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
@@ -198,6 +200,7 @@ The inherited-local-material contract is owned by [`secondmate-provisioning`](..
 Those inherited values are defaults and rules only; `fm-spawn` still permits a consciously chosen explicit runtime outside the config.
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
+AGY launches with accept-edits autonomy and lets its fresh-worktree trust dialog be accepted after spawn; it never edits AGY-managed settings or installs a lifecycle hook.
 For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install`, drops a per-task `.fm-kimi-turnend` pointer in the worktree, and records the matching private registry token for teardown.
 Kimi continues to use the captain's normal Kimi home, including the existing config, skills, and memory; Firstmate does not create an isolated Kimi home.
 The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, or surprising or when either tool requirement is unavailable.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -46,7 +46,7 @@ Verify setup by spawning a small task and confirming its `fm-<id>` window appear
 
 A target-existence check proves only that the pane exists.
 The deeper tmux agent-liveness probe first verifies exact window membership, then reads `#{pane_current_command}` to distinguish a running harness process from a bare idle shell.
-It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, Grok, and Kimi process names as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
+It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, and AGY process names as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
 Only `dead` and `missing` authorize recovery because a false dead result could launch a duplicate agent.
 
 The verified Pi Launcher path reports the exact foreground command `pi-launcher` for both pi and pi-signed, while direct executable identities `pi`, `pi-signed`, and `Pi` remain accepted exactly.
@@ -84,6 +84,7 @@ Ambiguous pending text never receives the busy-queue conversion.
 tests/fm-backend-tmux-smoke.test.sh
 tests/fm-composer-ghost.test.sh
 tests/fm-kimi-harness.test.sh
+tests/fm-agy-harness.test.sh
 tests/fm-tmux-submit-busy.test.sh
 tests/fm-bootstrap.test.sh
 ```

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -30,6 +30,7 @@ zsh
 A persistent parent shell waiting for a child remained reported as the parent process, while a shell that directly execed a simple command changed identity with the process itself.
 Claude, Codex, OpenCode, and Grok were observed under their own process names.
 Kimi Code CLI 0.29.1 was observed under `kimi` on 2026-07-25.
+Antigravity CLI 1.1.7 was observed under `agy` on 2026-07-27.
 Pi and pi-signed 0.82.0 were reverified on 2026-07-27 through real isolated `fm-spawn.sh` launches.
 
 Installed-wrapper checks:
@@ -83,6 +84,7 @@ The structural multi-row composer reader, Kimi pointer-delivery path, and OpenCo
 ```sh
 tests/fm-composer-ghost.test.sh
 tests/fm-kimi-harness.test.sh
+tests/fm-agy-harness.test.sh
 tests/fm-tmux-submit-busy.test.sh
 ```
 

--- a/tests/fm-agy-harness.test.sh
+++ b/tests/fm-agy-harness.test.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Behavior tests for the verified Antigravity CLI crewmate/scout adapter.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-agy-harness)
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+
+make_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *'#{pane_current_path}'*) printf '%s\n' "$FM_FAKE_PANE_PATH"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n' ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    prev=
+    for arg in "$@"; do
+      [ "$prev" = -l ] && printf '%s\n' "$arg" >> "$FM_FAKE_LAUNCH_LOG"
+      prev=$arg
+    done
+    ;;
+esac
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse agy
+  mkdir -p "$fakebin/base"
+  for tool in bash git grep sed tr mkdir mktemp sleep realpath readlink sort cut tail cat rm touch date seq awk dirname basename uname; do
+    ln -s "$(command -v "$tool")" "$fakebin/base/$tool"
+  done
+  printf '%s\n' "$fakebin"
+}
+
+make_case() {
+  local name=$1 id=$2 dir home project worktree fakebin
+  dir="$TMP_ROOT/$name"
+  home="$dir/home"
+  project="$dir/project"
+  worktree="$dir/worktree"
+  fakebin=$(make_fakebin "$dir/fake")
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'agy\n' > "$home/config/crew-harness"
+  printf 'brief for AGY\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$project" "$worktree" "wt-$name"
+  touch "$home/state/.last-watcher-beat"
+  : > "$dir/launch.log"
+  printf '%s|%s|%s|%s|%s\n' "$dir" "$home" "$project" "$worktree" "$fakebin"
+}
+
+read_case() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR WORKTREE_DIR FAKEBIN_DIR <<EOF
+$1
+EOF
+}
+
+run_spawn() {
+  local id=$1
+  HOME="$HOME_DIR" FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WORKTREE_DIR" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$CASE_DIR/launch.log" PATH="$FAKEBIN_DIR:$BASE_PATH" \
+    "$SPAWN" "$id" "$PROJECT_DIR" --harness agy "${@:2}" 2>&1
+}
+
+test_agy_launch_threads_only_supported_profile_axes() {
+  local id=agy-profile-z1 rec out status launch
+  rec=$(make_case profile "$id")
+  read_case "$rec"
+  out=$(run_spawn "$id" --model gemini-3.6-flash-high --effort high)
+  status=$?
+  expect_code 0 "$status" "AGY spawn with accepted profile axes should succeed"
+  assert_contains "$out" "spawned $id harness=agy" "AGY spawn did not report its harness"
+  assert_grep 'model=gemini-3.6-flash-high' "$HOME_DIR/state/$id.meta" "AGY metadata lost its model"
+  assert_grep 'effort=high' "$HOME_DIR/state/$id.meta" "AGY metadata lost its effort"
+  launch=$(cat "$CASE_DIR/launch.log")
+  assert_contains "$launch" "'$FAKEBIN_DIR/agy' --dangerously-skip-permissions --mode accept-edits --model 'gemini-3.6-flash-high' --effort 'high' --prompt-interactive" "AGY launch flags are incomplete"
+  assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" "AGY launch lost the canonical encoded brief"
+  pass "fm-spawn: AGY launches autonomously with model, accepted effort, and encoded brief"
+}
+
+test_agy_omits_unsupported_effort() {
+  local id=agy-max-z2 rec out status launch
+  rec=$(make_case max "$id")
+  read_case "$rec"
+  out=$(run_spawn "$id" --effort max)
+  status=$?
+  expect_code 0 "$status" "AGY spawn with unsupported effort should retain metadata and launch"
+  assert_grep 'effort=max' "$HOME_DIR/state/$id.meta" "AGY metadata lost unsupported requested effort"
+  launch=$(cat "$CASE_DIR/launch.log")
+  assert_not_contains "$launch" '--effort' "AGY launch passed an unsupported effort"
+  pass "fm-spawn: AGY omits unsupported effort values"
+}
+
+test_agy_missing_binary_refuses_before_pane_creation() {
+  local id=agy-missing-z3 rec out status
+  rec=$(make_case missing "$id")
+  read_case "$rec"
+  agy() { :; }
+  export -f agy
+  out=$(run_spawn "$id")
+  status=$?
+  unset -f agy
+  [ "$status" -ne 0 ] || fail "AGY spawn without its binary should refuse"
+  assert_contains "$out" 'agy executable not found in PATH' "AGY missing-binary refusal lacked its cause"
+  [ ! -s "$CASE_DIR/launch.log" ] || fail "AGY missing-binary refusal sent a launch command"
+  pass "fm-spawn: AGY missing binary refuses before launch"
+}
+
+test_agy_marker_detection_and_secondmate_refusal() {
+  local out rec id=agy-secondmate-z4 status
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT ANTIGRAVITY_AGENT=1 "$ROOT/bin/fm-harness.sh")
+  [ "$out" = agy ] || fail "AGY marker detection returned '$out'"
+  rec=$(make_case secondmate "$id")
+  read_case "$rec"
+  status=0
+  out=$(HOME="$HOME_DIR" FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
+    FM_DATA_OVERRIDE="$HOME_DIR/data" FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 PATH="$FAKEBIN_DIR:$BASE_PATH" "$SPAWN" "$id" "$HOME_DIR" --secondmate 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "AGY secondmate launch should refuse"
+  assert_contains "$out" 'not secondmates' "AGY secondmate refusal lacked its scope"
+  pass "fm-harness: AGY marker is recognized while secondmate launch remains refused"
+}
+
+test_agy_busy_and_composer_signatures_are_scoped() {
+  local capture out
+  capture="$TMP_ROOT/pane"
+  printf 'esc to cancel generation\n' > "$capture"
+  tmux() {
+    case "${1:-}" in
+      capture-pane) cat "$capture" ;;
+      display-message) printf '2\n' ;;
+    esac
+  }
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-tmux-lib.sh"
+  fm_pane_is_busy fake agy || fail "AGY cancel footer was not busy"
+  if fm_pane_is_busy fake codex; then
+    fail "AGY cancel footer leaked into Codex busy detection"
+  fi
+  printf '────────────────\n> \033[90mAccept-edits mode: file edits auto-approved (shift+tab to cycle)\033[0m\n────────────────\n? for shortcuts\n' > "$capture"
+  out=$(fm_tmux_composer_state fake agy)
+  [ "$out" = empty ] || fail "AGY separator composer should be empty, got '$out'"
+  out=$(fm_tmux_composer_state fake codex)
+  [ "$out" != empty ] || fail "AGY separator composer leaked into Codex classification"
+  pass "tmux: AGY busy and accept-edits composer signatures stay harness-scoped"
+}
+
+test_agy_tmux_submit_and_key_steering() {
+  local mode=empty out
+  tmux() {
+    case "${1:-}" in
+      display-message) printf '2\n' ;;
+      capture-pane)
+        case "$mode" in
+          empty) printf '────────────────\n> \033[90mAccept-edits mode: file edits auto-approved\033[0m\n────────────────\n' ;;
+          pending) printf '────────────────\n> steer\n────────────────\n' ;;
+        esac
+        ;;
+      send-keys)
+        case " $* " in
+          *' -l '*) mode=pending ;;
+          *' Enter '*) mode=empty ;;
+          *' Escape'*) : ;;
+        esac
+        ;;
+    esac
+  }
+  FM_BACKEND_LIB_DIR="$ROOT/bin"
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/backends/tmux.sh"
+  out=$(fm_backend_tmux_send_text_submit fake steer 1 0 0 ignored agy)
+  [ "$out" = empty ] || fail "AGY text steer was not confirmed, got '$out'"
+  fm_backend_tmux_send_key fake Escape || fail "AGY interrupt key was rejected"
+  pass "tmux: AGY text submission and Escape steering use the shared backend primitives"
+}
+
+test_agy_herdr_composer_uses_recorded_harness() {
+  local out
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/backends/herdr.sh"
+  fm_backend_herdr_parse_target() { FM_BACKEND_HERDR_SESSION=s; FM_BACKEND_HERDR_PANE=p; }
+  fm_backend_herdr_capture_ansi() { printf '────────────────\n> \033[90mAccept-edits mode: file edits auto-approved (shift+tab to cycle)\033[0m\n────────────────\n'; }
+  out=$(fm_backend_herdr_composer_state s:p agy)
+  [ "$out" = empty ] || fail "AGY Herdr composer should be empty, got '$out'"
+  out=$(fm_backend_herdr_composer_state s:p codex)
+  [ "$out" = unknown ] || fail "AGY Herdr composer leaked into Codex classification, got '$out'"
+  pass "Herdr: AGY separator composer applies only to recorded AGY tasks"
+}
+
+test_agy_launch_threads_only_supported_profile_axes
+test_agy_omits_unsupported_effort
+test_agy_missing_binary_refuses_before_pane_creation
+test_agy_marker_detection_and_secondmate_refusal
+test_agy_busy_and_composer_signatures_are_scoped
+test_agy_tmux_submit_and_key_steering
+test_agy_herdr_composer_uses_recorded_harness

--- a/tests/fm-agy-harness.test.sh
+++ b/tests/fm-agy-harness.test.sh
@@ -105,6 +105,7 @@ test_agy_missing_binary_refuses_before_pane_creation() {
   local id=agy-missing-z3 rec out status
   rec=$(make_case missing "$id")
   read_case "$rec"
+  # shellcheck disable=SC2329 # Exported and invoked by the spawned subprocess's PATH lookup.
   agy() { :; }
   export -f agy
   out=$(run_spawn "$id")
@@ -135,6 +136,7 @@ test_agy_busy_and_composer_signatures_are_scoped() {
   local capture out
   capture="$TMP_ROOT/pane"
   printf 'esc to cancel generation\n' > "$capture"
+  # shellcheck disable=SC2329 # Invoked by the sourced tmux-lib helpers, not directly here.
   tmux() {
     case "${1:-}" in
       capture-pane) cat "$capture" ;;
@@ -175,6 +177,7 @@ test_agy_tmux_submit_and_key_steering() {
         ;;
     esac
   }
+  # shellcheck disable=SC2034 # Consumed by tmux.sh's own sourcing of fm-tmux-lib.sh, not by this test.
   FM_BACKEND_LIB_DIR="$ROOT/bin"
   # shellcheck source=/dev/null
   . "$ROOT/bin/backends/tmux.sh"
@@ -188,6 +191,7 @@ test_agy_herdr_composer_uses_recorded_harness() {
   local out
   # shellcheck source=/dev/null
   . "$ROOT/bin/backends/herdr.sh"
+  # shellcheck disable=SC2034 # Consumed by fm_backend_herdr_composer_state after this override runs.
   fm_backend_herdr_parse_target() { FM_BACKEND_HERDR_SESSION=s; FM_BACKEND_HERDR_PANE=p; }
   fm_backend_herdr_capture_ansi() { printf '────────────────\n> \033[90mAccept-edits mode: file edits auto-approved (shift+tab to cycle)\033[0m\n────────────────\n'; }
   out=$(fm_backend_herdr_composer_state s:p agy)

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -752,6 +752,26 @@ test_crew_dispatch_active_rules_are_verbose_bootstrap_info() {
   pass "bootstrap surfaces active crew-dispatch rules only as verbose BOOTSTRAP_INFO"
 }
 
+test_agy_crew_harness_requires_binary() {
+  local case_dir home fakebin out
+  case_dir="$TMP_ROOT/agy-missing"
+  home="$case_dir/home"
+  mkdir -p "$home/config"
+  printf '%s\n' manual > "$home/config/backlog-backend"
+  printf '%s\n' agy > "$home/config/crew-harness"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  add_real_jq "$fakebin"
+  mkdir -p "$fakebin/base"
+  for tool in bash uname git grep sed tr cut head awk sort tail cat mkdir rm mktemp date sleep dirname basename find wc; do
+    ln -s "$(command -v "$tool")" "$fakebin/base/$tool"
+  done
+  out=$(PATH="$fakebin:$fakebin/base" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  assert_contains "$out" 'MISSING_MANUAL: agy (instructions: https://antigravity.google)' \
+    "bootstrap did not report a selected AGY binary as missing"
+  pass "bootstrap: a selected AGY crewmate harness requires its binary"
+}
+
 test_crew_dispatch_validation() {
   local label body expect mode case_dir fakebin out n
   n=0
@@ -782,6 +802,8 @@ unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","us
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
 pi-signed max effort is accepted^{"rules":[{"when":"signed coding","use":{"harness":"pi-signed","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
+agy model and supported effort are accepted^{"rules":[{"when":"Google work","use":{"harness":"agy","model":"gemini-3.6-flash-high","effort":"high"}}]}^empty^
+unsupported agy xhigh effort is flagged^{"rules":[{"when":"Google work","use":{"harness":"agy","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: agy:xhigh
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
 kimi model profile is accepted^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3"}}]}^empty^
 unsupported kimi effort is flagged^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: kimi:high
@@ -823,4 +845,5 @@ test_routine_bootstrap_confirmations_are_silent
 test_routine_bootstrap_contract_runs_under_system_bash
 test_bootstrap_info_is_no_load_and_actionable_lines_trigger
 test_crew_dispatch_active_rules_are_verbose_bootstrap_info
+test_agy_crew_harness_requires_binary
 test_crew_dispatch_validation

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -97,7 +97,7 @@ SH
 test_tmux_agent_state_classifies() {
   local fb out
 
-  for harness in claude codex opencode grok kimi pi pi-signed pi-launcher Pi; do
+  for harness in claude codex opencode grok kimi agy pi pi-signed pi-launcher Pi; do
     fb=$(make_probe_tmux "$TMP_ROOT/tmux-$harness" "$harness")
     out=$(PATH="$fb:$BASE_PATH" bash -c '. "$0/bin/fm-backend.sh"; fm_backend_agent_state tmux sess:win' "$ROOT")
     [ "$out" = alive ] || fail "a live $harness foreground process should classify as alive, got '$out'"


### PR DESCRIPTION
## Intent

Implement Antigravity CLI (agy) 1.1.7 as a verified Firstmate ordinary crewmate and scout runtime. Preserve the established safety boundaries: use autonomous accept-edits launch semantics, support only low/medium/high effort, recognize AGY's marker, busy and composer evidence, and keep AGY out of primary and secondmate roles. Add deterministic coverage for spawn, missing-binary diagnostics, lifecycle classification, steering, and backend composer handling. Ship only the AGY adapter changes through a PR.

## What Changed
- Adds Antigravity CLI (`agy`) support as a verified ordinary crewmate/scout runtime, with autonomous accept-edits launch semantics and low/medium/high effort levels only, across `bin/fm-spawn.sh`, `bin/fm-harness.sh`, `bin/fm-backend.sh`, `bin/fm-bootstrap.sh`, `bin/fm-composer-lib.sh`, and `bin/fm-send.sh`.
- Extends `bin/fm-tmux-lib.sh` and `bin/backends/tmux.sh`/`bin/backends/herdr.sh` to recognize AGY's marker, busy, and composer evidence for lifecycle classification and steering, while keeping AGY excluded from primary and secondmate roles.
- Adds deterministic test coverage (`tests/fm-agy-harness.test.sh`, additions to `tests/fm-bootstrap.test.sh`) for spawn, missing-binary diagnostics, lifecycle classification, steering, and backend composer handling, and updates `.agents/skills/harness-adapters/SKILL.md`, `AGENTS.md`, and docs (`docs/configuration.md`, `docs/tmux-backend.md`, `docs/verification/runtime-backends.md`) to document the new adapter.

## Risk Assessment

✅ Low: The AGY adapter closely follows the established per-harness pattern (marker detection, effort/model gating, composer/busy detection, secondmate refusal) with dedicated deterministic tests covering spawn, missing-binary diagnostics, lifecycle classification, steering, and composer handling; no contradiction with the stated intent was found.

## Testing

placeholder

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `placeholder`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
