### PR TITLE
fix(spawn): keep the axi tools on PATH for spawned agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,13 @@ jobs:
           command -v tar >/dev/null || { echo "::error::tar is required"; exit 1; }
           jq --version
           python3 --version
+      - name: Install tasks-axi
+        # fm-spawn.sh refuses to launch when it cannot resolve the axi agent tool
+        # directory, so the spawning Herdr lane needs it on PATH.
+        run: |
+          set -eu
+          npm install -g tasks-axi
+          tasks-axi --version
       - name: Install pinned Herdr
         run: |
           set -eu

--- a/bin/fm-axi-path-lib.sh
+++ b/bin/fm-axi-path-lib.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# fm-axi-path-lib.sh - resolve the directory holding the axi agent tools so a
+# spawned direct report can actually run them.
+#
+# The hazard: the axi tools (tasks-axi, gh-axi, chrome-devtools-axi, lavish-axi)
+# are npm globals installed into whichever Node toolchain was active when they
+# were installed, e.g. a mise-managed ~/.local/share/mise/installs/node/<ver>/bin.
+# That directory is on PATH only while that toolchain resolves. A crewmate works
+# in a different project directory, and a project that pins its own toolchain
+# (or ships a config file mise refuses to trust) resolves away from it, so the
+# axi tools vanish from the crewmate's PATH ALL AT ONCE. Nothing is uninstalled;
+# they are simply unreachable from where crewmates run. The generated brief still
+# tells the crewmate to use gh-axi, and bin/fm-decision-hold.sh hard-requires
+# tasks-axi, so the crewmate fails deep inside its task instead of at launch.
+#
+# fm-spawn.sh therefore resolves the directory HERE, in firstmate's own
+# environment where the tools do resolve, and exports it into the spawned
+# agent's shell.
+#
+# Three properties this deliberately holds:
+#
+#   1. The directory is resolved dynamically from where the tools actually live
+#      (command -v, then dirname). A hardcoded node/<major> path would break
+#      silently on the next toolchain bump and recreate this bug with extra
+#      steps, so no Node version, mise layout, or install prefix is assumed.
+#   2. It fails closed when NO axi tool resolves at all. That is the signature of
+#      the actual bug - a whole toolchain resolving away - and it leaves no
+#      directory to export, so the caller refuses the spawn rather than launching
+#      an agent that is told to use tools it does not have. A silent partial
+#      success is worse, because the failure then surfaces deep inside the task.
+#   3. A tool missing while others resolve is an INSTALL gap, not a PATH gap.
+#      Refusing every spawn over one uninstalled tool would be disproportionate,
+#      so that warns loudly instead - the brief instruction is still never
+#      silently false, but the fleet keeps moving.
+#
+# Callers use fm_axi_path_suffix, which prints a colon-joined PATH fragment to
+# APPEND to the agent's PATH. It is appended, not prepended, on purpose: the tool
+# directory is also a Node toolchain bin directory, and prepending it would
+# shadow a project's own pinned node/npm. Appending still resolves the axi tools,
+# because no other directory on the crewmate's PATH provides those names.
+
+FM_AXI_TOOLS="tasks-axi gh-axi chrome-devtools-axi lavish-axi"
+
+# fm_axi_tool_dir <tool> - print the absolute directory holding <tool>, or
+# return 1 when it does not resolve to an executable on PATH.
+fm_axi_tool_dir() {
+  local path
+  path=$(command -v "$1" 2>/dev/null) || return 1
+  [ -n "$path" ] && [ -x "$path" ] || return 1
+  cd "$(dirname "$path")" 2>/dev/null && pwd
+}
+
+# fm_axi_path_suffix - print the colon-joined directories to append to PATH.
+# Returns 1 with an actionable diagnostic when no axi tool resolves at all.
+# Warns on stderr for individually absent tools and still succeeds.
+fm_axi_path_suffix() {
+  local tool dir suffix missing
+  suffix=
+  missing=
+  for tool in $FM_AXI_TOOLS; do
+    if dir=$(fm_axi_tool_dir "$tool"); then
+      # Normally every tool shares one directory, so this collapses to a single
+      # entry; a split install is carried through rather than dropped.
+      case ":$suffix:" in
+        *":$dir:"*) ;;
+        *) suffix="${suffix:+$suffix:}$dir" ;;
+      esac
+    else
+      missing="$missing $tool"
+    fi
+  done
+  if [ -z "$suffix" ]; then
+    echo "error: cannot resolve the axi agent tool directory; none of these are on PATH:${missing}" >&2
+    echo "  Crewmate instructions tell workers to use these tools and bin/fm-decision-hold.sh requires" >&2
+    echo "  tasks-axi, so this spawn is refused rather than launching a worker that cannot run them." >&2
+    echo "  This usually means the Node toolchain they were installed into is not active here." >&2
+    echo "  Install them into the currently active toolchain (npm install -g tasks-axi gh-axi" >&2
+    echo "  chrome-devtools-axi lavish-axi), or start firstmate where they resolve, then retry." >&2
+    return 1
+  fi
+  if [ -n "$missing" ]; then
+    echo "warning: axi tools not installed anywhere on PATH:${missing}" >&2
+    echo "  The worker's instructions tell it to use them, so that instruction will be wrong for this" >&2
+    echo "  spawn. Install them (npm install -g <tool>) to make it true again." >&2
+  fi
+  printf '%s\n' "$suffix"
+}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -73,6 +73,14 @@
 #   the file governs the spawn, its model/effort tokens are re-resolved on every
 #   respawn exactly like the harness axis, and explicit --model/--effort flags
 #   still win over the file's tokens.
