### PR TITLE
test: stabilize tmux teardown conformance baseline

### DIFF
--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -110,9 +110,11 @@ resolve_permissive_tmux_kill_ref() {
   while IFS= read -r commit; do
     [ -n "$commit" ] || continue
     body=$(git -C "$ROOT" show "$commit:bin/backends/tmux.sh" 2>/dev/null) || continue
+    # shellcheck disable=SC2016
     case "$body" in
       *'tmux kill-window -t "=$session:=$window"'*) continue ;;
     esac
+    # shellcheck disable=SC2016
     case "$body" in
       *'tmux kill-window -t "$1"'*|*'tmux kill-window -t "$target"'*)
         printf '%s\n' "$commit"
@@ -966,15 +968,18 @@ test_permissive_tmux_kill_ref_stays_historical() {
     || fail "could not read historical tmux adapter at $ref"
   body_head=$(cat "$ROOT/bin/backends/tmux.sh")
 
+  # shellcheck disable=SC2016
   case "$body_hist" in
     *'tmux kill-window -t "=$session:=$window"'*)
       fail "resolve_permissive_tmux_kill_ref returned exact selectors at $ref"
       ;;
   esac
+  # shellcheck disable=SC2016
   case "$body_hist" in
     *'tmux kill-window -t "$1"'*|*'tmux kill-window -t "$target"'*) ;;
     *) fail "historical tmux adapter at $ref lacks a permissive kill-window target" ;;
   esac
+  # shellcheck disable=SC2016
   case "$body_head" in
     *'tmux kill-window -t "=$session:=$window"'*) ;;
     *) fail "current tmux adapter lost exact kill-window selectors" ;;

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -12,7 +12,10 @@
 #      binaries and fixtures as the REFACTORED versions in this checkout, then
 #      diffs the two command logs byte-for-byte - the report's P1 checklist
 #      item "run current main scripts and refactored scripts against the same
-#      fake tools and compare command logs".
+#      fake tools and compare command logs". The teardown old-vs-new case also
+#      overlays a content-historical permissive tmux kill fixture: after the
+#      exact-selector change lands on the default branch, merge-base with main
+#      collapses to HEAD and can no longer supply that baseline.
 #   3. Asserts the `--backend`/`FM_BACKEND` selection refuses unknown backends
 #      and the blocked `codex-app` backend loudly.
 #
@@ -80,6 +83,9 @@ SH
 }
 
 # The commit this branch started from - the P1 "current main" baseline.
+# Suitable for byte-identical old-vs-new checks while a branch still diverges
+# from main. After a squash lands, merge-base(HEAD, main) collapses to HEAD, so
+# callers that need a true pre-change fixture must not rely on this alone.
 resolve_base_ref() {
   local ref base
   for ref in main refs/heads/main origin/main refs/remotes/origin/main origin/HEAD refs/remotes/origin/HEAD; do
@@ -94,6 +100,28 @@ resolve_base_ref() {
 }
 BASE_REF=$(resolve_base_ref) \
   || fail "fm-backend baseline requires local main or origin/main; fetch the default branch before running this test"
+
+# Newest first-parent revision whose bin/backends/tmux.sh still uses the
+# pre-exact permissive kill-window target. Content-addressed from history so the
+# fixture stays historical on default-branch CI and on branches cut after the
+# exact-selector change, where merge-base with main is self-referential.
+resolve_permissive_tmux_kill_ref() {
+  local commit body
+  while IFS= read -r commit; do
+    [ -n "$commit" ] || continue
+    body=$(git -C "$ROOT" show "$commit:bin/backends/tmux.sh" 2>/dev/null) || continue
+    case "$body" in
+      *'tmux kill-window -t "=$session:=$window"'*) continue ;;
+    esac
+    case "$body" in
+      *'tmux kill-window -t "$1"'*|*'tmux kill-window -t "$target"'*)
+        printf '%s\n' "$commit"
+        return 0
+        ;;
+    esac
+  done < <(git -C "$ROOT" log --first-parent --format='%H' HEAD -- bin/backends/tmux.sh)
+  return 1
+}
 
 # --- shared: a pre-refactor bin/ shim --------------------------------------
 #
@@ -929,10 +957,49 @@ run_teardown_case() {
     "$script" "$id"
 }
 
