### PR TITLE
Re-exec fm-brief.sh under bash 5+ when env resolves to macOS 3.2

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -47,6 +47,33 @@
 # Refuses to overwrite an existing brief.
 set -eu
 
+# Re-exec under bash 5+ when env resolves to macOS /bin/bash 3.2. Ship-mode DOD
+# heredocs inside command substitution are unparseable on 3.2; this block runs
+# before that syntax is ever parsed.
+if [ "${FM_BASH_REEXEC:-}" = 1 ] && [ "${BASH_VERSINFO[0]}" -lt 5 ]; then
+  echo "error: fm-brief.sh: FM_BASH_REEXEC guard tripped — re-exec under a modern bash failed or looped" >&2
+  echo "error: install bash 5+ with: brew install bash" >&2
+  exit 1
+fi
+if [ "${BASH_VERSINFO[0]}" -lt 5 ]; then
+  modern_bash=
+  # shellcheck disable=SC2086  # deliberate word-split on FM_BASH_REEXEC_CANDIDATES
+  for candidate in ${FM_BASH_REEXEC_CANDIDATES:-/opt/homebrew/bin/bash /usr/local/bin/bash}; do
+    if [ -x "$candidate" ]; then
+      modern_bash=$candidate
+      break
+    fi
+  done
+  if [ -z "$modern_bash" ]; then
+    echo "error: fm-brief.sh requires bash 5+ but env bash is ${BASH_VERSION} (${BASH:-unknown})" >&2
+    echo "error: no modern bash found in /opt/homebrew/bin/bash or /usr/local/bin/bash" >&2
+    echo "error: install with: brew install bash" >&2
+    exit 1
+  fi
+  export FM_BASH_REEXEC=1
+  exec "$modern_bash" "$0" "$@"
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
@@ -103,48 +130,6 @@ shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
   printf "'"
