### PR TITLE
fix: repair herdr schema-probe broken pipe and crewmate completion signal

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2333,8 +2333,16 @@ fm_backend_herdr_events_capable() {  # <session>
   case "$protocol" in ''|*[!0-9]*) return 1 ;; esac
   [ "$protocol" -ge "$FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL" ] || return 1
   schema=$(herdr api schema --json 2>/dev/null) || return 1
-  printf '%s' "$schema" | grep -Fq 'events.subscribe' || return 1
-  printf '%s' "$schema" | grep -Fq 'pane.agent_status_changed' || return 1
+  # Herestrings, not `printf ... | grep`: `grep -q` exits at the first matching
+  # LINE, closing the pipe while printf still has most of the ~220KB schema
+  # unwritten. Under a parent that ignores SIGPIPE (the watcher's launch
+  # environment does), that write fails with EPIPE instead of killing printf
+  # silently, and bash reports `printf: write error: Broken pipe` on the
+  # watcher's stderr every arm cycle. A herestring has no concurrent writer
+  # process, so there is nothing to receive SIGPIPE. Regression:
+  # tests/fm-backend-herdr-schema-probe.test.sh.
+  grep -Fq 'events.subscribe' <<<"$schema" || return 1
+  grep -Fq 'pane.agent_status_changed' <<<"$schema" || return 1
   return 0
 }
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -251,6 +251,10 @@ The report is the only thing that survives, so anything worth keeping must be in
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
    FYI progress lines; firstmate reads your pane for that.
+   Your pane summary is NOT a completion signal. With no \`done:\` or \`failed:\` line appended
+   here, a finished task is indistinguishable from a worker that stopped for an unknown reason,
+   and firstmate escalates it as a possible wedge instead of cleaning it up. The append is the
+   task's last action - do it after your closing summary, before you stop.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
@@ -363,6 +367,10 @@ $RULE1
    firstmate reads your pane for that.
    A mid-task \`working:\` line (including setup complete) is nonterminal: do not end the
    turn after it; continue the same stage until a defined \`done:\` gate under Definition of done.
+   Your pane summary is NOT a completion signal. With no \`done:\` or \`failed:\` line appended
+   here, a finished task is indistinguishable from a worker that stopped for an unknown reason,
+   and firstmate escalates it as a possible wedge instead of cleaning it up. The append is the
+   task's last action - do it after your closing summary, before you stop.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -271,6 +271,7 @@ Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never 
 ```sh
 tests/fm-backend-herdr.test.sh
 tests/fm-backend-herdr-smoke.test.sh
+tests/fm-backend-herdr-schema-probe.test.sh
 tests/fm-backend-herdr-prune-safety-e2e.test.sh
 tests/fm-backend-herdr-respawn-idem-e2e.test.sh
 tests/fm-backend-herdr-workspace-per-home-e2e.test.sh

