### PR TITLE
fix(bootstrap): enforce safe Treehouse compatibility

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -17,7 +17,7 @@ The inline rules in `AGENTS.md` section 3 still bind: detect, then consent, then
 When any diagnostic needs captain attention, report the plain consequence and requested action using `AGENTS.md` section 9's captain-facing translation contract; do not name the diagnostic label unless the captain needs to paste it into a command or issue.
 
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
-  For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.
+  For `treehouse`, this also covers an installed build that fails the compatibility check (`docs/configuration.md` "Toolchain" owns the definition); treat it as an upgrade request.
   For `no-mistakes`, this also covers an installed version older than 1.31.2, because crewmate validation briefs delegate gate mechanics to no-mistakes' version-matched guidance.
   For `tasks-axi`, this also covers an installed build that fails the compatibility probe (`docs/configuration.md` "Backlog backend" owns the definition); `config/backlog-backend=manual` only suppresses the verbose `BOOTSTRAP_INFO: tasks-axi available` fact, not this missing-tool report.
   For `quota-axi`, bootstrap requires it because firstmate reads its current output directly before resolving every crew-dispatch profile array; without it, report the missing requirement and do not choose around an unexamined candidate.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -45,8 +45,11 @@
 #          A TANGLE line means the firstmate primary checkout (FM_ROOT) is stranded
 #          on a feature branch instead of its default branch - a crewmate's work
 #          landed in the primary instead of its own worktree; restore it per the line.
-#          treehouse is also MISSING when its installed version lacks
-#          "treehouse get --lease" support.
+#          treehouse is also MISSING when its installed version is older than
+#          2.0.1, does not print exactly one bare version line, or lacks
+#          "treehouse get --lease" support. Version 2.0.1 is the minimum safe
+#          release because it adds atomic state persistence and conservative
+#          corrupt-state recovery.
 #          no-mistakes is also MISSING when its installed version is older than
 #          1.31.2.
 #          tasks-axi and quota-axi are required bootstrap tools (same class as
@@ -535,6 +538,7 @@ if ! BACKEND_TOOLS=$(fm_backend_required_tools "$BACKEND"); then
   BACKEND_TOOLS=""
 fi
 TOOLS="$BACKEND_TOOLS $COMMON_TOOLS"