+test_permissive_tmux_kill_ref_stays_historical() {
+  local ref body_hist body_head head
+  head=$(git -C "$ROOT" rev-parse HEAD)
+  ref=$(resolve_permissive_tmux_kill_ref) \
+    || fail "unable to locate a historical bin/backends/tmux.sh with permissive kill-window selectors"
+  body_hist=$(git -C "$ROOT" show "$ref:bin/backends/tmux.sh") \
+    || fail "could not read historical tmux adapter at $ref"
+  body_head=$(cat "$ROOT/bin/backends/tmux.sh")
+
+  case "$body_hist" in
+    *'tmux kill-window -t "=$session:=$window"'*)
+      fail "resolve_permissive_tmux_kill_ref returned exact selectors at $ref"
+      ;;
+  esac
+  case "$body_hist" in
+    *'tmux kill-window -t "$1"'*|*'tmux kill-window -t "$target"'*) ;;
+    *) fail "historical tmux adapter at $ref lacks a permissive kill-window target" ;;
+  esac
+  case "$body_head" in
+    *'tmux kill-window -t "=$session:=$window"'*) ;;
+    *) fail "current tmux adapter lost exact kill-window selectors" ;;
+  esac
+  [ "$ref" != "$head" ] \
+    || fail "permissive tmux baseline collapsed to HEAD; fixture is no longer historical"
+
+  pass "historical permissive tmux kill baseline stays distinct from current exact selectors"
+}
+
 test_teardown_conformance_old_vs_new() {
-  local old_bin fb proj wt id
+  local old_bin fb proj wt id old_tmux_ref saved_base_ref
   local state_old state_new config_old config_new data log_old log_new out_old out_new rc_old rc_new
+  # Force the post-squash topology inside this case: merge-base with main may
+  # equal HEAD on default-branch CI, and that must not make the legacy kill
+  # fixture self-referential. build_old_bin still uses BASE_REF for entrypoints;
+  # only the tmux kill adapter is pinned to the content-historical permissive ref.
+  saved_base_ref=$BASE_REF
+  BASE_REF=$(git -C "$ROOT" rev-parse HEAD)
+  old_tmux_ref=$(resolve_permissive_tmux_kill_ref) \
+    || { BASE_REF=$saved_base_ref; fail "unable to locate a historical bin/backends/tmux.sh with permissive kill-window selectors"; }
   old_bin=$(build_old_bin teardown-old)
+  git -C "$ROOT" show "$old_tmux_ref:bin/backends/tmux.sh" > "$old_bin/bin/backends/tmux.sh" \
+    || { BASE_REF=$saved_base_ref; fail "could not materialize historical tmux adapter from $old_tmux_ref"; }
+  BASE_REF=$saved_base_ref
   proj="$TMP_ROOT/teardown-project"; wt="$TMP_ROOT/teardown-wt"
   id="teardownconform1"
   fm_git_worktree "$proj" "$wt" "fm/$id"
@@ -1106,6 +1173,7 @@ test_backend_of_selector_matches_explicit_target_meta
 test_send_conformance_old_vs_new
 test_peek_conformance_old_vs_new
 test_spawn_symlinked_project_prefix_avoids_false_refusal
+test_permissive_tmux_kill_ref_stays_historical
 test_teardown_conformance_old_vs_new
 test_spawn_refuses_unknown_backend_flag
 test_spawn_refuses_codex_app_backend_flag


### PR DESCRIPTION
## Intent

Repair the reproducible Firstmate main-branch CI regression exposed after PR #1171 landed, so the default branch and downstream PRs are green without weakening exact tmux cleanup safety.

Root cause: test_teardown_conformance_old_vs_new built its alleged pre-refactor fixture from merge-base HEAD main. Once the exact-selector squash became main, that baseline collapsed to HEAD, so the legacy side unexpectedly used the new exact selector =firstmate:=fm-... while the test still expected the historical permissive selector firstmate:fm-.... Local green was a masking condition from a stale local main still sitting before #1171.

The fix is narrowly scoped to tests/fm-backend.test.sh: keep production exact target selectors unchanged; resolve a content-historical permissive tmux kill adapter from first-parent history instead of branch topology; force the post-squash BASE_REF=HEAD topology inside the teardown conformance case so main and future feature branches keep the same old-vs-new contract; and add a focused assertion that the baseline stays historical while the current path stays exact. Do not hard-code transient PR SHAs. Do not touch PR 1197 or weaken cleanup safety.

## What Changed

- Resolve the permissive tmux teardown fixture from first-parent content history so its baseline remains stable after merging to `main`.
- Exercise the post-squash `BASE_REF=HEAD` topology and verify the historical fixture stays permissive while the current adapter retains exact selectors.
- Suppress ShellCheck warnings for intentional literal-pattern matching.

## Risk Assessment

✅ Low: The change is narrowly confined to the requested test, derives the permissive fixture from first-parent content history, explicitly exercises the post-squash HEAD topology, and preserves production exact-selector safety.

## Testing

Inspected the branch diff, ran the targeted backend test suite with failure propagation, manually demonstrated the forced post-squash historical/current selector split, and confirmed scope and worktree cleanliness; all checks passed with reviewer-visible CLI evidence captured.

<details>
<summary>Evidence: Targeted fm-backend test transcript</summary>

```text
ok - fm_backend_name: FM_BACKEND env > config/backend > default tmux
ok - fm_backend_detect: no markers -> undetected, HERDR_ENV=1 -> herdr, $TMUX -> tmux, CMUX_WORKSPACE_ID -> cmux, nested combinations resolve innermost-first
ok - fm_backend_detect: falls back to __CFBundleIdentifier=com.cmuxterm.app when CMUX_WORKSPACE_ID is absent (signal bundle-id; foreign bundle ids rejected)
ok - fm_backend_detect: the cmux fallback signals are macOS-only (inert on a non-Darwin uname)
ok - fm_backend_detect: an inherited cmux bundle id never outranks $TMUX or HERDR_ENV (tmux/herdr-inside-cmux false positive absorbed)
ok - fm_backend_detect: ancestry fallback matches the lsappinfo-resolved (bundle-id) cmux app pid in the parent chain
ok - fm_backend_detect: ancestry fallback matches a bundle-shaped cmux comm path at any install location when lsappinfo cannot resolve a pid
ok - fm_backend_detect: ancestry fallback stops undetected at launchd (a reparented tmux server never reaches cmux)
ok - fm_backend_name: a fallback-detected cmux prints a NOTICE naming the fallback signal; the primary-marker notice is unchanged
ok - fm_backend_name: auto-detect selects herdr or cmux (loud notice) or tmux (silent, including nested tmux-in-herdr/tmux-in-cmux)
ok - fm_backend_name: an explicit FM_BACKEND or config/backend setting always wins over runtime auto-detection, including an ambient cmux marker
ok - fm_backend_validate: implemented adapters accepted, unknown and blocked codex-app backends refused loudly
ok - zsh: fm_backend_source recognizes known backends and rejects unknown ones
ok - bash: fm_backend_source recognizes known backends and rejects unknown ones
ok - fm_backend_validate_spawn: all implemented lifecycle backends are spawn-supported
ok - fm_meta_get / fm_backend_of_meta: read key=value, default backend to tmux
ok - fm_backend_resolve_selector: session:window literal, exact task id first, legacy fm-<id> label fallback, ad hoc bare name via tmux list-windows
ok - fm_backend_of_selector: exact task ids, legacy fm-<id> labels, and matching explicit targets inherit metadata backend
ok - fm-send.sh: explicit tmux targets are verified, while --key/plain/slash send command shape stays old-compatible
ok - fm-peek.sh: capture-pane invocation and output are byte-identical old vs new
ok - fm-spawn.sh: a project reached through a symlinked prefix (e.g. macOS /tmp -> /private/tmp) does not trip the isolation guard's false refusal
ok - historical permissive tmux kill baseline stays distinct from current exact selectors
ok - fm-teardown.sh: treehouse return remains compatible while tmux cleanup uses exact selectors
ok - fm-spawn.sh --backend bogus is refused loudly
ok - fm-spawn.sh --backend codex-app is refused
ok - fm-spawn.sh honors FM_BACKEND and refuses an unimplemented value loudly
ok - fm-spawn.sh: an explicit --backend tmux resolves silently and writes no backend= (missing means tmux)
ok - fm-spawn.sh: explicit --backend tmux wins over an ambient HERDR_ENV=1 auto-detect marker
ok - fm-spawn.sh: auto-detect resolves nested tmux-in-herdr to tmux and stays silent end to end
```
</details>
<details>
<summary>Evidence: Post-squash historical/current selector evidence</summary>

<code>forced BASE_REF: HEAD (1efd598cf544850496fcea68c216cfae2eb09d93)&#10;historical permissive ref: b29621ba19a4d15b688ae277ca06b67f80baa365&#10;historical selector: tmux kill-window -t &#34;$1&#34;&#10;current selector: tmux kill-window -t &#34;=$session:=$window&#34;</code>

```text
forced BASE_REF: HEAD (1efd598cf544850496fcea68c216cfae2eb09d93)
historical permissive ref: b29621ba19a4d15b688ae277ca06b67f80baa365
historical selector source:
121:# fm-teardown.sh's `tmux kill-window -t "$T" 2>/dev/null || true`.
123:  tmux kill-window -t "$1" 2>/dev/null || true
current selector source:
135:  tmux kill-window -t "=$session:=$window" 2>/dev/null || true
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 514f0ab89e3f1964fddb05d8f206db18febe705c 1efd598cf544850496fcea68c216cfae2eb09d93 -- tests/fm-backend.test.sh`
- `set -o pipefail; bash tests/fm-backend.test.sh 2>&1 | tee .../fm-backend-targeted-test.txt`
- <code>First-parent history resolution check with forced `BASE_REF=HEAD`, recording historical and current `kill-window` selector source lines</code>
- <code>`git diff --name-only 514f0ab89e3f1964fddb05d8f206db18febe705c 1efd598cf544850496fcea68c216cfae2eb09d93` and added-line scan for hard-coded 40-hex commit IDs</code>
- <code>`git status --short` to confirm tests left no transient worktree changes</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Suppress intentional literal-pattern ShellCheck warnings
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