--- a/tests/fm-backend-herdr-schema-probe.test.sh
+++ b/tests/fm-backend-herdr-schema-probe.test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# tests/fm-backend-herdr-schema-probe.test.sh - regression guard for the
+# `herdr api schema --json` capability probe in fm_backend_herdr_events_capable
+# (bin/backends/herdr.sh).
+#
+# The probe searches a ~220KB schema for two capability markers. Written as
+# `printf '%s' "$schema" | grep -Fq <marker>`, it printed
+# `printf: write error: Broken pipe` on the watcher's stderr during ordinary
+# arm cycles: `grep -q` exits at the first matching LINE and closes the pipe
+# while printf still has most of the payload unwritten.
+#
+# Three preconditions have to hold together, which is why it read as
+# intermittent rather than constant:
+#   1. SIGPIPE is ignored in the calling environment, so the failed write is
+#      reported as EPIPE instead of killing printf silently.
+#   2. The payload exceeds the pipe buffer (64KB on macOS), so the writer is
+#      still mid-write when grep leaves.
+#   3. The payload is multi-line with the match on an early line, so grep can
+#      short-circuit at all - a single-line payload of any size is drained
+#      whole, and the marker's position in the real schema decides this.
+#
+# The fix is a herestring, which bash materializes as a temp file: there is no
+# concurrent writer process left to receive SIGPIPE. The exit status was always
+# correct (it is grep's, as the last command in the pipeline), so this is a
+# stderr-noise regression, not a capability-verdict regression - the assertions
+# below check both.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-backend-herdr-schema-probe-tests)
+mkdir -p "$TMP_ROOT"
+
+# A schema fixture shaped like the hazard: multi-line, well past the pipe
+# buffer, with both capability markers on the first line so grep short-circuits
+# immediately and leaves the writer blocked with almost everything unwritten.
+BIG_SCHEMA_FIXTURE="$TMP_ROOT/schema.json"
+{
+  printf '{"methods":["events.subscribe","pane.agent_status_changed"],"filler":[\n'
+  seq 1 40000
+  printf ']}\n'
+} > "$BIG_SCHEMA_FIXTURE"
+
+# make_schema_fakebin: a `herdr` stub answering only the two calls the
+# capability probe makes - `status --json` (protocol 16, at
+# FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL) and `api schema --json` (the large
+# fixture above).
+make_schema_fakebin() {  # <dir> -> echoes fakebin dir
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  "status --json") printf '{"client":{"version":"0.7.3","protocol":16},"server":{"running":true}}\n' ;;
+  "api schema") cat "${FM_FAKE_SCHEMA_FILE:?}" ;;
+  *) : ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/herdr"
+  printf '%s\n' "$fb"
+}
+
+# run_capable: call fm_backend_herdr_events_capable against the fixture under a
+# shell that IGNORES SIGPIPE, reproducing the watcher's launch environment
+# (precondition 1). Echoes stderr, then a final "rc=<n>" line.
+run_capable() {  # <fakebin> -> stderr text plus a trailing rc= line
+  PATH="$1:$PATH" FM_FAKE_SCHEMA_FILE="$BIG_SCHEMA_FIXTURE" \
+    FM_BACKEND_HERDR_EVENT_READER=/nonexistent/reader \
+    bash -c '
+      trap "" PIPE
+      . "$0/bin/backends/herdr.sh"
+      fm_backend_herdr_events_capable sess
+      echo "rc=$?"
+    ' "$ROOT" 2>&1
+}
+
+test_events_capable_silent_on_large_early_matching_schema() {
+  local dir fb out
+  dir="$TMP_ROOT/capable"; mkdir -p "$dir"
+  fb=$(make_schema_fakebin "$dir")
+  out=$(run_capable "$fb")
+  assert_not_contains "$out" "Broken pipe" \
+    "the schema capability probe must not write a broken-pipe error to the watcher's stderr"
+  assert_contains "$out" "rc=0" \
+    "the schema capability probe must still report a capable schema as capable"
+  pass "fm_backend_herdr_events_capable: large early-matching schema probed without a broken-pipe write error"
+}
+
+# Positive control for the fixture itself. A regression test that cannot fail is
+# worthless, so prove the fixture DOES expose the hazard through the old pipe
+# form under the same conditions. grep short-circuit behavior is
+# implementation-dependent (ugrep and BSD grep differ on when they stop
+# reading), so a control that does not reproduce is reported rather than
+# failed - the assertion above stays enforced either way.
+test_pipe_form_control_reproduces_broken_pipe() {
+  local out
+  out=$( FM_FAKE_SCHEMA_FILE="$BIG_SCHEMA_FIXTURE" bash -c '
+      trap "" PIPE
+      schema=$(cat "$FM_FAKE_SCHEMA_FILE")
+      printf "%s" "$schema" | grep -Fq "events.subscribe"
+    ' 2>&1 )
+  case "$out" in
+    *"Broken pipe"*)
+      pass "control: the old pipe form still reproduces the broken-pipe write error on this fixture" ;;
+    *)
+      pass "control: this grep drains the fixture instead of short-circuiting, so the pipe form cannot be exercised here (main assertion still enforced)" ;;
+  esac
+}
+
+# Static guard, independent of the runtime control above: the probe's two marker
+# searches must not reintroduce a pipe, on any grep implementation.
+test_events_capable_probe_reads_schema_without_a_pipe() {
+  local body
+  # Code only: the function's own comment explains the hazard by naming the old
+  # pipe form, which would otherwise trip the guard below.
+  body=$(awk '/^fm_backend_herdr_events_capable\(\)/,/^}/' "$ROOT/bin/backends/herdr.sh" | grep -v '^[[:space:]]*#')
+  [ -n "$body" ] || fail "could not locate fm_backend_herdr_events_capable in bin/backends/herdr.sh"
+  assert_contains "$body" "events.subscribe" \
+    "fm_backend_herdr_events_capable must still probe for the events.subscribe marker"
+  assert_not_contains "$body" '| grep' \
+    "fm_backend_herdr_events_capable must search the schema with a herestring, never a pipe (a pipe reintroduces the SIGPIPE race)"
+  pass "fm_backend_herdr_events_capable: schema markers are searched without piping the payload"
+}
+
+test_events_capable_silent_on_large_early_matching_schema
+test_pipe_form_control_reproduces_broken_pipe
+test_events_capable_probe_reads_schema_without_a_pipe

