### PR TITLE
feat(bin): add cost-discipline and PR-description rules to briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -44,6 +44,13 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
+# Ship and scout briefs both carry a cost-discipline rule: capped tool output, a codex
+# shell-output budget pragma, a ban on reading rollout/agent-session JSONL directly, and a
+# wait pattern split by runtime (log-backed capped checks for codex/Pi/other 30s-clamped
+# runtimes; long blocking calls or background wakes for Claude Code and similar runtimes).
+# Every PR-producing delivery mode (no-mistakes, direct-PR) requires a whole, self-contained
+# PR description written fresh rather than as a delta; local-only and scout produce no PR
+# and skip it.
 # Refuses to overwrite an existing brief.
 set -eu
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -226,6 +226,34 @@ EOF
 )
 fi
 
+COST_DISCIPLINE_RULE=$(cat <<'EOF'
+8. Cost discipline: cap tool output.
+   Do not dump large command output into context.
+   Aggregate with `rg -c` / `jq` counts, and pipe long logs through `tail -c 4000` or `cut -c1-200` before reading them.
+   On codex, set a small shell output budget for risky commands with `// @exec: {"max_output_tokens": 2000}` as the first line of the shell tool call.
+   Never `tail` or `cat` rollout or agent-session JSONL files.
+   Those files carry very large encrypted payload fields and can blow out context in one call.
+   Waiting is runtime-specific.
+   On codex, Pi, and other 30s-clamped runtimes, do not assemble a long wait out of repeated short sleeps.
+   Redirect long-running work to a log file, let it run, and check the log with capped reads.
+   On Claude Code and runtimes with true long blocking calls or background-completion wakes, use one long blocking call or the background wake instead of repeated empty polls.
+EOF
+)
+
+PR_DESCRIPTION_CONTRACT=$(cat <<'EOF'
+A PR description must be whole and self-contained for a reader with no prior context.
+It covers what the change does, why, how it was verified, and what it explicitly does not cover.
+Do not write it as a delta against a previous revision of itself, such as "addressed the review comments" or "as discussed above".
+Do not include task-process narration or firstmate task ids.
+When the PR grows in scope, rewrite the description rather than appending to it.
+EOF
+)
+
+VALIDATION_COST_REMINDER=$(cat <<'EOF'
+While driving validation, keep the cost-discipline rules active: cap long output, use the codex `// @exec: {"max_output_tokens": 2000}` pragma for shell output that could be long, never read rollout or agent-session JSONL files directly, and use the runtime-specific wait pattern instead of repeated empty polls.
+EOF
+)
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -262,6 +290,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+$COST_DISCIPLINE_RULE
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -290,6 +319,7 @@ case "$MODE" in
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+$PR_DESCRIPTION_CONTRACT
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
 )
@@ -320,14 +350,16 @@ Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+$VALIDATION_COST_REMINDER
 
 Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass firstmate authority checks and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+$PR_DESCRIPTION_CONTRACT
 EOF
 )
     ;;
