### PR TITLE
fix(bin): start crewmates on the project's recorded base branch

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -34,6 +34,7 @@ Choose the delivery mode when adding or creating the project:
 - `direct-PR` pushes and opens a PR without the no-mistakes pipeline.
 - `local-only` has no required remote or PR and lands only through the approved local fast-forward path.
 
+Record the project's base branch in the same registry entry whenever the project is developed off a branch other than its repository default, so a freshly allocated task worktree does not start a worker on a stale tree.
 The optional `+yolo` posture changes routine approval authority but does not change the delivery mode.
 Default it off, and enable it only on the captain's explicit instruction.
 `AGENTS.md` section 7 owns the complete authority boundary and exceptions when it is on.

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env bash
-# Resolve a project's delivery mode and yolo flag from the data/projects.md registry.
+# Resolve a project's delivery mode, yolo flag, and base branch from the
+# data/projects.md registry.
 # Prints two words to stdout: "<mode> <yolo>" where mode is one of
 # no-mistakes|direct-PR|local-only and yolo is on|off.
+# With --base, prints the recorded base branch instead, or nothing when the
+# project has no base= record (callers fall back to the repo's default branch).
 #
 # Registry line format (data/projects.md):
 #   - <name> - <desc> (added <date>)                  -> no-mistakes off  (legacy default)
 #   - <name> [<mode>] - <desc> (added <date>)          -> <mode> off
 #   - <name> [<mode> +yolo] - <desc> (added <date>)    -> <mode> on
+#   - <name> [<mode> base=<branch>] - <desc> ...       -> <mode> off, base <branch>
+# The bracket holds unordered tokens, so +yolo and base=<branch> may appear in
+# either order and either may be omitted.
 #
+# base = the branch a task worktree must start from. A freshly allocated pool
+#   worktree lands on the repo's DEFAULT branch, which is the wrong base for a
+#   project that develops elsewhere; bin/fm-spawn.sh checks this branch out and
+#   refuses to launch a worker it cannot confirm is on it.
 # mode = how a finished change reaches main:
 #   no-mistakes  full pipeline -> PR -> captain merge (default)
 #   direct-PR    push + PR via gh-axi, no pipeline -> captain merge
@@ -18,7 +28,7 @@
 #
 # An unknown/missing project or unknown mode falls back to "no-mistakes off" and warns
 # to stderr, so a typo never silently drops the gate.
-# Usage: fm-project-mode.sh <project-name>
+# Usage: fm-project-mode.sh [--base] <project-name>
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -26,38 +36,58 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 REG="$DATA/projects.md"
-NAME=${1:?usage: fm-project-mode.sh <project-name>}
+WANT_BASE=no
+if [ "${1:-}" = "--base" ]; then
+  WANT_BASE=yes
+  shift
+fi
+NAME=${1:?usage: fm-project-mode.sh [--base] <project-name>}
 
+# A base query is advisory: an absent registry, project, or base= record all mean
+# "no recorded base", and the caller falls back to the repo default branch.
 if [ ! -f "$REG" ]; then
+  [ "$WANT_BASE" = yes ] && exit 0
   echo "warn: no registry at $REG; defaulting $NAME to no-mistakes off" >&2
   echo "no-mistakes off"
   exit 0
 fi
 
