### PR TITLE
refactor(bin): share landing-branch resolver for local merge

### DIFF
--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Perform the approved local merge for a local-only ship task: fast-forward the
-# project's default branch to the crewmate's fm/<id> branch.
+# project's landing branch to the crewmate's fm/<id> branch.
 #
 # This is firstmate's merge gate-action (the captain's merge authority applied
 # locally instead of via a GitHub PR). It is the one sanctioned exception to hard
@@ -9,6 +9,9 @@
 # auto-approves), and only as a clean fast-forward - it refuses a diverged branch
 # and tells you to have the crewmate rebase. See AGENTS.md prime directives,
 # project management, and task lifecycle.
+# Landing branch resolution (origin/HEAD, main/master fallback, or the explicit
+# FM_MERGE_TARGET_BRANCH override) lives in bin/fm-merge-target-lib.sh and is
+# shared with bin/fm-teardown.sh.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
 
@@ -16,6 +19,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-merge-target-lib.sh
+. "$SCRIPT_DIR/fm-merge-target-lib.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=${1:?usage: fm-merge-local.sh <task-id>}
 META="$STATE/$ID.meta"
@@ -25,26 +30,15 @@ PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ "$MODE" = local-only ] || { echo "error: task $ID is mode=$MODE, not local-only; merge PR tasks with bin/fm-pr-merge.sh <id> <PR url> after approval" >&2; exit 1; }
 
