### PR TITLE
fix(pi): remove Calm's upper version ceiling

### DIFF
--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -1,11 +1,13 @@
 // Firstmate's home-persistent Pi transcript presentation toggle.
 //
-// Compatibility boundary: Pi 0.81.1 and 0.82.0 expose built-in ToolDefinitions, per-slot
+// Verified against Pi 0.81.1 and 0.82.0, which expose built-in ToolDefinitions, per-slot
 // renderers, renderShell: "self", session_start replacement reasons,
 // ExtensionUIContext.setToolsExpanded(), setWorkingVisible(), and
-// setHiddenThinkingLabel(). The focused tests pin those assumptions. Version-bounded
-// presentation adapters cover collapsed assistant thinking and operational user rows;
-// Pi still exposes no global renderer for arbitrary built-in or custom rows.
+// setHiddenThinkingLabel(). The focused tests pin those assumptions but never reject a
+// newer Pi solely for its version. The collapsed-thinking and operational-user
+// presentation adapters probe the exact API they patch and degrade independently with a
+// diagnostic (see installCalmPresentationAdapter below) if a future Pi removes it; Pi
+// still exposes no global renderer for arbitrary built-in or custom rows.
 // docs/configuration.md owns the home-local Calm preference contract.
 import { randomUUID } from "node:crypto";
 import {
@@ -74,9 +76,20 @@ const extensionFile = fileURLToPath(import.meta.url);
 const extensionDir = dirname(extensionFile);
 const root = resolve(extensionDir, "../..");
 
+// Each presentation adapter probes the exact Pi API it patches. If a future Pi removes
+// that API, only the affected adapter degrades; the rest of Calm keeps working.
+function installCalmPresentationAdapter(name: string, install: () => void): void {
+  try {
+    install();
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    console.error(`Firstmate Calm: ${name} presentation adapter unavailable, skipping. ${reason}`);
+  }
+}
+
 export default function (pi: ExtensionAPI) {
-  installCalmAssistantLayout();
-  installCalmOperationalUserLayout();
+  installCalmPresentationAdapter("collapsed-thinking", installCalmAssistantLayout);
+  installCalmPresentationAdapter("operational-user-row", installCalmOperationalUserLayout);
 
   let exportRendering = false;
   let removeTerminalInputHandler: (() => void) | undefined;

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -2,10 +2,11 @@
 // updateContent method. installCalmAssistantLayout() probes that exact method and throws
 // if it is missing; fm-calm.ts catches that and skips only this adapter with a diagnostic
 // instead of blocking Calm or Pi.
-import { AssistantMessageComponent } from "@earendil-works/pi-coding-agent";
+import type { AssistantMessageComponent as PiAssistantMessageComponent } from "@earendil-works/pi-coding-agent";
+import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
 import { calmPresentationHides } from "./fm-calm-visibility.ts";
 
-type AssistantMessage = Parameters<AssistantMessageComponent["updateContent"]>[0];
+type AssistantMessage = Parameters<PiAssistantMessageComponent["updateContent"]>[0];
 
 type AssistantMessagePresentationState = {
   hiddenThinkingLabel: string;
@@ -35,6 +36,10 @@ export function installCalmAssistantLayout(): void {
   }
 
   const patch: CalmAssistantLayoutPatch = { hidesThinking };
+  const AssistantMessageComponent = PiCodingAgent.AssistantMessageComponent;
+  if (typeof AssistantMessageComponent !== "function") {
+    throw new Error("Firstmate Calm requires Pi AssistantMessageComponent");
+  }
   const originalUpdateContent = AssistantMessageComponent.prototype.updateContent;
   if (typeof originalUpdateContent !== "function") {
     throw new Error("Firstmate Calm requires Pi AssistantMessageComponent.updateContent");

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -1,3 +1,7 @@
+// Verified against Pi 0.81.1 and 0.82.0, which export AssistantMessageComponent with an
+// updateContent method. installCalmAssistantLayout() probes that exact method and throws
+// if it is missing; fm-calm.ts catches that and skips only this adapter with a diagnostic
+// instead of blocking Calm or Pi.
 import { AssistantMessageComponent } from "@earendil-works/pi-coding-agent";
 import { calmPresentationHides } from "./fm-calm-visibility.ts";
 

--- a/.pi/extensions/lib/fm-calm-operational-user-layout.ts
+++ b/.pi/extensions/lib/fm-calm-operational-user-layout.ts
@@ -3,14 +3,12 @@
 // and throws if it is missing; fm-calm.ts catches that and skips only this adapter with a
 // diagnostic instead of blocking Calm or Pi. It changes only that presentation and never
 // message delivery.
-import {
-  InteractiveMode,
-  UserMessageComponent,
-} from "@earendil-works/pi-coding-agent";
+import type { UserMessageComponent as PiUserMessageComponent } from "@earendil-works/pi-coding-agent";
+import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
 import { calmPresentationHides } from "./fm-calm-visibility.ts";
 import { classifyFirstmateCurrentOperationalText } from "./fm-operational-input.ts";
 
-type UserMessageConstructorArgs = ConstructorParameters<typeof UserMessageComponent>;
+type UserMessageConstructorArgs = ConstructorParameters<typeof PiUserMessageComponent>;
 type UserMessageLike = {
   role: string;
   content: unknown;
@@ -21,7 +19,7 @@ type AddMessageOptions = {
 type InteractiveModePresentation = {
   chatContainer: {
     children: unknown[];
-    addChild(component: UserMessageComponent): void;
+    addChild(component: PiUserMessageComponent): void;
   };
   editor: {
     addToHistory?(text: string): void;
@@ -84,12 +82,20 @@ export function installCalmOperationalUserLayout(): void {
     hidesOperationalInput,
     isOperationalInput,
   };
+  const InteractiveMode = PiCodingAgent.InteractiveMode;
+  if (typeof InteractiveMode !== "function") {
+    throw new Error("Firstmate Calm requires Pi InteractiveMode");
+  }
   const prototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
   const originalAddMessageToChat = prototype.addMessageToChat;
   if (typeof originalAddMessageToChat !== "function") {
     throw new Error("Firstmate Calm requires Pi InteractiveMode.addMessageToChat");
   }
 
+  const UserMessageComponent = PiCodingAgent.UserMessageComponent;
+  if (typeof UserMessageComponent !== "function") {
+    throw new Error("Firstmate Calm requires Pi UserMessageComponent");
+  }
   class CalmOperationalUserMessageComponent extends UserMessageComponent {
     private readonly hasLeadingSpacer: boolean;
 

--- a/.pi/extensions/lib/fm-calm-operational-user-layout.ts
+++ b/.pi/extensions/lib/fm-calm-operational-user-layout.ts
@@ -1,5 +1,8 @@
-// Pi 0.81.1 and 0.82.0 add the ordinary-user spacer and row together.
-// This version-bounded adapter changes only that presentation and never message delivery.
+// Verified against Pi 0.81.1 and 0.82.0, which add the ordinary-user spacer and row
+// together via InteractiveMode.addMessageToChat. This adapter probes that exact method
+// and throws if it is missing; fm-calm.ts catches that and skips only this adapter with a
+// diagnostic instead of blocking Calm or Pi. It changes only that presentation and never
+// message delivery.
 import {
   InteractiveMode,
   UserMessageComponent,

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -9,14 +9,13 @@ A qualifying implementation must auto-load from the trusted project, persist the
 The governing presentation policy allows genuine original user prompts, genuine user-facing assistant text, and Pi's native working activity.
 Changing persisted context to remove hidden content, filtering provider context, patching installed harness code, or claiming coverage outside a supported renderer does not satisfy that boundary.
 
-## Compatibility contract
+## Compatibility evidence
 
-Firstmate never refuses a Pi version solely for being newer than the last version this document was reverified against.
-0.81.1 was the Pi version installed when this feature was first built, not a version that introduced a required API: the Pi CHANGELOG shows no relevant API added at 0.81.1 or 0.82.0, and the exported classes this document names (`AssistantMessageComponent`, `InteractiveMode`) are undocumented internals with no stated version guarantee in either direction.
-There is no evidence to support a numeric minimum, so none is enforced.
-Instead, `.pi/extensions/lib/fm-calm-assistant-layout.ts` and `.pi/extensions/lib/fm-calm-operational-user-layout.ts` each probe for the exact method they patch (`AssistantMessageComponent.prototype.updateContent` and `InteractiveMode.prototype.addMessageToChat`) and throw a descriptive error only when that method is absent.
-`.pi/extensions/fm-calm.ts` catches that per-adapter and logs a clear skip diagnostic instead of blocking the rest of Calm or Pi; a future Pi that removes one presentation seam degrades only that adapter.
-`tests/fm-calm-pi-extension.test.sh` records the installed Pi version as dated evidence without gating on it and covers both the no-upper-bound contract and the degraded-adapter diagnostic path directly.
+[`calm.md`](calm.md#pi-compatibility) owns the current Pi compatibility contract.
+Pi 0.81.1 was installed when Calm was first built, and Pi 0.82.0 was the later reverification target.
+The inspected Pi CHANGELOG shows no relevant presentation API introduced at either version, so those versions remain verification evidence rather than compatibility bounds.
+The exported classes used by the adapters (`AssistantMessageComponent` and `InteractiveMode`) are undocumented internals with no stated version guarantee.
+`tests/fm-calm-pi-extension.test.sh` records the installed Pi version as evidence without gating on it and covers both newer synthetic versions and an unavailable adapter seam.
 
 ## Pi 0.81.1 end-to-end reproduction
 
@@ -67,7 +66,7 @@ PR 927 made Calm persistent and described controlled rows as gapless while retai
 PR 936 removed the unsafe operational-input reroute and preserved legacy zero-height entries but did not change assistant-message layout.
 
 The fix installs one idempotent presentation adapter, verified on Pi 0.81.1 through 0.82.0, on the exported `AssistantMessageComponent.updateContent` method.
-The adapter probes for that exact method and, per the [compatibility contract](#compatibility-contract), degrades independently with a diagnostic rather than gating on a version number.
+The adapter probes for that exact method and, per the [compatibility contract](calm.md#pi-compatibility), degrades independently with a diagnostic rather than gating on a version number.
 Only while Calm is active and Pi has collapsed thinking does the adapter pass a shallow thinking-free presentation copy into Pi's ordinary layout calculation, then retain the original message on the component for invalidation and thinking expansion.
 The persisted assistant message, provider context, tool execution, export data, and expansion history remain unchanged.
 Collapsed thinking-only assistant messages now render zero rows, thinking before visible assistant text adds no spacing beyond the text-only baseline, and expanding thinking still renders the original reasoning.
@@ -125,7 +124,7 @@ The leading cause would have been falsified if the row or height remained, the p
 None occurred.
 
 The fix installs a separate idempotent presentation adapter, verified on Pi 0.81.1 through 0.82.0, on the exported `InteractiveMode.addMessageToChat` method.
-The adapter probes for that exact method and, per the [compatibility contract](#compatibility-contract), degrades independently with a diagnostic rather than gating on a version number.
+The adapter probes for that exact method and, per the [compatibility contract](calm.md#pi-compatibility), degrades independently with a diagnostic rather than gating on a version number.
 It delegates current recognition to `bin/fm-operational-input.sh`, adds only the evidence-backed bare-U+2063 `Supervisor escalate (` presentation compatibility shape, mounts a `UserMessageComponent` subclass that preserves Pi's stock row plus leading spacer while Calm is off, and returns zero rendered lines while Calm is on.
 It never intercepts the input event, rewrites the message, changes its role, filters model context, or changes session data.
 Messages containing an image are left on Pi's ordinary path even when their text equals an operational envelope because Firstmate's authoritative producers are text-only.
@@ -183,7 +182,7 @@ The test fixture enumerates every class below through the centralized policy, an
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
 The installed extension API has no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container API, or generic custom-tool wrapper.
-Pi 0.81.1 through 0.82.0 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](#compatibility-contract) for how a future Pi lacking one of those exports is handled.
+Pi 0.81.1 through 0.82.0 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](calm.md#pi-compatibility) for how a future Pi lacking one of those exports is handled.
 General component replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching remain rejected as unsupported or preservation-breaking workarounds.
 
 ## Cross-harness verification record
@@ -271,7 +270,7 @@ skip: set FM_PI_LIVE_E2E=1 to run the isolated interactive Pi regression
 ## 2026-07-26 Pi 0.82.0 compatibility verification
 
 Pi 0.82.0 preserved both API-probed presentation seams and every deterministic Calm TUI guarantee.
-The globally installed declaration package remained 0.81.1, so the strict typecheck continued to cover that lower supported boundary while the real CLI exercised 0.82.0.
+The globally installed declaration package remained 0.81.1, so the strict typecheck continued to cover that earlier declaration-evidence version while the real CLI exercised 0.82.0.
 
 ```text
 $ pi --version

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -9,9 +9,18 @@ A qualifying implementation must auto-load from the trusted project, persist the
 The governing presentation policy allows genuine original user prompts, genuine user-facing assistant text, and Pi's native working activity.
 Changing persisted context to remove hidden content, filtering provider context, patching installed harness code, or claiming coverage outside a supported renderer does not satisfy that boundary.
 
+## Compatibility contract
+
+Firstmate never refuses a Pi version solely for being newer than the last version this document was reverified against.
+0.81.1 was the Pi version installed when this feature was first built, not a version that introduced a required API: the Pi CHANGELOG shows no relevant API added at 0.81.1 or 0.82.0, and the exported classes this document names (`AssistantMessageComponent`, `InteractiveMode`) are undocumented internals with no stated version guarantee in either direction.
+There is no evidence to support a numeric minimum, so none is enforced.
+Instead, `.pi/extensions/lib/fm-calm-assistant-layout.ts` and `.pi/extensions/lib/fm-calm-operational-user-layout.ts` each probe for the exact method they patch (`AssistantMessageComponent.prototype.updateContent` and `InteractiveMode.prototype.addMessageToChat`) and throw a descriptive error only when that method is absent.
+`.pi/extensions/fm-calm.ts` catches that per-adapter and logs a clear skip diagnostic instead of blocking the rest of Calm or Pi; a future Pi that removes one presentation seam degrades only that adapter.
+`tests/fm-calm-pi-extension.test.sh` records the installed Pi version as dated evidence without gating on it and covers both the no-upper-bound contract and the degraded-adapter diagnostic path directly.
+
 ## Pi 0.81.1 end-to-end reproduction
 
-The current installed and regression-supported Pi version was verified on 2026-07-22.
+The Pi version installed at the time was verified on 2026-07-22.
 
 ```text
 $ pi --version
@@ -57,7 +66,8 @@ The single-thinking, tool-call-only, tool-result, Calm-off, and `clearOnShrink` 
 PR 927 made Calm persistent and described controlled rows as gapless while retaining a documented unsupported boundary for collapsed-thinking spacing.
 PR 936 removed the unsafe operational-input reroute and preserved legacy zero-height entries but did not change assistant-message layout.
 
-The fix installs one idempotent Pi 0.81.1 through 0.82.0 presentation adapter on the exported `AssistantMessageComponent.updateContent` method.
+The fix installs one idempotent presentation adapter, verified on Pi 0.81.1 through 0.82.0, on the exported `AssistantMessageComponent.updateContent` method.
+The adapter probes for that exact method and, per the [compatibility contract](#compatibility-contract), degrades independently with a diagnostic rather than gating on a version number.
 Only while Calm is active and Pi has collapsed thinking does the adapter pass a shallow thinking-free presentation copy into Pi's ordinary layout calculation, then retain the original message on the component for invalidation and thinking expansion.
 The persisted assistant message, provider context, tool execution, export data, and expansion history remain unchanged.
 Collapsed thinking-only assistant messages now render zero rows, thinking before visible assistant text adds no spacing beyond the text-only baseline, and expanding thinking still renders the original reasoning.
@@ -114,7 +124,8 @@ The real Pi viewport moved the unchanged assistant text from row 7 to row 2, ren
 The leading cause would have been falsified if the row or height remained, the provider lost or duplicated the message, or the persisted role or bytes changed.
 None occurred.
 
-The fix installs a separate idempotent Pi 0.81.1 through 0.82.0 presentation adapter on the exported `InteractiveMode.addMessageToChat` method.
+The fix installs a separate idempotent presentation adapter, verified on Pi 0.81.1 through 0.82.0, on the exported `InteractiveMode.addMessageToChat` method.
+The adapter probes for that exact method and, per the [compatibility contract](#compatibility-contract), degrades independently with a diagnostic rather than gating on a version number.
 It delegates current recognition to `bin/fm-operational-input.sh`, adds only the evidence-backed bare-U+2063 `Supervisor escalate (` presentation compatibility shape, mounts a `UserMessageComponent` subclass that preserves Pi's stock row plus leading spacer while Calm is off, and returns zero rendered lines while Calm is on.
 It never intercepts the input event, rewrites the message, changes its role, filters model context, or changes session data.
 Messages containing an image are left on Pi's ordinary path even when their text equals an operational envelope because Firstmate's authoritative producers are text-only.
@@ -148,7 +159,7 @@ Serialized session data and Pi 0.81.1's sidebar tree also retain legacy hidden o
 The taxonomy was derived from Pi 0.81.1's installed public declarations, documentation, examples, `interactive-mode.js`, and its exported component implementations.
 The test fixture enumerates every class below through the centralized policy, and the interactive fixture exercises the screenshot classes, current user-role operational input, and legacy synthetic presentation entries.
 
-| Policy class | Pi transcript path | Calm result on Pi 0.81.1 through 0.82.0 |
+| Policy class | Pi transcript path | Calm result (verified on Pi 0.81.1 through 0.82.0) |
 | --- | --- | --- |
 | `genuine-user-prompt` | `UserMessageComponent` | Visible, including every tested operational near miss. |
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
@@ -167,12 +178,12 @@ The test fixture enumerates every class below through the centralized policy, an
 | `system-notice` | `showStatus`, `showError`, compaction, retry, and startup warning rows | Unsupported boundary; remains visible. |
 | `cache-notice` | Non-persisted cache-miss `Text` row | Unsupported boundary; remains visible. |
 | `project-trust-warning` | Non-persisted startup `Text` row | Unsupported boundary; remains visible. |
-| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages stay ordinary semantic user messages but render through the zero-height Pi 0.81.1 through 0.82.0 adapter under Calm; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
+| `synthetic-user` | Firstmate extension `sendUserMessage`, terminal-injected input, Firstmate-generated Pi positional brief, or the already non-displayed session-start nudge | Canonically classified text-only operational user messages stay ordinary semantic user messages but render through the zero-height adapter (verified on Pi 0.81.1 through 0.82.0) under Calm; legacy entries stay gaplessly controllable, and the session-start nudge retains its existing non-displayed custom-message path. |
 | `synthetic-assistant` | No authoritative Firstmate source found | Policy-hidden, but Pi exposes no generic assistant-role renderer. |
 | `unknown` | Future or unclassified transcript component | Policy-hidden, but no generic renderer exists; never claimed as covered. |
 
 The installed extension API has no supported global transcript filter, user-message renderer, assistant-message renderer, chat-container API, or generic custom-tool wrapper.
-Pi 0.81.1 through 0.82.0 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate version-bounded, idempotent adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged.
+Pi 0.81.1 through 0.82.0 export `AssistantMessageComponent` and `InteractiveMode`, so Calm uses separate idempotent, API-probed adapters for assistant thinking layout and the complete operational-user transcript row while leaving all message data and non-Calm rendering unchanged; see the [compatibility contract](#compatibility-contract) for how a future Pi lacking one of those exports is handled.
 General component replacement, ANSI cursor erasure, provider-context mutation, and installed-file patching remain rejected as unsupported or preservation-breaking workarounds.
 
 ## Cross-harness verification record
@@ -197,7 +208,7 @@ grok 0.2.106 (bde89716f679)
 | Claude Code 2.1.218 | Not feasible through the inspected supported project surface. | Project hooks can observe lifecycle and tool events, while the plugin CLI packages supported components; neither inspected surface exposes a transcript-row renderer or transcript-wide redraw API. |
 | Codex CLI 0.144.6 | Not feasible through the inspected supported project surface. | The tracked hooks expose session, pre-tool, and stop handling, while the plugin and feature inventories expose no TUI tool-row renderer or transcript redraw control. |
 | OpenCode 1.17.18 | Not feasible without violating the preservation boundary. | Plugins expose events and tool execution hooks, not a built-in transcript-row renderer; same-name tool replacement changes execution rather than presentation alone. |
-| Pi 0.81.1 through 0.82.0 | Partially feasible with two version-bounded exported-class adapters. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the version-pinned collapsed-thinking and operational-user layout boundaries, while generic user, tool, and status filtering remains unavailable. |
+| Pi (verified 0.81.1 through 0.82.0) | Partially feasible with two API-probed exported-class adapters. | Public APIs control working visibility, collapsed labels, known tool slots, custom entries, and expansion redraws; exported assistant and interactive-mode classes provide the collapsed-thinking and operational-user layout boundaries, gated on the exact method's presence rather than a version number, while generic user, tool, and status filtering remains unavailable. |
 | Grok CLI 0.2.106 | Not feasible through the inspected supported project surface. | Project hooks expose lifecycle and tool interception, while the plugin CLI exposes no row-renderer contract; `--minimal` changes the whole screen mode rather than selected transcript rows. |
 
 These conclusions are deliberately limited to the named versions and supported surfaces.
@@ -259,7 +270,7 @@ skip: set FM_PI_LIVE_E2E=1 to run the isolated interactive Pi regression
 
 ## 2026-07-26 Pi 0.82.0 compatibility verification
 
-Pi 0.82.0 preserved both version-bounded presentation seams and every deterministic Calm TUI guarantee.
+Pi 0.82.0 preserved both API-probed presentation seams and every deterministic Calm TUI guarantee.
 The globally installed declaration package remained 0.81.1, so the strict typecheck continued to cover that lower supported boundary while the real CLI exercised 0.82.0.
 
 ```text

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -18,6 +18,12 @@ Pi's supported presentation API does not expose a global transcript filter.
 Expanded reasoning and its reserved spacing, built-in tool images, user-bash rows, skill and summary rows, generic status notices, and arbitrary custom-tool or extension rows remain visible.
 These are supported-API boundaries rather than hidden-content failures.
 
+## Pi compatibility
+
+Calm has no numeric Pi version minimum or maximum and never refuses Pi solely because its version is newer than a previously verified version.
+The collapsed-thinking and operational-user-row presentation adapters probe the exact Pi API seam they patch when Calm loads.
+If Pi removes one of those seams, Calm logs a diagnostic naming the unavailable adapter and skips only that adapter; `/calm`, the other adapter, and unrelated Pi extensions remain available.
+
 [`calm-mode-feasibility.md`](calm-mode-feasibility.md) owns the version-scoped renderer taxonomy and empirical evidence.
 [`configuration.md`](configuration.md#pi-calm-preference-configcalm) owns the persisted preference file and resolution rules.
 `.pi/extensions/lib/fm-calm-visibility.ts` owns the visibility policy, and `.pi/extensions/lib/fm-calm-operational-user-layout.ts` owns the zero-height operational-user row adapter.

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -16,14 +16,15 @@ PI_OPERATIONAL_INPUT="$ROOT/.pi/extensions/lib/fm-operational-input.ts"
 PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
 TMUX_SOCKET="fm-calm-$$"
 TMUX_SESSION="fm-calm-e2e"
-PI_COMPAT_VERSIONS="0.81.1 0.82.0"
-
-require_pi_compat_version() {
+# Verified against Pi 0.81.1 and 0.82.0 (docs/calm-mode-feasibility.md). This is
+# known-good evidence, not a support ceiling: the fixtures below run against whatever
+# Pi is actually installed, and record_pi_version_evidence never rejects a newer
+# version. The tracked presentation adapters probe the exact API they patch (see
+# .pi/extensions/fm-calm.ts) instead of relying on version inference, so a version
+# string is evidence for the record, not a gate.
+record_pi_version_evidence() {
   local version=$1 context=$2
-  case " $PI_COMPAT_VERSIONS " in
-    *" $version "*) return 0 ;;
-    *) fail "$context requires Pi $PI_COMPAT_VERSIONS, found $version" ;;
-  esac
+  [ -n "$version" ] || fail "$context could not determine the installed Pi version"
 }
 
 cleanup() {
@@ -91,8 +92,9 @@ test_static_contract() {
   assert_contains "$text" 'ctx.ui.setWorkingVisible(true)' "Pi calm extension does not preserve Pi's live working row"
   assert_not_contains "$text" 'ctx.ui.setWorkingVisible(!active)' "Pi calm extension still hides Pi's live working row"
   assert_contains "$text" 'ctx.ui.setHiddenThinkingLabel(active ? "" : undefined)' "Pi calm extension does not hide collapsed thinking labels"
-  assert_contains "$text" 'installCalmAssistantLayout()' "Pi Calm extension does not install its zero-height assistant layout"
-  assert_contains "$text" 'installCalmOperationalUserLayout()' "Pi Calm extension does not install its operational-user layout"
+  assert_contains "$text" 'installCalmPresentationAdapter("collapsed-thinking", installCalmAssistantLayout)' "Pi Calm extension does not install its zero-height assistant layout"
+  assert_contains "$text" 'installCalmPresentationAdapter("operational-user-row", installCalmOperationalUserLayout)' "Pi Calm extension does not install its operational-user layout"
+  assert_contains "$text" 'function installCalmPresentationAdapter' "Pi Calm extension does not degrade a missing presentation adapter independently with a diagnostic"
   assert_contains "$assistant_layout" 'AssistantMessageComponent.prototype.updateContent' "Pi Calm assistant layout does not control the exported component presentation path"
   assert_contains "$assistant_layout" 'block.type !== "thinking"' "Pi Calm assistant layout does not remove thinking from its presentation copy"
   assert_contains "$operational_user_layout" 'InteractiveMode.prototype' "Pi Calm operational-user layout does not control the transcript owner"
@@ -135,7 +137,7 @@ test_home_resolution() {
     return 0
   fi
   version=$(node -p "require('$PI_PACKAGE_DIR/package.json').version")
-  require_pi_compat_version "$version" "Pi calm compatibility assumptions"
+  record_pi_version_evidence "$version" "Pi calm compatibility assumptions"
 
   fixture="$TMP_ROOT/home-resolution"
   mkdir -p \
@@ -233,6 +235,121 @@ JS
   pass "Pi calm resolves its persistent home independently of Pi's launch directory"
 }
 
+test_pi_compat_no_upper_bound() {
+  local version
+  for version in 0.83.0 0.90.0 1.0.0 2.3.4 0.82.1 10.20.30; do
+    record_pi_version_evidence "$version" "synthetic newer Pi" \
+      || fail "record_pi_version_evidence rejected Pi $version solely for being newer than 0.82.0"
+  done
+  if (record_pi_version_evidence "" "malformed Pi version probe") 2>/dev/null; then
+    fail "record_pi_version_evidence accepted a missing/malformed Pi version"
+  fi
+  pass "Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version"
+}
+
+test_pi_compat_degraded_adapter() {
+  local fixture out status
+  if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    echo "skip: node or npm not found for Pi calm degraded-adapter test"
+    return 0
+  fi
+  if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+    echo "skip: installed @earendil-works/pi-coding-agent package not found"
+    return 0
+  fi
+
+  fixture="$TMP_ROOT/degraded-adapter"
+  mkdir -p \
+    "$fixture/project/.pi/extensions/lib" \
+    "$fixture/project/node_modules/@earendil-works"
+  cp "$EXT" "$fixture/project/.pi/extensions/fm-calm.ts"
+  cp "$ASSISTANT_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-assistant-layout.ts"
+  cp "$OPERATIONAL_USER_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-operational-user-layout.ts"
+  cp "$VISIBILITY" "$fixture/project/.pi/extensions/lib/fm-calm-visibility.ts"
+  cp "$PI_OPERATIONAL_INPUT" "$fixture/project/.pi/extensions/lib/fm-operational-input.ts"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/project/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/project/node_modules/typebox"
+  printf '%s\n' '{"type":"module"}' >"$fixture/project/package.json"
+
+  out=$(cd "$fixture/project" && \
+    EXT="$fixture/project/.pi/extensions/fm-calm.ts" \
+    PI_PACKAGE_DIR="$PI_PACKAGE_DIR" \
+    node --input-type=module 2>&1 <<'JS'
+import { pathToFileURL } from "node:url";
+
+const packageRoot = process.env.PI_PACKAGE_DIR;
+const { AssistantMessageComponent } = await import(
+  pathToFileURL(`${packageRoot}/dist/modes/interactive/components/assistant-message.js`).href
+);
+const originalUpdateContent = AssistantMessageComponent.prototype.updateContent;
+if (typeof originalUpdateContent !== "function") {
+  throw new Error(
+    "fixture precondition failed: installed Pi lacks AssistantMessageComponent.prototype.updateContent",
+  );
+}
+delete AssistantMessageComponent.prototype.updateContent;
+
+const diagnostics = [];
+const originalConsoleError = console.error;
+console.error = (...args) => diagnostics.push(args.join(" "));
+
+let calmCommand;
+const handlers = new Map();
+const pi = {
+  events: { emit() {}, on() {} },
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand(name, command) {
+    if (name === "calm") calmCommand = command;
+  },
+  registerEntryRenderer() {},
+  registerTool() {},
+};
+
+let threw = false;
+try {
+  const extension = await import(`${pathToFileURL(process.env.EXT).href}?degraded=${Date.now()}`);
+  extension.default(pi);
+} catch {
+  threw = true;
+}
+console.error = originalConsoleError;
+
+if (threw) {
+  throw new Error(
+    "a missing presentation API crashed the whole Calm extension instead of degrading just that adapter",
+  );
+}
+if (!calmCommand || !handlers.has("session_start")) {
+  throw new Error(
+    "Calm command/session lifecycle did not register when only one presentation adapter was unavailable",
+  );
+}
+if (typeof AssistantMessageComponent.prototype.updateContent !== "undefined") {
+  throw new Error(
+    "the degraded adapter path patched updateContent anyway despite the missing API, which would claim false success",
+  );
+}
+const sawClearSkipReason = diagnostics.some(
+  (line) => line.includes("collapsed-thinking") && /unavailable|skip/i.test(line),
+);
+if (!sawClearSkipReason) {
+  throw new Error(
+    `missing a clear skip reason for the degraded collapsed-thinking adapter; saw: ${JSON.stringify(diagnostics)}`,
+  );
+}
+
+AssistantMessageComponent.prototype.updateContent = originalUpdateContent;
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "Pi calm degraded-adapter path failed: $out"
+  [ -z "$out" ] || fail "Pi calm degraded-adapter test printed output: $out"
+  pass "a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers"
+}
+
 test_rendering_and_session_lifecycle() {
   local fixture out status version
   if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
@@ -244,7 +361,7 @@ test_rendering_and_session_lifecycle() {
     return 0
   fi
   version=$(node -p "require('$PI_PACKAGE_DIR/package.json').version")
-  require_pi_compat_version "$version" "Pi calm compatibility assumptions"
+  record_pi_version_evidence "$version" "Pi calm compatibility assumptions"
 
   fixture="$TMP_ROOT/renderer"
   mkdir -p "$fixture/home" "$fixture/lib" "$fixture/node_modules/@earendil-works"
@@ -895,7 +1012,7 @@ test_operational_followup_turn_e2e() {
     return 0
   fi
   version=$(pi --version 2>/dev/null || true)
-  require_pi_compat_version "$version" "Pi operational follow-up E2E"
+  record_pi_version_evidence "$version" "Pi operational follow-up E2E"
 
   project="$TMP_ROOT/followup-project"
   home="$TMP_ROOT/followup-home"
@@ -1248,7 +1365,7 @@ test_hidden_block_geometry_e2e() {
     return 0
   fi
   version=$(pi --version 2>/dev/null || true)
-  require_pi_compat_version "$version" "Pi Calm hidden-block geometry E2E"
+  record_pi_version_evidence "$version" "Pi Calm hidden-block geometry E2E"
 
   project="$TMP_ROOT/geometry-project"
   home="$TMP_ROOT/geometry-home"
@@ -1488,7 +1605,7 @@ test_interactive_terminal_e2e() {
     return 0
   fi
   version=$(pi --version 2>/dev/null || true)
-  require_pi_compat_version "$version" "Pi calm interactive E2E"
+  record_pi_version_evidence "$version" "Pi calm interactive E2E"
 
   project="$TMP_ROOT/e2e-project"
   config="$TMP_ROOT/e2e-config"
@@ -1977,6 +2094,8 @@ JS
 
 test_static_contract
 test_home_resolution
+test_pi_compat_no_upper_bound
+test_pi_compat_degraded_adapter
 test_rendering_and_session_lifecycle
 test_operational_followup_turn_e2e
 test_hidden_block_geometry_e2e

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -95,8 +95,10 @@ test_static_contract() {
   assert_contains "$text" 'installCalmPresentationAdapter("collapsed-thinking", installCalmAssistantLayout)' "Pi Calm extension does not install its zero-height assistant layout"
   assert_contains "$text" 'installCalmPresentationAdapter("operational-user-row", installCalmOperationalUserLayout)' "Pi Calm extension does not install its operational-user layout"
   assert_contains "$text" 'function installCalmPresentationAdapter' "Pi Calm extension does not degrade a missing presentation adapter independently with a diagnostic"
+  assert_contains "$assistant_layout" 'import * as PiCodingAgent' "Pi Calm assistant layout still requires its optional runtime class as a named import"
   assert_contains "$assistant_layout" 'AssistantMessageComponent.prototype.updateContent' "Pi Calm assistant layout does not control the exported component presentation path"
   assert_contains "$assistant_layout" 'block.type !== "thinking"' "Pi Calm assistant layout does not remove thinking from its presentation copy"
+  assert_contains "$operational_user_layout" 'import * as PiCodingAgent' "Pi Calm operational-user layout still requires its optional runtime class as a named import"
   assert_contains "$operational_user_layout" 'InteractiveMode.prototype' "Pi Calm operational-user layout does not control the transcript owner"
   assert_contains "$operational_user_layout" 'classifyFirstmateCurrentOperationalText(text)' "Pi Calm operational-user layout bypasses canonical current classification"
   assert_contains "$operational_user_layout" 'text.includes("\u2063")' "Pi Calm operational-user layout spawns its classifier for ordinary captain rows"
@@ -348,6 +350,58 @@ JS
   [ "$status" -eq 0 ] || fail "Pi calm degraded-adapter path failed: $out"
   [ -z "$out" ] || fail "Pi calm degraded-adapter test printed output: $out"
   pass "a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers"
+}
+
+test_pi_compat_missing_adapter_exports() {
+  local fixture out status
+  if ! command -v node >/dev/null 2>&1; then
+    echo "skip: node not found for Pi calm missing-adapter-export test"
+    return 0
+  fi
+
+  fixture="$TMP_ROOT/missing-adapter-exports"
+  mkdir -p \
+    "$fixture/project/.pi/extensions/lib" \
+    "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
+  cp "$ASSISTANT_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-assistant-layout.ts"
+  cp "$OPERATIONAL_USER_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-operational-user-layout.ts"
+  cp "$VISIBILITY" "$fixture/project/.pi/extensions/lib/fm-calm-visibility.ts"
+  cp "$PI_OPERATIONAL_INPUT" "$fixture/project/.pi/extensions/lib/fm-operational-input.ts"
+  printf '%s\n' '{"type":"module"}' >"$fixture/project/package.json"
+  printf '%s\n' \
+    '{"name":"@earendil-works/pi-coding-agent","type":"module","exports":"./index.js"}' \
+    >"$fixture/project/node_modules/@earendil-works/pi-coding-agent/package.json"
+  printf '%s\n' \
+    'export function getMarkdownTheme() { return {}; }' \
+    'export class UserMessageComponent {}' \
+    >"$fixture/project/node_modules/@earendil-works/pi-coding-agent/index.js"
+
+  out=$(cd "$fixture/project" && node --input-type=module 2>&1 <<'JS'
+const assistant = await import("./.pi/extensions/lib/fm-calm-assistant-layout.ts");
+const operational = await import("./.pi/extensions/lib/fm-calm-operational-user-layout.ts");
+
+for (const [name, install, expected] of [
+  ["collapsed-thinking", assistant.installCalmAssistantLayout, "AssistantMessageComponent"],
+  ["operational-user-row", operational.installCalmOperationalUserLayout, "InteractiveMode"],
+]) {
+  let reason;
+  try {
+    install();
+  } catch (error) {
+    reason = error instanceof Error ? error.message : String(error);
+  }
+  if (!reason?.includes(expected)) {
+    throw new Error(
+      `${name} adapter did not load and report its missing runtime export: ${String(reason)}`,
+    );
+  }
+}
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "Pi calm missing-adapter-export path failed: $out"
+  [ -z "$out" ] || fail "Pi calm missing-adapter-export test printed output: $out"
+  pass "missing Pi presentation class exports reach the independent adapter degradation path"
 }
 
 test_rendering_and_session_lifecycle() {
@@ -2096,6 +2150,7 @@ test_static_contract
 test_home_resolution
 test_pi_compat_no_upper_bound
 test_pi_compat_degraded_adapter
+test_pi_compat_missing_adapter_exports
 test_rendering_and_session_lifecycle
 test_operational_followup_turn_e2e
 test_hidden_block_geometry_e2e


### PR DESCRIPTION
## Intent

Remove Firstmate Calm's exclusive Pi upper-version ceiling per a captain-approved decision (see dispatch: fm-calm-pi-no-upper-bound-r1). The bug: tests/fm-calm-pi-extension.test.sh gated on a closed PI_COMPAT_VERSIONS allowlist ('0.81.1 0.82.0') that refused any installed Pi outside that exact set, and docs described that range as a supported ceiling. Required behavior: never refuse a newer Pi solely for being newer; keep a minimum only if a real API requires it, otherwise prefer probing the exact presentation API seam; a missing future seam should disable/skip only the affected Calm adapter with a clear diagnostic, not block Pi or unrelated extensions; preserve dated verification evidence but never state it as a ceiling.

Investigation before implementing: reproduced the bug end-to-end (installed Pi is 0.82.0, inside the old allowed set, so a smallest-counterfactual probe against the exact tracked shell function proved 0.83.0 was refused). Read the installed Pi extension docs (extensions.md, including the Error Handling section) and the Pi CHANGELOG around 0.81.1/0.82.0 to check whether any API was actually introduced at those versions - it was not; those were simply the versions installed when this feature was first built and later reverified. The two Calm presentation adapters (fm-calm-assistant-layout.ts, fm-calm-operational-user-layout.ts) already used duck-typing (throw only if the exact patched method is absent) rather than version checks, so I deliberately did not add a numeric minimum anywhere - there was no evidence to support one. The one real gap versus the required behavior: a missing adapter API previously crashed the whole Calm extension (no /calm command at all) instead of degrading only that one adapter.

Changes made: (1) fm-calm.ts now wraps each adapter install in installCalmPresentationAdapter(), which catches a missing-API error and logs a clear skip diagnostic naming the adapter, so only that adapter degrades and the rest of Calm (command registration, tool wrapping, the other adapter) keeps working; (2) removed PI_COMPAT_VERSIONS/require_pi_compat_version from the test file and replaced it with record_pi_version_evidence, which only fails on an empty/undeterminable version string and never rejects a version for being 'too new'; (3) added test_pi_compat_no_upper_bound (deterministic, feeds synthetic versions like 0.83.0/1.0.0/10.20.30 through the new function and confirms none are rejected, plus confirms an empty version still fails closed) and test_pi_compat_degraded_adapter (deletes the real installed Pi's AssistantMessageComponent.prototype.updateContent, confirms the extension does not throw, /calm still registers, no false-success patching happened, and a clear 'collapsed-thinking ... unavailable' diagnostic was logged); (4) rewrote docs/calm-mode-feasibility.md's 'Pi 0.81.1 through 0.82.0' ceiling phrasing throughout (added a new 'Compatibility contract' section stating no minimum is enforced and why) while preserving dated verification evidence blocks unchanged; docs/calm.md needed no edits since it had no ceiling language. Extension header comments changed from 'Compatibility boundary: Pi X and Y expose...' to 'Verified against Pi X and Y, which expose...'.

Deliberately out of scope and left unchanged: the built-in tool-wrapping code path (registerBuiltIn in fm-calm.ts) that also throws if a built-in tool's render slots are missing - that's a different, more fundamental Pi surface than the two named 'presentation adapters' the captain's decision and required-behavior list call out, so I did not add degrade-with-diagnostic there to keep the change limited to removing the ceiling. Did not touch dated verification records in .agents/skills/harness-adapters/SKILL.md or docs/verification/*.md since they already state exact versions as evidence ('Verified on...'), not as a support ceiling. Never ran pi update or modified the installed Pi (still 0.82.0 throughout).

## What Changed

- Remove Calm’s closed Pi version allowlist so newer releases are recorded as compatibility evidence instead of rejected.
- Probe presentation APIs at runtime and skip only the affected Calm adapter with a clear diagnostic when its Pi seam or export is unavailable.
- Add regression coverage for unbounded versions and degraded adapters, and document the no-minimum/no-maximum compatibility contract while preserving dated verification evidence.

## Risk Assessment

✅ Low: The follow-up safely converts optional runtime class imports into namespace probes, so missing presentation exports or methods now reach the per-adapter diagnostic path without preventing the rest of Calm from registering.

## Testing

Change inspection, the focused automated suite, native Pi terminal E2E flows, a manual missing-seam startup probe, and direct future-version probes all passed; text transcripts are the appropriate reviewer evidence because this change affects compatibility gating and startup diagnostics rather than visual layout, so no screenshot was produced.

<details>
<summary>Evidence: Targeted Calm automated and native Pi E2E transcript</summary>

```text
ok - Pi calm extension is presentation-only with one persisted visibility choice, no Calm status row, native working visibility, supported redraw controls, and the Firstmate watcher-tool integration
ok - Pi calm resolves its persistent home independently of Pi's launch directory
ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
ok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers
ok - missing Pi presentation class exports reach the independent adapter degradation path
ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps native working visible, and persists its choice across session starts
ok - Pi operational follow-up E2E processes exact user-role notifications once while Calm hides current and adjacent rows, Calm off and absent render them, and restart preserves semantics
ok - Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering
ok - Pi calm native E2E keeps Working and captain turns visible, hides exact operational user rows without changing persistence, restores them Calm-off, survives restart, and preserves export plus Ctrl+O behavior
```
</details>
<details>
<summary>Evidence: Degraded-adapter startup evidence</summary>

<code>Installed Pi evidence version: 0.81.1&#10;Extension startup error: none&#10;/calm command registered: true&#10;session_start registered: true&#10;unrelated operational-user-row adapter installed: true&#10;collapsed-thinking seam remains unpatched: true&#10;Startup diagnostic: Firstmate Calm: collapsed-thinking presentation adapter unavailable, skipping. Firstmate Calm requires Pi AssistantMessageComponent.updateContent</code>

```text
Installed Pi evidence version: 0.81.1
Extension startup error: none
/calm command registered: true
session_start registered: true
unrelated operational-user-row adapter installed: true
collapsed-thinking seam remains unpatched: true
Startup diagnostic: Firstmate Calm: collapsed-thinking presentation adapter unavailable, skipping. Firstmate Calm requires Pi AssistantMessageComponent.updateContent
```
</details>
<details>
<summary>Evidence: Future-version acceptance probe</summary>

<code>accepted future Pi: 0.83.0&#10;accepted future Pi: 1.0.0&#10;accepted future Pi: 10.20.30&#10;rejected empty version as undeterminable</code>

```text
accepted future Pi: 0.83.0
accepted future Pi: 1.0.0
accepted future Pi: 10.20.30
rejected: missing Pi could not determine the installed Pi version
rejected empty version as undeterminable
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.pi/extensions/fm-calm.ts:91` - Required behavior says “a missing future seam should disable/skip only the affected Calm adapter,” but these guarded calls occur only after both adapter modules have loaded. Each adapter eagerly imports its Pi class as a named export, so if a future Pi removes `AssistantMessageComponent` or `InteractiveMode`, ESM evaluation fails before `installCalmPresentationAdapter()` can catch anything, preventing all of Calm from registering. Probe optional class exports at the adapter module boundary, such as through a namespace import, so an absent export reaches the per-adapter diagnostic path.

🔧 Fix: Probe missing Calm adapter exports safely
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff e5bd082a82202062f5e4957e249f88f95d5a49e9..06c2a08227c95e8f6399be76b9860062f35a4a71` against the authoritative intent.</code>
- <code>Ran `tests/fm-calm-pi-extension.test.sh 2&gt;&amp;1 | tee .../fm-calm-pi-extension.txt`.</code>
- <code>Ran a `node --input-type=module` fixture that deleted the installed Pi `AssistantMessageComponent.prototype.updateContent`, loaded the real extension, and recorded registration, isolation, and diagnostic behavior.</code>
- <code>Extracted and exercised the tracked `record_pi_version_evidence` function with `0.83.0`, `1.0.0`, `10.20.30`, and an empty value.</code>
- <code>Searched the changed Calm surfaces with `rg` for the removed allowlist and obsolete ceiling terminology; no matches remained.</code>
- <code>Verified `git status --short` remained clean after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