-# awk emits "<mode> <yolo>" (one line) or nothing if the project is absent.
+# awk emits "<mode> <yolo> <base>" (one line, base may be empty) or nothing if
+# the project is absent.
 parsed=$(awk -v n="$NAME" '
   $1=="-" && $2==n {
-    mode="no-mistakes"; yolo="off";
+    mode="no-mistakes"; yolo="off"; base="";
     if ($3 ~ /^\[/) {
       s="";
       for (i=3; i<=NF; i++) { s = s (s==""?"":" ") $i; if ($i ~ /\]$/) break }
       gsub(/^\[|\]$/, "", s);           # strip the surrounding brackets
       k = split(s, a, " ");
-      if (a[1] != "" && a[1] != "+yolo") mode = a[1];
-      for (j=1; j<=k; j++) if (a[j]=="+yolo") yolo="on";
+      if (a[1] != "" && a[1] != "+yolo" && a[1] !~ /^base=/) mode = a[1];
+      for (j=1; j<=k; j++) {
+        if (a[j]=="+yolo") yolo="on";
+        if (a[j] ~ /^base=/) base = substr(a[j], 6);
+      }
     }
-    print mode, yolo; exit
+    print mode, yolo, base; exit
   }
 ' "$REG")
 
 if [ -z "$parsed" ]; then
+  [ "$WANT_BASE" = yes ] && exit 0
   echo "warn: project \"$NAME\" not in registry; defaulting to no-mistakes off" >&2
   echo "no-mistakes off"
   exit 0
 fi
 
-mode=${parsed%% *}
-yolo=${parsed##* }
+read -r mode yolo base <<EOF
+$parsed
+EOF
+
+if [ "$WANT_BASE" = yes ]; then
+  # A bracket token of "base=" alone records nothing usable; treat it as absent.
+  [ -n "${base:-}" ] && echo "$base"
+  exit 0
+fi
 case "$mode" in
   no-mistakes|direct-PR|local-only) ;;
   *) echo "warn: unknown mode \"$mode\" for $NAME; defaulting to no-mistakes off" >&2; mode=no-mistakes; yolo=off ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -85,6 +85,10 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
+#   That worktree is then detached at the project's base branch - its base=
+#   record in data/projects.md (bin/fm-project-mode.sh), else the repo default
+#   branch - and the spawn is refused, naming expected branch, actual base, and
+#   the gap, when the resulting base cannot be confirmed correct.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -809,6 +813,9 @@ if [ "$KIND" = secondmate ]; then
   fi
 else
   PROJ_ABS="$(cd "$(resolve_project_dir_arg "$PROJ")" && pwd)"
+  # Registry key for this project: needed by the base-branch check below, well
+  # before the delivery-mode lookup at the end reuses it.
+  PROJ_NAME=$(basename "$PROJ_ABS")
   WT=""
   BRIEF="$DATA/$ID/brief.md"
 fi
