### PR TITLE
fix(brief): generalize member-surface write-path doctrine

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -325,7 +325,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass the firstmate authority check and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -235,6 +235,10 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 $HERDR_SECTION
 
+# Doctrine (non-negotiable)
+- **Standing rule (member surfaces).** Creating a member surface is a call to the product's write path, never a new module, component, route, or seed script. Terminal requests are not an exemption. See the project's own write-path mandate (e.g. docs/operational/SITE_WRITE_PATH_MANDATE.md) if the project defines one.
+- **Acceptance test.** After this ships, is the next member cheaper to serve? If no, it was built wrong regardless of how it looks.
+
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 This is a SCOUT task: the deliverable is a written report, not a PR.
@@ -340,6 +344,10 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 $HERDR_SECTION
+
+# Doctrine (non-negotiable)
+- **Standing rule (member surfaces).** Creating a member surface is a call to the product's write path, never a new module, component, route, or seed script. Terminal requests are not an exemption. See the project's own write-path mandate (e.g. docs/operational/SITE_WRITE_PATH_MANDATE.md) if the project defines one.
+- **Acceptance test.** After this ships, is the next member cheaper to serve? If no, it was built wrong regardless of how it looks.
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.


### PR DESCRIPTION
Bridges the no-mistakes heredoc parse failure that opened the brief-doctrine-generate-and-repair session, and generalizes fm-brief.sh so the same shape works for member-surface write-path tasks instead of just brief edits.

Sourced from session fm-brief-heredoc-fix-v0 + fm-dispatch-config-review-v0. 
Two commits: one for the generalized doctrine (bin/fm-brief.sh supports a member-surface write-path template), one for the heredoc wording fix (apostrophe escape).