### PR TITLE
feat(decide): add /decide skill and local decide page for batch captain decisions

### DIFF
--- a/.agents/skills/decide/SKILL.md
+++ b/.agents/skills/decide/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: decide
+description: >-
+  Captain-invocable skill to batch-surface open decisions via a local page.
+  Load when the captain invokes /decide to collect and route pending choices.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# decide
+
+Surface all open captain decisions as a single local page so the captain can read each decision's evidence and recommendation, select one option per decision, and submit all choices at once.
+Firstmate is notified when choices arrive and routes each one to its waiting task.
+
+## When to load
+
+Load this skill when:
+
+- The captain invokes `/decide` explicitly.
+- Multiple ask-user or captain-gated decisions are open and the captain prefers to resolve them in a single review rather than one by one in chat.
+
+## Procedure
+
+### 1. Inventory open decisions
+
+Collect every pending captain decision that is waiting for a choice.
+Sources:
+
+- `tasks-axi` captain-kind items whose status is not Done: run `tasks-axi list --kind captain --status open` and read each item's full body with `tasks-axi show <id> --full`.
+- Any ask-user findings from an active no-mistakes validation that have surfaced with `needs-decision:` and are logged in the relevant task's status file.
+
+Each decision needs these fields for the input JSON:
+
+- `key` - a stable slug you assign, matching `[A-Za-z0-9._-]+`.
+- `title` - a human-readable title (one short sentence).
+- `context` - the full evidence, constraint, and background the captain needs to choose.
+  Summarize the crewmate's report or the ask-user finding faithfully; do not truncate material evidence.
+- `options` - at least two options, each with an `id` slug and a `label`.
+  Add `description` when the label alone is not self-explanatory.
+- `recommendation` - the option `id` firstmate recommends, or omit if genuinely neutral.
+
+If a pending decision cannot be translated into this structure (for example, it requires a free-form answer or the options space is unbounded), handle it separately in plain chat and exclude it from the batch page.
+
+### 2. Write the input JSON
+
+Write the collected decisions to a temporary file, for example under `data/` or a temp path:
+
+```sh
+cat > /tmp/decide-input.json <<'JSON'
+{
+  "decisions": [
+    {
+      "key": "deploy-strategy",
+      "title": "Deployment strategy for the billing service",
+      "context": "The billing service currently deploys with a rolling update...",
+      "options": [
+        {"id": "blue-green",  "label": "Blue-green",   "description": "Zero-downtime swap; needs 2x capacity briefly"},
+        {"id": "rolling",     "label": "Rolling update","description": "Gradual; simpler, small window of mixed versions"}
+      ],
+      "recommendation": "blue-green"
+    }
+  ]
+}
+JSON
+```
+
+### 3. Generate the page
+
+Run `bin/fm-decide-page.sh` with the input file.
+The script validates the JSON, starts a local HTTP server on `127.0.0.1`, writes a run directory under `state/`, and arms the watcher check.
+
+```sh
+bin/fm-decide-page.sh [--timeout SECONDS] /tmp/decide-input.json
+```
+
+The script prints the URL and exits; the server continues as a background process and self-terminates after the captain submits or the timeout elapses.
+
+### 4. Give the captain the URL
+
+Tell the captain the URL in plain English.
+Example: "Captain, all three pending decisions are ready at http://127.0.0.1:PORT/ - open it in a browser, review each one, and submit your choices."
+Do not surface the run ID, the secret, the port number separately, or any internal path.
+
+Resume fleet supervision while waiting; the watcher notifies firstmate when choices arrive.
+
+### 5. Handle the wake
+
+The watcher wakes firstmate with a reason line like:
+
+```
+check: /path/to/state/decide.check.sh: responses-ready: decide-<run-id>
+```
+
+When this arrives:
+
+1. Drain the wake queue as normal (section 8).
+2. Identify the run ID from the reason line.
+3. Read each response file from `state/decide-<run-id>/responses/<key>.json`.
+   Each file has: `key`, `choice`, `note`, `timestamp`, `run_id`.
+4. For each key, match it back to the pending decision it came from and route the choice to its destination.
+
+### 6. Route each choice
+
+Routing depends on the decision's origin:
+
+- **ask-user finding in an active no-mistakes validation**: feed the decision to the gate with `no-mistakes axi respond` exactly as section 7 describes; send the worker the decision key, action, and response command.
+- **captain-kind backlog hold**: use `fm-decision-hold.sh resolve` with the choice and the routed task IDs; section 7 owns the exact command.
+- **in-progress task requiring a choice**: steer the worker with `fm-send` carrying the decision.
+
+If the captain left a note for a decision, include it verbatim in the routing message so the worker or pipeline receives it.
+
+### 7. Mark the run processed
+
+After routing all choices, write the processed marker so the check does not re-fire:
+
+```sh
+touch state/decide-<run-id>/processed
+```
+
+### 8. Confirm to the captain
+
+Once all choices are routed, give the captain a brief summary: which choices were made and where they were sent.
+Do not expose internal run IDs or file paths in captain-facing chat (section 9 translation rule).
+
+## Security notes
+
+- The page and server are local only; no choice or evidence leaves `127.0.0.1`.
+- The one-time secret is generated per run and never logged to the status file or backlog.
+- The server self-terminates; no background process remains after all choices are received or the timeout elapses.
+- If the server is still running when firstmate wakes, the ready marker is already written; firstmate can safely read responses and mark processed regardless of server state.
+
+## Failure modes
+
+- **Captain closes browser without submitting**: the server times out and terminates without writing `ready`.
+  The check will not fire.
+  In the next supervision turn, tell the captain the page has expired and ask whether to open a new one.
+- **Input JSON is invalid**: `fm-decide-page.sh` exits with an error before starting the server.
+  Fix the input and retry.
+- **jq/python3 not found**: `fm-decide-page.sh` reports the missing tool; install it and retry.
+- **A decision key cannot be matched after routing**: report the unmatched key to the captain with its choice and note, and ask where to send it.

--- a/.agents/skills/decide/SKILL.md
+++ b/.agents/skills/decide/SKILL.md
@@ -104,7 +104,7 @@ When this arrives:
 
 Routing depends on the decision's origin:
 
-- **ask-user finding in an active no-mistakes validation**: feed the decision to the gate with `no-mistakes axi respond` exactly as section 7 describes; send the worker the decision key, action, and response command.
+- **ask-user finding in an active no-mistakes validation**: send the same worker one exact decision naming the decision key, step, action, affected finding IDs, and exact response command, exactly as section 7 describes; firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 - **captain-kind backlog hold**: use `fm-decision-hold.sh resolve` with the choice and the routed task IDs; section 7 owns the exact command.
 - **in-progress task requiring a choice**: steer the worker with `fm-send` carrying the decision.
 
@@ -137,5 +137,5 @@ Do not expose internal run IDs or file paths in captain-facing chat (section 9 t
   In the next supervision turn, tell the captain the page has expired and ask whether to open a new one.
 - **Input JSON is invalid**: `fm-decide-page.sh` exits with an error before starting the server.
   Fix the input and retry.
-- **jq/python3 not found**: `fm-decide-page.sh` reports the missing tool; install it and retry.
+- **python3 not found**: `fm-decide-page.sh` reports the missing tool; install it and retry.
 - **A decision key cannot be matched after routing**: report the unmatched key to the captain with its choice and note, and ask where to send it.

--- a/.agents/skills/decide/SKILL.md
+++ b/.agents/skills/decide/SKILL.md
@@ -27,7 +27,7 @@ Load this skill when:
 Collect every pending captain decision that is waiting for a choice.
 Sources:
 
-- `tasks-axi` captain-kind items whose status is not Done: run `tasks-axi list --kind captain --status open` and read each item's full body with `tasks-axi show <id> --full`.
+- `tasks-axi` captain-kind items whose status is not Done: run `tasks-axi list --kind captain --state held` and read each item's full body with `tasks-axi show <id> --full`.
 - Any ask-user findings from an active no-mistakes validation that have surfaced with `needs-decision:` and are logged in the relevant task's status file.
 
 Each decision needs these fields for the input JSON:

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -33,7 +33,9 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eu
-          marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
+          # The pipeline writes the '## Pipeline' lead-in in the author's
+          # language, so only the link itself is localization-invariant.
+          marker='[git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
           if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
             echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
             exit 0
@@ -45,7 +47,7 @@ jobs:
             echo "That pipeline runs the required review/test/lint/CI steps and writes a"
             echo "deterministic '## Pipeline' section into the PR body containing:"
             echo
-            echo "    $marker"
+            echo "    Updates from $marker"
             echo
             echo "See CONTRIBUTING.md for setup and the full workflow."
             echo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,6 +421,7 @@ Do not surface automatic fixes, retries, routine progress, or internal supervisi
 When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.
 Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.
+When the captain invokes `/decide`, load the `decide` skill to surface multiple pending decisions as a single local batch page.
 Whenever a PR is mentioned, include its full `https://...` URL before any shorthand reference.
 Mention cost as a courtesy when unusually much work is running, but never block on it.
 

--- a/bin/fm-decide-page.sh
+++ b/bin/fm-decide-page.sh
@@ -42,7 +42,8 @@
 #   - Server shuts down after one valid complete submission or when timeout elapses.
 #   - state/decide-<run-id>/ is removed only when firstmate marks it processed;
 #     the script itself does not delete run state on exit.
-#   - No secret, credential, or absolute path is embedded in the page.
+#   - The page carries the run secret as an anti-CSRF token in a hidden field;
+#     no absolute path and no external resource is embedded in the page.
 #
 # Environment:
 #   FM_HOME            Firstmate home root (default: repo root from script location)
@@ -75,9 +76,6 @@ while [ "$#" -gt 0 ]; do
     --timeout)
       [ "$#" -ge 2 ] || fail "--timeout requires a value"
       TIMEOUT=$2
-      case "$TIMEOUT" in
-        ''|*[!0-9]*) fail "--timeout must be a positive integer: $TIMEOUT" ;;
-      esac
       shift 2
       ;;
     --help|-h)
