### PR TITLE
fix(codex): preserve supervision across checkpoints

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -225,6 +225,7 @@ Verified on 2026-07-08: Codex runs the Stop hook command with process PWD set to
 The tracked hook anchors to `pwd -P`, verifies that root is firstmate-shaped and hook-bearing, and then invokes `bin/fm-turnend-guard.sh` with the original payload.
 Codex's primary watcher protocol is `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`, not `bin/fm-watch-arm.sh`.
 The checkpoint is deliberately foreground and bounded so Codex regains control regularly to process user messages and queued wakes.
+Its watcher lock records `bounded-checkpoint`, so the Stop guard forces a continuation instead of accepting that expiring process as a durable turn-end owner.
 
 ## opencode (VERIFIED 2026-06-11, v1.15.7-1.17.6; 1.18.4 busy-queue re-verified 2026-07-20)
 

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -32,6 +32,9 @@
 # Codex uses stop_hook_active and Grok uses stopHookActive; typed camel-case
 # takes precedence when both spellings are present. A true value means the
 # current stop attempt already follows a block, so this guard always allows it.
+# On the first Stop attempt, a live bounded Codex checkpoint is not a durable
+# supervision owner: the guard blocks so the checkpoint returns into a model
+# continuation that drains wakes and starts the next checkpoint.
 # Passive harness adapters provide their own one-follow-up guard before calling
 # this script.
 # That bounds those harnesses to at most one forced continuation per turn -
@@ -145,9 +148,22 @@ else
     exit 0
   fi
 fi
+BOUNDED_CHECKPOINT=0
 if fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
-  budget_reset
-  exit 0
+  supervision_owner=$(fm_watcher_supervision_owner "$STATE" 2>/dev/null || printf unknown)
+  case "$supervision_owner" in
+    bounded-checkpoint)
+      [ "$CLAUDE_MODE" -eq 0 ] && BOUNDED_CHECKPOINT=1
+      ;;
+    durable)
+      budget_reset
+      exit 0
+      ;;
+  esac
+  if [ "$CLAUDE_MODE" -eq 1 ]; then
+    budget_reset
+    exit 0
+  fi
 fi
 
 block_stop() {
@@ -156,13 +172,19 @@ block_stop() {
   [ -e "$STATE/.afk" ] && afk=1
   x_mode=0
   [ -f "$CONFIG/x-mode.env" ] && x_mode=1
-  reason=$("$SCRIPT_DIR/fm-supervision-instructions.sh" --afk "$afk" --x-mode "$x_mode" --repair-line 2>/dev/null \
-    || printf '%s\n' 'tasks in flight, no live watcher - repair missing watcher supervision according to the session-start operating block before ending the turn')
+  if [ "$BOUNDED_CHECKPOINT" -eq 1 ]; then
+    reason='Keep this Codex model turn active until the foreground checkpoint returns, drain queued wakes, handle any user message, and immediately start the next checkpoint.'
+  else
+    reason=$("$SCRIPT_DIR/fm-supervision-instructions.sh" --afk "$afk" --x-mode "$x_mode" --repair-line 2>/dev/null \
+      || printf '%s\n' 'tasks in flight, no live watcher - repair missing watcher supervision according to the session-start operating block before ending the turn')
+  fi
   rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
   {
     printf '●%s\n' "$rule"
     printf '●  TURN WOULD END BLIND - SUPERVISION IS OFF\n'
-    if [ "$FM_SUP_IN_FLIGHT" -gt 0 ]; then
+    if [ "$BOUNDED_CHECKPOINT" -eq 1 ]; then
+      printf '●  %s task(s) in flight, but the only supervision owner is a bounded Codex checkpoint that will expire.\n' "$FM_SUP_IN_FLIGHT"
+    elif [ "$FM_SUP_IN_FLIGHT" -gt 0 ]; then
       printf '●  %s task(s) in flight, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_IN_FLIGHT" "$FM_SUP_BEACON_DESC"
     else
       printf '●  X-mode relay polling needs supervision, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_BEACON_DESC"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -83,6 +83,16 @@ fm_watcher_lock_matches_pid() {
   [ "$current_identity" = "$lock_identity" ]
 }
 
+fm_watcher_supervision_owner() {
+  local state=$1 owner
+  owner=$(cat "$state/.watch.lock/supervision-owner" 2>/dev/null || true)
+  case "$owner" in
+    bounded-checkpoint|durable) printf '%s\n' "$owner" ;;
+    '') printf '%s\n' durable ;;
+    *) return 1 ;;
+  esac
+}
+
 FM_WATCHER_HEALTHY_PID=
 fm_watcher_healthy() {
   local state=$1 watch_path=$2 grace=${3:-${FM_GUARD_GRACE:-300}} home=${4:-$FM_HOME} lockdir beat pid age
@@ -105,6 +115,7 @@ fm_lock_clean_known_files() {
     "$lockdir/pid" \
     "$lockdir/fm-home" \
     "$lockdir/pid-identity" \
+    "$lockdir/supervision-owner" \
     "$lockdir/watcher-path" \
     2>/dev/null || true
 }

--- a/bin/fm-watch-checkpoint.sh
+++ b/bin/fm-watch-checkpoint.sh
@@ -5,12 +5,14 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SECONDS_ARG=${FM_CODEX_WATCH_CHECKPOINT:-180}
+export FM_WATCHER_SUPERVISION_OWNER=bounded-checkpoint
 
 usage() {
   cat <<'EOF'
 Usage: fm-watch-checkpoint.sh [--seconds <n>]
 
 Run bin/fm-watch.sh in the foreground for a bounded checkpoint.
+The watcher lock records this process as a bounded checkpoint, not a durable supervisor.
 On an actionable watcher wake, pass through the watcher output and exit 0.
 On a quiet checkpoint, print "checkpoint: no actionable wake within <n>s" and exit 124.
 EOF

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -69,6 +69,14 @@ mkdir -p "$STATE"
 
 WATCH_LOCK="$STATE/.watch.lock"
 WATCH_PATH="$SCRIPT_DIR/fm-watch.sh"
+SUPERVISION_OWNER=${FM_WATCHER_SUPERVISION_OWNER:-durable}
+case "$SUPERVISION_OWNER" in
+  durable|bounded-checkpoint) ;;
+  *)
+    echo "watcher: invalid supervision owner: $SUPERVISION_OWNER" >&2
+    exit 2
+    ;;
+esac
 WATCHER_STALE_GRACE=${FM_WATCHER_STALE_GRACE:-${FM_GUARD_GRACE:-300}}
 # The singleton-lock acquisition, EXIT trap, and the blocking supervision loop
 # all live below the source guard at the very bottom of this file (see "Main