@@ -374,6 +406,7 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+$COST_DISCIPLINE_RULE
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -68,9 +68,118 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
+    assert_grep "**Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`" "$brief" \
+      "$id: brief missing the worktree-isolation assertion"
+    assert_grep "blocked: launched in primary checkout, not an isolated worktree" "$brief" \
+      "$id: brief missing the primary-checkout block status"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
+}
+
+test_cost_discipline_rules_render_for_ship_and_scout() {
+  local home item kind id proj brief
+  home="$TMP_ROOT/cost-discipline-home"
+  write_registry "$home"
+
+  for item in \
+    "no-mistakes:brief-cost-nm:no-registry-proj" \
+    "direct-PR:brief-cost-direct:direct-proj" \
+    "local-only:brief-cost-local:local-proj" \
+    "scout:brief-cost-scout:scout-proj"; do
+    kind=${item%%:*}
+    id=${item#*:}
+    id=${id%%:*}
+    proj=${item##*:}
+    if [ "$kind" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "$proj" --scout >/dev/null 2>&1
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "$proj" >/dev/null 2>&1
+    fi
+    brief="$home/data/$id/brief.md"
+    assert_grep "8. Cost discipline: cap tool output." "$brief" \
+      "$kind brief missing cost discipline rule"
+    # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+    assert_grep 'Aggregate with `rg -c` / `jq` counts, and pipe long logs through `tail -c 4000` or `cut -c1-200` before reading them.' "$brief" \
+      "$kind brief missing capped aggregation guidance"
+    # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+    assert_grep 'On codex, set a small shell output budget for risky commands with `// @exec: {"max_output_tokens": 2000}` as the first line of the shell tool call.' "$brief" \
+      "$kind brief missing codex max output budget guidance"
+    # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+    assert_grep 'Never `tail` or `cat` rollout or agent-session JSONL files.' "$brief" \
+      "$kind brief missing rollout JSONL guard"
+    assert_grep "Waiting is runtime-specific." "$brief" \
+      "$kind brief missing runtime-specific wait framing"
+    assert_grep "On codex, Pi, and other 30s-clamped runtimes, do not assemble a long wait out of repeated short sleeps." "$brief" \
+      "$kind brief missing 30s-clamped runtime wait guidance"
+    assert_grep "Redirect long-running work to a log file, let it run, and check the log with capped reads." "$brief" \
+      "$kind brief missing log-backed wait guidance"
+    assert_grep "On Claude Code and runtimes with true long blocking calls or background-completion wakes, use one long blocking call or the background wake instead of repeated empty polls." "$brief" \
+      "$kind brief missing true-long-wait runtime guidance"
+    if grep -Ei 'codex.*(one long blocking call|background wake)' "$brief" >/dev/null; then
+      fail "$kind brief told codex to use an unsupported long wait path"
+    fi
+  done
+  pass "fm-brief.sh: ship and scout briefs render runtime-specific cost discipline"
+}
+
+test_no_mistakes_validation_keeps_cost_discipline() {
+  local home id brief
+  home="$TMP_ROOT/validation-cost-home"
+  mkdir -p "$home/data"
+  id="brief-validation-cost"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep 'While driving validation, keep the cost-discipline rules active' "$brief" \
+    "no-mistakes DOD missing validation cost reminder"
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_grep 'use the codex `// @exec: {"max_output_tokens": 2000}` pragma for shell output that could be long' "$brief" \
+    "no-mistakes DOD missing codex output budget reminder"
+  assert_grep "use the runtime-specific wait pattern instead of repeated empty polls" "$brief" \
+    "no-mistakes DOD missing wait-poll cost reminder"
+  pass "fm-brief.sh: no-mistakes validation DOD keeps cost discipline active"
+}
+
+test_pr_description_contract_renders_only_for_pr_modes() {
+  local home item kind id proj brief
+  home="$TMP_ROOT/pr-description-home"
+  write_registry "$home"
+
+  for item in \
+    "no-mistakes:brief-prdesc-nm:no-registry-proj" \
+    "direct-PR:brief-prdesc-direct:direct-proj" \
+    "local-only:brief-prdesc-local:local-proj" \
+    "scout:brief-prdesc-scout:scout-proj"; do
+    kind=${item%%:*}
+    id=${item#*:}
+    id=${id%%:*}
+    proj=${item##*:}
+    if [ "$kind" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "$proj" --scout >/dev/null 2>&1
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "$proj" >/dev/null 2>&1
+    fi
+    brief="$home/data/$id/brief.md"
+    case "$kind" in
+      no-mistakes|direct-PR)
+        assert_grep "A PR description must be whole and self-contained for a reader with no prior context." "$brief" \
+          "$kind brief missing whole PR description contract"
+        assert_grep "It covers what the change does, why, how it was verified, and what it explicitly does not cover." "$brief" \
+          "$kind brief missing PR description content requirements"
+        assert_grep 'Do not write it as a delta against a previous revision of itself, such as "addressed the review comments" or "as discussed above".' "$brief" \
+          "$kind brief missing no-delta PR description rule"
+        assert_grep "Do not include task-process narration or firstmate task ids." "$brief" \
+          "$kind brief missing PR process-narration guard"
+        assert_grep "When the PR grows in scope, rewrite the description rather than appending to it." "$brief" \
+          "$kind brief missing PR description rewrite rule"
+        ;;
+      *)
+        assert_no_grep "A PR description must be whole and self-contained for a reader with no prior context." "$brief" \
+          "$kind brief should not carry PR description guidance"
+        ;;
+    esac
+  done
+  pass "fm-brief.sh: whole PR description contract renders only for PR modes"
 }
 
 test_faster_paths_use_configured_authority_without_stacked_review() {
@@ -385,6 +494,9 @@ test_scout_and_secondmate_scaffold() {
 test_script_parses
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_cost_discipline_rules_render_for_ship_and_scout
+test_no_mistakes_validation_keeps_cost_discipline
+test_pr_description_contract_renders_only_for_pr_modes
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording


### PR DESCRIPTION
## Intent

Bake two recurring conventions into the Firstmate brief scaffold `bin/fm-brief.sh` so future crewmates get them by default. Add concise cost-discipline guidance to generated ship and scout Rules sections, including capped tool output, codex shell output budgeting, a prohibition on reading rollout or agent-session JSONL directly, and waiting guidance that is explicitly per runtime: codex, Pi, and other 30s-clamped runtimes should use log-backed capped checks instead of repeated sleeps, while Claude Code and runtimes with true long blocking calls or background-completion wakes should use those instead of polling. Add no-mistakes validation DOD guidance to keep those cost-discipline rules active. Add whole, self-contained PR description requirements to every PR-producing delivery mode, but not local-only or scout. Keep existing safety contracts intact, especially worktree isolation, keep AGENTS.md out of scope, use plain dashes, preserve shell parse safety, and add deterministic colocated tests asserting the generated text for no-mistakes, direct-PR, local-only, and scout. The previous no-mistakes run already completed review, test, document, and lint on this branch; this retry is only to publish through the newly configured fork target and reach PR/CI.

## What Changed
- `bin/fm-brief.sh` now injects a shared cost-discipline rule into ship (no-mistakes, direct-PR, local-only) and scout briefs: cap tool output, budget codex shell output via `// @exec: {"max_output_tokens": 2000}`, never read rollout/agent-session JSONL directly, and follow a runtime-specific wait pattern (log-backed capped checks for codex/Pi/30s-clamped runtimes vs. long blocking calls or background wakes for Claude Code).
- Adds a validation-time reminder in the no-mistakes DOD section to keep those cost-discipline rules active while driving the gate, and a whole/self-contained PR-description contract injected into the no-mistakes and direct-PR modes only (not local-only or scout).
- Adds colocated tests in `tests/fm-brief.test.sh` asserting the generated cost-discipline text across no-mistakes, direct-PR, local-only, and scout briefs, and asserting the PR-description contract appears only for PR-producing modes.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
