### PR TITLE
fix(brief): restore bash 3.2 parse of the no-mistakes definition-of-done

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -277,6 +277,14 @@ fi
 # Ship task: shape Setup / Rule 1 / Definition of done by the project's delivery mode.
 # yolo does not affect the brief because the worker never owns approval decisions;
 # firstmate applies the authority contract in AGENTS.md section 7, so discard it.
+
+# Bash 3.2 (stock on macOS) mis-scans a bare apostrophe inside a heredoc that is
+# nested in $( ), treating it as an unterminated quote and failing the whole file
+# with "unexpected EOF while looking for matching `''". Every other script here
+# parses under 3.2, so interpolate possessives in $( )-nested heredocs through
+# this instead of typing the apostrophe. The rest of the repo uses no bash 4+
+# features; keep it that way.
+APOS="'"
 read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
@@ -325,7 +333,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass firstmate${APOS}s authority check and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF


### PR DESCRIPTION
## Failure mode

`bin/fm-brief.sh` has not parsed under stock macOS bash since #945:

```
bin/fm-brief.sh: line 314: unexpected EOF while looking for matching `''
bin/fm-brief.sh: line 388: syntax error: unexpected end of file
```

Bash 3.2 mis-scans a **bare apostrophe inside a heredoc nested in `$( )`**, treating it as an unterminated single quote and failing the whole file. The apostrophe in `firstmate's authority check` (line 328, added by #945) is enough on its own.

Minimal reproduction:

```sh
$ cat repro.sh
X=$(cat <<EOF
firstmate's authority check
EOF
)
$ /bin/bash -n repro.sh          # bash 3.2.57, stock macOS
repro.sh: line 2: unexpected EOF while looking for matching `''
```

Quoting the delimiter (`<<'EOF'`) does not help; the `$( )` scan is what breaks.

**Why CI is green:** the runner is Linux with bash 5, where the file is valid. This is invisible from CI and only bites macOS users, where `fm-brief.sh` cannot execute at all, so brief scaffolding is dead.

ShellCheck also reports the file as clean, since it parses as modern bash. `bash -n` under 3.2 is the only signal.

**This is a regression, not an unsupported platform.** Every other script in `bin/` parses under bash 3.2, and the repo uses no bash 4+ constructs (no `declare -A`, no `${var,,}`, no `mapfile`/`readarray`).

## Correction

Interpolate the apostrophe through `$APOS` so the scanner never encounters a bare quote. The heredoc is unquoted, so `${APOS}` expands normally and **the generated brief text is unchanged byte for byte** — which matters, because `tests/fm-ask-user-authority.test.sh` pins that exact sentence.

I first tried simply rewording the possessive; that broke the contract test, which is the correct outcome. The brief text is a contract, so the mechanism is what changed instead.

## Scope

**One file.** `bin/fm-brief.sh`, +9/-1, and the only behavioral line is the `${APOS}` interpolation; the rest is the comment explaining the constraint.

`bin/fm-teardown.sh` is untouched, as is every other script. Confirmed against this branch:

- `git diff --name-only origin/main` lists `bin/fm-brief.sh` and nothing else
- `tests/fm-teardown.test.sh`: **32/32**, identical to the `origin/main` baseline

## Tests

On this branch (`origin/main` + this commit), macOS bash 3.2:

| suite | before | after |
|---|---|---|
| `fm-brief` | fails to parse | **15/15** |
| `fm-ask-user-authority` | 8 ok, 1 fail | **9/9** |
| `fm-tangle-guard` | 5 ok, 1 fail | **6/6** |
| `fm-secondmate-safety` | 0 ok, 1 fail | **59/59** |
| `fm-teardown` | 32/32 | **32/32** (unchanged) |

`fm-secondmate-safety` going from an immediate abort to 59 passing shows the reach: it depends on brief scaffolding and could not get past it.

`shellcheck -e SC1091 bin/fm-brief.sh` is clean, and `/bin/bash -n bin/fm-brief.sh` now exits 0.