### PR TITLE
fix(teardown): remove the scout worktree-safety exemption

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -668,8 +668,24 @@ validate_worktree_teardown_safety() {
   local dirty_raw dirty unpushed_raw unpushed DEFAULT unmerged_raw unmerged branch
   [ -d "$WT" ] || return 0
   [ "$FORCE" != "--force" ] || return 0
+  # This was `secondmate|scout`, which returned 0 before any check ran and
+  # destroyed 46 uncommitted files across 11 worktrees on 2026-07-26.
+  #
+  # scout is removed: a scout's worktree IS a git worktree, so every check below
+  # applies, and the "scouts leave scratch behind" rationale is already covered by
+  # the dirty filter, which ignores .claude/ and .fm-*-turnend. A scout lane wrote
+  # ADR 0058 and a guard script, so "scouts are read-only" was false in practice.
+  #
+  # secondmate stays, and is load-bearing rather than redundant: a secondmate home
+  # is a plain directory carrying a .fm-secondmate-home marker, not a git worktree
+  # (see the teardown case in tests/fm-secondmate-safety.test.sh). Every check
+  # below shells out to `git -C "$WT"`, which fails on a non-repo and correctly
+  # fail-safes to REFUSED, so dropping this would make every secondmate teardown
+  # impossible. There is no uncommitted git state here for the checks to protect.
+  #
+  # --force remains the explicit escape hatch.
   case "$KIND" in
-    secondmate|scout) return 0 ;;
+    secondmate) return 0 ;;
   esac
 
   if ! dirty_raw=$(git -C "$WT" status --porcelain 2>/dev/null); then
@@ -1146,8 +1162,13 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   # to pool. treehouse resolves the pool from the working directory, so run it from
   # the project. teardown_treehouse_return tolerates transient and stale git locks
   # left by a killed crew process; see the script header for retry and stale-lock proof.
+  # Same exemption class as the one deleted from validate_worktree_teardown_safety:
+  # this recheck is what catches work written between the first safety check and
+  # the return that resets the worktree, and skipping it for scouts reopened the
+  # hole on the lock path. (secondmate never reaches here; the elif above excludes
+  # it.) --force remains the escape hatch.
   post_lock_cleanup_check=
