### PR TITLE
feat(bin): add Firstmate-owned extension framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Firstmate's skills live in two separate places with different audiences:
 
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
+- [docs/extensions.md](docs/extensions.md) - current Stage 0 local extension host boundary and supported No Mistakes seams.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - current setup and limits for the tmux reference backend.

--- a/bin/fm-extension-host.mjs
+++ b/bin/fm-extension-host.mjs
@@ -457,8 +457,7 @@ function writeGeneratedFile(file, content, validated) {
     if (st.isSymbolicLink() || !st.isFile()) {
       fail(`refusing to overwrite unsafe generated path: ${file}`);
     }
-    const current = fs.readFileSync(file, "utf8");
-    if (!current.includes(GENERATED_MARKER)) {
+    if (!isOwnedGeneratedFile(file, validated.id)) {
       fail(`refusing to overwrite unowned generated path: ${file}`);
     }
   }

--- a/bin/fm-extension-host.mjs
+++ b/bin/fm-extension-host.mjs
@@ -103,6 +103,25 @@ function lstatSafe(file, label) {
   }
 }
 
+function assertNoSymlinkPathAncestry(target, label) {
+  const resolved = path.resolve(target);
+  const root = path.parse(resolved).root;
+  const parts = path.relative(root, resolved).split(path.sep).filter(Boolean);
+  let current = root;
+  for (const part of parts) {
+    current = path.join(current, part);
+    let st;
+    try {
+      st = fs.lstatSync(current);
+    } catch (error) {
+      if (error && error.code === "ENOENT") return false;
+      throw error;
+    }
+    if (st.isSymbolicLink()) fail(`${label} path must not contain a symlink: ${current}`);
+  }
+  return true;
+}
+
 function assertSafeRegularFile(file, label, options = {}) {
   const st = lstatSafe(file, label);
   if (st.isSymbolicLink()) fail(`${label} must not be a symlink: ${file}`);
@@ -418,6 +437,7 @@ function generatedWrapperPath(validated, entrypointName) {
 }
 
 function ensureCreatedDirectory(dir, mode = 0o700) {
+  assertNoSymlinkPathAncestry(dir, "generated directory");
   const existed = fs.existsSync(dir);
   fs.mkdirSync(dir, { recursive: true, mode });
   const st = lstatSafe(dir, "generated directory");
@@ -564,7 +584,7 @@ function commandDeactivate(opts, id) {
   if (!opts.home) fail("FM_HOME is required; pass --home or set FM_HOME", 2);
   validateId(id, "extension id");
   const generatedDir = path.join(opts.home, "state", "extensions", id, "generated");
-  if (!fs.existsSync(generatedDir)) {
+  if (!assertNoSymlinkPathAncestry(generatedDir, "generated directory")) {
     process.stdout.write(`fm-extension: no generated material for ${id}\n`);
     return;
   }

--- a/bin/fm-extension-host.mjs
+++ b/bin/fm-extension-host.mjs
@@ -1,0 +1,701 @@
+#!/usr/bin/env node
+// Firstmate-owned local extension host for Stage 0.
+//
+// This file owns the structured JSON parsing and fail-closed validation for
+// firstmate.extension/v1 manifests. The shell wrapper owns user-facing help and
+// keeps shell lint coverage on the operator entrypoint.
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const CONFIG_API = "firstmate.extension.config/v1";
+const MANIFEST_API = "firstmate.extension/v1";
+const GENERATED_API = "firstmate.extension.generated/v1";
+const HOST_FIRSTMATE_VERSION = "0.0.0";
+const ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,62}$/;
+const VERSION_PATTERN = /^[0-9]+[.][0-9]+[.][0-9]+(?:[-+][0-9A-Za-z.-]+)?$/;
+const HASH_PATTERN = /^[0-9a-f]{64}$/;
+const KNOWN_CAPABILITIES = new Set([
+  "no_mistakes.repo_command",
+  "no_mistakes.wrapper",
+  "no_mistakes.axi_observe",
+]);
+const KNOWN_REPO_COMMANDS = new Set(["lint", "test", "format"]);
+const READ_ONLY_AXI = new Set(["status", "logs"]);
+const GENERATED_MARKER = "# firstmate-extension-generated firstmate.extension.generated/v1";
+
+function usage() {
+  process.stdout.write(`fm-extension.sh usage is documented in bin/fm-extension.sh.
+Run:
+  bin/fm-extension.sh --help
+`);
+}
+
+function fail(message, code = 1) {
+  const error = new Error(message);
+  error.exitCode = code;
+  throw error;
+}
+
+function parseGlobal(argv) {
+  const opts = {
+    fmRoot: "",
+    home: process.env.FM_HOME || "",
+    config: "",
+    noMistakesBin: process.env.NO_MISTAKES_BIN || "no-mistakes",
+  };
+  const rest = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--fm-root" || arg === "--home" || arg === "--config" || arg === "--no-mistakes-bin") {
+      if (i + 1 >= argv.length) fail(`${arg} requires a value`, 2);
+      const value = argv[i + 1];
+      if (arg === "--fm-root") opts.fmRoot = value;
+      if (arg === "--home") opts.home = value;
+      if (arg === "--config") opts.config = value;
+      if (arg === "--no-mistakes-bin") opts.noMistakesBin = value;
+      i += 1;
+      continue;
+    }
+    if (arg === "-h" || arg === "--help") {
+      opts.help = true;
+      continue;
+    }
+    rest.push(...argv.slice(i));
+    break;
+  }
+  if (!opts.fmRoot) {
+    opts.fmRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+  }
+  opts.fmRoot = path.resolve(opts.fmRoot);
+  if (opts.home) opts.home = path.resolve(opts.home);
+  if (opts.config) opts.config = path.resolve(opts.config);
+  return { opts, rest };
+}
+
+function readJson(file, label) {
+  let raw;
+  try {
+    raw = fs.readFileSync(file, "utf8");
+  } catch (error) {
+    fail(`${label} is not readable: ${file}: ${error.message}`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    fail(`${label} is malformed JSON: ${file}: ${error.message}`);
+  }
+}
+
+function sha256File(file) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(file));
+  return hash.digest("hex");
+}
+
+function lstatSafe(file, label) {
+  try {
+    return fs.lstatSync(file);
+  } catch (error) {
+    fail(`${label} does not exist: ${file}`);
+  }
+}
+
+function assertSafeRegularFile(file, label, options = {}) {
+  const st = lstatSafe(file, label);
+  if (st.isSymbolicLink()) fail(`${label} must not be a symlink: ${file}`);
+  if (!st.isFile()) fail(`${label} must be a regular file: ${file}`);
+  if ((st.mode & 0o022) !== 0) fail(`${label} must not be group- or world-writable: ${file}`);
+  if (options.executable && (st.mode & 0o100) === 0) {
+    fail(`${label} must be owner-executable: ${file}`);
+  }
+  return st;
+}
+
+function assertSafeDirectory(dir, label) {
+  const st = lstatSafe(dir, label);
+  if (st.isSymbolicLink()) fail(`${label} must not be a symlink: ${dir}`);
+  if (!st.isDirectory()) fail(`${label} must be a directory: ${dir}`);
+  if ((st.mode & 0o022) !== 0) fail(`${label} must not be group- or world-writable: ${dir}`);
+  return st;
+}
+
+function hasScheme(value) {
+  return /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value);
+}
+
+function isInside(parent, child) {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function resolveStrictChild(base, rel, label) {
+  if (typeof rel !== "string" || rel.length === 0) fail(`${label} path must be a non-empty string`);
+  if (rel.includes("\0")) fail(`${label} path contains a NUL byte`);
+  if (hasScheme(rel)) fail(`${label} path must be local, not a URL or scheme path: ${rel}`);
+  if (path.isAbsolute(rel)) fail(`${label} path must be relative to the extension source root: ${rel}`);
+  const resolved = path.resolve(base, rel);
+  if (!isInside(base, resolved)) fail(`${label} path escapes the extension source root: ${rel}`);
+  return resolved;
+}
+
+function validateId(value, label) {
+  if (typeof value !== "string" || !ID_PATTERN.test(value)) {
+    fail(`${label} must match ${ID_PATTERN}`);
+  }
+}
+
+function validateVersion(value, label) {
+  if (typeof value !== "string" || !VERSION_PATTERN.test(value)) {
+    fail(`${label} must be a semver-like version`);
+  }
+}
+
+function validateHash(value, label) {
+  if (typeof value !== "string" || !HASH_PATTERN.test(value)) {
+    fail(`${label} must be a lowercase 64-hex SHA-256`);
+  }
+}
+
+function ensureObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+  return value;
+}
+
+function ensureStringArray(value, label) {
+  if (!Array.isArray(value)) fail(`${label} must be an array`);
+  for (const item of value) {
+    if (typeof item !== "string" || item.length === 0) fail(`${label} must contain non-empty strings`);
+  }
+  return value;
+}
+
+function normalizeCapabilities(value, label) {
+  if (typeof value === "string") return [value];
+  return ensureStringArray(value, label);
+}
+
+function parseVersion(value) {
+  const match = String(value).match(/v?([0-9]+)[.]([0-9]+)[.]([0-9]+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function parseFloorRequirement(value, label) {
+  if (typeof value !== "string") fail(`${label} must be a string`);
+  const match = value.match(/^>=\s*v?([0-9]+)[.]([0-9]+)[.]([0-9]+)(?:[-+][0-9A-Za-z.-]+)?$/);
+  if (!match) fail(`${label} supports only >= semver floors`);
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function versionAtLeast(actual, floor) {
+  for (let i = 0; i < 3; i += 1) {
+    if (actual[i] > floor[i]) return true;
+    if (actual[i] < floor[i]) return false;
+  }
+  return true;
+}
+
+function currentNoMistakesVersion(noMistakesBin, env) {
+  const result = spawnSync(noMistakesBin, ["--version"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...env,
+      NO_MISTAKES_NO_UPDATE_CHECK: "1",
+    },
+  });
+  if (result.error) fail(`no-mistakes version check failed: ${result.error.message}`);
+  if (result.status !== 0) {
+    fail(`no-mistakes --version exited ${result.status}: ${(result.stderr || result.stdout || "").trim()}`);
+  }
+  const parsed = parseVersion(result.stdout) || parseVersion(`${result.stdout}\n${result.stderr}`);
+  if (!parsed) fail(`no-mistakes --version did not contain a parseable semver: ${result.stdout.trim()}`);
+  return { raw: result.stdout.trim(), parsed };
+}
+
+function discoverConfig(opts, id) {
+  if (opts.config) return opts.config;
+  if (!opts.home) fail("FM_HOME is required; pass --home or set FM_HOME", 2);
+  const dir = path.join(opts.home, "config", "extensions.d");
+  if (id) return path.join(dir, `${id}.json`);
+  let entries = [];
+  try {
+    entries = fs.readdirSync(dir).filter((name) => name.endsWith(".json")).sort();
+  } catch {
+    fail(`no extension config directory found: ${dir}`);
+  }
+  if (entries.length !== 1) {
+    fail(`expected exactly one extension config in ${dir}, found ${entries.length}`, 2);
+  }
+  return path.join(dir, entries[0]);
+}
+
+function validateConfig(configPath, requestedId) {
+  assertSafeRegularFile(configPath, "extension config");
+  const config = ensureObject(readJson(configPath, "extension config"), "extension config");
+  if (config.api_version !== CONFIG_API) fail(`extension config api_version must be ${CONFIG_API}`);
+  validateId(config.id, "extension config id");
+  if (requestedId && config.id !== requestedId) fail(`requested extension id ${requestedId} does not match config id ${config.id}`);
+  if (typeof config.manifest_path !== "string" || !path.isAbsolute(config.manifest_path)) {
+    fail("extension config manifest_path must be an absolute local path");
+  }
+  if (hasScheme(config.manifest_path)) fail("extension config manifest_path must not use a URL or scheme");
+  validateHash(config.manifest_sha256, "extension config manifest_sha256");
+  return {
+    id: config.id,
+    configPath,
+    manifestPath: path.resolve(config.manifest_path),
+    manifestSha256: config.manifest_sha256,
+  };
+}
+
+function validatePermissions(permissions) {
+  if (permissions === undefined) return;
+  const value = ensureObject(permissions, "manifest permissions");
+  const allowed = new Set(["network", "read", "write"]);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) fail(`manifest permissions contains unknown key: ${key}`);
+  }
+  if (value.network !== undefined && value.network !== false) {
+    fail("manifest permissions.network must be false in Stage 0");
+  }
+  for (const key of ["read", "write"]) {
+    if (value[key] === undefined) continue;
+    const grants = ensureStringArray(value[key], `manifest permissions.${key}`);
+    if (grants.length > 0) fail(`manifest permissions.${key} must be empty in Stage 0`);
+  }
+}
+
+function validateSource(manifestPath, manifest) {
+  const source = ensureObject(manifest.source, "manifest source");
+  if (source.type !== "local_path") fail("manifest source.type must be local_path");
+  if (typeof source.path !== "string" || source.path.length === 0) fail("manifest source.path must be a non-empty string");
+  if (source.path.includes("\0")) fail("manifest source.path contains a NUL byte");
+  if (hasScheme(source.path)) fail("manifest source.path must be a local path");
+
+  const manifestDir = path.dirname(manifestPath);
+  const resolved = path.resolve(manifestDir, source.path);
+  const manifestDirReal = fs.realpathSync(manifestDir);
+  const sourceReal = fs.realpathSync(resolved);
+  if (!isInside(manifestDirReal, sourceReal)) {
+    fail(`manifest source.path escapes the manifest directory: ${source.path}`);
+  }
+  assertSafeDirectory(resolved, "extension source root");
+  return { sourceRoot: resolved, sourceRootReal: sourceReal };
+}
+
+function validateRequires(manifest, noMistakesBin, env) {
+  const requires = manifest.requires === undefined ? {} : ensureObject(manifest.requires, "manifest requires");
+  const known = new Set(["firstmate", "no_mistakes"]);
+  for (const key of Object.keys(requires)) {
+    if (!known.has(key)) fail(`manifest requires contains unknown key: ${key}`);
+  }
+  if (requires.firstmate !== undefined) {
+    const floor = parseFloorRequirement(requires.firstmate, "manifest requires.firstmate");
+    const actual = parseVersion(HOST_FIRSTMATE_VERSION);
+    if (!versionAtLeast(actual, floor)) {
+      fail(`firstmate ${HOST_FIRSTMATE_VERSION} does not satisfy ${requires.firstmate}`);
+    }
+  }
+  let noMistakes = null;
+  if (requires.no_mistakes !== undefined) {
+    const floor = parseFloorRequirement(requires.no_mistakes, "manifest requires.no_mistakes");
+    noMistakes = currentNoMistakesVersion(noMistakesBin, env);
+    if (!versionAtLeast(noMistakes.parsed, floor)) {
+      fail(`no-mistakes ${noMistakes.raw} does not satisfy ${requires.no_mistakes}`);
+    }
+  }
+  return { requires, noMistakes };
+}
+
+function validateExtension(opts, requestedId = "") {
+  if (!opts.home) fail("FM_HOME is required; pass --home or set FM_HOME", 2);
+  const configPath = discoverConfig(opts, requestedId);
+  const config = validateConfig(configPath, requestedId);
+
+  assertSafeRegularFile(config.manifestPath, "extension manifest");
+  const actualManifestHash = sha256File(config.manifestPath);
+  if (actualManifestHash !== config.manifestSha256) {
+    fail(`extension manifest hash mismatch: expected ${config.manifestSha256}, got ${actualManifestHash}`);
+  }
+
+  const manifest = ensureObject(readJson(config.manifestPath, "extension manifest"), "extension manifest");
+  if (manifest.api_version !== MANIFEST_API) fail(`extension manifest api_version must be ${MANIFEST_API}`);
+  validateId(manifest.id, "manifest id");
+  if (manifest.id !== config.id) fail(`manifest id ${manifest.id} does not match config id ${config.id}`);
+  validateVersion(manifest.version, "manifest version");
+  validatePermissions(manifest.permissions);
+
+  const { sourceRoot, sourceRootReal } = validateSource(config.manifestPath, manifest);
+  const manifestCapabilities = new Set(normalizeCapabilities(manifest.capabilities, "manifest capabilities"));
+  if (manifestCapabilities.size === 0) fail("manifest capabilities must not be empty");
+  for (const capability of manifestCapabilities) {
+    if (!KNOWN_CAPABILITIES.has(capability)) fail(`manifest capability is unknown: ${capability}`);
+  }
+
+  const versionEnv = {};
+  if (process.env.NM_HOME) versionEnv.NM_HOME = process.env.NM_HOME;
+  const needsNoMistakes = Array.from(manifestCapabilities).some((capability) => capability.startsWith("no_mistakes."));
+  const { noMistakes } = validateRequires(
+    {
+      ...manifest,
+      requires: needsNoMistakes
+        ? { no_mistakes: ">=0.0.0", ...(manifest.requires || {}) }
+        : manifest.requires,
+    },
+    opts.noMistakesBin,
+    versionEnv,
+  );
+
+  const rawEntrypoints = ensureObject(manifest.entrypoints, "manifest entrypoints");
+  const entrypoints = {};
+  for (const [name, entrypoint] of Object.entries(rawEntrypoints)) {
+    validateId(name, `entrypoint name ${name}`);
+    const value = ensureObject(entrypoint, `entrypoint ${name}`);
+    const entryPath = resolveStrictChild(sourceRoot, value.path, `entrypoint ${name}`);
+    assertSafeRegularFile(entryPath, `entrypoint ${name}`, { executable: true });
+    const entryReal = fs.realpathSync(entryPath);
+    if (!isInside(sourceRootReal, entryReal)) {
+      fail(`entrypoint ${name} resolves outside the extension source root`);
+    }
+    validateHash(value.sha256, `entrypoint ${name} sha256`);
+    const actualEntryHash = sha256File(entryPath);
+    if (actualEntryHash !== value.sha256) {
+      fail(`entrypoint ${name} hash mismatch: expected ${value.sha256}, got ${actualEntryHash}`);
+    }
+    const entryCapabilities = new Set(normalizeCapabilities(value.capabilities ?? value.capability, `entrypoint ${name} capabilities`));
+    if (entryCapabilities.size === 0) fail(`entrypoint ${name} capabilities must not be empty`);
+    for (const capability of entryCapabilities) {
+      if (!KNOWN_CAPABILITIES.has(capability)) fail(`entrypoint ${name} capability is unknown: ${capability}`);
+      if (!manifestCapabilities.has(capability)) fail(`entrypoint ${name} capability is not granted by manifest: ${capability}`);
+    }
+    let repoCommand = "";
+    if (entryCapabilities.has("no_mistakes.repo_command")) {
+      if (typeof value.no_mistakes_command !== "string" || !KNOWN_REPO_COMMANDS.has(value.no_mistakes_command)) {
+        fail(`entrypoint ${name} no_mistakes_command must be lint, test, or format`);
+      }
+      repoCommand = value.no_mistakes_command;
+    }
+    entrypoints[name] = {
+      name,
+      path: entryPath,
+      sha256: value.sha256,
+      capabilities: Array.from(entryCapabilities).sort(),
+      noMistakesCommand: repoCommand,
+    };
+  }
+  if (Object.keys(entrypoints).length === 0) fail("manifest entrypoints must not be empty");
+
+  return {
+    id: manifest.id,
+    version: manifest.version,
+    fmRoot: opts.fmRoot,
+    home: opts.home,
+    configPath,
+    manifestPath: config.manifestPath,
+    manifestSha256: config.manifestSha256,
+    sourceRoot,
+    capabilities: Array.from(manifestCapabilities).sort(),
+    entrypoints,
+    noMistakesBin: opts.noMistakesBin,
+    noMistakesVersion: noMistakes ? noMistakes.raw : "",
+  };
+}
+
+function stateDirFor(validated) {
+  return path.join(validated.home, "state", "extensions", validated.id);
+}
+
+function generatedDirFor(validated) {
+  return path.join(stateDirFor(validated), "generated");
+}
+
+function generatedWrapperPath(validated, entrypointName) {
+  return path.join(generatedDirFor(validated), "wrappers", entrypointName);
+}
+
+function ensureCreatedDirectory(dir, mode = 0o700) {
+  const existed = fs.existsSync(dir);
+  fs.mkdirSync(dir, { recursive: true, mode });
+  const st = lstatSafe(dir, "generated directory");
+  if (st.isSymbolicLink()) fail(`generated directory must not be a symlink: ${dir}`);
+  if (!st.isDirectory()) fail(`generated directory must be a directory: ${dir}`);
+  if ((st.mode & 0o022) !== 0) fail(`generated directory must not be group- or world-writable: ${dir}`);
+  if (!existed) fs.chmodSync(dir, mode);
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function writeGeneratedFile(file, content) {
+  if (fs.existsSync(file)) {
+    const st = fs.lstatSync(file);
+    if (st.isSymbolicLink() || !st.isFile()) {
+      fail(`refusing to overwrite unsafe generated path: ${file}`);
+    }
+    const current = fs.readFileSync(file, "utf8");
+    if (!current.includes(GENERATED_MARKER)) {
+      fail(`refusing to overwrite unowned generated path: ${file}`);
+    }
+  }
+  const dir = path.dirname(file);
+  ensureCreatedDirectory(dir);
+  const tmp = path.join(dir, `.tmp.${process.pid}.${Date.now()}`);
+  fs.writeFileSync(tmp, content, { mode: 0o700 });
+  fs.renameSync(tmp, file);
+  fs.chmodSync(file, 0o700);
+}
+
+function ownerJson(validated) {
+  return `${JSON.stringify(
+    {
+      api_version: GENERATED_API,
+      id: validated.id,
+      version: validated.version,
+      manifest_path: validated.manifestPath,
+      manifest_sha256: validated.manifestSha256,
+      generated_by: "bin/fm-extension.sh",
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function writeOwnerMarker(file, validated) {
+  if (fs.existsSync(file)) {
+    const st = fs.lstatSync(file);
+    if (st.isSymbolicLink() || !st.isFile()) {
+      fail(`refusing to overwrite unsafe generated owner marker: ${file}`);
+    }
+    if (!isOwnedGeneratedFile(file, validated.id)) {
+      fail(`refusing to overwrite unowned generated owner marker: ${file}`);
+    }
+  }
+  const dir = path.dirname(file);
+  ensureCreatedDirectory(dir);
+  const tmp = path.join(dir, `.tmp-owner.${process.pid}.${Date.now()}`);
+  fs.writeFileSync(tmp, ownerJson(validated), { mode: 0o600 });
+  fs.renameSync(tmp, file);
+  fs.chmodSync(file, 0o600);
+}
+
+function commandActivate(opts, id) {
+  const validated = validateExtension(opts, id);
+  const generatedDir = generatedDirFor(validated);
+  const wrappersDir = path.join(generatedDir, "wrappers");
+  ensureCreatedDirectory(generatedDir);
+  ensureCreatedDirectory(wrappersDir);
+  writeOwnerMarker(path.join(generatedDir, ".owner.json"), validated);
+  for (const entrypoint of Object.values(validated.entrypoints)) {
+    const wrapper = `#!/usr/bin/env bash
+${GENERATED_MARKER} id=${validated.id} entrypoint=${entrypoint.name}
+set -u
+exec ${shellQuote(path.join(validated.fmRoot, "bin", "fm-extension.sh"))} --home ${shellQuote(validated.home)} --config ${shellQuote(validated.configPath)} --no-mistakes-bin ${shellQuote(validated.noMistakesBin)} run ${shellQuote(validated.id)} ${shellQuote(entrypoint.name)} -- "$@"
+`;
+    writeGeneratedFile(generatedWrapperPath(validated, entrypoint.name), wrapper);
+  }
+  process.stdout.write(`fm-extension: activated ${validated.id} generated=${generatedDir}\n`);
+}
+
+function isOwnedGeneratedFile(file, id) {
+  const name = path.basename(file);
+  if (name === ".owner.json") {
+    try {
+      const value = readJson(file, "generated owner marker");
+      return value.api_version === GENERATED_API && value.id === id;
+    } catch {
+      return false;
+    }
+  }
+  try {
+    const st = fs.lstatSync(file);
+    if (!st.isFile() || st.isSymbolicLink()) return false;
+    const fd = fs.openSync(file, "r");
+    const buffer = Buffer.alloc(512);
+    const bytes = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    fs.closeSync(fd);
+    const head = buffer.subarray(0, bytes).toString("utf8");
+    return head.includes(`${GENERATED_MARKER} id=${id} `);
+  } catch {
+    return false;
+  }
+}
+
+function walkFiles(root) {
+  const files = [];
+  const dirs = [];
+  if (!fs.existsSync(root)) return { files, dirs };
+  const visit = (dir) => {
+    dirs.push(dir);
+    for (const name of fs.readdirSync(dir)) {
+      const file = path.join(dir, name);
+      const st = fs.lstatSync(file);
+      if (st.isDirectory() && !st.isSymbolicLink()) {
+        visit(file);
+      } else {
+        files.push(file);
+      }
+    }
+  };
+  visit(root);
+  return { files, dirs };
+}
+
+function commandDeactivate(opts, id) {
+  if (!id) fail("deactivate requires an extension id", 2);
+  if (!opts.home) fail("FM_HOME is required; pass --home or set FM_HOME", 2);
+  validateId(id, "extension id");
+  const generatedDir = path.join(opts.home, "state", "extensions", id, "generated");
+  if (!fs.existsSync(generatedDir)) {
+    process.stdout.write(`fm-extension: no generated material for ${id}\n`);
+    return;
+  }
+  const rootStat = lstatSafe(generatedDir, "generated directory");
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) fail(`generated path is not a safe directory: ${generatedDir}`);
+  const { files, dirs } = walkFiles(generatedDir);
+  let removed = 0;
+  let left = 0;
+  for (const file of files) {
+    if (isOwnedGeneratedFile(file, id)) {
+      fs.unlinkSync(file);
+      removed += 1;
+    } else {
+      left += 1;
+    }
+  }
+  dirs.sort((a, b) => b.length - a.length);
+  for (const dir of dirs) {
+    try {
+      fs.rmdirSync(dir);
+    } catch {
+      // Non-empty directories are preserved when they contain unmarked material.
+    }
+  }
+  process.stdout.write(`fm-extension: deactivated ${id} removed=${removed} left_unowned=${left}\n`);
+}
+
+function runSpawn(command, args, env) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    env,
+  });
+  if (result.error) {
+    process.stderr.write(`fm-extension: failed to execute ${command}: ${result.error.message}\n`);
+    return 127;
+  }
+  if (result.signal) {
+    process.stderr.write(`fm-extension: ${command} terminated by ${result.signal}\n`);
+    return 128;
+  }
+  return result.status ?? 1;
+}
+
+function commandRun(opts, rest) {
+  const id = rest[0];
+  const entrypointName = rest[1];
+  if (!id || !entrypointName) fail("run requires <id> <entrypoint>", 2);
+  validateId(id, "extension id");
+  validateId(entrypointName, "entrypoint name");
+  let args = rest.slice(2);
+  if (args[0] === "--") args = args.slice(1);
+  const validated = validateExtension(opts, id);
+  const entrypoint = validated.entrypoints[entrypointName];
+  if (!entrypoint) fail(`unknown entrypoint for ${id}: ${entrypointName}`, 2);
+  const env = {
+    ...process.env,
+    FM_EXTENSION_ID: validated.id,
+    FM_EXTENSION_VERSION: validated.version,
+    FM_EXTENSION_ENTRYPOINT: entrypoint.name,
+    FM_EXTENSION_ROOT: validated.sourceRoot,
+    FM_EXTENSION_MANIFEST: validated.manifestPath,
+    FM_EXTENSION_MANIFEST_SHA256: validated.manifestSha256,
+    FM_EXTENSION_GENERATED_DIR: generatedDirFor(validated),
+    FM_EXTENSION_NETWORK: "0",
+    FM_EXTENSION_READ_ROOTS: "",
+    FM_EXTENSION_WRITE_ROOTS: "",
+    FM_HOME: validated.home,
+    FM_ROOT: validated.fmRoot,
+    NO_MISTAKES_BIN: validated.noMistakesBin,
+    NO_MISTAKES_VERSION: validated.noMistakesVersion,
+    NO_MISTAKES_NO_UPDATE_CHECK: "1",
+  };
+  process.exitCode = runSpawn(entrypoint.path, args, env);
+}
+
+function commandDoctor(opts, id) {
+  const validated = validateExtension(opts, id);
+  process.stdout.write(
+    `fm-extension: ok ${validated.id} ${validated.version} manifest=${validated.manifestPath} capabilities=${validated.capabilities.join(",")}\n`,
+  );
+}
+
+function yamlSingleQuote(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function commandRenderNoMistakes(opts, id) {
+  const validated = validateExtension(opts, id);
+  const commands = [];
+  for (const entrypoint of Object.values(validated.entrypoints)) {
+    if (!entrypoint.capabilities.includes("no_mistakes.repo_command")) continue;
+    commands.push([entrypoint.noMistakesCommand, generatedWrapperPath(validated, entrypoint.name)]);
+  }
+  if (commands.length === 0) fail(`extension ${validated.id} has no no_mistakes.repo_command entrypoints`);
+  process.stdout.write("commands:\n");
+  for (const [name, wrapper] of commands) {
+    process.stdout.write(`  ${name}: ${yamlSingleQuote(wrapper)}\n`);
+  }
+}
+
+function commandObserveNoMistakes(opts, rest) {
+  const id = rest[0];
+  const action = rest[1];
+  if (!id || !action) fail("observe-no-mistakes requires <id> <status|logs>", 2);
+  validateId(id, "extension id");
+  if (!READ_ONLY_AXI.has(action)) {
+    fail(`observe-no-mistakes only permits read-only AXI actions: ${Array.from(READ_ONLY_AXI).join(", ")}`, 2);
+  }
+  let args = rest.slice(2);
+  if (args[0] === "--") args = args.slice(1);
+  const validated = validateExtension(opts, id);
+  if (!validated.capabilities.includes("no_mistakes.axi_observe")) {
+    fail(`extension ${validated.id} is not granted no_mistakes.axi_observe`);
+  }
+  const env = {
+    ...process.env,
+    FM_EXTENSION_ID: validated.id,
+    FM_EXTENSION_VERSION: validated.version,
+    FM_HOME: validated.home,
+    FM_ROOT: validated.fmRoot,
+    NO_MISTAKES_NO_UPDATE_CHECK: "1",
+  };
+  process.exitCode = runSpawn(validated.noMistakesBin, ["axi", action, ...args], env);
+}
+
+function main() {
+  const { opts, rest } = parseGlobal(process.argv.slice(2));
+  if (opts.help || rest.length === 0) {
+    usage();
+    return;
+  }
+  const command = rest[0];
+  const args = rest.slice(1);
+  if (command === "doctor") commandDoctor(opts, args[0] || "");
+  else if (command === "activate") commandActivate(opts, args[0] || "");
+  else if (command === "deactivate") commandDeactivate(opts, args[0] || "");
+  else if (command === "run") commandRun(opts, args);
+  else if (command === "render-no-mistakes") commandRenderNoMistakes(opts, args[0] || "");
+  else if (command === "observe-no-mistakes") commandObserveNoMistakes(opts, args);
+  else fail(`unknown command: ${command}`, 2);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`fm-extension: ${error.message}\n`);
+  process.exitCode = error.exitCode || 1;
+}

--- a/bin/fm-extension-host.mjs
+++ b/bin/fm-extension-host.mjs
@@ -431,7 +431,7 @@ function shellQuote(value) {
   return `'${String(value).replace(/'/g, "'\\''")}'`;
 }
 