+#   Every spawn exports the axi agent tool directory into the agent's shell, so a
+#   worker keeps tasks-axi, gh-axi, chrome-devtools-axi, and lavish-axi even when its
+#   project selects a different Node toolchain and resolves away from them. The
+#   directory is resolved dynamically from where the tools actually live, never from a
+#   hardcoded Node version, and it is APPENDED to PATH so a project's own pinned
+#   node/npm still wins. When NO axi tool resolves the spawn is refused before any
+#   endpoint is created; an individually uninstalled tool warns instead
+#   (bin/fm-axi-path-lib.sh owns that fail-closed contract).
 #   A --secondmate spawn also propagates the primary's declared inherited local
 #   material, so the secondmate's OWN crewmates inherit primary config and the
 #   secondmate receives the primary's read-only shared captain-preference file
@@ -115,7 +123,7 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
-  sed -n '2,78p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,86p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 case "${1:-}" in
@@ -141,6 +149,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-axi-path-lib.sh
+. "$SCRIPT_DIR/fm-axi-path-lib.sh"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
 # a direct report (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
@@ -196,6 +206,15 @@ case "$EFFORT" in
   ''|low|medium|high|xhigh|max) ;;
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
 esac
+
+# Resolve the axi agent tool directory in FIRSTMATE's environment, where the
+# tools do resolve, so it can be exported into the agent's shell below. A
+# crewmate's project directory can select a different Node toolchain and lose
+# them from PATH (bin/fm-axi-path-lib.sh owns the mechanism and the fail-closed
+# contract). Resolved HERE, before any endpoint is created, so an unresolvable
+# tool directory refuses the spawn instead of leaving a half-created endpoint
+# behind or launching a worker that was told to use tools it cannot run.
+AXI_PATH_SUFFIX=$(fm_axi_path_suffix) || exit 1
 
 # Backend selection (data/fm-backend-design-d7): explicit --backend, else
 # FM_BACKEND env, else config/backend, else runtime auto-detection, else
@@ -1498,6 +1517,12 @@ fi
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
 spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
