### PR TITLE
fix(bin): execute checkpoint watchers from paths with spaces

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -325,7 +325,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass the Firstmate authority check and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF

--- a/bin/fm-watch-checkpoint.sh
+++ b/bin/fm-watch-checkpoint.sh
@@ -58,7 +58,7 @@ run_with_perl_timeout() {
     die "fork failed\n" unless defined $pid;
     if (!$pid) {
       setpgrp(0, 0);
-      exec @ARGV;
+      exec { $ARGV[0] } @ARGV;
       die "exec failed: $!\n";
     }
     local $SIG{ALRM} = sub {

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -131,7 +131,7 @@ test_primary_and_secondmate_instruction_generation() {
     "generated implementation brief lets the worker own an ask-user decision"
   assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$ship" \
     "generated implementation brief bypasses the primary authority owner"
-  assert_grep "silently bypass firstmate's authority check and any required captain escalation" "$ship" \
+  assert_grep "silently bypass the Firstmate authority check and any required captain escalation" "$ship" \
     "generated implementation brief permits silent ask-user auto-resolution"
   assert_no_grep 'the captain, not you, owns the ask-user decisions' "$ship" \
     "generated implementation brief retained conflicting captain-only wording"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 # Behavior tests for bin/fm-brief.sh.
 #
-# Regression coverage for the heredoc-in-command-substitution parse bug (issue
-# #166): each ship-mode branch builds its Definition-of-done text with
-# `VAR=$(cat <<EOF ... EOF)`. Bash's lexer tracks quote state through the
-# heredoc body while it scans for the matching `)` of the command
-# substitution, so a single unescaped apostrophe anywhere in that body breaks
-# parsing of the *entire rest of the script* - `bash -n` fails, not just the
-# generated brief. A plain `cat > file <<EOF ... EOF` (not wrapped in `$(...)`)
-# is unaffected, so the secondmate charter block does not need this guard.
+# Regression coverage for the macOS Bash 3.2
+# heredoc-in-command-substitution parse bug (issue #166).
+# Each ship-mode branch builds its Definition-of-done text with
+# `VAR=$(cat <<EOF ... EOF)`.
+# Stock macOS Bash tracks quote state through the heredoc body while scanning
+# for the matching `)` of the command substitution, so one apostrophe in that
+# body breaks parsing of the rest of the script.
+# Linux Bash accepts the same source, so the portable source inspection below
+# carries the macOS-only regression guard in Linux CI.
+# A plain `cat > file <<EOF ... EOF` outside `$(...)` is unaffected, so the
+# secondmate charter block does not need this guard.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -18,15 +21,28 @@ TMP_ROOT=$(fm_test_tmproot fm-brief)
 BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
 
-# The script itself must always parse. This is the direct regression test for
-# issue #166: a stray apostrophe in any of the three DOD heredoc bodies
-# (no-mistakes/direct-PR/local-only) breaks `bash -n` on the whole file.
+# The script itself must parse under the Bash running the test.
+# On stock macOS Bash this directly catches issue #166; Linux CI relies on the
+# portable source guard below for apostrophes in the three DOD heredoc bodies.
 test_script_parses() {
   local out rc
   out=$(bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
   expect_code 0 "$rc" "bash -n bin/fm-brief.sh must parse cleanly (got: $out)"
   [ -z "$out" ] || fail "bash -n bin/fm-brief.sh emitted unexpected output: $out"
   pass "fm-brief.sh: bash -n succeeds"
+}
+
+# Source-level tripwire for issue #166 so Linux CI catches the macOS-only
+# failure before the script can run under Bash 3.2.
+test_dod_heredocs_avoid_apostrophes() {
+  local out
+  out=$(awk '
+    /DOD=\$\(cat <<EOF/ { in_dod = 1 }
+    in_dod && index($0, sprintf("%c", 39)) { print NR ":" $0 }
+    in_dod && /^EOF$/ { in_dod = 0 }
+  ' "$ROOT/bin/fm-brief.sh")
+  [ -z "$out" ] || fail "DOD heredoc contains an apostrophe that breaks macOS Bash 3.2: $out"
+  pass "fm-brief.sh: DOD heredocs avoid macOS Bash 3.2 apostrophe parsing"
 }
 
 test_help_includes_entire_header() {
@@ -383,6 +399,7 @@ test_scout_and_secondmate_scaffold() {
 }
 
 test_script_parses
+test_dod_heredocs_avoid_apostrophes
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -87,6 +87,34 @@ test_existing_singleton_watcher_is_not_success() {
   pass "checkpoint rejects an existing watcher singleton as unowned"
 }
 
+test_perl_fallback_executes_watcher_path_with_spaces() {
+  local fixture_root fixture_bin tool_bin tool source out err status
+  fixture_root="$TMP_ROOT/watcher path with spaces"
+  fixture_bin="$fixture_root/bin"
+  tool_bin="$TMP_ROOT/perl-fallback-tools"
+  mkdir -p "$TMP_ROOT/watcher" "$fixture_bin" "$tool_bin"
+  cp "$CHECKPOINT" "$fixture_bin/fm-watch-checkpoint.sh"
+  cat > "$fixture_bin/fm-watch.sh" <<'SH'
+#!/bin/sh
+printf '%s\n' 'signal: fixture watcher launched'
+SH
+  chmod +x "$fixture_bin/fm-watch-checkpoint.sh" "$fixture_bin/fm-watch.sh"
+
+  for tool in bash cat dirname grep mktemp perl rm; do
+    source=$(command -v "$tool") || fail "$tool is required for the Perl fallback test"
+    ln -s "$source" "$tool_bin/$tool"
+  done
+
+  out="$fixture_root/out.txt"
+  err="$fixture_root/err.txt"
+  status=0
+  PATH="$tool_bin" "$fixture_bin/fm-watch-checkpoint.sh" --seconds 2 >"$out" 2>"$err" || status=$?
+  expect_code 0 "$status" "Perl fallback watcher path with spaces"
+  assert_contains "$(cat "$out")" "signal: fixture watcher launched" "Perl fallback did not launch the watcher child"
+  pass "Perl fallback directly executes a watcher path containing spaces"
+}
+
+test_perl_fallback_executes_watcher_path_with_spaces
 test_quiet_checkpoint_exits_124_cleanly
 test_signal_passes_through_and_exits_zero
 test_registered_check_uses_preserved_watcher_environment


### PR DESCRIPTION
## What Changed

- Use Perl direct-exec semantics in the macOS checkpoint timeout fallback so watcher scripts at absolute paths containing spaces launch correctly.
- Add an execution-based regression test that forces the Perl fallback and runs a watcher fixture from a spaced path.