+TREEHOUSE_MIN=2.0.1
 NO_MISTAKES_MIN=1.31.2
 
 treehouse_supports_lease() {
@@ -545,12 +549,36 @@ treehouse_supports_lease() {
 # cannot be parsed into exactly one major.minor.patch triple is incompatible,
 # never assumed current, so a development or vendored build cannot pass a floor
 # it was never checked against.
-tool_version_at_least() {  # <tool> <min-version>
-  local tool=$1 min=$2 output parts major minor patch extra
+# The optional third argument tightens that further: `exact-line` requires the
+# whole `--version` output to be one bare version line, so surrounding text, an
+# extra diagnostic line, or a trailing blank line is incompatible rather than
+# silently parsed for the first triple it happens to contain.
+tool_version_at_least() {  # <tool> <min-version> [exact-line]
+  local tool=$1 min=$2 strict=${3:-} output rc parts major minor patch extra
   local min_major min_minor min_patch min_extra
   command -v "$tool" >/dev/null 2>&1 || return 1
-  output=$("$tool" --version 2>/dev/null) || return 1
-  parts=$(printf '%s\n' "$output" | sed -nE 's/.*[vV]?([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 \2 \3/p' | head -n 1)
+  if [ "$strict" = exact-line ]; then
+    # Command substitution strips every trailing newline, so a sentinel byte
+    # preserves them long enough to reject output that carries an extra line.
+    output=$(
+      "$tool" --version 2>/dev/null
+      rc=$?
+      printf '\034'
+      exit "$rc"
+    ) || return 1
+    case "$output" in
+      *$'\034') output=${output%$'\034'} ;;
+      *) return 1 ;;
+    esac
+    output=${output%$'\n'}
+    case "$output" in
+      *$'\n'*) return 1 ;;
+    esac
+    parts=$(printf '%s\n' "$output" | sed -nE 's/^[[:space:]]*[vV]?([0-9]+)\.([0-9]+)\.([0-9]+)[[:space:]]*$/\1 \2 \3/p')
+  else
+    output=$("$tool" --version 2>/dev/null) || return 1
+    parts=$(printf '%s\n' "$output" | sed -nE 's/.*[vV]?([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 \2 \3/p' | head -n 1)
+  fi
   IFS=' ' read -r major minor patch extra <<< "$parts"
   [ -n "$major" ] && [ -n "$minor" ] && [ -n "$patch" ] && [ -z "$extra" ] || return 1
   IFS='.' read -r min_major min_minor min_patch min_extra <<< "$min"
@@ -560,6 +588,10 @@ tool_version_at_least() {  # <tool> <min-version>
   [ "$minor" -gt "$min_minor" ] && return 0
   [ "$minor" -eq "$min_minor" ] || return 1
   [ "$patch" -ge "$min_patch" ]
+}
+
+treehouse_compatible() {
+  tool_version_at_least treehouse "$TREEHOUSE_MIN" exact-line && treehouse_supports_lease
 }
 
 x_mode_write_if_changed() {
@@ -865,11 +897,11 @@ done
 for t in $COMMON_TOOLS; do
   command -v "$t" >/dev/null || missing_tool_diagnostic "$t"
 done
-# The treehouse lease-support upgrade check is only relevant when the resolved
-# backend actually requires treehouse (every backend except orca, which owns its
-# own worktrees); an orca home must not be told to upgrade a provider it never uses.
+# Treehouse compatibility is only relevant when the resolved backend requires
+# it (every backend except orca, which owns its own worktrees); an orca home must
+# not be told to upgrade a provider it never uses.
 if fm_backend_list_contains "$TOOLS" treehouse \
-  && command -v treehouse >/dev/null 2>&1 && ! treehouse_supports_lease; then
+  && command -v treehouse >/dev/null 2>&1 && ! treehouse_compatible; then
   echo "MISSING: treehouse (install: $(install_cmd treehouse))"
 fi
 if command -v no-mistakes >/dev/null 2>&1 && ! tool_version_at_least no-mistakes "$NO_MISTAKES_MIN"; then

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,10 +275,11 @@ This section is the single owner of that universal toolchain list; backend guide
 In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-aware array dispatch.
 The per-backend delta is required only for the backend resolved from `FM_BACKEND`, then `config/backend`, then runtime auto-detection, then default `tmux`, so a home is never told to install a tool an inactive backend or feature would need.
 That delta is owned in code by `fm_backend_required_tools` in `bin/fm-backend.sh`: the resolved backend's own session-provider CLI (`tmux`, `herdr`, `zellij`, `orca`, or `cmux`), `jq` for the JSON-emitting experimental adapters (`herdr`, `zellij`, `cmux`) whose spawn and liveness paths parse the backend's JSON output, and the `treehouse` worktree provider for every session-provider-only backend (`tmux`, `herdr`, `zellij`, `cmux`).
+For those Treehouse-backed runtimes, bootstrap requires Treehouse v2.0.1 or newer with `treehouse get --lease` support; older versions, unparseable version output, or missing lease support report Treehouse as missing because v2.0.1 adds atomic state persistence and conservative corrupt-state recovery.
 Backend tool availability uses the adapter's own executable resolver, so bootstrap and spawn agree on supported non-`PATH` locations such as cmux's bundled CLI.
 An unknown resolved backend emits `BACKEND_INVALID` and blocks dispatch instead of silently dropping its dependency delta or falling back to tmux.
 Orca provides both the task worktree and terminal endpoint (see "Runtime backend" above), so `backend=orca` requires only `orca` on top of the universal toolchain and skips both `treehouse` and every other backend's session CLI.
-A herdr, zellij, or cmux home is therefore never told `tmux` is missing, and the `treehouse` durable-lease upgrade check runs only for the backends that actually use treehouse.
+A herdr, zellij, or cmux home is therefore never told `tmux` is missing, and the Treehouse compatibility check runs only for the backends that actually use Treehouse.
 When `config/crew-dispatch.json` exists, bootstrap also requires `jq` for dispatch profile validation.
 When X mode is opted in, bootstrap also requires `curl` and `jq` before arming the relay poll shim.
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -6,8 +6,9 @@
 # all is well. firstmate consumes the exact 'MISSING: treehouse (install: ...)',
 # 'MISSING: tasks-axi (install: ...)', 'MISSING: quota-axi (install: ...)', and
 # 'BOOTSTRAP_INFO: ...' lines, so those contracts are pinned verbatim. The cases
-# are table-driven over the inputs that vary: whether `treehouse get --help`
-# advertises --lease, which (if any) tasks-axi version is on PATH, whether
+# are table-driven over the inputs that vary: Treehouse version and whether
+# `treehouse get --help` advertises --lease, which (if any) tasks-axi version is
+# on PATH, whether
 # tasks-axi update advertises --archive-body, whether its mv help advertises
 # multi-ID moves, whether quota-axi is on PATH,
 # whether the local backend config opts out of tasks-axi backlog mutations, and
@@ -34,7 +35,8 @@ unset TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_SESSION HERDR_SOCKET_PATH \
   CMUX_WORKSPACE_ID CMUX_SURFACE_ID CMUX_SOCKET_PATH CMUX_TAB_ID CMUX_PANEL_ID 2>/dev/null || true
 
 # A fake toolchain where every required tool is present and gh is authenticated.
-# treehouse's `get --help` advertises --lease only when FM_FAKE_TREEHOUSE_LEASE_HELP=1.
+# Treehouse defaults to the minimum compatible v2.0.1, and its `get --help`
+# advertises --lease only when FM_FAKE_TREEHOUSE_LEASE_HELP=1.
 make_fake_toolchain() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
@@ -49,6 +51,10 @@ SH
   chmod +x "$fakebin/gh"
   cat > "$fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' "${FM_FAKE_TREEHOUSE_VERSION:-v2.0.1}"
+  exit 0
+fi
 if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   if [ "${FM_FAKE_TREEHOUSE_LEASE_HELP:-}" = 1 ]; then
     printf '%s\n' 'Usage: treehouse get [--lease] [--lease-holder <holder>]'
@@ -281,7 +287,7 @@ test_bootstrap_reporting() {
         ;;
     esac
   done <<'ROWS'
-treehouse --lease support is accepted silently^1^0.1.1^1^manual^empty^^
+minimum compatible treehouse is accepted silently^1^0.1.1^1^manual^empty^^
 treehouse without --lease reports an upgrade, gh auth is fine^0^0.1.1^1^-^grep^MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)^NEEDS_GH_AUTH
 compatible tasks-axi is silent by default^1^0.1.1^1^-^empty^^
 missing tasks-axi is required by default^1^-^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi)^
@@ -292,7 +298,76 @@ missing quota-axi is required by default^1^0.1.1^0^manual^exact^MISSING: quota-a
 manual backlog backend still requires missing tasks-axi^1^-^1^manual^exact^MISSING: tasks-axi (install: npm install -g tasks-axi)^
 manual backlog backend suppresses tasks-axi availability^1^0.1.1^1^manual^empty^^
 ROWS
-  pass "bootstrap reports treehouse lease + tasks-axi/quota-axi bootstrap contracts"
+  pass "bootstrap reports treehouse compatibility + tasks-axi/quota-axi bootstrap contracts"
+}
+
+test_treehouse_min_version() {
+  local label version lease backend mode case_dir fakebin out missing n
+  missing='MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)'
+  n=0
+  while IFS='^' read -r label version lease backend mode; do
+    [ -n "$label" ] || continue
+    n=$((n + 1))
+    case_dir="$TMP_ROOT/treehouse-version-$n"
+    mkdir -p "$case_dir/home/config"
+    printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+    if [ "$backend" != "-" ]; then
+      printf '%s\n' "$backend" > "$case_dir/home/config/backend"
+    fi
+    fakebin=$(make_fake_toolchain "$case_dir")
+    if [ "$backend" = orca ]; then
+      fm_fake_exit0 "$fakebin" orca
+    fi
+    out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+      FM_FAKE_TREEHOUSE_VERSION="$version" FM_FAKE_TREEHOUSE_LEASE_HELP="$lease" \
+      "$ROOT/bin/fm-bootstrap.sh")
+    case "$mode" in
+      empty)
+        [ -z "$out" ] || fail "$label: expected silence, got: $out" ;;
+      missing)
+        [ "$out" = "$missing" ] || fail "$label: expected '$missing', got: $out" ;;
+    esac
+  done <<'ROWS'
+minimum Treehouse version is accepted^v2.0.1^1^-^empty
+newer Treehouse patch is accepted^2.0.2^1^-^empty
+newer Treehouse minor is accepted^v2.1.0^1^-^empty
+newer Treehouse major is accepted^v3.0.0^1^-^empty
+Treehouse v2.0.0 reports an upgrade^v2.0.0^1^-^missing
+older Treehouse major reports an upgrade^v1.99.99^1^-^missing
+unparseable Treehouse version reports an upgrade^treehouse development build^1^-^missing
+prerelease at the version floor reports an upgrade^v2.0.1-rc.1^1^-^missing
+compatible Treehouse without lease support reports an upgrade^v2.1.0^0^-^missing
+old Treehouse without lease support reports one upgrade^v2.0.0^0^-^missing
+Orca ignores an incompatible unused Treehouse^treehouse development build^0^orca^empty
+ROWS
+  pass "bootstrap enforces the Treehouse 2.0.1 minimum and lease support"
+}
+
+test_treehouse_rejects_extra_version_output() {
+  local label mode version case_dir fakebin out missing n
+  missing='MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)'
+  n=0
+  while IFS='^' read -r label mode; do
+    [ -n "$label" ] || continue
+    n=$((n + 1))
+    case "$mode" in
+      diagnostic) version=$'v2.0.1\nunexpected diagnostic line' ;;
+      blank) version=$'v2.0.1\n' ;;
+    esac
+    case_dir="$TMP_ROOT/treehouse-extra-version-output-$n"
+    mkdir -p "$case_dir/home/config"
+    printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+    fakebin=$(make_fake_toolchain "$case_dir")
+    out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+      FM_FAKE_TREEHOUSE_VERSION="$version" FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+      "$ROOT/bin/fm-bootstrap.sh")
+    [ "$out" = "$missing" ] \
+      || fail "$label: expected '$missing', got: $out"
+  done <<'ROWS'
+diagnostic line after Treehouse version^diagnostic
+blank line after Treehouse version^blank
+ROWS
+  pass "bootstrap rejects extra Treehouse version output"
 }
 
 test_no_mistakes_min_version() {
@@ -833,6 +908,8 @@ ROWS
 }
 
 test_bootstrap_reporting
