### PR TITLE
fix(pi): rearm watcher across session transitions

### DIFF
--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -3,7 +3,7 @@
 // Session-generation ownership (stated once here):
 // Pi emits session_shutdown for ordinary same-process replacements (/new, /resume,
 // /fork, reload) as well as terminal quit. This extension binds one generation per
-// factory activation. Only the active live generation may start, stop, rearm, or
+// session activation. Only the active live generation may start, stop, rearm, or
 // clear the arm child. Replacement session_start (or a fresh factory bind) activates
 // a new live generation so monitoring can arm again without restarting Pi. Terminal
 // quit leaves the final generation stopped so late callbacks cannot rearm. Stale
@@ -191,9 +191,6 @@ function createGeneration(): SessionGeneration {
 }
 
 function activateGeneration(generation: SessionGeneration): void {
-  generation.stopping = false;
-  generation.retryFailures = 0;
-  generation.restoring = false;
   activeGeneration = generation;
 }
 
@@ -201,8 +198,21 @@ function generationIsLive(generation: SessionGeneration): boolean {
   return activeGeneration === generation && !generation.stopping;
 }
 
+function stopGeneration(generation: SessionGeneration): void {
+  generation.stopping = true;
+  if (generation.retryTimer) clearTimeout(generation.retryTimer);
+  generation.retryTimer = null;
+  if (generation.child) generation.child.kill("SIGTERM");
+  generation.child = null;
+}
+
+const cleanupOnProcessExit = () => {
+  if (activeGeneration) stopGeneration(activeGeneration);
+};
+process.once("exit", cleanupOnProcessExit);
+
 export default function (pi: ExtensionAPI) {
-  const generation = createGeneration();
+  let generation = createGeneration();
   activateGeneration(generation);
 
   let calmPresentation: CalmPresentationState = {
@@ -221,21 +231,8 @@ export default function (pi: ExtensionAPI) {
     !calmPresentation.stockExportRendering &&
     !calmTranscriptClassIsVisible(itemClass);
 
-  function stopArm(): void {
-    generation.stopping = true;
-    if (generation.retryTimer) clearTimeout(generation.retryTimer);
-    generation.retryTimer = null;
-    if (generation.child) generation.child.kill("SIGTERM");
-    generation.child = null;
-  }
-
-  const cleanupOnProcessExit = () => {
-    stopArm();
-  };
-  process.once("exit", cleanupOnProcessExit);
-
-  async function sendWake(message: string): Promise<void> {
-    if (!generationIsLive(generation)) return;
+  async function sendWake(owner: SessionGeneration, message: string): Promise<void> {
+    if (!generationIsLive(owner)) return;
     const content = encodeFirstmateOperationalInput(
       "watcher",
       `FIRSTMATE WATCHER WAKE: ${message}\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.`,
@@ -243,8 +240,8 @@ export default function (pi: ExtensionAPI) {
     await pi.sendUserMessage(content, { deliverAs: "followUp" });
   }
 
-  function surfaceFailure(message: string): void {
-    void sendWake(message).catch(() => {
+  function surfaceFailure(owner: SessionGeneration, message: string): void {
+    void sendWake(owner, message).catch(() => {
       // Pi owns delivery errors; continuity restoration never waits on prompting.
     });
   }
@@ -288,12 +285,12 @@ export default function (pi: ExtensionAPI) {
     });
   }
 
-  async function restoreAfterActionableClose(predecessorArmPid: string): Promise<string> {
+  async function restoreAfterActionableClose(owner: SessionGeneration, predecessorArmPid: string): Promise<string> {
     let failure = "";
     for (let attempt = 0; attempt <= retryLimit; attempt += 1) {
-      if (!generationIsLive(generation)) return "";
-      const replacement = startArm(predecessorArmPid);
-      const successorChild = generation.child;
+      if (!generationIsLive(owner)) return "";
+      const replacement = startArm(owner, predecessorArmPid);
+      const successorChild = owner.child;
       if (replacement.ok && successorChild && await waitForReadiness(successorChild)) return "";
       if (replacement.ok) {
         failure = "watcher: FAILED - Pi extension could not verify a ready successor watcher";
@@ -312,32 +309,32 @@ export default function (pi: ExtensionAPI) {
     return `${failure}\nwatcher: FAILED - Pi extension could not restore watcher continuity after ${retryLimit} retries`;
   }
 
-  function scheduleRetry(message: string, predecessorArmPid: string): void {
-    if (!generationIsLive(generation) || generation.child || generation.retryTimer) return;
+  function scheduleRetry(owner: SessionGeneration, message: string, predecessorArmPid: string): void {
+    if (!generationIsLive(owner) || owner.child || owner.retryTimer) return;
     const ownership = lockOwnership();
     if (ownership !== "owned") {
-      surfaceFailure(`watcher: FAILED - Pi extension cannot restore continuity because this session no longer owns the lock\n${message}`);
+      surfaceFailure(owner, `watcher: FAILED - Pi extension cannot restore continuity because this session no longer owns the lock\n${message}`);
       return;
     }
-    generation.retryFailures += 1;
-    if (generation.retryFailures > retryLimit) {
-      surfaceFailure(`watcher: FAILED - Pi extension could not restore watcher continuity after ${retryLimit} retries\n${message}`);
+    owner.retryFailures += 1;
+    if (owner.retryFailures > retryLimit) {
+      surfaceFailure(owner, `watcher: FAILED - Pi extension could not restore watcher continuity after ${retryLimit} retries\n${message}`);
       return;
     }
     const timer = setTimeout(() => {
-      if (generation.retryTimer === timer) generation.retryTimer = null;
-      if (!generationIsLive(generation)) return;
-      const result = startArm(predecessorArmPid);
+      if (owner.retryTimer === timer) owner.retryTimer = null;
+      if (!generationIsLive(owner)) return;
+      const result = startArm(owner, predecessorArmPid);
       if (!result.ok) {
-        surfaceFailure(`watcher: FAILED - Pi extension could not launch a continuity retry\n${result.message}`);
+        surfaceFailure(owner, `watcher: FAILED - Pi extension could not launch a continuity retry\n${result.message}`);
       }
-    }, retryDelay(generation.retryFailures));
+    }, retryDelay(owner.retryFailures));
     timer.unref();
-    generation.retryTimer = timer;
+    owner.retryTimer = timer;
   }
 
-  function startArm(predecessorArmPid = ""): ArmResult {
-    if (!generationIsLive(generation)) return { ok: false, message: shuttingDownMessage };
+  function startArm(owner: SessionGeneration, predecessorArmPid = ""): ArmResult {
+    if (!generationIsLive(owner)) return { ok: false, message: shuttingDownMessage };
     const ownership = lockOwnership();
     if (ownership === "other") return { ok: false, message: "watcher: read-only - session lock is held by another firstmate session" };
     if (ownership === "missing") {
@@ -347,19 +344,19 @@ export default function (pi: ExtensionAPI) {
       };
     }
     markLoaded();
-    if (generation.child) {
+    if (owner.child) {
       return {
         ok: true,
         message: `watcher: unchanged - Pi extension already owns an arm child; no manual re-arm needed; ${repairOnlyHint}`,
       };
     }
-    if (generation.retryTimer) {
+    if (owner.retryTimer) {
       return {
         ok: true,
         message: `watcher: unchanged - Pi extension already owns a scheduled continuity retry; no manual re-arm needed; ${repairOnlyHint}`,
       };
     }
-    const id = ++generation.seq;
+    const id = ++owner.seq;
     const env = {
       ...process.env,
       FM_HOME: fmHome,
@@ -373,7 +370,7 @@ export default function (pi: ExtensionAPI) {
       env,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    generation.child = armChild;
+    owner.child = armChild;
     let stdout = "";
     let stderr = "";
     let settled = false;
@@ -399,7 +396,7 @@ export default function (pi: ExtensionAPI) {
       }
     };
     const releaseChild = (): void => {
-      if (generation.child === armChild) generation.child = null;
+      if (owner.child === armChild) owner.child = null;
     };
     armChild.stdout.on("data", (chunk: Buffer) => {
       stdout += chunk.toString();
@@ -415,24 +412,24 @@ export default function (pi: ExtensionAPI) {
       resolveClosed();
       settleReadiness(false);
       releaseChild();
-      if (!generationIsLive(generation)) return;
+      if (!generationIsLive(owner)) return;
       const classification = classifyClose(stdout, stderr, code, signal);
       const predecessor = String(armChild.pid ?? "");
       if (classification.kind === "actionable") {
-        generation.retryFailures = 0;
-        generation.restoring = true;
+        owner.retryFailures = 0;
+        owner.restoring = true;
         void (async () => {
-          const failure = await restoreAfterActionableClose(predecessor);
-          if (generationIsLive(generation)) generation.restoring = false;
-          if (!generationIsLive(generation)) return;
+          const failure = await restoreAfterActionableClose(owner, predecessor);
+          if (generationIsLive(owner)) owner.restoring = false;
+          if (!generationIsLive(owner)) return;
           const message = failure ? `${classification.message}\n\n${failure}` : classification.message;
-          await sendWake(message);
+          await sendWake(owner, message);
         })().catch(() => {
         });
         return;
       }
-      if (generation.restoring) return;
-      scheduleRetry(classification.message, predecessor);
+      if (owner.restoring) return;
+      scheduleRetry(owner, classification.message, predecessor);
     });
     armChild.on("error", (error: Error) => {
       if (settled) return;
@@ -440,9 +437,9 @@ export default function (pi: ExtensionAPI) {
       resolveClosed();
       settleReadiness(false);
       releaseChild();
-      if (!generationIsLive(generation)) return;
-      if (generation.restoring) return;
-      scheduleRetry(`watcher: FAILED - Pi extension arm child ${id} failed: ${error.message}`, String(armChild.pid ?? ""));
+      if (!generationIsLive(owner)) return;
+      if (owner.restoring) return;
+      scheduleRetry(owner, `watcher: FAILED - Pi extension arm child ${id} failed: ${error.message}`, String(armChild.pid ?? ""));
     });
     return {
       ok: true,
@@ -451,19 +448,18 @@ export default function (pi: ExtensionAPI) {
   }
 
   pi.on?.("session_start", () => {
-    // Activate this bound instance for startup and ordinary same-process replacement.
+    if (generation.stopping) generation = createGeneration();
     activateGeneration(generation);
     markLoaded();
   });
   pi.on?.("session_shutdown", () => {
-    stopArm();
-    process.off("exit", cleanupOnProcessExit);
+    stopGeneration(generation);
   });
 
   pi.registerCommand?.("fm-watch-arm-pi", {
     description: "Arm firstmate watcher supervision through the Pi extension instead of foreground bash.",
     handler: async (_args, ctx) => {
-      const result = startArm();
+      const result = startArm(generation);
       ctx.ui.notify(result.message, result.ok ? "info" : "warning");
     },
   });
@@ -504,7 +500,7 @@ export default function (pi: ExtensionAPI) {
       return new Container();
     },
     execute: async () => {
-      const result = startArm();
+      const result = startArm(generation);
       return {
         content: [{ type: "text", text: result.message }],
         details: result,

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -1,4 +1,13 @@
 // Firstmate primary watcher bridge for Pi.
+//
+// Session-generation ownership (stated once here):
+// Pi emits session_shutdown for ordinary same-process replacements (/new, /resume,
+// /fork, reload) as well as terminal quit. This extension binds one generation per
+// factory activation. Only the active live generation may start, stop, rearm, or
+// clear the arm child. Replacement session_start (or a fresh factory bind) activates
+// a new live generation so monitoring can arm again without restarting Pi. Terminal
+// quit leaves the final generation stopped so late callbacks cannot rearm. Stale
+// callbacks from a prior generation are no-ops against the active replacement.
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -37,6 +46,16 @@ type WatchToolRenderContext = {
   isPartial: boolean;
 };
 
+type SessionGeneration = {
+  id: number;
+  stopping: boolean;
+  child: ChildProcess | null;
+  retryTimer: ReturnType<typeof setTimeout> | null;
+  retryFailures: number;
+  restoring: boolean;
+  seq: number;
+};
+
 function refreshWatchToolShell(
   state: WatchToolShellState,
   theme: Theme,
@@ -72,13 +91,10 @@ const retryLimit = positiveInteger("FM_WATCH_REARM_RETRY_LIMIT", 5);
 const armReadyTimeoutMs = positiveInteger("FM_PI_ARM_READY_TIMEOUT_MS", 12000);
 const armRetireTimeoutMs = positiveInteger("FM_WATCH_ARM_RETIRE_TIMEOUT_MS", 1000);
 const repairOnlyHint = "call fm_watch_arm_pi again only after a later notification says the cycle is missing, failed, or unhealthy";
+const shuttingDownMessage = "watcher: not armed - Pi session is shutting down";
 
-let child: ChildProcess | null = null;
-let retryTimer: ReturnType<typeof setTimeout> | null = null;
-let retryFailures = 0;
-let stopping = false;
-let seq = 0;
-let restoring = false;
+let nextGenerationId = 0;
+let activeGeneration: SessionGeneration | null = null;
 const armReadiness = new WeakMap<ChildProcess, Promise<boolean>>();
 const armClose = new WeakMap<ChildProcess, Promise<void>>();
 
@@ -162,7 +178,33 @@ function classifyClose(stdout: string, stderr: string, code: number | null, sign
   };
 }
 
+function createGeneration(): SessionGeneration {
+  return {
+    id: ++nextGenerationId,
+    stopping: false,
+    child: null,
+    retryTimer: null,
+    retryFailures: 0,
+    restoring: false,
+    seq: 0,
+  };
+}
+
+function activateGeneration(generation: SessionGeneration): void {
+  generation.stopping = false;
+  generation.retryFailures = 0;
+  generation.restoring = false;
+  activeGeneration = generation;
+}
+
+function generationIsLive(generation: SessionGeneration): boolean {
+  return activeGeneration === generation && !generation.stopping;
+}
+
 export default function (pi: ExtensionAPI) {
+  const generation = createGeneration();
+  activateGeneration(generation);
+
   let calmPresentation: CalmPresentationState = {
     active: false,
     stockExportRendering: false,
@@ -180,11 +222,11 @@ export default function (pi: ExtensionAPI) {
     !calmTranscriptClassIsVisible(itemClass);
 
   function stopArm(): void {
-    stopping = true;
-    if (retryTimer) clearTimeout(retryTimer);
-    retryTimer = null;
-    if (child) child.kill("SIGTERM");
-    child = null;
+    generation.stopping = true;
+    if (generation.retryTimer) clearTimeout(generation.retryTimer);
+    generation.retryTimer = null;
+    if (generation.child) generation.child.kill("SIGTERM");
+    generation.child = null;
   }
 
   const cleanupOnProcessExit = () => {
@@ -193,6 +235,7 @@ export default function (pi: ExtensionAPI) {
   process.once("exit", cleanupOnProcessExit);
 
   async function sendWake(message: string): Promise<void> {
+    if (!generationIsLive(generation)) return;
     const content = encodeFirstmateOperationalInput(
       "watcher",
       `FIRSTMATE WATCHER WAKE: ${message}\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.`,
@@ -248,9 +291,9 @@ export default function (pi: ExtensionAPI) {
   async function restoreAfterActionableClose(predecessorArmPid: string): Promise<string> {
     let failure = "";
     for (let attempt = 0; attempt <= retryLimit; attempt += 1) {
-      if (stopping) return "";
+      if (!generationIsLive(generation)) return "";
       const replacement = startArm(predecessorArmPid);
-      const successorChild = child;
+      const successorChild = generation.child;
       if (replacement.ok && successorChild && await waitForReadiness(successorChild)) return "";
       if (replacement.ok) {
         failure = "watcher: FAILED - Pi extension could not verify a ready successor watcher";
@@ -270,30 +313,31 @@ export default function (pi: ExtensionAPI) {
   }
 
   function scheduleRetry(message: string, predecessorArmPid: string): void {
-    if (stopping || child || retryTimer) return;
+    if (!generationIsLive(generation) || generation.child || generation.retryTimer) return;
     const ownership = lockOwnership();
     if (ownership !== "owned") {
       surfaceFailure(`watcher: FAILED - Pi extension cannot restore continuity because this session no longer owns the lock\n${message}`);
       return;
     }
-    retryFailures += 1;
-    if (retryFailures > retryLimit) {
+    generation.retryFailures += 1;
+    if (generation.retryFailures > retryLimit) {
       surfaceFailure(`watcher: FAILED - Pi extension could not restore watcher continuity after ${retryLimit} retries\n${message}`);
       return;
     }
     const timer = setTimeout(() => {
-      if (retryTimer === timer) retryTimer = null;
+      if (generation.retryTimer === timer) generation.retryTimer = null;
+      if (!generationIsLive(generation)) return;
       const result = startArm(predecessorArmPid);
       if (!result.ok) {
         surfaceFailure(`watcher: FAILED - Pi extension could not launch a continuity retry\n${result.message}`);
       }
-    }, retryDelay(retryFailures));
+    }, retryDelay(generation.retryFailures));
     timer.unref();
-    retryTimer = timer;
+    generation.retryTimer = timer;
   }
 
   function startArm(predecessorArmPid = ""): ArmResult {
-    if (stopping) return { ok: false, message: "watcher: not armed - Pi session is shutting down" };
+    if (!generationIsLive(generation)) return { ok: false, message: shuttingDownMessage };
     const ownership = lockOwnership();
     if (ownership === "other") return { ok: false, message: "watcher: read-only - session lock is held by another firstmate session" };
     if (ownership === "missing") {
@@ -303,19 +347,19 @@ export default function (pi: ExtensionAPI) {
       };
     }
     markLoaded();
-    if (child) {
+    if (generation.child) {
       return {
         ok: true,
         message: `watcher: unchanged - Pi extension already owns an arm child; no manual re-arm needed; ${repairOnlyHint}`,
       };
     }
-    if (retryTimer) {
+    if (generation.retryTimer) {
       return {
         ok: true,
         message: `watcher: unchanged - Pi extension already owns a scheduled continuity retry; no manual re-arm needed; ${repairOnlyHint}`,
       };
     }
-    const id = ++seq;
+    const id = ++generation.seq;
     const env = {
       ...process.env,
       FM_HOME: fmHome,
@@ -329,7 +373,7 @@ export default function (pi: ExtensionAPI) {
       env,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    child = armChild;
+    generation.child = armChild;
     let stdout = "";
     let stderr = "";
     let settled = false;
@@ -355,7 +399,7 @@ export default function (pi: ExtensionAPI) {
       }
     };
     const releaseChild = (): void => {
-      if (child === armChild) child = null;
+      if (generation.child === armChild) generation.child = null;
     };
     armChild.stdout.on("data", (chunk: Buffer) => {
       stdout += chunk.toString();
@@ -371,23 +415,23 @@ export default function (pi: ExtensionAPI) {
       resolveClosed();
       settleReadiness(false);
       releaseChild();
-      if (stopping) return;
+      if (!generationIsLive(generation)) return;
       const classification = classifyClose(stdout, stderr, code, signal);
       const predecessor = String(armChild.pid ?? "");
       if (classification.kind === "actionable") {
-        retryFailures = 0;
-        restoring = true;
+        generation.retryFailures = 0;
+        generation.restoring = true;
         void (async () => {
           const failure = await restoreAfterActionableClose(predecessor);
-          restoring = false;
-          if (stopping) return;
+          if (generationIsLive(generation)) generation.restoring = false;
+          if (!generationIsLive(generation)) return;
           const message = failure ? `${classification.message}\n\n${failure}` : classification.message;
           await sendWake(message);
         })().catch(() => {
         });
         return;
       }
-      if (restoring) return;
+      if (generation.restoring) return;
       scheduleRetry(classification.message, predecessor);
     });
     armChild.on("error", (error: Error) => {
@@ -396,8 +440,8 @@ export default function (pi: ExtensionAPI) {
       resolveClosed();
       settleReadiness(false);
       releaseChild();
-      if (stopping) return;
-      if (restoring) return;
+      if (!generationIsLive(generation)) return;
+      if (generation.restoring) return;
       scheduleRetry(`watcher: FAILED - Pi extension arm child ${id} failed: ${error.message}`, String(armChild.pid ?? ""));
     });
     return {
@@ -407,6 +451,8 @@ export default function (pi: ExtensionAPI) {
   }
 
   pi.on?.("session_start", () => {
+    // Activate this bound instance for startup and ordinary same-process replacement.
+    activateGeneration(generation);
     markLoaded();
   });
   pi.on?.("session_shutdown", () => {

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -8,7 +8,7 @@ When this session owns supervision and away mode is not active:
    Never run `bin/fm-watch-arm.sh` through Pi's bash tool because that foreground arm can wedge the agent and bypasses extension-owned cleanup.
 4. If the extension says no live session holds the lock, run `bin/fm-session-start.sh` to reclaim the session lock, then call `fm_watch_arm_pi` again.
 5. The extension starts `bin/fm-watch-arm.sh --restart`, keeps the child attached to the live Pi process, and owns every later successor launch.
-6. Ordinary same-process session replacement (`/new`, `/resume`, `/fork`, reload) retires only the prior generation; call `fm_watch_arm_pi` once for the first cycle of the replacement session without restarting Pi. The generation-owner contract lives in `.pi/extensions/fm-primary-pi-watch.ts` and `docs/watcher-continuity.md`.
+6. Ordinary same-process session replacement (`/new`, `/resume`, `/fork`, reload) retires only the prior generation; call `fm_watch_arm_pi` once for the first cycle of the replacement session without restarting Pi. The generation-owner contract lives in `.pi/extensions/fm-primary-pi-watch.ts`.
 7. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
 8. Ordinary work, turn completion, and ordinary signal, stale, check, heartbeat, or other wake handling: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
 9. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -8,7 +8,8 @@ When this session owns supervision and away mode is not active:
    Never run `bin/fm-watch-arm.sh` through Pi's bash tool because that foreground arm can wedge the agent and bypasses extension-owned cleanup.
 4. If the extension says no live session holds the lock, run `bin/fm-session-start.sh` to reclaim the session lock, then call `fm_watch_arm_pi` again.
 5. The extension starts `bin/fm-watch-arm.sh --restart`, keeps the child attached to the live Pi process, and owns every later successor launch.
-6. Ordinary same-process session replacement (`/new`, `/resume`, `/fork`, reload) retires only the prior generation; call `fm_watch_arm_pi` once for the first cycle of the replacement session without restarting Pi. The generation-owner contract lives in `.pi/extensions/fm-primary-pi-watch.ts`.
+6. Ordinary same-process session replacement (`/new`, `/resume`, `/fork`, reload) retires only the prior generation; call `fm_watch_arm_pi` once for the first cycle of the replacement session without restarting Pi.
+   The generation-owner contract lives in `.pi/extensions/fm-primary-pi-watch.ts`.
 7. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
 8. Ordinary work, turn completion, and ordinary signal, stale, check, heartbeat, or other wake handling: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
 9. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -8,12 +8,13 @@ When this session owns supervision and away mode is not active:
    Never run `bin/fm-watch-arm.sh` through Pi's bash tool because that foreground arm can wedge the agent and bypasses extension-owned cleanup.
 4. If the extension says no live session holds the lock, run `bin/fm-session-start.sh` to reclaim the session lock, then call `fm_watch_arm_pi` again.
 5. The extension starts `bin/fm-watch-arm.sh --restart`, keeps the child attached to the live Pi process, and owns every later successor launch.
-6. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
-7. Ordinary work, turn completion, and ordinary signal, stale, check, heartbeat, or other wake handling: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
-8. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.
-9. Missing, failed, or unhealthy cycle only: if a later notification explicitly reports one of those repair conditions, drain queued wakes, inspect the failure text, call `fm_watch_arm_pi`, and restart the selected Pi-family executable with both extensions loaded if needed.
+6. Ordinary same-process session replacement (`/new`, `/resume`, `/fork`, reload) retires only the prior generation; call `fm_watch_arm_pi` once for the first cycle of the replacement session without restarting Pi. The generation-owner contract lives in `.pi/extensions/fm-primary-pi-watch.ts` and `docs/watcher-continuity.md`.
+7. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
+8. Ordinary work, turn completion, and ordinary signal, stale, check, heartbeat, or other wake handling: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
+9. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.
+10. Missing, failed, or unhealthy cycle only: if a later notification explicitly reports one of those repair conditions, drain queued wakes, inspect the failure text, call `fm_watch_arm_pi`, and restart the selected Pi-family executable with both extensions loaded if needed.
    A redundant call while the extension owns an arm child or scheduled retry is an ownership-based `watcher: unchanged` no-op, not an independent health claim.
-10. Never use shell `&` for watcher supervision.
+11. Never use shell `&` for watcher supervision.
    The arm mechanism above is extension-owned, not a model tool call, but a manual recovery probe that backgrounds, pipes, or bundles the arm is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, wired into the turn-end guard extension at `__FM_PI_TURNEND_EXT__`).
 
 The turn-end guard extension lives at `__FM_PI_TURNEND_EXT__`.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -121,7 +121,7 @@ grok 0.2.103 (89c3d36fb6f1) [stable]
 
 Pi 0.81.1 repeated the continuity and clean-exit lifecycle on 2026-07-23 after the Calm presentation changes.
 
-Pi same-process session-transition ownership was verified on 2026-07-28 against the tracked extension with a faithful in-process factory rebind (module cache retained, real arm children):
+Pi same-process session-transition ownership was verified on 2026-07-27 against the tracked extension with a faithful in-process factory rebind (module cache retained, real arm children):
 
 ```sh
 pi --version

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -121,10 +121,23 @@ grok 0.2.103 (89c3d36fb6f1) [stable]
 
 Pi 0.81.1 repeated the continuity and clean-exit lifecycle on 2026-07-23 after the Calm presentation changes.
 
+Pi same-process session-transition ownership was verified on 2026-07-28 against the tracked extension with a faithful in-process factory rebind (module cache retained, real arm children):
+
+```sh
+pi --version
+tests/fm-pi-watch-extension.test.sh
+tests/fm-pi-primary-types.test.sh
+```
+
+Observed guarantee: after ordinary `session_shutdown` for `/new`, `/resume`, and `/fork`, plus same-instance shutdown-plus-start, the replacement generation armed again without a Pi restart and without the `watcher: not armed - Pi session is shutting down` refusal.
+Stale prior-generation tool callbacks could not mutate the active child, repeated transitions kept exactly one live arm cycle, and terminal `quit` still refused late rearm.
+Plain Pi and pi-signed share the same tracked `.pi/extensions/fm-primary-pi-watch.ts` path, so both inherit the generation owner; other primary harnesses are not applicable because they do not use this Pi extension lifecycle.
+
 Deterministic entry points:
 
 ```sh
 tests/fm-pi-watch-extension.test.sh
+tests/fm-pi-primary-types.test.sh
 tests/fm-watcher-lock.test.sh
 tests/fm-subagent-pretool-check.test.sh
 tests/fm-claude-stop-autoarm.test.sh

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -8,6 +8,9 @@ Must-work continuity now lives above that process boundary instead of depending 
 Pi's `.pi/extensions/fm-primary-pi-watch.ts` and OpenCode's `.opencode/plugins/fm-primary-watch-arm.js` own continuous re-arm after an actionable child close.
 Each adapter starts the next arm before delivering the wake prompt, checks current session-lock ownership at launch, preserves one child or scheduled retry at a time, and applies bounded exponential retry after an unexpected or failed close.
 A failed follow-up never cancels continuity restoration.
+Pi also owns same-process session replacement: ordinary `session_shutdown` for `/new`, `/resume`, `/fork`, or reload retires only that session generation, and the replacement session can arm again without restarting Pi.
+Only the active live generation may start, stop, rearm, or clear the arm child, so stale callbacks from a prior generation are no-ops and a real terminal quit still blocks late rearming.
+The generation-owner contract is stated once in `.pi/extensions/fm-primary-pi-watch.ts`.
 Claude's `.claude/settings.json` Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns routine tokenless re-arm.
 The hook fires on every Stop, and an eligible primary with supervision need admits one home-scoped owner that foregrounds `bin/fm-watch-arm.sh` inside the hook-owned process tree.
 A numeric session-lock owner that fails the shared `fm_harness_pid_alive` predicate is reclaimed through `bin/fm-lock.sh` before auto-arm state changes, while a live owner, absent lock, or malformed lock keeps the competing hook inert.
@@ -52,6 +55,7 @@ Only the watcher process touches `state/.last-watcher-beat`; no helper process c
 ## Regression coverage
 
 `tests/fm-pi-watch-extension.test.sh` checks Pi's first-cycle-or-explicit-repair tool metadata and ownership-based redundant-call no-ops, then simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
+The same suite covers ordinary same-process session replacement for `/new`, `/resume`, and `/fork`, same-instance shutdown-plus-start, stale prior-generation callbacks, repeated transitions with exactly one live cycle, disappearance of the shutting-down refusal after a valid replacement activates, and terminal quit still refusing late rearm.
 `tests/fm-watcher-lock.test.sh` covers verified-successor attach, the typed self-eviction failure, bounded and successor-linked lifecycle rows, and a SIGSTOP counterfactual that distinguishes a live PID from a stale beacon before classifying termination.
 `tests/fm-subagent-pretool-check.test.sh` proves Claude retains only the non-status Bash seatbelts.
 `tests/fm-claude-stop-autoarm.test.sh` covers the auto-arm's scope, stale and live session owners, unchanged AFK and need boundaries, single-flight, and exit-2 translation.

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -8,9 +8,7 @@ Must-work continuity now lives above that process boundary instead of depending 
 Pi's `.pi/extensions/fm-primary-pi-watch.ts` and OpenCode's `.opencode/plugins/fm-primary-watch-arm.js` own continuous re-arm after an actionable child close.
 Each adapter starts the next arm before delivering the wake prompt, checks current session-lock ownership at launch, preserves one child or scheduled retry at a time, and applies bounded exponential retry after an unexpected or failed close.
 A failed follow-up never cancels continuity restoration.
-Pi also owns same-process session replacement: ordinary `session_shutdown` for `/new`, `/resume`, `/fork`, or reload retires only that session generation, and the replacement session can arm again without restarting Pi.
-Only the active live generation may start, stop, rearm, or clear the arm child, so stale callbacks from a prior generation are no-ops and a real terminal quit still blocks late rearming.
-The generation-owner contract is stated once in `.pi/extensions/fm-primary-pi-watch.ts`.
+Pi same-process session replacement follows the generation-owner contract in `.pi/extensions/fm-primary-pi-watch.ts`.
 Claude's `.claude/settings.json` Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns routine tokenless re-arm.
 The hook fires on every Stop, and an eligible primary with supervision need admits one home-scoped owner that foregrounds `bin/fm-watch-arm.sh` inside the hook-owned process tree.
 A numeric session-lock owner that fails the shared `fm_harness_pid_alive` predicate is reclaimed through `bin/fm-lock.sh` before auto-arm state changes, while a live owner, absent lock, or malformed lock keeps the competing hook inert.

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -98,6 +98,10 @@ test_tracked_extension_present_and_self_hashing() {
   assert_contains "$text" 'details: result' "tracked extension tool is missing structured result details"
   assert_contains "$text" 'ctx.ui.notify' "tracked extension command does not notify through Pi's UI"
   assert_contains "$text" 'process.once("exit", cleanupOnProcessExit)' "tracked extension lacks clean-process-exit cleanup"
+  assert_contains "$text" "type SessionGeneration" "tracked extension lacks an explicit session-generation owner"
+  assert_contains "$text" "function activateGeneration" "tracked extension does not activate a live generation for replacement sessions"
+  assert_contains "$text" "function generationIsLive" "tracked extension does not gate arm mutations on the live generation"
+  assert_contains "$text" "watcher: not armed - Pi session is shutting down" "tracked extension missing the terminal shutdown refusal"
   assert_not_contains "$text" "[ -f config/x-mode.env ]" "tracked extension kept a repo-relative x-mode config path"
   pass "Pi primary watcher extension is tracked, self-hashing, and self-locating"
 }
@@ -932,6 +936,187 @@ EOF
   expect_code 0 "$status" "Pi watcher arm must distinguish owned, live-other, and missing or dead session locks"
   [ -z "$out" ] || fail "Pi lock-ownership arm test printed output: $out"
   pass "Pi watcher arm distinguishes all session lock ownership states"
+}
+
+test_pi_session_transition_generation_owner() {
+  local repo home plugin child_pid_file arm_log out status
+  repo="$TMP_ROOT/pi-session-transition-root"
+  home="$TMP_ROOT/pi-session-transition-home"
+  child_pid_file="$TMP_ROOT/pi-session-transition-child.pid"
+  arm_log="$TMP_ROOT/pi-session-transition-arm.log"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'watcher: started pid=%s\n' "$$"
+printf '%s\n' "$$" > "${FM_CHILD_PID_FILE:?}"
+printf 'arm pid=%s\n' "$$" >> "${FM_ARM_LOG:?}"
+trap 'exit 0' TERM INT
+while :; do sleep 0.2; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_CHILD_PID_FILE="$child_pid_file" FM_ARM_LOG="$arm_log" FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+function makePi() {
+  const handlers = new Map();
+  let tool = null;
+  const pi = {
+    on(event, handler) {
+      handlers.set(event, handler);
+    },
+    registerCommand() {},
+    registerTool(candidate) {
+      if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+    },
+    sendUserMessage: async () => {},
+    events: { on() {} },
+  };
+  return { pi, handlers, getTool: () => tool };
+}
+
+function pidAlive(pid) {
+  try {
+    process.kill(Number(pid), 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(pred, label, attempts = 250) {
+  for (let i = 0; i < attempts; i += 1) {
+    if (pred()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`timeout waiting for ${label}`);
+}
+
+function liveArmPids() {
+  if (!existsSync(process.env.FM_ARM_LOG)) return [];
+  return readFileSync(process.env.FM_ARM_LOG, "utf8")
+    .trim()
+    .split(/\n/)
+    .filter(Boolean)
+    .map((line) => {
+      const match = /pid=(\d+)/.exec(line);
+      return match ? match[1] : "";
+    })
+    .filter(Boolean)
+    .filter(pidAlive);
+}
+
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+
+const startup = makePi();
+mod.default(startup.pi);
+await startup.handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+const first = await startup.getTool().execute("startup", {}, undefined, undefined, {});
+if (!first.details?.ok || !String(first.details.message).includes("started Pi extension arm child")) {
+  throw new Error(`startup arm failed: ${JSON.stringify(first.details)}`);
+}
+await waitFor(() => existsSync(process.env.FM_CHILD_PID_FILE), "startup child");
+const startupChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+if (!pidAlive(startupChild)) throw new Error("startup child was not alive");
+const staleTool = startup.getTool();
+
+async function replaceSession(previous, reason) {
+  const previousChild = existsSync(process.env.FM_CHILD_PID_FILE)
+    ? readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim()
+    : "";
+  await previous.handlers.get("session_shutdown")?.({ type: "session_shutdown", reason }, {});
+  if (previousChild) {
+    await waitFor(() => !pidAlive(previousChild), `${reason} previous child exit`);
+  }
+  const next = makePi();
+  mod.default(next.pi);
+  await next.handlers.get("session_start")?.({
+    type: "session_start",
+    reason,
+    previousSessionFile: `/tmp/previous-${reason}.jsonl`,
+  }, {});
+  const armed = await next.getTool().execute(`arm-${reason}`, {}, undefined, undefined, {});
+  if (!armed.details?.ok) {
+    throw new Error(`${reason} replacement arm failed: ${JSON.stringify(armed.details)}`);
+  }
+  if (String(armed.details.message).includes("shutting down")) {
+    throw new Error(`${reason} replacement still refused with shutting-down latch`);
+  }
+  await waitFor(() => {
+    if (!existsSync(process.env.FM_CHILD_PID_FILE)) return false;
+    const child = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+    return child && child !== previousChild && pidAlive(child);
+  }, `${reason} replacement child`);
+  const live = liveArmPids();
+  if (live.length !== 1) {
+    throw new Error(`${reason} expected exactly one live arm child, got ${live.join(",") || "(none)"}`);
+  }
+  return next;
+}
+
+let current = await replaceSession(startup, "new");
+current = await replaceSession(current, "resume");
+current = await replaceSession(current, "fork");
+
+// Same bound instance: ordinary shutdown then session_start without a fresh factory.
+const sameInstanceChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+await current.handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "new" }, {});
+await waitFor(() => !pidAlive(sameInstanceChild), "same-instance previous child exit");
+await current.handlers.get("session_start")?.({ type: "session_start", reason: "new" }, {});
+const sameInstanceArm = await current.getTool().execute("same-instance", {}, undefined, undefined, {});
+if (!sameInstanceArm.details?.ok || String(sameInstanceArm.details.message).includes("shutting down")) {
+  throw new Error(`same-instance replacement arm failed: ${JSON.stringify(sameInstanceArm.details)}`);
+}
+await waitFor(() => {
+  if (!existsSync(process.env.FM_CHILD_PID_FILE)) return false;
+  const child = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+  return child !== sameInstanceChild && pidAlive(child);
+}, "same-instance replacement child");
+if (liveArmPids().length !== 1) {
+  throw new Error(`same-instance expected one live arm child, got ${liveArmPids().join(",")}`);
+}
+
+// Stale prior-generation callback must not stop, rearm, or clear the active generation.
+const activeChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+const stale = await staleTool.execute("stale-prior-generation", {}, undefined, undefined, {});
+if (stale.details?.ok !== false || !String(stale.details.message).includes("shutting down")) {
+  throw new Error(`stale prior generation did not refuse: ${JSON.stringify(stale.details)}`);
+}
+if (!pidAlive(activeChild)) throw new Error("active generation child died after stale callback");
+if (pidAlive(startupChild)) throw new Error("startup generation child was resurrected");
+if (liveArmPids().length !== 1 || liveArmPids()[0] !== activeChild) {
+  throw new Error(`stale callback mutated live arm set: ${liveArmPids().join(",")}`);
+}
+const redundant = await current.getTool().execute("redundant", {}, undefined, undefined, {});
+if (!redundant.details?.ok || !String(redundant.details.message).includes("unchanged")) {
+  throw new Error(`active generation lost single-flight ownership: ${JSON.stringify(redundant.details)}`);
+}
+
+// Repeated transitions keep exactly one live cycle and never revive the refusal.
+for (const reason of ["resume", "fork", "new", "resume"]) {
+  current = await replaceSession(current, reason);
+}
+
+// Real terminal shutdown still blocks late rearming.
+const finalChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+await current.handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+await waitFor(() => !pidAlive(finalChild), "terminal shutdown child exit");
+const quitArm = await current.getTool().execute("after-quit", {}, undefined, undefined, {});
+if (quitArm.details?.ok !== false || quitArm.details.message !== "watcher: not armed - Pi session is shutting down") {
+  throw new Error(`terminal quit must keep the shutting-down refusal: ${JSON.stringify(quitArm.details)}`);
+}
+if (liveArmPids().length !== 0) {
+  throw new Error(`terminal quit left live arm children: ${liveArmPids().join(",")}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi session transitions must rearm through an explicit generation owner"
+  [ -z "$out" ] || fail "Pi session-transition generation owner test printed output: $out"
+  pass "Pi session transitions use a generation owner across /new /resume /fork, stale callbacks, and quit"
 }
 
 test_pi_process_exit_cleanup_listener_lifecycle() {
@@ -2012,6 +2197,7 @@ test_pi_empty_close_retries_instead_of_disappearing
 test_pi_established_empty_close_honors_retry_limit
 test_pi_actionable_close_rechecks_session_lock
 test_pi_arm_distinguishes_session_lock_ownership
+test_pi_session_transition_generation_owner
 test_pi_process_exit_cleanup_listener_lifecycle
 test_pi_process_exit_cleanup_stops_arm_child
 test_opencode_primary_watch_plugin_static_wiring

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -1064,7 +1064,6 @@ current = await replaceSession(current, "fork");
 // Same bound instance: ordinary shutdown then session_start without a fresh factory.
 const sameInstanceChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
 await current.handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "new" }, {});
-await waitFor(() => !pidAlive(sameInstanceChild), "same-instance previous child exit");
 await current.handlers.get("session_start")?.({ type: "session_start", reason: "new" }, {});
 const sameInstanceArm = await current.getTool().execute("same-instance", {}, undefined, undefined, {});
 if (!sameInstanceArm.details?.ok || String(sameInstanceArm.details.message).includes("shutting down")) {
@@ -1075,6 +1074,7 @@ await waitFor(() => {
   const child = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
   return child !== sameInstanceChild && pidAlive(child);
 }, "same-instance replacement child");
+await waitFor(() => !pidAlive(sameInstanceChild), "same-instance previous child exit");
 if (liveArmPids().length !== 1) {
   throw new Error(`same-instance expected one live arm child, got ${liveArmPids().join(",")}`);
 }
@@ -1147,15 +1147,19 @@ if (process.listenerCount("exit") !== before + 1) {
   throw new Error("Pi extension did not install exactly one process-exit fallback");
 }
 await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, {});
-if (process.listenerCount("exit") !== before) {
-  throw new Error("session_shutdown did not remove the process-exit fallback");
+if (process.listenerCount("exit") !== before + 1) {
+  throw new Error("session_shutdown removed the process-lifetime exit fallback");
+}
+await handlers.get("session_start")?.({ type: "session_start" }, {});
+if (process.listenerCount("exit") !== before + 1) {
+  throw new Error("replacement activation duplicated the process-exit fallback");
 }
 EOF
 )
   status=$?
-  expect_code 0 "$status" "Pi cleanup fallback listener must install once and unregister on session shutdown"
+  expect_code 0 "$status" "Pi cleanup fallback listener must remain singular across session replacement"
   [ -z "$out" ] || fail "Pi listener-lifecycle test printed output: $out"
-  pass "Pi process-exit cleanup listener has a bounded lifecycle"
+  pass "Pi process-exit cleanup listener remains singular across session replacement"
 }
 
 test_pi_process_exit_cleanup_stops_arm_child() {
@@ -1169,18 +1173,21 @@ test_pi_process_exit_cleanup_stops_arm_child() {
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
-trap 'printf "cleaned\n" > "$FM_CLEANUP_LOG"; exit 0' TERM
+trap 'printf "%s\n" "$$" >> "$FM_CLEANUP_LOG"; exit 0' TERM
 printf '%s\n' "$$" > "$FM_CHILD_PID_FILE"
 while :; do sleep 1; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
   out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_CLEANUP_LOG="$cleanup_log" FM_CHILD_PID_FILE="$pid_file" node --input-type=module 2>&1 <<'EOF'
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 let tool = null;
+const handlers = new Map();
 const pi = {
-  on() {},
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
   registerCommand() {},
   registerTool(candidate) {
     if (candidate.name === "fm_watch_arm_pi") tool = candidate;
@@ -1195,19 +1202,31 @@ for (let i = 0; i < 250 && !existsSync(process.env.FM_CHILD_PID_FILE); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_CHILD_PID_FILE)) throw new Error("arm child did not start");
+const firstChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, {});
+await handlers.get("session_start")?.({ type: "session_start" }, {});
+await tool.execute("tool-call-replacement", {}, undefined, undefined, {});
+for (let i = 0; i < 250; i += 1) {
+  const currentChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+  if (currentChild !== firstChild) break;
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+if (readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim() === firstChild) {
+  throw new Error("replacement arm child did not start");
+}
 process.exit(0);
 EOF
 )
   status=$?
   expect_code 0 "$status" "Pi process exit must run the watcher cleanup fallback"
   [ -z "$out" ] || fail "Pi process-exit cleanup test printed output: $out"
+  pid=$(cat "$pid_file")
   i=0
-  while [ "$i" -lt 250 ] && [ ! -f "$cleanup_log" ]; do
+  while [ "$i" -lt 250 ] && ! grep -qx "$pid" "$cleanup_log" 2>/dev/null; do
     sleep 0.02
     i=$((i + 1))
   done
-  [ -f "$cleanup_log" ] || fail "Pi process-exit fallback did not deliver TERM to the arm child"
-  pid=$(cat "$pid_file")
+  grep -qx "$pid" "$cleanup_log" 2>/dev/null || fail "Pi process-exit fallback did not deliver TERM to the replacement arm child"
   if kill -0 "$pid" 2>/dev/null; then
     kill -TERM "$pid" 2>/dev/null || true
     fail "Pi arm child $pid survived process-exit cleanup"


### PR DESCRIPTION
## Intent

Fix Pi's same-process session-transition monitoring outage under task identity fm-pi-session-transition-watch-fix-r1 (originating public request req-IpYa4ft2DenpfvPprBjSvg). End users hit a multi-hour watcher outage while Pi stayed alive: after ordinary /new, /resume, or /fork, every arm attempt returned 'watcher: not armed - Pi session is shutting down' until Pi was restarted. Root cause established by isolated reproduction: module-level stopping in .pi/extensions/fm-primary-pi-watch.ts latched true on any session_shutdown, and Pi emits session_shutdown for ordinary same-process session replacement as well as quit, while the extension module/instance persists in-process. Fix introduces an explicit session-generation owner so only the active live generation may start/stop/rearm the arm child; replacement sessions can arm again without restarting Pi; stale prior-generation callbacks cannot mutate the active generation; real terminal quit still blocks late rearm. Keep the change narrow - no unrelated watcher redesign. Add regressions for /new /resume /fork equivalents, same-instance replacement, quit, stale callbacks, repeated single-cycle transitions, and refusal disappearance. Preserve reporter contribution in PR description without private machine details. Ship via no-mistakes to a green PR; do not merge.

## What Changed

- Replace the module-wide shutdown latch with per-session generation ownership so `/new`, `/resume`, `/fork`, and same-instance replacements can rearm monitoring without restarting Pi, while terminal quit still blocks late rearm.
- Isolate watcher children, retries, restoration callbacks, and process-exit cleanup by generation so stale callbacks cannot mutate the active session or create overlapping watcher cycles.
- Add documentation and regression coverage for replacement transitions, refusal recovery, stale callbacks, single-child ownership, repeated cycles, and terminal shutdown, based on public report `req-IpYa4ft2DenpfvPprBjSvg`.

## Risk Assessment

✅ Low: The follow-up creates a fresh generation on same-instance replacement, binds asynchronous mutations to their originating owner, preserves terminal refusal, and retains singular process-exit cleanup without broadening the watcher design.

## Testing

The focused watcher-extension suite passed, and an end-user-aligned lifecycle replay demonstrated that `/new`, `/resume`, and `/fork` each rearm without the shutdown refusal, stale callbacks cannot disturb the active watcher, and terminal quit still blocks rearm. Several supplemental harness setup attempts failed before product execution and were corrected; the final replay passed and produced the attached transcript. No visual artifact was needed because the changed surface is a Pi tool response and watcher-process lifecycle, which the CLI transcript directly captures.

<details>
<summary>Evidence: Pi session-transition lifecycle transcript</summary>

`After /new, /resume, and /fork: watcher armed with exactly one live child. Stale callback preserved the active child. Terminal quit refused rearm and left zero children.`

```text
startup: watcher: started Pi extension arm child 1; future ordinary re-arms are automatic; call fm_watch_arm_pi again only after a later notification says the cycle is missing, failed, or unhealthy
  live arm children: 1
after /new: watcher: started Pi extension arm child 1; future ordinary re-arms are automatic; call fm_watch_arm_pi again only after a later notification says the cycle is missing, failed, or unhealthy
  live arm children: 1
after /resume: watcher: started Pi extension arm child 1; future ordinary re-arms are automatic; call fm_watch_arm_pi again only after a later notification says the cycle is missing, failed, or unhealthy
  live arm children: 1
after /fork: watcher: started Pi extension arm child 1; future ordinary re-arms are automatic; call fm_watch_arm_pi again only after a later notification says the cycle is missing, failed, or unhealthy
  live arm children: 1
stale prior-session callback: watcher: not armed - Pi session is shutting down
  active child preserved: yes
after terminal quit: watcher: not armed - Pi session is shutting down
  live arm children: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `.pi/extensions/fm-primary-pi-watch.ts:455` - The required invariant &#34;stale prior-generation callbacks cannot mutate the active generation&#34; is not satisfied for Pi&#39;s actual same-instance replacement path. `session_start` reactivates the same `generation` object stopped by `session_shutdown`; therefore a prior child&#39;s delayed close, retry, or actionable-restoration continuation becomes live again and can schedule a retry, start a child, or send a stale wake into the replacement session. The regression hides this race by waiting for the old child to exit before firing `session_start` (test line 1067). Create a fresh generation at the session-transition boundary and ensure child callbacks retain their original generation token.
- ⚠️ `.pi/extensions/fm-primary-pi-watch.ts:455` - After the first `session_shutdown`, the process-exit cleanup listener is removed, but same-instance `session_start` reactivation does not restore it. A later process exit without another shutdown callback can therefore leave the replacement session&#39;s arm child running. Re-register the bounded exit listener when activating a replacement generation, or retain one generation-aware listener for the process lifetime.
- ℹ️ `docs/watcher-continuity.md:11` - These lines restate the full generation-owner contract immediately before claiming it is stated once in the extension, while the Pi protocol also names both files as contract owners. This violates the repository&#39;s one-owner rule and creates competing lifecycle definitions. Keep the full contract in one authoritative location and replace the other copies with concise cross-references.

🔧 Fix: Preserve Pi generation isolation and exit cleanup
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff b29621ba19a4d15b688ae277ca06b67f80baa365..0712a0057dfa5e96783373eedd9de16bf0f5cc0d` for the watcher extension and focused regressions.</code>
- `bash tests/fm-pi-watch-extension.test.sh`
- <code>Ran a focused Pi extension lifecycle harness covering startup, `/new`, `/resume`, `/fork`, stale prior-session callback isolation, single live-child ownership, and terminal quit; captured its transcript.</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
