### PR TITLE
fix: preserve dispatch identity across authentication checks

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -127,6 +127,8 @@ The supported launch-profile flags below are verified locally; each row records 
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
 
+The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
+
 ### Model support discovery
 
 Treat model and provider knowledge as current source-of-truth discovery, not as a permanent namespace or provider mapping.

--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -20,7 +20,8 @@ Do not add a daemon, opaque composite score, routing wrapper, hard-coded model-s
 ## Collect facts
 
 Run `quota-axi --json` once per intake and reuse that snapshot for every candidate.
-For each candidate, establish the harness/model/provider relationship from `harness-adapters`, then record only inspectable facts:
+For each candidate, use explicit `harness`, `model`, and `provider` tuple; `harness-adapters` owns identity, and model/provider never infer harness, then record only inspectable facts:
+Before stopping for auth or unresolved data, scope evidence to that tuple; another harness CLI cannot block it.
 
 - task/profile fit and required reasoning class
 - raw applicable headroom (`effectivePercentRemaining` or the tightest applicable remaining percentage)
@@ -45,7 +46,7 @@ Conservation pressure is present when effective pace status is `ahead`, effectiv
 Apply only among candidates that already satisfy required fit and the strongest reasoning class the request needs.
 Never use pace or raw headroom to silently replace that reasoning class.
 
-1. Unresolved relationship or quota data: stop and report the blocked candidate.
+1. Unresolved relationship, auth, or quota: report exact `harness`, `model`, auth surface, and concrete failure evidence for that tuple.
 2. All-tight: keep the strongest-reasoning class; dispatch inside it or stop and report that the tight choice cannot proceed.
 3. When fit and reasoning are comparable, prefer a candidate without ahead-of-reset conservation pressure over one with conservation pressure, even when the pressured candidate has somewhat higher raw remaining percentage.
 4. Among pressured candidates, prefer the least-negative worst applicable reserve.
@@ -60,4 +61,5 @@ Never use pace or raw headroom to silently replace that reasoning class.
    Report duplicate concrete profiles as a configuration error.
 
 Name the inspectable facts used for every candidate.
+A blocked credential report must name `harness`, `model`, authentication surface, and concrete failure evidence; never emit a bare `Grok unauthenticated` statement.
 Never conclude with an unexplained "best quota" label.

--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -45,7 +45,7 @@ Conservation pressure is present for effective pace status `ahead`, effective pa
 Apply only among candidates satisfying required fit and strongest reasoning class.
 Never use pace or raw headroom to silently replace that reasoning class.
 
-1. Unresolved relationship, auth, or quota: stop and report the tuple and concrete evidence.
+1. Unresolved relationship or quota: stop and report the tuple and concrete evidence.
 2. All-tight: keep strongest reasoning; dispatch inside it or report if blocked.
 3. Comparable fit/reasoning: prefer no ahead pressure over pressure, even with higher raw headroom.
 4. Among pressured candidates, prefer the least-negative worst applicable reserve.
@@ -60,6 +60,6 @@ Never use pace or raw headroom to silently replace that reasoning class.
    Report duplicate concrete profiles as a configuration error.
 
 Name the inspectable facts used for every candidate.
-Check auth only through the selected tuple's surface; another harness CLI cannot block it.
+After selecting, check auth only through that tuple's surface; another harness CLI cannot block it.
 A blocked credential report must name `harness`, `model`, authentication surface, and concrete failure evidence; never emit a bare `Grok unauthenticated` statement.
 Never conclude with an unexplained "best quota" label.

--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -20,8 +20,7 @@ Do not add a daemon, opaque composite score, routing wrapper, hard-coded model-s
 ## Collect facts
 
 Run `quota-axi --json` once per intake and reuse that snapshot for every candidate.
-For each candidate, use explicit `harness`, `model`, and `provider` tuple; `harness-adapters` owns identity, and model/provider never infer harness, then record only inspectable facts:
-Before stopping for auth or unresolved data, scope evidence to that tuple; another harness CLI cannot block it.
+For each candidate, preserve its explicit `harness`, `model`, and `provider` tuple and record only the following inspectable facts; `harness-adapters` owns identity, and the model or provider never determines the harness:
 
 - task/profile fit and required reasoning class
 - raw applicable headroom (`effectivePercentRemaining` or the tightest applicable remaining percentage)
