### PR TITLE
Fix brief scaffold parser regression

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -325,7 +325,7 @@ Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+- Avoid \`--yes\`: it would silently bypass the authority check enforced by firstmate and any required captain escalation.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -131,7 +131,7 @@ test_primary_and_secondmate_instruction_generation() {
     "generated implementation brief lets the worker own an ask-user decision"
   assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$ship" \
     "generated implementation brief bypasses the primary authority owner"
-  assert_grep "silently bypass firstmate's authority check and any required captain escalation" "$ship" \
+  assert_grep "silently bypass the authority check enforced by firstmate and any required captain escalation" "$ship" \
     "generated implementation brief permits silent ask-user auto-resolution"
   assert_no_grep 'the captain, not you, owns the ask-user decisions' "$ship" \
     "generated implementation brief retained conflicting captain-only wording"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -114,7 +114,9 @@ test_no_mistakes_dod_wording() {
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
   assert_grep '`help`' "$brief" \
     "no-mistakes DOD must render literal backticks around help"
-  assert_no_grep "no-mistakes' own guidance" "$brief" \
+  assert_grep "the authority check enforced by firstmate and any required captain escalation" "$brief" \
+    "no-mistakes DOD lost the authority-check policy wording"
+  assert_no_grep "firstmate's authority check" "$brief" \
     "no-mistakes DOD regressed to the apostrophe form that breaks bash -n"
   pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
 }


### PR DESCRIPTION
## Summary
- rephrase the no-mistakes authority-check sentence so its apostrophe cannot break the command-substitution heredoc parser
- exercise shell syntax and representative no-mistakes scaffold generation in the colocated regression tests
- keep the ask-user authority wording assertion aligned with the generated brief

## Validation
- `bash -n bin/fm-brief.sh`
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-ask-user-authority.test.sh`
- `bin/fm-lint.sh`
