### PR TITLE
chore(opencode): mark opencode.json as captain-private operator config

### DIFF
--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+package.json
+package-lock.json
+bun.lock
+# opencode.json is the opencode CLI's per-user plugin/extension config; it
+# declares the openrouter ai-sdk provider and may vary per host. Keep it
+# captain-private and out of accidental commits.
+opencode.json
+.gitignore


### PR DESCRIPTION
.opencode/opencode.json contains operator-side harness and model mappings. It joins the .gitignore alongside state/, data/, .env, projects/, and the rest of the captain-private runtime — but it differs in one important way: it is operator config, not fleet state. Anyone who clones firstmate and runs opencode will get their own copy from the harness defaults.

Verified: git status clean in primary checkout; tests unaffected.