### PR TITLE
fix(bin): parse fm-brief.sh under macOS bash 3.2

### DIFF
--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -131,7 +131,7 @@ test_primary_and_secondmate_instruction_generation() {
     "generated implementation brief lets the worker own an ask-user decision"
   assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$ship" \
     "generated implementation brief bypasses the primary authority owner"
-  assert_grep "silently bypass firstmate's authority check and any required captain escalation" "$ship" \
+  assert_grep "silently bypass the firstmate authority check and any required captain escalation" "$ship" \
     "generated implementation brief permits silent ask-user auto-resolution"
   assert_no_grep 'the captain, not you, owns the ask-user decisions' "$ship" \
     "generated implementation brief retained conflicting captain-only wording"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -170,6 +170,38 @@ exit 0;
 PERL
 }
 
+# Version-portable regression guard for issue #1179. `test_script_parses` runs
+# whatever `bash` is on PATH; on Linux CI that is bash 4+/5+, which parses the
+# offending construct fine and so never caught #1179. Bash 3.2 (the macOS system
+# shell) does not: its lexer tracks quote state through a heredoc body while
+# scanning for the `)` of the enclosing `$(...)`, so a lone apostrophe in a
+# `VAR=$(cat <<EOF ... EOF)` body opens a quote it never closes and `bash -n`
+# fails on the whole file. This scan flags such an apostrophe on every platform,
+# so a reintroduced possessive fails CI even where the running bash tolerates it.
+test_no_apostrophe_in_cmdsubst_heredoc() {
+  local offenders
+  offenders=$(awk '
+    # Start of a command-substitution heredoc: VAR=$(cat <<EOF or <<'\''EOF'\''.
+    !indoc && /=\$\(cat <<-?['\''"]?[A-Za-z_][A-Za-z_0-9]*['\''"]?/ {
+      delim = $0
+      sub(/.*<<-?['\''"]?/, "", delim)
+      sub(/['\''"].*/, "", delim)
+      indoc = 1
+      next
+    }
+    indoc {
+      line = $0
+      stripped = line
+      sub(/^[ \t]+/, "", stripped)   # <<- strips leading tabs from the terminator
+      if (stripped == delim) { indoc = 0; next }
+      if (index(line, "'\''") > 0) printf "%d: %s\n", NR, line
+    }
+  ' "$ROOT/bin/fm-brief.sh")
+  [ -z "$offenders" ] || fail "fm-brief.sh: apostrophe inside a \$(cat <<EOF) body breaks bash 3.2 parsing:
+$offenders"
+  pass "fm-brief.sh: no apostrophe in any command-substitution heredoc body"
+}
+
 test_help_includes_entire_header() {
   local help
   help=$("$ROOT/bin/fm-brief.sh" --help)
@@ -529,6 +561,7 @@ test_scout_and_secondmate_scaffold() {
 
 test_script_parses
 test_no_heredoc_in_command_substitution
+test_no_apostrophe_in_cmdsubst_heredoc
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -2,15 +2,17 @@
 # Behavior tests for bin/fm-brief.sh.
 #
 # Regression coverage for the heredoc-in-command-substitution parse bug (issues
-# #166, #958, #1069). Building a variable with `VAR=$(cat <<EOF ... EOF)` is
-# unsafe on Bash 3.2 (macOS /bin/bash): the lexer scans for the matching `)` of
-# the command substitution textually and tracks quote state through the heredoc
-# body, so a single apostrophe, unbalanced quote, or unbalanced paren anywhere
-# in that body breaks parsing of the *entire rest of the script* - `bash -n`
-# fails, not just the generated brief. The DOD and Herdr-section builders now
-# use `IFS= read -r -d '' VAR <<EOF || true` instead, which removes the `$(...)`
-# wrapper and eliminates the whole defect class regardless of future prose.
-# test_no_heredoc_in_command_substitution guards that structure directly.
+# #166, #958, #1069, #1179). Building a variable with `VAR=$(cat <<EOF ... EOF)`
+# is unsafe on Bash 3.2 (macOS /bin/bash): the lexer scans for the matching `)`
+# of the command substitution textually and tracks quote state through the
+# heredoc body, so a single apostrophe, unbalanced quote, or unbalanced paren
+# anywhere in that body breaks parsing of the *entire rest of the script* -
+# `bash -n` fails, not just the generated brief. The DOD and Herdr-section
+# builders now use `IFS= read -r -d '' VAR <<EOF || true` instead, which removes
+# the `$(...)` wrapper and eliminates the whole defect class regardless of
+# future prose. test_no_heredoc_in_command_substitution guards that structure
+# directly, and test_no_apostrophe_in_cmdsubst_heredoc is a version-portable
+# static scan that flags the offending apostrophe everywhere.
 # Ambient `bash -n` here is Bash 5 and cannot see the bug, so the real
 # cross-version enforcement lives in the macos-stock-bash CI job.
 set -u


### PR DESCRIPTION
## Intent

Fix bin/fm-brief.sh so it parses under macOS system bash 3.2 (issue #1179). Root cause: a lone apostrophe in a possessive word (firstmate's) inside a VAR=$(cat <<EOF ... EOF) command-substitution heredoc body. Bash 3.2's lexer tracks quote state through the heredoc body while scanning for the closing ) of the command substitution, so the apostrophe opens a quote it never closes and 'bash -n' fails on the whole file with 'unexpected EOF while looking for matching )'. bash 4+ parses it fine, which is why Linux CI never caught it. Fix: reworded the no-mistakes Definition-of-done heredoc line from 'bypass firstmate's authority check' to 'bypass the firstmate authority check', dropping the possessive. This was the only offender in a command-substitution heredoc; the other cat<<EOF DOD branches have no apostrophes and the 'cat > BRIEF <<EOF' block is a plain redirect (not command substitution) so its apostrophes are harmless. Regression guard: the existing test_script_parses runs 'bash -n' with whatever bash is on PATH, which on Linux CI is bash 4+/5+ and does not reproduce the failure, so I added a version-portable static-scan test (test_no_apostrophe_in_cmdsubst_heredoc) to tests/fm-brief.test.sh that uses awk to flag an apostrophe inside any $(cat <<EOF) body on every platform. Verified: /bin/bash -n exits 0 on bash 3.2.57, negative test confirms the scan flags a reintroduced apostrophe, all 16 brief tests pass, fm-lint.sh clean. Scope strictly limited to this parse fix; no restructuring.

## What Changed

- Reworded the no-mistakes Definition-of-done line inside the `VAR=$(cat <<EOF ... EOF)` command-substitution heredoc in `bin/fm-brief.sh` from "bypass firstmate's authority check" to "bypass the firstmate authority check", dropping the lone possessive apostrophe that left bash 3.2's lexer with an unclosed quote and made `bash -n` fail the whole file with `unexpected EOF while looking for matching )`.
- Added `test_no_apostrophe_in_cmdsubst_heredoc` to `tests/fm-brief.test.sh`, a version-portable awk static scan that flags any apostrophe inside a `$(cat <<EOF)` body so the regression is caught on bash 4+/5+ CI where `bash -n` alone cannot reproduce it.
- Synced the test header comment to document the bash 3.2 parse-fix regression guard.

## Risk Assessment

✅ Low: Two-file change: a one-word reword that removes the only bash-3.2-breaking apostrophe, plus a correct, version-portable regression test; no behavioral change to generated briefs.

## Testing

Reproduced the exact #1179 failure on macOS system bash 3.2.57 by reintroducing the possessive apostrophe (bash -n fails with 'unexpected EOF while looking for matching )'), confirmed the committed fix parses clean on the same shell, ran the full 16-test fm-brief suite (all pass), and independently exercised the new pure-awk regression guard against mutated and clean copies to prove it flags a reintroduced apostrophe on any platform where bash 4+/5+ CI's bash -n would not. No source files modified; working tree restored clean.

<details>
<summary>Evidence: Bash 3.2 parse + repro + guard evidence transcript</summary>

```text
Issue #1179 — fm-brief.sh must parse under macOS system bash 3.2
Fix commit: c86be00 (base fa0d85d)

== 1. macOS system bash version ==
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

== 2. FIXED file parses clean on bash 3.2 (the end-user surface) ==
$ /bin/bash -n bin/fm-brief.sh && echo PARSE_OK
PARSE_OK   (exit 0)

== 3. Reproduce original #1179 failure — reintroduce the possessive apostrophe
        ("bypass the firstmate authority check" -> "bypass firstmate's authority check") ==
$ /bin/bash -n bin/fm-brief.sh
bin/fm-brief.sh: line 314: unexpected EOF while looking for matching `)'
bin/fm-brief.sh: line 388: syntax error: unexpected end of file
(exit 2)
=> confirms root cause: lone apostrophe in a $(cat <<EOF ...) body breaks the
   bash 3.2 lexer while it scans for the closing ) of the command substitution.

== 4. Full brief test suite on the fixed file (16/16 pass) ==
$ bash tests/fm-brief.test.sh
ok - fm-brief.sh: bash -n succeeds
ok - fm-brief.sh: no apostrophe in any command-substitution heredoc body   <- new guard
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
suite exit=0

== 5. Regression guard is version-portable (fires where bash -n would NOT) ==
The new test_no_apostrophe_in_cmdsubst_heredoc uses pure awk, independent of the
running bash. Ran the guard's exact awk program standalone (awk 20200816):

  MUTATED (apostrophe reintroduced):
    328: - Avoid `--yes`: it would silently bypass firstmate's authority check ...
    => offender flagged
  CLEAN (committed fix):
    no offenders -> guard passes

This proves the guard catches a reintroduced possessive on any platform, including
bash 4+/5+ Linux CI where `bash -n` alone parses the construct fine and missed #1179.

== 6. Working tree restored clean after mutation tests ==
$ git status --porcelain   -> (empty)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/fm-brief.test.sh:56` - The new regression guard (test_no_apostrophe_in_cmdsubst_heredoc) forbids ALL apostrophes inside any $(cat &lt;&lt;EOF) body in bin/fm-brief.sh, not just possessives. Future edits to the direct-PR/local-only/no-mistakes Definition-of-done text cannot use contractions (don&#39;t, it&#39;s, you&#39;re) or possessives without failing CI. This is the intended bash-3.2 workaround, but it is a permanent constraint on that prose worth being aware of.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`/bin/bash --version` — confirmed macOS system shell is GNU bash 3.2.57</code>
- <code>`/bin/bash -n bin/fm-brief.sh` — parses clean, exit 0 (the fixed end-user surface)</code>
- <code>Reproduced #1179: sed-reintroduced `firstmate&#39;s` into the $(cat &lt;&lt;EOF) body, then `/bin/bash -n` → `unexpected EOF while looking for matching `)&#39;` exit 2</code>
- <code>`bash tests/fm-brief.test.sh` — 16/16 pass on the fixed file</code>
- `Ran the guard's exact awk program standalone (awk 20200816) against mutated vs clean copies: flags line 328 offender when reintroduced, no offenders on committed fix — proves platform-independence vs bash -n`
- <code>`git status --porcelain` — working tree clean after all mutation tests</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