+test_treehouse_min_version
+test_treehouse_rejects_extra_version_output
 test_no_mistakes_min_version
 test_quota_axi_min_version
 test_git_is_required_with_supported_install_instruction

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -320,6 +320,10 @@ SH
   chmod +x "$fakebin/gh"
   cat > "$fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' 'v2.0.1'
+  exit 0
+fi
 if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   printf '%s\n' 'Usage: treehouse get [--lease]'
 fi

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -67,6 +67,10 @@ SH
   chmod +x "$fakebin/gh"
   cat > "$fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' 'v2.0.1'
+  exit 0
+fi
 if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   printf '%s\n' 'Usage: treehouse get [--lease]'
   exit 0
@@ -768,7 +772,19 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' 'v2.0.0'
+  exit 0
+fi
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  printf '%s\n' 'Usage: treehouse get [--lease]'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -791,7 +807,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: treehouse' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -1050,7 +1066,6 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
 
   printf 'needs-decision: pick a library\n' > "$home/state/task-z.status"
   append_wake "$home/state" signal task-z.status "needs-decision: pick a library"
@@ -1060,7 +1075,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: tasks-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z.status\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
   assert_contains "$out" "wake annotation: latest wake-EVENT observed at drain, not current state: task-z.status: needs-decision: pick a library" "fm-session-start.sh did not preserve the drain's separate annotation line"

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -29,6 +29,10 @@ exit 0
 SH
   cat > "$fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' 'v2.0.1'
