### PR TITLE
feat(bin): instruct crewmates to verify web behavior by driving the browser

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -33,6 +33,13 @@
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
+# Ship and scout scaffolds share one browser rule: web work must reproduce and
+# verify user-visible behavior by driving the browser as a real user, with
+# chrome-devtools-axi for interactive rendered state and the project's
+# Playwright/e2e harness for a scripted repeatable flow that becomes the
+# regression test once a fix is authorized. It stays environment-agnostic:
+# when a bundled interactive browser cannot launch, Playwright drives the
+# system browser instead of the worker falling back to code reading.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Every scaffold's status protocol distinguishes the configured
@@ -226,6 +233,17 @@ EOF
 )
 fi
 
+# Rule 3 is shared by the ship and scout scaffolds so the browser-as-a-user
+# contract has one owner and cannot drift between the two variants.
+BROWSER_RULE=$(cat <<'EOF'
+3. Use gh-axi for GitHub operations.
+   When the task involves user-visible web behavior, reproduce and verify it by driving the browser AS A REAL USER; reading code, API responses, or database rows never proves what a page actually rendered.
+   Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project's Playwright/e2e harness for a scripted, repeatable run of the same user flow.
+   If a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.
+   When a fix is authorized, that reproduction becomes the regression test.
+EOF
+)
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -244,7 +262,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 # Rules
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+$BROWSER_RULE
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -353,7 +371,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 # Rules
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+$BROWSER_RULE
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -37,9 +37,15 @@
 # verify user-visible behavior by driving the browser as a real user, with
 # chrome-devtools-axi for interactive rendered state and the project's
 # Playwright/e2e harness for a scripted repeatable flow that becomes the
-# regression test once a fix is authorized. It stays environment-agnostic:
-# when a bundled interactive browser cannot launch, Playwright drives the
-# system browser instead of the worker falling back to code reading.
+# regression test once a fix is authorized, where such a harness already
+# exists - the rule never asks a project to adopt one. It stays
+# environment-agnostic: when a bundled interactive browser cannot launch,
+# Playwright drives the system browser instead of the worker falling back to
+# code reading, and when no browser driver at all is available the worker
+# reports that gap as blocked rather than silently skipping the check.
+# Both scaffolds' rule 2 carries a matching narrow exemption for the profile
+# and cache directories a browser or its driver manages for itself, with the
+# rest of each variant's own outside-the-worktree wording unchanged.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Every scaffold's status protocol distinguishes the configured
@@ -233,6 +239,14 @@ EOF
 )
 fi
 
