### PR TITLE
feat(watchdog): launchd beacon backstop for watcher continuity

### DIFF
--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -134,7 +134,7 @@ family_for_basename() {
     fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
     fm-supervision-events.test.sh|fm-turnend-guard.test.sh|fm-wake-daemon-lifecycle-e2e.test.sh|\
     fm-wake-queue.test.sh|fm-watch-checkpoint.test.sh|fm-watch-triage.test.sh|\
-    fm-watcher-lock.test.sh)
+    fm-watcher-lock.test.sh|fm-watchdog-check.test.sh)
       printf '%s\n' watcher-wake-lock
       ;;
     fm-afk-inject-herdr-e2e.test.sh|fm-afk-launch.test.sh|fm-backend-autodetect-smoke.test.sh|\

--- a/bin/fm-watchdog-check.sh
+++ b/bin/fm-watchdog-check.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# fm-watchdog-check.sh - turn-independent beacon watchdog for watcher continuity.
+#
+# A continuity backstop that does NOT depend on any harness turn cadence. The
+# Claude Stop asyncRewake auto-arm (bin/fm-claude-stop-autoarm.sh) restores a
+# watcher only while Claude is turning; a watcher that dies silently during an
+# idle gap raises no exit-2 wake, so nothing re-arms it and state/.last-watcher-beat
+# goes stale while the home sits blind for hours. This checker runs on a launchd
+# timer (launchd/com.firstmate.watcher-watchdog.plist, installed by
+# bin/fm-watchdog-install.sh), independent of Claude's turns and surviving
+# firstmate restarts and reboots, and re-arms the watcher exactly when it would
+# otherwise stay dead. See docs/watcher-watchdog.md for the full mechanism.
+#
+# It applies the SAME gates the Stop auto-arm uses, so it never arms an idle,
+# away, or unowned home, and it never double-arms:
+#   - Scope: only a genuine primary checkout (or marked secondmate home) with
+#     AGENTS.md, bin/, and the effective state dir - the fm-primary-scope gate,
+#     identical to the Stop auto-arm and fm-turnend-guard.sh.
+#   - Need: only while work is in flight (state/*.meta) or an X-mode relay poll
+#     (state/x-watch.check.sh) needs a watcher; an idle home exits 0.
+#   - AFK: while state/.afk exists the away daemon owns the watcher; exit 0.
+#   - Session: only while THIS home holds a live session lock (state/.lock names
+#     a live harness pid). Unlike the Stop auto-arm, launchd launches this
+#     checker OUTSIDE any harness process tree, so it cannot prove it descends
+#     from the lock owner; it instead confirms a live firstmate session still
+#     owns the home and never reclaims a stale lock itself - a restarted session
+#     re-acquires its own.
+#   - Beacon: only when state/.last-watcher-beat is older than the grace window,
+#     i.e. no fresh watcher is keeping the home supervised. A fresh beacon means
+#     the Stop auto-arm or an attached arm already supervises the home, so this
+#     exits 0 without even touching the single-flight lock.
+#   - Single-flight: acquire the SAME owner lock the Stop auto-arm uses
+#     (state/.claude-autoarm.lock). If another arm - the Stop hook or a prior
+#     checker tick still foregrounding an arm cycle - holds it with a live owner,
+#     exit 0. Only one arm ever runs per home, across the hook and this watchdog.
+#
+# When every gate passes it foregrounds bin/fm-watch-arm.sh (NEVER shell &),
+# exactly as the Stop auto-arm does, holding the owner lock for the arm cycle's
+# lifetime and releasing it on exit. The arm forks the watcher as its tracked
+# child, so this checker staying foregrounded for the cycle is what keeps the
+# watcher (and its fresh beacon) alive between Claude turns.
+#
+# This checker does NOT write outcome=rewake to the epoch ledger. That outcome
+# lets the synchronous Stop guard (bin/fm-turnend-guard.sh --claude) allow a stop
+# WITHOUT a Claude continuation, and a launchd arm produces no Claude
+# continuation, so a rewake outcome here would falsely suppress one. The guard
+# already recognizes a live owner-lock pid as "recovery owned", which is the
+# correct signal while this checker holds the lock.
+#
+# Only the watcher process (bin/fm-watch.sh) ever touches state/.last-watcher-beat;
+# this checker only reads its age and never writes the beacon.
+#
+# Exit 0 in every non-arming case and after an arm cycle completes. It never
+# exits 2: a launchd agent's exit code carries no harness rewake, so there is no
+# rewake to signal. The outcome is observable via the beacon going fresh and the
+# arm's bounded cycle ledger (state/.watch-cycle-exits.log).
+#
+# Usage:
+#   FM_HOME=<home> bin/fm-watchdog-check.sh
+# Grace honors FM_GUARD_GRACE (default 300), matching the arm and guard layers.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+GRACE=${FM_GUARD_GRACE:-300}
+BEAT="$STATE/.last-watcher-beat"
+OWNER_LOCK="$STATE/.claude-autoarm.lock"
+WATCH_ARM="$SCRIPT_DIR/fm-watch-arm.sh"
+case "$GRACE" in ''|*[!0-9]*) GRACE=300 ;; esac
+
+# shellcheck source=bin/fm-primary-scope-lib.sh
+. "$SCRIPT_DIR/fm-primary-scope-lib.sh"
+# shellcheck source=bin/fm-supervision-lib.sh
+. "$SCRIPT_DIR/fm-supervision-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
+
+# --- scope: genuine primary home only -----------------------------------------
+fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
+
+# --- need: in-flight work or an X-mode relay poll -----------------------------
+fm_supervision_needed "$STATE" "$GRACE" || exit 0
+
+# --- AFK: the away daemon owns the watcher and triage -------------------------
+[ -e "$STATE/.afk" ] && exit 0
+
+# --- session: a live firstmate session must still own this home ---------------
+# launchd launched us outside any harness process tree, so we cannot prove we
+# descend from the lock owner the way the Stop auto-arm does. Confirm only that a
+# live harness still holds state/.lock; never reclaim a stale lock here.
+session_lock_live() {
+  local lock_pid
+  [ -f "$STATE/.lock" ] || return 1
+  lock_pid=$(cat "$STATE/.lock" 2>/dev/null || true)
+  case "$lock_pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  fm_harness_pid_alive "$lock_pid"
+}
+session_lock_live || exit 0
+
+# --- beacon: only act when no fresh watcher supervises the home ----------------
+beacon_age=$(fm_path_age "$BEAT")
+[ "$beacon_age" -ge "$GRACE" ] || exit 0
+
+# --- single-flight: the same owner lock the Stop auto-arm uses -----------------
+# A live holder (the Stop hook or a prior checker tick foregrounding an arm) means
+# recovery is already under way; step aside rather than double-arm.
+fm_lock_try_acquire "$OWNER_LOCK" || exit 0
+trap 'fm_lock_release "$OWNER_LOCK"' EXIT
+
+# --- foreground the real arm wrapper (NEVER shell &) --------------------------
+# Blocks for the arm cycle, which is exactly what keeps a watcher (and its fresh
+# beacon) alive between Claude turns. Subsequent timer ticks see the owner lock
+# held and no-op.
+"$WATCH_ARM" >/dev/null 2>&1
+
+# The arm's outcome is recorded in its cycle ledger and the beacon it refreshed;
+# a launchd exit carries no harness rewake, so always settle at exit 0.
+exit 0

