### PR TITLE
fix(codex): preserve thread lock fallback

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -17,12 +17,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-arm-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-arm-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-arm-pretool-check.sh\"'",
+            "command": "bash -c 'root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-codex-hook-dispatch.sh\" ] || exit 0; exec \"$root/bin/fm-codex-hook-dispatch.sh\" PreToolUse fm-arm-pretool-check.sh'",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-cd-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-cd-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-cd-pretool-check.sh\"'",
+            "command": "bash -c 'root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-codex-hook-dispatch.sh\" ] || exit 0; exec \"$root/bin/fm-codex-hook-dispatch.sh\" PreToolUse fm-cd-pretool-check.sh'",
             "timeout": 10
           }
         ]
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-turnend-guard.sh\"'",
+            "command": "bash -c 'root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-codex-hook-dispatch.sh\" ] || exit 0; exec \"$root/bin/fm-codex-hook-dispatch.sh\" Stop fm-turnend-guard.sh'",
             "timeout": 30
           }
         ]

--- a/bin/fm-claude-stop-autoarm.sh
+++ b/bin/fm-claude-stop-autoarm.sh
@@ -71,8 +71,11 @@ cat >/dev/null 2>&1 || true
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
 # --- identity: only the lock-owning session's hooks may arm ------------------
-# A prior session may have died after leaving its numeric harness pid in .lock.
+# A prior process-backed session may have died after leaving its harness pid in
+# .lock.
 # Use the shared liveness predicate to recognize only that stale-owner case.
+# Non-process lock identities, such as Codex thread fallback locks, remain inert
+# for Claude auto-arm unless they belong to this same session.
 # Defer the mutating claim until after the unchanged AFK and need gates, so an
 # idle or away home remains byte-for-byte inert. Missing or malformed locks are
 # uncertainty rather than stale-owner evidence and remain inert.

--- a/bin/fm-codex-hook-dispatch.sh
+++ b/bin/fm-codex-hook-dispatch.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Codex hook transport for firstmate's tracked `.codex/hooks.json`.
+#
+# Codex hook stdin has regressed in the past from "closed after payload" to an
+# open stream that can leave a plain `cat` blocked until Codex kills the hook.
+# This adapter reads at most one short burst with a bounded wait, then fails
+# open on absent input instead of making every tool call wait for the hook timeout.
+set -u
+
+usage() {
+  cat <<'EOF'
+Usage: fm-codex-hook-dispatch.sh <PreToolUse|Stop> <checker-script>
+
+Reads one Codex hook payload from stdin with a short timeout, verifies that the
+tracked hook file still points at the requested checker, then forwards the
+payload to bin/<checker-script>.
+EOF
+}
+
+[ "$#" -eq 2 ] || { usage >&2; exit 2; }
+
+EVENT=$1
+CHECKER=$2
+
+case "$EVENT:$CHECKER" in
+  PreToolUse:fm-arm-pretool-check.sh|PreToolUse:fm-cd-pretool-check.sh|Stop:fm-turnend-guard.sh) ;;
+  *) exit 0 ;;
+esac
+
+ROOT=$(pwd -P) || exit 0
+[ -x "$ROOT/bin/$CHECKER" ] || exit 0
+[ -f "$ROOT/AGENTS.md" ] || exit 0
+[ -f "$ROOT/.codex/hooks.json" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+case "$EVENT" in
+  PreToolUse)
+    # shellcheck disable=SC2016 # $checker is a jq variable supplied with --arg.
+    jq_expr='any(.hooks.PreToolUse[]?.hooks[]?.command?; type == "string" and contains($checker))'
+    ;;
+  Stop)
+    # shellcheck disable=SC2016 # $checker is a jq variable supplied with --arg.
+    jq_expr='any(.hooks.Stop[]?.hooks[]?.command?; type == "string" and contains($checker))'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+jq -e --arg checker "$CHECKER" "$jq_expr" "$ROOT/.codex/hooks.json" >/dev/null 2>&1 || exit 0
+command -v perl >/dev/null 2>&1 || exit 0
+
+PAYLOAD=$(perl -MIO::Select -e '
+  my $timeout = $ENV{FM_CODEX_HOOK_READ_TIMEOUT} || 0.2;
+  my $sel = IO::Select->new(\*STDIN);
+  exit 0 unless $sel->can_read($timeout);
+  my $buf = "";
+  my $n = sysread(STDIN, $buf, 65536);
+  print $buf if $n;
+' 2>/dev/null || true)
+
+[ -n "$PAYLOAD" ] || exit 0
+printf '%s' "$PAYLOAD" | "$ROOT/bin/$CHECKER"

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -30,11 +30,12 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # and kimi are markerless, so a foreign marker retained in a terminal
-  # multiplexer's stored environment can silently misidentify one of them before
-  # ancestry is consulted. This is a precedence hazard, not evidence that
-  # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
+  # Only claude, pi, and grok set verified markers of their own; codex exposes
+  # CODEX_THREAD_ID only as a final fallback because opencode and kimi are
+  # markerless, so a foreign marker retained in a terminal multiplexer can
+  # silently misidentify one of them before ancestry is consulted. This is a
+  # precedence hazard, not evidence that CLAUDECODE inheritance into a kimi child
+  # was observed; it was not observed.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
@@ -72,6 +73,7 @@ detect_own() {
       break
     fi
   done
+  [ -n "${CODEX_THREAD_ID:-}" ] && { echo codex; return; }
   echo unknown
 }
 

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Acquire or inspect the per-home firstmate session lock.
-# Writes the harness (agent) process PID found by walking the shell's ancestry,
-# which lives as long as the firstmate session - unlike the transient subshell
-# PID of any one tool call, which is dead moments after it is written.
+# Writes the harness identity found by walking the shell's ancestry.
+# API-hosted Codex sessions may hide that process ancestry, so the shared
+# identity owner falls back to CODEX_THREAD_ID.
 # Usage: fm-lock.sh           acquire; exit 1 unless ownership is verified
 #        fm-lock.sh status    print holder and liveness; always exits 0
 set -u
@@ -29,7 +29,17 @@ if [ "${1:-}" = "status" ]; then
     echo "lock: unreadable"
     exit 0
   }