-  if [ "$FORCE" != "--force" ] && [ "$KIND" != scout ] && [ "$KIND" != secondmate ]; then
+  if [ "$FORCE" != "--force" ]; then
     post_lock_cleanup_check=validate_worktree_teardown_safety
   fi
   teardown_treehouse_return "$WT" "$PROJ" "worktree" "$post_lock_cleanup_check" || {

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -866,6 +866,82 @@ test_dirty_worktree_refuses() {
   pass "dirty worktree is refused even when its committed work has landed (dirty always wins)"
 }
 
+# Regression: on 2026-07-26 a KIND=scout|secondmate exemption at the top of
+# validate_worktree_teardown_safety returned 0 before any check ran, and a
+# teardown sweep destroyed 46 uncommitted files across 11 worktrees. The
+# exemption's rationale (scouts leave scratch files) is already covered by the
+# dirty filter, which ignores .claude/ and .fm-*-turnend. These three cases pin
+# both halves: real scout work refuses, scratch-only scout work still tears down.
+# A scout refuses teardown until it has filed data/<id>/report.md and cleared the
+# unresolved-decision inventory. Both gates are about the work product, not the
+# worktree, so a scout that has satisfied them still reaches the dirty check.
+# Satisfying them here is what makes these cases exercise worktree safety rather
+# than stopping at an earlier scout gate.
+satisfy_scout_work_product_gates() {
+  local case_dir=$1
+  mkdir -p "$case_dir/data/task-x1"
+  printf '%s\n' '# scout report' > "$case_dir/data/task-x1/report.md"
+  printf '%s\n' 'decisions_reviewed=1' >> "$case_dir/state/task-x1.meta"
+}
+
+assert_kind_dirty_refuses() {
+  local kind=$1 case_dir rc pr_head
+  case_dir=$(make_case "dirty-wt-$kind")
+  write_meta "$case_dir" no-mistakes "$kind"
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  satisfy_scout_work_product_gates "$case_dir"
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  land_on_origin_main "$case_dir" feature.txt hello
+  pr_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head"
+  printf '%s\n' "uncommitted edit" > "$case_dir/wt/feature.txt"
+
+  set +e
+  FM_DATA_OVERRIDE="$case_dir/data" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "dirty-wt-$kind: teardown must refuse a dirty $kind worktree, not exempt it"
+  grep -q REFUSED "$case_dir/stderr" || fail "dirty-wt-$kind: no REFUSED line in stderr"
+  grep -q "uncommitted changes" "$case_dir/stderr" || fail "dirty-wt-$kind: refusal did not cite uncommitted changes"
+  pass "dirty $kind worktree is refused (kind grants no safety exemption)"
+}
+
+test_scout_dirty_worktree_refuses() { assert_kind_dirty_refuses scout; }
+
+# The deleted exemption covered `secondmate|scout` as one branch, so the scout
+# case above is what discriminates: before the fix it exited 0 with empty stderr.
+# There is deliberately no secondmate twin. A secondmate refuses earlier still,
+# on the seeded-home check, so such a case would pass whether or not the
+# exemption existed and would only look like coverage.
+
+test_scout_scratch_only_worktree_tears_down() {
+  local case_dir rc pr_head
+  case_dir=$(make_case scratch-only-scout)
+  write_meta "$case_dir" no-mistakes scout
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  satisfy_scout_work_product_gates "$case_dir"
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  land_on_origin_main "$case_dir" feature.txt hello
+  pr_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head"
+  # Only agent scratch is left behind: the dirty filter must ignore it.
+  mkdir -p "$case_dir/wt/.claude"
+  printf '%s\n' 'scratch' > "$case_dir/wt/.claude/settings.local.json"
+  printf '%s\n' 'done' > "$case_dir/wt/.fm-grok-turnend"
+
+  set +e
+  FM_DATA_OVERRIDE="$case_dir/data" \
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "scratch-only-scout: agent scratch alone must not block teardown"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "scratch-only-scout: teardown printed a REFUSED line"
+  pass "scout worktree holding only agent scratch still tears down cleanly"
+}
+
 test_gh_error_and_content_absent_refuses() {
   local case_dir rc
   case_dir=$(make_case gh-error)
@@ -1392,6 +1468,8 @@ test_pr_check_records_remote_head_when_local_lags
 test_content_in_default_fallback_allows
 test_content_fallback_refreshes_stale_origin_ref
 test_dirty_worktree_refuses
+test_scout_dirty_worktree_refuses
+test_scout_scratch_only_worktree_tears_down
 test_gh_error_and_content_absent_refuses
 test_stale_index_lock_cleared_and_teardown_succeeds
 test_live_index_lock_is_never_removed_and_teardown_refuses


### PR DESCRIPTION
## What

`validate_worktree_teardown_safety()` returns `0` before any check runs when `KIND` is `secondmate` or `scout`:

```sh
[ "$FORCE" != "--force" ] || return 0
case "$KIND" in
  secondmate|scout) return 0 ;;   # skips dirty / unpushed / unmerged
esac
```

This removes the `scout` half and keeps `secondmate`.

## Why

A teardown sweep across 104 worktrees hit 11 that held uncommitted work and destroyed **46 files**. They were untracked and unstaged, so they had never entered git's object store and were unrecoverable. Branches survived, so committed history was fine; the uncommitted deltas were not.

The safety function itself is well built (checks dirty, unpushed, unmerged; refuses on any). It simply never ran.

### Why `scout` goes

A scout's worktree is a real git worktree, so every check below the exemption applies to it. The stated rationale, that scouts leave scratch behind, is already covered by the dirty filter's `.claude/` and `.fm-*-turnend` exclusions.

The premise that scouts are read-only is false in practice: a scout lane in our fleet authored an ADR and a guard script, both lost.

### Why `secondmate` stays

This half is load-bearing rather than redundant, and worth stating explicitly so it is not "cleaned up" later.

A secondmate home is a plain directory carrying a `.fm-secondmate-home` marker, **not** a git worktree. Every check in the function shells out to `git -C "$WT"`, which fails on a non-repo and correctly fail-safes to `REFUSED`. Removing this exemption makes *every* secondmate teardown impossible. `tests/fm-secondmate-safety.test.sh` catches it immediately ("teardown failed for empty secondmate home").

There is no uncommitted git state there for these checks to protect.

## Also

The same exemption guarded `post_lock_cleanup_check`, the recheck that catches work written between the first safety check and the `treehouse return` that resets the worktree. Leaving it would have kept the hole open on the lock path. `secondmate` never reaches that branch, since the `elif` above it already excludes it, so no exemption is needed there.

`--force` remains the explicit escape hatch in both places.

## Tests

The exemption survived because it was never tested: `tests/fm-teardown.test.sh` was 1,405 lines with **zero** occurrences of `scout` or `secondmate`.

- `test_scout_dirty_worktree_refuses` reproduces the incident against the old code exactly: **exit 0, empty stderr**, worktree torn down with an uncommitted edit present.
- `test_scout_scratch_only_worktree_tears_down` pins the exemption's original rationale, so a scout holding only agent scratch still tears down clean.

Reaching the dirty check as a scout means satisfying two earlier scout gates first (`data/<id>/report.md`, and `decisions_reviewed=1`). Those are about the work product, not the worktree, which is why they are not a substitute for this check.

There is deliberately no `secondmate` twin: a secondmate refuses earlier on the seeded-home check, so such a case would pass with or without the exemption and would only look like coverage.

`tests/fm-teardown.test.sh`: **34/34**, up from 32.

Full suite on this branch shows no new failures. Note that `tests/fm-secondmate-safety.test.sh` currently fails on macOS at `origin/main` for an unrelated reason: `bin/fm-brief.sh` has not parsed under bash 3.2 since #945, which I am happy to send as a separate PR.