--- a/bin/fm-watchdog-check.sh
+++ b/bin/fm-watchdog-check.sh
@@ -64,6 +64,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 GRACE=${FM_GUARD_GRACE:-300}
 BEAT="$STATE/.last-watcher-beat"
 OWNER_LOCK="$STATE/.claude-autoarm.lock"
@@ -112,6 +113,12 @@ beacon_age=$(fm_path_age "$BEAT")
 # recovery is already under way; step aside rather than double-arm.
 fm_lock_try_acquire "$OWNER_LOCK" || exit 0
 trap 'fm_lock_release "$OWNER_LOCK"' EXIT
+
+# X mode cadence: source the generated config so an X instance polls at its
+# 30s cadence (fm-bootstrap.sh x_mode_setup contract), matching the Stop
+# auto-arm. Without it the forked watcher would run at the 300s default.
+# shellcheck source=/dev/null
+[ -f "$CONFIG/x-mode.env" ] && . "$CONFIG/x-mode.env"
 
 # --- foreground the real arm wrapper (NEVER shell &) --------------------------
 # Blocks for the arm cycle, which is exactly what keeps a watcher (and its fresh

--- a/bin/fm-watchdog-install.sh
+++ b/bin/fm-watchdog-install.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# fm-watchdog-install.sh - install/uninstall the launchd beacon watchdog for one home.
+#
+# Stamps launchd/com.firstmate.watcher-watchdog.plist with this home's real
+# absolute paths and a per-home unique label, then loads it as a per-user
+# LaunchAgent so bin/fm-watchdog-check.sh re-arms a silently-dead watcher on a
+# timer, independent of any harness turn cadence (docs/watcher-watchdog.md).
+#
+# Usage:
+#   FM_HOME=<home> bin/fm-watchdog-install.sh install    # default verb
+#   FM_HOME=<home> bin/fm-watchdog-install.sh uninstall
+#   FM_HOME=<home> bin/fm-watchdog-install.sh status
+#
+# FM_HOME defaults to this repo root. The stamped agent carries FM_HOME and a
+# label derived from that path, so several firstmate homes under one macOS user
+# do not collide. install is idempotent (it reloads the current plist). It fails
+# loud (nonzero) when launchctl is unavailable - i.e. on non-macOS - rather than
+# silently misinstall a LaunchAgent that can never run.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+TEMPLATE="$FM_ROOT/launchd/com.firstmate.watcher-watchdog.plist"
+CHECKER="$SCRIPT_DIR/fm-watchdog-check.sh"
+LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
+
+die() {
+  printf 'fm-watchdog-install.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v launchctl >/dev/null 2>&1 || die "launchctl not found; the watchdog LaunchAgent is macOS-only"
+[ -f "$TEMPLATE" ] || die "missing plist template: $TEMPLATE"
+[ -x "$CHECKER" ] || die "missing or non-executable checker: $CHECKER"
+[ -d "$FM_HOME" ] || die "FM_HOME does not exist: $FM_HOME"
+
+FM_HOME_ABS=$(cd "$FM_HOME" 2>/dev/null && pwd -P) || die "cannot resolve FM_HOME: $FM_HOME"
+
+# A per-home label fragment: the absolute home path reduced to [A-Za-z0-9], with
+# runs of other characters collapsed to a single dash. Keeps several homes under
+# one user distinct without a path that launchd Labels cannot hold.
+home_slug() {
+  local slug
+  slug=$(printf '%s' "$FM_HOME_ABS" | LC_ALL=C tr -cs 'A-Za-z0-9' '-' | sed 's/^-*//; s/-*$//')
+  [ -n "$slug" ] || slug=default
+  printf '%s\n' "$slug"
+}
+
+LABEL="com.firstmate.watcher-watchdog.$(home_slug)"
+PLIST="$LAUNCH_AGENTS/$LABEL.plist"
+DOMAIN="gui/$(id -u)"
+
+stamp_plist() {
+  mkdir -p "$LAUNCH_AGENTS" || die "cannot create $LAUNCH_AGENTS"
+  local tmp
+  tmp="$PLIST.tmp.$$"
+  sed -e "s|@@LABEL@@|$LABEL|g" \
+      -e "s|@@CHECKER@@|$CHECKER|g" \
+      -e "s|@@FM_HOME@@|$FM_HOME_ABS|g" \
+      "$TEMPLATE" > "$tmp" 2>/dev/null || { rm -f "$tmp"; die "failed to stamp plist"; }
+  mv -f "$tmp" "$PLIST" || { rm -f "$tmp"; die "failed to write $PLIST"; }
+}
+
+unload_agent() {
+  launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null \
+    || launchctl unload -w "$PLIST" 2>/dev/null \
+    || true
+}
+
+load_agent() {
+  # Prefer the modern API; fall back to the legacy subcommand on older macOS or
+  # when bootstrap reports the service already bootstrapped.
+  if launchctl bootstrap "$DOMAIN" "$PLIST" 2>/dev/null; then
+    return 0
+  fi
+  launchctl load -w "$PLIST" 2>/dev/null
+}
+
+is_loaded() {
+  launchctl list "$LABEL" >/dev/null 2>&1
+}
+
+do_install() {
+  stamp_plist
+  # Reload so the currently-loaded agent always matches the stamped plist.
+  unload_agent
+  if ! load_agent; then
+    die "launchctl refused to load $PLIST; inspect with: launchctl print $DOMAIN/$LABEL"
+  fi
+  printf 'watchdog: installed and loaded label=%s home=%s\n' "$LABEL" "$FM_HOME_ABS"
+  printf 'watchdog: status with: FM_HOME=%s bin/fm-watchdog-install.sh status\n' "$FM_HOME_ABS"
+}
+
+do_uninstall() {
+  unload_agent
+  rm -f "$PLIST" 2>/dev/null || true
+  printf 'watchdog: uninstalled label=%s home=%s\n' "$LABEL" "$FM_HOME_ABS"
+}
+
+do_status() {
+  printf 'watchdog home:  %s\n' "$FM_HOME_ABS"
+  printf 'watchdog label: %s\n' "$LABEL"
+  if [ -f "$PLIST" ]; then
+    printf 'watchdog plist: %s (present)\n' "$PLIST"
+  else
+    printf 'watchdog plist: %s (absent)\n' "$PLIST"
+  fi
+  if is_loaded; then
+    printf 'watchdog loaded: yes\n'
+  else
+    printf 'watchdog loaded: no\n'
+  fi
+}
+
+case "${1:-install}" in
+  install) do_install ;;
+  uninstall) do_uninstall ;;
+  status) do_status ;;
+  *) die "usage: fm-watchdog-install.sh [install|uninstall|status]" ;;
+esac

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -316,6 +316,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/watcher-watchdog.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/wedge-alarm.md",
       "audience": "operator-current"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -58,6 +58,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with loud cycle endings and bounded lifecycle ledger |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
 | `fm-watch.sh`            | Singleton-safe always-on watcher: absorb benign wakes, queue and exit on actionable ones |