-  if fm_harness_pid_alive "$old"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
+  if fm_harness_pid_alive "$old"; then
+    case "$old" in
+      codex-thread:*) echo "lock: held by current codex thread ${old#codex-thread:}" ;;
+      *) echo "lock: held by live harness pid $old" ;;
+    esac
+  else
+    case "$old" in
+      codex-thread:*) echo "lock: stale (codex thread ${old#codex-thread:} is not this session)" ;;
+      *) echo "lock: stale (pid $old dead or not a harness)" ;;
+    esac
+  fi
   exit 0
 fi
 
@@ -84,4 +94,7 @@ if [ ! -f "$LOCK" ] || [ -L "$LOCK" ] || [ "$written" != "$me" ]; then
   exit 1
 fi
 release_claim_lock
-echo "lock acquired: harness pid $me"
+case "$me" in
+  codex-thread:*) echo "lock acquired: codex thread ${me#codex-thread:}" ;;
+  *) echo "lock acquired: harness pid $me" ;;
+esac

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Shared session-lock harness identity.
 #
-# ONE owner of the "which verified-harness process holds this home's session
-# lock, and does the current process descend from that same harness?" decision.
+# ONE owner of the "which verified-harness identity holds this home's session
+# lock, and does the current process descend from or match that identity?" decision.
 # bin/fm-lock.sh uses it to acquire and inspect state/.lock;
 # bin/fm-claude-stop-autoarm.sh uses it to prove a Stop hook fires inside the
 # lock-owning primary session before it may arm or rewake.
@@ -11,7 +11,14 @@
 # Known harness command names; extend when a new adapter is verified.
 FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
 
-# Walk the current process ancestry (up to 16 hops) and print a harness pid.
+# Print Codex's thread identity when API-hosted Codex hides the harness process
+# ancestry that process-backed adapters expose.
+fm_codex_thread_identity() {
+  [ -n "${CODEX_THREAD_ID:-}" ] || return 1
+  printf 'codex-thread:%s\n' "$CODEX_THREAD_ID"
+}
+
+# Walk the current process ancestry (up to 16 hops) and print a harness identity.
 # For every harness except Claude, the first match wins (innermost pid), which
 # is where e.g. Pi's shared signed-wrapper ancestry actually holds the session:
 # a "pi-signed" launcher can be the direct parent of the inner "pi" engine