+sleep 0.3
+# Same reason, for the axi agent tools: append the directory firstmate resolved
+# them from so they survive a project toolchain that resolves away from it. $PATH
+# stays literal so the pane's own shell expands it; the resolved directory is
+# quoted so nothing in the path is expanded or word-split.
+spawn_send_text_line "$T" "export PATH=\"\$PATH\":$(shell_quote "$AXI_PATH_SUFFIX")"
 sleep 0.3
 spawn_send_literal "$T" "$LAUNCH"
 sleep 0.3

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -160,7 +160,7 @@ family_for_basename() {
     fm-send-secondmate-marker-herdr-e2e.test.sh)
       printf '%s\n' live-harness-optin
       ;;
-    fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
+    fm-axi-path.test.sh|fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|fm-spawn-worktree-settle.test.sh)
       printf '%s\n' backend-dispatch

--- a/tests/fm-axi-path.test.sh
+++ b/tests/fm-axi-path.test.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Behavior tests for the axi agent tool PATH contract.
+#
+# Two halves, because the dangerous failure here is a SILENT partial success:
+#
+#   1. bin/fm-axi-path-lib.sh resolution - the happy path resolves the directory
+#      dynamically from where the tools actually live, dedupes, warns loudly for an
+#      individually uninstalled tool, and FAILS when no axi tool resolves at all.
+#   2. bin/fm-spawn.sh integration - a resolvable directory is exported into the
+#      agent's pane appended to PATH, and an unresolvable one refuses the spawn
+#      before any endpoint or metadata exists.
+#
+# The refusal half is the point of the test: proving only the happy path would
+# leave exactly the silent-launch failure this contract exists to prevent.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LIB="$ROOT/bin/fm-axi-path-lib.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-axi-path)
+SCRATCH="$TMP_ROOT/scratch"
+mkdir -p "$SCRATCH"
+
+# A PATH with the ordinary system directories but WITHOUT whatever Node toolchain
+# directory the real axi tools live in, so "required tool absent" is reproducible
+# on a developer machine that has them installed.
+BARE_PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+make_axi_bin() {  # <dir> <tool>...
+  local dir=$1 tool
+  shift
+  mkdir -p "$dir"
+  # The resolver canonicalizes with cd/pwd, so hand back the canonical path and
+  # keep every assertion comparing like with like.
+  dir=$(cd "$dir" && pwd)
+  for tool in "$@"; do
+    cat > "$dir/$tool" <<SH
+#!/usr/bin/env bash
+printf '%s ok\n' "$tool"
+SH
+    chmod +x "$dir/$tool"
+  done
+  printf '%s\n' "$dir"
+}
+
+# Run fm_axi_path_suffix with an exact PATH, capturing stdout, stderr and status
+# separately so a warning is never mistaken for the resolved value.
+run_suffix() {  # <path>
+  local path=$1 errfile
+  errfile="$SCRATCH/suffix.err.$$"
+  SUFFIX_OUT=$(PATH="$path" bash -c '. "$1"; fm_axi_path_suffix' _ "$LIB" 2>"$errfile") \
+    && SUFFIX_STATUS=0 || SUFFIX_STATUS=$?
+  SUFFIX_ERR=$(cat "$errfile")
+  rm -f "$errfile"
+}
+
+test_resolves_directory_from_actual_tool_location() {
+  local dir
+  dir=$(make_axi_bin "$TMP_ROOT/resolve/bin" tasks-axi gh-axi chrome-devtools-axi lavish-axi)
+
+  run_suffix "$dir:$BARE_PATH"
+  expect_code 0 "$SUFFIX_STATUS" "resolution should succeed when every axi tool is present"
+  [ "$SUFFIX_OUT" = "$dir" ] || fail "suffix should be the directory the tools actually live in"$'\n'"expected: $dir"$'\n'"actual:   $SUFFIX_OUT"
+  [ -z "$SUFFIX_ERR" ] || fail "a complete install should warn about nothing, got: $SUFFIX_ERR"
+  pass "resolves the tool directory dynamically from where the tools actually live"
+}
+
+test_resolution_hardcodes_no_node_version() {
+  local dir_a dir_b
+  # The same lib, run against two unrelated install locations, must follow the
+  # tools rather than any fixed toolchain path.
+  dir_a=$(make_axi_bin "$TMP_ROOT/nover/a/bin" tasks-axi gh-axi chrome-devtools-axi)
+  dir_b=$(make_axi_bin "$TMP_ROOT/nover/b/other-bin" tasks-axi gh-axi chrome-devtools-axi)
+
+  run_suffix "$dir_a:$BARE_PATH"
+  [ "$SUFFIX_OUT" = "$dir_a" ] || fail "expected $dir_a, got $SUFFIX_OUT"
+  run_suffix "$dir_b:$BARE_PATH"
+  [ "$SUFFIX_OUT" = "$dir_b" ] || fail "expected $dir_b, got $SUFFIX_OUT"
+  assert_not_contains "$SUFFIX_OUT" "node/" "resolution must not assume a Node toolchain layout"
+  pass "resolution follows the tools and assumes no Node version or install layout"
+}
+
+test_split_install_locations_are_all_carried() {
+  local dir_req dir_exp
+  dir_req=$(make_axi_bin "$TMP_ROOT/split/req" tasks-axi)
+  dir_exp=$(make_axi_bin "$TMP_ROOT/split/exp" gh-axi chrome-devtools-axi)
+
+  run_suffix "$dir_req:$dir_exp:$BARE_PATH"
+  expect_code 0 "$SUFFIX_STATUS" "a split install should still resolve"
+  [ "$SUFFIX_OUT" = "$dir_req:$dir_exp" ] || fail "both install directories should be carried"$'\n'"expected: $dir_req:$dir_exp"$'\n'"actual:   $SUFFIX_OUT"
+  pass "tools installed in separate directories are all carried into the suffix"
+}
+
+test_shared_directory_is_not_duplicated() {
+  local dir
+  dir=$(make_axi_bin "$TMP_ROOT/dedupe/bin" tasks-axi gh-axi chrome-devtools-axi lavish-axi)
+
+  run_suffix "$dir:$BARE_PATH"
+  case "$SUFFIX_OUT" in
+    *:*) fail "one shared directory should appear once, got: $SUFFIX_OUT" ;;
+  esac
+  pass "one shared install directory is emitted once, not once per tool"
+}
+
+test_individually_missing_tool_warns_but_still_resolves() {
+  local dir
+  # One tool installed, the rest genuinely absent: an install gap, not the
+  # toolchain-resolved-away failure, so the fleet keeps moving with a loud warning.
+  dir=$(make_axi_bin "$TMP_ROOT/warn/bin" tasks-axi)
+
+  run_suffix "$dir:$BARE_PATH"
+  expect_code 0 "$SUFFIX_STATUS" "an uninstalled tool is an install gap, not a resolution failure"
+  [ "$SUFFIX_OUT" = "$dir" ] || fail "expected $dir, got $SUFFIX_OUT"
+  assert_contains "$SUFFIX_ERR" "gh-axi" "warning should name an absent tool"
+  assert_contains "$SUFFIX_ERR" "chrome-devtools-axi" "warning should name every absent tool"
+  assert_contains "$SUFFIX_ERR" "instructions tell it to use them" \
+    "warning should say why an absent tool matters"
+  pass "an individually uninstalled tool warns loudly so the brief instruction is never silently false"
+}
+
+test_no_tool_resolving_fails_with_actionable_message() {
+  # Every axi tool gone at once: the signature of a project toolchain resolving
+  # away from the one they were installed into.
+  run_suffix "$BARE_PATH"
+  expect_code 1 "$SUFFIX_STATUS" "an unresolvable tool directory must fail, not resolve to nothing"
+  [ -z "$SUFFIX_OUT" ] || fail "a failed resolution must print no suffix, got: $SUFFIX_OUT"
+  assert_contains "$SUFFIX_ERR" "cannot resolve the axi agent tool directory" \
+    "failure should name the unresolvable directory"
+  assert_contains "$SUFFIX_ERR" "tasks-axi" "failure should name the missing tools"
+  assert_contains "$SUFFIX_ERR" "Node toolchain they were installed into is not active" \
+    "failure should name the likely cause"
+  assert_contains "$SUFFIX_ERR" "npm install -g" "failure should be actionable"
+  pass "an unresolvable tool directory fails with a clear, actionable message"
+}
+
+# --- fm-spawn.sh integration -------------------------------------------------
+
+make_spawn_fakebin() {  # <dir> [--with-axi]
+  local dir=$1 with_axi=${2:-} fakebin
+  fakebin=$(fm_fakebin "$dir")
+  fakebin=$(cd "$fakebin" && pwd)
+  # Logs BOTH plain send-keys lines (the env exports) and literal -l sends (the
+  # launch command), so the PATH export is asserted as sent, not inferred.
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_SEND_LOG:-}" ]; then
+      shift
+      prev=
+      for a in "$@"; do
+        case "$a" in
+          -t|-l|Enter) prev=$a; continue ;;
+        esac
+        [ "$prev" = "-t" ] || printf '%s\n' "$a" >> "$FM_FAKE_SEND_LOG"
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse pi-signed
+  if [ "$with_axi" = --with-axi ]; then
+    make_axi_bin "$fakebin" tasks-axi gh-axi chrome-devtools-axi lavish-axi >/dev/null
+  fi
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {  # <name> <task-id> [--with-axi]
+  local name=$1 id=$2 with_axi=${3:-} case_dir home proj wt fakebin sendlog
+  case_dir="$TMP_ROOT/spawn-$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  sendlog="$case_dir/send.log"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake" "$with_axi")
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'claude\n' > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  touch "$home/state/.last-watcher-beat"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  printf '%s\n' "$home|$proj|$wt|$fakebin|$sendlog"
+}
+
+read_case_record() {
+  IFS='|' read -r HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR SEND_LOG <<EOF
+$1
+EOF
+}
+
+run_spawn() {  # <home> <wt> <fakebin> <sendlog> <path> <spawn args...>
+  local home=$1 wt=$2 fakebin=$3 sendlog=$4 path=$5
+  shift 5
+  : > "$sendlog"
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_SEND_LOG="$sendlog" PATH="$fakebin:$path" \
+    "$SPAWN" "$@" 2>&1
+}
+
+test_spawn_exports_the_tool_directory_appended_to_path() {
+  local rec id out status export_line expected
+  id=axi-export-a1
+  rec=$(make_spawn_case export "$id" --with-axi)
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$SEND_LOG" "$BARE_PATH" "$id" "$PROJ_DIR") \
+    && status=0 || status=$?
+  expect_code 0 "$status" "spawn with resolvable axi tools should succeed: $out"
+
+  export_line=$(grep '^export PATH=' "$SEND_LOG" || true)
+  [ -n "$export_line" ] || fail "spawn did not export a PATH into the agent's shell"$'\n'"sent: $(cat "$SEND_LOG")"
+  expected="export PATH=\"\$PATH\":'$FAKEBIN_DIR'"
+  [ "$export_line" = "$expected" ] || \
+    fail "PATH export should APPEND the quoted tool directory so a project's own node/npm still wins"$'\n'"expected: $expected"$'\n'"actual:   $export_line"
+  pass "spawn exports the resolved axi tool directory appended to the agent's PATH"
+}
+
+test_spawn_refuses_when_tool_directory_is_unresolvable() {
+  local rec id out status
+  id=axi-refuse-b2
+  # No --with-axi: the fake bin dir has tmux/treehouse but no axi tools, and the
+  # bare PATH excludes the real install location.
+  rec=$(make_spawn_case refuse "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$SEND_LOG" "$BARE_PATH" "$id" "$PROJ_DIR") \
+    && status=0 || status=$?
+  expect_code 1 "$status" "spawn must refuse when the axi tool directory cannot be resolved"
+  assert_contains "$out" "cannot resolve the axi agent tool directory" \
+    "refusal should say what could not be resolved"
+  assert_contains "$out" "npm install -g tasks-axi" "refusal should be actionable"
+  assert_absent "$HOME_DIR/state/$id.meta" "refusal must happen before task metadata is written"
+  [ ! -s "$SEND_LOG" ] || fail "refusal must happen before anything is sent to an endpoint"$'\n'"sent: $(cat "$SEND_LOG")"
+  pass "an unresolvable tool directory refuses the spawn before any endpoint or metadata exists"
+}
+
+test_resolves_directory_from_actual_tool_location
+test_resolution_hardcodes_no_node_version
+test_split_install_locations_are_all_carried
+test_shared_directory_is_not_duplicated
+test_individually_missing_tool_warns_but_still_resolves
+test_no_tool_resolving_fails_with_actionable_message
+test_spawn_exports_the_tool_directory_appended_to_path
+test_spawn_refuses_when_tool_directory_is_unresolvable

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -715,6 +715,9 @@ test_spawn_fast_forwards_before_launch() {
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  # fm-spawn.sh refuses to launch when no axi agent tool resolves, and BASE_PATH
+  # deliberately excludes the toolchain they live in.
+  fm_fake_exit0 "$fakebin" tasks-axi gh-axi chrome-devtools-axi lavish-axi
 
   PATH="$fakebin:$BASE_PATH" TMUX='' \
     FM_ROOT_OVERRIDE="$w/main" FM_HOME="$w/home" \
@@ -749,6 +752,9 @@ test_spawn_warns_when_sync_skipped_before_launch() {
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  # fm-spawn.sh refuses to launch when no axi agent tool resolves, and BASE_PATH
+  # deliberately excludes the toolchain they live in.
+  fm_fake_exit0 "$fakebin" tasks-axi gh-axi chrome-devtools-axi lavish-axi
 
   PATH="$fakebin:$BASE_PATH" TMUX='' \
     FM_ROOT_OVERRIDE="$w/main" FM_HOME="$w/home" \

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -213,6 +213,9 @@ make_fake_spawn_toolchain() {
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  # fm-spawn.sh refuses to launch when no axi agent tool resolves, and BASE_PATH
+  # deliberately excludes the toolchain they live in.
+  fm_fake_exit0 "$fakebin" tasks-axi gh-axi chrome-devtools-axi lavish-axi
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -42,7 +42,10 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse pi-signed
+  # fm-spawn.sh refuses to launch when it cannot resolve the axi agent tool
+  # directory, so every case here supplies it; the cases that sanitize PATH would
+  # otherwise trip that refusal instead of the behavior they are pinning.
+  fm_fake_exit0 "$fakebin" treehouse pi-signed tasks-axi gh-axi chrome-devtools-axi lavish-axi
   printf '%s\n' "$fakebin"
 }
 


### PR DESCRIPTION
## The defect

The axi tools (`tasks-axi`, `gh-axi`, `chrome-devtools-axi`, `lavish-axi`) are npm globals.
They install into whichever Node toolchain was active at install time, for example a mise-managed `~/.local/share/mise/installs/node/<version>/bin`.
That directory is on `PATH` only while that toolchain is the one being resolved.

`bin/fm-spawn.sh` launches an agent in a different project directory, and mise resolves toolchains per directory.
When the target project selects a different toolchain, the tools drop off `PATH` **all at once**.
A project pinning its own Node version does it, and so does a project whose config file mise declines to trust, since the failed config load takes the whole toolchain with it.

Nothing is uninstalled; the tools are simply unreachable from where the agent runs.

Two concrete consequences:

- `bin/fm-decision-hold.sh` refuses outright with `compatible tasks-axi is required`, so that path cannot be used at all from a spawned agent's worktree.
- Every generated brief instructs the agent to use `gh-axi` for GitHub operations. That instruction is silently false. An agent may notice and fall back to plain `gh`, or may not.

This is not specific to any one project layout. Any user whose axi tools live in a version-managed Node toolchain hits it as soon as an agent works in a directory that resolves a different toolchain.

## The fix

`bin/fm-spawn.sh` resolves the tool directory in the spawning process's own environment, where the tools do resolve, and exports it into the spawned agent's shell.
The resolution logic lives in a new `bin/fm-axi-path-lib.sh`.

Four properties worth checking in review:

1. **Resolved dynamically, with no hardcoded Node version.** The directory comes from `command -v` on the tools themselves, then `dirname`. A hardcoded `node/24` path would keep working until the day it becomes `node/25`, then silently recreate this exact bug. No Node version, mise layout, or install prefix is assumed anywhere in the change.

2. **The unresolvable case fails loudly at spawn.** If no axi tool resolves, the spawn is refused with an actionable message naming the missing tools and the likely cause, before any session endpoint or task metadata is created. The alternative — launching an agent that has been told to use tools it cannot see — moves the failure deep inside the task, where it is far more expensive. A single uninstalled tool while others resolve is an install gap rather than a `PATH` gap, so that warns loudly and proceeds rather than blocking every spawn.

3. **Proven by running the tools, not by printing `PATH`.** A directory being present on `PATH` is not evidence a binary executes. Verified in a shell in a directory that reproduces the bug (a project whose own mise config selects a different toolchain), before and after:

   ```
   BEFORE                          AFTER
   tasks-axi: not found            tasks-axi           0.2.2
   gh-axi: not found               gh-axi              0.1.25
   chrome-devtools-axi: not found  chrome-devtools-axi 0.1.26
   lavish-axi: not found           lavish-axi          0.1.37

   bin/fm-decision-hold.sh:
   "compatible tasks-axi is required"   ->   registers the hold successfully
   ```

   `fm-decision-hold.sh` is called out specifically because it is the concrete thing that was broken.

4. **The failure path is tested, not only the happy path.** `tests/fm-axi-path.test.sh` adds 8 cases. Two pin the refusal: the actionable message, and that `fm-spawn.sh` refuses before any endpoint or task metadata exists. The rest cover dynamic resolution against two unrelated install locations, deduplication, split installs, and the warn-but-proceed path.

The directory is **appended** to `PATH` rather than prepended, on purpose: it is also a Node toolchain `bin` directory, and prepending it would shadow a project's own pinned `node`/`npm`. Appending still resolves the axi tools, since no other directory on the agent's `PATH` provides those names.

## Regressions this change caused, and their correction

An earlier revision of this change made `tasks-axi` individually mandatory, so a spawn refused whenever that one tool was missing.
That was stricter than the defect requires and it broke four spawn-related suites that deliberately run with a stripped-down `PATH`: `fm-secondmate-sync`, `fm-shared-captain-inheritance`, `fm-session-start`, and `fm-kimi-harness`.

The refusal now triggers only when no axi tool resolves at all, which is the actual signature of a toolchain resolving away, since it takes all four together.
That fixed two of the four outright.
The other two had fixtures with no axi tools present at all and now supply stubs, since the spawn genuinely requires resolving the directory.
All four pass.

## Test results

Locally, 91 of 101 suites run; the remaining 10 are gated on real Herdr.

- Both portable parallel lanes: 0 failures.
- Portable serial lane: 3 failures, all pre-existing.
- `bin/fm-lint.sh`, the coverage guard, and `bin/fm-doc-audience-check.sh` are all clean.

The three serial failures were **proven** pre-existing rather than assumed. With this change fully removed and the working tree reverted to base `fa0d85d`, all three fail identically: a real-zellij pane check reporting an empty working directory, a bootstrap check that wants `cmux` installed on the host, and a signed-wrapper harness-ancestry check. None of them touch spawning or `PATH` resolution.

## Coverage limits, stated plainly

- The automated tests exercise resolution and the refusal through the tmux backend only. The export reaches the herdr, zellij, orca, and cmux backends via the same shared send path that already carries the existing `GOTMPDIR` export, so it is structurally identical, but it is not separately covered by a test.
- The end-to-end proof from a toolchain-pinned worktree, shown above, was performed manually. It is not automated, since it depends on a second project's toolchain configuration being present on the host.

## Notes

- CI's Herdr lane now installs `tasks-axi`, because that lane performs real spawns and would otherwise hit the new refusal.
- No change to any global mise configuration, shell profile, or installed package. The fix is entirely at spawn time, where the problem is created.
