### PR TITLE
fix(session-start): print the secondmate charter in the context digest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Firstmate
 
 You are the first mate.
+If this home has a `data/charter.md`, you are instead a second mate: identify yourself as the second mate for the domain that charter names, never as the first mate.
 The user is the captain.
 This file is your entire job description.
 
@@ -77,6 +78,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
   captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
   captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
+  charter.md         secondmate charter, copied from the parent's charter brief at seed time; LOCAL, gitignored, present only in a secondmate home, and its presence is this home's identity signal
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
   projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)
   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
@@ -128,6 +130,7 @@ Tracked native session-open adapters only nudge this command; `docs/sessionstart
 
 Read the complete digest once and trust it as this turn's startup and recovery input.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.
+An `ABSENT` charter means this is a primary home rather than a secondmate one.
 An `ABSENT` captain, shared-captain, secondmate, or learnings file means the firstmate repo's built-in defaults, no shared captain preferences, no registered secondmates, or no captured learnings; rebuild an absent or stale project registry from the clones before dispatch.
 
 If the session lock cannot be acquired and verified, report its exact diagnostic and remain read-only; another active session is only one possible cause.
@@ -140,7 +143,7 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
    The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous or unreadable targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`).
 3. **Wake queue** - when locked, drains the durable wake queue and prints the raw records prominently as this turn's first work queue; a bounded, clearly labeled historical status-event annotation may follow a valid `signal` record but never replaces it or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
    When the lock could not be acquired and verified, the queue is left untouched because no session mutation is authorized, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