-}
-
-fm_brief_dod_direct_pr() {
-  cat <<'EOF'
-# Definition of done
-This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
-Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
-EOF
-}
-
-fm_brief_dod_local_only() {
-  cat <<EOF
-# Definition of done
-This project ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
-Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
-The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
-EOF
-}
-
-fm_brief_dod_no_mistakes() {
-  cat <<'EOF'
-# Definition of done
-The task is complete only when committed on your branch.
-When you believe it is complete, append `done: {summary}` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
-
-You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
-Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
-
-Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
-  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
-  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.
-
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
-EOF
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
@@ -323,29 +308,55 @@ read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
 
-# Build delivery-mode Definition-of-done text via functions. Bash 3.2's lexer
-# mishandles `VAR=$(cat <<EOF ... EOF)` when a later outer `cat > file <<EOF`
-# follows; function-returned heredocs avoid that parse bug.
-DOD_DIRECT_PR=$(fm_brief_dod_direct_pr)
-DOD_LOCAL_ONLY=$(fm_brief_dod_local_only)
-DOD_NO_MISTAKES=$(fm_brief_dod_no_mistakes)
-
 case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD="$DOD_DIRECT_PR"
+    DOD=$(cat <<EOF
+# Definition of done
+This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
+The task is complete only when committed on your branch.
+When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+EOF
+)
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD="$DOD_LOCAL_ONLY"
+    DOD=$(cat <<EOF
+# Definition of done
+This project ships **local-only**: no remote, no PR, no pipeline.
+The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
+When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
+EOF
+)
     ;;
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD="$DOD_NO_MISTAKES"
+    DOD=$(cat <<EOF
+# Definition of done
+The task is complete only when committed on your branch.
+When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+
+You drive no-mistakes by responding to its gates, not by implementing fixes.
+Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+
+Two firstmate-specific rules layer on top of that guidance:
+- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
+  Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
+  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
+- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+EOF
+)
     ;;
 esac
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -105,6 +105,48 @@ shell_quote() {
   printf "'"
 }
 
+fm_brief_dod_direct_pr() {
+  cat <<'EOF'
+# Definition of done
+This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
+The task is complete only when committed on your branch.
+When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
+Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+EOF
+}
+
+fm_brief_dod_local_only() {
+  cat <<EOF
+# Definition of done
+This project ships **local-only**: no remote, no PR, no pipeline.
+The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
+When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
+EOF
+}
+
+fm_brief_dod_no_mistakes() {
+  cat <<'EOF'
+# Definition of done
+The task is complete only when committed on your branch.
+When you believe it is complete, append `done: {summary}` to the status file and stop.
+Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+
+You drive no-mistakes by responding to its gates, not by implementing fixes.
+Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
+Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+
+Two firstmate-specific rules layer on top of that guidance:
+- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
+  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
+  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
+- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.
+
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
+EOF
+}
+
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
 
 if [ "$KIND" = secondmate ]; then
@@ -281,55 +323,29 @@ read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
 
+# Build delivery-mode Definition-of-done text via functions. Bash 3.2's lexer
+# mishandles `VAR=$(cat <<EOF ... EOF)` when a later outer `cat > file <<EOF`
+# follows; function-returned heredocs avoid that parse bug.
+DOD_DIRECT_PR=$(fm_brief_dod_direct_pr)
+DOD_LOCAL_ONLY=$(fm_brief_dod_local_only)
+DOD_NO_MISTAKES=$(fm_brief_dod_no_mistakes)
+
 case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
-EOF
-)
+    DOD="$DOD_DIRECT_PR"
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
-Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
-The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
-EOF
-)
+    DOD="$DOD_LOCAL_ONLY"
     ;;
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
-
-You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
-Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
-
-Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
-  Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
-  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
-
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
-EOF
-)
+    DOD="$DOD_NO_MISTAKES"
     ;;
 esac
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -26,6 +26,11 @@ test_script_parses() {
   out=$(bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
   expect_code 0 "$rc" "bash -n bin/fm-brief.sh must parse cleanly (got: $out)"
   [ -z "$out" ] || fail "bash -n bin/fm-brief.sh emitted unexpected output: $out"
+  if [ -x /bin/bash ]; then
+    out=$(/bin/bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
+    expect_code 0 "$rc" "/bin/bash -n bin/fm-brief.sh must parse cleanly (got: $out)"
+    [ -z "$out" ] || fail "/bin/bash -n bin/fm-brief.sh emitted unexpected output: $out"
+  fi
   pass "fm-brief.sh: bash -n succeeds"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 # Behavior tests for bin/fm-brief.sh.
 #
-# Regression coverage for the heredoc-in-command-substitution parse bug (issue
-# #166): each ship-mode branch builds its Definition-of-done text with
-# `VAR=$(cat <<EOF ... EOF)`. Bash's lexer tracks quote state through the
-# heredoc body while it scans for the matching `)` of the command
-# substitution, so a single unescaped apostrophe anywhere in that body breaks
-# parsing of the *entire rest of the script* - `bash -n` fails, not just the
-# generated brief. A plain `cat > file <<EOF ... EOF` (not wrapped in `$(...)`)
-# is unaffected, so the secondmate charter block does not need this guard.
+# Regression coverage for macOS /bin/bash 3.2: ship-mode DOD heredocs inside
+# command substitution are unparseable on 3.2 when env resolves PATH to /bin.
+# bin/fm-brief.sh re-execs under bash 5+ before that syntax is parsed; tests
+# here assert the prologue, re-exec success under a /bin-first PATH, and the
+# loud install-bash error when no modern candidate exists.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -18,20 +15,80 @@ TMP_ROOT=$(fm_test_tmproot fm-brief)
 BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
 
-# The script itself must always parse. This is the direct regression test for
-# issue #166: a stray apostrophe in any of the three DOD heredoc bodies
-# (no-mistakes/direct-PR/local-only) breaks `bash -n` on the whole file.
-test_script_parses() {
-  local out rc
-  out=$(bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
-  expect_code 0 "$rc" "bash -n bin/fm-brief.sh must parse cleanly (got: $out)"
-  [ -z "$out" ] || fail "bash -n bin/fm-brief.sh emitted unexpected output: $out"
-  if [ -x /bin/bash ]; then
-    out=$(/bin/bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
-    expect_code 0 "$rc" "/bin/bash -n bin/fm-brief.sh must parse cleanly (got: $out)"
-    [ -z "$out" ] || fail "/bin/bash -n bin/fm-brief.sh emitted unexpected output: $out"
+# Modern bash must parse the full script. Default `bash` on macOS is 3.2, so use
+# an explicit 5+ candidate when present; skip when no modern bash is installed.
+test_script_parses_under_modern_bash() {
+  local out rc modern
+  modern=
+  for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [ -x "$candidate" ]; then
+      modern=$candidate
+      break
+    fi
+  done
+  if [ -z "$modern" ]; then
+    pass "fm-brief.sh: no modern bash installed — skip full-script parse check"
+    return 0
   fi
-  pass "fm-brief.sh: bash -n succeeds"
+  out=$("$modern" -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
+  expect_code 0 "$rc" "$modern -n bin/fm-brief.sh must parse cleanly (got: $out)"
+  [ -z "$out" ] || fail "$modern -n bin/fm-brief.sh emitted unexpected output: $out"
+  pass "fm-brief.sh: modern bash -n succeeds"
+}
+
+test_reexec_prologue_parses_under_bin_bash() {
+  local out rc prologue
+  if ! [ -x /bin/bash ]; then
+    pass "fm-brief.sh: /bin/bash absent — skip prologue parse check"
+    return 0
+  fi
+  prologue=$(awk '/^set -eu$/ {found=1} found {print} /^SCRIPT_DIR=/ {exit}' "$ROOT/bin/fm-brief.sh")
+  out=$(printf '%s\n' "$prologue" | /bin/bash -n 2>&1); rc=$?
+  expect_code 0 "$rc" "/bin/bash -n on re-exec prologue must parse cleanly (got: $out)"
+  [ -z "$out" ] || fail "/bin/bash -n on re-exec prologue emitted unexpected output: $out"
+  pass "fm-brief.sh: re-exec prologue parses under /bin/bash"
+}
+
+test_reexec_succeeds_when_path_prefers_bin_bash() {
+  local home id brief modern rc
+  if ! [ -x /bin/bash ]; then
+    pass "fm-brief.sh: /bin/bash absent — skip PATH re-exec check"
+    return 0
+  fi
+  modern=
+  for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [ -x "$candidate" ] && [ "${candidate##*/}" = bash ]; then
+      modern=$candidate
+      break
+    fi
+  done
+  if [ -z "$modern" ]; then
+    pass "fm-brief.sh: no modern bash installed — skip PATH re-exec check"
+    return 0
+  fi
+  home="$TMP_ROOT/reexec-home"
+  mkdir -p "$home/data"
+  id="brief-reexec-e1"
+  PATH="/bin:/usr/bin:/usr/sbin:/sbin" FM_HOME="$home" \
+    "$ROOT/bin/fm-brief.sh" "$id" firstmate >/dev/null 2>&1; rc=$?
+  expect_code 0 "$rc" "fm-brief.sh must scaffold via re-exec when PATH prefers /bin/bash"
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "re-exec scaffold did not write a brief"
+  pass "fm-brief.sh: re-execs under modern bash when env resolves to /bin/bash"
+}
+
+test_reexec_errors_when_no_modern_bash() {
+  local out rc
+  if ! [ -x /bin/bash ]; then
+    pass "fm-brief.sh: /bin/bash absent — skip no-modern-bash error check"
+    return 0
+  fi
+  out=$(FM_BASH_REEXEC_CANDIDATES=/nonexistent/bash \
+    /bin/bash "$ROOT/bin/fm-brief.sh" test-id test-repo 2>&1); rc=$?
+  expect_code 1 "$rc" "fm-brief.sh must exit 1 when no modern bash candidate exists"
+  assert_contains "$out" "brew install bash" \
+    "no-modern-bash error must tell the operator to install bash"
+  pass "fm-brief.sh: loud error when no modern bash is available"
 }
 
 test_help_includes_entire_header() {
@@ -387,7 +444,10 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
-test_script_parses
+test_script_parses_under_modern_bash
+test_reexec_prologue_parses_under_bin_bash
+test_reexec_succeeds_when_path_prefers_bin_bash
+test_reexec_errors_when_no_modern_bash
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -78,9 +78,14 @@ test_reexec_succeeds_when_path_prefers_bin_bash() {
 }
 
 test_reexec_errors_when_no_modern_bash() {
-  local out rc
+  local out rc bin_bash_major
   if ! [ -x /bin/bash ]; then
     pass "fm-brief.sh: /bin/bash absent — skip no-modern-bash error check"
+    return 0
+  fi
+  bin_bash_major=$(/bin/bash -c 'echo "${BASH_VERSINFO[0]}"')
+  if [ "$bin_bash_major" -ge 5 ]; then
+    pass "fm-brief.sh: /bin/bash is already 5+ — skip no-modern-bash error check"
     return 0
   fi
   out=$(FM_BASH_REEXEC_CANDIDATES=/nonexistent/bash \


### PR DESCRIPTION
## Summary
- Add a re-exec prologue to `bin/fm-brief.sh` so brief scaffolding works when `env bash` resolves to macOS `/bin/bash` 3.2
- Re-exec under bash 5+ (`/opt/homebrew/bin/bash` or `/usr/local/bin/bash`) before unparseable ship-mode DOD heredoc syntax is parsed
- Generated brief output is unchanged; regression tests cover prologue parse, PATH re-exec success, and loud error when no modern bash exists

## Test plan
- [x] `bin/fm-lint.sh` passes
- [x] `tests/fm-brief.test.sh` passes
- [x] Generated briefs byte-identical across no-mistakes, direct-PR, local-only, and scout modes
- [x] Scaffolding succeeds with PATH preferring `/bin/bash` 3.2 via re-exec


Made with [Cursor](https://cursor.com)