### PR TITLE
feat(bin): add guarded forge remote branch prune helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ Hard rules, in priority order:
 
 1. **Never write to a project.**
    Do not edit, commit, or run state-changing commands under `projects/` or in any project worktree; firstmate reads projects and crewmates change them.
-   The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths owned by their referenced skills and scripts.
-   Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
+   The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, approved `local-only` merge paths, and forge remote-branch prune (`bin/fm-branch-prune.sh`) owned by their referenced skills and scripts.
+   Those paths never authorize forcing, stashing, discarding unlanded work, hand-writing a project's `AGENTS.md`, or hand-deleting project refs outside `bin/fm-branch-prune.sh`.
 2. **Never merge a PR without the captain's explicit word.**
    A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns its exceptions and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
 3. **Never tear down unlanded work.**

--- a/bin/fm-branch-prune.sh
+++ b/bin/fm-branch-prune.sh
@@ -1,0 +1,525 @@
+#!/usr/bin/env bash
+# Guarded forge-level prune of remote branches whose pull request is merged.
+#
+# This is the sanctioned path for deleting remote refs on a GitHub repo.
+# Firstmate must not hand-delete project branches: ancestry checks break under
+# squash-merge, and a bulk delete with no audit trail is how work is lost.
+# Local gone-upstream pruning remains owned by bin/fm-fleet-sync.sh; this helper
+# only classifies and (optionally) deletes remote refs on the forge.
+#
+# Classification uses the pull request's own merged signal, never git ancestry:
+#   merged          -> candidate for delete
+#   open            -> keep
+#   closed unmerged -> keep and surface by PR number
+#   no PR           -> keep and surface for investigation
+#
+# Protected refs (main/master/uat/prod/production/release/develop/staging and
+# any path under them) are never deleted. A candidate is also refused when it is
+# the base (or head) of any still-open PR, so pruning cannot orphan another PR.
+#
+# Default is dry-run (plan only). Pass --apply to perform deletions. Every kept
+# and deleted decision is appended to data/branch-prune.log under FM_HOME.
+#
+# Usage:
+#   fm-branch-prune.sh --repo OWNER/REPO [--apply] [--yes]
+#   fm-branch-prune.sh --repo OWNER/REPO \
+#     --prs-file PATH --branches-file PATH [--apply] [--yes]
+#
+# --prs-file / --branches-file feed fixture JSON (GitHub REST list shapes) so
+# tests exercise classification without the network. Live mode pages the same
+# shapes through `gh api --paginate` (machine-readable JSON; gh-axi remains the
+# interactive human CLI and is not used here because its list output is not JSON).
+# Deletions call `gh api --method DELETE repos/OWNER/REPO/git/refs/heads/BRANCH`.
+# jq is required (already a firstmate bootstrap tool).
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+LOG="${FM_BRANCH_PRUNE_LOG:-$DATA/branch-prune.log}"
+
+REPO=""
+APPLY=0
+ASSUME_YES=0
+PRS_FILE=""
+BRANCHES_FILE=""
+
+usage() {
+  cat <<'EOF' >&2
+Usage: fm-branch-prune.sh --repo OWNER/REPO [--apply] [--yes]
+       fm-branch-prune.sh --repo OWNER/REPO --prs-file PATH --branches-file PATH [--apply] [--yes]
+
+Classify remote branches by PR merge state and optionally delete only safe ones.
+Default is dry-run. --apply performs deletions; --yes skips the apply confirm.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ "$#" -ge 2 ] || { echo "error: --repo needs OWNER/REPO" >&2; exit 2; }
+      REPO=$2
+      shift 2
+      ;;
+    --repo=*)
+      REPO=${1#--repo=}
+      shift
+      ;;
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    --yes|-y)
+      ASSUME_YES=1
+      shift
+      ;;
+    --prs-file)
+      [ "$#" -ge 2 ] || { echo "error: --prs-file needs a path" >&2; exit 2; }
+      PRS_FILE=$2
+      shift 2
+      ;;
+    --prs-file=*)
+      PRS_FILE=${1#--prs-file=}
+      shift
+      ;;
+    --branches-file)
+      [ "$#" -ge 2 ] || { echo "error: --branches-file needs a path" >&2; exit 2; }
+      BRANCHES_FILE=$2
+      shift 2
+      ;;
+    --branches-file=*)
+      BRANCHES_FILE=${1#--branches-file=}
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      echo "error: unexpected argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$REPO" ]; then
+  echo "error: --repo OWNER/REPO is required" >&2
+  usage
+  exit 2
+fi
+
+# Exactly one slash, non-empty owner and name, no nested path segments.
+OWNER=""
+NAME=""
+case "$REPO" in
+  */*)
+    OWNER=${REPO%%/*}
+    NAME=${REPO#*/}
+    ;;
+esac
+if [ -z "$OWNER" ] || [ -z "$NAME" ] \
+  || [ "$OWNER/$NAME" != "$REPO" ] \
+  || [ "${NAME#*/}" != "$NAME" ] \
+  || [ "${OWNER#*/}" != "$OWNER" ]; then
+  echo "error: --repo must be OWNER/REPO" >&2
+  exit 2
+fi
+
+if [ -n "$PRS_FILE" ] && [ -z "$BRANCHES_FILE" ]; then
+  echo "error: --prs-file requires --branches-file" >&2
+  exit 2
+fi
+if [ -n "$BRANCHES_FILE" ] && [ -z "$PRS_FILE" ]; then
+  echo "error: --branches-file requires --prs-file" >&2
+  exit 2
+fi
+if [ -n "$PRS_FILE" ] && [ ! -f "$PRS_FILE" ]; then
+  echo "error: --prs-file is not a file: $PRS_FILE" >&2
+  exit 2
+fi
+if [ -n "$BRANCHES_FILE" ] && [ ! -f "$BRANCHES_FILE" ]; then
+  echo "error: --branches-file is not a file: $BRANCHES_FILE" >&2
+  exit 2
+fi
+
+command -v jq >/dev/null 2>&1 || {
+  echo "error: jq is required" >&2
+  exit 1
+}
+
+# Protected long-lived refs: never candidates, regardless of PR state.
+is_protected_ref() {
+  local branch=$1 lower
+  lower=$(printf '%s' "$branch" | tr '[:upper:]' '[:lower:]')
+  case "$lower" in
+    main|master|uat|prod|production|release|develop|staging) return 0 ;;
+    main/*|master/*|uat/*|prod/*|production/*|release/*|develop/*|staging/*) return 0 ;;
+  esac
+  return 1
+}
+
+iso_now() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+ensure_log() {
+  mkdir -p "$(dirname "$LOG")"
+  if [ ! -e "$LOG" ]; then
+    : > "$LOG"
+  fi
+  if [ -L "$LOG" ] || [ ! -f "$LOG" ]; then
+    echo "error: prune log is not a regular file: $LOG" >&2
+    exit 1
+  fi
+}
+
+append_log() {
+  # tab-separated: ts action repo branch detail
+  printf '%s\t%s\t%s\t%s\t%s\n' "$(iso_now)" "$1" "$REPO" "$2" "$3" >> "$LOG"
+}
+
+fetch_prs_json() {
+  if [ -n "$PRS_FILE" ]; then
+    cat "$PRS_FILE"
+    return 0
+  fi
+  command -v gh >/dev/null 2>&1 || {
+    echo "error: gh is required for live prune (or pass --prs-file/--branches-file)" >&2
+    return 1
+  }
+  # Page every PR. A truncated page silently turns landed branches into "no PR".
+  gh api --paginate \
+    "repos/$OWNER/$NAME/pulls?state=all&per_page=100"
+}
+
+fetch_branches_json() {
+  if [ -n "$BRANCHES_FILE" ]; then
+    cat "$BRANCHES_FILE"
+    return 0
+  fi
+  command -v gh >/dev/null 2>&1 || {
+    echo "error: gh is required for live prune (or pass --prs-file/--branches-file)" >&2
+    return 1
+  }
+  gh api --paginate \
+    "repos/$OWNER/$NAME/branches?per_page=100"
+}
+
+delete_remote_branch() {
+  local branch=$1 encoded
+  # Encode the full branch name so slashes become %2F in the ref path.
+  encoded=$(printf '%s' "$branch" | jq -sRr @uri)
+  gh api --method DELETE "repos/$OWNER/$NAME/git/refs/heads/$encoded" >/dev/null
+}
+
+# gh --paginate may emit one JSON array or a stream of arrays; normalize to one.
+normalize_json_array() {
+  local src=$1 dest=$2
+  if ! [ -s "$src" ]; then
+    echo "error: empty forge response" >&2
+    return 1
+  fi
+  if jq -e 'type == "array"' "$src" >/dev/null 2>&1; then
+    # Nested array-of-arrays (rare) -> flatten; else already a flat array.
+    if jq -e 'length > 0 and (.[0] | type == "array")' "$src" >/dev/null 2>&1; then
+      jq 'add' "$src" > "$dest"
+    else
+      cp "$src" "$dest"
+    fi
+    return 0
+  fi
+  # NDJSON / multi-document stream of arrays from paginate.
+  if jq -s 'add // []' "$src" > "$dest" 2>/dev/null \
+    && jq -e 'type == "array"' "$dest" >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "error: could not parse JSON array from forge response" >&2
+  return 1
+}
+
+WORKDIR=
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-branch-prune.XXXXXX")
+# shellcheck disable=SC2317,SC2329 # Invoked by trap handlers below.
+cleanup() {
+  [ -n "${WORKDIR:-}" ] && rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+PRS_JSON="$WORKDIR/prs.json"
+BRANCHES_JSON="$WORKDIR/branches.json"
+PR_HEAD_MAP="$WORKDIR/pr_head.tsv"
+OPEN_BASES="$WORKDIR/open_bases.txt"
+OPEN_HEADS="$WORKDIR/open_heads.txt"
+CANDIDATES="$WORKDIR/candidates.txt"
+DELETE_LIST="$WORKDIR/delete.txt"
+SUMMARY="$WORKDIR/summary.txt"
+
+if ! fetch_prs_json > "$WORKDIR/prs.raw.json"; then
+  echo "error: failed to load pull requests for $REPO" >&2
+  exit 1
+fi
+if ! fetch_branches_json > "$WORKDIR/branches.raw.json"; then
+  echo "error: failed to load branches for $REPO" >&2
+  exit 1
+fi
+
+normalize_json_array "$WORKDIR/prs.raw.json" "$PRS_JSON" || exit 1
+normalize_json_array "$WORKDIR/branches.raw.json" "$BRANCHES_JSON" || exit 1
+
+# Emit one TSV row per PR: head \t kind \t number \t url \t base
+jq -r '
+  def url:
+    (.html_url // (
+      if ((.base.repo.full_name // "") != "") then
+        "https://github.com/\(.base.repo.full_name)/pull/\(.number)"
+      else
+        "#\(.number)"
+      end
+    ));
+  def kind:
+    if .state == "open" then "open"
+    elif ((.merged_at != null) and (.merged_at != "")) or (.merged == true) then "merged"
+    else "closed_unmerged"
+    end;
+  .[]
+  | select((.head.ref // "") != "")
+  | [(.head.ref // ""), kind, (.number|tostring), url, (.base.ref // "")]
+  | @tsv
+' "$PRS_JSON" > "$WORKDIR/pr_rows.tsv"
+
+: > "$PR_HEAD_MAP"
+: > "$OPEN_BASES"
+: > "$OPEN_HEADS"
+
+# Collapse PR rows per head ref. Precedence: open > merged > closed_unmerged.
+# bash 3.2 portable (no associative arrays in the outer script path beyond awk).
+awk -F '\t' '
+  BEGIN {
+    rank["open"] = 3
+    rank["merged"] = 2
+    rank["closed_unmerged"] = 1
+  }
+  NF >= 4 {
+    head = $1
+    kind = $2
+    pr = $3
+    url = $4
+    base = (NF >= 5 ? $5 : "")
+    r = rank[kind] + 0
+    if (r >= best[head] + 0) {
+      best[head] = r
+      out_kind[head] = kind
+      out_pr[head] = pr
+      out_url[head] = url
+    }
+    if (kind == "open") {
+      if (base != "") print base >> bases_file
+      print head >> heads_file
+    }
+  }
+  END {
+    for (h in out_kind) {
+      printf "%s\t%s\t%s\t%s\n", h, out_kind[h], out_pr[h], out_url[h]
+    }
+  }
+' bases_file="$OPEN_BASES" heads_file="$OPEN_HEADS" \
+  "$WORKDIR/pr_rows.tsv" > "$PR_HEAD_MAP"
+
+sort -u "$OPEN_BASES" -o "$OPEN_BASES" 2>/dev/null || : > "$OPEN_BASES"
+sort -u "$OPEN_HEADS" -o "$OPEN_HEADS" 2>/dev/null || : > "$OPEN_HEADS"
+
+jq -r '.[] | .name // empty' "$BRANCHES_JSON" | sort -u > "$WORKDIR/branches.txt"
+
+ensure_log
+
+: > "$CANDIDATES"
+: > "$DELETE_LIST"
+: > "$SUMMARY"
+
+deleted=0
+kept=0
+candidates=0
+
+while IFS= read -r branch || [ -n "${branch:-}" ]; do
+  [ -n "${branch:-}" ] || continue
+
+  if is_protected_ref "$branch"; then
+    printf 'keep\t%s\tprotected_ref\n' "$branch" >> "$SUMMARY"
+    append_log "kept" "$branch" "reason=protected_ref"
+    kept=$((kept + 1))
+    continue
+  fi
+
+  pr_line=$(awk -F '\t' -v b="$branch" '$1 == b { print; exit }' "$PR_HEAD_MAP" || true)
+  if [ -z "$pr_line" ]; then
+    printf 'keep\t%s\tno_pr\n' "$branch" >> "$SUMMARY"
+    append_log "kept" "$branch" "reason=no_pr"
+    kept=$((kept + 1))
+    continue
+  fi
+
+  kind=$(printf '%s\n' "$pr_line" | cut -f2)
+  pr=$(printf '%s\n' "$pr_line" | cut -f3)
+  url=$(printf '%s\n' "$pr_line" | cut -f4)
+
+  case "$kind" in
+    open)
+      printf 'keep\t%s\topen_pr:%s\t%s\n' "$branch" "$pr" "$url" >> "$SUMMARY"
+      append_log "kept" "$branch" "reason=open_pr pr=#$pr url=$url"
+      kept=$((kept + 1))
+      ;;
+    closed_unmerged)
+      printf 'keep\t%s\tclosed_unmerged:%s\t%s\n' "$branch" "$pr" "$url" >> "$SUMMARY"
+      append_log "kept" "$branch" "reason=closed_unmerged pr=#$pr url=$url"
+      kept=$((kept + 1))
+      ;;
+    merged)
+      if grep -Fxq -- "$branch" "$OPEN_BASES"; then
+        printf 'keep\t%s\topen_pr_base\tpr_merged:#%s\n' "$branch" "$pr" >> "$SUMMARY"
+        append_log "kept" "$branch" "reason=open_pr_base pr_merged=#$pr url=$url"
+        kept=$((kept + 1))
+        continue
+      fi
+      if grep -Fxq -- "$branch" "$OPEN_HEADS"; then
+        # Defensive: precedence should have classified this open, but fail closed.
+        printf 'keep\t%s\topen_pr_head\tpr_merged:#%s\n' "$branch" "$pr" >> "$SUMMARY"
+        append_log "kept" "$branch" "reason=open_pr_head pr_merged=#$pr url=$url"
+        kept=$((kept + 1))
+        continue
+      fi
+      printf 'delete\t%s\tmerged_pr:%s\t%s\n' "$branch" "$pr" "$url" >> "$SUMMARY"
+      printf '%s\t%s\t%s\n' "$branch" "$pr" "$url" >> "$CANDIDATES"
+      candidates=$((candidates + 1))
+      ;;
+    *)
+      printf 'keep\t%s\tunknown_kind:%s\n' "$branch" "$kind" >> "$SUMMARY"
+      append_log "kept" "$branch" "reason=unknown_kind kind=$kind"
+      kept=$((kept + 1))
+      ;;
+  esac
+done < "$WORKDIR/branches.txt"
+
+branch_count=$(wc -l < "$WORKDIR/branches.txt" | tr -d ' ')
+
+echo "repo: $REPO"
+if [ "$APPLY" -eq 1 ]; then
+  echo "mode: apply"
+else
+  echo "mode: dry-run"
+fi
+echo "branches_scanned: $branch_count"
+echo "candidates: $candidates"
+echo "kept: $kept"
+echo
+
+if [ "$candidates" -gt 0 ]; then
+  echo "SAFE TO DELETE (merged PR, not protected, not an open PR base/head):"
+  while IFS=$'\t' read -r branch pr url || [ -n "${branch:-}" ]; do
+    [ -n "${branch:-}" ] || continue
+    printf '  %s  (merged PR #%s  %s)\n' "$branch" "$pr" "$url"
+  done < "$CANDIDATES"
+  echo
+fi
+
+kept_closed=$(awk -F '\t' '$1 == "keep" && $3 ~ /^closed_unmerged:/ { c++ } END { print c+0 }' "$SUMMARY")
+kept_nopr=$(awk -F '\t' '$1 == "keep" && $3 == "no_pr" { c++ } END { print c+0 }' "$SUMMARY")
+if [ "$kept_closed" -gt 0 ]; then
+  echo "KEPT closed-unmerged (may hold abandoned-but-wanted work):"
+  awk -F '\t' '$1 == "keep" && $3 ~ /^closed_unmerged:/ {
+    split($3, a, ":")
+    printf "  %s  PR #%s  %s\n", $2, a[2], $4
+  }' "$SUMMARY"
+  echo
+fi
+if [ "$kept_nopr" -gt 0 ]; then
+  echo "KEPT with no PR (not provably landed - investigate):"
+  awk -F '\t' '$1 == "keep" && $3 == "no_pr" { printf "  %s\n", $2 }' "$SUMMARY"
+  echo
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+  if [ -s "$CANDIDATES" ]; then
+    while IFS=$'\t' read -r branch pr url || [ -n "${branch:-}" ]; do
+      [ -n "${branch:-}" ] || continue
+      append_log "dry-run" "$branch" "would_delete pr=#$pr url=$url"
+    done < "$CANDIDATES"
+  fi
+  echo "dry-run only; re-run with --apply to delete the candidates above."
+  echo "log: $LOG"
+  exit 0
+fi
+
+if [ "$candidates" -eq 0 ]; then
+  echo "nothing to delete."
+  echo "log: $LOG"
+  exit 0
+fi
+
+if [ "$ASSUME_YES" -ne 1 ]; then
+  if [ ! -t 0 ]; then
+    echo "error: --apply without --yes requires an interactive confirm (or pass --yes)" >&2
+    exit 2
+  fi
+  printf 'Delete %s candidate branch(es) on %s? [y/N] ' "$candidates" "$REPO" >&2
+  read -r answer || answer=
+  case "$answer" in
+    y|Y|yes|YES) ;;
+    *)
+      echo "aborted; no branches deleted."
+      append_log "aborted" "-" "reason=confirm_declined candidates=$candidates"
+      exit 1
+      ;;
+  esac
+fi
+
+failures=0
+while IFS=$'\t' read -r branch pr url || [ -n "${branch:-}" ]; do
+  [ -n "${branch:-}" ] || continue
+  if delete_remote_branch "$branch"; then
+    printf 'deleted: %s (PR #%s)\n' "$branch" "$pr"
+    append_log "deleted" "$branch" "pr=#$pr url=$url"
+    deleted=$((deleted + 1))
+    printf '%s\n' "$branch" >> "$DELETE_LIST"
+  else
+    printf 'error: failed to delete %s (PR #%s)\n' "$branch" "$pr" >&2
+    append_log "delete_failed" "$branch" "pr=#$pr url=$url"
+    failures=$((failures + 1))
+  fi
+done < "$CANDIDATES"
+
+# Post-delete orphan check against open PRs known before the delete pass.
+if [ -s "$DELETE_LIST" ]; then
+  orphan=0
+  while IFS= read -r b || [ -n "${b:-}" ]; do
+    [ -n "${b:-}" ] || continue
+    if grep -Fxq -- "$b" "$OPEN_BASES" || grep -Fxq -- "$b" "$OPEN_HEADS"; then
+      printf 'ORPHAN RISK after delete: %s still referenced by an open PR\n' "$b" >&2
+      append_log "orphan_risk" "$b" "reason=open_pr_still_references"
+      orphan=$((orphan + 1))
+    fi
+  done < "$DELETE_LIST"
+  if [ "$orphan" -gt 0 ]; then
+    echo "error: post-delete orphan check failed for $orphan ref(s)" >&2
+    failures=$((failures + orphan))
+  fi
+fi
+
+echo "deleted: $deleted"
+echo "failures: $failures"
+echo "log: $LOG"
+
+if [ "$failures" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -83,6 +83,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
+| `fm-branch-prune.sh`    | Classify and optionally delete remote branches by PR merge state with a durable log |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/tests/fm-branch-prune.test.sh
+++ b/tests/fm-branch-prune.test.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-branch-prune.sh: the guarded forge-level remote branch prune.
+#
+# Classification must use PR merge state (not git ancestry), protect long-lived
+# refs, refuse base-branch orphaning, keep closed-unmerged and no-PR branches,
+# dry-run by default, and append a durable decision log under data/.
+#
+# Matrix:
+#   (a) dry-run classifies merged as candidates and does not call delete
+#   (b) protected refs (main) are never candidates even with a merged PR head
+#   (c) open PR heads are kept
+#   (d) closed-unmerged heads are kept and surfaced
+#   (e) no-PR branches are kept and surfaced
+#   (f) a merged head that is another open PR's base is kept (orphan guard)
+#   (g) --apply --yes deletes only safe candidates and logs them
+#   (h) --apply without --yes on a non-tty refuses before any delete
+#   (i) missing --repo / bad repo shape fail fast
+#   (j) durable log records kept and dry-run decisions
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PRUNE="$ROOT/bin/fm-branch-prune.sh"
+TMP_ROOT=$(fm_test_tmproot fm-branch-prune-tests)
+
+make_case() {
+  local name=$1 case_dir
+  case_dir="$TMP_ROOT/$name"
+  mkdir -p "$case_dir/data" "$case_dir/fakebin" "$case_dir/fixtures"
+  printf '%s\n' "$case_dir"
+}
+
+# Minimal GitHub REST-shaped fixtures covering the classification buckets.
+write_fixtures() {
+  local case_dir=$1
+  cat > "$case_dir/fixtures/prs.json" <<'JSON'
+[
+  {
+    "number": 10,
+    "state": "closed",
+    "merged_at": "2026-07-01T00:00:00Z",
+    "html_url": "https://github.com/example/repo/pull/10",
+    "head": { "ref": "fm/landed-feature" },
+    "base": { "ref": "main", "repo": { "full_name": "example/repo" } }
+  },
+  {
+    "number": 11,
+    "state": "open",
+    "merged_at": null,
+    "html_url": "https://github.com/example/repo/pull/11",
+    "head": { "ref": "fm/open-work" },
+    "base": { "ref": "main", "repo": { "full_name": "example/repo" } }
+  },
+  {
+    "number": 12,
+    "state": "closed",
+    "merged_at": null,
+    "html_url": "https://github.com/example/repo/pull/12",
+    "head": { "ref": "fm/abandoned" },
+    "base": { "ref": "main", "repo": { "full_name": "example/repo" } }
+  },
+  {
+    "number": 13,
+    "state": "closed",
+    "merged_at": "2026-07-02T00:00:00Z",
+    "html_url": "https://github.com/example/repo/pull/13",
+    "head": { "ref": "fm/integration-base" },
+    "base": { "ref": "main", "repo": { "full_name": "example/repo" } }
+  },
+  {
+    "number": 14,
+    "state": "open",
+    "merged_at": null,
+    "html_url": "https://github.com/example/repo/pull/14",
+    "head": { "ref": "fm/stacked-on-integration" },
+    "base": { "ref": "fm/integration-base", "repo": { "full_name": "example/repo" } }
+  },
+  {
+    "number": 15,
+    "state": "closed",
+    "merged_at": "2026-07-03T00:00:00Z",
+    "html_url": "https://github.com/example/repo/pull/15",
+    "head": { "ref": "main" },
+    "base": { "ref": "main", "repo": { "full_name": "example/repo" } }
+  }
+]
+JSON
+
+  cat > "$case_dir/fixtures/branches.json" <<'JSON'
+[
+  { "name": "main" },
+  { "name": "fm/landed-feature" },
+  { "name": "fm/open-work" },
+  { "name": "fm/abandoned" },
+  { "name": "fm/integration-base" },
+  { "name": "fm/stacked-on-integration" },
+  { "name": "fm/never-proposed" },
+  { "name": "develop" }
+]
+JSON
+}
+
+# gh mock that records DELETE calls and succeeds. Live list paths are unused
+# when fixtures are provided; still refuse unexpected non-DELETE traffic so a
+# regression that drops --prs-file fails loudly.
+add_gh_mock() {
+  local case_dir=$1 mode=${2:-ok}
+  cat > "$case_dir/fakebin/gh" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/gh.log"
+# Capture method + path for assertions.
+if [ "\${1:-}" = "api" ] && [ "\${2:-}" = "--method" ] && [ "\${3:-}" = "DELETE" ]; then
+  printf '%s\n' "\$4" >> "$case_dir/gh-delete.log"
+  if [ "$mode" = "fail-delete" ]; then
+    echo "error: delete failed" >&2
+    exit 1
+  fi
+  exit 0
+fi
+echo "error: unexpected gh invocation in fixture mode: \$*" >&2
+exit 99
+SH
+  chmod +x "$case_dir/fakebin/gh"
+}
+
+run_prune() {
+  local case_dir=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_HOME="$case_dir" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
+  FM_BRANCH_PRUNE_LOG="$case_dir/data/branch-prune.log" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$PRUNE" "$@"
+}
+
+run_prune_fixtures() {
+  local case_dir=$1
+  shift
+  run_prune "$case_dir" \
+    --repo example/repo \
+    --prs-file "$case_dir/fixtures/prs.json" \
+    --branches-file "$case_dir/fixtures/branches.json" \
+    "$@"
+}
+
+test_dry_run_classifies_without_deleting() {
+  local case_dir rc out
+  case_dir=$(make_case dry-run-classify)
+  write_fixtures "$case_dir"
+  add_gh_mock "$case_dir"
+  : > "$case_dir/gh.log"
+  : > "$case_dir/gh-delete.log"
+
+  set +e
+  run_prune_fixtures "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "dry-run-classify: should succeed"
+  out=$(cat "$case_dir/stdout")
+  assert_contains "$out" "mode: dry-run" "dry-run-classify: mode"
+  assert_contains "$out" "fm/landed-feature" "dry-run-classify: merged candidate listed"
+  assert_contains "$out" "SAFE TO DELETE" "dry-run-classify: safe section"
+  assert_contains "$out" "candidates: 1" "dry-run-classify: only one safe candidate"
+  assert_contains "$out" "KEPT closed-unmerged" "dry-run-classify: closed-unmerged surfaced"
+  assert_contains "$out" "fm/abandoned" "dry-run-classify: abandoned branch named"
+  assert_contains "$out" "KEPT with no PR" "dry-run-classify: no-pr surfaced"
+  assert_contains "$out" "fm/never-proposed" "dry-run-classify: never-proposed named"
+  # Open heads and open-PR bases are kept quietly in the durable log (not a
+  # captain-facing "investigate" bucket like closed-unmerged / no-PR).
+  assert_grep "reason=open_pr" "$case_dir/data/branch-prune.log" \
+    "dry-run-classify: open_pr not logged"
+  assert_grep "fm/open-work" "$case_dir/data/branch-prune.log" \
+    "dry-run-classify: open-work branch not logged"
+  assert_grep "reason=open_pr_base" "$case_dir/data/branch-prune.log" \
+    "dry-run-classify: open_pr_base not logged for integration-base"
+  if [ -s "$case_dir/gh-delete.log" ]; then
+    fail "dry-run-classify: delete was invoked in dry-run"
+  fi
+  assert_grep "dry-run" "$case_dir/data/branch-prune.log" \
+    "dry-run-classify: log missing dry-run entry"
+  assert_grep "fm/landed-feature" "$case_dir/data/branch-prune.log" \
+    "dry-run-classify: log missing candidate branch"
+  pass "dry-run classifies merged vs kept buckets without deleting"
+}
+
+test_protected_and_orphan_base_kept() {
+  local case_dir rc out
+  case_dir=$(make_case protect-orphan)
+  write_fixtures "$case_dir"
+  add_gh_mock "$case_dir"
+
+  set +e
+  run_prune_fixtures "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "protect-orphan: should succeed"
+  out=$(cat "$case_dir/stdout")
+
+  # main and develop are protected - never candidates even if a PR head is main.
+  assert_contains "$out" "candidates: 1" "protect-orphan: only landed-feature is safe"
+  # integration-base is merged but is base of open PR 14 -> kept, not candidate.
+  assert_no_grep $'delete\tfm/integration-base' "$case_dir/stdout" \
+    "protect-orphan: integration-base must not be listed as SAFE alone wrongly"
+  # Log should record protected + open_pr_base keeps.
+  assert_grep "reason=protected_ref" "$case_dir/data/branch-prune.log" \
+    "protect-orphan: protected_ref not logged"
+  assert_grep "reason=open_pr_base" "$case_dir/data/branch-prune.log" \
+    "protect-orphan: open_pr_base not logged for integration-base"
+  assert_grep "reason=open_pr" "$case_dir/data/branch-prune.log" \
+    "protect-orphan: open_pr not logged"
+  pass "protected refs and open-PR bases are kept, not deleted"
+}
+
+test_apply_deletes_only_safe_candidate() {
+  local case_dir rc out
+  case_dir=$(make_case apply-safe)
+  write_fixtures "$case_dir"
+  add_gh_mock "$case_dir"
+  : > "$case_dir/gh-delete.log"
+
+  set +e
+  run_prune_fixtures "$case_dir" --apply --yes \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "apply-safe: should succeed"
+  out=$(cat "$case_dir/stdout")
+  assert_contains "$out" "mode: apply" "apply-safe: mode"
+  assert_contains "$out" "deleted: 1" "apply-safe: one delete"
+  assert_contains "$out" "deleted: fm/landed-feature" "apply-safe: landed-feature deleted"
+  # Exactly one DELETE path, and it is the safe branch.
+  lines=$(wc -l < "$case_dir/gh-delete.log" | tr -d ' ')
+  [ "$lines" = "1" ] || fail "apply-safe: expected 1 delete call, got $lines"
+  assert_grep "git/refs/heads/fm%2Flanded-feature" "$case_dir/gh-delete.log" \
+    "apply-safe: delete path missing encoded branch"
+  assert_grep $'deleted\texample/repo\tfm/landed-feature' "$case_dir/data/branch-prune.log" \
+    "apply-safe: durable deleted log missing"
+  # Must not delete open / abandoned / integration-base / never-proposed / main.
+  assert_no_grep "fm%2Fopen-work" "$case_dir/gh-delete.log" "apply-safe: open deleted"
+  assert_no_grep "fm%2Fabandoned" "$case_dir/gh-delete.log" "apply-safe: abandoned deleted"
+  assert_no_grep "fm%2Fintegration-base" "$case_dir/gh-delete.log" "apply-safe: base deleted"
+  assert_no_grep "fm%2Fnever-proposed" "$case_dir/gh-delete.log" "apply-safe: no-pr deleted"
+  assert_no_grep "heads/main" "$case_dir/gh-delete.log" "apply-safe: main deleted"
+  pass "apply --yes deletes only the safe merged candidate and logs it"
+}
+
+test_apply_without_yes_refuses_nontty() {
+  local case_dir rc
+  case_dir=$(make_case apply-no-yes)
+  write_fixtures "$case_dir"
+  add_gh_mock "$case_dir"
+  : > "$case_dir/gh-delete.log"
+
+  set +e
+  # stdin is not a tty in the test harness.
+  run_prune_fixtures "$case_dir" --apply \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 2 "$rc" "apply-no-yes: should refuse without --yes on non-tty"
+  assert_grep "requires an interactive confirm" "$case_dir/stderr" \
+    "apply-no-yes: missing confirm error"
+  if [ -s "$case_dir/gh-delete.log" ]; then
+    fail "apply-no-yes: delete ran despite missing --yes"
+  fi
+  pass "apply without --yes refuses on non-tty before any delete"
+}
+
+test_missing_repo_fails_fast() {
+  local case_dir rc
+  case_dir=$(make_case missing-repo)
+  write_fixtures "$case_dir"
+  add_gh_mock "$case_dir"
+
+  set +e
+  run_prune "$case_dir" \
+    --prs-file "$case_dir/fixtures/prs.json" \
+    --branches-file "$case_dir/fixtures/branches.json" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "missing-repo: should exit 2"
+  assert_grep "--repo" "$case_dir/stderr" "missing-repo: should mention --repo"
+  pass "missing --repo fails fast"
+}
+
+test_bad_repo_shape_fails_fast() {
+  local case_dir rc
+  case_dir=$(make_case bad-repo)
+  write_fixtures "$case_dir"
+  add_gh_mock "$case_dir"
+
+  set +e
+  run_prune "$case_dir" --repo "not-a-pair" \
+    --prs-file "$case_dir/fixtures/prs.json" \
+    --branches-file "$case_dir/fixtures/branches.json" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "bad-repo: should exit 2"
+  assert_grep "OWNER/REPO" "$case_dir/stderr" "bad-repo: should mention OWNER/REPO"
+  pass "bad --repo shape fails fast"
+}
+
+test_delete_failure_propagates() {
+  local case_dir rc
+  case_dir=$(make_case delete-fail)
+  write_fixtures "$case_dir"
+  add_gh_mock "$case_dir" fail-delete
+
+  set +e
+  run_prune_fixtures "$case_dir" --apply --yes \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "delete-fail: should exit 1 on delete failure"
+  assert_grep "delete_failed" "$case_dir/data/branch-prune.log" \
+    "delete-fail: delete_failed not logged"
+  pass "delete failure is logged and non-zero"
+}
+
+test_help_exits_zero() {
+  local case_dir rc
+  case_dir=$(make_case help)
+  set +e
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$case_dir" \
+    "$PRUNE" --help > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "help: should exit 0"
+  assert_contains "$(cat "$case_dir/stderr")" "Usage:" "help: usage on stderr"
+  pass "help exits zero"
+}
+
+test_dry_run_classifies_without_deleting
+test_protected_and_orphan_base_kept
+test_apply_deletes_only_safe_candidate
+test_apply_without_yes_refuses_nontty
+test_missing_repo_fails_fast
+test_bad_repo_shape_fails_fast
+test_delete_failure_propagates
+test_help_exits_zero


### PR DESCRIPTION
## Summary

- Add `bin/fm-branch-prune.sh`: the sanctioned path for deleting **remote** branches on a GitHub repo (local gone-upstream prune stays with `fm-fleet-sync.sh`).
- Classify by PR **merge state** (not git ancestry — squash-safe): merged → candidate; open / closed-unmerged / no-PR → keep and surface.
- Protect long-lived refs (`main`/`master`/`uat`/`prod`/`production`/`release`/`develop`/`staging` and subpaths).
- Refuse deleting a ref that is still an open PR's base (or head).
- Dry-run by default; `--apply` (+ `--yes` non-interactive) performs deletes via `gh api DELETE`.
- Durable decision log at `data/branch-prune.log` under `FM_HOME`.
- Fixture tests cover the keep/delete matrix; `fm-lint` clean.
- Point `AGENTS.md` hard rule 1 and `docs/scripts.md` at the helper so firstmate never hand-deletes project refs.

## Test plan

- [x] `bash tests/fm-branch-prune.test.sh` (8/8)
- [x] `bin/fm-lint.sh bin/fm-branch-prune.sh tests/fm-branch-prune.test.sh`
- [x] `/bin/bash -n` on script + test