### PR TITLE
fix(bin): re-own the Kimi turn-end hook region after a config rewrite

### DIFF
--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -7,6 +7,16 @@
 # and remove excises only that region. Missing, malformed, symlinked, partially
 # marked, or otherwise surprising config is refused without a config write.
 #
+# The Kimi CLI rewrites its own config.toml and drops comments, which erases the
+# region's comment markers while leaving the hook table itself intact. When the
+# markers are absent, the region is re-identified structurally: exactly one
+# [[hooks]] table whose parsed content equals Firstmate's own hook entry, whose
+# text span is confirmed by re-parsing the config with that span excised. That
+# span is then re-owned and re-marked in place, so repeated installs neither
+# refuse nor accumulate duplicate hook tables. A [[hooks]] table that references
+# fm-turn-end.sh but is not byte-for-byte Firstmate's own entry stays foreign and
+# is still refused.
+#
 # The installed Stop hook always exits 0 and stays silent. It reads cwd from the
 # hook payload, checks for a .fm-kimi-turnend pointer before registry work, and
 # touches a task turn-end marker only when the pointer names a Firstmate-created
@@ -69,6 +79,8 @@ BEGIN_OWNS_NEWLINE = BEGIN + b" (OWNS PRECEDING NEWLINE)"
 END = b"# END FIRSTMATE KIMI TURN-END HOOK"
 IDENTIFIER = b"FIRSTMATE KIMI TURN-END HOOK"
 HOOK_NAME = b"fm-turn-end.sh"