+| `fm-watchdog-check.sh`   | Launchd beacon checker: re-arm a silently-dead watcher when its beacon is stale, under the shared single-flight lock (docs/watcher-watchdog.md) |
+| `fm-watchdog-install.sh` | Stamp and load/unload the macOS launchd watcher-watchdog agent for one home; idempotent, with status (docs/watcher-watchdog.md) |
 | `fm-afk-start.sh`        | Run the common sourceable away-mode daemon entry in the foreground                      |
 | `fm-afk-launch.sh`       | Own away-mode entry, exit, rollback, and any backend terminal lifecycle                 |
 | `fm-afk-return.sh`       | Own deterministic return shutdown, catch-up evidence, and the firstmate-actionable blocker gate |

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -2,6 +2,7 @@
 
 The watcher remains intentionally one-shot: one actionable reason closes one watcher cycle.
 Must-work continuity now lives above that process boundary instead of depending on the model remembering a re-arm step.
+A turn-independent launchd backstop ([watcher-watchdog.md](watcher-watchdog.md)) covers the gap where a watcher dies silently during an idle gap with no Stop hook to re-arm it.
 
 ## Ownership
 

--- a/docs/watcher-watchdog.md
+++ b/docs/watcher-watchdog.md
@@ -1,0 +1,52 @@
+# Watcher watchdog (launchd beacon backstop)
+
+A turn-independent continuity backstop for the watcher, layered above the existing continuity model in [watcher-continuity.md](watcher-continuity.md).
+It exists for one gap: the Claude Stop `asyncRewake` auto-arm (`bin/fm-claude-stop-autoarm.sh`) restores a watcher only while Claude is turning, so a watcher that dies silently during an idle gap raises no exit-2 wake, nothing re-arms it, and `state/.last-watcher-beat` goes stale while the home sits blind.
+A launchd timer runs the checker outside any harness turn cadence and re-arms exactly when the beacon has gone stale.
+It is opt-in and macOS-only; nothing changes until the home installs the agent.
+
+## Mechanism and ownership
+
+`bin/fm-watchdog-check.sh` is the checker.
+`launchd/com.firstmate.watcher-watchdog.plist` is a per-user LaunchAgent template that runs it with `RunAtLoad=true` and `StartInterval=90`, `FM_HOME` set to the target home.
+`bin/fm-watchdog-install.sh` stamps the template's `@@LABEL@@`, `@@CHECKER@@`, and `@@FM_HOME@@` placeholders with real absolute paths and a per-home unique label, then loads it from `~/Library/LaunchAgents`.
+
+The checker applies the same gates the Stop auto-arm uses, so it never arms an idle, away, or unowned home, and it never double-arms:
+
+- Scope - only a genuine primary checkout (or marked secondmate home); the `fm-primary-scope` gate, identical to the Stop auto-arm and `fm-turnend-guard.sh`.
+- Need - only while work is in flight (`state/*.meta`) or an X-mode relay poll (`state/x-watch.check.sh`) needs a watcher.
+- AFK - while `state/.afk` exists the away daemon owns the watcher.
+- Session - only while this home holds a live session lock (`state/.lock` names a live harness pid).
+- Beacon - only when `state/.last-watcher-beat` is older than the grace window, so a home already kept fresh by the Stop auto-arm is left alone.
+- Single-flight - it acquires the same owner lock the Stop auto-arm uses (`state/.claude-autoarm.lock`); if another arm holds it, the checker steps aside.
+
+When every gate passes it foregrounds `bin/fm-watch-arm.sh` (never shell `&`), holding the owner lock for the arm cycle and releasing it on exit.
+Staying foregrounded for the cycle is what keeps the watcher - and its fresh beacon - alive between Claude turns; later timer ticks see the owner lock held and no-op.
+
+The checker never writes `outcome=rewake` to the epoch ledger.
+That outcome lets the synchronous Stop guard (`bin/fm-turnend-guard.sh --claude`) allow a stop without a Claude continuation, and a launchd arm produces no continuation, so a rewake outcome here would falsely suppress one.
+The guard already recognizes a live owner-lock pid as recovery owned, which is the correct signal while the checker holds the lock.
+
+Only the watcher process (`bin/fm-watch.sh`) ever touches the beacon; the checker only reads its age.
+
+## Install, uninstall, and status
+
+```sh
+# Default home is this repo; set FM_HOME for a secondmate home.
+FM_HOME=<home> bin/fm-watchdog-install.sh install     # stamp + load the agent
+FM_HOME=<home> bin/fm-watchdog-install.sh status      # show label, plist, loaded state
+FM_HOME=<home> bin/fm-watchdog-install.sh uninstall   # unload + remove the agent
+```
+
+Install is idempotent: it reloads the currently-stamped plist.
+The installer fails loud (nonzero) when `launchctl` is unavailable, so it never silently misinstalls a LaunchAgent on a non-macOS host.
+
+## The independence property
+
+The checker runs on a launchd timer and at login/reboot, not on a Claude Stop event, so continuity survives firstmate restarts and reboots and does not depend on the model remembering a re-arm step.
+The checker always exits 0: a launchd exit carries no harness rewake, so there is no reason to signal one.
+Outcome is observable via the beacon going fresh and the arm's bounded cycle ledger (`state/.watch-cycle-exits.log`).
+
+## Regression coverage
+
+`tests/fm-watchdog-check.test.sh` runs the real checker against a hermetic fixture home and covers re-arm when the beacon is stale with every gate passing, no-op when the beacon is fresh or any gate fails (idle, AFK, no live session lock, child worktree), no-op while the single-flight lock is held, and never double-arming across concurrent timer ticks, plus the installer and plist-template contract.

