### PR TITLE
docs: document secure Mac control path

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/orca-backend.md](docs/orca-backend.md) - current setup and limits for the experimental Orca backend.
 - [docs/cmux-backend.md](docs/cmux-backend.md) - current setup, socket security, and limits for the experimental cmux backend.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - the current blocked Codex App backend boundary and rollout contract.
+- [docs/remote-access.md](docs/remote-access.md) - attach to a server-resident Firstmate from a laptop and reach its loopback web tools over an authenticated SSH forward.
+- [docs/verification/remote-access.md](docs/verification/remote-access.md) - active maintainer verification for the remote-access client configuration and forwarding behavior.
 - [docs/verification/runtime-backends.md](docs/verification/runtime-backends.md) - active maintainer verification for runtime backend guarantees.
 - [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - maintainer verification for GitLab merge watching on arbitrary instances.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's current "no turn ends blind" backstop, scope, loop safety, and compatibility limits.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -30,7 +30,8 @@
     "docs/herdr-backend.md",
     "docs/zellij-backend.md",
     "docs/orca-backend.md",
-    "docs/cmux-backend.md"
+    "docs/cmux-backend.md",
+    "docs/remote-access.md"
   ],
   "requiredOwnerPointers": [
     {
@@ -100,6 +101,10 @@
     {
       "source": "docs/codex-app-backend.md",
       "target": "docs/verification/runtime-backends.md"
+    },
+    {
+      "source": "docs/remote-access.md",
+      "target": "docs/verification/remote-access.md"
     }
   ],
   "surfaces": [
@@ -260,6 +265,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/remote-access.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/scripts.md",
       "audience": "operator-current"
     },
@@ -302,6 +311,10 @@
     {
       "path": "docs/turnend-guard.md",
       "audience": "operator-current"
+    },
+    {
+      "path": "docs/verification/remote-access.md",
+      "audience": "maintainer-verification"
     },
     {
       "path": "docs/verification/runtime-backends.md",

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -38,6 +38,8 @@ Host shadowbyte-agent
     ServerAliveCountMax 3
     ExitOnForwardFailure yes
     ClearAllForwardings yes
+    ControlMaster no
+    ControlPath none
 ```
 
 | Placeholder | What it is | Where to read the real value |
@@ -57,6 +59,7 @@ Host shadowbyte-agent
 | `ServerAliveInterval 30` and `ServerAliveCountMax 3` | An idle attach or tunnel that a NAT or a sleeping laptop has already dropped is ended within about 90 seconds instead of hanging silently. |
 | `ExitOnForwardFailure yes` | A forward that cannot bind its local port ends the connection with a visible error instead of leaving SSH connected with a dead tunnel. |
 | `ClearAllForwardings yes` | Clears inherited `LocalForward` and `DynamicForward` entries so this alias cannot carry ambient tunnels. |
+| `ControlMaster no` and `ControlPath none` | Disables connection sharing and prevents this alias from reusing a master created with different connection settings. |
 
 No step in this path needs agent forwarding, which is why `ForwardAgent no` costs nothing and removes a real risk.
 Check the entry on the Mac without connecting:
@@ -116,6 +119,8 @@ Host shadowbyte-agent
     ServerAliveInterval 30
     ServerAliveCountMax 3
     ExitOnForwardFailure yes
+    ControlMaster no
+    ControlPath none
 ```
 
 The `-F` option makes this tunnel read the minimal file instead of the normal user and system SSH configuration, so no ambient `LocalForward` or `DynamicForward` can be added.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -9,25 +9,35 @@ This page owns the Mac-side setup for attaching to a server-resident Firstmate a
 
 - Every command, file, git worktree, and agent process stays on the server.
 - The Mac contributes a terminal and a browser and holds no project state.
-- The server keeps exactly one Firstmate primary agent on its own harness, and the launcher attaches to the existing named session whenever that agent is already running.
-- Attaching repeatedly from the Mac therefore joins the one primary rather than starting a second one, and it does not change which harness the primary runs.
+- The server keeps exactly one Firstmate primary agent on its own harness, and the launcher described under Terminal 1 is expected to attach to that agent's existing named session rather than start a second one.
+- That launcher is the operator's own script living outside this repository, so the attach behavior is a property of that launcher pattern rather than a guarantee this repository keeps.
+- With such a launcher in place, attaching repeatedly from the Mac joins the one primary, and it does not change which harness the primary runs.
 - Nothing here publishes a service to the public internet, and nothing here changes a firewall, a service bind address, an SSH server configuration, or a service's own authentication.
 - Browser-facing tools stay bound to server loopback and are reached only through an explicit SSH local forward that exists for as long as you keep its terminal open.
 
 ## Mac `~/.ssh/config`
 
 Add one block to `~/.ssh/config` on the Mac.
-The example uses the server's Tailscale MagicDNS name and its Linux user; substitute your own for another host.
+Angle-bracket values are placeholders for your own infrastructure; the table below names each one and where to read its real value.
 
 ```text
 Host shadowbyte-agent
-    HostName shadowbyte.tail46929b.ts.net
-    User chris
+    HostName <server-host>.<tailnet>.ts.net
+    User <server-user>
     ForwardAgent no
     ServerAliveInterval 30
     ServerAliveCountMax 3
     ExitOnForwardFailure yes
 ```
+
+| Placeholder | What it is | Where to read the real value |
+| --- | --- | --- |
+| `<server-host>.<tailnet>.ts.net` | The server's Tailscale MagicDNS name. | `tailscale status` on either device, or the machine's row in the tailnet admin console. |
+| `<server-user>` | The Linux account on the server that owns the Firstmate operational home. | `whoami` in a shell on the server. |
+| `<launcher-dir>` | The directory on the server holding the operator's own Firstmate launcher script used in Terminal 1. | Wherever you keep that script; it is not part of this repository. |
+| `<session-id>` | The id inside a Lavish session URL. | The `lavish-axi` session listing on the server. |
+
+`shadowbyte-agent` is not a placeholder; it is a local alias that exists only in the Mac's own `~/.ssh/config`, so any name works as long as the commands below use the same one.
 
 | Directive | Why it is here |
 | --- | --- |
@@ -54,21 +64,27 @@ Confirm which one is active by reading `RunSSH` in `tailscale debug prefs` on th
 | | Tailscale SSH | Host OpenSSH |
 | --- | --- | --- |
 | Authentication | Tailnet identity plus the tailnet SSH policy; a `check` rule adds a periodic browser approval | A public key installed in the remote user's `~/.ssh/authorized_keys` |
-| Local port forwarding | Permitted only when the matching policy rule allows it | Permitted unless the server disables TCP forwarding |
+| Local port forwarding | Carried by `tailscaled` itself once some rule matches; the policy file has no field that grants or denies forwarding | Permitted unless the server disables TCP forwarding |
 | Key needed on the Mac | None | Yes |
 
 Both are reached by the same `~/.ssh/config` entry and the same commands below; only the authentication step differs.
-On the server documented here, Tailscale SSH is enabled and answers the MagicDNS name, and the tailnet SSH policy matching the Mac permits local port forwarding, so the tunnel below works with no key on the Mac.
-A tailnet policy change can withdraw either of those, which surfaces as one of the authentication or forwarding failures under troubleshooting.
+The tailnet SSH policy gates one thing here: whether any `ssh` rule matches this device and user at all.
+Its rules carry action, src, dst, users, checkPeriod, acceptEnv, and srcPosture, and none of those govern TCP forwarding, so forwarding is `tailscaled`'s own behavior rather than an operator-settable policy knob.
+Current Tailscale releases carry local (`-L`) forwarding, which is what this page needs; remote (`-R`) forwarding is unsupported.
+A tailnet policy change can therefore withdraw access entirely by removing the rule that matches the Mac, which surfaces as the authentication failure under troubleshooting, but it cannot selectively withdraw forwarding from a session that authenticates.
+These Tailscale statements come from Tailscale's own policy-syntax reference and its current forwarding support rather than from this page's verification record, which exercises an OpenSSH server only.
 Before relying on the OpenSSH path as a fallback, verify that a usable public key is actually installed for the remote user, because installing one is a separate operator decision rather than part of this setup.
 
 ## Terminal 1: attach to Firstmate
 
 ```sh
-ssh -t shadowbyte-agent /home/chris/agentic-workstation/launch-firstmate.sh
+ssh -t shadowbyte-agent /home/<server-user>/<launcher-dir>/launch-firstmate.sh
 ```
 
+That launcher is the operator's own script on the server and is not tracked in this repository, so the path above is a placeholder for wherever yours lives.
 `-t` forces a terminal, which the launcher needs in order to attach you to the existing session rather than run headless.
+For the single-primary property under Boundaries to hold, the launcher must attach to the primary's existing named session whenever that agent is already running, rather than start a fresh one.
+A launcher that starts a second Firstmate against the same operational home instead of attaching cannot acquire the per-home session lock, so that session stays read-only.
 Leave this window open for as long as you want to watch or talk to Firstmate.
 Closing it detaches the view; the session and every worker keep running on the server.
 
@@ -78,10 +94,11 @@ Lavish serves review artifacts on server loopback `127.0.0.1:4387` and is not re
 Open a second Mac terminal and start the forward:
 
 ```sh
-ssh -N -L 4387:127.0.0.1:4387 shadowbyte-agent
+ssh -N -L 127.0.0.1:4387:127.0.0.1:4387 shadowbyte-agent
 ```
 
 `-N` runs no remote command, so this connection only carries the forward.
+The leading `127.0.0.1` pins the Mac-side listener to loopback explicitly, because a bare `-L 4387:...` follows whatever `GatewayPorts` the Mac's ssh config resolves to and would publish the forwarded tool to the local network if any `Host *` block or included file enabled it.
 It prints nothing while healthy.
 Leave it running for as long as you are reading artifacts, and end it with Ctrl-C.
 
@@ -113,11 +130,12 @@ The tool's own CLI already prints the current session URLs, and a wrapper would 
 The same shape reaches any future server-resident web tool:
 
 ```sh
-ssh -N -L LOCAL_PORT:127.0.0.1:REMOTE_PORT shadowbyte-agent
+ssh -N -L 127.0.0.1:LOCAL_PORT:127.0.0.1:REMOTE_PORT shadowbyte-agent
 ```
 
 `REMOTE_PORT` is the port the service listens on inside the server, and `LOCAL_PORT` is the port the Mac browser visits.
 Keep them equal whenever the tool prints absolute URLs containing its own port.
+Keep the explicit local `127.0.0.1` in every forward you add, for the same reason it is in the Lavish command above.
 
 ## What to forward, and what not to
 
@@ -142,7 +160,7 @@ Adding one to the routine setup means reviewing that service's own authenticatio
 
 `ssh: Could not resolve hostname` means the tailnet name is not resolvable from the Mac.
 Confirm the Mac is connected and the server is online with `tailscale status` on the Mac, and confirm MagicDNS is enabled for the tailnet.
-`tailscale ping <server-name>` proves tailnet reachability independently of SSH.
+`tailscale ping <server-host>` proves tailnet reachability independently of SSH.
 As a temporary check only, substituting the server's Tailscale IPv4 address for `HostName` isolates a DNS problem from a connectivity problem.
 
 ### Authentication fails or keeps re-prompting
@@ -152,6 +170,7 @@ Being asked to re-approve in a browser after that window expires is the configur
 Each terminal authenticates on its own, so an expired approval can stop a new tunnel from starting while an already-established attach keeps running.
 A permission-denied refusal under Tailscale SSH means no policy rule matched this device and user, which is a tailnet policy question rather than something to fix on the Mac.
 Under the host's OpenSSH server, the same refusal means the Mac's public key is not installed for the remote user.
+If authentication succeeds but the forward itself fails under Tailscale SSH, that is a `tailscaled` behavior or version question rather than a policy setting to change, because the tailnet policy has no forwarding field to toggle.
 
 ### The local port is already in use
 
@@ -167,7 +186,7 @@ Find the local process holding it with `lsof -nP -iTCP:4387 -sTCP:LISTEN` on the
 Either stop that process, or pick a free local port and visit that port in the browser instead:
 
 ```sh
-ssh -N -L 14387:127.0.0.1:4387 shadowbyte-agent
+ssh -N -L 127.0.0.1:14387:127.0.0.1:4387 shadowbyte-agent
 ```
 
 Then the artifact is at `http://127.0.0.1:14387/session/<session-id>`, with the session id unchanged.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -7,8 +7,8 @@ This page owns the Mac-side setup for attaching to a server-resident Firstmate a
 
 ## Boundaries
 
-- Every command, file, git worktree, and agent process stays on the server.
-- The Mac contributes a terminal and a browser and holds no project state.
+- Firstmate and all project state, files, git worktrees, and agent processes stay on the server.
+- The Mac intentionally holds only its SSH config, terminal, browser, and local tunnel process as the control and viewing surface, and holds no Firstmate or project state.
 - Pi is the only Firstmate primary.
 - The authoritative Firstmate runs in the named Herdr session `firstmate`.
 - Claude Code, Codex, and every other harness are supervised crewmates only and must not start a competing primary.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -26,6 +26,8 @@ Private operator configuration was verified separately while this guide preserve
 
 Add one block to `~/.ssh/config` on the Mac.
 Angle-bracket values are placeholders for your own infrastructure; the table below names each one and where to read its real value.
+Place this block before every broad `Host *` block and every `Include` directive in the file.
+OpenSSH uses the first value obtained for most settings, while forwarding directives can accumulate from later matching blocks.
 
 ```text
 Host shadowbyte-agent
@@ -35,6 +37,7 @@ Host shadowbyte-agent
     ServerAliveInterval 30
     ServerAliveCountMax 3
     ExitOnForwardFailure yes
+    ClearAllForwardings yes
 ```
 
 | Placeholder | What it is | Where to read the real value |
@@ -53,6 +56,7 @@ Host shadowbyte-agent
 | `ForwardAgent no` | The Mac's SSH agent stays off the server, so a shared or compromised server session cannot borrow the Mac's keys to reach other hosts. |
 | `ServerAliveInterval 30` and `ServerAliveCountMax 3` | An idle attach or tunnel that a NAT or a sleeping laptop has already dropped is ended within about 90 seconds instead of hanging silently. |
 | `ExitOnForwardFailure yes` | A forward that cannot bind its local port ends the connection with a visible error instead of leaving SSH connected with a dead tunnel. |
+| `ClearAllForwardings yes` | Clears inherited `LocalForward` and `DynamicForward` entries so this alias cannot carry ambient tunnels. |
 
 No step in this path needs agent forwarding, which is why `ForwardAgent no` costs nothing and removes a real risk.
 Check the entry on the Mac without connecting:
@@ -62,6 +66,8 @@ ssh -G shadowbyte-agent
 ```
 
 That prints the fully expanded settings, so a typo in the host alias or a directive is visible before any connection attempt.
+Use `shadowbyte-agent` for the Firstmate attach only.
+`ClearAllForwardings yes` also clears command-line forwards, so the Lavish tunnel below uses a separate minimal configuration file.
 
 ## Which SSH server answers
 
@@ -100,8 +106,22 @@ Closing it detaches the view; the session and every worker keep running on the s
 Lavish serves review artifacts on server loopback `127.0.0.1:4387` and is not reachable from the Mac by any other route.
 Open a second Mac terminal and start the forward:
 
+Create `~/.ssh/shadowbyte-lavish.conf` on the Mac with only this host block:
+
+```text
+Host shadowbyte-agent
+    HostName <server-host>.<tailnet>.ts.net
+    User <server-user>
+    ForwardAgent no
+    ServerAliveInterval 30
+    ServerAliveCountMax 3
+    ExitOnForwardFailure yes
+```
+
+The `-F` option makes this tunnel read the minimal file instead of the normal user and system SSH configuration, so no ambient `LocalForward` or `DynamicForward` can be added.
+
 ```sh
-ssh -N -L 127.0.0.1:4387:127.0.0.1:4387 shadowbyte-agent
+ssh -F ~/.ssh/shadowbyte-lavish.conf -o ForwardAgent=no -o ExitOnForwardFailure=yes -N -L 127.0.0.1:4387:127.0.0.1:4387 shadowbyte-agent
 ```
 
 `-N` runs no remote command, so this connection only carries the forward.
@@ -137,12 +157,13 @@ The tool's own CLI already prints the current session URLs, and a wrapper would 
 The same shape reaches any future server-resident web tool:
 
 ```sh
-ssh -N -L 127.0.0.1:LOCAL_PORT:127.0.0.1:REMOTE_PORT shadowbyte-agent
+ssh -F ~/.ssh/shadowbyte-lavish.conf -o ForwardAgent=no -o ExitOnForwardFailure=yes -N -L 127.0.0.1:LOCAL_PORT:127.0.0.1:REMOTE_PORT shadowbyte-agent
 ```
 
 `REMOTE_PORT` is the port the service listens on inside the server, and `LOCAL_PORT` is the port the Mac browser visits.
 Keep them equal whenever the tool prints absolute URLs containing its own port.
 Keep the explicit local `127.0.0.1` in every forward you add, for the same reason it is in the Lavish command above.
+Use a separate minimal `-F` file for each tunnel when the destination or local port changes.
 
 ## What to forward, and what not to
 
@@ -196,7 +217,7 @@ Find the local process holding it with `lsof -nP -iTCP:4387 -sTCP:LISTEN` on the
 Either stop that process, or pick a free local port and visit that port in the browser instead:
 
 ```sh
-ssh -N -L 127.0.0.1:14387:127.0.0.1:4387 shadowbyte-agent
+ssh -F ~/.ssh/shadowbyte-lavish.conf -o ForwardAgent=no -o ExitOnForwardFailure=yes -N -L 127.0.0.1:14387:127.0.0.1:4387 shadowbyte-agent
 ```
 
 Then the artifact is at `http://127.0.0.1:14387/session/<session-id>`, with the session id unchanged.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -9,11 +9,18 @@ This page owns the Mac-side setup for attaching to a server-resident Firstmate a
 
 - Every command, file, git worktree, and agent process stays on the server.
 - The Mac contributes a terminal and a browser and holds no project state.
-- The server keeps exactly one Firstmate primary agent on its own harness, and the launcher described under Terminal 1 is expected to attach to that agent's existing named session rather than start a second one.
+- Pi is the only Firstmate primary.
+- The authoritative Firstmate runs in the named Herdr session `firstmate`.
+- Claude Code, Codex, and every other harness are supervised crewmates only and must not start a competing primary.
+- The launcher described under Terminal 1 is expected to attach to that agent's existing named session rather than start a second one.
 - That launcher is the operator's own script living outside this repository, so the attach behavior is a property of that launcher pattern rather than a guarantee this repository keeps.
 - With such a launcher in place, attaching repeatedly from the Mac joins the one primary, and it does not change which harness the primary runs.
 - Nothing here publishes a service to the public internet, and nothing here changes a firewall, a service bind address, an SSH server configuration, or a service's own authentication.
 - Browser-facing tools stay bound to server loopback and are reached only through an explicit SSH local forward that exists for as long as you keep its terminal open.
+
+This public guide intentionally redacts private Tailscale hostnames, IP addresses, SSH usernames, launcher paths, and live Lavish URLs.
+The exact values belong in private operator documentation, and a current Lavish URL is ephemeral and must come from active session output.
+Private operator configuration was verified separately while this guide preserves the safe structure and commands.
 
 ## Mac `~/.ssh/config`
 
@@ -63,16 +70,16 @@ Confirm which one is active by reading `RunSSH` in `tailscale debug prefs` on th
 
 | | Tailscale SSH | Host OpenSSH |
 | --- | --- | --- |
-| Authentication | Tailnet identity plus the tailnet SSH policy; a `check` rule adds a periodic browser approval | A public key installed in the remote user's `~/.ssh/authorized_keys` |
-| Local port forwarding | Carried by `tailscaled` itself once some rule matches; the policy file has no field that grants or denies forwarding | Permitted unless the server disables TCP forwarding |
+| Authentication | Reachable tailnet TCP port 22 plus tailnet identity and an effective SSH rule matching source, destination, and user; a `check` action adds a periodic browser approval | A public key installed in the remote user's `~/.ssh/authorized_keys` |
+| Local port forwarding | The effective matched SSH action must allow local (`-L`) forwarding with `allowLocalPortForwarding`; authentication alone is insufficient | Permitted only if the server's forwarding policy, such as `AllowTcpForwarding`, allows it |
 | Key needed on the Mac | None | Yes |
 
 Both are reached by the same `~/.ssh/config` entry and the same commands below; only the authentication step differs.
-The tailnet SSH policy gates one thing here: whether any `ssh` rule matches this device and user at all.
-Its rules carry action, src, dst, users, checkPeriod, acceptEnv, and srcPosture, and none of those govern TCP forwarding, so forwarding is `tailscaled`'s own behavior rather than an operator-settable policy knob.
-Current Tailscale releases carry local (`-L`) forwarding, which is what this page needs; remote (`-R`) forwarding is unsupported.
-A tailnet policy change can therefore withdraw access entirely by removing the rule that matches the Mac, which surfaces as the authentication failure under troubleshooting, but it cannot selectively withdraw forwarding from a session that authenticates.
-These Tailscale statements come from Tailscale's own policy-syntax reference and its current forwarding support rather than from this page's verification record, which exercises an OpenSSH server only.
+For Tailscale SSH, check network reachability to the server's tailnet TCP port 22, SSH authorization by the effective matching rule, and local-forward permission in that rule's action as separate gates.
+`tailscale ping` can confirm the tailnet node path, but it does not prove that TCP port 22 is reachable, that the SSH rule authorizes this user, or that the action permits `-L` forwarding.
+An authenticated session can therefore still reject a local forward when `allowLocalPortForwarding` is not enabled by the effective action.
+Current Tailscale releases support local (`-L`) forwarding when that action permits it; remote (`-R`) forwarding is not part of this path.
+These Tailscale statements come from Tailscale's own policy-syntax and SSH action references rather than from this page's verification record, which exercises an OpenSSH server only.
 Before relying on the OpenSSH path as a fallback, verify that a usable public key is actually installed for the remote user, because installing one is a separate operator decision rather than part of this setup.
 
 ## Terminal 1: attach to Firstmate
@@ -146,7 +153,8 @@ Forward a service only after deciding that is acceptable for that specific servi
 | Service class | Forward it? | Reason |
 | --- | --- | --- |
 | Firstmate's review surface on loopback `4387` | Yes | It exists to be read by the operator, it serves the artifacts you asked for, and it has no other Mac-reachable path. |
-| A service already published to the tailnet, whether by a Tailscale proxy or by binding a non-loopback address | No forward needed | It already has a tailnet address; a second path through a tunnel only creates two ways to reach one service and two ways to get confused about which is live. |
+| A service verified reachable at a Tailscale address or through Tailscale Serve | No forward needed | It already has a verified tailnet path; a second path through a tunnel only creates two ways to reach one service and two ways to get confused about which is live. |
+| A service bound to an arbitrary non-loopback address without verified Tailscale or Serve reachability | Review separately | A non-loopback bind alone does not prove a tailnet route, ACL allowance, firewall access, or the intended service identity. |
 | Local model or inference servers on loopback | Not without a separate review | They are bound to loopback precisely because they expose an unauthenticated API to anything that can reach the port. |
 | Editor, IDE, and agent control ports | No | They carry code execution authority for the server account, and their ports are ephemeral and change on every restart. |
 | System daemons such as the DNS resolver stub or the print spooler | No | No operator value and no reason to widen their reach. |
@@ -160,7 +168,8 @@ Adding one to the routine setup means reviewing that service's own authenticatio
 
 `ssh: Could not resolve hostname` means the tailnet name is not resolvable from the Mac.
 Confirm the Mac is connected and the server is online with `tailscale status` on the Mac, and confirm MagicDNS is enabled for the tailnet.
-`tailscale ping <server-host>` proves tailnet reachability independently of SSH.
+`tailscale ping <server-host>` checks the tailnet node path independently of SSH, but it does not check TCP port 22.
+Check that the server's tailnet address accepts TCP port 22 before debugging SSH policy, because a reachable node and an unreachable SSH port fail at different layers.
 As a temporary check only, substituting the server's Tailscale IPv4 address for `HostName` isolates a DNS problem from a connectivity problem.
 
 ### Authentication fails or keeps re-prompting
@@ -170,7 +179,8 @@ Being asked to re-approve in a browser after that window expires is the configur
 Each terminal authenticates on its own, so an expired approval can stop a new tunnel from starting while an already-established attach keeps running.
 A permission-denied refusal under Tailscale SSH means no policy rule matched this device and user, which is a tailnet policy question rather than something to fix on the Mac.
 Under the host's OpenSSH server, the same refusal means the Mac's public key is not installed for the remote user.
-If authentication succeeds but the forward itself fails under Tailscale SSH, that is a `tailscaled` behavior or version question rather than a policy setting to change, because the tailnet policy has no forwarding field to toggle.
+If TCP 22 is reachable and authentication succeeds but the forward itself fails under Tailscale SSH, inspect the effective action for `allowLocalPortForwarding` before treating it as a `tailscaled` behavior or version question.
+For host OpenSSH, inspect the server's `AllowTcpForwarding` policy separately from public-key authentication.
 
 ### The local port is already in use
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -1,0 +1,189 @@
+# Remote Mac control path
+
+Firstmate runs on the server that owns the projects, the worktrees, and the primary session.
+A Mac is a control and viewing surface only, reached over one authenticated SSH connection per purpose.
+This page owns the Mac-side setup for attaching to a server-resident Firstmate and for viewing a server loopback web tool such as Lavish.
+[`configuration.md`](configuration.md) owns the operational-home layout and the configuration files themselves.
+
+## Boundaries
+
+- Every command, file, git worktree, and agent process stays on the server.
+- The Mac contributes a terminal and a browser and holds no project state.
+- The server keeps exactly one Firstmate primary agent on its own harness, and the launcher attaches to the existing named session whenever that agent is already running.
+- Attaching repeatedly from the Mac therefore joins the one primary rather than starting a second one, and it does not change which harness the primary runs.
+- Nothing here publishes a service to the public internet, and nothing here changes a firewall, a service bind address, an SSH server configuration, or a service's own authentication.
+- Browser-facing tools stay bound to server loopback and are reached only through an explicit SSH local forward that exists for as long as you keep its terminal open.
+
+## Mac `~/.ssh/config`
+
+Add one block to `~/.ssh/config` on the Mac.
+The example uses the server's Tailscale MagicDNS name and its Linux user; substitute your own for another host.
+
+```text
+Host shadowbyte-agent
+    HostName shadowbyte.tail46929b.ts.net
+    User chris
+    ForwardAgent no
+    ServerAliveInterval 30
+    ServerAliveCountMax 3
+    ExitOnForwardFailure yes
+```
+
+| Directive | Why it is here |
+| --- | --- |
+| `HostName` | The MagicDNS name resolves from any device on the tailnet without a public DNS record or a static route. |
+| `User` | The Linux account that owns the Firstmate home on the server. |
+| `ForwardAgent no` | The Mac's SSH agent stays off the server, so a shared or compromised server session cannot borrow the Mac's keys to reach other hosts. |
+| `ServerAliveInterval 30` and `ServerAliveCountMax 3` | An idle attach or tunnel that a NAT or a sleeping laptop has already dropped is ended within about 90 seconds instead of hanging silently. |
+| `ExitOnForwardFailure yes` | A forward that cannot bind its local port ends the connection with a visible error instead of leaving SSH connected with a dead tunnel. |
+
+No step in this path needs agent forwarding, which is why `ForwardAgent no` costs nothing and removes a real risk.
+Check the entry on the Mac without connecting:
+
+```sh
+ssh -G shadowbyte-agent
+```
+
+That prints the fully expanded settings, so a typo in the host alias or a directive is visible before any connection attempt.
+
+## Which SSH server answers
+
+When Tailscale SSH is enabled on the server, `tailscaled` answers port 22 on the tailnet addresses, so a connection to the MagicDNS name reaches Tailscale SSH rather than the host's own OpenSSH server.
+Confirm which one is active by reading `RunSSH` in `tailscale debug prefs` on the server, or by checking that machine's Tailscale SSH setting in the tailnet admin console.
+
+| | Tailscale SSH | Host OpenSSH |
+| --- | --- | --- |
+| Authentication | Tailnet identity plus the tailnet SSH policy; a `check` rule adds a periodic browser approval | A public key installed in the remote user's `~/.ssh/authorized_keys` |
+| Local port forwarding | Permitted only when the matching policy rule allows it | Permitted unless the server disables TCP forwarding |
+| Key needed on the Mac | None | Yes |
+
+Both are reached by the same `~/.ssh/config` entry and the same commands below; only the authentication step differs.
+On the server documented here, Tailscale SSH is enabled and answers the MagicDNS name, and the tailnet SSH policy matching the Mac permits local port forwarding, so the tunnel below works with no key on the Mac.
+A tailnet policy change can withdraw either of those, which surfaces as one of the authentication or forwarding failures under troubleshooting.
+Before relying on the OpenSSH path as a fallback, verify that a usable public key is actually installed for the remote user, because installing one is a separate operator decision rather than part of this setup.
+
+## Terminal 1: attach to Firstmate
+
+```sh
+ssh -t shadowbyte-agent /home/chris/agentic-workstation/launch-firstmate.sh
+```
+
+`-t` forces a terminal, which the launcher needs in order to attach you to the existing session rather than run headless.
+Leave this window open for as long as you want to watch or talk to Firstmate.
+Closing it detaches the view; the session and every worker keep running on the server.
+
+## Terminal 2: view a loopback web tool
+
+Lavish serves review artifacts on server loopback `127.0.0.1:4387` and is not reachable from the Mac by any other route.
+Open a second Mac terminal and start the forward:
+
+```sh
+ssh -N -L 4387:127.0.0.1:4387 shadowbyte-agent
+```
+
+`-N` runs no remote command, so this connection only carries the forward.
+It prints nothing while healthy.
+Leave it running for as long as you are reading artifacts, and end it with Ctrl-C.
+
+Then ask the server for the current session URL.
+Run `lavish-axi` with no arguments in the Firstmate terminal; it lists every open session with its URL:
+
+```text
+sessions[2]{file,status,url,pending_prompts}:
+  /path/to/artifact.html,open,"http://127.0.0.1:4387/session/<session-id>",0
+```
+
+Open that exact URL in the Mac browser:
+
+```text
+http://127.0.0.1:4387/session/<session-id>
+```
+
+Three details make the URL work unchanged on the Mac:
+
+- Keep the local port equal to the remote port, so the address the server prints is the address the Mac browser needs.
+- Use `127.0.0.1` throughout rather than mixing in `localhost`, so the address matches what the tool prints.
+- Use a full session URL, because `http://127.0.0.1:4387/` has no index page and answers 404 while only `/session/<session-id>` renders an artifact.
+
+Firstmate adds no wrapper for this lookup.
+The tool's own CLI already prints the current session URLs, and a wrapper would only duplicate it and drift from it.
+
+## Any other loopback service
+
+The same shape reaches any future server-resident web tool:
+
+```sh
+ssh -N -L LOCAL_PORT:127.0.0.1:REMOTE_PORT shadowbyte-agent
+```
+
+`REMOTE_PORT` is the port the service listens on inside the server, and `LOCAL_PORT` is the port the Mac browser visits.
+Keep them equal whenever the tool prints absolute URLs containing its own port.
+
+## What to forward, and what not to
+
+A local forward relocates a trust boundary.
+It takes a service that only processes on the server could reach and makes it reachable by anything that can open the Mac's loopback port, and it adds no authentication of its own.
+Forward a service only after deciding that is acceptable for that specific service.
+
+| Service class | Forward it? | Reason |
+| --- | --- | --- |
+| Firstmate's review surface on loopback `4387` | Yes | It exists to be read by the operator, it serves the artifacts you asked for, and it has no other Mac-reachable path. |
+| A service already published to the tailnet, whether by a Tailscale proxy or by binding a non-loopback address | No forward needed | It already has a tailnet address; a second path through a tunnel only creates two ways to reach one service and two ways to get confused about which is live. |
+| Local model or inference servers on loopback | Not without a separate review | They are bound to loopback precisely because they expose an unauthenticated API to anything that can reach the port. |
+| Editor, IDE, and agent control ports | No | They carry code execution authority for the server account, and their ports are ephemeral and change on every restart. |
+| System daemons such as the DNS resolver stub or the print spooler | No | No operator value and no reason to widen their reach. |
+
+Anything outside this table is a separate decision, not a default.
+Adding one to the routine setup means reviewing that service's own authentication first.
+
+## Troubleshooting
+
+### The name does not resolve
+
+`ssh: Could not resolve hostname` means the tailnet name is not resolvable from the Mac.
+Confirm the Mac is connected and the server is online with `tailscale status` on the Mac, and confirm MagicDNS is enabled for the tailnet.
+`tailscale ping <server-name>` proves tailnet reachability independently of SSH.
+As a temporary check only, substituting the server's Tailscale IPv4 address for `HostName` isolates a DNS problem from a connectivity problem.
+
+### Authentication fails or keeps re-prompting
+
+Under Tailscale SSH, a policy rule in `check` mode prints an approval URL and grants access for a bounded window.
+Being asked to re-approve in a browser after that window expires is the configured behavior, not a fault.
+Each terminal authenticates on its own, so an expired approval can stop a new tunnel from starting while an already-established attach keeps running.
+A permission-denied refusal under Tailscale SSH means no policy rule matched this device and user, which is a tailnet policy question rather than something to fix on the Mac.
+Under the host's OpenSSH server, the same refusal means the Mac's public key is not installed for the remote user.
+
+### The local port is already in use
+
+With `ExitOnForwardFailure yes` in place, SSH reports the conflict and exits immediately:
+
+```text
+bind [127.0.0.1]:4387: Address already in use
+channel_setup_fwd_listener_tcpip: cannot listen to port: 4387
+Could not request local forwarding.
+```
+
+Find the local process holding it with `lsof -nP -iTCP:4387 -sTCP:LISTEN` on the Mac.
+Either stop that process, or pick a free local port and visit that port in the browser instead:
+
+```sh
+ssh -N -L 14387:127.0.0.1:4387 shadowbyte-agent
+```
+
+Then the artifact is at `http://127.0.0.1:14387/session/<session-id>`, with the session id unchanged.
+
+### The tunnel stops working
+
+An `-N` tunnel prints nothing while healthy, so silence is normal and a returned shell prompt means it ended.
+After a laptop sleep or a network change, the keepalive settings end the dead connection within about 90 seconds; rerun the same command to reconnect.
+If the browser fails while the tunnel terminal is still running, confirm the service is still up on the server before suspecting the tunnel.
+
+### The artifact URL is stale
+
+Each artifact has its own session URL, so a URL kept from an earlier artifact will not show the current one.
+Re-read the list on the server with `lavish-axi` and use the URL for the artifact you actually want.
+A 404 on a session URL means that session id is not open, which is a stale URL rather than a tunnel failure.
+
+## Verification
+
+[`verification/remote-access.md`](verification/remote-access.md) records the reusable evidence for the configuration snippet, the forward, and the forward-failure behavior documented here.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -46,7 +46,7 @@ Host shadowbyte-agent
 | --- | --- | --- |
 | `<server-host>.<tailnet>.ts.net` | The server's Tailscale MagicDNS name. | `tailscale status` on either device, or the machine's row in the tailnet admin console. |
 | `<server-user>` | The Linux account on the server that owns the Firstmate operational home. | `whoami` in a shell on the server. |
-| `<launcher-dir>` | The directory on the server holding the operator's own Firstmate launcher script used in Terminal 1. | Wherever you keep that script; it is not part of this repository. |
+| `<launcher-path>` | The full path on the server to the operator's own Firstmate launcher script used in Terminal 1. | Wherever you keep that script; it is not part of this repository. |
 | `<session-id>` | The id inside a Lavish session URL. | The `lavish-axi` session listing on the server. |
 
 `shadowbyte-agent` is not a placeholder; it is a local alias that exists only in the Mac's own `~/.ssh/config`, so any name works as long as the commands below use the same one.
@@ -94,7 +94,7 @@ Before relying on the OpenSSH path as a fallback, verify that a usable public ke
 ## Terminal 1: attach to Firstmate
 
 ```sh
-ssh -t shadowbyte-agent /home/<server-user>/<launcher-dir>/launch-firstmate.sh
+ssh -t shadowbyte-agent <launcher-path>
 ```
 
 That launcher is the operator's own script on the server and is not tracked in this repository, so the path above is a placeholder for wherever yours lives.

--- a/docs/verification/remote-access.md
+++ b/docs/verification/remote-access.md
@@ -6,7 +6,7 @@ This record contains reusable evidence for the client-side guarantees in [`../re
 That page owns the current setup, the forwarding-safety classification, and troubleshooting.
 Task chronology, host service inventories, temporary directories, and delivery transcripts remain in private reports or PR evidence.
 
-Every check below runs entirely against an ephemeral loopback SSH server created for the run.
+The forwarding checks below run entirely against an ephemeral loopback SSH server created for the run.
 None of them changes a system SSH configuration, a user's `authorized_keys`, a firewall, or a Tailscale setting.
 
 ## Client version

--- a/docs/verification/remote-access.md
+++ b/docs/verification/remote-access.md
@@ -1,0 +1,133 @@
+# Remote access verification
+
+Audience: maintainer verification.
+
+This record contains reusable evidence for the client-side guarantees in [`../remote-access.md`](../remote-access.md).
+That page owns the current setup, the forwarding-safety classification, and troubleshooting.
+Task chronology, host service inventories, temporary directories, and delivery transcripts remain in private reports or PR evidence.
+
+Every check below runs entirely against an ephemeral loopback SSH server created for the run.
+None of them changes a system SSH configuration, a user's `authorized_keys`, a firewall, or a Tailscale setting.
+
+## Client version
+
+Verified on 2026-07-28 with the OpenSSH client on Ubuntu 25.04.
+
+```sh
+ssh -V
+```
+
+```text
+OpenSSH_9.9p1 Ubuntu-3ubuntu3.2, OpenSSL 3.4.1 11 Feb 2025
+```
+
+## Config entry expands as documented
+
+The documented `~/.ssh/config` block was written to a standalone file and expanded with the OpenSSH parser.
+`ssh -G` resolves the entry without connecting and without needing any private key.
+
+```sh
+ssh -F <config-file> -G shadowbyte-agent |
+  grep -iE '^(host|hostname|user|forwardagent|serveralive|exitonforwardfailure|port) '
+```
+
+Observed output:
+
+```text
+host shadowbyte-agent
+user chris
+hostname shadowbyte.tail46929b.ts.net
+port 22
+exitonforwardfailure yes
+serveralivecountmax 3
+serveraliveinterval 30
+forwardagent no
+```
+
+Every documented directive survives expansion, and the alias resolves to the intended host and user.
+
+## Forwarding harness
+
+The forwarding checks use a throwaway server bound to loopback with its own host key, its own authorized key, and its own configuration file.
+
+```sh
+ssh-keygen -q -t ed25519 -N '' -f "$D/hostkey"
+ssh-keygen -q -t ed25519 -N '' -f "$D/clientkey"
+cp "$D/clientkey.pub" "$D/authorized_keys"
+/usr/sbin/sshd -f "$D/sshd_config" -E "$D/sshd.log"
+```
+
+`$D/sshd_config` sets `Port 2222`, `ListenAddress 127.0.0.1`, `HostKey $D/hostkey`, `AuthorizedKeysFile $D/authorized_keys`, `PasswordAuthentication no`, `UsePAM no`, and `AllowTcpForwarding yes`.
+The generated keys exist only for the run and are deleted with the directory afterward.
+
+## A local forward reaches a loopback-only service
+
+The forward targeted a service bound to `127.0.0.1:4387` on the server side, which is the shape [`../remote-access.md`](../remote-access.md) documents.
+
+```sh
+ssh -F "$D/test_ssh_config" -N -L 14387:127.0.0.1:4387 fm-forward-test &
+curl -sS -o /dev/null -w 'http_code=%{http_code} size=%{size_download}\n' \
+  --max-time 8 http://127.0.0.1:14387/session/<session-id>
+```
+
+Observed output:
+
+```text
+http_code=200 size=9810
+```
+
+The same request sent directly to the server's non-loopback address before the forward existed failed to connect, confirming the service is loopback-only and the forward is what makes it reachable.
+
+## `ExitOnForwardFailure yes` reports a busy local port and exits
+
+A dual-stack listener occupied local port 14388 before SSH was started, reproducing the case where something on the Mac already holds the intended port.
+
+```sh
+ssh -F "$D/test_ssh_config" -N -L 14388:127.0.0.1:4387 fm-forward-test
+echo "exit=$?"
+```
+
+Observed output:
+
+```text
+bind [127.0.0.1]:14388: Address already in use
+channel_setup_fwd_listener_tcpip: cannot listen to port: 14388
+Could not request local forwarding.
+exit=255
+```
+
+The three message lines are quoted verbatim in the troubleshooting section, and the immediate non-zero exit is what makes the failure visible.
+
+## Without the directive, the same conflict is silent
+
+The identical conflict was rerun with the directive overridden.
+
+```sh
+timeout 6 ssh -F "$D/test_ssh_config" -o ExitOnForwardFailure=no \
+  -N -L 14388:127.0.0.1:4387 fm-forward-test
+echo "exit=$?"
+```
+
+Observed output:
+
+```text
+Terminated
+exit=124
+```
+
+SSH printed no diagnostic and stayed connected until the external timeout killed it, leaving a live session with a dead tunnel.
+This is the failure mode the directive prevents, and it is why the setting is part of the documented config rather than an optional extra.
+
+## No listener survives the checks
+
+After each forward ended and the harness was stopped, the ports were rechecked.
+
+```sh
+ss -ltn | grep -E ':(1438[78]|2222)' || echo 'no listeners'
+```
+
+```text
+no listeners
+```
+
+The forwarded ports and the throwaway server all released cleanly, so a failed or cancelled tunnel leaves nothing behind to conflict with the next attempt.

--- a/docs/verification/remote-access.md
+++ b/docs/verification/remote-access.md
@@ -31,12 +31,12 @@ ssh -F <config-file> -G shadowbyte-agent |
   grep -iE '^(host|hostname|user|forwardagent|serveralive|exitonforwardfailure|port) '
 ```
 
-Observed output:
+Observed output, with the real host and account rendered as the same placeholders [`../remote-access.md`](../remote-access.md) uses:
 
 ```text
 host shadowbyte-agent
-user chris
-hostname shadowbyte.tail46929b.ts.net
+user <server-user>
+hostname <server-host>.<tailnet>.ts.net
 port 22
 exitonforwardfailure yes
 serveralivecountmax 3
@@ -44,6 +44,7 @@ serveraliveinterval 30
 forwardagent no
 ```
 
+The check ran with concrete values in those two fields; only their spelling is substituted here, and every other line is as observed.
 Every documented directive survives expansion, and the alias resolves to the intended host and user.
 
 ## Forwarding harness
@@ -77,6 +78,7 @@ http_code=200 size=9810
 ```
 
 The same request sent directly to the server's non-loopback address before the forward existed failed to connect, confirming the service is loopback-only and the forward is what makes it reachable.
+These checks ran with the local bind address left implicit, which OpenSSH resolves to loopback under the default `GatewayPorts no`; the reader-facing page writes that bind address out as `127.0.0.1:LOCAL_PORT` so the result does not depend on a client setting this harness controlled and a Mac may not.
 
 ## `ExitOnForwardFailure yes` reports a busy local port and exits
 
@@ -96,7 +98,7 @@ Could not request local forwarding.
 exit=255
 ```
 
-The three message lines are quoted verbatim in the troubleshooting section, and the immediate non-zero exit is what makes the failure visible.
+The troubleshooting section reproduces these three message lines with the port substituted for the one it documents, and the immediate non-zero exit is what makes the failure visible.
 
 ## Without the directive, the same conflict is silent
 

--- a/docs/verification/remote-access.md
+++ b/docs/verification/remote-access.md
@@ -28,7 +28,7 @@ The documented `~/.ssh/config` block was written to a standalone file and expand
 
 ```sh
 ssh -F <config-file> -G shadowbyte-agent |
-  grep -iE '^(host|hostname|user|forwardagent|serveralive|exitonforwardfailure|clearallforwardings|controlmaster|controlpath|port) '
+  grep -iE '^(host|hostname|user|forwardagent|serveralive[^ ]*|exitonforwardfailure|clearallforwardings|controlmaster|controlpath|port) '
 ```
 
 Observed output, with the real host and account rendered as the same placeholders [`../remote-access.md`](../remote-access.md) uses:
@@ -105,7 +105,7 @@ exit=255
 
 The troubleshooting section reproduces these three message lines with the port substituted for the one it documents, and the immediate non-zero exit is what makes the failure visible.
 
-## Without the directive, the same conflict is silent
+## Without the directive, the same conflict leaves SSH connected
 
 The identical conflict was rerun with the directive overridden.
 
@@ -118,11 +118,13 @@ echo "exit=$?"
 Observed output:
 
 ```text
-Terminated
+bind [127.0.0.1]:14388: Address already in use
+channel_setup_fwd_listener_tcpip: cannot listen to port: 14388
+Could not request local forwarding.
 exit=124
 ```
 
-SSH printed no diagnostic and stayed connected until the external timeout killed it, leaving a live session with a dead tunnel.
+OpenSSH printed the forwarding diagnostics but stayed connected until the external timeout killed it, leaving a live session with a dead tunnel.
 This is the failure mode the directive prevents, and it is why the setting is part of the documented config rather than an optional extra.
 
 ## No listener survives the checks

--- a/docs/verification/remote-access.md
+++ b/docs/verification/remote-access.md
@@ -28,7 +28,7 @@ The documented `~/.ssh/config` block was written to a standalone file and expand
 
 ```sh
 ssh -F <config-file> -G shadowbyte-agent |
-  grep -iE '^(host|hostname|user|forwardagent|serveralive|exitonforwardfailure|clearallforwardings|port) '
+  grep -iE '^(host|hostname|user|forwardagent|serveralive|exitonforwardfailure|clearallforwardings|controlmaster|controlpath|port) '
 ```
 
 Observed output, with the real host and account rendered as the same placeholders [`../remote-access.md`](../remote-access.md) uses:
@@ -40,6 +40,7 @@ hostname <server-host>.<tailnet>.ts.net
 port 22
 exitonforwardfailure yes
 clearallforwardings yes
+controlmaster false
 serveralivecountmax 3
 serveraliveinterval 30
 forwardagent no
@@ -47,6 +48,7 @@ forwardagent no
 
 The check ran with concrete values in those two fields; only their spelling is substituted here, and every other line is as observed.
 Every documented directive survives expansion, and the alias resolves to the intended host and user.
+OpenSSH's `ssh -G` omits `controlpath` when `ControlPath none` resolves to no control socket.
 The reader-facing page uses this alias for attach only because `ClearAllForwardings yes` also clears command-line forwards.
 Its Lavish tunnel uses a dedicated `-F` file so the explicit local forward cannot inherit unrelated user or system forwarding entries.
 

--- a/docs/verification/remote-access.md
+++ b/docs/verification/remote-access.md
@@ -11,7 +11,7 @@ None of them changes a system SSH configuration, a user's `authorized_keys`, a f
 
 ## Client version
 
-Verified on 2026-07-28 with the OpenSSH client on Ubuntu 25.04.
+Rechecked on 2026-07-29 with the OpenSSH client on Ubuntu 25.04.
 
 ```sh
 ssh -V
@@ -28,7 +28,7 @@ The documented `~/.ssh/config` block was written to a standalone file and expand
 
 ```sh
 ssh -F <config-file> -G shadowbyte-agent |
-  grep -iE '^(host|hostname|user|forwardagent|serveralive|exitonforwardfailure|port) '
+  grep -iE '^(host|hostname|user|forwardagent|serveralive|exitonforwardfailure|clearallforwardings|port) '
 ```
 
 Observed output, with the real host and account rendered as the same placeholders [`../remote-access.md`](../remote-access.md) uses:
@@ -39,6 +39,7 @@ user <server-user>
 hostname <server-host>.<tailnet>.ts.net
 port 22
 exitonforwardfailure yes
+clearallforwardings yes
 serveralivecountmax 3
 serveraliveinterval 30
 forwardagent no
@@ -46,6 +47,8 @@ forwardagent no
 
 The check ran with concrete values in those two fields; only their spelling is substituted here, and every other line is as observed.
 Every documented directive survives expansion, and the alias resolves to the intended host and user.
+The reader-facing page uses this alias for attach only because `ClearAllForwardings yes` also clears command-line forwards.
+Its Lavish tunnel uses a dedicated `-F` file so the explicit local forward cannot inherit unrelated user or system forwarding entries.
 
 ## Forwarding harness
 


### PR DESCRIPTION
## Summary

- Add secure Mac-to-server access documentation using authenticated SSH/Tailscale access and explicit loopback forwarding.
- Keep infrastructure placeholders in public documentation; exact host, user, launcher, and Lavish session values remain private.
- Document Pi as the sole Firstmate primary, the authoritative named Herdr session `firstmate`, and supervised-crewmate restrictions.
- Harden the Lavish tunnel pattern with an explicit Mac loopback bind and isolated SSH forwarding settings.
- Separate maintainer verification evidence from the operator-facing guide.

## Validation

- Automated review completed.
- Focused SSH configuration and loopback-forwarding checks completed against an ephemeral local SSH harness.
- Documentation verification completed, including busy-port and `ExitOnForwardFailure` behavior.
- The live Lavish listener was not restored or disturbed; the bounded incomplete-live-proof limitation was accepted.
- ShellCheck was unavailable. No shell files were changed by this pull request.

## Safety

- No credentials, tokens, private Tailscale values, or live session identifiers were committed.
- No SSH, Tailscale, firewall, service-bind, or active runtime settings were changed.
- The public guide does not expose the server's private infrastructure values.
