### PR TITLE
fix: re-own Kimi turn-end hook after config rewrite

### DIFF
--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -3,8 +3,8 @@
 #
 # This command is the sole owner of the text-level edit to
 # $HOME/.kimi-code/config.toml. It validates the existing TOML but never
-# serializes it: install adds or replaces one marker-delimited Firstmate region,
-# and remove excises only that region. Missing, malformed, symlinked, partially
+# serializes it: install adds or replaces one Firstmate-owned region, and remove
+# excises only that region. Missing, malformed, symlinked, partially
 # marked, or otherwise surprising config is refused without a config write.
 #
 # The Kimi CLI rewrites its own config.toml and drops comments, which erases the
@@ -14,7 +14,7 @@
 # text span is confirmed by re-parsing the config with that span excised. That
 # span is then re-owned and re-marked in place, so repeated installs neither
 # refuse nor accumulate duplicate hook tables. A [[hooks]] table that references
-# fm-turn-end.sh but is not byte-for-byte Firstmate's own entry stays foreign and
+# fm-turn-end.sh but does not parse to Firstmate's exact entry stays foreign and
 # is still refused.
 #
 # The installed Stop hook always exits 0 and stays silent. It reads cwd from the

--- a/bin/fm-kimi-turnend-hook.sh
+++ b/bin/fm-kimi-turnend-hook.sh
@@ -7,6 +7,16 @@
 # and remove excises only that region. Missing, malformed, symlinked, partially
 # marked, or otherwise surprising config is refused without a config write.
 #
+# The Kimi CLI rewrites its own config.toml and drops comments, which erases the
+# region's comment markers while leaving the hook table itself intact. When the
+# markers are absent, the region is re-identified structurally: exactly one
+# [[hooks]] table whose parsed content equals Firstmate's own hook entry, whose
+# text span is confirmed by re-parsing the config with that span excised. That
+# span is then re-owned and re-marked in place, so repeated installs neither
+# refuse nor accumulate duplicate hook tables. A [[hooks]] table that references
+# fm-turn-end.sh but is not byte-for-byte Firstmate's own entry stays foreign and
+# is still refused.
+#
 # The installed Stop hook always exits 0 and stays silent. It reads cwd from the
 # hook payload, checks for a .fm-kimi-turnend pointer before registry work, and
 # touches a task turn-end marker only when the pointer names a Firstmate-created
@@ -69,6 +79,8 @@ BEGIN_OWNS_NEWLINE = BEGIN + b" (OWNS PRECEDING NEWLINE)"
 END = b"# END FIRSTMATE KIMI TURN-END HOOK"
 IDENTIFIER = b"FIRSTMATE KIMI TURN-END HOOK"
 HOOK_NAME = b"fm-turn-end.sh"