+HOOKS_HEADER = re.compile(rb"^[ \t]*\[\[[ \t]*hooks[ \t]*\]\][ \t]*(#.*)?$")
+TABLE_HEADER = re.compile(rb"^[ \t]*\[")
 TOKEN_NAME = re.compile(r"fm\.[A-Za-z0-9]{12}\Z")
 
 HOOK_BYTES = b'''#!/usr/bin/env bash
@@ -170,6 +182,81 @@ def block(marker: bytes) -> bytes:
     )
 
 
+def expected_entry() -> dict:
+    # The generated block is the single owner of the hook table's content; the
+    # structural fallback compares against whatever that block currently emits.
+    return tomllib.loads(block(BEGIN).decode("utf-8"))["hooks"][0]
+
+
+def line_spans(data: bytes):
+    spans = []
+    cursor = 0
+    total = len(data)
+    while cursor < total:
+        newline = data.find(b"\n", cursor)
+        if newline < 0:
+            spans.append((cursor, total, data[cursor:total]))
+            break
+        spans.append((cursor, newline + 1, data[cursor:newline]))
+        cursor = newline + 1
+    return spans
+
+
+def excision_matches(data: bytes, parsed: dict, start: int, end: int, index: int) -> bool:
+    # Confirm the located span really is that one hook table and nothing else:
+    # the config with the span removed must parse to the original document minus
+    # exactly that entry. Any scanning mistake fails this check instead of
+    # silently rewriting the captain's config.
+    try:
+        remainder = (data[:start] + data[end:]).decode("utf-8")
+        actual = tomllib.loads(remainder)
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return False
+    expected = dict(parsed)
+    survivors = [entry for position, entry in enumerate(parsed["hooks"]) if position != index]
+    if survivors:
+        expected["hooks"] = survivors
+    else:
+        expected.pop("hooks", None)
+    return actual == expected
+
+
+def adopt_unmarked_region(data: bytes, parsed: dict):
+    # Recover ownership after a Kimi config rewrite dropped the comment markers.
+    hooks = parsed.get("hooks") or []
+    referencing = [
+        position
+        for position, entry in enumerate(hooks)
+        if isinstance(entry, dict)
+        and any(isinstance(value, str) and HOOK_NAME.decode("utf-8") in value for value in entry.values())
+    ]
+    if len(referencing) != 1:
+        return None
+    index = referencing[0]
+    if hooks[index] != expected_entry():
+        return None
+    spans = line_spans(data)
+    headers = [position for position, span in enumerate(spans) if HOOKS_HEADER.match(span[2])]
+    if len(headers) != len(hooks):
+        return None
+    first = headers[index]
+    stop = len(spans)
+    for position in range(first + 1, len(spans)):
+        if TABLE_HEADER.match(spans[position][2]):
+            stop = position
+            break
+    last = first
+    for position in range(first + 1, stop):
+        body = spans[position][2].strip()
+        if body and not body.startswith(b"#"):
+            last = position
+    start = spans[first][0]
+    end = spans[last][1]
+    if not excision_matches(data, parsed, start, end, index):
+        return None
+    return start, end, BEGIN
+
+
 def without_region(data: bytes, region) -> bytes:
     prefix = data[: region[0]]
     suffix = data[region[1] :]
@@ -223,8 +310,10 @@ try:
     config_info = regular_not_symlink(CONFIG, "Kimi config")
     with open(CONFIG, "rb") as stream:
         original = stream.read()
-    parse_toml(original, "config.toml")
+    parsed = parse_toml(original, "config.toml")
     region = locate_region(original)
+    if region is None:
+        region = adopt_unmarked_region(original, parsed)
     outside = original if region is None else without_region(original, region)
     if HOOK_NAME in outside:
         refuse("config.toml references fm-turn-end.sh outside the Firstmate-owned region.")

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -75,6 +75,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - Kimi Code CLI 0.29.1 exposes only global `[[hooks]]` configuration in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
 - Kimi has no project-level hook configuration and remains outside the primary guard integrations above.
 - Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to edit only one marker-delimited Firstmate region in that global config and install a silent always-zero hook.
+- The Kimi CLI rewrites that global config and drops comments, so an unmarked region whose single hook table still matches Firstmate's own entry is re-identified structurally, re-owned, and re-marked in place instead of refusing or duplicating, while any hook table Firstmate does not own is still refused.
 - The hook remains inert unless the payload `cwd` contains a per-task token pointer that resolves through Firstmate's private registry to one `state/<id>.turn-ended` marker.
 - Installation refuses before writing unless `python3` with `tomllib` and `jq` are available.
 - If `jq` is removed after installation, the hook remains silent and exits 0, turn-end wakes stop, and Kimi crews fall back to idle detection.
@@ -84,7 +85,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 ## Regression coverage
 
 `tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, and Grok resume permission and recursion safety.
-`tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
+`tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, comment-stripping-rewrite re-ownership, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.
 [`verification/supervision.md`](verification/supervision.md#turn-end-guard) records the active cross-harness empirical evidence, including the 2026-07-24 Claude `asyncRewake` revalidation.

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -270,6 +270,120 @@ EOF
   pass "Kimi hook install is idempotent and removal restores every foreign config byte"
 }
 
+strip_toml_comments() {
+  # Reproduce the Kimi CLI's own config.toml rewrite, which normalizes the TOML
+  # and drops every comment while leaving the hook table itself intact.
+  local target=$1 scratch
+  scratch="$target.stripped"
+  sed '/^[[:space:]]*#/d' "$target" > "$scratch"
+  mv "$scratch" "$target"
+}
+
+test_kimi_hook_reowns_its_region_after_a_comment_stripping_rewrite() {
+  local home config original marked count
+  home="$TMP_ROOT/config-comment-stripped"
+  config="$home/.kimi-code/config.toml"
+  original="$home/original.toml"
+  marked="$home/marked.toml"
+  mkdir -p "$home/.kimi-code"
+  cat > "$config" <<'EOF'
+default_model = "kimi-k2"
+
+[ui]
+theme = "night"
+
+[[hooks]]
+event = "Stop"
+command = "printf foreign"
+
+[providers.example]
+model = "some/model"
+EOF
+  cp "$config" "$original"
+
+  HOME="$home" "$KIMI_HOOK" install || fail "Kimi hook install refused a fresh config"
+  assert_grep '# BEGIN FIRSTMATE KIMI TURN-END HOOK' "$config" "fresh install wrote no Firstmate marker"
+
+  strip_toml_comments "$config"
+  assert_not_contains "$(cat "$config")" 'BEGIN FIRSTMATE' "the simulated Kimi rewrite left a comment marker"
+  assert_contains "$(cat "$config")" 'fm-turn-end.sh' "the simulated Kimi rewrite dropped the hook table itself"
+
+  HOME="$home" "$KIMI_HOOK" install \
+    || fail "Kimi hook install refused its own hook table after the Kimi rewrite stripped the markers"
+  assert_grep '# BEGIN FIRSTMATE KIMI TURN-END HOOK' "$config" "re-install did not re-mark the adopted region"
+  count=$(grep -c '^\[\[hooks\]\]' "$config")
+  [ "$count" -eq 2 ] || fail "re-install after a comment-stripping rewrite left $count hook tables, expected 2"
+  cp "$config" "$marked"
+  HOME="$home" "$KIMI_HOOK" install || fail "install after region adoption stopped being idempotent"
+  cmp -s "$marked" "$config" || fail "install after region adoption changed config bytes"
+
+  strip_toml_comments "$config"
+  HOME="$home" "$KIMI_HOOK" remove || fail "Kimi hook removal refused its own unmarked region"
+  cmp -s "$original" "$config" \
+    || fail "removal of an unmarked Firstmate region did not restore every foreign config byte"
+  pass "Kimi hook re-owns its region after a comment-stripping config rewrite without duplicating it"
+}
+
+test_kimi_hook_still_refuses_unmarked_foreign_hook_tables() {
+  local home config before out rc case_name
+  for case_name in other-path extra-key duplicated inline-array; do
+    home="$TMP_ROOT/config-foreign-$case_name"
+    config="$home/.kimi-code/config.toml"
+    before="$home/before.toml"
+    mkdir -p "$home/.kimi-code"
+    case "$case_name" in
+      other-path)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash /captain/elsewhere/fm-turn-end.sh"
+timeout = 1
+EOF
+        ;;
+      extra-key)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1
+captain_owned = true
+EOF
+        ;;
+      duplicated)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1
+
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1
+EOF
+        ;;
+      inline-array)
+        cat > "$config" <<'EOF'
+hooks = [{ event = "Stop", matcher = "^$", command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true", timeout = 1 }]
+EOF
+        ;;
+    esac
+    cp "$config" "$before"
+    rc=0
+    out=$(HOME="$home" "$KIMI_HOOK" install 2>&1) || rc=$?
+    [ "$rc" -ne 0 ] || fail "install adopted an unowned hook table in the $case_name case"
+    assert_contains "$out" "outside the Firstmate-owned region" \
+      "the $case_name refusal lacked its concrete reason"
+    cmp -s "$before" "$config" || fail "the $case_name refusal changed config bytes"
+    assert_absent "$home/.kimi-code/fm-turn-end.sh" "the $case_name refusal wrote the hook script"
+  done
+  pass "Kimi hook install still refuses unmarked hook tables it does not own"
+}
+
 test_kimi_hook_remove_preserves_owned_newline_boundary() {
   local appended config expected home original
   home="$TMP_ROOT/config-owned-newline"
@@ -676,6 +790,8 @@ test_kimi_bordered_prompt_needs_no_override() {
 test_tracked_files_have_no_user_absolute_paths
 test_existing_launch_templates_are_byte_pinned
 test_kimi_hook_install_is_surgical_idempotent_and_removable
+test_kimi_hook_reowns_its_region_after_a_comment_stripping_rewrite
+test_kimi_hook_still_refuses_unmarked_foreign_hook_tables
 test_kimi_hook_remove_preserves_owned_newline_boundary
 test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config
 test_kimi_hook_install_refuses_without_jq


### PR DESCRIPTION
Fixes #1064.

## Problem

The Kimi CLI rewrites its own `~/.kimi-code/config.toml` and drops every comment as part of TOML normalization. That erases the `# BEGIN FIRSTMATE KIMI TURN-END HOOK` / `# END ...` markers delimiting Firstmate's turn-end hook region, while leaving the `[[hooks]]` table itself byte-identical. The next crewmate spawn then refused:

```
fm-kimi-turnend-hook: refused: config.toml references fm-turn-end.sh outside the Firstmate-owned region.
```

So the second Kimi spawn onward could not launch, which made the Kimi crew adapter unusable for repeated work.

### Reproduction

Install into a fresh config, delete every comment line (the CLI's own normalization), then install again:

```
$ HOME=$repro bin/fm-kimi-turnend-hook.sh install          # ok, region written with markers
$ sed -i '' '/^[[:space:]]*#/d' $repro/.kimi-code/config.toml   # simulate the Kimi rewrite
$ HOME=$repro bin/fm-kimi-turnend-hook.sh install
fm-kimi-turnend-hook: refused: config.toml references fm-turn-end.sh outside the Firstmate-owned region.
rc=1
```

The `[[hooks]]` table survives the rewrite intact; only the two comment lines are gone.

## Fix

Region identification no longer depends on the comment markers surviving. Markers remain the fast path; when they are absent, the region is re-identified structurally:

1. Exactly one `[[hooks]]` entry may reference `fm-turn-end.sh`, and its parsed content must equal the hook entry the installer itself emits. That expected entry is derived by parsing the generated block rather than restated, so the block stays the single owner of the hook table's content.
2. The entry's text span is located by scanning `[[hooks]]` headers in document order, ending at the last non-blank, non-comment line before the next table header, so trailing blank lines and comments belonging to the following section are left alone.
3. The span is verified before use: the config with that span excised must parse, and must equal the original parsed document minus exactly that one entry. Any scanning mistake fails this check and refuses instead of rewriting the captain's config.
4. The verified span is then re-owned and re-marked in place. Repeated installs neither refuse nor accumulate duplicate hook tables, and removal still restores the surrounding bytes exactly.

Adoption runs before both the install and remove branches, so a config whose markers were stripped can also be cleanly uninstalled.

## Safety property preserved

The refusal exists to stop Firstmate clobbering a hook it does not own, and that is unchanged. A `[[hooks]]` table that references `fm-turn-end.sh` but is not the installer's own entry stays foreign and is still refused before any config write. All four shapes are covered by tests:

- a different script path
- Firstmate's entry plus an extra captain-added key
- two identical unmarked Firstmate blocks
- the inline-array `hooks = [{ ... }]` form

## Tests

`tests/fm-kimi-harness.test.sh` gains two cases:

- `test_kimi_hook_reowns_its_region_after_a_comment_stripping_rewrite` - fresh install, simulated comment-stripping rewrite, re-install succeeds and re-marks the region, exactly two hook tables remain (one foreign, one Firstmate's), a further install is byte-idempotent, and removal after another rewrite restores the original config byte-for-byte.
- `test_kimi_hook_still_refuses_unmarked_foreign_hook_tables` - the four foreign shapes above each refuse with the concrete reason, without changing config bytes and without writing the hook script.

All 21 cases in that file pass, as do `fm-turnend-guard`, `fm-documentation-audiences`, `fm-instruction-owners`, and `fm-lint`. `bin/fm-lint.sh`, `shellcheck`, and `bin/fm-doc-audience-check.sh` are clean.

## Docs

`docs/turnend-guard.md` records the rewrite behavior and the structural re-ownership as a current Kimi fact, and its regression-coverage line now names the new coverage.

## Note for maintainers

The installer requires a `python3` with `tomllib`, so Python 3.11 or newer. On a host whose first `python3` on PATH is older, it refuses before touching the config. That behavior is pre-existing and unchanged here, but it is worth confirming on Kimi hosts.