--- a/launchd/com.firstmate.watcher-watchdog.plist
+++ b/launchd/com.firstmate.watcher-watchdog.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd per-user agent template for the firstmate watcher watchdog.
+
+  This is a TEMPLATE, not a loadable plist: bin/fm-watchdog-install.sh stamps the
+  @@LABEL@@, @@CHECKER@@, and @@FM_HOME@@ placeholders with this home's real
+  absolute paths and a per-home unique label, then loads the result from
+  ~/Library/LaunchAgents. One stamped copy per firstmate home keeps several homes
+  under one user from colliding. See docs/watcher-watchdog.md.
+
+  RunAtLoad arms once at login/reboot so a home with in-flight work is never left
+  blind across a restart; StartInterval re-checks the beacon on a short timer so a
+  watcher that dies silently mid-gap is restored within the grace window,
+  independent of any harness turn cadence.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>@@LABEL@@</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>@@CHECKER@@</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>FM_HOME</key>
+    <string>@@FM_HOME@@</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>90</integer>
+  <key>StandardOutPath</key>
+  <string>@@FM_HOME@@/state/watchdog.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>@@FM_HOME@@/state/watchdog.err.log</string>
+</dict>
+</plist>

--- a/tests/fm-watchdog-check.test.sh
+++ b/tests/fm-watchdog-check.test.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# Behavior tests for the launchd beacon watchdog checker
+# (bin/fm-watchdog-check.sh, launchd/com.firstmate.watcher-watchdog.plist,
+# bin/fm-watchdog-install.sh, docs/watcher-watchdog.md).
+#
+# The checker runs launchd-spawned, OUTSIDE any harness process tree, so unlike
+# the Claude Stop auto-arm it gates on a LIVE session-lock holder rather than its
+# own ancestry. These tests run the real checker against a hermetic fixture home:
+# a plain git checkout with the checker and its sourced libs copied in, a fake
+# fm-watch-arm.sh that records when it ran, and a fake-claude symlink pid written
+# into state/.lock to stand in for a live firstmate session. No real watcher,
+# model, fleet state, or launchd agent is touched.
+# shellcheck disable=SC2016 # single quotes are deliberate: $FM_HOME expands inside the fake harness child
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CHECKER="$ROOT/bin/fm-watchdog-check.sh"
+INSTALLER="$ROOT/bin/fm-watchdog-install.sh"
+PLIST_TEMPLATE="$ROOT/launchd/com.firstmate.watcher-watchdog.plist"
+
+TMP_ROOT=$(fm_test_tmproot fm-watchdog-check)
+fm_git_identity fmtest fmtest@example.invalid
+
+FAKEBIN=$(fm_fakebin "$TMP_ROOT/fakebin")
+ln -s /bin/bash "$FAKEBIN/claude"
+FAKE_CLAUDE="$FAKEBIN/claude"
+
+# Copy the checker and its sourced dependencies into a fixture checkout so the
+# checker's SCRIPT_DIR resolves to the fixture bin and it runs the fixture's
+# fake fm-watch-arm.sh, never the real arm.
+install_watchdog_scripts() {
+  local dir=$1
+  mkdir -p "$dir/bin"
+  cp "$ROOT/bin/fm-watchdog-check.sh" "$dir/bin/fm-watchdog-check.sh"
+  cp "$ROOT/bin/fm-primary-scope-lib.sh" "$dir/bin/fm-primary-scope-lib.sh"
+  cp "$ROOT/bin/fm-supervision-lib.sh" "$dir/bin/fm-supervision-lib.sh"
+  cp "$ROOT/bin/fm-wake-lib.sh" "$dir/bin/fm-wake-lib.sh"
+  cp "$ROOT/bin/fm-session-lock-lib.sh" "$dir/bin/fm-session-lock-lib.sh"
+  chmod +x "$dir/bin/fm-watchdog-check.sh"
+}
+
+make_primary_dir() {
+  local dir=$1
+  mkdir -p "$dir/state"
+  git init -q "$dir"
+  git -C "$dir" commit -q --allow-empty -m init
+  : > "$dir/AGENTS.md"
+  install_watchdog_scripts "$dir"
+  printf '%s\n' "$dir"
+}
+
+# A genuine linked git worktree (git-dir != git-common-dir): the crewmate/scout
+# shape, which must keep the checker inert (not a primary home).
+make_crewmate_worktree_dir() {
+  local base=$1 dir=$2
+  fm_git_worktree "$base" "$dir" fm/watchdog-test-branch
+  mkdir -p "$dir/state"
+  : > "$dir/AGENTS.md"
+  install_watchdog_scripts "$dir"
+  printf '%s\n' "$dir"
+}
+
+# Run the checker against fixture $1; exit code on stdout of the caller.
+run_checker() {
+  local dir=$1
+  FM_HOME="$dir" bash "$dir/bin/fm-watchdog-check.sh" >/dev/null 2>&1
+}
+
+# Background a fake-claude process and record it as the fixture's live session
+# owner. Echoes the pid; the caller kills it when done.
+start_session_owner() {
+  local dir=$1 pid
+  # Redirect the backgrounded owner's fds so it does not inherit this call's
+  # stdout pipe when invoked under command substitution, which would otherwise
+  # keep owner=$(...) open until the sleeper exits.
+  "$FAKE_CLAUDE" -c 'sleep 300; :' >/dev/null 2>&1 &
+  pid=$!
+  printf '%s\n' "$pid" > "$dir/state/.lock"
+  printf '%s\n' "$pid"
+}
+
+# Fake arm variants, installed as <dir>/bin/fm-watch-arm.sh.
+write_arm_fixture() {
+  local dir=$1 kind=$2
+  case "$kind" in
+    actionable)
+      cat > "$dir/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" >> "$FM_HOME/state/arm-ran"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+printf 'signal: fixture done\n'
+exit 0
+SH
+      ;;
+    slow-actionable)
+      cat > "$dir/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" >> "$FM_HOME/state/arm-ran"
+sleep 2
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+printf 'signal: fixture done\n'
+exit 0
+SH
+      ;;
+    *)
+      echo "unknown arm fixture: $kind" >&2
+      return 2
+      ;;
+  esac
+  chmod +x "$dir/bin/fm-watch-arm.sh"
+}
+
+# --- re-arm when the beacon is stale and every gate passes --------------------
+
+test_re_arms_when_beacon_absent_and_gates_pass() {
+  local dir owner status
+  dir=$(make_primary_dir "$TMP_ROOT/stale-absent")
+  : > "$dir/state/task.meta"
+  owner=$(start_session_owner "$dir")
+  write_arm_fixture "$dir" actionable
+  run_checker "$dir"; status=$?
+  kill "$owner" 2>/dev/null || true; wait "$owner" 2>/dev/null || true
+  expect_code 0 "$status" "checker must exit 0 even when it arms (no launchd rewake)"
+  [ -e "$dir/state/arm-ran" ] || fail "checker did not re-arm a stale beacon with all gates passing"
+  [ ! -e "$dir/state/.claude-autoarm.lock" ] || fail "checker left the single-flight owner lock held"
+  [ ! -e "$dir/state/.claude-autoarm-epoch" ] || fail "checker must not write the auto-arm epoch ledger"
+  pass "watchdog: re-arms when the beacon is absent and every gate passes"
+}
+
+test_re_arms_when_beacon_mtime_past_grace() {
+  local dir owner status
+  dir=$(make_primary_dir "$TMP_ROOT/stale-old")
+  : > "$dir/state/task.meta"
+  owner=$(start_session_owner "$dir")
+  : > "$dir/state/.last-watcher-beat"
+  # mtime far in the past: well beyond the 300s grace window.
+  touch -t 197001010000 "$dir/state/.last-watcher-beat"
+  write_arm_fixture "$dir" actionable
+  run_checker "$dir"; status=$?
+  kill "$owner" 2>/dev/null || true; wait "$owner" 2>/dev/null || true
+  expect_code 0 "$status" "checker must exit 0 when it arms"
+  [ -e "$dir/state/arm-ran" ] || fail "checker did not re-arm an old beacon with all gates passing"
+  pass "watchdog: re-arms when the beacon mtime is past the grace window"
+}
+
+# --- no-op when the beacon is fresh -------------------------------------------
+
+test_noop_when_beacon_fresh() {
+  local dir owner status
+  dir=$(make_primary_dir "$TMP_ROOT/fresh")
+  : > "$dir/state/task.meta"
+  owner=$(start_session_owner "$dir")
+  touch "$dir/state/.last-watcher-beat"
+  write_arm_fixture "$dir" actionable
+  run_checker "$dir"; status=$?
+  kill "$owner" 2>/dev/null || true; wait "$owner" 2>/dev/null || true
+  expect_code 0 "$status" "checker must exit 0 with a fresh beacon"
+  [ ! -e "$dir/state/arm-ran" ] || fail "checker re-armed despite a fresh beacon"
+  [ ! -e "$dir/state/.claude-autoarm.lock" ] || fail "checker touched the single-flight lock with a fresh beacon"
+  pass "watchdog: no-ops when the beacon is fresh"
+}
+
+# --- no-op when a gate fails --------------------------------------------------
+
+test_noop_when_idle() {
+  local dir owner status
+  dir=$(make_primary_dir "$TMP_ROOT/idle")
+  owner=$(start_session_owner "$dir")
+  write_arm_fixture "$dir" actionable
+  run_checker "$dir"; status=$?
+  kill "$owner" 2>/dev/null || true; wait "$owner" 2>/dev/null || true
+  expect_code 0 "$status" "checker must exit 0 with nothing in flight"
+  [ ! -e "$dir/state/arm-ran" ] || fail "checker armed an idle home"
+  pass "watchdog: no-op when no work is in flight"
+}
+
+test_noop_when_afk() {
+  local dir owner status
+  dir=$(make_primary_dir "$TMP_ROOT/afk")
+  : > "$dir/state/task.meta"
+  owner=$(start_session_owner "$dir")
+  : > "$dir/state/.afk"
+  write_arm_fixture "$dir" actionable
+  run_checker "$dir"; status=$?
+  kill "$owner" 2>/dev/null || true; wait "$owner" 2>/dev/null || true
+  expect_code 0 "$status" "checker must exit 0 while away mode owns triage"
+  [ ! -e "$dir/state/arm-ran" ] || fail "checker armed while state/.afk existed"
+  pass "watchdog: no-op while AFK owns supervision"
+}
+
+test_noop_when_no_live_session_lock() {
+  local dir status
+  dir=$(make_primary_dir "$TMP_ROOT/no-session")
+  : > "$dir/state/task.meta"
+  # No state/.lock at all: no firstmate session owns the home.
+  write_arm_fixture "$dir" actionable
+  run_checker "$dir"; status=$?
+  expect_code 0 "$status" "checker must exit 0 with no session lock"
+  [ ! -e "$dir/state/arm-ran" ] || fail "checker armed with no live session lock"
+
+  # A non-harness live pid in .lock is not a firstmate session owner.
+  sleep 300 &
+  local sleeper=$!
+  printf '%s\n' "$sleeper" > "$dir/state/.lock"
+  run_checker "$dir"; status=$?
+  kill "$sleeper" 2>/dev/null || true; wait "$sleeper" 2>/dev/null || true
+  expect_code 0 "$status" "checker must exit 0 when the lock holder is not a harness"
+  [ ! -e "$dir/state/arm-ran" ] || fail "checker armed for a non-harness lock holder"
+  pass "watchdog: no-op unless a live harness holds the session lock"
+}
+
+test_noop_in_child_worktree() {
+  local base dir status
+  base="$TMP_ROOT/crew-base"
+  dir="$TMP_ROOT/crew-wt"
+  make_crewmate_worktree_dir "$base" "$dir" >/dev/null
+  : > "$dir/state/task.meta"
+  write_arm_fixture "$dir" actionable
+  run_checker "$dir"; status=$?
+  expect_code 0 "$status" "checker must stay inert in a child task worktree"
+  [ ! -e "$dir/state/arm-ran" ] || fail "checker armed inside a child worktree"
+  pass "watchdog: inert in a linked child worktree even when in-flight"
+}
+
+# --- single-flight: never double-arm with the Stop hook or a prior tick -------
+
+test_noop_when_single_flight_lock_held() {
+  local dir owner status
+  dir=$(make_primary_dir "$TMP_ROOT/held")
+  : > "$dir/state/task.meta"
+  owner=$(start_session_owner "$dir")
+  write_arm_fixture "$dir" actionable
+  # Acquire the same owner lock the Stop auto-arm uses, held by THIS process.
+  FM_HOME="$dir" . "$ROOT/bin/fm-wake-lib.sh"
+  fm_lock_try_acquire "$dir/state/.claude-autoarm.lock" \
+    || { kill "$owner" 2>/dev/null || true; fail "test could not pre-acquire the single-flight lock"; }
+  run_checker "$dir"; status=$?
+  fm_lock_release "$dir/state/.claude-autoarm.lock"
+  kill "$owner" 2>/dev/null || true; wait "$owner" 2>/dev/null || true
+  expect_code 0 "$status" "checker must exit 0 when the single-flight lock is held"
+  [ ! -e "$dir/state/arm-ran" ] || fail "checker armed while another owner held the single-flight lock"
+  pass "watchdog: no-op while the single-flight owner lock is held by another arm"
+}
+
+test_second_tick_noops_while_first_arms() {
+  local dir owner pid status rc2 count i
+  dir=$(make_primary_dir "$TMP_ROOT/concurrent")
+  : > "$dir/state/task.meta"
+  owner=$(start_session_owner "$dir")
+  write_arm_fixture "$dir" slow-actionable
+  # First tick: acquires the lock and blocks on the slow arm.
+  FM_HOME="$dir" bash "$dir/bin/fm-watchdog-check.sh" >/dev/null 2>&1 &
+  pid=$!
+  i=0
+  while [ "$i" -lt 60 ] && [ ! -e "$dir/state/.claude-autoarm.lock" ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -e "$dir/state/.claude-autoarm.lock" ] || { kill "$pid" 2>/dev/null || true; kill "$owner" 2>/dev/null || true; fail "first tick did not acquire the single-flight lock"; }
+  # Second tick while the first still holds the lock: must no-op without arming.
+  FM_HOME="$dir" bash "$dir/bin/fm-watchdog-check.sh" >/dev/null 2>&1; rc2=$?
+  wait "$pid" 2>/dev/null || true
+  kill "$owner" 2>/dev/null || true; wait "$owner" 2>/dev/null || true
+  expect_code 0 "$rc2" "a concurrent tick must exit 0 without error"
+  count=$(wc -l < "$dir/state/arm-ran" 2>/dev/null | tr -d ' ')
+  [ "${count:-0}" -eq 1 ] || fail "concurrent ticks must arm exactly once, saw ${count:-0}"
+  pass "watchdog: a second timer tick never double-arms while the first holds the lock"
+}
+
+# --- installer + plist template contract --------------------------------------
+
+test_installer_is_macos_only_idempotent_and_per_home() {
+  [ -x "$INSTALLER" ] || fail "fm-watchdog-install.sh must be executable"
+  assert_grep 'launchctl not found' "$INSTALLER" \
+    "installer must fail loud when launchctl is unavailable (non-macOS)"
+  assert_grep 'command -v launchctl' "$INSTALLER" \
+    "installer must detect launchctl before installing"
+  assert_grep 'do_uninstall' "$INSTALLER" "installer must support uninstall"
+  assert_grep 'do_status' "$INSTALLER" "installer must support status"
+  assert_grep 'home_slug' "$INSTALLER" \
+    "installer must derive a per-home label so homes under one user do not collide"
+  # install reloads (unload then load) so the loaded agent always matches the
+  # stamped plist - idempotent across re-runs.
+  assert_grep 'unload_agent' "$INSTALLER" "installer must reload the agent idempotently"
+  assert_grep 'com.firstmate.watcher-watchdog.' "$INSTALLER" \
+    "installer label must be namespaced under com.firstmate.watcher-watchdog"
+  pass "installer: macOS-only guard, install/uninstall/status, idempotent reload, per-home label"
+}
+
+test_plist_template_matches_checker_contract() {
+  [ -f "$PLIST_TEMPLATE" ] || fail "missing plist template"
+  assert_grep '@@LABEL@@' "$PLIST_TEMPLATE" "template must carry a stamped Label placeholder"
+  assert_grep '@@CHECKER@@' "$PLIST_TEMPLATE" "template must carry a stamped checker path placeholder"
+  assert_grep '@@FM_HOME@@' "$PLIST_TEMPLATE" "template must carry a stamped FM_HOME placeholder"
+  assert_grep '<key>RunAtLoad</key>' "$PLIST_TEMPLATE" "agent must run at load (boot/login)"
+  assert_grep '<true/>' "$PLIST_TEMPLATE" "RunAtLoad must be true"
+  assert_grep '<key>StartInterval</key>' "$PLIST_TEMPLATE" "agent must define a timer interval"
+  assert_grep '<integer>90</integer>' "$PLIST_TEMPLATE" "agent interval must be the short ~90s watchdog cadence"
+  assert_grep '<key>FM_HOME</key>' "$PLIST_TEMPLATE" "agent must pass FM_HOME to the checker"
+  # The template invokes the checker via the @@CHECKER@@ placeholder; the
+  # installer owns binding that placeholder to bin/fm-watchdog-check.sh.
+  assert_grep 'fm-watchdog-check.sh' "$INSTALLER" "installer must stamp the real checker path"
+  pass "plist template: stamped placeholders, RunAtLoad, 90s StartInterval, FM_HOME, checker"
+}
+
+test_settings_and_lint_wire_watchdog_into_repo() {
+  # The checker never exits 2 and never writes the beacon: a launchd agent's
+  # exit carries no rewake, and only the watcher may touch the beacon.
+  assert_no_grep 'exit 2' "$CHECKER" "checker must never exit 2 (no launchd rewake exists)"
+  assert_grep 'fm-watch-arm.sh' "$CHECKER" "checker must foreground the real arm wrapper"
+  assert_no_grep 'watch-arm.sh &"' "$CHECKER" "checker must never background the arm with shell &"
+  assert_grep 'fm_lock_try_acquire "$OWNER_LOCK"' "$CHECKER" "checker must honor the shared single-flight owner lock"
+  assert_grep 'fm_primary_scope_matches' "$CHECKER" "checker must apply the primary-scope gate"
+  assert_grep 'fm_supervision_needed' "$CHECKER" "checker must apply the supervision-need gate"
+  assert_grep 'state/.afk' "$CHECKER" "checker must defer to away mode"
+  pass "checker: foreground arm, single-flight, scope/need/afk gates, never exit 2"
+}
+
+test_re_arms_when_beacon_absent_and_gates_pass
+test_re_arms_when_beacon_mtime_past_grace
+test_noop_when_beacon_fresh
+test_noop_when_idle
+test_noop_when_afk
+test_noop_when_no_live_session_lock
+test_noop_in_child_worktree
+test_noop_when_single_flight_lock_held
+test_second_tick_noops_while_first_arms
+test_installer_is_macos_only_idempotent_and_per_home
+test_plist_template_matches_checker_contract
+test_settings_and_lint_wire_watchdog_into_repo


