### PR TITLE
fix(watch): keep a declared pause on its bounded cadence

### DIFF
--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -30,15 +30,24 @@
 #                                                          this arm attaches and follows it
 #   watcher: FAILED - no live watcher with a fresh beacon  - could not confirm one
 #   watcher: FAILED - cycle ended without an actionable reason
-#                                                        - a clean cycle ended with no wake and no
-#                                                          verified healthy successor
+#                                                        - a clean cycle ended with no wake, no
+#                                                          verified healthy successor, and nothing
+#                                                          on the durable wake queue to explain it
+#   watcher: cycle closed on a wake already queued by a concurrent arm
+#                                                        - the followed cycle closed on a wake this
+#                                                          arm did not print itself; the queued
+#                                                          reason lines follow and this arm exits 0
 # It NEVER reports started/attached/healthy off a stale beacon or a dead/reused pid: a
 # stale-beacon or dead-pid holder either self-heals (the fresh child steals the
 # dead lock per the singleton self-eviction/steal path and is confirmed) or this
 # returns the FAILED line. On started it waits the child and propagates the wake
 # reason; on attached it stays live across identity-matched successors. An
-# attached cycle that ends without a healthy successor is a typed nonzero failure,
-# never a clean empty completion. On FAILED it exits non-zero so the failure is
+# attached cycle that ends without a healthy successor is a typed nonzero failure
+# whenever nothing explains the close, never a clean empty completion; when the
+# durable wake queue shows the cycle surfaced a wake at or after this cycle began
+# and the beacon is still fresh, that close is instead reported with its queued
+# reason lines, because supervision did its job and one of several concurrent
+# arms simply did not own the print. On FAILED it exits non-zero so the failure is
 # loud. A live cycle already present means re-arm attaches - do not start a second
 # watcher.
 #
@@ -250,7 +259,46 @@ wait_for_healthy_successor() {
   done
 }
 
-fail_unexplained_cycle() {
+# The durable wake queue is the ONE shared record of what a watcher cycle
+# surfaced, and it is written before the watcher prints its reason and exits. An
+# arm that merely FOLLOWED that cycle - it attached to a live peer, or its own
+# child stood down when a peer won the singleton - never sees the reason line,
+# because the winning arm printed it on its own stdout. Reading the queue is how
+# such a follower proves the close was explained. 0 when a record was appended at
+# or after this cycle began.
+cycle_close_was_queued() {
+  local last epoch
+  case "$cycle_started_at" in
+    ''|*[!0-9]*|0) return 1 ;;
+  esac
+  last=$(tail -1 "$STATE/.wake-queue" 2>/dev/null || true)
+  [ -n "$last" ] || return 1
+  epoch=${last%%$'\t'*}
+  case "$epoch" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$epoch" -ge "$cycle_started_at" ]
+}
+
+# Print the wakes this cycle put on the durable queue, so a follower's close
+# carries the same actionable reason lines the winning arm printed.
+report_queued_cycle_close() {
+  echo "watcher: cycle closed on a wake already queued by a concurrent arm"
+  awk -F '\t' -v since="$cycle_started_at" '$1 >= since { print $5 }' "$STATE/.wake-queue" 2>/dev/null || true
+}
+
+# A followed cycle that ended with no successor. It is a real failure ONLY when
+# nothing explains the close: a fresh queued wake plus a fresh liveness beacon
+# prove a genuine watcher ran this cycle, surfaced supervision's own work, and
+# closed on it, which is a HEALTHY one-shot close rather than down supervision.
+# Without this test a chatty fleet false-failed every duplicate arm: the winner
+# reported the wake while the follower reported a typed FAILED cycle for the same
+# close, and each of those failures forced another repair turn.
+close_followed_cycle() {
+  if cycle_close_was_queued && [ "$(fm_path_age "$BEAT")" -lt "$GRACE" ]; then
+    report_queued_cycle_close
+    return 0
+  fi
   echo "watcher: FAILED - cycle ended without an actionable reason"
   return 1
 }
@@ -279,8 +327,8 @@ attach_and_wait() {
       continue
     fi
     cycle_log_append unknown unknown attached-cycle-ended none
-    fail_unexplained_cycle
-    return 1
+    close_followed_cycle
+    return $?
   done
 }
 