-default_branch() {
-  local ref branch
-  ref=$(git -C "$PROJ" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
-  if [ -n "$ref" ]; then
-    echo "${ref#origin/}"
-    return 0
-  fi
-  for branch in main master; do
-    if git -C "$PROJ" show-ref --verify --quiet "refs/heads/$branch"; then
-      echo "$branch"
-      return 0
-    fi
-  done
-  return 1
-}
-
 BRANCH="fm/$ID"
 git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $PROJ" >&2; exit 1; }
 
-DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
+# FM_MERGE_TARGET_BRANCH is the explicit override for a home or project whose
+# working branch is not the remote's default (e.g. a long-lived fork branch,
+# where origin/HEAD still points at main). Every guard below still applies to
+# the resolved branch: the checkout must already be on it, clean, and the merge
+# must be a clean fast-forward.
+DEFAULT=$(fm_merge_target_branch "$PROJ") || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 
 # The project's main checkout must be on its default branch and clean, so the
 # fast-forward lands predictably (firstmate never writes here otherwise).

--- a/bin/fm-merge-target-lib.sh
+++ b/bin/fm-merge-target-lib.sh
@@ -1,0 +1,34 @@
+# shellcheck shell=bash
+# Shared landing-branch resolver for the local merge and teardown guards.
+# Usage: . bin/fm-merge-target-lib.sh
+#
+# bin/fm-merge-local.sh and bin/fm-teardown.sh both need the same answer to
+# "which local branch counts as landed?": normally origin/HEAD (falling back to
+# a local main/master), or an explicit FM_MERGE_TARGET_BRANCH when a home or
+# project tracks a long-lived fork branch that is not the remote's default.
+# One owner keeps the override and the origin/HEAD default from drifting apart.
+
+# Resolve the landing branch name for the git repo at <dir>.
+# Prefers FM_MERGE_TARGET_BRANCH when set (must already exist as a local branch),
+# then refs/remotes/origin/HEAD, then a local main/master.
+# Echoes the branch name, or returns 1 when none can be resolved.
+fm_merge_target_branch() {
+  local dir=$1 ref branch
+  if [ -n "${FM_MERGE_TARGET_BRANCH:-}" ]; then
+    git -C "$dir" show-ref --verify --quiet "refs/heads/$FM_MERGE_TARGET_BRANCH" || return 1
+    printf '%s\n' "$FM_MERGE_TARGET_BRANCH"
+    return 0
+  fi
+  ref=$(git -C "$dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -n "$ref" ]; then
+    printf '%s\n' "${ref#origin/}"
+    return 0
+  fi
+  for branch in main master; do
+    if git -C "$dir" show-ref --verify --quiet "refs/heads/$branch"; then
+      printf '%s\n' "$branch"
+      return 0
+    fi
+  done
+  return 1
+}

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -106,6 +106,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-merge-target-lib.sh
+. "$SCRIPT_DIR/fm-merge-target-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   echo "error: invalid teardown request" >&2
   exit 2
@@ -141,20 +143,13 @@ KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes
 
+# Landing branch resolution (origin/HEAD, main/master fallback, or the explicit
+# FM_MERGE_TARGET_BRANCH override shared with bin/fm-merge-local.sh) lives in
+# bin/fm-merge-target-lib.sh. The landed-work test itself is unchanged: work must
+# be merged into the resolved branch or be on a remote before a worktree may be
+# discarded.
 default_branch() {
-  local ref branch
-  ref=$(git -C "$PROJ" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
-  if [ -n "$ref" ]; then
-    echo "${ref#origin/}"
-    return 0
-  fi
-  for branch in main master; do
-    if git -C "$PROJ" show-ref --verify --quiet "refs/heads/$branch"; then
-      echo "$branch"
-      return 0
-    fi
-  done
-  return 1
+  fm_merge_target_branch "$PROJ"
 }
 
 meta_value() {

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -123,7 +123,7 @@ family_for_basename() {
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
-    fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
+    fm-install-herdr.test.sh|fm-merge-target-lib.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\
     fm-subagent-pretool-check.test.sh|\
@@ -687,7 +687,7 @@ families_for_changed_path() {
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
-    bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
+    bin/fm-ff-lib.sh|bin/fm-merge-target-lib.sh|bin/fm-gotmp*|bin/*pretool*)
       printf '%s\n' pure-contract-unit
       ;;
     .agents/skills/*/SKILL.md)

--- a/tests/fm-merge-target-lib.test.sh
+++ b/tests/fm-merge-target-lib.test.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-merge-target-lib.sh.
+#
+# fm_merge_target_branch is the shared landing-branch resolver used by
+# bin/fm-merge-local.sh and bin/fm-teardown.sh. It must honour FM_MERGE_TARGET_BRANCH
+# when set (and refuse a non-existent override), otherwise follow origin/HEAD,
+# then fall back to a local main/master.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-merge-target-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-merge-target-lib)
+fm_git_identity fmtest fmtest@example.invalid
+
+# Fresh git repo on `main` with one commit and origin/HEAD -> main. Echoes path.
+make_repo_with_origin_head() {
+  local dir=$1 bare=$2
+  git init -q --bare "$bare"
+  git -C "$bare" symbolic-ref HEAD refs/heads/main
+  git clone -q "$bare" "$dir"
+  git -C "$dir" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  git -C "$dir" push -q origin main
+  git -C "$dir" remote set-head origin main 2>/dev/null || true
+  printf '%s\n' "$dir"
+}
+
+test_origin_head_default() {
+  local repo out
+  repo=$(make_repo_with_origin_head "$TMP_ROOT/origin-head" "$TMP_ROOT/origin-head.git")
+  unset FM_MERGE_TARGET_BRANCH || true
+  out=$(fm_merge_target_branch "$repo") || fail "origin/HEAD resolution returned non-zero"
+  [ "$out" = main ] || fail "expected main from origin/HEAD, got '$out'"
+  pass "fm_merge_target_branch: origin/HEAD default resolves to main"
+}
+
+test_main_master_fallback_without_origin_head() {
+  local repo out
+  repo="$TMP_ROOT/no-origin-head"
+  git init -q -b main "$repo"
+  git -C "$repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  # No origin remote at all - fall back to local main.
+  unset FM_MERGE_TARGET_BRANCH || true
+  out=$(fm_merge_target_branch "$repo") || fail "local main fallback returned non-zero"
+  [ "$out" = main ] || fail "expected main fallback, got '$out'"
+  pass "fm_merge_target_branch: falls back to local main without origin/HEAD"
+}
+
+test_override_uses_existing_branch() {
+  local repo out
+  repo=$(make_repo_with_origin_head "$TMP_ROOT/override-ok" "$TMP_ROOT/override-ok.git")
+  git -C "$repo" checkout -q -B feat/gitea-pr-adapter
+  # origin/HEAD still points at main; override must win.
+  out=$(FM_MERGE_TARGET_BRANCH=feat/gitea-pr-adapter fm_merge_target_branch "$repo") \
+    || fail "override of an existing branch returned non-zero"
+  [ "$out" = feat/gitea-pr-adapter ] || fail "expected override branch, got '$out'"
+  pass "fm_merge_target_branch: FM_MERGE_TARGET_BRANCH overrides origin/HEAD"
+}
+
+test_override_missing_branch_refuses() {
+  local repo rc
+  repo=$(make_repo_with_origin_head "$TMP_ROOT/override-missing" "$TMP_ROOT/override-missing.git")
+  set +e
+  FM_MERGE_TARGET_BRANCH=does-not-exist fm_merge_target_branch "$repo" >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "missing override branch must refuse"
+  pass "fm_merge_target_branch: missing FM_MERGE_TARGET_BRANCH refuses"
+}
+
+test_merge_local_honours_override() {
+  local case_dir id=merge-ov project wt state out rc before after
+  case_dir="$TMP_ROOT/merge-local-override"
+  project="$case_dir/project"
+  wt="$case_dir/wt"
+  state="$case_dir/state"
+  mkdir -p "$state" "$case_dir/fakebin"
+
+  # Project lives on a long-lived fork branch while origin/HEAD stays on main.
+  make_repo_with_origin_head "$project" "$case_dir/origin.git" >/dev/null
+  git -C "$project" checkout -q -B feat/gitea-pr-adapter
+  git -C "$project" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "fork baseline"
+  git -C "$project" worktree add -q -b "fm/$id" "$wt" feat/gitea-pr-adapter
+  git -C "$wt" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "crew work"
+
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" \
+    "worktree=$wt" \
+    "project=$project" \
+    "kind=ship" \
+    "mode=local-only"
+  touch "$state/.last-watcher-beat"
+
+  # Without the override, merge must refuse (project is not on main).
+  set +e
+  FM_HOME="$case_dir" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" \
+    "$ROOT/bin/fm-merge-local.sh" "$id" >"$case_dir/stdout-no" 2>"$case_dir/stderr-no"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "merge-local without override should refuse a non-default checkout"
+  grep -q "expected default branch 'main'" "$case_dir/stderr-no" \
+    || fail "merge-local without override did not name main: $(cat "$case_dir/stderr-no")"
+
+  before=$(git -C "$project" rev-parse feat/gitea-pr-adapter)
+  set +e
+  FM_HOME="$case_dir" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" \
+    FM_MERGE_TARGET_BRANCH=feat/gitea-pr-adapter \
+    "$ROOT/bin/fm-merge-local.sh" "$id" >"$case_dir/stdout-yes" 2>"$case_dir/stderr-yes"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "merge-local with override should succeed"$'\n'"$(cat "$case_dir/stderr-yes")"
+  after=$(git -C "$project" rev-parse feat/gitea-pr-adapter)
+  [ "$before" != "$after" ] || fail "merge-local override did not advance the fork branch"
+  git -C "$project" merge-base --is-ancestor "fm/$id" feat/gitea-pr-adapter \
+    || fail "crew branch is not an ancestor of the landing branch after merge"
+  pass "fm-merge-local.sh: FM_MERGE_TARGET_BRANCH lands on a non-default working branch"
+}
+
+test_teardown_honours_override() {
+  local case_dir id=task-x1 project wt state fakebin rc
+  case_dir="$TMP_ROOT/teardown-override"
+  project="$case_dir/project"
+  wt="$case_dir/wt"
+  state="$case_dir/state"
+  fakebin="$case_dir/fakebin"
+  mkdir -p "$state" "$fakebin"
+
+  make_repo_with_origin_head "$project" "$case_dir/origin.git" >/dev/null
+  git -C "$project" checkout -q -B feat/gitea-pr-adapter
+  git -C "$project" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "fork baseline"
+  git -C "$project" worktree add -q -b "fm/$id" "$wt" feat/gitea-pr-adapter
+  git -C "$wt" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "crew work"
+
+  # Land the crew commit on the fork branch only (not main).
+  git -C "$project" update-ref refs/heads/feat/gitea-pr-adapter "$(git -C "$wt" rev-parse HEAD)"
+
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" \
+    "worktree=$wt" \
+    "project=$project" \
+    "kind=ship" \
+    "mode=local-only"
+  touch "$state/.last-watcher-beat"
+
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr list") printf '%s\n' "count: 0 (showing first 0)" "pull_requests[]: []" ; exit 0 ;;
+  "pr view") echo "error: pull request not found" >&2 ; exit 1 ;;
+esac
+exit 0
+SH
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr view") echo "error: pull request not found" >&2 ; exit 1 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse" "$fakebin/tmux" "$fakebin/gh-axi" "$fakebin/gh"
+
+  # Without override: commits are on feat/*, not main -> REFUSE.
+  set +e
+  PATH="$fakebin:$PATH" FM_HOME="$case_dir" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" \
+    "$ROOT/bin/fm-teardown.sh" "$id" >"$case_dir/stdout-no" 2>"$case_dir/stderr-no"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "teardown without override should refuse work only on the fork branch"
+  grep -q REFUSED "$case_dir/stderr-no" || fail "teardown without override printed no REFUSED line"
+
+  # With override pointing at the fork branch the work landed on -> ALLOW.
+  set +e
+  PATH="$fakebin:$PATH" FM_HOME="$case_dir" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$state" \
+    FM_MERGE_TARGET_BRANCH=feat/gitea-pr-adapter \
+    "$ROOT/bin/fm-teardown.sh" "$id" >"$case_dir/stdout-yes" 2>"$case_dir/stderr-yes"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "teardown with override should succeed"$'\n'"$(cat "$case_dir/stderr-yes")"
+  ! grep -q REFUSED "$case_dir/stderr-yes" || fail "teardown with override printed a REFUSED line"
+  [ ! -f "$state/$id.meta" ] || fail "successful teardown did not remove meta"
+  pass "fm-teardown.sh: FM_MERGE_TARGET_BRANCH treats the fork branch as landed"
+}
+
+test_origin_head_default
+test_main_master_fallback_without_origin_head
+test_override_uses_existing_branch
+test_override_missing_branch_refuses
+test_merge_local_honours_override
+test_teardown_honours_override


### PR DESCRIPTION
## Summary
- Factor the landing-branch resolver shared by `bin/fm-merge-local.sh` and `bin/fm-teardown.sh` into `bin/fm-merge-target-lib.sh` (`fm_merge_target_branch`).
- One owner for `FM_MERGE_TARGET_BRANCH` override, `origin/HEAD`, and `main`/`master` fallback so merge and teardown cannot drift.
- Behavior unchanged: every existing guard still applies to the resolved branch.

## Test plan
- [x] `bash tests/fm-merge-target-lib.test.sh` (override + origin/HEAD default + both callers)
- [x] `bin/fm-lint.sh` on changed scripts
- [x] Registered `fm-merge-target-lib.test.sh` under `pure-contract-unit` in `bin/fm-test-run.sh`