### PR DESCRIPTION
## Intent

Build a launchd-backed beacon watchdog for firstmate's watcher continuity. Root cause: the Claude Stop asyncRewake auto-arm only re-arms while Claude is turning, so a watcher that dies silently during an idle gap leaves the liveness beacon stale with nothing to re-arm it (observed ~4h blind). The fix must be independent of Claude's turn cadence and survive firstmate restarts and reboots.

Deliverables: a checker script, a per-user launchd agent template (RunAtLoad + 90s StartInterval), an install/uninstall/status helper, a behavior test, a mechanism+install doc with a cross-reference from the existing watcher-continuity doc, and wiring in the scripts doc, the documentation-audiences inventory, and the test family mapping.

Key deliberate decisions and tradeoffs a reviewer should know:
- The checker reuses the EXACT gates the Stop auto-arm uses (primary scope, supervision need, not-AFK, plus a live session lock), so it never arms an idle/away/unowned home. It only acts when the beacon age is past the grace window (default 300s), matching the system's liveness window.
- Single-flight coordination: the checker acquires the SAME owner lock the Stop hook uses (the home-scoped auto-arm owner lock); a live holder (hook or a prior checker tick) makes it exit 0, so it never double-arms across the hook and the watchdog. It foregrounds the real arm wrapper (never shell ampersand), exactly like the hook; blocking for the arm cycle is what keeps the watcher and its fresh beacon alive between turns.
- The launchd checker is NOT in a harness process tree, so unlike the hook it cannot prove it descends from the lock owner. It instead gates on a LIVE session-lock holder, and intentionally does NOT reclaim a stale lock (a restarted session re-acquires its own).
- The checker NEVER writes the rewake outcome to the epoch ledger: that outcome lets the synchronous Stop guard allow a stop WITHOUT a Claude continuation, and a launchd arm produces no continuation, so writing it would falsely suppress one. The guard already recognizes a live owner-lock pid as recovery-owned, which is the correct signal while the checker holds the lock. The checker always exits 0 (never 2): a launchd exit carries no rewake.
- Only the watcher process ever touches the beacon; the checker only reads its age.
- The installer is macOS-only (fails loud if launchctl is unavailable), derives a per-home label so several homes under one user do not collide, and reloads idempotently.
- AGENTS.md is intentionally untouched: the watchdog is opt-in operator install (operator-current docs), not an always-loaded agent-runtime trigger.

