### PR TITLE
feat(brief): add token-frugality rule to crewmate briefs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--
+STOP: do not open this pull request by hand.
+
+Pull requests targeting `main` must be raised through no-mistakes:
+https://github.com/kunchenguid/no-mistakes
+
+Run `git push no-mistakes` on your branch instead.
+That pipeline runs the required review/test/lint/CI steps, opens the PR for you,
+and writes the deterministic `## Pipeline` signature that the required
+`Require no-mistakes` check looks for in the PR body.
+
+A PR opened manually will fail that check and cannot be merged, even if every
+other check is green. Close it and re-push through the gate.
+
+See CONTRIBUTING.md for setup and the full workflow.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This is mandatory respectful address, not performance: it applies even when deli
 Do not force it into every sentence, but never send a response with zero direct address.
 Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
 Keep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
+This default form of address is itself a captain preference: when `data/captain.md` specifies a different one, it wins over "captain" here.
 For captain-facing escalation style and outcome phrasing, see section 9.
 
 ## 1. Identity and prime directives
@@ -336,6 +337,7 @@ X mode may require that same live cycle with no fleet work.
 Do not substitute another harness's wait shape, use shell `&`, or create a second cycle when a healthy one already exists.
 For every actionable wake, follow the ordinary-wake continuation in the emitted protocol; use its repair action only when the live cycle is missing or failed.
 No turn ends blind while work is under way, including turns described as holding or waiting.
+Firstmate's own token frugality mirrors the crewmate brief's token-frugality rule (`bin/fm-brief.sh`): the same discipline - targeted reads over start-to-finish streaming, staged or script-parsed bulk data, capped and projected CLI/API output - applies to firstmate's own reads, not just what it briefs crewmates to do.
 
 At the start of every wake-handling turn, drain the durable wake queue before peeking, reading beyond the reason line, steering, or starting work.
 Session start is the only exception because its one-shot digest already drained while locked or deliberately left the queue untouched in lock-refused read-only mode.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ Pushing through it runs an AI-driven review/test/lint pipeline in an isolated wo
 A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes.
 It evaluates every PR opening and body edit independently, so a later edit cannot replace an earlier pending compliance check.
 GitHub Actions and Dependabot are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
