### PR TITLE
fix: avoid apostrophe in fm-brief.sh heredoc nested in command substitution

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -325,7 +325,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass the firstmate authority check and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF


### PR DESCRIPTION
## Summary
- `bin/fm-brief.sh` crashes with `unexpected EOF while looking for matching \`'\''` on macOS's default bash (3.2.57) when scaffolding a ship brief for a `no-mistakes`-mode project.
- Root cause: macOS ships bash 3.2, which mis-parses a literal apostrophe inside a heredoc when that heredoc is nested inside a `$(...)` command substitution (reproduced independently outside this repo; a standalone top-level heredoc with the same apostrophe is fine, only the nested-in-`$()` case breaks).
- The `no-mistakes`-mode DOD heredoc (`DOD=$(cat <<EOF ... EOF)`) in the ship-brief case block contains the word "firstmate's", which trips this.
- Fix: reworded that one line to drop the apostrophe ("firstmate's authority check" -> "the firstmate authority check"). No behavior change, no other heredocs in the file are affected (verified none of the other apostrophes in the file sit inside a heredoc nested in `$(...)`).

## Test plan
- [x] `bash -n bin/fm-brief.sh` passes (previously failed with the EOF/quote error)
- [x] `bin/fm-brief.sh <id> <repo>` (no-mistakes mode) scaffolds successfully end to end