-function writeGeneratedFile(file, content) {
+function writeGeneratedFile(file, content, validated) {
   if (fs.existsSync(file)) {
     const st = fs.lstatSync(file);
     if (st.isSymbolicLink() || !st.isFile()) {
@@ -443,7 +443,7 @@ function writeGeneratedFile(file, content) {
     }
   }
   const dir = path.dirname(file);
-  ensureCreatedDirectory(dir);
+  ensureOwnedGeneratedDirectory(dir, validated);
   const tmp = path.join(dir, `.tmp.${process.pid}.${Date.now()}`);
   fs.writeFileSync(tmp, content, { mode: 0o700 });
   fs.renameSync(tmp, file);
@@ -483,20 +483,24 @@ function writeOwnerMarker(file, validated) {
   fs.chmodSync(file, 0o600);
 }
 
+function ensureOwnedGeneratedDirectory(dir, validated) {
+  ensureCreatedDirectory(dir);
+  writeOwnerMarker(path.join(dir, ".owner.json"), validated);
+}
+
 function commandActivate(opts, id) {
   const validated = validateExtension(opts, id);
   const generatedDir = generatedDirFor(validated);
   const wrappersDir = path.join(generatedDir, "wrappers");
-  ensureCreatedDirectory(generatedDir);
-  ensureCreatedDirectory(wrappersDir);
-  writeOwnerMarker(path.join(generatedDir, ".owner.json"), validated);
+  ensureOwnedGeneratedDirectory(generatedDir, validated);
+  ensureOwnedGeneratedDirectory(wrappersDir, validated);
   for (const entrypoint of Object.values(validated.entrypoints)) {
     const wrapper = `#!/usr/bin/env bash
 ${GENERATED_MARKER} id=${validated.id} entrypoint=${entrypoint.name}
 set -u
 exec ${shellQuote(path.join(validated.fmRoot, "bin", "fm-extension.sh"))} --home ${shellQuote(validated.home)} --config ${shellQuote(validated.configPath)} --no-mistakes-bin ${shellQuote(validated.noMistakesBin)} run ${shellQuote(validated.id)} ${shellQuote(entrypoint.name)} -- "$@"
 `;
-    writeGeneratedFile(generatedWrapperPath(validated, entrypoint.name), wrapper);
+    writeGeneratedFile(generatedWrapperPath(validated, entrypoint.name), wrapper, validated);
   }
   process.stdout.write(`fm-extension: activated ${validated.id} generated=${generatedDir}\n`);
 }
@@ -520,6 +524,16 @@ function isOwnedGeneratedFile(file, id) {
     fs.closeSync(fd);
     const head = buffer.subarray(0, bytes).toString("utf8");
     return head.includes(`${GENERATED_MARKER} id=${id} `);
+  } catch {
+    return false;
+  }
+}
+
+function isOwnedGeneratedDirectory(dir, id) {
+  try {
+    const st = fs.lstatSync(dir);
+    if (!st.isDirectory() || st.isSymbolicLink()) return false;
+    return isOwnedGeneratedFile(path.join(dir, ".owner.json"), id);
   } catch {
     return false;
   }
@@ -557,9 +571,14 @@ function commandDeactivate(opts, id) {
   const rootStat = lstatSafe(generatedDir, "generated directory");
   if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) fail(`generated path is not a safe directory: ${generatedDir}`);
   const { files, dirs } = walkFiles(generatedDir);
+  const ownedDirs = dirs.filter((dir) => isInside(generatedDir, dir) && isOwnedGeneratedDirectory(dir, id));
+  const ownedDirSet = new Set(ownedDirs);
   let removed = 0;
   let left = 0;
   for (const file of files) {
+    if (path.basename(file) === ".owner.json" && ownedDirSet.has(path.dirname(file))) {
+      continue;
+    }
     if (isOwnedGeneratedFile(file, id)) {
       fs.unlinkSync(file);
       removed += 1;
@@ -567,12 +586,19 @@ function commandDeactivate(opts, id) {
       left += 1;
     }
   }
-  dirs.sort((a, b) => b.length - a.length);
   for (const dir of dirs) {
+    if (!ownedDirs.includes(dir)) left += 1;
+  }
+  ownedDirs.sort((a, b) => b.length - a.length);
+  for (const dir of ownedDirs) {
     try {
+      const marker = path.join(dir, ".owner.json");
+      const entries = fs.readdirSync(dir).filter((name) => name !== ".owner.json");
+      if (entries.length > 0 || !isOwnedGeneratedFile(marker, id)) continue;
+      fs.unlinkSync(marker);
+      removed += 1;
       fs.rmdirSync(dir);
     } catch {
-      // Non-empty directories are preserved when they contain unmarked material.
     }
   }
   process.stdout.write(`fm-extension: deactivated ${id} removed=${removed} left_unowned=${left}\n`);

--- a/bin/fm-extension.sh
+++ b/bin/fm-extension.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# fm-extension.sh - minimal Firstmate-owned local extension host.
+#
+# Stage 0 intentionally supports one explicit local extension at a time.
+# The extension is discovered from a local config JSON file, validated against a
+# `firstmate.extension/v1` manifest, and invoked only as a subprocess wrapper.
+# No code is loaded in-process, no remote source is downloaded, and no upstream
+# No Mistakes repository or shared daemon state is mutated by this host.
+#
+# Config discovery:
+#   --config <path>                    use one explicit config file
+#   --home <FM_HOME> <id>              use <FM_HOME>/config/extensions.d/<id>.json
+#   --home <FM_HOME>                   discover only when that dir has exactly one JSON config
+#
+# Config JSON:
+#   {
+#     "api_version": "firstmate.extension.config/v1",
+#     "id": "owned-nm-policy",
+#     "manifest_path": "/absolute/local/extension/extension.json",
+#     "manifest_sha256": "<64 lowercase hex sha256>"
+#   }
+#
+# Manifest JSON:
+#   {
+#     "api_version": "firstmate.extension/v1",
+#     "id": "owned-nm-policy",
+#     "version": "0.1.0",
+#     "source": { "type": "local_path", "path": "." },
+#     "requires": { "firstmate": ">=0.0.0", "no_mistakes": ">=1.40.1" },
+#     "capabilities": ["no_mistakes.repo_command", "no_mistakes.axi_observe"],
+#     "permissions": { "network": false, "read": [], "write": [] },
+#     "entrypoints": {
+#       "lint": {
+#         "path": "bin/lint-wrapper",
+#         "sha256": "<64 lowercase hex sha256>",
+#         "capabilities": ["no_mistakes.repo_command"],
+#         "no_mistakes_command": "lint"
+#       }
+#     }
+#   }
+#
+# Commands:
+#   fm-extension.sh doctor [id]                         validate only
+#   fm-extension.sh activate [id]                       render owner-marked local wrappers
+#   fm-extension.sh deactivate [id]                     remove only owner-marked generated files
+#   fm-extension.sh run <id> <entrypoint> -- [args...]  run one validated wrapper entrypoint
+#   fm-extension.sh render-no-mistakes [id]             print trusted repo-command YAML snippets
+#   fm-extension.sh observe-no-mistakes <id> status -- [args...]
+#   fm-extension.sh observe-no-mistakes <id> logs -- [args...]
+#
+# Global options:
+#   --home <FM_HOME>             local firstmate home for config/state
+#   --config <path>              explicit extension config JSON
+#   --no-mistakes-bin <path>     No Mistakes binary for version checks and AXI observation
+#   -h, --help                   print this header
+#
+# Generated material lives under:
+#   <FM_HOME>/state/extensions/<id>/generated/
+#
+# Deactivation only removes generated files carrying this host's owner marker.
+set -u
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SELF_DIR/.." && pwd)"
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  sed -n '2,58{s/^# \{0,1\}//;p;}' "$0"
+  exit 0
+fi
+
+exec node "$SELF_DIR/fm-extension-host.mjs" --fm-root "$ROOT" "$@"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -120,7 +120,7 @@ family_for_basename() {
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|fm-brief.test.sh|\
     fm-calm-pi-extension.test.sh|fm-captain-translation-contract.test.sh|fm-cd-pretool-check.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
-    fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
+    fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|fm-extension.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
     fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
@@ -684,6 +684,7 @@ families_for_changed_path() {
       ;;
     bin/fm-lint.sh|bin/fm-install-shellcheck.sh|\
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
+    bin/fm-extension.sh|bin/fm-extension-host.mjs|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
@@ -702,7 +703,7 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       ;;
     .github/*|.tasks.toml|AGENTS.md|CLAUDE.md|CONTRIBUTING.md|\
-    docs/configuration.md|docs/supervision-protocols/*)
+    docs/configuration.md|docs/extensions.md|docs/supervision-protocols/*)
       printf '%s\n' pure-contract-unit
       ;;
     tests/lib.sh|tests/*-helpers.sh)

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -25,6 +25,7 @@
   ],
   "readmeSetupTargets": [
     "docs/configuration.md",
+    "docs/extensions.md",
     "docs/wedge-alarm.md",
     "docs/tmux-backend.md",
     "docs/herdr-backend.md",

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -224,6 +224,10 @@
       "audience": "maintainer-architecture"
     },
     {
+      "path": "docs/extensions.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/documentation-audiences.md",
       "audience": "maintainer-architecture"
     },

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,74 @@
+# Firstmate-Owned Extensions
+
+`bin/fm-extension.sh` owns the Stage 0 local extension host mechanics and help output.
+This page records the current operating boundary and the supported proof surface.
+
+Stage 0 exists to validate one explicitly configured local extension pack.
+It does not implement a plugin marketplace, automatic network installs, secondmate distribution, ACP proxying, new No Mistakes pipeline phases, an upstream No Mistakes fork, or production activation.
+
+## Manifest Boundary
+
+The only supported manifest API is `firstmate.extension/v1`.
+The only supported config API is `firstmate.extension.config/v1`.
+The config file names one absolute local manifest path and the expected SHA-256 of that manifest.
+The manifest names an ID, version, local source path, version requirements, explicit capabilities, default-deny permissions, and hashed entrypoints.
+The source path must be local and must stay inside the directory that contains the manifest.
+Entry points must be regular owner-executable files, must not be symlinks, must not escape the source root, must not be group-writable, and must not be world-writable.
+The extension source root, config file, manifest file, and entrypoint files must not be unsafe group-writable or world-writable paths.
+
+Stage 0 accepts only these capabilities.
+
+- `no_mistakes.repo_command` allows a generated wrapper to be used as a trusted No Mistakes `commands.lint`, `commands.test`, or `commands.format` command.
+- `no_mistakes.wrapper` is reserved for wrapper entrypoints that call the installed No Mistakes binary without replacing it.
+- `no_mistakes.axi_observe` allows read-only `no-mistakes axi status` and `no-mistakes axi logs` observation through the host.
+
+Unknown capabilities fail closed.
+Capability grants are not inherited across capability families.
+The host never calls `no-mistakes axi run` or `no-mistakes axi respond`.
+
+Stage 0 permissions are default-deny metadata, not an operating-system sandbox.
+`permissions.network` must be absent or `false`.
+`permissions.read` and `permissions.write` must be absent or empty arrays.
+Any requested read, write, or network permission fails activation and execution.
+
+## Local Lifecycle
+
+Use `bin/fm-extension.sh doctor` to validate a configured extension without writing generated material.
+Use `bin/fm-extension.sh activate` to render owner-marked local wrapper files under `<FM_HOME>/state/extensions/<id>/generated/`.
+Use `bin/fm-extension.sh render-no-mistakes` to print the trusted `.no-mistakes.yaml` command snippet for activated wrappers.
+Use `bin/fm-extension.sh run <id> <entrypoint> -- ...` to execute one validated entrypoint as a subprocess with a deterministic environment.
+Use `bin/fm-extension.sh observe-no-mistakes <id> status` or `logs` for read-only AXI observation.
+Use `bin/fm-extension.sh deactivate <id>` to remove only owner-marked generated files.
+
+Deactivation leaves unmarked local files in place.
+Deactivation leaves logs and other non-generated state in place.
+This prevents the host from deleting material it did not create.
+
+## No Mistakes Boundary
+
+The host treats No Mistakes as an installed external binary.
+It checks compatibility with `no-mistakes --version`.
+It never replaces `/home/exedev/.local/bin/no-mistakes`.
+It never mutates `/home/exedev/kun-agent-workspace/projects/no-mistakes`.
+It never starts, stops, restarts, or updates the shared No Mistakes daemon.
+Tests use disposable scratch repositories and isolated `NM_HOME` values.
+
+The Stage 0 proof uses No Mistakes only through supported command and AXI seams.
+Generated repo-command wrappers are ordinary subprocesses that No Mistakes can call from `commands.lint`, `commands.test`, or `commands.format`.
+Read-only observability is limited to `axi status` and `axi logs`.
+Pipeline ownership remains with the worker that starts a No Mistakes run, as required by `AGENTS.md`.
+
+External No Mistakes PR #588 is outside this implementation path.
+That PR is not required for implementation, certification, deployment, or release of the Firstmate-owned extension host.
+Any future workflow affected by branchsync custody behavior must be gated by installed No Mistakes version checks rather than by upstream PR status.
+
+## Integration Review
+
+The Stage 0 host is a standalone subprocess tool under `bin/`.
+It does not change any supported worker harness launch adapter.
+It does not change any supported runtime backend adapter.
+It does not change `fm-spawn.sh`, `fm-harness.sh`, `fm-backend.sh`, or `bin/backends/*`.
+Those axes are not applicable to this milestone because no dispatch, terminal, turn-end, watcher lifecycle, or backend protocol path invokes the host automatically.
+
+The affected integration axes are local config discovery, generated local state, No Mistakes repo-command wrappers, and read-only No Mistakes AXI observation.
+`tests/fm-extension.test.sh` covers malformed manifests, unknown capabilities, path traversal, symlinks, unsafe modes, world-writable paths, hash mismatches, incompatible versions, explicit write and network denial, activation ownership markers, clean deactivation, wrapper failure propagation, isolated `NM_HOME`, and read-only AXI observation.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -48,8 +48,8 @@ This prevents the host from deleting material it did not create.
 
 The host treats No Mistakes as an installed external binary.
 It checks compatibility with `no-mistakes --version`.
-It never replaces `/home/exedev/.local/bin/no-mistakes`.
-It never mutates `/home/exedev/kun-agent-workspace/projects/no-mistakes`.
+It never replaces the installed `no-mistakes` binary.
+It never mutates any No Mistakes project clone.
 It never starts, stops, restarts, or updates the shared No Mistakes daemon.
 Tests use disposable scratch repositories and isolated `NM_HOME` values.
 
@@ -60,6 +60,7 @@ Pipeline ownership remains with the worker that starts a No Mistakes run, as req
 
 External No Mistakes PR #588 is outside this implementation path.
 That PR is not required for implementation, certification, deployment, or release of the Firstmate-owned extension host.
+Uncontrolled repositories, including `kunchenguid/no-mistakes` and any upstream fork, remain outside implementation, certification, deployment, and release for this milestone.
 Any future workflow affected by branchsync custody behavior must be gated by installed No Mistakes version checks rather than by upstream PR status.
 
 ## Integration Review

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -26,6 +26,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
+| `fm-extension.sh`       | Validate and run one explicitly configured local Firstmate extension without loading extension code in-process |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |

--- a/tests/fm-extension.test.sh
+++ b/tests/fm-extension.test.sh
@@ -219,7 +219,7 @@ test_manifest_security_rejections() {
 }
 
 test_activation_and_deactivation_markers() {
-  local tmp generated wrapper unowned out
+  local tmp generated wrapper unowned out owned_empty owned_nested unmarked_empty mismatch_dir escape_target escape_link
   tmp=$(fm_test_tmproot fm-extension-unowned-marker)
   setup_case "$tmp"
   generated="$CASE_HOME/state/extensions/$CASE_ID/generated"
@@ -234,6 +234,7 @@ test_activation_and_deactivation_markers() {
   generated="$CASE_HOME/state/extensions/$CASE_ID/generated"
   wrapper="$generated/wrappers/lint"
   assert_present "$generated/.owner.json" "activation did not write owner marker"
+  assert_present "$generated/wrappers/.owner.json" "activation did not mark generated wrapper directory"
   assert_present "$wrapper" "activation did not write generated wrapper"
   [ -x "$wrapper" ] || fail "generated wrapper is not executable"
   assert_grep "firstmate-extension-generated firstmate.extension.generated/v1 id=$CASE_ID" "$wrapper" \
@@ -244,14 +245,54 @@ test_activation_and_deactivation_markers() {
 
   unowned="$generated/wrappers/unowned"
   printf 'do not remove me\n' > "$unowned"
+  unmarked_empty="$generated/unmarked-empty"
+  mkdir -p "$unmarked_empty"
+  mismatch_dir="$generated/mismatch-empty"
+  mkdir -p "$mismatch_dir"
+  printf '{"api_version":"firstmate.extension.generated/v1","id":"other-extension"}\n' > "$mismatch_dir/.owner.json"
+  owned_empty="$generated/owned-empty"
+  mkdir -p "$owned_empty"
+  cp "$generated/.owner.json" "$owned_empty/.owner.json"
+  owned_nested="$generated/owned-nested/child"
+  mkdir -p "$owned_nested"
+  cp "$generated/.owner.json" "$generated/owned-nested/.owner.json"
+  cp "$generated/.owner.json" "$owned_nested/.owner.json"
+  escape_target="$tmp/escape-target"
+  mkdir -p "$escape_target"
+  cp "$generated/.owner.json" "$escape_target/.owner.json"
+  escape_link="$generated/wrappers/escape-link"
+  ln -s "$escape_target" "$escape_link"
   out=$(fm_ext deactivate "$CASE_ID") || fail "deactivate should succeed: $out"
   assert_absent "$wrapper" "deactivate removed no generated wrapper"
-  assert_absent "$generated/.owner.json" "deactivate did not remove owner marker"
+  assert_present "$generated/.owner.json" "deactivate removed a blocked directory owner marker"
+  assert_present "$generated/wrappers/.owner.json" "deactivate removed a blocked nested directory owner marker"
   assert_present "$unowned" "deactivate removed unowned material"
+  assert_present "$unmarked_empty" "deactivate removed an empty unmarked directory"
+  assert_present "$mismatch_dir" "deactivate removed a mismatched directory"
+  assert_present "$mismatch_dir/.owner.json" "deactivate removed mismatched owner marker"
+  assert_absent "$owned_empty" "deactivate preserved an empty marked directory"
+  assert_absent "$generated/owned-nested" "deactivate preserved a nested marked directory"
+  assert_present "$escape_link" "deactivate removed an unowned symlink escape"
+  assert_present "$escape_target/.owner.json" "deactivate followed a symlink escape"
   rm -f "$unowned"
+  rm -f "$escape_link"
+  rm -rf "$unmarked_empty" "$mismatch_dir"
   out=$(fm_ext deactivate "$CASE_ID") || fail "second deactivate should clean empty dirs: $out"
   assert_absent "$generated" "deactivate did not remove empty generated directory"
   pass "activation and deactivation honor owner markers"
+}
+
+test_deactivation_is_idempotent_without_unowned_material() {
+  local tmp generated out
+  tmp=$(fm_test_tmproot fm-extension-idempotent)
+  setup_case "$tmp"
+  fm_ext activate "$CASE_ID" >/dev/null || fail "activate should succeed"
+  generated="$CASE_HOME/state/extensions/$CASE_ID/generated"
+  out=$(fm_ext deactivate "$CASE_ID") || fail "deactivate should succeed: $out"
+  assert_absent "$generated" "deactivate did not remove owned generated tree"
+  out=$(fm_ext deactivate "$CASE_ID") || fail "second deactivate should be idempotent: $out"
+  assert_contains "$out" "no generated material" "second deactivate did not report idempotent no-op"
+  pass "deactivation is idempotent after owned generated cleanup"
 }
 
 test_wrapper_failure_behavior() {
@@ -321,6 +362,7 @@ test_read_only_no_mistakes_observability() {
 test_valid_manifest_doctor
 test_manifest_security_rejections
 test_activation_and_deactivation_markers
+test_deactivation_is_idempotent_without_unowned_material
 test_wrapper_failure_behavior
 test_isolated_nm_home_repo_command_wrapper
 test_read_only_no_mistakes_observability

--- a/tests/fm-extension.test.sh
+++ b/tests/fm-extension.test.sh
@@ -219,7 +219,7 @@ test_manifest_security_rejections() {
 }
 
 test_activation_and_deactivation_markers() {
-  local tmp generated wrapper unowned out owned_empty owned_nested unmarked_empty mismatch_dir escape_target escape_link
+  local tmp generated wrapper unowned out owned_empty owned_nested unmarked_empty mismatch_dir escape_target escape_link before
   tmp=$(fm_test_tmproot fm-extension-unowned-marker)
   setup_case "$tmp"
   generated="$CASE_HOME/state/extensions/$CASE_ID/generated"
@@ -227,6 +227,31 @@ test_activation_and_deactivation_markers() {
   printf '{"api_version":"other","id":"someone-else"}\n' > "$generated/.owner.json"
   expect_fm_ext_fail "activation refuses unowned generated owner markers" \
     "refusing to overwrite unowned generated owner marker" activate "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-unowned-wrapper)
+  setup_case "$tmp"
+  generated="$CASE_HOME/state/extensions/$CASE_ID/generated"
+  wrapper="$generated/wrappers/lint"
+  mkdir -p "$generated/wrappers"
+  printf '{"api_version":"firstmate.extension.generated/v1","id":"%s"}\n' "$CASE_ID" > "$generated/.owner.json"
+  printf '{"api_version":"firstmate.extension.generated/v1","id":"%s"}\n' "$CASE_ID" > "$generated/wrappers/.owner.json"
+  printf 'user-created wrapper\n' > "$wrapper"
+  expect_fm_ext_fail "activation refuses unmarked generated wrapper files" \
+    "refusing to overwrite unowned generated path" activate "$CASE_ID"
+  assert_grep "user-created wrapper" "$wrapper" "activation overwrote unmarked wrapper material"
+
+  tmp=$(fm_test_tmproot fm-extension-mismatched-wrapper)
+  setup_case "$tmp"
+  generated="$CASE_HOME/state/extensions/$CASE_ID/generated"
+  wrapper="$generated/wrappers/lint"
+  mkdir -p "$generated/wrappers"
+  printf '{"api_version":"firstmate.extension.generated/v1","id":"%s"}\n' "$CASE_ID" > "$generated/.owner.json"
+  printf '{"api_version":"firstmate.extension.generated/v1","id":"%s"}\n' "$CASE_ID" > "$generated/wrappers/.owner.json"
+  printf '#!/usr/bin/env bash\n# firstmate-extension-generated firstmate.extension.generated/v1 id=other-extension entrypoint=lint\nprintf mismatched\\n\n' > "$wrapper"
+  chmod 700 "$wrapper"
+  expect_fm_ext_fail "activation refuses mismatched generated wrapper files" \
+    "refusing to overwrite unowned generated path" activate "$CASE_ID"
+  assert_grep "id=other-extension" "$wrapper" "activation overwrote mismatched wrapper material"
 
   tmp=$(fm_test_tmproot fm-extension-activate)
   setup_case "$tmp"
@@ -239,6 +264,12 @@ test_activation_and_deactivation_markers() {
   [ -x "$wrapper" ] || fail "generated wrapper is not executable"
   assert_grep "firstmate-extension-generated firstmate.extension.generated/v1 id=$CASE_ID" "$wrapper" \
     "generated wrapper lacks owner marker"
+  before=$(sha256_file "$wrapper")
+  printf '#!/usr/bin/env bash\n# firstmate-extension-generated firstmate.extension.generated/v1 id=%s entrypoint=lint\nprintf stale\\n\n' "$CASE_ID" > "$wrapper"
+  chmod 700 "$wrapper"
+  out=$(fm_ext activate "$CASE_ID") || fail "activation should overwrite matching owned wrapper: $out"
+  [ "$(sha256_file "$wrapper")" = "$before" ] || fail "activation did not refresh matching owned wrapper"
+  assert_grep "exec " "$wrapper" "activation failed to restore matching owned wrapper content"
   out=$(fm_ext render-no-mistakes "$CASE_ID") || fail "render-no-mistakes should succeed"
   assert_contains "$out" "commands:" "render-no-mistakes did not print commands root"
   assert_contains "$out" "lint:" "render-no-mistakes did not print lint command"

--- a/tests/fm-extension.test.sh
+++ b/tests/fm-extension.test.sh
@@ -295,6 +295,40 @@ test_deactivation_is_idempotent_without_unowned_material() {
   pass "deactivation is idempotent after owned generated cleanup"
 }
 
+test_deactivation_rejects_generated_path_symlinks() {
+  local tmp generated outside out rc
+  tmp=$(fm_test_tmproot fm-extension-ancestor-symlink)
+  setup_case "$tmp"
+  fm_ext activate "$CASE_ID" >/dev/null || fail "activate should succeed"
+  generated="$CASE_HOME/state/extensions/$CASE_ID/generated"
+  outside="$tmp/outside-extension-state"
+  mkdir -p "$outside"
+  mv "$generated" "$outside/generated"
+  rm -rf "$CASE_HOME/state/extensions/$CASE_ID"
+  ln -s "$outside" "$CASE_HOME/state/extensions/$CASE_ID"
+  out=$(fm_ext deactivate "$CASE_ID" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "deactivate should reject ancestor symlink"
+  assert_contains "$out" "generated directory path must not contain a symlink" \
+    "ancestor symlink rejection was not explicit"
+  assert_present "$outside/generated/.owner.json" "deactivate followed ancestor symlink and removed escaped material"
+
+  tmp=$(fm_test_tmproot fm-extension-final-symlink)
+  setup_case "$tmp"
+  fm_ext activate "$CASE_ID" >/dev/null || fail "activate should succeed"
+  generated="$CASE_HOME/state/extensions/$CASE_ID/generated"
+  outside="$tmp/outside-generated"
+  mv "$generated" "$outside"
+  ln -s "$outside" "$generated"
+  out=$(fm_ext deactivate "$CASE_ID" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "deactivate should reject final generated symlink"
+  assert_contains "$out" "generated directory path must not contain a symlink" \
+    "final symlink rejection was not explicit"
+  assert_present "$outside/.owner.json" "deactivate followed final symlink and removed escaped material"
+  pass "deactivation rejects generated path symlink escapes"
+}
+
 test_wrapper_failure_behavior() {
   local tmp wrapper rc
   tmp=$(fm_test_tmproot fm-extension-wrapper-fail)
@@ -363,6 +397,7 @@ test_valid_manifest_doctor
 test_manifest_security_rejections
 test_activation_and_deactivation_markers
 test_deactivation_is_idempotent_without_unowned_material
+test_deactivation_rejects_generated_path_symlinks
 test_wrapper_failure_behavior
 test_isolated_nm_home_repo_command_wrapper
 test_read_only_no_mistakes_observability

--- a/tests/fm-extension.test.sh
+++ b/tests/fm-extension.test.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# Focused regressions for the Stage 0 Firstmate-owned extension host.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+EXT="$ROOT/bin/fm-extension.sh"
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+write_fake_no_mistakes() {
+  local file=$1
+  cat > "$file" <<'SH'
+#!/usr/bin/env bash
+printf '%s\t%s\t%s\n' "${NM_HOME:-}" "${NO_MISTAKES_NO_UPDATE_CHECK:-}" "$*" >> "${FM_FAKE_NM_LOG:?}"
+if [ "${1:-}" = "--version" ]; then
+  printf 'no-mistakes version %s\n' "${FM_FAKE_NM_VERSION:-v1.40.1}"
+  exit 0
+fi
+if [ "${1:-}" = "axi" ] && [ "${2:-}" = "status" ]; then
+  printf 'fake-status\n'
+  exit 0
+fi
+if [ "${1:-}" = "axi" ] && [ "${2:-}" = "logs" ]; then
+  printf 'fake-logs\n'
+  exit 0
+fi
+printf 'unexpected no-mistakes call: %s\n' "$*" >&2
+exit 2
+SH
+  chmod 700 "$file"
+}
+
+write_config() {
+  local manifest_hash=$1
+  mkdir -p "$(dirname "$CASE_CONFIG")"
+  cat > "$CASE_CONFIG" <<JSON
+{
+  "api_version": "firstmate.extension.config/v1",
+  "id": "$CASE_ID",
+  "manifest_path": "$CASE_MANIFEST",
+  "manifest_sha256": "$manifest_hash"
+}
+JSON
+  chmod 600 "$CASE_CONFIG"
+}
+
+write_manifest_config() {
+  local capabilities_json=${1:-'"no_mistakes.repo_command", "no_mistakes.axi_observe"'}
+  local permissions_json=${2:-'"network": false, "read": [], "write": []'}
+  local entry_path=${3:-bin/lint-wrapper}
+  local entry_hash=${4:-$CASE_ENTRY_HASH}
+  local requires_json=${5:-'{ "firstmate": ">=0.0.0", "no_mistakes": ">=1.40.1" }'}
+  local source_path=${6:-.}
+  cat > "$CASE_MANIFEST" <<JSON
+{
+  "api_version": "firstmate.extension/v1",
+  "id": "$CASE_ID",
+  "version": "0.1.0",
+  "source": { "type": "local_path", "path": "$source_path" },
+  "requires": $requires_json,
+  "capabilities": [ $capabilities_json ],
+  "permissions": { $permissions_json },
+  "entrypoints": {
+    "lint": {
+      "path": "$entry_path",
+      "sha256": "$entry_hash",
+      "capabilities": ["no_mistakes.repo_command"],
+      "no_mistakes_command": "lint"
+    }
+  }
+}
+JSON
+  chmod 600 "$CASE_MANIFEST"
+  CASE_MANIFEST_HASH=$(sha256_file "$CASE_MANIFEST")
+  write_config "$CASE_MANIFEST_HASH"
+}
+
+setup_case() {
+  local tmp=$1
+  local wrapper_kind=${2:-pass}
+  CASE_ID=owned-nm-policy
+  CASE_HOME="$tmp/fm-home"
+  CASE_EXT="$tmp/extension"
+  CASE_MANIFEST="$CASE_EXT/extension.json"
+  CASE_CONFIG="$CASE_HOME/config/extensions.d/$CASE_ID.json"
+  CASE_FAKE_NM="$tmp/fake-no-mistakes"
+  CASE_FAKE_NM_LOG="$tmp/fake-no-mistakes.log"
+  mkdir -p "$CASE_HOME/config/extensions.d" "$CASE_EXT/bin"
+  chmod 700 "$CASE_HOME" "$CASE_HOME/config" "$CASE_HOME/config/extensions.d" "$CASE_EXT" "$CASE_EXT/bin"
+  : > "$CASE_FAKE_NM_LOG"
+  write_fake_no_mistakes "$CASE_FAKE_NM"
+  case "$wrapper_kind" in
+    pass)
+      cat > "$CASE_EXT/bin/lint-wrapper" <<'SH'
+#!/usr/bin/env bash
+printf 'lint-wrapper cwd=%s nm=%s network=%s writes=%s entry=%s\n' \
+  "$PWD" "${NM_HOME:-}" "${FM_EXTENSION_NETWORK:-}" "${FM_EXTENSION_WRITE_ROOTS:-}" "${FM_EXTENSION_ENTRYPOINT:-}"
+SH
+      ;;
+    fail)
+      cat > "$CASE_EXT/bin/lint-wrapper" <<'SH'
+#!/usr/bin/env bash
+printf 'wrapper failed intentionally\n' >&2
+exit 42
+SH
+      ;;
+    *)
+      fail "unknown wrapper kind: $wrapper_kind"
+      ;;
+  esac
+  chmod 700 "$CASE_EXT/bin/lint-wrapper"
+  CASE_ENTRY_HASH=$(sha256_file "$CASE_EXT/bin/lint-wrapper")
+  write_manifest_config
+}
+
+fm_ext() {
+  FM_FAKE_NM_LOG="$CASE_FAKE_NM_LOG" "$EXT" \
+    --home "$CASE_HOME" \
+    --config "$CASE_CONFIG" \
+    --no-mistakes-bin "$CASE_FAKE_NM" \
+    "$@"
+}
+
+expect_fm_ext_fail() {
+  local label=$1 expected=$2 out rc
+  shift 2
+  out=$(fm_ext "$@" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "$label should fail"
+  assert_contains "$out" "$expected" "$label"
+  pass "$label"
+}
+
+refresh_manifest_hash() {
+  CASE_MANIFEST_HASH=$(sha256_file "$CASE_MANIFEST")
+  write_config "$CASE_MANIFEST_HASH"
+}
+
+test_valid_manifest_doctor() {
+  local tmp out
+  tmp=$(fm_test_tmproot fm-extension-valid)
+  setup_case "$tmp"
+  out=$(fm_ext doctor "$CASE_ID") || fail "doctor should accept a valid extension"
+  assert_contains "$out" "fm-extension: ok $CASE_ID 0.1.0" "doctor did not report valid extension"
+  assert_contains "$out" "no_mistakes.axi_observe,no_mistakes.repo_command" "doctor did not report capabilities"
+  pass "valid firstmate.extension/v1 manifest validates"
+}
+
+test_manifest_security_rejections() {
+  local tmp
+
+  tmp=$(fm_test_tmproot fm-extension-bad-json)
+  setup_case "$tmp"
+  printf '{not json\n' > "$CASE_MANIFEST"
+  chmod 600 "$CASE_MANIFEST"
+  refresh_manifest_hash
+  expect_fm_ext_fail "malformed manifest JSON is rejected" "malformed JSON" doctor "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-bad-cap)
+  setup_case "$tmp"
+  write_manifest_config '"no_mistakes.repo_command", "unknown.capability"'
+  expect_fm_ext_fail "unknown capabilities are rejected" "capability is unknown" doctor "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-traversal)
+  setup_case "$tmp"
+  write_manifest_config '"no_mistakes.repo_command"' '"network": false, "read": [], "write": []' "../outside"
+  expect_fm_ext_fail "path traversal entrypoints are rejected" "escapes the extension source root" doctor "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-symlink)
+  setup_case "$tmp"
+  mv "$CASE_EXT/bin/lint-wrapper" "$CASE_EXT/bin/real-wrapper"
+  ln -s real-wrapper "$CASE_EXT/bin/lint-wrapper"
+  CASE_ENTRY_HASH=$(sha256_file "$CASE_EXT/bin/lint-wrapper")
+  write_manifest_config
+  expect_fm_ext_fail "symlink entrypoints are rejected" "must not be a symlink" doctor "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-entry-mode)
+  setup_case "$tmp"
+  chmod 720 "$CASE_EXT/bin/lint-wrapper"
+  write_manifest_config
+  expect_fm_ext_fail "group-writable entrypoints are rejected" "must not be group- or world-writable" doctor "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-root-mode)
+  setup_case "$tmp"
+  chmod 777 "$CASE_EXT"
+  expect_fm_ext_fail "world-writable extension roots are rejected" "source root must not be group- or world-writable" doctor "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-manifest-hash)
+  setup_case "$tmp"
+  write_config "0000000000000000000000000000000000000000000000000000000000000000"
+  expect_fm_ext_fail "manifest hash mismatches are rejected" "manifest hash mismatch" doctor "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-entry-hash)
+  setup_case "$tmp"
+  write_manifest_config '"no_mistakes.repo_command"' '"network": false, "read": [], "write": []' "bin/lint-wrapper" "0000000000000000000000000000000000000000000000000000000000000000"
+  expect_fm_ext_fail "entrypoint hash mismatches are rejected" "entrypoint lint hash mismatch" doctor "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-version)
+  setup_case "$tmp"
+  FM_FAKE_NM_VERSION=v1.39.0 expect_fm_ext_fail "incompatible No Mistakes versions are rejected" "does not satisfy >=1.40.1" doctor "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-network)
+  setup_case "$tmp"
+  write_manifest_config '"no_mistakes.repo_command"' '"network": true, "read": [], "write": []'
+  expect_fm_ext_fail "explicit network permission is rejected" "permissions.network must be false" doctor "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-write)
+  setup_case "$tmp"
+  write_manifest_config '"no_mistakes.repo_command"' "\"network\": false, \"read\": [], \"write\": [\"\$WORKTREE\"]"
+  expect_fm_ext_fail "explicit write permission is rejected" "permissions.write must be empty" doctor "$CASE_ID"
+}
+
+test_activation_and_deactivation_markers() {
+  local tmp generated wrapper unowned out
+  tmp=$(fm_test_tmproot fm-extension-unowned-marker)
+  setup_case "$tmp"
+  generated="$CASE_HOME/state/extensions/$CASE_ID/generated"
+  mkdir -p "$generated"
+  printf '{"api_version":"other","id":"someone-else"}\n' > "$generated/.owner.json"
+  expect_fm_ext_fail "activation refuses unowned generated owner markers" \
+    "refusing to overwrite unowned generated owner marker" activate "$CASE_ID"
+
+  tmp=$(fm_test_tmproot fm-extension-activate)
+  setup_case "$tmp"
+  out=$(fm_ext activate "$CASE_ID") || fail "activate should succeed: $out"
+  generated="$CASE_HOME/state/extensions/$CASE_ID/generated"
+  wrapper="$generated/wrappers/lint"
+  assert_present "$generated/.owner.json" "activation did not write owner marker"
+  assert_present "$wrapper" "activation did not write generated wrapper"
+  [ -x "$wrapper" ] || fail "generated wrapper is not executable"
+  assert_grep "firstmate-extension-generated firstmate.extension.generated/v1 id=$CASE_ID" "$wrapper" \
+    "generated wrapper lacks owner marker"
+  out=$(fm_ext render-no-mistakes "$CASE_ID") || fail "render-no-mistakes should succeed"
+  assert_contains "$out" "commands:" "render-no-mistakes did not print commands root"
+  assert_contains "$out" "lint:" "render-no-mistakes did not print lint command"
+
+  unowned="$generated/wrappers/unowned"
+  printf 'do not remove me\n' > "$unowned"
+  out=$(fm_ext deactivate "$CASE_ID") || fail "deactivate should succeed: $out"
+  assert_absent "$wrapper" "deactivate removed no generated wrapper"
+  assert_absent "$generated/.owner.json" "deactivate did not remove owner marker"
+  assert_present "$unowned" "deactivate removed unowned material"
+  rm -f "$unowned"
+  out=$(fm_ext deactivate "$CASE_ID") || fail "second deactivate should clean empty dirs: $out"
+  assert_absent "$generated" "deactivate did not remove empty generated directory"
+  pass "activation and deactivation honor owner markers"
+}
+
+test_wrapper_failure_behavior() {
+  local tmp wrapper rc
+  tmp=$(fm_test_tmproot fm-extension-wrapper-fail)
+  setup_case "$tmp" fail
+  fm_ext activate "$CASE_ID" >/dev/null || fail "activate should succeed for failing wrapper"
+  wrapper="$CASE_HOME/state/extensions/$CASE_ID/generated/wrappers/lint"
+  FM_FAKE_NM_LOG="$CASE_FAKE_NM_LOG" "$wrapper" >/dev/null 2>"$tmp/err"
+  rc=$?
+  [ "$rc" -eq 42 ] || fail "generated wrapper should propagate entrypoint exit 42, got $rc"
+  assert_grep "wrapper failed intentionally" "$tmp/err" "wrapper stderr was not preserved"
+  pass "wrapper failures propagate through the host"
+}
+
+test_isolated_nm_home_repo_command_wrapper() {
+  local tmp wrapper scratch nm_home out rendered
+  tmp=$(fm_test_tmproot fm-extension-nm-home)
+  setup_case "$tmp"
+  fm_ext activate "$CASE_ID" >/dev/null || fail "activate should succeed"
+  wrapper="$CASE_HOME/state/extensions/$CASE_ID/generated/wrappers/lint"
+  scratch="$tmp/scratch-repo"
+  nm_home="$tmp/isolated-nm-home"
+  mkdir -p "$nm_home"
+  fm_git_init_commit "$scratch"
+  rendered=$(fm_ext render-no-mistakes "$CASE_ID") || fail "render-no-mistakes should succeed"
+  printf '%s\n' "$rendered" > "$scratch/.no-mistakes.yaml"
+
+  out=$(cd "$scratch" && FM_FAKE_NM_LOG="$CASE_FAKE_NM_LOG" NM_HOME="$nm_home" "$wrapper") \
+    || fail "generated lint wrapper should run from scratch repo"
+  assert_contains "$out" "cwd=$scratch" "wrapper did not preserve the scratch repository CWD"
+  assert_contains "$out" "nm=$nm_home" "wrapper did not preserve isolated NM_HOME"
+  assert_contains "$out" "network=0" "wrapper did not receive default-deny network env"
+  assert_contains "$out" "writes= entry=lint" "wrapper did not receive default-deny write env and entrypoint"
+  assert_grep "$nm_home"$'\t'"1"$'\t'"--version" "$CASE_FAKE_NM_LOG" \
+    "version check did not use the isolated No Mistakes home"
+  pass "repo-command wrapper works in a scratch repo with isolated NM_HOME"
+}
+
+test_read_only_no_mistakes_observability() {
+  local tmp out rc
+  tmp=$(fm_test_tmproot fm-extension-observe)
+  setup_case "$tmp"
+  out=$(fm_ext observe-no-mistakes "$CASE_ID" status -- --json) \
+    || fail "observe-no-mistakes status should succeed"
+  assert_contains "$out" "fake-status" "status observation did not relay no-mistakes output"
+  assert_grep "axi status --json" "$CASE_FAKE_NM_LOG" "status observation did not call read-only AXI status"
+
+  out=$(fm_ext observe-no-mistakes "$CASE_ID" logs -- --step lint) \
+    || fail "observe-no-mistakes logs should succeed"
+  assert_contains "$out" "fake-logs" "logs observation did not relay no-mistakes output"
+  assert_grep "axi logs --step lint" "$CASE_FAKE_NM_LOG" "logs observation did not call read-only AXI logs"
+
+  out=$(fm_ext observe-no-mistakes "$CASE_ID" respond 2>&1)
+  rc=$?
+  [ "$rc" -eq 2 ] || fail "respond observation should fail with usage exit 2, got $rc"
+  assert_contains "$out" "only permits read-only AXI actions" "respond refusal was not explicit"
+
+  write_manifest_config '"no_mistakes.repo_command"'
+  out=$(fm_ext observe-no-mistakes "$CASE_ID" status 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "observe should fail without no_mistakes.axi_observe capability"
+  assert_contains "$out" "not granted no_mistakes.axi_observe" "capability denial was not explicit"
+  pass "No Mistakes AXI observability is read-only and capability-gated"
+}
+
+test_valid_manifest_doctor
+test_manifest_security_rejections
+test_activation_and_deactivation_markers
+test_wrapper_failure_behavior
+test_isolated_nm_home_repo_command_wrapper
+test_read_only_no_mistakes_observability


### PR DESCRIPTION
## Intent

Implement the captain-approved Stage 0 proof of concept from data/firstmate-owned-extension-framework-scout/report.md as a Firstmate-owned extension framework that requires no changes, merge access, publication, or review in kunchenguid/no-mistakes or any other uncontrolled repository. Keep the milestone minimal and reversible: validate a small firstmate.extension/v1 manifest for one explicitly configured local unpacked folder or owned local repository; default-deny permissions; validate identity, version, path safety, hashes, capabilities, and incompatible versions; activate only owner-marked generated local material; remove only owner-marked generated material on deactivation; run deterministic wrapper entrypoints; prove a local policy pack can supply a No Mistakes lint/test wrapper in a disposable scratch repository with isolated NM_HOME; add read-only No Mistakes AXI observability without owning or responding to the pipeline; never replace the installed no-mistakes binary, mutate the no-mistakes project clone, or start/stop/restart/update the shared daemon. Do not broaden into ACP proxying, marketplace installs, automatic network installs, secondmate distribution, new No Mistakes pipeline phases, upstream forks, or production activation. Documentation should follow Firstmate knowledge-placement and one-owner rules, keep AGENTS.md unchanged unless a new skill is introduced, and explain that external PR #588 and uncontrolled repositories remain outside implementation, certification, deployment, and release.

## What Changed

- Adds a Firstmate-owned extension host and `fm-extension.sh` CLI for validating local `firstmate.extension/v1` packs, activating deterministic owner-marked generated wrappers, observing No Mistakes state/logs read-only, and deactivating only owned generated material.
- Documents the Stage 0 extension boundary in README, extension docs, script docs, and documentation audience metadata, including the limits around uncontrolled repositories and external PR #588.
- Adds focused extension tests covering manifest validation, path/hash/capability safety, wrapper rendering, No Mistakes observability permissions, and activation/deactivation ownership behavior.

## Risk Assessment

✅ Low: The branch is well-bounded to a Stage 0 local extension host, and the reviewed fixes now enforce id-aware owner markers plus generated-path symlink rejection for activation and deactivation.

## Testing

Focused tests covered manifest/security validation, activation/deactivation ownership, wrapper execution, isolated `NM_HOME`, AXI observability, and docs inventory; the end-to-end CLI transcript shows the local pack working in a disposable scratch repo and using only read-only No Mistakes AXI calls, with no test failures or actionable issues found.

<details>
<summary>Evidence: End-to-end CLI transcript</summary>

```text
## doctor validates the local manifest and compatibility
fm-extension: ok owned-nm-policy 0.1.0 manifest=/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/extension/extension.json capabilities=no_mistakes.axi_observe,no_mistakes.repo_command

## activate creates only owner-marked generated local wrappers
fm-extension: activated owned-nm-policy generated=/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/fm-home/state/extensions/owned-nm-policy/generated
#!/usr/bin/env bash
# firstmate-extension-generated firstmate.extension.generated/v1 id=owned-nm-policy entrypoint=lint
set -u
exec '/home/exedev/.no-mistakes/worktrees/579deb6a33c1/01KYFPQA1H7QV0ADBZNB98A5ZK/bin/fm-extension.sh' --home '/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/fm-home' --config '/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/fm-home/config/extensions.d/owned-nm-policy.json' --no-mistakes-bin '/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/fake-no-mistakes' run 'owned-nm-policy' 'lint' -- "$@"

## render-no-mistakes produces a repo-command snippet for the generated wrapper
commands:
  lint: '/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/fm-home/state/extensions/owned-nm-policy/generated/wrappers/lint'

## generated wrapper runs in a disposable scratch repository with isolated NM_HOME
lint-wrapper proof
cwd=/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/scratch-repo
FM_HOME=/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/fm-home
NM_HOME=/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/isolated-nm-home
network=0 read_roots= write_roots= entry=lint
args=--sample-arg

## read-only No Mistakes AXI observation is relayed, while respond is denied
{"status":"observed","mode":"read_only"}
lint log observed through read-only AXI
respond_exit=2
fm-extension: observe-no-mistakes only permits read-only AXI actions: status, logs

## fake no-mistakes call log shows version checks and read-only AXI only
/home/exedev/.no-mistakes	1	--version
/home/exedev/.no-mistakes	1	--version
/home/exedev/.no-mistakes	1	--version
/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/isolated-nm-home	1	--version
/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/isolated-nm-home	1	--version
/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/isolated-nm-home	1	axi status --json
/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/isolated-nm-home	1	--version
/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/isolated-nm-home	1	axi logs --step lint

## deactivate removes owner-marked generated wrappers
fm-extension: deactivated owned-nm-policy removed=3 left_unowned=0
wrapper_still_present=no
```
</details>
<details>
<summary>Evidence: Rendered No Mistakes command snippet</summary>

```text
commands:
  lint: '/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/fm-home/state/extensions/owned-nm-policy/generated/wrappers/lint'
```
</details>
<details>
<summary>Evidence: Fake No Mistakes call log</summary>

```text
/home/exedev/.no-mistakes	1	--version
/home/exedev/.no-mistakes	1	--version
/home/exedev/.no-mistakes	1	--version
/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/isolated-nm-home	1	--version
/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/isolated-nm-home	1	--version
/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/isolated-nm-home	1	axi status --json
/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/isolated-nm-home	1	--version
/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo/isolated-nm-home	1	axi logs --step lint
```
</details>
<details>
<summary>Evidence: Focused test timing JSON</summary>

```text
{
  "families": [
    {
      "count": 2,
      "duration_ms": 2984,
      "failed": 0,
      "name": "pure-contract-unit"
    }
  ],
  "finished_at": "2026-07-27T15:53:16Z",
  "run_id": "fm-test-run-1785167592959-1855903",
  "scripts": [
    {
      "duration_ms": 2302,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-extension.test.sh"
    },
    {
      "duration_ms": 682,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-documentation-audiences.test.sh"
    }
  ],
  "selection": "scripts",
  "started_at": "2026-07-27T15:53:12Z",
  "summary": {
    "duration_ms": 3076,
    "failed": 0,
    "skipped_gate": 0,
    "total": 2
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-extension-host.mjs:573` - Intent requires: &#34;remove only owner-marked generated material on deactivation&#34;. The deactivation path first preserves unmarked files, but then calls `fs.rmdirSync(dir)` for every directory under `generated`, so any empty unmarked/user-created directory under that tree is removed despite having no owner marker. Either directory removal needs owner marking too, or the accepted lifecycle contract should explicitly allow cleanup of empty unmarked directories.

🔧 Fix: Mark generated directories before deactivation
1 error still open:
- 🚨 `bin/fm-extension-host.mjs:566` - Intent requires &#34;path safety&#34; and the fix instruction requires deactivation to &#34;remain confined to the generated root and preserve symlink/path safety,&#34; but `generatedDir` is used lexically and only the final component is `lstat`-checked. If `$FM_HOME/state/extensions/&lt;id&gt;` is a symlink, `fs.existsSync`, `lstatSafe(generatedDir)`, and `walkFiles(generatedDir)` traverse into the symlink target and deactivation can remove owner-marked files outside the real generated tree. Reject symlinks in the generated path ancestry or resolve and verify the real generated root before walking/removing.

🔧 Fix: Reject generated path symlink escapes
1 error still open:
- 🚨 `bin/fm-extension-host.mjs:461` - Intent requires &#34;activate only owner-marked generated local material,&#34; but existing wrapper files are considered safe to overwrite when they merely contain the generic generated marker. A file marked for a different extension id under this generated tree would pass `current.includes(GENERATED_MARKER)` and be replaced during activation; reuse the same id-aware ownership check used by deactivation before overwriting generated files.

🔧 Fix: Require exact owner before wrapper overwrite
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --short --branch` and `git diff --stat a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499..9be340893423af23d168bc262b6f3a4ea27f0f19` to confirm the scoped change under test</code>
- <code>`bin/fm-test-run.sh --list --changed --base a5fe1bcc8c2ac01951e6a68d1c8b1b1ecae21499` to inspect changed-test expansion without executing the broad pure-contract family</code>
- `bin/fm-test-run.sh --json /tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/fm-extension-focused-tests.json tests/fm-extension.test.sh tests/fm-documentation-audiences.test.sh`
- <code>Manual evidence run in `/tmp/no-mistakes-evidence/01KYFPQA1H7QV0ADBZNB98A5ZK/end-to-end-demo`: created a local `firstmate.extension/v1` pack and fake `no-mistakes`, then ran `doctor`, `activate`, `render-no-mistakes`, generated wrapper execution from a scratch git repo with isolated `NM_HOME`, `observe-no-mistakes status`, `observe-no-mistakes logs`, denied `observe-no-mistakes respond`, and `deactivate`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
