### PR TITLE
fix(fleet-snapshot): classify decorated backlog headings

### DIFF
--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -258,9 +258,13 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
   jq -Rn --arg path "$backlog" '
     def trim: gsub("^[[:space:]]+|[[:space:]]+$"; "");
     def section_state:
-      if . == "In flight" then "in_flight"
-      elif . == "Queued" then "queued"
-      elif . == "Done" then "done"
+      # Prefix match so decorated headings still classify
+      # (e.g. "## Done (LIVE + verified)", "## Queued — next").
+      # Exact equality dropped those rows and broke Done counts,
+      # bearings landed, and blocked-by resolution.
+      if test("^In flight(\\b|[[:space:]]|$)") then "in_flight"
+      elif test("^Queued(\\b|[[:space:]]|$)") then "queued"
+      elif test("^Done(\\b|[[:space:]]|$)") then "done"
       else null end;
     def cap($rest; $re):
       (((($rest | capture($re)?) // {}) | .v) // null) as $v

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -755,6 +755,53 @@ test_parked_scout_decision_stays_pending() {
   pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
 }
 
+# Decorated section headings must still classify. Exact-match section_state
+# dropped "## Done (LIVE + verified)" so done counts stayed 0, bearings landed
+# empty, and blocked-by never resolved against Done ids.
+test_decorated_section_headings_classify() {
+  local home out
+  home=$(make_home decorated-headings)
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight (active work)
+- [ ] live-a - Live A (repo: alpha) (kind: ship) (since 2026-07-07)
+
+## Queued — next up
+- [ ] q-a - Queued A blocked-by: done-a (repo: alpha) (kind: ship)
+- [ ] captain-go - Run go blocked-by: done-a (repo: alpha) (kind: captain) (hold: captain runs go) (hold-kind: captain)
+
+## Done (LIVE + verified)
+- [x] done-a - Done A https://github.com/kunchenguid/firstmate/pull/7 (repo: alpha) (kind: ship) (merged 2026-07-06)
+EOF
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    ([.backlog.records[] | select(.state == "done")] | length) == 1
+      and ([.backlog.records[] | select(.state == "queued")] | length) == 2
+      and ([.backlog.records[] | select(.state == "in_flight")] | length) == 1
+  ' >/dev/null || fail "decorated headings must still classify In flight/Queued/Done: $out"
+  printf '%s' "$out" | jq -e '
+    .backlog.records[] | select(.id == "done-a")
+    | .state == "done"
+      and .pr_url == "https://github.com/kunchenguid/firstmate/pull/7"
+      and .completion == {verb:"merged",date:"2026-07-06"}
+  ' >/dev/null || fail "decorated Done heading dropped done-a: $out"
+  printf '%s' "$out" | jq -e '
+    .backlog.records[] | select(.id == "q-a")
+    | .state == "queued"
+      and .blocked_by_ids == ["done-a"]
+      and .unresolved_blocker_ids == []
+  ' >/dev/null || fail "Done id under decorated heading must resolve blocked-by: $out"
+  printf '%s' "$out" | jq -e '
+    .backlog.records[] | select(.id == "captain-go")
+    | .captain_actionable == true
+      and .unresolved_blocker_ids == []
+  ' >/dev/null || fail "captain hold blocked only by decorated Done must be actionable: $out"
+  printf '%s' "$out" | jq -e '
+    .backlog.records[] | select(.id == "live-a")
+    | .state == "in_flight" and .current_role == "worker"
+  ' >/dev/null || fail "decorated In flight heading dropped live-a: $out"
+  pass "decorated In flight/Queued/Done headings classify and resolve blockers"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
@@ -770,3 +817,4 @@ test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot
 test_view_renders_dead_secondmate_agent_status
+test_decorated_section_headings_classify


### PR DESCRIPTION
## Summary
- `fm-fleet-snapshot.sh` `section_state` used exact equality for `In flight` / `Queued` / `Done`, so decorated headings like `## Done (LIVE + verified)` classified as null.
- That zeroed done counts (live home: done=0 with 12 Done rows), emptied bearings landed, and left blocked-by unresolved against Done ids.
- Switch to prefix match (`^Done(\b|[[:space:]]|$)` and siblings) and add a RED/GREEN test that proves decorated headings classify and resolve blockers.

## Verification
- Neutered fix → `test_decorated_section_headings_classify` failed (`not ok`).
- Restored fix → full `tests/fm-fleet-snapshot-view.test.sh` green, including the new case.
- Live home snapshot: done 0 → 12 under `## Done (LIVE + verified)`.
- `shellcheck -x bin/fm-fleet-snapshot.sh` clean.

## Follow-up (out of scope)
Same exact-match defect exists in `bin/fm-session-start.sh` `state_for_heading` (awk lines ~150–152). Decorated headings make the compact session-start backlog listing drop those section items. Same fix class; not changed here.

## Test plan
- [x] Decorated-heading unit coverage in `tests/fm-fleet-snapshot-view.test.sh`
- [x] Live home `FM_HOME=... bin/fm-fleet-snapshot.sh --json` reports done>0