+  exit 0
+fi
 if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   printf '%s\n' 'Usage: treehouse get [--lease]'
 fi


### PR DESCRIPTION
## Intent

Prevent Firstmate from accepting unsafe Treehouse versions after v2.0.0's non-atomic state persistence corrupted a shared worktree-pool record. Require Treehouse 2.0.1 or newer plus durable lease support only for backends that use Treehouse, reject malformed output including any treehouse --version output with an extra line, preserve the exact existing MISSING upgrade diagnostic and captain-consent install path, and retain the accepted focused regression. Preserve fm-teardown.sh's generic-error refusal and do not touch recovered project pools or task cleanup. This reconciled history intentionally preserves original accepted commits 6c245b2 and 0b3e604 together with every prior pipeline-generated commit through 85311e39; publish only through the authorized Moshik21/firstmate fork while keeping kunchenguid/firstmate as the official upstream and PR base.

## What Changed

- Require Treehouse 2.0.1+ with durable lease support for Treehouse-backed runtimes while preserving the existing `MISSING` upgrade diagnostic and Orca exemption.
- Reject unparseable, prerelease, multiline, and trailing-blank-line version output.
- Document the compatibility requirements and add focused bootstrap regression coverage for version boundaries, lease support, malformed output, and backend scoping.

## Risk Assessment