@@ -46,7 +45,7 @@ Conservation pressure is present when effective pace status is `ahead`, effectiv
 Apply only among candidates that already satisfy required fit and the strongest reasoning class the request needs.
 Never use pace or raw headroom to silently replace that reasoning class.
 
-1. Unresolved relationship, auth, or quota: report exact `harness`, `model`, auth surface, and concrete failure evidence for that tuple.
+1. Unresolved relationship or quota data: stop and report the candidate.
 2. All-tight: keep the strongest-reasoning class; dispatch inside it or stop and report that the tight choice cannot proceed.
 3. When fit and reasoning are comparable, prefer a candidate without ahead-of-reset conservation pressure over one with conservation pressure, even when the pressured candidate has somewhat higher raw remaining percentage.
 4. Among pressured candidates, prefer the least-negative worst applicable reserve.
@@ -61,5 +60,6 @@ Never use pace or raw headroom to silently replace that reasoning class.
    Report duplicate concrete profiles as a configuration error.
 
 Name the inspectable facts used for every candidate.
+After selecting a candidate, check authentication only through that tuple's authentication surface; another harness CLI cannot block it.
 A blocked credential report must name `harness`, `model`, authentication surface, and concrete failure evidence; never emit a bare `Grok unauthenticated` statement.
 Never conclude with an unexplained "best quota" label.

--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -20,16 +20,16 @@ Do not add a daemon, opaque composite score, routing wrapper, hard-coded model-s
 ## Collect facts
 
 Run `quota-axi --json` once per intake and reuse that snapshot for every candidate.
-For each candidate, preserve its explicit `harness`, `model`, and `provider` tuple and record only the following inspectable facts; `harness-adapters` owns identity, and the model or provider never determines the harness:
+For each candidate, preserve explicit `harness`, `model`, and `provider`; `harness-adapters` owns identity, and model/provider never infer harness:
 
 - task/profile fit and required reasoning class
-- raw applicable headroom (`effectivePercentRemaining` or the tightest applicable remaining percentage)
-- effective pace status, signed reserve per applicable window, and worst applicable reserve (`worstReservePercentPoints` when present, else the minimum signed reserve)
-- whether any applicable window or effective summary is ahead of reset, or any applicable pace is `unknown`
+- raw applicable headroom (`effectivePercentRemaining` or tightest applicable percentage)
+- effective pace, signed reserve per window, and worst reserve (`worstReservePercentPoints` or minimum signed reserve)
+- whether applicable windows/summary are ahead, or pace is `unknown`
 - schema note when pace fields are absent
 
-Stale raw windows are diagnostic only, never current headroom.
-Read every bounding window named by `boundedBy`, `limitingWindowIds`, `aheadWindowIds`, `behindWindowIds`, `onPaceWindowIds`, and `unknownWindowIds`.
+Stale raw windows are diagnostic, never headroom.
+Read all windows named by `boundedBy`, `limitingWindowIds`, `aheadWindowIds`, `behindWindowIds`, `onPaceWindowIds`, and `unknownWindowIds`.
 
 ## Pace semantics
 