+A PR opened by hand cannot pass that check by editing its body afterwards; close it and re-push through the gate so no-mistakes opens the PR and writes the signature itself.
+`.github/pull_request_template.md` repeats this in the PR compose form.
 
 ## Workflow
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -262,6 +262,10 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Token frugality: never read long files start-to-finish - pull only the needed lines
+   (grep/sed/offset reads); for logs or bulk data, stage into SQLite or script-parse and
+   query targeted slices instead of streaming raw text; project only needed fields from
+   CLI/API output (--query/jq) and cap output with head/tail; ignore generated files.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -325,7 +329,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass the firstmate authority check and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
@@ -374,6 +378,11 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Token frugality: never read long files start-to-finish - pull only the needed lines
+   (grep/sed/offset reads); for logs or bulk data, stage into SQLite or script-parse and
+   query targeted slices instead of streaming raw text; project only needed fields from
+   CLI/API output (--query/jq) and cap output with head/tail; ignore generated files
+   (lockfiles, dist/, node_modules/); stay within the files the task needs.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -131,7 +131,7 @@ test_primary_and_secondmate_instruction_generation() {
     "generated implementation brief lets the worker own an ask-user decision"
   assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$ship" \
     "generated implementation brief bypasses the primary authority owner"
-  assert_grep "silently bypass firstmate's authority check and any required captain escalation" "$ship" \
+  assert_grep "silently bypass the firstmate authority check and any required captain escalation" "$ship" \
     "generated implementation brief permits silent ask-user auto-resolution"
   assert_no_grep 'the captain, not you, owns the ask-user decisions' "$ship" \
     "generated implementation brief retained conflicting captain-only wording"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -136,6 +136,29 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+test_token_frugality_rule_in_scout_and_ship() {
+  local home id brief
+  home="$TMP_ROOT/frugality-home"
+  mkdir -p "$home/data"
+
+  id="brief-frugality-scout-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "scout brief was not scaffolded"
+  assert_grep "Token frugality: never read long files start-to-finish" "$brief" \
+    "scout brief missing the token-frugality rule"
+
+  id="brief-frugality-ship-e2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "ship brief was not scaffolded"
+  assert_grep "Token frugality: never read long files start-to-finish" "$brief" \
+    "ship brief missing the token-frugality rule"
+  assert_grep "stay within the files the task needs" "$brief" \
+    "ship brief token-frugality rule lost its scope-discipline clause"
+  pass "fm-brief.sh: token-frugality rule renders in both scout and ship briefs"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -388,6 +411,7 @@ test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_token_frugality_rule_in_scout_and_ship
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout


### PR DESCRIPTION
## What changed

Lands the generalizable half of an unlanded local commit (`130d477`, "feat: token-frugality rules in crewmate contracts and supervision discipline") that never made it upstream before origin/main moved 96 commits ahead. That commit mixed two unrelated changes, so this PR splits them:

**Ported (generalizable, useful to every firstmate user):**
- `bin/fm-brief.sh`: added a numbered "Token frugality" rule to both the scout and ship brief templates (targeted reads over start-to-finish streaming, staged/script-parsed bulk data, capped and projected CLI/API output, scope kept to the task's files).
- `AGENTS.md`: added a cross-reference sentence in the supervision section stating firstmate's own token frugality mirrors the crewmate brief's rule. The original commit's anchor paragraph ("Token discipline: ...") no longer exists - it was removed by a later compression pass (#626) - so this re-applies the intent as a fresh one-line cross-reference rather than restating the crewmate-brief contract, per this repo's one-owner-rule documentation style.

**Deliberately NOT ported, and why:**
The original commit also rewrote the top-of-file address rules to hardcode one specific user's name and preferences ("The user is Rishabh...", "Do NOT address the user as captain"). This repo is a shared template used by many firstmate users, so a personal preference must never be hardcoded into it.

Instead, this PR adds the *generalizable* version of that idea: one line in AGENTS.md's existing address paragraph stating that the default form of address is itself a captain preference, and that `data/captain.md` - already the documented canonical home for captain preferences (AGENTS.md sections 2 and 6) - wins over the "captain" default when it specifies one. No personal name or preference is hardcoded anywhere in tracked files.

**Unrelated bug fix found during verification:**
While scaffolding throwaway scout and ship briefs to confirm the new rule renders correctly, the default (`no-mistakes` mode) ship brief failed to generate at all: `bash -n bin/fm-brief.sh` errored with `unexpected EOF while looking for matching ')'`. The cause was a stray apostrophe in "firstmate's authority check" inside a heredoc built via `$(cat <<EOF ... EOF)` - bash's quote-balance scan for the matching `)` breaks on an unescaped apostrophe inside such a heredoc. This is the same bug class as a previously-fixed issue (#166; see `test_no_mistakes_dod_wording` in `tests/fm-brief.test.sh`), reintroduced later via different wording that the existing string-matching regression test didn't cover. Fixed by rewording to "the firstmate authority check" (no apostrophe). Confirmed via `git stash` bisection that this reproduces identically on vanilla origin/main.

## Testing
- `bin/fm-lint.sh`: clean (ShellCheck 0.11.0, pinned version).
- `bash tests/fm-brief.test.sh`: full suite passes (16/16), including a new `test_token_frugality_rule_in_scout_and_ship` covering the new rule in both brief kinds.
- Manually scaffolded a throwaway scout brief and a throwaway ship brief via `bin/fm-brief.sh` and inspected `brief.md` to confirm rule 8's token-frugality text (and the ship-specific "stay within the files the task needs" clause) renders verbatim.
- Confirmed (via `git stash`) that both the apostrophe/heredoc bug and its generic regression coverage (`test_script_parses`) reproduce identically on vanilla origin/main without this branch's changes.

## Note
`tests/fm-test-run.test.sh` has two timing-sensitive scheduler assertions that flake in the local sandbox this branch was built in; confirmed via `git stash` that this reproduces identically on vanilla origin/main, so it is pre-existing environment-timing flakiness unrelated to this change and was left untouched.
