### PR TITLE
fix(spawn): forward CLAUDE_CONFIG_DIR to claude crewmates

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1490,6 +1490,16 @@ LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
+# Crewmate panes are created by a long-lived tmux/herdr daemon that does not
+# inherit firstmate's current environment, so a bare `claude` in the pane falls
+# back to the default ~/.claude store even when firstmate itself runs under a
+# different CLAUDE_CONFIG_DIR (for example a work-vs-personal subscription split).
+# Forward firstmate's own resolved store onto the claude launch so the crewmate
+# uses the same credential/config firstmate is authenticated with. Only when set;
+# an unset value is the single-store default and needs no prefix.
+if [ "$HARNESS" = claude ] && [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
+  LAUNCH="CLAUDE_CONFIG_DIR=$(shell_quote "$CLAUDE_CONFIG_DIR") $LAUNCH"
+fi
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -447,12 +447,12 @@ test_claude_forwards_firstmate_config_dir_when_set() {
   rec=$(make_spawn_case profile-claude-cfgdir claude "$id")
   read_case_record "$rec"
 
-  out=$(FM_TEST_CLAUDE_CONFIG_DIR="/Users/test/.claude-work" \
+  out=$(FM_TEST_CLAUDE_CONFIG_DIR="/opt/test/claude-work" \
     run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
   status=$?
   expect_code 0 "$status" "claude spawn with CLAUDE_CONFIG_DIR set should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/Users/test/.claude-work' CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
     "claude launch did not forward firstmate's CLAUDE_CONFIG_DIR to the crewmate pane"
   pass "claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store"
 }
@@ -480,7 +480,7 @@ test_non_claude_harness_ignores_config_dir() {
   rec=$(make_spawn_case profile-codex-nocfgdir codex "$id")
   read_case_record "$rec"
 
-  out=$(FM_TEST_CLAUDE_CONFIG_DIR="/Users/test/.claude-work" \
+  out=$(FM_TEST_CLAUDE_CONFIG_DIR="/opt/test/claude-work" \
     run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
   status=$?
   expect_code 0 "$status" "codex spawn with CLAUDE_CONFIG_DIR set should succeed"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -84,10 +84,15 @@ run_spawn() {
   local home=$1 wt=$2 fakebin=$3 launchlog=$4
   shift 4
   : > "$launchlog"
+  # CLAUDE_CONFIG_DIR is forwarded onto claude launches by fm-spawn, so pin it
+  # explicitly (empty by default) instead of leaking the invoking shell's value,
+  # which would make launch assertions depend on the developer's environment.
+  # A test opts in to the set case via FM_TEST_CLAUDE_CONFIG_DIR.
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
@@ -436,6 +441,55 @@ test_batch_forwards_shared_profile_flags() {
   pass "batch dispatch forwards shared --harness, --model, and --effort to every pair"
 }
 
+test_claude_forwards_firstmate_config_dir_when_set() {
+  local rec id out status launch
+  id=profile-claude-cfgdir-z17
+  rec=$(make_spawn_case profile-claude-cfgdir claude "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_CLAUDE_CONFIG_DIR="/Users/test/.claude-work" \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "claude spawn with CLAUDE_CONFIG_DIR set should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/Users/test/.claude-work' CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
+    "claude launch did not forward firstmate's CLAUDE_CONFIG_DIR to the crewmate pane"
+  pass "claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store"
+}
+
+test_claude_omits_config_dir_prefix_when_unset() {
+  local rec id out status launch
+  id=profile-claude-nocfgdir-z18
+  rec=$(make_spawn_case profile-claude-nocfgdir claude "$id")
+  read_case_record "$rec"
+
+  # run_spawn pins CLAUDE_CONFIG_DIR empty by default, exercising the single-store
+  # default path where fm-spawn adds no prefix.
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "claude spawn without CLAUDE_CONFIG_DIR should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "CLAUDE_CONFIG_DIR=" \
+    "claude launch must not add a config-dir prefix when firstmate has no CLAUDE_CONFIG_DIR set"
+  pass "claude omits the config-dir prefix when firstmate runs with the single-store default"
+}
+
+test_non_claude_harness_ignores_config_dir() {
+  local rec id out status launch
+  id=profile-codex-nocfgdir-z19
+  rec=$(make_spawn_case profile-codex-nocfgdir codex "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_CLAUDE_CONFIG_DIR="/Users/test/.claude-work" \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "codex spawn with CLAUDE_CONFIG_DIR set should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "CLAUDE_CONFIG_DIR=" \
+    "non-claude harness launch must not receive the claude-specific config-dir prefix"
+  pass "non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix"
+}
+
 test_active_dispatch_profile_does_not_block_secondmate_launch() {
   local rec id sm out status
   id=profile-secondmate-z16
@@ -472,6 +526,9 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata
 test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity
 test_batch_forwards_shared_profile_flags
+test_claude_forwards_firstmate_config_dir_when_set
+test_claude_omits_config_dir_prefix_when_unset
+test_non_claude_harness_ignores_config_dir
 test_active_dispatch_profile_does_not_block_secondmate_launch
 
 echo "# all fm-spawn-dispatch-profile tests passed"


### PR DESCRIPTION
## Intent

Forward firstmate's CLAUDE_CONFIG_DIR to claude crewmates in fm-spawn so multi-subscription setups launch authenticated; adds tests

## What Changed

- Added a guard in `bin/fm-spawn.sh` that prefixes the claude crewmate launch command with firstmate's resolved `CLAUDE_CONFIG_DIR` when it is set, so panes created by the long-lived tmux/herdr daemon (which does not inherit firstmate's environment) use the same credential/config store instead of falling back to the default `~/.claude`.
- Scoped the prefix to `HARNESS = claude` and only when `CLAUDE_CONFIG_DIR` is non-empty; an unset value is treated as the single-store default and no prefix is emitted. The forwarded value is passed through `shell_quote`.
- Added three tests to `tests/fm-spawn-dispatch-profile.test.sh` covering the claude-with-value, claude-unset, and non-claude harness cases.

## Risk Assessment

✅ Low: A tightly scoped, single-boundary env-forwarding change guarded on harness and non-empty value, with matching set/unset/non-claude tests and no sibling-path or sibling-test breakage, fully conforming to the stated intent.

## Testing

Ran the targeted `tests/fm-spawn-dispatch-profile.test.sh` suite (all cases pass, including the three new CLAUDE_CONFIG_DIR tests) and, because passing unit tests alone are not sufficient evidence, drove the real bin/fm-spawn.sh end-to-end through the same fake-tmux pane the suite uses to capture the exact crewmate launch command line. The transcript proves the intent: a claude crewmate inherits firstmate's CLAUDE_CONFIG_DIR prefix (launches authenticated), an unset value adds no prefix (default store preserved), and the claude-specific prefix never leaks onto a codex crewmate. This is a CLI/launch-construction change with no rendered UI surface, so the reviewer-visible artifact is the captured launch-command transcript rather than a screenshot. Worktree left clean and transient temp dirs removed.

<details>
<summary>Evidence: End-to-end crewmate launch-command transcript (real fm-spawn.sh, 3 scenarios)</summary>

<code>SCENARIO 1 claude crewmate, firstmate CLAUDE_CONFIG_DIR=/Users/test/.claude-work&#10;Actual crewmate launch command:&#10;CLAUDE_CONFIG_DIR=&#39;/Users/test/.claude-work&#39; CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions &#34;$(... encode launch-brief &lt; &#39;.../brief.md&#39;)&#34;&#10;RESULT: PASS - crewmate inherits firstmate&#39;s CLAUDE_CONFIG_DIR&#10;&#10;SCENARIO 2 claude crewmate, CLAUDE_CONFIG_DIR unset (single-store default)&#10;Actual crewmate launch command:&#10;CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions &#34;$(...)&#34;&#10;RESULT: PASS - no prefix added; default store path unchanged&#10;&#10;SCENARIO 3 codex crewmate, firstmate CLAUDE_CONFIG_DIR=/Users/test/.claude-work&#10;Actual crewmate launch command:&#10;codex --dangerously-bypass-approvals-and-sandbox -c &#34;notify=[...]&#34; &#34;$(...)&#34;&#10;RESULT: PASS - non-claude harness left untouched</code>

```text
===========================================================================
 fm-spawn CLAUDE_CONFIG_DIR forwarding - end-to-end launch-command evidence
 Real bin/fm-spawn.sh, real launch construction, launch line captured from
 the exact 'tmux send-keys -l' text firstmate types into the crewmate pane.
===========================================================================

SCENARIO 1  claude crewmate, firstmate CLAUDE_CONFIG_DIR=/Users/test/.claude-work
  Expectation: crewmate launch is prefixed with the same store so it launches authenticated.
  Actual crewmate launch command:
    CLAUDE_CONFIG_DIR='/Users/test/.claude-work' CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/Users/lhalbert/.no-mistakes/worktrees/15dc3859dff7/01KYMP7WB1RTTJFE3A6Y199AES/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/lc/8y0jst9s42j0zdkdt7snqblr0000gn/T//fm-spawn-cfgdir-e2e.c9bnVF/claude-set/home/data/cfgdir-set-01/brief.md')"
  RESULT: PASS - crewmate inherits firstmate's CLAUDE_CONFIG_DIR

SCENARIO 2  claude crewmate, firstmate CLAUDE_CONFIG_DIR unset (single-store default)
  Expectation: no config-dir prefix added; bare claude uses the default ~/.claude store.
  Actual crewmate launch command:
    CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/Users/lhalbert/.no-mistakes/worktrees/15dc3859dff7/01KYMP7WB1RTTJFE3A6Y199AES/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/lc/8y0jst9s42j0zdkdt7snqblr0000gn/T//fm-spawn-cfgdir-e2e.c9bnVF/claude-unset/home/data/cfgdir-unset-02/brief.md')"
  RESULT: PASS - no prefix added; default store path unchanged

SCENARIO 3  codex crewmate, firstmate CLAUDE_CONFIG_DIR=/Users/test/.claude-work
  Expectation: the claude-specific store prefix must NOT leak onto a non-claude harness.
  Actual crewmate launch command:
    codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/lc/8y0jst9s42j0zdkdt7snqblr0000gn/T/fm-spawn-cfgdir-e2e.c9bnVF/codex-set/home/state/cfgdir-codex-03.turn-ended'\"]" "$('/Users/lhalbert/.no-mistakes/worktrees/15dc3859dff7/01KYMP7WB1RTTJFE3A6Y199AES/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/lc/8y0jst9s42j0zdkdt7snqblr0000gn/T//fm-spawn-cfgdir-e2e.c9bnVF/codex-set/home/data/cfgdir-codex-03/brief.md')"
  RESULT: PASS - non-claude harness left untouched

===========================================================================
 END OF EVIDENCE
===========================================================================
```
</details>
<details>
<summary>Evidence: Evidence driver script (reproducible)</summary>

```text
#!/usr/bin/env bash
# End-to-end evidence driver for: forward firstmate's CLAUDE_CONFIG_DIR to claude
# crewmates in fm-spawn.
#
# This runs the REAL bin/fm-spawn.sh through the same fake-tmux pane the behavior
# suite uses. The fake tmux records the literal command line firstmate types into
# the crewmate pane with `tmux send-keys -l`. That launch command is what an end
# user's crewmate would actually run, so it is the product-level artifact that
# proves the crewmate inherits firstmate's credential store.
#
# It exercises three end-user scenarios:
#   1. firstmate runs under CLAUDE_CONFIG_DIR (a work-vs-personal subscription
#      split) and dispatches a claude crewmate  -> prefix MUST be forwarded.
#   2. firstmate runs with the single-store default (unset)                -> no prefix.
#   3. firstmate runs under CLAUDE_CONFIG_DIR but dispatches a codex crewmate -> no
#      claude-specific prefix leaks onto a non-claude harness.
set -u

ROOT=${1:?repo root required}
OUT=${2:?output transcript path required}

. "$ROOT/tests/lib.sh"

SPAWN="$ROOT/bin/fm-spawn.sh"
TMP_ROOT=$(fm_test_tmproot fm-spawn-cfgdir-e2e)

make_fakebin() {
  local dir=$1 fakebin
  fakebin=$(fm_fakebin "$dir")
  cat > "$fakebin/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "$*" in
  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
esac
case "${1:-}" in
  display-message) printf 'firstmate\n'; exit 0 ;;
  list-windows) exit 0 ;;
  has-session|new-session|new-window|kill-window) exit 0 ;;
  send-keys)
    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
      prev=
      for a in "$@"; do
        if [ "$prev" = "-l" ]; then
          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
        fi
        prev=$a
      done
    fi
    exit 0
    ;;
esac
exit 0
SH
  chmod +x "$fakebin/tmux"
  fm_fake_exit0 "$fakebin" treehouse pi-signed
  printf '%s\n' "$fakebin"
}

setup_case() {
  local name=$1 harness=$2 id=$3 case_dir
  case_dir="$TMP_ROOT/$name"
  CASE_HOME="$case_dir/home"
  CASE_PROJ="$case_dir/project"
  CASE_WT="$case_dir/wt"
  CASE_LOG="$case_dir/launch.log"
  CASE_FAKEBIN=$(make_fakebin "$case_dir/fake")
  mkdir -p "$CASE_HOME/data" "$CASE_HOME/projects" "$CASE_HOME/state" "$CASE_HOME/config"
  printf '%s\n' "$harness" > "$CASE_HOME/config/crew-harness"
  fm_git_worktree "$CASE_PROJ" "$CASE_WT" "wt-$name"
  touch "$CASE_HOME/state/.last-watcher-beat"
  mkdir -p "$CASE_HOME/data/$id"
  printf 'brief for %s\n' "$id" > "$CASE_HOME/data/$id/brief.md"
}

run_case() {
  local cfgdir=$1
  shift
  : > "$CASE_LOG"
  FM_ROOT_OVERRIDE='' FM_HOME="$CASE_HOME" \
    FM_STATE_OVERRIDE="$CASE_HOME/state" FM_DATA_OVERRIDE="$CASE_HOME/data" \
    FM_PROJECTS_OVERRIDE="$CASE_HOME/projects" FM_CONFIG_OVERRIDE="$CASE_HOME/config" \
    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$CASE_WT" TMUX="fake,1,0" \
    CLAUDE_CONFIG_DIR="$cfgdir" \
    FM_FAKE_LAUNCH_LOG="$CASE_LOG" GROK_HOME="$CASE_HOME/grok-home" PATH="$CASE_FAKEBIN:$PATH" \
    "$SPAWN" "$@" >"$CASE_LOG.spawnout" 2>&1
}

emit() { printf '%s\n' "$1" | tee -a "$OUT"; }

: > "$OUT"
emit "==========================================================================="
emit " fm-spawn CLAUDE_CONFIG_DIR forwarding - end-to-end launch-command evidence"
emit " Real bin/fm-spawn.sh, real launch construction, launch line captured from"
emit " the exact 'tmux send-keys -l' text firstmate types into the crewmate pane."
emit "==========================================================================="
emit ""

# ---- Scenario 1: claude crewmate, firstmate under a work subscription store ----
setup_case claude-set claude cfgdir-set-01
run_case "/Users/test/.claude-work" cfgdir-set-01 "$CASE_PROJ" --harness claude
emit "SCENARIO 1  claude crewmate, firstmate CLAUDE_CONFIG_DIR=/Users/test/.claude-work"
emit "  Expectation: crewmate launch is prefixed with the same store so it launches authenticated."
emit "  Actual crewmate launch command:"
emit "    $(cat "$CASE_LOG")"
if grep -q "CLAUDE_CONFIG_DIR='/Users/test/.claude-work' CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" "$CASE_LOG"; then
  emit "  RESULT: PASS - crewmate inherits firstmate's CLAUDE_CONFIG_DIR"
else
  emit "  RESULT: FAIL - config dir was not forwarded"
fi
emit ""

# ---- Scenario 2: claude crewmate, firstmate on the single-store default --------
setup_case claude-unset claude cfgdir-unset-02
run_case "" cfgdir-unset-02 "$CASE_PROJ" --harness claude
emit "SCENARIO 2  claude crewmate, firstmate CLAUDE_CONFIG_DIR unset (single-store default)"
emit "  Expectation: no config-dir prefix added; bare claude uses the default ~/.claude store."
emit "  Actual crewmate launch command:"
emit "    $(cat "$CASE_LOG")"
if grep -q "CLAUDE_CONFIG_DIR=" "$CASE_LOG"; then
  emit "  RESULT: FAIL - unexpected config-dir prefix on the single-store default"
else
  emit "  RESULT: PASS - no prefix added; default store path unchanged"
fi
emit ""

# ---- Scenario 3: codex crewmate, config dir set but must not leak to non-claude -
setup_case codex-set codex cfgdir-codex-03
run_case "/Users/test/.claude-work" cfgdir-codex-03 "$CASE_PROJ" --harness codex
emit "SCENARIO 3  codex crewmate, firstmate CLAUDE_CONFIG_DIR=/Users/test/.claude-work"
emit "  Expectation: the claude-specific store prefix must NOT leak onto a non-claude harness."
emit "  Actual crewmate launch command:"
emit "    $(cat "$CASE_LOG")"
if grep -q "CLAUDE_CONFIG_DIR=" "$CASE_LOG"; then
  emit "  RESULT: FAIL - claude config-dir prefix leaked onto codex"
else
  emit "  RESULT: PASS - non-claude harness left untouched"
fi
emit ""
emit "==========================================================================="
emit " END OF EVIDENCE"
emit "==========================================================================="
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` - full dispatch-profile suite passes, including the 3 new tests: `test_claude_forwards_firstmate_config_dir_when_set`, `test_claude_omits_config_dir_prefix_when_unset`, `test_non_claude_harness_ignores_config_dir`</code>
- <code>End-to-end evidence driver `e2e-config-dir-forwarding.sh` running the real `bin/fm-spawn.sh` through a fake-tmux pane, capturing the literal `tmux send-keys -l` crewmate launch command across three scenarios (claude+set, claude+unset, codex+set)</code>
- <code>Verified worktree remained clean (`git status --short`) and removed transient temp worktrees created during evidence runs</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