@@ -662,6 +670,7 @@ trap 'exit 1' HUP INT TERM
 # ${BASHPID:-$$} from this same main shell). Read directly, never via a command
 # substitution, so it matches the stored holder pid for the self-eviction check.
 WATCHER_PID=${BASHPID:-$$}
+printf '%s\n' "$SUPERVISION_OWNER" > "$WATCH_LOCK/supervision-owner" || exit 1
 printf '%s\n' "$FM_HOME" > "$WATCH_LOCK/fm-home" || true
 printf '%s\n' "$WATCH_PATH" > "$WATCH_LOCK/watcher-path" || true
 fm_pid_identity "$WATCHER_PID" > "$WATCH_LOCK/pid-identity" 2>/dev/null || true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,7 @@ Optional X mode integrates with the watcher only after explicit opt-in; [configu
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
 That block owns the live wait shape for the running primary harness: Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
+Watcher locks distinguish `durable` owners from Codex `bounded-checkpoint` owners, so the Codex Stop guard cannot mistake an expiring checkpoint for supervision that survives the turn.
 `bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints an honest `started`, `attached`, or nonzero `FAILED` status.
 On `attached` it stays live across identity-matched successors, and an unexplained clean child close either attaches to a verified healthy successor or becomes the typed nonzero `watcher: FAILED - cycle ended without an actionable reason` result.
 The arm layer records one bounded lifecycle row per observed cycle in `state/.watch-cycle-exits.log`; `state/.watch-triage.log` remains exclusively the absorbed-wake debug log.

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -6,10 +6,14 @@ When this session owns supervision and away mode is not active:
 3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
 4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
 5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
-6. Never use shell `&` or Codex background tasks for firstmate watcher supervision.
-7. Do not run `bin/fm-watch-arm.sh` as Codex's normal supervision command.
+6. A foreground checkpoint records `bounded-checkpoint` ownership in the watcher lock.
+   The Stop guard rejects a turn end while that bounded process is the only supervision owner, so quiet expiry returns into a model continuation that performs step 5.
+7. A durable watcher records `durable` ownership and remains a valid turn-end owner.
+8. Never use shell `&` or Codex background tasks for firstmate watcher supervision.
+9. Do not run `bin/fm-watch-arm.sh` as Codex's normal supervision command.
    If it is ever shelled anyway, a backgrounded, piped, or bundled anti-pattern is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`) registered in `.codex/hooks.json`.