@@ -23,9 +30,10 @@ FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
 # looking for a still-more-ancestral claude-named match, and stops the
 # instant a non-match follows - never walking past that gap to an unrelated
 # claude-named process further up the real process tree (e.g. the live
-# session that launched a test as its own subprocess). The harness pid lives
-# as long as the session, unlike the transient subshell pid of any one tool
-# call.
+# session that launched a test as its own subprocess). Process-backed adapters
+# print a harness pid, which lives as long as the session, unlike the transient
+# subshell pid of any one tool call. API-hosted Codex falls back to
+# `codex-thread:<thread-id>` when no process ancestry match is visible.
 fm_harness_ancestry_pid() {
   local pid=$$ comm args best='' bc extending=0 hit=0 is_claude=0
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
@@ -61,12 +69,20 @@ fm_harness_ancestry_pid() {
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
   done
   [ -n "$best" ] && { echo "$best"; return 0; }
-  return 1
+  fm_codex_thread_identity || return 1
 }
 
-# True if $1 is a live process that looks like a verified harness.
+# True if $1 is a live process or current Codex thread that looks like a
+# verified harness identity.
 fm_harness_pid_alive() {
   local pid=$1 comm args
+  case "$pid" in
+    codex-thread:*)
+      [ -n "${CODEX_THREAD_ID:-}" ] && [ "$pid" = "codex-thread:$CODEX_THREAD_ID" ]
+      return
+      ;;
+    ''|*[!0-9]*) return 1 ;;
+  esac
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   if printf '%s' "$(basename "$comm")" | grep -qE "$FM_HARNESS_RE"; then
@@ -81,16 +97,17 @@ fm_harness_pid_alive() {
   esac
 }
 
-# True when state dir $1 holds a session lock whose pid is the harness ancestor
-# of the current process: this script runs inside the session that owns the
-# home's fleet lock. A missing lock, a lock held by another live harness, or an
-# ancestry that cannot be resolved all fail closed.
+# True when state dir $1 holds a session lock whose identity belongs to the
+# current process: this script runs inside the session that owns the home's
+# fleet lock. A missing lock, a lock held by another live harness, or an
+# identity that cannot be resolved all fail closed.
 fm_session_lock_owned_by_self() {
-  local state=$1 lock_pid my_pid
-  lock_pid=$(cat "$state/.lock" 2>/dev/null || true)
-  case "$lock_pid" in
+  local state=$1 lock_id my_id
+  lock_id=$(cat "$state/.lock" 2>/dev/null || true)
+  case "$lock_id" in
+    codex-thread:*) fm_harness_pid_alive "$lock_id"; return ;;
     ''|*[!0-9]*) return 1 ;;
   esac
-  my_pid=$(fm_harness_ancestry_pid) || return 1
-  [ "$my_pid" = "$lock_pid" ]
+  my_id=$(fm_harness_ancestry_pid) || return 1
+  [ "$my_id" = "$lock_id" ]
 }

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -157,7 +157,7 @@ Prose may improve without changing adapter behavior.
 
 | Harness | Exact command field | Adapter behavior on checker exit 2 |
 | --- | --- | --- |
-| Codex | `.tool_input.command` | The `.codex/hooks.json` command forwards the complete stdin payload and Codex blocks on exit 2. |
+| Codex | `.tool_input.command` | `.codex/hooks.json` invokes `bin/fm-codex-hook-dispatch.sh`, which performs a bounded stdin read before forwarding the payload; Codex blocks on exit 2. |
 | Claude | `.tool_input.command` | `.claude/settings.json` forwards stdin with `--claude`, leaving stdout empty and returning the stderr deny object. |
 | Grok | `.toolInput.command` | `.grok/hooks/fm-primary-pretool-check.json` forwards stdin and Grok consumes the stdout `decision=deny` object. |
 | OpenCode | `output.args.command` | `.opencode/plugins/fm-primary-pretool-check.js` passes one `--command` argument and throws only for exit 2. |

--- a/docs/cd-guard.md
+++ b/docs/cd-guard.md
@@ -113,7 +113,7 @@ The cd-guard never duplicates shell lexing; it adds only the cd-specific decisio
 | Harness | Entry | Adapter behavior on checker exit 2 |
 | --- | --- | --- |
 | Claude | `.claude/settings.json` PreToolUse Bash hook forwarding stdin with `--claude` | Blocks the tool call; stderr deny object, stdout empty. |