## What Changed
- Added a launchd-backed beacon watchdog: `fm-watchdog-check.sh` reuses the Stop auto-arm's exact gates (primary scope, supervision need, not-AFK, live session lock) and re-arms a watcher when the liveness beacon ages past its grace window, plus a RunAtLoad + 90s `StartInterval` LaunchAgent template and a macOS-only `fm-watchdog-install.sh` (install/uninstall/status).
- Wired the watchdog into docs and the test inventory: new `docs/watcher-watchdog.md` mechanism+install doc cross-referenced from `docs/watcher-continuity.md`, with entries in `docs/scripts.md`, `docs/documentation-audiences.json`, and the test family mapping, plus a `fm-watchdog-check.test.sh` behavior suite.
- Bundled supporting fixes carried on the branch: spawn forwards `CLAUDE_CONFIG_DIR` to crewmates, session-lock resolves ancestry to the outermost Claude pid, and `fm-brief.sh` parses under stock macOS Bash 3.2.

## Risk Assessment

✅ Low: The one substantive finding (X-mode cadence) from round 1 was fixed correctly by mirroring the Stop auto-arm's x-mode.env sourcing; the watchdog feature and the surrounding fixes are otherwise clean, well-tested, and conform to the stated intent.

## Testing

Ran the full behavior suite (12/12 pass) which exercises the real checker against hermetic fixtures covering every gate and the single-flight invariant. Since the suite only greps (never runs) the installer, I additionally drove the real installer install→status→uninstall under a fake launchctl shim and proved the stamped LaunchAgent is valid (`plutil -lint: OK`, RunAtLoad=true, StartInterval=90, FM_HOME, real checker path, per-home label). Confirmed exact gate parity with the Stop auto-arm and the absence of both forbidden behaviors (epoch-ledger write, exit 2). All documentation deliverables and cross-references are in place; AGENTS.md is correctly untouched. No issues found.

