### PR TITLE
fix(bin): handle dash-leading harness process names

### DIFF
--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -48,7 +48,7 @@ detect_own() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
-    case "$(basename "$comm")" in
+    case "$(basename -- "$comm")" in
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -31,7 +31,7 @@ fm_harness_ancestry_pid() {
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
-    bc=$(basename "$comm")
+    bc=$(basename -- "$comm")
     hit=0; is_claude=0
     if printf '%s' "$bc" | grep -qE "$FM_HARNESS_RE"; then
       hit=1
@@ -69,7 +69,7 @@ fm_harness_pid_alive() {
   local pid=$1 comm args
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  if printf '%s' "$(basename "$comm")" | grep -qE "$FM_HARNESS_RE"; then
+  if printf '%s' "$(basename -- "$comm")" | grep -qE "$FM_HARNESS_RE"; then
     return 0
   fi
   case "$comm" in

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -188,6 +188,56 @@ SH
   pass "pi-signed identity: authoritative launch selection distinguishes shared wrapper ancestry"
 }
 
+test_dash_leading_process_names_are_basename_operands() {
+  local dir fakebin got err status
+  dir="$TMP_ROOT/dash-leading-process-names"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  4242:comm=) printf '%s\n' '/opt/test/bin/codex' ;;
+  4242:args=) printf '%s\n' 'codex' ;;
+  4242:ppid=) printf '%s\n' 1 ;;
+  5252:comm=) printf '%s\n' '-codex' ;;
+  5252:args=) printf '%s\n' '-codex' ;;
+  5252:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' '-zsh' ;;
+  *:args=) printf '%s\n' '-zsh' ;;
+  *:ppid=) printf '%s\n' 4242 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  err="$dir/fm-harness.err"
+  got=$(PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh" 2>"$err")
+  [ "$got" = codex ] || fail "dash-leading shell ancestry resolved '$got', expected codex"
+  [ ! -s "$err" ] || fail "fm-harness wrote basename option noise for literal -zsh: $(cat "$err")"
+
+  err="$dir/fm-session-lock-ancestry.err"
+  got=$(PATH="$fakebin:$BASE_PATH" bash -c \
+    '. "$0/bin/fm-session-lock-lib.sh"; fm_harness_ancestry_pid' "$ROOT" 2>"$err")
+  [ "$got" = 4242 ] || fail "session-lock dash-leading ancestry selected '$got', expected pid 4242"
+  [ ! -s "$err" ] || fail "session-lock ancestry wrote basename option noise for literal -zsh: $(cat "$err")"
+
+  err="$dir/fm-session-lock-alive.err"
+  PATH="$fakebin:$BASE_PATH" bash -c \
+    '. "$0/bin/fm-session-lock-lib.sh"; kill() { return 0; }; fm_harness_pid_alive 5252' \
+    "$ROOT" 2>"$err"; status=$?
+  expect_code 0 "$status" "session-lock liveness should accept literal -codex as a harness process name"
+  [ ! -s "$err" ] || fail "session-lock liveness wrote basename option noise for literal -codex: $(cat "$err")"
+
+  pass "harness identity: dash-leading ps command names are basename operands, not options"
+}
+
 # ===========================================================================
 # B) propagate_inheritable_config unit behavior
 # ===========================================================================
@@ -2246,6 +2296,7 @@ SH
 test_harness_resolution
 test_secondmate_model_effort_tokens
 test_pi_signed_detection_and_session_lock_identity
+test_dash_leading_process_names_are_basename_operands
 test_propagate_lib
 test_spawn_split_and_inherit
 test_spawn_backward_compat_crew_fallback


### PR DESCRIPTION
## Intent

Fix the macOS guard-path noise caused by BSD basename treating dash-leading process command names from ps as options. On current main at 99533c5, make every equivalent ps-derived basename operand in bin/fm-harness.sh and the shared session-lock ancestry/liveness helpers use an explicit option terminator so a login-shell command name such as literal -zsh is treated as data, preserving existing harness detection semantics. Survey bin/ for comparable basename, dirname, or similar calls that can receive dash-leading values from ps, Git, or user paths; fix direct equivalents and report broader unrelated CLI-path cases rather than expanding this patch. Add a regression test that fails on the unfixed macOS code with literal -zsh-style input, keep the diff proportionate, target the pull request at main on the captain fork origin, and do not merge.

## What Changed

- Add an explicit option terminator to `basename` calls in harness detection and shared session-lock helpers so dash-leading `ps` command names are treated as operands without emitting option errors.
- Add regression coverage for harness resolution, ancestry, and liveness with literal `-zsh` and `-codex` process names.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, fixes every equivalent ps-derived basename call in the affected harness and session-lock paths, preserves detection semantics, and adds focused regression coverage for dash-leading command names.

## Testing

On Darwin, reproduced the unfixed BSD basename noise and liveness failure at base `99533c5`, passed the focused harness regression, exercised all three changed paths end-to-end at `cacd47e` with preserved detection and zero stderr, captured the transcript, and found no additional direct ps-derived equivalent in `bin/`.

<details>
<summary>Evidence: macOS dash-leading basename before/after transcript</summary>

<code>Darwin: base 99533c5 emitted `basename: illegal option` for `-zsh` and rejected `-codex` liveness. Target cacd47e detected codex ancestry/liveness with zero stderr.</code>

```text
Host: Darwin

BSD basename control
with terminator: value=-zsh stderr_bytes=0
without terminator: status=1 value=<empty> stderr=/usr/bin/basename: illegal option -- z

Target commit cacd47e
fm-harness through -zsh ancestry: result=codex stderr_bytes=0
session-lock through -zsh ancestry: pid=4242 stderr_bytes=0
session-lock liveness for literal -codex: status=0 stderr_bytes=0

Unfixed base commit 99533c5
fm-harness through -zsh ancestry: result=codex stderr=basename: illegal option -- z
session-lock through -zsh ancestry: pid=4242 stderr=basename: illegal option -- z
session-lock liveness for literal -codex: status=1 stderr=basename: illegal option -- c
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-secondmate-harness.test.sh`
- <code>`uname -s`; `/usr/bin/basename -- -zsh`; `/usr/bin/basename -zsh`</code>
- <code>Manual exported-fake-`ps` exercise of `bin/fm-harness.sh`, `fm_harness_ancestry_pid`, and `fm_harness_pid_alive` at base `99533c5` and target `cacd47e`</code>
- <code>`rg -n -C 3 &#39;\b(basename|dirname)\b&#39; bin --glob &#39;*.sh&#39; --glob &#39;*.mjs&#39;` plus ps-output call-site survey</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