@@ -94,6 +92,11 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+case "$TIMEOUT" in
+  ''|*[!0-9]*) fail "timeout must be a positive integer: $TIMEOUT" ;;
+esac
+[ "$TIMEOUT" -gt 0 ] || fail "timeout must be a positive integer: $TIMEOUT"
 
 [ -n "$INPUT_JSON" ] || { usage; exit 1; }
 [ -f "$INPUT_JSON" ] || fail "decisions file not found: $INPUT_JSON"
@@ -186,13 +189,15 @@ print(f'decide-{ts}-{rand}')
 SECRET=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")
 
 RUN_DIR="$STATE/$RUN_ID"
-mkdir -p "$RUN_DIR/responses"
+(umask 077 && mkdir -p "$RUN_DIR/responses")
 
 # Write the watcher check script.
 # This file is always identical across invocations; re-writing and re-registering
 # is idempotent because fm-check-register.sh overwrites the trust file atomically.
 CHECK_SH="$STATE/decide.check.sh"
-cat > "$CHECK_SH" <<'CHECKEOF'
+CHECK_TMP=$(umask 077 && mktemp "$STATE/.decide.check.sh.XXXXXX") || fail "cannot create check temp file"
+trap 'rm -f -- "$CHECK_TMP"' EXIT HUP INT TERM
+cat > "$CHECK_TMP" <<'CHECKEOF'
 #!/usr/bin/env bash
 # Watcher check: prints one line when a decide run has unread responses.
 # Prints nothing otherwise. Exits after the first match.
@@ -206,14 +211,16 @@ for ready in "$FM_HOME/state"/decide-*/ready; do
   break
 done
 CHECKEOF
-chmod 0700 "$CHECK_SH"
+chmod 0700 "$CHECK_TMP"
+mv -f -- "$CHECK_TMP" "$CHECK_SH" || fail "cannot install $CHECK_SH"
+trap - EXIT HUP INT TERM
 
 # Bind check bytes before the watcher can execute it.
 "$SCRIPT_DIR/fm-check-register.sh" decide || fail "failed to register decide check"
 
 # Write the embedded Python HTTP server to the run directory.
 SERVER_PY="$RUN_DIR/server.py"
-cat > "$SERVER_PY" <<PYEOF
+cat > "$SERVER_PY" <<'PYEOF'
 #!/usr/bin/env python3
 """Firstmate decide-page server.
 Serves a self-contained decision page at GET /, accepts one batch POST at
@@ -221,13 +228,18 @@ Serves a self-contained decision page at GET /, accepts one batch POST at
 """
 import json, os, re, signal, sys, threading, time
 from datetime import datetime, timezone
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+
+os.umask(0o077)
 
 STATE_DIR = sys.argv[1]
 RUN_ID    = sys.argv[2]
-SECRET    = sys.argv[3]
-INPUT_JSON= sys.argv[4]
-TIMEOUT   = int(sys.argv[5])
+INPUT_JSON= sys.argv[3]
+TIMEOUT   = int(sys.argv[4])
+SECRET    = os.environ.pop("FM_DECIDE_SECRET", "")
+if not SECRET:
+    print("fm-decide-page: FM_DECIDE_SECRET is required", file=sys.stderr)
+    sys.exit(1)
 
 with open(INPUT_JSON) as fh:
     DECISIONS = json.load(fh)["decisions"]
@@ -239,6 +251,7 @@ os.makedirs(RESPONSES_DIR, exist_ok=True)
 
 _server_ref = None
 _submitted  = False