+# The rule 2 carve-out is shared by the ship and scout scaffolds so the one
+# exemption driving a real browser needs has a single owner, while each variant
+# keeps its own distinct outside-the-worktree wording ahead of it.
+BROWSER_PATH_EXEMPTION=$(cat <<'EOF'
+   One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. Nothing else outside this worktree is exempt - not project paths, not repository paths, not any other location.
+EOF
+)
+
 # Rule 3 is shared by the ship and scout scaffolds so the browser-as-a-user
 # contract has one owner and cannot drift between the two variants.
 BROWSER_RULE=$(cat <<'EOF'
@@ -240,7 +254,8 @@ BROWSER_RULE=$(cat <<'EOF'
    When the task involves user-visible web behavior, reproduce and verify it by driving the browser AS A REAL USER; reading code, API responses, or database rows never proves what a page actually rendered.
    Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project's Playwright/e2e harness for a scripted, repeatable run of the same user flow.
    If a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.
-   When a fix is authorized, that reproduction becomes the regression test.
+   If no browser driver at all is available, append `blocked: no browser driver available to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.
+   Where the project already has an e2e harness, that reproduction becomes the regression test once a fix is authorized; a project without one gains no obligation here, so do not introduce a harness for it.
 EOF
 )
 
@@ -262,6 +277,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 # Rules
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
+$BROWSER_PATH_EXEMPTION
 $BROWSER_RULE
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -371,6 +387,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 # Rules
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
+$BROWSER_PATH_EXEMPTION
 $BROWSER_RULE
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -37,12 +37,14 @@
 # verify user-visible behavior by driving the browser as a real user, with
 # chrome-devtools-axi for interactive rendered state and the project's
 # Playwright/e2e harness for a scripted repeatable flow that becomes the
-# regression test once a fix is authorized, where such a harness already
-# exists - the rule never asks a project to adopt one. It stays
+# regression test once a fix is authorized. The gate is the nature of the task,
+# not the current state of the project: a task that genuinely involves
+# user-visible web behavior may add the e2e tooling it needs, and a task with no
+# user-visible web behavior is untouched by the rule. It stays
 # environment-agnostic: when a bundled interactive browser cannot launch,
 # Playwright drives the system browser instead of the worker falling back to
-# code reading, and when no browser driver at all is available the worker
-# reports that gap as blocked rather than silently skipping the check.
+# code reading, and a worker who cannot drive a browser by any available means
+# reports that as blocked and stops rather than silently skipping the check.
 # Both scaffolds' rule 2 carries a matching narrow exemption for the profile
 # and cache directories a browser or its driver manages for itself, with the
 # rest of each variant's own outside-the-worktree wording unchanged.
@@ -250,12 +252,12 @@ EOF
 # Rule 3 is shared by the ship and scout scaffolds so the browser-as-a-user
 # contract has one owner and cannot drift between the two variants.
 BROWSER_RULE=$(cat <<'EOF'
-3. Use gh-axi for GitHub operations.
+3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
    When the task involves user-visible web behavior, reproduce and verify it by driving the browser AS A REAL USER; reading code, API responses, or database rows never proves what a page actually rendered.
-   Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project's Playwright/e2e harness for a scripted, repeatable run of the same user flow.
+   Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project's Playwright/e2e harness for a scripted, repeatable run of the same user flow; when such a task needs e2e tooling this project does not have yet, adding it is part of that work.
    If a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.
-   If no browser driver at all is available, append `blocked: no browser driver available to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.
-   Where the project already has an e2e harness, that reproduction becomes the regression test once a fix is authorized; a project without one gains no obligation here, so do not introduce a harness for it.
+   If you cannot successfully drive a browser by any available means, append `blocked: cannot drive a browser to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.
+   That reproduction becomes the regression test once a fix is authorized.
 EOF
 )
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -245,7 +245,7 @@ fi
 # exemption driving a real browser needs has a single owner, while each variant
 # keeps its own distinct outside-the-worktree wording ahead of it.
 BROWSER_PATH_EXEMPTION=$(cat <<'EOF'
-   One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. Nothing else outside this worktree is exempt - not project paths, not repository paths, not any other location.
+   One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. No other path a browser or driver touches is exempt - not project paths, not repository paths - and this changes nothing else in this rule.
 EOF
 )
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -33,24 +33,9 @@
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
-# Ship and scout scaffolds share one browser rule: web work must reproduce and
-# verify user-visible behavior by driving the browser as a real user, with
-# chrome-devtools-axi for interactive rendered state and the project's
-# Playwright/e2e harness for a scripted repeatable flow that becomes the
-# regression test once a fix is authorized, recorded where that task's
-# deliverable lives - on the branch for a ship task, in the report for a scout.
-# The gate is the nature of the task, not the current state of the project: a
-# task that genuinely involves user-visible web behavior may add the e2e tooling
-# it needs, and a task with no user-visible web behavior is untouched by the
-# rule, including its fallback and its escalation. It stays
-# environment-agnostic: on such a task, when a bundled interactive browser
-# cannot launch, Playwright drives the system browser instead of the worker
-# falling back to code reading, and a worker who cannot drive a browser by any
-# available means reports that as blocked and stops rather than silently
-# skipping the check.
-# Both scaffolds' rule 2 carries a matching narrow exemption for the profile
-# and cache directories a browser or its driver manages for itself, with the
-# rest of each variant's own outside-the-worktree wording unchanged.
+# Ship and scout scaffolds share one browser rule and its matching rule 2
+# exemption; the BROWSER_RULE and BROWSER_PATH_EXEMPTION heredocs in this
+# script own that text and its scope.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Every scaffold's status protocol distinguishes the configured
@@ -248,7 +233,7 @@ fi
 # exemption driving a real browser needs has a single owner, while each variant
 # keeps its own distinct outside-the-worktree wording ahead of it.
 BROWSER_PATH_EXEMPTION=$(cat <<'EOF'
-   One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. No other path a browser or driver touches is exempt - not project paths, not repository paths - and this changes nothing else in this rule.
+   One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. Outside this worktree, no other path a browser or driver touches is exempt - not project or repository paths elsewhere on disk - and this changes nothing else in this rule.
 EOF
 )
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -37,14 +37,17 @@
 # verify user-visible behavior by driving the browser as a real user, with
 # chrome-devtools-axi for interactive rendered state and the project's
 # Playwright/e2e harness for a scripted repeatable flow that becomes the
-# regression test once a fix is authorized. The gate is the nature of the task,
-# not the current state of the project: a task that genuinely involves
-# user-visible web behavior may add the e2e tooling it needs, and a task with no
-# user-visible web behavior is untouched by the rule. It stays
-# environment-agnostic: when a bundled interactive browser cannot launch,
-# Playwright drives the system browser instead of the worker falling back to
-# code reading, and a worker who cannot drive a browser by any available means
-# reports that as blocked and stops rather than silently skipping the check.
+# regression test once a fix is authorized, recorded where that task's
+# deliverable lives - on the branch for a ship task, in the report for a scout.
+# The gate is the nature of the task, not the current state of the project: a
+# task that genuinely involves user-visible web behavior may add the e2e tooling
+# it needs, and a task with no user-visible web behavior is untouched by the
+# rule, including its fallback and its escalation. It stays
+# environment-agnostic: on such a task, when a bundled interactive browser
+# cannot launch, Playwright drives the system browser instead of the worker
+# falling back to code reading, and a worker who cannot drive a browser by any
+# available means reports that as blocked and stops rather than silently
+# skipping the check.
 # Both scaffolds' rule 2 carries a matching narrow exemption for the profile
 # and cache directories a browser or its driver manages for itself, with the
 # rest of each variant's own outside-the-worktree wording unchanged.
@@ -255,9 +258,9 @@ BROWSER_RULE=$(cat <<'EOF'
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
    When the task involves user-visible web behavior, reproduce and verify it by driving the browser AS A REAL USER; reading code, API responses, or database rows never proves what a page actually rendered.
    Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project's Playwright/e2e harness for a scripted, repeatable run of the same user flow; when such a task needs e2e tooling this project does not have yet, adding it is part of that work.
-   If a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.
-   If you cannot successfully drive a browser by any available means, append `blocked: cannot drive a browser to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.
-   That reproduction becomes the regression test once a fix is authorized.
+   On such a task, if a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.
+   On such a task, if you cannot successfully drive a browser by any available means, append `blocked: cannot drive a browser to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.
+   That reproduction becomes the regression test once a fix is authorized; record it, and any e2e tooling it needed, where this task's deliverable lives - on the branch for a ship task, in the report for a scout.
 EOF
 )
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -374,6 +374,12 @@ browser_carve_out_block() {
   awk '/^3\. Use gh-axi/{printf "%s", buf; exit} /^2\. /{buf=""; next} {buf = buf $0 "\n"}' "$1"
 }
 
+# An extraction that comes back empty makes the drift diff pass vacuously, so
+# each block must be proven present at its own rule boundary before comparison.
+assert_block_non_empty() {
+  [ -n "$1" ] || fail "$2"
+}
+
 # The browser-as-a-user rule has a single owner shared by the ship and scout
 # scaffolds, so it must render identically in both rather than drifting into
 # two divergent copies.
@@ -411,8 +417,12 @@ test_browser_as_user_rule_reaches_ship_and_scout() {
       "$kind brief still forbids the e2e harness adoption the browser rule can require"
     assert_grep "the profile and cache directories a browser or its driver creates and manages for itself" "$brief" \
       "$kind brief lost the rule 2 browser profile and cache carve-out"
-    assert_grep "not project paths, not repository paths, not any other location" "$brief" \
-      "$kind brief no longer bounds the rule 2 carve-out"
+    assert_grep "No other path a browser or driver touches is exempt" "$brief" \
+      "$kind brief no longer bounds the rule 2 carve-out to browser paths"
+    assert_grep "this changes nothing else in this rule" "$brief" \
+      "$kind brief carve-out no longer leaves the rest of rule 2 intact"
+    assert_no_grep "Nothing else outside this worktree is exempt" "$brief" \
+      "$kind brief carve-out still overrides rule 2's own outside-the-worktree permissions"
   done
   assert_grep "Stay inside this worktree; modify nothing outside it" \
     "$home/data/brief-browser-ship/brief.md" \
@@ -423,13 +433,22 @@ test_browser_as_user_rule_reaches_ship_and_scout() {
   # Both shared blocks are extracted by their surrounding rule boundaries, not
   # by their own current wording, so a divergent per-variant line added anywhere
   # inside either block is caught rather than falling outside the range.
-  diff <(browser_rule_block "$home/data/brief-browser-ship/brief.md") \
-       <(browser_rule_block "$home/data/brief-browser-scout/brief.md") \
-    >/dev/null 2>&1 \
+  local ship_rule scout_rule ship_carve_out scout_carve_out
+  ship_rule=$(browser_rule_block "$home/data/brief-browser-ship/brief.md")
+  scout_rule=$(browser_rule_block "$home/data/brief-browser-scout/brief.md")
+  ship_carve_out=$(browser_carve_out_block "$home/data/brief-browser-ship/brief.md")
+  scout_carve_out=$(browser_carve_out_block "$home/data/brief-browser-scout/brief.md")
+  assert_block_non_empty "$ship_rule" \
+    "ship brief has no rule 3 block between rule 3 and rule 4"
+  assert_block_non_empty "$scout_rule" \
+    "scout brief has no rule 3 block between rule 3 and rule 4"
+  assert_block_non_empty "$ship_carve_out" \
+    "ship brief has no browser carve-out between its rule 2 and rule 3"
+  assert_block_non_empty "$scout_carve_out" \
+    "scout brief has no browser carve-out between its rule 2 and rule 3"
+  [ "$ship_rule" = "$scout_rule" ] \
     || fail "ship and scout browser rules diverged; they must share one owner"
-  diff <(browser_carve_out_block "$home/data/brief-browser-ship/brief.md") \
-       <(browser_carve_out_block "$home/data/brief-browser-scout/brief.md") \
-    >/dev/null 2>&1 \
+  [ "$ship_carve_out" = "$scout_carve_out" ] \
     || fail "ship and scout rule 2 browser carve-outs diverged; they must share one owner"
   pass "fm-brief.sh: ship and scout share one browser-as-a-user rule"
 }

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -419,8 +419,10 @@ test_browser_as_user_rule_reaches_ship_and_scout() {
       "$kind brief still forbids the e2e harness adoption the browser rule can require"
     assert_grep "the profile and cache directories a browser or its driver creates and manages for itself" "$brief" \
       "$kind brief lost the rule 2 browser profile and cache carve-out"
-    assert_grep "No other path a browser or driver touches is exempt" "$brief" \
-      "$kind brief no longer bounds the rule 2 carve-out to browser paths"
+    assert_grep "Outside this worktree, no other path a browser or driver touches is exempt" "$brief" \
+      "$kind brief no longer bounds the rule 2 carve-out to browser paths outside the worktree"
+    assert_no_grep "not project paths, not repository paths" "$brief" \
+      "$kind brief carve-out again reads as forbidding the in-worktree writes the browser rule requires"
     assert_grep "this changes nothing else in this rule" "$brief" \
       "$kind brief carve-out no longer leaves the rest of rule 2 intact"
     assert_no_grep "Nothing else outside this worktree is exempt" "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -385,11 +385,27 @@ test_browser_as_user_rule_reaches_ship_and_scout() {
       "$kind brief lost the scripted repeatable reproduction path"
     assert_grep "drive the system browser with Playwright instead of falling back to code reading" "$brief" \
       "$kind brief lost the environment-agnostic system-browser fallback"
-    assert_grep "that reproduction becomes the regression test" "$brief" \
-      "$kind brief lost the reproduction-becomes-the-regression-test rule"
+    assert_grep "If no browser driver at all is available, append" "$brief" \
+      "$kind brief lost the no-browser-driver escalation"
+    assert_grep "never silently skip the browser check and report success" "$brief" \
+      "$kind brief no longer makes an omitted browser check visible"
+    assert_grep "Where the project already has an e2e harness, that reproduction becomes the regression test" "$brief" \
+      "$kind brief lost the conditional reproduction-becomes-the-regression-test rule"
+    assert_grep "do not introduce a harness for it" "$brief" \
+      "$kind brief no longer disclaims e2e harness adoption for projects without one"
+    assert_grep "the profile and cache directories a browser or its driver creates and manages for itself" "$brief" \
+      "$kind brief lost the rule 2 browser profile and cache carve-out"
+    assert_grep "not project paths, not repository paths, not any other location" "$brief" \
+      "$kind brief no longer bounds the rule 2 carve-out"
   done
-  diff <(sed -n '/^3\. Use gh-axi/,/regression test\.$/p' "$home/data/brief-browser-ship/brief.md") \
-       <(sed -n '/^3\. Use gh-axi/,/regression test\.$/p' "$home/data/brief-browser-scout/brief.md") \
+  assert_grep "Stay inside this worktree; modify nothing outside it" \
+    "$home/data/brief-browser-ship/brief.md" \
+    "ship rule 2 lost its own outside-the-worktree wording"
+  assert_grep "the only files you may write outside it are the report and the status file" \
+    "$home/data/brief-browser-scout/brief.md" \
+    "scout rule 2 lost its own outside-the-worktree wording"
+  diff <(sed -n '/^3\. Use gh-axi/,/do not introduce a harness for it\.$/p' "$home/data/brief-browser-ship/brief.md") \
+       <(sed -n '/^3\. Use gh-axi/,/do not introduce a harness for it\.$/p' "$home/data/brief-browser-scout/brief.md") \
     >/dev/null 2>&1 \
     || fail "ship and scout browser rules diverged; they must share one owner"
   pass "fm-brief.sh: ship and scout share one browser-as-a-user rule"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -362,6 +362,39 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+# The browser-as-a-user rule has a single owner shared by the ship and scout
+# scaffolds, so it must render identically in both rather than drifting into
+# two divergent copies.
+test_browser_as_user_rule_reaches_ship_and_scout() {
+  local home brief kind
+  home="$TMP_ROOT/browser-rule-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-browser-ship some-proj >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-browser-scout some-proj --scout >/dev/null 2>&1
+  for kind in ship scout; do
+    brief="$home/data/brief-browser-$kind/brief.md"
+    assert_present "$brief" "$kind brief was not scaffolded"
+    assert_grep "driving the browser AS A REAL USER" "$brief" \
+      "$kind brief lost the drive-the-browser-as-a-user instruction"
+    assert_grep "never proves what a page actually rendered" "$brief" \
+      "$kind brief lost the reason code and database reads are insufficient"
+    # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+    assert_grep 'Use `chrome-devtools-axi` to drive a real browser interactively' "$brief" \
+      "$kind brief lost the interactive browser tool"
+    assert_grep "Playwright/e2e harness for a scripted, repeatable run" "$brief" \
+      "$kind brief lost the scripted repeatable reproduction path"
+    assert_grep "drive the system browser with Playwright instead of falling back to code reading" "$brief" \
+      "$kind brief lost the environment-agnostic system-browser fallback"
+    assert_grep "that reproduction becomes the regression test" "$brief" \
+      "$kind brief lost the reproduction-becomes-the-regression-test rule"
+  done
+  diff <(sed -n '/^3\. Use gh-axi/,/regression test\.$/p' "$home/data/brief-browser-ship/brief.md") \
+       <(sed -n '/^3\. Use gh-axi/,/regression test\.$/p' "$home/data/brief-browser-scout/brief.md") \
+    >/dev/null 2>&1 \
+    || fail "ship and scout browser rules diverged; they must share one owner"
+  pass "fm-brief.sh: ship and scout share one browser-as-a-user rule"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -396,4 +429,5 @@ test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_browser_as_user_rule_reaches_ship_and_scout
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -362,6 +362,18 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+# Rule 3 in full: everything from its own first line up to rule 4.
+browser_rule_block() {
+  awk '/^4\. Report status/{exit} /^3\. Use gh-axi/{inside=1} inside' "$1"
+}
+
+# The rule 2 carve-out in full: everything after the variant's own last rule 2
+# line and before rule 3, so each variant's distinct rule 2 wording is excluded
+# while the whole shared block is compared.
+browser_carve_out_block() {
+  awk '/^3\. Use gh-axi/{printf "%s", buf; exit} /^2\. /{buf=""; next} {buf = buf $0 "\n"}' "$1"
+}
+
 # The browser-as-a-user rule has a single owner shared by the ship and scout
 # scaffolds, so it must render identically in both rather than drifting into
 # two divergent copies.
@@ -374,6 +386,8 @@ test_browser_as_user_rule_reaches_ship_and_scout() {
   for kind in ship scout; do
     brief="$home/data/brief-browser-$kind/brief.md"
     assert_present "$brief" "$kind brief was not scaffolded"
+    assert_grep "Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations." "$brief" \
+      "$kind brief lost the unconditional browser-operations tool clause"
     assert_grep "driving the browser AS A REAL USER" "$brief" \
       "$kind brief lost the drive-the-browser-as-a-user instruction"
     assert_grep "never proves what a page actually rendered" "$brief" \
@@ -385,14 +399,16 @@ test_browser_as_user_rule_reaches_ship_and_scout() {
       "$kind brief lost the scripted repeatable reproduction path"
     assert_grep "drive the system browser with Playwright instead of falling back to code reading" "$brief" \
       "$kind brief lost the environment-agnostic system-browser fallback"
-    assert_grep "If no browser driver at all is available, append" "$brief" \
-      "$kind brief lost the no-browser-driver escalation"
+    assert_grep "adding it is part of that work" "$brief" \
+      "$kind brief no longer allows a web task to add the e2e tooling it needs"
+    assert_grep "If you cannot successfully drive a browser by any available means, append" "$brief" \
+      "$kind brief lost the outcome-keyed cannot-drive-a-browser escalation"
     assert_grep "never silently skip the browser check and report success" "$brief" \
       "$kind brief no longer makes an omitted browser check visible"
-    assert_grep "Where the project already has an e2e harness, that reproduction becomes the regression test" "$brief" \
-      "$kind brief lost the conditional reproduction-becomes-the-regression-test rule"
-    assert_grep "do not introduce a harness for it" "$brief" \
-      "$kind brief no longer disclaims e2e harness adoption for projects without one"
+    assert_grep "That reproduction becomes the regression test once a fix is authorized." "$brief" \
+      "$kind brief lost the reproduction-becomes-the-regression-test rule"
+    assert_no_grep "do not introduce a harness for it" "$brief" \
+      "$kind brief still forbids the e2e harness adoption the browser rule can require"
     assert_grep "the profile and cache directories a browser or its driver creates and manages for itself" "$brief" \
       "$kind brief lost the rule 2 browser profile and cache carve-out"
     assert_grep "not project paths, not repository paths, not any other location" "$brief" \
@@ -404,10 +420,17 @@ test_browser_as_user_rule_reaches_ship_and_scout() {
   assert_grep "the only files you may write outside it are the report and the status file" \
     "$home/data/brief-browser-scout/brief.md" \
     "scout rule 2 lost its own outside-the-worktree wording"
-  diff <(sed -n '/^3\. Use gh-axi/,/do not introduce a harness for it\.$/p' "$home/data/brief-browser-ship/brief.md") \
-       <(sed -n '/^3\. Use gh-axi/,/do not introduce a harness for it\.$/p' "$home/data/brief-browser-scout/brief.md") \
+  # Both shared blocks are extracted by their surrounding rule boundaries, not
+  # by their own current wording, so a divergent per-variant line added anywhere
+  # inside either block is caught rather than falling outside the range.
+  diff <(browser_rule_block "$home/data/brief-browser-ship/brief.md") \
+       <(browser_rule_block "$home/data/brief-browser-scout/brief.md") \
     >/dev/null 2>&1 \
     || fail "ship and scout browser rules diverged; they must share one owner"
+  diff <(browser_carve_out_block "$home/data/brief-browser-ship/brief.md") \
+       <(browser_carve_out_block "$home/data/brief-browser-scout/brief.md") \
+    >/dev/null 2>&1 \
+    || fail "ship and scout rule 2 browser carve-outs diverged; they must share one owner"
   pass "fm-brief.sh: ship and scout share one browser-as-a-user rule"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -403,16 +403,18 @@ test_browser_as_user_rule_reaches_ship_and_scout() {
       "$kind brief lost the interactive browser tool"
     assert_grep "Playwright/e2e harness for a scripted, repeatable run" "$brief" \
       "$kind brief lost the scripted repeatable reproduction path"
-    assert_grep "drive the system browser with Playwright instead of falling back to code reading" "$brief" \
-      "$kind brief lost the environment-agnostic system-browser fallback"
+    assert_grep "On such a task, if a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading" "$brief" \
+      "$kind brief lost the environment-agnostic system-browser fallback, or stopped scoping it to a web task"
     assert_grep "adding it is part of that work" "$brief" \
       "$kind brief no longer allows a web task to add the e2e tooling it needs"
-    assert_grep "If you cannot successfully drive a browser by any available means, append" "$brief" \
-      "$kind brief lost the outcome-keyed cannot-drive-a-browser escalation"
+    assert_grep "On such a task, if you cannot successfully drive a browser by any available means, append" "$brief" \
+      "$kind brief lost the outcome-keyed cannot-drive-a-browser escalation, or stopped scoping it to a web task"
     assert_grep "never silently skip the browser check and report success" "$brief" \
       "$kind brief no longer makes an omitted browser check visible"
-    assert_grep "That reproduction becomes the regression test once a fix is authorized." "$brief" \
+    assert_grep "That reproduction becomes the regression test once a fix is authorized;" "$brief" \
       "$kind brief lost the reproduction-becomes-the-regression-test rule"
+    assert_grep "record it, and any e2e tooling it needed, where this task's deliverable lives - on the branch for a ship task, in the report for a scout." "$brief" \
+      "$kind brief no longer preserves the reproduction with the task's deliverable"
     assert_no_grep "do not introduce a harness for it" "$brief" \
       "$kind brief still forbids the e2e harness adoption the browser rule can require"
     assert_grep "the profile and cache directories a browser or its driver creates and manages for itself" "$brief" \
@@ -450,6 +452,19 @@ test_browser_as_user_rule_reaches_ship_and_scout() {
     || fail "ship and scout browser rules diverged; they must share one owner"
   [ "$ship_carve_out" = "$scout_carve_out" ] \
     || fail "ship and scout rule 2 browser carve-outs diverged; they must share one owner"
+  # The secondmate charter supervises rather than doing web work and has no rule
+  # 3 at all, so its exclusion from both shared blocks is pinned like the
+  # ship/scout inclusion is.
+  local charter
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='browser rule exclusion' \
+    FM_SECONDMATE_SCOPE='supervision only' \
+    "$ROOT/bin/fm-brief.sh" brief-browser-secondmate --secondmate --no-projects >/dev/null 2>&1
+  charter="$home/data/brief-browser-secondmate/brief.md"
+  assert_present "$charter" "secondmate charter was not scaffolded"
+  assert_no_grep "driving the browser AS A REAL USER" "$charter" \
+    "secondmate charter picked up the ship/scout browser rule it deliberately excludes"
+  assert_no_grep "the profile and cache directories a browser or its driver creates and manages for itself" "$charter" \
+    "secondmate charter picked up the ship/scout rule 2 browser carve-out it deliberately excludes"
   pass "fm-brief.sh: ship and scout share one browser-as-a-user rule"
 }
 


### PR DESCRIPTION
## Intent

Make browser-based, act-like-a-user web debugging a standard, instructed capability for firstmate crewmates. Background: the generated crewmate brief's Rule 3 only said 'use gh-axi for GitHub operations and chrome-devtools-axi for browser operations', which was too weak - a recent web investigation could not confirm what a page actually rendered and fell back to reading code and querying the database instead. The captain asked to close that gap in the shared brief scaffold (bin/fm-brief.sh), which is firstmate's shared tracked instruction surface.

Deliberate decisions, so they read as intent and not mistakes:
- The guidance REPLACES the weak Rule 3 line rather than adding a redundant new section, because firstmate-coding-guidelines require one owner per contract and the scaffold keeps a terse voice. Rule numbering (1,2,3,4...) is deliberately preserved.
- The rule is defined ONCE as a shared BROWSER_RULE heredoc and interpolated into both the ship scaffold and the scout/diagnostic scaffold, specifically so the two variants cannot drift. The test asserts byte-identical rendering in both variants for exactly this reason.
- It deliberately names BOTH tools with distinct roles: chrome-devtools-axi for interactive drive-the-real-browser inspection of live rendered state, and the project's Playwright/e2e harness for a scripted repeatable run of the same user flow that becomes the regression test once a fix is authorized.
- The scaffold is deliberately ENVIRONMENT-AGNOSTIC: the system-browser-via-Playwright line is the general fallback for when a bundled interactive browser cannot launch. No machine-specific quirk is hardcoded (the fleet-local WSL detail lives in the operator's learnings file, not this shared scaffold), so the absence of concrete environment detail here is intentional.
- Scope was explicitly bounded by the captain to bin/fm-brief.sh plus its test: no project AGENTS.md edits, no Playwright installed into any project by this task, and diagnostic-reasoning deliberately left untouched.
- Every existing safety line is preserved untouched: worktree isolation assertion, never-push-to-default, the status protocol, the Herdr hard safety gate, and the scout report contract.

Earlier gate rounds on this branch already produced four no-mistakes(review) fix commits that are part of the accepted design and should not be re-litigated: the browser instruction is scoped to tasks involving user-visible web behavior rather than every task; a cannot-drive-a-browser case escalates via the existing blocked: status protocol instead of silently reporting success on rendered behavior never seen; the reproduction is recorded where the task's deliverable lives (branch for ship, report for scout); and drift guards were added to the test.

Acceptance: a freshly scaffolded ship brief and the scout/diagnostic variant both contain clear guidance to reproduce and verify user-visible web behavior by driving the browser as a user, stated once in a shared location, with existing scaffold behavior and safety lines preserved and the brief-scaffold test extended to cover it.

## What Changed

- Replaced the one-line rule 3 in `bin/fm-brief.sh` with a shared `BROWSER_RULE` heredoc interpolated into both the ship and scout scaffolds: on tasks involving user-visible web behavior, the crewmate must reproduce and verify it by driving a real browser as a user (`chrome-devtools-axi` for interactive inspection, the project's Playwright/e2e harness for a scripted repeatable run, adding that tooling when the project lacks it), fall back to the system browser via Playwright when a bundled browser cannot launch, append `blocked: cannot drive a browser to verify {the behavior}` rather than report success on rendered behavior never seen, and record the reproduction where the task's deliverable lives — the branch for a ship task, the report for a scout.
- Added a matching shared `BROWSER_PATH_EXEMPTION` block that carves browser/driver profile and cache directories out of rule 2, explicitly scoped to paths outside the worktree so it does not read as forbidding the in-worktree writes the browser rule requires; the file header was reduced to a pointer at these two heredocs so the rule text has a single owner. Secondmate charters are unaffected.
- Extended `tests/fm-brief.test.sh` with a test that pins every line of the new rule and carve-out in both variants, extracts each block by its rule boundaries and asserts the ship and scout renderings are byte-identical (failing loudly on an empty extraction), and asserts the charter excludes both blocks. Review raised one open informational note about Playwright not being part of the bootstrap-verified toolchain, deferred as a follow-up under the captain's bounded scope; all other pipeline gates passed.

## Risk Assessment

✅ Low: The change is confined to text in one scaffold script plus its colocated tests, the rule has a single owner interpolated into both variants with byte-identity drift guards, both rendered variants and the --help output were inspected and are correct, and no executable behavior or safety line was altered.

## Testing

Ran the brief-scaffold suite and five adjacent suites that also scaffold briefs — all pass, including the new shared-browser-rule check. Beyond the suite, I scaffolded real ship and scout briefs and captured the text a worker actually receives, plus a screenshot of the rendered Rules block; a full diff against briefs generated by the base-commit script shows only the new browser rule and its rule 2 carve-out, with the worktree-isolation assertion, never-push-to-default, status protocol, Herdr gate, and scout report contract byte-for-byte unchanged. Rule 3 is byte-identical across both variants and correctly absent from the supervision-only secondmate charter. Four mutations (old one-liner restored, escalation line dropped, carve-out widened, scout-only line added) each fail the test with a targeted message, so the new coverage is not vacuous. Only environment note: the bundled interactive browser would not launch on this WSL host, so the screenshot was produced via the system Chromium — the exact fallback the new rule prescribes, not a defect in the change.

- Evidence: Rendered Rules block of the generated ship and scout briefs (new lines highlighted) (local file: <code>/tmp/no-mistakes-evidence/01KYJ09E5WAEA6Y85TRJGQ9R73/brief-rules.png</code>)
<details>
<summary>Evidence: Before/after Rules block, base a5fe1bc vs this branch, ship and scout</summary>

<code>=== BEFORE (base a5fe1bc) - ship brief, Rules block ===&#10;# Rules&#10;1. Never push to the default branch. Never merge a PR.&#10;2. Stay inside this worktree; modify nothing outside it.&#10;3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.&#10;4. Report status by appending one line:&#10;&#10;=== AFTER (ade08f8) - ship brief, Rules block ===&#10;# Rules&#10;1. Never push to the default branch. Never merge a PR.&#10;2. Stay inside this worktree; modify nothing outside it.&#10;One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. Outside this worktree, no other path a browser or driver touches is exempt - not project or repository paths elsewhere on disk - and this changes nothing else in this rule.&#10;3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.&#10;When the task involves user-visible web behavior, reproduce and verify it by driving the browser AS A REAL USER; reading code, API responses, or database rows never proves what a page actually rendered.&#10;Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project&#39;s Playwright/e2e harness for a scripted, repeatable run of the same user flow; when such a task needs e2e tooling this project does not have yet, adding it is part of that work.&#10;On such a task, if a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.&#10;On such a task, if you cannot successfully drive a browser by any available means, append `blocked: cannot drive a browser to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.&#10;That reproduction becomes the regression test once a fix is authorized; record it, and any e2e tooling it needed, where this task&#39;s deliverable lives - on the branch for a ship task, in the report for a scout.&#10;4. Report status by appending one line:&#10;&#10;(the scout variant renders the same two added blocks; full file also covers scout before/after)</code>

```text
=== BEFORE (base a5fe1bc) — ship brief, Rules block ===
# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:

=== BEFORE (base a5fe1bc) — scout brief, Rules block ===
# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:

=== AFTER (ade08f8) — ship brief, Rules block ===
# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
   One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. Outside this worktree, no other path a browser or driver touches is exempt - not project or repository paths elsewhere on disk - and this changes nothing else in this rule.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
   When the task involves user-visible web behavior, reproduce and verify it by driving the browser AS A REAL USER; reading code, API responses, or database rows never proves what a page actually rendered.
   Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project's Playwright/e2e harness for a scripted, repeatable run of the same user flow; when such a task needs e2e tooling this project does not have yet, adding it is part of that work.
   On such a task, if a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.
   On such a task, if you cannot successfully drive a browser by any available means, append `blocked: cannot drive a browser to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.
   That reproduction becomes the regression test once a fix is authorized; record it, and any e2e tooling it needed, where this task's deliverable lives - on the branch for a ship task, in the report for a scout.
4. Report status by appending one line:

=== AFTER (ade08f8) — scout brief, Rules block ===
# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
   One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. Outside this worktree, no other path a browser or driver touches is exempt - not project or repository paths elsewhere on disk - and this changes nothing else in this rule.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
   When the task involves user-visible web behavior, reproduce and verify it by driving the browser AS A REAL USER; reading code, API responses, or database rows never proves what a page actually rendered.
   Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project's Playwright/e2e harness for a scripted, repeatable run of the same user flow; when such a task needs e2e tooling this project does not have yet, adding it is part of that work.
   On such a task, if a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.
   On such a task, if you cannot successfully drive a browser by any available means, append `blocked: cannot drive a browser to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.
   That reproduction becomes the regression test once a fix is authorized; record it, and any e2e tooling it needed, where this task's deliverable lives - on the branch for a ship task, in the report for a scout.
4. Report status by appending one line:
```
</details>
<details>
<summary>Evidence: Full generated-brief diff, base vs branch (safety lines unchanged)</summary>

```text
### Full generated ship brief: base a5fe1bc -> ade08f8 (task-id/home paths normalized)
--- /tmp/tmp.MxZLMPfkEX/n-base-ship.md	2026-07-27 16:57:36.528953648 +0200
+++ /tmp/tmp.MxZLMPfkEX/n-new-ship.md	2026-07-27 16:57:36.535653029 +0200
@@ -21,7 +21,13 @@
 # Rules
 1. Never push to the default branch. Never merge a PR.
 2. Stay inside this worktree; modify nothing outside it.
+   One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. Outside this worktree, no other path a browser or driver touches is exempt - not project or repository paths elsewhere on disk - and this changes nothing else in this rule.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+   When the task involves user-visible web behavior, reproduce and verify it by driving the browser AS A REAL USER; reading code, API responses, or database rows never proves what a page actually rendered.
+   Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project's Playwright/e2e harness for a scripted, repeatable run of the same user flow; when such a task needs e2e tooling this project does not have yet, adding it is part of that work.
+   On such a task, if a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.
+   On such a task, if you cannot successfully drive a browser by any available means, append `blocked: cannot drive a browser to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.
+   That reproduction becomes the regression test once a fix is authorized; record it, and any e2e tooling it needed, where this task's deliverable lives - on the branch for a ship task, in the report for a scout.
 4. Report status by appending one line:
    `echo "{state}: {one short line}" >> 'FM_HOME/state/TASK-ID.status'`
    States: working, needs-decision, blocked, paused, done, failed.
@@ -44,10 +50,10 @@
    daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
 
 # Project memory
-If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/tmp/tmp.MxZLMPfkEX/bin/fm-ensure-agents-md.sh .` in the worktree.
+If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/luke/.no-mistakes/worktrees/e18853bcb219/01KYJ09E5WAEA6Y85TRJGQ9R73/bin/fm-ensure-agents-md.sh .` in the worktree.
 Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
-If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/tmp/tmp.MxZLMPfkEX/bin/fm-ensure-agents-md.sh` in the same pass.
+If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/luke/.no-mistakes/worktrees/e18853bcb219/01KYJ09E5WAEA6Y85TRJGQ9R73/bin/fm-ensure-agents-md.sh` in the same pass.
 Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.
 
 # Definition of done

### Full generated scout brief: base a5fe1bc -> ade08f8
--- /tmp/tmp.MxZLMPfkEX/n-base-scout.md	2026-07-27 16:57:36.534217060 +0200
+++ /tmp/tmp.MxZLMPfkEX/n-new-scout.md	2026-07-27 16:57:36.537235046 +0200
@@ -17,7 +17,13 @@
 # Rules
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
+   One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. Outside this worktree, no other path a browser or driver touches is exempt - not project or repository paths elsewhere on disk - and this changes nothing else in this rule.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+   When the task involves user-visible web behavior, reproduce and verify it by driving the browser AS A REAL USER; reading code, API responses, or database rows never proves what a page actually rendered.
+   Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project's Playwright/e2e harness for a scripted, repeatable run of the same user flow; when such a task needs e2e tooling this project does not have yet, adding it is part of that work.
+   On such a task, if a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.
+   On such a task, if you cannot successfully drive a browser by any available means, append `blocked: cannot drive a browser to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.
+   That reproduction becomes the regression test once a fix is authorized; record it, and any e2e tooling it needed, where this task's deliverable lives - on the branch for a ship task, in the report for a scout.
 4. Report status by appending one line:
    `echo "{state}: {one short line}" >> 'FM_HOME/state/TASK-ID.status'`
    States: working, needs-decision, blocked, paused, done, failed.
@@ -39,6 +45,6 @@
 # Definition of done
 Write your findings to `FM_HOME/data/TASK-ID/report.md`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
-Before reporting done, read and follow `/tmp/tmp.MxZLMPfkEX/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
+Before reporting done, read and follow `/home/luke/.no-mistakes/worktrees/e18853bcb219/01KYJ09E5WAEA6Y85TRJGQ9R73/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
 When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Single-owner check: ship rule 3 == scout rule 3, charter excluded</summary>

<code># Single-owner check: rule 3 renders byte-identically in both variants&#10;IDENTICAL: ship rule 3 == scout rule 3 (sha 1c0c5d682c2cf67a)&#10;&#10;# Secondmate charter (supervision-only) correctly has no browser rule:&#10;0 occurrences (expected)</code>

```text
# Single-owner check: rule 3 renders byte-identically in both variants
IDENTICAL: ship rule 3 == scout rule 3 (sha 1c0c5d682c2cf67a)

# Secondmate charter (supervision-only) correctly has no browser rule:
0
0 occurrences (expected)
```
</details>
<details>
<summary>Evidence: Drift-guard mutation checks (each mutation fails the test specifically)</summary>

<code># Baseline, unmutated:&#10;ok - fm-brief.sh: ship and scout share one browser-as-a-user rule&#10;&#10;## A. rule 3 reverted to the old weak one-liner (mutated script still parses)&#10;not ok - ship brief lost the drive-the-browser-as-a-user instruction&#10;&#10;## B. cannot-drive-a-browser escalation line dropped&#10;not ok - ship brief lost the outcome-keyed cannot-drive-a-browser escalation, or stopped scoping it to a web task&#10;&#10;## C. rule 2 carve-out widened back to the over-broad wording&#10;not ok - ship brief no longer bounds the rule 2 carve-out to browser paths outside the worktree&#10;&#10;## D. scout variant given its own extra line (drift between the two owners)&#10;not ok - ship and scout browser rules diverged; they must share one owner</code>

```text
# Drift-guard mutation checks (tests/fm-brief.test.sh run against a mutated copy of bin/fm-brief.sh)
# Baseline, unmutated:
ok - fm-brief.sh: ship and scout share one browser-as-a-user rule

## A. rule 3 reverted to the old weak one-liner (mutated script still parses)
not ok - ship brief lost the drive-the-browser-as-a-user instruction

## B. cannot-drive-a-browser escalation line dropped
not ok - ship brief lost the outcome-keyed cannot-drive-a-browser escalation, or stopped scoping it to a web task

## C. rule 2 carve-out widened back to the over-broad wording
not ok - ship brief no longer bounds the rule 2 carve-out to browser paths outside the worktree

## D. scout variant given its own extra line (drift between the two owners)
not ok - ship and scout browser rules diverged; they must share one owner
```
</details>
<details>
<summary>Evidence: Generated ship brief (full)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of acme-web, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-ship`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
   One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. Outside this worktree, no other path a browser or driver touches is exempt - not project or repository paths elsewhere on disk - and this changes nothing else in this rule.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
   When the task involves user-visible web behavior, reproduce and verify it by driving the browser AS A REAL USER; reading code, API responses, or database rows never proves what a page actually rendered.
   Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project's Playwright/e2e harness for a scripted, repeatable run of the same user flow; when such a task needs e2e tooling this project does not have yet, adding it is part of that work.
   On such a task, if a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.
   On such a task, if you cannot successfully drive a browser by any available means, append `blocked: cannot drive a browser to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.
   That reproduction becomes the regression test once a fix is authorized; record it, and any e2e tooling it needed, where this task's deliverable lives - on the branch for a ship task, in the report for a scout.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.Nvg1fEQwK9/fmhome/state/demo-ship.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/luke/.no-mistakes/worktrees/e18853bcb219/01KYJ09E5WAEA6Y85TRJGQ9R73/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/luke/.no-mistakes/worktrees/e18853bcb219/01KYJ09E5WAEA6Y85TRJGQ9R73/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated scout brief (full)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of acme-web, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
   One narrow exemption: the profile and cache directories a browser or its driver creates and manages for itself. Outside this worktree, no other path a browser or driver touches is exempt - not project or repository paths elsewhere on disk - and this changes nothing else in this rule.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
   When the task involves user-visible web behavior, reproduce and verify it by driving the browser AS A REAL USER; reading code, API responses, or database rows never proves what a page actually rendered.
   Use `chrome-devtools-axi` to drive a real browser interactively and inspect live rendered state, and the project's Playwright/e2e harness for a scripted, repeatable run of the same user flow; when such a task needs e2e tooling this project does not have yet, adding it is part of that work.
   On such a task, if a bundled interactive browser cannot launch in this environment, drive the system browser with Playwright instead of falling back to code reading.
   On such a task, if you cannot successfully drive a browser by any available means, append `blocked: cannot drive a browser to verify {the behavior}` and stop - never silently skip the browser check and report success on rendered behavior you never saw.
   That reproduction becomes the regression test once a fix is authorized; record it, and any e2e tooling it needed, where this task's deliverable lives - on the branch for a ship task, in the report for a scout.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.Nvg1fEQwK9/fmhome/state/demo-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/tmp/tmp.Nvg1fEQwK9/fmhome/data/demo-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/home/luke/.no-mistakes/worktrees/e18853bcb219/01KYJ09E5WAEA6Y85TRJGQ9R73/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Generated secondmate charter (no browser rule, as intended)</summary>

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
supervise the acme domain

# Routing scope
acme web work

# Project clones
None. This is a project-less domain: its subject is the firstmate repo this home lives in, so it needs no separate clones under `projects/`; its crews take pooled worktrees of that firstmate repo.

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.Nvg1fEQwK9/fmhome/state/demo-secondmate.status'`
States: working, needs-decision, blocked, paused, done, failed.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
When a decision you escalated is answered or a blocker clears and your domain resumes, append `resolved: {how it was decided or unblocked}` (keyed with `[key=<slug>]` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-brief.sh:260` - Rule 3 tells the crewmate that when a web task &#34;needs e2e tooling this project does not have yet, adding it is part of that work&#34;. For a ship task that means a crewmate can add Playwright, its browser binaries, and the associated CI surface to any project and land it in the PR on its own authority. That sits in tension with rule 6 in the same brief (&#34;If a decision belongs above the implementation worker (product choices...) append needs-decision and stop&#34;) and with AGENTS.md section 7&#39;s rule that standing autonomy never approves work that materially expands the engineering contract. Worth confirming the intended boundary - e.g. adopting an existing-but-uninstalled harness is autonomous, while introducing a brand-new test framework declares itself via needs-decision, or at minimum is called out explicitly in the PR.
- ℹ️ `bin/fm-brief.sh:35` - The new header block restates the full semantics of the browser rule - the web-task gate, the system-browser fallback, the blocked escalation, and the rule 2 carve-out - which the BROWSER_RULE and BROWSER_PATH_EXEMPTION heredocs already own. Since usage() prints the entire header and test_help_includes_entire_header only pins its terminator line, the two copies can diverge with nothing catching it, which is the drift the shared heredoc was introduced to prevent. Consider reducing the header to a short pointer (&#34;ship and scout share one browser rule; see BROWSER_RULE below&#34;) so the rule text has a single owner in the file as well as in the output.
- ℹ️ `bin/fm-brief.sh:251` - The carve-out reads &#34;No other path a browser or driver touches is exempt - not project paths, not repository paths&#34;. Strictly it means no other path gains an exemption from rule 2, which only governs writes outside the worktree. But to a crewmate, &#34;project paths&#34; and &#34;repository paths&#34; most naturally name the worktree it is working in - the one place it is explicitly allowed to write - so the sentence can be read as forbidding the very writes rule 3 requires (installing the e2e harness, node_modules, test-results/, playwright-report/). Scoping the phrase explicitly to paths outside the worktree would remove the ambiguity.

🔧 Fix: reduce header to pointer, scope browser carve-out outside worktree
1 info still open:
- ℹ️ `bin/fm-brief.sh:246` - Rule 3 now names Playwright twice as load-bearing: as the scripted-reproduction harness and, more strongly, as the mandated fallback when a bundled interactive browser cannot launch (&#34;drive the system browser with Playwright instead of falling back to code reading&#34;). Playwright is not part of the universal toolchain firstmate verifies or offers to install - docs/configuration.md:251 and bin/fm-bootstrap.sh:516 list node, git, gh, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi, tasks-axi, quota-axi and nothing else. On a home where chrome-devtools-axi cannot launch a browser and Playwright is absent, the crewmate has no fallback left and lands on the next line&#39;s `blocked: cannot drive a browser to verify {the behavior}`. That degrades safely rather than silently, which is the right shape, but it means web tasks can routinely block on a dependency bootstrap never detects. The captain bounded this task&#39;s scope to bin/fm-brief.sh plus its test, so this reads as a deliberate deferral rather than an oversight; worth confirming it should be a follow-up (add Playwright to the bootstrap detect-and-consent list, or soften the fallback to &#34;a system browser driven by any available automation tool&#34;) rather than part of this change.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` (16 checks incl. new `fm-brief.sh: ship and scout share one browser-as-a-user rule`)</code>
- <code>`bash tests/fm-ask-user-authority.test.sh`, `tests/fm-secondmate-safety.test.sh`, `tests/fm-tangle-guard.test.sh`, `tests/fm-instruction-owners.test.sh`, `tests/fm-captain-translation-contract.test.sh`</code>
- <code>Manual scaffold of a real ship brief and scout brief: `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh demo-ship acme-web` and `... demo-scout acme-web --scout`</code>
- <code>Before/after comparison: generated the same two briefs from the base-commit copy of `bin/fm-brief.sh` (a5fe1bc) and diffed the full brief text to prove only the browser rule and rule 2 carve-out changed</code>
- <code>Single-owner proof: `diff` of the extracted rule 3 block from the ship vs scout brief (byte-identical, sha 1c0c5d68…)</code>
- <code>Secondmate charter exclusion: `FM_SECONDMATE_CHARTER=... bin/fm-brief.sh demo-secondmate --secondmate --no-projects` then grep for the browser rule (0 occurrences, as intended)</code>
- <code>Drift-guard mutation checks against a temp copy: reverted rule 3 to the old one-liner, deleted the cannot-drive-a-browser escalation, widened the rule 2 carve-out, and added a scout-only line — each produced a specific `not ok` failure</code>
- <code>Visual capture: rendered the Rules block of both variants to HTML and screenshotted it (bundled `chrome-devtools-axi` would not stay alive on this WSL host, so the shot was taken with the system Chromium — the fallback the new rule itself prescribes)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
