### PR TITLE
fix(bin): normalize relative durable paths

### DIFF
--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -58,6 +58,18 @@ case "$FM_HOME" in
     }
     ;;
 esac
+if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
+  case "$FM_STATE_OVERRIDE" in
+    /*) ;;
+    *)
+      FM_AFK_LAUNCH_STATE_INPUT=$FM_STATE_OVERRIDE
+      FM_STATE_OVERRIDE=$(cd "$FM_AFK_LAUNCH_STATE_INPUT" 2>/dev/null && pwd -P) || {
+        echo "error: FM_STATE_OVERRIDE directory cannot be resolved: $FM_AFK_LAUNCH_STATE_INPUT" >&2
+        exit 1
+      }
+      ;;
+  esac
+fi
 FM_AFK_LAUNCH_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 FM_AFK_LAUNCH_RECORD="$FM_AFK_LAUNCH_STATE/.afk-daemon-terminal"
 FM_AFK_LAUNCH_LOCK="$FM_AFK_LAUNCH_STATE/.afk-launch.lock"

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -52,7 +52,7 @@ case "$FM_HOME" in
   /*) ;;
   *)
     FM_AFK_LAUNCH_HOME_INPUT=$FM_HOME
-    FM_HOME=$(CDPATH= cd -- "$FM_AFK_LAUNCH_HOME_INPUT" 2>/dev/null && pwd -P) || {
+    FM_HOME=$(CDPATH='' cd -- "$FM_AFK_LAUNCH_HOME_INPUT" 2>/dev/null && pwd -P) || {
       echo "error: FM_HOME directory cannot be resolved: $FM_AFK_LAUNCH_HOME_INPUT" >&2
       exit 1
     }
@@ -63,7 +63,7 @@ if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
     /*) ;;
     *)
       FM_AFK_LAUNCH_STATE_INPUT=$FM_STATE_OVERRIDE
-      FM_STATE_OVERRIDE=$(CDPATH= cd -- "$FM_AFK_LAUNCH_STATE_INPUT" 2>/dev/null && pwd -P) || {
+      FM_STATE_OVERRIDE=$(CDPATH='' cd -- "$FM_AFK_LAUNCH_STATE_INPUT" 2>/dev/null && pwd -P) || {
         echo "error: FM_STATE_OVERRIDE directory cannot be resolved: $FM_AFK_LAUNCH_STATE_INPUT" >&2
         exit 1
       }

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -52,7 +52,7 @@ case "$FM_HOME" in
   /*) ;;
   *)
     FM_AFK_LAUNCH_HOME_INPUT=$FM_HOME
-    FM_HOME=$(cd "$FM_AFK_LAUNCH_HOME_INPUT" 2>/dev/null && pwd -P) || {
+    FM_HOME=$(CDPATH= cd -- "$FM_AFK_LAUNCH_HOME_INPUT" 2>/dev/null && pwd -P) || {
       echo "error: FM_HOME directory cannot be resolved: $FM_AFK_LAUNCH_HOME_INPUT" >&2
       exit 1
     }
@@ -63,7 +63,7 @@ if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
     /*) ;;
     *)
       FM_AFK_LAUNCH_STATE_INPUT=$FM_STATE_OVERRIDE
-      FM_STATE_OVERRIDE=$(cd "$FM_AFK_LAUNCH_STATE_INPUT" 2>/dev/null && pwd -P) || {
+      FM_STATE_OVERRIDE=$(CDPATH= cd -- "$FM_AFK_LAUNCH_STATE_INPUT" 2>/dev/null && pwd -P) || {
         echo "error: FM_STATE_OVERRIDE directory cannot be resolved: $FM_AFK_LAUNCH_STATE_INPUT" >&2
         exit 1
       }

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -48,6 +48,16 @@ set -u
 FM_AFK_LAUNCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_AFK_LAUNCH_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+case "$FM_HOME" in
+  /*) ;;
+  *)
+    FM_AFK_LAUNCH_HOME_INPUT=$FM_HOME
+    FM_HOME=$(cd "$FM_AFK_LAUNCH_HOME_INPUT" 2>/dev/null && pwd -P) || {
+      echo "error: FM_HOME directory cannot be resolved: $FM_AFK_LAUNCH_HOME_INPUT" >&2
+      exit 1
+    }
+    ;;
+esac
 FM_AFK_LAUNCH_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 FM_AFK_LAUNCH_RECORD="$FM_AFK_LAUNCH_STATE/.afk-daemon-terminal"
 FM_AFK_LAUNCH_LOCK="$FM_AFK_LAUNCH_STATE/.afk-launch.lock"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -686,7 +686,7 @@ x_mode_setup() {
   case "$FM_HOME" in
     /*) shim_home=$FM_HOME ;;
     *)
-      shim_home=$(cd "$FM_HOME" 2>/dev/null && pwd -P) \
+      shim_home=$(CDPATH= cd -- "$FM_HOME" 2>/dev/null && pwd -P) \
         || { fmx_arm_failed; return 0; }
       ;;
   esac

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -686,7 +686,7 @@ x_mode_setup() {
   case "$FM_HOME" in
     /*) shim_home=$FM_HOME ;;
     *)
-      shim_home=$(CDPATH= cd -- "$FM_HOME" 2>/dev/null && pwd -P) \
+      shim_home=$(CDPATH='' cd -- "$FM_HOME" 2>/dev/null && pwd -P) \
         || { fmx_arm_failed; return 0; }
       ;;
   esac

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -620,7 +620,7 @@ x_mode_remove_artifact() {
 # applying a cadence transition to a running watcher is the caller's job via
 # the emitted harness-aware supervision repair instruction.
 x_mode_setup() {
-  local env_file token shim cadence shim_body cadence_body tool missing
+  local env_file token shim cadence shim_body cadence_body tool missing shim_home
   env_file="$FM_HOME/.env"
   shim="$STATE/x-watch.check.sh"
   cadence="$CONFIG/x-mode.env"
@@ -683,9 +683,16 @@ x_mode_setup() {
 
   mkdir -p "$STATE" "$CONFIG" 2>/dev/null || { fmx_arm_failed; return 0; }
 
-  shim_body=$(fmx_poll_shim_content "$FM_HOME" "$FM_ROOT")
+  case "$FM_HOME" in
+    /*) shim_home=$FM_HOME ;;
+    *)
+      shim_home=$(cd "$FM_HOME" 2>/dev/null && pwd -P) \
+        || { fmx_arm_failed; return 0; }
+      ;;
+  esac
+  shim_body=$(fmx_poll_shim_content "$shim_home" "$FM_ROOT")
   x_mode_write_if_changed "$shim" "$shim_body" 700 || { fmx_arm_failed; return 0; }
-  fmx_poll_shim_valid "$shim" "$FM_HOME" "$FM_ROOT" \
+  fmx_poll_shim_valid "$shim" "$shim_home" "$FM_ROOT" \
     || { fmx_arm_failed; return 0; }
 
   cadence_body=$(cat <<'EOF'

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -66,10 +66,31 @@ esac
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
+
+resolve_directory_input() {
+  local name=$1 path=$2 resolved
+  case "$path" in
+    /*) printf '%s\n' "$path"; return 0 ;;
+  esac
+  resolved=$(cd "$path" 2>/dev/null && pwd -P) || {
+    echo "error: $name directory cannot be resolved: $path" >&2
+    return 1
+  }
+  printf '%s\n' "$resolved"
+}
+
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
-FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
-DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
-STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+FM_HOME=$(resolve_directory_input FM_HOME "${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}") || exit 1
+if [ -n "${FM_DATA_OVERRIDE:-}" ]; then
+  DATA=$(resolve_directory_input FM_DATA_OVERRIDE "$FM_DATA_OVERRIDE") || exit 1
+else
+  DATA="$FM_HOME/data"
+fi
+if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
+  STATE=$(resolve_directory_input FM_STATE_OVERRIDE "$FM_STATE_OVERRIDE") || exit 1
+else
+  STATE="$FM_HOME/state"
+fi
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -72,7 +72,7 @@ resolve_directory_input() {
   case "$path" in
     /*) printf '%s\n' "$path"; return 0 ;;
   esac
-  resolved=$(cd "$path" 2>/dev/null && pwd -P) || {
+  resolved=$(CDPATH= cd -- "$path" 2>/dev/null && pwd -P) || {
     echo "error: $name directory cannot be resolved: $path" >&2
     return 1
   }

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -72,7 +72,7 @@ resolve_directory_input() {
   case "$path" in
     /*) printf '%s\n' "$path"; return 0 ;;
   esac
-  resolved=$(CDPATH= cd -- "$path" 2>/dev/null && pwd -P) || {
+  resolved=$(CDPATH='' cd -- "$path" 2>/dev/null && pwd -P) || {
     echo "error: $name directory cannot be resolved: $path" >&2
     return 1
   }

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -48,7 +48,7 @@ detect_own() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
-    case "$(basename "$comm")" in
+    case "$(basename -- "$comm")" in
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -31,7 +31,7 @@ fm_harness_ancestry_pid() {
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
-    bc=$(basename "$comm")
+    bc=$(basename -- "$comm")
     hit=0; is_claude=0
     if printf '%s' "$bc" | grep -qE "$FM_HARNESS_RE"; then
       hit=1
@@ -69,7 +69,7 @@ fm_harness_pid_alive() {
   local pid=$1 comm args
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  if printf '%s' "$(basename "$comm")" | grep -qE "$FM_HARNESS_RE"; then
+  if printf '%s' "$(basename -- "$comm")" | grep -qE "$FM_HARNESS_RE"; then
     return 0
   fi
   case "$comm" in

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -130,7 +130,7 @@ resolve_directory_input() {
   case "$path" in
     /*) printf '%s\n' "$path"; return 0 ;;
   esac
-  resolved=$(CDPATH= cd -- "$path" 2>/dev/null && pwd -P) || {
+  resolved=$(CDPATH='' cd -- "$path" 2>/dev/null && pwd -P) || {
     echo "error: $name directory cannot be resolved: $path" >&2
     return 1
   }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -124,6 +124,25 @@ esac
 
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+resolve_directory_input() {
+  local name=$1 path=$2 resolved
+  case "$path" in
+    /*) printf '%s\n' "$path"; return 0 ;;
+  esac
+  resolved=$(cd "$path" 2>/dev/null && pwd -P) || {
+    echo "error: $name directory cannot be resolved: $path" >&2
+    return 1
+  }
+  printf '%s\n' "$resolved"
+}
+
+if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
+  FM_STATE_OVERRIDE=$(resolve_directory_input FM_STATE_OVERRIDE "$FM_STATE_OVERRIDE") || exit 1
+fi
+if [ -n "${FM_DATA_OVERRIDE:-}" ]; then
+  FM_DATA_OVERRIDE=$(resolve_directory_input FM_DATA_OVERRIDE "$FM_DATA_OVERRIDE") || exit 1
+fi
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
@@ -1475,9 +1494,9 @@ META_WINDOW=$T
 } > "$STATE/$ID.meta"
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
-sq_brief=$(shell_quote "$BRIEF_REAL")
+sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
-sq_piext=$(shell_quote "$STATE_REAL/$ID.pi-ext.ts")
+sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1475,9 +1475,9 @@ META_WINDOW=$T
 } > "$STATE/$ID.meta"
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
-sq_brief=$(shell_quote "$BRIEF")
+sq_brief=$(shell_quote "$BRIEF_REAL")
 sq_turnend=$(shell_quote "$TURNEND")
-sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
+sq_piext=$(shell_quote "$STATE_REAL/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -130,7 +130,7 @@ resolve_directory_input() {
   case "$path" in
     /*) printf '%s\n' "$path"; return 0 ;;
   esac
-  resolved=$(cd "$path" 2>/dev/null && pwd -P) || {
+  resolved=$(CDPATH= cd -- "$path" 2>/dev/null && pwd -P) || {
     echo "error: $name directory cannot be resolved: $path" >&2
     return 1
   }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -137,6 +137,7 @@ resolve_directory_input() {
   printf '%s\n' "$resolved"
 }
 
+FM_HOME=$(resolve_directory_input FM_HOME "$FM_HOME") || exit 1
 if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
   FM_STATE_OVERRIDE=$(resolve_directory_input FM_STATE_OVERRIDE "$FM_STATE_OVERRIDE") || exit 1
 fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,6 +169,8 @@ When it is unset, most scripts use the repo root as the home; when it is set, sc
 When `FM_HOME` is unset, it also behaves as the old whole-root override.
 `bin/fm-send.sh` is intentionally stricter than that general fallback: it requires `FM_HOME` to be set before resolving a target, so operator steers cannot silently resolve against the wrong home.
 `FM_STATE_OVERRIDE`, `FM_DATA_OVERRIDE`, `FM_PROJECTS_OVERRIDE`, and `FM_CONFIG_OVERRIDE` override individual operational directories for tests and specialized harness setup.
+Before `fm-brief.sh`, `fm-spawn.sh`, or `fm-afk-launch.sh` persists a path or passes it to another process, it resolves each applicable relative `FM_HOME`, `FM_STATE_OVERRIDE`, or `FM_DATA_OVERRIDE` directory against the caller's working directory, preserves absolute spellings unchanged, and rejects an unresolvable relative directory with the offending variable named.
+Bootstrap applies the same relative `FM_HOME` resolution only when embedding that home in the generated X-mode poll shim; other transient consumers retain their existing shell-relative behavior.
 For the herdr backend, `FM_HOME` also determines the workspace label used by the adapter.
 For the zellij backend, `FM_HOME` does not split containers, but it determines the readable home prefix embedded in visible tab titles; use `FM_ZELLIJ_SESSION` when a separate zellij session is needed.
 The full zellij home label also includes a short hash of the resolved `FM_ROOT` path.

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -73,16 +73,16 @@ unit_clear_stale() {
 unit_relative_paths_are_absolute_before_daemon_launch() {
   local root home state out status linked_home
   root=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-relative-home.XXXXXX")
-  mkdir -p "$root/home/state"
+  mkdir -p "$root/home/state" "$root/cdpath/home/state"
   home=$(cd "$root/home" && pwd -P)
   state="$home/state"
   out=$(
     cd "$root" || exit 1
-    FM_HOME=home FM_STATE_OVERRIDE=home/state \
+    CDPATH="$root/cdpath" FM_HOME=home FM_STATE_OVERRIDE=home/state \
       bash -c '. "$1"; printf "%s\n%s\n" "$FM_HOME" "$FM_AFK_LAUNCH_STATE"' _ "$LAUNCH"
   )
   if [ "$out" = "$home"$'\n'"$state" ]; then
-    pass "launcher paths: relative home and state are absolute before daemon command construction"
+    pass "launcher paths: relative home and state ignore CDPATH before daemon command construction"
   else
     fail "launcher paths: relative home or state remained cwd-dependent ($out)"
   fi

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -70,19 +70,30 @@ unit_clear_stale() {
   rm -rf "$st"
 }
 
-unit_relative_home_is_absolute_before_daemon_launch() {
-  local root home out status
+unit_relative_paths_are_absolute_before_daemon_launch() {
+  local root home state out status linked_home
   root=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-relative-home.XXXXXX")
-  mkdir -p "$root/home"
+  mkdir -p "$root/home/state"
   home=$(cd "$root/home" && pwd -P)
+  state="$home/state"
   out=$(
     cd "$root" || exit 1
-    FM_HOME=home bash -c '. "$1"; printf "%s\n" "$FM_HOME"' _ "$LAUNCH"
+    FM_HOME=home FM_STATE_OVERRIDE=home/state \
+      bash -c '. "$1"; printf "%s\n%s\n" "$FM_HOME" "$FM_AFK_LAUNCH_STATE"' _ "$LAUNCH"
   )
-  if [ "$out" = "$home" ]; then
-    pass "launcher paths: relative FM_HOME is absolute before daemon command construction"
+  if [ "$out" = "$home"$'\n'"$state" ]; then
+    pass "launcher paths: relative home and state are absolute before daemon command construction"
   else
-    fail "launcher paths: relative FM_HOME remained cwd-dependent ($out)"
+    fail "launcher paths: relative home or state remained cwd-dependent ($out)"
+  fi
+  linked_home="$root/home-link"
+  ln -s "$root/home" "$linked_home"
+  out=$(FM_HOME="$linked_home" FM_STATE_OVERRIDE="$linked_home/state" \
+    bash -c '. "$1"; printf "%s\n%s\n" "$FM_HOME" "$FM_AFK_LAUNCH_STATE"' _ "$LAUNCH")
+  if [ "$out" = "$linked_home"$'\n'"$linked_home/state" ]; then
+    pass "launcher paths: absolute symlink spellings are preserved"
+  else
+    fail "launcher paths: absolute symlink spelling changed ($out)"
   fi
   out=$(
     cd "$root" || exit 1
@@ -93,6 +104,16 @@ unit_relative_home_is_absolute_before_daemon_launch() {
     pass "launcher paths: unresolved relative FM_HOME fails loudly"
   else
     fail "launcher paths: unresolved relative FM_HOME did not name the bad input ($out)"
+  fi
+  out=$(
+    cd "$root" || exit 1
+    FM_HOME=home FM_STATE_OVERRIDE=missing-state "$LAUNCH" help 2>&1
+  )
+  status=$?
+  if [ "$status" -ne 0 ] && printf '%s\n' "$out" | grep -F "FM_STATE_OVERRIDE directory cannot be resolved: missing-state" >/dev/null; then
+    pass "launcher paths: unresolved relative FM_STATE_OVERRIDE fails loudly"
+  else
+    fail "launcher paths: unresolved relative FM_STATE_OVERRIDE did not name the bad input ($out)"
   fi
   rm -rf "$root"
 }
@@ -888,7 +909,7 @@ e2e_tmux() {
 }
 
 unit_clear_stale
-unit_relative_home_is_absolute_before_daemon_launch
+unit_relative_paths_are_absolute_before_daemon_launch
 unit_fresh_vs_refresh
 unit_stop_ordering
 unit_stop_rejects_reused_pid

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -70,6 +70,33 @@ unit_clear_stale() {
   rm -rf "$st"
 }
 
+unit_relative_home_is_absolute_before_daemon_launch() {
+  local root home out status
+  root=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-relative-home.XXXXXX")
+  mkdir -p "$root/home"
+  home=$(cd "$root/home" && pwd -P)
+  out=$(
+    cd "$root" || exit 1
+    FM_HOME=home bash -c '. "$1"; printf "%s\n" "$FM_HOME"' _ "$LAUNCH"
+  )
+  if [ "$out" = "$home" ]; then
+    pass "launcher paths: relative FM_HOME is absolute before daemon command construction"
+  else
+    fail "launcher paths: relative FM_HOME remained cwd-dependent ($out)"
+  fi
+  out=$(
+    cd "$root" || exit 1
+    FM_HOME=missing-home "$LAUNCH" help 2>&1
+  )
+  status=$?
+  if [ "$status" -ne 0 ] && printf '%s\n' "$out" | grep -F "FM_HOME directory cannot be resolved: missing-home" >/dev/null; then
+    pass "launcher paths: unresolved relative FM_HOME fails loudly"
+  else
+    fail "launcher paths: unresolved relative FM_HOME did not name the bad input ($out)"
+  fi
+  rm -rf "$root"
+}
+
 # ---------------------------------------------------------------------------
 # UNIT 2: a FRESH entry clears; a REFRESH (daemon already alive) preserves the
 # current session's buffered escalations.
@@ -861,6 +888,7 @@ e2e_tmux() {
 }
 
 unit_clear_stale
+unit_relative_home_is_absolute_before_daemon_launch
 unit_fresh_vs_refresh
 unit_stop_ordering
 unit_stop_rejects_reused_pid

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -444,7 +444,9 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
   home="$root/home"
   data_override="$root/data-override"
   state_override="$root/state-override"
-  mkdir -p "$home/data" "$home/state" "$data_override" "$state_override"
+  mkdir -p "$home/data" "$home/state" "$data_override" "$state_override" \
+    "$root/cdpath/home/data" "$root/cdpath/home/state" \
+    "$root/cdpath/data-override" "$root/cdpath/state-override"
 
   brief="$home/data/relative-home/brief.md"
   FM_HOME="$home" FM_SECONDMATE_CHARTER=x \
@@ -454,7 +456,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
   rm -f "$brief"
   (
     cd "$root" || exit 1
-    FM_HOME=home FM_SECONDMATE_CHARTER=x \
+    CDPATH="$root/cdpath" FM_HOME=home FM_SECONDMATE_CHARTER=x \
       "$ROOT/bin/fm-brief.sh" relative-home --secondmate --no-projects >/dev/null 2>&1
   )
   cmp -s "$baseline" "$brief" \
@@ -470,7 +472,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
   rm -f "$brief"
   (
     cd "$root" || exit 1
-    FM_HOME="$home" FM_STATE_OVERRIDE=state-override FM_SECONDMATE_CHARTER=x \
+    CDPATH="$root/cdpath" FM_HOME="$home" FM_STATE_OVERRIDE=state-override FM_SECONDMATE_CHARTER=x \
       "$ROOT/bin/fm-brief.sh" relative-state --secondmate --no-projects >/dev/null 2>&1
   )
   cmp -s "$baseline" "$brief" \
@@ -486,7 +488,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
   rm -f "$brief"
   (
     cd "$root" || exit 1
-    FM_HOME="$home" FM_DATA_OVERRIDE=data-override FM_SECONDMATE_CHARTER=x \
+    CDPATH="$root/cdpath" FM_HOME="$home" FM_DATA_OVERRIDE=data-override FM_SECONDMATE_CHARTER=x \
       "$ROOT/bin/fm-brief.sh" relative-data --secondmate --no-projects >/dev/null 2>&1
   )
   cmp -s "$baseline" "$brief" \
@@ -522,7 +524,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
   assert_grep "FM_DATA_OVERRIDE directory cannot be resolved: missing-data" "$err" \
     "unresolved relative FM_DATA_OVERRIDE did not fail loudly"
 
-  pass "fm-brief.sh: relative directory inputs render stable absolute charter paths or fail loudly"
+  pass "fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly"
 }
 
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates() {

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -436,6 +436,95 @@ test_secondmate_marked_request_reporting_contract() {
   pass "fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting"
 }
 
+test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
+  local root home data_override state_override brief baseline err status
+  root="$TMP_ROOT/relative-directory-inputs"
+  mkdir -p "$root"
+  root=$(cd "$root" && pwd -P)
+  home="$root/home"
+  data_override="$root/data-override"
+  state_override="$root/state-override"
+  mkdir -p "$home/data" "$home/state" "$data_override" "$state_override"
+
+  brief="$home/data/relative-home/brief.md"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER=x \
+    "$ROOT/bin/fm-brief.sh" relative-home --secondmate --no-projects >/dev/null 2>&1
+  baseline="$root/absolute-home-charter"
+  cp "$brief" "$baseline"
+  rm -f "$brief"
+  (
+    cd "$root" || exit 1
+    FM_HOME=home FM_SECONDMATE_CHARTER=x \
+      "$ROOT/bin/fm-brief.sh" relative-home --secondmate --no-projects >/dev/null 2>&1
+  )
+  cmp -s "$baseline" "$brief" \
+    || fail "relative FM_HOME changed charter bytes compared with the same absolute home"
+  assert_grep ">> '$home/state/relative-home.status'" "$brief" \
+    "relative FM_HOME did not render an absolute secondmate status path"
+
+  brief="$home/data/relative-state/brief.md"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$state_override" FM_SECONDMATE_CHARTER=x \
+    "$ROOT/bin/fm-brief.sh" relative-state --secondmate --no-projects >/dev/null 2>&1
+  baseline="$root/absolute-state-charter"
+  cp "$brief" "$baseline"
+  rm -f "$brief"
+  (
+    cd "$root" || exit 1
+    FM_HOME="$home" FM_STATE_OVERRIDE=state-override FM_SECONDMATE_CHARTER=x \
+      "$ROOT/bin/fm-brief.sh" relative-state --secondmate --no-projects >/dev/null 2>&1
+  )
+  cmp -s "$baseline" "$brief" \
+    || fail "relative FM_STATE_OVERRIDE changed charter bytes compared with the same absolute state directory"
+  assert_grep ">> '$state_override/relative-state.status'" "$brief" \
+    "relative FM_STATE_OVERRIDE did not render an absolute secondmate status path"
+
+  brief="$data_override/relative-data/brief.md"
+  FM_HOME="$home" FM_DATA_OVERRIDE="$data_override" FM_SECONDMATE_CHARTER=x \
+    "$ROOT/bin/fm-brief.sh" relative-data --secondmate --no-projects >/dev/null 2>&1
+  baseline="$root/absolute-data-charter"
+  cp "$brief" "$baseline"
+  rm -f "$brief"
+  (
+    cd "$root" || exit 1
+    FM_HOME="$home" FM_DATA_OVERRIDE=data-override FM_SECONDMATE_CHARTER=x \
+      "$ROOT/bin/fm-brief.sh" relative-data --secondmate --no-projects >/dev/null 2>&1
+  )
+  cmp -s "$baseline" "$brief" \
+    || fail "relative FM_DATA_OVERRIDE changed charter bytes compared with the same absolute data directory"
+  assert_grep ">> '$home/state/relative-data.status'" "$brief" \
+    "relative FM_DATA_OVERRIDE changed the absolute default status path"
+
+  err="$root/unresolved.err"
+  (
+    cd "$root" || exit 1
+    FM_HOME=missing-home FM_SECONDMATE_CHARTER=x \
+      "$ROOT/bin/fm-brief.sh" unresolved-home --secondmate --no-projects >/dev/null 2>"$err"
+  ); status=$?
+  expect_code 1 "$status" "an unresolved relative FM_HOME must fail"
+  assert_grep "FM_HOME directory cannot be resolved: missing-home" "$err" \
+    "unresolved relative FM_HOME did not fail loudly"
+
+  (
+    cd "$root" || exit 1
+    FM_HOME="$home" FM_STATE_OVERRIDE=missing-state FM_SECONDMATE_CHARTER=x \
+      "$ROOT/bin/fm-brief.sh" unresolved-state --secondmate --no-projects >/dev/null 2>"$err"
+  ); status=$?
+  expect_code 1 "$status" "an unresolved relative FM_STATE_OVERRIDE must fail"
+  assert_grep "FM_STATE_OVERRIDE directory cannot be resolved: missing-state" "$err" \
+    "unresolved relative FM_STATE_OVERRIDE did not fail loudly"
+
+  (
+    cd "$root" || exit 1
+    FM_HOME="$home" FM_DATA_OVERRIDE=missing-data FM_SECONDMATE_CHARTER=x \
+      "$ROOT/bin/fm-brief.sh" unresolved-data --secondmate --no-projects >/dev/null 2>"$err"
+  ); status=$?
+  expect_code 1 "$status" "an unresolved relative FM_DATA_OVERRIDE must fail"
+  assert_grep "FM_DATA_OVERRIDE directory cannot be resolved: missing-data" "$err" \
+    "unresolved relative FM_DATA_OVERRIDE did not fail loudly"
+
+  pass "fm-brief.sh: relative directory inputs render stable absolute charter paths or fail loudly"
+}
+
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates() {
   local home brief status=0
   home="$TMP_ROOT/herdr-kind-home"
@@ -540,6 +629,7 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates
 test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract
+test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -188,6 +188,57 @@ SH
   pass "pi-signed identity: authoritative launch selection distinguishes shared wrapper ancestry"
 }
 
+test_dash_leading_process_names_are_basename_operands() {
+  local dir fakebin got err status
+  dir="$TMP_ROOT/dash-leading-process-names"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  4242:comm=) printf '%s\n' '/opt/test/bin/codex' ;;
+  4242:args=) printf '%s\n' 'codex' ;;
+  4242:ppid=) printf '%s\n' 1 ;;
+  5252:comm=) printf '%s\n' '-codex' ;;
+  5252:args=) printf '%s\n' '-codex' ;;
+  5252:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' '-zsh' ;;
+  *:args=) printf '%s\n' '-zsh' ;;
+  *:ppid=) printf '%s\n' 4242 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  err="$dir/fm-harness.err"
+  got=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh" 2>"$err")
+  [ "$got" = codex ] || fail "dash-leading shell ancestry resolved '$got', expected codex"
+  [ ! -s "$err" ] || fail "fm-harness wrote basename option noise for literal -zsh: $(cat "$err")"
+
+  err="$dir/fm-session-lock-ancestry.err"
+  got=$(PATH="$fakebin:$BASE_PATH" bash -c \
+    '. "$0/bin/fm-session-lock-lib.sh"; fm_harness_ancestry_pid' "$ROOT" 2>"$err")
+  [ "$got" = 4242 ] || fail "session-lock dash-leading ancestry selected '$got', expected pid 4242"
+  [ ! -s "$err" ] || fail "session-lock ancestry wrote basename option noise for literal -zsh: $(cat "$err")"
+
+  err="$dir/fm-session-lock-alive.err"
+  PATH="$fakebin:$BASE_PATH" bash -c \
+    '. "$0/bin/fm-session-lock-lib.sh"; kill() { return 0; }; fm_harness_pid_alive 5252' \
+    "$ROOT" 2>"$err"; status=$?
+  expect_code 0 "$status" "session-lock liveness should accept literal -codex as a harness process name"
+  [ ! -s "$err" ] || fail "session-lock liveness wrote basename option noise for literal -codex: $(cat "$err")"
+
+  pass "harness identity: dash-leading ps command names are basename operands, not options"
+}
+
 # ===========================================================================
 # B) propagate_inheritable_config unit behavior
 # ===========================================================================
@@ -2246,6 +2297,7 @@ SH
 test_harness_resolution
 test_secondmate_model_effort_tokens
 test_pi_signed_detection_and_session_lock_identity
+test_dash_leading_process_names_are_basename_operands
 test_propagate_lib
 test_spawn_split_and_inherit
 test_spawn_backward_compat_crew_fallback

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -156,6 +156,55 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
   pass "relative home overrides become absolute before spawn launch construction"
 }
 
+test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
+  local rec relative_id absolute_id out status launch home_real linked_home
+  relative_id=profile-relative-home-defaults-z1c
+  absolute_id=profile-absolute-home-defaults-z1d
+  rec=$(make_spawn_case profile-home-defaults pi "$relative_id" "$absolute_id")
+  read_case_record "$rec"
+  home_real=$(cd "$HOME_DIR" && pwd -P)
+
+  : > "$LAUNCH_LOG"
+  out=$(
+    cd "$CASE_DIR" || exit 1
+    FM_ROOT_OVERRIDE='' FM_HOME=home \
+      FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
+      FM_PROJECTS_OVERRIDE=home/projects FM_CONFIG_OVERRIDE=home/config \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+      CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
+      GROK_HOME=home/grok-home PATH="$FAKEBIN_DIR:$PATH" \
+      "$SPAWN" "$relative_id" "$PROJ_DIR" 2>&1
+  )
+  status=$?
+  expect_code 0 "$status" "spawn with relative FM_HOME defaults should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "-e '$home_real/state/$relative_id.pi-ext.ts'" \
+    "relative FM_HOME leaked into Pi's default cross-process extension path"
+  assert_contains "$launch" "< '$home_real/data/$relative_id/brief.md'" \
+    "relative FM_HOME leaked into the default cross-process brief path"
+
+  linked_home="$CASE_DIR/home-link"
+  ln -s "$HOME_DIR" "$linked_home"
+  : > "$LAUNCH_LOG"
+  out=$(
+    FM_ROOT_OVERRIDE='' FM_HOME="$linked_home" \
+      FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
+      FM_PROJECTS_OVERRIDE="$linked_home/projects" FM_CONFIG_OVERRIDE="$linked_home/config" \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+      CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
+      GROK_HOME="$linked_home/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
+      "$SPAWN" "$absolute_id" "$PROJ_DIR" 2>&1
+  )
+  status=$?
+  expect_code 0 "$status" "spawn with absolute symlink-spelled FM_HOME defaults should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "-e '$linked_home/state/$absolute_id.pi-ext.ts'" \
+    "absolute FM_HOME spelling changed in Pi's default cross-process extension path"
+  assert_contains "$launch" "< '$linked_home/data/$absolute_id/brief.md'" \
+    "absolute FM_HOME spelling changed in the default cross-process brief path"
+  pass "FM_HOME defaults resolve relative paths and preserve absolute spellings"
+}
+
 test_absolute_override_spelling_is_preserved_in_launch_paths() {
   local rec id out status launch linked_home
   id=profile-absolute-paths-z1c
@@ -189,6 +238,17 @@ test_unresolvable_relative_overrides_fail_loudly() {
   id=profile-unresolvable-paths-z1d
   rec=$(make_spawn_case profile-unresolvable-paths pi "$id")
   read_case_record "$rec"
+
+  out=$(
+    cd "$CASE_DIR" || exit 1
+    FM_ROOT_OVERRIDE='' FM_HOME=missing-home \
+      FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
+      "$SPAWN" "$id" "$PROJ_DIR" 2>&1
+  )
+  status=$?
+  expect_code 1 "$status" "spawn with an unresolvable relative home should fail"
+  assert_contains "$out" "FM_HOME directory cannot be resolved: missing-home" \
+    "spawn did not name the unresolvable FM_HOME"
 
   out=$(
     cd "$CASE_DIR" || exit 1
@@ -596,6 +656,7 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
 
 test_no_profile_keeps_claude_profile_defaults
 test_relative_home_overrides_launch_with_absolute_cross_process_paths
+test_home_defaults_preserve_absolute_or_resolve_relative_paths
 test_absolute_override_spelling_is_preserved_in_launch_paths
 test_unresolvable_relative_overrides_fail_loudly
 test_active_dispatch_profile_requires_explicit_harness_for_ship

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -134,11 +134,12 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
   rec=$(make_spawn_case profile-relative-paths pi "$id")
   read_case_record "$rec"
   home_real=$(cd "$HOME_DIR" && pwd -P)
+  mkdir -p "$CASE_DIR/cdpath/home/state" "$CASE_DIR/cdpath/home/data"
   : > "$LAUNCH_LOG"
 
   out=$(
     cd "$CASE_DIR" || exit 1
-    FM_ROOT_OVERRIDE='' FM_HOME=home \
+    CDPATH="$CASE_DIR/cdpath" FM_ROOT_OVERRIDE='' FM_HOME=home \
       FM_STATE_OVERRIDE=home/state FM_DATA_OVERRIDE=home/data \
       FM_PROJECTS_OVERRIDE=home/projects FM_CONFIG_OVERRIDE=home/config \
       FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
@@ -153,7 +154,7 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
     "relative FM_STATE_OVERRIDE leaked into Pi's cross-process extension path"
   assert_contains "$launch" "< '$home_real/data/$id/brief.md'" \
     "relative FM_DATA_OVERRIDE leaked into the cross-process brief path"
-  pass "relative home overrides become absolute before spawn launch construction"
+  pass "relative home overrides ignore CDPATH and become absolute before spawn launch construction"
 }
 
 test_home_defaults_preserve_absolute_or_resolve_relative_paths() {

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -111,11 +111,10 @@ assert_meta_profile() {
 }
 
 test_no_profile_keeps_claude_profile_defaults() {
-  local rec id out status expected launch home_real
+  local rec id out status expected launch
   id=profile-off-z1
   rec=$(make_spawn_case profile-off claude "$id")
   read_case_record "$rec"
-  home_real=$(cd "$HOME_DIR" && pwd -P)
 
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
   status=$?
@@ -124,7 +123,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$home_real/data/$id/brief.md')\""
+  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -155,6 +154,64 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
   assert_contains "$launch" "< '$home_real/data/$id/brief.md'" \
     "relative FM_DATA_OVERRIDE leaked into the cross-process brief path"
   pass "relative home overrides become absolute before spawn launch construction"
+}
+
+test_absolute_override_spelling_is_preserved_in_launch_paths() {
+  local rec id out status launch linked_home
+  id=profile-absolute-paths-z1c
+  rec=$(make_spawn_case profile-absolute-paths pi "$id")
+  read_case_record "$rec"
+  linked_home="$CASE_DIR/home-link"
+  ln -s "$HOME_DIR" "$linked_home"
+  : > "$LAUNCH_LOG"
+
+  out=$(
+    FM_ROOT_OVERRIDE='' FM_HOME="$linked_home" \
+      FM_STATE_OVERRIDE="$linked_home/state" FM_DATA_OVERRIDE="$linked_home/data" \
+      FM_PROJECTS_OVERRIDE="$linked_home/projects" FM_CONFIG_OVERRIDE="$linked_home/config" \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+      CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
+      GROK_HOME="$linked_home/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
+      "$SPAWN" "$id" "$PROJ_DIR" 2>&1
+  )
+  status=$?
+  expect_code 0 "$status" "spawn with absolute symlink-spelled overrides should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "-e '$linked_home/state/$id.pi-ext.ts'" \
+    "absolute FM_STATE_OVERRIDE spelling changed in Pi's cross-process extension path"
+  assert_contains "$launch" "< '$linked_home/data/$id/brief.md'" \
+    "absolute FM_DATA_OVERRIDE spelling changed in the cross-process brief path"
+  pass "absolute override spellings are preserved in spawn launch paths"
+}
+
+test_unresolvable_relative_overrides_fail_loudly() {
+  local rec id out status
+  id=profile-unresolvable-paths-z1d
+  rec=$(make_spawn_case profile-unresolvable-paths pi "$id")
+  read_case_record "$rec"
+
+  out=$(
+    cd "$CASE_DIR" || exit 1
+    FM_ROOT_OVERRIDE='' FM_HOME=home \
+      FM_STATE_OVERRIDE=missing-state FM_DATA_OVERRIDE=home/data \
+      "$SPAWN" "$id" "$PROJ_DIR" 2>&1
+  )
+  status=$?
+  expect_code 1 "$status" "spawn with an unresolvable relative state override should fail"
+  assert_contains "$out" "FM_STATE_OVERRIDE directory cannot be resolved: missing-state" \
+    "spawn did not name the unresolvable FM_STATE_OVERRIDE"
+
+  out=$(
+    cd "$CASE_DIR" || exit 1
+    FM_ROOT_OVERRIDE='' FM_HOME=home \
+      FM_STATE_OVERRIDE=home/state FM_DATA_OVERRIDE=missing-data \
+      "$SPAWN" "$id" "$PROJ_DIR" 2>&1
+  )
+  status=$?
+  expect_code 1 "$status" "spawn with an unresolvable relative data override should fail"
+  assert_contains "$out" "FM_DATA_OVERRIDE directory cannot be resolved: missing-data" \
+    "spawn did not name the unresolvable FM_DATA_OVERRIDE"
+  pass "unresolvable relative spawn overrides fail with named diagnostics"
 }
 
 test_active_dispatch_profile_requires_explicit_harness_for_ship() {
@@ -539,6 +596,8 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
 
 test_no_profile_keeps_claude_profile_defaults
 test_relative_home_overrides_launch_with_absolute_cross_process_paths
+test_absolute_override_spelling_is_preserved_in_launch_paths
+test_unresolvable_relative_overrides_fail_loudly
 test_active_dispatch_profile_requires_explicit_harness_for_ship
 test_active_dispatch_profile_requires_explicit_harness_for_scout
 test_active_dispatch_profile_allows_explicit_harness

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -111,10 +111,11 @@ assert_meta_profile() {
 }
 
 test_no_profile_keeps_claude_profile_defaults() {
-  local rec id out status expected launch
+  local rec id out status expected launch home_real
   id=profile-off-z1
   rec=$(make_spawn_case profile-off claude "$id")
   read_case_record "$rec"
+  home_real=$(cd "$HOME_DIR" && pwd -P)
 
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
   status=$?
@@ -123,9 +124,37 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$home_real/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
+}
+
+test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
+  local rec id out status launch home_real
+  id=profile-relative-paths-z1b
+  rec=$(make_spawn_case profile-relative-paths pi "$id")
+  read_case_record "$rec"
+  home_real=$(cd "$HOME_DIR" && pwd -P)
+  : > "$LAUNCH_LOG"
+
+  out=$(
+    cd "$CASE_DIR" || exit 1
+    FM_ROOT_OVERRIDE='' FM_HOME=home \
+      FM_STATE_OVERRIDE=home/state FM_DATA_OVERRIDE=home/data \
+      FM_PROJECTS_OVERRIDE=home/projects FM_CONFIG_OVERRIDE=home/config \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+      CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
+      GROK_HOME=home/grok-home PATH="$FAKEBIN_DIR:$PATH" \
+      "$SPAWN" "$id" "$PROJ_DIR" 2>&1
+  )
+  status=$?
+  expect_code 0 "$status" "spawn with relative home overrides should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "-e '$home_real/state/$id.pi-ext.ts'" \
+    "relative FM_STATE_OVERRIDE leaked into Pi's cross-process extension path"
+  assert_contains "$launch" "< '$home_real/data/$id/brief.md'" \
+    "relative FM_DATA_OVERRIDE leaked into the cross-process brief path"
+  pass "relative home overrides become absolute before spawn launch construction"
 }
 
 test_active_dispatch_profile_requires_explicit_harness_for_ship() {
@@ -509,6 +538,7 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
 }
 
 test_no_profile_keeps_claude_profile_defaults
+test_relative_home_overrides_launch_with_absolute_cross_process_paths
 test_active_dispatch_profile_requires_explicit_harness_for_ship
 test_active_dispatch_profile_requires_explicit_harness_for_scout
 test_active_dispatch_profile_allows_explicit_harness

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -703,18 +703,18 @@ test_bootstrap_activates_on_env_token() {
 test_bootstrap_relative_home_writes_absolute_poll_shim() {
   local root home out quoted_home
   root="$TMP_ROOT/boot-relative-home"
-  mkdir -p "$root/home"
+  mkdir -p "$root/home" "$root/cdpath/home"
   home=$(cd "$root/home" && pwd -P)
   printf 'FMX_PAIRING_TOKEN=tok-relative\n' > "$home/.env"
   out=$(
     cd "$root" || exit 1
-    FM_HOME=home "$ROOT/bin/fm-bootstrap.sh" 2>/dev/null
+    CDPATH="$root/cdpath" FM_HOME=home "$ROOT/bin/fm-bootstrap.sh" 2>/dev/null
   )
   assert_contains "$out" "FMX: X mode on" "relative-home bootstrap must announce X mode"
   quoted_home=$(printf '%q' "$home")
   assert_grep "export FM_HOME=$quoted_home" "$home/state/x-watch.check.sh" \
     "relative FM_HOME leaked into the durable X-mode poll shim"
-  pass "bootstrap writes an absolute FM_HOME into the durable X-mode poll shim"
+  pass "bootstrap ignores CDPATH when writing absolute FM_HOME into the durable X-mode poll shim"
 }
 
 test_bootstrap_reports_missing_x_dependency() {

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -700,6 +700,23 @@ test_bootstrap_activates_on_env_token() {
   pass "bootstrap activates X mode from an .env token, idempotently"
 }
 
+test_bootstrap_relative_home_writes_absolute_poll_shim() {
+  local root home out quoted_home
+  root="$TMP_ROOT/boot-relative-home"
+  mkdir -p "$root/home"
+  home=$(cd "$root/home" && pwd -P)
+  printf 'FMX_PAIRING_TOKEN=tok-relative\n' > "$home/.env"
+  out=$(
+    cd "$root" || exit 1
+    FM_HOME=home "$ROOT/bin/fm-bootstrap.sh" 2>/dev/null
+  )
+  assert_contains "$out" "FMX: X mode on" "relative-home bootstrap must announce X mode"
+  quoted_home=$(printf '%q' "$home")
+  assert_grep "export FM_HOME=$quoted_home" "$home/state/x-watch.check.sh" \
+    "relative FM_HOME leaked into the durable X-mode poll shim"
+  pass "bootstrap writes an absolute FM_HOME into the durable X-mode poll shim"
+}
+
 test_bootstrap_reports_missing_x_dependency() {
   local home fakebin out tool tool_path
   home="$TMP_ROOT/boot-missing-x"; mkdir -p "$home"
@@ -2862,6 +2879,7 @@ test_followup_post_dry_run_increments_counter_keeps_link
 test_followup_post_dry_run_final_clears_link
 test_followup_usage_errors
 test_bootstrap_activates_on_env_token
+test_bootstrap_relative_home_writes_absolute_poll_shim
 test_bootstrap_reports_missing_x_dependency
 test_bootstrap_does_not_announce_when_arm_fails
 test_bootstrap_does_not_follow_x_artifact_symlinks


### PR DESCRIPTION
## Intent

Fix the relative-FM_HOME fault that can bake an unresolvable status path into a durable secondmate charter and silently hide replies. Reproduce relative FM_HOME, FM_STATE_OVERRIDE, and FM_DATA_OVERRIDE inputs; normalize relative directory inputs to absolute paths before deriving durable or cross-process paths; fail loudly with the offending variable named when an input cannot be resolved; preserve existing absolute-path output byte-for-byte and preserve charter wording, contracts, and semantics. Survey bin/ and fix only equivalent durable-path or cross-process exposures, leaving transient relative-home consumers unchanged. Preserve safety boundaries, do not rewrite live charters or live data/state, keep the diff proportionate, add regression coverage across affected scripts, and ship a PR without merging.

## What Changed

- Normalize relative `FM_HOME`, `FM_STATE_OVERRIDE`, and `FM_DATA_OVERRIDE` values before generating charters or constructing durable and cross-process paths, while preserving absolute path spellings and naming invalid inputs in errors.
- Embed an absolute home in generated X-mode poll shims without changing transient relative-home consumers.
- Document the resolution behavior and add regression coverage across brief generation, spawning, AFK launch, and X-mode bootstrap.

## Risk Assessment

✅ Low: The change is well-bounded and now closes the reviewed relative FM_HOME, FM_STATE_OVERRIDE, and FM_DATA_OVERRIDE durable/cross-process paths while preserving already-absolute path spelling and existing charter semantics.

## Testing

Inspected the exact base-to-target change, ran the four focused regression suites, and manually exercised real secondmate charter generation. Relative home/state/data inputs produced an absolute durable reply path byte-identical to equivalent physical absolute inputs; absolute spelling was preserved; every unresolvable input failed loudly naming its variable. Reviewer-visible CLI and charter evidence was captured. No screenshot applies because this is a shell-only change.

<details>
<summary>Evidence: Relative status-path CLI transcript</summary>

```text
$ fm-brief.sh with physical absolute FM_HOME/FM_STATE_OVERRIDE/FM_DATA_OVERRIDE
scaffolded: /private/var/folders/bd/ky17fvwx45353ky4s2bg8ys80000gn/T/no-mistakes-evidence/01KYQDJKBR0VDEEQR0Z626A7E3/demo2-data/route-proof-2/brief.md (secondmate charter)
$ same command from evidence root with relative directory inputs
scaffolded: /private/var/folders/bd/ky17fvwx45353ky4s2bg8ys80000gn/T/no-mistakes-evidence/01KYQDJKBR0VDEEQR0Z626A7E3/demo2-data/route-proof-2/brief.md (secondmate charter)
byte comparison: IDENTICAL
generated durable reply instruction:
36:   `echo "{state}: {one short line}" >> '/private/var/folders/bd/ky17fvwx45353ky4s2bg8ys80000gn/T/no-mistakes-evidence/01KYQDJKBR0VDEEQR0Z626A7E3/demo2-state/route-proof-2.status'`
preserved charter fields:
3:# Charter
6:# Routing scope
$ absolute symlink-spelled input remains byte-spelled /var
scaffolded: /var/folders/bd/ky17fvwx45353ky4s2bg8ys80000gn/T/no-mistakes-evidence/01KYQDJKBR0VDEEQR0Z626A7E3/demo-data/absolute-spelling/brief.md (secondmate charter)
36:   `echo "{state}: {one short line}" >> '/var/folders/bd/ky17fvwx45353ky4s2bg8ys80000gn/T/no-mistakes-evidence/01KYQDJKBR0VDEEQR0Z626A7E3/demo-state/absolute-spelling.status'`
$ bad relative FM_HOME
error: FM_HOME directory cannot be resolved: missing-home
exit: 1
$ bad relative FM_STATE_OVERRIDE
error: FM_STATE_OVERRIDE directory cannot be resolved: missing-state
exit: 1
$ bad relative FM_DATA_OVERRIDE
error: FM_DATA_OVERRIDE directory cannot be resolved: missing-data
exit: 1
```
</details>
<details>
<summary>Evidence: Generated charter from relative inputs</summary>

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
Savanti reply routing

# Routing scope
Route Savanti replies

# Project clones
None. This is a project-less domain: its subject is the firstmate repo this home lives in, so it needs no separate clones under `projects/`; its crews take pooled worktrees of that firstmate repo.

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '/private/var/folders/bd/ky17fvwx45353ky4s2bg8ys80000gn/T/no-mistakes-evidence/01KYQDJKBR0VDEEQR0Z626A7E3/demo2-state/route-proof-2.status'`
States: working, needs-decision, blocked, paused, done, failed.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
When a decision you escalated is answered or a blocker clears and your domain resumes, append `resolved: {how it was decided or unblocked}` (keyed with `[key=<slug>]` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>
<details>
<summary>Evidence: Absolute-input comparison charter</summary>

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
Savanti reply routing

# Routing scope
Route Savanti replies

# Project clones
None. This is a project-less domain: its subject is the firstmate repo this home lives in, so it needs no separate clones under `projects/`; its crews take pooled worktrees of that firstmate repo.

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '/private/var/folders/bd/ky17fvwx45353ky4s2bg8ys80000gn/T/no-mistakes-evidence/01KYQDJKBR0VDEEQR0Z626A7E3/demo2-state/route-proof-2.status'`
States: working, needs-decision, blocked, paused, done, failed.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
When a decision you escalated is answered or a blocker clears and your domain resumes, append `resolved: {how it was decided or unblocked}` (keyed with `[key=<slug>]` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-spawn.sh:1478` - The required criterion says to “preserve existing absolute-path output byte-for-byte,” but these changed substitutions use BRIEF_REAL and STATE_REAL. Those values are produced with pwd -P, so an already-absolute path containing a symlink now becomes its physical path in Claude/Pi launch commands. Preserve absolute inputs unchanged and normalize only relative FM_DATA_OVERRIDE/FM_STATE_OVERRIDE values.
- 🚨 `bin/fm-afk-launch.sh:55` - The required criterion says to normalize relative directory inputs before deriving durable or cross-process paths and to name an unresolvable variable. This block normalizes only FM_HOME; FM_STATE_OVERRIDE remains relative at line 61. With a relative override, the launcher writes its durable record under the caller&#39;s cwd, while a Herdr daemon starts under the normalized FM_HOME and inherits the same relative override, so its lock and replies resolve under a different directory. Normalize FM_STATE_OVERRIDE at this boundary and report it by name on failure.

🔧 Fix: Preserve absolute overrides and normalize relative durable paths
1 error still open:
- 🚨 `bin/fm-spawn.sh:140` - The required criteria say to reproduce relative FM_HOME and normalize relative inputs before cross-process paths, but this hunk normalizes only explicit FM_STATE_OVERRIDE and FM_DATA_OVERRIDE values. With `FM_HOME=home` and no overrides, STATE and DATA remain relative; lines 1497/1499 then embed `home/data/.../brief.md` and `home/state/...pi-ext.ts` in a launch executed from the project worktree, so the brief or Pi extension is unresolved. Normalize relative FM_HOME before deriving its default state/data paths, while preserving already-absolute spelling, and cover the no-override case.

🔧 Fix: Normalize relative home before deriving durable paths
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 99533c5d7d3702050e6084429dddff6ea4fe1aa0..588276cd97c0cb9911ddd7bf0c97108178a6b3db` and confirmed the target checkout.</code>
- `bin/fm-test-run.sh tests/fm-brief.test.sh tests/fm-spawn-dispatch-profile.test.sh tests/fm-afk-launch.test.sh tests/fm-x-mode.test.sh`
- <code>Ran `bin/fm-brief.sh route-proof-2 --secondmate --no-projects` with physical absolute inputs and again with relative `FM_HOME`, `FM_STATE_OVERRIDE`, and `FM_DATA_OVERRIDE`; compared the charter bytes using `cmp -s`.</code>
- <code>Generated a charter with absolute `/var/...` inputs and verified that exact spelling remained in the durable status instruction.</code>
- <code>Invoked `bin/fm-brief.sh` with separately unresolvable relative `FM_HOME`, `FM_STATE_OVERRIDE`, and `FM_DATA_OVERRIDE` values; captured each named diagnostic and nonzero exit.</code>
- <code>Read back the evidence transcript and charters, confirmed equal byte sizes, and verified `git status --short` remained empty.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