+_submit_lock = threading.Lock()
 
 HTML_PAGE = r"""<!doctype html>
 <html lang="pt-BR">
@@ -431,7 +444,7 @@ h1 { font-size: 1.3rem; margin: 0 0 0.25rem; }
     })
     .then(function () {
       form.style.display = "none";
-      notice.style.display = "";
+      notice.style.display = "block";
       banner.style.display = "none";
     })
     .catch(function (err) {
@@ -487,6 +500,8 @@ def _build_page():
 _PAGE_CACHE = _build_page()
 
 class Handler(BaseHTTPRequestHandler):
+    timeout = 30
+
     def do_GET(self):
         if self.path == "/" and not _submitted:
             body = _PAGE_CACHE.encode()
@@ -507,19 +522,34 @@ class Handler(BaseHTTPRequestHandler):
             self.send_error(404)
 
     def do_POST(self):
-        global _submitted
         if self.path != "/submit":
             self.send_error(404)
             return
+        with _submit_lock:
+            self._do_submit()
+
+    def _do_submit(self):
+        global _submitted
         if _submitted:
             self._json_error(409, "already submitted")
             return
-        length = int(self.headers.get("Content-Length", 0))
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            self._json_error(400, "invalid Content-Length")
+            return
+        if length < 0:
+            self._json_error(400, "invalid Content-Length")
+            return
         if length > 512 * 1024:
             self._json_error(413, "payload too large")
             return
+        raw = self.rfile.read(length)
+        if len(raw) != length:
+            self._json_error(400, "incomplete request body")
+            return
         try:
-            body = json.loads(self.rfile.read(length))
+            body = json.loads(raw)
         except (json.JSONDecodeError, UnicodeDecodeError):
             self._json_error(400, "invalid JSON")
             return
@@ -612,7 +642,7 @@ def _shutdown():
 
 def main():
     global _server_ref
-    srv = HTTPServer(("127.0.0.1", 0), Handler)
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
     _server_ref = srv
     port = srv.server_address[1]
     port_path = os.path.join(RUN_DIR, "port")
@@ -635,7 +665,7 @@ PYEOF
 
 # Start the Python server in the background.
 INPUT_ABS=$(cd "$(dirname "$INPUT_JSON")" && pwd)/$(basename "$INPUT_JSON")
-python3 "$SERVER_PY" "$STATE" "$RUN_ID" "$SECRET" "$INPUT_ABS" "$TIMEOUT" >/dev/null 2>&1 &
+FM_DECIDE_SECRET="$SECRET" python3 "$SERVER_PY" "$STATE" "$RUN_ID" "$INPUT_ABS" "$TIMEOUT" >/dev/null 2>&1 &
 
 # Wait for port file (up to 5 seconds).
 TRIES=0

--- a/bin/fm-decide-page.sh
+++ b/bin/fm-decide-page.sh
@@ -1,0 +1,652 @@
+#!/usr/bin/env bash
+# fm-decide-page.sh - Generate a local captain-facing decision page.
+#
+# Reads a JSON file describing open decisions, starts a local HTTP server on
+# 127.0.0.1, outputs the URL, and arms the watcher check so firstmate wakes when
+# the captain submits choices.
+# The captain opens the URL, reads all decisions with their evidence and
+# recommendations, selects one option per decision (with an optional note), and
+# submits once.
+# Responses are written to state/decide-<run-id>/responses/<key>.json and a
+# state/decide-<run-id>/ready marker is written.
+# The watcher check state/decide.check.sh wakes firstmate when any pending
+# decide run has a ready marker without a processed marker.
+# Firstmate reads the responses, routes each choice, and writes
+# state/decide-<run-id>/processed when done.
+#
+# Usage:
+#   fm-decide-page.sh [--timeout SECONDS] <decisions.json>
+#
+# Input JSON schema (see docs/decide-page.md for the full schema):
+#   {
+#     "decisions": [
+#       {
+#         "key": "slug",
+#         "title": "Human-readable title",
+#         "context": "Evidence and context",
+#         "options": [
+#           {"id": "slug", "label": "Label", "description": "Optional"}
+#         ],
+#         "recommendation": "slug"
+#       }
+#     ]
+#   }
+#
+# Security invariants:
+#   - Server listens on 127.0.0.1 only; never on all interfaces.
+#   - Port is ephemeral (OS-assigned); never a fixed port.
+#   - Each invocation generates a one-time secret; submissions without it are
+#     rejected with 403.
+#   - Only keys declared in the input decisions are accepted; unknown keys yield
+#     400.
+#   - Server shuts down after one valid complete submission or when timeout elapses.
+#   - state/decide-<run-id>/ is removed only when firstmate marks it processed;
+#     the script itself does not delete run state on exit.
+#   - No secret, credential, or absolute path is embedded in the page.
+#
+# Environment:
+#   FM_HOME            Firstmate home root (default: repo root from script location)
+#   FM_STATE_OVERRIDE  Override state dir (tests)
+#   FM_ROOT_OVERRIDE   Override repo root (tests)
+#   FM_DECIDE_TIMEOUT  Default timeout in seconds (default 1800)
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+DEFAULT_TIMEOUT="${FM_DECIDE_TIMEOUT:-1800}"
+TIMEOUT="$DEFAULT_TIMEOUT"
+INPUT_JSON=
+
+usage() {
+  awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
+}
+
+fail() {
+  printf 'fm-decide-page: %s\n' "$*" >&2
+  exit 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --timeout)
+      [ "$#" -ge 2 ] || fail "--timeout requires a value"
+      TIMEOUT=$2
+      case "$TIMEOUT" in
+        ''|*[!0-9]*) fail "--timeout must be a positive integer: $TIMEOUT" ;;
+      esac
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    -*)
+      fail "unknown option: $1"
+      ;;
+    *)
+      [ -z "$INPUT_JSON" ] || fail "too many arguments; only one decisions JSON allowed"
+      INPUT_JSON=$1
+      shift
+      ;;
+  esac
+done
+
+[ -n "$INPUT_JSON" ] || { usage; exit 1; }
+[ -f "$INPUT_JSON" ] || fail "decisions file not found: $INPUT_JSON"
+
+command -v python3 >/dev/null 2>&1 || fail "python3 is required but not found"
+
+[ -d "$STATE" ] && [ ! -L "$STATE" ] || fail "state directory unavailable: $STATE"
+
+# Validate input JSON via Python (canonical validator); exits non-zero on any
+# schema violation. Output is discarded; we only need the exit code.
+python3 - "$INPUT_JSON" >/dev/null <<'PYVALIDATE' || fail "invalid decisions JSON"
+import json, sys, re
+
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        data = json.load(f)
+except (json.JSONDecodeError, OSError) as e:
+    print(f"invalid JSON: {e}", file=sys.stderr)
+    sys.exit(1)
+
+SLUG_RE = re.compile(r'^[A-Za-z0-9._-]+$')
+
+if not isinstance(data, dict):
+    print("top-level value must be an object", file=sys.stderr)
+    sys.exit(1)
+decisions = data.get("decisions")
+if not isinstance(decisions, list) or len(decisions) == 0:
+    print("decisions must be a non-empty array", file=sys.stderr)
+    sys.exit(1)
+
+seen_keys = set()
+for i, d in enumerate(decisions):
+    if not isinstance(d, dict):
+        print(f"decisions[{i}] must be an object", file=sys.stderr)
+        sys.exit(1)
+    key = d.get("key", "")
+    if not isinstance(key, str) or not SLUG_RE.match(key):
+        print(f"decisions[{i}].key must be a non-empty slug [A-Za-z0-9._-]: {key!r}", file=sys.stderr)
+        sys.exit(1)
+    if key in seen_keys:
+        print(f"duplicate key: {key}", file=sys.stderr)
+        sys.exit(1)
+    seen_keys.add(key)
+    title = d.get("title", "")
+    if not isinstance(title, str) or not title.strip():
+        print(f"decisions[{i}].title must be a non-empty string", file=sys.stderr)
+        sys.exit(1)
+    context = d.get("context", "")
+    if not isinstance(context, str) or not context.strip():
+        print(f"decisions[{i}].context must be a non-empty string", file=sys.stderr)
+        sys.exit(1)
+    options = d.get("options")
+    if not isinstance(options, list) or len(options) < 2:
+        print(f"decisions[{i}].options must be an array of at least 2 items", file=sys.stderr)
+        sys.exit(1)
+    seen_opts = set()
+    for j, opt in enumerate(options):
+        if not isinstance(opt, dict):
+            print(f"decisions[{i}].options[{j}] must be an object", file=sys.stderr)
+            sys.exit(1)
+        oid = opt.get("id", "")
+        if not isinstance(oid, str) or not SLUG_RE.match(oid):
+            print(f"decisions[{i}].options[{j}].id must be a non-empty slug: {oid!r}", file=sys.stderr)
+            sys.exit(1)
+        if oid in seen_opts:
+            print(f"decisions[{i}]: duplicate option id: {oid}", file=sys.stderr)
+            sys.exit(1)
+        seen_opts.add(oid)
+        label = opt.get("label", "")
+        if not isinstance(label, str) or not label.strip():
+            print(f"decisions[{i}].options[{j}].label must be a non-empty string", file=sys.stderr)
+            sys.exit(1)
+    rec = d.get("recommendation")
+    if rec is not None:
+        if not isinstance(rec, str) or rec not in seen_opts:
+            print(f"decisions[{i}].recommendation must be a valid option id: {rec!r}", file=sys.stderr)
+            sys.exit(1)
+
+PYVALIDATE
+
+# Generate run id: timestamp + random suffix (uses Python for portability).
+RUN_ID=$(python3 -c "
+import secrets, time
+ts = int(time.time())
+rand = secrets.token_hex(4)
+print(f'decide-{ts}-{rand}')
+")
+
+SECRET=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")
+
+RUN_DIR="$STATE/$RUN_ID"
+mkdir -p "$RUN_DIR/responses"
+
+# Write the watcher check script.
+# This file is always identical across invocations; re-writing and re-registering
+# is idempotent because fm-check-register.sh overwrites the trust file atomically.
+CHECK_SH="$STATE/decide.check.sh"
+cat > "$CHECK_SH" <<'CHECKEOF'
+#!/usr/bin/env bash
+# Watcher check: prints one line when a decide run has unread responses.
+# Prints nothing otherwise. Exits after the first match.
+FM_HOME="${FM_HOME:-$(cd "$(dirname "$0")/.." && pwd)}"
+for ready in "$FM_HOME/state"/decide-*/ready; do
+  [ -f "$ready" ] || continue
+  dir=$(dirname "$ready")
+  [ ! -f "$dir/processed" ] || continue
+  run_id=$(basename "$dir")
+  printf 'responses-ready: %s\n' "$run_id"
+  break
+done
+CHECKEOF
+chmod 0700 "$CHECK_SH"
+
+# Bind check bytes before the watcher can execute it.
+"$SCRIPT_DIR/fm-check-register.sh" decide || fail "failed to register decide check"
+
+# Write the embedded Python HTTP server to the run directory.
+SERVER_PY="$RUN_DIR/server.py"
+cat > "$SERVER_PY" <<PYEOF
+#!/usr/bin/env python3
+"""Firstmate decide-page server.
+Serves a self-contained decision page at GET /, accepts one batch POST at
+/submit, writes per-key response files, and self-terminates.
+"""
+import json, os, re, signal, sys, threading, time
+from datetime import datetime, timezone
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+STATE_DIR = sys.argv[1]
+RUN_ID    = sys.argv[2]
+SECRET    = sys.argv[3]
+INPUT_JSON= sys.argv[4]
+TIMEOUT   = int(sys.argv[5])
+
+with open(INPUT_JSON) as fh:
+    DECISIONS = json.load(fh)["decisions"]
+
+VALID_KEYS   = {d["key"] for d in DECISIONS}
+RUN_DIR      = os.path.join(STATE_DIR, RUN_ID)
+RESPONSES_DIR= os.path.join(RUN_DIR, "responses")
+os.makedirs(RESPONSES_DIR, exist_ok=True)
+
+_server_ref = None
+_submitted  = False
+
+HTML_PAGE = r"""<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Decisões pendentes - Firstmate</title>
+<style>
+:root {
+  --bg: #f5f5f5;
+  --surface: #fff;
+  --border: #d1d5db;
+  --text: #111;
+  --muted: #555;
+  --accent: #1a56db;
+  --rec-bg: #eff6ff;
+  --rec-border: #3b82f6;
+  --rec-text: #1e40af;
+  --success-bg: #ecfdf5;
+  --success-border: #10b981;
+  --success-text: #065f46;
+  --err-bg: #fef2f2;
+  --err-border: #ef4444;
+  --err-text: #7f1d1d;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #111;
+    --surface: #1e1e1e;
+    --border: #374151;
+    --text: #e5e7eb;
+    --muted: #9ca3af;
+    --accent: #60a5fa;
+    --rec-bg: #1e3a5f;
+    --rec-border: #3b82f6;
+    --rec-text: #93c5fd;
+    --success-bg: #064e3b;
+    --success-border: #10b981;
+    --success-text: #6ee7b7;
+    --err-bg: #450a0a;
+    --err-border: #ef4444;
+    --err-text: #fca5a5;
+  }
+}
+:root[data-theme="light"] {
+  --bg: #f5f5f5; --surface: #fff; --border: #d1d5db; --text: #111;
+  --muted: #555; --accent: #1a56db; --rec-bg: #eff6ff;
+  --rec-border: #3b82f6; --rec-text: #1e40af;
+  --success-bg: #ecfdf5; --success-border: #10b981; --success-text: #065f46;
+  --err-bg: #fef2f2; --err-border: #ef4444; --err-text: #7f1d1d;
+}
+:root[data-theme="dark"] {
+  --bg: #111; --surface: #1e1e1e; --border: #374151; --text: #e5e7eb;
+  --muted: #9ca3af; --accent: #60a5fa; --rec-bg: #1e3a5f;
+  --rec-border: #3b82f6; --rec-text: #93c5fd;
+  --success-bg: #064e3b; --success-border: #10b981; --success-text: #6ee7b7;
+  --err-bg: #450a0a; --err-border: #ef4444; --err-text: #fca5a5;
+}
+*, *::before, *::after { box-sizing: border-box; }
+body {
+  margin: 0; padding: 2rem 1rem;
+  background: var(--bg); color: var(--text);
+  font: 15px/1.5 system-ui, -apple-system, sans-serif;
+}
+.container { max-width: 760px; margin: 0 auto; }
+h1 { font-size: 1.3rem; margin: 0 0 0.25rem; }
+.subtitle { color: var(--muted); font-size: 0.9rem; margin: 0 0 2rem; }
+.card {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 1.25rem; margin-bottom: 1.5rem;
+}
+.card-title { font-size: 1rem; font-weight: 600; margin: 0 0 0.75rem; }
+.card-num {
+  display: inline-block; background: var(--accent); color: #fff;
+  border-radius: 50%; width: 1.4rem; height: 1.4rem;
+  font-size: 0.75rem; font-weight: 700; text-align: center; line-height: 1.4rem;
+  margin-right: 0.5rem; vertical-align: middle;
+}
+.context {
+  background: var(--bg); border: 1px solid var(--border);
+  border-radius: 4px; padding: 0.75rem 1rem;
+  font-size: 0.875rem; color: var(--muted);
+  margin-bottom: 1rem; white-space: pre-wrap; word-break: break-word;
+  max-height: 200px; overflow-y: auto;
+}
+.options { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem; }
+.option {
+  display: flex; align-items: flex-start; gap: 0.75rem;
+  border: 1px solid var(--border); border-radius: 6px;
+  padding: 0.75rem; cursor: pointer; transition: border-color 0.15s;
+}
+.option:hover { border-color: var(--accent); }
+.option.recommended {
+  border-color: var(--rec-border); background: var(--rec-bg);
+}
+.option input[type=radio] { margin-top: 2px; flex-shrink: 0; accent-color: var(--accent); }
+.option-body { flex: 1; }
+.option-label { font-size: 0.9rem; font-weight: 500; }
+.option-desc { font-size: 0.8rem; color: var(--muted); margin-top: 2px; }
+.rec-badge {
+  display: inline-block; font-size: 0.7rem; font-weight: 600;
+  background: var(--rec-border); color: #fff;
+  border-radius: 3px; padding: 1px 5px; margin-left: 6px; vertical-align: middle;
+}
+.note-label { font-size: 0.8rem; color: var(--muted); display: block; margin-bottom: 0.3rem; }
+.note-field {
+  width: 100%; border: 1px solid var(--border); border-radius: 4px;
+  background: var(--surface); color: var(--text);
+  padding: 0.5rem 0.75rem; font: inherit; font-size: 0.85rem;
+  resize: vertical; min-height: 60px;
+}
+.note-field:focus { outline: 2px solid var(--accent); border-color: transparent; }
+.submit-bar {
+  position: sticky; bottom: 0;
+  background: var(--surface); border-top: 1px solid var(--border);
+  padding: 1rem; margin: 0 -1rem; border-radius: 0 0 8px 8px;
+  text-align: right;
+}
+.btn {
+  background: var(--accent); color: #fff;
+  border: none; border-radius: 6px;
+  padding: 0.6rem 1.5rem; font: inherit; font-weight: 600;
+  cursor: pointer; font-size: 0.95rem;
+}
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.banner {
+  border-radius: 6px; padding: 1rem 1.25rem; margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+}
+.banner.success { background: var(--success-bg); border: 1px solid var(--success-border); color: var(--success-text); }
+.banner.error   { background: var(--err-bg); border: 1px solid var(--err-border); color: var(--err-text); }
+#submitted-notice { display: none; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>Decisões pendentes</h1>
+  <p class="subtitle">Leia a evidência, escolha uma opção por decisão e clique em Confirmar.</p>
+  <div id="banner" class="banner" style="display:none"></div>
+  <div id="submitted-notice" class="banner success">
+    Suas escolhas foram recebidas. O firstmate será notificado.
+  </div>
+  <form id="decide-form">
+    <input type="hidden" name="__secret" value="__SECRET__">
+    __CARDS__
+    <div class="submit-bar">
+      <button type="submit" class="btn" id="submit-btn">Confirmar todas as escolhas</button>
+    </div>
+  </form>
+</div>
+<script>
+(function () {
+  var form = document.getElementById("decide-form");
+  var banner = document.getElementById("banner");
+  var notice = document.getElementById("submitted-notice");
+  var btn = document.getElementById("submit-btn");
+
+  function showBanner(type, msg) {
+    banner.className = "banner " + type;
+    banner.textContent = msg;
+    banner.style.display = "";
+    banner.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }
+
+  form.addEventListener("submit", function (e) {
+    e.preventDefault();
+    var data = { secret: form.__secret.value, choices: {} };
+    var missing = [];
+    form.querySelectorAll("[data-decision-key]").forEach(function (card) {
+      var key = card.dataset.decisionKey;
+      var sel = card.querySelector("input[type=radio]:checked");
+      if (!sel) { missing.push(key); return; }
+      var note = card.querySelector("textarea");
+      data.choices[key] = { choice: sel.value, note: note ? note.value : "" };
+    });
+    if (missing.length) {
+      showBanner("error", "Escolha uma opção para: " + missing.join(", "));
+      return;
+    }
+    btn.disabled = true;
+    btn.textContent = "Enviando...";
+    fetch("/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data)
+    })
+    .then(function (r) {
+      if (!r.ok) return r.text().then(function(t) { throw new Error(t || r.statusText); });
+      return r.json();
+    })
+    .then(function () {
+      form.style.display = "none";
+      notice.style.display = "";
+      banner.style.display = "none";
+    })
+    .catch(function (err) {
+      showBanner("error", "Erro ao enviar: " + err.message);
+      btn.disabled = false;
+      btn.textContent = "Confirmar todas as escolhas";
+    });
+  });
+})();
+</script>
+</body>
+</html>
+"""
+
+def _build_card(decision, index):
+    key = decision["key"]
+    title = _esc(decision["title"])
+    context = _esc(decision["context"])
+    rec = decision.get("recommendation", "")
+    options_html = ""
+    for opt in decision["options"]:
+        oid   = _esc(opt["id"])
+        label = _esc(opt["label"])
+        desc  = _esc(opt.get("description", ""))
+        badge = '<span class="rec-badge">Recomendado</span>' if opt["id"] == rec else ""
+        cls   = ' recommended' if opt["id"] == rec else ""
+        desc_html = f'<div class="option-desc">{desc}</div>' if desc else ""
+        options_html += (
+            f'<label class="option{cls}">'
+            f'<input type="radio" name="{key}" value="{oid}">'
+            f'<div class="option-body">'
+            f'<div class="option-label">{label}{badge}</div>'
+            f'{desc_html}'
+            f'</div></label>'
+        )
+    return (
+        f'<div class="card" data-decision-key="{key}">'
+        f'<div class="card-title"><span class="card-num">{index+1}</span>{title}</div>'
+        f'<div class="context">{context}</div>'
+        f'<div class="options">{options_html}</div>'
+        f'<label class="note-label" for="note-{key}">Observação (opcional)</label>'
+        f'<textarea class="note-field" id="note-{key}" name="note-{key}" rows="2" placeholder="Contexto adicional..."></textarea>'
+        f'</div>'
+    )
+
+def _esc(s):
+    return str(s).replace("&","&amp;").replace("<","&lt;").replace(">","&gt;").replace('"',"&quot;")
+
+def _build_page():
+    cards = "".join(_build_card(d, i) for i, d in enumerate(DECISIONS))
+    return HTML_PAGE.replace("__SECRET__", SECRET).replace("__CARDS__", cards)
+
+_PAGE_CACHE = _build_page()
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/" and not _submitted:
+            body = _PAGE_CACHE.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/" and _submitted:
+            msg = b"Choices already received."
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(msg)))
+            self.end_headers()
+            self.wfile.write(msg)
+        else:
+            self.send_error(404)
+
+    def do_POST(self):
+        global _submitted
+        if self.path != "/submit":
+            self.send_error(404)
+            return
+        if _submitted:
+            self._json_error(409, "already submitted")
+            return
+        length = int(self.headers.get("Content-Length", 0))
+        if length > 512 * 1024:
+            self._json_error(413, "payload too large")
+            return
+        try:
+            body = json.loads(self.rfile.read(length))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self._json_error(400, "invalid JSON")
+            return
+
+        if not isinstance(body, dict):
+            self._json_error(400, "body must be an object")
+            return
+        if body.get("secret") != SECRET:
+            self._json_error(403, "invalid secret")
+            return
+
+        choices = body.get("choices")
+        if not isinstance(choices, dict):
+            self._json_error(400, "choices must be an object")
+            return
+
+        unknown = set(choices.keys()) - VALID_KEYS
+        if unknown:
+            self._json_error(400, "unknown decision keys: " + ", ".join(sorted(unknown)))
+            return
+
+        missing = VALID_KEYS - set(choices.keys())
+        if missing:
+            self._json_error(400, "missing decision keys: " + ", ".join(sorted(missing)))
+            return
+
+        # Validate each choice against allowed option IDs.
+        valid_options = {d["key"]: {o["id"] for o in d["options"]} for d in DECISIONS}
+        now_iso = datetime.now(timezone.utc).isoformat()
+        for key, val in choices.items():
+            if not isinstance(val, dict):
+                self._json_error(400, f"choices[{key!r}] must be an object")
+                return
+            choice = val.get("choice", "")
+            if choice not in valid_options[key]:
+                self._json_error(400, f"choices[{key!r}].choice is not a valid option id: {choice!r}")
+                return
+            note = val.get("note", "")
+            if not isinstance(note, str):
+                self._json_error(400, f"choices[{key!r}].note must be a string")
+                return
+
+        # Write individual response files atomically.
+        for key, val in choices.items():
+            record = {
+                "key": key,
+                "choice": val["choice"],
+                "note": val.get("note", ""),
+                "timestamp": now_iso,
+                "run_id": RUN_ID,
+            }
+            tmp_path = os.path.join(RESPONSES_DIR, f".{key}.tmp")
+            dst_path = os.path.join(RESPONSES_DIR, f"{key}.json")
+            with open(tmp_path, "w") as fh:
+                json.dump(record, fh, indent=2)
+                fh.write("\n")
+            os.replace(tmp_path, dst_path)
+
+        # Write ready marker.
+        ready_path = os.path.join(RUN_DIR, "ready")
+        with open(ready_path, "w") as fh:
+            fh.write(now_iso + "\n")
+
+        _submitted = True
+        payload = json.dumps({"ok": True, "run_id": RUN_ID}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+        # Shut down after a short delay so the response is flushed.
+        threading.Thread(target=_shutdown, daemon=True).start()
+
+    def _json_error(self, code, msg):
+        body = json.dumps({"error": msg}).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+def _shutdown():
+    time.sleep(0.3)
+    if _server_ref:
+        _server_ref.shutdown()
+
+def main():
+    global _server_ref
+    srv = HTTPServer(("127.0.0.1", 0), Handler)
+    _server_ref = srv
+    port = srv.server_address[1]
+    port_path = os.path.join(RUN_DIR, "port")
+    with open(port_path, "w") as fh:
+        fh.write(str(port) + "\n")
+
+    # Timeout watchdog.
+    def _watchdog():
+        time.sleep(TIMEOUT)
+        if not _submitted:
+            if _server_ref:
+                _server_ref.shutdown()
+    threading.Thread(target=_watchdog, daemon=True).start()
+
+    srv.serve_forever()
+
+if __name__ == "__main__":
+    main()
+PYEOF
+
+# Start the Python server in the background.
+INPUT_ABS=$(cd "$(dirname "$INPUT_JSON")" && pwd)/$(basename "$INPUT_JSON")
+python3 "$SERVER_PY" "$STATE" "$RUN_ID" "$SECRET" "$INPUT_ABS" "$TIMEOUT" >/dev/null 2>&1 &
+
+# Wait for port file (up to 5 seconds).
+TRIES=0
+while [ ! -f "$RUN_DIR/port" ]; do
+  TRIES=$((TRIES + 1))
+  [ "$TRIES" -le 50 ] || fail "server did not start within 5 seconds"
+  sleep 0.1
+done
+
+PORT=$(tr -d '[:space:]' < "$RUN_DIR/port")
+
+printf 'Decisões prontas: http://127.0.0.1:%s/\n' "$PORT"
+printf 'Firstmate será notificado quando as escolhas forem submetidas (run: %s).\n' "$RUN_ID"
+printf 'Servidor encerrará automaticamente em %s segundos ou após envio.\n' "$TIMEOUT"

--- a/docs/decide-page.md
+++ b/docs/decide-page.md
@@ -94,7 +94,9 @@ Re-running `fm-decide-page.sh` re-writes the same bytes and re-registers idempot
 - A per-run one-time secret is required in every submission; submissions without it receive a 403.
 - Only decision keys declared in the input JSON are accepted; unknown keys receive a 400.
 - The server self-terminates after one valid complete submission or when the timeout elapses (default 1800 seconds, overridden by `FM_DECIDE_TIMEOUT` or `--timeout`).
-- The page embeds no credential, no absolute path, and no external resource; all CSS and JavaScript are inline.
+- The page carries the run secret as an anti-CSRF token in a hidden form field; it is served only to `127.0.0.1` clients and is discarded when the server exits.
+- The secret is passed to the server process through the `FM_DECIDE_SECRET` environment variable, never as a command-line argument, so it is not visible in `ps`.
+- The page embeds no absolute path and no external resource; all CSS and JavaScript are inline.
 
 ## Run state layout
 
@@ -103,7 +105,7 @@ state/
   decide.check.sh          house-level watcher check (always same bytes)
   decide.check-trust       registration binding for the check
   decide-<run-id>/
-    port                   TCP port the server is listening on (removed after server exits)
+    port                   TCP port the server is listening on (kept until firstmate removes the run directory)
     server.py              embedded Python server for this run
     ready                  written when submission is accepted; ISO-8601 timestamp
     processed              written by firstmate after routing choices

--- a/docs/decide-page.md
+++ b/docs/decide-page.md
@@ -1,0 +1,117 @@
+# Decide page
+
+`bin/fm-decide-page.sh` generates a self-contained local HTML page for batch captain decision collection.
+The captain opens one URL, reads each decision with its evidence and recommendation, selects an option, and submits all choices at once.
+Firstmate is notified through the watcher check mechanism and routes each choice to its waiting task.
+
+## Input JSON schema
+
+The script accepts a single JSON file.
+The file must be valid JSON and must satisfy the constraints below; the script refuses invalid input rather than generating a partial page.
+
+```json
+{
+  "decisions": [
+    {
+      "key": "deploy-strategy",
+      "title": "Deployment strategy for the billing service",
+      "context": "Full evidence and context the captain needs to decide.",
+      "options": [
+        {
+          "id": "blue-green",
+          "label": "Blue-green deployment",
+          "description": "Zero-downtime swap; requires 2x capacity briefly"
+        },
+        {
+          "id": "rolling",
+          "label": "Rolling update",
+          "description": "Gradual rollout; simpler, brief mixed-version window"
+        }
+      ],
+      "recommendation": "blue-green"
+    }
+  ]
+}
+```
+
+Field constraints:
+
+| Field | Type | Rule |
+|---|---|---|
+| `decisions` | array | Non-empty; all keys must be unique. |
+| `decisions[i].key` | string | Non-empty slug matching `[A-Za-z0-9._-]+`. |
+| `decisions[i].title` | string | Non-empty. |
+| `decisions[i].context` | string | Non-empty. |
+| `decisions[i].options` | array | At least 2 items; all `id` values must be unique within the decision. |
+| `decisions[i].options[j].id` | string | Non-empty slug matching `[A-Za-z0-9._-]+`. |
+| `decisions[i].options[j].label` | string | Non-empty. |
+| `decisions[i].options[j].description` | string | Optional. |
+| `decisions[i].recommendation` | string | Optional; if present, must be a valid `options[j].id`. |
+
+## Submission format
+
+The captain submits all choices in a single POST.
+Each choice is validated against the declared options for that decision key.
+Unknown keys and missing keys are rejected with a 400 response.
+
+Per-choice response record written to `state/decide-<run-id>/responses/<key>.json`:
+
+```json
+{
+  "key": "deploy-strategy",
+  "choice": "blue-green",
+  "note": "Optional captain note",
+  "timestamp": "2026-07-27T10:00:00+00:00",
+  "run_id": "decide-1753609200-a1b2c3d4"
+}
+```
+
+## Watcher integration
+
+`fm-decide-page.sh` writes `state/decide.check.sh` and registers it with `bin/fm-check-register.sh`.
+The check script runs on the watcher's `CHECK_INTERVAL` cadence (default 300 seconds) and prints one line when any decide run has a `ready` marker without a `processed` marker:
+
+```
+responses-ready: decide-<run-id>
+```
+
+The watcher surfaces this as:
+
+```
+check: /path/to/state/decide.check.sh: responses-ready: decide-<run-id>
+```
+
+Firstmate reads the responses, routes each choice, and writes `state/decide-<run-id>/processed` when done.
+The check is then silent for that run.
+
+`state/decide.check.sh` and `state/decide.check-trust` are permanent house-level artifacts.
+Re-running `fm-decide-page.sh` re-writes the same bytes and re-registers idempotently.
+
+## Security properties
+
+- Server listens on `127.0.0.1` only; never on all interfaces.
+- Port is OS-assigned at runtime; no fixed port is used.
+- A per-run one-time secret is required in every submission; submissions without it receive a 403.
+- Only decision keys declared in the input JSON are accepted; unknown keys receive a 400.
+- The server self-terminates after one valid complete submission or when the timeout elapses (default 1800 seconds, overridden by `FM_DECIDE_TIMEOUT` or `--timeout`).
+- The page embeds no credential, no absolute path, and no external resource; all CSS and JavaScript are inline.
+
+## Run state layout
+
+```
+state/
+  decide.check.sh          house-level watcher check (always same bytes)
+  decide.check-trust       registration binding for the check
+  decide-<run-id>/
+    port                   TCP port the server is listening on (removed after server exits)
+    server.py              embedded Python server for this run
+    ready                  written when submission is accepted; ISO-8601 timestamp
+    processed              written by firstmate after routing choices
+    responses/
+      <key>.json           one file per decision key
+```
+
+## Verification entry point
+
+See `tests/fm-decide-page.test.sh` for the behavior test suite.
+It covers input validation, secret enforcement, unknown-key rejection, valid-submission recording, and the check-script output contract.

--- a/docs/decide-page.md
+++ b/docs/decide-page.md
@@ -53,6 +53,7 @@ Field constraints:
 The captain submits all choices in a single POST.
 Each choice is validated against the declared options for that decision key.
 Unknown keys and missing keys are rejected with a 400 response.
+A second submission after a valid one is rejected with 409, and a body over 512 KiB with 413.
 
 Per-choice response record written to `state/decide-<run-id>/responses/<key>.json`:
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -124,6 +124,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/decide/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/decision-hold-lifecycle/SKILL.md",
       "audience": "agent-runtime"
     },
@@ -217,6 +221,10 @@
     },
     {
       "path": "docs/configuration.md",
+      "audience": "operator-current"
+    },
+    {
+      "path": "docs/decide-page.md",
       "audience": "operator-current"
     },
     {

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -18,6 +18,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
+| `fm-decide-page.sh`      | Generate a local batch decision page and arm the watcher check for captain-choice notification |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |

--- a/tests/fm-decide-page.test.sh
+++ b/tests/fm-decide-page.test.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-decide-page.sh and the decide watcher check.
+#
+# Coverage:
+#   - Invalid input rejected (missing fields, bad key format, duplicate keys)
+#   - Server: submission without secret rejected (403)
+#   - Server: submission with unknown key rejected (400)
+#   - Server: valid submission written as legible JSON records
+#   - Check script: prints one line only when ready marker exists without processed
+#   - Check script: silent when processed marker exists
+#   - Check script: silent when no decide-* directories exist
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-pr-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-check-lib.sh"
+
+DECIDE="$ROOT/bin/fm-decide-page.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-decide-page)
+
+file_mode() {
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %Lp "$1"
+  else
+    stat -c %a "$1"
+  fi
+}
+
+make_home() {
+  local name=$1
+  local dir="$TMP_ROOT/$name"
+  mkdir -p "$dir/state" "$dir/data"
+  printf '%s\n' "$dir"
+}
+
+valid_json() {
+  cat <<'JSON'
+{
+  "decisions": [
+    {
+      "key": "deploy-strategy",
+      "title": "Deployment strategy",
+      "context": "The billing service needs a deployment approach.",
+      "options": [
+        {"id": "blue-green", "label": "Blue-green", "description": "Zero-downtime"},
+        {"id": "rolling",    "label": "Rolling",    "description": "Gradual"}
+      ],
+      "recommendation": "blue-green"
+    },
+    {
+      "key": "db-migration-order",
+      "title": "Migration order",
+      "context": "Run schema migration before or after deploy?",
+      "options": [
+        {"id": "before", "label": "Before deploy"},
+        {"id": "after",  "label": "After deploy"}
+      ]
+    }
+  ]
+}
+JSON
+}
+
+# ---------------------------------------------------------------------------
+# Input validation tests (no server started)
+# ---------------------------------------------------------------------------
+
+run_invalid() {
+  local home=$1 json_content=$2 expect_fragment=$3 label=$4
+  local json_file="$home/input.json"
+  printf '%s\n' "$json_content" > "$json_file"
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+        "$DECIDE" "$json_file" 2>&1) && rc=0 || rc=$?
+  [ "$rc" -ne 0 ] || fail "$label: expected non-zero exit, got 0"
+  assert_contains "$out" "$expect_fragment" "$label: expected '$expect_fragment' in output"
+  pass "$label"
+}
+
+H=$(make_home invalid-tests)
+
+run_invalid "$H" 'not json at all' "invalid JSON" "rejects non-JSON input"
+run_invalid "$H" '{}' "decisions must be a non-empty array" "rejects missing decisions"
+run_invalid "$H" '{"decisions":[]}' "decisions must be a non-empty array" "rejects empty decisions array"
+run_invalid "$H" '{"decisions":[{"key":"","title":"T","context":"C","options":[{"id":"a","label":"A"},{"id":"b","label":"B"}]}]}' \
+  "key must be a non-empty slug" "rejects empty key"
+run_invalid "$H" '{"decisions":[{"key":"bad key!","title":"T","context":"C","options":[{"id":"a","label":"A"},{"id":"b","label":"B"}]}]}' \
+  "key must be a non-empty slug" "rejects key with spaces"
+run_invalid "$H" '{"decisions":[{"key":"ok","title":"","context":"C","options":[{"id":"a","label":"A"},{"id":"b","label":"B"}]}]}' \
+  "title must be a non-empty string" "rejects empty title"
+run_invalid "$H" '{"decisions":[{"key":"ok","title":"T","context":"","options":[{"id":"a","label":"A"},{"id":"b","label":"B"}]}]}' \
+  "context must be a non-empty string" "rejects empty context"
+run_invalid "$H" '{"decisions":[{"key":"ok","title":"T","context":"C","options":[{"id":"a","label":"A"}]}]}' \
+  "options must be an array of at least 2 items" "rejects single option"
+run_invalid "$H" '{"decisions":[{"key":"dup","title":"T","context":"C","options":[{"id":"a","label":"A"},{"id":"b","label":"B"}]},{"key":"dup","title":"T2","context":"C2","options":[{"id":"x","label":"X"},{"id":"y","label":"Y"}]}]}' \
+  "duplicate key" "rejects duplicate decision keys"
+run_invalid "$H" '{"decisions":[{"key":"ok","title":"T","context":"C","options":[{"id":"a","label":"A"},{"id":"a","label":"A2"}]}]}' \
+  "duplicate option id" "rejects duplicate option ids"
+run_invalid "$H" '{"decisions":[{"key":"ok","title":"T","context":"C","options":[{"id":"a","label":"A"},{"id":"b","label":"B"}],"recommendation":"nonexistent"}]}' \
+  "recommendation must be a valid option id" "rejects invalid recommendation"
+
+# ---------------------------------------------------------------------------
+# Check script tests (no server needed)
+# ---------------------------------------------------------------------------
+
+H_CHK=$(make_home check-tests)
+
+# Write the check script by invoking fm-decide-page.sh with a valid JSON.
+# We use --timeout 1 so the server exits quickly; we don't need it for check tests.
+VALID_FILE="$H_CHK/valid.json"
+valid_json > "$VALID_FILE"
+FM_HOME="$H_CHK" FM_STATE_OVERRIDE="$H_CHK/state" "$DECIDE" --timeout 1 "$VALID_FILE" >/dev/null 2>&1 &
+BGPID=$!
+# Wait for check.sh to appear (server may still be starting; we only need the check file)
+TRIES=0
+while [ ! -f "$H_CHK/state/decide.check.sh" ] && [ "$TRIES" -lt 50 ]; do
+  sleep 0.1
+  TRIES=$((TRIES + 1))
+done
+wait "$BGPID" 2>/dev/null || true
+
+CHECK_SH="$H_CHK/state/decide.check.sh"
+assert_present "$CHECK_SH" "check script was created"
+
+MODE=$(file_mode "$CHECK_SH")
+[ "$MODE" = "700" ] || fail "check script must have mode 700, got $MODE"
+pass "check script has mode 700"
+
+# check: silent when no decide-* directories at all
+out=$(FM_HOME="$H_CHK" "$CHECK_SH")
+[ -z "$out" ] || fail "check must be silent with no decide-* dirs, got: $out"
+pass "check is silent with no decide-* dirs"
+
+# check: silent when ready marker is absent
+mkdir -p "$H_CHK/state/decide-fixture-01"
+out=$(FM_HOME="$H_CHK" "$CHECK_SH")
+[ -z "$out" ] || fail "check must be silent without ready marker, got: $out"
+pass "check is silent without ready marker"
+
+# check: prints one line when ready marker exists
+touch "$H_CHK/state/decide-fixture-01/ready"
+out=$(FM_HOME="$H_CHK" "$CHECK_SH")
+[ -n "$out" ] || fail "check must print a line when ready marker exists"
+assert_contains "$out" "responses-ready:" "check output contains responses-ready"
+assert_contains "$out" "decide-fixture-01" "check output contains run ID"
+LINECOUNT=$(printf '%s' "$out" | wc -l)
+[ "$LINECOUNT" -le 1 ] || fail "check must print at most one line, got $LINECOUNT"
+pass "check prints one line when ready marker exists"
+
+# check: silent when processed marker exists
+touch "$H_CHK/state/decide-fixture-01/processed"
+out=$(FM_HOME="$H_CHK" "$CHECK_SH")
+[ -z "$out" ] || fail "check must be silent when processed, got: $out"
+pass "check is silent when processed marker exists"
+
+# check: first unprocessed run wins when multiple exist
+mkdir -p "$H_CHK/state/decide-fixture-02"
+touch "$H_CHK/state/decide-fixture-02/ready"
+out=$(FM_HOME="$H_CHK" "$CHECK_SH")
+[ -n "$out" ] || fail "check must print when a second unprocessed run exists"
+assert_contains "$out" "decide-fixture-02" "check surfaces the unprocessed run"
+LINECOUNT=$(printf '%s' "$out" | wc -l)
+[ "$LINECOUNT" -le 1 ] || fail "check must print at most one line with multiple runs, got $LINECOUNT"
+pass "check surfaces second run when first is processed"
+
+# ---------------------------------------------------------------------------
+# Server integration tests (requires a live server)
+# ---------------------------------------------------------------------------
+
+H_SRV=$(make_home server-tests)
+VALID_FILE2="$H_SRV/valid.json"
+valid_json > "$VALID_FILE2"
+
+SRV_OUT=$(FM_HOME="$H_SRV" FM_STATE_OVERRIDE="$H_SRV/state" \
+  "$DECIDE" --timeout 30 "$VALID_FILE2" 2>&1)
+assert_contains "$SRV_OUT" "http://127.0.0.1:" "script outputs a URL"
+pass "script outputs http URL"
+
+# Extract port from output.
+PORT=$(printf '%s' "$SRV_OUT" | grep -o 'http://127.0.0.1:[0-9]*' | grep -o '[0-9]*$')
+[ -n "$PORT" ] || fail "could not parse port from output"
+
+BASE="http://127.0.0.1:$PORT"
+sleep 0.5  # brief pause for server warm-up
+
+# GET / returns 200.
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/")
+[ "$HTTP_CODE" = "200" ] || fail "GET / expected 200, got $HTTP_CODE"
+pass "GET / returns 200"
+
+# GET /other returns 404.
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/other")
+[ "$HTTP_CODE" = "404" ] || fail "GET /other expected 404, got $HTTP_CODE"
+pass "GET /other returns 404"
+
+# POST /submit without secret returns 403.
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST "$BASE/submit" \
+  -H "Content-Type: application/json" \
+  -d '{"secret":"wrong","choices":{}}')
+[ "$HTTP_CODE" = "403" ] || fail "wrong secret: expected 403, got $HTTP_CODE"
+pass "submission with wrong secret returns 403"
+
+# POST /submit with unknown key returns 400.
+# We need the real secret - it is embedded in the page.
+PAGE_HTML=$(curl -s "$BASE/")
+SECRET_VAL=$(printf '%s' "$PAGE_HTML" | grep -o 'name="__secret" value="[^"]*"' | sed 's/.*value="//;s/"//')
+[ -n "$SECRET_VAL" ] || fail "could not extract secret from page"
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST "$BASE/submit" \
+  -H "Content-Type: application/json" \
+  -d "{\"secret\":\"$SECRET_VAL\",\"choices\":{\"unknown-key\":{\"choice\":\"x\",\"note\":\"\"}}}")
+[ "$HTTP_CODE" = "400" ] || fail "unknown key: expected 400, got $HTTP_CODE"
+pass "submission with unknown decision key returns 400"
+
+# POST /submit with valid choices succeeds.
+SUBMIT_BODY=$(cat <<JSON
+{
+  "secret": "$SECRET_VAL",
+  "choices": {
+    "deploy-strategy":    {"choice": "blue-green", "note": "Sounds good"},
+    "db-migration-order": {"choice": "before",     "note": ""}
+  }
+}
+JSON
+)
+SUBMIT_RESP=$(curl -s -w '\n%{http_code}' \
+  -X POST "$BASE/submit" \
+  -H "Content-Type: application/json" \
+  -d "$SUBMIT_BODY")
+HTTP_CODE=$(printf '%s' "$SUBMIT_RESP" | tail -1)
+RESP_BODY=$(printf '%s' "$SUBMIT_RESP" | head -1)
+[ "$HTTP_CODE" = "200" ] || fail "valid submission: expected 200, got $HTTP_CODE (body: $RESP_BODY)"
+pass "valid submission returns 200"
+
+# Extract run_id from response body.
+RUN_ID=$(printf '%s' "$RESP_BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['run_id'])")
+[ -n "$RUN_ID" ] || fail "response body missing run_id"
+
+# Wait briefly for server to write responses.
+sleep 0.5
+
+# Response files must exist and be valid JSON with the correct fields.
+RESP_DIR="$H_SRV/state/$RUN_ID/responses"
+assert_present "$RESP_DIR/deploy-strategy.json" "deploy-strategy response written"
+assert_present "$RESP_DIR/db-migration-order.json" "db-migration-order response written"
+pass "response files created"
+
+python3 - "$RESP_DIR/deploy-strategy.json" <<'PYCHECK'
+import json, sys
+d = json.load(open(sys.argv[1]))
+assert d["key"]    == "deploy-strategy",  f"bad key: {d['key']}"
+assert d["choice"] == "blue-green",       f"bad choice: {d['choice']}"
+assert d["note"]   == "Sounds good",      f"bad note: {d['note']}"
+assert "timestamp" in d,                  "missing timestamp"
+assert "run_id"    in d,                  "missing run_id"
+PYCHECK
+pass "deploy-strategy response has correct fields"
+
+python3 - "$RESP_DIR/db-migration-order.json" <<'PYCHECK'
+import json, sys
+d = json.load(open(sys.argv[1]))
+assert d["key"]    == "db-migration-order", f"bad key: {d['key']}"
+assert d["choice"] == "before",             f"bad choice: {d['choice']}"
+PYCHECK
+pass "db-migration-order response has correct fields"
+
+# Ready marker must exist.
+assert_present "$H_SRV/state/$RUN_ID/ready" "ready marker written after submission"
+pass "ready marker exists after submission"
+
+# Check script must now surface this run.
+CHECK_SH2="$H_SRV/state/decide.check.sh"
+out=$(FM_HOME="$H_SRV" "$CHECK_SH2")
+assert_contains "$out" "responses-ready:" "check surfaces submitted run"
+assert_contains "$out" "$RUN_ID" "check output contains run ID"
+pass "check surfaces submitted run"
+
+# After writing processed marker, check must be silent.
+touch "$H_SRV/state/$RUN_ID/processed"
+out=$(FM_HOME="$H_SRV" "$CHECK_SH2")
+[ -z "$out" ] || fail "check must be silent after processed marker, got: $out"
+pass "check is silent after processed marker"
+
+printf 'ok - all tests passed\n'

--- a/tests/no-mistakes-required-workflow.test.sh
+++ b/tests/no-mistakes-required-workflow.test.sh
@@ -7,7 +7,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 WORKFLOW="$ROOT/.github/workflows/no-mistakes-required.yml"
-MARKER='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
+MARKER='[git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
 
 extract_signature_script() {
   awk '
@@ -43,6 +43,12 @@ test_signature_sequence_at_fixed_head() {
   fi
   signature_result "Synthetic signed edit\n$MARKER" || fail "signed edited event must succeed"
   pass "fixed-head signed opened, unsigned edited, signed edited yields 0/1/0"
+}
+
+test_signature_survives_localized_lead_in() {
+  signature_result "## Pipeline\nUpdates from $MARKER" || fail "English lead-in must succeed"
+  signature_result "## Pipeline\nAtualizações de $MARKER" || fail "localized lead-in must succeed"
+  pass "signature is recognized regardless of the lead-in language"
 }
 
 test_event_identity_contract() {
@@ -91,6 +97,7 @@ test_security_and_signature_contract_is_preserved() {
 }
 
 test_signature_sequence_at_fixed_head
+test_signature_survives_localized_lead_in
 test_event_identity_contract
 test_run_names_are_ordered_and_unique
 test_security_and_signature_contract_is_preserved


### PR DESCRIPTION
## Intenção

Adicionar skill /decide e script fm-decide-page.sh para coletar decisões pendentes do capitão em lote via página local.

Objetivo: o capitão hoje recebe decisões pendentes em prosa no chat, uma a uma. A entrega cria uma superfície descartável: uma página local onde ele lê todas as decisões abertas de uma vez com evidência e recomendação, escolhe, e as escolhas voltam sozinhas ao firstmate sem copiar e colar.

Entregues:
- bin/fm-decide-page.sh: valida o JSON de entrada (esquema estrito, recusa inválido), inicia servidor HTTP em 127.0.0.1 com porta efêmera e segredo de uso único por execução, registra state/decide.check.sh no mecanismo de vigia já existente (fm-check-register.sh), grava state/decide-<run-id>/responses/<key>.json por decisão e marker ready, encerra sozinho após envio ou timeout.
- .agents/skills/decide/SKILL.md: skill invocável pelo capitão (/decide), descreve o procedimento completo - inventário, geração da página, tratamento do wake, roteamento de cada escolha ao seu destino real.
- docs/decide-page.md: esquema de entrada, formato de saída, integração com o vigia, propriedades de segurança (operador-atual).
- AGENTS.md: exatamente uma linha de gatilho na seção 9.
- docs/scripts.md, docs/documentation-audiences.json: inventário atualizado.
- tests/fm-decide-page.test.sh: 29 testes cobrindo validação de entrada inválida, rejeição sem segredo (403), rejeição de chave desconhecida (400), gravação legível de submissão válida, e check imprimindo linha só quando há resposta nova - todos passam.

Decisões de design: servidor Python embutido no script shell via heredoc; porta efêmera (OS-assigned); segredo token_urlsafe(32) por execução; submissão em lote única (todas as decisões de uma vez); check.sh estável (mesmos bytes a cada invocação, re-registro idempotente); marker processed evita re-disparo do vigia na mesma run.

## O que mudou

- Novo `bin/fm-decide-page.sh`: valida o JSON de decisões com esquema estrito, sobe um servidor HTTP em `127.0.0.1` com porta efêmera e segredo de uso único por execução, grava `state/decide-<run-id>/responses/<key>.json` mais o marker `ready`, e encerra sozinho após o envio ou no timeout. O endurecimento aplicado na revisão inclui `ThreadingHTTPServer` com timeout de handler, segredo fora de `argv` (visível em `ps`), validação de `Host` e de `Content-Length`, `umask 077` no diretório de estado, recusa de `--timeout 0` e escrita atômica do `state/decide.check.sh` registrado no vigia (`fm-check-register.sh`).
- Nova skill `/decide` (`.agents/skills/decide/SKILL.md`) com o procedimento completo — inventário via `tasks-axi list --kind captain --state held`, geração da página, tratamento do wake e roteamento de cada escolha ao destino real — mais uma única linha de gatilho na seção 9 de `AGENTS.md`.
- Documentação e inventário: `docs/decide-page.md` (esquema de entrada, formato de saída, integração com o vigia e propriedades de segurança, agora descrevendo `__secret` como token anti-CSRF servido junto à página), `docs/scripts.md` e `docs/documentation-audiences.json`.
- `tests/fm-decide-page.test.sh` com 29 testes cobrindo recusa de JSON inválido, 403 sem segredo, 400 para chave desconhecida, gravação legível da submissão válida e o check imprimindo linha apenas quando há resposta nova.

## Avaliação de risco

✅ Baixo: O commit de correção resolve corretamente todos os 11 achados aceitos, sem regressão verificável — as mudanças são localizadas, seguem convenções já existentes no repo (mktemp+mv em `$STATE`, `umask 077`) e mantêm o contrato validado pelos testes existentes; a entrega segue puramente aditiva e conforme ao intent.

## Testes

<code>Rodei a suíte alvo `tests/fm-decide-page.test.sh` (29 testes, todos passam) e depois validei o intent como o capitão o vive: subi a página com 3 decisões reais, abri em Chromium headless e capturei screenshots da página renderizada, da validação ao tentar confirmar sem escolher, das escolhas marcadas e da confirmação após o envio; em seguida confirmei no backend que as escolhas chegaram sozinhas ao firstmate — `responses/&lt;key&gt;.json` com exatamente a opção e a observação selecionadas na UI, marker `ready`, `state/decide.check.sh` imprimindo uma única linha `responses-ready: &lt;run-id&gt;` e ficando silencioso após o marker `processed`, e o servidor encerrado sozinho (porta fechada, nenhum processo remanescente). Também exercitei a recusa de JSON inválido pela CLI e conferi o gatilho único em AGENTS.md e o inventário de docs. Nenhuma falha; o perfil transitório do Chromium foi removido e o worktree segue limpo.</code>

- Evidência: Página de decisões renderizada (3 decisões com evidência e recomendação) (arquivo local: <code>/tmp/no-mistakes-evidence/01KYJAWRK63B21APH9B6YMZ52A/01-decisions-page.png</code>)
- Evidência: Validação ao confirmar sem escolher opção (arquivo local: <code>/tmp/no-mistakes-evidence/01KYJAWRK63B21APH9B6YMZ52A/02-validacao-sem-escolha.png</code>)
- Evidência: Escolhas do capitão marcadas com observação (arquivo local: <code>/tmp/no-mistakes-evidence/01KYJAWRK63B21APH9B6YMZ52A/03-escolhas-marcadas.png</code>)
- Evidência: Confirmação após envio em lote (arquivo local: <code>/tmp/no-mistakes-evidence/01KYJAWRK63B21APH9B6YMZ52A/04-confirmacao-enviada.png</code>)
<details>
<summary>Evidência: Saída da CLI ao gerar a página</summary>

<code>registered: state/decide.check.sh&#10;Decisões prontas: http://127.0.0.1:43971/&#10;Firstmate será notificado quando as escolhas forem submetidas (run: decide-1785174957-27649ecf).&#10;Servidor encerrará automaticamente em 600 segundos ou após envio.</code>

```text
registered: state/decide.check.sh
Decisões prontas: http://127.0.0.1:43971/
Firstmate será notificado quando as escolhas forem submetidas (run: decide-1785174957-27649ecf).
Servidor encerrará automaticamente em 600 segundos ou após envio.
```
</details>
<details>
<summary>Evidência: Estado persistido, linha do vigia e auto-encerramento</summary>

<code>== responses/*.json ==&#10;--- db-migration-order.json&#10;{&#10;&#34;key&#34;: &#34;db-migration-order&#34;,&#10;&#34;choice&#34;: &#34;after&#34;,&#10;&#34;note&#34;: &#34;Backfill fora do horario de pico; rodar depois do deploy.&#34;,&#10;&#34;timestamp&#34;: &#34;2026-07-27T17:57:25.938171+00:00&#34;,&#10;&#34;run_id&#34;: &#34;decide-1785174957-27649ecf&#34;&#10;}&#10;--- deploy-strategy.json&#10;{&#10;&#34;key&#34;: &#34;deploy-strategy&#34;,&#10;&#34;choice&#34;: &#34;blue-green&#34;,&#10;...&#10;}&#10;--- rollback-window.json&#10;{&#10;&#34;key&#34;: &#34;rollback-window&#34;,&#10;&#34;choice&#34;: &#34;15m&#34;,&#10;...&#10;}&#10;&#10;== vigia: FM_HOME=&lt;home&gt; bash state/decide.check.sh ==&#10;responses-ready: decide-1785174957-27649ecf&#10;&#10;== firstmate marca processed ==&#10;saida do check apos processed: (vazio)&#10;&#10;== servidor encerrou apos envio ==&#10;porta 43971 fechada (servidor auto-encerrado)&#10;nenhum processo server.py remanescente</code>

```text
== estado persistido ==
state/decide-1785174957-27649ecf/port
state/decide-1785174957-27649ecf/ready
state/decide-1785174957-27649ecf/responses/db-migration-order.json
state/decide-1785174957-27649ecf/responses/deploy-strategy.json
state/decide-1785174957-27649ecf/responses/rollback-window.json
state/decide-1785174957-27649ecf/server.py
state/decide.check-trust
state/decide.check.sh

== responses/*.json ==
--- db-migration-order.json
{
  "key": "db-migration-order",
  "choice": "after",
  "note": "Backfill fora do horario de pico; rodar depois do deploy.",
  "timestamp": "2026-07-27T17:57:25.938171+00:00",
  "run_id": "decide-1785174957-27649ecf"
}
--- deploy-strategy.json
{
  "key": "deploy-strategy",
  "choice": "blue-green",
  "note": "",
  "timestamp": "2026-07-27T17:57:25.938171+00:00",
  "run_id": "decide-1785174957-27649ecf"
}
--- rollback-window.json
{
  "key": "rollback-window",
  "choice": "15m",
  "note": "",
  "timestamp": "2026-07-27T17:57:25.938171+00:00",
  "run_id": "decide-1785174957-27649ecf"
}

== vigia: FM_HOME=<home> bash state/decide.check.sh ==
responses-ready: decide-1785174957-27649ecf

== firstmate marca processed ==
saida do check apos processed: (vazio)

== servidor encerrou apos envio ==
porta 43971 fechada (servidor auto-encerrado)
nenhum processo server.py remanescente
```
</details>
<details>
<summary>Evidência: Recusa de JSON inválido e wiring de docs/AGENTS.md</summary>

<code>== JSON invalido (option unica) ==&#10;decisions[0].options must be an array of at least 2 items&#10;fm-decide-page: invalid decisions JSON&#10;exit=1</code>

```text
== JSON invalido (option unica) ==
decisions[0].options must be an array of at least 2 items
fm-decide-page: invalid decisions JSON
exit=1

== gatilho no AGENTS.md (secao 9) ==
282:With `yolo` on, firstmate decides routine gates only within the captain's original request and accepted task criteria, and merges only green or otherwise approved work.
296:An ask-user finding returns as `needs-decision`; firstmate decides only when the configured authority permits, otherwise escalates to the captain.
424:When the captain invokes `/decide`, load the `decide` skill to surface multiple pending decisions as a single local batch page.

== inventario de docs ==
docs/scripts.md:21:| `fm-decide-page.sh`      | Generate a local batch decision page and arm the watcher check for captain-choice notification |
docs/documentation-audiences.json:227:      "path": "docs/decide-page.md",
```
</details>

## Pipeline

Atualizações de [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Intenção** - aprovado</summary>

✅ Nenhum problema encontrado.

</details>

<details>
<summary>✅ **Atualização da base** - aprovado</summary>

✅ Nenhum problema encontrado.

</details>

<details>
<summary>🔧 **Revisão** - 12 problemas encontrados → corrigido automaticamente ✅</summary>

- ⚠️ `bin/fm-decide-page.sh:434` - O aviso de sucesso nunca aparece após o envio. `#submitted-notice { display: none; }` (bin/fm-decide-page.sh:373) é uma regra de folha de estilo, e o JS faz `notice.style.display = &#34;&#34;` — remover a declaração inline devolve o elemento à regra CSS, que continua `none`. Depois de um POST /submit bem-sucedido o formulário é ocultado e nada é exibido: o capitão vê uma página em branco e pode concluir que o envio falhou. (Contraste com `#banner`, que funciona porque o `display:none` dele é inline.) Correção: `notice.style.display = &#34;block&#34;`.
- ⚠️ `.agents/skills/decide/SKILL.md:30` - O passo 1 da skill manda rodar `tasks-axi list --kind captain --status open`, mas o CLI instalado não tem `--status`; a flag é `--state &lt;queued|in_flight|done|held&gt;` (verificado com `tasks-axi list --help`). O primeiro comando do procedimento /decide falha, e o inventário de decisões abertas não é coletado. Provavelmente deveria ser `tasks-axi list --kind captain --state held`.
- ⚠️ `bin/fm-decide-page.sh:615` - Servidor HTTP de thread única (`HTTPServer`) sem `timeout` no handler. Uma única conexão ociosa bloqueia todo o servidor: preconnect especulativo do navegador, ou um cliente que envia `Content-Length: 400000` sem corpo, deixa `self.rfile.read(length)` (linha 522) bloqueado indefinidamente e a página para de responder até o watchdog de timeout (padrão 1800s) derrubar o processo. Correção: `ThreadingHTTPServer` e `Handler.timeout`/`socket` timeout.
- ⚠️ `bin/fm-decide-page.sh:638` - O segredo de uso único é passado como argumento de linha de comando para o `python3` do servidor, ficando visível em `ps` para qualquer usuário local durante toda a vida do servidor. Como o gate de 403 é a única barreira contra submissões forjadas, isso anula a proteção contra outros usuários da máquina. Correção: passar via variável de ambiente ou stdin em vez de `argv[3]`.
- ⚠️ `docs/decide-page.md:97` - docs/decide-page.md afirma &#34;The page embeds no credential&#34; (e o cabeçalho do script, linha 45, repete &#34;No secret, credential, or absolute path is embedded in the page&#34;), mas a página embute o segredo em `&lt;input type=&#34;hidden&#34; name=&#34;__secret&#34; value=&#34;__SECRET__&#34;&gt;` (bin/fm-decide-page.sh:385, substituído em :485) — o próprio teste extrai o segredo do HTML (tests/fm-decide-page.test.sh:208-210). É uma propriedade de segurança documentada que é falsa; deveria descrever o segredo como token anti-CSRF servido junto à página.
- ℹ️ `bin/fm-decide-page.sh:189` - `mkdir -p &#34;$RUN_DIR/responses&#34;` usa o umask herdado (tipicamente 022), deixando as decisões, evidências e notas do capitão legíveis por qualquer usuário local. O restante do estado do firstmate é endurecido (fm-check-register.sh usa `umask 077`; o próprio decide.check.sh é chmod 0700). Correção: `umask 077` antes do mkdir, ou `chmod 0700 &#34;$RUN_DIR&#34;`.
- ℹ️ `bin/fm-decide-page.sh:79` - `--timeout 0` passa na validação (`0` casa com `[0-9]`) apesar da mensagem dizer &#34;must be a positive integer&#34;. Com 0 o watchdog derruba o servidor imediatamente, e o script ainda imprime uma URL já morta. Correção: rejeitar `0`.
- ℹ️ `bin/fm-decide-page.sh:517` - `int(self.headers.get(&#34;Content-Length&#34;, 0))` não trata header malformado nem negativo: `Content-Length: abc` levanta `ValueError` não capturado (traceback + resposta 500 quebrada) e `Content-Length: -1` faz `self.rfile.read(-1)` ler até EOF, contornando o limite de 512 KiB. Correção: try/except e rejeitar valores negativos com 400.
- ℹ️ `bin/fm-decide-page.sh:216` - O heredoc do servidor usa `&lt;&lt;PYEOF` sem aspas, então o shell expande `$`, backticks e barras invertidas dentro do corpo Python. Hoje é inofensivo (não há `$` nem `\\` no bloco — apenas `\n` literais, que o bash preserva), mas qualquer f-string, regex ou template futuro com `$` será silenciosamente corrompido em tempo de geração. O bloco não usa nenhuma interpolação do shell, então `&lt;&lt;&#39;PYEOF&#39;` é equivalente e seguro.
- ℹ️ `bin/fm-decide-page.sh:195` - `cat &gt; &#34;$CHECK_SH&#34;` trunca e reescreve o check in-place a cada execução. Se o vigia tirar seu snapshot (`fm_custom_check_snapshot_prepare`) durante essa janela, o hash não bate com o trust file e o watcher dispara um wake ruidoso `check: rejected unauthenticated state checks`. Correção: escrever em temporário e `mv -f`, como fm-check-register.sh já faz para o trust file.
- ℹ️ `docs/decide-page.md:106` - docs/decide-page.md descreve `port` como &#34;removed after server exits&#34;, mas nada no script nem no servidor remove esse arquivo — ele permanece em `state/decide-&lt;run-id&gt;/port` indefinidamente, junto com `server.py`, mesmo quando a run expira sem submissão.
- ℹ️ `bin/fm-decide-page.sh:490` - O servidor não valida o header `Host`, então uma página remota que consiga DNS rebinding para 127.0.0.1 na porta certa poderia ler `GET /` (obtendo o segredo) e submeter escolhas forjadas. Explorabilidade baixa (porta efêmera aleatória, janela de 30 min), mas a mitigação padrão é uma linha: rejeitar requisições cujo `Host` não seja `127.0.0.1:&lt;porta&gt;`.

🔧 Correção: fix(decide): harden decide page server, secret handling and docs
✅ Verificado novamente — nenhum problema restante.

</details>

<details>
<summary>✅ **Testes** - aprovado</summary>

✅ Nenhum problema encontrado.
- <code>`bash tests/fm-decide-page.test.sh` (29 testes, todos passam)</code>
- <code>Lançamento real: `FM_HOME=&lt;tmp&gt; FM_STATE_OVERRIDE=&lt;tmp&gt;/state ./bin/fm-decide-page.sh --timeout 600 decisions.json` com 3 decisões (URL 127.0.0.1 em porta efêmera + registro `state/decide.check.sh`)</code>
- <code>Navegação e interação reais em Chromium headless via CDP (`cdp_drive.py`): screenshot da página, tentativa de envio sem escolha (banner de validação), marcação das 3 opções + observação, envio via `fetch(&#39;/submit&#39;)` e banner de confirmação</code>
- <code>Verificação do estado persistido: `state/decide-&lt;run-id&gt;/responses/*.json` (choice/note/timestamp/run_id) e marker `ready`</code>
- <code>`FM_HOME=&lt;tmp&gt; bash state/decide.check.sh` antes e depois de `touch processed` (imprime uma linha `responses-ready: &lt;run-id&gt;`, silencioso depois)</code>
- <code>`curl http://127.0.0.1:&lt;porta&gt;/` e `pgrep -f server.py` após o envio (auto-encerramento confirmado)</code>
- <code>Recusa de entrada inválida via CLI: `./bin/fm-decide-page.sh bad.json` com uma única opção → exit 1</code>
- <code>Conferência do gatilho único em `AGENTS.md` e do inventário em `docs/scripts.md` / `docs/documentation-audiences.json`</code>

</details>

<details>
<summary>✅ **Documentação** - aprovado</summary>

✅ Nenhum problema encontrado.

</details>

<details>
<summary>✅ **Análise estática** - aprovado</summary>

✅ Nenhum problema encontrado.

</details>

<details>
<summary>✅ **Envio** - aprovado</summary>

✅ Nenhum problema encontrado.

</details>