<details>
<summary>Evidence: Stamped, validated launchd agent produced by the installer</summary>

`plutil -lint stamped-agent.plist → OK; carries Label, /bin/bash + fm-watchdog-check.sh, FM_HOME, RunAtLoad <true/>, StartInterval <integer>90</integer>, log paths`

```text
<?xml version="1.0" encoding="UTF-8"?>
<!--
  launchd per-user agent template for the firstmate watcher watchdog.

  This is a TEMPLATE, not a loadable plist: bin/fm-watchdog-install.sh stamps the
  com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1, /Users/vivek/.no-mistakes/worktrees/052c8ba410de/01KYQ6R9KMT0FK96XSZV0Y0H8G/bin/fm-watchdog-check.sh, and /private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1 placeholders with this home's real
  absolute paths and a per-home unique label, then loads the result from
  ~/Library/LaunchAgents. One stamped copy per firstmate home keeps several homes
  under one user from colliding. See docs/watcher-watchdog.md.

  RunAtLoad arms once at login/reboot so a home with in-flight work is never left
  blind across a restart; StartInterval re-checks the beacon on a short timer so a
  watcher that dies silently mid-gap is restored within the grace window,
  independent of any harness turn cadence.
-->
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
  <key>Label</key>
  <string>com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1</string>
  <key>ProgramArguments</key>
  <array>
    <string>/bin/bash</string>
    <string>/Users/vivek/.no-mistakes/worktrees/052c8ba410de/01KYQ6R9KMT0FK96XSZV0Y0H8G/bin/fm-watchdog-check.sh</string>
  </array>
  <key>EnvironmentVariables</key>
  <dict>
    <key>FM_HOME</key>
    <string>/private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1</string>
  </dict>
  <key>RunAtLoad</key>
  <true/>
  <key>StartInterval</key>
  <integer>90</integer>
  <key>StandardOutPath</key>
  <string>/private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1/state/watchdog.out.log</string>
  <key>StandardErrorPath</key>
  <string>/private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1/state/watchdog.err.log</string>
</dict>
</plist>
```
</details>
<details>
<summary>Evidence: Installer install/status/uninstall transcript (fake launchctl, sandboxed HOME)</summary>