-8. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
+10. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
 
 Codex cannot reason while a foreground tool call is running.
 The bounded checkpoint returns control regularly so user messages and queued wakes can be handled without relying on background-task wake semantics.
+The checkpoint remains bounded and interruptible; the Stop guard adds a continuation instead of turning one shell call into an indefinite supervisor.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -31,6 +31,11 @@ Claude's `--claude` mode also treats `state/x-watch.check.sh` as supervision nee
 Otherwise it calls `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] [home]` from `bin/fm-wake-lib.sh`, the same identity-matched lock and fresh-beacon check used by `bin/fm-watch-arm.sh`.
 A stale beacon blocks even when a watcher pid is live.
 A fresh leftover beacon blocks when the lock is missing, dead, or identity-mismatched.
+Every watcher lock also records `supervision-owner`.
+A durable watcher is a valid turn-end owner.
+A Codex foreground checkpoint records `bounded-checkpoint`; on the first Stop attempt the guard treats it as insufficient even while its lock and beacon are healthy, because that process will expire without a model re-arm owner.
+Blocking the Stop creates the continuation that receives the checkpoint result, drains queued wakes, and starts the next checkpoint.
+Locks from versions before this field default to `durable` for rolling compatibility.
 
 `FM_STATE_OVERRIDE` wins over `FM_HOME/state`, and `FM_HOME` wins over repository-root `state/`.
 `FM_GUARD_GRACE` controls beacon freshness and defaults to 300 seconds.
@@ -48,6 +53,8 @@ If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot s
 Claude and Codex can block a Stop directly with exit status 2 and stderr.
 Both payloads carry `stop_hook_active`.
 In the default Codex mode, a true value lets the second stop finish after one forced continuation.
+That loop guard remains unchanged.
+A first Stop while only a bounded Codex checkpoint is live blocks even though the generic watcher health predicate succeeds; a live durable watcher still allows the Stop.
 
 Claude runs the guard with `--claude`, which ignores `stop_hook_active` and cooperates with the Stop-owned auto-arm.
 Claude Code sets `stop_hook_active=true` on every stop after any stop-hook continuation, including `asyncRewake` rewakes, which re-opened the 2026-07-21 blind window under the default one-shot behavior.
@@ -90,7 +97,8 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 ## Regression coverage
 
-`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
+`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, durable watcher acceptance, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
+`tests/fm-watch-checkpoint.test.sh` covers bounded ownership, the unsafe stop-while-checkpoint-live sequence, two consecutive quiet boundaries, actionable wake pass-through, registered checks, and singleton rejection.
 `tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -118,6 +118,17 @@ FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh
 FM_GROK_STOP_LIVE_E2E=1 FM_GROK_NATIVE_BIN="$native_grok" FM_GROK_LEGACY_BIN="$pre_native_grok" tests/fm-grok-stop-live-e2e.test.sh
 ```
 
+The Codex checkpoint-owner regression was reverified hermetically on 2026-07-27 in the Codex CLI 0.145.0 environment:
+
+```sh
+tests/fm-watch-checkpoint.test.sh
+tests/fm-turnend-guard.test.sh
+```
+
+The hermetic incident sequence created in-flight work, started a real bounded checkpoint, waited for its identity-matched lock and fresh beacon, invoked the Codex Stop predicate, and observed exit 2 with the bounded-owner reason.
+The same checkpoint suite completed two consecutive quiet boundaries, released and reacquired the singleton lock each time, then surfaced a registered check through the durable wake queue.
+The durable-owner guard case remained silent, and the existing `stop_hook_active=true` case still allowed the second Stop attempt.
+
 ## Watcher continuity
 
 The cross-harness evidence combines the 2026-07-17 live pass with Claude's replacement Stop-owned path revalidated on 2026-07-24, all against isolated project and home state.
@@ -134,7 +145,7 @@ grok 0.2.103 (89c3d36fb6f1) [stable]
 | Harness | Exact opt-in command | Observed guarantee |
 | --- | --- | --- |
 | Claude | `FM_CLAUDE_LIVE_E2E=1 tests/fm-claude-stop-autoarm-live-e2e.test.sh` | Session start reclaimed a stale owner before two Stop-owned cycles, and a competing live owner prevented arm, rewake, epoch write, or lock replacement. |
