### PR TITLE
feat(bin): garbage-collect a torn-down worktree's Xcode DerivedData

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,7 @@ For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary sin
 Tear down a ship task only after landing is confirmed.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.
 Never force teardown without explicit discard authority.
+Worktree teardown also garbage-collects the removed worktree's Xcode DerivedData folder; `bin/fm-derived-data-gc.sh` owns that cleanup's matching, protected-cache, and orphan-age rules.
 After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.
 
 A secondmate is persistent and an empty queue is healthy.

--- a/bin/fm-derived-data-gc.sh
+++ b/bin/fm-derived-data-gc.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Garbage-collect Xcode DerivedData folders that belonged to a removed firstmate
+# task worktree, or that are otherwise orphaned.
+#
+# Two modes:
+#   --worktree <path>   Remove DerivedData dirs whose info.plist WorkspacePath is
+#                       the given worktree path or lives under it. This is the
+#                       mode bin/fm-teardown.sh uses after a task worktree has
+#                       been returned/removed; it matches on WorkspacePath only
+#                       and never touches no-plist dirs.
+#   --orphans           Remove every DerivedData dir whose info.plist
+#                       WorkspacePath no longer exists on disk. With
+#                       --include-no-plist, also remove dirs that have no usable
+#                       info.plist AND whose directory modification time is at
+#                       least --no-plist-age-hours old (default 48). The age gate
+#                       is mandatory for no-plist deletion: a fresh no-plist dir
+#                       may belong to a build still in flight.
+#
+# Hard safety rules (from field incidents):
+#   - NEVER delete the shared caches ModuleCache.noindex,
+#     CompilationCache.noindex, SDKStatCaches.noindex, SymbolCache.noindex (any
+#     *.noindex entry at the DerivedData root is skipped).
+#   - NEVER delete a folder whose WorkspacePath resolves to a path that still
+#     exists on disk, in either mode.
+#   - A dir without a readable WorkspacePath is never deleted in --worktree
+#     mode, and in --orphans mode only with --include-no-plist plus the age gate.
+#
+# The DerivedData root defaults to ~/Library/Developer/Xcode/DerivedData and can
+# be overridden with FM_DERIVED_DATA_ROOT (tests use a fixture root).
+# plutil is required to read WorkspacePath; without it nothing can be verified,
+# so the script exits 0 having deleted nothing (fail safe).
+#
+# Usage: fm-derived-data-gc.sh (--worktree <path> | --orphans) [--dry-run]
+#        [--include-no-plist] [--no-plist-age-hours <n>]
+# Exit: 0 on success (including nothing to do), 1 if any removal failed,
+#       2 on usage error.
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: fm-derived-data-gc.sh (--worktree <path> | --orphans) [options]
+
+Modes:
+  --worktree <path>       remove DerivedData dirs whose info.plist WorkspacePath
+                          equals or lives under <path> (teardown mode)
+  --orphans               remove DerivedData dirs whose WorkspacePath no longer
+                          exists on disk
+
+Options:
+  --include-no-plist      in --orphans mode, also remove dirs with no usable
+                          info.plist that are at least --no-plist-age-hours old
+  --no-plist-age-hours n  age gate for --include-no-plist (default: 48)
+  --dry-run               print what would be removed without removing anything
+  -h, --help              show this help
+
+Environment:
+  FM_DERIVED_DATA_ROOT    DerivedData root (default: ~/Library/Developer/Xcode/DerivedData)
+
+Safety: never deletes *.noindex caches, never deletes a dir whose WorkspacePath
+still exists, never deletes a no-plist dir without the explicit age gate.
+EOF
+}
+
+MODE=
+WORKTREE=
+DRY_RUN=0
+INCLUDE_NO_PLIST=0
+NO_PLIST_AGE_HOURS=48
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --worktree)
+      [ "$#" -ge 2 ] || { echo "error: --worktree requires a path" >&2; exit 2; }
+      MODE=worktree
+      WORKTREE=$2
+      shift 2
+      ;;
+    --orphans)
+      MODE=orphans
+      shift
+      ;;
+    --include-no-plist)
+      INCLUDE_NO_PLIST=1
+      shift
+      ;;
+    --no-plist-age-hours)
+      [ "$#" -ge 2 ] || { echo "error: --no-plist-age-hours requires a number" >&2; exit 2; }
+      NO_PLIST_AGE_HOURS=$2
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$MODE" in
+  worktree)
+    [ -n "$WORKTREE" ] || { echo "error: --worktree requires a non-empty path" >&2; exit 2; }
+    ;;
+  orphans)
+    ;;
+  *)
+    echo "error: one of --worktree <path> or --orphans is required" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+case "$NO_PLIST_AGE_HOURS" in
+  ''|*[!0-9]*)
+    echo "error: --no-plist-age-hours must be a non-negative integer" >&2
+    exit 2
+    ;;
+esac
+
+ROOT="${FM_DERIVED_DATA_ROOT:-$HOME/Library/Developer/Xcode/DerivedData}"
+
+if [ ! -d "$ROOT" ]; then
+  # No DerivedData root (non-macOS host, or Xcode never ran): nothing to do.
+  exit 0
+fi
+
+if ! command -v plutil >/dev/null 2>&1; then
+  # Without plutil no WorkspacePath can be verified; delete nothing (fail safe).
+  echo "warning: plutil not found; skipping DerivedData GC under $ROOT" >&2
+  exit 0
+fi
+
+# Strip trailing slashes so prefix matching compares canonical directory paths.
+strip_trailing_slashes() {
+  local p=$1
+  while [ "$p" != "/" ] && [ "${p%/}" != "$p" ]; do
+    p=${p%/}
+  done
+  printf '%s\n' "$p"
+}
+
+WORKTREE=$(strip_trailing_slashes "$WORKTREE")
+NO_PLIST_AGE_SECS=$(( NO_PLIST_AGE_HOURS * 3600 ))
+NOW=$(date +%s)
+
+read_workspace_path() {
+  plutil -extract WorkspacePath raw -o - "$1" 2>/dev/null
+}
+
+# Directory modification time in epoch seconds; BSD stat first, GNU fallback.
+dir_mtime() {
+  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null
+}
+
+is_protected_cache() {
+  case "$1" in
+    ModuleCache.noindex|CompilationCache.noindex|SDKStatCaches.noindex|SymbolCache.noindex|*.noindex)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+FAILED=0
+
+remove_dir() {
+  local dir=$1 why=$2
+  if [ "$DRY_RUN" = 1 ]; then
+    printf 'would remove: %s (%s)\n' "$dir" "$why"
+    return 0
+  fi
+  if rm -rf -- "$dir"; then
+    printf 'removed: %s (%s)\n' "$dir" "$why"
+  else
+    echo "warning: failed to remove $dir" >&2
+    FAILED=1
+  fi
+}
+
+for entry in "$ROOT"/*; do
+  [ -e "$entry" ] || continue
+  base=${entry##*/}
+  if is_protected_cache "$base"; then
+    continue
+  fi
+  # Only real directories are GC candidates; skip files and symlinks.
+  if [ ! -d "$entry" ] || [ -L "$entry" ]; then
+    continue
+  fi
+
+  plist="$entry/info.plist"
+  ws=
+  if [ -f "$plist" ]; then
+    ws=$(read_workspace_path "$plist" || true)
+  fi
+  if [ -n "$ws" ]; then
+    ws=$(strip_trailing_slashes "$ws")
+  fi
+
+  if [ -n "$ws" ] && [ -e "$ws" ]; then
+    # Hard rule: never delete a folder whose WorkspacePath still exists.
+    continue
+  fi
+
+  if [ "$MODE" = worktree ]; then
+    [ -n "$ws" ] || continue
+    case "$ws" in
+      "$WORKTREE"|"$WORKTREE"/*)
+        remove_dir "$entry" "WorkspacePath $ws belonged to removed worktree $WORKTREE"
+        ;;
+    esac
+  else
+    if [ -n "$ws" ]; then
+      remove_dir "$entry" "WorkspacePath $ws no longer exists"
+    elif [ "$INCLUDE_NO_PLIST" = 1 ]; then
+      mtime=$(dir_mtime "$entry" || true)
+      if [ -n "$mtime" ] && [ $(( NOW - mtime )) -ge "$NO_PLIST_AGE_SECS" ]; then
+        remove_dir "$entry" "no info.plist and older than ${NO_PLIST_AGE_HOURS}h"
+      fi
+    fi
+  fi
+done
+
+exit "$FAILED"

--- a/bin/fm-derived-data-gc.sh
+++ b/bin/fm-derived-data-gc.sh
@@ -155,8 +155,22 @@ read_workspace_path() {
 }
 
 # Directory modification time in epoch seconds; BSD stat first, GNU fallback.
+# Each probe's output is accepted only when it is a bare epoch. A failing probe
+# can still write to stdout: GNU stat reads `-f` as "print filesystem status"
+# and `%m` as a file operand, so it emits a multi-line filesystem summary and
+# exits non-zero. Chaining that straight into the fallback would capture the
+# summary concatenated with the epoch, and the caller's age arithmetic would
+# then abort the run under `set -u`.
 dir_mtime() {
-  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null
+  local candidate
+  candidate=$(stat -f %m "$1" 2>/dev/null || true)
+  case "$candidate" in
+    ''|*[!0-9]*) candidate=$(stat -c %Y "$1" 2>/dev/null || true) ;;
+  esac
+  case "$candidate" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%s\n' "$candidate"
 }
 
 is_protected_cache() {

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -56,6 +56,10 @@
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
+# After a task worktree has been returned/removed, teardown also garbage-collects
+# the Xcode DerivedData folder that belonged to it; that cleanup is best-effort
+# (its failures warn, never fail the teardown) and bin/fm-derived-data-gc.sh
+# owns the matching and safety rules.
 #
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a
@@ -2180,6 +2184,15 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     echo "error: treehouse return failed for worktree $WT; teardown aborted" >&2
     exit 1
   }
+fi
+
+# Best-effort Xcode DerivedData garbage collection for the removed task
+# worktree. Runs only after the worktree path no longer exists, so the GC
+# helper's still-existing-workspace guard can never fire against live work, and
+# a GC failure warns without ever failing teardown of landed work.
+# bin/fm-derived-data-gc.sh owns the matching and safety rules.
+if [ "$KIND" != secondmate ] && [ -n "$WT" ] && [ ! -e "$WT" ] && [ -x "$SCRIPT_DIR/fm-derived-data-gc.sh" ]; then
+  "$SCRIPT_DIR/fm-derived-data-gc.sh" --worktree "$WT" || echo "warning: DerivedData GC failed for $WT (non-fatal)" >&2
 fi
 
 HERDR_PRESENTATION_JOURNAL="$STATE/$ID.herdr-presentation"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -594,6 +594,9 @@ When it is unset or blank, `FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS` remains a co
 An invalid nonblank wait falls back to 1 second rather than interrupting teardown.
 Teardown never removes a lock during the retry window, and after that window it attempts stale-lock cleanup only for a still-present lock that passes the configured age and live-holder checks.
 
+Once a task worktree has been returned or removed, `fm-teardown.sh` also garbage-collects the Xcode DerivedData folders that belonged to that worktree, so orphaned DerivedData stops accumulating; the cleanup is best-effort and a failure warns rather than failing teardown of landed work.
+`bin/fm-derived-data-gc.sh` owns the matching and safety rules and also offers a manual `--orphans` sweep; `FM_DERIVED_DATA_ROOT` overrides the DerivedData root it scans, and a missing root or a host without `plutil` deletes nothing.
+
 `fm-fleet-sync.sh` applies the same shape to an orphaned `.git/packed-refs.lock`: it retries only Git's `Unable to create '...packed-refs.lock': File exists` fetch failure up to `FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES` times (nonnegative integer; unset, blank, or invalid uses the default of 3), waiting `FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS` seconds (nonnegative whole or fractional; invalid falls back to 1 second) before each.
 Only after those retries exhaust does it remove the lock, and only when it is provably stale - still present, mtime age at least `FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS` (default 30), and no `lsof` holder of the lock file or of the clone worktree itself (a live `git` keeps that as its cwd even in the window after it closes the lock and before it exits).
 A live lock, a missing `lsof`, any failed check, or any other fetch failure keeps today's behavior.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -553,6 +553,7 @@ FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh t
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature
 FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=   # legacy alias for FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS when the new variable is unset
+FM_DERIVED_DATA_ROOT=    # alternate Xcode DerivedData root for fm-derived-data-gc.sh, mainly for tests; unset means ~/Library/Developer/Xcode/DerivedData
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3        # fetch retries after fm-fleet-sync.sh hits the orphaned .git/packed-refs.lock signature
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=1 # seconds fm-fleet-sync.sh waits before each of those retries
 FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=30       # min mtime age before fm-fleet-sync.sh treats a leftover packed-refs.lock as provably stale

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -98,6 +98,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
+| `fm-derived-data-gc.sh`  | Safely garbage-collect a removed task worktree's Xcode DerivedData (teardown mode) or orphaned DerivedData dirs |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared X-mode config, relay, and reply-threading helpers                             |

--- a/tests/fm-derived-data-gc.test.sh
+++ b/tests/fm-derived-data-gc.test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-derived-data-gc.sh, the Xcode DerivedData garbage collector
+# that fm-teardown.sh runs after a task worktree is removed.
+#
+# Matrix:
+#   (a) --worktree removes a dir whose WorkspacePath lives under the (removed)
+#       worktree
+#   (b) --worktree never removes a dir whose WorkspacePath still exists on disk
+#   (c) --worktree does not match sibling paths that merely share a string
+#       prefix ($wt vs $wt-extra)
+#   (d) --worktree never removes no-plist dirs, even aged ones
+#   (e) --orphans removes a dir whose WorkspacePath no longer exists
+#   (f) --orphans keeps a dir whose WorkspacePath still exists
+#   (g) --orphans without --include-no-plist keeps no-plist dirs, even aged ones
+#   (h) --orphans --include-no-plist keeps fresh no-plist dirs (age gate)
+#   (i) --orphans --include-no-plist removes no-plist dirs older than 48h
+#   (j) protected *.noindex caches are never removed, even aged and plist-less
+#   (k) --dry-run reports but removes nothing
+#   (l) a missing DerivedData root is a quiet no-op
+#   (m) no mode is a usage error (exit 2)
+#   (n) a plist without a WorkspacePath key counts as no-plist (age gate applies)
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# The helper verifies WorkspacePath through plutil; without it the script
+# itself refuses to delete anything, so there is nothing to test.
+command -v plutil >/dev/null 2>&1 || { echo "skip: plutil not found (DerivedData GC is macOS-only)"; exit 0; }
+
+GC="$ROOT/bin/fm-derived-data-gc.sh"
+TMP_ROOT=$(fm_test_tmproot fm-derived-data-gc-tests)
+DD="$TMP_ROOT/DerivedData"
+WS="$TMP_ROOT/workspaces"
+mkdir -p "$DD" "$WS"
+
+write_plist() {
+  local dir=$1 ws_path=$2
+  mkdir -p "$dir"
+  cat > "$dir/info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>WorkspacePath</key>
+	<string>$ws_path</string>
+</dict>
+</plist>
+EOF
+}
+
+age_dir() {
+  # Backdate a directory's mtime well beyond the default 48h gate.
+  touch -t 202001010000 "$1"
+}
+
+run_gc() {
+  FM_DERIVED_DATA_ROOT="$DD" "$GC" "$@"
+}
+
+# --- fixtures ---------------------------------------------------------------
+# Removed worktree wt1 (never created on disk) with a matching DerivedData dir.
+write_plist "$DD/App-aaa" "$WS/wt1/App.xcodeproj"
+# Live worktree wt2 whose DerivedData dir must survive even when named.
+mkdir -p "$WS/wt2/App.xcodeproj"
+write_plist "$DD/App-bbb" "$WS/wt2/App.xcodeproj"
+# Sibling path sharing only a string prefix with wt1.
+write_plist "$DD/App-ccc" "$WS/wt1-extra/App.xcodeproj"
+# Orphan plist dir (workspace never existed).
+write_plist "$DD/App-ddd" "$WS/gone/App.xcodeproj"
+# No-plist dirs: one fresh, one aged.
+mkdir -p "$DD/App-fresh" "$DD/App-aged"
+age_dir "$DD/App-aged"
+# Aged plist dir missing the WorkspacePath key (unreadable-as-WorkspacePath).
+mkdir -p "$DD/App-nokey"
+cat > "$DD/App-nokey/info.plist" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Name</key>
+	<string>App</string>
+</dict>
+</plist>
+EOF
+age_dir "$DD/App-nokey"
+# Protected shared caches, aged and plist-less: must survive everything.
+mkdir -p "$DD/ModuleCache.noindex" "$DD/CompilationCache.noindex" \
+  "$DD/SDKStatCaches.noindex" "$DD/SymbolCache.noindex" "$DD/OtherCache.noindex"
+age_dir "$DD/ModuleCache.noindex"
+age_dir "$DD/CompilationCache.noindex"
+age_dir "$DD/SDKStatCaches.noindex"
+age_dir "$DD/SymbolCache.noindex"
+age_dir "$DD/OtherCache.noindex"
+
+# (m) no mode is a usage error.
+set +e
+run_gc > "$TMP_ROOT/usage-out" 2>&1
+rc=$?
+set -e
+expect_code 2 "$rc" "no mode"
+pass "no mode is a usage error"
+
+# (l) missing DerivedData root is a quiet no-op.
+out=$(FM_DERIVED_DATA_ROOT="$TMP_ROOT/no-such-root" "$GC" --orphans)
+expect_code 0 "$?" "missing root exit"
+[ -z "$out" ] || fail "missing root printed output: $out"
+pass "missing DerivedData root is a quiet no-op"
+
+# (k) dry-run reports but removes nothing.
+out=$(run_gc --worktree "$WS/wt1" --dry-run)
+assert_contains "$out" "would remove: $DD/App-aaa" "dry-run should report App-aaa"
+assert_present "$DD/App-aaa" "dry-run removed App-aaa"
+pass "--dry-run reports but removes nothing"
+
+# (a) worktree mode removes the dir whose WorkspacePath is under the worktree.
+out=$(run_gc --worktree "$WS/wt1")
+assert_contains "$out" "removed: $DD/App-aaa" "worktree GC should remove App-aaa"
+assert_absent "$DD/App-aaa" "App-aaa should be removed"
+# (c) sibling string-prefix path survives.
+assert_present "$DD/App-ccc" "App-ccc (wt1-extra) must not match worktree wt1"
+pass "--worktree removes dirs under the worktree and respects prefix boundaries"
+
+# (b) worktree mode never removes a dir whose WorkspacePath still exists.
+out=$(run_gc --worktree "$WS/wt2")
+assert_not_contains "$out" "App-bbb" "App-bbb has a live WorkspacePath and must not be reported removed"
+assert_present "$DD/App-bbb" "App-bbb has a live WorkspacePath and must survive"
+pass "--worktree never removes a dir whose WorkspacePath still exists"
+
+# (d) worktree mode never removes no-plist dirs, even aged ones.
+run_gc --worktree "$WS/wt1" > /dev/null
+assert_present "$DD/App-aged" "worktree mode must never touch no-plist dirs"
+pass "--worktree never removes no-plist dirs"
+
+# (g) orphans without --include-no-plist keeps no-plist dirs, even aged ones.
+out=$(run_gc --orphans)
+# (e) orphans removes the dir whose WorkspacePath no longer exists.
+assert_contains "$out" "removed: $DD/App-ddd" "orphans GC should remove App-ddd"
+assert_absent "$DD/App-ddd" "App-ddd should be removed"
+# App-ccc's workspace wt1-extra also never existed, so it is an orphan too.
+assert_absent "$DD/App-ccc" "App-ccc (orphan) should be removed by orphans GC"
+# (f) orphans keeps the live-workspace dir.
+assert_present "$DD/App-bbb" "App-bbb (live) must survive orphans GC"
+assert_present "$DD/App-fresh" "fresh no-plist dir must survive without --include-no-plist"
+assert_present "$DD/App-aged" "aged no-plist dir must survive without --include-no-plist"
+assert_present "$DD/App-nokey" "no-WorkspacePath-key dir must survive without --include-no-plist"
+pass "--orphans removes dead-workspace dirs and keeps no-plist dirs without the flag"
+
+# (h)+(i) age gate on --include-no-plist.
+out=$(run_gc --orphans --include-no-plist)
+assert_present "$DD/App-fresh" "fresh no-plist dir must survive the age gate"
+assert_absent "$DD/App-aged" "aged no-plist dir should be removed with --include-no-plist"
+# (n) plist without a WorkspacePath key counts as no-plist.
+assert_absent "$DD/App-nokey" "plist without WorkspacePath counts as no-plist and ages out"
+pass "--include-no-plist removes only no-plist dirs older than the age gate"
+
+# (j) protected caches survived every run above.
+assert_present "$DD/ModuleCache.noindex" "ModuleCache.noindex must never be removed"
+assert_present "$DD/CompilationCache.noindex" "CompilationCache.noindex must never be removed"
+assert_present "$DD/SDKStatCaches.noindex" "SDKStatCaches.noindex must never be removed"
+assert_present "$DD/SymbolCache.noindex" "SymbolCache.noindex must never be removed"
+assert_present "$DD/OtherCache.noindex" "any *.noindex entry must never be removed"
+pass "protected *.noindex caches are never removed"

--- a/tests/fm-derived-data-gc.test.sh
+++ b/tests/fm-derived-data-gc.test.sh
@@ -19,6 +19,8 @@
 #   (l) a missing DerivedData root is a quiet no-op
 #   (m) no mode is a usage error (exit 2)
 #   (n) a plist without a WorkspacePath key counts as no-plist (age gate applies)
+#   (o) the mtime probe survives a GNU stat that answers `-f` on stdout and still
+#       fails, instead of concatenating that text with the fallback epoch
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -161,3 +163,49 @@ assert_present "$DD/SDKStatCaches.noindex" "SDKStatCaches.noindex must never be 
 assert_present "$DD/SymbolCache.noindex" "SymbolCache.noindex must never be removed"
 assert_present "$DD/OtherCache.noindex" "any *.noindex entry must never be removed"
 pass "protected *.noindex caches are never removed"
+
+# (o) mtime probe under GNU stat.
+# GNU coreutils stat has no BSD-style `-f <format>`: it reads `-f` as "print
+# filesystem status" and treats `%m` as a file operand, so it writes a
+# multi-line filesystem summary for the real operand to STDOUT and still exits
+# non-zero. A probe that pipes that failure into a `||` fallback captures the
+# summary text concatenated with the fallback epoch, and the age arithmetic then
+# aborts the whole run under `set -u` with "File: unbound variable".
+# This stub reproduces that stat flavor on any host, so the case is a real
+# regression guard on macOS rather than something only Linux CI would catch.
+GNU_STAT_ROOT=$(fm_test_tmproot fm-derived-data-gc-gnustat)
+GNU_DD="$GNU_STAT_ROOT/DerivedData"
+mkdir -p "$GNU_DD/App-aged-gnu"
+age_dir "$GNU_DD/App-aged-gnu"
+FAKEBIN=$(fm_fakebin "$GNU_STAT_ROOT")
+cat > "$FAKEBIN/stat" <<'SH'
+#!/usr/bin/env bash
+# GNU-coreutils stat emulation, narrowed to the two probes the GC issues.
+case "$1" in
+  -c)
+    [ "$2" = "%Y" ] || exit 1
+    # Fixed epoch (2020-01-01), far past any age gate the tests use.
+    printf '%s\n' 1577836800
+    exit 0
+    ;;
+  -f)
+    printf "stat: cannot read file system information for '%%m': No such file or directory\n" >&2
+    printf '  File: "%s"\n    ID: 0        Namelen: 255     Type: apfs\n' "$3"
+    exit 1
+    ;;
+esac
+exit 1
+SH
+chmod +x "$FAKEBIN/stat"
+
+set +e
+out=$(PATH="$FAKEBIN:$PATH" FM_DERIVED_DATA_ROOT="$GNU_DD" \
+  "$GC" --orphans --include-no-plist 2>&1)
+rc=$?
+set -e
+expect_code 0 "$rc" "GNU-stat mtime probe should not abort the run"
+assert_not_contains "$out" "unbound variable" \
+  "GNU stat's filesystem summary must not reach the age arithmetic"
+assert_absent "$GNU_DD/App-aged-gnu" \
+  "aged no-plist dir should still be removed under GNU stat"
+pass "mtime probe tolerates a GNU stat that answers -f on stdout and fails"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -76,7 +76,7 @@ make_case() {
   local name=$1 case_dir fakebin
   case_dir="$TMP_ROOT/$name"
   fakebin="$case_dir/fakebin"
-  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin" "$case_dir/derived-data-empty"
 
   # Mocks for the post-check teardown steps. Refuse logic exits before these
   # run; the ALLOW cases need them so the script can complete cleanly.
@@ -545,6 +545,7 @@ run_teardown() {
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
   FM_CONFIG_OVERRIDE="$case_dir/config" \
+  FM_DERIVED_DATA_ROOT="${FM_DERIVED_DATA_ROOT:-$case_dir/derived-data-empty}" \
   PATH="$case_dir/fakebin:${FM_TEARDOWN_TEST_PATH:-$PATH}" \
     "$TEARDOWN" task-x1 "$@"
 }

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -653,6 +653,70 @@ test_local_only_merged_to_local_main_allows() {
   pass "local-only worktree with work merged into local main is torn down (no regression)"
 }
 
+# Write a minimal Xcode DerivedData info.plist with a WorkspacePath key.
+# Args: <DerivedData dir> <workspace path>
+write_dd_plist() {
+  cat > "$1/info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>WorkspacePath</key>
+	<string>$2</string>
+</dict>
+</plist>
+EOF
+}
+
+# Teardown integration for bin/fm-derived-data-gc.sh: after the worktree is
+# returned, teardown garbage-collects the Xcode DerivedData dir whose
+# WorkspacePath lived under that worktree, while protected caches and dirs for
+# live workspaces survive. Needs plutil to read the fixture plist; without it
+# the helper itself deletes nothing, so there is nothing to assert.
+test_teardown_runs_derived_data_gc_after_worktree_return() {
+  if ! command -v plutil >/dev/null 2>&1; then
+    pass "teardown DerivedData GC integration (not run: plutil unavailable)"
+    return 0
+  fi
+  local case_dir rc dd
+  case_dir=$(make_case dd-gc)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit "$case_dir" "shippable work"
+  # Push the task branch to origin and fetch so the worktree sees it.
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+  # The default treehouse mock leaves the worktree in place; replace it with
+  # one that removes the worktree, as the real `treehouse return` does.
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    return|--force) shift ;;
+    *) rm -rf "$1"; shift ;;
+  esac
+done
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+  # Fixture DerivedData root: one dir belonging to the removed worktree, one
+  # protected cache, and one dir belonging to a different live workspace.
+  dd="$case_dir/DerivedData"
+  mkdir -p "$dd/App-aaa" "$dd/ModuleCache.noindex" "$dd/Other-bbb" "$case_dir/live/Other.xcodeproj"
+  write_dd_plist "$dd/App-aaa" "$case_dir/wt/App.xcodeproj"
+  write_dd_plist "$dd/Other-bbb" "$case_dir/live/Other.xcodeproj"
+
+  set +e
+  FM_DERIVED_DATA_ROOT="$dd" run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "dd-gc: teardown should succeed when HEAD is on origin"
+  assert_absent "$dd/App-aaa" "dd-gc: DerivedData dir for the removed worktree was not collected"
+  assert_present "$dd/ModuleCache.noindex" "dd-gc: protected cache was removed"
+  assert_present "$dd/Other-bbb" "dd-gc: DerivedData dir for a live workspace was removed"
+  pass "teardown garbage-collects the removed worktree's DerivedData (caches and live workspaces kept)"
+}
+
 test_no_mistakes_origin_remote_allows() {
   local case_dir rc
   case_dir=$(make_case nm-origin)
@@ -2477,6 +2541,7 @@ EOF
 
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
+test_teardown_runs_derived_data_gc_after_worktree_return
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -669,12 +669,21 @@ write_dd_plist() {
 EOF
 }
 
-# Teardown integration for bin/fm-derived-data-gc.sh: after the worktree is
-# returned, teardown garbage-collects the Xcode DerivedData dir whose
-# WorkspacePath lived under that worktree, while protected caches and dirs for
-# live workspaces survive. Needs plutil to read the fixture plist; without it
-# the helper itself deletes nothing, so there is nothing to assert.
-test_teardown_runs_derived_data_gc_after_worktree_return() {
+# Teardown integration for bin/fm-derived-data-gc.sh, scoped to the case the
+# teardown hook actually fires on: a task worktree whose path no longer exists
+# once backend cleanup has run (the Orca-style per-task worktree, or a path that
+# was already gone). In that case teardown garbage-collects the Xcode
+# DerivedData dir whose WorkspacePath lived under that worktree, while protected
+# caches and dirs for live workspaces survive.
+#
+# This case deliberately does NOT cover the default treehouse-backed backends:
+# `treehouse return` leaves the pooled worktree directory on disk, so the hook's
+# path-is-gone guard does not fire there. Making the GC reach pooled worktrees is
+# tracked as separate follow-up work.
+#
+# Needs plutil to read the fixture plist; without it the helper itself deletes
+# nothing, so there is nothing to assert.
+test_teardown_runs_derived_data_gc_when_worktree_path_is_gone() {
   if ! command -v plutil >/dev/null 2>&1; then
     pass "teardown DerivedData GC integration (not run: plutil unavailable)"
     return 0
@@ -686,8 +695,12 @@ test_teardown_runs_derived_data_gc_after_worktree_return() {
   # Push the task branch to origin and fetch so the worktree sees it.
   git -C "$case_dir/wt" push -q origin fm/task-x1
   git -C "$case_dir/project" fetch -q origin
-  # The default treehouse mock leaves the worktree in place; replace it with
-  # one that removes the worktree, as the real `treehouse return` does.
+  # The real `treehouse return` terminates lingering processes and returns the
+  # worktree to its pool, leaving the directory on disk (its removal verbs are
+  # `destroy` and `prune`), and the default mock matches that. Replace it with a
+  # mock that removes the directory purely to stand in for a backend whose task
+  # worktree really is gone by this point, which is what the teardown hook's
+  # path-is-gone guard requires.
   cat > "$case_dir/fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
 while [ "$#" -gt 0 ]; do
@@ -715,7 +728,7 @@ SH
   assert_absent "$dd/App-aaa" "dd-gc: DerivedData dir for the removed worktree was not collected"
   assert_present "$dd/ModuleCache.noindex" "dd-gc: protected cache was removed"
   assert_present "$dd/Other-bbb" "dd-gc: DerivedData dir for a live workspace was removed"
-  pass "teardown garbage-collects the removed worktree's DerivedData (caches and live workspaces kept)"
+  pass "teardown garbage-collects DerivedData for a worktree whose path is gone (caches and live workspaces kept)"
 }
 
 test_no_mistakes_origin_remote_allows() {
@@ -2542,7 +2555,7 @@ EOF
 
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
-test_teardown_runs_derived_data_gc_after_worktree_return
+test_teardown_runs_derived_data_gc_when_worktree_path_is_gone
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -34,6 +34,18 @@ FM_TEST_LIB_SOURCED=1
 # strips this to verify real refusal.
 export FM_GATE_REFUSE_BYPASS=1
 
+# Keep DerivedData garbage collection hermetic for every suite. fm-teardown.sh
+# runs bin/fm-derived-data-gc.sh whenever a task worktree path is already gone,
+# and that helper falls back to ~/Library/Developer/Xcode/DerivedData - so on a
+# developer's macOS host any test driving the real teardown would walk their live
+# DerivedData. Pin an empty fixture root instead; suites that actually exercise
+# the GC override this with a fixture of their own. mkdir failure is tolerated
+# because the helper treats a missing root as a quiet no-op, which is equally
+# hermetic.
+FM_TEST_DERIVED_DATA_ROOT="${TMPDIR:-/tmp}/fm-test-derived-data-empty"
+mkdir -p "$FM_TEST_DERIVED_DATA_ROOT" 2>/dev/null || true
+export FM_DERIVED_DATA_ROOT="${FM_DERIVED_DATA_ROOT:-$FM_TEST_DERIVED_DATA_ROOT}"
+
 # Resolve the repo root from this library's own location. Consumed by sourcing
 # test files, not by this library, so it reads as "unused" here.
 # shellcheck disable=SC2034


### PR DESCRIPTION
## Intent

Captain's request: make Xcode DerivedData cleanup permanent - every time a firstmate ship/scout worktree is torn down after landed work, also remove the DerivedData folder that belonged to that worktree, so orphaned DerivedData stops accumulating.

Deliberate design decisions already made and accepted on this branch:
- bin/fm-derived-data-gc.sh is the single owner of DerivedData GC, with two modes. --worktree <path> is the teardown path and matches ONLY on info.plist WorkspacePath equal to or under the removed worktree; it never touches no-plist dirs. --orphans removes dirs whose WorkspacePath no longer exists, and only with the explicit --include-no-plist flag plus a mandatory age gate (default 48h) will it remove dirs with no usable info.plist.
- Hard safety rules come from prior field incidents and are intentional: never delete *.noindex shared caches (ModuleCache, CompilationCache, SDKStatCaches, SymbolCache); never delete a dir whose WorkspacePath still resolves to an existing path, in either mode; never delete a no-plist dir without the age gate. Missing plutil or a missing DerivedData root is a deliberate quiet exit-0 no-op (fail safe, delete nothing).
- fm-teardown.sh calls the helper after the worktree is safely removable. GC failure is deliberately only a warning and must never fail teardown of landed work.
- Out of scope by the captain's instruction: CoreSimulator deletion, Docker/colima prune, and force-deleting no-plist dirs without an age gate.
- FM_DERIVED_DATA_ROOT exists so tests can point at a fixture root.

What this round adds, and why:
The repo's automated reviewer left an unanswered P2 on bin/fm-derived-data-gc.sh: dir_mtime chained 'stat -f %m' into a 'stat -c %Y' fallback with ||. GNU coreutils stat has no BSD-style '-f <format>' - it reads -f as 'print filesystem status' and treats %m as a file operand, so it writes a multi-line filesystem summary for the real operand to STDOUT and still exits non-zero. The fallback epoch was appended to that summary, and the caller's age arithmetic then aborted the entire run under set -u with 'File: unbound variable', breaking --orphans --include-no-plist and the test suite on any host with that stat flavor.

Deliberate choice: I validate each probe's output as a bare epoch rather than merely reordering the probes to put GNU stat first. Reordering fixes only this one stat pair; validation rejects ANY probe whose failure path writes to stdout, which is the actual class of defect. BSD order is kept first because DerivedData is macOS-only in practice, and the validation makes order irrelevant to correctness.

The test was written failing-first: case (o) in tests/fm-derived-data-gc.test.sh was confirmed to fail on the unfixed helper ('expected exit 0, got 1') before the fix landed. It stubs a GNU-flavored stat on PATH so the regression is guarded on macOS too, not only where Linux CI happens to expose it - that PATH stub is intentional, not a test smell.

The branch was also rebased onto current main (52 commits) this round; a git range-diff confirmed the three original commits replayed unchanged apart from one docs/scripts.md context line that main itself had edited.

## What Changed

- Added `bin/fm-derived-data-gc.sh`, the single owner of Xcode DerivedData cleanup, with a teardown mode (`--worktree <path>`, matching only on `info.plist` `WorkspacePath` equal to or under the removed worktree) and a manual `--orphans` sweep that needs an explicit `--include-no-plist` plus an age gate (default 48h) before touching plist-less dirs. It never removes `*.noindex` shared caches or a dir whose `WorkspacePath` still resolves, and quietly no-ops when `plutil` or the DerivedData root is missing.
- `bin/fm-teardown.sh` now invokes that helper after the task worktree path is gone (skipping `kind=secondmate`); a GC failure only prints `warning: DerivedData GC failed ... (non-fatal)` and never fails teardown of landed work.
- Hardened the helper's `dir_mtime` probe to validate each `stat` result as a bare epoch, so a GNU-flavored `stat` writing a filesystem summary to stdout no longer poisons the age arithmetic and abort the run under `set -u`; covered by a new `tests/fm-derived-data-gc.test.sh` suite (including a PATH-stubbed GNU `stat` regression case written failing-first), a teardown integration case, and a hermetic `FM_DERIVED_DATA_ROOT` fixture pinned in `tests/lib.sh`. Documented the helper and `FM_DERIVED_DATA_ROOT` in `docs/scripts.md`, `docs/configuration.md`, and `AGENTS.md`.

## Risk Assessment

✅ Low: This round is test-only, applies both captain-approved fixes correctly, leaves the accepted deliverable (the dir_mtime validation and case (o)) and the deliberately deferred teardown guard untouched, and the two residuals are comment/dead-code nits with no behavioral effect.

## Testing

I exercised the change at the product level rather than only through unit tests. The two targeted suites pass (`tests/fm-derived-data-gc.test.sh`, 10 cases; `tests/fm-teardown.test.sh`, 40 cases including the new DerivedData integration case). For the headline intent I wrote a driver that stands up a real git project and task worktree with landed work plus a realistic DerivedData root, then ran the shipped `bin/fm-teardown.sh`: the 4 MB DerivedData folder whose WorkspacePath pointed into the torn-down worktree was removed with an explicit `removed: …` line, while an unrelated live project's dir and the shared `ModuleCache.noindex`/`SymbolCache.noindex` caches survived. A second run with the DerivedData root made unwritable confirmed the deliberate fail-safe: teardown of landed work still exits 0 and only emits `warning: DerivedData GC failed … (non-fatal)`. For this round's fix I reproduced the original defect on the shipped CLI with a GNU-flavored `stat` on PATH (`line 224: File: unbound variable`, exit 1, nothing collected) and showed the same command succeeding after the fix, and I independently confirmed the author's failing-first claim by re-running the suite against the pre-fix helper, where only case (o) failed with exactly `expected exit 0, got 1`. The real `~/Library/Developer/Xcode/DerivedData` was untouched throughout and the worktree is clean. No UI surface is involved — this is a shell/CLI change, so CLI transcripts are the end-user-visible artifact.

<details>
<summary>Evidence: End-to-end teardown: worktree DerivedData collected, live workspace and shared caches kept</summary>

<code>=== BEFORE teardown: ~/Library/Developer/Xcode/DerivedData ===&#10;0B …/DerivedData/ModuleCache.noindex&#10;4.0M …/DerivedData/MyApp-abcdefgh&#10;4.0K …/DerivedData/OtherApp-zzzzzzzz&#10;0B …/DerivedData/SymbolCache.noindex&#10;&#10;=== $ fm-teardown.sh task-x1 ===&#10;removed: …/DerivedData/MyApp-abcdefgh (WorkspacePath …/wt/MyApp.xcodeproj belonged to removed worktree …/wt)&#10;…/project: already current&#10;teardown task-x1 complete (window firstmate:fm-task-x1, worktree …/wt)&#10;exit=0&#10;&#10;=== AFTER teardown: ~/Library/Developer/Xcode/DerivedData ===&#10;0B …/DerivedData/ModuleCache.noindex&#10;4.0K …/DerivedData/OtherApp-zzzzzzzz&#10;0B …/DerivedData/SymbolCache.noindex&#10;&#10;task worktree gone: yes&#10;its DerivedData gone: yes&#10;unrelated live-project DerivedData kept: yes&#10;shared ModuleCache.noindex kept: yes&#10;shared SymbolCache.noindex kept: yes</code>

```text
=== BEFORE teardown: ~/Library/Developer/Xcode/DerivedData ===
  0B	…/DerivedData/ModuleCache.noindex
4.0M	…/DerivedData/MyApp-abcdefgh
4.0K	…/DerivedData/OtherApp-zzzzzzzz
  0B	…/DerivedData/SymbolCache.noindex

=== $ fm-teardown.sh task-x1 ===
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: 1s ago, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
removed: …/DerivedData/MyApp-abcdefgh (WorkspacePath …/wt/MyApp.xcodeproj belonged to removed worktree …/wt)
…/project: already current
teardown task-x1 complete (window firstmate:fm-task-x1, worktree …/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --pr PR_URL, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
exit=0

=== AFTER teardown: ~/Library/Developer/Xcode/DerivedData ===
  0B	…/DerivedData/ModuleCache.noindex
4.0K	…/DerivedData/OtherApp-zzzzzzzz
  0B	…/DerivedData/SymbolCache.noindex

task worktree gone: yes
its DerivedData gone: yes
unrelated live-project DerivedData kept: yes
shared ModuleCache.noindex kept: yes
shared SymbolCache.noindex kept: yes
```
</details>
<details>
<summary>Evidence: GC failure is non-fatal: teardown of landed work still exits 0</summary>

<code>=== $ fm-teardown.sh task-x1 (DerivedData root not writable) ===&#10;rm: …/DerivedData/MyApp-abcdefgh: Permission denied&#10;warning: failed to remove …/DerivedData/MyApp-abcdefgh&#10;warning: DerivedData GC failed for …/wt (non-fatal)&#10;…/project: already current&#10;teardown task-x1 complete (window firstmate:fm-task-x1, worktree …/wt)&#10;exit=0&#10;&#10;teardown exit code (must be 0 -- GC failure is only a warning): 0&#10;its DerivedData still present (GC could not remove it): yes&#10;unrelated live-project DerivedData kept: yes&#10;shared ModuleCache.noindex kept: yes</code>

```text
=== BEFORE teardown: ~/Library/Developer/Xcode/DerivedData ===
  0B	…/DerivedData/ModuleCache.noindex
4.0M	…/DerivedData/MyApp-abcdefgh
4.0K	…/DerivedData/OtherApp-zzzzzzzz
  0B	…/DerivedData/SymbolCache.noindex

=== $ fm-teardown.sh task-x1 (DerivedData root not writable) ===
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: 1s ago, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
rm: …/DerivedData/MyApp-abcdefgh: Permission denied
warning: failed to remove …/DerivedData/MyApp-abcdefgh
warning: DerivedData GC failed for …/wt (non-fatal)
…/project: already current
teardown task-x1 complete (window firstmate:fm-task-x1, worktree …/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --pr PR_URL, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
exit=0

=== AFTER teardown: ~/Library/Developer/Xcode/DerivedData ===
  0B	…/DerivedData/ModuleCache.noindex
  0B	…/DerivedData/MyApp-abcdefgh
4.0K	…/DerivedData/OtherApp-zzzzzzzz
  0B	…/DerivedData/SymbolCache.noindex

task worktree gone: yes
teardown exit code (must be 0 -- GC failure is only a warning): 0
its DerivedData still present (GC could not remove it): yes
unrelated live-project DerivedData kept: yes
shared ModuleCache.noindex kept: yes
shared SymbolCache.noindex kept: yes
```
</details>
<details>
<summary>Evidence: mtime-probe fix: same CLI command under a GNU-flavored stat, before vs after</summary>

<code>### BEFORE fix (helper at 8f26a46) — real CLI run on a host whose stat is GNU-flavored&#10;$ fm-derived-data-gc.sh --orphans --include-no-plist&#10;bin/fm-derived-data-gc.sh: line 224: File: unbound variable&#10;exit=1&#10;&#10;$ ls DerivedData/ # orphaned dir still there — GC never ran&#10;App-aged-gnu&#10;&#10;### AFTER fix (0f3e9b2) — same host, same stat flavor, same command&#10;$ fm-derived-data-gc.sh --orphans --include-no-plist&#10;removed: /tmp/gnu-stat-repro.j6NhCH/DerivedData/App-aged-gnu (no info.plist and older than 48h)&#10;exit=0&#10;&#10;$ ls DerivedData/ # empty — the orphaned DerivedData dir was collected&#10;(entries: 0)</code>

```text
### AFTER fix (0f3e9b2) — same host, same stat flavor, same command
$ fm-derived-data-gc.sh --orphans --include-no-plist
removed: /tmp/gnu-stat-repro.j6NhCH/DerivedData/App-aged-gnu (no info.plist and older than 48h)
exit=0

$ ls DerivedData/   # empty — the orphaned DerivedData dir was collected
(entries: 0)
```
</details>
<details>
<summary>Evidence: Failing-first confirmation: case (o) against the pre-fix helper</summary>

<code>ok - protected *.noindex caches are never removed&#10;not ok - GNU-stat mtime probe should not abort the run: expected exit 0, got 1&#10;exit=1</code>

```text
ok - no mode is a usage error
ok - missing DerivedData root is a quiet no-op
ok - --dry-run reports but removes nothing
ok - --worktree removes dirs under the worktree and respects prefix boundaries
ok - --worktree never removes a dir whose WorkspacePath still exists
ok - --worktree never removes no-plist dirs
ok - --orphans removes dead-workspace dirs and keeps no-plist dirs without the flag
ok - --include-no-plist removes only no-plist dirs older than the age gate
ok - protected *.noindex caches are never removed
not ok - GNU-stat mtime probe should not abort the run: expected exit 0, got 1
exit=1
```
</details>
<details>
<summary>Evidence: Reusable end-to-end driver script (teardown + DerivedData)</summary>

```text
#!/usr/bin/env bash
# End-to-end demo: a landed ship task is torn down with the real
# bin/fm-teardown.sh, and the Xcode DerivedData folder that belonged to that
# worktree disappears with it. No test framework -- just the shipped scripts.
set -eu
REPO=$1
C=$(mktemp -d "${TMPDIR:-/tmp}/fm-dd-e2e.XXXXXX")
mkdir -p "$C/state" "$C/config" "$C/fakebin"

# --- backend / GitHub mocks (stand-ins for treehouse + gh on this machine) ---
cat > "$C/fakebin/treehouse" <<'SH'
#!/usr/bin/env bash
while [ "$#" -gt 0 ]; do
  case "$1" in return|--force) shift ;; *) rm -rf "$1"; shift ;; esac
done
exit 0
SH
cat > "$C/fakebin/tmux" <<'SH'
#!/usr/bin/env bash
exit 0
SH
cat > "$C/fakebin/gh-axi" <<'SH'
#!/usr/bin/env bash
case "${1:-} ${2:-}" in
  "pr list") printf '%s\n' "count: 0 (showing first 0)" "pull_requests[]: []"; exit 0 ;;
  "pr view") echo "error: pull request not found" >&2; exit 1 ;;
esac
exit 0
SH
cp "$C/fakebin/gh-axi" "$C/fakebin/gh"
chmod +x "$C/fakebin/"*

# --- a real project + a real task worktree with landed work ------------------
git init -q --bare "$C/origin.git"
git -C "$C/origin.git" symbolic-ref HEAD refs/heads/main
git clone -q "$C/origin.git" "$C/_seed" 2>/dev/null
git -C "$C/_seed" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "origin baseline"
git -C "$C/_seed" push -q origin main
rm -rf "$C/_seed"
git clone -q "$C/origin.git" "$C/project"
git -C "$C/project" remote set-head origin main >/dev/null 2>&1 || true
git -C "$C/project" worktree add -q -b fm/task-x1 "$C/wt" main
git -C "$C/wt" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "shippable work"
git -C "$C/wt" push -q origin fm/task-x1
git -C "$C/project" fetch -q origin
touch "$C/state/.last-watcher-beat"
cat > "$C/state/task-x1.meta" <<EOF
window=firstmate:fm-task-x1
endpoint_task_id=task-x1
worktree=$C/wt
project=$C/project
kind=ship
mode=no-mistakes
EOF

# --- Xcode DerivedData as Xcode would leave it -------------------------------
DD="$C/DerivedData"
mkdir -p "$DD/MyApp-abcdefgh" "$DD/OtherApp-zzzzzzzz" "$DD/ModuleCache.noindex" \
         "$DD/SymbolCache.noindex" "$C/live-project/OtherApp.xcodeproj" "$C/wt/MyApp.xcodeproj"
plist() { cat > "$1/info.plist" <<EOF
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict><key>WorkspacePath</key><string>$2</string></dict>
</plist>
EOF
}
plist "$DD/MyApp-abcdefgh" "$C/wt/MyApp.xcodeproj"          # built inside the task worktree
plist "$DD/OtherApp-zzzzzzzz" "$C/live-project/OtherApp.xcodeproj"  # unrelated, still live
mkdir -p "$DD/MyApp-abcdefgh/Build/Products/Debug"
dd if=/dev/zero of="$DD/MyApp-abcdefgh/Build/Products/Debug/MyApp" bs=1024 count=4096 2>/dev/null

echo "=== BEFORE teardown: ~/Library/Developer/Xcode/DerivedData ==="
du -sh "$DD"/* | sed "s#$DD#…/DerivedData#"
echo
echo "=== \$ fm-teardown.sh task-x1 ==="
set +e
FM_GATE_REFUSE_BYPASS=1 FM_ROOT_OVERRIDE="$REPO" FM_STATE_OVERRIDE="$C/state" FM_CONFIG_OVERRIDE="$C/config" \
FM_DERIVED_DATA_ROOT="$DD" PATH="$C/fakebin:$PATH" \
  "$REPO/bin/fm-teardown.sh" task-x1 2>&1 | sed "s#$C#…#g"
rc=${PIPESTATUS[0]}
set -e
echo "exit=$rc"
echo
echo "=== AFTER teardown: ~/Library/Developer/Xcode/DerivedData ==="
du -sh "$DD"/* | sed "s#$DD#…/DerivedData#"
echo
echo "task worktree gone: $([ -e "$C/wt" ] && echo NO || echo yes)"
echo "its DerivedData gone: $([ -e "$DD/MyApp-abcdefgh" ] && echo NO || echo yes)"
echo "unrelated live-project DerivedData kept: $([ -e "$DD/OtherApp-zzzzzzzz" ] && echo yes || echo NO)"
echo "shared ModuleCache.noindex kept: $([ -e "$DD/ModuleCache.noindex" ] && echo yes || echo NO)"
echo "shared SymbolCache.noindex kept: $([ -e "$DD/SymbolCache.noindex" ] && echo yes || echo NO)"
rm -rf "$C"
```
</details>
<details>
<summary>Evidence: Reusable end-to-end driver script (GC failure non-fatal)</summary>

```text
#!/usr/bin/env bash
# End-to-end demo: a landed ship task is torn down with the real
# bin/fm-teardown.sh, and the Xcode DerivedData folder that belonged to that
# worktree disappears with it. No test framework -- just the shipped scripts.
set -eu
REPO=$1
C=$(mktemp -d "${TMPDIR:-/tmp}/fm-dd-e2e.XXXXXX")
mkdir -p "$C/state" "$C/config" "$C/fakebin"

# --- backend / GitHub mocks (stand-ins for treehouse + gh on this machine) ---
cat > "$C/fakebin/treehouse" <<'SH'
#!/usr/bin/env bash
while [ "$#" -gt 0 ]; do
  case "$1" in return|--force) shift ;; *) rm -rf "$1"; shift ;; esac
done
exit 0
SH
cat > "$C/fakebin/tmux" <<'SH'
#!/usr/bin/env bash
exit 0
SH
cat > "$C/fakebin/gh-axi" <<'SH'
#!/usr/bin/env bash
case "${1:-} ${2:-}" in
  "pr list") printf '%s\n' "count: 0 (showing first 0)" "pull_requests[]: []"; exit 0 ;;
  "pr view") echo "error: pull request not found" >&2; exit 1 ;;
esac
exit 0
SH
cp "$C/fakebin/gh-axi" "$C/fakebin/gh"
chmod +x "$C/fakebin/"*

# --- a real project + a real task worktree with landed work ------------------
git init -q --bare "$C/origin.git"
git -C "$C/origin.git" symbolic-ref HEAD refs/heads/main
git clone -q "$C/origin.git" "$C/_seed" 2>/dev/null
git -C "$C/_seed" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "origin baseline"
git -C "$C/_seed" push -q origin main
rm -rf "$C/_seed"
git clone -q "$C/origin.git" "$C/project"
git -C "$C/project" remote set-head origin main >/dev/null 2>&1 || true
git -C "$C/project" worktree add -q -b fm/task-x1 "$C/wt" main
git -C "$C/wt" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "shippable work"
git -C "$C/wt" push -q origin fm/task-x1
git -C "$C/project" fetch -q origin
touch "$C/state/.last-watcher-beat"
cat > "$C/state/task-x1.meta" <<EOF
window=firstmate:fm-task-x1
endpoint_task_id=task-x1
worktree=$C/wt
project=$C/project
kind=ship
mode=no-mistakes
EOF

# --- Xcode DerivedData as Xcode would leave it -------------------------------
DD="$C/DerivedData"
mkdir -p "$DD/MyApp-abcdefgh" "$DD/OtherApp-zzzzzzzz" "$DD/ModuleCache.noindex" \
         "$DD/SymbolCache.noindex" "$C/live-project/OtherApp.xcodeproj" "$C/wt/MyApp.xcodeproj"
plist() { cat > "$1/info.plist" <<EOF
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict><key>WorkspacePath</key><string>$2</string></dict>
</plist>
EOF
}
plist "$DD/MyApp-abcdefgh" "$C/wt/MyApp.xcodeproj"          # built inside the task worktree
plist "$DD/OtherApp-zzzzzzzz" "$C/live-project/OtherApp.xcodeproj"  # unrelated, still live
mkdir -p "$DD/MyApp-abcdefgh/Build/Products/Debug"
dd if=/dev/zero of="$DD/MyApp-abcdefgh/Build/Products/Debug/MyApp" bs=1024 count=4096 2>/dev/null

echo "=== BEFORE teardown: ~/Library/Developer/Xcode/DerivedData ==="
du -sh "$DD"/* | sed "s#$DD#…/DerivedData#"
echo
chmod a-w "$DD"   # simulate a DerivedData dir that cannot be removed
echo "=== \$ fm-teardown.sh task-x1 (DerivedData root not writable) ==="
set +e
FM_GATE_REFUSE_BYPASS=1 FM_ROOT_OVERRIDE="$REPO" FM_STATE_OVERRIDE="$C/state" FM_CONFIG_OVERRIDE="$C/config" \
FM_DERIVED_DATA_ROOT="$DD" PATH="$C/fakebin:$PATH" \
  "$REPO/bin/fm-teardown.sh" task-x1 2>&1 | sed "s#$C#…#g"
rc=${PIPESTATUS[0]}
set -e
echo "exit=$rc"
echo
chmod u+w "$DD"
echo "=== AFTER teardown: ~/Library/Developer/Xcode/DerivedData ==="
du -sh "$DD"/* | sed "s#$DD#…/DerivedData#"
echo
echo "task worktree gone: $([ -e "$C/wt" ] && echo NO || echo yes)"
echo "teardown exit code (must be 0 -- GC failure is only a warning): $rc"
echo "its DerivedData still present (GC could not remove it): $([ -e "$DD/MyApp-abcdefgh" ] && echo yes || echo NO)"
echo "unrelated live-project DerivedData kept: $([ -e "$DD/OtherApp-zzzzzzzz" ] && echo yes || echo NO)"
echo "shared ModuleCache.noindex kept: $([ -e "$DD/ModuleCache.noindex" ] && echo yes || echo NO)"
echo "shared SymbolCache.noindex kept: $([ -e "$DD/SymbolCache.noindex" ] && echo yes || echo NO)"
rm -rf "$C"
```
</details>
<details>
<summary>Evidence: tests/fm-teardown.test.sh full output</summary>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: 0s ago, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown garbage-collects DerivedData for a worktree whose path is gone (caches and live workspaces kept)
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: 1s ago, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
ok - herdr flat teardown preflight refuses before every destructive change
ok - forced secondmate teardown preflights every Herdr child before cleanup mutation
ok - forced secondmate teardown retains Herdr child identity until exact pane disappearance
ok - forced teardown retains a nested secondmate home and its grandchild's Herdr identity when the grandchild close is unconfirmed
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains every record when post-close presence is unknown
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: 0s ago, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
WARNING: watcher still down (same stale episode; last beat: 1s ago, grace 300s) - full banner already printed this episode.
ok - fm-pr-check does not refresh PR head after HEAD moves
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: 0s ago, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
exit=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `bin/fm-teardown.sh:1831` - The `[ ! -e &#34;$WT&#34; ]` guard makes the DerivedData GC a no-op for every treehouse-backed backend (tmux/herdr/zellij/cmux -- the default ship/scout path). `treehouse return --force` cleans and resets the pooled worktree but leaves its directory on disk; verified on this host, where `~/.treehouse/estimate-os-a2a014/treehouse-state.json` lists slots 1-3 with no `owner_pid` (returned/free) while `~/.treehouse/&lt;pool&gt;/&lt;n&gt;/&lt;repo&gt;` still exists, and treehouse&#39;s own removal verbs are `destroy` and `prune`, not `return`. So the hook only fires for Orca per-task worktrees or paths that were already missing. This contradicts the intent&#39;s required behavior: &#34;every time a firstmate ship/scout worktree is torn down after landed work, also remove the DerivedData folder that belonged to that worktree&#34;. Note the genuine tension with another accepted rule -- &#34;never delete a dir whose WorkspacePath still resolves to an existing path&#34; -- since a returned pool slot&#39;s `&lt;slot&gt;/App.xcodeproj` does still exist, so the helper would correctly refuse anyway; that DerivedData is also reused by the next task in the same slot rather than orphaned. The accumulation the captain observed comes from slots that treehouse later prunes/destroys and from Orca worktrees, and nothing in the repo ever invokes `--orphans` (grep confirms no caller, no cron, no daemon). Decision needed: accept the narrower teardown coverage and schedule `--orphans` somewhere to actually close the accumulation goal, or widen the teardown condition.
- ⚠️ `tests/fm-teardown.test.sh:626` - The dd-gc integration test overrides the treehouse mock with one that `rm -rf`s the worktree, commented &#34;as the real `treehouse return` does&#34;. That premise is incorrect (see the pool-state evidence above), so the test makes `[ ! -e &#34;$WT&#34; ]` true and validates a path production takes only on Orca or already-missing worktrees. The test is green but does not demonstrate that teardown collects DerivedData on the default backend. Retarget it at a backend whose worktree really disappears (Orca), or re-scope its stated claim.
- ⚠️ `tests/fm-backend-orca.test.sh:869` - `test_teardown_removes_orca_worktree_when_path_missing` sets `wt=&#34;$TMP_ROOT/missing-path-wt&#34;` and never creates it, so teardown passes the new hook&#39;s `[ ! -e &#34;$WT&#34; ]` guard and invokes fm-derived-data-gc.sh with no `FM_DERIVED_DATA_ROOT`. The helper then defaults to `$HOME/Library/Developer/Xcode/DerivedData` and runs `plutil -extract` over every entry in the developer&#39;s real DerivedData. No deletion is possible (matching is scoped to the temp worktree path) and Linux CI exits early on the missing root, but the macOS run is non-hermetic and scales with the real DerivedData size. Commit 42dd1e8 pinned a fixture root only in tests/fm-teardown.test.sh:497; the same pin belongs on the other teardown-invoking tests that can reach the hook.
- ℹ️ `bin/fm-derived-data-gc.sh:178` - In `is_protected_cache`, `ModuleCache.noindex|CompilationCache.noindex|SDKStatCaches.noindex|SymbolCache.noindex` are fully subsumed by the trailing `*.noindex` alternative in the same pattern, so they are unreachable-as-distinct branches. Keeping the names as a comment above a bare `*.noindex)` case would preserve the field-incident documentation without reading as live matching logic.

🔧 Fix: pin hermetic DerivedData root suite-wide; re-scope teardown GC test
2 infos still open:
- ℹ️ `tests/fm-teardown.test.sh:497` - Now that tests/lib.sh:47 exports a non-empty FM_DERIVED_DATA_ROOT for every sourcing suite, run_teardown&#39;s `${FM_DERIVED_DATA_ROOT:-$case_dir/derived-data-empty}` default is unreachable and the `$case_dir/derived-data-empty` directory created in make_case (line 75) is never read. Both roots are empty fixture roots so there is no behavioral difference, but the dead fallback reads as the live owner of the pinned root. Either drop the per-case root and its mkdir so tests/lib.sh is the single owner, or keep it and note in a comment that it is defense-in-depth only.
- ℹ️ `tests/lib.sh:37` - The new comment says the pin keeps DerivedData GC hermetic &#34;for every suite&#34;, but it only reaches suites that source tests/lib.sh. Four suites invoke bin/fm-teardown.sh without sourcing it: tests/fm-backend-autodetect-smoke.test.sh, tests/fm-backend-herdr-launcher-workspace-e2e.test.sh, tests/fm-backend-herdr-workspace-per-home-e2e.test.sh, and tests/fm-secondmate-safety.test.sh. None can reach the GC today -- the first three drive real treehouse, whose `return` leaves the pooled worktree directory on disk so bin/fm-teardown.sh:1831&#39;s path-is-gone guard never fires, and the fourth is kind=secondmate, which that same guard excludes. Given this round&#39;s stated goal was removing an overstated scope claim from a comment, narrowing this one to &#34;every suite that sources this library&#34; (and naming why the non-sourcing teardown suites are safe) would keep it honest.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-derived-data-gc.test.sh` — all 10 cases (a)–(o) pass on the fixed helper</code>
- <code>`bash tests/fm-teardown.test.sh` — 40 cases pass, including `teardown garbage-collects DerivedData for a worktree whose path is gone (caches and live workspaces kept)`</code>
- <code>Failing-first check: `git show 8f26a46:bin/fm-derived-data-gc.sh` restored over the helper, then `bash tests/fm-derived-data-gc.test.sh` → only case (o) fails with `not ok - GNU-stat mtime probe should not abort the run: expected exit 0, got 1`; helper restored via `git checkout --`</code>
- <code>Manual CLI repro with a GNU-flavored `stat` stub on PATH: `PATH=$FAKEBIN:$PATH FM_DERIVED_DATA_ROOT=… bin/fm-derived-data-gc.sh --orphans --include-no-plist` → before fix `line 224: File: unbound variable`, exit 1, dir not collected; after fix `removed: …/App-aged-gnu (no info.plist and older than 48h)`, exit 0</code>
- <code>End-to-end product run: custom driver builds a real bare origin + project clone + `fm/task-x1` worktree with pushed (landed) work and a realistic DerivedData root, then runs the shipped `bin/fm-teardown.sh task-x1`; captured before/after `du -sh` of the DerivedData root</code>
- <code>End-to-end fail-safe run: same driver with `chmod a-w` on the DerivedData root so `rm -rf` fails → teardown prints `warning: DerivedData GC failed for …/wt (non-fatal)` and still exits 0</code>
- <code>Hermeticity check: `ls ~/Library/Developer/Xcode/DerivedData` after all runs (real user dirs intact) and `ls -A $TMPDIR/fm-test-derived-data-empty` (0 entries)</code>
- <code>`git status --porcelain` — clean worktree after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