```text
########## INSTALL ##########
watchdog: installed and loaded label=com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1 home=/private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1
watchdog: status with: FM_HOME=/private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1 bin/fm-watchdog-install.sh status
########## STATUS ##########
watchdog home:  /private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1
watchdog label: com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1
watchdog plist: /var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/Library/LaunchAgents/com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1.plist (present)
watchdog loaded: yes
########## launchctl calls ##########
CALL: bootout gui/501/com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1
CALL: bootstrap gui/501 <SANDBOX>/Library/LaunchAgents/com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1.plist
CALL: list com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1
########## stamped plist content ##########
<?xml version="1.0" encoding="UTF-8"?>
<!--
  launchd per-user agent template for the firstmate watcher watchdog.

  This is a TEMPLATE, not a loadable plist: bin/fm-watchdog-install.sh stamps the
  com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1, /Users/vivek/.no-mistakes/worktrees/052c8ba410de/01KYQ6R9KMT0FK96XSZV0Y0H8G/bin/fm-watchdog-check.sh, and /private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1 placeholders with this home's real
  absolute paths and a per-home unique label, then loads the result from
  ~/Library/LaunchAgents. One stamped copy per firstmate home keeps several homes
  under one user from colliding. See docs/watcher-watchdog.md.

  RunAtLoad arms once at login/reboot so a home with in-flight work is never left
  blind across a restart; StartInterval re-checks the beacon on a short timer so a
  watcher that dies silently mid-gap is restored within the grace window,
  independent of any harness turn cadence.
-->
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
  <key>Label</key>
  <string>com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1</string>
  <key>ProgramArguments</key>
  <array>
    <string>/bin/bash</string>
    <string>/Users/vivek/.no-mistakes/worktrees/052c8ba410de/01KYQ6R9KMT0FK96XSZV0Y0H8G/bin/fm-watchdog-check.sh</string>
  </array>
  <key>EnvironmentVariables</key>
  <dict>
    <key>FM_HOME</key>
    <string>/private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1</string>
  </dict>
  <key>RunAtLoad</key>
  <true/>
  <key>StartInterval</key>
  <integer>90</integer>
  <key>StandardOutPath</key>
  <string>/private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1/state/watchdog.out.log</string>
  <key>StandardErrorPath</key>
  <string>/private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1/state/watchdog.err.log</string>
</dict>
</plist>
########## plutil lint ##########
/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/no-mistakes-evidence/01KYQ6R9KMT0FK96XSZV0Y0H8G/stamped-agent.plist: OK
########## UNINSTALL ##########
watchdog: uninstalled label=com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1 home=/private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1
########## status after uninstall ##########
watchdog home:  /private/var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/home1
watchdog label: com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1
watchdog plist: /var/folders/jh/bb35jdhn0dv1wrsclqx1n4t40000gn/T/fm-wd-sandbox.aX7w0fyWD6/Library/LaunchAgents/com.firstmate.watcher-watchdog.private-var-folders-jh-bb35jdhn0dv1wrsclqx1n4t40000gn-T-fm-wd-sandbox-aX7w0fyWD6-home1.plist (absent)
watchdog loaded: yes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `.agents/skills/afk/SKILL.md` - branch carries 4 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (83 file(s)) into the PR:
- 6616b0d fix(spawn): forward CLAUDE_CONFIG_DIR to claude crewmates (#1195)
- 556e03c fix(session-lock): resolve Claude bg-spare ancestry to the outermost claude pid (#1206)
- e72ca60 no-mistakes(review): fix CONTRIBUTING bash -n example to use /bin/bash
- 6c7555d fix(bin): make fm-brief.sh parse under stock macOS Bash 3.2

Push main to origin, or rebase your branch onto origin/main, before gating.

🔧 Fix applied.
1 warning still open:
- ⚠️ `.agents/skills/afk/SKILL.md` - branch carries 4 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (83 file(s)) into the PR:
- 6616b0d fix(spawn): forward CLAUDE_CONFIG_DIR to claude crewmates (#1195)
- 556e03c fix(session-lock): resolve Claude bg-spare ancestry to the outermost claude pid (#1206)
- e72ca60 no-mistakes(review): fix CONTRIBUTING bash -n example to use /bin/bash
- 6c7555d fix(bin): make fm-brief.sh parse under stock macOS Bash 3.2

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-watchdog-check.sh:116` - The watchdog checker arms a watcher for X-mode relay-poll homes (its `fm_supervision_needed` gate admits any home with `state/x-watch.check.sh`) but never sources `config/x-mode.env` before running the arm. The Stop auto-arm sources it (`[ -f &#34;$CONFIG/x-mode.env&#34; ] &amp;&amp; . &#34;$CONFIG/x-mode.env&#34;` in bin/fm-claude-stop-autoarm.sh:131) because it exports `FM_CHECK_INTERVAL=30`, which bin/fm-watch.sh:98 consumes (`CHECK_INTERVAL=${FM_CHECK_INTERVAL:-300}`). The arm itself does not source it. Result: when the watchdog re-arms an X-mode home during an idle gap, the forked watcher runs at the 300s default cadence instead of X-mode&#39;s 30s — a 10x relay-poll slowdown for that mode, and an inconsistency with the intent&#39;s stated &#39;foregrounds the real arm wrapper ... exactly like the hook.&#39; Fix: resolve `CONFIG=&#34;${FM_CONFIG_OVERRIDE:-$FM_HOME/config}&#34;` and add `[ -f &#34;$CONFIG/x-mode.env&#34; ] &amp;&amp; . &#34;$CONFIG/x-mode.env&#34;` immediately before invoking `$WATCH_ARM`, mirroring the hook.

🔧 Fix: source x-mode.env in watchdog checker before arming
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-watchdog-check.test.sh` (12 behavior tests: re-arm when beacon absent/old-mtime, no-op when fresh/idle/AFK/no-live-session-lock/child-worktree/single-flight-held, second-tick-doesn&#39;t-double-arm, installer+plist contract, checker never exits 2 / foreground arm)</code>
- <code>Manual end-to-end installer drive with a fake `launchctl` shim against a fixture primary home: `fm-watchdog-install.sh install|status|uninstall`; captured the stamped LaunchAgent and validated it with `plutil -lint` (OK)</code>
- <code>Gate-parity check: compared checker gate calls against bin/fm-claude-stop-autoarm.sh (same scope/need/AFK/single-flight-owner-lock `state/.claude-autoarm.lock`, same foreground `fm-watch-arm.sh`, same `x-mode.env` sourcing)</code>
- <code>Forbidden-behavior grep on the checker: no epoch-ledger write, no `exit 2`</code>
- `Doc/cross-reference verification: docs/watcher-watchdog.md present, cross-ref from watcher-continuity.md, wiring in docs/scripts.md, entry in docs/documentation-audiences.json, family mapping in bin/fm-test-run.sh, AGENTS.md intentionally untouched`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