-| Codex | `FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh` | The one-second foreground checkpoint returned without switching to the arm wrapper. |
+| Codex | `FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh` | The one-second foreground checkpoint returned without switching to the arm wrapper; deterministic owner tests cover the Stop boundary and repeated quiet cycles. |
 | OpenCode | `FM_OPENCODE_LIVE_E2E=1 tests/fm-opencode-primary-live-e2e.test.sh` | A verified successor existed before prompt handling, with no model re-arm or turn-end fallback. |
 | Pi | `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` | One initial tool call led to extension-owned successors and clean child retirement on exit. |
 | Grok | `FM_GROK_LIVE_E2E=1 tests/fm-grok-continuity-live-e2e.test.sh` | Native task completion surfaced the actionable close and the cycle ledger recorded `reason=actionable-signal`. |
@@ -162,6 +173,7 @@ tests/fm-watcher-lock.test.sh
 tests/fm-subagent-pretool-check.test.sh
 tests/fm-claude-stop-autoarm.test.sh
 tests/fm-turnend-guard.test.sh
+tests/fm-watch-checkpoint.test.sh
 ```
 
 ## Wedge-alarm channels

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -200,7 +200,7 @@ watcher_identity() {
 }
 
 record_watcher_lock() {
-  local dir=$1 pid=$2 identity=$3 root bin_dir
+  local dir=$1 pid=$2 identity=$3 owner=${4:-durable} root bin_dir
   root=$(cd "$dir" && pwd)
   bin_dir=$(cd "$dir/bin" && pwd)
   mkdir -p "$dir/state/.watch.lock"
@@ -208,6 +208,7 @@ record_watcher_lock() {
   printf '%s\n' "$root" > "$dir/state/.watch.lock/fm-home"
   printf '%s\n' "$bin_dir/fm-watch.sh" > "$dir/state/.watch.lock/watcher-path"
   printf '%s\n' "$identity" > "$dir/state/.watch.lock/pid-identity"
+  printf '%s\n' "$owner" > "$dir/state/.watch.lock/supervision-owner"
 }
 
 test_hook_silent_when_no_work_in_flight() {

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -6,13 +6,27 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 CHECKPOINT="$ROOT/bin/fm-watch-checkpoint.sh"
+GUARD="$ROOT/bin/fm-turnend-guard.sh"
 TMP_ROOT=$(fm_test_tmproot fm-watch-checkpoint)
+fm_git_identity fmtest fmtest@example.invalid
 
 make_home() {
   local name=$1 home
   home="$TMP_ROOT/$name"
   mkdir -p "$home/state" "$home/data" "$home/config"
   printf '%s\n' "$home"
+}
+
+wait_for_checkpoint_lock() {
+  local home=$1 i=0
+  while [ "$i" -lt 100 ]; do
+    if [ "$(cat "$home/state/.watch.lock/supervision-owner" 2>/dev/null || true)" = bounded-checkpoint ]; then
+      return 0
+    fi
+    sleep 0.02
+    i=$((i + 1))
+  done
+  return 1
 }
 
 test_quiet_checkpoint_exits_124_cleanly() {
@@ -25,7 +39,94 @@ test_quiet_checkpoint_exits_124_cleanly() {
   expect_code 124 "$status" "quiet checkpoint exit"
   assert_contains "$(cat "$out")" "checkpoint: no actionable wake within 1s" "quiet checkpoint line missing"
   assert_absent "$home/state/.watch.lock/pid" "watch lock pid survived quiet checkpoint timeout"
+  assert_absent "$home/state/.watch.lock/supervision-owner" "watch ownership survived quiet checkpoint timeout"
   pass "quiet checkpoint exits 124 with a clean checkpoint line and no live lock"
+}
+
+test_two_quiet_checkpoints_reacquire_and_release_cleanly() {
+  local home cycle out err status
+  home=$(make_home quiet-twice)
+  cycle=1
+  while [ "$cycle" -le 2 ]; do
+    out="$home/out-$cycle.txt"
+    err="$home/err-$cycle.txt"
+    status=0
+    FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 1 >"$out" 2>"$err" || status=$?
+    expect_code 124 "$status" "quiet checkpoint cycle $cycle exit"
+    assert_contains "$(cat "$out")" "checkpoint: no actionable wake within 1s" "quiet checkpoint cycle $cycle line missing"
+    assert_absent "$home/state/.watch.lock/pid" "watch lock survived quiet checkpoint cycle $cycle"
+    assert_absent "$home/state/.watch.lock/supervision-owner" "watch ownership survived quiet checkpoint cycle $cycle"
+    cycle=$((cycle + 1))
+  done
+  pass "two consecutive quiet checkpoints each reacquire and release the watcher lock"
+}
+
+test_registered_check_fires_after_two_quiet_boundaries() {
+  local home cycle out err status drained check_count
+  home=$(make_home check-after-quiet)
+  printf '%s\n' fm-pr-check-migration-scan-v1 > "$home/state/.pr-check-migration-scan-v1"
+  printf '%s\n' fm-pr-check-migration-v1 > "$home/state/.pr-check-migration-v1"
+  chmod 0600 "$home/state/.pr-check-migration-scan-v1" "$home/state/.pr-check-migration-v1"
+  cat > "$home/state/after-quiet.check.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'registered check survived quiet boundaries\n'
+SH
+  chmod 0700 "$home/state/after-quiet.check.sh"
+  FM_HOME="$home" "$ROOT/bin/fm-check-register.sh" after-quiet >/dev/null \
+    || fail "could not register post-boundary custom check"
+  touch "$home/state/.last-check"
+
+  cycle=1
+  while [ "$cycle" -le 2 ]; do
+    out="$home/quiet-$cycle.out"
+    err="$home/quiet-$cycle.err"
+    status=0
+    FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 1 >"$out" 2>"$err" || status=$?
+    expect_code 124 "$status" "pre-check quiet boundary $cycle exit"
+    cycle=$((cycle + 1))
+  done
+
+  touch -t 202001010000 "$home/state/.last-check"
+  status=0
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=1 "$CHECKPOINT" --seconds 5 >"$home/check.out" 2>"$home/check.err" || status=$?
+  expect_code 0 "$status" "registered check after quiet boundaries exit"
+  assert_contains "$(cat "$home/check.out")" "check:" "registered check did not surface after quiet boundaries"
+  assert_contains "$(cat "$home/check.out")" "registered check survived quiet boundaries" "registered check output missing after quiet boundaries"
+  drained=$(FM_ROOT_OVERRIDE="$home" FM_HOME="$home" "$ROOT/bin/fm-wake-drain.sh")
+  check_count=$(printf '%s\n' "$drained" | awk -F '\t' '$3 == "check" { count++ } END { print count + 0 }')
+  [ "$check_count" -eq 1 ] || fail "registered check wake surfaced $check_count times after quiet boundaries"
+  pass "registered checks continue after two consecutive quiet checkpoint boundaries"
+}
+
+test_stop_guard_rejects_live_bounded_checkpoint() {
+  local home out err guard_out status checkpoint_pid
+  home=$(make_home stop-live)
+  out="$home/out.txt"
+  err="$home/err.txt"
+  git init -q "$home"
+  git -C "$home" commit -q --allow-empty -m init
+  : > "$home/AGENTS.md"
+  mkdir -p "$home/bin"
+  : > "$home/state/task.meta"
+
+  FM_ROOT_OVERRIDE="$home" FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
+    "$CHECKPOINT" --seconds 3 >"$out" 2>"$err" &
+  checkpoint_pid=$!
+  wait_for_checkpoint_lock "$home" || {
+    kill "$checkpoint_pid" 2>/dev/null || true
+    wait "$checkpoint_pid" 2>/dev/null || true
+    fail "bounded checkpoint did not publish its watcher ownership"
+  }
+
+  guard_out=$(printf '{"stop_hook_active":false}' \
+    | FM_ROOT_OVERRIDE="$home" FM_HOME="$home" FM_GUARD_GRACE=300 bash "$GUARD" 2>&1)
+  status=$?
+  wait "$checkpoint_pid" 2>/dev/null || true
+
+  expect_code 2 "$status" "turn-end guard must block while a bounded checkpoint is the only owner"
+  assert_contains "$guard_out" "bounded Codex checkpoint" "bounded checkpoint block reason missing"
+  assert_absent "$home/state/.watch.lock/pid" "watch lock survived bounded checkpoint expiry"
+  pass "turn-end guard blocks the unsafe stop-while-checkpoint-live sequence"
 }
 
 test_signal_passes_through_and_exits_zero() {
@@ -41,7 +142,7 @@ test_signal_passes_through_and_exits_zero() {
   FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 8 >"$out" 2>"$err" || status=$?
   expect_code 0 "$status" "signal checkpoint exit"
   assert_contains "$(cat "$out")" "signal:" "signal wake was not passed through"
-  drained=$(FM_HOME="$home" "$ROOT/bin/fm-wake-drain.sh")
+  drained=$(FM_ROOT_OVERRIDE="$home" FM_HOME="$home" "$ROOT/bin/fm-wake-drain.sh")
   assert_contains "$drained" $'\tsignal\tdemo.status\t' "signal wake was not queued durably"
   pass "checkpoint passes through a real watcher wake and leaves the queue for drain"
 }
@@ -88,6 +189,9 @@ test_existing_singleton_watcher_is_not_success() {
 }
 
 test_quiet_checkpoint_exits_124_cleanly
+test_two_quiet_checkpoints_reacquire_and_release_cleanly
+test_registered_check_fires_after_two_quiet_boundaries
+test_stop_guard_rejects_live_bounded_checkpoint
 test_signal_passes_through_and_exits_zero
 test_registered_check_uses_preserved_watcher_environment
 test_existing_singleton_watcher_is_not_success


### PR DESCRIPTION
## Intent

Fix Firstmate Codex supervision so a bounded foreground checkpoint cannot be mistaken for durable turn-end supervision. Record bounded-checkpoint versus durable watcher ownership; block the first Codex Stop when only the bounded owner is live so checkpoint expiry returns to a model continuation that drains the durable wake queue, handles user steering, and immediately starts the next checkpoint. Preserve stop_hook_active loop safety, durable watcher acceptance, lock exclusivity, read-only lock refusal, other harness protocols, and exact-once actionable wakes. Do not add a daemon, shell-background supervision, broad pkill, a Trello special case, or a longer timeout. Add regressions for the exact stop-while-checkpoint-live incident and at least two quiet checkpoint cycles, update the Codex supervision and verification docs, push dv/codex-supervision-reliable to the configured fork, and open a draft PR to kunchenguid/firstmate without reviewers, readying, merging, or committing generated artifacts.

## What Changed

- Track bounded-checkpoint versus durable watcher ownership separately, and block the first Codex Stop when only the bounded checkpoint owner is live so checkpoint expiry falls back to a model continuation that drains the wake queue and starts the next checkpoint instead of silently ending supervision.
- Extend `fm-turnend-guard.sh`, `fm-wake-lib.sh`, `fm-watch.sh`, and `fm-watch-checkpoint.sh` with the ownership-recording and stop-blocking logic, while preserving `stop_hook_active` loop safety, durable watcher acceptance, lock exclusivity, and exact-once actionable wakes.
- Add regression coverage for the stop-while-checkpoint-live case and for two consecutive quiet checkpoint cycles, and update the Codex supervision, architecture, and verification docs to describe the new ownership contract.

## Risk Assessment

✅ Low: The change is small, self-contained to the Codex checkpoint/turnend-guard path, defaults safely to "durable" for pre-existing locks (backward compatible), writes the new supervision-owner marker before the identity file so no unsafe race window exists, cleans up the marker on lock release, and is covered by new regression tests for the exact incident (stop-while-checkpoint-live) plus repeated quiet-cycle and durable-watcher-acceptance cases; docs were updated consistently with the code.

## Testing

Ran the full checkpoint test suite (all pass, including the two new regressions that directly reproduce the stop-while-checkpoint-live incident and quiet-cycle safety) and the turnend-guard suite (35/36 pass, with the single failure confirmed pre-existing on the base commit and unrelated to this change); the working tree was left clean with no stray artifacts.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-watch-checkpoint.test.sh` — all 7 tests pass, including new `test_stop_guard_rejects_live_bounded_checkpoint` (the stop-while-checkpoint-live regression) and `test_two_quiet_checkpoints_reacquire_and_release_cleanly`/`test_registered_check_fires_after_two_quiet_boundaries`</code>
- <code>`bash tests/fm-turnend-guard.test.sh` — 35/36 pass; verified the one failing case (&#39;OpenCode plugin must run the guard from worktree even when directory is elsewhere&#39;) fails identically on base commit b29621b, confirming it&#39;s pre-existing and unrelated to this change</code>
- <code>`git diff b29621b..c616fc8` review of bin/fm-turnend-guard.sh, bin/fm-wake-lib.sh, bin/fm-watch.sh, bin/fm-watch-checkpoint.sh to confirm the supervision-owner file mechanism and block logic match the described behavior</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
