### PR TITLE
fix(backends): avoid Herdr schema check SIGPIPE noise

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -3049,8 +3049,8 @@ fm_backend_herdr_events_capable() {  # <session>
   case "$protocol" in ''|*[!0-9]*) return 1 ;; esac
   [ "$protocol" -ge "$FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL" ] || return 1
   schema=$(herdr api schema --json 2>/dev/null) || return 1
-  printf '%s' "$schema" | grep -Fq 'events.subscribe' || return 1
-  printf '%s' "$schema" | grep -Fq 'pane.agent_status_changed' || return 1
+  grep -Fq 'events.subscribe' <<<"$schema" || return 1
+  grep -Fq 'pane.agent_status_changed' <<<"$schema" || return 1
   return 0
 }
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -139,6 +139,33 @@ herdr 0.7.5
 ["pane.output_matched","pane.agent_status_changed","pane.scroll_changed"]
 ```
 
+The Herdr events capability gate was reverified on 2026-07-27 against the live schema with Herdr 0.7.5 and client/server protocol 17/17.
+The patched gate returned success with empty stderr.
+For contrast, the upstream form using `printf '%s' "$schema" | grep -Fq` and an early-exit grep stand-in returned success but emitted two broken-pipe diagnostics under Bash 3.2 against the same schema.
+This confirms that the change removes SIGPIPE noise without changing the capability result.
+
+```sh
+herdr --version
+herdr status --json | jq -c '{client:.client.protocol,server:.server.protocol}'
+herdr api schema --json | jq -c '.schemas.subscription_event["$defs"].SubscriptionEventKind.enum'
+. bin/backends/herdr.sh
+fm_backend_herdr_events_capable default 2>patched.stderr
+```
+
+Observed output:
+
+```text
+herdr 0.7.5
+{"client":17,"server":17}
+["pane.output_matched","pane.agent_status_changed","pane.scroll_changed"]
+patched_rc=0
+patched_stderr_bytes=0
+unpatched_rc=0
+unpatched_stderr:
+printf: write error: Broken pipe
+printf: write error: Broken pipe
+```
+
 The CLI matrix was checked directly:
 
 | Guarantee | Command shape | Result |

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -120,7 +120,7 @@ Claude, Codex, OpenCode, Pi, pi-signed, Grok, and Kimi share that backend cleanu
 ## Herdr
 
 The compatibility floor is protocol 14.
-The latest active verification uses Herdr 0.7.5 protocol 17 on macOS aarch64, with earlier 0.7.5 protocol-16, 0.7.4, protocol-14, and 0.7.3 evidence retained where they define current behavior or fallbacks.
+The latest active event-gate verification uses Herdr 0.7.5 client/server protocol 17/17 on macOS aarch64, with earlier 0.7.5 protocol-16, 0.7.4, protocol-14, and 0.7.3 evidence retained where they define current behavior or fallbacks.
 Protocol 17 keeps every protocol-16 feature gate satisfied; the event and workspace-move floors remain 16.
 
 Core read-only probes:

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3620,6 +3620,45 @@ SH
   printf '%s\n' "$path"
 }
 
+test_events_capability_large_schema_has_no_sigpipe_noise() {
+  local dir fb grepbin err schema
+  dir="$TMP_ROOT/events-capability-sigpipe"; mkdir -p "$dir/responses" "$dir/grep-bin"
+  fb=$(make_herdr_fakebin "$dir")
+  printf '%s\n' '{"client":{"version":"0.7.3","protocol":16}}' > "$dir/responses/1.out"
+  schema="$dir/responses/2.out"
+  {
+    printf '%s\n' '{"events.subscribe":true,"pane.agent_status_changed":true}'
+    awk 'BEGIN { for (i = 0; i < 220000; i++) printf "padding-%06d\n", i }'
+  } > "$schema"
+
+  grepbin="$dir/grep-bin/grep"
+  cat > "$grepbin" <<'SH'
+#!/usr/bin/env bash
+set -u
+pattern=${2:-}
+IFS= read -r line || exit 1
+case "$line" in
+  *"$pattern"*) exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$grepbin"
+
+  err="$dir/stderr"
+  if ! (
+    PATH="$dir/grep-bin:$fb:$PATH" \
+      FM_HERDR_RESPONSES="$dir/responses" FM_HERDR_LOG="$dir/log" FM_HERDR_SCRIPT_STATUS=1 \
+      bash -c 'trap '\'''\'' PIPE; . "$0/bin/backends/herdr.sh"; fm_backend_herdr_events_capable synthetic-session' "$ROOT"
+  ) 2>"$err"; then
+    fail "large-schema capability detection should succeed"
+  fi
+  case "$(cat "$err")" in
+    *"Broken pipe"*|*"write error"*)
+      fail "large-schema capability detection emitted SIGPIPE noise: $(cat "$err")" ;;
+  esac
+  pass "fm_backend_herdr_events_capable: large schema capability detection emits no SIGPIPE noise"
+}
+
 set_fake_agent() {  # <agent-dir> <window-or-pane> <status>
   local dir=$1 target=$2 status=$3 key
   key=$(printf '%s' "$target" | tr ':/.' '___')
@@ -3887,6 +3926,7 @@ test_repeated_cycles_reuse_one_workspace_no_orphans
 test_adopted_workspace_never_prunes_default_tab
 test_label_collision_startup_workspace_leaves_live_tab_alone
 test_prune_refuses_a_working_agent_pane_defense_in_depth
+test_events_capability_large_schema_has_no_sigpipe_noise
 test_create_task_refuses_duplicate_label
 test_create_task_refuses_duplicate_label_when_agent_live
 test_create_task_refuses_when_any_duplicate_label_is_live


### PR DESCRIPTION
## Summary
Herdr watcher cycles repeatedly emitted `printf: write error: Broken pipe` from `bin/backends/herdr.sh` lines 1960 and 1961.
The firsthand reproduction occurred on roughly fifteen separate watcher cycles over several hours while running the unpatched code on current upstream `main`.
No existing upstream pull request touches this code path.
Searches for SIGPIPE, broken pipe, and the Herdr schema check found no duplicate proposal.
Three open pull requests address a different Bash 3.2 parse issue in `bin/fm-brief.sh` and are unrelated to this fix.

## Cause
`fm_backend_herdr_events_capable` piped the full `herdr api schema --json` output into `grep -Fq` for two capability checks.
Because `grep -q` exits after its first match, it closed the read end while `printf` was still writing the approximately 220 KB schema.
The resulting SIGPIPE caused Bash to print the broken-pipe diagnostic even though capability detection succeeded.

## Fix
Both pipelines now use here-strings, so the checks have no pipe that can trigger SIGPIPE.
The change is behavior-preserving because it keeps the same two capability checks and return values while removing the pipe entirely.
This fix has existed in the personal fork since 2026-07-23 and had not reached upstream.

## Testing
The regression test feeds a deliberately large schema through a first-match-and-exit `grep` stand-in and fails if broken-pipe or write-error text reaches stderr.
Live Herdr 0.7.5 evidence recorded client/server protocol 17/17, successful patched detection, empty patched stderr, and the two unpatched broken-pipe diagnostics against the same schema under Bash 3.2.
`bin/fm-doc-audience-check.sh`, all Bash syntax checks, `bin/fm-lint.sh` with ShellCheck 0.11.0, and `tests/fm-backend-herdr.test.sh` passed.

## Evidence Note
The runtime-backend evidence note is included because `CONTRIBUTING.md` requires current empirical evidence for runtime session backend changes.
The note updates the documented Herdr capability gate that this fix touches.

## Pipeline
Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)
