### PR TITLE
fix(git): stop embedding Gitea tokens in remote URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ config/x-mode.env
 config/cmux-socket-password
 config/wedge-alarm
 config/herdr-presentation-spaces
+config/gitea-token
+config/gitea-username
+config/gitea-host
+config/fm-gitea-credential.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,9 @@ config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inhe
 config/herdr-presentation-spaces  optional presence flag for Herdr's default-off disposable single-task visual projection; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Optional presentation spaces"
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
+config/gitea-token  private Gitea HTTPS token (single line); LOCAL, gitignored mode 600; consumed by bin/fm-gitea-credential.sh so project remotes never embed userinfo (docs/configuration.md "Gitea HTTPS auth")
+config/gitea-username  Gitea username for the credential helper; LOCAL, gitignored; default written by bin/fm-gitea-auth-setup.sh
+config/gitea-host  Gitea HTTPS host gate for the credential helper; LOCAL, gitignored; default private-git.ocin.cloud
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -35,6 +35,8 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 # shellcheck source=bin/fm-lock-lib.sh
 . "$SCRIPT_DIR/fm-lock-lib.sh"
+# shellcheck source=bin/fm-git-remote-sanitize-lib.sh
+. "$SCRIPT_DIR/fm-git-remote-sanitize-lib.sh"
 FM_LOCK_LOG_PREFIX=fleet-sync
 "$FM_ROOT/bin/fm-guard.sh" || true
 
