### PR TITLE
fix(brief): parse fm-brief.sh on bash 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,23 @@ jobs:
           esac
           /bin/bash --version | head -1
           command -v jq >/dev/null || { echo "::error::jq is required"; exit 1; }
-          /bin/bash -n bin/fm-fleet-snapshot.sh
+
+          # Every shipped script must parse on the bash macOS ships, not just the
+          # snapshot ones: bash 3.2 reads a command substitution as a flat
+          # character stream, so a construct that is fine under bash 4+ can make a
+          # whole script unparseable here and nowhere else.
+          parse_failures=''
+          for script in bin/*.sh bin/backends/*.sh; do
+            [ -f "$script" ] || continue
+            if ! script_error=$(/bin/bash -n "$script" 2>&1); then
+              parse_failures="$parse_failures
+  $script: ${script_error:-no diagnostic emitted}"
+            fi
+          done
+          [ -z "$parse_failures" ] || {
+            echo "::error::these scripts do not parse under stock macOS Bash $BASH_VERSION:$parse_failures"
+            exit 1
+          }
 
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,12 +305,12 @@ jobs:
           if-no-files-found: warn
 
   macos-stock-bash:
-    name: Stock macOS Bash snapshot compatibility
+    name: Stock macOS Bash compatibility
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - name: Run snapshot consumers with stock Bash
+      - name: Parse the toolbelt and run snapshot consumers with stock Bash
         shell: /bin/bash {0}
         env:
           PATH: /bin:/usr/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin
@@ -327,18 +327,17 @@ jobs:
           # snapshot ones: bash 3.2 reads a command substitution as a flat
           # character stream, so a construct that is fine under bash 4+ can make a
           # whole script unparseable here and nowhere else.
-          parse_failures=''
+          parse_log=$(mktemp)
+          parse_failed=0
           for script in bin/*.sh bin/backends/*.sh; do
             [ -f "$script" ] || continue
-            if ! script_error=$(/bin/bash -n "$script" 2>&1); then
-              parse_failures="$parse_failures
-  $script: ${script_error:-no diagnostic emitted}"
-            fi
+            /bin/bash -n "$script" 2>>"$parse_log" || parse_failed=1
           done
-          [ -z "$parse_failures" ] || {
-            echo "::error::these scripts do not parse under stock macOS Bash $BASH_VERSION:$parse_failures"
+          if [ "$parse_failed" -ne 0 ]; then
+            echo "::error::these scripts do not parse under stock macOS Bash $BASH_VERSION"
+            cat "$parse_log"
             exit 1
-          }
+          fi
 
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,9 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
   A local `config/backend` file explicitly overrides runtime auto-detection for new task endpoints and stays gitignored; spawn-supported values are `tmux` plus experimental `herdr`, `zellij`, `orca`, and `cmux`, while `codex-app` is documented only in `docs/codex-app-backend.md`.
   It does not make `data/` tracked.
 - Helper scripts in `bin/` are plain bash.
+  Everything under `bin/` and `bin/backends/` must parse under bash 3.2.57, the version macOS still ships as `/bin/bash`, because firstmate is expected to run on a stock Mac.
+  The `macos-stock-bash` job in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) syntax-checks the whole toolbelt on that interpreter for every pull request, so a bash 4+ construct fails there even though it parsed fine on your machine and on the Linux lanes.
+  When you genuinely need newer syntax, keep it out of `bin/` and put that logic in a helper the script invokes through an explicitly newer interpreter, rather than raising the floor for the whole toolbelt.
   Each starts with a usage header comment; keep it accurate when you change behavior.
   Test scripts and helpers in `tests/` are plain bash too.
   `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, and pinned shellcheck version), and both CI and the no-mistakes pre-push gate run it, so local and CI can never diverge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Its header and `--help` own the flags, family labels, lanes, and changed-file ma
 Portable shard balance evidence lives in `docs/fm-test-portable-shards.md`.
 Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk.
 Family selection is the ordinary local path; `--all` is deliberate full regression only.
-CI owns broad regression across required portable parallel shards, the portable serial lane, the Herdr lane, lint, invariants, the coverage guard, and macOS snapshot compatibility in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+CI owns broad regression across required portable parallel shards, the portable serial lane, the Herdr lane, lint, invariants, the coverage guard, and macOS stock-bash compatibility in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 Use `bin/fm-test-run.sh --help` for lane names, `--jobs` rules, and required gate-skip flags when reproducing a lane locally.
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -105,6 +105,28 @@ shell_quote() {
   printf "'"
 }
 
+# capture_block <var-name> <<EOF ... EOF
+# Read a here-document into <var-name>, stripping trailing newlines so the
+# result matches what VAR=$(cat <<EOF ... EOF) would have produced.
+#
+# Never capture a here-document with a command substitution in this file.
+# Bash 3.2, which macOS still ships as /bin/bash, scans a command substitution
+# for its closing parenthesis as a flat character stream and does not honour
+# here-document boundaries, so the body is read as shell syntax: one unbalanced
+# apostrophe, double quote, backtick, or parenthesis anywhere inside it makes
+# the whole script fail to parse. Quoting the delimiter does not help, because
+# that only affects expansion of the body, which is a later stage than the scan
+# that is already failing. Bash 4+ parses it correctly, so the breakage is
+# invisible to Linux CI and hits every stock Mac. The bodies here are English
+# prose, where apostrophes are a matter of time.
+# A plain redirect (cat > file <<EOF) is unaffected: no command substitution.
+capture_block() {
+  local __name=$1 __buf=''
+  IFS= read -r -d '' __buf || true
+  while [ "${__buf%$'\n'}" != "$__buf" ]; do __buf=${__buf%$'\n'}; done
+  printf -v "$__name" '%s' "$__buf"
+}
+
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
 
 if [ "$KIND" = secondmate ]; then
@@ -217,13 +239,12 @@ HERDR_SECTION=$(printf '%s\n' \
 'Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.' \
 'The captain fleet uses the running `default` session.')
 else
-HERDR_SECTION=$(cat <<'EOF'
+capture_block HERDR_SECTION <<'EOF'
 # Herdr lifecycle declaration - NOT ENABLED
 **HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
 If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
 Do not add Herdr lifecycle commands to this unguarded brief by hand.
 EOF
-)
 fi
 
 if [ "$KIND" = scout ]; then
@@ -285,19 +306,18 @@ case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
+    capture_block DOD <<EOF
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
-)
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
+    capture_block DOD <<EOF
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
@@ -305,13 +325,12 @@ Keep your branch a clean fast-forward onto the current default branch - if \`mai
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
-)
     ;;
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
+    capture_block DOD <<EOF
 # Definition of done
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
@@ -329,7 +348,6 @@ Two firstmate-specific rules layer on top of that guidance:
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
-)
     ;;
 esac
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -2,13 +2,25 @@
 # Behavior tests for bin/fm-brief.sh.
 #
 # Regression coverage for the heredoc-in-command-substitution parse bug (issue
-# #166): each ship-mode branch builds its Definition-of-done text with
-# `VAR=$(cat <<EOF ... EOF)`. Bash's lexer tracks quote state through the
-# heredoc body while it scans for the matching `)` of the command
-# substitution, so a single unescaped apostrophe anywhere in that body breaks
-# parsing of the *entire rest of the script* - `bash -n` fails, not just the
-# generated brief. A plain `cat > file <<EOF ... EOF` (not wrapped in `$(...)`)
-# is unaffected, so the secondmate charter block does not need this guard.
+# #166). Bash 3.2, which macOS still ships as /bin/bash, scans a command
+# substitution for its closing `)` as a flat character stream and does not
+# honour here-document boundaries, so the body of a `VAR=$(cat <<EOF ... EOF)`
+# is read as shell syntax. One unbalanced apostrophe, double quote, backtick,
+# or parenthesis anywhere in that body breaks parsing of the *entire* file -
+# `bash -n` fails, not just the generated brief. Bash 4+ parses it correctly,
+# so the breakage is invisible on Linux CI and hits every stock Mac.
+#
+# Two corrections to the original issue #166 diagnosis, both verified against
+# bash 3.2.57 on macOS:
+#   - Quoting the delimiter (`<<'EOF'`) does NOT help. It changes expansion of
+#     the body, which happens later than the scan that already failed.
+#   - The trigger is not apostrophes specifically. Any unbalanced quote,
+#     backtick, or parenthesis does it.
+# So the construct itself is the defect, not the text inside it, and the guard
+# below bans the construct rather than policing the prose.
+#
+# A plain `cat > file <<EOF ... EOF` (not wrapped in `$(...)`) is unaffected,
+# so the secondmate charter block does not need this guard.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -18,15 +30,73 @@ TMP_ROOT=$(fm_test_tmproot fm-brief)
 BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
 
-# The script itself must always parse. This is the direct regression test for
-# issue #166: a stray apostrophe in any of the three DOD heredoc bodies
-# (no-mistakes/direct-PR/local-only) breaks `bash -n` on the whole file.
+# The script itself must always parse. Note this runs under whatever bash the
+# test host provides, which on CI is bash 4+ and therefore cannot observe the
+# issue #166 breakage at all. The two checks after it carry that guarantee.
 test_script_parses() {
   local out rc
   out=$(bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
   expect_code 0 "$rc" "bash -n bin/fm-brief.sh must parse cleanly (got: $out)"
   [ -z "$out" ] || fail "bash -n bin/fm-brief.sh emitted unexpected output: $out"
   pass "fm-brief.sh: bash -n succeeds"
+}
+
+# Structural guard, and the check that actually holds on Linux CI: it asserts a
+# property of the source text, so it is exact under every bash version.
+#
+# fm-brief.sh builds its Definition-of-done and Herdr sections out of English
+# prose, where an apostrophe is only a matter of time. Rather than police the
+# prose, ban the construct that makes prose dangerous: no here-document in this
+# file may be captured by a command substitution. Use capture_block instead.
+#
+# Scoped to fm-brief.sh deliberately. Other scripts (fm-fleet-snapshot.sh,
+# fm-bootstrap.sh) capture embedded jq and bash programs the same way and parse
+# fine today because that content is balanced; a repo-wide ban would be churn
+# for no safety gain. The bash 3.2 check below is what covers those files.
+test_no_command_substitution_heredocs() {
+  local hits
+  # A command substitution that opens a here-document on the same line, e.g.
+  # `VAR=$(cat <<EOF` or `VAR=$(cat <<'EOF'`.
+  # Comment lines are stripped first: capture_block's own docstring names the
+  # banned construct in order to explain why it is banned.
+  # shellcheck disable=SC2016  # single quotes are deliberate: this is a literal grep pattern, not an expansion
+  hits=$(grep -vn '^[[:space:]]*#' "$ROOT/bin/fm-brief.sh" | grep '\$([^)]*<<' || true)
+  [ -z "$hits" ] || fail "fm-brief.sh captures a here-document with a command substitution, which fails to parse on bash 3.2 (use capture_block instead):
+$hits"
+  # ...and capture_block must still be the mechanism actually in use, so this
+  # guard cannot pass vacuously by the sections having been deleted.
+  assert_grep 'capture_block DOD' "$ROOT/bin/fm-brief.sh" \
+    "fm-brief.sh must build its Definition-of-done through capture_block"
+  assert_grep 'capture_block HERDR_SECTION' "$ROOT/bin/fm-brief.sh" \
+    "fm-brief.sh must build its Herdr section through capture_block"
+  pass "fm-brief.sh: no here-document is captured by a command substitution"
+}
+
+# Real bash 3.2 parse check across every shipped script. This is the strongest
+# guarantee available, but only where a legacy bash exists - macOS developer
+# machines, and CI only if it installs one. It skips loudly rather than
+# silently so a green run never overstates what was verified.
+test_all_bin_scripts_parse_under_legacy_bash() {
+  local candidate legacy='' legacy_ver='' ver failures='' f
+  for candidate in "${FM_TEST_BASH32:-}" /bin/bash "$(command -v bash-3.2 || true)"; do
+    [ -n "$candidate" ] && [ -x "$candidate" ] || continue
+    # shellcheck disable=SC2016  # single quotes are deliberate: BASH_VERSION must expand in the candidate shell, not this one
+    ver=$("$candidate" -c 'echo "$BASH_VERSION"' 2>/dev/null || true)
+    case "$ver" in
+      3.*) legacy=$candidate; legacy_ver=$ver; break ;;
+    esac
+  done
+  if [ -z "$legacy" ]; then
+    skip "fm-brief.sh: bin/ parses under bash 3.x" \
+      "no bash 3.x found (set FM_TEST_BASH32 to a bash 3.2 binary); the structural guard still applies"
+    return
+  fi
+  for f in "$ROOT"/bin/*.sh "$ROOT"/bin/backends/*.sh; do
+    [ -f "$f" ] || continue
+    "$legacy" -n "$f" 2>/dev/null || failures="$failures ${f#"$ROOT"/}"
+  done
+  [ -z "$failures" ] || fail "these scripts do not parse under $legacy (bash $legacy_ver):$failures"
+  pass "fm-brief.sh: every bin/ script parses under bash $legacy_ver"
 }
 
 test_help_includes_entire_header() {
@@ -383,6 +453,8 @@ test_scout_and_secondmate_scaffold() {
 }
 
 test_script_parses
+test_no_command_substitution_heredocs
+test_all_bin_scripts_parse_under_legacy_bash
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -72,28 +72,52 @@ $hits"
   pass "fm-brief.sh: no here-document is captured by a command substitution"
 }
 
+# Echo the version <path> reports as its own $BASH_VERSION, or nothing when it
+# is not an executable that answers as a bash.
+bash_version_of() {
+  [ -n "$1" ] && [ -x "$1" ] || return 0
+  # shellcheck disable=SC2016  # single quotes are deliberate: BASH_VERSION must expand in the candidate shell, not this one
+  "$1" -c 'echo "$BASH_VERSION"' 2>/dev/null || true
+}
+
 # Real bash 3.2 parse check across every shipped script. This is the strongest
 # guarantee available, but only where a legacy bash exists - macOS developer
 # machines, and CI only if it installs one. It skips loudly rather than
 # silently so a green run never overstates what was verified.
+#
+# An explicit FM_TEST_BASH32 and the autodiscovered candidates are deliberately
+# not the same kind of thing. Discovery may come up empty and skip; a pin is an
+# operator asserting "run the strong check against this binary", so a pin that
+# cannot deliver fails instead of quietly degrading to the same skip the
+# operator would have seen had they never set it.
 test_all_bin_scripts_parse_under_legacy_bash() {
-  local candidate legacy='' legacy_ver='' ver failures='' f
-  for candidate in "${FM_TEST_BASH32:-}" /bin/bash "$(command -v bash-3.2 || true)"; do
-    [ -n "$candidate" ] && [ -x "$candidate" ] || continue
-    # shellcheck disable=SC2016  # single quotes are deliberate: BASH_VERSION must expand in the candidate shell, not this one
-    ver=$("$candidate" -c 'echo "$BASH_VERSION"' 2>/dev/null || true)
+  local candidate legacy='' legacy_ver='' ver failures='' f err
+  if [ -n "${FM_TEST_BASH32:-}" ]; then
+    ver=$(bash_version_of "$FM_TEST_BASH32")
     case "$ver" in
-      3.*) legacy=$candidate; legacy_ver=$ver; break ;;
+      3.*) legacy=$FM_TEST_BASH32; legacy_ver=$ver ;;
+      *) fail "FM_TEST_BASH32 is set to '$FM_TEST_BASH32', which is not an executable bash 3.x (reports: ${ver:-no bash version}); point it at a bash 3.2 binary or unset it" ;;
     esac
-  done
+  else
+    for candidate in /bin/bash "$(command -v bash-3.2 || true)"; do
+      ver=$(bash_version_of "$candidate")
+      case "$ver" in
+        3.*) legacy=$candidate; legacy_ver=$ver; break ;;
+      esac
+    done
+  fi
   if [ -z "$legacy" ]; then
     skip "fm-brief.sh: bin/ parses under bash 3.x" \
       "no bash 3.x found (set FM_TEST_BASH32 to a bash 3.2 binary); the structural guard still applies"
     return
   fi
+  # Report each failure with the line and message bash gives, since that
+  # breakage is invisible on the contributor's own CI.
   for f in "$ROOT"/bin/*.sh "$ROOT"/bin/backends/*.sh; do
     [ -f "$f" ] || continue
-    "$legacy" -n "$f" 2>/dev/null || failures="$failures ${f#"$ROOT"/}"
+    err=$("$legacy" -n "$f" 2>&1) && continue
+    failures="$failures
+  ${f#"$ROOT"/}: ${err:-no diagnostic emitted}"
   done
   [ -z "$failures" ] || fail "these scripts do not parse under $legacy (bash $legacy_ver):$failures"
   pass "fm-brief.sh: every bin/ script parses under bash $legacy_ver"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -31,8 +31,11 @@ BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
 
 # The script itself must always parse. Note this runs under whatever bash the
-# test host provides, which on CI is bash 4+ and therefore cannot observe the
-# issue #166 breakage at all. The two checks after it carry that guarantee.
+# test host provides, which on the Linux lanes is bash 4+ and therefore cannot
+# observe the issue #166 breakage at all. The structural guard below carries
+# that guarantee under any bash, and the `macos-stock-bash` job in
+# .github/workflows/ci.yml syntax-checks bin/ and bin/backends/ on the real
+# bash 3.2.57 for every pull request.
 test_script_parses() {
   local out rc
   out=$(bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
@@ -41,8 +44,9 @@ test_script_parses() {
   pass "fm-brief.sh: bash -n succeeds"
 }
 
-# Structural guard, and the check that actually holds on Linux CI: it asserts a
-# property of the source text, so it is exact under every bash version.
+# Structural guard, and the check that holds on every lane regardless of host
+# bash: it asserts a property of the source text, so it is exact under every
+# bash version.
 #
 # fm-brief.sh builds its Definition-of-done and Herdr sections out of English
 # prose, where an apostrophe is only a matter of time. Rather than police the
@@ -52,7 +56,9 @@ test_script_parses() {
 # Scoped to fm-brief.sh deliberately. Other scripts (fm-fleet-snapshot.sh,
 # fm-bootstrap.sh) capture embedded jq and bash programs the same way and parse
 # fine today because that content is balanced; a repo-wide ban would be churn
-# for no safety gain. The bash 3.2 check below is what covers those files.
+# for no safety gain. The repo-wide bash 3.2 parse floor that covers those
+# files is enforced by the `macos-stock-bash` CI job and stated in
+# CONTRIBUTING.md.
 test_no_command_substitution_heredocs() {
   local hits
   # A command substitution that opens a here-document on the same line, e.g.
@@ -70,57 +76,6 @@ $hits"
   assert_grep 'capture_block HERDR_SECTION' "$ROOT/bin/fm-brief.sh" \
     "fm-brief.sh must build its Herdr section through capture_block"
   pass "fm-brief.sh: no here-document is captured by a command substitution"
-}
-
-# Echo the version <path> reports as its own $BASH_VERSION, or nothing when it
-# is not an executable that answers as a bash.
-bash_version_of() {
-  [ -n "$1" ] && [ -x "$1" ] || return 0
-  # shellcheck disable=SC2016  # single quotes are deliberate: BASH_VERSION must expand in the candidate shell, not this one
-  "$1" -c 'echo "$BASH_VERSION"' 2>/dev/null || true
-}
-
-# Real bash 3.2 parse check across every shipped script. This is the strongest
-# guarantee available, but only where a legacy bash exists - macOS developer
-# machines, and CI only if it installs one. It skips loudly rather than
-# silently so a green run never overstates what was verified.
-#
-# An explicit FM_TEST_BASH32 and the autodiscovered candidates are deliberately
-# not the same kind of thing. Discovery may come up empty and skip; a pin is an
-# operator asserting "run the strong check against this binary", so a pin that
-# cannot deliver fails instead of quietly degrading to the same skip the
-# operator would have seen had they never set it.
-test_all_bin_scripts_parse_under_legacy_bash() {
-  local candidate legacy='' legacy_ver='' ver failures='' f err
-  if [ -n "${FM_TEST_BASH32:-}" ]; then
-    ver=$(bash_version_of "$FM_TEST_BASH32")
-    case "$ver" in
-      3.*) legacy=$FM_TEST_BASH32; legacy_ver=$ver ;;
-      *) fail "FM_TEST_BASH32 is set to '$FM_TEST_BASH32', which is not an executable bash 3.x (reports: ${ver:-no bash version}); point it at a bash 3.2 binary or unset it" ;;
-    esac
-  else
-    for candidate in /bin/bash "$(command -v bash-3.2 || true)"; do
-      ver=$(bash_version_of "$candidate")
-      case "$ver" in
-        3.*) legacy=$candidate; legacy_ver=$ver; break ;;
-      esac
-    done
-  fi
-  if [ -z "$legacy" ]; then
-    skip "fm-brief.sh: bin/ parses under bash 3.x" \
-      "no bash 3.x found (set FM_TEST_BASH32 to a bash 3.2 binary); the structural guard still applies"
-    return
-  fi
-  # Report each failure with the line and message bash gives, since that
-  # breakage is invisible on the contributor's own CI.
-  for f in "$ROOT"/bin/*.sh "$ROOT"/bin/backends/*.sh; do
-    [ -f "$f" ] || continue
-    err=$("$legacy" -n "$f" 2>&1) && continue
-    failures="$failures
-  ${f#"$ROOT"/}: ${err:-no diagnostic emitted}"
-  done
-  [ -z "$failures" ] || fail "these scripts do not parse under $legacy (bash $legacy_ver):$failures"
-  pass "fm-brief.sh: every bin/ script parses under bash $legacy_ver"
 }
 
 test_help_includes_entire_header() {
@@ -478,7 +433,6 @@ test_scout_and_secondmate_scaffold() {
 
 test_script_parses
 test_no_command_substitution_heredocs
-test_all_bin_scripts_parse_under_legacy_bash
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review

--- a/tests/fm-nm-test-contract.test.sh
+++ b/tests/fm-nm-test-contract.test.sh
@@ -112,7 +112,7 @@ test_ci_still_runs_broad_behavior_suite() {
   # Preserve other CI lanes this task must not shrink.
   grep -Eq 'name:[[:space:]]*Lint shell scripts' "$CI" \
     || fail "CI must retain the lint job"
-  grep -Eq 'name:[[:space:]]*Stock macOS Bash snapshot compatibility' "$CI" \
+  grep -Fq 'macos-stock-bash:' "$CI" \
     || fail "CI must retain the macOS stock Bash compatibility job"
   grep -Eq 'name:[[:space:]]*Repo invariants' "$CI" \
     || fail "CI must retain the repo invariants job"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -50,6 +50,14 @@ pass() {
   printf 'ok - %s\n' "$1"
 }
 
+# skip <name> <reason>
+# For a check that cannot run here because the environment lacks something it
+# needs, rather than one that ran and succeeded. The reason is always printed,
+# so a check that silently stops covering anything is visible in the output.
+skip() {
+  printf 'ok - %s # SKIP %s\n' "$1" "$2"
+}
+
 # --- self-cleaning temp root ------------------------------------------------
 #
 # fm_test_tmproot <prefix> echoes a fresh temp dir and registers it for removal

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -50,14 +50,6 @@ pass() {
   printf 'ok - %s\n' "$1"
 }
 
-# skip <name> <reason>
-# For a check that cannot run here because the environment lacks something it
-# needs, rather than one that ran and succeeded. The reason is always printed,
-# so a check that silently stops covering anything is visible in the output.
-skip() {
-  printf 'ok - %s # SKIP %s\n' "$1" "$2"
-}
-
 # --- self-cleaning temp root ------------------------------------------------
 #
 # fm_test_tmproot <prefix> echoes a fresh temp dir and registers it for removal


### PR DESCRIPTION
## Problem

`bin/fm-brief.sh` failed to parse on the bash that ships with macOS (3.2.57), which blocked every brief scaffold and therefore every crewmate dispatch on a stock Mac.

Bash 3.2 scans a command substitution for its closing parenthesis as a flat character stream and does not honour here-document boundaries, so the body of `VAR=$(cat <<EOF ... EOF)` is read as shell syntax. The apostrophe in `firstmate's` was taken as an opening quote that never closed:

```
bin/fm-brief.sh: line 314: unexpected EOF while looking for matching `)'
bin/fm-brief.sh: line 388: syntax error: unexpected end of file
```

Bash 4+ parses it correctly, so Linux CI never saw it.

## Approach: fix the construct, not the prose

Rewording dodges one instance but leaves the trap armed for the next contributor who writes a possessive, and only on macOS. A new `capture_block` helper reads here-documents with `read`, keeping the body out of any command substitution. All four capture sites use it.

The prose is deliberately unchanged, apostrophe included. `firstmate's` is still there. Preserving it is what proves the fix works.

## Two corrections to the original issue #166 diagnosis

Both verified empirically against bash 3.2.57 rather than assumed:

1. **Quoting the delimiter does not help.** `<<'EOF'` only affects expansion of the body, which is a later stage than the scan that already failed. The Herdr block previously believed immune was equally armed, and is converted too.
2. **Apostrophes are not the trigger.** Any unbalanced quote, backtick, or parenthesis breaks it. Even `it's a 'quote'` fails, on odd apostrophe parity.

So the defect is the construct, not the text inside it.

## Regression coverage

Extends `tests/fm-brief.test.sh` and the existing runner rather than adding a new one.

- **Structural guard** asserts no here-document in `fm-brief.sh` is captured by a command substitution. It checks source text, so it holds under every bash version. It also asserts `capture_block` is still the mechanism in use, so it cannot pass vacuously if the sections are deleted.
- **Repo-wide bash 3.2 parse check** across all 92 scripts in `bin/` and `bin/backends/`, wired into the **existing** `macos-stock-bash` CI job, which already pins `$BASH_VERSION` to `3.2.57*`. No new workflow, job, or matrix entry. This replaces an earlier design that skipped when no bash 3.x was present, and makes the guarantee unconditional on CI rather than weaker there.

`skip()` was removed rather than reformatted: it emitted `ok - ... # SKIP ...`, which matches the `grep -c '^ok - '` exact-count assertions in that same job (15 and 42). A skipped check would have counted as a passing one and silently lost coverage.

The bash 3.2 floor is now documented, including what to do when bash 4+ syntax is genuinely needed.

## Verification

| Check | Result |
|---|---|
| `/bin/bash -n` across `bin/` + `bin/backends/` on bash 3.2.57 | 92/92 (was 91/92) |
| Rendered brief output vs pre-change baseline | Byte-identical, 10 mode variants, under bash 3.2 and 5.3 |
| New test against unfixed script | Fails, as intended |
| New test against fixed script | Passes |
| `bin/fm-lint.sh` (pinned ShellCheck 0.11.0) | Pass |
| `ci.yml` structure | 9 jobs, no stray key, run block 39 lines |
| CI exact-count assertions | 15 and 42, unchanged |

Byte-identity was proven by capturing every mode variant before and after and diffing, not by inspection.

## Known follow-up, deliberately not in this PR

Workflow YAML has no structural validation. This branch demonstrated the gap on itself: an intermediate commit shipped a `run: |` block whose indentation silently closed the scalar and promoted a shell variable to a top-level job key. It parsed as valid YAML, so a linter would not have caught it, and every repo assertion about `ci.yml` is a string grep. Filed as separate work rather than widening this PR.
