### PR TITLE
fix(bin): fall back to HTTPS when ssh-agent is dead

### DIFF
--- a/bin/fm-ff-lib.sh
+++ b/bin/fm-ff-lib.sh
@@ -26,6 +26,18 @@
 
 SUB_HOME_MARKER="${SUB_HOME_MARKER:-.fm-secondmate-home}"
 
+# Transport fallback for origin fetches (dead ssh-agent -> HTTPS).
+# shellcheck source=bin/fm-git-transport-lib.sh
+if [ -n "${FM_ROOT-}" ] && [ -f "$FM_ROOT/bin/fm-git-transport-lib.sh" ]; then
+  # shellcheck disable=SC1091
+  . "$FM_ROOT/bin/fm-git-transport-lib.sh"
+elif [ -n "${BASH_SOURCE[0]-}" ]; then
+  _fm_ff_lib_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  # shellcheck disable=SC1091
+  . "$_fm_ff_lib_dir/fm-git-transport-lib.sh"
+  unset _fm_ff_lib_dir
+fi
+
 # --- helpers ---------------------------------------------------------------
 
 first_line() {
@@ -200,7 +212,7 @@ fetch_once() {
       *" $common "*) return 0 ;;
     esac
   fi
-  if git -C "$dir" fetch origin --prune --quiet 2>/dev/null; then
+  if fm_git_fetch_with_fallback "$dir" origin --prune --quiet; then
     [ -n "$common" ] && FETCHED="$FETCHED $common"
     return 0
   fi

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -35,6 +35,8 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 # shellcheck source=bin/fm-lock-lib.sh
 . "$SCRIPT_DIR/fm-lock-lib.sh"
+# shellcheck source=bin/fm-git-transport-lib.sh
+. "$SCRIPT_DIR/fm-git-transport-lib.sh"
 FM_LOCK_LOG_PREFIX=fleet-sync
 "$FM_ROOT/bin/fm-guard.sh" || true
 
@@ -161,7 +163,12 @@ packed_refs_lock_path() {
 # a session-start refresh (which discards fleet-sync stderr) still surfaces it.
 fetch_with_packed_refs_lock_guard() {
   local rc attempt=0 lock lock_desc
-  FETCH_OUTPUT=$(git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
+  if fm_git_fetch_with_fallback "$PROJ" origin --prune --quiet; then
+    rc=0
+  else
+    rc=$?
+  fi
+  FETCH_OUTPUT=$FM_GIT_LAST_OUTPUT
   [ "$rc" -eq 0 ] && return 0
   is_packed_refs_lock_error "$FETCH_OUTPUT" || return "$rc"
 
@@ -171,7 +178,12 @@ fetch_with_packed_refs_lock_guard() {
     attempt=$(( attempt + 1 ))
     echo "$label: fetch blocked by packed-refs lock ($lock_desc); waiting ${FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${FLEET_SYNC_PACKED_REFS_LOCK_RETRIES}) (owning process may be exiting)" >&2
     sleep "$FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS"
-    FETCH_OUTPUT=$(git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
+    if fm_git_fetch_with_fallback "$PROJ" origin --prune --quiet; then
+      rc=0
+    else
+      rc=$?
+    fi
+    FETCH_OUTPUT=$FM_GIT_LAST_OUTPUT
     if [ "$rc" -eq 0 ]; then
       echo "$label: fetch succeeded on retry; packed-refs lock cleared on its own" >&2
       # One stdout summary so a session-start refresh (which discards fleet-sync
@@ -195,7 +207,12 @@ fetch_with_packed_refs_lock_guard() {
         return "$rc"
       fi
       echo "$label: removed provably-stale packed-refs lock $lock (age >= ${FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS}s, no live holder) and retrying fetch" >&2
-      FETCH_OUTPUT=$(git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
+      if fm_git_fetch_with_fallback "$PROJ" origin --prune --quiet; then
+        rc=0
+      else
+        rc=$?
+      fi
+      FETCH_OUTPUT=$FM_GIT_LAST_OUTPUT
       if [ "$rc" -eq 0 ]; then
         echo "$label: fetch succeeded after stale packed-refs lock cleanup" >&2
         echo "$label: recovered: removed a stale packed-refs lock (no live holder)"
@@ -209,7 +226,6 @@ fetch_with_packed_refs_lock_guard() {
   echo "$label: fetch packed-refs lock signature persisted across ${FLEET_SYNC_PACKED_REFS_LOCK_RETRIES} retries even after the lock file disappeared" >&2
   return "$rc"
 }
-
 prune_gone_branches() {
   # Delete local branches whose upstream tracking branch is gone - the remote
   # branch was deleted, which in this fleet means its PR merged - as long as

--- a/bin/fm-git-transport-lib.sh
+++ b/bin/fm-git-transport-lib.sh
@@ -1,0 +1,431 @@
+# shellcheck shell=bash
+# Shared git transport recovery for firstmate spawn, fleet-sync, seed, and review paths.
+#
+# Usage: . bin/fm-git-transport-lib.sh   (after FM_ROOT / FM_HOME are set when available)
+#
+# Operator fault this owns:
+#   A dead or missing ssh-agent (common with a stale wezterm SSH_AUTH_SOCK) makes every
+#   git@ / ssh:// remote fail even when HTTPS + a credential helper still works.
+#   Sandboxed agent shells can also break getpwuid and git's own DNS while Python still
+#   resolves hosts. Prefer HTTPS remotes authenticated by gh/tea/credential-helper (or a
+#   one-shot FM_GITEA_TOKEN / config/gitea-token read) over embedding tokens in stored
+#   remotes or writing a second at-rest copy into global git config.
+#
+# Operator fix when ssh-agent is dead:
+#   1. Confirm: `ssh-add -l` prints "Error connecting to agent" (not "The agent has no
+#      identities").
+#   2. Restart the agent and export a live socket, e.g. `eval "$(ssh-agent -s)"` then
+#      `ssh-add --apple-use-keychain ~/.ssh/id_ed25519` (or your key).
+#   3. If WezTerm owns the agent, restart WezTerm (or clear a stale
+#      ~/.local/share/wezterm/agent.* socket) so SSH_AUTH_SOCK points at a live listener.
+#   4. Prefer durable HTTPS: `gh auth login` (GitHub) and/or a home-local
+#      config/gitea-token / FM_GITEA_TOKEN for private-git hosts - never a second copy in
+#      ~/.gitconfig. Firstmate will fall back to HTTPS automatically when the agent is
+#      dead; fixing the agent restores plain git@ without further config.
+#
+# Contract:
+#   - Never rewrite stored remotes or global git config.
+#   - Never write tokens to disk; read FM_GITEA_TOKEN or $FM_HOME/config/gitea-token only
+#     for a one-shot process-local credential helper.
+#   - Try the caller's native git command first; fall back to HTTPS only on SSH-shaped
+#     failure or a known-dead agent + SSH remote.
+#   - Fail closed to the original git exit code when no HTTPS fallback is available.
+#   - FM_GIT_LAST_OUTPUT holds the combined stdout+stderr of the last attempt.
+#   - Portable on bash 3.2 (no nameref, no associative arrays).
+
+# --- detection --------------------------------------------------------------
+
+# fm_git_ssh_agent_dead: 0 when SSH cannot use an agent (unset/missing/dead socket, or
+# ssh-add cannot connect). 1 when an agent answers - including "no identities", which is
+# a live agent with an empty key list, not a dead one.
+fm_git_ssh_agent_dead() {
+  local sock out
+  sock=${SSH_AUTH_SOCK-}
+  if [ -z "$sock" ]; then
+    return 0
+  fi
+  if [ ! -S "$sock" ] && [ ! -e "$sock" ]; then
+    return 0
+  fi
+  # A dangling symlink or non-socket path is dead for agent use.
+  if [ -e "$sock" ] && [ ! -S "$sock" ]; then
+    return 0
+  fi
+  if ! command -v ssh-add >/dev/null 2>&1; then
+    # No probe tool: treat a present socket as live rather than force HTTPS.
+    return 1
+  fi
+  out=$(ssh-add -l 2>&1) || true
+  case "$out" in
+    *"Error connecting to agent"*|*"Could not open a connection to your authentication agent"*|*"No such file or directory"*|*"Connection refused"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# fm_git_url_is_ssh <url>: 0 when the URL is an SSH form git will dial via ssh.
+fm_git_url_is_ssh() {
+  local url=$1
+  case "$url" in
+    git@*:*|ssh://*) return 0 ;;
+  esac
+  return 1
+}
+
+# Cluster-internal Gitea HTTP is often rewritten on this workstation to git@ via
+# global insteadOf, so it inherits the same dead-agent failure mode.
+fm_git_url_is_cluster_http() {
+  local url=$1
+  case "$url" in
+    *gitea-http.gitea.svc.cluster.local*) return 0 ;;
+  esac
+  return 1
+}
+
+# fm_git_output_looks_like_ssh_failure <text>: 0 when git/ssh stderr indicates an
+# SSH-transport failure worth an HTTPS retry.
+fm_git_output_looks_like_ssh_failure() {
+  local text=$1
+  case "$text" in
+    *"Permission denied (publickey)"*|*"Permission denied (keyboard-interactive,publickey)"*)
+      return 0
+      ;;
+    *"Could not read from remote repository"*|*"Connection refused"*|*"Error connecting to agent"*)
+      return 0
+      ;;
+    *"No user exists for uid"*|*"Could not resolve hostname"*|*"Host key verification failed"*)
+      return 0
+      ;;
+    *"correct access rights"*|*"Authentication failed"*|*"kex_exchange_identification"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# True when a failed attempt against <url> with <output> should try HTTPS next.
+fm_git_should_retry_https() {
+  local url=$1 output=$2
+  if fm_git_url_is_ssh "$url" || fm_git_url_is_cluster_http "$url"; then
+    return 0
+  fi
+  if fm_git_output_looks_like_ssh_failure "$output"; then
+    return 0
+  fi
+  return 1
+}
+
+# --- URL conversion ---------------------------------------------------------
+
+# fm_git_ssh_to_https <url>: convert git@host:path and ssh://git@host[:port]/path to
+# https://host/path (optional .git suffix preserved). Non-SSH URLs echo unchanged.
+# Prints the URL; returns 0 always for pure conversion.
+fm_git_ssh_to_https() {
+  local url=$1 host path
+  case "$url" in
+    git@*:*)
+      host=${url#git@}
+      host=${host%%:*}
+      path=${url#*:}
+      path=${path#/}
+      printf 'https://%s/%s\n' "$host" "$path"
+      return 0
+      ;;
+    ssh://*)
+      # ssh://[user@]host[:port]/path
+      host=${url#ssh://}
+      host=${host#*@}
+      path=${host#*/}
+      host=${host%%/*}
+      case "$host" in
+        *:*)
+          host=${host%:*}
+          ;;
+      esac
+      printf 'https://%s/%s\n' "$host" "$path"
+      return 0
+      ;;
+    *)
+      printf '%s\n' "$url"
+      return 0
+      ;;
+  esac
+}
+
+# fm_git_https_host <url>: echo the host of an https:// URL, or empty.
+fm_git_https_host() {
+  local url=$1 rest host
+  case "$url" in
+    https://*)
+      rest=${url#https://}
+      rest=${rest#*@}
+      host=${rest%%/*}
+      host=${host%%:*}
+      printf '%s\n' "$host"
+      ;;
+    *)
+      printf '\n'
+      ;;
+  esac
+}
+
+# Cluster-internal Gitea HTTP -> public HTTPS host used on this workstation.
+# fm_git_cluster_http_to_https <url>
+fm_git_cluster_http_to_https() {
+  local url=$1
+  case "$url" in
+    http://gitea-http.gitea.svc.cluster.local:3000/*)
+      printf 'https://private-git.ocin.cloud/%s\n' "${url#http://gitea-http.gitea.svc.cluster.local:3000/}"
+      ;;
+    https://gitea-http.gitea.svc.cluster.local:3000/*)
+      printf 'https://private-git.ocin.cloud/%s\n' "${url#https://gitea-http.gitea.svc.cluster.local:3000/}"
+      ;;
+    *)
+      printf '%s\n' "$url"
+      ;;
+  esac
+}
+
+# fm_git_prefer_https_url <url>: SSH or cluster-HTTP -> public HTTPS; else unchanged.
+fm_git_prefer_https_url() {
+  local url=$1
+  url=$(fm_git_cluster_http_to_https "$url")
+  if fm_git_url_is_ssh "$url"; then
+    fm_git_ssh_to_https "$url"
+    return 0
+  fi
+  printf '%s\n' "$url"
+}
+
+# --- credentials (process-local only) ---------------------------------------
+
+# fm_git_gitea_token: print a Gitea token for private-git HTTPS auth.
+# Order: FM_GITEA_TOKEN, FM_GITEA_TOKEN_FILE, $FM_HOME/config/gitea-token,
+# $FM_ROOT/config/gitea-token. Never writes. Never caches across calls. Returns 1
+# when none found.
+fm_git_gitea_token() {
+  local f token
+  if [ -n "${FM_GITEA_TOKEN-}" ]; then
+    printf '%s' "$FM_GITEA_TOKEN"
+    return 0
+  fi
+  for f in \
+    "${FM_GITEA_TOKEN_FILE-}" \
+    "${FM_HOME-}/config/gitea-token" \
+    "${FM_ROOT-}/config/gitea-token"; do
+    [ -n "$f" ] || continue
+    [ -f "$f" ] || continue
+    token=$(sed -n '1p' "$f" | tr -d '\r\n')
+    if [ -n "$token" ]; then
+      printf '%s' "$token"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# fm_git_resolve_host_ip <host>: print an A/AAAA via Python (works when git's
+# libcurl resolver is broken). Empty + non-zero on failure.
+fm_git_resolve_host_ip() {
+  local host=$1 ip
+  [ -n "$host" ] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  ip=$(python3 -c 'import socket,sys; print(socket.gethostbyname(sys.argv[1]))' "$host" 2>/dev/null) || return 1
+  [ -n "$ip" ] || return 1
+  printf '%s\n' "$ip"
+}
+
+# fm_git_https_extra_config <https-url>: print git -c key=value lines (one per
+# line) for a one-shot HTTPS fetch/clone: curloptResolve when resolvable, and a
+# host-appropriate credential helper. Never embeds the token in a stored remote.
+fm_git_https_extra_config() {
+  local url=$1 host ip token helper
+  host=$(fm_git_https_host "$url")
+  [ -n "$host" ] || return 0
+  if ip=$(fm_git_resolve_host_ip "$host"); then
+    printf 'http.curloptResolve=%s:443:%s\n' "$host" "$ip"
+  fi
+  case "$host" in
+    github.com|*.github.com)
+      if command -v gh >/dev/null 2>&1; then
+        printf 'credential.helper=\n'
+        printf 'credential.helper=!gh auth git-credential\n'
+      fi
+      ;;
+    *)
+      # Private hosts (Gitea and similar): one-shot helper from env/file token.
+      if token=$(fm_git_gitea_token); then
+        # Password is expanded when this function runs; the helper body itself is
+        # single-quoted to git so shell metacharacters in the token stay literal.
+        # shellcheck disable=SC2016 # $1 is for the credential-helper protocol, not bash.
+        helper=$(printf '!f() { test \"$1\" = get || exit 0; echo username=oauth2; echo password=%s; }; f' "$token")
+        printf 'credential.helper=\n'
+        printf 'credential.helper=%s\n' "$helper"
+      fi
+      ;;
+  esac
+}
+
+# --- fetch / clone / submodule ----------------------------------------------
+
+FM_GIT_LAST_OUTPUT=""
+
+# fm_git_remote_url <dir> <remote>: print the configured remote URL.
+fm_git_remote_url() {
+  local dir=$1 remote=$2
+  git -C "$dir" remote get-url "$remote" 2>/dev/null
+}
+
+# Internal: run `git -C dir "$@"` capturing combined output into FM_GIT_LAST_OUTPUT.
+fm_git_capture() {
+  local dir=$1
+  shift
+  local out rc
+  set +e
+  out=$(git -C "$dir" "$@" 2>&1)
+  rc=$?
+  set -e
+  FM_GIT_LAST_OUTPUT=$out
+  return "$rc"
+}
+
+# fm_git_capture_with_https_config <dir> <https_url> <git-args...>:
+# Like fm_git_capture, but prefixes process-local -c pairs for <https_url>.
+# Safe under bash 3.2 set -u when no config is produced (no empty-array expand).
+fm_git_capture_with_https_config() {
+  local dir=$1 url=$2
+  shift 2
+  local line
+  local -a args=()
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    args+=(-c "$line")
+  done < <(fm_git_https_extra_config "$url")
+
+  if [ "${#args[@]}" -gt 0 ]; then
+    fm_git_capture "$dir" "${args[@]}" "$@"
+  else
+    fm_git_capture "$dir" "$@"
+  fi
+}
+
+# fm_git_fetch_with_fallback <dir> <remote> [git fetch args...]:
+# Try the stored remote first (same pattern as packed-refs recovery). On
+# SSH-shaped failure - or when the remote is SSH/cluster-HTTP - retry once
+# against a process-local HTTPS URL + credential helper.
+# Does not rewrite remotes. Sets FM_GIT_LAST_OUTPUT; returns git rc.
+fm_git_fetch_with_fallback() {
+  local dir=$1 remote=$2
+  shift 2
+  local url https_url
+
+  url=$(fm_git_remote_url "$dir" "$remote") || url=""
+
+  # Native attempt first - preserves packed-refs and ordinary happy-path behavior.
+  if fm_git_capture "$dir" fetch "$remote" "$@"; then
+    return 0
+  fi
+
+  if [ -z "$url" ]; then
+    return 1
+  fi
+  if ! fm_git_should_retry_https "$url" "$FM_GIT_LAST_OUTPUT"; then
+    return 1
+  fi
+
+  https_url=$(fm_git_prefer_https_url "$url")
+  case "$https_url" in
+    https://*) ;;
+    *) return 1 ;;
+  esac
+
+  if fm_git_capture_with_https_config "$dir" "$https_url" fetch "$https_url" "$@"; then
+    return 0
+  fi
+  return 1
+}
+
+# fm_git_clone_with_fallback <url> <dest> [git clone args...]:
+# Clone url into dest. On SSH/agent failure, retry with HTTPS + credential helper.
+# Destination must not already exist after a failed first attempt (same as git).
+# Sets FM_GIT_LAST_OUTPUT.
+fm_git_clone_with_fallback() {
+  local url=$1 dest=$2
+  shift 2
+  local https_url rc line
+  local -a args=()
+
+  set +e
+  FM_GIT_LAST_OUTPUT=$(git clone "$@" "$url" "$dest" 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] && return 0
+
+  if ! fm_git_should_retry_https "$url" "$FM_GIT_LAST_OUTPUT"; then
+    return "$rc"
+  fi
+
+  https_url=$(fm_git_prefer_https_url "$url")
+  case "$https_url" in
+    https://*) ;;
+    *) return "$rc" ;;
+  esac
+
+  # If dest was partially created, refuse rather than clobber.
+  if [ -e "$dest" ]; then
+    return "$rc"
+  fi
+
+  args=()
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    args+=(-c "$line")
+  done < <(fm_git_https_extra_config "$https_url")
+
+  set +e
+  if [ "${#args[@]}" -gt 0 ]; then
+    FM_GIT_LAST_OUTPUT=$(git "${args[@]}" clone "$@" "$https_url" "$dest" 2>&1)
+  else
+    FM_GIT_LAST_OUTPUT=$(git clone "$@" "$https_url" "$dest" 2>&1)
+  fi
+  rc=$?
+  set -e
+  return "$rc"
+}
+
+# fm_git_submodule_update_with_fallback <dir> [git submodule update args...]:
+# Run submodule update in <dir>. On failure with a dead agent / SSH signature,
+# retry with process-local insteadOf rewrites from cluster-HTTP and git@ to the
+# public HTTPS host, plus credential helper. Does not persist URL rewrites.
+fm_git_submodule_update_with_fallback() {
+  local dir=$1
+  shift
+  local host=private-git.ocin.cloud https_base line
+  local -a args=()
+
+  if fm_git_capture "$dir" submodule update "$@"; then
+    return 0
+  fi
+  if ! fm_git_ssh_agent_dead && ! fm_git_output_looks_like_ssh_failure "$FM_GIT_LAST_OUTPUT"; then
+    return 1
+  fi
+
+  https_base="https://${host}/OpenCloud/"
+  args=(
+    -c "url.${https_base}.insteadOf=http://gitea-http.gitea.svc.cluster.local:3000/OpenCloud/"
+    -c "url.${https_base}.insteadOf=git@${host}:OpenCloud/"
+    -c "url.${https_base}.insteadOf=ssh://git@${host}/OpenCloud/"
+  )
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    args+=(-c "$line")
+  done < <(fm_git_https_extra_config "https://${host}/OpenCloud/core.git")
+
+  if [ "${#args[@]}" -gt 0 ]; then
+    fm_git_capture "$dir" "${args[@]}" submodule update "$@"
+  else
+    fm_git_capture "$dir" submodule update "$@"
+  fi
+}

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -39,6 +39,9 @@ PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 REG="$DATA/secondmates.md"
 SUB_HOME_MARKER=".fm-secondmate-home"
 
+# shellcheck source=bin/fm-git-transport-lib.sh
+. "$SCRIPT_DIR/fm-git-transport-lib.sh"
+
 usage() {
   echo "usage: fm-home-seed.sh <id> <home|-> {<project>...|--no-projects}" >&2
   echo "       fm-home-seed.sh validate" >&2
@@ -558,7 +561,10 @@ EOF
     return 0
   fi
   url=$(source_origin_url "$project" "$mode" "$src") || return 1
-  git clone --quiet "$url" "$dst"
+  if ! fm_git_clone_with_fallback "$url" "$dst" --quiet; then
+    echo "error: git clone failed for $project: ${FM_GIT_LAST_OUTPUT:-unknown}" >&2
+    return 1
+  fi
 }
 
 validate_seed_project() {

--- a/bin/fm-review-diff.sh
+++ b/bin/fm-review-diff.sh
@@ -16,6 +16,8 @@ set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+# shellcheck source=bin/fm-git-transport-lib.sh
+. "$SCRIPT_DIR/fm-git-transport-lib.sh"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 "$FM_ROOT/bin/fm-guard.sh" || true
@@ -96,7 +98,7 @@ fetch_pull_head() {
   git -C "$WT" remote get-url origin >/dev/null 2>&1 || return 1
   # Fetch into a private ref so a later base-branch fetch cannot clobber the
   # compare tip via FETCH_HEAD, and so we never review a stale local object.
-  git -C "$WT" fetch --quiet origin \
+  fm_git_fetch_with_fallback "$WT" origin --quiet \
     "+refs/pull/$n/head:refs/fm-review/pull/$n/head" >/dev/null 2>&1 || return 1
   resolved=$(git -C "$WT" rev-parse --verify "refs/fm-review/pull/$n/head^{commit}" 2>/dev/null) || return 1
   [ -n "$resolved" ] || return 1
@@ -136,7 +138,7 @@ fi
 if git -C "$PROJ" remote get-url origin >/dev/null 2>&1; then
   # Update the remote-tracking ref itself; a bare single-branch fetch can leave
   # origin/<default> stale on some Git versions and only refresh FETCH_HEAD.
-  git -C "$WT" fetch origin "+refs/heads/$DEFAULT:refs/remotes/origin/$DEFAULT" --quiet
+  fm_git_fetch_with_fallback "$WT" origin "+refs/heads/$DEFAULT:refs/remotes/origin/$DEFAULT" --quiet
   BASE="origin/$DEFAULT"
 else
   BASE="$DEFAULT"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -90,6 +90,8 @@ set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+# shellcheck source=bin/fm-git-transport-lib.sh
+. "$SCRIPT_DIR/fm-git-transport-lib.sh"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
@@ -319,7 +321,7 @@ ensure_commit_object() {
   git -C "$WT" cat-file -e "$commit^{commit}" 2>/dev/null && return 0
   n=$(pr_number_from_target "$target") || return 1
   git -C "$WT" remote get-url origin >/dev/null 2>&1 || return 1
-  git -C "$WT" fetch --quiet origin "refs/pull/$n/head" >/dev/null 2>&1 || return 1
+  fm_git_fetch_with_fallback "$WT" origin --quiet "refs/pull/$n/head" >/dev/null 2>&1 || return 1
   git -C "$WT" cat-file -e "$commit^{commit}" 2>/dev/null
 }
 
@@ -394,7 +396,7 @@ content_in_default() {
   local name ref default_tree merged_tree
   name=$(default_branch) || return 1
   if git -C "$WT" remote get-url origin >/dev/null 2>&1; then
-    git -C "$WT" fetch --quiet origin "+refs/heads/$name:refs/remotes/origin/$name" >/dev/null 2>&1 || return 1
+    fm_git_fetch_with_fallback "$WT" origin --quiet "+refs/heads/$name:refs/remotes/origin/$name" >/dev/null 2>&1 || return 1
     ref="refs/remotes/origin/$name"
   elif git -C "$WT" rev-parse --quiet --verify "refs/heads/$name" >/dev/null 2>&1; then
     ref="refs/heads/$name"

--- a/tests/fm-git-transport-lib.test.sh
+++ b/tests/fm-git-transport-lib.test.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# Unit tests for bin/fm-git-transport-lib.sh.
+#
+# Covers pure URL conversion, dead-ssh-agent detection (stubbed SSH_AUTH_SOCK /
+# ssh-add), SSH-failure classification, and the HTTPS fallback decision path for
+# fetch (stubbed git). No network. Portable on bash 3.2.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-git-transport-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-git-transport-lib)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+export PATH="$FAKEBIN:$PATH"
+
+# --- pure URL conversion ----------------------------------------------------
+
+test_ssh_to_https_scp_form() {
+  local out
+  out=$(fm_git_ssh_to_https 'git@github.com:kunchenguid/firstmate.git')
+  [ "$out" = 'https://github.com/kunchenguid/firstmate.git' ] \
+    || fail "scp-form conversion got '$out'"
+  out=$(fm_git_ssh_to_https 'git@private-git.ocin.cloud:OpenCloud/core.git')
+  [ "$out" = 'https://private-git.ocin.cloud/OpenCloud/core.git' ] \
+    || fail "private-git scp-form got '$out'"
+  pass "fm_git_ssh_to_https converts git@host:path to https://host/path"
+}
+
+test_ssh_to_https_ssh_url_form() {
+  local out
+  out=$(fm_git_ssh_to_https 'ssh://git@github.com/kunchenguid/firstmate.git')
+  [ "$out" = 'https://github.com/kunchenguid/firstmate.git' ] \
+    || fail "ssh:// form got '$out'"
+  out=$(fm_git_ssh_to_https 'ssh://git@private-git.ocin.cloud:2222/OpenCloud/core.git')
+  [ "$out" = 'https://private-git.ocin.cloud/OpenCloud/core.git' ] \
+    || fail "ssh:// with port got '$out'"
+  pass "fm_git_ssh_to_https converts ssh://git@host[/port]/path"
+}
+
+test_ssh_to_https_leaves_https_alone() {
+  local out
+  out=$(fm_git_ssh_to_https 'https://github.com/kunchenguid/firstmate.git')
+  [ "$out" = 'https://github.com/kunchenguid/firstmate.git' ] \
+    || fail "https passthrough got '$out'"
+  pass "fm_git_ssh_to_https leaves https:// URLs unchanged"
+}
+
+test_cluster_http_to_public_https() {
+  local out
+  out=$(fm_git_cluster_http_to_https \
+    'http://gitea-http.gitea.svc.cluster.local:3000/OpenCloud/console-backend.git')
+  [ "$out" = 'https://private-git.ocin.cloud/OpenCloud/console-backend.git' ] \
+    || fail "cluster http rewrite got '$out'"
+  out=$(fm_git_prefer_https_url \
+    'git@private-git.ocin.cloud:OpenCloud/console-backend.git')
+  [ "$out" = 'https://private-git.ocin.cloud/OpenCloud/console-backend.git' ] \
+    || fail "prefer_https ssh got '$out'"
+  out=$(fm_git_prefer_https_url \
+    'http://gitea-http.gitea.svc.cluster.local:3000/OpenCloud/core.git')
+  [ "$out" = 'https://private-git.ocin.cloud/OpenCloud/core.git' ] \
+    || fail "prefer_https cluster got '$out'"
+  pass "cluster-HTTP and git@ both prefer public HTTPS"
+}
+
+# --- agent dead detection ---------------------------------------------------
+
+test_ssh_agent_dead_when_sock_unset() {
+  local old=${SSH_AUTH_SOCK-}
+  unset SSH_AUTH_SOCK || true
+  if ! fm_git_ssh_agent_dead; then
+    if [ -n "$old" ]; then export SSH_AUTH_SOCK=$old; else unset SSH_AUTH_SOCK; fi
+    fail "unset SSH_AUTH_SOCK must count as dead agent"
+  fi
+  if [ -n "$old" ]; then export SSH_AUTH_SOCK=$old; else unset SSH_AUTH_SOCK; fi
+  pass "fm_git_ssh_agent_dead: unset SSH_AUTH_SOCK is dead"
+}
+
+test_ssh_agent_dead_when_sock_missing() {
+  local old=${SSH_AUTH_SOCK-}
+  export SSH_AUTH_SOCK="$TMP_ROOT/no-such-agent-socket"
+  if ! fm_git_ssh_agent_dead; then
+    if [ -n "$old" ]; then export SSH_AUTH_SOCK=$old; else unset SSH_AUTH_SOCK; fi
+    fail "missing SSH_AUTH_SOCK path must count as dead"
+  fi
+  if [ -n "$old" ]; then export SSH_AUTH_SOCK=$old; else unset SSH_AUTH_SOCK; fi
+  pass "fm_git_ssh_agent_dead: missing socket path is dead"
+}
+
+test_ssh_agent_dead_when_sock_not_socket() {
+  local old=${SSH_AUTH_SOCK-}
+  : > "$TMP_ROOT/not-a-socket"
+  export SSH_AUTH_SOCK="$TMP_ROOT/not-a-socket"
+  if ! fm_git_ssh_agent_dead; then
+    if [ -n "$old" ]; then export SSH_AUTH_SOCK=$old; else unset SSH_AUTH_SOCK; fi
+    fail "non-socket SSH_AUTH_SOCK must count as dead"
+  fi
+  if [ -n "$old" ]; then export SSH_AUTH_SOCK=$old; else unset SSH_AUTH_SOCK; fi
+  pass "fm_git_ssh_agent_dead: non-socket path is dead"
+}
+
+_make_unix_socket() {
+  local path=$1
+  python3 - "$path" <<'PY'
+import os, socket, sys
+path = sys.argv[1]
+try:
+    os.unlink(path)
+except OSError:
+    pass
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.bind(path)
+PY
+}
+
+test_ssh_agent_live_when_ssh_add_reports_no_identities() {
+  local old=${SSH_AUTH_SOCK-}
+  _make_unix_socket "$TMP_ROOT/live.sock"
+  cat > "$FAKEBIN/ssh-add" <<'SH'
+#!/usr/bin/env bash
+echo "The agent has no identities." >&2
+exit 1
+SH
+  chmod +x "$FAKEBIN/ssh-add"
+  export SSH_AUTH_SOCK="$TMP_ROOT/live.sock"
+  if fm_git_ssh_agent_dead; then
+    if [ -n "$old" ]; then export SSH_AUTH_SOCK=$old; else unset SSH_AUTH_SOCK; fi
+    rm -f "$FAKEBIN/ssh-add"
+    fail "live agent with no identities must NOT count as dead"
+  fi
+  if [ -n "$old" ]; then export SSH_AUTH_SOCK=$old; else unset SSH_AUTH_SOCK; fi
+  rm -f "$FAKEBIN/ssh-add"
+  pass "fm_git_ssh_agent_dead: live agent with no identities is not dead"
+}
+
+test_ssh_agent_dead_when_ssh_add_connection_refused() {
+  local old=${SSH_AUTH_SOCK-}
+  _make_unix_socket "$TMP_ROOT/deadish.sock"
+  cat > "$FAKEBIN/ssh-add" <<'SH'
+#!/usr/bin/env bash
+echo "Error connecting to agent: Connection refused" >&2
+exit 2
+SH
+  chmod +x "$FAKEBIN/ssh-add"
+  export SSH_AUTH_SOCK="$TMP_ROOT/deadish.sock"
+  if ! fm_git_ssh_agent_dead; then
+    if [ -n "$old" ]; then export SSH_AUTH_SOCK=$old; else unset SSH_AUTH_SOCK; fi
+    rm -f "$FAKEBIN/ssh-add"
+    fail "ssh-add connection refused must count as dead"
+  fi
+  if [ -n "$old" ]; then export SSH_AUTH_SOCK=$old; else unset SSH_AUTH_SOCK; fi
+  rm -f "$FAKEBIN/ssh-add"
+  pass "fm_git_ssh_agent_dead: ssh-add connection refused is dead"
+}
+
+# --- failure classification -------------------------------------------------
+
+test_output_looks_like_ssh_failure() {
+  fm_git_output_looks_like_ssh_failure 'Permission denied (publickey).' \
+    || fail "publickey deny should match"
+  fm_git_output_looks_like_ssh_failure 'fatal: Could not read from remote repository.' \
+    || fail "could not read should match"
+  fm_git_output_looks_like_ssh_failure 'ssh: Could not resolve hostname github.com' \
+    || fail "resolve hostname should match"
+  if fm_git_output_looks_like_ssh_failure 'error: failed to push some refs'; then
+    fail "generic push reject must not look like SSH failure"
+  fi
+  pass "fm_git_output_looks_like_ssh_failure matches SSH signatures only"
+}
+
+test_should_retry_https_for_ssh_url_even_without_signature() {
+  fm_git_should_retry_https 'git@github.com:o/r.git' 'some unrelated failure' \
+    || fail "ssh URL should always be eligible for HTTPS retry"
+  fm_git_should_retry_https \
+    'http://gitea-http.gitea.svc.cluster.local:3000/OpenCloud/core.git' 'x' \
+    || fail "cluster HTTP should always be eligible"
+  if fm_git_should_retry_https 'https://github.com/o/r.git' 'HTTP 500'; then
+    fail "plain HTTPS 500 without SSH signature must not force retry"
+  fi
+  pass "fm_git_should_retry_https gates on URL class and SSH signatures"
+}
+
+# --- fetch fallback decision (stubbed git) ----------------------------------
+
+install_git_stub() {
+  local remote_url=$1
+  cat > "$FAKEBIN/git" <<SH
+#!/usr/bin/env bash
+log="$TMP_ROOT/git-argv.log"
+printf '%s\n' "\$*" >> "\$log"
+args=("\$@")
+i=0
+while [ \$i -lt \${#args[@]} ]; do
+  case "\${args[\$i]}" in
+    -C) i=\$((i + 2)) ;;
+    -c) i=\$((i + 2)) ;;
+    *) break ;;
+  esac
+done
+set -- "\${args[@]:\$i}"
+if [ "\$1" = "remote" ] && [ "\$2" = "get-url" ]; then
+  printf '%s\n' '$remote_url'
+  exit 0
+fi
+if [ "\$1" = "fetch" ]; then
+  target="\$2"
+  case "\$target" in
+    origin|git@*|ssh://*)
+      echo "git@host: Permission denied (publickey)." >&2
+      echo "fatal: Could not read from remote repository." >&2
+      exit 128
+      ;;
+    https://*)
+      echo ok >> "$TMP_ROOT/git-https-ok"
+      exit 0
+      ;;
+    *)
+      echo "stub: unexpected fetch target '\$target'" >&2
+      exit 2
+      ;;
+  esac
+fi
+echo "stub: unhandled git args: \$*" >&2
+exit 3
+SH
+  chmod +x "$FAKEBIN/git"
+  : > "$TMP_ROOT/git-argv.log"
+  rm -f "$TMP_ROOT/git-https-ok"
+}
+
+test_fetch_fallback_retries_https_after_ssh_failure() {
+  install_git_stub 'git@github.com:kunchenguid/firstmate.git'
+  unset FM_GITEA_TOKEN || true
+  unset FM_GITEA_TOKEN_FILE || true
+  local dir="$TMP_ROOT/repo-fetch"
+  mkdir -p "$dir"
+  if ! fm_git_fetch_with_fallback "$dir" origin --prune --quiet; then
+    fail "fetch_with_fallback should succeed via HTTPS after SSH failure; out=$FM_GIT_LAST_OUTPUT"
+  fi
+  [ -f "$TMP_ROOT/git-https-ok" ] \
+    || fail "HTTPS fetch path was never taken; argv=$(cat "$TMP_ROOT/git-argv.log")"
+  grep -q 'fetch origin' "$TMP_ROOT/git-argv.log" \
+    || fail "native origin fetch was never attempted first; argv=$(cat "$TMP_ROOT/git-argv.log")"
+  pass "fm_git_fetch_with_fallback retries HTTPS after SSH failure"
+}
+
+test_fetch_fallback_does_not_retry_on_unrelated_https_failure() {
+  cat > "$FAKEBIN/git" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$TMP_ROOT/git-argv.log"
+if [ "\$1" = "-C" ]; then shift 2; fi
+while [ "\$1" = "-c" ]; do shift 2; done
+if [ "\$1" = "remote" ] && [ "\$2" = "get-url" ]; then
+  echo 'https://github.com/kunchenguid/firstmate.git'
+  exit 0
+fi
+if [ "\$1" = "fetch" ]; then
+  echo "error: RPC failed; HTTP 500" >&2
+  exit 128
+fi
+exit 3
+SH
+  chmod +x "$FAKEBIN/git"
+  : > "$TMP_ROOT/git-argv.log"
+  local dir="$TMP_ROOT/repo-https"
+  mkdir -p "$dir"
+  if fm_git_fetch_with_fallback "$dir" origin --prune --quiet; then
+    fail "unrelated HTTPS failure must not be reported as success"
+  fi
+  local n
+  n=$(grep -cE '(^| )fetch( |$)' "$TMP_ROOT/git-argv.log" || true)
+  [ "$n" = "1" ] || fail "expected exactly one fetch attempt, got $n: $(cat "$TMP_ROOT/git-argv.log")"
+  pass "fm_git_fetch_with_fallback does not HTTPS-retry a plain HTTPS 500"
+}
+
+# --- gitea token resolution (no persist) ------------------------------------
+
+test_gitea_token_reads_env_not_disk_write() {
+  export FM_GITEA_TOKEN='env-token-value'
+  local got
+  got=$(fm_git_gitea_token) || fail "env token should resolve"
+  [ "$got" = 'env-token-value' ] || fail "got '$got'"
+  unset FM_GITEA_TOKEN
+  local tf="$TMP_ROOT/gitea-token"
+  printf 'file-token-value\n' > "$tf"
+  export FM_GITEA_TOKEN_FILE=$tf
+  got=$(fm_git_gitea_token) || fail "file token should resolve"
+  [ "$got" = 'file-token-value' ] || fail "file got '$got'"
+  unset FM_GITEA_TOKEN_FILE
+  if git config --global --get-regexp 'url\..*\.insteadof' 2>/dev/null | grep -q 'oauth2:'; then
+    fail "lib must not write token-bearing insteadOf into global git config"
+  fi
+  pass "fm_git_gitea_token reads env/file and never writes global git config"
+}
+
+# --- run --------------------------------------------------------------------
+
+test_ssh_to_https_scp_form
+test_ssh_to_https_ssh_url_form
+test_ssh_to_https_leaves_https_alone
+test_cluster_http_to_public_https
+test_ssh_agent_dead_when_sock_unset
+test_ssh_agent_dead_when_sock_missing
+test_ssh_agent_dead_when_sock_not_socket
+test_ssh_agent_live_when_ssh_add_reports_no_identities
+test_ssh_agent_dead_when_ssh_add_connection_refused
+test_output_looks_like_ssh_failure
+test_should_retry_https_for_ssh_url_even_without_signature
+test_fetch_fallback_retries_https_after_ssh_failure
+test_fetch_fallback_does_not_retry_on_unrelated_https_failure
+test_gitea_token_reads_env_not_disk_write
+
+echo "# fm-git-transport-lib.test.sh: all assertions passed"


### PR DESCRIPTION
## Summary
Crew fetch/clone paths wedge when the workstation ssh-agent is dead (stale wezterm `SSH_AUTH_SOCK`) even though HTTPS + `gh` / `config/gitea-token` still work.

This adds `bin/fm-git-transport-lib.sh` and wires it under the shared git call sites so firstmate retries SSH-shaped failures over process-local HTTPS without rewriting stored remotes or writing a second at-rest token into global git config.

## Changes
- New `bin/fm-git-transport-lib.sh`: dead-agent detection, `git@`/cluster-HTTP → HTTPS URL conversion, process-local credential helper (`gh auth git-credential` or `FM_GITEA_TOKEN` / `config/gitea-token`), `fm_git_fetch_with_fallback` / `clone` / `submodule_update`.
- Wire under `fm-fleet-sync.sh` (under packed-refs recovery), `fm-ff-lib.sh` `fetch_once`, `fm-home-seed.sh` project clone, `fm-review-diff.sh`, `fm-teardown.sh`.
- Operator fix for a dead agent is documented in the lib header (restart agent / fix `SSH_AUTH_SOCK`; prefer durable HTTPS auth).
- Non-vacuous unit tests in `tests/fm-git-transport-lib.test.sh` (URL conversion, agent detection, fallback decision with stubbed git).

## Coordination
Does **not** add a second at-rest token copy. Token is read fresh from env/file per call for a one-shot helper only. Sibling `cozystack-clone-token-at-rest` still owns cleaning embedded tokens out of clone remotes.

## Test plan
- [x] `bash tests/fm-git-transport-lib.test.sh` (bash 5 + stock `/bin/bash` 3.2)
- [x] `bash tests/fm-fleet-sync.test.sh`
- [x] `bin/fm-lint.sh` on touched scripts