### PR TITLE
feat(bin): give each project its own leased worktree pool on the repo's filesystem

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # GitHub concurrency groups retain at most one pending run, replacing older
 # pending runs even when cancel-in-progress is false. Give body-bearing events
@@ -31,11 +32,31 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
-          if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
-            echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
+          # The payload body is a point-in-time snapshot, and no-mistakes pushes
+          # commits (synchronize) BEFORE it writes the '## Pipeline' section
+          # (edited). A head-change run that starts late therefore replays a
+          # pre-signature body after the body was already signed, and because
+          # body events and head changes sit in different concurrency groups
+          # that stale verdict is never superseded - leaving a compliant PR red.
+          # Judge the live body; fall back to the snapshot only if it is
+          # unreadable, so an unreachable API can never pass an unsigned PR.
+          body=${PR_BODY:-}
+          origin='event payload'
+          if [ -n "${GH_TOKEN:-}" ] && [ -n "${GH_REPO:-}" ] && command -v gh >/dev/null 2>&1; then
+            if live=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' 2>/dev/null); then
+              body=$live
+              origin='live PR body'
+            else
+              echo "::warning::could not read the live body for PR #${PR_NUMBER}; judging the event payload snapshot instead."
+            fi
+          fi
+          if printf '%s' "$body" | grep -qF -- "$marker"; then
+            echo "Found no-mistakes signature in PR #${PR_NUMBER} (${origin})."
             exit 0
           fi
           {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Pushing through it runs an AI-driven review/test/lint pipeline in an isolated wo
 
 A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes.
 It evaluates every PR opening and body edit independently, so a later edit cannot replace an earlier pending compliance check.
+Each run judges the body the PR carries at that moment rather than the snapshot in its own event payload, so a check triggered by a push that landed before the signature was written still passes.
 GitHub Actions and Dependabot are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
 
 ## Workflow

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -30,10 +30,18 @@
 #   bin/fm-backend.sh's fm_backend_detect, with cmux fallback details in
 #   docs/cmux-backend.md),
 #   then tmux.
+#   For every backend except orca, firstmate leases the task worktree itself with
+#   `treehouse get --lease`, run under a HOME that puts the pool on the repo's own
+#   filesystem (bin/fm-treehouse-lib.sh owns why that HOME is the only lever), and
+#   then sends the pane a plain cd. The lease is durable, so fm-teardown.sh returning
+#   the worktree is what frees the pool slot; a spawn that fails before publishing
+#   state/<id>.meta returns its own lease.
 #   Spawn-capable backends are the reference tmux adapter and experimental
 #   herdr, zellij, orca, and cmux. Orca owns both the task worktree and
-#   terminal, so ship/scout Orca spawns do not run treehouse get; cmux is a
-#   session provider only, exactly like herdr/zellij, so it does. An
+#   terminal, so ship/scout Orca spawns acquire no treehouse lease and firstmate
+#   cannot place their worktree - a split from the object store is reported, not
+#   refused; cmux is a session provider only, exactly like herdr/zellij, so it
+#   leases like the rest. An
 #   auto-detected herdr or cmux spawn prints a loud stderr notice;
 #   auto-detected tmux stays silent; zellij and orca are never auto-detected.
 #   codex-app is not a known backend yet; docs/codex-app-backend.md owns that
@@ -211,6 +219,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-trace-context-lib.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh
 . "$SCRIPT_DIR/fm-remote-readiness-lib.sh"
+# shellcheck source=bin/fm-treehouse-lib.sh
+. "$SCRIPT_DIR/fm-treehouse-lib.sh"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
 # a direct report (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
@@ -614,6 +624,7 @@ fi
 ORCA_ABORT_CLEANUP=0
 ORCA_WORKTREE_ID=
 ORCA_TERMINAL=
+TREEHOUSE_LEASE_ABORT_CLEANUP=0
 HERDR_PROJECTION_ABORT_CLEANUP=0
 HERDR_PROJECTION_ABORT_SESSION=
 HERDR_PROJECTION_ABORT_TASK_PANE=
@@ -644,6 +655,17 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$?
+  # A treehouse lease is durable: unlike the old interactive `treehouse get`, the
+  # pool slot is NOT freed when the pane dies. If this spawn fails before the task
+  # exists in state/, teardown will never run for it, so the lease has to come back
+  # here or the slot is held with nothing to release it.
+  if [ "$TREEHOUSE_LEASE_ABORT_CLEANUP" = 1 ]; then
+    TREEHOUSE_LEASE_ABORT_CLEANUP=0
+    if [ -n "${WT:-}" ] && [ -n "${PROJ_ABS:-}" ]; then
+      ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 \
+        || echo "warning: could not return the leased worktree $WT; run 'treehouse return --force $WT' from $PROJ_ABS to free the pool slot" >&2
+    fi
+  fi
   if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ] \
      && [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" != 1 ]; then
     if ! spawn_herdr_presentation_order_lock_acquire "${HERDR_PROJECTION_ABORT_SESSION:-}"; then
@@ -1291,6 +1313,21 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# A worktree split from its object store cannot run the validation pipeline at
+# all: git blocks in read_gitfile_gently and `no-mistakes init`/`axi run` hang
+# forever (bin/fm-treehouse-lib.sh owns the full explanation). Refuse the spawn
+# instead of launching a crew that is guaranteed to wedge hours later, on the one
+# path firstmate places itself. An undeterminable answer is not a violation.
+assert_worktree_colocated() {  # <worktree> <pool-home>
+  local wt=$1 pool_home=$2 status=0
+  fm_treehouse_worktree_colocated "$wt" || status=$?
+  if [ "$status" = 1 ]; then
+    echo "error: worktree $wt (filesystem $FM_TREEHOUSE_WT_DEVICE) is on a different filesystem than its object store $FM_TREEHOUSE_STORE (filesystem $FM_TREEHOUSE_STORE_DEVICE); the validation pipeline would hang in that worktree, so refusing to launch. Firstmate selected pool root $pool_home/.treehouse; a treehouse.toml in the repo root overrides that." >&2
+    exit 1
+  fi
+  return 0
+}
+
 herdr_projection_meta_field_exact() {  # <meta> <key>
   local meta=$1 key=$2 count
   [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
@@ -1589,6 +1626,16 @@ EOF
       exit 1
     fi
     validate_spawn_worktree "orca worktree create" "$W"
+    # Orca owns its own worktree placement - `orca worktree create` takes no root
+    # or path argument - so firstmate cannot put this one on the object store's
+    # filesystem the way it does for a treehouse pool. Report a split rather than
+    # refusing: the crew can still ship through direct-PR or local-only, and this
+    # is pre-existing Orca behavior, not something this spawn introduced.
+    ORCA_COLOCATED_STATUS=0
+    fm_treehouse_worktree_colocated "$WT" || ORCA_COLOCATED_STATUS=$?
+    if [ "$ORCA_COLOCATED_STATUS" = 1 ]; then
+      echo "warning: orca placed worktree $WT (filesystem $FM_TREEHOUSE_WT_DEVICE) on a different filesystem than its object store $FM_TREEHOUSE_STORE (filesystem $FM_TREEHOUSE_STORE_DEVICE); the no-mistakes validation pipeline will hang in that worktree. Use a delivery mode that does not run it, or configure Orca to place worktrees on the repo's filesystem." >&2
+    fi
     if [ -z "$ORCA_TERMINAL" ]; then
       ORCA_TERMINAL=$(fm_backend_orca_terminal_create "$ORCA_WORKTREE_ID" "$W") || exit 1
     fi
@@ -1694,53 +1741,60 @@ kimi_spawn_fail() {  # <detail>
 }
 
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  # Firstmate acquires the worktree itself rather than sending `treehouse get` to
+  # the pane, because the pool has to land on the repo's own filesystem and the
+  # only way to select it is the HOME treehouse runs under (bin/fm-treehouse-lib.sh
+  # owns why). An interactive `treehouse get` opens the crew's shell as a child of
+  # treehouse, so that HOME would be inherited by the agent and by everything it
+  # runs - wrong ~/.claude, wrong git config, wrong gh credentials. Leasing here
+  # keeps the override inside this process: the pane only ever receives a plain cd.
+  #
+  # The lease is durable, so every exit path between here and metadata publication
+  # must return it; TREEHOUSE_LEASE_ABORT_CLEANUP arms spawn_abort_cleanup for that.
+  # fm-teardown.sh already returns the worktree by absolute path on the normal path.
+  POOL_HOME=$(fm_treehouse_pool_home "$PROJ_ABS") || exit 1
+  WT=$( cd "$PROJ_ABS" && HOME="$POOL_HOME" treehouse get --lease --lease-holder "fm-$ID" 2>/dev/null ) || {
+    echo "error: treehouse could not lease a worktree for $PROJ_ABS under pool root $POOL_HOME/.treehouse" >&2
+    exit 1
+  }
+  if [ -z "$WT" ] || [ ! -d "$WT" ]; then
+    echo "error: treehouse returned no usable worktree path for $PROJ_ABS (got '${WT:-}')" >&2
+    exit 1
+  fi
+  TREEHOUSE_LEASE_ABORT_CLEANUP=1
 
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+  validate_spawn_worktree "treehouse get --lease" "$T"
+  assert_worktree_colocated "$WT" "$POOL_HOME"
+
+  # Move the pane into the leased worktree. `cd` is the one instruction every
+  # supported pane shell understands identically, which matters because the shell
+  # is the operator's, not ours.
+  spawn_send_text_line "$WT_TARGET" "cd $(shell_quote "$WT")"
+
+  # Confirm the pane really landed there before anything is launched into it.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
   # automatic-rename slips through), display-message -t <bad-name> falls back to the
   # active client's window, which would misread firstmate's OWN pane path as the
   # worktree and tangle a hook into the primary checkout. The window id never lies.
-  # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
-  # prefix would otherwise make the pane's OS-level cwd read differ from
-  # PROJ_ABS on the very first poll, before the pane has actually moved.
-  #
-  # A single read that already differs from PROJ_ABS_REAL is not proof the pane
-  # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
-  # transiently reports an unrelated stale path (seen live as another real git
-  # checkout entirely) before the shell catches up with treehouse get's cd. That
-  # stale path still passes the PROJ_ABS_REAL comparison and validate_spawn_worktree
-  # below (it resolves to a real, distinct worktree top-level too), so accepting it
-  # on one read alone silently records the wrong worktree= in state/<id>.meta. Require
-  # two consecutive reads to agree on the same non-project path before accepting it;
-  # a mismatch just becomes the new candidate rather than resetting the wait, so a
-  # pane that is already settled by the first real read only costs the one existing
-  # inter-poll sleep as confirmation, not a whole extra cycle on top.
-  candidate=""
-  for _ in $(seq 1 60); do
+  # The expected path is known exactly now, so - unlike the old "any path that is
+  # not the project" wait - a transient stale pane_current_path (seen live on some
+  # tmux/WSL setups as another real git checkout entirely) can never be mistaken
+  # for arrival. Compare physically: a symlinked prefix would otherwise never match.
+  WT_REAL=$(real_path_or_raw "$WT")
+  landed=0
+  SETTLE_POLLS=${FM_SPAWN_SETTLE_POLLS:-60}
+  for _ in $(seq 1 "$SETTLE_POLLS"); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ]; then
-      p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
-        if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
-          WT="$p"
-          break
-        fi
-        candidate="$p_real"
-      else
-        candidate=""
-      fi
-    else
-      candidate=""
+    if [ -n "$p" ] && [ "$(real_path_or_raw "$p")" = "$WT_REAL" ]; then
+      landed=1
+      break
     fi
     sleep 1
   done
-  if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+  if [ "$landed" -ne 1 ]; then
+    echo "error: pane did not enter the leased worktree $WT within 60s; inspect window $T" >&2
     exit 1
   fi
-
-  validate_spawn_worktree "treehouse get" "$T"
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
@@ -2075,6 +2129,10 @@ META_WINDOW=$T
   fi
 } > "$STATE/$ID.meta"
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
+# The task now exists in state/, so fm-teardown.sh owns returning its worktree.
+# Returning it from here after this point would pull the lease out from under a
+# live task.
+TREEHOUSE_LEASE_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -654,23 +654,18 @@ parse_orca_worktree_result() {
 }
 
 spawn_abort_cleanup() {
-  local status=$?
-  # A treehouse lease is durable: unlike the old interactive `treehouse get`, the
-  # pool slot is NOT freed when the pane dies. If this spawn fails before the task
-  # exists in state/, teardown will never run for it, so the lease has to come back
-  # here or the slot is held with nothing to release it.
-  if [ "$TREEHOUSE_LEASE_ABORT_CLEANUP" = 1 ]; then
-    TREEHOUSE_LEASE_ABORT_CLEANUP=0
-    if [ -n "${WT:-}" ] && [ -n "${PROJ_ABS:-}" ]; then
-      ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 \
-        || echo "warning: could not return the leased worktree $WT; run 'treehouse return --force $WT' from $PROJ_ABS to free the pool slot" >&2
-    fi
-  fi
+  local status=$? herdr_pane_close_refused=0
+  # The projection pane close must run BEFORE the lease return below: under the
+  # leased flow the pane's top-level shell has cwd in the worktree, so
+  # `treehouse return --force` kills that shell and Herdr's last-pane cleanup
+  # destroys the workspace and steals focus before the exact-pane close could
+  # restore it (same ordering fm-teardown.sh enforces on the normal path).
   if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ] \
      && [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" != 1 ]; then
     if ! spawn_herdr_presentation_order_lock_acquire "${HERDR_PROJECTION_ABORT_SESSION:-}"; then
       echo "warning: herdr presentation focus lock unavailable; retaining the projection journal and refusing concurrent abort cleanup" >&2
       HERDR_PROJECTION_ABORT_CLEANUP=0
+      herdr_pane_close_refused=1
     fi
   fi
   if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ]; then
@@ -683,6 +678,23 @@ spawn_abort_cleanup() {
   if [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" = 1 ]; then
     HERDR_PRESENTATION_ORDER_LOCK_HELD=0
     fm_lock_release "$HERDR_PRESENTATION_ORDER_LOCK" || true
+  fi
+  # A treehouse lease is durable: unlike the old interactive `treehouse get`, the
+  # pool slot is NOT freed when the pane dies. If this spawn fails before the task
+  # exists in state/, teardown will never run for it, so the lease has to come back
+  # here or the slot is held with nothing to release it. The one exception is a
+  # refused pane close above: returning then would kill the still-live pane and
+  # steal focus, so the slot is left with the exact recovery command instead.
+  if [ "$TREEHOUSE_LEASE_ABORT_CLEANUP" = 1 ]; then
+    TREEHOUSE_LEASE_ABORT_CLEANUP=0
+    if [ -n "${WT:-}" ] && [ -n "${PROJ_ABS:-}" ]; then
+      if [ "$herdr_pane_close_refused" = 1 ]; then
+        echo "warning: leased worktree $WT was not returned because its herdr pane is still open; close the pane, then run 'treehouse return --force $WT' from $PROJ_ABS to free the pool slot" >&2
+      else
+        ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 \
+          || echo "warning: could not return the leased worktree $WT; run 'treehouse return --force $WT' from $PROJ_ABS to free the pool slot" >&2
+      fi
+    fi
   fi
   if [ "$ORCA_ABORT_CLEANUP" = 1 ]; then
     ORCA_ABORT_CLEANUP=0
@@ -1753,10 +1765,14 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # must return it; TREEHOUSE_LEASE_ABORT_CLEANUP arms spawn_abort_cleanup for that.
   # fm-teardown.sh already returns the worktree by absolute path on the normal path.
   POOL_HOME=$(fm_treehouse_pool_home "$PROJ_ABS") || exit 1
-  WT=$( cd "$PROJ_ABS" && HOME="$POOL_HOME" treehouse get --lease --lease-holder "fm-$ID" 2>/dev/null ) || {
+  LEASE_ERR_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-spawn-lease-err.XXXXXXXX")
+  WT=$( cd "$PROJ_ABS" && HOME="$POOL_HOME" treehouse get --lease --lease-holder "fm-$ID" 2>"$LEASE_ERR_FILE" ) || {
     echo "error: treehouse could not lease a worktree for $PROJ_ABS under pool root $POOL_HOME/.treehouse" >&2
+    [ ! -s "$LEASE_ERR_FILE" ] || sed 's/^/  treehouse: /' "$LEASE_ERR_FILE" >&2
+    rm -f "$LEASE_ERR_FILE"
     exit 1
   }
+  rm -f "$LEASE_ERR_FILE"
   if [ -z "$WT" ] || [ ! -d "$WT" ]; then
     echo "error: treehouse returned no usable worktree path for $PROJ_ABS (got '${WT:-}')" >&2
     exit 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -45,6 +45,12 @@
 # Projected closes share the presentation-order lock, refuse to close the
 # captain's active tab, and restore the exact response-derived pre-close tab
 # if Herdr's last-pane cleanup focuses an unrelated neighboring workspace.
+# This gate, lock, and exact-pane close all run BEFORE the worktree is
+# returned to its treehouse pool below. Under the leased worktree-acquisition
+# flow the task pane's own top-level shell has cwd set to the worktree, so a
+# post-hoc worktree return would kill that shell first and let Herdr's own
+# last-pane cleanup steal focus with no firstmate code left in the loop to
+# restore it.
 # Secondmates (kind=secondmate in meta) are retired explicitly. Normal
 # teardown refuses while their home has in-flight crewmate meta files; --force
 # is the approved discard path that prevalidates child removal targets, discards

--- a/bin/fm-treehouse-lib.sh
+++ b/bin/fm-treehouse-lib.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Where a task worktree is allowed to live, and how firstmate puts it there.
+#
+# THE INVARIANT: a linked worktree and the object store it points at must sit on
+# ONE filesystem. When they are split, git's read_gitfile_gently blocks inside
+# open(), and `no-mistakes init` and `no-mistakes axi run` hang forever - so a
+# crew in a split worktree can never run the validation pipeline. Ordinary git
+# reads inherit the open descriptor and look completely healthy, which is what
+# makes this a trap rather than an obvious failure.
+#
+# HOW TREEHOUSE PICKS THE POOL: a repo's pool lives at {root}/.treehouse/, where
+# root comes from a treehouse.toml in the REPO ROOT (no ancestor search) and
+# otherwise defaults to $HOME. There is no environment override - TREEHOUSE_DIR
+# appears in the binary but does not select the pool; verified inert against the
+# v2.0.0 build and the v2.0.1 pin in bin/fm-install-treehouse.sh. Firstmate
+# therefore selects the pool by running treehouse under a HOME of its own
+# choosing, as a per-command assignment so that nothing else - above all not the
+# crew agent's own shell - inherits it.
+#
+# A repo-root treehouse.toml still outranks that HOME, so this file cannot make
+# placement unconditional. fm_treehouse_worktree_colocated is the backstop: it
+# checks the invariant on the acquired worktree itself, whoever placed it.
+
+fm_treehouse_device() {  # <path>
+  local path=$1
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %d "$path" 2>/dev/null
+  else
+    stat -c %d "$path" 2>/dev/null
+  fi
+}
+
+# The object store a working tree actually reads through, canonicalized.
+# --path-format=absolute needs git 2.31+; the fallback resolves the relative form
+# against the repo so an older git still answers instead of silently returning "".
+fm_treehouse_object_store() {  # <repo-or-worktree-dir>
+  local repo=$1 common
+  common=$(git -C "$repo" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
+    || common=$(git -C "$repo" rev-parse --git-common-dir 2>/dev/null) \
+    || return 1
+  [ -n "$common" ] || return 1
+  case "$common" in
+    /*) ;;
+    *) common="$repo/$common" ;;
+  esac
+  [ -d "$common" ] || return 1
+  (CDPATH='' cd -- "$common" 2>/dev/null && pwd -P)
+}
+
+# The mount point of an existing directory: walk up until the device id changes.
+# Deriving it this way avoids parsing `df`, whose filesystem and mount-point
+# columns can both contain spaces.
+fm_treehouse_mount_point() {  # <existing-dir>
+  local path=$1 dev parent parent_dev
+  path=$(CDPATH='' cd -- "$path" 2>/dev/null && pwd -P) || return 1
+  dev=$(fm_treehouse_device "$path")
+  [ -n "$dev" ] || return 1
+  while [ "$path" != / ]; do
+    parent=$(dirname "$path")
+    parent_dev=$(fm_treehouse_device "$parent")
+    [ -n "$parent_dev" ] || return 1
+    [ "$parent_dev" = "$dev" ] || break
+    path=$parent
+  done
+  printf '%s\n' "$path"
+}
+
+# The HOME to run treehouse under so this repo's pool lands on the repo's own
+# filesystem. Derived from the repo, never from a hardcoded volume: a fleet can
+# hold repos on several volumes, and the requirement is "same filesystem as this
+# repo's object store", not one fixed path.
+#
+# When $HOME is already on that filesystem the answer is $HOME, so the default
+# layout stays exactly as it was for every same-volume fleet.
+fm_treehouse_pool_home() {  # <repo-dir>
+  local repo=$1 store store_dev home_dev mount
+  store=$(fm_treehouse_object_store "$repo") || {
+    echo "error: cannot resolve the git object store for $repo" >&2
+    return 1
+  }
+  store_dev=$(fm_treehouse_device "$store")
+  home_dev=$(fm_treehouse_device "${HOME:-/}")
+  [ -n "$store_dev" ] || {
+    echo "error: cannot read the filesystem of $store" >&2
+    return 1
+  }
+  if [ -n "$home_dev" ] && [ "$store_dev" = "$home_dev" ]; then
+    printf '%s\n' "$HOME"
+    return 0
+  fi
+  mount=$(fm_treehouse_mount_point "$store") || {
+    echo "error: cannot resolve the filesystem holding $store" >&2
+    return 1
+  }
+  printf '%s\n' "$mount"
+}
+
+# Check the invariant on a worktree that already exists, whoever created it.
+# Exit 0 colocated, 1 split, 2 undeterminable (never treat 2 as a violation).
+# On 0 or 1 the three FM_TREEHOUSE_* variables carry the evidence for the caller's
+# diagnostic, so a refusal can name both devices instead of asserting a verdict.
+FM_TREEHOUSE_WT_DEVICE=
+FM_TREEHOUSE_STORE=
+FM_TREEHOUSE_STORE_DEVICE=
+fm_treehouse_worktree_colocated() {  # <worktree>
+  local wt=$1 store wt_dev store_dev
+  FM_TREEHOUSE_WT_DEVICE=
+  FM_TREEHOUSE_STORE=
+  FM_TREEHOUSE_STORE_DEVICE=
+  store=$(fm_treehouse_object_store "$wt") || return 2
+  wt_dev=$(fm_treehouse_device "$wt")
+  store_dev=$(fm_treehouse_device "$store")
+  [ -n "$wt_dev" ] && [ -n "$store_dev" ] || return 2
+  # shellcheck disable=SC2034 # Read by callers after this function returns.
+  FM_TREEHOUSE_WT_DEVICE=$wt_dev
+  # shellcheck disable=SC2034 # Read by callers after this function returns.
+  FM_TREEHOUSE_STORE=$store
+  # shellcheck disable=SC2034 # Read by callers after this function returns.
+  FM_TREEHOUSE_STORE_DEVICE=$store_dev
+  [ "$wt_dev" = "$store_dev" ]
+}

--- a/bin/fm-treehouse-lib.sh
+++ b/bin/fm-treehouse-lib.sh
@@ -65,15 +65,36 @@ fm_treehouse_mount_point() {  # <existing-dir>
   printf '%s\n' "$path"
 }
 
-# The HOME to run treehouse under so this repo's pool lands on the repo's own
-# filesystem. Derived from the repo, never from a hardcoded volume: a fleet can
-# hold repos on several volumes, and the requirement is "same filesystem as this
-# repo's object store", not one fixed path.
+# A stable per-project pool identity: the repo's own directory name plus a
+# discriminator derived from the canonical object-store path, so two projects
+# that happen to share a name never share a pool.
+fm_treehouse_project_slug() {  # <canonical-object-store-path>
+  local store=$1 name discriminator
+  name=$(basename "$(dirname "$store")")
+  case "$name" in
+    ''|.|/) name=repo ;;
+  esac
+  # cksum is POSIX and present on every supported host; the value only has to be
+  # stable and collision-resistant enough to separate two same-named projects.
+  discriminator=$(printf '%s' "$store" | cksum | awk '{print $1}')
+  printf '%s-%s\n' "$name" "$discriminator"
+}
+
+# The HOME to run treehouse under, so this repo's pool lands on the repo's own
+# filesystem AND in a pool of its own. Derived from the repo, never from a
+# hardcoded volume: a fleet can hold repos on several volumes, and the
+# requirement is "same filesystem as this repo's object store", not one path.
 #
-# When $HOME is already on that filesystem the answer is $HOME, so the default
-# layout stays exactly as it was for every same-volume fleet.
+# Each project gets its own pool root under .fm-pools/<slug>/. That segregation
+# is a safety property, not tidiness: treehouse's prune and destroy operate on a
+# pool, so one shared pool means a cleanup aimed at one project can reach into
+# another project's worktrees - including ones holding work that has not been
+# pushed anywhere else. Per-project pools bound that blast radius to one project.
+#
+# Existing pooled worktrees are unaffected: they keep their absolute paths, and
+# fm-teardown.sh returns them by absolute path regardless of pool root.
 fm_treehouse_pool_home() {  # <repo-dir>
-  local repo=$1 store store_dev home_dev mount
+  local repo=$1 store store_dev home_dev base
   store=$(fm_treehouse_object_store "$repo") || {
     echo "error: cannot resolve the git object store for $repo" >&2
     return 1
@@ -85,14 +106,14 @@ fm_treehouse_pool_home() {  # <repo-dir>
     return 1
   }
   if [ -n "$home_dev" ] && [ "$store_dev" = "$home_dev" ]; then
-    printf '%s\n' "$HOME"
-    return 0
+    base=$HOME
+  else
+    base=$(fm_treehouse_mount_point "$store") || {
+      echo "error: cannot resolve the filesystem holding $store" >&2
+      return 1
+    }
   fi
-  mount=$(fm_treehouse_mount_point "$store") || {
-    echo "error: cannot resolve the filesystem holding $store" >&2
-    return 1
-  }
-  printf '%s\n' "$mount"
+  printf '%s/.fm-pools/%s\n' "$base" "$(fm_treehouse_project_slug "$store")"
 }
 
 # Check the invariant on a worktree that already exists, whoever created it.

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # Shared durable wake queue and portable lock helpers.
 
-FM_WAKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FM_WAKE_DEFAULT_ROOT="$(cd "$FM_WAKE_LIB_DIR/.." && pwd)"
+# pwd -P so this default root is canonical.
+# A home is routinely reachable through a symlinked ancestor, and a logical pwd
+# keeps whichever route the caller happened to use, so two scripts in the same
+# home can derive two different strings for it.
+# fm_lock_paths_equal below is what keeps that survivable for lock identity;
+# deriving canonically here removes the divergence at the source.
+FM_WAKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+FM_WAKE_DEFAULT_ROOT="$(cd "$FM_WAKE_LIB_DIR/.." && pwd -P)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_WAKE_DEFAULT_ROOT}}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-${STATE:-$FM_HOME/state}}"
@@ -79,6 +85,45 @@ fm_path_age() {
 }
 
 FM_WATCHER_MATCHED_IDENTITY=
+# Compare two watcher-lock identity paths for "names the same place".
+#
+# The home and watcher-path recorded in the lock come from whichever script forked
+# the watcher, and are re-read by whichever script is checking it. Those scripts do
+# not agree on symlink resolution: bin/fm-arm-pretool-check.sh and
+# bin/fm-cd-pretool-check.sh resolve with pwd -P, while most of bin/ derives its
+# root with a logical pwd. When a home is reachable through a symlinked ancestor
+# (a real fleet layout, not a hypothetical), the two styles produce two different
+# strings for one directory, and a raw string comparison then reports the home's
+# own live watcher as somebody else's forever - every identity check fails, and
+# nothing can repair it because re-arming records the same divergent pair again.
+#
+# Resolving both sides makes any mix of the two styles agree. Equal raw strings
+# short-circuit, so the common case costs nothing. A path that cannot be resolved
+# (a stale lock naming a removed home) keeps its raw value rather than becoming
+# empty, so an unresolvable path never matches a different unresolvable path.
+# Resolve a lock identity path as far as it can be resolved.
+# A home is a directory whose own final component can be the symlink (~/dev ->
+# an external volume), so it must be resolved too - fm_lock_abs_path deliberately
+# leaves the final component alone, which is right for the watcher-path file but
+# would leave a symlinked home unresolved.
+fm_lock_resolve_path() {  # <path>
+  local path=$1 real
+  if [ -d "$path" ] && real=$(CDPATH='' cd -- "$path" 2>/dev/null && pwd -P); then
+    printf '%s\n' "$real"
+    return 0
+  fi
+  fm_lock_abs_path "$path"
+}
+
+fm_lock_paths_equal() {  # <a> <b>
+  local a=$1 b=$2 a_real b_real
+  [ "$a" = "$b" ] && return 0
+  [ -n "$a" ] && [ -n "$b" ] || return 1
+  a_real=$(fm_lock_resolve_path "$a" 2>/dev/null) || a_real=$a
+  b_real=$(fm_lock_resolve_path "$b" 2>/dev/null) || b_real=$b
+  [ "$a_real" = "$b_real" ]
+}
+
 fm_watcher_lock_matches_pid() {
   local state=$1 watch_path=$2 pid=$3 home=${4:-$FM_HOME} lockdir lock_home lock_path lock_identity current_identity
   FM_WATCHER_MATCHED_IDENTITY=
@@ -86,8 +131,8 @@ fm_watcher_lock_matches_pid() {
   lock_home=$(cat "$lockdir/fm-home" 2>/dev/null || true)
   lock_path=$(cat "$lockdir/watcher-path" 2>/dev/null || true)
   lock_identity=$(cat "$lockdir/pid-identity" 2>/dev/null || true)
-  [ "$lock_home" = "$home" ] || return 1
-  [ "$lock_path" = "$watch_path" ] || return 1
+  fm_lock_paths_equal "$lock_home" "$home" || return 1
+  fm_lock_paths_equal "$lock_path" "$watch_path" || return 1
   [ -n "$lock_identity" ] || return 1
   current_identity=$(fm_pid_identity "$pid") || return 1
   [ "$current_identity" = "$lock_identity" ] || return 1

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -60,7 +60,11 @@
 # (secondmate homes run the same script) and would kill siblings.
 set -u
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# pwd -P so the recorded watcher path and home are canonical: this script both
+# publishes the lock identity (through the watcher it forks) and re-reads it, and
+# a home reached through a symlinked ancestor would otherwise be recorded under
+# whichever route armed it. fm_lock_paths_equal is the comparison contract.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
@@ -227,8 +231,10 @@ clear_stale_recorded_watcher_lock() {
   lock_home=$(cat "$WATCH_LOCK/fm-home" 2>/dev/null || true)
   lock_path=$(cat "$WATCH_LOCK/watcher-path" 2>/dev/null || true)
   lock_identity=$(cat "$WATCH_LOCK/pid-identity" 2>/dev/null || true)
-  [ "$lock_home" = "$FM_HOME" ] || return 0
-  [ "$lock_path" = "$WATCH" ] || return 0
+  # Same comparison contract as fm_watcher_lock_matches_pid: a lock this home
+  # published through a symlinked route is still this home's lock to clear.
+  fm_lock_paths_equal "$lock_home" "$FM_HOME" || return 0
+  fm_lock_paths_equal "$lock_path" "$WATCH" || return 0
   [ -n "$lock_identity" ] || return 0
   fm_lock_remove_path "$WATCH_LOCK" || true
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,6 +135,8 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
+`fm-spawn.sh` acquires each pooled worktree itself with a durable `treehouse get --lease` and sends the pane only a plain `cd`; the lease is freed by `fm-teardown.sh` returning the worktree (or by spawn-abort cleanup), not by pane death.
+Each project's pool lands under `.fm-pools/<slug>` on the repo's own filesystem, and spawn refuses a pooled worktree that sits on a different filesystem than its object store; `bin/fm-treehouse-lib.sh` owns the placement mechanism, the per-project blast-radius rationale, and that colocation invariant.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -87,8 +87,8 @@ A genuinely fresh surface returns an internal error from `read-screen` until som
 Target readiness therefore uses the structural `list-panes` response instead of a content read.
 Capture remains bounded and locally trimmed after `read-screen` becomes available.
 
-`current_directory` follows a top-level shell `cd` but not the foreground subshell opened by `treehouse get`.
-Spawn-time worktree discovery sends begin and end markers around `pwd`, captures the marked block, and joins wrapped path lines.
+`current_directory` follows a top-level shell `cd` but never a foreground command's internal `cd`.
+Spawn sends the surface a plain `cd` into the worktree firstmate leased itself, then confirms arrival with begin and end markers around `pwd`, capturing the marked block and joining wrapped path lines.
 
 Literal send and Enter are separate calls.
 Enter, Escape, and Ctrl-C are supported.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -549,6 +549,7 @@ FM_WEDGE_DEMAND_INSPECT_COUNT=3    # consecutive provably-working stale escalati
 FM_WATCH_TRIAGE_LOG_MAX_BYTES=262144   # size cap for the watcher's absorbed-wake debug log
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=     # optional seconds allowed for bootstrap's best-effort clone refresh; unset/blank defaults to max(20, 5 + 3 * origin-backed-project-count)
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
+FM_SPAWN_SETTLE_POLLS=60   # one-second polls fm-spawn.sh waits for the pane to land in the leased worktree before failing the spawn
 FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh treats a leftover worktree git index.lock as provably stale
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -70,6 +70,7 @@ It never raw-deletes an Orca worktree.
 - Escape is unsupported.
 - Orca exposes no stable CLI version or protocol marker, so readiness is the compatibility gate rather than a version floor.
 - Only the verified terminal-handle and worktree result fields are accepted; speculative response shapes are rejected.
+- Orca chooses worktree placement itself, so a worktree on a different filesystem than the repository's object store is reported with a loud spawn warning rather than refused; the no-mistakes validation pipeline hangs in such a split worktree (`bin/fm-treehouse-lib.sh` owns the invariant).
 
 ## Regression entry points
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -46,6 +46,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-home-seed.sh` | Register and provision a whole secondmate home on an SSH-reachable host              |
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
+| `fm-treehouse-lib.sh`    | Shared per-project worktree-pool placement and the worktree/object-store same-filesystem invariant |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer-content classification for all backends          |

--- a/docs/zellij-backend.md
+++ b/docs/zellij-backend.md
@@ -66,9 +66,9 @@ A pane can still disappear between verification and the operation; downstream su
 
 Every pane operation passes an explicit `--pane-id` because a new session can focus its release-notes plugin pane, whose numeric plugin id is in a separate namespace from terminal pane ids.
 
-`pane_cwd` follows a top-level shell `cd` but not the foreground subshell opened by `treehouse get`.
-Worktree discovery therefore sends begin and end markers around `pwd`, captures the marked block, and joins wrapped path lines.
-This active probe is scoped to spawn-time worktree discovery and is not advertised as a general live-cwd API.
+`pane_cwd` follows a top-level shell `cd` but never a foreground command's internal `cd`.
+Spawn sends the pane a plain `cd` into the worktree firstmate leased itself, then confirms arrival with begin and end markers around `pwd`, capturing the marked block and joining wrapped path lines.
+This active probe is scoped to spawn-time arrival confirmation and is not advertised as a general live-cwd API.
 
 `new-tab` has no no-focus flag and temporarily focuses the created tab in attached clients.
 The adapter records the previously active tab and immediately restores it with `go-to-tab-by-id`.

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -208,6 +208,14 @@ set -u
   printf '\n'
 } >> "$TREEHOUSE_CALL_LOG"
 if [ -d "$POST_CREATE_ABORT_CONTROL" ] && [ "${1:-}" = get ]; then
+  # Post-create abort: yield a path that exists but is NOT an isolated worktree —
+  # the invoking project checkout itself. Under the leased-acquisition flow the
+  # spawn then proceeds past acquisition with WT=<primary checkout> and must be
+  # stopped by the armed isolation validation, which is the invariant this
+  # fixture exists to pin. (A bare `exit 0` with no output now dies earlier on
+  # the leased flow's empty-path check, a different error, so the armed
+  # validation would never be reached.)
+  pwd
   exit 0
 fi
 exec "$REAL_TREEHOUSE" "$@"

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -806,7 +806,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  fm_fake_treehouse "$fb" "$wt"
   printf '%s\n' "$fb"
 }
 
@@ -876,7 +876,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  fm_fake_treehouse "$fb" "$wt"
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -27,7 +27,8 @@ make_home() {  # <name>
 ## Done
 EOF
   fakebin=$(fm_fakebin "$home")
-  fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$home"
 }
 
@@ -426,7 +427,8 @@ test_secondmate_hold_stays_in_authoritative_home() {
 ## Done
 EOF
   fakebin=$(fm_fakebin "$mate")
-  fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_fake_exit0 "$fakebin" tmux no-mistakes gh gh-axi
+  fm_fake_treehouse "$fakebin"
   origin=sample-mate-review
   mkdir -p "$mate/data/$origin"
   tasks_in "$mate" add "$origin" "Investigate secondmate sample" --kind scout --repo sample --start >/dev/null

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -152,7 +152,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -26,7 +26,8 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_treehouse "$fakebin"
+  fm_fake_exit0 "$fakebin" gh-axi gh
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -125,7 +125,8 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_treehouse "$fakebin"
+  fm_fake_exit0 "$fakebin" gh-axi gh
   fm_fake_exit0 "$fakebin" kimi
   ln -s "$JQ_BIN" "$fakebin/jq"
   printf '%s\n' "$fakebin"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -577,6 +577,10 @@ meta_field() { grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2-; }
 make_launch_capturing_tmux() {
   local dir=$1 fakebin="$1/fakebin"
   mkdir -p "$fakebin"
+  # This fixture builds its fakebin directly rather than through fm_fakebin, so
+  # it needs the treehouse stub explicitly: without it a crew spawn reaches the
+  # real binary and leases a real pool slot for a throwaway repo.
+  fm_fake_treehouse "$fakebin"
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -328,6 +328,7 @@ EOF
     > "$data_override/secondmates.md"
   fakebin=$(make_fake_spawn_toolchain "$w")
   add_bootstrap_compatible_tools "$fakebin"
+  fm_fake_treehouse "$fakebin"
 
   out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$root" \
     FM_DATA_OVERRIDE="$data_override" \
@@ -379,6 +380,7 @@ EOF
   fakebin=$(make_fake_spawn_toolchain "$w")
   add_bootstrap_compatible_tools "$fakebin"
   fm_fake_exit0 "$fakebin" pgrep
+  fm_fake_treehouse "$fakebin"
 
   out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$root" \
     "$ROOT/bin/fm-session-start.sh")

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -42,7 +42,11 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse pi-signed
+  fm_fake_exit0 "$fakebin" pi-signed
+  # Must come AFTER fm_fake_exit0: fm-spawn now executes treehouse to lease the
+  # worktree and reads the path off its stdout, so the exit-0-with-no-output stub
+  # would read as treehouse failing to produce a worktree at all.
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -1,23 +1,26 @@
 #!/usr/bin/env bash
-# Regression test for the fm-spawn.sh treehouse-get worktree-detection settle
-# loop (bin/fm-spawn.sh, the `for _ in $(seq 1 60)` loop after `treehouse get`).
+# How fm-spawn.sh acquires a task worktree, and where that worktree is allowed
+# to live (bin/fm-spawn.sh's lease + settle block, bin/fm-treehouse-lib.sh).
 #
-# On some tmux/WSL setups a brand-new window's pane_current_path transiently
-# reports a stale, unrelated-but-real path on the very first poll, before the
-# pane actually settles into the worktree treehouse get moved it to. That stale
-# path still passes the loop's "differs from the project" check and
-# validate_spawn_worktree's "is a real, distinct worktree" check (it IS a real
-# git checkout, just the wrong one), so a naive single-read loop silently
-# records the wrong worktree= in state/<id>.meta. This test simulates that
-# transient-then-settled pane_current_path sequence with a fake tmux and
-# asserts the recorded worktree resolves to the real, settled worktree, never
-# the stale first read.
+# Firstmate leases the worktree itself and sends the pane a plain cd, because the
+# pool must land on the repo's own filesystem and the only lever for that is the
+# HOME treehouse runs under - which an interactive `treehouse get` would leak into
+# the crew agent's shell. These tests hold that contract in place:
+#
+#   - the lease output, not the pane's cwd, decides worktree= in state/<id>.meta,
+#     so the transient stale pane_current_path some tmux/WSL setups report on a
+#     brand-new window can no longer record another real checkout as the worktree
+#   - the pane is sent a cd and never a command that would change its HOME
+#   - treehouse is invoked under the pool HOME firstmate resolved
+#   - a worktree split from its object store is refused, because git blocks in
+#     read_gitfile_gently there and the validation pipeline hangs forever
 set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
+LIB="$ROOT/bin/fm-treehouse-lib.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-worktree-settle)
 
 # make_settle_fakebin <dir> builds a fake tmux whose `#{pane_current_path}`
@@ -49,12 +52,34 @@ case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
-  send-keys) exit 0 ;;
+  send-keys)
+    # Record everything sent to the pane so a test can prove what the crew's
+    # shell was actually asked to run.
+    printf '%s\n' "$*" >> "${FM_FAKE_SENDKEYS_LOG:-/dev/null}"
+    exit 0
+    ;;
 esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  # Fake treehouse: `get --lease` prints the worktree path on stdout, exactly as
+  # the real one does, and records the HOME it was invoked under - that HOME is
+  # the entire pool-selection mechanism, so a test can assert it arrived.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  get)
+    printf '%s\n' "${HOME:-}" > "${FM_FAKE_TREEHOUSE_HOMEFILE:-/dev/null}"
+    printf '%s\n' "$*" >> "${FM_FAKE_TREEHOUSE_ARGSFILE:-/dev/null}"
+    printf '%s\n' "${FM_FAKE_TREEHOUSE_WT:-}"
+    exit 0
+    ;;
+  return) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -83,19 +108,26 @@ make_settle_case() {
 }
 
 read_settle_record() {
-  IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR COUNTFILE STALE_READS <<EOF
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR COUNTFILE STALE_READS <<EOF
 $1
 EOF
+  SENDKEYS_LOG="$CASE_DIR/sendkeys.log"
+  TREEHOUSE_HOMEFILE="$CASE_DIR/treehouse-home"
+  TREEHOUSE_ARGSFILE="$CASE_DIR/treehouse-args"
 }
 
 run_settle_spawn() {
-  local id=$1
+  local id=$1 lease_wt=${2:-$WT_DIR}
   FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
+    FM_FAKE_TREEHOUSE_WT="$lease_wt" \
+    FM_FAKE_TREEHOUSE_HOMEFILE="$TREEHOUSE_HOMEFILE" \
+    FM_FAKE_TREEHOUSE_ARGSFILE="$TREEHOUSE_ARGSFILE" \
+    FM_FAKE_SENDKEYS_LOG="$SENDKEYS_LOG" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
 }
@@ -141,7 +173,176 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+# The crew agent inherits whatever the pane's shell has. An interactive
+# `treehouse get` runs that shell as a child of treehouse, so the pool HOME would
+# become the agent's HOME - wrong ~/.claude, wrong git config, wrong gh
+# credentials. Firstmate must therefore send the pane a cd and nothing else.
+test_pane_is_sent_a_cd_and_never_a_home_changing_command() {
+  local rec id out status
+  id=settle-pane-cd-z3
+  rec=$(make_settle_case settle-pane-cd "$id" 0)
+  read_settle_record "$rec"
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed"
+  assert_grep "cd '$WT_DIR'" "$SENDKEYS_LOG" \
+    "the pane was never sent a cd into the leased worktree"
+  # Match the invocation, not the bare word: firstmate's own checkout is itself a
+  # treehouse pool path, so it appears inside the launch command legitimately.
+  assert_no_grep "treehouse get" "$SENDKEYS_LOG" \
+    "the pane was sent a treehouse get, which would run the agent's shell under the pool HOME"
+  assert_no_grep "HOME=" "$SENDKEYS_LOG" \
+    "the pane was sent a HOME assignment, which the agent would inherit"
+  pass "the pane receives a plain cd and nothing that changes its HOME"
+}
+
+# The pool is selected solely by the HOME treehouse runs under, so that override
+# reaching the treehouse process - and carrying --lease - is the mechanism.
+test_treehouse_is_leased_under_the_resolved_pool_home() {
+  local rec id out status expected_home recorded_home
+  id=settle-pool-home-z4
+  rec=$(make_settle_case settle-pool-home "$id" 0)
+  read_settle_record "$rec"
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed"
+  assert_grep "--lease" "$TREEHOUSE_ARGSFILE" "treehouse was not invoked with --lease"
+  assert_grep "fm-$id" "$TREEHOUSE_ARGSFILE" "the lease did not record this task as its holder"
+  expected_home=$(bash -c '. "$1"; fm_treehouse_pool_home "$2"' _ "$LIB" "$PROJ_DIR")
+  recorded_home=$(cat "$TREEHOUSE_HOMEFILE")
+  [ "$recorded_home" = "$expected_home" ] \
+    || fail "treehouse ran under HOME '$recorded_home', expected the resolved pool home '$expected_home'"
+  pass "treehouse is leased under the pool HOME firstmate resolved for the repo"
+}
+
+# The lease output is the authority for worktree=. A pane that never arrives is a
+# failed spawn, not a spawn that silently records some other path.
+test_pane_that_never_lands_fails_the_spawn() {
+  local rec id out status
+  id=settle-never-lands-z5
+  rec=$(make_settle_case settle-never-lands "$id" 999999)
+  read_settle_record "$rec"
+
+  out=$(FM_SPAWN_SETTLE_POLLS=2 run_settle_spawn "$id")
+  status=$?
+  [ "$status" != 0 ] || fail "spawn reported success though the pane never entered the worktree"
+  assert_contains "$out" "did not enter the leased worktree" \
+    "the failure did not name the pane never reaching the worktree"
+  [ ! -f "$HOME_DIR/state/$id.meta" ] \
+    || fail "a spawn whose pane never landed still published task metadata"
+  pass "a pane that never enters the leased worktree fails the spawn loudly"
+}
+
+# --- bin/fm-treehouse-lib.sh decisions --------------------------------------
+#
+# Placement decisions are driven through a stubbed fm_treehouse_device rather than
+# real mounts: a second filesystem is not something a test can rely on having, and
+# the behavior under test is what these functions do with a given pair of device
+# ids. FM_TEST_DEVICES holds "<path-prefix>=<device>" entries, longest-matching
+# intent first. Both the raw and the physically-resolved form of every path are
+# registered, because the library canonicalizes the object store with pwd -P
+# (/var -> /private/var on macOS) while reading $HOME as given.
+phys() {  # <path>
+  (CDPATH='' cd -- "$1" 2>/dev/null && pwd -P) || printf '%s\n' "$1"
+}
+
+run_lib_with_devices() {  # <arg>...  (FM_TEST_BODY / FM_TEST_DEVICES in env)
+  bash -c '
+    . "$1"
+    shift
+    fm_treehouse_device() {  # <path>
+      local path=$1 entry
+      for entry in $FM_TEST_DEVICES; do
+        case "$path" in
+          "${entry%%=*}"*) printf "%s\n" "${entry#*=}"; return 0 ;;
+        esac
+      done
+      printf "0\n"
+    }
+    eval "$FM_TEST_BODY"
+  ' _ "$LIB" "$@"
+}
+
+test_pool_home_stays_home_when_the_repo_is_on_the_home_filesystem() {
+  local repo out
+  repo="$TMP_ROOT/pool-home-same"
+  fm_git_init_commit "$repo"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the body is eval'd inside the subshell
+  out=$(FM_TEST_BODY='fm_treehouse_pool_home "$1"' \
+    FM_TEST_DEVICES="$HOME=10 $(phys "$HOME")=10 $TMP_ROOT=10 $(phys "$TMP_ROOT")=10" \
+    run_lib_with_devices "$repo")
+  [ "$out" = "$HOME" ] \
+    || fail "same-filesystem repo should keep the default pool home '$HOME', got '$out'"
+  pass "a repo on \$HOME's filesystem keeps the default pool location"
+}
+
+test_pool_home_moves_to_the_object_store_filesystem_when_split() {
+  local repo out expected
+  repo="$TMP_ROOT/pool-home-split"
+  fm_git_init_commit "$repo"
+  # Everything under TMP_ROOT is device 77, $HOME is 10, and TMP_ROOT's parent is
+  # unregistered (0) - so the mount-point walk stops exactly at TMP_ROOT.
+  expected=$(phys "$TMP_ROOT")
+  # shellcheck disable=SC2016  # single quotes are deliberate: the body is eval'd inside the subshell
+  out=$(FM_TEST_BODY='fm_treehouse_pool_home "$1"' \
+    FM_TEST_DEVICES="$HOME=10 $(phys "$HOME")=10 $TMP_ROOT=77 $(phys "$TMP_ROOT")=77" \
+    run_lib_with_devices "$repo")
+  [ -n "$out" ] || fail "split repo produced no pool home"
+  [ "$out" != "$HOME" ] \
+    || fail "a repo on another filesystem must not use \$HOME's pool"
+  [ "$out" = "$expected" ] \
+    || fail "split repo should pool at its own filesystem's mount point '$expected', got '$out'"
+  pass "a repo on another filesystem pools at that filesystem's mount point"
+}
+
+test_colocation_check_separates_split_from_undeterminable() {
+  local repo repo_phys status
+  repo="$TMP_ROOT/colocation-check"
+  fm_git_init_commit "$repo"
+  repo_phys=$(phys "$repo")
+  status=0
+  # shellcheck disable=SC2016  # single quotes are deliberate: the body is eval'd inside the subshell
+  FM_TEST_BODY='fm_treehouse_worktree_colocated "$1"' \
+    FM_TEST_DEVICES="$repo=42 $repo_phys=42" \
+    run_lib_with_devices "$repo" >/dev/null || status=$?
+  expect_code 0 "$status" "a worktree sharing its object store's filesystem should report colocated"
+  status=0
+  # shellcheck disable=SC2016  # single quotes are deliberate: the body is eval'd inside the subshell
+  FM_TEST_BODY='fm_treehouse_worktree_colocated "$1"' \
+    FM_TEST_DEVICES="$repo_phys/.git=99 $repo/.git=99 $repo=42 $repo_phys=42" \
+    run_lib_with_devices "$repo" >/dev/null || status=$?
+  expect_code 1 "$status" "a worktree split from its object store should report split"
+  status=0
+  # shellcheck disable=SC2016  # single quotes are deliberate: the body is eval'd inside the subshell
+  FM_TEST_BODY='fm_treehouse_worktree_colocated "$1"' \
+    FM_TEST_DEVICES="" \
+    run_lib_with_devices "$TMP_ROOT/not-a-repo-at-all" >/dev/null || status=$?
+  expect_code 2 "$status" "a path with no resolvable object store should report undeterminable, not split"
+  pass "the colocation check distinguishes colocated, split, and undeterminable"
+}
+
+test_mount_point_resolves_to_a_real_ancestor() {
+  local out
+  out=$(bash -c '. "$1"; fm_treehouse_mount_point "$2"' _ "$LIB" "$TMP_ROOT")
+  [ -n "$out" ] && [ -d "$out" ] \
+    || fail "mount point of $TMP_ROOT did not resolve to a directory (got '$out')"
+  case "$(phys "$TMP_ROOT")" in
+    "$out"*) : ;;
+    *) fail "mount point '$out' is not an ancestor of $TMP_ROOT" ;;
+  esac
+  pass "the mount-point walk resolves to a real ancestor directory"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
+test_pane_is_sent_a_cd_and_never_a_home_changing_command
+test_treehouse_is_leased_under_the_resolved_pool_home
+test_pane_that_never_lands_fails_the_spawn
+test_pool_home_stays_home_when_the_repo_is_on_the_home_filesystem
+test_pool_home_moves_to_the_object_store_filesystem_when_split
+test_colocation_check_separates_split_from_undeterminable
+test_mount_point_resolves_to_a_real_ancestor
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -265,7 +265,7 @@ run_lib_with_devices() {  # <arg>...  (FM_TEST_BODY / FM_TEST_DEVICES in env)
   ' _ "$LIB" "$@"
 }
 
-test_pool_home_stays_home_when_the_repo_is_on_the_home_filesystem() {
+test_pool_home_stays_on_the_home_filesystem_when_not_split() {
   local repo out
   repo="$TMP_ROOT/pool-home-same"
   fm_git_init_commit "$repo"
@@ -273,9 +273,57 @@ test_pool_home_stays_home_when_the_repo_is_on_the_home_filesystem() {
   out=$(FM_TEST_BODY='fm_treehouse_pool_home "$1"' \
     FM_TEST_DEVICES="$HOME=10 $(phys "$HOME")=10 $TMP_ROOT=10 $(phys "$TMP_ROOT")=10" \
     run_lib_with_devices "$repo")
-  [ "$out" = "$HOME" ] \
-    || fail "same-filesystem repo should keep the default pool home '$HOME', got '$out'"
-  pass "a repo on \$HOME's filesystem keeps the default pool location"
+  case "$out" in
+    "$HOME"/.fm-pools/*) : ;;
+    *) fail "same-filesystem repo should pool under \$HOME/.fm-pools/, got '$out'" ;;
+  esac
+  pass "a repo on \$HOME's filesystem pools on that filesystem"
+}
+
+# Segregation is a safety property: treehouse's prune and destroy act on a pool,
+# so two projects sharing one pool means a cleanup aimed at one can reach the
+# other's worktrees - including work that exists nowhere else yet.
+test_each_project_gets_its_own_pool() {
+  local repo_a repo_b out_a out_b
+  repo_a="$TMP_ROOT/segregation-a"
+  repo_b="$TMP_ROOT/segregation-b"
+  fm_git_init_commit "$repo_a"
+  fm_git_init_commit "$repo_b"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the body is eval'd inside the subshell
+  out_a=$(FM_TEST_BODY='fm_treehouse_pool_home "$1"' \
+    FM_TEST_DEVICES="$HOME=10 $(phys "$HOME")=10 $TMP_ROOT=10 $(phys "$TMP_ROOT")=10" \
+    run_lib_with_devices "$repo_a")
+  # shellcheck disable=SC2016  # single quotes are deliberate: the body is eval'd inside the subshell
+  out_b=$(FM_TEST_BODY='fm_treehouse_pool_home "$1"' \
+    FM_TEST_DEVICES="$HOME=10 $(phys "$HOME")=10 $TMP_ROOT=10 $(phys "$TMP_ROOT")=10" \
+    run_lib_with_devices "$repo_b")
+  [ -n "$out_a" ] && [ -n "$out_b" ] || fail "pool home resolution produced an empty path"
+  [ "$out_a" != "$out_b" ] \
+    || fail "two projects resolved to the same pool '$out_a'; a prune for one could reach the other"
+  case "$out_a" in *segregation-a-*) : ;; *) fail "pool '$out_a' does not name its project" ;; esac
+  case "$out_b" in *segregation-b-*) : ;; *) fail "pool '$out_b' does not name its project" ;; esac
+  pass "each project resolves to its own pool root"
+}
+
+# Same directory name, different location: the discriminator must still separate
+# them, or a prune for one project would reach the other's worktrees.
+test_same_named_projects_do_not_share_a_pool() {
+  local repo_a repo_b out_a out_b
+  repo_a="$TMP_ROOT/copy-one/samename"
+  repo_b="$TMP_ROOT/copy-two/samename"
+  fm_git_init_commit "$repo_a"
+  fm_git_init_commit "$repo_b"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the body is eval'd inside the subshell
+  out_a=$(FM_TEST_BODY='fm_treehouse_pool_home "$1"' \
+    FM_TEST_DEVICES="$HOME=10 $(phys "$HOME")=10 $TMP_ROOT=10 $(phys "$TMP_ROOT")=10" \
+    run_lib_with_devices "$repo_a")
+  # shellcheck disable=SC2016  # single quotes are deliberate: the body is eval'd inside the subshell
+  out_b=$(FM_TEST_BODY='fm_treehouse_pool_home "$1"' \
+    FM_TEST_DEVICES="$HOME=10 $(phys "$HOME")=10 $TMP_ROOT=10 $(phys "$TMP_ROOT")=10" \
+    run_lib_with_devices "$repo_b")
+  [ "$out_a" != "$out_b" ] \
+    || fail "two same-named projects shared pool '$out_a'"
+  pass "two projects with the same directory name still get separate pools"
 }
 
 test_pool_home_moves_to_the_object_store_filesystem_when_split() {
@@ -292,8 +340,10 @@ test_pool_home_moves_to_the_object_store_filesystem_when_split() {
   [ -n "$out" ] || fail "split repo produced no pool home"
   [ "$out" != "$HOME" ] \
     || fail "a repo on another filesystem must not use \$HOME's pool"
-  [ "$out" = "$expected" ] \
-    || fail "split repo should pool at its own filesystem's mount point '$expected', got '$out'"
+  case "$out" in
+    "$expected"/.fm-pools/*) : ;;
+    *) fail "split repo should pool under $expected/.fm-pools/, got '$out'" ;;
+  esac
   pass "a repo on another filesystem pools at that filesystem's mount point"
 }
 
@@ -340,7 +390,9 @@ test_already_settled_pane_costs_one_confirm_sleep
 test_pane_is_sent_a_cd_and_never_a_home_changing_command
 test_treehouse_is_leased_under_the_resolved_pool_home
 test_pane_that_never_lands_fails_the_spawn
-test_pool_home_stays_home_when_the_repo_is_on_the_home_filesystem
+test_pool_home_stays_on_the_home_filesystem_when_not_split
+test_each_project_gets_its_own_pool
+test_same_named_projects_do_not_share_a_pool
 test_pool_home_moves_to_the_object_store_filesystem_when_split
 test_colocation_check_separates_split_from_undeterminable
 test_mount_point_resolves_to_a_real_ancestor

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -169,7 +169,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$fakebin"
 }
 
@@ -248,7 +248,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$fakebin"
 }
 
@@ -292,9 +292,13 @@ test_spawn_tmux_window_construction() {
   assert_grep "set-window-option -t @spawnwid allow-rename off" "$rec" \
     "must disable allow-rename on the spawned window"
 
-  # Bug 2 fix (b): treehouse-get and the worktree wait loop target the stable id.
-  assert_grep "send-keys -t @spawnwid treehouse get Enter" "$rec" \
-    "treehouse get must be sent to the stable window id"
+  # Bug 2 fix (b): the cd into the leased worktree and the wait loop target the
+  # stable id. Firstmate leases the worktree itself, so the pane is sent a cd
+  # rather than a treehouse command (bin/fm-treehouse-lib.sh owns why).
+  assert_grep "send-keys -t @spawnwid cd " "$rec" \
+    "the cd into the leased worktree must be sent to the stable window id"
+  assert_no_grep "send-keys -t @spawnwid treehouse" "$rec" \
+    "the pane must not be sent a treehouse command"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
     "the worktree wait loop must query the stable window id, not the name"
 

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -973,6 +973,69 @@ SH
   pass "fm_pid_identity is locale-invariant across LC_ALL/LC_TIME"
 }
 
+test_lock_identity_survives_symlinked_home() {
+  # One home reachable through a symlinked ancestor has two names, and bin/ derives
+  # its root both ways: bin/fm-arm-pretool-check.sh and bin/fm-cd-pretool-check.sh
+  # resolve with pwd -P while most scripts use a logical pwd. So the lock can be
+  # published under one name and re-read under the other. Comparing the raw strings
+  # rejects the home's own live watcher, and re-arming records the same divergent
+  # pair again, so nothing recovers. Both names must resolve to one identity.
+  local dir real link state live identity
+  dir=$(make_case symlinked-home)
+  real="$dir/real-home"
+  link="$dir/link-home"
+  mkdir -p "$real/bin" "$real/state/.watch.lock" "$dir/other-home/bin"
+  : > "$real/bin/fm-watch.sh"
+  : > "$dir/other-home/bin/fm-watch.sh"
+  ln -s "$real" "$link"
+  state="$real/state"
+  sleep 300 &
+  live=$!
+  identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$live" 2>/dev/null)
+  # Publish the lock under the PHYSICAL names, the way a pwd -P deriver records it.
+  printf '%s\n' "$live" > "$state/.watch.lock/pid"
+  printf '%s\n' "$real" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$real/bin/fm-watch.sh" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
+
+  # Re-read under the SYMLINKED names, the way a logical-pwd deriver sees them.
+  FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_watcher_lock_matches_pid "$2" "$3" "$4" "$5"' \
+    _ "$LIB" "$state" "$link/bin/fm-watch.sh" "$live" "$link" \
+    || { kill "$live" 2>/dev/null; fail "lock published under the physical home did not match the same home read through a symlink"; }
+  FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_watcher_healthy "$2" "$3" 300 "$4"' \
+    _ "$LIB" "$state" "$link/bin/fm-watch.sh" "$link" \
+    && { kill "$live" 2>/dev/null; fail "fm_watcher_healthy passed with a stale beacon"; }
+  touch "$state/.last-watcher-beat"
+  FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_watcher_healthy "$2" "$3" 300 "$4"' \
+    _ "$LIB" "$state" "$link/bin/fm-watch.sh" "$link" \
+    || { kill "$live" 2>/dev/null; fail "a fresh watcher was not healthy when read through the symlinked home"; }
+
+  # A genuinely different home must still be rejected: resolving is not loosening.
+  if FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_watcher_lock_matches_pid "$2" "$3" "$4" "$5"' \
+    _ "$LIB" "$state" "$dir/other-home/bin/fm-watch.sh" "$live" "$dir/other-home"; then
+    kill "$live" 2>/dev/null
+    fail "a different home matched this home's watcher lock"
+  fi
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+  pass "watcher lock identity resolves symlinked and physical home names to one identity"
+}
+
+test_lock_paths_equal_keeps_unresolvable_paths_distinct() {
+  # A stale lock can name a home that no longer exists. Those paths cannot be
+  # resolved, so they must fall back to their raw value: collapsing them to an
+  # empty string would make every removed home match every other removed home.
+  FM_STATE_OVERRIDE="$TMP_ROOT/paths-equal-state" bash -c '
+    . "$1"
+    fm_lock_paths_equal "$2/gone-a" "$2/gone-a" || exit 1
+    fm_lock_paths_equal "$2/gone-a" "$2/gone-b" && exit 1
+    fm_lock_paths_equal "" "$2/gone-a" && exit 1
+    exit 0
+  ' _ "$LIB" "$TMP_ROOT/removed-homes" \
+    || fail "fm_lock_paths_equal mishandled unresolvable or empty paths"
+  pass "fm_lock_paths_equal keeps unresolvable and empty paths distinct"
+}
+
 write_fake_proc_identity() {
   local proc_root=$1 pid=$2 starttime=$3
   mkdir -p "$proc_root/$pid"
@@ -1034,6 +1097,8 @@ test_msys_pid_identity_uses_proc() {
 
 test_singleton_start
 test_pid_identity_is_locale_invariant
+test_lock_identity_survives_symlinked_home
+test_lock_paths_equal_keeps_unresolvable_paths_distinct
 test_proc_pid_identity_ignores_wall_clock_and_detects_pid_reuse
 test_msys_pid_identity_uses_proc
 test_stale_watch_lock_reclaimed

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -155,6 +155,12 @@ fm_test_reap_orphans
 fm_fakebin() {
   local dir=$1 fakebin="$1/fakebin"
   mkdir -p "$fakebin"
+  # Every fakebin gets the treehouse stub by default. fm-spawn.sh now EXECUTES
+  # treehouse to lease the worktree instead of sending `treehouse get` to a fake
+  # pane, so a fakebin without this stub falls through to the real binary and
+  # leases real pool slots against a test's throwaway repo. Suites that want to
+  # record the invocation call fm_fake_treehouse again with their own arguments.
+  fm_fake_treehouse "$fakebin"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -187,6 +187,31 @@ SH
   chmod +x "$fakebin/$tool"
 }
 
+# fm_fake_treehouse <fakebin> [worktree]: stub treehouse for a spawn fixture.
+# fm-spawn.sh leases the worktree itself and reads the path off treehouse's
+# stdout, so an exit-0-with-no-output stub is not enough - it reads as treehouse
+# failing to produce a worktree at all. The path is <worktree> when given (for
+# fixtures that bake the path into their fake tmux), otherwise
+# FM_FAKE_TREEHOUSE_WT, otherwise FM_FAKE_PANE_PATH - which in these fixtures is
+# the same worktree the pane is made to report.
+fm_fake_treehouse() {
+  local fakebin=$1 baked=${2:-}
+  cat > "$fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+set -u
+case "\${1:-}" in
+  get)
+    printf '%s\n' "\$*" >> "\${FM_FAKE_TREEHOUSE_ARGSFILE:-/dev/null}"
+    printf '%s\n' "\${HOME:-}" > "\${FM_FAKE_TREEHOUSE_HOMEFILE:-/dev/null}"
+    printf '%s\n' "\${FM_FAKE_TREEHOUSE_WT:-\${FM_FAKE_PANE_PATH:-$baked}}"
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+}
+
 # --- deterministic git identity and fixtures --------------------------------
 
 # fm_git_identity [name] [email]: export a fixed author/committer identity so


### PR DESCRIPTION
## Intent

PR #1142 (per-project worktree pools): fix the two Behavior-tests-Herdr CI failures — post-create abort fixture updated for leased acquisition, and the projected-teardown focus regression root-caused (treehouse return --force killed the pane's shell before the presentation restore block) and fixed by closing the presentation pane before returning the worktree; 22/22 presentation e2e x3 + 132/132 backend suite green locally. Goal: green Herdr CI lane + the Require-no-mistakes signature on PR #1142.

## What Changed

- Spawn now acquires crew worktrees through `treehouse get --lease` from a per-project pool placed on the repo's own filesystem. The new `bin/fm-treehouse-lib.sh` selects the pool by running treehouse under a per-command `HOME` and verifies the acquired worktree is colocated with the object store, preventing the cross-filesystem split that made `no-mistakes init`/`axi run` hang inside git's gitfile open.
- Teardown and the spawn-abort cleanup path now close the Herdr presentation pane before returning the leased worktree (previously `treehouse return --force` killed the pane's shell first, letting Herdr's last-pane cleanup destroy the workspace and steal focus), and lease failures now surface treehouse's stderr instead of a generic error. Watcher lock checks also resolve identity paths before comparing.
- Tests and docs follow the new flow: leased-acquisition and post-create abort fixtures, treehouse stubs in every fakebin, new watcher-lock and pool-settle coverage (11/11 settle, 22/22 Herdr presentation e2e across three runs), plus pool/spawn/teardown doc alignment and recorded verification evidence.

## Risk Assessment

✅ Low: All three accepted round-1 findings are fixed correctly in 94148ff (abort-path pane-close-before-return ordering, teardown abort instead of focus-unsafe return under lock contention, lease stderr surfaced with proper temp-file hygiene), no test pins the replaced behaviors, and the only remaining item is an informational version-skew note that CI will confirm.

## Testing

Ran the intent-targeted suites against the real Herdr 0.7.4 lab: the presentation e2e passed 22/22 in three consecutive runs with both previously-failing CI checks (post-create abort serialization with focus restoration, and task-pane close restoring the captain's workspace/tab after Herdr's focus steal) green every time; the leased-acquisition/pool-relocation suite passed 11/11; and the teardown, watcher-lock, and backend suites covering the other changed scripts all passed. No UI surface exists for this terminal-multiplexer change, so the real-Herdr lab transcripts serve as the product-level evidence; the full 132-test backend suite is owned by remote CI per repo policy and was deliberately not re-run locally.

<details>
<summary>Evidence: Distilled evidence summary (both fixed CI checks + x3 stability tally)</summary>

<code>## The two previously-failing Herdr CI checks, now green in a real Herdr lab (Herdr 0.7.4):&#10;ok - real Herdr lab: concurrent post-create abort cleanup stays serialized with exact focus restoration&#10;ok - real Herdr lab: exact task-pane close restores the exact captain workspace/tab after Herdr&#39;s raw focus steal&#10;&#10;## Presentation e2e stability, three consecutive full runs:&#10;run 1: 22/22 ok, 0 failures (duration_ms=72440)&#10;run 2: 22/22 ok, 0 failures (duration_ms=72315)&#10;run 3: 22/22 ok, 0 failures (duration_ms=72177)</code>

```text
# PR #1142 test-phase evidence (branch fm/fm-pool-relocation @ 94148ff)

## The two previously-failing Herdr CI checks, now green in a real Herdr lab (Herdr 0.7.4):
ok - real Herdr lab: concurrent post-create abort cleanup stays serialized with exact focus restoration
ok - real Herdr lab: exact task-pane close restores the exact captain workspace/tab after Herdr's raw focus steal

## Presentation e2e stability, three consecutive full runs:
run 1: 22/22 ok, 0 failures (duration_ms=72440)
run 2: 22/22 ok, 0 failures (duration_ms=72315)
run 3: 22/22 ok, 0 failures (duration_ms=72177)

## Post-create abort fixture / leased worktree acquisition (fm-spawn-worktree-settle, 11/11):
ok - a single transient stale pane_current_path read is not accepted as the worktree
ok - an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle
ok - the pane receives a plain cd and nothing that changes its HOME
ok - treehouse is leased under the pool HOME firstmate resolved for the repo
ok - a pane that never enters the leased worktree fails the spawn loudly
ok - a repo on $HOME's filesystem pools on that filesystem
ok - each project resolves to its own pool root
ok - two projects with the same directory name still get separate pools
ok - a repo on another filesystem pools at that filesystem's mount point
ok - the colocation check distinguishes colocated, split, and undeterminable
ok - the mount-point walk resolves to a real ancestor directory

## Other suites owning the changed scripts (fm-teardown.sh, fm-watch-arm.sh, fm-backend.sh):
FM_TEST_END 2026-07-28T10:05:19Z tests/fm-teardown.test.sh exit=0 duration_ms=17060 gate_skip=false
FM_TEST_END 2026-07-28T10:07:00Z tests/fm-watcher-lock.test.sh exit=0 duration_ms=101369 gate_skip=false
FM_TEST_END 2026-07-28T10:07:10Z tests/fm-backend.test.sh exit=0 duration_ms=9615 gate_skip=false
```
</details>
<details>
<summary>Evidence: Presentation e2e full transcript, run 1</summary>

```text
FM_TEST_BEGIN 2026-07-28T10:01:02Z tests/fm-backend-herdr-presentation-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - real Herdr lab: flag-off spawn retains the Stage 1 Herdr command sequence with zero ordering calls
ok - real Herdr lab: every projected create, task-tab create, seeded prune, and move preserves active workspace and tab
warning: herdr presentation cleanup could not verify the exact pane; refusing focus-unsafe pane close
ok - real Herdr lab: active seeded-tab pruning refuses the exact pane and preserves exact focus
ok - real Herdr lab: bounded lock contention warns and falls back flat without projection or focus drift
ok - real Herdr lab: concurrent primary workers form one stable contiguous block without active workspace/tab drift
ok - real Herdr lab: forced workspace.move failure leaves a successful worker in default order with a warning and no cleanup
ok - real Herdr lab: concurrent post-create abort cleanup stays serialized with exact focus restoration
ok - real Herdr lab: Treehouse commands and metadata shape are byte-identical except for Herdr container IDs
ok - real Herdr lab: exact task-pane close restores the exact captain workspace/tab after Herdr's raw focus steal
ok - real Herdr lab: concurrent projected cleanup is serialized and leaves active workspace/tab unchanged
ok - real Herdr lab: three repeated concurrent create/order/cleanup waves have zero active workspace or tab drift
ok - real Herdr lab: primary presentation opt-in inherits into real secondmate homes
ok - real Herdr lab: primary and two secondmate homes each own a top-level contiguous child block
ok - real Herdr lab: concurrent primary/A/B spawns preserve parent order and exact focus
ok - real Herdr lab: session lock contention from a secondmate home falls back flat with no journal
ok - real Herdr lab: Hi Bit and Wheelhouse-style same-identity restarts reclaim one nested space with exact focus and idempotence
ok - real Herdr lab: secondmate restart binding and reclaim stay isolated to the exact child home and parent
ok - real Herdr lab: concurrent cross-home recoveries replace exact husks under one session lock with no focus drift
ok - real Herdr lab: legacy projection labels and flat secondmate tabs are left unmigrated
ok - real Herdr lab: multi-home exact-pane teardowns restore captain focus without workspace close authority
warning: no exact herdr presentation token match for missing1; leaving any stale space untouched and spawning flat
warning: no exact herdr presentation token match for renamed1; leaving any stale space untouched and spawning flat
warning: 2 exact herdr presentation token matches for duplicate1 are quarantined; inspecting only for duplicate-agent risk
warning: quarantined herdr presentation for duplicate1 is dead or agent-free; exact bound reclaim may proceed, otherwise spawning flat
warning: 2 exact herdr presentation token matches for duplicate1 are quarantined; inspecting only for duplicate-agent risk
error: quarantined herdr presentation for duplicate1 has a live pane; refusing duplicate launch
ok - real Herdr lab: missing, renamed, and duplicate tokens trigger zero destructive or adoptive calls, and live duplicate risk refuses launch
ok - real Herdr lab validation completed on Herdr 0.7.4 with the default-session tripwire intact
FM_TEST_END 2026-07-28T10:02:15Z tests/fm-backend-herdr-presentation-e2e.test.sh exit=0 duration_ms=72440 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=72467
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=1 duration_ms=72440 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-backend-herdr-presentation-e2e.test.sh duration_ms=72440
```
</details>
<details>
<summary>Evidence: Presentation e2e full transcript, run 2</summary>

```text
FM_TEST_BEGIN 2026-07-28T10:02:25Z tests/fm-backend-herdr-presentation-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - real Herdr lab: flag-off spawn retains the Stage 1 Herdr command sequence with zero ordering calls
ok - real Herdr lab: every projected create, task-tab create, seeded prune, and move preserves active workspace and tab
warning: herdr presentation cleanup could not verify the exact pane; refusing focus-unsafe pane close
ok - real Herdr lab: active seeded-tab pruning refuses the exact pane and preserves exact focus
ok - real Herdr lab: bounded lock contention warns and falls back flat without projection or focus drift
ok - real Herdr lab: concurrent primary workers form one stable contiguous block without active workspace/tab drift
ok - real Herdr lab: forced workspace.move failure leaves a successful worker in default order with a warning and no cleanup
ok - real Herdr lab: concurrent post-create abort cleanup stays serialized with exact focus restoration
ok - real Herdr lab: Treehouse commands and metadata shape are byte-identical except for Herdr container IDs
ok - real Herdr lab: exact task-pane close restores the exact captain workspace/tab after Herdr's raw focus steal
ok - real Herdr lab: concurrent projected cleanup is serialized and leaves active workspace/tab unchanged
ok - real Herdr lab: three repeated concurrent create/order/cleanup waves have zero active workspace or tab drift
ok - real Herdr lab: primary presentation opt-in inherits into real secondmate homes
ok - real Herdr lab: primary and two secondmate homes each own a top-level contiguous child block
ok - real Herdr lab: concurrent primary/A/B spawns preserve parent order and exact focus
ok - real Herdr lab: session lock contention from a secondmate home falls back flat with no journal
ok - real Herdr lab: Hi Bit and Wheelhouse-style same-identity restarts reclaim one nested space with exact focus and idempotence
ok - real Herdr lab: secondmate restart binding and reclaim stay isolated to the exact child home and parent
ok - real Herdr lab: concurrent cross-home recoveries replace exact husks under one session lock with no focus drift
ok - real Herdr lab: legacy projection labels and flat secondmate tabs are left unmigrated
ok - real Herdr lab: multi-home exact-pane teardowns restore captain focus without workspace close authority
warning: no exact herdr presentation token match for missing1; leaving any stale space untouched and spawning flat
warning: no exact herdr presentation token match for renamed1; leaving any stale space untouched and spawning flat
warning: 2 exact herdr presentation token matches for duplicate1 are quarantined; inspecting only for duplicate-agent risk
warning: quarantined herdr presentation for duplicate1 is dead or agent-free; exact bound reclaim may proceed, otherwise spawning flat
warning: 2 exact herdr presentation token matches for duplicate1 are quarantined; inspecting only for duplicate-agent risk
error: quarantined herdr presentation for duplicate1 has a live pane; refusing duplicate launch
ok - real Herdr lab: missing, renamed, and duplicate tokens trigger zero destructive or adoptive calls, and live duplicate risk refuses launch
ok - real Herdr lab validation completed on Herdr 0.7.4 with the default-session tripwire intact
FM_TEST_END 2026-07-28T10:03:37Z tests/fm-backend-herdr-presentation-e2e.test.sh exit=0 duration_ms=72315 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=72345
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=1 duration_ms=72315 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-backend-herdr-presentation-e2e.test.sh duration_ms=72315
```
</details>
<details>
<summary>Evidence: Presentation e2e full transcript, run 3</summary>

```text
FM_TEST_BEGIN 2026-07-28T10:03:42Z tests/fm-backend-herdr-presentation-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - real Herdr lab: flag-off spawn retains the Stage 1 Herdr command sequence with zero ordering calls
ok - real Herdr lab: every projected create, task-tab create, seeded prune, and move preserves active workspace and tab
warning: herdr presentation cleanup could not verify the exact pane; refusing focus-unsafe pane close
ok - real Herdr lab: active seeded-tab pruning refuses the exact pane and preserves exact focus
ok - real Herdr lab: bounded lock contention warns and falls back flat without projection or focus drift
ok - real Herdr lab: concurrent primary workers form one stable contiguous block without active workspace/tab drift
ok - real Herdr lab: forced workspace.move failure leaves a successful worker in default order with a warning and no cleanup
ok - real Herdr lab: concurrent post-create abort cleanup stays serialized with exact focus restoration
ok - real Herdr lab: Treehouse commands and metadata shape are byte-identical except for Herdr container IDs
ok - real Herdr lab: exact task-pane close restores the exact captain workspace/tab after Herdr's raw focus steal
ok - real Herdr lab: concurrent projected cleanup is serialized and leaves active workspace/tab unchanged
ok - real Herdr lab: three repeated concurrent create/order/cleanup waves have zero active workspace or tab drift
ok - real Herdr lab: primary presentation opt-in inherits into real secondmate homes
ok - real Herdr lab: primary and two secondmate homes each own a top-level contiguous child block
ok - real Herdr lab: concurrent primary/A/B spawns preserve parent order and exact focus
ok - real Herdr lab: session lock contention from a secondmate home falls back flat with no journal
ok - real Herdr lab: Hi Bit and Wheelhouse-style same-identity restarts reclaim one nested space with exact focus and idempotence
ok - real Herdr lab: secondmate restart binding and reclaim stay isolated to the exact child home and parent
ok - real Herdr lab: concurrent cross-home recoveries replace exact husks under one session lock with no focus drift
ok - real Herdr lab: legacy projection labels and flat secondmate tabs are left unmigrated
ok - real Herdr lab: multi-home exact-pane teardowns restore captain focus without workspace close authority
warning: no exact herdr presentation token match for missing1; leaving any stale space untouched and spawning flat
warning: no exact herdr presentation token match for renamed1; leaving any stale space untouched and spawning flat
warning: 2 exact herdr presentation token matches for duplicate1 are quarantined; inspecting only for duplicate-agent risk
warning: quarantined herdr presentation for duplicate1 is dead or agent-free; exact bound reclaim may proceed, otherwise spawning flat
warning: 2 exact herdr presentation token matches for duplicate1 are quarantined; inspecting only for duplicate-agent risk
error: quarantined herdr presentation for duplicate1 has a live pane; refusing duplicate launch
ok - real Herdr lab: missing, renamed, and duplicate tokens trigger zero destructive or adoptive calls, and live duplicate risk refuses launch
ok - real Herdr lab validation completed on Herdr 0.7.4 with the default-session tripwire intact
FM_TEST_END 2026-07-28T10:04:54Z tests/fm-backend-herdr-presentation-e2e.test.sh exit=0 duration_ms=72177 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=72206
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=1 duration_ms=72177 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-backend-herdr-presentation-e2e.test.sh duration_ms=72177
```
</details>
<details>
<summary>Evidence: Leased acquisition / worktree settle transcript (11/11)</summary>

```text
FM_TEST_BEGIN 2026-07-28T10:00:49Z tests/fm-spawn-worktree-settle.test.sh family=backend-dispatch expected_gate_skip=none
ok - a single transient stale pane_current_path read is not accepted as the worktree
ok - an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle
ok - the pane receives a plain cd and nothing that changes its HOME
ok - treehouse is leased under the pool HOME firstmate resolved for the repo
ok - a pane that never enters the leased worktree fails the spawn loudly
ok - a repo on $HOME's filesystem pools on that filesystem
ok - each project resolves to its own pool root
ok - two projects with the same directory name still get separate pools
ok - a repo on another filesystem pools at that filesystem's mount point
ok - the colocation check distinguishes colocated, split, and undeterminable
ok - the mount-point walk resolves to a real ancestor directory
# all fm-spawn-worktree-settle tests passed
FM_TEST_END 2026-07-28T10:00:55Z tests/fm-spawn-worktree-settle.test.sh exit=0 duration_ms=5990 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=6018
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=5990 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-spawn-worktree-settle.test.sh duration_ms=5990
```
</details>
<details>
<summary>Evidence: Teardown, watcher-lock, and backend suite transcript</summary>

```text
FM_TEST_BEGIN 2026-07-28T10:05:02Z tests/fm-teardown.test.sh family=pr-forge expected_gate_skip=none
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains the stale journal and attempts no workspace cleanup when exact-pane close is unconfirmed
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
ok - fm-pr-check does not refresh PR head after HEAD moves
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
FM_TEST_END 2026-07-28T10:05:19Z tests/fm-teardown.test.sh exit=0 duration_ms=17060 gate_skip=false
FM_TEST_BEGIN 2026-07-28T10:05:19Z tests/fm-watcher-lock.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - watcher lock identity resolves symlinked and physical home names to one identity
ok - fm_lock_paths_equal keeps unresolvable and empty paths distinct
ok - Linux process identity ignores simulated btime changes
ok - Linux process identity detects pid reuse
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when fresh
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart refuses to signal a reused pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts+confirms a fresh watcher on a clean lock and self-heals a dead-pid lock (never healthy off a dead pid)
ok - arm cleans child watcher and temp output on HUP
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 890946 but heartbeat is stale for 838548379s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
FM_TEST_END 2026-07-28T10:07:00Z tests/fm-watcher-lock.test.sh exit=0 duration_ms=101369 gate_skip=false
FM_TEST_BEGIN 2026-07-28T10:07:00Z tests/fm-backend.test.sh family=backend-dispatch expected_gate_skip=none
ok - fm_backend_name: FM_BACKEND env > config/backend > default tmux
ok - fm_backend_detect: no markers -> undetected, HERDR_ENV=1 -> herdr, $TMUX -> tmux, CMUX_WORKSPACE_ID -> cmux, nested combinations resolve innermost-first
ok - fm_backend_detect: falls back to __CFBundleIdentifier=com.cmuxterm.app when CMUX_WORKSPACE_ID is absent (signal bundle-id; foreign bundle ids rejected)
ok - fm_backend_detect: the cmux fallback signals are macOS-only (inert on a non-Darwin uname)
ok - fm_backend_detect: an inherited cmux bundle id never outranks $TMUX or HERDR_ENV (tmux/herdr-inside-cmux false positive absorbed)
ok - fm_backend_detect: ancestry fallback matches the lsappinfo-resolved (bundle-id) cmux app pid in the parent chain
ok - fm_backend_detect: ancestry fallback matches a bundle-shaped cmux comm path at any install location when lsappinfo cannot resolve a pid
ok - fm_backend_detect: ancestry fallback stops undetected at launchd (a reparented tmux server never reaches cmux)
ok - fm_backend_name: a fallback-detected cmux prints a NOTICE naming the fallback signal; the primary-marker notice is unchanged
ok - fm_backend_name: auto-detect selects herdr or cmux (loud notice) or tmux (silent, including nested tmux-in-herdr/tmux-in-cmux)
ok - fm_backend_name: an explicit FM_BACKEND or config/backend setting always wins over runtime auto-detection, including an ambient cmux marker
ok - fm_backend_validate: implemented adapters accepted, unknown and blocked codex-app backends refused loudly
ok - zsh: shell-portable backend matching skipped (zsh not found)
ok - bash: fm_backend_source recognizes known backends and rejects unknown ones
ok - fm_backend_validate_spawn: all implemented lifecycle backends are spawn-supported
ok - fm_meta_get / fm_backend_of_meta: read key=value, default backend to tmux
ok - fm_backend_resolve_selector: session:window literal, exact task id first, legacy fm-<id> label fallback, ad hoc bare name via tmux list-windows
ok - fm_backend_of_selector: exact task ids, legacy fm-<id> labels, and matching explicit targets inherit metadata backend
ok - fm-send.sh: explicit tmux targets are verified, while --key/plain/slash send command shape stays old-compatible
ok - fm-peek.sh: capture-pane invocation and output are byte-identical old vs new
ok - fm-spawn.sh: a project reached through a symlinked prefix (e.g. macOS /tmp -> /private/tmp) does not trip the isolation guard's false refusal
ok - fm-teardown.sh: treehouse return + tmux kill-window command log is byte-identical old vs new for a scout task
ok - fm-spawn.sh --backend bogus is refused loudly
ok - fm-spawn.sh --backend codex-app is refused
ok - fm-spawn.sh honors FM_BACKEND and refuses an unimplemented value loudly
ok - fm-spawn.sh: an explicit --backend tmux resolves silently and writes no backend= (missing means tmux)
ok - fm-spawn.sh: explicit --backend tmux wins over an ambient HERDR_ENV=1 auto-detect marker
ok - fm-spawn.sh: auto-detect resolves nested tmux-in-herdr to tmux and stays silent end to end
FM_TEST_END 2026-07-28T10:07:10Z tests/fm-backend.test.sh exit=0 duration_ms=9615 gate_skip=false
FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0 duration_ms=128104
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=9615 failed=0
FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=17060 failed=0
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=101369 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-watcher-lock.test.sh duration_ms=101369
FM_TEST_SLOWEST rank=2 script=tests/fm-teardown.test.sh duration_ms=17060
FM_TEST_SLOWEST rank=3 script=tests/fm-backend.test.sh duration_ms=9615
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-spawn.sh:273` - spawn_abort_cleanup returns the leased worktree before the herdr projection exact-pane close, reintroducing on the spawn-abort path the same ordering failure commit ab5cadf root-caused and fixed in fm-teardown.sh. Concrete path: projected herdr spawn arms HERDR_PROJECTION_ABORT_CLEANUP (~line 1043) and TREEHOUSE_LEASE_ABORT_CLEANUP (line 1309); after the pane lands in the leased worktree, any set -e failure before meta publication at line 1533 (hook-file write, TASK_TMP mkdir, exclude_path git call) fires the EXIT trap, which runs `treehouse return --force $WT` (line 276) first — killing the pane&#39;s top-level shell whose cwd is the worktree — so Herdr&#39;s last-pane cleanup destroys the workspace and steals focus before fm_backend_herdr_projection_cleanup_exact (line 289) can close the pane focus-preservingly. Fix at the shared boundary: perform the HERDR_PROJECTION_ABORT_CLEANUP blocks before the lease return inside spawn_abort_cleanup, mirroring the teardown ordering fix.
- ⚠️ `bin/fm-teardown.sh:1179` - When the presentation focus lock cannot be acquired within ~5s (50 x 0.1s), teardown skips the exact-pane close with a warning but still proceeds to teardown_treehouse_return, which kills the still-live pane shell — the same Herdr last-pane focus steal this branch fixes, now reachable only under lock contention. The fix&#39;s own invariant (&#39;close the presentation pane before returning the worktree&#39;) is violated on this branch. Consider deferring/aborting the worktree return (or retrying the lock longer) instead of proceeding with an unclosed live pane; whether teardown should block on contention is the author&#39;s call.
- ⚠️ `bin/fm-spawn.sh:1301` - The `treehouse get --lease` invocation discards stderr (2&gt;/dev/null), so every lease failure — pool exhaustion, unwritable mount-root .fm-pools directory (a real case when fm_treehouse_pool_home resolves to a filesystem mount point), unsupported --lease flag on an older treehouse — collapses into the same generic &#39;could not lease a worktree&#39; message with no root cause for the operator. Capture treehouse&#39;s stderr (e.g. to a temp file or variable) and include it in the failure diagnostic.
- ℹ️ `docs/verification/runtime-backends.md:199` - The recorded reverification evidence for the teardown-ordering fix was gathered against Treehouse v2.1.0, while CI installs the v2.0.1 pin from bin/fm-install-treehouse.sh (FM_TREEHOUSE_CI_VERSION=2.0.1). The intent&#39;s narrative (only 2 of 22 presentation e2e tests failing in CI under the leased flow) evidences that v2.0.1 supports `get --lease`, so this is a version skew in the evidence, not a demonstrated defect; the pipeline&#39;s CI step will confirm behavior on the pinned version.

🔧 Fix: fix abort/teardown pane-close ordering and surface lease stderr
1 info still open:
- ℹ️ `docs/verification/runtime-backends.md:199` - Carried forward from round 1 (unaddressed by the fix commit, informational only): the recorded reverification evidence for the teardown-ordering fix was gathered against Treehouse v2.1.0, while CI installs the v2.0.1 pin from bin/fm-install-treehouse.sh (FM_TREEHOUSE_CI_VERSION=2.0.1). The intent&#39;s narrative (only 2 of 22 presentation e2e tests failing in CI under the leased flow) evidences that v2.0.1 supports `get --lease`, so this is a version skew in the evidence, not a demonstrated defect; the pipeline&#39;s CI step will confirm behavior on the pinned version.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-spawn-worktree-settle.test.sh` — leased acquisition, per-project pools, and post-create abort/settle contract (11/11 ok)</code>
- <code>`bin/fm-test-run.sh tests/fm-backend-herdr-presentation-e2e.test.sh` run 1 — real Herdr 0.7.4 lab, 22/22 ok including &#39;concurrent post-create abort cleanup stays serialized with exact focus restoration&#39; and &#39;exact task-pane close restores the exact captain workspace/tab after Herdr&#39;s raw focus steal&#39;</code>
- <code>`bin/fm-test-run.sh tests/fm-backend-herdr-presentation-e2e.test.sh` run 2 — 22/22 ok (flake check)</code>
- <code>`bin/fm-test-run.sh tests/fm-backend-herdr-presentation-e2e.test.sh` run 3 — 22/22 ok (flake check)</code>
- <code>`bin/fm-test-run.sh tests/fm-teardown.test.sh tests/fm-watcher-lock.test.sh tests/fm-backend.test.sh` — remaining suites owning the changed scripts, all exit=0</code>
- <code>`git status --porcelain` — worktree clean, no transient test artifacts left behind</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/backends/zellij.sh:388` - bin/backends/zellij.sh and bin/backends/cmux.sh current-path comments still narrate the old in-pane `treehouse get` foreground-subshell flow as the probe&#39;s rationale (and zellij.sh cites a docs/zellij-backend.md heading that no longer exists - a pre-existing mismatch). Left intact because they preserve verified empirical pitfall evidence; a follow-up comment refresh to the leased plain-`cd` flow would be reasonable.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
