### PR TITLE
fix: restore Herdr lab briefs on Bash 3.2

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -197,7 +197,7 @@ REPO=${POS[1]}
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
 # shellcheck disable=SC2016  # single quotes are deliberate: these lines are literal brief text whose backtick-wrapped $(...) and "$HERDR_LAB_SESSION" snippets must reach the reading agent verbatim, not expand at scaffold time; only the '"$VAR"' break-outs interpolate.
-HERDR_SECTION=$(printf '%s\n' \
+printf -v HERDR_SECTION '%s\n' \
 '# Herdr isolation - HARD SAFETY CONTRACT' \
 'This brief was explicitly scaffolded with `--herdr-lab` because the task will drive Herdr lifecycle behavior.' \
 'On Herdr 0.7.3 the API socket is not relocatable by `HERDR_CONFIG_PATH`, `XDG_CONFIG_HOME`, or `HOME`.' \
@@ -215,7 +215,8 @@ HERDR_SECTION=$(printf '%s\n' \
 '   A missing, stopped, or changed default session is a hard tripwire failure, never a cleanup warning to ignore.' \
 '' \
 'Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.' \
-'The captain fleet uses the running `default` session.')
+'The captain fleet uses the running `default` session.'
+HERDR_SECTION=${HERDR_SECTION%$'\n'}
 else
 IFS= read -r -d '' HERDR_SECTION <<'EOF' || true
 # Herdr lifecycle declaration - NOT ENABLED

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -282,34 +282,60 @@ test_ship_project_memory_wording() {
 }
 
 test_herdr_lab_contract_is_explicit_and_complete() {
-  local home id brief
+  local home kind id brief status
   home="$TMP_ROOT/herdr-lab-home"
   mkdir -p "$home/data"
-  id="brief-herdr-lab-d1"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --herdr-lab >/dev/null 2>&1
-  brief="$home/data/$id/brief.md"
-  assert_present "$brief" "Herdr lab brief was not scaffolded"
-  assert_grep "# Herdr isolation - HARD SAFETY CONTRACT" "$brief" \
-    "Herdr lab brief missing its hard safety contract"
-  assert_grep "HERDR_LAB_HELPER='$ROOT/bin/fm-herdr-lab.sh'" "$brief" \
-    "Herdr lab brief must bind the absolute Firstmate helper path"
-  assert_grep "HERDR_LAB_SESSION=\$(\"\$HERDR_LAB_HELPER\" name $id)" "$brief" \
-    "Herdr lab brief missing helper-owned session naming"
-  assert_grep "\"\$HERDR_LAB_HELPER\" provision \"\$HERDR_LAB_SESSION\"" "$brief" \
-    "Herdr lab brief missing helper-owned provisioning"
-  assert_grep "\"\$HERDR_LAB_HELPER\" teardown \"\$HERDR_LAB_SESSION\"" "$brief" \
-    "Herdr lab brief missing helper-owned teardown"
-  assert_grep "required trailing \`--session \"\$HERDR_LAB_SESSION\"\`" "$brief" \
-    "Herdr lab brief missing the per-call trailing session contract"
-  assert_grep "direct \`herdr server stop\`" "$brief" \
-    "Herdr lab brief missing the forbidden server-global command list"
-  assert_grep "records the live default session before provisioning" "$brief" \
-    "Herdr lab brief missing the before tripwire"
-  assert_grep "verifies the identical fleet state after teardown" "$brief" \
-    "Herdr lab brief missing the after tripwire"
-  assert_no_grep "Herdr lifecycle declaration - NOT ENABLED" "$brief" \
-    "Herdr lab brief retained the unguarded declaration"
-  pass "fm-brief.sh: --herdr-lab emits the complete hard safety contract"
+
+  for kind in ship scout; do
+    id="brief-herdr-$kind-d1"
+    if [ "$kind" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout --herdr-lab >/dev/null 2>&1; status=$?
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --herdr-lab >/dev/null 2>&1; status=$?
+    fi
+    expect_code 0 "$status" "$kind --herdr-lab scaffold should exit 0"
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind Herdr lab brief was not scaffolded"
+    assert_grep "# Herdr isolation - HARD SAFETY CONTRACT" "$brief" \
+      "$kind Herdr lab brief missing its hard safety contract"
+    assert_grep "HERDR_LAB_HELPER='$ROOT/bin/fm-herdr-lab.sh'" "$brief" \
+      "$kind Herdr lab brief must bind the quoted absolute Firstmate helper path"
+    assert_grep "HERDR_LAB_SESSION=\$(\"\$HERDR_LAB_HELPER\" name $id)" "$brief" \
+      "$kind Herdr lab brief missing literal task-derived session naming"
+    assert_no_grep "HERDR_LAB_SESSION=\$(\"\$HERDR_LAB_HELPER\" name default)" "$brief" \
+      "$kind Herdr lab brief allowed the default session name"
+    assert_grep "trap '\"\$HERDR_LAB_HELPER\" teardown \"\$HERDR_LAB_SESSION\"' EXIT" "$brief" \
+      "$kind Herdr lab brief missing the guarded teardown trap"
+    assert_grep "\"\$HERDR_LAB_HELPER\" provision \"\$HERDR_LAB_SESSION\"" "$brief" \
+      "$kind Herdr lab brief missing helper-owned provisioning"
+    assert_grep "\"\$HERDR_LAB_HELPER\" run \"\$HERDR_LAB_SESSION\" <arguments...>" "$brief" \
+      "$kind Herdr lab brief missing helper-owned command execution"
+    assert_grep "\"\$HERDR_LAB_HELPER\" stop \"\$HERDR_LAB_SESSION\"" "$brief" \
+      "$kind Herdr lab brief missing helper-owned mid-run stop"
+    assert_grep "\"\$HERDR_LAB_HELPER\" teardown \"\$HERDR_LAB_SESSION\"" "$brief" \
+      "$kind Herdr lab brief missing helper-owned teardown"
+    assert_grep "required trailing \`--session \"\$HERDR_LAB_SESSION\"\`" "$brief" \
+      "$kind Herdr lab brief missing the per-call trailing session contract"
+    assert_grep "direct \`herdr server stop\`" "$brief" \
+      "$kind Herdr lab brief missing the direct server-stop warning"
+    assert_grep "server-global operation such as \`herdr server live-handoff\` or reload/update operations" "$brief" \
+      "$kind Herdr lab brief missing the other server-global warning"
+    assert_grep "direct \`herdr session stop\`" "$brief" \
+      "$kind Herdr lab brief missing the direct session-stop warning"
+    assert_grep "direct \`herdr session delete\`" "$brief" \
+      "$kind Herdr lab brief missing the direct session-delete warning"
+    assert_grep "scoped only by ambient or inline \`HERDR_SESSION\`" "$brief" \
+      "$kind Herdr lab brief missing the ambient-session warning"
+    assert_grep "records the live default session before provisioning" "$brief" \
+      "$kind Herdr lab brief missing the before tripwire"
+    assert_grep "verifies the identical fleet state after teardown" "$brief" \
+      "$kind Herdr lab brief missing the after tripwire"
+    assert_grep "Never bypass the helper, even for a read-only lifecycle probe" "$brief" \
+      "$kind Herdr lab brief missing the read-only lifecycle warning"
+    assert_no_grep "Herdr lifecycle declaration - NOT ENABLED" "$brief" \
+      "$kind Herdr lab brief retained the unguarded declaration"
+  done
+  pass "fm-brief.sh: ship and scout --herdr-lab scaffolds emit the complete hard safety contract"
 }
 
 test_herdr_lab_contract_quotes_foreign_firstmate_path() {

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -286,6 +286,9 @@ test_herdr_lab_contract_is_explicit_and_complete() {
   home="$TMP_ROOT/herdr-lab-home"
   mkdir -p "$home/data"
 
+  assert_no_grep "HERDR_SECTION=\$(" "$ROOT/bin/fm-brief.sh" \
+    "Herdr lab section must not be built inside a Bash 3.2 command-substitution parse path"
+
   for kind in ship scout; do
     id="brief-herdr-$kind-d1"
     if [ "$kind" = scout ]; then


### PR DESCRIPTION
## Intent

Repair Firstmate's bin/fm-brief.sh --herdr-lab scaffold so Bash 3.2 no longer aborts with an unmatched command-substitution parenthesis and live product work can safely start an independent visible review. Preserve the generated no-mistakes ask-user wording while removing the literal apostrophe from the nested heredoc parse path. Under strict TDD, execute real ship and scout --herdr-lab scaffolds and prove their text retains the literal runtime session-name substitution, shell-quoted absolute helper path, task-derived non-default name, guarded trap/provision/run/stop/teardown commands, trailing session scope, and every forbidden direct or global Herdr warning. Preserve ordinary ship/scout scaffolds, secondmate charters, all delivery-mode shaping, exact status paths, worktree isolation, and refusal to overwrite. Change only bin/fm-brief.sh and tests/fm-brief.test.sh, invoke no Herdr lifecycle operations, and validate with bash -n, affected tests, bin/fm-lint.sh, and git diff --check.

## What Changed

- Preserve the generated `firstmate's authority check` wording through safe variable substitution so `fm-brief.sh` parses on Bash 3.2 and Herdr lab briefs scaffold successfully.
- Expand Herdr lab regression coverage across ship and scout briefs, including task-derived session naming, quoted helper paths, guarded lifecycle commands, trailing session scope, and prohibited direct or global operations.

## Risk Assessment

✅ Low: Captain, the narrowly scoped quoting fix preserves generated wording and the expanded regression coverage matches the Herdr scaffold requirements without introducing material source risk.

## Testing

The baseline script reproduced the unmatched-parenthesis failure under macOS Bash 3.2.57, while the target parsed cleanly; the affected behavior suite passed, and real ship/scout scaffolds produced reviewer-visible Markdown containing every required safety and wording detail without executing Herdr lifecycle operations. The working tree remained clean. Per this validation task’s explicit prohibition on linters and static analysis, `bin/fm-lint.sh` and `git diff --check` were not run.

<details>
<summary>Evidence: Generated Herdr-lab ship brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr isolation - HARD SAFETY CONTRACT
This brief was explicitly scaffolded with `--herdr-lab` because the task will drive Herdr lifecycle behavior.
On Herdr 0.7.3 the API socket is not relocatable by `HERDR_CONFIG_PATH`, `XDG_CONFIG_HOME`, or `HOME`.
A named non-`default` session plus a trailing `--session <name>` on every call is the only viable local isolation.

1. Set `HERDR_LAB_HELPER='/Users/darrencarter/.no-mistakes/worktrees/437ec9ddfa86/01KYHX6WDV4155C1XVWA7WWCRJ/bin/fm-herdr-lab.sh'` and generate the session name with `HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name review-herdr-ship)`.
   Install `trap '"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"' EXIT` before provisioning, then provision only with `"$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION"`.
2. Run every task-specific non-lifecycle Herdr command through `"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" <arguments...>`.
   The helper appends the required trailing `--session "$HERDR_LAB_SESSION"`; `HERDR_SESSION` alone is never accepted as isolation.
3. Teardown only through `"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"`.
   It re-checks refuse-default immediately before stop and again immediately before delete, and fails closed on ambiguity.
4. If an experiment requires a deliberate mid-run session stop, use only `"$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION"`; it performs the same immediate refuse-default check.
5. Forbidden commands: direct `herdr server stop`, every other server-global operation such as `herdr server live-handoff` or reload/update operations, direct `herdr session stop`, direct `herdr session delete`, and any Herdr call scoped only by ambient or inline `HERDR_SESSION`.
6. The helper records the live default session before provisioning and verifies the identical fleet state after teardown.
   A missing, stopped, or changed default session is a hard tripwire failure, never a cleanup warning to ignore.

Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.
The captain fleet uses the running `default` session.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/review-herdr-ship`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/1w/55d1ycvx033f1zjldh2j0sxh0000gn/T/no-mistakes-evidence/01KYHX6WDV4155C1XVWA7WWCRJ/runtime-home/state/review-herdr-ship.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/darrencarter/.no-mistakes/worktrees/437ec9ddfa86/01KYHX6WDV4155C1XVWA7WWCRJ/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/darrencarter/.no-mistakes/worktrees/437ec9ddfa86/01KYHX6WDV4155C1XVWA7WWCRJ/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated Herdr-lab scout brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr isolation - HARD SAFETY CONTRACT
This brief was explicitly scaffolded with `--herdr-lab` because the task will drive Herdr lifecycle behavior.
On Herdr 0.7.3 the API socket is not relocatable by `HERDR_CONFIG_PATH`, `XDG_CONFIG_HOME`, or `HOME`.
A named non-`default` session plus a trailing `--session <name>` on every call is the only viable local isolation.

1. Set `HERDR_LAB_HELPER='/Users/darrencarter/.no-mistakes/worktrees/437ec9ddfa86/01KYHX6WDV4155C1XVWA7WWCRJ/bin/fm-herdr-lab.sh'` and generate the session name with `HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name review-herdr-scout)`.
   Install `trap '"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"' EXIT` before provisioning, then provision only with `"$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION"`.
2. Run every task-specific non-lifecycle Herdr command through `"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" <arguments...>`.
   The helper appends the required trailing `--session "$HERDR_LAB_SESSION"`; `HERDR_SESSION` alone is never accepted as isolation.
3. Teardown only through `"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"`.
   It re-checks refuse-default immediately before stop and again immediately before delete, and fails closed on ambiguity.
4. If an experiment requires a deliberate mid-run session stop, use only `"$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION"`; it performs the same immediate refuse-default check.
5. Forbidden commands: direct `herdr server stop`, every other server-global operation such as `herdr server live-handoff` or reload/update operations, direct `herdr session stop`, direct `herdr session delete`, and any Herdr call scoped only by ambient or inline `HERDR_SESSION`.
6. The helper records the live default session before provisioning and verifies the identical fleet state after teardown.
   A missing, stopped, or changed default session is a hard tripwire failure, never a cleanup warning to ignore.

Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.
The captain fleet uses the running `default` session.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/1w/55d1ycvx033f1zjldh2j0sxh0000gn/T/no-mistakes-evidence/01KYHX6WDV4155C1XVWA7WWCRJ/runtime-home/state/review-herdr-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/var/folders/1w/55d1ycvx033f1zjldh2j0sxh0000gn/T/no-mistakes-evidence/01KYHX6WDV4155C1XVWA7WWCRJ/runtime-home/data/review-herdr-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/Users/darrencarter/.no-mistakes/worktrees/437ec9ddfa86/01KYHX6WDV4155C1XVWA7WWCRJ/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Bash 3.2 regression comparison</summary>

```text
Base Bash 3.2 parse: rc=2, unexpected EOF while looking for matching `)`. Target Bash 3.2 parse: rc=0.
```
</details>
<details>
<summary>Evidence: Existing-brief overwrite refusal</summary>

```text
repeat scaffold rc=1: error: .../review-herdr-ship/brief.md already exists
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --unified=100 a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499..2abc421093f15acc63e15dcdf6617b54a946fcae -- bin/fm-brief.sh tests/fm-brief.test.sh`
- <code>`git show a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499:bin/fm-brief.sh | /bin/bash -n /dev/stdin` (confirmed the baseline Bash 3.2 failure)</code>
- `/bin/bash -n bin/fm-brief.sh`
- `/bin/bash tests/fm-brief.test.sh`
- `FM_HOME=/var/folders/1w/55d1ycvx033f1zjldh2j0sxh0000gn/T/no-mistakes-evidence/01KYHX6WDV4155C1XVWA7WWCRJ/runtime-home /bin/bash bin/fm-brief.sh review-herdr-ship firstmate --herdr-lab`
- `FM_HOME=/var/folders/1w/55d1ycvx033f1zjldh2j0sxh0000gn/T/no-mistakes-evidence/01KYHX6WDV4155C1XVWA7WWCRJ/runtime-home /bin/bash bin/fm-brief.sh review-herdr-scout firstmate --scout --herdr-lab`
- <code>Inspected both generated Herdr safety sections and verified literal runtime substitution, quoted absolute helper path, distinct non-default names, guarded lifecycle commands, trailing session scope, forbidden-operation warnings, and rendered `firstmate&#39;s authority check` wording.</code>
- `Repeated the ship scaffold against the same task ID and confirmed exit 1 with the existing-brief refusal.`
- <code>`git status --short` (confirmed testing left the working tree clean)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