--- a/tests/fm-brief-done-signal.test.sh
+++ b/tests/fm-brief-done-signal.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# tests/fm-brief-done-signal.test.sh - guard for the terminal-status
+# reinforcement in the briefs scaffolded by bin/fm-brief.sh.
+#
+# Observed live on 2026-07-28: four consecutive crewmates finished their work,
+# wrote their deliverable, printed a closing summary to the pane, and stopped -
+# none appended the mandatory `done:` line. With no terminal status the only
+# evidence firstmate has is an idle pane whose hash stopped changing, which is
+# by design indistinguishable from a wedge (bin/fm-watch.sh:913-927 says so in
+# as many words), so the watcher wedge-escalates a finished task forever.
+#
+# The `done:` append is the one step of the brief with no deterministic
+# enforcement: the first action and the worktree-isolation check are both hard
+# STOP gates, the last action was a bare instruction in a list. This test pins
+# the reinforcement that states the consequence at the point of the risk.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-brief-done-signal-tests)
+mkdir -p "$TMP_ROOT"
+
+# scaffold <id> <flag...>: run fm-brief.sh against a throwaway data/state pair
+# and echo the path of the brief it wrote.
+scaffold() {  # <id> [args...] -> brief path
+  local id=$1
+  shift
+  FM_DATA_OVERRIDE="$TMP_ROOT/data" FM_STATE_OVERRIDE="$TMP_ROOT/state" \
+    "$ROOT/bin/fm-brief.sh" "$id" "$@" >/dev/null \
+    || fail "fm-brief.sh failed to scaffold $id"
+  printf '%s\n' "$TMP_ROOT/data/$id/brief.md"
+}
+
+# assert_done_reinforcement <brief> <label>: the brief must name the pane
+# summary as a non-signal, name the consequence, and place the append last.
+assert_done_reinforcement() {  # <brief> <label>
+  local brief=$1 label=$2
+  assert_grep 'pane summary is NOT a completion signal' "$brief" \
+    "$label brief must state that a pane summary does not signal completion"
+  assert_grep 'possible wedge' "$brief" \
+    "$label brief must state the consequence of a missing terminal status: escalation as a possible wedge"
+  assert_grep "task's last action" "$brief" \
+    "$label brief must place the status append as the task's last action"
+  pass "$label brief: terminal-status append is reinforced at the status protocol"
+}
+
+test_scout_brief_reinforces_the_done_append() {
+  local brief
+  brief=$(scaffold scout-task alpha --scout)
+  assert_done_reinforcement "$brief" scout
+}
+
+# The ship half of fm-brief.sh builds its delivery-mode Definition of done with
+# `DOD=$(cat <<EOF ... EOF\n)`, which bash 3.2 (the system bash on macOS) cannot
+# parse - a heredoc inside a command substitution. That is pre-existing and
+# equally true at HEAD; the scout half still runs because bash parses a script
+# incrementally and scout exits before reaching it. Report the skip rather than
+# failing a developer's local run on a limitation this change did not introduce.
+test_ship_brief_reinforces_the_done_append() {
+  local brief
+  if ! bash -n "$ROOT/bin/fm-brief.sh" 2>/dev/null; then
+    pass "skip: this bash ($BASH_VERSION) cannot parse fm-brief.sh's ship half (heredoc in command substitution)"
+    return 0
+  fi
+  brief=$(scaffold ship-task alpha)
+  assert_done_reinforcement "$brief" ship
+}
+
+# Static companion, so the ship scaffold stays covered on a bash that cannot run
+# it: both scaffolds carry rule 4, and each copy must carry the reinforcement.
+test_both_scaffolds_carry_the_reinforcement() {
+  local rules reinforcements
+  rules=$(grep -c 'Report status by appending one line' "$ROOT/bin/fm-brief.sh")
+  reinforcements=$(grep -c 'pane summary is NOT a completion signal' "$ROOT/bin/fm-brief.sh")
+  [ "$reinforcements" -eq "$rules" ] || fail \
+    "every status-protocol block in bin/fm-brief.sh must carry the terminal-status reinforcement (blocks: $rules, reinforced: $reinforcements)"
+  [ "$rules" -ge 2 ] || fail \
+    "expected a status-protocol block in both the scout and ship scaffolds of bin/fm-brief.sh, found $rules"
+  pass "bin/fm-brief.sh: all $rules status-protocol blocks reinforce the terminal-status append"
+}
+
+test_scout_brief_reinforces_the_done_append
+test_ship_brief_reinforces_the_done_append
+test_both_scaffolds_carry_the_reinforcement