✅ Low: The sentinel-based capture now preserves and rejects trailing extra lines while retaining the Treehouse version floor, lease check, backend scoping, exact diagnostic, install-consent path, and required history.

## Testing

The focused bootstrap and teardown suites passed; manual CLI evidence shows safe Treehouse is accepted, unsafe/malformed/lease-less versions receive the exact existing MISSING diagnostic, and Orca ignores unused Treehouse, while diff and ancestry checks confirmed teardown/data boundaries and required history were preserved.

<details>
<summary>Evidence: Treehouse bootstrap compatibility CLI transcript</summary>

```text
CASE: minimum-safe
treehouse --version: v2.0.1
lease support: 1
backend: -
bootstrap output: <silent: accepted>

CASE: corruption-prone-v2.0.0
treehouse --version: v2.0.0
lease support: 1
backend: -
bootstrap output: MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)

CASE: extra-diagnostic-line
treehouse --version: $'v2.0.1\nunexpected diagnostic line'
lease support: 1
backend: -
bootstrap output: MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)

CASE: extra-blank-line
treehouse --version: $'v2.0.1\n'
lease support: 1
backend: -
bootstrap output: MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)

CASE: missing-durable-lease
treehouse --version: v2.1.0
lease support: 0
backend: -
bootstrap output: MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)

CASE: orca-does-not-use-treehouse
treehouse --version: $'v2.0.1\nunexpected diagnostic line'
lease support: 0
backend: orca
bootstrap output: <silent: accepted>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-bootstrap.sh:542` - The required criterion says to “reject malformed output including any treehouse --version output with an extra line,” but command substitution strips all trailing newlines before the newline check. Consequently, output such as `v2.0.1\n\n` becomes `v2.0.1` and is accepted. Capture with a sentinel or another mechanism that preserves trailing newlines, then validate exactly one line.

🔧 Fix: Reject trailing lines in Treehouse version output
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-bootstrap.test.sh`
- `bash tests/fm-teardown-endpoint-safety.test.sh`
- `Manual bootstrap CLI matrix covering Treehouse v2.0.1, v2.0.0, extra diagnostic/blank lines, missing lease support, and the Orca exemption`
- `git diff --quiet 99533c5d7d3702050e6084429dddff6ea4fe1aa0..bb774dc1ed51483d070802e9d87b6229a850bb76 -- bin/fm-teardown.sh`
- <code>`git merge-base --is-ancestor` checks for preserved commits `6c245b2`, `0b3e604`, and `85311e39`</code>
- <code>Diff inspection confirming no changes under `projects`, `data`, or `state`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Confirm clean lint with pinned ShellCheck 0.11.0
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