@@ -37,29 +37,29 @@ Read every bounding window named by `boundedBy`, `limitingWindowIds`, `aheadWind
 Negative reserve means usage is ahead of reset pace and creates conservation pressure.
 Positive reserve means usage is behind reset pace.
 `on_pace` is neutral.
-Conservation pressure is present when effective pace status is `ahead`, effective pace status is `mixed` and any `aheadWindowIds` remain, or any applicable bounding window itself has pace status `ahead`.
-`unknown` is valid explicit uncertainty from quota-axi, not a parser failure and not permission to assume the window is healthy or exhausted.
+Conservation pressure is present for effective pace status `ahead`, effective pace status is `mixed` and any `aheadWindowIds` remain, or a bounding window is `ahead`.
+`unknown` is valid explicit uncertainty from quota-axi, not parser failure or permission to assume health.
 
 ## Selection order
 
-Apply only among candidates that already satisfy required fit and the strongest reasoning class the request needs.
+Apply only among candidates satisfying required fit and strongest reasoning class.
 Never use pace or raw headroom to silently replace that reasoning class.
 
-1. Unresolved relationship or quota data: stop and report the candidate.
-2. All-tight: keep the strongest-reasoning class; dispatch inside it or stop and report that the tight choice cannot proceed.
-3. When fit and reasoning are comparable, prefer a candidate without ahead-of-reset conservation pressure over one with conservation pressure, even when the pressured candidate has somewhat higher raw remaining percentage.
+1. Unresolved relationship, auth, or quota: stop and report the tuple and concrete evidence.
+2. All-tight: keep strongest reasoning; dispatch inside it or report if blocked.
+3. Comparable fit/reasoning: prefer no ahead pressure over pressure, even with higher raw headroom.
 4. Among pressured candidates, prefer the least-negative worst applicable reserve.
-5. Among sustainable candidates, use known behind/on-pace evidence plus raw headroom transparently.
-   Prefer known sustainable evidence over `unknown` pace when otherwise comparable.
+5. Sustainable candidates: use known pace plus raw headroom.
+   Prefer known sustainable evidence over `unknown` when comparable.
    Do not collapse those facts into an opaque composite score.
-6. If the dispatch choice materially hinges on unresolved pace, report the uncertainty rather than inventing a conclusion.
-7. Absent pace or older schema: do not crash, fabricate pace, or silently reinterpret absence as healthy/`on_pace`.
-   Compare raw applicable headroom only, state that pace is unavailable, and keep every other safety rule.
+6. If unresolved pace changes the choice, report uncertainty.
+7. Absent pace or older schema: do not crash, fabricate pace, or treat absence as healthy/`on_pace`.
+   Compare raw headroom only, state pace is unavailable, and keep safety rules.
 8. Genuine ties: stop and report every tied candidate for captain choice.
    Do not select by array order, harness name, or another arbitrary identity ordering.
    Report duplicate concrete profiles as a configuration error.
 
 Name the inspectable facts used for every candidate.
-After selecting a candidate, check authentication only through that tuple's authentication surface; another harness CLI cannot block it.
+Check auth only through the selected tuple's surface; another harness CLI cannot block it.
 A blocked credential report must name `harness`, `model`, authentication surface, and concrete failure evidence; never emit a bare `Grok unauthenticated` statement.
 Never conclude with an unexplained "best quota" label.

--- a/tests/fixtures/quota-array-dispatch/cases.json
+++ b/tests/fixtures/quota-array-dispatch/cases.json
@@ -200,6 +200,48 @@
       ]
     },
     {
+      "id": "select-pi-xai-before-authentication",
+      "expect": "pi-xai",
+      "reason": "an unauthenticated standalone Grok candidate cannot block selected authenticated Pi/xAI",
+      "candidates": [
+        {
+          "id": "pi-xai",
+          "harness": "pi",
+          "model": "xai/grok-4.5",
+          "provider": "xai",
+          "authenticationSurface": "Pi xAI OAuth",
+          "authAvailable": true,
+          "fit": "comparable",
+          "reasoningClass": "strong",
+          "tight": false,
+          "rawHeadroom": 55,
+          "paceStatus": "behind",
+          "aheadWindowIds": [],
+          "worstReserve": 15.0,
+          "unknownPace": false,
+          "paceAvailable": true
+        },
+        {
+          "id": "standalone-grok",
+          "harness": "grok",
+          "model": "grok-4.5",
+          "provider": "grok",
+          "authenticationSurface": "Grok Build CLI",
+          "authAvailable": false,
+          "authFailure": "Grok Build CLI login missing",
+          "fit": "comparable",
+          "reasoningClass": "strong",
+          "tight": false,
+          "rawHeadroom": 80,
+          "paceStatus": "ahead",
+          "aheadWindowIds": ["weekly"],
+          "worstReserve": -12.0,
+          "unknownPace": false,
+          "paceAvailable": true
+        }
+      ]
+    },
+    {
       "id": "all-tight-strongest-reasoning",
       "expect": "A",
       "reason": "preserve strongest-reasoning class when every candidate is tight",

--- a/tests/fm-quota-array-dispatch.test.sh
+++ b/tests/fm-quota-array-dispatch.test.sh
@@ -161,15 +161,15 @@ test_owner_contains_selection_procedure() {
     'Positive reserve means usage is behind reset pace' \
     '`on_pace` is neutral' \
     'effective pace status is `mixed` and any `aheadWindowIds` remain' \
-    'prefer a candidate without ahead-of-reset conservation pressure over one with conservation pressure' \
-    'even when the pressured candidate has somewhat higher raw remaining percentage' \
+    'Comparable fit/reasoning: prefer no ahead pressure over pressure' \
+    'even with higher raw headroom' \
     'prefer the least-negative worst applicable reserve' \
-    'use known behind/on-pace evidence plus raw headroom transparently' \
+    'Sustainable candidates: use known pace plus raw headroom' \
     'Do not collapse those facts into an opaque composite score' \
     '`unknown` is valid explicit uncertainty from quota-axi' \
-    'Prefer known sustainable evidence over `unknown` pace when otherwise comparable' \
-    'If the dispatch choice materially hinges on unresolved pace, report the uncertainty' \
-    'do not crash, fabricate pace, or silently reinterpret absence as healthy' \
+    'Prefer known sustainable evidence over `unknown` when comparable' \
+    'If unresolved pace changes the choice, report uncertainty' \
+    'do not crash, fabricate pace, or treat absence as healthy' \
     'stop and report every tied candidate for captain choice' \
     'Do not select by array order, harness name, or another arbitrary identity ordering' \
     'Do not add a daemon, opaque composite score, routing wrapper, hard-coded model-specific policy' \
@@ -193,7 +193,7 @@ test_owner_contains_selection_procedure() {
   words=$(wc -w < "$OWNER" | tr -d ' ')
   bytes=$(wc -c < "$OWNER" | tr -d ' ')
   [ "$lines" -le 65 ] || fail "quota-array-dispatch skill is too long: $lines lines (want <= 65)"
-  [ "$words" -le 600 ] || fail "quota-array-dispatch skill is too wordy: $words words (want <= 600)"
+  [ "$words" -le 550 ] || fail "quota-array-dispatch skill is too wordy: $words words (want <= 550)"
   [ "$bytes" -le 4600 ] || fail "quota-array-dispatch skill is too large: $bytes bytes (want <= 4600)"
   pass "quota-array-dispatch owns the compact pace procedure ($lines lines, $words words, $bytes bytes)"
 }

--- a/tests/fm-quota-array-dispatch.test.sh
+++ b/tests/fm-quota-array-dispatch.test.sh
@@ -289,24 +289,35 @@ test_dispatch_identity_and_blocked_report() {
   reports=$(python3 - <<'PY'
 
 def auth_surface(harness, model, provider):
-    if harness == "pi" and model.startswith("xai/") and provider == "xai":
-        return "Pi xAI OAuth"
-    if harness == "grok":
-        return "Grok Build CLI"
-    raise AssertionError("unresolved concrete profile")
+    surfaces = {
+        ("pi", "xai/grok-4.5", "xai"): "Pi xAI OAuth",
+        ("grok", "grok-4.5", "grok"): "Grok Build CLI",
+    }
+    try:
+        return surfaces[(harness, model, provider)]
+    except KeyError:
+        raise AssertionError("unresolved concrete profile") from None
 
 def blocked(harness, model, provider, failure):
     surface = auth_surface(harness, model, provider)
     return (f"blocked: harness={harness} model={model} provider={provider} "
             f"authentication surface checked={surface} failure evidence={failure}")
 
-model = "xai/grok-4.5"
-provider = "xai"
-pi = blocked("pi", model, provider, "Pi xAI OAuth unavailable")
-grok = blocked("grok", model, provider, "Grok Build CLI login missing")
+pi = blocked("pi", "xai/grok-4.5", "xai", "Pi xAI OAuth unavailable")
+grok = blocked("grok", "grok-4.5", "grok", "Grok Build CLI login missing")
 assert "Grok Build CLI" not in pi
 assert "Pi xAI OAuth" in pi
 assert "Grok Build CLI" in grok
+for mismatched in (
+    ("grok", "xai/grok-4.5", "xai"),
+    ("pi", "grok-4.5", "grok"),
+):
+    try:
+        auth_surface(*mismatched)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError(f"accepted mismatched profile: {mismatched}")
 print(pi)
 print(grok)
 PY
@@ -315,7 +326,7 @@ PY
     "Pi/xAI blocked evidence was not scoped to Pi"
   assert_not_contains "$reports" 'harness=pi model=xai/grok-4.5 provider=xai authentication surface checked=Grok Build CLI' \
     "Pi/xAI was reported with the standalone Grok CLI surface"
-  assert_contains "$reports" 'blocked: harness=grok model=xai/grok-4.5 provider=xai authentication surface checked=Grok Build CLI' \
+  assert_contains "$reports" 'blocked: harness=grok model=grok-4.5 provider=grok authentication surface checked=Grok Build CLI' \
     "explicit Grok candidate did not use the Grok Build CLI surface"
   for field in harness=pi model=xai/grok-4.5 provider=xai 'authentication surface checked=Pi xAI OAuth' 'failure evidence=Pi xAI OAuth unavailable'; do
     assert_contains "$reports" "$field" "Pi blocked report lost '$field'"

--- a/tests/fm-quota-array-dispatch.test.sh
+++ b/tests/fm-quota-array-dispatch.test.sh
@@ -94,6 +94,14 @@ def select(case):
             "candidates": sorted(c["id"] for c in winners),
         }
     winner = winners[0]
+    if winner.get("authAvailable") is False:
+        return {
+            "error": "selected candidate authentication unavailable",
+            "harness": winner["harness"],
+            "model": winner["model"],
+            "authenticationSurface": winner["authenticationSurface"],
+            "failureEvidence": winner["authFailure"],
+        }
     return {
         "id": winner["id"],
         "pressured": conservation_pressure(winner),
@@ -174,6 +182,8 @@ test_owner_contains_selection_procedure() {
     'Do not select by array order, harness name, or another arbitrary identity ordering' \
     'Do not add a daemon, opaque composite score, routing wrapper, hard-coded model-specific policy' \
     'Report duplicate concrete profiles as a configuration error' \
+    'Unresolved relationship or quota: stop and report the tuple and concrete evidence' \
+    'After selecting, check auth only through that tuple'\''s surface' \
     'Name the inspectable facts used for every candidate'; do
     assert_grep "$phrase" "$OWNER" "quota-array-dispatch procedure lost '$phrase'"
   done
@@ -273,8 +283,10 @@ test_dispatch_identity_and_blocked_report() {
   local reports
   assert_grep '`harness-adapters` owns identity' "$OWNER" \
     "quota-array-dispatch does not point to the adapter identity owner"
-  assert_grep "another harness CLI cannot block it" "$OWNER" \
+  assert_grep "After selecting, check auth only through that tuple's surface; another harness CLI cannot block it" "$OWNER" \
     "quota-array-dispatch does not scope evidence to the concrete tuple"
+  assert_no_grep 'Unresolved relationship, auth, or quota' "$OWNER" \
+    "quota-array-dispatch checks authentication before selecting a candidate"
   assert_grep 'A blocked credential report must name `harness`, `model`, authentication surface, and concrete failure evidence' "$OWNER" \
     "blocked reports do not preserve the minimum identity and evidence fields"
   assert_grep 'The concrete `harness` field owns adapter identity independently of the model provider' "$HARNESS" \

--- a/tests/fm-quota-array-dispatch.test.sh
+++ b/tests/fm-quota-array-dispatch.test.sh
@@ -298,13 +298,16 @@ def auth_surface(harness, model, provider):
     except KeyError:
         raise AssertionError("unresolved concrete profile") from None
 
-def blocked(harness, model, provider, failure):
+def evaluate(harness, model, provider, auth_available, failure):
     surface = auth_surface(harness, model, provider)
+    if auth_available:
+        return (f"ready: harness={harness} model={model} provider={provider} "
+                f"authentication surface checked={surface}")
     return (f"blocked: harness={harness} model={model} provider={provider} "
             f"authentication surface checked={surface} failure evidence={failure}")
 
-pi = blocked("pi", "xai/grok-4.5", "xai", "Pi xAI OAuth unavailable")
-grok = blocked("grok", "grok-4.5", "grok", "Grok Build CLI login missing")
+pi = evaluate("pi", "xai/grok-4.5", "xai", True, None)
+grok = evaluate("grok", "grok-4.5", "grok", False, "Grok Build CLI login missing")
 assert "Grok Build CLI" not in pi
 assert "Pi xAI OAuth" in pi
 assert "Grok Build CLI" in grok
@@ -322,15 +325,16 @@ print(pi)
 print(grok)
 PY
 ) || fail "identity counterfactual fixture failed"
-  assert_contains "$reports" 'blocked: harness=pi model=xai/grok-4.5 provider=xai authentication surface checked=Pi xAI OAuth' \
-    "Pi/xAI blocked evidence was not scoped to Pi"
+  assert_contains "$reports" 'ready: harness=pi model=xai/grok-4.5 provider=xai authentication surface checked=Pi xAI OAuth' \
+    "Pi/xAI did not remain dispatchable with its own authentication"
   assert_not_contains "$reports" 'harness=pi model=xai/grok-4.5 provider=xai authentication surface checked=Grok Build CLI' \
     "Pi/xAI was reported with the standalone Grok CLI surface"
   assert_contains "$reports" 'blocked: harness=grok model=grok-4.5 provider=grok authentication surface checked=Grok Build CLI' \
     "explicit Grok candidate did not use the Grok Build CLI surface"
-  for field in harness=pi model=xai/grok-4.5 provider=xai 'authentication surface checked=Pi xAI OAuth' 'failure evidence=Pi xAI OAuth unavailable'; do
-    assert_contains "$reports" "$field" "Pi blocked report lost '$field'"
+  for field in harness=grok model=grok-4.5 provider=grok 'authentication surface checked=Grok Build CLI' 'failure evidence=Grok Build CLI login missing'; do
+    assert_contains "$reports" "$field" "Grok blocked report lost '$field'"
   done
+  printf '%s\n' "$reports"
   pass "dispatch identity stays concrete across the Pi/xAI versus Grok counterfactual"
 }
 

--- a/tests/fm-quota-array-dispatch.test.sh
+++ b/tests/fm-quota-array-dispatch.test.sh
@@ -193,7 +193,7 @@ test_owner_contains_selection_procedure() {
   words=$(wc -w < "$OWNER" | tr -d ' ')
   bytes=$(wc -c < "$OWNER" | tr -d ' ')
   [ "$lines" -le 65 ] || fail "quota-array-dispatch skill is too long: $lines lines (want <= 65)"
-  [ "$words" -le 550 ] || fail "quota-array-dispatch skill is too wordy: $words words (want <= 550)"
+  [ "$words" -le 600 ] || fail "quota-array-dispatch skill is too wordy: $words words (want <= 600)"
   [ "$bytes" -le 4600 ] || fail "quota-array-dispatch skill is too large: $bytes bytes (want <= 4600)"
   pass "quota-array-dispatch owns the compact pace procedure ($lines lines, $words words, $bytes bytes)"
 }
@@ -269,6 +269,60 @@ elif got.get("id") != expect:
   done < <(python3 -c 'import json,sys; data=json.load(sys.stdin); [print(json.dumps(c, separators=(",", ":"))) for c in data["cases"]]' <<<"$raw")
 }
 
+test_dispatch_identity_and_blocked_report() {
+  local reports
+  assert_grep '`harness-adapters` owns identity' "$OWNER" \
+    "quota-array-dispatch does not point to the adapter identity owner"
+  assert_grep "another harness CLI cannot block it" "$OWNER" \
+    "quota-array-dispatch does not scope evidence to the concrete tuple"
+  assert_grep 'A blocked credential report must name `harness`, `model`, authentication surface, and concrete failure evidence' "$OWNER" \
+    "blocked reports do not preserve the minimum identity and evidence fields"
+  assert_grep 'The concrete `harness` field owns adapter identity independently of the model provider' "$HARNESS" \
+    "harness-adapters lost the anti-conflation owner paragraph"
+  assert_grep '`harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`' "$HARNESS" \
+    "harness-adapters lost the concrete Pi/xAI versus Grok distinction"
+  assert_grep 'does not require Grok CLI login' "$HARNESS" \
+    "Pi/xAI guidance incorrectly requires Grok CLI login"
+  assert_no_grep '### Dispatch identity mapping' "$HARNESS" \
+    "identity guidance grew a separate table instead of one owner paragraph"
+
+  reports=$(python3 - <<'PY'
+
+def auth_surface(harness, model, provider):
+    if harness == "pi" and model.startswith("xai/") and provider == "xai":
+        return "Pi xAI OAuth"
+    if harness == "grok":
+        return "Grok Build CLI"
+    raise AssertionError("unresolved concrete profile")
+
+def blocked(harness, model, provider, failure):
+    surface = auth_surface(harness, model, provider)
+    return (f"blocked: harness={harness} model={model} provider={provider} "
+            f"authentication surface checked={surface} failure evidence={failure}")
+
+model = "xai/grok-4.5"
+provider = "xai"
+pi = blocked("pi", model, provider, "Pi xAI OAuth unavailable")
+grok = blocked("grok", model, provider, "Grok Build CLI login missing")
+assert "Grok Build CLI" not in pi
+assert "Pi xAI OAuth" in pi
+assert "Grok Build CLI" in grok
+print(pi)
+print(grok)
+PY
+) || fail "identity counterfactual fixture failed"
+  assert_contains "$reports" 'blocked: harness=pi model=xai/grok-4.5 provider=xai authentication surface checked=Pi xAI OAuth' \
+    "Pi/xAI blocked evidence was not scoped to Pi"
+  assert_not_contains "$reports" 'harness=pi model=xai/grok-4.5 provider=xai authentication surface checked=Grok Build CLI' \
+    "Pi/xAI was reported with the standalone Grok CLI surface"
+  assert_contains "$reports" 'blocked: harness=grok model=xai/grok-4.5 provider=xai authentication surface checked=Grok Build CLI' \
+    "explicit Grok candidate did not use the Grok Build CLI surface"
+  for field in harness=pi model=xai/grok-4.5 provider=xai 'authentication surface checked=Pi xAI OAuth' 'failure evidence=Pi xAI OAuth unavailable'; do
+    assert_contains "$reports" "$field" "Pi blocked report lost '$field'"
+  done
+  pass "dispatch identity stays concrete across the Pi/xAI versus Grok counterfactual"
+}
+
 test_no_duplicate_procedure_in_agents() {
   # Guard against re-expanding the full procedure into AGENTS.md.
   local count
@@ -284,4 +338,5 @@ test_owner_contains_selection_procedure
 test_cross_references_stay_pointers
 test_schema_v3_shape_fixture
 test_deterministic_acceptance_cases
+test_dispatch_identity_and_blocked_report
 test_no_duplicate_procedure_in_agents


### PR DESCRIPTION
## Intent

Prevent Firstmate dispatch identity conflation while preserving the minimal captain-approved contract: keep the explicit harness/model/provider tuple intact, keep Pi with xai/grok-* distinct from the standalone Grok Build CLI harness without requiring Grok CLI login, scope authentication evidence to the selected candidate, and require blocked credential reports to name the harness, model, authentication surface, and concrete failure evidence. Restore the established 550-word quota-array-dispatch ceiling by pruning existing prose without losing quota pace, strongest-reasoning, malformed-configuration, full-candidate-accounting, tie, or authentication guarantees, and retain deterministic Pi/xAI versus explicit Grok regression coverage without adding instruction or schema expansion.

## What Changed

- Preserve explicit harness, model, and provider identity so Pi using xAI Grok models remains distinct from the standalone Grok Build CLI.
- Check authentication only after candidate selection and require blocked credential reports to include the selected harness, model, authentication surface, and concrete failure evidence.
- Restore the 550-word dispatch instruction ceiling and add deterministic regression coverage for Pi/xAI selection when an explicit Grok candidate lacks CLI authentication.

## Risk Assessment

✅ Low: The fix cleanly restores post-selection authentication, preserves the dispatch tuple and quota rules, adds ordered Pi/xAI versus Grok regression coverage, and remains within the 550-word ceiling.

## Testing

Inspected the change, ran the focused quota-selection and spawn-profile suites, and captured an operator-visible counterfactual transcript. Pi using xAI authenticated through Pi xAI OAuth despite unavailable Grok CLI login; explicit Grok produced a complete blocked credential report. Pace, strongest-reasoning, malformed-configuration, full-accounting, tie, tuple-forwarding, and compactness guarantees also passed. No screenshot was applicable because this is an instruction and CLI dispatch change with no rendered UI.

<details>
<summary>Evidence: Pi/xAI versus standalone Grok dispatch evidence</summary>

<code>ready: harness=pi model=xai/grok-4.5 provider=xai authentication surface checked=Pi xAI OAuth&#10;blocked: harness=grok model=grok-4.5 provider=grok authentication surface checked=Grok Build CLI failure evidence=Grok Build CLI login missing</code>

```text
ok - quota-array-dispatch has one conditional owner and a concise always-loaded boundary
ok - quota-array-dispatch owns the compact pace procedure (65 lines, 505 words, 3801 bytes)
ok - cross-references point at the single procedure owner
ok - sanitized schemaVersion 3 fixture preserves producer pace shape without private details
ok - case higher-raw-ahead-vs-lower-raw-sustainable -> B (prefer sustainable pace over higher raw headroom with conservation pressure)
ok - case mixed-effective-with-ahead-bound -> B (mixed with aheadWindowIds is conservation pressure)
ok - case both-ahead-least-negative-reserve -> B (among pressured candidates prefer least-negative worst reserve)
ok - case ahead-bounding-window-overrides-neutral-effective-summary -> B (an ahead applicable bounding window creates conservation pressure even when the effective summary is neutral)
ok - case known-sustainable-vs-unknown -> A (prefer known sustainable evidence over unknown pace)
ok - case select-pi-xai-before-authentication -> pi-xai (an unauthenticated standalone Grok candidate cannot block selected authenticated Pi/xAI)
ok - case all-tight-strongest-reasoning -> A (preserve strongest-reasoning class when every candidate is tight)
ok - case genuine-tie-captain-choice -> genuine tie requires captain choice (report genuine ties instead of selecting by array order or harness identity)
ok - case genuine-tie-reversed-array-order -> genuine tie requires captain choice (reversing a genuine tie must still require captain choice)
ok - case schema-v2-absent-pace -> A (absent pace degrades to raw headroom without fabricating pace health)
ready: harness=pi model=xai/grok-4.5 provider=xai authentication surface checked=Pi xAI OAuth
blocked: harness=grok model=grok-4.5 provider=grok authentication surface checked=Grok Build CLI failure evidence=Grok Build CLI login missing
ok - dispatch identity stays concrete across the Pi/xAI versus Grok counterfactual
ok - AGENTS.md does not duplicate the pace procedure body
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.agents/skills/quota-array-dispatch/SKILL.md:48` - Intent requires authentication evidence to be scoped to the selected candidate, but rule 1 now treats unresolved auth as a pre-selection blocker. With an authenticated Pi/xAI candidate and an unauthenticated explicit Grok candidate, this rule stops on Grok before Pi can be selected, despite line 63&#39;s later constraint. Restore authentication checking exclusively after selection and make the regression exercise that ordered sequence; the current fixture evaluates both candidates independently and cannot catch this failure.

🔧 Fix: Scope dispatch authentication after candidate selection
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the commit-range diff and dispatch ownership paths for `41ffd450..27cb472`.</code>
- `tests/fm-quota-array-dispatch.test.sh`
- `tests/fm-spawn-dispatch-profile.test.sh`
- `wc -w .agents/skills/quota-array-dispatch/SKILL.md`
- <code>Verified `git status --short` remained clean after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