### PR DESCRIPTION
## Intent

Fix two bugs found live in production: (1) a broken-pipe stderr write in the herdr backend's schema capability probe, and (2) crewmates finishing without appending a terminal done: status, which makes the watcher wedge-escalate finished tasks forever. Each fix ships with a regression test.

## What Changed

- **`bin/backends/herdr.sh`**: Replaced `printf ... | grep` with herestring (`grep -Fq ... <<<"$schema"`) in the schema capability probe to eliminate a broken-pipe EPIPE error that occurred when grep exited early on the ~220KB schema payload in SIGPIPE-ignoring watcher environments.
- **`bin/fm-brief.sh`**: Added an explicit warning in both crewmate brief templates clarifying that the pane summary is not a completion signal — a missing `done:` or `failed:` append causes the watcher to escalate a finished task as a wedge indefinitely.
- **`tests/`**: Added two regression tests (`fm-backend-herdr-schema-probe.test.sh`, `fm-brief-done-signal.test.sh`) covering both fixes; both pass in CI.

## Risk Assessment

✅ Low: Both fixes are narrow and correct: the herestring substitution eliminates the SIGPIPE race without altering grep exit semantics, and the brief reinforcement is a pure textual addition with no behavioral side-effects; both carry well-structured regression tests.

## Testing

`Ran both regression tests added by the change. The schema probe test exercised a >220KB multi-line fixture under a SIGPIPE-ignored shell, confirmed no broken-pipe error appears, verified the positive control still reproduces the error with the old pipe form, and confirmed the code no longer pipes to grep. The done-signal test scaffolded a real brief and confirmed all three reinforcement phrases are present, plus a static count guard that both status-protocol blocks carry the reinforcement. All assertions passed (ship-brief runtime test gracefully skipped on macOS bash 3.2 due to a pre-existing heredoc-in-command-substitution limitation unrelated to this change).`

<details>
<summary>Evidence: Regression test output</summary>

<code>=== Schema probe regression test ===&#10;ok - fm_backend_herdr_events_capable: large early-matching schema probed without a broken-pipe write error&#10;ok - control: the old pipe form still reproduces the broken-pipe write error on this fixture&#10;ok - fm_backend_herdr_events_capable: schema markers are searched without piping the payload&#10;&#10;=== Done-signal regression test ===&#10;ok - scout brief: terminal-status append is reinforced at the status protocol&#10;ok - skip: this bash (3.2.57(1)-release) cannot parse fm-brief.sh&#39;s ship half (heredoc in command substitution)&#10;ok - bin/fm-brief.sh: all 2 status-protocol blocks reinforce the terminal-status append</code>

```text
=== Schema probe regression test ===
ok - fm_backend_herdr_events_capable: large early-matching schema probed without a broken-pipe write error
ok - control: the old pipe form still reproduces the broken-pipe write error on this fixture
ok - fm_backend_herdr_events_capable: schema markers are searched without piping the payload

=== Done-signal regression test ===
ok - scout brief: terminal-status append is reinforced at the status protocol
ok - skip: this bash (3.2.57(1)-release) cannot parse fm-brief.sh's ship half (heredoc in command substitution)
ok - bin/fm-brief.sh: all 2 status-protocol blocks reinforce the terminal-status append
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-backend-herdr-schema-probe.test.sh`
- `bash tests/fm-brief-done-signal.test.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