@@ -429,8 +477,8 @@ owned_child_finished() {
     rm -f "$child_out" 2>/dev/null || true
     child=
     child_out=
-    fail_unexplained_cycle
-    return 1
+    close_followed_cycle
+    return $?
   fi
 
   reason_type="nonzero-exit"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -329,8 +329,25 @@ clear_pause_tracking() {  # <window>
   rm -f "$STATE/.stale-$key" "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
 }
 
+# 0 when this window's declared pause or captain-held transfer has ALREADY been
+# surfaced once inside the current bounded-recheck window, proved by the
+# .paused-resurfaced-<key> throttle marker every pause surface writes.
+# The always-on path surfaces a LIVE declaration once so firstmate sees it, and
+# must then hand that declaration to the PAUSE_RESURFACE_SECS cadence. Without
+# this test the live-agent reconciliation below demoted the same declaration back
+# to `none` on every fresh stale hash, so a crew legitimately parked on long
+# external monitors - whose pane text keeps drifting one line at a time - had its
+# declared wait surfaced again on every watcher cycle, and each surface then wiped
+# the cadence markers, leaving no bound on the repetition at all.
+pause_declaration_already_surfaced() {  # <key>
+  local key=$1
+  [ -e "$STATE/.paused-$key" ] || return 1
+  [ "$(age_of "$STATE/.paused-resurfaced-$key")" -lt "$PAUSE_RESURFACE_SECS" ]
+}
+
 # Reconcile a declared pause or captain-held status with authoritative crew state.
-# Only a confidently dead ordinary crew may recover paused classification after
+# Only a confidently dead ordinary crew, or a declaration already surfaced inside
+# the current bounded window, may recover paused classification after
 # fm-crew-state has fallen back to stopped or unknown.
 pause_state_class() {  # <window> <task>
   local win=$1 task=$2 key last recheck_file class agent_alive
@@ -345,7 +362,7 @@ pause_state_class() {  # <window> <task>
     return
   fi
   if [ -e "$STATE/.paused-$key" ] && [ "$(age_of "$recheck_file")" -lt "$STALE_ESCALATE_SECS" ]; then
-    if [ "$(window_kind "$win")" != secondmate ]; then
+    if [ "$(window_kind "$win")" != secondmate ] && ! pause_declaration_already_surfaced "$key"; then
       agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
       if [ "$agent_alive" != dead ]; then
         rm -f "$recheck_file"
@@ -360,6 +377,14 @@ pause_state_class() {  # <window> <task>
   if [ "$class" = working ]; then
     rm -f "$recheck_file"
     printf 'working'
+    return
+  fi
+  # An active run always outranks the declaration (handled just above); once it
+  # does not, an already-surfaced declaration stays on its bounded cadence
+  # whether or not its agent is still live.
+  if pause_declaration_already_surfaced "$key"; then
+    date +%s > "$recheck_file"
+    printf 'paused'
     return
   fi
   if [ "$(window_kind "$win")" != secondmate ]; then
@@ -959,10 +984,13 @@ EOF
         fi
       else
         # Pane busy or not yet stably stale: reset pending escalation bookkeeping.
+        # The pause cadence markers deliberately survive a busy pane: while the
+        # status still DECLARES a wait, the bounded PAUSE_RESURFACE_SECS cadence
+        # owns this window, and the withdrawal check at the top of this loop is
+        # the one owner of clearing it. Clearing here on a busy blip re-armed the
+        # first-sight surface, so a crew parked on monitors that briefly look
+        # busy surfaced the same declared wait again on the next idle hash.
         rm -f "$ssf" "$ewf"
-        if [ -e "$pf" ] && { [ "$n" -ge 2 ] || ! status_is_paused_or_captain_held "$(last_status_line "$STATE/$(window_to_task "$w" "$STATE").status")"; }; then
-          clear_pause_tracking "$w"
-        fi
       fi
     else
       printf '%s' "$h" > "$hf"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,7 @@ Absorbed wakes advance their suppression markers, log to `state/.watch-triage.lo
 After each drain, `fm-wake-drain.sh` runs the same liveness guard as the supervision scripts, so a lapsed watcher chain surfaces even on a turn that only drains and handles queued wakes.
 Routine watcher polling, supervision no-ops, elapsed waiting time, and absorbed benign wakes stay silent.
 A declared external wait trades that silence for one bounded recheck per pause window, so a forgotten pause cannot remain invisible indefinitely.
+That window is anchored on the declaration itself rather than on pane content, so a crew parked on long external monitors keeps its cadence even while its pane text drifts or briefly looks busy, and only withdrawing the declaration returns it to ordinary stale handling.
 Crew status files are append-only wake-event logs, not current-state fields.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes a no-mistakes run, active or terminal, only when it matches the crew's branch and current code identity, then keeps that run-step authoritative even if the pane has closed.
 The script header owns the exact run-head ancestry rules.
@@ -56,7 +57,7 @@ Optional X mode integrates with the watcher only after explicit opt-in; [configu
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
 That block owns the live wait shape for the running primary harness: Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
 `bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints an honest `started`, `attached`, or nonzero `FAILED` status.
-On `attached` it stays live across identity-matched successors, and an unexplained clean child close either attaches to a verified healthy successor or becomes the typed nonzero `watcher: FAILED - cycle ended without an actionable reason` result.
+On `attached` it stays live across identity-matched successors, and an unexplained clean child close either attaches to a verified healthy successor or becomes the typed nonzero `watcher: FAILED - cycle ended without an actionable reason` result; [`watcher-continuity.md`](watcher-continuity.md) owns the durable-queue exception that keeps concurrent arms following one cycle from each reporting that failure.
 The arm layer records one bounded lifecycle row per observed cycle in `state/.watch-cycle-exits.log`; `state/.watch-triage.log` remains exclusively the absorbed-wake debug log.
 Pi and OpenCode verify session-lock ownership and launch one singleton successor from their child-close handlers before delivering an actionable wake prompt, with bounded exponential retry for failed restoration.
 Claude's `bin/fm-claude-stop-autoarm.sh` hook fires on every Stop and, when the home is eligible and still needs supervision, claims one home-scoped cycle, foregrounds the arm wrapper, and translates an actionable close or typed failure into one exit-2 rewake.

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -40,6 +40,9 @@ The turn-end guard remains the final backstop rather than the normal continuity 
 An actionable child output returns that reason normally.
 A zero/empty child return rechecks the home lock and beacon, attaches to a verified healthy successor when one exists, or emits `watcher: FAILED - cycle ended without an actionable reason` and exits nonzero.
 An attached arm follows verified identity-matched successors and reports the same typed failure if that chain ends without one.
+One exception keeps concurrent arms honest: several arms can follow the same cycle, and only the one that owns the watcher prints its wake reason.
+When the durable wake queue holds a record appended at or after the followed cycle began and the liveness beacon is still fresh, the close is explained, so the follower prints `watcher: cycle closed on a wake already queued by a concurrent arm` with those queued reason lines and exits zero instead of reporting a failure.
+A stale or absent beacon never qualifies, so genuinely down supervision still fails loudly.
 
 The arm layer appends one tab-separated record per observed cycle to `state/.watch-cycle-exits.log`.
 Each record includes arm and watcher PIDs, start and end timestamps, exit code and signal, classified reason, beacon age, lock identity before and after close, and successor disposition.

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -264,6 +264,40 @@ test_hook_silent_with_live_lock_and_fresh_beacon() {
   pass "fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon"
 }
 
+# A chatty fleet is not a broken one. While the watcher absorbs benign wakes and
+# queues the actionable ones it keeps holding the lock and beating the beacon,
+# and pending durable-queue records are ordinary work waiting for the next turn,
+# not evidence that supervision is down. The guard must therefore stay silent on
+# that state and block only on the beacon itself going stale or absent - the
+# genuinely-down case its banner exists for.
+test_hook_silent_with_pending_wakes_and_fresh_beacon() {
+  local dir pid identity out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-pending-wakes")
+  : > "$dir/state/task1.meta"
+  printf '%s\t1\tstale\ttest:fm-op\tstale: test:fm-op\n' "$(date +%s)" > "$dir/state/.wake-queue"
+  sleep 60 &
+  pid=$!
+  identity=$(watcher_identity "$dir" "$pid") || {
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "could not identify live watcher holder"
+  }
+  record_watcher_lock "$dir" "$pid" "$identity"
+  touch "$dir/state/.last-watcher-beat"
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 0 "$status" "hook must exit 0 for a live beating watcher with wakes queued for the next turn"
+  [ -z "$out" ] || fail "hook produced output for a chatty but healthy fleet: $out"
+  # Same live lock and same pending wakes, but nothing has beaten the beacon at
+  # all: supervision really is down and the block must stand.
+  rm -f "$dir/state/.last-watcher-beat"
+  out=$(run_hook "$dir" false); status=$?
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  expect_code 2 "$status" "hook must block when no beacon exists, whatever the queue holds"
+  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
+  pass "fm-turnend-guard: silent for a chatty healthy fleet, still blocking when the beacon is absent"
+}
+
 test_hook_blocks_with_live_lock_and_stale_beacon() {
   local dir pid identity out status
   dir=$(make_primary_dir "$TMP_ROOT/hook-live-lock-stale")
@@ -1096,6 +1130,7 @@ test_hook_silent_when_no_work_in_flight
 test_hook_blocks_when_fresh_beacon_has_no_live_lock
 test_hook_blocks_when_dead_lock_has_fresh_beacon
 test_hook_silent_with_live_lock_and_fresh_beacon
+test_hook_silent_with_pending_wakes_and_fresh_beacon
 test_hook_blocks_with_live_lock_and_stale_beacon
 test_hook_blocks_when_unhealthy_in_primary
 test_hook_blocks_from_fm_home_state

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -753,6 +753,80 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   pass "exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once"
 }
 
+# --- supervision churn: a LIVE declared pause on a DRIFTING pane -------------
+# The live 2026-07-28 case: an operator crewmate parked on long sub-agent and
+# build monitors declared `paused:`, but its pane text kept drifting one printed
+# line at a time. Every drift reclassified the still-live declaration as `none`,
+# which wiped the pause cadence markers, so the very next stable hash surfaced
+# the same declared wait again and the watcher closed its cycle on it - on every
+# single cycle, forever. A declaration must surface ONCE and then hold its
+# bounded PAUSE_RESURFACE_SECS cadence across pane drift, while a pane whose
+# declaration is withdrawn still trips stale normally.
+test_live_declared_pause_absorbs_across_pane_drift() {
+  local dir state fakebin out capture_file statusf window key sig pid round wakes pane
+  dir=$(make_case live-pause-drift); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/op.status"
+  window="test:fm-op"
+  pane='operator: monitoring build 1'
+  printf '%s\n' "$pane" > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/op.meta"
+  printf 'paused: parked on long sub-agent build monitors\n' > "$statusf"
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-op_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  # Prime the pane hash so the first poll of each cycle already sees a stably
+  # stale pane, exactly as a re-armed watcher does on a long-running task.
+  printf '%s' "$(hash_text "$pane")" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+
+  # Phase A: first sight of the live declaration still surfaces once, so a
+  # declared wait firstmate has not seen yet is never hidden by the cadence.
+  run_pause_drift_cycle() {  # -> 0 absorbed (still blocking), 1 exited
+    PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+      FM_FAKE_TMUX_CURRENT_COMMAND=grok \
+      FM_FAKE_CREW_STATE='state: paused · source: status-log · parked on long sub-agent build monitors' \
+      FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+      FM_PAUSE_RESURFACE_SECS=3600 FM_STALE_ESCALATE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+      FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
+    pid=$!
+    if wait_live "$pid" 30; then reap "$pid"; return 0; fi
+    wait "$pid" 2>/dev/null || true
+    return 1
+  }
+  run_pause_drift_cycle && fail "live declared pause did not surface on first sight"
+  grep -F "stale: $window" "$out" >/dev/null || fail "first sight of a live declared pause printed no stale wake"
+
+  # Phase B: the operator keeps printing - a fresh pane hash every cycle. Each
+  # of those cycles must ABSORB, never close on the same declared wait again.
+  round=2
+  while [ "$round" -le 5 ]; do
+    printf 'operator: monitoring build %s\n' "$round" >> "$capture_file"
+    run_pause_drift_cycle || fail "drift cycle $round re-surfaced a declared pause instead of absorbing it: $(cat "$out")"
+    round=$((round + 1))
+  done
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$wakes" -eq 1 ] || fail "a live declared pause churned $wakes stale wakes across a drifting pane"
+  [ -e "$state/.paused-$key" ] || fail "pane drift wiped the pause cadence flag"
+  [ -e "$state/.paused-resurfaced-$key" ] || fail "pane drift wiped the bounded re-surface anchor"
+  [ ! -e "$state/.stale-since-$key" ] || fail "a declared pause must never run the wedge timer"
+
+  # Phase C: the crew withdraws the declaration and goes quiet with no running
+  # pipeline. That is an ordinary stopped/wedged pane again and must surface.
+  printf 'working: back on the build\n' >> "$statusf"
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-op_status"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok \
+    FM_FAKE_CREW_STATE='state: stopped · source: pane · idle composer' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_PAUSE_RESURFACE_SECS=3600 FM_STALE_ESCALATE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 60 || fail "a withdrawn pause left an idle stopped pane unsurfaced"
+  grep -F "stale: $window" "$out" >/dev/null || fail "a withdrawn pause did not restore ordinary stale surfacing"
+  [ ! -e "$state/.paused-$key" ] || fail "a withdrawn declaration kept its pause cadence flag"
+  pass "a live declared pause surfaces once then absorbs across pane drift, and still surfaces when withdrawn"
+}
+
 test_secondmate_paused_resurfaces_in_normal_mode() {
   local dir state fakebin out capture_file statusf window key pane_hash sig pid back
   dir=$(make_case secondmate-paused-resurface); state="$dir/state"; fakebin="$dir/fakebin"
@@ -1291,6 +1365,7 @@ test_wedge_escalation_resets_when_pane_becomes_active
 test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
+test_live_declared_pause_absorbs_across_pane_drift
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed
 test_secondmate_unpause_clears_pause_tracking

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -444,8 +444,19 @@ test_watch_restart_attaches_to_healthy_peer() {
   fakebin="$dir/fakebin"
   out="$dir/restart.out"
   mark_pr_check_migration_complete "$state"
-  node -e 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 300000)' &
+  # The peer stands in for a TERM-resistant watcher, so the restart under test
+  # must find it still alive. Node installs the handler some milliseconds after
+  # fork, so wait for the peer to announce readiness before arming: without that
+  # the restart's TERM can land during interpreter startup, kill the peer, and
+  # turn this into a spurious "started" instead of the attach it asserts.
+  node -e 'process.on("SIGTERM", () => {}); require("fs").writeFileSync(process.argv[1], "ready"); setTimeout(() => {}, 300000)' "$state/.peer-ready" &
   peer=$!
+  i=0
+  while [ "$i" -lt 100 ] && [ ! -s "$state/.peer-ready" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -s "$state/.peer-ready" ] || fail "TERM-resistant peer never became ready"
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"
@@ -763,6 +774,95 @@ test_arm_waits_for_peer_beacon_after_child_stands_down() {
   pass "arm attaches to a peer watcher after child stands down and surfaces a missing successor"
 }
 
+# A cycle can be followed by more than one arm at once (the model's background
+# task and the Claude Stop-owned auto-arm both run bin/fm-watch-arm.sh). Only the
+# arm that owns the watcher prints its wake reason; every follower sees the same
+# close with no successor. The durable wake queue is the shared record of what
+# that cycle did, so a follower whose cycle queued a wake while the beacon stayed
+# fresh must report that wake, not a typed failure - a chatty fleet otherwise
+# turned every duplicate arm into a "cycle FAILED" repair demand. A queued wake
+# alone is not enough: with a stale beacon no watcher is really running and the
+# failure must stand.
+seed_peer_watcher_lock() {  # <state> <dir> <peer-pid>
+  local state=$1 dir=$2 peer=$3 identity
+  identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || return 1
+  mkdir -p "$state/.watch.lock"
+  printf '%s\n' "$peer" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
+  touch "$state/.last-watcher-beat"
+}
+
+wait_for_arm_attach() {  # <armout> <peer-pid>
+  local armout=$1 peer=$2 i=0
+  while [ "$i" -lt 80 ]; do
+    grep -qF "watcher: attached pid=$peer" "$armout" 2>/dev/null && return 0
+    sleep 0.1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+test_arm_follower_reports_queued_wake_instead_of_failure() {
+  local dir state fakebin armout peer armpid status
+  dir=$(make_case arm-follower-queued-wake)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  armout="$dir/arm.out"
+  mark_pr_check_migration_complete "$state"
+  sleep 300 &
+  peer=$!
+  seed_peer_watcher_lock "$state" "$dir" "$peer" || fail "could not seed the peer watcher lock"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=1 FM_ARM_ATTACH_POLL=0.1 "$WATCH_ARM" > "$armout" &
+  armpid=$!
+  wait_for_arm_attach "$armout" "$peer" || fail "arm did not attach to the seeded peer watcher: $(cat "$armout")"
+  # The followed cycle surfaces a wake (queued by the watcher before it prints
+  # and exits) and then ends. The beacon stays fresh, as it is while a real
+  # watcher beats right up to its close.
+  append_wake "$state" stale "test:fm-op" "stale: test:fm-op" || fail "could not queue the cycle's wake"
+  touch "$state/.last-watcher-beat"
+  kill "$peer" 2>/dev/null || true
+  wait "$peer" 2>/dev/null || true
+  wait_for_exit "$armpid" 120
+  status=$?
+  [ "$status" -ne 124 ] || fail "follower arm never returned after its followed cycle closed"
+  expect_code 0 "$status" "a followed cycle explained by a queued wake must not exit non-zero"
+  ! grep -qF 'watcher: FAILED' "$armout" || fail "follower arm reported FAILED for a cycle that queued a wake: $(cat "$armout")"
+  grep -qF 'watcher: cycle closed on a wake already queued by a concurrent arm' "$armout" \
+    || fail "follower arm did not report the queued close: $(cat "$armout")"
+  grep -qF 'stale: test:fm-op' "$armout" || fail "follower arm did not propagate the queued wake reason"
+  pass "an arm following a cycle that queued a wake reports that wake instead of a typed failure"
+}
+
+test_arm_follower_still_fails_on_stale_beacon() {
+  local dir state fakebin armout peer armpid status
+  dir=$(make_case arm-follower-stale-beacon)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  armout="$dir/arm.out"
+  mark_pr_check_migration_complete "$state"
+  sleep 300 &
+  peer=$!
+  seed_peer_watcher_lock "$state" "$dir" "$peer" || fail "could not seed the peer watcher lock"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=1 FM_ARM_ATTACH_POLL=0.1 "$WATCH_ARM" > "$armout" &
+  armpid=$!
+  wait_for_arm_attach "$armout" "$peer" || fail "arm did not attach to the seeded peer watcher: $(cat "$armout")"
+  # Same queued wake, but supervision itself is genuinely down: nothing has beaten
+  # the liveness beacon for far longer than the grace window.
+  append_wake "$state" stale "test:fm-op" "stale: test:fm-op" || fail "could not queue the cycle's wake"
+  touch -t 200001010000 "$state/.last-watcher-beat"
+  kill "$peer" 2>/dev/null || true
+  wait "$peer" 2>/dev/null || true
+  wait_for_exit "$armpid" 120
+  status=$?
+  [ "$status" -ne 124 ] || fail "arm never returned for a stale-beacon cycle close"
+  [ "$status" -ne 0 ] || fail "arm exited zero with a stale beacon and no live watcher"
+  grep -qF 'watcher: FAILED - cycle ended without an actionable reason' "$armout" \
+    || fail "a stale beacon must still produce the typed cycle-end failure: $(cat "$armout")"
+  pass "a queued wake never excuses a stale beacon: down supervision still fails loudly"
+}
+
 test_arm_fails_loud_when_no_fresh_watcher_confirmable() {
   local dir state fakebin armout live armpid status
   dir=$(make_case arm-failed-stale)
@@ -980,6 +1080,8 @@ test_arm_starts_and_self_heals
 test_arm_hup_cleans_child_and_temp_output
 test_arm_propagates_immediate_wake_before_confirmation
 test_arm_waits_for_peer_beacon_after_child_stands_down
+test_arm_follower_reports_queued_wake_instead_of_failure
+test_arm_follower_still_fails_on_stale_beacon
 test_arm_fails_loud_when_no_fresh_watcher_confirmable
 test_cycle_exit_ledger_links_successor_and_stays_bounded
 test_stopped_watcher_is_live_but_stale_then_exit_is_classified


### PR DESCRIPTION
## The problem

A crew that declares `paused:` and then sits on long external monitors made the watcher churn. Every arm cycle started a watcher that immediately closed on `stale: <window>` for that same declared wait, so no watcher stayed up to hold the home lock, and the turn-end path then reported `watcher: FAILED - cycle ended without an actionable reason` and demanded a supervision repair. This repeated every few seconds and never settled. Declaring the pause helped the first surface only; the repetition continued.

## Root cause

Two independent defects, both reproduced before changing any code.

**Watcher, `bin/fm-watch.sh`.** `pause_state_class` demoted a still-declared pause to `none` whenever the crew's agent was still live, so a live declaration was designed to surface exactly once per stale hash. That holds only for a byte-static pane. A live crew's pane text keeps drifting, and on every drift the changed-hash branch reclassified the declaration as `none` and called `clear_pause_tracking`, which deletes `.paused-<key>` and the `.paused-resurfaced-<key>` cadence anchor. Two polls later the pane was stably stale again with no suppressor, so the same declared wait surfaced as a bare `stale:` wake and the cycle closed on it. Nothing bounded the repetition: the `FM_PAUSE_RESURFACE_SECS` cadence never applied to a live paused crew at all. A briefly busy pane wiped the same markers through the second clear in the busy branch.

Reproduction, five consecutive watcher cycles over a live paused crew whose pane gained one line between cycles:

```
round 1: EXITED -> stale: test:fm-op
round 2: EXITED -> stale: test:fm-op
round 3: EXITED -> stale: test:fm-op
round 4: EXITED -> stale: test:fm-op
round 5: EXITED -> stale: test:fm-op
stale wakes queued: 5
```

The same fixture with a byte-static pane surfaced once and absorbed the remaining four cycles, which isolates pane drift as the amplifier.

**Arm layer, `bin/fm-watch-arm.sh`.** Several arms can follow one watcher cycle. Only the arm that owns the watcher prints the wake reason; a follower attaches, then sees the cycle close with no successor and reported the typed failure for a close supervision had handled correctly:

```
round 1: armA rc=1 [watcher: already running pid N|watcher: attached pid=N (beacon 0s)|watcher: FAILED - cycle ended without an actionable reason|]
round 1: armB rc=0 [watcher: started pid=N (beacon fresh)|signal: .../op.status|]
```

## The fix

A declaration stays on its bounded `FM_PAUSE_RESURFACE_SECS` cadence once it has been surfaced inside the current window, whether or not its agent is still live, and its cadence markers survive both pane drift and a briefly busy pane. The withdrawal check at the top of the stale loop remains the one owner of clearing them.

Preserved: an active run still outranks the declaration and takes the ordinary wedge timer; a crew with no declaration still trips stale immediately; a forgotten pause still re-surfaces once per window as an awaiting-external recheck; a live declaration firstmate has not seen yet still surfaces once on first sight.

A follower arm now consults the durable wake queue, the shared record of what a cycle surfaced. A record appended at or after the cycle began, together with a fresh liveness beacon, explains the close, so the follower prints those queued reason lines and exits zero. A stale or absent beacon never qualifies, so genuinely down supervision still fails loudly and the guard keeps its real protection.

After the fix, the same five-cycle reproduction surfaces once and absorbs the rest, and both concurrent arms return zero with the queued reason.

## Tests

- `tests/fm-watch-triage.test.sh` - a live declared pause surfaces once, absorbs across pane drift with its cadence markers and wedge-timer exemption intact, and returns to ordinary stale surfacing once withdrawn. Fails on the pre-fix watcher at drift cycle 2.
- `tests/fm-watcher-lock.test.sh` - a follower arm whose cycle queued a wake reports that wake instead of a typed failure, and the same setup with an ancient beacon still fails loudly. The first fails on the pre-fix arm with exit 1.
- `tests/fm-turnend-guard.test.sh` - the guard stays silent for a live beating watcher with wakes queued for the next turn, and still blocks when no beacon exists.

Also fixes a pre-existing race in the watcher-lock suite: the TERM-resistant peer fixture is now waited on until it has installed its signal handler, since the restart's signal could otherwise land during interpreter startup, kill the peer, and fail the attach assertion for reasons unrelated to the code under test. That failure reproduces on `main`.

## Validation

`bin/fm-lint.sh` clean, `bin/fm-doc-audience-check.sh` clean, and `bin/fm-test-run.sh --family watcher-wake-lock` green (10 suites, 0 failed), plus the auto-arm, instruction-owner, and documentation-audience suites.