@@ -860,6 +867,102 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
+  fi
+}
+
+# Base branch of a task worktree.
+#
+# A freshly allocated pool worktree lands on the repo's DEFAULT branch. For a
+# project that develops elsewhere that is silently the wrong base: task
+# jt-style-number-column audited a tree 1036 commits behind origin/develop and
+# correctly reported that nothing described in its brief existed. A REUSED slot
+# already sits on the right branch, which is why this only bites a cold slot.
+#
+# So the intended base is checked out first (the project's base= record in
+# data/projects.md, else the repo default branch as before), then asserted: a
+# worker is never launched onto a base that cannot be confirmed correct.
+# Detached, exactly like treehouse's own handoff - the branch is often already
+# checked out in the primary checkout, and the worker cuts its own branch here.
+spawn_expected_base_branch() {  # -> "<branch> recorded|default"; empty if unresolvable
+  local recorded ref
+  recorded=$("$FM_ROOT/bin/fm-project-mode.sh" --base "$PROJ_NAME" 2>/dev/null || true)
+  if [ -n "$recorded" ]; then
+    echo "$recorded recorded"
+    return 0
+  fi
+  ref=$(git -C "$WT" symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -n "$ref" ]; then
+    echo "${ref#origin/} default"
+    return 0
+  fi
+  # No remote HEAD (a local-only project): the primary checkout's own branch is
+  # the closest thing to a default branch this repo has.
+  ref=$(git -C "$PROJ_ABS" symbolic-ref -q --short HEAD 2>/dev/null || true)
+  [ -n "$ref" ] && echo "$ref default"
+  return 0
+}
+
+# origin/<branch> is the fetched truth for a shared clone; a local branch of the
+# same name can itself be stale. Empty when the branch exists in neither form.
+spawn_base_ref() {  # <branch>
+  local branch=$1
+  if git -C "$WT" rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null 2>&1; then
+    echo "origin/$branch"
+  elif git -C "$WT" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null 2>&1; then
+    echo "$branch"
+  fi
+  return 0
+}
+
+spawn_base_gap() {  # <from-ref> <to-ref> -> "<behind> behind, <ahead> ahead"
+  local counts behind ahead
+  counts=$(git -C "$WT" rev-list --left-right --count "$1...$2" 2>/dev/null || true)
+  [ -n "$counts" ] || { echo "gap unknown (unrelated histories)"; return 0; }
+  behind=$(echo "$counts" | awk '{print $1}')
+  ahead=$(echo "$counts" | awk '{print $2}')
+  echo "$behind behind, $ahead ahead"
+}
+
+ensure_spawn_base_branch() {
+  local resolved base source ref want head actual primary primary_ref behind
+  resolved=$(spawn_expected_base_branch)
+  if [ -z "$resolved" ]; then
+    echo "warning: no expected base branch could be resolved for $PROJ_NAME; launching $ID on the worktree's current base" >&2
+    return 0
+  fi
+  base=${resolved%% *}
+  source=${resolved##* }
+  ref=$(spawn_base_ref "$base")
+  if [ -z "$ref" ]; then
+    echo "error: expected base branch '$base' ($source) does not exist in $WT; refusing to launch $ID onto an unconfirmed base. Fetch that branch, or fix the base= record for $PROJ_NAME in data/projects.md." >&2
+    exit 1
+  fi
+  git -C "$WT" checkout --quiet --detach "$ref" 2>/dev/null || true
+
+  want=$(git -C "$WT" rev-parse "$ref")
+  head=$(git -C "$WT" rev-parse HEAD 2>/dev/null || true)
+  if [ "$head" != "$want" ]; then
+    actual=$(git -C "$WT" name-rev --name-only --always HEAD 2>/dev/null || echo unknown)
+    echo "error: $WT is not on its base branch and could not be moved there; refusing to launch $ID onto a stale tree. Expected $base ($ref, ${want:0:12}); actual base $actual (${head:-unknown}); $(spawn_base_gap "$ref" "HEAD"). Resolve the worktree by hand (uncommitted work, or a checkout conflict), then respawn." >&2
+    exit 1
+  fi
+
+  # No recorded base means the default branch was only assumed correct. The
+  # primary checkout's own branch is independent evidence: if the assumed base
+  # is strictly behind it, this is the incident above, so refuse rather than
+  # launch a worker a thousand commits in the past.
+  if [ "$source" = default ]; then
+    primary=$(git -C "$PROJ_ABS" symbolic-ref -q --short HEAD 2>/dev/null || true)
+    if [ -n "$primary" ] && [ "$primary" != "$base" ]; then
+      primary_ref=$(spawn_base_ref "$primary")
+      if [ -n "$primary_ref" ]; then
+        behind=$(git -C "$WT" rev-list --count "$ref..$primary_ref" 2>/dev/null || echo 0)
+        if [ "${behind:-0}" -gt 0 ]; then
+          echo "error: refusing to launch $ID onto a base that cannot be confirmed correct. Actual base '$base' (the repo default branch) is $behind commits behind '$primary', the branch $PROJ_ABS is on; expected base '$primary'. No base branch is recorded for $PROJ_NAME: record it in data/projects.md as \"[<mode> base=$primary]\", then respawn." >&2
+          exit 1
+        fi
+      fi
+    fi
   fi
 }
 
@@ -1288,6 +1391,11 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   validate_spawn_worktree "treehouse get" "$T"
 fi
 
+# Both worktree sources (treehouse and orca) have produced $WT by here, and no
+# harness has launched yet, so this is the one point where the base can still be
+# corrected. A secondmate home is a firstmate worktree, not a project one.
+[ "$KIND" = secondmate ] || ensure_spawn_base_branch
+
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
 # create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.
 # Nested (not a bare /tmp/fm-<id>/gotmp) so other per-task temp can live alongside
@@ -1425,7 +1533,6 @@ if [ "$KIND" = secondmate ]; then
   YOLO=off
   SECONDMATE_PROJECTS=$(secondmate_registry_value "$ID" projects || true)
 else
-  PROJ_NAME=$(basename "$PROJ_ABS")
   read -r MODE YOLO <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$PROJ_NAME")
 EOF

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -903,13 +903,20 @@ spawn_expected_base_branch() {  # -> "<branch> recorded|default"; empty if unres
 }
 
 # origin/<branch> is the fetched truth for a shared clone; a local branch of the
-# same name can itself be stale. Empty when the branch exists in neither form.
+# same name can itself be stale. A local-only project inverts that: it lands work
+# with bin/fm-merge-local.sh, which fast-forwards the LOCAL branch and never
+# pushes, so there origin/<branch> is the stale one whenever an origin exists at
+# all. Empty when the branch exists in neither form.
 spawn_base_ref() {  # <branch>
-  local branch=$1
-  if git -C "$WT" rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null 2>&1; then
-    echo "origin/$branch"
-  elif git -C "$WT" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null 2>&1; then
-    echo "$branch"
+  local branch=$1 local_ref="" origin_ref=""
+  git -C "$WT" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null 2>&1 && local_ref="$branch"
+  git -C "$WT" rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null 2>&1 && origin_ref="origin/$branch"
+  if [ "${SPAWN_BASE_MODE:-}" = local-only ] && [ -n "$local_ref" ]; then
+    echo "$local_ref"
+  elif [ -n "$origin_ref" ]; then
+    echo "$origin_ref"
+  elif [ -n "$local_ref" ]; then
+    echo "$local_ref"
   fi
   return 0
 }
@@ -924,7 +931,8 @@ spawn_base_gap() {  # <from-ref> <to-ref> -> "<behind> behind, <ahead> ahead"
 }
 
 ensure_spawn_base_branch() {
-  local resolved base source ref want head actual primary primary_ref behind
+  local resolved base source ref want head actual primary primary_ref behind err
+  SPAWN_BASE_MODE=$("$FM_ROOT/bin/fm-project-mode.sh" "$PROJ_NAME" 2>/dev/null | awk 'NR==1{print $1}' || true)
   resolved=$(spawn_expected_base_branch)
   if [ -z "$resolved" ]; then
     echo "warning: no expected base branch could be resolved for $PROJ_NAME; launching $ID on the worktree's current base" >&2
@@ -937,13 +945,13 @@ ensure_spawn_base_branch() {
     echo "error: expected base branch '$base' ($source) does not exist in $WT; refusing to launch $ID onto an unconfirmed base. Fetch that branch, or fix the base= record for $PROJ_NAME in data/projects.md." >&2
     exit 1
   fi
-  git -C "$WT" checkout --quiet --detach "$ref" 2>/dev/null || true
+  err=$(git -C "$WT" checkout --quiet --detach "$ref" 2>&1) || true
 
   want=$(git -C "$WT" rev-parse "$ref")
   head=$(git -C "$WT" rev-parse HEAD 2>/dev/null || true)
   if [ "$head" != "$want" ]; then
     actual=$(git -C "$WT" name-rev --name-only --always HEAD 2>/dev/null || echo unknown)
-    echo "error: $WT is not on its base branch and could not be moved there; refusing to launch $ID onto a stale tree. Expected $base ($ref, ${want:0:12}); actual base $actual (${head:-unknown}); $(spawn_base_gap "$ref" "HEAD"). Resolve the worktree by hand (uncommitted work, or a checkout conflict), then respawn." >&2
+    echo "error: $WT is not on its base branch and could not be moved there; refusing to launch $ID onto a stale tree. Expected $base ($ref, ${want:0:12}); actual base $actual (${head:-unknown}); $(spawn_base_gap "$ref" "HEAD"). Resolve the worktree by hand (uncommitted work, or a checkout conflict), then respawn.${err:+ git said: $(echo "$err" | tr '\n' ' ')}" >&2
     exit 1
   fi
 
@@ -958,7 +966,7 @@ ensure_spawn_base_branch() {
       if [ -n "$primary_ref" ]; then
         behind=$(git -C "$WT" rev-list --count "$ref..$primary_ref" 2>/dev/null || echo 0)
         if [ "${behind:-0}" -gt 0 ]; then
-          echo "error: refusing to launch $ID onto a base that cannot be confirmed correct. Actual base '$base' (the repo default branch) is $behind commits behind '$primary', the branch $PROJ_ABS is on; expected base '$primary'. No base branch is recorded for $PROJ_NAME: record it in data/projects.md as \"[<mode> base=$primary]\", then respawn." >&2
+          echo "error: refusing to launch $ID onto a base that cannot be confirmed correct. Actual base '$base' (the repo default branch) is $behind commits behind '$primary', the branch $PROJ_ABS is on; expected base '$primary'. No base branch is recorded for $PROJ_NAME, so which one is right depends on why the checkout is on '$primary': if the project genuinely develops there, record it in data/projects.md as \"[<mode> base=$primary]\"; if the checkout is merely parked on a transient branch (a leftover fm/<id>, a checked-out PR), do NOT record it - return the checkout to '$base' instead. Then respawn." >&2
           exit 1
         fi
       fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -161,7 +161,8 @@ family_for_basename() {
       printf '%s\n' live-harness-optin
       ;;
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
-    fm-herdr-session-cleanup.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
+    fm-herdr-session-cleanup.test.sh|fm-send-strict.test.sh|fm-spawn-base-branch.test.sh|\
+    fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|fm-spawn-worktree-settle.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,8 +187,9 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 
 ## Project modes are explicit
 
-`data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
+`data/projects.md` records each project's delivery mode, optional `+yolo` autonomy flag, and optional base branch.
 `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
+The recorded base branch is what a task worktree must start from, because a freshly allocated pool worktree otherwise lands on the repo's default branch, which is the wrong base for a project developed elsewhere; `bin/fm-spawn.sh` checks that branch out and refuses to launch a worker onto a base it cannot confirm.
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -48,7 +48,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/orca.sh`       | Experimental Orca backend adapter owning both worktree and terminal                  |
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live secondmates mid-session and send a pointer to the literal-content config reread when config changed |
-| `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
+| `fm-project-mode.sh`     | Resolve a project's delivery mode, `+yolo` flag, and base branch from `data/projects.md` |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |

--- a/tests/fm-spawn-base-branch.test.sh
+++ b/tests/fm-spawn-base-branch.test.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# Regression test for fm-spawn.sh's task-worktree base branch
+# (bin/fm-spawn.sh's ensure_spawn_base_branch, bin/fm-project-mode.sh's base=).
+#
+# A freshly allocated pool worktree lands on the repo's DEFAULT branch. For a
+# project that develops on another branch that is silently the wrong base: task
+# jt-style-number-column audited a tree 1036 commits behind origin/develop and
+# correctly reported that nothing described in its brief existed. A REUSED slot
+# already sits on the right branch, which is why only a cold slot is affected.
+#
+# The fixtures below build exactly that shape - a main-defaulted clone whose
+# work happens on develop, plus a cold worktree detached at main - and assert
+# the recorded base is checked out, an unconfirmable base is refused instead of
+# launched, and a project with no base= record still spawns as it does today.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+MODE="$ROOT/bin/fm-project-mode.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-base-branch)
+fm_git_identity
+
+# make_base_fakebin <dir>: fake tmux reporting the cold worktree as the pane's
+# cwd (standing in for treehouse get), plus a no-op treehouse.
+make_base_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# make_base_case <name> <id> <primary-branch> [registry-line]: build a home plus
+# a project clone whose default branch is main and whose develop branch is three
+# commits ahead, with a COLD worktree detached at main. <primary-branch> is the
+# branch the project clone itself sits on; a registry line is written only when
+# one is given (its absence is the unregistered-project case).
+make_base_case() {
+  local name=$1 id=$2 primary=$3 reg_line=${4:-}
+  local case_dir home src bare proj wt fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  src="$case_dir/src"
+  bare="$case_dir/remote.git"
+  proj="$case_dir/projects/$name"
+  wt="$case_dir/cold-slot"
+  fakebin=$(make_base_fakebin "$case_dir/fake")
+
+  fm_git_init_commit "$src"
+  git -C "$src" branch -M main
+  git -C "$src" checkout -q -b develop
+  local i
+  for i in 1 2 3; do
+    printf 'develop work %s\n' "$i" > "$src/dev-$i.txt"
+    git -C "$src" add "dev-$i.txt"
+    git -C "$src" commit -qm "develop $i"
+  done
+  git -C "$src" checkout -q main
+  git clone --quiet --bare "$src" "$bare"
+  mkdir -p "$case_dir/projects"
+  git clone --quiet "$bare" "$proj"
+  git -C "$proj" checkout -q "$primary"
+  # The cold slot: a brand-new worktree off the DEFAULT branch, exactly what a
+  # freshly allocated pool slot hands over.
+  git -C "$proj" worktree add --quiet --detach "$wt" main
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+  if [ -n "$reg_line" ]; then
+    printf '# Projects\n%s\n' "$reg_line" > "$home/data/projects.md"
+  fi
+
+  printf '%s|%s|%s|%s\n' "$home" "$proj" "$wt" "$fakebin"
+}
+
+read_base_record() {
+  IFS='|' read -r HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR <<EOF
+$1
+EOF
+}
+
+run_base_spawn() {
+  local id=$1
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH="$WT_DIR" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" 2>&1
+}
+
+head_sha() { git -C "$1" rev-parse HEAD; }
+
+# A cold slot for a develop-based project starts the worker on develop, not on
+# the default branch the slot was allocated from.
+test_recorded_base_is_checked_out() {
+  local rec id out status
+  id=base-recorded-b1
+  rec=$(make_base_case base-recorded "$id" main \
+    '- base-recorded [no-mistakes base=develop] - develop-based (added 2026-07-28)')
+  read_base_record "$rec"
+
+  out=$(run_base_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed with a recorded base branch: $out"
+  [ "$(head_sha "$WT_DIR")" = "$(git -C "$PROJ_DIR" rev-parse origin/develop)" ] \
+    || fail "cold slot was not moved to the recorded base branch (HEAD $(head_sha "$WT_DIR"))"
+  pass "a cold slot for a develop-based project starts the worker on develop"
+}
+
+# The assertion fires: no base record, and the default branch the slot came from
+# is genuinely behind the branch the project is actually developed on.
+test_unconfirmable_base_is_refused() {
+  local rec id out status
+  id=base-stale-b2
+  rec=$(make_base_case base-stale "$id" develop \
+    '- base-stale [no-mistakes] - no base record (added 2026-07-28)')
+  read_base_record "$rec"
+
+  out=$(run_base_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn onto an unconfirmable base should have been refused: $out"
+  assert_contains "$out" "cannot be confirmed correct" "refusal did not explain the base could not be confirmed"
+  assert_contains "$out" "expected base 'develop'" "refusal did not name the expected branch"
+  assert_contains "$out" "Actual base 'main'" "refusal did not name the actual base"
+  assert_contains "$out" "3 commits behind" "refusal did not report the gap"
+  assert_contains "$out" "base=develop" "refusal did not say how to record the base"
+  [ -f "$HOME_DIR/state/$id.meta" ] && fail "a refused spawn must not publish task metadata"
+  pass "a worker whose base cannot be confirmed is refused, naming branch, base, and gap"
+}
+
+# The assertion passes when the default branch IS the right base: no record, and
+# the project develops on its default branch.
+test_default_base_passes_assertion() {
+  local rec id out status
+  id=base-default-b3
+  rec=$(make_base_case base-default "$id" main \
+    '- base-default [direct-PR] - main-based (added 2026-07-28)')
+  read_base_record "$rec"
+
+  out=$(run_base_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed when the default branch is the right base: $out"
+  [ "$(head_sha "$WT_DIR")" = "$(git -C "$PROJ_DIR" rev-parse origin/main)" ] \
+    || fail "worker was not left on the default branch"
+  assert_grep "mode=direct-PR" "$HOME_DIR/state/$id.meta" "delivery mode was not recorded"
+  pass "a project whose default branch is the right base passes the assertion"
+}
+
+# An unregistered project - no registry at all - spawns exactly as it does today.
+test_unregistered_project_spawns_as_today() {
+  local rec id out status
+  id=base-unregistered-b4
+  rec=$(make_base_case base-unregistered "$id" main)
+  read_base_record "$rec"
+  [ -f "$HOME_DIR/data/projects.md" ] && fail "fixture should have no registry"
+
+  out=$(run_base_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "an unregistered project must still spawn: $out"
+  [ "$(head_sha "$WT_DIR")" = "$(git -C "$PROJ_DIR" rev-parse origin/main)" ] \
+    || fail "unregistered project did not fall back to the repo default branch"
+  assert_grep "mode=no-mistakes" "$HOME_DIR/state/$id.meta" "unregistered fallback mode changed"
+  pass "an unregistered project falls back to the default branch and spawns as today"
+}
+
+# A base= record naming a branch this repo does not have is refused rather than
+# silently ignored back to the default branch.
+test_missing_base_branch_is_refused() {
+  local rec id out status
+  id=base-typo-b5
+  rec=$(make_base_case base-typo "$id" main \
+    '- base-typo [no-mistakes base=develp] - typo in the base record (added 2026-07-28)')
+  read_base_record "$rec"
+
+  out=$(run_base_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a base= record naming a missing branch should be refused: $out"
+  assert_contains "$out" "'develp'" "refusal did not name the missing base branch"
+  pass "a base= record naming a branch the repo does not have is refused"
+}
+
+# The registry parse: base= is readable alongside the delivery mode, and every
+# pre-existing line shape keeps parsing to exactly the same two words.
+test_registry_parse_is_backward_compatible() {
+  local dir out
+  dir="$TMP_ROOT/parse/data"
+  mkdir -p "$dir"
+  cat > "$dir/projects.md" <<'EOF'
+# Projects
+- legacy - plain line (added 2026-01-01)
+- moded [direct-PR] - mode only (added 2026-01-01)
+- yolod [local-only +yolo] - mode and yolo (added 2026-01-01)
+- based [no-mistakes base=develop] - base record (added 2026-01-01)
+- everything [direct-PR +yolo base=develop] - all tokens (added 2026-01-01)
+- reordered [direct-PR base=develop +yolo] - unordered tokens (added 2026-01-01)
+- baseonly [base=develop] - base without a mode (added 2026-01-01)
+EOF
+
+  local name want
+  while IFS='|' read -r name want; do
+    [ -n "$name" ] || continue
+    out=$(FM_DATA_OVERRIDE="$dir" "$MODE" "$name" 2>/dev/null)
+    [ "$out" = "$want" ] \
+      || fail "delivery-mode parse changed for $name: got '$out', want '$want'"
+  done <<'EOF'
+legacy|no-mistakes off
+moded|direct-PR off
+yolod|local-only on
+based|no-mistakes off
+everything|direct-PR on
+reordered|direct-PR on
+baseonly|no-mistakes off
+EOF
+
+  for name in based everything reordered baseonly; do
+    out=$(FM_DATA_OVERRIDE="$dir" "$MODE" --base "$name" 2>/dev/null)
+    [ "$out" = develop ] || fail "--base did not read base= for $name: got '$out'"
+  done
+  for name in legacy moded yolod absent; do
+    out=$(FM_DATA_OVERRIDE="$dir" "$MODE" --base "$name" 2>/dev/null)
+    [ -z "$out" ] || fail "--base invented a base branch for $name: got '$out'"
+  done
+  out=$(FM_DATA_OVERRIDE="$TMP_ROOT/parse/absent" "$MODE" --base anything 2>/dev/null)
+  [ -z "$out" ] || fail "--base against a missing registry should print nothing: got '$out'"
+
+  pass "base= parses alongside the delivery mode without changing any existing line's mode"
+}
+
+test_registry_parse_is_backward_compatible
+test_recorded_base_is_checked_out
+test_unconfirmable_base_is_refused
+test_default_base_passes_assertion
+test_unregistered_project_spawns_as_today
+test_missing_base_branch_is_refused
+
+echo "# all fm-spawn-base-branch tests passed"

--- a/tests/fm-spawn-base-branch.test.sh
+++ b/tests/fm-spawn-base-branch.test.sh
@@ -196,6 +196,29 @@ test_missing_base_branch_is_refused() {
   pass "a base= record naming a branch the repo does not have is refused"
 }
 
+# A local-only project lands work with bin/fm-merge-local.sh, which fast-forwards
+# the LOCAL default branch and never pushes, so origin/main is the stale ref
+# there and the worker must start from the local branch instead.
+test_local_only_prefers_local_branch() {
+  local rec id out status
+  id=base-localonly-b6
+  rec=$(make_base_case base-localonly "$id" main \
+    '- base-localonly [local-only] - merged locally, never pushed (added 2026-07-28)')
+  read_base_record "$rec"
+  printf 'landed locally\n' > "$PROJ_DIR/landed.txt"
+  git -C "$PROJ_DIR" add landed.txt
+  git -C "$PROJ_DIR" commit -qm "landed locally"
+
+  out=$(run_base_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "a local-only project must still spawn: $out"
+  [ "$(head_sha "$WT_DIR")" = "$(git -C "$PROJ_DIR" rev-parse main)" ] \
+    || fail "local-only worker did not start from the local default branch (HEAD $(head_sha "$WT_DIR"))"
+  [ "$(head_sha "$WT_DIR")" != "$(git -C "$PROJ_DIR" rev-parse origin/main)" ] \
+    || fail "local-only worker started from the stale origin/main"
+  pass "a local-only project starts the worker from the local default branch"
+}
+
 # The registry parse: base= is readable alongside the delivery mode, and every
 # pre-existing line shape keeps parsing to exactly the same two words.
 test_registry_parse_is_backward_compatible() {
@@ -249,5 +272,6 @@ test_unconfirmable_base_is_refused
 test_default_base_passes_assertion
 test_unregistered_project_spawns_as_today
 test_missing_base_branch_is_refused
+test_local_only_prefers_local_branch
 
 echo "# all fm-spawn-base-branch tests passed"


### PR DESCRIPTION
## Intent

Stop fm-spawn from silently launching crewmates onto the wrong base branch: record each project's intended base branch in the registry, check it out in a freshly allocated task worktree, and refuse to launch a worker whose base cannot be confirmed correct.

## What Changed

- `bin/fm-project-mode.sh` now parses an optional `base=<branch>` token from a project's bracket in `data/projects.md` (unordered alongside `+yolo`) and gains a `--base` flag that prints the recorded base branch, or nothing when none is recorded.
- `bin/fm-spawn.sh` resolves the expected base for every task spawn — the `base=` record, else `origin/HEAD`, else the primary checkout's branch — detaches the freshly allocated worktree at that ref, and refuses to launch when the branch is missing, when the checkout can't be moved there (reporting expected/actual base and the behind/ahead gap), or when an assumed default base is strictly behind the branch the primary checkout is on. `local-only` projects prefer the local branch over `origin/<branch>`, which merge-local leaves stale.
- Added `tests/fm-spawn-base-branch.test.sh` (registered in the `backend-dispatch` family in `bin/fm-test-run.sh`) and documented the recorded base branch in `docs/architecture.md`, `docs/scripts.md`, and the project-management skill.

## Testing

- ⏭️ **Test** - skipped

## Registry edits for the operator's local `data/projects.md`

`data/projects.md` is captain-private and gitignored, so this branch cannot contain the edit and this worktree's copy is not the live one. Apply these lines to the live registry - add `base=develop` inside the existing bracket, keeping the current mode and any `+yolo` untouched:

```
- jt2627s [<existing mode><, keep +yolo if present> base=develop] - <keep existing description>
- oc [<existing mode><, keep +yolo if present> base=develop] - <keep existing description>
```

A line with no bracket today becomes `[no-mistakes base=develop]`, which preserves its current default mode.

Until those lines exist, spawns for `jt2627s` and `oc` will refuse rather than start a worker on a stale tree - the intended loud failure, but it means the registry edit should land before the next dispatch.

## Validation note

The Review, Test, Document, and Lint steps show as skipped above because this run resumed at the Push step after an earlier push was rejected (no write access to this repository; the branch is now pushed from a fork). Those four steps ran and passed on this exact head in run `01KYMC3QNPFHRDRCZBTRAVCATC`, whose review findings were fixed in commit `180fe58`.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

