### PR TITLE
fix: re-own Kimi turn-end hook after config rewrite

### DIFF
--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -188,6 +188,21 @@ def expected_entry() -> dict:
     return tomllib.loads(block(BEGIN).decode("utf-8"))["hooks"][0]
 
 
+def type_strict_equal(left, right) -> bool:
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            type_strict_equal(left[key], right[key]) for key in left
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(
+            type_strict_equal(left_value, right_value)
+            for left_value, right_value in zip(left, right)
+        )
+    return left == right
+
+
 def line_spans(data: bytes):
     spans = []
     cursor = 0
@@ -218,7 +233,7 @@ def excision_matches(data: bytes, parsed: dict, start: int, end: int, index: int
         expected["hooks"] = survivors
     else:
         expected.pop("hooks", None)
-    return actual == expected
+    return type_strict_equal(actual, expected)
 
 
 def adopt_unmarked_region(data: bytes, parsed: dict):
@@ -233,7 +248,7 @@ def adopt_unmarked_region(data: bytes, parsed: dict):
     if len(referencing) != 1:
         return None
     index = referencing[0]
-    if hooks[index] != expected_entry():
+    if not type_strict_equal(hooks[index], expected_entry()):
         return None
     spans = line_spans(data)
     headers = [position for position, span in enumerate(spans) if HOOKS_HEADER.match(span[2])]

--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -7,6 +7,16 @@
 # and remove excises only that region. Missing, malformed, symlinked, partially
 # marked, or otherwise surprising config is refused without a config write.
 #
+# The Kimi CLI rewrites its own config.toml and drops comments, which erases the
+# region's comment markers while leaving the hook table itself intact. When the
+# markers are absent, the region is re-identified structurally: exactly one
+# [[hooks]] table whose parsed content equals Firstmate's own hook entry, whose
+# text span is confirmed by re-parsing the config with that span excised. That
+# span is then re-owned and re-marked in place, so repeated installs neither
+# refuse nor accumulate duplicate hook tables. A [[hooks]] table that references
+# fm-turn-end.sh but is not byte-for-byte Firstmate's own entry stays foreign and
+# is still refused.
+#
 # The installed Stop hook always exits 0 and stays silent. It reads cwd from the
 # hook payload, checks for a .fm-kimi-turnend pointer before registry work, and
 # touches a task turn-end marker only when the pointer names a Firstmate-created
@@ -69,6 +79,8 @@ BEGIN_OWNS_NEWLINE = BEGIN + b" (OWNS PRECEDING NEWLINE)"
 END = b"# END FIRSTMATE KIMI TURN-END HOOK"
 IDENTIFIER = b"FIRSTMATE KIMI TURN-END HOOK"
 HOOK_NAME = b"fm-turn-end.sh"
+HOOKS_HEADER = re.compile(rb"^[ \t]*\[\[[ \t]*hooks[ \t]*\]\][ \t]*(#.*)?$")
+TABLE_HEADER = re.compile(rb"^[ \t]*\[")
 TOKEN_NAME = re.compile(r"fm\.[A-Za-z0-9]{12}\Z")
 
 HOOK_BYTES = b'''#!/usr/bin/env bash
@@ -170,6 +182,81 @@ def block(marker: bytes) -> bytes:
     )
 
 
+def expected_entry() -> dict:
+    # The generated block is the single owner of the hook table's content; the
+    # structural fallback compares against whatever that block currently emits.
+    return tomllib.loads(block(BEGIN).decode("utf-8"))["hooks"][0]
+
+
+def line_spans(data: bytes):
+    spans = []
+    cursor = 0
+    total = len(data)
+    while cursor < total:
+        newline = data.find(b"\n", cursor)
+        if newline < 0:
+            spans.append((cursor, total, data[cursor:total]))
+            break
+        spans.append((cursor, newline + 1, data[cursor:newline]))
+        cursor = newline + 1
+    return spans
+
+
+def excision_matches(data: bytes, parsed: dict, start: int, end: int, index: int) -> bool:
+    # Confirm the located span really is that one hook table and nothing else:
+    # the config with the span removed must parse to the original document minus
+    # exactly that entry. Any scanning mistake fails this check instead of
+    # silently rewriting the captain's config.
+    try:
+        remainder = (data[:start] + data[end:]).decode("utf-8")
+        actual = tomllib.loads(remainder)
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return False
+    expected = dict(parsed)
+    survivors = [entry for position, entry in enumerate(parsed["hooks"]) if position != index]
+    if survivors:
+        expected["hooks"] = survivors
+    else:
+        expected.pop("hooks", None)
+    return actual == expected
+
+
+def adopt_unmarked_region(data: bytes, parsed: dict):
+    # Recover ownership after a Kimi config rewrite dropped the comment markers.
+    hooks = parsed.get("hooks") or []
+    referencing = [
+        position
+        for position, entry in enumerate(hooks)
+        if isinstance(entry, dict)
+        and any(isinstance(value, str) and HOOK_NAME.decode("utf-8") in value for value in entry.values())
+    ]
+    if len(referencing) != 1:
+        return None
+    index = referencing[0]
+    if hooks[index] != expected_entry():
+        return None
+    spans = line_spans(data)
+    headers = [position for position, span in enumerate(spans) if HOOKS_HEADER.match(span[2])]
+    if len(headers) != len(hooks):
+        return None
+    first = headers[index]
+    stop = len(spans)
+    for position in range(first + 1, len(spans)):
+        if TABLE_HEADER.match(spans[position][2]):
+            stop = position
+            break
+    last = first
+    for position in range(first + 1, stop):
+        body = spans[position][2].strip()
+        if body and not body.startswith(b"#"):
+            last = position
+    start = spans[first][0]
+    end = spans[last][1]
+    if not excision_matches(data, parsed, start, end, index):
+        return None
+    return start, end, BEGIN
+
+
 def without_region(data: bytes, region) -> bytes:
     prefix = data[: region[0]]
     suffix = data[region[1] :]
@@ -223,8 +310,10 @@ try:
     config_info = regular_not_symlink(CONFIG, "Kimi config")
     with open(CONFIG, "rb") as stream:
         original = stream.read()
-    parse_toml(original, "config.toml")
+    parsed = parse_toml(original, "config.toml")
     region = locate_region(original)
+    if region is None:
+        region = adopt_unmarked_region(original, parsed)
     outside = original if region is None else without_region(original, region)
     if HOOK_NAME in outside:
         refuse("config.toml references fm-turn-end.sh outside the Firstmate-owned region.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,7 +201,7 @@ For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under 
 For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install`, drops a per-task `.fm-kimi-turnend` pointer in the worktree, and records the matching private registry token for teardown.
 Kimi continues to use the captain's normal Kimi home, including the existing config, skills, and memory; Firstmate does not create an isolated Kimi home.
 The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, or surprising or when either tool requirement is unavailable.
-Its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
+[`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns the installer's exact config-edit ownership, recovery, and removal contract.
 For Pi and pi-signed secondmate launches, `fm-spawn.sh` starts the selected executable with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -75,6 +75,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - Kimi Code CLI 0.29.1 exposes only global `[[hooks]]` configuration in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
 - Kimi has no project-level hook configuration and remains outside the primary guard integrations above.
 - Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to edit only one marker-delimited Firstmate region in that global config and install a silent always-zero hook.
+- The Kimi CLI rewrites that global config and drops comments, so an unmarked region whose single hook table still matches Firstmate's own entry is re-identified structurally, re-owned, and re-marked in place instead of refusing or duplicating, while any hook table Firstmate does not own is still refused.
 - The hook remains inert unless the payload `cwd` contains a per-task token pointer that resolves through Firstmate's private registry to one `state/<id>.turn-ended` marker.
 - Installation refuses before writing unless `python3` with `tomllib` and `jq` are available.
 - If `jq` is removed after installation, the hook remains silent and exits 0, turn-end wakes stop, and Kimi crews fall back to idle detection.
@@ -84,7 +85,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 ## Regression coverage
 
 `tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, and Grok resume permission and recursion safety.
-`tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
+`tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, comment-stripping-rewrite re-ownership, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.
 [`verification/supervision.md`](verification/supervision.md#turn-end-guard) records the active cross-harness empirical evidence, including the 2026-07-24 Claude `asyncRewake` revalidation.

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -326,7 +326,7 @@ EOF
 
 test_kimi_hook_still_refuses_unmarked_foreign_hook_tables() {
   local home config before out rc case_name
-  for case_name in other-path extra-key duplicated inline-array; do
+  for case_name in other-path extra-key duplicated inline-array boolean-timeout float-timeout; do
     home="$TMP_ROOT/config-foreign-$case_name"
     config="$home/.kimi-code/config.toml"
     before="$home/before.toml"
@@ -369,6 +369,24 @@ EOF
       inline-array)
         cat > "$config" <<'EOF'
 hooks = [{ event = "Stop", matcher = "^$", command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true", timeout = 1 }]
+EOF
+        ;;
+      boolean-timeout)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = true
+EOF
+        ;;
+      float-timeout)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1.0
 EOF
         ;;
     esac

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -270,6 +270,120 @@ EOF
   pass "Kimi hook install is idempotent and removal restores every foreign config byte"
 }
 
+strip_toml_comments() {
+  # Reproduce the Kimi CLI's own config.toml rewrite, which normalizes the TOML
+  # and drops every comment while leaving the hook table itself intact.
+  local target=$1 scratch
+  scratch="$target.stripped"
+  sed '/^[[:space:]]*#/d' "$target" > "$scratch"
+  mv "$scratch" "$target"
+}
+
+test_kimi_hook_reowns_its_region_after_a_comment_stripping_rewrite() {
+  local home config original marked count
+  home="$TMP_ROOT/config-comment-stripped"
+  config="$home/.kimi-code/config.toml"
+  original="$home/original.toml"
+  marked="$home/marked.toml"
+  mkdir -p "$home/.kimi-code"
+  cat > "$config" <<'EOF'
+default_model = "kimi-k2"
+
+[ui]
+theme = "night"
+
+[[hooks]]
+event = "Stop"
+command = "printf foreign"
+
+[providers.example]
+model = "some/model"
+EOF
+  cp "$config" "$original"
+
+  HOME="$home" "$KIMI_HOOK" install || fail "Kimi hook install refused a fresh config"
+  assert_grep '# BEGIN FIRSTMATE KIMI TURN-END HOOK' "$config" "fresh install wrote no Firstmate marker"
+
+  strip_toml_comments "$config"
+  assert_not_contains "$(cat "$config")" 'BEGIN FIRSTMATE' "the simulated Kimi rewrite left a comment marker"
+  assert_contains "$(cat "$config")" 'fm-turn-end.sh' "the simulated Kimi rewrite dropped the hook table itself"
+
+  HOME="$home" "$KIMI_HOOK" install \
+    || fail "Kimi hook install refused its own hook table after the Kimi rewrite stripped the markers"
+  assert_grep '# BEGIN FIRSTMATE KIMI TURN-END HOOK' "$config" "re-install did not re-mark the adopted region"
+  count=$(grep -c '^\[\[hooks\]\]' "$config")
+  [ "$count" -eq 2 ] || fail "re-install after a comment-stripping rewrite left $count hook tables, expected 2"
+  cp "$config" "$marked"
+  HOME="$home" "$KIMI_HOOK" install || fail "install after region adoption stopped being idempotent"
+  cmp -s "$marked" "$config" || fail "install after region adoption changed config bytes"
+
+  strip_toml_comments "$config"
+  HOME="$home" "$KIMI_HOOK" remove || fail "Kimi hook removal refused its own unmarked region"
+  cmp -s "$original" "$config" \
+    || fail "removal of an unmarked Firstmate region did not restore every foreign config byte"
+  pass "Kimi hook re-owns its region after a comment-stripping config rewrite without duplicating it"
+}
+
+test_kimi_hook_still_refuses_unmarked_foreign_hook_tables() {
+  local home config before out rc case_name
+  for case_name in other-path extra-key duplicated inline-array; do
+    home="$TMP_ROOT/config-foreign-$case_name"
+    config="$home/.kimi-code/config.toml"
+    before="$home/before.toml"
+    mkdir -p "$home/.kimi-code"
+    case "$case_name" in
+      other-path)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash /captain/elsewhere/fm-turn-end.sh"
+timeout = 1
+EOF
+        ;;
+      extra-key)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1
+captain_owned = true
+EOF
+        ;;
+      duplicated)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1
+
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1
+EOF
+        ;;
+      inline-array)
+        cat > "$config" <<'EOF'
+hooks = [{ event = "Stop", matcher = "^$", command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true", timeout = 1 }]
+EOF
+        ;;
+    esac
+    cp "$config" "$before"
+    rc=0
+    out=$(HOME="$home" "$KIMI_HOOK" install 2>&1) || rc=$?
+    [ "$rc" -ne 0 ] || fail "install adopted an unowned hook table in the $case_name case"
+    assert_contains "$out" "outside the Firstmate-owned region" \
+      "the $case_name refusal lacked its concrete reason"
+    cmp -s "$before" "$config" || fail "the $case_name refusal changed config bytes"
+    assert_absent "$home/.kimi-code/fm-turn-end.sh" "the $case_name refusal wrote the hook script"
+  done
+  pass "Kimi hook install still refuses unmarked hook tables it does not own"
+}
+
 test_kimi_hook_remove_preserves_owned_newline_boundary() {
   local appended config expected home original
   home="$TMP_ROOT/config-owned-newline"
@@ -676,6 +790,8 @@ test_kimi_bordered_prompt_needs_no_override() {
 test_tracked_files_have_no_user_absolute_paths
 test_existing_launch_templates_are_byte_pinned
 test_kimi_hook_install_is_surgical_idempotent_and_removable
+test_kimi_hook_reowns_its_region_after_a_comment_stripping_rewrite
+test_kimi_hook_still_refuses_unmarked_foreign_hook_tables
 test_kimi_hook_remove_preserves_owned_newline_boundary
 test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config
 test_kimi_hook_install_refuses_without_jq


### PR DESCRIPTION
## Intent

Re-deliver, through the no-mistakes pipeline, the exact fix already written and reviewed in PR #1152 (Fixes #1064) so it satisfies the repository's required 'Require no-mistakes / PR must be raised via no-mistakes' check. PR #1152 was raised directly with a plain branch push, so it can never pass that gate; this branch re-delivers the same fix and will supersede it. It started byte-for-byte identical to #1152; the pipeline's review step then found a real type-strictness defect in that original fix and hardened it (see the Review and Test sections below), so `bin/fm-kimi-turnend-hook.sh` and `tests/fm-kimi-harness.test.sh` now intentionally differ from #1152 while `docs/turnend-guard.md` remains identical.

The underlying bug: the Kimi Code CLI rewrites its own ~/.kimi-code/config.toml and drops all comments. That erases the comment markers delimiting the Firstmate-owned region while leaving the [[hooks]] table itself intact, so bin/fm-kimi-turnend-hook.sh could no longer find its own region and refused to install (and a naive fix would have duplicated the hook table).

The fix adds a structural fallback in bin/fm-kimi-turnend-hook.sh: when the markers are absent, the region is re-identified structurally - exactly one [[hooks]] table whose parsed content equals Firstmate's own generated hook entry, with its text span confirmed by re-parsing the config with that span excised and requiring the result to equal the original document minus exactly that entry. The span is then re-owned and re-marked in place, so repeated installs neither refuse nor accumulate duplicate hook tables.

Deliberate decisions a reviewer reading only the diff would not know:
- Safety is deliberately conservative and fails closed. A [[hooks]] table that references fm-turn-end.sh but is not byte-for-byte Firstmate's own entry (different path, extra key, duplicated, or expressed as an inline array) stays foreign and is still refused without writing the config. Any scanning mistake fails the excision re-parse check rather than silently rewriting the captain's config. Returning None (refuse) on every ambiguity is intended, not an oversight.
- The generated block() is deliberately the single owner of the hook table's content; expected_entry() compares against whatever that block currently emits rather than restating the entry, per this repo's one-owner rule.
- Scope is intentionally narrow: only the unmarked-region adoption path, plus its regression coverage in tests/fm-kimi-harness.test.sh (comment-stripping rewrite re-ownership, idempotence after adoption, unmarked removal restoring every foreign byte, and four foreign-table refusal cases) and a one-line current-behavior note in docs/turnend-guard.md. This is a re-delivery, not a redesign - behavior must be preserved exactly as reviewed in #1152.

## What Changed

- Re-identify and re-mark the Firstmate-owned Kimi turn-end hook when Kimi rewrites its config and removes ownership comments, without duplicating hook tables.
- Fail closed for ambiguous or non-identical hook entries using type-strict structural equality, preserving foreign configuration during install and removal.
- Add regression coverage for re-ownership, idempotence, removal, and foreign-hook refusal, and update the configuration documentation.

## Risk Assessment

✅ Low: Captain, the recursive type-strict comparison fully closes the prior ownership loophole at both adoption and excision checks, with narrowly scoped regression coverage and no remaining material risks found.

## Testing

The initial harness attempt exposed a fixable Python-version setup issue; under installed Python 3.12 the full harness and end-to-end CLI recovery checks passed with direct transcript evidence, but exact comparison to PR #1152 failed for two files and demonstrated that restoring byte identity would reintroduce a fail-closed safety gap.

<details>
<summary>Evidence: End-to-end Kimi recovery transcript</summary>

```text
=== Real installer recovery after Kimi-style comment loss ===
original_sha256=1b7d9ada505530b926f26711b811958783282393c41fbf8d46a4484d766c79cc
fresh_install: marker_count=1 hook_table_count=2
after_kimi_rewrite: marker_count=0 hook_table_count=2 firstmate_entry_present=yes
base_commit_reinstall: rc=1 unchanged=yes message=fm-kimi-turnend-hook: refused: config.toml references fm-turn-end.sh outside the Firstmate-owned region.
target_reinstall: rc=0 marker_count=1 hook_table_count=2
target_second_reinstall: byte_identical=yes
unmarked_remove: rc=0 restored_sha256=1b7d9ada505530b926f26711b811958783282393c41fbf8d46a4484d766c79cc equals_original=yes hook_script_absent=yes registry_absent=yes

=== Foreign unmarked tables fail closed ===
different-path: rc=1 config_unchanged=yes hook_script_absent=yes message=fm-kimi-turnend-hook: refused: config.toml references fm-turn-end.sh outside the Firstmate-owned region.
extra-key: rc=1 config_unchanged=yes hook_script_absent=yes message=fm-kimi-turnend-hook: refused: config.toml references fm-turn-end.sh outside the Firstmate-owned region.
duplicated: rc=1 config_unchanged=yes hook_script_absent=yes message=fm-kimi-turnend-hook: refused: config.toml references fm-turn-end.sh outside the Firstmate-owned region.
inline-array: rc=1 config_unchanged=yes hook_script_absent=yes message=fm-kimi-turnend-hook: refused: config.toml references fm-turn-end.sh outside the Firstmate-owned region.
```
</details>
<details>
<summary>Evidence: PR #1152 versus target byte hashes</summary>

```text
PR #1152 head: 3668300acd4abf72b496b734aa7734933a87e69f
Target commit: 93b62af3d2758440ad6f61d373541d7866228fed
bin/fm-kimi-turnend-hook.sh
  pr1152_sha256=db9609c8bf7fe3a7b71a6bbe74bd3b2c5a1a5400bcaab6d1c0454d5576aa2ab6
  target_sha256=f811d1822f396cc432fa1e498acd31af2f01ddb0682bdfdc2b734599084bbeb2
  byte_identical=no
docs/turnend-guard.md
  pr1152_sha256=c1ef7a2fd649a08940025196519737b0c4c27601a49d9149d3fe4a6c9497d51f
  target_sha256=c1ef7a2fd649a08940025196519737b0c4c27601a49d9149d3fe4a6c9497d51f
  byte_identical=yes
tests/fm-kimi-harness.test.sh
  pr1152_sha256=92608b9796d3628c70625dd7a934ee99c3697020c332f6e9c66c3aa4bbbeef70
  target_sha256=cfa3ea26fe3e1405284109c8fdaa4f184380bf9a2345fd8e69dc0bf9d7dfc0a7
  byte_identical=no
```
</details>
<details>
<summary>Evidence: Exact PR #1152 versus target differences</summary>

```text
--- PR1152/bin/fm-kimi-turnend-hook.sh
+++ TARGET/bin/fm-kimi-turnend-hook.sh
@@ -188,6 +188,21 @@
     return tomllib.loads(block(BEGIN).decode("utf-8"))["hooks"][0]
 
 
+def type_strict_equal(left, right) -> bool:
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            type_strict_equal(left[key], right[key]) for key in left
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(
+            type_strict_equal(left_value, right_value)
+            for left_value, right_value in zip(left, right)
+        )
+    return left == right
+
+
 def line_spans(data: bytes):
     spans = []
     cursor = 0
@@ -218,7 +233,7 @@
         expected["hooks"] = survivors
     else:
         expected.pop("hooks", None)
-    return actual == expected
+    return type_strict_equal(actual, expected)
 
 
 def adopt_unmarked_region(data: bytes, parsed: dict):
@@ -233,7 +248,7 @@
     if len(referencing) != 1:
         return None
     index = referencing[0]
-    if hooks[index] != expected_entry():
+    if not type_strict_equal(hooks[index], expected_entry()):
         return None
     spans = line_spans(data)
     headers = [position for position, span in enumerate(spans) if HOOKS_HEADER.match(span[2])]
--- PR1152/tests/fm-kimi-harness.test.sh
+++ TARGET/tests/fm-kimi-harness.test.sh
@@ -326,7 +326,7 @@
 
 test_kimi_hook_still_refuses_unmarked_foreign_hook_tables() {
   local home config before out rc case_name
-  for case_name in other-path extra-key duplicated inline-array; do
+  for case_name in other-path extra-key duplicated inline-array boolean-timeout float-timeout; do
     home="$TMP_ROOT/config-foreign-$case_name"
     config="$home/.kimi-code/config.toml"
     before="$home/before.toml"
@@ -369,8 +369,26 @@
       inline-array)
         cat > "$config" <<'EOF'
 hooks = [{ event = "Stop", matcher = "^$", command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true", timeout = 1 }]
+EOF
+        ;;
+      boolean-timeout)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = true
 EOF
         ;;
+      float-timeout)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1.0
+EOF
+        ;;
     esac
     cp "$config" "$before"
     rc=0
```
</details>
<details>
<summary>Evidence: PR #1152 type-equality safety counterexample</summary>

```text
=== PR #1152 head counterexample to type-strict foreign-table refusal ===
timeout=true rc=0 refused=no config_unchanged=no marker_count=1 hook_script_written=yes output=<silent>
timeout=1.0 rc=0 refused=no config_unchanged=no marker_count=1 hook_script_written=yes output=<silent>
```
</details>
- Outcome: ⚠️ 1 error across 1 run (5m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-kimi-turnend-hook.sh:236` - `hooks[index] != expected_entry()` uses Python dict equality, where `True == 1` and `1.0 == 1`; an unmarked foreign hook with `timeout = true` or `timeout = 1.0` can therefore be adopted, rewritten, or deleted. This contradicts the required criterion that safety “fails closed” and non-identical entries “stay foreign.” Use recursive type-strict TOML equality and add boolean/float refusal coverage.

🔧 Fix: Harden Kimi hook ownership equality
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 `bin/fm-kimi-turnend-hook.sh:191` - The authoritative requirements conflict. The target adds type-strict comparison and two regression cases absent from PR #1152, so two of the required three files are not byte-identical. Reverting those additions would restore exact identity, but PR #1152 then silently adopts foreign entries with `timeout = true` or `timeout = 1.0`, violating the stated fail-closed ownership requirement. Decide whether exact PR identity or the additional safety hardening takes precedence.
- <code>Inspected `git diff fa0d85d00be145196d60eee5dffcbe18ab3af901..93b62af3d2758440ad6f61d373541d7866228fed`.</code>
- <code>Ran `/bin/bash tests/fm-kimi-harness.test.sh`; the initial attempt correctly refused because default Python 3.9 lacks `tomllib`.</code>
- <code>Retried with `PATH=&#34;/opt/homebrew/opt/python@3.12/libexec/bin:$PATH&#34; /bin/bash tests/fm-kimi-harness.test.sh`; the complete Kimi harness passed.</code>
- <code>Manually exercised real `install`/`remove` commands: reproduced the base refusal, recovered after comment stripping, confirmed two hook tables without duplication, confirmed repeat-install byte idempotence, and restored the original SHA-256 on unmarked removal.</code>
- `Manually verified different-path, extra-key, duplicated, and inline-array foreign hook tables refuse without modifying config or writing the hook script.`
- <code>Downloaded PR #1152 head `3668300acd4abf72b496b734aa7734933a87e69f` through the GitHub Contents API and compared all three files against target commit `93b62af3d2758440ad6f61d373541d7866228fed` using SHA-256 and `cmp -s`.</code>
- <code>Executed PR #1152’s installer against `timeout = true` and `timeout = 1.0` counterexamples; both were incorrectly adopted and rewritten.</code>
- <code>Verified `git status --porcelain=v1` is clean after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