+HOOKS_HEADER = re.compile(rb"^[ \t]*\[\[[ \t]*hooks[ \t]*\]\][ \t]*(#.*)?$")
+TABLE_HEADER = re.compile(rb"^[ \t]*\[")
 TOKEN_NAME = re.compile(r"fm\.[A-Za-z0-9]{12}\Z")
 
 HOOK_BYTES = b'''#!/usr/bin/env bash
@@ -170,6 +182,96 @@ def block(marker: bytes) -> bytes:
     )
 
 
+def expected_entry() -> dict:
+    # The generated block is the single owner of the hook table's content; the
+    # structural fallback compares against whatever that block currently emits.
+    return tomllib.loads(block(BEGIN).decode("utf-8"))["hooks"][0]
+
+
+def type_strict_equal(left, right) -> bool:
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            type_strict_equal(left[key], right[key]) for key in left
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(
+            type_strict_equal(left_value, right_value)
+            for left_value, right_value in zip(left, right)
+        )
+    return left == right
+
+
+def line_spans(data: bytes):
+    spans = []
+    cursor = 0
+    total = len(data)
+    while cursor < total:
+        newline = data.find(b"\n", cursor)
+        if newline < 0:
+            spans.append((cursor, total, data[cursor:total]))
+            break
+        spans.append((cursor, newline + 1, data[cursor:newline]))
+        cursor = newline + 1
+    return spans
+
+
+def excision_matches(data: bytes, parsed: dict, start: int, end: int, index: int) -> bool:
+    # Confirm the located span really is that one hook table and nothing else:
+    # the config with the span removed must parse to the original document minus
+    # exactly that entry. Any scanning mistake fails this check instead of
+    # silently rewriting the captain's config.
+    try:
+        remainder = (data[:start] + data[end:]).decode("utf-8")
+        actual = tomllib.loads(remainder)
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return False
+    expected = dict(parsed)
+    survivors = [entry for position, entry in enumerate(parsed["hooks"]) if position != index]
+    if survivors:
+        expected["hooks"] = survivors
+    else:
+        expected.pop("hooks", None)
+    return type_strict_equal(actual, expected)
+
+
+def adopt_unmarked_region(data: bytes, parsed: dict):
+    # Recover ownership after a Kimi config rewrite dropped the comment markers.
+    hooks = parsed.get("hooks") or []
+    referencing = [
+        position
+        for position, entry in enumerate(hooks)
+        if isinstance(entry, dict)
+        and any(isinstance(value, str) and HOOK_NAME.decode("utf-8") in value for value in entry.values())
+    ]
+    if len(referencing) != 1:
+        return None
+    index = referencing[0]
+    if not type_strict_equal(hooks[index], expected_entry()):
+        return None
+    spans = line_spans(data)
+    headers = [position for position, span in enumerate(spans) if HOOKS_HEADER.match(span[2])]
+    if len(headers) != len(hooks):
+        return None
+    first = headers[index]
+    stop = len(spans)
+    for position in range(first + 1, len(spans)):
+        if TABLE_HEADER.match(spans[position][2]):
+            stop = position
+            break
+    last = first
+    for position in range(first + 1, stop):
+        body = spans[position][2].strip()
+        if body and not body.startswith(b"#"):
+            last = position
+    start = spans[first][0]
+    end = spans[last][1]
+    if not excision_matches(data, parsed, start, end, index):
+        return None
+    return start, end, BEGIN
+
+
 def without_region(data: bytes, region) -> bytes:
     prefix = data[: region[0]]
     suffix = data[region[1] :]
@@ -223,8 +325,10 @@ try:
     config_info = regular_not_symlink(CONFIG, "Kimi config")
     with open(CONFIG, "rb") as stream:
         original = stream.read()
-    parse_toml(original, "config.toml")
+    parsed = parse_toml(original, "config.toml")
     region = locate_region(original)
+    if region is None:
+        region = adopt_unmarked_region(original, parsed)
     outside = original if region is None else without_region(original, region)
     if HOOK_NAME in outside:
         refuse("config.toml references fm-turn-end.sh outside the Firstmate-owned region.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -204,7 +204,7 @@ For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under 
 For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install`, drops a per-task `.fm-kimi-turnend` pointer in the worktree, and records the matching private registry token for teardown.
 Kimi continues to use the captain's normal Kimi home, including the existing config, skills, and memory; Firstmate does not create an isolated Kimi home.
 The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, or surprising or when either tool requirement is unavailable.
-Its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
+[`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns the installer's exact config-edit ownership, recovery, and removal contract.
 For Pi and pi-signed secondmate launches, `fm-spawn.sh` starts the selected executable with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,8 +203,7 @@ Those inherited values are defaults and rules only; `fm-spawn` still permits a c
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 For Kimi crews, `fm-spawn.sh` runs `fm-kimi-turnend-hook.sh install`, drops a per-task `.fm-kimi-turnend` pointer in the worktree, and records the matching private registry token for teardown.
 Kimi continues to use the captain's normal Kimi home, including the existing config, skills, and memory; Firstmate does not create an isolated Kimi home.
-The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, or surprising or when either tool requirement is unavailable.
-[`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns the installer's exact config-edit ownership, recovery, and removal contract.
+[`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns the Kimi installer's prerequisites and exact config-edit ownership, recovery, and removal contract.
 For Pi and pi-signed secondmate launches, `fm-spawn.sh` starts the selected executable with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -82,6 +82,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - Kimi Code CLI 0.29.1 exposes only global `[[hooks]]` configuration in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
 - Kimi has no project-level hook configuration and remains outside the primary guard integrations above.
 - Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to edit only one marker-delimited Firstmate region in that global config and install a silent always-zero hook.
+- The Kimi CLI rewrites that global config and drops comments, so an unmarked region whose single hook table still matches Firstmate's own entry is re-identified structurally, re-owned, and re-marked in place instead of refusing or duplicating, while any hook table Firstmate does not own is still refused.
 - The hook remains inert unless the payload `cwd` contains a per-task token pointer that resolves through Firstmate's private registry to one `state/<id>.turn-ended` marker.
 - Installation refuses before writing unless `python3` with `tomllib` and `jq` are available.
 - If `jq` is removed after installation, the hook remains silent and exits 0, turn-end wakes stop, and Kimi crews fall back to idle detection.
@@ -91,7 +92,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 ## Regression coverage
 
 `tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
-`tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
+`tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, comment-stripping-rewrite re-ownership, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.
 [`verification/supervision.md`](verification/supervision.md#turn-end-guard) records the active cross-harness empirical evidence, including the 2026-07-24 Claude `asyncRewake` revalidation.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -83,6 +83,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - Kimi has no project-level hook configuration and remains outside the primary guard integrations above.
 - Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to edit only one marker-delimited Firstmate region in that global config and install a silent always-zero hook.
 - The Kimi CLI rewrites that global config and drops comments, so an unmarked region whose single hook table still matches Firstmate's own entry is re-identified structurally, re-owned, and re-marked in place instead of refusing or duplicating, while any hook table Firstmate does not own is still refused.
+- The remove action excises only the marker-delimited Firstmate region and removes Firstmate's own hook files, leaving every foreign config byte and any hook table Firstmate does not own untouched.
 - The hook remains inert unless the payload `cwd` contains a per-task token pointer that resolves through Firstmate's private registry to one `state/<id>.turn-ended` marker.
 - Installation refuses before writing unless `python3` with `tomllib` and `jq` are available.
 - If `jq` is removed after installation, the hook remains silent and exits 0, turn-end wakes stop, and Kimi crews fall back to idle detection.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -81,11 +81,12 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - OpenCode headless mode and untrusted Grok project hooks remain fail-open at the host boundary.
 - Kimi Code CLI 0.29.1 exposes only global `[[hooks]]` configuration in `~/.kimi-code/config.toml`, including a `Stop` event with snake_case payload fields `hook_event_name`, `session_id`, `cwd`, and `stop_hook_active`.
 - Kimi has no project-level hook configuration and remains outside the primary guard integrations above.
-- Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to edit only one marker-delimited Firstmate region in that global config and install a silent always-zero hook.
-- The Kimi CLI rewrites that global config and drops comments, so an unmarked region whose single hook table still matches Firstmate's own entry is re-identified structurally, re-owned, and re-marked in place instead of refusing or duplicating, while any hook table Firstmate does not own is still refused.
-- The remove action excises only the marker-delimited Firstmate region and removes Firstmate's own hook files, leaving every foreign config byte and any hook table Firstmate does not own untouched.
+- Captain-approved Kimi crew wake support uses `bin/fm-kimi-turnend-hook.sh` to install a silent always-zero hook in one Firstmate-owned region of that global config.
+- The command requires an existing regular non-symlink config and `python3` with `tomllib`, while installation additionally requires `jq`; it validates but never serializes the captain's TOML and refuses without a config write when the config is missing, malformed, symlinked, partially marked, or otherwise surprising or when a required tool is unavailable.
+- The Kimi CLI rewrites that global config and drops comments, so an unmarked `[[hooks]]` table is re-identified structurally only when it is the sole hook entry referencing `fm-turn-end.sh`, its parsed content exactly matches Firstmate's own entry, and excising its text span yields the original document minus that entry.
+- Install then re-marks that recovered region in place instead of refusing or duplicating, while remove excises either the recovered unmarked region or the marker-delimited region and removes Firstmate's own hook files.
+- Multiple hook entries referencing `fm-turn-end.sh` or one that does not parse to Firstmate's exact entry are refused as foreign; unrelated hook tables and every other foreign config byte remain untouched.
 - The hook remains inert unless the payload `cwd` contains a per-task token pointer that resolves through Firstmate's private registry to one `state/<id>.turn-ended` marker.
-- Installation refuses before writing unless `python3` with `tomllib` and `jq` are available.
 - If `jq` is removed after installation, the hook remains silent and exits 0, turn-end wakes stop, and Kimi crews fall back to idle detection.
 - Unreadable hook input remains fail-open.
 - No harness adapter uses a shell ampersand to manufacture supervision.

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -962,14 +962,16 @@ test_teardown_conformance_old_vs_new() {
 
   expect_code 0 "$rc_old" "old fm-teardown.sh (scout, report present) should succeed"$'\n'"$out_old"
   expect_code 0 "$rc_new" "new fm-teardown.sh (scout, report present) should succeed"$'\n'"$out_new"
-  diff -u "$log_old" "$log_new" > "$TMP_ROOT/teardown-diff.txt" 2>&1 \
-    || fail "fm-teardown.sh: tmux+treehouse command log differs baseline vs current"$'\n'"$(cat "$TMP_ROOT/teardown-diff.txt")"
   assert_contains "$(cat "$log_new")" "treehouse"$'\x1f''return'$'\x1f''--force'$'\x1f'"$wt" \
     "teardown did not call treehouse return --force <worktree>"
+  if ! grep -Fqx -- "tmux"$'\x1f''kill-window'$'\x1f''-t'$'\x1f'"firstmate:fm-$id" "$log_old" \
+    && ! grep -Fqx -- "tmux"$'\x1f''kill-window'$'\x1f''-t'$'\x1f'"=firstmate:=fm-$id" "$log_old"; then
+    fail "baseline teardown fixture did not exercise tmux cleanup for the task"$'\n'"$(cat "$log_old")"
+  fi
   assert_contains "$(cat "$log_new")" "tmux"$'\x1f''kill-window'$'\x1f''-t'$'\x1f'"=firstmate:=fm-$id" \
     "teardown did not call tmux kill-window with exact session and window selectors"
 
-  pass "fm-teardown.sh: baseline and current cleanup match and use exact tmux selectors"
+  pass "fm-teardown.sh: treehouse return remains compatible while tmux cleanup uses exact selectors"
 }
 
 # --- backend selection loudly refuses an unknown backend --------------------

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -962,14 +962,14 @@ test_teardown_conformance_old_vs_new() {
 
   expect_code 0 "$rc_old" "old fm-teardown.sh (scout, report present) should succeed"$'\n'"$out_old"
   expect_code 0 "$rc_new" "new fm-teardown.sh (scout, report present) should succeed"$'\n'"$out_new"
+  diff -u "$log_old" "$log_new" > "$TMP_ROOT/teardown-diff.txt" 2>&1 \
+    || fail "fm-teardown.sh: tmux+treehouse command log differs baseline vs current"$'\n'"$(cat "$TMP_ROOT/teardown-diff.txt")"
   assert_contains "$(cat "$log_new")" "treehouse"$'\x1f''return'$'\x1f''--force'$'\x1f'"$wt" \
     "teardown did not call treehouse return --force <worktree>"
-  assert_contains "$(cat "$log_old")" "tmux"$'\x1f''kill-window'$'\x1f''-t'$'\x1f'"firstmate:fm-$id" \
-    "legacy teardown fixture did not exercise tmux's permissive target selector"
   assert_contains "$(cat "$log_new")" "tmux"$'\x1f''kill-window'$'\x1f''-t'$'\x1f'"=firstmate:=fm-$id" \
     "teardown did not call tmux kill-window with exact session and window selectors"
 
-  pass "fm-teardown.sh: treehouse return remains compatible while tmux cleanup uses exact selectors"
+  pass "fm-teardown.sh: baseline and current cleanup match and use exact tmux selectors"
 }
 
 # --- backend selection loudly refuses an unknown backend --------------------

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -270,6 +270,138 @@ EOF
   pass "Kimi hook install is idempotent and removal restores every foreign config byte"
 }
 
+strip_toml_comments() {
+  # Reproduce the Kimi CLI's own config.toml rewrite, which normalizes the TOML
+  # and drops every comment while leaving the hook table itself intact.
+  local target=$1 scratch
+  scratch="$target.stripped"
+  sed '/^[[:space:]]*#/d' "$target" > "$scratch"
+  mv "$scratch" "$target"
+}
+
+test_kimi_hook_reowns_its_region_after_a_comment_stripping_rewrite() {
+  local home config original marked count
+  home="$TMP_ROOT/config-comment-stripped"
+  config="$home/.kimi-code/config.toml"
+  original="$home/original.toml"
+  marked="$home/marked.toml"
+  mkdir -p "$home/.kimi-code"
+  cat > "$config" <<'EOF'
+default_model = "kimi-k2"
+
+[ui]
+theme = "night"
+
+[[hooks]]
+event = "Stop"
+command = "printf foreign"
+
+[providers.example]
+model = "some/model"
+EOF
+  cp "$config" "$original"
+
+  HOME="$home" "$KIMI_HOOK" install || fail "Kimi hook install refused a fresh config"
+  assert_grep '# BEGIN FIRSTMATE KIMI TURN-END HOOK' "$config" "fresh install wrote no Firstmate marker"
+
+  strip_toml_comments "$config"
+  assert_not_contains "$(cat "$config")" 'BEGIN FIRSTMATE' "the simulated Kimi rewrite left a comment marker"
+  assert_contains "$(cat "$config")" 'fm-turn-end.sh' "the simulated Kimi rewrite dropped the hook table itself"
+
+  HOME="$home" "$KIMI_HOOK" install \
+    || fail "Kimi hook install refused its own hook table after the Kimi rewrite stripped the markers"
+  assert_grep '# BEGIN FIRSTMATE KIMI TURN-END HOOK' "$config" "re-install did not re-mark the adopted region"
+  count=$(grep -c '^\[\[hooks\]\]' "$config")
+  [ "$count" -eq 2 ] || fail "re-install after a comment-stripping rewrite left $count hook tables, expected 2"
+  cp "$config" "$marked"
+  HOME="$home" "$KIMI_HOOK" install || fail "install after region adoption stopped being idempotent"
+  cmp -s "$marked" "$config" || fail "install after region adoption changed config bytes"
+
+  strip_toml_comments "$config"
+  HOME="$home" "$KIMI_HOOK" remove || fail "Kimi hook removal refused its own unmarked region"
+  cmp -s "$original" "$config" \
+    || fail "removal of an unmarked Firstmate region did not restore every foreign config byte"
+  pass "Kimi hook re-owns its region after a comment-stripping config rewrite without duplicating it"
+}
+
+test_kimi_hook_still_refuses_unmarked_foreign_hook_tables() {
+  local home config before out rc case_name
+  for case_name in other-path extra-key duplicated inline-array boolean-timeout float-timeout; do
+    home="$TMP_ROOT/config-foreign-$case_name"
+    config="$home/.kimi-code/config.toml"
+    before="$home/before.toml"
+    mkdir -p "$home/.kimi-code"
+    case "$case_name" in
+      other-path)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash /captain/elsewhere/fm-turn-end.sh"
+timeout = 1
+EOF
+        ;;
+      extra-key)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1
+captain_owned = true
+EOF
+        ;;
+      duplicated)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1
+
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1
+EOF
+        ;;
+      inline-array)
+        cat > "$config" <<'EOF'
+hooks = [{ event = "Stop", matcher = "^$", command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true", timeout = 1 }]
+EOF
+        ;;
+      boolean-timeout)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = true
+EOF
+        ;;
+      float-timeout)
+        cat > "$config" <<'EOF'
+[[hooks]]
+event = "Stop"
+matcher = "^$"
+command = "bash \"$HOME/.kimi-code/fm-turn-end.sh\" >/dev/null 2>&1 || true"
+timeout = 1.0
+EOF
+        ;;
+    esac
+    cp "$config" "$before"
+    rc=0
+    out=$(HOME="$home" "$KIMI_HOOK" install 2>&1) || rc=$?
+    [ "$rc" -ne 0 ] || fail "install adopted an unowned hook table in the $case_name case"
+    assert_contains "$out" "outside the Firstmate-owned region" \
+      "the $case_name refusal lacked its concrete reason"
+    cmp -s "$before" "$config" || fail "the $case_name refusal changed config bytes"
+    assert_absent "$home/.kimi-code/fm-turn-end.sh" "the $case_name refusal wrote the hook script"
+  done
+  pass "Kimi hook install still refuses unmarked hook tables it does not own"
+}
+
 test_kimi_hook_remove_preserves_owned_newline_boundary() {
   local appended config expected home original
   home="$TMP_ROOT/config-owned-newline"
@@ -676,6 +808,8 @@ test_kimi_bordered_prompt_needs_no_override() {
 test_tracked_files_have_no_user_absolute_paths
 test_existing_launch_templates_are_byte_pinned
 test_kimi_hook_install_is_surgical_idempotent_and_removable
+test_kimi_hook_reowns_its_region_after_a_comment_stripping_rewrite
+test_kimi_hook_still_refuses_unmarked_foreign_hook_tables
 test_kimi_hook_remove_preserves_owned_newline_boundary
 test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config
 test_kimi_hook_install_refuses_without_jq


### PR DESCRIPTION
## Intent

Fix #1064: Kimi crew turn-end wakes must keep working after the Kimi CLI rewrites `~/.kimi-code/config.toml` and strips the comments that marked Firstmate's hook region. The installer must structurally re-identify and re-mark only an exact Firstmate-owned hook table, while refusing foreign or ambiguous hook configuration without modifying it.

## What Changed

- Re-identify an exact unmarked Firstmate Kimi hook after comment-stripping config rewrites, then re-mark it in place without creating duplicates.
- Preserve fail-closed handling for modified, duplicated, inline, or foreign hook tables.
- Add colocated regression coverage for re-ownership, idempotence, removal, and foreign-hook refusal.
- Make `docs/turnend-guard.md` the single owner of the Kimi installer's prerequisites and config-edit/removal contract, with `docs/configuration.md` pointing to it.
- Make the teardown conformance fixture accept either a historical permissive baseline selector or an already-hardened exact baseline selector, while still requiring the current implementation's exact tmux selector.

## Risk Assessment

Low. The hook recovery path requires a type-strict exact structural match and validates the candidate span by reparsing the config after excision. Ambiguous or captain-owned entries remain untouched and are refused. The fixture-only CI correction changes no production behavior.

## Testing

- `bash tests/fm-backend.test.sh`
- `env PATH="/opt/homebrew/opt/python@3.12/libexec/bin:$PATH" bash tests/fm-kimi-harness.test.sh`
- `bin/fm-lint.sh`
- `bin/fm-doc-audience-check.sh`
- `git diff --check`

Fixes #1064