-| Codex | `.codex/hooks.json` PreToolUse hook that anchors from `pwd -P`, verifies the hook-loaded firstmate root, and forwards the payload | Blocks on exit 2 and displays stderr. |
+| Codex | `.codex/hooks.json` PreToolUse hook that anchors from `pwd -P` and invokes `bin/fm-codex-hook-dispatch.sh` for a bounded payload read | Blocks on exit 2 and displays stderr. |
 | Grok | `.grok/hooks/fm-primary-cd-check.json` PreToolUse hook anchored on `${GROK_WORKSPACE_ROOT:-}` | Consumes the stdout `decision=deny` object. |
 | OpenCode | `.opencode/plugins/fm-primary-cd-check.js` `tool.execute.before` | Throws, which surfaces as the failed tool result. |
 | Pi | `.pi/extensions/fm-primary-turnend-guard.ts` `tool_call` handler | Returns `{block: true}`; piggybacks on the already-loaded primary extension so no extra `-e` flag is needed. |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -33,6 +33,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-kimi-turnend-hook.sh` | Surgically install or remove Kimi's guarded global crew turn-end hook                |
+| `fm-codex-hook-dispatch.sh` | Bounded stdin dispatcher for tracked Codex hook commands                          |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |
 | `fm-subagent-pretool-check.sh` | Primary-home delegation-shape PreToolUse guard (docs/subagent-guard.md) |

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -39,7 +39,7 @@ If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot s
 ## Harness integrations
 
 - Claude registers two `Stop` hooks in `.claude/settings.json`, both anchored through `CLAUDE_PROJECT_DIR`: `bin/fm-turnend-guard.sh --claude`, and `bin/fm-claude-stop-autoarm.sh` with `asyncRewake: true` and `timeout: 28800`.
-- Codex registers a `Stop` hook in `.codex/hooks.json`, anchors the executable to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and passes the original payload to the shared guard.
+- Codex registers a `Stop` hook in `.codex/hooks.json`, anchors the executable to the hook process working directory, then invokes `bin/fm-codex-hook-dispatch.sh` to verify the hook-bearing root and perform a bounded payload read before forwarding to the shared guard.
 - OpenCode listens for `session.idle` in `.opencode/plugins/fm-primary-turnend-guard.js`, lets the watcher coordinator act first, and calls `client.session.promptAsync` once when the guard returns 2.
 - Pi listens for `agent_settled` in `.pi/extensions/fm-primary-turnend-guard.ts`, runs once per logical agent run, and calls `pi.sendUserMessage(..., { deliverAs: "followUp" })` once when the guard returns 2.
 - Grok registers a `Stop` hook in `.grok/hooks/fm-primary-turnend-guard.json` and delegates capability selection to `bin/fm-turnend-guard-grok.sh`.

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -11,7 +11,7 @@ A failed follow-up never cancels continuity restoration.
 Pi same-process session replacement follows the generation-owner contract in `.pi/extensions/fm-primary-pi-watch.ts`.
 Claude's `.claude/settings.json` Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns routine tokenless re-arm.
 The hook fires on every Stop, and an eligible primary with supervision need admits one home-scoped owner that foregrounds `bin/fm-watch-arm.sh` inside the hook-owned process tree.
-A numeric session-lock owner that fails the shared `fm_harness_pid_alive` predicate is reclaimed through `bin/fm-lock.sh` before auto-arm state changes, while a live owner, absent lock, or malformed lock keeps the competing hook inert.
+A process-backed session-lock owner that fails the shared `fm_harness_pid_alive` predicate is reclaimed through `bin/fm-lock.sh` before auto-arm state changes, while a live owner, absent lock, non-process owner, or malformed lock keeps the competing hook inert.
 The stale-owner claim occurs only after the existing AFK and supervision-need gates pass.
 While supervision is still needed and away mode remains inactive, an actionable close or typed failure wakes the idle session through exit 2.
 

--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -493,11 +493,22 @@ test_codex_hooks_pretool_wired() {
   [ -n "$command" ] || fail "PreToolUse hook command is missing from codex primary hooks"
   assert_contains "$command" 'fm-arm-pretool-check.sh' "codex pretool hook must invoke the shared checker"
   assert_contains "$command" 'pwd -P' "codex pretool hook must anchor to the hook process root like the Stop hook does"
-  assert_contains "$command" 'printf "%s" "$payload" | "$root/bin/fm-arm-pretool-check.sh"' "codex pretool hook must forward the exact captured payload to the checker"
+  assert_contains "$command" 'fm-codex-hook-dispatch.sh' "codex pretool hook must use the bounded stdin dispatcher"
   local matcher
   matcher=$(jq -r '.hooks.PreToolUse[0].matcher // empty' "$settings")
   [ "$matcher" = "Bash" ] || fail "codex pretool hook must matcher-scope to Bash, got: $matcher"
   pass ".codex/hooks.json: PreToolUse hook invokes the shared checker"
+}
+
+test_codex_dispatcher_fails_open_without_stdin() {
+  local out rc start end
+  start=$(date +%s)
+  out=$(FM_CODEX_HOOK_READ_TIMEOUT=0.1 bash "$ROOT/bin/fm-codex-hook-dispatch.sh" PreToolUse fm-arm-pretool-check.sh < /dev/null 2>&1); rc=$?
+  end=$(date +%s)
+  [ "$rc" -eq 0 ] || fail "codex dispatcher should fail open without stdin, rc=$rc out=$out"
+  [ -z "$out" ] || fail "codex dispatcher should stay silent without stdin, got: $out"
+  [ $((end - start)) -lt 2 ] || fail "codex dispatcher took too long without stdin"
+  pass "fm-codex-hook-dispatch: fails open quickly without stdin"
 }
 
 test_opencode_pretool_plugin_wired() {
@@ -557,6 +568,7 @@ test_grok_pretool_hook_wired
 test_grok_turnend_hook_uses_safe_var_pattern
 test_claude_settings_pretool_hook_wired
 test_codex_hooks_pretool_wired
+test_codex_dispatcher_fails_open_without_stdin
 test_opencode_pretool_plugin_wired
 test_pi_extension_carries_pretool_check
 test_shellcheck_clean

--- a/tests/fm-cd-pretool-check.test.sh
+++ b/tests/fm-cd-pretool-check.test.sh
@@ -393,6 +393,7 @@ test_codex_wiring() {
   [ -n "$command" ] || fail "codex PreToolUse must invoke fm-cd-pretool-check.sh"
   assert_contains "$command" 'pwd -P' "codex cd hook must anchor from the hook process working directory"
   assert_contains "$command" 'fm-cd-pretool-check.sh' "codex cd hook must invoke the cd-guard"
+  assert_contains "$command" 'fm-codex-hook-dispatch.sh' "codex cd hook must use the bounded stdin dispatcher"
   jq -e '[.hooks.PreToolUse[0].hooks[].command | select(contains("fm-arm-pretool-check.sh"))] | length == 1' "$settings" >/dev/null \
     || fail "codex cd hook must not displace the watcher-arm hook"
   pass ".codex/hooks.json: PreToolUse invokes the cd-guard alongside the arm guard"

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -137,6 +137,104 @@ SH
   pass "fm-lock recognizes grok harness processes"
 }
 
+make_non_harness_ps() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/bin/sh'; exit 0 ;;
+  *"args="*) printf '%s\n' 'sh'; exit 0 ;;
+  *"ppid="*) printf '%s\n' '1'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
+make_codex_harness_ps() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/usr/local/bin/codex'; exit 0 ;;
+  *"args="*) printf '%s\n' 'codex'; exit 0 ;;
+  *"ppid="*) printf '%s\n' '1'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
+test_fm_lock_uses_codex_thread_fallback() {
+  local home fakebin out
+  home="$TMP_ROOT/lock-codex-thread-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/lock-codex-thread-fake")
+  mkdir -p "$home/state"
+  make_non_harness_ps "$fakebin"
+
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    FM_HOME="$home" CODEX_THREAD_ID=thread-one PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh")
+  assert_contains "$out" "lock acquired: codex thread thread-one" "fm-lock did not acquire with CODEX_THREAD_ID fallback"
+
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    FM_HOME="$home" CODEX_THREAD_ID=thread-one PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by current codex thread thread-one" "fm-lock did not recognize current CODEX_THREAD_ID holder"
+
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    FM_HOME="$home" CODEX_THREAD_ID=thread-two PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: stale (codex thread thread-one is not this session)" "fm-lock did not treat another codex thread as stale"
+  pass "fm-lock falls back to CODEX_THREAD_ID when process ancestry is hidden"
+}
+
+test_session_lock_owned_by_codex_thread_self() {
+  local home fakebin
+  home="$TMP_ROOT/session-lock-codex-thread-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/session-lock-codex-thread-fake")
+  mkdir -p "$home/state"
+  make_non_harness_ps "$fakebin"
+  printf '%s\n' 'codex-thread:thread-one' > "$home/state/.lock"
+
+  # shellcheck disable=SC2016 # $1 and $2 are child bash -c arguments.
+  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    CODEX_THREAD_ID=thread-one PATH="$fakebin:$PATH" bash -c \
+    '. "$1/bin/fm-session-lock-lib.sh"; fm_session_lock_owned_by_self "$2"' _ "$ROOT" "$home/state" \
+    || fail "session-lock self proof did not accept the current Codex thread"
+
+  # shellcheck disable=SC2016 # $1 and $2 are child bash -c arguments.
+  if env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    CODEX_THREAD_ID=thread-two PATH="$fakebin:$PATH" bash -c \
+    '. "$1/bin/fm-session-lock-lib.sh"; fm_session_lock_owned_by_self "$2"' _ "$ROOT" "$home/state"; then
+    fail "session-lock self proof accepted another Codex thread"
+  fi
+
+  make_codex_harness_ps "$fakebin"
+  # shellcheck disable=SC2016 # $1 and $2 are child bash -c arguments.
+  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    CODEX_THREAD_ID=thread-one PATH="$fakebin:$PATH" bash -c \
+    '. "$1/bin/fm-session-lock-lib.sh"; fm_session_lock_owned_by_self "$2"' _ "$ROOT" "$home/state" \
+    || fail "session-lock self proof let a numeric Codex ancestor hide the matching Codex thread"
+
+  pass "session-lock self proof supports the current Codex thread identity only"
+}
+
+test_fm_harness_detects_codex_thread_marker_after_stronger_markers() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/fm-harness-codex-thread-fake")
+  make_non_harness_ps "$fakebin"
+
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    CODEX_THREAD_ID=thread-one PATH="$fakebin:$PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$out" = codex ] || fail "fm-harness did not detect CODEX_THREAD_ID as codex (got '$out')"
+
+  out=$(env -u CLAUDECODE -u GROK_AGENT \
+    PI_CODING_AGENT=true CODEX_THREAD_ID=thread-one PATH="$fakebin:$PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$out" = pi ] || fail "CODEX_THREAD_ID overrode Pi's current-harness marker (got '$out')"
+  pass "fm-harness detects Codex API sessions without overriding stronger harness markers"
+}
+
 test_grok_hook_requires_registered_token
 test_grok_teardown_removes_pointer_and_token
 test_fm_lock_recognizes_grok_holder
+test_fm_lock_uses_codex_thread_fallback
+test_session_lock_owned_by_codex_thread_self
+test_fm_harness_detects_codex_thread_marker_after_stronger_markers

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -732,8 +732,8 @@ test_codex_hook_invokes_shared_guard() {
   command=$(jq -r '.hooks.Stop[0].hooks[0].command // empty' "$settings")
   [ -n "$command" ] || fail "Stop hook command is missing from .codex/hooks.json"
   assert_contains "$command" 'pwd -P' "codex hook must anchor from the hook process working directory"
-  assert_contains "$command" '.codex/hooks.json' "codex hook must verify the hook-loaded firstmate root"
   assert_contains "$command" 'fm-turnend-guard.sh' "codex hook must invoke the shared guard"
+  assert_contains "$command" 'fm-codex-hook-dispatch.sh' "codex Stop hook must use the bounded stdin dispatcher"
   assert_not_contains "$command" '.cwd' "codex hook must not use payload cwd to select the guard executable"
   pass ".codex/hooks.json: Stop hook invokes the shared primary guard"
 }
@@ -749,12 +749,13 @@ test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root() {
   expected_root=$(cd "$dir" && pwd -P)
   outside="$TMP_ROOT/codex-hook-outside"
   mkdir -p "$outside"
+  cp "$ROOT/bin/fm-codex-hook-dispatch.sh" "$dir/bin/fm-codex-hook-dispatch.sh"
   cat > "$dir/bin/fm-turnend-guard.sh" <<'EOF'
 #!/usr/bin/env bash
 printf 'guard=%s\n' "$0"
 cat
 EOF
-  chmod +x "$dir/bin/fm-turnend-guard.sh"
+  chmod +x "$dir/bin/fm-turnend-guard.sh" "$dir/bin/fm-codex-hook-dispatch.sh"
   payload=$(jq -cn --arg cwd "$outside" '{cwd:$cwd,stop_hook_active:false}')
   out=$(printf '%s' "$payload" | (cd "$dir" && bash -c "$command") 2>&1); status=$?
   expect_code 0 "$status" "codex hook must execute successfully when payload cwd is outside the firstmate root"
@@ -772,6 +773,7 @@ test_codex_hook_ignores_nested_git_root_guard() {
   dir=$(make_primary_dir "$TMP_ROOT/codex-hook-outer")
   mark_codex_hook_root "$dir"
   expected_root=$(cd "$dir" && pwd -P)
+  cp "$ROOT/bin/fm-codex-hook-dispatch.sh" "$dir/bin/fm-codex-hook-dispatch.sh"
   nested="$dir/projects/other"
   mkdir -p "$nested"
   git init -q "$nested"
@@ -790,7 +792,7 @@ EOF
 printf 'guard=%s\n' "$0"
 cat
 EOF
-  chmod +x "$dir/bin/fm-turnend-guard.sh"
+  chmod +x "$dir/bin/fm-turnend-guard.sh" "$dir/bin/fm-codex-hook-dispatch.sh"
   subdir="$nested/deep/path"
   mkdir -p "$subdir"
   payload=$(jq -cn --arg cwd "$subdir" '{cwd:$cwd,stop_hook_active:false}')
@@ -835,7 +837,7 @@ exit 2
 EOF
   chmod +x "$worktree_dir/bin/fm-turnend-guard.sh"
   # Runtime module-format warnings are host noise; this assertion owns plugin output only.
-  out=$(NODE_NO_WARNINGS=1 PLUGIN="$plugin" DIRECTORY="$wrong_dir" WORKTREE="$worktree_dir" node 2>&1 <<'EOF'
+  out=$(NODE_NO_WARNINGS=1 PLUGIN="$plugin" DIRECTORY="$wrong_dir" WORKTREE="$worktree_dir" node --input-type=module 2>&1 <<'EOF'
 import { pathToFileURL } from "node:url";
 
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
@@ -923,7 +925,7 @@ SH
 exit 0
 SH
   chmod +x "$repo/bin/fm-turnend-guard.sh" "$repo/bin/fm-arm-pretool-check.sh"
-  out=$(PLUGIN="$ext" FM_HOME="$home" FM_GUARD_LOG="$log" node --input-type=module 2>&1 <<'EOF'
+  out=$(NODE_NO_WARNINGS=1 PLUGIN="$ext" FM_HOME="$home" FM_GUARD_LOG="$log" node --input-type=module 2>&1 <<'EOF'
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -988,7 +990,7 @@ SH
 exit 0
 SH
   chmod +x "$repo/bin/fm-turnend-guard.sh" "$repo/bin/fm-arm-pretool-check.sh"
-  out=$(PLUGIN="$ext" FM_HOME="$home" node --input-type=module 2>&1 <<'EOF'
+  out=$(NODE_NO_WARNINGS=1 PLUGIN="$ext" FM_HOME="$home" node --input-type=module 2>&1 <<'EOF'
 import { pathToFileURL } from "node:url";
 
 const handlers = new Map();


### PR DESCRIPTION
## Summary

Fix Codex API/Desktop-hosted Firstmate sessions becoming read-only when process ancestry inspection is unavailable.

This preserves process-backed harness PID ownership, including the current Claude outermost-ancestry behavior, and adds a `CODEX_THREAD_ID` fallback for Codex sessions where `ps` cannot expose a local `codex` parent process.

## Validation

- `FM_HOME=/private/tmp/fm-codex-thread-test-home CODEX_THREAD_ID=fm-test-thread-1 bin/fm-session-start.sh`
  - confirmed `lock acquired: codex thread fm-test-thread-1`
  - confirmed `primary harness: codex`
- `tests/fm-grok-harness.test.sh`

## Known unrelated local issue

- `tests/fm-turnend-guard.test.sh` fails locally on Pi TypeScript extension import with Node v20:
  - `TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"`
- The same Pi TypeScript import failure reproduces on current `main`.