@@ -311,6 +313,14 @@ sync_project() {
     echo "$label: skipped: no origin remote"
     return 0
   fi
+
+  # Drop embedded userinfo from every remote before fetch so a compromised-at-rest
+  # token in .git/config cannot keep spreading via treehouse worktrees. Best-effort;
+  # failures never block the sync.
+  while IFS= read -r _san_line || [ -n "${_san_line:-}" ]; do
+    [ -n "${_san_line:-}" ] || continue
+    echo "$label: $_san_line"
+  done < <(fm_git_remote_sanitize_repo "$PROJ")
 
   if ! fetch_with_packed_refs_lock_guard; then
     reason="fetch failed"

--- a/bin/fm-git-remote-sanitize-lib.sh
+++ b/bin/fm-git-remote-sanitize-lib.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Strip embedded userinfo credentials from git remote URLs in a repository
+# (and optionally its worktrees/submodules when callers pass those paths).
+#
+# Usage: . bin/fm-git-remote-sanitize-lib.sh
+#
+# Public:
+#   fm_git_remote_url_strip_userinfo <url> -> stdout rewritten URL
+#     Leaves scp-like and non-http(s) URLs untouched. For http(s)://user:pass@host
+#     and http(s)://user@host, drops the userinfo and keeps scheme://host/path.
+#   fm_git_remote_sanitize_repo <repo-dir>
+#     For every remote in <repo-dir>, if its URL has userinfo, rewrite it in
+#     place via `git remote set-url`. Prints one line per change to stdout:
+#       sanitized remote <name>
+#     Never prints the secret or the full pre-rewrite URL. Exit 0 always for
+#     missing/non-git dirs (callers treat as best-effort hygiene).
+#   fm_git_remote_sanitize_home_projects [<projects-dir>]
+#     Walk <projects-dir>/* (default $FM_HOME/projects or $FM_PROJECTS_OVERRIDE)
+#     and sanitize each clone. Intended for fleet-sync and one-shot repair.
+#
+# Safety: never logs passwords. set-url only runs when the stripped form differs.
+
+fm_git_remote_url_strip_userinfo() {
+  local url=$1
+  case "$url" in
+    http://*@*|https://*@*)
+      # Drop userinfo between scheme:// and the first remaining host slash-or-end.
+      # Handles user:pass@host and user@host; leaves path/query intact.
+      printf '%s\n' "$url" | sed -E 's#^(https?://)[^/@]+@#\1#'
+      ;;
+    *)
+      printf '%s\n' "$url"
+      ;;
+  esac
+}
+
+fm_git_remote_has_userinfo() {
+  local url=$1
+  case "$url" in
+    http://*@*|https://*@*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_git_remote_sanitize_repo() {
+  local repo=$1
+  local name url cleaned remote_list
+
+  [ -n "$repo" ] || return 0
+  [ -d "$repo" ] || return 0
+  git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+  remote_list=$(git -C "$repo" remote 2>/dev/null || true)
+  [ -n "$remote_list" ] || return 0
+
+  while IFS= read -r name || [ -n "$name" ]; do
+    [ -n "$name" ] || continue
+    url=$(git -C "$repo" remote get-url "$name" 2>/dev/null || true)
+    [ -n "$url" ] || continue
+    fm_git_remote_has_userinfo "$url" || continue
+    cleaned=$(fm_git_remote_url_strip_userinfo "$url")
+    [ -n "$cleaned" ] || continue
+    [ "$cleaned" != "$url" ] || continue
+    if git -C "$repo" remote set-url "$name" "$cleaned" 2>/dev/null; then
+      # Callers prefix with their own project label. Never print the secret URL.
+      printf 'sanitized remote %s\n' "$name"
+    fi
+  done <<EOF
+$remote_list
+EOF
+}
+
+fm_git_remote_sanitize_home_projects() {
+  local projects=${1:-}
+  local proj
+
+  if [ -z "$projects" ]; then
+    projects="${FM_PROJECTS_OVERRIDE:-${FM_HOME:-.}/projects}"
+  fi
+  [ -d "$projects" ] || return 0
+
+  for proj in "$projects"/*; do
+    [ -d "$proj" ] || continue
+    fm_git_remote_sanitize_repo "$proj"
+  done
+}

--- a/bin/fm-gitea-auth-setup.sh
+++ b/bin/fm-gitea-auth-setup.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Wire HTTPS Gitea auth through config/gitea-token + a git credential helper,
+# and strip any embedded userinfo credentials from project remote URLs.
+#
+# Usage:
+#   fm-gitea-auth-setup.sh
+#     Configure the helper for the Gitea host (global git config, host-scoped),
+#     ensure config/gitea-username exists when discoverable, and sanitize every
+#     clone under this home's projects/.
+#   fm-gitea-auth-setup.sh --repo <path>
+#     Same helper install, sanitize only <path>.
+#   fm-gitea-auth-setup.sh --print-helper
+#     Print the credential.helper value that would be installed and exit.
+#   fm-gitea-auth-setup.sh --dry-run
+#     Report planned changes without writing git config or rewriting remotes.
+#
+# Requires config/gitea-token (mode 600) under the effective home. Username from
+# FM_GITEA_USERNAME, config/gitea-username, or default apinant when the token
+# file is present (override with config/gitea-username). Host from FM_GITEA_HOST,
+# config/gitea-host, or private-git.ocin.cloud.
+#
+# Does NOT rotate the token. Token creation on this Gitea requires a password
+# session; print the captain-facing rotate steps when --check-rotate is passed
+# and the current token cannot mint a replacement.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+# shellcheck source=bin/fm-git-remote-sanitize-lib.sh
+. "$SCRIPT_DIR/fm-git-remote-sanitize-lib.sh"
+
+DRY_RUN=0
+PRINT_HELPER=0
+CHECK_ROTATE=0
+REPO=
+
+usage() {
+  cat <<'EOF' >&2
+usage: fm-gitea-auth-setup.sh [--dry-run] [--repo <path>] [--print-helper] [--check-rotate]
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --print-helper) PRINT_HELPER=1; shift ;;
+    --check-rotate) CHECK_ROTATE=1; shift ;;
+    --repo)
+      [ $# -ge 2 ] || { usage; exit 1; }
+      REPO=$2
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; exit 1 ;;
+  esac
+done
+
+HOST=${FM_GITEA_HOST:-}
+if [ -z "$HOST" ] && [ -f "$CONFIG/gitea-host" ]; then
+  HOST=$(sed -n '1s/[[:space:]]*$//p' "$CONFIG/gitea-host" 2>/dev/null || true)
+fi
+[ -n "$HOST" ] || HOST=private-git.ocin.cloud
+
+HELPER_PATH=$SCRIPT_DIR/fm-gitea-credential.sh
+STABLE_HELPER=$CONFIG/fm-gitea-credential.sh
+# Prefer the stable home copy when present so --print-helper matches install.
+if [ -f "$STABLE_HELPER" ]; then
+  HELPER_VALUE="!${STABLE_HELPER}"
+else
+  HELPER_VALUE="!${HELPER_PATH}"
+fi
+
+if [ "$PRINT_HELPER" -eq 1 ]; then
+  printf '%s\n' "$HELPER_VALUE"
+  exit 0
+fi
+
+TOKEN_FILE=${FM_GITEA_TOKEN_FILE:-$CONFIG/gitea-token}
+if [ ! -f "$TOKEN_FILE" ]; then
+  echo "gitea-auth-setup: missing token file $TOKEN_FILE" >&2
+  echo "gitea-auth-setup: create it (mode 600, single line token) then re-run" >&2
+  exit 1
+fi
+
+USERNAME=${FM_GITEA_USERNAME:-}
+if [ -z "$USERNAME" ] && [ -f "$CONFIG/gitea-username" ]; then
+  USERNAME=$(sed -n '1s/[[:space:]]*$//p' "$CONFIG/gitea-username" 2>/dev/null || true)
+fi
+if [ -z "$USERNAME" ]; then
+  USERNAME=apinant
+fi
+
+# Install a stable copy of the credential helper under the home's config/ so the
+# global git config does not point at a disposable crew worktree path that
+# vanishes on teardown. Re-copied on every setup so it tracks the tracked bin/.
+STABLE_HELPER=$CONFIG/fm-gitea-credential.sh
+if [ "$DRY_RUN" -eq 0 ]; then
+  mkdir -p "$CONFIG"
+  if [ ! -f "$CONFIG/gitea-username" ]; then
+    printf '%s\n' "$USERNAME" > "$CONFIG/gitea-username"
+    chmod 600 "$CONFIG/gitea-username"
+    echo "gitea-auth-setup: wrote config/gitea-username"
+  fi
+  if [ ! -f "$CONFIG/gitea-host" ]; then
+    printf '%s\n' "$HOST" > "$CONFIG/gitea-host"
+    chmod 644 "$CONFIG/gitea-host"
+    echo "gitea-auth-setup: wrote config/gitea-host"
+  fi
+  chmod 600 "$TOKEN_FILE" 2>/dev/null || true
+  cp "$HELPER_PATH" "$STABLE_HELPER"
+  chmod 700 "$STABLE_HELPER"
+  echo "gitea-auth-setup: installed stable helper at config/fm-gitea-credential.sh"
+else
+  echo "gitea-auth-setup: dry-run would ensure config/gitea-username=$USERNAME host=$HOST"
+  echo "gitea-auth-setup: dry-run would copy helper to $STABLE_HELPER"
+fi
+
+HELPER_VALUE="!${STABLE_HELPER}"
+
+# Host-scoped helper so only this Gitea host uses the token file.
+# Use --global so every project/worktree inherits it; local repo config is not
+# required and would be lost when a worktree is discarded.
+# An empty helper entry clears inherited helpers (e.g. osxkeychain) for this
+# host so config/gitea-token is authoritative rather than a stale keychain user.
+if [ "$DRY_RUN" -eq 0 ]; then
+  git config --global --unset-all "credential.https://${HOST}.helper" 2>/dev/null || true
+  git config --global --add "credential.https://${HOST}.helper" ''
+  git config --global --add "credential.https://${HOST}.helper" "$HELPER_VALUE"
+  git config --global --unset-all "credential.https://${HOST}.useHttpPath" 2>/dev/null || true
+  echo "gitea-auth-setup: installed credential helper for https://${HOST}"
+else
+  echo "gitea-auth-setup: dry-run would set credential.https://${HOST}.helper=$HELPER_VALUE"
+fi
+
+sanitize_one() {
+  local path=$1 line
+  if [ "$DRY_RUN" -eq 1 ]; then
+    local name url
+    git -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+    while IFS= read -r name; do
+      [ -n "$name" ] || continue
+      url=$(git -C "$path" remote get-url "$name" 2>/dev/null || true)
+      if fm_git_remote_has_userinfo "$url"; then
+        echo "gitea-auth-setup: dry-run would sanitize $(basename "$path") remote $name"
+      fi
+    done < <(git -C "$path" remote 2>/dev/null || true)
+    return 0
+  fi
+  while IFS= read -r line || [ -n "${line:-}" ]; do
+    [ -n "${line:-}" ] || continue
+    echo "gitea-auth-setup: $(basename "$path"): $line"
+  done < <(fm_git_remote_sanitize_repo "$path")
+}
+
+if [ -n "$REPO" ]; then
+  sanitize_one "$REPO"
+elif [ -d "$PROJECTS" ]; then
+  for proj in "$PROJECTS"/*; do
+    [ -d "$proj" ] || continue
+    sanitize_one "$proj"
+  done
+fi
+
+if [ "$CHECK_ROTATE" -eq 1 ]; then
+  cat <<EOF
+gitea-auth-setup: rotate steps (current token treated compromised-at-rest):
+  1. Open https://${HOST}/user/settings/applications as ${USERNAME}
+  2. Generate a new token with repo read/write scope; copy it once
+  3. printf '%s\\n' '<new-token>' > ${TOKEN_FILE} && chmod 600 ${TOKEN_FILE}
+  4. Delete the old token in the same Applications page
+  5. Re-run: FM_HOME=${FM_HOME} ${SCRIPT_DIR}/fm-gitea-auth-setup.sh
+  6. Prove: git -C <project> ls-remote https://${HOST}/OpenCloud/core.git HEAD
+Note: this Gitea rejects token-list/create with a bearer token alone (HTTP 401);
+password/session login is required for mint+revoke. No automatic rotate from here.
+EOF
+fi
+
+echo "gitea-auth-setup: done"

--- a/bin/fm-gitea-credential.sh
+++ b/bin/fm-gitea-credential.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Git credential helper for the private Gitea host.
+# Reads username/token from the effective Firstmate home so remote URLs never
+# need embedded userinfo. Invoked by git as:
+#   git credential-xxx get|store|erase
+# or as an absolute-path helper:
+#   !/path/to/fm-gitea-credential.sh
+#
+# Usage (as a credential helper; git feeds the action on argv and attributes on stdin):
+#   fm-gitea-credential.sh get
+#   fm-gitea-credential.sh store   # no-op (token file is the store)
+#   fm-gitea-credential.sh erase   # no-op (does not delete the token file)
+#
+# Resolution order for the token file:
+#   1. FM_GITEA_TOKEN_FILE
+#   2. $FM_HOME/config/gitea-token (FM_HOME, else FM_CONFIG_OVERRIDE, else
+#      the tracked root derived from this script)
+# Username resolution:
+#   1. FM_GITEA_USERNAME
+#   2. $config_dir/gitea-username
+#   3. fail closed (print nothing) so git can try the next helper
+# Host gate (only answer for this host):
+#   FM_GITEA_HOST or $config_dir/gitea-host or private-git.ocin.cloud
+#
+# Never prints the token to stderr. store/erase are intentional no-ops so a
+# successful clone cannot rewrite or delete the captain-managed token file.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+action=${1:-}
+case "$action" in
+  get|store|erase) ;;
+  *) exit 0 ;;
+esac
+
+# Parse credential attributes from stdin (key=value lines, blank line ends).
+protocol=''
+host=''
+username=''
+while IFS= read -r line || [ -n "$line" ]; do
+  [ -n "$line" ] || break
+  case "$line" in
+    protocol=*) protocol=${line#protocol=} ;;
+    host=*) host=${line#host=} ;;
+    username=*) username=${line#username=} ;;
+  esac
+done
+
+# Only HTTPS to the configured Gitea host is in scope.
+[ "$protocol" = https ] || exit 0
+[ -n "$host" ] || exit 0
+
+if [ -n "${FM_CONFIG_OVERRIDE:-}" ]; then
+  CONFIG_DIR=$FM_CONFIG_OVERRIDE
+elif [ -n "${FM_HOME:-}" ]; then
+  CONFIG_DIR=$FM_HOME/config
+else
+  CONFIG_DIR=$FM_ROOT/config
+fi
+
+configured_host=${FM_GITEA_HOST:-}
+if [ -z "$configured_host" ] && [ -f "$CONFIG_DIR/gitea-host" ]; then
+  configured_host=$(sed -n '1s/[[:space:]]*$//p' "$CONFIG_DIR/gitea-host" 2>/dev/null || true)
+fi
+[ -n "$configured_host" ] || configured_host=private-git.ocin.cloud
+
+# Host match is exact (including optional :port on either side after stripping
+# a trailing default :443).
+normalize_host() {
+  local h=$1
+  case "$h" in
+    *:443) h=${h%:443} ;;
+  esac
+  printf '%s' "$h"
+}
+host_n=$(normalize_host "$host")
+cfg_n=$(normalize_host "$configured_host")
+[ "$host_n" = "$cfg_n" ] || exit 0
+
+case "$action" in
+  store|erase)
+    # Token file is captain-managed; do not mutate it from git's credential API.
+    exit 0
+    ;;
+esac
+
+token_file=${FM_GITEA_TOKEN_FILE:-$CONFIG_DIR/gitea-token}
+[ -f "$token_file" ] || exit 0
+
+# Refuse group/other-readable token files (must be owner-only bits on the
+# group/other nybbles: mode ends in 00). Missing/unreadable mode fails closed.
+if command -v stat >/dev/null 2>&1; then
+  mode=$(stat -f '%Lp' "$token_file" 2>/dev/null || stat -c '%a' "$token_file" 2>/dev/null || echo '')
+  case "$mode" in
+    [0-7]00) ;;
+    *) exit 0 ;;
+  esac
+fi
+
+token=$(sed -n '1s/[[:space:]]*$//p' "$token_file" 2>/dev/null || true)
+[ -n "$token" ] || exit 0
+
+if [ -z "$username" ]; then
+  username=${FM_GITEA_USERNAME:-}
+  if [ -z "$username" ] && [ -f "$CONFIG_DIR/gitea-username" ]; then
+    username=$(sed -n '1s/[[:space:]]*$//p' "$CONFIG_DIR/gitea-username" 2>/dev/null || true)
+  fi
+fi
+[ -n "$username" ] || exit 0
+
+printf 'username=%s\n' "$username"
+printf 'password=%s\n' "$token"
+printf '\n'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,15 @@ An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisel
 A missing or failing channel logs and falls through to the next, never crashing the daemon.
 See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
 
+## Gitea HTTPS auth (config/gitea-token)
+
+Private Gitea HTTPS access uses a home-local token file plus a git credential helper so project remote URLs never embed userinfo.
+`config/gitea-token` holds one token line at mode `600`; `config/gitea-username` and optional `config/gitea-host` (default `private-git.ocin.cloud`) select the account and host gate.
+`bin/fm-gitea-credential.sh` is the tracked credential helper; `bin/fm-gitea-auth-setup.sh` copies it to gitignored `config/fm-gitea-credential.sh`, installs that stable path host-scoped in global git config, and strips embedded credentials from every clone under `projects/`.
+`bin/fm-fleet-sync.sh` re-runs that strip before each fetch so a reintroduced embedded token cannot keep spreading through worktrees.
+These files are local and gitignored; never commit them.
+Token rotation requires a password/session login on the Gitea Applications page - a bearer token alone cannot mint or revoke tokens on this host; `fm-gitea-auth-setup.sh --check-rotate` prints the exact steps.
+
 ## Gate defaults (.no-mistakes.yaml)
 
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.

--- a/tests/fm-gitea-remote-sanitize.test.sh
+++ b/tests/fm-gitea-remote-sanitize.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# fm-gitea-remote-sanitize.test.sh - strip embedded remote userinfo and feed
+# HTTPS Gitea auth through config/gitea-token without printing secrets.
+set -euo pipefail
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+fm_git_identity
+
+# shellcheck source=bin/fm-git-remote-sanitize-lib.sh
+. "$ROOT/bin/fm-git-remote-sanitize-lib.sh"
+
+assert_eq() {
+  local got=$1 want=$2 msg=${3:-}
+  if [ "$got" != "$want" ]; then
+    fail "assert_eq failed${msg:+: $msg}: got=[$got] want=[$want]"
+  fi
+}
+
+test_strip_userinfo_variants() {
+  assert_eq \
+    "$(fm_git_remote_url_strip_userinfo 'https://user:s3cret@private-git.ocin.cloud/OpenCloud/core.git')" \
+    'https://private-git.ocin.cloud/OpenCloud/core.git' \
+    'user:pass https'
+  assert_eq \
+    "$(fm_git_remote_url_strip_userinfo 'https://user@private-git.ocin.cloud/OpenCloud/core.git')" \
+    'https://private-git.ocin.cloud/OpenCloud/core.git' \
+    'user-only https'
+  assert_eq \
+    "$(fm_git_remote_url_strip_userinfo 'http://user:pass@example.test/r.git')" \
+    'http://example.test/r.git' \
+    'http user:pass'
+  assert_eq \
+    "$(fm_git_remote_url_strip_userinfo 'git@private-git.ocin.cloud:OpenCloud/core.git')" \
+    'git@private-git.ocin.cloud:OpenCloud/core.git' \
+    'ssh untouched'
+  assert_eq \
+    "$(fm_git_remote_url_strip_userinfo 'https://private-git.ocin.cloud/OpenCloud/core.git')" \
+    'https://private-git.ocin.cloud/OpenCloud/core.git' \
+    'clean https untouched'
+  pass "strip userinfo variants"
+}
+
+test_sanitize_repo_rewrites_and_is_quiet_on_secrets() {
+  local repo out url
+  repo=$(fm_test_tmproot sanitize-repo)
+  fm_git_init_commit "$repo"
+  git -C "$repo" remote add origin 'https://apinant:deadbeefdeadbeef@private-git.ocin.cloud/OpenCloud/core.git'
+  git -C "$repo" remote add gitea-https 'https://apinant:deadbeefdeadbeef@private-git.ocin.cloud/OpenCloud/core.git'
+  git -C "$repo" remote add clean 'https://private-git.ocin.cloud/OpenCloud/other.git'
+  git -C "$repo" remote add ssh 'git@private-git.ocin.cloud:OpenCloud/core.git'
+
+  out=$(fm_git_remote_sanitize_repo "$repo")
+  printf '%s\n' "$out" | grep -Fq 'sanitized remote origin' \
+    || fail "expected origin sanitize line, got: $out"
+  printf '%s\n' "$out" | grep -Fq 'sanitized remote gitea-https' \
+    || fail "expected gitea-https sanitize line, got: $out"
+  printf '%s\n' "$out" | grep -Eqi 'deadbeef|apinant:|password' \
+    && fail "sanitize output leaked secret material: $out"
+
+  url=$(git -C "$repo" remote get-url origin)
+  assert_eq "$url" 'https://private-git.ocin.cloud/OpenCloud/core.git' 'origin cleaned'
+  url=$(git -C "$repo" remote get-url gitea-https)
+  assert_eq "$url" 'https://private-git.ocin.cloud/OpenCloud/core.git' 'gitea-https cleaned'
+  url=$(git -C "$repo" remote get-url clean)
+  assert_eq "$url" 'https://private-git.ocin.cloud/OpenCloud/other.git' 'clean unchanged'
+  url=$(git -C "$repo" remote get-url ssh)
+  assert_eq "$url" 'git@private-git.ocin.cloud:OpenCloud/core.git' 'ssh unchanged'
+
+  # Idempotent second pass produces no output.
+  out=$(fm_git_remote_sanitize_repo "$repo")
+  [ -z "$out" ] || fail "second sanitize should be quiet, got: $out"
+  pass "sanitize repo rewrites without leaking"
+}
+
+test_credential_helper_get() {
+  local home cfg helper out
+  home=$(fm_test_tmproot gitea-cred-home)
+  cfg="$home/config"
+  mkdir -p "$cfg"
+  printf 'tokensecretvalue00000000000000000001\n' > "$cfg/gitea-token"
+  chmod 600 "$cfg/gitea-token"
+  printf 'apinant\n' > "$cfg/gitea-username"
+  printf 'private-git.ocin.cloud\n' > "$cfg/gitea-host"
+  helper=$ROOT/bin/fm-gitea-credential.sh
+
+  out=$(
+    FM_HOME="$home" FM_CONFIG_OVERRIDE="$cfg" \
+      "$helper" get <<'EOF'
+protocol=https
+host=private-git.ocin.cloud
+path=OpenCloud/core.git
+
+EOF
+  )
+  printf '%s\n' "$out" | grep -Fx 'username=apinant' >/dev/null \
+    || fail "helper missing username: $out"
+  printf '%s\n' "$out" | grep -Fx 'password=tokensecretvalue00000000000000000001' >/dev/null \
+    || fail "helper missing password"
+  pass "credential helper get happy path"
+}
+
+test_credential_helper_host_gate_and_mode() {
+  local home cfg helper out
+  home=$(fm_test_tmproot gitea-cred-gate)
+  cfg="$home/config"
+  mkdir -p "$cfg"
+  printf 'tokensecretvalue00000000000000000002\n' > "$cfg/gitea-token"
+  chmod 600 "$cfg/gitea-token"
+  printf 'apinant\n' > "$cfg/gitea-username"
+  helper=$ROOT/bin/fm-gitea-credential.sh
+
+  out=$(
+    FM_HOME="$home" FM_CONFIG_OVERRIDE="$cfg" \
+      "$helper" get <<'EOF'
+protocol=https
+host=evil.example
+path=OpenCloud/core.git
+
+EOF
+  )
+  [ -z "$out" ] || fail "helper answered wrong host: $out"
+
+  out=$(
+    FM_HOME="$home" FM_CONFIG_OVERRIDE="$cfg" \
+      "$helper" get <<'EOF'
+protocol=http
+host=private-git.ocin.cloud
+
+EOF
+  )
+  [ -z "$out" ] || fail "helper answered non-https: $out"
+
+  chmod 644 "$cfg/gitea-token"
+  out=$(
+    FM_HOME="$home" FM_CONFIG_OVERRIDE="$cfg" \
+      "$helper" get <<'EOF'
+protocol=https
+host=private-git.ocin.cloud
+
+EOF
+  )
+  [ -z "$out" ] || fail "helper answered world-readable token file: $out"
+  pass "credential helper host gate and mode refuse"
+}
+
+test_fleet_sync_sanitizes_before_fetch() {
+  # Build a bare origin + clone with an embedded-token extra remote; fleet-sync
+  # must strip it even when origin fetch is the only network path.
+  local home work remote_abs out url
+  home=$(fm_test_tmproot fleet-san)
+  mkdir -p "$home/projects" "$home/data" "$home/config" "$home/remotes"
+  work=$(fm_test_tmproot fleet-san-work)
+  fm_git_init_commit "$work"
+  # Default branch name may be master on older git; rename to main for fleet-sync.
+  git -C "$work" branch -M main 2>/dev/null || true
+  git clone --quiet --bare "$work" "$home/remotes/alpha.git"
+  remote_abs=$(cd "$home/remotes/alpha.git" && pwd)
+  git clone --quiet "file://$remote_abs" "$home/projects/alpha"
+  git -C "$home/projects/alpha" remote add gitea-https \
+    'https://apinant:deadbeefdeadbeef@private-git.ocin.cloud/OpenCloud/core.git'
+  printf -- '- alpha [direct-PR] - alpha (added 2026-06-22)\n' > "$home/data/projects.md"
+
+  out=$(
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_PROJECTS_OVERRIDE="$home/projects" \
+      "$ROOT/bin/fm-fleet-sync.sh" alpha 2>&1
+  ) || fail "fleet-sync failed: $out"
+
+  printf '%s\n' "$out" | grep -Fq 'sanitized remote gitea-https' \
+    || fail "fleet-sync did not report sanitize: $out"
+  url=$(git -C "$home/projects/alpha" remote get-url gitea-https)
+  assert_eq "$url" 'https://private-git.ocin.cloud/OpenCloud/core.git' \
+    'fleet-sync cleaned gitea-https'
+  printf '%s\n' "$out" | grep -Eqi 'deadbeef' \
+    && fail "fleet-sync leaked token: $out"
+  pass "fleet-sync sanitizes embedded remote before fetch"
+}
+
+test_strip_userinfo_variants
+test_sanitize_repo_rewrites_and_is_quiet_on_secrets
+test_credential_helper_get
+test_credential_helper_host_gate_and_mode
+test_fleet_sync_sanitizes_before_fetch
+
+echo "ok: fm-gitea-remote-sanitize"


### PR DESCRIPTION
## Summary
- Strip embedded `https://user:token@...` userinfo from project remote URLs (and re-strip on every fleet-sync fetch) so treehouse crews cannot read the private Gitea token from `.git/config`.
- Add `bin/fm-gitea-credential.sh` + `bin/fm-gitea-auth-setup.sh`: host-scoped git credential helper fed by gitignored `config/gitea-token` (stable copy under `config/fm-gitea-credential.sh`), clearing inherited osxkeychain for that host so the token file is authoritative.
- Document `config/gitea-{token,username,host}` and the rotation path that still requires a password/session Applications login (bearer alone returns 401 on token mint/revoke).

## Live remediation (already applied on this home)
- `projects/cozystack` `gitea-https` remote cleaned to `https://private-git.ocin.cloud/OpenCloud/core.git` (0 embedded passwords).
- Global helper installed: `credential.https://private-git.ocin.cloud.helper` → `config/fm-gitea-credential.sh`.
- Proven: `git credential fill` returns `username=apinant`; `git ls-remote gitea-https` succeeds.

## Rotate (captain action still required)
1. Open https://private-git.ocin.cloud/user/settings/applications as `apinant`
2. Generate a new repo-scope token; write it to `config/gitea-token` mode 600
3. Delete the old token
4. `FM_HOME=... bin/fm-gitea-auth-setup.sh` and re-prove `ls-remote`

## Test plan
- [x] `bash tests/fm-gitea-remote-sanitize.test.sh`
- [x] `bin/fm-lint.sh` on touched scripts
- [x] `bin/fm-doc-audience-check.sh`
- [x] Live cozystack remote sanitize + HTTPS fetch via helper