-4. **Context digest** - the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited.
+4. **Context digest** - the full contents of `data/charter.md`, `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited.
    A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
 5. **Fleet-state digest** - the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
    That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -4,8 +4,9 @@
 # Collapses AGENTS.md sections 3 (bootstrap) and 5 (recovery) into ONE script
 # producing ONE ordered digest, so a session starts in one or two turns
 # instead of the six-plus separate reads the old docs required: run
-# fm-bootstrap.sh, then separately read data/projects.md, data/secondmates.md,
-# data/captain.md, data/captain-shared.md, data/learnings.md, then run
+# fm-bootstrap.sh, then separately read data/charter.md, data/projects.md,
+# data/secondmates.md, data/captain.md, data/captain-shared.md,
+# data/learnings.md, then run
 # fm-lock.sh, fm-wake-drain.sh, then read data/backlog.md, every state/*.meta,
 # and every state/*.status.
 # Every one of those reads is UNCONDITIONAL at every session start, so they
@@ -35,9 +36,10 @@
 #                       also run only when locked.
 #   3. wake-drain     - mutates the durable wake queue, so it also only runs
 #                       when locked.
-#   4. context digest - data/projects.md, data/secondmates.md, data/captain.md,
-#                       data/captain-shared.md, data/learnings.md: read-only,
-#                       always safe, always runs.
+#   4. context digest - data/charter.md (first: identity governs how the rest
+#                       is read), data/projects.md, data/secondmates.md,
+#                       data/captain.md, data/captain-shared.md,
+#                       data/learnings.md: read-only, always safe, always runs.
 #   5. fleet digest   - a compact data/backlog.md identity/metadata listing,
 #                       every state/*.meta, a bounded state/*.status tail,
 #                       state/.afk, and a cheap per-task endpoint-liveness read:
@@ -334,6 +336,10 @@ fi
 
 # --- 4. context digest -----------------------------------------------------
 section "CONTEXT"
+# charter.md FIRST: it answers "who am I" (secondmate for a named domain vs
+# primary home), which governs how everything after it is read. ABSENT here
+# means this is a primary home, not a secondmate.
+print_file_or_absent "$DATA/charter.md" "data/charter.md (secondmate charter; ABSENT = this is a primary home)"
 print_file_or_absent "$DATA/projects.md" "data/projects.md"
 print_file_or_absent "$DATA/secondmates.md" "data/secondmates.md"
 print_file_or_absent "$DATA/captain.md" "data/captain.md"
@@ -426,7 +432,7 @@ EOF
 fi
 cat <<'EOF'
 The digest above is complete for this session start. Do NOT re-read
-data/projects.md, data/secondmates.md, data/captain.md,
+data/charter.md, data/projects.md, data/secondmates.md, data/captain.md,
 data/captain-shared.md, data/learnings.md,
 or state/*.meta now - they were just printed in full.
 Do NOT bulk-read data/backlog.md now either: the compact identity/metadata

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -563,7 +563,8 @@ EOF
 
   printf '%s\n' '- demo [no-mistakes] - a demo project (added 2026-07-01)' > "$home/data/projects.md"
   : > "$home/data/captain.md"
-  # secondmates.md, captain-shared.md, and learnings.md deliberately absent
+  # charter.md, secondmates.md, captain-shared.md, and learnings.md
+  # deliberately absent
 
   out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
@@ -577,16 +578,83 @@ EOF
   assert_contains "$out" "data/secondmates.md" "digest did not label the secondmates.md section"
   assert_contains "$out" "data/learnings.md" "digest did not label the learnings.md section"
 
-  # Exactly four context ABSENT markers (secondmates.md, captain-shared.md,
-  # learnings.md; backlog.md is covered by its own test) - and the
-  # present-but-empty captain.md must NOT print ABSENT.
+  # Exactly five context ABSENT markers (charter.md, secondmates.md,
+  # captain-shared.md, learnings.md; backlog.md is covered by its own test) -
+  # and the present-but-empty captain.md must NOT print ABSENT.
   absent_count=$(printf '%s\n' "$out" | grep -c '^ABSENT$')
-  [ "$absent_count" -eq 4 ] || fail "expected 4 ABSENT markers (secondmates.md, captain-shared.md, learnings.md, backlog.md), got $absent_count: $out"
+  [ "$absent_count" -eq 5 ] || fail "expected 5 ABSENT markers (charter.md, secondmates.md, captain-shared.md, learnings.md, backlog.md), got $absent_count: $out"
 
   cap_section=$(printf '%s\n' "$out" | awk '/^data\/captain\.md$/{flag=1;next}/^data\//{flag=0}flag')
   assert_contains "$cap_section" "(present, empty)" "empty-but-present captain.md was not distinguished from ABSENT"
 
   pass "context digest distinguishes ABSENT, empty-but-present, and populated files"
+}
+
+# --- context digest: charter identity ---------------------------------------
+#
+# A seeded secondmate home carries data/charter.md. Without it in the digest,
+# AGENTS.md's "You are the first mate." is the only identity line the session
+# ever loads, so a second mate opens every session claiming the wrong role.
+# The charter must print FIRST in CONTEXT (identity governs how the rest is
+# read), and its absence must stay distinguishable from an empty file because
+# ABSENT is what marks a primary home.
+
+test_context_digest_charter_present() {
+  local rec root home fakebin out charter_line projects_line
+  rec=$(new_world context-charter)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+
+  printf '%s\n' 'You are a persistent second mate managed by the main firstmate.' \
+    'Your domain is the budget app.' > "$home/data/charter.md"
+  printf '%s\n' '- home_budget_app [no-mistakes] - the budget app (added 2026-07-01)' > "$home/data/projects.md"
+
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_contains "$out" "data/charter.md (secondmate charter; ABSENT = this is a primary home)" \
+    "digest did not label the charter.md section"
+  assert_contains "$out" "You are a persistent second mate managed by the main firstmate." \
+    "digest did not print charter.md content"
+  assert_contains "$out" "Your domain is the budget app." \
+    "digest did not print the charter's domain line"
+
+  charter_line=$(printf '%s\n' "$out" | grep -n '^data/charter\.md ' | head -1 | cut -d: -f1)
+  projects_line=$(printf '%s\n' "$out" | grep -n '^data/projects\.md$' | head -1 | cut -d: -f1)
+  [ -n "$charter_line" ] || fail "charter.md section header not found: $out"
+  [ -n "$projects_line" ] || fail "projects.md section header not found: $out"
+  [ "$charter_line" -lt "$projects_line" ] || fail "charter.md did not print first in CONTEXT"
+
+  assert_contains "$out" "data/charter.md, data/projects.md" \
+    "closing reminder did not list charter.md among the already-printed context files"
+
+  pass "context digest prints the secondmate charter first, before projects.md"
+}
+
+test_context_digest_charter_absent() {
+  local rec root home fakebin out charter_section
+  rec=$(new_world context-charter-absent)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+
+  # charter.md deliberately absent: this is a primary home.
+  printf '%s\n' '- demo [no-mistakes] - a demo project (added 2026-07-01)' > "$home/data/projects.md"
+
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_contains "$out" "data/charter.md (secondmate charter; ABSENT = this is a primary home)" \
+    "digest did not label the charter.md section when absent"
+  charter_section=$(printf '%s\n' "$out" | awk '/^data\/charter\.md /{flag=1;next}/^data\//{flag=0}flag')
+  assert_contains "$charter_section" "ABSENT" "absent charter.md did not print the ABSENT marker"
+  assert_not_contains "$charter_section" "(present, empty)" \
+    "absent charter.md was reported as empty-but-present"
+
+  pass "context digest marks a missing charter ABSENT, identifying a primary home"
 }
 
 # --- lock refusal: read-only path --------------------------------------------
@@ -1386,6 +1454,8 @@ EOF
 }
 
 test_context_digest_absent_empty_present
+test_context_digest_charter_present
+test_context_digest_charter_absent
 test_lock_refusal_read_only_path
 test_lock_write_failure_read_only_path
 test_session_lock_concurrent_single_winner


### PR DESCRIPTION
## Problem

A seeded secondmate home carries its charter at `data/charter.md`, but `bin/fm-session-start.sh` never printed it.
The CONTEXT digest listed only `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`.

`AGENTS.md` line 3 ("You are the first mate.") is loaded every session in every home, while the charter that would correct it in a secondmate home was loaded in none.
The result is a reproduced identity bug: a second mate opens the session announcing itself as the first mate and describing a fleet-wide role it does not have.

## Changes

**`bin/fm-session-start.sh`** - print `data/charter.md` in the CONTEXT digest, first, before `data/projects.md`.
It answers "who am I", which governs how everything after it is read.
It uses the existing `print_file_or_absent` helper rather than a second emission path, so absence prints the same explicit `ABSENT` marker and stays distinguishable from an empty-but-present file.
Absence is meaningful: no charter means this is a primary home rather than a secondmate one.
`data/charter.md` is also added to the digest's closing "do NOT re-read" trailer and to the two header comments that enumerate the context files.

**`AGENTS.md`** - one line in the top address block stating the identity rule, plus `charter.md` in the section 2 `data/` layout listing, one line in the section 3 ABSENT-meaning sentence, and `data/charter.md` in the section 3 context-digest enumeration.
The last two are cross-reference updates to existing lists, not restatements of the rule.
The additions are deliberately tight because that file's token cost is paid by every session of every fleet member.

## Deliberate non-changes

The identity rule is **not** added to the charter template in `bin/fm-brief.sh`.
This is a one-owner-rule decision: `AGENTS.md` owns the rule and the charter supplies only the domain.
Duplicating it into the generated charter would create two copies to drift, and would leave already-seeded homes - whose charters were copied at seed time and are gitignored local state - still broken.
The two changes here fix every existing home with no per-home edits, which is a required property of the fix.

No home's `data/charter.md` was edited.

`AGENTS.md` section 1's "only point of contact for all software work across all of their projects" sentence was reviewed and deliberately left alone; that remit wording is tracked as its own separate item.

## Verification

Extended `tests/fm-session-start.test.sh` rather than adding a new runner, per the repo's colocated-test rule:

- `test_context_digest_charter_present` - content printed, ordered before `projects.md`, listed in the trailer.
- `test_context_digest_charter_absent` - `ABSENT` marker, not `(present, empty)`.
- The pre-existing digest test's expected `ABSENT` count moves from 4 to 5, since `charter.md` is now a sixth context file.

`bin/fm-lint.sh` and `bin/fm-doc-audience-check.sh` both run clean (`ok surfaces=55 local_links=151`).

One pre-existing unrelated failure in that suite, `not ok - MISSING diagnostic did not appear at all`, reproduces identically on the base commit b29621b and is not caused by this change.

### Digest output

Charter present:

```
data/charter.md (secondmate charter; ABSENT = this is a primary home)
--------------------------------------------------------------------------------
You are a persistent second mate managed by the main firstmate.
Your domain is the budget app (home_budget_app).

data/projects.md
--------------------------------------------------------------------------------
- home_budget_app [no-mistakes] - the budget app (added 2026-07-01)
```

Charter absent:

```
data/charter.md (secondmate charter; ABSENT = this is a primary home)
--------------------------------------------------------------------------------
ABSENT

data/projects.md
--------------------------------------------------------------------------------
- demo [no-mistakes] - a demo project (added 2026-07-01)
```

## Compatibility

Checked rather than assumed.
The CONTEXT section of `fm-session-start.sh` is a sequence of unconditional `print_file_or_absent` calls with no reference to `PRIMARY_HARNESS` or any backend variable.
Harness branching in that script is confined to the supervision-instructions step, and backend reads to the fleet-state endpoint liveness loop; neither gates CONTEXT.
This change is therefore independent of both the harness axis and the runtime-backend axis.
