### PR TITLE
feat(bin): add read-only /learn sessions and captain-session task windows

### DIFF
--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: learn
+description: Open a read-only learning session for one active Firstmate agent. Use when the captain invokes /learn or asks to learn from, inspect, understand, or study an active agent's work without changing it.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# learn
+
+`/learn` is a read-only context exposure path, not a second task lifecycle.
+It uses the shared `bin/fm-learn.sh` core, so Claude and Pi use the same adapter seam.
+
+## Procedure
+
+1. Run `bin/fm-learn.sh list`.
+2. Present the numbered learning candidates with their id, task kind, current state, project, harness, backend, and endpoint availability.
+3. If there are no candidates, say that no active agent is available and stop.
+4. If the captain did not identify one agent, ask them to choose an id before opening context.
+5. Run `bin/fm-learn.sh start <agent-id>` for the selected candidate.
+6. Use the returned task brief, bounded status events, backlog record, and fleet snapshot to explain the selected agent's work.
+
+The command reads the authoritative fleet snapshot and task records only.
+It never reads or edits project files or the selected agent's worktree.
+It does not dispatch, steer, merge, tear down, alter the backlog, or change any task lifecycle state.
+The current learning conversation stays in the firstmate process.
+The session JSON is the seam for a future separate learner process and future Obsidian persistence, neither of which is implemented here.
+If a future learner becomes an agent, it must use the normal isolated spawn path and the primary session's one-window-per-agent behavior rather than introducing pane placement.
+
+## Adapter boundary
+
+Claude discovers this skill through `.claude/skills`, which points to `.agents/skills`.
+Pi discovers the same skill directory through its normal `.agents/skills` loading path.
+No harness-specific extension or pane command is needed for this slice.

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -29,6 +29,5 @@ If a future learner becomes an agent, it must use the normal isolated spawn path
 
 ## Adapter boundary
 
-Claude discovers this skill through `.claude/skills`, which points to `.agents/skills`.
-Pi discovers the same skill directory through its normal `.agents/skills` loading path.
 No harness-specific extension or pane command is needed for this slice.
+[`docs/learn.md`](../../../docs/learn.md) "Harness entry points" owns which harness entry paths are verified.

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learn
-description: Open a read-only learning session for one active Firstmate agent. Use when the captain invokes /learn or asks to learn from, inspect, understand, or study an active agent's work without changing it.
+description: Open a read-only learning session for one Firstmate agent record, whether the agent is still working or its task is already done or failed. Use when the captain invokes /learn or asks to learn from, inspect, understand, or study an agent's recorded work without changing it.
 user-invocable: true
 metadata:
   internal: true

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -15,7 +15,7 @@ It uses the shared `bin/fm-learn.sh` core, so Claude and Pi use the same adapter
 
 1. Run `bin/fm-learn.sh list`.
 2. Present the numbered learning candidates with their id, task kind, current state, project, harness, backend, and endpoint availability.
-3. If there are no candidates, say that no active agent is available and stop.
+3. If there are no candidates, say that no First Mate agent records are available and stop.
 4. If the captain did not identify one agent, ask them to choose an id before opening context.
 5. Run `bin/fm-learn.sh start <agent-id>` for the selected candidate.
 6. Use the returned task brief, bounded status events, backlog record, and fleet snapshot to explain the selected agent's work.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 - **A visible crew** - every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.
 - **Disposable worktrees** - each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides.
 - **Two task shapes** - ship tasks deliver authorized changes; scout tasks leave standalone investigation reports when the intake contract warrants separate research.
-- **Read-only learning sessions** - `/learn` exposes one active agent's fleet snapshot and task records without entering its worktree or changing its lifecycle; see [docs/learn.md](docs/learn.md).
+- **Read-only learning sessions** - `/learn` exposes one agent record's fleet snapshot and task records without entering its worktree or changing its lifecycle; see [docs/learn.md](docs/learn.md).
 - **Explicit project modes** - each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.
 - **Optional secondmates** - opt in to persistent second mates that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, supervising project clones or a project-less firstmate-repo domain, kept on the primary firstmate version by guarded local fast-forwards and checked for live agent processes at session start.
 - **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.
@@ -173,7 +173,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
 | `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, falling back to Bearings when invoked as the session's first real captain message |
 | `/bearings`        | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
-| `/learn`           | Open a read-only learning session for one active agent from the authoritative fleet snapshot and bounded task records; no learner process, project-file read, or persistence is created in this slice |
+| `/learn`           | Open a read-only learning session for one agent record from the authoritative fleet snapshot and bounded task records; no learner process, project-file read, or persistence is created in this slice |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 - **A visible crew** - every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.
 - **Disposable worktrees** - each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides.
 - **Two task shapes** - ship tasks deliver authorized changes; scout tasks leave standalone investigation reports when the intake contract warrants separate research.
+- **Read-only learning sessions** - `/learn` exposes one active agent's fleet snapshot and task records without entering its worktree or changing its lifecycle; see [docs/learn.md](docs/learn.md).
 - **Explicit project modes** - each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.
 - **Optional secondmates** - opt in to persistent second mates that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, supervising project clones or a project-less firstmate-repo domain, kept on the primary firstmate version by guarded local fast-forwards and checked for live agent processes at session start.
 - **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.
@@ -172,6 +173,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
 | `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, falling back to Bearings when invoked as the session's first real captain message |
 | `/bearings`        | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
+| `/learn`           | Open a read-only learning session for one active agent from the authoritative fleet snapshot and bounded task records; no learner process, project-file read, or persistence is created in this slice |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
 
@@ -204,6 +206,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's current "no turn ends blind" backstop, scope, loop safety, and compatibility limits.
 - [docs/verification/supervision.md](docs/verification/supervision.md) - active maintainer verification for session-start, guard, continuity, and wedge integrations.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi and `pi-signed`, Grok, and unknown harness fallback.
+- [docs/learn.md](docs/learn.md) - the read-only learning-session contract and harness entry-point seam.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [docs/documentation-audiences.md](docs/documentation-audiences.md) - documentation audiences and the machine-checked placement boundary.
 - [`AGENTS.md`](AGENTS.md) - the distro's always-loaded operating contract and routing index for conditional procedures.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -63,11 +63,14 @@ fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> 
 # session name, or nothing when no server is running or no client is attached -
 # in which case there is no primary session to target and the caller falls back.
 # client_activity is an integer epoch, so a numeric reverse sort puts the most
-# recently active client first; the tab field separator keeps a session name that
-# contains spaces intact.
+# recently active client first. The separator must be a character tmux emits
+# verbatim: tmux renders control characters in a format string as `_`, so a
+# literal TAB would come back as part of one unsplittable field. A space is
+# passed through untouched, and because client_activity never contains one,
+# taking every field from the second on keeps a spaced session name intact.
 fm_backend_tmux_primary_session() {
-  tmux list-clients -F "#{client_activity}$(printf '\t')#{client_session}" 2>/dev/null \
-    | sort -rn -k1,1 | head -n1 | cut -f2-
+  tmux list-clients -F '#{client_activity} #{client_session}' 2>/dev/null \
+    | sort -rn -k1,1 | head -n1 | cut -d' ' -f2-
 }
 
 # fm_backend_tmux_container_ensure: resolve the session a new task window is

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -54,17 +54,47 @@ fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> 
   fm_tmux_submit_core "$@"
 }
 
-# fm_backend_tmux_container_ensure: reuse the current tmux session when
-# firstmate itself runs inside tmux, else ensure a dedicated detached
-# "firstmate" session exists. Mirrors fm-spawn.sh's container-ensure block;
-# prints the resolved session name.
+# fm_backend_tmux_primary_session: the captain's CURRENT tmux session - the one
+# the most-recently-active ATTACHED client is viewing. This is how the primary
+# session is resolved when the spawning shell's own $TMUX is empty (fm-spawn can
+# be invoked without $TMUX inherited even though the primary firstmate/captain is
+# attached to a live session). Bare `tmux` reaches the running server on the
+# default socket, exactly like every other call in this adapter. Prints the
+# session name, or nothing when no server is running or no client is attached -
+# in which case there is no primary session to target and the caller falls back.
+# client_activity is an integer epoch, so a numeric reverse sort puts the most
+# recently active client first; the tab field separator keeps a session name that
+# contains spaces intact.
+fm_backend_tmux_primary_session() {
+  tmux list-clients -F "#{client_activity}$(printf '\t')#{client_session}" 2>/dev/null \
+    | sort -rn -k1,1 | head -n1 | cut -f2-
+}
+
+# fm_backend_tmux_container_ensure: resolve the session a new task window is
+# created in, printing its name. Precedence:
+#   1. When the spawning shell is itself inside tmux ($TMUX set), its own current
+#      session (`#S`) - the primary firstmate's session.
+#   2. Otherwise, the captain's CURRENT attached session
+#      (fm_backend_tmux_primary_session). This is the key fix: a spawn shell with
+#      empty $TMUX must still land the window in the session the captain is
+#      actually in, not a separate detached "firstmate" session.
+#   3. Only when neither resolves (no server, or a server with no attached
+#      client) fall back to a dedicated detached "firstmate" session - the
+#      deterministic, fail-closed outside-tmux behavior.
+# Mirrors fm-spawn.sh's container-ensure block.
 fm_backend_tmux_container_ensure() {
+  local primary
   if [ -n "${TMUX:-}" ]; then
     tmux display-message -p '#S'
-  else
-    tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate
-    printf 'firstmate'
+    return 0
   fi
+  primary=$(fm_backend_tmux_primary_session)
+  if [ -n "$primary" ]; then
+    printf '%s' "$primary"
+    return 0
+  fi
+  tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate
+  printf 'firstmate'
 }
 
 # fm_backend_tmux_create_task: create the task's window in <proj-abs>,

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -86,7 +86,7 @@ fm_backend_tmux_container_ensure() {
   local primary
   if [ -n "${TMUX:-}" ]; then
     tmux display-message -p '#S'
-    return 0
+    return
   fi
   primary=$(fm_backend_tmux_primary_session)
   if [ -n "$primary" ]; then

--- a/bin/fm-learn.sh
+++ b/bin/fm-learn.sh
@@ -34,8 +34,8 @@ usage: fm-learn.sh list [--json]
 Expose a read-only learning-session view of Firstmate's active agent records.
 
 list prints learning candidates from bin/fm-fleet-snapshot.sh.
-Every candidate is selectable; active is true only for a non-terminal record
-whose recorded endpoint is present.
+Every candidate is selectable; active is true only for a record in a known
+non-terminal state (working, parked, paused, blocked) with a present endpoint.
 start and snapshot print the selected agent's bounded learning context.
 --json prints the machine-readable list or fm-learning-session.v1 contract.
 The selected agent's project files and worktree are never read or changed.
@@ -121,9 +121,10 @@ SNAPSHOT=$(FM_ROOT_OVERRIDE="$FM_ROOT" \
 
 list_json() {
   # Every task metadata row is listed as a selectable learning candidate. active
-  # is derived from the authoritative current state and endpoint presence: a
-  # terminal (done/failed) record, or one whose recorded endpoint is absent or
-  # unrecorded, stays selectable for learning but is not an active agent.
+  # is derived from the authoritative current state and endpoint presence, and is
+  # claimed only for a KNOWN non-terminal state with a present endpoint. A
+  # terminal (done/failed) record, an unestablished (unknown) state, or an absent
+  # or unrecorded endpoint stays selectable for learning but is not active.
   printf '%s\n' "$SNAPSHOT" | jq '
     {
       schema:"fm-learning-agent-list.v1",
@@ -135,7 +136,8 @@ list_json() {
             id,
             active:(
               (.current_state.state // "") as $state
-              | $state != "done" and $state != "failed" and (.endpoint.exists == true)
+              | (["working","parked","paused","blocked"] | index($state) != null)
+                and (.endpoint.exists == true)
             ),
             kind,
             project,

--- a/bin/fm-learn.sh
+++ b/bin/fm-learn.sh
@@ -194,7 +194,7 @@ if [ "$COMMAND" = list ]; then
   printf 'Learning candidates (read-only)\n\n'
   printf '%s\n' "$SNAPSHOT" | jq -r '
     if (.tasks | length) == 0 then
-      "No active First Mate agents found."
+      "No First Mate agent records found."
     else
       (.tasks | to_entries[]
        | "\(.key + 1). \(.value.id) [\(.value.kind)] - \(.value.backlog.repo // .value.project // "unknown project") - state \(.value.current_state.state) / \(.value.current_state.source) - \(.value.harness // "unknown harness") / \(.value.backend) - endpoint "

--- a/bin/fm-learn.sh
+++ b/bin/fm-learn.sh
@@ -33,17 +33,19 @@ esac
 
 usage() {
   cat <<'EOF'
-usage: fm-learn.sh list [--json]
-       fm-learn.sh start <agent-id> [--json]
-       fm-learn.sh snapshot <agent-id> [--json]
+usage: fm-learn.sh list|agents [--json]
+       fm-learn.sh start|snapshot|context <agent-id> [--json]
 
 Expose a read-only learning-session view of Firstmate's active agent records.
 
-list prints learning candidates from bin/fm-fleet-snapshot.sh.
+list prints learning candidates from bin/fm-fleet-snapshot.sh; agents is an
+accepted alias.
 Every candidate is selectable; active is true only for a record in a known
 non-terminal state (working, parked, paused, blocked) with a present endpoint.
-start and snapshot print the selected agent's bounded learning context.
---json prints the machine-readable list or fm-learning-session.v1 contract.
+start, snapshot, and context are aliases that print the selected agent's
+bounded learning context.
+--json prints the machine-readable contract: fm-learning-agent-list.v1 for the
+candidate list, fm-learning-session.v1 for the selected agent's context.
 The selected agent's project files and worktree are never read or changed.
 No learner process or persistence adapter is created in this slice.
 --agent <agent-id> is accepted as an alternate selection spelling.

--- a/bin/fm-learn.sh
+++ b/bin/fm-learn.sh
@@ -206,7 +206,7 @@ fi
 
 SELECTED=$(printf '%s\n' "$SNAPSHOT" | jq -c --arg id "$ID" '[.tasks[] | select(.id == $id)][0] // empty')
 if [ -z "$SELECTED" ]; then
-  echo "fm-learn: no active agent record for '$ID'" >&2
+  echo "fm-learn: no agent record for '$ID'" >&2
   exit 1
 fi
 

--- a/bin/fm-learn.sh
+++ b/bin/fm-learn.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# fm-learn.sh - read-only learning-session core over the authoritative fleet snapshot.
+#
+# Usage:
+#   fm-learn.sh list [--json]
+#   fm-learn.sh start <agent-id> [--json]
+#   fm-learn.sh snapshot <agent-id> [--json]
+#
+# `list` enumerates every direct-report metadata row in the fresh fleet
+# snapshot as a learning candidate.
+# `start` and `snapshot` expose one selected candidate's bounded context without
+# spawning a process, editing task state, or reading the selected worktree.
+# JSON output is the stable handoff contract for a future separate learner
+# process and persistence adapter.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+FM_LEARN_RECORD_LINES=${FM_LEARN_RECORD_LINES:-120}
+case "$FM_LEARN_RECORD_LINES" in
+  ''|*[!0-9]*|0) FM_LEARN_RECORD_LINES=120 ;;
+esac
+
+usage() {
+  cat <<'EOF'
+usage: fm-learn.sh list [--json]
+       fm-learn.sh start <agent-id> [--json]
+       fm-learn.sh snapshot <agent-id> [--json]
+
+Expose a read-only learning-session view of Firstmate's active agent records.
+
+list prints learning candidates from bin/fm-fleet-snapshot.sh.
+start and snapshot print the selected agent's bounded learning context.
+--json prints the machine-readable list or fm-learning-session.v1 contract.
+The selected agent's project files and worktree are never read or changed.
+No learner process or persistence adapter is created in this slice.
+--agent <agent-id> is accepted as an alternate selection spelling.
+FM_LEARN_RECORD_LINES bounds task-record content and defaults to 120 lines.
+EOF
+}
+
+command -v jq >/dev/null 2>&1 || {
+  echo "fm-learn: jq not found" >&2
+  exit 1
+}
+
+COMMAND=
+ID=
+JSON=0
+POSITIONAL=()
+while [ "$#" -gt 0 ]; do
+  arg=$1
+  shift
+  case "$arg" in
+    -h|--help) usage; exit 0 ;;
+    --json) JSON=1 ;;
+    --agent)
+      [ "$#" -gt 0 ] || { echo "fm-learn: --agent requires a value" >&2; exit 2; }
+      POSITIONAL+=("$1")
+      shift
+      ;;
+    --agent=*) POSITIONAL+=("${arg#--agent=}") ;;
+    list|agents)
+      [ -z "$COMMAND" ] || { echo "fm-learn: more than one command" >&2; exit 2; }
+      COMMAND=list
+      ;;
+    start|snapshot|context)
+      [ -z "$COMMAND" ] || { echo "fm-learn: more than one command" >&2; exit 2; }
+      COMMAND=$arg
+      ;;
+    *) POSITIONAL+=("$arg") ;;
+  esac
+done
+
+if [ "${#POSITIONAL[@]}" -gt 1 ]; then
+  echo "fm-learn: expected one agent id" >&2
+  exit 2
+fi
+if [ "${#POSITIONAL[@]}" -eq 1 ]; then
+  ID=${POSITIONAL[0]}
+fi
+COMMAND=${COMMAND:-list}
+case "$COMMAND" in
+  list)
+    [ -z "$ID" ] || { echo "fm-learn: list does not take an agent id" >&2; exit 2; }
+    ;;
+  start|snapshot|context)
+    [ -n "$ID" ] || { echo "fm-learn: $COMMAND requires an agent id" >&2; exit 2; }
+    ;;
+  *)
+    echo "fm-learn: unknown command '$COMMAND'" >&2
+    exit 2
+    ;;
+esac
+
+# Keep the task id path-safe before constructing any task-record path.
+case "$ID" in
+  .*|*[!A-Za-z0-9._-]*)
+    [ -z "$ID" ] || { echo "fm-learn: invalid agent id" >&2; exit 2; }
+    ;;
+esac
+if [ "${#ID}" -gt 64 ]; then
+  echo "fm-learn: invalid agent id" >&2
+  exit 2
+fi
+
+SNAPSHOT=$(FM_ROOT_OVERRIDE="$FM_ROOT" \
+  FM_HOME="$FM_HOME" \
+  FM_STATE_OVERRIDE="$STATE" \
+  FM_DATA_OVERRIDE="$DATA" \
+  "$SCRIPT_DIR/fm-fleet-snapshot.sh" --json) || {
+  echo "fm-learn: could not read the authoritative fleet snapshot" >&2
+  exit 1
+}
+
+list_json() {
+  printf '%s\n' "$SNAPSHOT" | jq '
+    {
+      schema:"fm-learning-agent-list.v1",
+      generated:.generated,
+      read_only:true,
+      agents:[
+        .tasks[]
+        | {
+            id,
+            active:true,
+            kind,
+            project,
+            repo:(.backlog.repo // null),
+            harness,
+            backend,
+            current_state,
+            endpoint,
+            worktree:{path:(.paths.worktree.path // null),present:.paths.worktree.present},
+            task:(.backlog.title // null)
+          }
+      ] | sort_by(.id)
+    }
+  '
+}
+
+record_json() {  # <name> <path>
+  local name=$1 path=$2 present=0 truncated=false bytes=0 lines=0 content=
+  if [ -f "$path" ] && [ ! -L "$path" ]; then
+    present=1
+    bytes=$(wc -c < "$path" | tr -d '[:space:]')
+    lines=$(awk 'END { print NR + 0 }' "$path")
+    content=$(awk -v max="$FM_LEARN_RECORD_LINES" 'NR <= max { print }' "$path")
+    if [ "$lines" -gt "$FM_LEARN_RECORD_LINES" ]; then
+      truncated=true
+    fi
+  fi
+  local present_json=false
+  [ "$present" -eq 1 ] && present_json=true
+  jq -n \
+    --arg name "$name" \
+    --arg path "$path" \
+    --arg content "$content" \
+    --argjson present "$present_json" \
+    --argjson truncated "$truncated" \
+    --argjson bytes "${bytes:-0}" \
+    --argjson lines "${lines:-0}" \
+    '{name:$name,path:$path,present:$present,truncated:$truncated,bytes:$bytes,lines:$lines,content:(if $present then $content else null end)}'
+}
+
+if [ "$COMMAND" = list ]; then
+  if [ "$JSON" -eq 1 ]; then
+    list_json
+    exit 0
+  fi
+  printf 'Learning candidates (read-only)\n\n'
+  printf '%s\n' "$SNAPSHOT" | jq -r '
+    if (.tasks | length) == 0 then
+      "No active First Mate agents found."
+    else
+      (.tasks | to_entries[]
+       | "\(.key + 1). \(.value.id) [\(.value.kind)] - \(.value.backlog.repo // .value.project // "unknown project") - state \(.value.current_state.state) / \(.value.current_state.source) - \(.value.harness // "unknown harness") / \(.value.backend) - endpoint "
+         + (if .value.endpoint.exists == true then "present" elif .value.endpoint.exists == false then "absent" else "unknown" end))
+    end
+  '
+  exit 0
+fi
+
+SELECTED=$(printf '%s\n' "$SNAPSHOT" | jq -c --arg id "$ID" '[.tasks[] | select(.id == $id)][0] // empty')
+if [ -z "$SELECTED" ]; then
+  echo "fm-learn: no active agent record for '$ID'" >&2
+  exit 1
+fi
+
+BACKLOG=$(printf '%s\n' "$SELECTED" | jq -c '.backlog // null')
+META_RECORD=$(record_json metadata "$STATE/$ID.meta")
+BRIEF_RECORD=$(record_json brief "$DATA/$ID/brief.md")
+STATUS_RECORD=$(record_json status_log "$STATE/$ID.status")
+REPORT_RECORD=$(record_json report "$DATA/$ID/report.md")
+SESSION=$(jq -n \
+  --arg generated "$(printf '%s\n' "$SNAPSHOT" | jq -r '.generated')" \
+  --arg selected_id "$ID" \
+  --argjson fleet_snapshot "$SNAPSHOT" \
+  --argjson selected_agent "$SELECTED" \
+  --argjson backlog "$BACKLOG" \
+  --argjson metadata "$META_RECORD" \
+  --argjson brief "$BRIEF_RECORD" \
+  --argjson status_log "$STATUS_RECORD" \
+  --argjson report "$REPORT_RECORD" \
+  '{
+    schema:"fm-learning-session.v1",
+    generated:$generated,
+    selected_id:$selected_id,
+    selected_agent:$selected_agent,
+    context:{
+      fleet_snapshot:$fleet_snapshot,
+      task_records:{backlog:$backlog,metadata:$metadata,brief:$brief,status_log:$status_log,report:$report}
+    },
+    learner:{
+      delivery:"inline",
+      process:"current-firstmate",
+      separate_process:false,
+      future_process_seam:"consume this context contract in a separate learner process",
+      persistence:"none",
+      future_persistence_seam:"Obsidian adapter"
+    },
+    boundary:{
+      read_only:true,
+      project_files_read:false,
+      selected_worktree_read:false,
+      task_lifecycle_unchanged:true,
+      spawned_agent:false
+    }
+  }')
+
+if [ "$JSON" -eq 1 ]; then
+  printf '%s\n' "$SESSION" | jq .
+  exit 0
+fi
+
+printf '%s\n' "$SESSION" | jq -r '
+  "Learning session (read-only)",
+  "Selected agent: \(.selected_agent.id) [\(.selected_agent.kind)]",
+  "Project: \(.selected_agent.backlog.repo // .selected_agent.project // "unknown project")",
+  "Current state: \(.selected_agent.current_state.state) / \(.selected_agent.current_state.source)",
+  "Harness and backend: \(.selected_agent.harness // "unknown harness") / \(.selected_agent.backend)",
+  "Worktree content: not read",
+  "Learner process: current Firstmate; separate-process seam is reserved",
+  "Persistence: none; Obsidian is not integrated",
+  "",
+  "Task brief:",
+  (if .context.task_records.brief.present then .context.task_records.brief.content else "(absent)" end),
+  "",
+  "Recent task events:",
+  (if .context.task_records.status_log.present then .context.task_records.status_log.content else "(absent)" end)
+'

--- a/bin/fm-learn.sh
+++ b/bin/fm-learn.sh
@@ -7,11 +7,17 @@
 #   fm-learn.sh snapshot <agent-id> [--json]
 #
 # `list` enumerates every direct-report metadata row in the fresh fleet
-# snapshot as a learning candidate.
+# snapshot as a learning candidate; `agents` is an accepted alias.
 # `start` and `snapshot` expose one selected candidate's bounded context without
-# spawning a process, editing task state, or reading the selected worktree.
-# JSON output is the stable handoff contract for a future separate learner
-# process and persistence adapter.
+# spawning a process, editing task state, or reading the selected worktree;
+# `context` is an accepted alias, and the selected id may also be given as
+# `--agent <agent-id>`.
+# `list --json` emits schema fm-learning-agent-list.v1 and the selected-context
+# commands emit fm-learning-session.v1; both are the stable handoff contract for
+# a future separate learner process and persistence adapter.
+# FM_LEARN_RECORD_LINES bounds each task-record excerpt and defaults to 120
+# lines; a non-numeric or zero value falls back to that default.
+# docs/learn.md owns the operator-facing contract and its safety boundary.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-learn.sh
+++ b/bin/fm-learn.sh
@@ -34,6 +34,8 @@ usage: fm-learn.sh list [--json]
 Expose a read-only learning-session view of Firstmate's active agent records.
 
 list prints learning candidates from bin/fm-fleet-snapshot.sh.
+Every candidate is selectable; active is true only for a non-terminal record
+whose recorded endpoint is present.
 start and snapshot print the selected agent's bounded learning context.
 --json prints the machine-readable list or fm-learning-session.v1 contract.
 The selected agent's project files and worktree are never read or changed.
@@ -118,6 +120,10 @@ SNAPSHOT=$(FM_ROOT_OVERRIDE="$FM_ROOT" \
 }
 
 list_json() {
+  # Every task metadata row is listed as a selectable learning candidate. active
+  # is derived from the authoritative current state and endpoint presence: a
+  # terminal (done/failed) record, or one whose recorded endpoint is absent or
+  # unrecorded, stays selectable for learning but is not an active agent.
   printf '%s\n' "$SNAPSHOT" | jq '
     {
       schema:"fm-learning-agent-list.v1",
@@ -127,7 +133,10 @@ list_json() {
         .tasks[]
         | {
             id,
-            active:true,
+            active:(
+              (.current_state.state // "") as $state
+              | $state != "done" and $state != "failed" and (.endpoint.exists == true)
+            ),
             kind,
             project,
             repo:(.backlog.repo // null),

--- a/bin/fm-learn.sh
+++ b/bin/fm-learn.sh
@@ -36,7 +36,7 @@ usage() {
 usage: fm-learn.sh list|agents [--json]
        fm-learn.sh start|snapshot|context <agent-id> [--json]
 
-Expose a read-only learning-session view of Firstmate's active agent records.
+Expose a read-only learning-session view of Firstmate's agent records.
 
 list prints learning candidates from bin/fm-fleet-snapshot.sh; agents is an
 accepted alias.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -225,6 +225,7 @@ fi
 ORCA_ABORT_CLEANUP=0
 ORCA_WORKTREE_ID=
 ORCA_TERMINAL=
+SPAWN_RESOURCE_ABORT_CLEANUP=0
 HERDR_PROJECTION_ABORT_CLEANUP=0
 HERDR_PROJECTION_ABORT_SESSION=
 HERDR_PROJECTION_ABORT_TASK_PANE=
@@ -250,6 +251,27 @@ parse_orca_worktree_result() {
     ORCA_TERMINAL=${rest#*$'\t'}
   else
     ORCA_TERMINAL=
+  fi
+}
+
+# Release the endpoint and worktree this spawn already created, for the abort
+# paths that happen after creation but before state/<id>.meta exists as a usable
+# record. Nothing downstream can reap them then: fm-teardown.sh keys off meta, so
+# an unreleased pane/window and a checked-out treehouse worktree would leak with
+# no owner. Orca's terminal and worktree belong to the ORCA_ABORT_CLEANUP block
+# instead, which also owns orca's rescue-record fallback.
+spawn_release_created_resources() {
+  [ "$BACKEND" != orca ] || return 0
+  if [ "$KIND" != secondmate ] && [ -n "${WT:-}" ] && [ "$WT" != "${PROJ_ABS:-}" ] \
+     && [ -d "$WT" ]; then
+    if ! command -v treehouse >/dev/null 2>&1; then
+      echo "warning: treehouse command not found; worktree $WT is still checked out and must be returned manually" >&2
+    elif ! ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1; then
+      echo "warning: could not return worktree $WT; return it manually with 'treehouse return --force $WT'" >&2
+    fi
+  fi
+  if [ -n "${T:-}" ]; then
+    fm_backend_kill "$BACKEND" "$T" "${ZELLIJ_TAB_ID:-}" "${W:-}" 2>/dev/null || true
   fi
 }
 
@@ -300,6 +322,10 @@ spawn_abort_cleanup() {
         fi
       fi
     fi
+  fi
+  if [ "$SPAWN_RESOURCE_ABORT_CLEANUP" = 1 ]; then
+    SPAWN_RESOURCE_ABORT_CLEANUP=0
+    spawn_release_created_resources
   fi
   if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
     SPAWN_TASK_LOCK_HELD=0
@@ -1480,6 +1506,10 @@ if {
   :
 else
   echo "error: could not publish metadata for $ID" >&2
+  # The endpoint and worktree are already created at this point, and without a
+  # meta record nothing can ever find them again, so this abort owns releasing
+  # them for every backend.
+  SPAWN_RESOURCE_ABORT_CLEANUP=1
   exit 1
 fi
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1433,7 +1433,7 @@ fi
 
 META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
-{
+if {
   echo "window=$META_WINDOW"
   echo "endpoint_task_id=$ID"
   echo "worktree=$WT"
@@ -1472,7 +1472,12 @@ META_WINDOW=$T
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
   fi
-} > "$STATE/$ID.meta"
+} > "$STATE/$ID.meta"; then
+  :
+else
+  echo "error: could not publish metadata for $ID" >&2
+  exit 1
+fi
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1433,6 +1433,10 @@ fi
 
 META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
+# state/<id>.meta is the only record every guard, supervision path, and
+# read-only reader counts work from, so a task whose metadata never landed is
+# invisible fleet-wide (docs/subagent-guard.md). Fail the spawn loudly instead
+# of continuing with an absent or truncated record.
 if {
   echo "window=$META_WINDOW"
   echo "endpoint_task_id=$ID"

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1064,10 +1064,11 @@ window_for_task() {  # <task-key> [state]
     w=$(fm_backend_target_of_meta "$meta")
     [ -n "$w" ] && { printf '%s' "$w"; return 0; }
   done
-  for w in $(tmux list-windows -a -F '#{session_name}:#{window_name}' 2>/dev/null | grep ':fm-' || true); do
+  while IFS= read -r w; do
+    [ -n "$w" ] || continue
     t=$(window_to_task "$w" "$state")
     [ "$(_stale_key "$t")" = "$key" ] && { printf '%s' "$w"; return 0; }
-  done
+  done < <(tmux list-windows -a -F '#{session_name}:#{window_name}' 2>/dev/null | grep ':fm-' || true)
   return 1
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ Decision-only events such as `resolved` never become current state or leak their
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.
 For herdr, that pane fallback trusts a native `busy` verdict outright, but corroborates native `idle` or unknown verdicts against the recorded harness's rendered busy signature before deciding the crew is not working.
 For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, and secondmate return-channel guidance.
-`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
+`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, and `bin/fm-learn.sh` derives the read-only learning-session context ([`docs/learn.md`](learn.md)), so every consumer reads one structured contract instead of reparsing raw fleet files.
 The script header owns the exact JSON schema.
 
 ### Registered secondmate current state

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -144,6 +144,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/learn/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/fmx-respond/SKILL.md",
       "audience": "agent-runtime"
     },
@@ -253,6 +257,10 @@
     },
     {
       "path": "docs/herdr-backend.md",
+      "audience": "operator-current"
+    },
+    {
+      "path": "docs/learn.md",
       "audience": "operator-current"
     },
     {

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -34,6 +34,9 @@ If a future learner becomes an agent, it must use the existing isolated spawn li
 
 ## Harness entry points
 
-Claude and Pi share the same `/learn` skill at `.agents/skills/learn/SKILL.md`.
-Claude discovers it through the `.claude/skills` symlink, and Pi discovers it through its normal `.agents/skills` loading path.
-No harness-specific extension or runtime backend is required for this slice.
+The learning core in `bin/fm-learn.sh` is harness-independent, and `/learn` is a plain `.agents/skills` entry with no harness-specific extension or runtime backend.
+
+This slice verifies the shared entry path on Claude and Pi only.
+Claude discovers the skill through the `.claude/skills` symlink, and Pi discovers it through its normal `.agents/skills` loading path.
+Other supported harnesses are not verified here: whether `/learn` is discovered and how it is invoked follows each harness's own skill-discovery and invocation conventions, which the [`harness-adapters` skill](../.agents/skills/harness-adapters/SKILL.md) owns.
+The core itself needs no change to reach them.

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -9,7 +9,8 @@ It is intended for understanding work under way without steering the agent or en
 It calls `bin/fm-fleet-snapshot.sh --json`, the authoritative read-only fleet snapshot, and renders each task metadata row as a candidate with its task kind, project, current state, harness, backend, and endpoint availability.
 The command does not infer current state from the last status event.
 A candidate remains selectable when its endpoint is unavailable so the firstmate can learn from a recorded task that needs recovery.
-Selectability is therefore not the same as liveness: the JSON `active` field is derived from the authoritative record rather than asserted, and is true only when the current state is neither `done` nor `failed` and the recorded endpoint is present.
+Selectability is therefore not the same as liveness: the JSON `active` field is derived from the authoritative record rather than asserted, and is true only when the current state is a known non-terminal state (`working`, `parked`, `paused`, or `blocked`) and the recorded endpoint is present.
+A terminal (`done`, `failed`) record, a record whose state could not be established (`unknown`, for example a task mid-teardown whose worktree is already gone), and a record with an absent or unrecorded endpoint are all reported as not active.
 A candidate that is not active is still listed and can still be selected.
 
 `bin/fm-learn.sh start <agent-id>` opens the first learning-session exposure path.

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -5,7 +5,7 @@ It is intended for understanding work under way without steering the agent or en
 
 ## Current slice
 
-`bin/fm-learn.sh list` is the harness-independent candidate enumeration command.
+`bin/fm-learn.sh list` is the harness-independent candidate enumeration command, printing the human candidate list or, with `--json`, schema `fm-learning-agent-list.v1`.
 It calls `bin/fm-fleet-snapshot.sh --json`, the authoritative read-only fleet snapshot, and renders each task metadata row as a candidate with its task kind, project, current state, harness, backend, and endpoint availability.
 The command does not infer current state from the last status event.
 A candidate remains selectable when its endpoint is unavailable so the firstmate can learn from a recorded task that needs recovery.
@@ -14,10 +14,9 @@ A terminal (`done`, `failed`) record, a record whose state could not be establis
 A candidate that is not active is still listed and can still be selected.
 
 `bin/fm-learn.sh start <agent-id>` opens the first learning-session exposure path.
-The `snapshot` subcommand is an alias for `start`.
 The JSON result has schema `fm-learning-session.v1` and includes the complete fleet snapshot, the selected agent row, its matching backlog record, and bounded metadata, brief, status-event, and report records.
 The human result shows the selected task brief and recent task events with the same read-only boundary.
-`FM_LEARN_RECORD_LINES` bounds each task-record excerpt and defaults to 120 lines.
+`FM_LEARN_RECORD_LINES` bounds each task-record excerpt; the script header owns its default and the exact subcommand and flag spellings.
 
 The core reads task records under the Firstmate home only.
 It does not open project files or selected-agent worktree content, and it never writes any project, task, backlog, status, or learning-session file.

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -9,6 +9,8 @@ It is intended for understanding work under way without steering the agent or en
 It calls `bin/fm-fleet-snapshot.sh --json`, the authoritative read-only fleet snapshot, and renders each task metadata row as a candidate with its task kind, project, current state, harness, backend, and endpoint availability.
 The command does not infer current state from the last status event.
 A candidate remains selectable when its endpoint is unavailable so the firstmate can learn from a recorded task that needs recovery.
+Selectability is therefore not the same as liveness: the JSON `active` field is derived from the authoritative record rather than asserted, and is true only when the current state is neither `done` nor `failed` and the recorded endpoint is present.
+A candidate that is not active is still listed and can still be selected.
 
 `bin/fm-learn.sh start <agent-id>` opens the first learning-session exposure path.
 The `snapshot` subcommand is an alias for `start`.

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -1,0 +1,37 @@
+# Read-only learning sessions
+
+`/learn` opens a read-only conversation about one active Firstmate agent.
+It is intended for understanding work under way without steering the agent or entering its project files.
+
+## Current slice
+
+`bin/fm-learn.sh list` is the harness-independent candidate enumeration command.
+It calls `bin/fm-fleet-snapshot.sh --json`, the authoritative read-only fleet snapshot, and renders each task metadata row as a candidate with its task kind, project, current state, harness, backend, and endpoint availability.
+The command does not infer current state from the last status event.
+A candidate remains selectable when its endpoint is unavailable so the firstmate can learn from a recorded task that needs recovery.
+
+`bin/fm-learn.sh start <agent-id>` opens the first learning-session exposure path.
+The `snapshot` subcommand is an alias for `start`.
+The JSON result has schema `fm-learning-session.v1` and includes the complete fleet snapshot, the selected agent row, its matching backlog record, and bounded metadata, brief, status-event, and report records.
+The human result shows the selected task brief and recent task events with the same read-only boundary.
+`FM_LEARN_RECORD_LINES` bounds each task-record excerpt and defaults to 120 lines.
+
+The core reads task records under the Firstmate home only.
+It does not open project files or selected-agent worktree content, and it never writes any project, task, backlog, status, or learning-session file.
+The authoritative fleet snapshot may perform its existing bounded read-only current-state probes before the learning context is assembled.
+
+## Lifecycle and persistence boundary
+
+The current slice keeps the learning conversation inside the running firstmate process.
+It does not spawn a learner, create a worker, alter supervision, steer an agent, merge work, or change any task lifecycle state.
+It does not implement Obsidian integration or write a learning-session artifact.
+
+The JSON result is the seam for a future separate learner process.
+Its `learner` object identifies the current inline delivery, the reserved separate-process seam, and the absent persistence adapter.
+If a future learner becomes an agent, it must use the existing isolated spawn lifecycle and the primary session's one-new-agent-per-tmux-window behavior rather than adding pane placement.
+
+## Harness entry points
+
+Claude and Pi share the same `/learn` skill at `.agents/skills/learn/SKILL.md`.
+Claude discovers it through the `.claude/skills` symlink, and Pi discovers it through its normal `.agents/skills` loading path.
+No harness-specific extension or runtime backend is required for this slice.

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -1,7 +1,7 @@
 # Read-only learning sessions
 
-`/learn` opens a read-only conversation about one active Firstmate agent.
-It is intended for understanding work under way without steering the agent or entering its project files.
+`/learn` opens a read-only conversation about one Firstmate agent record.
+It is intended for understanding an agent's work without steering the agent or entering its project files.
 
 ## Current slice
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -13,6 +13,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
+| `fm-learn.sh`            | Enumerate learning candidates and expose a selected read-only learning-session context |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -13,9 +13,9 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
-| `fm-learn.sh`            | Enumerate learning candidates and expose a selected read-only learning-session context |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
+| `fm-learn.sh`            | Enumerate learning candidates and expose a selected read-only learning-session context |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -22,7 +22,7 @@ For the best visible experience, launch the primary harness inside a tmux sessio
 tmux new -s firstmate
 ```
 
-Each crew task is its own tmux window named `fm-<id>`, created in the primary session's **current** session - the one the captain is actually in - so a spawned agent appears as a new window (tab) right where the captain is watching.
+Each crew task is its own tmux window named `fm-<id>`, created in the captain's **current** session - the one the captain is actually attached to - so a spawned agent appears as a new window (tab) right where the captain is watching.
 The target session is resolved in this order: the spawning shell's own session when it is inside tmux (`$TMUX` set, `tmux display-message -p '#S'`); otherwise the session the most-recently-active attached client is viewing, so a spawn shell that lost `$TMUX` still lands the window in the captain's current session rather than a separate one.
 Only when neither resolves - no server, or a running server with no attached client - does Firstmate fall back to a dedicated detached session named `firstmate`:
 

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -22,15 +22,15 @@ For the best visible experience, launch the primary harness inside a tmux sessio
 tmux new -s firstmate
 ```
 
-Crew tasks become windows in that session.
-`tmux display-message -p '#S'` prints its name.
-If the primary harness runs outside tmux, Firstmate creates or reuses a detached session named `firstmate`:
+Each crew task is its own tmux window named `fm-<id>`, created in the primary session's **current** session - the one the captain is actually in - so a spawned agent appears as a new window (tab) right where the captain is watching.
+The target session is resolved in this order: the spawning shell's own session when it is inside tmux (`$TMUX` set, `tmux display-message -p '#S'`); otherwise the session the most-recently-active attached client is viewing, so a spawn shell that lost `$TMUX` still lands the window in the captain's current session rather than a separate one.
+Only when neither resolves - no server, or a running server with no attached client - does Firstmate fall back to a dedicated detached session named `firstmate`:
 
 ```sh
 tmux attach -t firstmate
 ```
 
-Each task window is named `fm-<id>`.
+List and select task windows in the resolved session:
 
 ```sh
 tmux list-windows -t <session-name>
@@ -40,7 +40,7 @@ tmux select-window -t <session-name>:fm-<id>
 Typing into an attached task window is authoritative direct intervention.
 Routine supervision does not require attachment: `bin/fm-peek.sh <id>` captures a bounded tail and `FM_HOME=<home> bin/fm-send.sh <id> '<text>'` steers the recorded endpoint.
 
-Verify setup by spawning a small task and confirming its `fm-<id>` window appears in the selected session.
+Verify setup by spawning a small task and confirming its `fm-<id>` window appears as a new window in the session you are attached to.
 
 ## Current behavior and safety
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -117,6 +117,28 @@ Valid cleanup removed only the exact task-bound target and left the control wind
 The metadata-only validation covers tmux, Herdr, Zellij, Orca, and cmux before backend dispatch.
 Claude, Codex, OpenCode, Pi, pi-signed, Grok, and Kimi share that backend cleanup boundary; their harness-specific hook files and token cleanup run only after it, so no harness needs a separate endpoint parser.
 
+### Primary session targeting
+
+Task windows are created in the captain's current session rather than a separate detached session.
+The attached-client resolution was validated on 2026-07-28 with tmux 3.7b on macOS, including the observed case where the spawning shell has empty `$TMUX` while a server with the captain's attached session exists.
+
+```sh
+tmux list-clients -F "#{client_activity}\t#{client_session}"
+env -u TMUX -u TMUX_PANE tmux list-clients -F "#{client_activity}\t#{client_session}" \
+  | sort -rn -k1,1 | head -n1 | cut -f2-
+```
+
+Observed shapes:
+
+```text
+1785284498	lets-learn
+lets-learn
+```
+
+`client_activity` is an integer epoch, so a numeric reverse sort selects the most recently active attached client, and bare `tmux` reaches the running server on the default socket even with `$TMUX` unset.
+A server with no attached client yields empty output, which is the deterministic trigger for the dedicated detached `firstmate` fallback.
+`tests/fm-backend-tmux-smoke.test.sh` exercises the attached-session resolution and the no-client fallback against a real private-socket server.
+
 ## Herdr
 
 The compatibility floor is protocol 14.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -123,19 +123,21 @@ Task windows are created in the captain's current session rather than a separate
 The attached-client resolution was validated on 2026-07-28 with tmux 3.7b on macOS, including the observed case where the spawning shell has empty `$TMUX` while a server with the captain's attached session exists.
 
 ```sh
-tmux list-clients -F "#{client_activity}$(printf '\t')#{client_session}"
-env -u TMUX -u TMUX_PANE tmux list-clients -F "#{client_activity}$(printf '\t')#{client_session}" \
-  | sort -rn -k1,1 | head -n1 | cut -f2-
+tmux list-clients -F '#{client_activity} #{client_session}'
+env -u TMUX -u TMUX_PANE tmux list-clients -F '#{client_activity} #{client_session}' \
+  | sort -rn -k1,1 | head -n1 | cut -d' ' -f2-
 ```
 
 Observed shapes:
 
 ```text
-1785284498	lets-learn
+1785288039 lets-learn
 lets-learn
 ```
 
-tmux does not expand `\t` inside a format string, so the field separator is produced by the shell with `$(printf '\t')`, exactly as `fm_backend_tmux_primary_session` does.
+The separator is a space because that is what tmux emits verbatim.
+A literal TAB, whether written as `\t` or produced by the shell with `$(printf '\t')`, is rendered by tmux as `_`, so the output arrives as the single unsplittable field `1785288039_lets-learn` and no `cut` can recover the session name; this was confirmed with `od -c` on tmux 3.7b.
+`client_session` may contain spaces, but `client_activity` cannot, so taking every field from the second on preserves a spaced session name, verified against a session literally named `probe one`.
 `client_activity` is an integer epoch, so a numeric reverse sort selects the most recently active attached client, and bare `tmux` reaches the running server on the default socket even with `$TMUX` unset.
 A server with no attached client yields empty output, which is the deterministic trigger for the dedicated detached `firstmate` fallback.
 `tests/fm-backend-tmux-smoke.test.sh` exercises the attached-session resolution and the no-client fallback against a real private-socket server.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -123,8 +123,8 @@ Task windows are created in the captain's current session rather than a separate
 The attached-client resolution was validated on 2026-07-28 with tmux 3.7b on macOS, including the observed case where the spawning shell has empty `$TMUX` while a server with the captain's attached session exists.
 
 ```sh
-tmux list-clients -F "#{client_activity}\t#{client_session}"
-env -u TMUX -u TMUX_PANE tmux list-clients -F "#{client_activity}\t#{client_session}" \
+tmux list-clients -F "#{client_activity}$(printf '\t')#{client_session}"
+env -u TMUX -u TMUX_PANE tmux list-clients -F "#{client_activity}$(printf '\t')#{client_session}" \
   | sort -rn -k1,1 | head -n1 | cut -f2-
 ```
 
@@ -135,6 +135,7 @@ Observed shapes:
 lets-learn
 ```
 
+tmux does not expand `\t` inside a format string, so the field separator is produced by the shell with `$(printf '\t')`, exactly as `fm_backend_tmux_primary_session` does.
 `client_activity` is an integer epoch, so a numeric reverse sort selects the most recently active attached client, and bare `tmux` reaches the running server on the default socket even with `$TMUX` unset.
 A server with no attached client yields empty output, which is the deterministic trigger for the dedicated detached `firstmate` fallback.
 `tests/fm-backend-tmux-smoke.test.sh` exercises the attached-session resolution and the no-client fallback against a real private-socket server.

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -81,26 +81,31 @@ pass "real tmux: fm_backend_tmux_create_task creates a window and refuses a dupl
 # Selection + attached-session logic is exercised with a shell-function tmux
 # that shadows the PATH shim, so multi-client ordering and spaced session names
 # are deterministic without needing a real attached client (which needs a tty).
-(
+# Each override lives inside a command substitution that yields only the
+# resolved value: the shadowing stays scoped, the assertion runs at top level so
+# a wrong result aborts the whole suite, and the PATH shim is never torn down
+# mid-run (a `fail` from a subshell would rm -rf it and drop the remaining real
+# tmux calls onto the host's default socket).
+got=$(
   # shellcheck disable=SC2329 # invoked indirectly by the sourced fm_backend_tmux_* function.
   tmux() { [ "$1" = list-clients ] && printf '100\tsession-a\n300\tteam work\n200\tsession-b\n'; return 0; }
-  got=$(fm_backend_tmux_primary_session)
-  [ "$got" = "team work" ] || fail "primary_session must pick the most-recently-active client's session (spaces intact), got '$got'"
+  fm_backend_tmux_primary_session
 )
-(
+[ "$got" = "team work" ] || fail "primary_session must pick the most-recently-active client's session (spaces intact), got '$got'"
+got=$(
   export TMUX="fake,1,0"
   # shellcheck disable=SC2329 # invoked indirectly by the sourced fm_backend_tmux_* function.
   tmux() { [ "$1" = display-message ] && printf 'own-session\n'; return 0; }
-  got=$(fm_backend_tmux_container_ensure)
-  [ "$got" = own-session ] || fail "container_ensure with \$TMUX set must return its own #S, got '$got'"
+  fm_backend_tmux_container_ensure
 )
-(
+[ "$got" = own-session ] || fail "container_ensure with \$TMUX set must return its own #S, got '$got'"
+got=$(
   unset TMUX TMUX_PANE
   # shellcheck disable=SC2329 # invoked indirectly by the sourced fm_backend_tmux_* function.
   tmux() { [ "$1" = list-clients ] && printf '7\tlets-learn\n'; return 0; }
-  got=$(fm_backend_tmux_container_ensure)
-  [ "$got" = lets-learn ] || fail "container_ensure with empty \$TMUX must target the attached client's session, got '$got'"
+  fm_backend_tmux_container_ensure
 )
+[ "$got" = lets-learn ] || fail "container_ensure with empty \$TMUX must target the attached client's session, got '$got'"
 pass "tmux backend: primary-session resolution prefers own #S then the most-recently-active attached client's session"
 
 # Real-server fallback: on this private socket no client is attached, so an

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -29,10 +29,14 @@ wait_for_capture_text() {  # <target> <text> [samples]
 command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found"; exit 0; }
 REAL_TMUX=$(command -v tmux)
 SOCKET="fm-backend-smoke-$$"
+# A second private socket hosting the client that ATTACHES to $SOCKET, so the
+# attached-session resolution can be exercised against a real client.
+VIEW_SOCKET="fm-backend-smoke-view-$$"
 SHIM_DIR=
 trap cleanup_all EXIT
 
 cleanup_all() {
+  "$REAL_TMUX" -L "$VIEW_SOCKET" kill-server >/dev/null 2>&1 || true
   "$REAL_TMUX" -L "$SOCKET" kill-server >/dev/null 2>&1 || true
   [ -n "${SHIM_DIR:-}" ] && rm -rf "$SHIM_DIR"
 }
@@ -88,7 +92,7 @@ pass "real tmux: fm_backend_tmux_create_task creates a window and refuses a dupl
 # tmux calls onto the host's default socket).
 got=$(
   # shellcheck disable=SC2329 # invoked indirectly by the sourced fm_backend_tmux_* function.
-  tmux() { [ "$1" = list-clients ] && printf '100\tsession-a\n300\tteam work\n200\tsession-b\n'; return 0; }
+  tmux() { [ "$1" = list-clients ] && printf '100 session-a\n300 team work\n200 session-b\n'; return 0; }
   fm_backend_tmux_primary_session
 )
 [ "$got" = "team work" ] || fail "primary_session must pick the most-recently-active client's session (spaces intact), got '$got'"
@@ -102,7 +106,7 @@ got=$(
 got=$(
   unset TMUX TMUX_PANE
   # shellcheck disable=SC2329 # invoked indirectly by the sourced fm_backend_tmux_* function.
-  tmux() { [ "$1" = list-clients ] && printf '7\tlets-learn\n'; return 0; }
+  tmux() { [ "$1" = list-clients ] && printf '7 lets-learn\n'; return 0; }
   fm_backend_tmux_container_ensure
 )
 [ "$got" = lets-learn ] || fail "container_ensure with empty \$TMUX must target the attached client's session, got '$got'"
@@ -121,6 +125,47 @@ fallback_session=$(env -u TMUX -u TMUX_PANE bash -c '. "$1/bin/fm-backend.sh"; f
 tmux has-session -t firstmate 2>/dev/null || fail "the fallback must have created the detached 'firstmate' session"
 tmux kill-session -t firstmate 2>/dev/null || true
 pass "real tmux: with no attached client, primary_session is empty and container_ensure creates the 'firstmate' fallback session"
+
+# Real ATTACHED client - the scenario this resolution order exists for: the
+# spawning shell has an empty $TMUX while the captain is attached to a live
+# session. The shell-function stubs above cannot cover it, because they assert
+# against text the test itself printed; only a real server proves what tmux's
+# own `-F` output actually looks like. An attach needs a tty, so the client is
+# manufactured by attaching to this private socket from inside a SECOND private
+# tmux server. The viewer is sized like the smoke session and killed again at
+# the end of the block, so the later capture-bounds assertions still run
+# against an unattached session of the original geometry.
+"$REAL_TMUX" -L "$VIEW_SOCKET" new-session -d -s viewer -x 200 -y 50 \
+  "TERM=xterm-256color '$REAL_TMUX' -L '$SOCKET' attach -t '$SESSION'" \
+  || fail "could not start the viewer server that attaches a real client"
+attached=
+for _ in $(seq 1 100); do
+  attached=$(tmux list-clients -F '#{client_session}' 2>/dev/null | head -n1)
+  [ -n "$attached" ] && break
+  sleep 0.1
+done
+[ "$attached" = "$SESSION" ] || fail "could not manufacture a real attached client on the smoke socket, got '$attached'"
+tmux kill-session -t firstmate 2>/dev/null || true
+# shellcheck disable=SC2016 # $1 expands inside the isolated child shell, not here.
+live_primary=$(env -u TMUX -u TMUX_PANE bash -c '. "$1/bin/fm-backend.sh"; fm_backend_source tmux; fm_backend_tmux_primary_session' _ "$ROOT")
+[ "$live_primary" = "$SESSION" ] \
+  || fail "primary_session must return the real attached client's session name '$SESSION', got '$live_primary'"
+# shellcheck disable=SC2016 # $1 expands inside the isolated child shell, not here.
+live_session=$(env -u TMUX -u TMUX_PANE bash -c '. "$1/bin/fm-backend.sh"; fm_backend_source tmux; fm_backend_tmux_container_ensure' _ "$ROOT")
+[ "$live_session" = "$SESSION" ] \
+  || fail "container_ensure with empty \$TMUX must target the real attached session '$SESSION', got '$live_session'"
+# The resolved name must be a usable target: this is what fm-spawn.sh hands to
+# fm_backend_tmux_create_task as "<session>:fm-<id>".
+fm_backend_tmux_create_task "$live_session" "fm-smoke-attached" "$HOME" \
+  || fail "the resolved attached session '$live_session' is not a usable new-window target"
+tmux list-windows -t "$SESSION" -F '#{window_name}' | grep -qx "fm-smoke-attached" \
+  || fail "the task window did not land in the attached session '$SESSION'"
+if tmux has-session -t firstmate 2>/dev/null; then
+  fail "container_ensure must not create the detached 'firstmate' fallback while a client is attached"
+fi
+tmux kill-window -t "$SESSION:fm-smoke-attached" 2>/dev/null || true
+"$REAL_TMUX" -L "$VIEW_SOCKET" kill-server >/dev/null 2>&1 || true
+pass "real tmux: with a real attached client, container_ensure targets that session and the task window lands there"
 
 # --- send text + Enter -------------------------------------------------------
 

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -73,6 +73,50 @@ if fm_backend_tmux_create_task "$SESSION" "$WINDOW" "$HOME" 2>/dev/null; then
 fi
 pass "real tmux: fm_backend_tmux_create_task creates a window and refuses a duplicate"
 
+# --- primary-session resolution ----------------------------------------------
+# The task window is created in the captain's CURRENT session. Resolution:
+# $TMUX-set -> own #S; else the most-recently-active attached client's session;
+# else a dedicated detached "firstmate" fallback.
+
+# Selection + attached-session logic is exercised with a shell-function tmux
+# that shadows the PATH shim, so multi-client ordering and spaced session names
+# are deterministic without needing a real attached client (which needs a tty).
+(
+  # shellcheck disable=SC2329 # invoked indirectly by the sourced fm_backend_tmux_* function.
+  tmux() { [ "$1" = list-clients ] && printf '100\tsession-a\n300\tteam work\n200\tsession-b\n'; return 0; }
+  got=$(fm_backend_tmux_primary_session)
+  [ "$got" = "team work" ] || fail "primary_session must pick the most-recently-active client's session (spaces intact), got '$got'"
+)
+(
+  export TMUX="fake,1,0"
+  # shellcheck disable=SC2329 # invoked indirectly by the sourced fm_backend_tmux_* function.
+  tmux() { [ "$1" = display-message ] && printf 'own-session\n'; return 0; }
+  got=$(fm_backend_tmux_container_ensure)
+  [ "$got" = own-session ] || fail "container_ensure with \$TMUX set must return its own #S, got '$got'"
+)
+(
+  unset TMUX TMUX_PANE
+  # shellcheck disable=SC2329 # invoked indirectly by the sourced fm_backend_tmux_* function.
+  tmux() { [ "$1" = list-clients ] && printf '7\tlets-learn\n'; return 0; }
+  got=$(fm_backend_tmux_container_ensure)
+  [ "$got" = lets-learn ] || fail "container_ensure with empty \$TMUX must target the attached client's session, got '$got'"
+)
+pass "tmux backend: primary-session resolution prefers own #S then the most-recently-active attached client's session"
+
+# Real-server fallback: on this private socket no client is attached, so an
+# empty-$TMUX resolution finds no primary session and must fall back to a
+# dedicated detached "firstmate" session (deterministic, fail-closed).
+tmux kill-session -t firstmate 2>/dev/null || true
+# shellcheck disable=SC2016 # $1 expands inside the isolated child shell, not here.
+empty_primary=$(env -u TMUX -u TMUX_PANE bash -c '. "$1/bin/fm-backend.sh"; fm_backend_source tmux; fm_backend_tmux_primary_session' _ "$ROOT")
+[ -z "$empty_primary" ] || fail "primary_session must be empty when no client is attached, got '$empty_primary'"
+# shellcheck disable=SC2016 # $1 expands inside the isolated child shell, not here.
+fallback_session=$(env -u TMUX -u TMUX_PANE bash -c '. "$1/bin/fm-backend.sh"; fm_backend_source tmux; fm_backend_tmux_container_ensure' _ "$ROOT")
+[ "$fallback_session" = firstmate ] || fail "container_ensure must fall back to 'firstmate' with no attached client, got '$fallback_session'"
+tmux has-session -t firstmate 2>/dev/null || fail "the fallback must have created the detached 'firstmate' session"
+tmux kill-session -t firstmate 2>/dev/null || true
+pass "real tmux: with no attached client, primary_session is empty and container_ensure creates the 'firstmate' fallback session"
+
 # --- send text + Enter -------------------------------------------------------
 
 # A newly-created interactive shell can exist before its startup files and line

--- a/tests/fm-learn.test.sh
+++ b/tests/fm-learn.test.sh
@@ -283,6 +283,10 @@ test_adapter_seam_is_shared_by_pi_and_claude() {
     "learn skill does not document the Claude adapter seam"
   assert_grep "Pi discovers the same skill directory" "$skill" \
     "learn skill does not document the Pi adapter seam"
+  assert_grep "no First Mate agent records are available" "$skill" \
+    "learn skill does not report an empty candidate set as absent records"
+  assert_not_contains "$(cat "$skill")" "no active agent is available" \
+    "learn skill confuses absent records with inactive agents"
   [ "$(readlink "$ROOT/.claude/skills")" = "../.agents/skills" ] \
     || fail "Claude skill directory is not the shared agent skill directory"
   pass "Pi and Claude share the tested skill entry point without harness-specific spawning"

--- a/tests/fm-learn.test.sh
+++ b/tests/fm-learn.test.sh
@@ -49,7 +49,12 @@ test_empty_list_is_explicit() {
       and .read_only == true
       and (.agents | length) == 0
   ' >/dev/null || fail "empty learning list was not explicit: $out"
-  pass "learning list reports an explicit empty active-agent set"
+  out=$(run_learn "$home" "$fakebin" list)
+  assert_contains "$out" "No First Mate agent records found." \
+    "empty human learning list did not report an absent record set"
+  assert_not_contains "$out" "No active First Mate agents found." \
+    "empty human learning list confused absent records with inactive ones"
+  pass "learning list reports an explicit empty candidate set in both contracts"
 }
 
 write_agent_fixture() {

--- a/tests/fm-learn.test.sh
+++ b/tests/fm-learn.test.sh
@@ -102,6 +102,89 @@ test_list_enumerates_snapshot_agents() {
   pass "learning list enumerates active agents from the fleet snapshot"
 }
 
+# A fake tmux that reports an idle pane, and no endpoint at all for gone-agent,
+# so the snapshot yields one terminal record and one endpoint-absent record.
+make_terminal_fakebin() {
+  local fakebin
+  fakebin=$(fm_fakebin "$1")
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *gone-agent*) exit 1 ;;
+esac
+case "${1:-}" in
+  display-message) printf '%%1\n' ;;
+  capture-pane) printf 'ready\n' ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/no-mistakes" "$fakebin/tmux"
+  printf '%s\n' "$fakebin"
+}
+
+write_inactive_fixtures() {
+  local home=$1 done_worktree="$1/projects/done-worktree" gone_worktree="$1/projects/gone-worktree"
+  mkdir -p "$home/data/done-agent" "$home/data/gone-agent" "$done_worktree" "$gone_worktree"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] done-agent - Improve the login flow (repo: alpha) (kind: ship) (since 2026-07-28)
+- [ ] gone-agent - Improve the signup flow (repo: beta) (kind: ship) (since 2026-07-28)
+
+## Queued
+
+## Done
+EOF
+  cat > "$home/state/done-agent.meta" <<EOF
+window=firstmate:fm-done-agent
+worktree=$done_worktree
+project=alpha
+harness=codex
+kind=ship
+mode=ship
+yolo=off
+EOF
+  printf 'done: shipped the login flow\n' > "$home/state/done-agent.status"
+  cat > "$home/state/gone-agent.meta" <<EOF
+window=firstmate:fm-gone-agent
+worktree=$gone_worktree
+project=beta
+harness=codex
+kind=ship
+mode=ship
+yolo=off
+EOF
+  printf 'working: improving the signup flow\n' > "$home/state/gone-agent.status"
+}
+
+test_active_is_derived_and_inactive_stays_selectable() {
+  local home fakebin out
+  home=$(make_home "$TMP_ROOT/active")
+  write_inactive_fixtures "$home"
+  fakebin=$(make_terminal_fakebin "$home")
+  out=$(run_learn "$home" "$fakebin" list --json)
+  printf '%s\n' "$out" | jq -e '
+    (.agents | length) == 2
+      and ((.agents[] | select(.id == "done-agent"))
+           | .current_state.state == "done" and .endpoint.exists == true and .active == false)
+      and ((.agents[] | select(.id == "gone-agent"))
+           | .current_state.state != "done" and .endpoint.exists == false and .active == false)
+  ' >/dev/null || fail "active was not derived from current state and endpoint: $out"
+
+  out=$(run_learn "$home" "$fakebin" start done-agent --json) \
+    || fail "a terminal record stopped being selectable for learning"
+  printf '%s\n' "$out" | jq -e '.selected_agent.id == "done-agent"' >/dev/null \
+    || fail "terminal learning candidate did not expose its context: $out"
+  out=$(run_learn "$home" "$fakebin" start gone-agent --json) \
+    || fail "an endpoint-absent record stopped being selectable for learning"
+  printf '%s\n' "$out" | jq -e '.selected_agent.id == "gone-agent"' >/dev/null \
+    || fail "endpoint-absent learning candidate did not expose its context: $out"
+  pass "active is derived from state and endpoint while every candidate stays selectable"
+}
+
 test_start_is_read_only_and_contains_bounded_context() {
   local home fakebin out before_meta before_status before_brief before_worktree
   home=$(make_home "$TMP_ROOT/start")
@@ -186,6 +269,7 @@ test_adapter_seam_is_shared_by_pi_and_claude() {
 
 test_empty_list_is_explicit
 test_list_enumerates_snapshot_agents
+test_active_is_derived_and_inactive_stays_selectable
 test_start_is_read_only_and_contains_bounded_context
 test_snapshot_alias_and_invalid_selection
 test_adapter_seam_is_shared_by_pi_and_claude

--- a/tests/fm-learn.test.sh
+++ b/tests/fm-learn.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Behavior tests for the harness-independent read-only learning-session core.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-learn)
+LEARN="$ROOT/bin/fm-learn.sh"
+
+make_fakebin() {
+  local fakebin
+  fakebin=$(fm_fakebin "$1")
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  display-message) printf '%%1\n' ;;
+  capture-pane) printf 'work in progress\nesc to interrupt\n' ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/no-mistakes" "$fakebin/tmux"
+  printf '%s\n' "$fakebin"
+}
+
+make_home() {
+  local home=$1
+  mkdir -p "$home/state" "$home/data" "$home/config" "$home/projects"
+  printf '%s\n' "$home"
+}
+
+run_learn() {
+  local home=$1 fakebin=$2
+  shift 2
+  PATH="$fakebin:$PATH" FM_HOME="$home" "$LEARN" "$@"
+}
+
+test_empty_list_is_explicit() {
+  local home fakebin out
+  home=$(make_home "$TMP_ROOT/empty")
+  fakebin=$(make_fakebin "$home")
+  out=$(run_learn "$home" "$fakebin" list --json)
+  printf '%s\n' "$out" | jq -e '
+    .schema == "fm-learning-agent-list.v1"
+      and .read_only == true
+      and (.agents | length) == 0
+  ' >/dev/null || fail "empty learning list was not explicit: $out"
+  pass "learning list reports an explicit empty active-agent set"
+}
+
+write_agent_fixture() {
+  local home=$1 worktree="$1/projects/agent-worktree"
+  mkdir -p "$home/data/learn-agent" "$worktree"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] learn-agent - Improve the login flow (repo: alpha) (kind: ship) (since 2026-07-28)
+
+## Queued
+
+## Done
+EOF
+  cat > "$home/state/learn-agent.meta" <<EOF
+window=firstmate:fm-learn-agent
+worktree=$worktree
+project=alpha
+harness=codex
+kind=ship
+mode=ship
+yolo=off
+EOF
+  printf 'working: implementing login flow\n' > "$home/state/learn-agent.status"
+  cat > "$home/data/learn-agent/brief.md" <<'EOF'
+# Learning fixture
+
+Acceptance criteria: understand the login flow without changing it.
+EOF
+  printf 'private worktree content that must not be read\n' > "$worktree/README.md"
+}
+
+test_list_enumerates_snapshot_agents() {
+  local home fakebin out
+  home=$(make_home "$TMP_ROOT/list")
+  write_agent_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_learn "$home" "$fakebin" list --json)
+  printf '%s\n' "$out" | jq -e '
+    .agents == [
+      (.agents[0]
+       | select(.id == "learn-agent")
+       | select(.active == true)
+       | select(.kind == "ship")
+       | select(.project == "alpha")
+       | select(.backend == "tmux")
+       | select(.current_state.state == "working")
+       | select(.endpoint.exists == true))
+    ]
+  ' >/dev/null || fail "learning list did not expose the authoritative task row: $out"
+  pass "learning list enumerates active agents from the fleet snapshot"
+}
+
+test_start_is_read_only_and_contains_bounded_context() {
+  local home fakebin out before_meta before_status before_brief before_worktree
+  home=$(make_home "$TMP_ROOT/start")
+  write_agent_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  before_meta=$(shasum -a 256 "$home/state/learn-agent.meta")
+  before_status=$(shasum -a 256 "$home/state/learn-agent.status")
+  before_brief=$(shasum -a 256 "$home/data/learn-agent/brief.md")
+  before_worktree=$(shasum -a 256 "$home/projects/agent-worktree/README.md")
+
+  out=$(run_learn "$home" "$fakebin" start learn-agent --json)
+  printf '%s\n' "$out" | jq -e '
+    .schema == "fm-learning-session.v1"
+      and .selected_id == "learn-agent"
+      and .selected_agent.id == "learn-agent"
+      and .context.fleet_snapshot.schema == "fm-fleet-snapshot.v1"
+      and .context.task_records.backlog.id == "learn-agent"
+      and .context.task_records.brief.present == true
+      and (.context.task_records.brief.content | contains("understand the login flow"))
+      and .context.task_records.status_log.present == true
+      and .learner.delivery == "inline"
+      and .learner.separate_process == false
+      and .learner.persistence == "none"
+      and .boundary.read_only == true
+      and .boundary.project_files_read == false
+      and .boundary.selected_worktree_read == false
+      and .boundary.task_lifecycle_unchanged == true
+      and .boundary.spawned_agent == false
+  ' >/dev/null || fail "learning session context or boundary contract was wrong: $out"
+  assert_not_contains "$out" "private worktree content that must not be read" \
+    "learning session read selected worktree content"
+
+  [ "$(shasum -a 256 "$home/state/learn-agent.meta")" = "$before_meta" ] \
+    || fail "learning session changed task metadata"
+  [ "$(shasum -a 256 "$home/state/learn-agent.status")" = "$before_status" ] \
+    || fail "learning session changed task status events"
+  [ "$(shasum -a 256 "$home/data/learn-agent/brief.md")" = "$before_brief" ] \
+    || fail "learning session changed task brief"
+  [ "$(shasum -a 256 "$home/projects/agent-worktree/README.md")" = "$before_worktree" ] \
+    || fail "learning session changed the selected worktree"
+  pass "selected learning context is bounded, read-only, and does not read worktree content"
+}
+
+test_snapshot_alias_and_invalid_selection() {
+  local home fakebin out status
+  home=$(make_home "$TMP_ROOT/selection")
+  write_agent_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  out=$(run_learn "$home" "$fakebin" snapshot learn-agent)
+  assert_contains "$out" "Learning session (read-only)" "snapshot alias did not expose a learning session"
+  assert_contains "$out" "Learner process: current Firstmate" "human learning session omitted the process seam"
+  assert_contains "$out" "Persistence: none; Obsidian is not integrated" \
+    "human learning session omitted the persistence seam"
+
+  out=$(run_learn "$home" "$fakebin" start missing-agent 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "missing agent selection should fail"
+  assert_contains "$out" "no active agent record" "missing selection error was unclear"
+
+  out=$(run_learn "$home" "$fakebin" start ../outside 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "path traversal agent id should fail"
+  assert_contains "$out" "invalid agent id" "unsafe agent id was not refused"
+  pass "learning selection aliases and path-safe errors are covered"
+}
+
+test_adapter_seam_is_shared_by_pi_and_claude() {
+  local skill
+  skill="$ROOT/.agents/skills/learn/SKILL.md"
+  assert_present "$skill" "learn skill is missing"
+  assert_grep "user-invocable: true" "$skill" "learn skill is not user invocable"
+  assert_grep "bin/fm-learn.sh list" "$skill" "learn skill does not use the shared list core"
+  assert_grep "bin/fm-learn.sh start <agent-id>" "$skill" "learn skill does not use the shared start core"
+  assert_grep 'Claude discovers this skill through `.claude/skills`' "$skill" \
+    "learn skill does not document the Claude adapter seam"
+  assert_grep "Pi discovers the same skill directory" "$skill" \
+    "learn skill does not document the Pi adapter seam"
+  [ "$(readlink "$ROOT/.claude/skills")" = "../.agents/skills" ] \
+    || fail "Claude skill directory is not the shared agent skill directory"
+  pass "Pi and Claude share the tested skill entry point without harness-specific spawning"
+}
+
+test_empty_list_is_explicit
+test_list_enumerates_snapshot_agents
+test_start_is_read_only_and_contains_bounded_context
+test_snapshot_alias_and_invalid_selection
+test_adapter_seam_is_shared_by_pi_and_claude

--- a/tests/fm-learn.test.sh
+++ b/tests/fm-learn.test.sh
@@ -102,8 +102,9 @@ test_list_enumerates_snapshot_agents() {
   pass "learning list enumerates active agents from the fleet snapshot"
 }
 
-# A fake tmux that reports an idle pane, and no endpoint at all for gone-agent,
-# so the snapshot yields one terminal record and one endpoint-absent record.
+# A fake tmux that reports an idle pane, and no endpoint at all for gone-agent, so
+# the snapshot yields one terminal record, one unestablished-state record whose
+# endpoint is still readable, and one endpoint-absent record.
 make_terminal_fakebin() {
   local fakebin
   fakebin=$(fm_fakebin "$1")
@@ -128,11 +129,13 @@ SH
 
 write_inactive_fixtures() {
   local home=$1 done_worktree="$1/projects/done-worktree" gone_worktree="$1/projects/gone-worktree"
-  mkdir -p "$home/data/done-agent" "$home/data/gone-agent" "$done_worktree" "$gone_worktree"
+  mkdir -p "$home/data/done-agent" "$home/data/gone-agent" "$home/data/stale-agent" \
+    "$done_worktree" "$gone_worktree"
   cat > "$home/data/backlog.md" <<'EOF'
 ## In flight
 - [ ] done-agent - Improve the login flow (repo: alpha) (kind: ship) (since 2026-07-28)
 - [ ] gone-agent - Improve the signup flow (repo: beta) (kind: ship) (since 2026-07-28)
+- [ ] stale-agent - Improve the logout flow (repo: gamma) (kind: ship) (since 2026-07-28)
 
 ## Queued
 
@@ -158,6 +161,16 @@ mode=ship
 yolo=off
 EOF
   printf 'working: improving the signup flow\n' > "$home/state/gone-agent.status"
+  cat > "$home/state/stale-agent.meta" <<EOF
+window=firstmate:fm-stale-agent
+worktree=$1/projects/torn-down-worktree
+project=gamma
+harness=codex
+kind=ship
+mode=ship
+yolo=off
+EOF
+  printf 'working: improving the logout flow\n' > "$home/state/stale-agent.status"
 }
 
 test_active_is_derived_and_inactive_stays_selectable() {
@@ -167,22 +180,23 @@ test_active_is_derived_and_inactive_stays_selectable() {
   fakebin=$(make_terminal_fakebin "$home")
   out=$(run_learn "$home" "$fakebin" list --json)
   printf '%s\n' "$out" | jq -e '
-    (.agents | length) == 2
+    (.agents | length) == 3
       and ((.agents[] | select(.id == "done-agent"))
            | .current_state.state == "done" and .endpoint.exists == true and .active == false)
+      and ((.agents[] | select(.id == "stale-agent"))
+           | .current_state.state == "unknown" and .endpoint.exists == true and .active == false)
       and ((.agents[] | select(.id == "gone-agent"))
-           | .current_state.state != "done" and .endpoint.exists == false and .active == false)
+           | .endpoint.exists == false and .active == false)
   ' >/dev/null || fail "active was not derived from current state and endpoint: $out"
 
-  out=$(run_learn "$home" "$fakebin" start done-agent --json) \
-    || fail "a terminal record stopped being selectable for learning"
-  printf '%s\n' "$out" | jq -e '.selected_agent.id == "done-agent"' >/dev/null \
-    || fail "terminal learning candidate did not expose its context: $out"
-  out=$(run_learn "$home" "$fakebin" start gone-agent --json) \
-    || fail "an endpoint-absent record stopped being selectable for learning"
-  printf '%s\n' "$out" | jq -e '.selected_agent.id == "gone-agent"' >/dev/null \
-    || fail "endpoint-absent learning candidate did not expose its context: $out"
-  pass "active is derived from state and endpoint while every candidate stays selectable"
+  local id
+  for id in done-agent stale-agent gone-agent; do
+    out=$(run_learn "$home" "$fakebin" start "$id" --json) \
+      || fail "an inactive record stopped being selectable for learning: $id"
+    printf '%s\n' "$out" | jq -e --arg id "$id" '.selected_agent.id == $id' >/dev/null \
+      || fail "inactive learning candidate did not expose its context: $id: $out"
+  done
+  pass "active requires a known non-terminal state and endpoint while candidates stay selectable"
 }
 
 test_start_is_read_only_and_contains_bounded_context() {

--- a/tests/fm-learn.test.sh
+++ b/tests/fm-learn.test.sh
@@ -287,16 +287,20 @@ test_help_frames_candidates_as_records() {
 }
 
 test_adapter_seam_is_shared_by_pi_and_claude() {
-  local skill
+  local skill doc
   skill="$ROOT/.agents/skills/learn/SKILL.md"
+  doc="$ROOT/docs/learn.md"
   assert_present "$skill" "learn skill is missing"
+  assert_present "$doc" "learn documentation is missing"
   assert_grep "user-invocable: true" "$skill" "learn skill is not user invocable"
   assert_grep "bin/fm-learn.sh list" "$skill" "learn skill does not use the shared list core"
   assert_grep "bin/fm-learn.sh start <agent-id>" "$skill" "learn skill does not use the shared start core"
-  assert_grep 'Claude discovers this skill through `.claude/skills`' "$skill" \
-    "learn skill does not document the Claude adapter seam"
-  assert_grep "Pi discovers the same skill directory" "$skill" \
-    "learn skill does not document the Pi adapter seam"
+  assert_grep "docs/learn.md" "$skill" \
+    "learn skill does not delegate to the harness entry-point owner"
+  assert_grep "Claude discovers the skill through the \`.claude/skills\` symlink" "$doc" \
+    "learn documentation does not document the Claude adapter seam"
+  assert_grep "Pi discovers it through its normal \`.agents/skills\` loading path" "$doc" \
+    "learn documentation does not document the Pi adapter seam"
   assert_grep "no First Mate agent records are available" "$skill" \
     "learn skill does not report an empty candidate set as absent records"
   assert_not_contains "$(cat "$skill")" "no active agent is available" \

--- a/tests/fm-learn.test.sh
+++ b/tests/fm-learn.test.sh
@@ -272,6 +272,20 @@ test_snapshot_alias_and_invalid_selection() {
   pass "learning selection aliases and path-safe errors are covered"
 }
 
+test_help_frames_candidates_as_records() {
+  local home fakebin out
+  home=$(make_home "$TMP_ROOT/help")
+  fakebin=$(make_fakebin "$home")
+  out=$(run_learn "$home" "$fakebin" --help)
+  assert_contains "$out" "Firstmate's agent records" \
+    "help text does not describe the view as covering agent records"
+  assert_not_contains "$out" "active agent records" \
+    "help text scopes the view to active records while every candidate is selectable"
+  assert_contains "$out" "Every candidate is selectable" \
+    "help text does not state that every candidate is selectable"
+  pass "help text frames candidates as records without contradicting selectability"
+}
+
 test_adapter_seam_is_shared_by_pi_and_claude() {
   local skill
   skill="$ROOT/.agents/skills/learn/SKILL.md"
@@ -287,6 +301,10 @@ test_adapter_seam_is_shared_by_pi_and_claude() {
     "learn skill does not report an empty candidate set as absent records"
   assert_not_contains "$(cat "$skill")" "no active agent is available" \
     "learn skill confuses absent records with inactive agents"
+  assert_grep "description: Open a read-only learning session for one Firstmate agent record" "$skill" \
+    "learn skill does not route on agent records"
+  assert_no_grep "one active Firstmate agent" "$skill" \
+    "learn skill routes only on active agents, excluding selectable done and failed records"
   [ "$(readlink "$ROOT/.claude/skills")" = "../.agents/skills" ] \
     || fail "Claude skill directory is not the shared agent skill directory"
   pass "Pi and Claude share the tested skill entry point without harness-specific spawning"
@@ -297,4 +315,5 @@ test_list_enumerates_snapshot_agents
 test_active_is_derived_and_inactive_stays_selectable
 test_start_is_read_only_and_contains_bounded_context
 test_snapshot_alias_and_invalid_selection
+test_help_frames_candidates_as_records
 test_adapter_seam_is_shared_by_pi_and_claude

--- a/tests/fm-learn.test.sh
+++ b/tests/fm-learn.test.sh
@@ -256,7 +256,9 @@ test_snapshot_alias_and_invalid_selection() {
   out=$(run_learn "$home" "$fakebin" start missing-agent 2>&1)
   status=$?
   [ "$status" -ne 0 ] || fail "missing agent selection should fail"
-  assert_contains "$out" "no active agent record" "missing selection error was unclear"
+  assert_contains "$out" "no agent record for 'missing-agent'" "missing selection error was unclear"
+  assert_not_contains "$out" "no active agent record" \
+    "missing selection error confused absence with inactivity"
 
   out=$(run_learn "$home" "$fakebin" start ../outside 2>&1)
   status=$?

--- a/tests/fm-spawn-meta-publish.test.sh
+++ b/tests/fm-spawn-meta-publish.test.sh
@@ -7,7 +7,9 @@
 # snapshot derives current state and endpoints from it, and bin/fm-learn.sh
 # enumerates and selects learning candidates from those rows. If the write
 # silently fails, spawn reports success while the fleet loses the task, so the
-# failure must abort the spawn with a clear error instead of being swallowed.
+# failure must abort the spawn with a clear error instead of being swallowed,
+# and that abort must release the endpoint and worktree it already created -
+# with no meta record, nothing downstream can ever reap them.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -28,13 +30,19 @@ esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window) exit 0 ;;
+  kill-window) [ -z "${FM_FAKE_LOG:-}" ] || printf 'tmux %s\n' "$*" >> "$FM_FAKE_LOG"; exit 0 ;;
+  has-session|new-session|new-window) exit 0 ;;
   send-keys) exit 0 ;;
 esac
 exit 0
 SH
-  chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -z "${FM_FAKE_LOG:-}" ] || printf 'treehouse %s\n' "$*" >> "$FM_FAKE_LOG"
+exit 0
+SH
+  chmod +x "$fakebin/tmux" "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -68,6 +76,7 @@ run_spawn() {
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$WT_DIR" \
+    FM_FAKE_LOG="$HOME_DIR/fake-calls.log" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" 2>&1
 }
@@ -84,6 +93,8 @@ test_metadata_publication_is_reported() {
   assert_contains "$out" "spawned $id" "spawn did not report success"
   assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
     "published metadata does not record the worktree the fleet reads"
+  assert_not_contains "$(cat "$HOME_DIR/fake-calls.log" 2>/dev/null || true)" "treehouse return" \
+    "a successful spawn released the worktree it had just handed to the crewmate"
   pass "a successful spawn publishes the authoritative task metadata record"
 }
 
@@ -107,5 +118,25 @@ test_unpublishable_metadata_fails_closed() {
   pass "a failed metadata publication aborts the spawn instead of being swallowed"
 }
 
+# Without a meta record nothing downstream can find the endpoint or the worktree
+# the aborted spawn already created - fm-teardown.sh keys off meta and there is
+# no orphan reaper - so the abort itself has to release both.
+test_unpublishable_metadata_releases_created_resources() {
+  local rec id out calls
+  id=meta-publish-leak-z1
+  rec=$(make_case publish-leak "$id")
+  read_case "$rec"
+  mkdir -p "$HOME_DIR/state/$id.meta"
+
+  out=$(run_spawn "$id")
+  calls=$(cat "$HOME_DIR/fake-calls.log" 2>/dev/null || true)
+  assert_contains "$calls" "kill-window" \
+    "aborted spawn left its backend window running with no metadata record: $out"
+  assert_contains "$calls" "treehouse return --force $WT_DIR" \
+    "aborted spawn left its worktree checked out with no metadata record: $out"
+  pass "a failed metadata publication releases the endpoint and worktree it created"
+}
+
 test_metadata_publication_is_reported
 test_unpublishable_metadata_fails_closed
+test_unpublishable_metadata_releases_created_resources

--- a/tests/fm-spawn-meta-publish.test.sh
+++ b/tests/fm-spawn-meta-publish.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Regression test for fail-closed publication of state/<id>.meta in
+# bin/fm-spawn.sh (the `if { ... } > "$STATE/$ID.meta"; then` block).
+#
+# state/<id>.meta is the authoritative record every read-only consumer trusts:
+# bin/fm-crew-state.sh resolves worktree/backend/kind from it, the fleet
+# snapshot derives current state and endpoints from it, and bin/fm-learn.sh
+# enumerates and selects learning candidates from those rows. If the write
+# silently fails, spawn reports success while the fleet loses the task, so the
+# failure must abort the spawn with a clear error instead of being swallowed.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-meta-publish)
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# make_case <name> <id> builds a home, a project with a real worktree the fake
+# pane reports as its cwd, and a brief - the minimum a tmux spawn needs.
+make_case() {
+  local name=$1 id=$2 case_dir home proj wt fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  mkdir -p "$home/data/$id"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s|%s|%s|%s\n' "$home" "$proj" "$wt" "$fakebin"
+}
+
+read_case() {
+  IFS='|' read -r HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR <<EOF
+$1
+EOF
+}
+
+run_spawn() {
+  local id=$1
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$WT_DIR" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" 2>&1
+}
+
+test_metadata_publication_is_reported() {
+  local rec id out status
+  id=meta-publish-ok-z1
+  rec=$(make_case publish-ok "$id")
+  read_case "$rec"
+
+  out=$(run_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed when metadata can be published"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "published metadata does not record the worktree the fleet reads"
+  pass "a successful spawn publishes the authoritative task metadata record"
+}
+
+# An unwritable state/<id>.meta path stands in for any failed publication
+# (full disk, read-only state dir, a stale directory left at the path).
+test_unpublishable_metadata_fails_closed() {
+  local rec id out status
+  id=meta-publish-fail-z1
+  rec=$(make_case publish-fail "$id")
+  read_case "$rec"
+  mkdir -p "$HOME_DIR/state/$id.meta"
+
+  out=$(run_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] \
+    || fail "spawn reported success while task metadata could not be published: $out"
+  assert_contains "$out" "could not publish metadata for $id" \
+    "unpublishable metadata did not produce a clear error"
+  assert_not_contains "$out" "spawned $id" \
+    "spawn announced a task whose authoritative metadata was never published"
+  pass "a failed metadata publication aborts the spawn instead of being swallowed"
+}
+
+test_metadata_publication_is_reported
+test_unpublishable_metadata_fails_closed


### PR DESCRIPTION
## Intent

The developer was building PR2 of First Mate's `/learn` feature: a harness-independent, read-only learning-session core that enumerates active First Mate agents, builds a context snapshot for a selected agent from the authoritative fleet snapshot and task records, and exposes thin Pi/Claude `/learn` entry points, with seams left for a future separate learner process and Obsidian persistence. They set explicit constraints: no Obsidian integration yet, no reintroduction of tmux pane placement (one agent per new tmux window in the primary session, per merged PR1), preserve the existing task lifecycle, isolated worktrees, read-only learner boundary, and primary-session safety, follow the firstmate coding-guidelines skill, and ship with colocated tests and docs on branch `fm/learn-pr2`. After the implementation commit, they directed the agent to drive the full no-mistakes validation pipeline without hand-fixing findings outside it, escalating only supervisor-actionable gates. At each gate they made specific calls: rebase `fm/learn-pr2` onto `origin/main` rather than pushing local main; fix `learn-active-hardcoded` by deriving `active` from current state and endpoint instead of hardcoding it; fix the follow-up so `active` is true only for known non-terminal states with `unknown`/unclassifiable treated as inactive; skip the pre-existing unrelated bearings-snapshot test failure without touching bearings logic; fix the help text to cover the `agents`/`context` aliases and both JSON contracts; skip lint since ShellCheck 0.11.0 was unavailable, recording the missing dependency without installing anything. Finally, after a 403 on push, they instructed the agent to retarget the push to the `elirantism/firstmate` fork without changing the implementation and re-run the pipeline preserving all commits and approved gate dispositions.

## What Changed

- New `bin/fm-learn.sh` core plus a `/learn` skill in `.agents/skills/learn/`: `list`/`agents` enumerates every task metadata row from the authoritative `bin/fm-fleet-snapshot.sh --json` output as a selectable candidate (schema `fm-learning-agent-list.v1`), and `start`/`context`/`snapshot` assembles a bounded read-only context for one selected record (schema `fm-learning-session.v1`) covering the fleet snapshot, backlog record, task brief, status events, and report, with `FM_LEARN_RECORD_LINES` capping each excerpt. `active` is derived from the record - true only for a known non-terminal state with a present endpoint - and inactive records stay listed and selectable. The core reads Firstmate home records only; it never opens project files or the agent's worktree, spawns a learner, or touches task lifecycle state, and the session JSON carries the seams reserved for a future separate learner process and Obsidian persistence.
- `bin/backends/tmux.sh` now resolves the target session for a new `fm-<id>` window as: the spawning shell's own session when `$TMUX` is set, else the session the most-recently-active attached client is viewing (new `fm_backend_tmux_primary_session`), else the dedicated detached `firstmate` session. A spawn shell that lost `$TMUX` therefore lands the window where the captain is actually attached instead of in a separate session. `bin/fm-supervise-daemon.sh`'s window lookup switched to a `while read` loop so session names with spaces resolve.
- `bin/fm-spawn.sh` fails the spawn when `state/<id>.meta` cannot be published, and the new `spawn_release_created_resources` abort path returns the treehouse worktree and kills the created backend endpoint so a task with no metadata record cannot leak an unreapable window and worktree.
- Docs and tests: new `docs/learn.md` contract with a "Harness entry points" section scoping verification to Claude and Pi, README skills-table and docs-index entries, updated `docs/tmux-backend.md`, and new `tests/fm-learn.test.sh` (7 cases), `tests/fm-spawn-meta-publish.test.sh` (3), and `tests/fm-backend-tmux-smoke.test.sh` (11), all passing. The Test gate also recorded a pre-existing, unrelated `tests/fm-bearings-snapshot.test.sh` failure on untouched bearings code, and Lint was skipped because ShellCheck 0.11.0 was unavailable.

## Risk Assessment

⚠️ Medium: This round's change is a clean documentation-and-test-only edit that closes the wording chain with verified assertions, but the branch as a whole still modifies fm-spawn.sh's abort lifecycle with residual cleanup gaps the user has explicitly accepted as follow-ups.

## Testing

Ran the new `tests/fm-learn.test.sh` suite (7/7 pass) plus the branch's other changed suites (tmux smoke, spawn meta-publish) and neighboring fleet/spawn/docs regressions - all green. For product-level evidence I drove `/learn` end-to-end against a live demo `FM_HOME` with real tmux windows so the fleet snapshot performed genuine endpoint and pane-state probes, and captured CLI transcripts of the candidate list, both alias spellings, both JSON contracts, the human learning session for active/terminal/endpoint-less records, the `FM_LEARN_RECORD_LINES` truncation seam, and a real tmux pane capture of the captain-facing flow. The read-only boundary was verified rather than asserted: sha256 of all 15 files under `$FM_HOME` and the tmux window inventory were unchanged after 8 invocations, and a string seeded in the selected agent's worktree never appears in the session output. No screenshot or rendered-HTML artifact applies - this change ships only bash CLI commands, a skill markdown file, and docs, so the terminal transcripts are the actual end-user surface. Two non-blocking issues surfaced: one pre-existing `fm-bearings-snapshot` failure in code this branch does not touch, and a tmux 3.7b quirk in pre-existing `fm_backend_target_exists` that prevents reproducing the "recorded window is gone" endpoint case against real tmux on this host (covered by the suite's fake-tmux fixture).

<details>
<summary>Evidence: Evidence index (fleet used, file-by-file map)</summary>

```text
# /learn (fm/learn-pr2) - end-to-end evidence

All transcripts were produced against a live demo `FM_HOME` with **real tmux windows**
(real endpoints, real `bin/fm-fleet-snapshot.sh` probes) - no stubbed snapshot.

Fleet used for the demo:

| record | state | endpoint | expected `active` |
|---|---|---|---|
| `alpha-login` (ship) | working | present | **true** |
| `beta-signup` (scout) | done (terminal) | present | false, still selectable |
| `gamma-logout` (ship) | unknown (unclassifiable) | present | false, still selectable |
| `delta-deploy` (ship) | unknown, no recorded window | unknown (`null`) | false, still selectable |

| file | shows |
|---|---|
| `00-fm-learn-test-suite.txt` | `tests/fm-learn.test.sh` behavior suite |
| `01-learn-list.txt` | `--help`, `list`, the `agents` alias, and the `fm-learning-agent-list.v1` active matrix |
| `02-learn-session-human.txt` | human learning session for an active, a done, and an endpoint-less record (`start` / `context` / `snapshot --agent`) |
| `03-learn-session-json-contract.txt` | `fm-learning-session.v1`: embedded `fm-fleet-snapshot.v1`, backlog record, bounded metadata/brief/status/report records, `learner` + `boundary` seams, `FM_LEARN_RECORD_LINES` truncation |
| `04-read-only-boundary.txt` | sha256 of all 15 files under `$FM_HOME` unchanged after 8 invocations, tmux fleet unchanged, worktree content never surfaced, path-safe id + absence errors |
| `05-harness-entry-points.txt` | Claude `.claude/skills` and Pi `.agents/skills` resolve `/learn` to one identical SKILL.md that calls only the shared core; no pane placement |
| `06-terminal-session.txt` | real tmux pane capture of the captain-facing `/learn` flow (skill steps 1-2 then 5-6) |
| `07-tmux-endpoint-probe-note.txt` | pre-existing tmux 3.7b probe quirk and how it bounds what could be reproduced live |
```
</details>
<details>
<summary>Evidence: Captain-facing /learn flow, captured from a real tmux pane</summary>

<code>captain@firstmate:~/firstmate$ # captain types /learn -- the skill runs the shared core&#10;&#10;captain@firstmate:~/firstmate$ bin/fm-learn.sh list&#10;Learning candidates (read-only)&#10;&#10;1. alpha-login [ship] - alpha - state working / pane - codex / tmux - endpoint present&#10;2. beta-signup [scout] - beta - state done / status-log - codex / tmux - endpoint present&#10;3. delta-deploy [ship] - delta - state unknown / none - claude / tmux - endpoint unknown&#10;4. gamma-logout [ship] - gamma - state unknown / none - claude / tmux - endpoint present&#10;&#10;captain@firstmate:~/firstmate$ # captain: &#34;learn from alpha-login&#34;&#10;&#10;captain@firstmate:~/firstmate$ bin/fm-learn.sh start alpha-login&#10;Learning session (read-only)&#10;Selected agent: alpha-login [ship]&#10;Project: alpha&#10;Current state: working / pane&#10;Harness and backend: codex / tmux&#10;Worktree content: not read&#10;Learner process: current Firstmate; separate-process seam is reserved&#10;Persistence: none; Obsidian is not integrated&#10;&#10;Task brief:&#10;# Harden the login flow&#10;&#10;Acceptance criteria:&#10;- Replayed session tokens are rejected.&#10;- No change to the public login API shape.&#10;&#10;Recent task events:&#10;working: rewriting the session token check&#10;&#10;captain@firstmate:~/firstmate$</code>

```text
captain@firstmate:~/firstmate$ # captain types /learn -- the skill runs the shared core

captain@firstmate:~/firstmate$ bin/fm-learn.sh list
Learning candidates (read-only)

1. alpha-login [ship] - alpha - state working / pane - codex / tmux - endpoint present
2. beta-signup [scout] - beta - state done / status-log - codex / tmux - endpoint present
3. delta-deploy [ship] - delta - state unknown / none - claude / tmux - endpoint unknown
4. gamma-logout [ship] - gamma - state unknown / none - claude / tmux - endpoint present

captain@firstmate:~/firstmate$ # captain: "learn from alpha-login"

captain@firstmate:~/firstmate$ bin/fm-learn.sh start alpha-login
Learning session (read-only)
Selected agent: alpha-login [ship]
Project: alpha
Current state: working / pane
Harness and backend: codex / tmux
Worktree content: not read
Learner process: current Firstmate; separate-process seam is reserved
Persistence: none; Obsidian is not integrated

Task brief:
# Harden the login flow

Acceptance criteria:
- Replayed session tokens are rejected.
- No change to the public login API shape.

Recent task events:
working: rewriting the session token check

captain@firstmate:~/firstmate$
```
</details>
<details>
<summary>Evidence: Derived `active` matrix from live tmux endpoints (fm-learning-agent-list.v1)</summary>

<code>$ bin/fm-learn.sh list --json | jq &#39;{schema, read_only, agents: [.agents[] | {id, active, state: .current_state.state, endpoint: .endpoint.exists}]}&#39;&#10;{&#10;&#34;schema&#34;: &#34;fm-learning-agent-list.v1&#34;,&#10;&#34;read_only&#34;: true,&#10;&#34;agents&#34;: [&#10;{ &#34;id&#34;: &#34;alpha-login&#34;, &#34;active&#34;: true, &#34;state&#34;: &#34;working&#34;, &#34;endpoint&#34;: true },&#10;{ &#34;id&#34;: &#34;beta-signup&#34;, &#34;active&#34;: false, &#34;state&#34;: &#34;done&#34;, &#34;endpoint&#34;: true },&#10;{ &#34;id&#34;: &#34;delta-deploy&#34;, &#34;active&#34;: false, &#34;state&#34;: &#34;unknown&#34;, &#34;endpoint&#34;: null },&#10;{ &#34;id&#34;: &#34;gamma-logout&#34;, &#34;active&#34;: false, &#34;state&#34;: &#34;unknown&#34;, &#34;endpoint&#34;: true }&#10;]&#10;}</code>

```text
$ tmux list-windows -t firstmate -F "#S:#W  (#{pane_current_command})"   # real agent endpoints, real tmux 3.7b
firstmate:fm-alpha-login
firstmate:fm-beta-signup

$ bin/fm-learn.sh --help
usage: fm-learn.sh list|agents [--json]
       fm-learn.sh start|snapshot|context <agent-id> [--json]

Expose a read-only learning-session view of Firstmate's agent records.

list prints learning candidates from bin/fm-fleet-snapshot.sh; agents is an
accepted alias.
Every candidate is selectable; active is true only for a record in a known
non-terminal state (working, parked, paused, blocked) with a present endpoint.
start, snapshot, and context are aliases that print the selected agent's
bounded learning context.
--json prints the machine-readable contract: fm-learning-agent-list.v1 for the
candidate list, fm-learning-session.v1 for the selected agent's context.
The selected agent's project files and worktree are never read or changed.
No learner process or persistence adapter is created in this slice.
--agent <agent-id> is accepted as an alternate selection spelling.
FM_LEARN_RECORD_LINES bounds task-record content and defaults to 120 lines.

$ bin/fm-learn.sh list        # step 1-2 of the /learn skill: enumerate candidates
Learning candidates (read-only)

1. alpha-login [ship] - alpha - state working / pane - codex / tmux - endpoint present
2. beta-signup [scout] - beta - state done / status-log - codex / tmux - endpoint present
3. delta-deploy [ship] - delta - state unknown / none - claude / tmux - endpoint unknown
4. gamma-logout [ship] - gamma - state unknown / none - claude / tmux - endpoint present

$ bin/fm-learn.sh agents      # documented alias, same output
Learning candidates (read-only)

1. alpha-login [ship] - alpha - state working / pane - codex / tmux - endpoint present
2. beta-signup [scout] - beta - state done / status-log - codex / tmux - endpoint present
3. delta-deploy [ship] - delta - state unknown / none - claude / tmux - endpoint unknown
4. gamma-logout [ship] - gamma - state unknown / none - claude / tmux - endpoint present

$ bin/fm-learn.sh list --json | jq "{schema, read_only, agents: [.agents[] | {id, active, state: .current_state.state, endpoint: .endpoint.exists}]}"
{
  "schema": "fm-learning-agent-list.v1",
  "read_only": true,
  "agents": [
    {
      "id": "alpha-login",
      "active": true,
      "state": "working",
      "endpoint": true
    },
    {
      "id": "beta-signup",
      "active": false,
      "state": "done",
      "endpoint": true
    },
    {
      "id": "delta-deploy",
      "active": false,
      "state": "unknown",
      "endpoint": null
    },
    {
      "id": "gamma-logout",
      "active": false,
      "state": "unknown",
      "endpoint": true
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Read-only boundary verified against live state</summary>

<code># Read-only boundary, verified against the live demo home after 8 /learn invocations&#10;&#10;$ diff before.sums after.sums # sha256 of every file under $FM_HOME (state, data, projects/worktrees)&#10;(no output: nothing under $FM_HOME changed)&#10;&#10;files hashed: 15&#10;&#10;$ diff &lt;(windows before) &lt;(windows after) # no agent endpoint was created, killed, or steered&#10;(no output: tmux fleet unchanged)&#10;&#10;# The selected agent worktree content is never surfaced&#10;$ cat $FM_HOME/projects/alpha-login/README.md&#10;secret worktree source that /learn must never read&#10;$ bin/fm-learn.sh start alpha-login --json | grep -c &#34;secret worktree source&#34;&#10;0&#10;(0 occurrences = worktree content absent from the learning session)&#10;&#10;# Path-safe selection and clear absence errors&#10;$ bin/fm-learn.sh start ../../etc/passwd ; echo &#34;exit=$?&#34;&#10;fm-learn: invalid agent id&#10;exit=2&#10;$ bin/fm-learn.sh start no-such-agent ; echo &#34;exit=$?&#34;&#10;fm-learn: no agent record for &#39;no-such-agent&#39;&#10;exit=1</code>

```text
# Read-only boundary, verified against the live demo home after 8 /learn invocations

$ diff before.sums after.sums   # sha256 of every file under $FM_HOME (state, data, projects/worktrees)
(no output: nothing under $FM_HOME changed)

files hashed: 15

$ diff <(windows before) <(windows after)   # no agent endpoint was created, killed, or steered
(no output: tmux fleet unchanged)

# The selected agent worktree content is never surfaced
$ cat $FM_HOME/projects/alpha-login/README.md
secret worktree source that /learn must never read
$ bin/fm-learn.sh start alpha-login --json | grep -c "secret worktree source"
0
(0 occurrences = worktree content absent from the learning session)

# Path-safe selection and clear absence errors
$ bin/fm-learn.sh start ../../etc/passwd ; echo "exit=$?"
fm-learn: invalid agent id
exit=2
$ bin/fm-learn.sh start no-such-agent ; echo "exit=$?"
fm-learn: no agent record for 'no-such-agent'
exit=1
```
</details>
<details>
<summary>Evidence: fm-learning-session.v1 contract: learner and boundary seams</summary>

<code>$ bin/fm-learn.sh start alpha-login --json | jq &#39;{schema, selected_id, learner, boundary}&#39;&#10;{&#10;&#34;schema&#34;: &#34;fm-learning-session.v1&#34;,&#10;&#34;selected_id&#34;: &#34;alpha-login&#34;,&#10;&#34;learner&#34;: {&#10;&#34;delivery&#34;: &#34;inline&#34;,&#10;&#34;process&#34;: &#34;current-firstmate&#34;,&#10;&#34;separate_process&#34;: false,&#10;&#34;future_process_seam&#34;: &#34;consume this context contract in a separate learner process&#34;,&#10;&#34;persistence&#34;: &#34;none&#34;,&#10;&#34;future_persistence_seam&#34;: &#34;Obsidian adapter&#34;&#10;},&#10;&#34;boundary&#34;: {&#10;&#34;read_only&#34;: true,&#10;&#34;project_files_read&#34;: false,&#10;&#34;selected_worktree_read&#34;: false,&#10;&#34;task_lifecycle_unchanged&#34;: true,&#10;&#34;spawned_agent&#34;: false&#10;}&#10;}&#10;&#10;# Bounded excerpt seam&#10;$ FM_LEARN_RECORD_LINES=2 bin/fm-learn.sh start alpha-login --json | jq &#39;.context.task_records.brief | {lines, truncated, content}&#39;&#10;{ &#34;lines&#34;: 5, &#34;truncated&#34;: true, &#34;content&#34;: &#34;# Harden the login flow&#34; }</code>

```text
$ bin/fm-learn.sh start alpha-login --json | jq "{schema, selected_id, learner, boundary}"
{
  "schema": "fm-learning-session.v1",
  "selected_id": "alpha-login",
  "learner": {
    "delivery": "inline",
    "process": "current-firstmate",
    "separate_process": false,
    "future_process_seam": "consume this context contract in a separate learner process",
    "persistence": "none",
    "future_persistence_seam": "Obsidian adapter"
  },
  "boundary": {
    "read_only": true,
    "project_files_read": false,
    "selected_worktree_read": false,
    "task_lifecycle_unchanged": true,
    "spawned_agent": false
  }
}

$ ... | jq "{fleet_snapshot_schema: .context.fleet_snapshot.schema, records: (.context.task_records | map_values(...))}"
{
  "fleet_snapshot_schema": "fm-fleet-snapshot.v1",
  "backlog_record": {
    "order": 1,
    "state": "in_flight",
    "structured": true,
    "id": "alpha-login",
    "checked": false,
    "title": "Harden the login flow against replayed sessions",
    "repo": "alpha",
    "kind": "ship",
    "priority": null,
    "hold_reason": null,
    "hold_kind": null,
    "blocked_by": null,
    "blocked_by_ids": [],
    "blocked_reason": null,
    "since": "2026-07-28",
    "merged": null,
    "reported": null,
    "done": null,
    "completion": {
      "verb": null,
      "date": null
    },
    "links": [],
    "pr_url": null,
    "report_path": null,
    "local_note": null,
    "raw": "- [ ] alpha-login - Harden the login flow against replayed sessions (repo: alpha) (kind: ship) (since 2026-07-28)",
    "body_lines": [],
    "body_excerpt": null,
    "unresolved_blocker_ids": [],
    "current_role": "worker",
    "requires_child_metadata": true,
    "captain_actionable": false
  },
  "bounded_records": {
    "metadata": {
      "present": true,
      "lines": 7,
      "bytes": 150,
      "truncated": false,
      "path": "/tmp/fm-learn-demo.MWa9tA/home/state/alpha-login.meta"
    },
    "brief": {
      "present": true,
      "lines": 5,
      "bytes": 129,
      "truncated": false,
      "path": "/tmp/fm-learn-demo.MWa9tA/home/data/alpha-login/brief.md"
    },
    "status_log": {
      "present": true,
      "lines": 1,
      "bytes": 43,
      "truncated": false,
      "path": "/tmp/fm-learn-demo.MWa9tA/home/state/alpha-login.status"
    },
    "report": {
      "present": false,
      "lines": 0,
      "bytes": 0,
      "truncated": false,
      "path": "/tmp/fm-learn-demo.MWa9tA/home/data/alpha-login/report.md"
    }
  }
}

$ bin/fm-learn.sh start beta-signup --json | jq -r ".context.task_records.report.content"   # scout report is in context
# Signup drop-off report

52% of drop-off happens on the email verification step.

# Bounded excerpt seam: FM_LEARN_RECORD_LINES=2 truncates the brief
$ FM_LEARN_RECORD_LINES=2 bin/fm-learn.sh start alpha-login --json | jq ".context.task_records.brief | {lines, truncated, content}"
{
  "lines": 5,
  "truncated": true,
  "content": "# Harden the login flow"
}
```
</details>
<details>
<summary>Evidence: Human learning sessions: active, done, and endpoint-less records</summary>

```text
$ bin/fm-learn.sh start alpha-login      # step 5-6 of the /learn skill: open context for the chosen agent
Learning session (read-only)
Selected agent: alpha-login [ship]
Project: alpha
Current state: working / pane
Harness and backend: codex / tmux
Worktree content: not read
Learner process: current Firstmate; separate-process seam is reserved
Persistence: none; Obsidian is not integrated

Task brief:
# Harden the login flow

Acceptance criteria:
- Replayed session tokens are rejected.
- No change to the public login API shape.

Recent task events:
working: rewriting the session token check

$ bin/fm-learn.sh context beta-signup    # a DONE record is still selectable for learning
Learning session (read-only)
Selected agent: beta-signup [scout]
Project: beta
Current state: done / status-log
Harness and backend: codex / tmux
Worktree content: not read
Learner process: current Firstmate; separate-process seam is reserved
Persistence: none; Obsidian is not integrated

Task brief:
# Investigate signup drop-off

Acceptance criteria: leave a standalone report, change nothing.

Recent task events:
done: signup drop-off report delivered

$ bin/fm-learn.sh snapshot --agent delta-deploy   # alias + --agent selection spelling, endpoint-less record
Learning session (read-only)
Selected agent: delta-deploy [ship]
Project: delta
Current state: unknown / none
Harness and backend: claude / tmux
Worktree content: not read
Learner process: current Firstmate; separate-process seam is reserved
Persistence: none; Obsidian is not integrated

Task brief:
# Ship the deploy script

Acceptance criteria: no production deploy without captain confirmation.

Recent task events:
parked: waiting on the captain to confirm the deploy window
```
</details>
<details>
<summary>Evidence: Shared Claude/Pi /learn entry point (identical SKILL.md, no pane placement)</summary>

<code>$ ls -l .claude/skills&#10;lrwxr-xr-x .claude/skills -&gt; ../.agents/skills&#10;&#10;$ shasum -a 256 .claude/skills/learn/SKILL.md .agents/skills/learn/SKILL.md # identical file, one seam&#10;d4f5231fbd9421c8175592a9ed5ed27ab3df82e1526aa80074fe9a913949ad8c .claude/skills/learn/SKILL.md&#10;d4f5231fbd9421c8175592a9ed5ed27ab3df82e1526aa80074fe9a913949ad8c .agents/skills/learn/SKILL.md&#10;&#10;$ grep -n &#34;fm-learn.sh&#34; .agents/skills/learn/SKILL.md # skill body calls only the shared core&#10;12:It uses the shared `bin/fm-learn.sh` core, so Claude and Pi use the same adapter seam.&#10;16:1. Run `bin/fm-learn.sh list`.&#10;20:5. Run `bin/fm-learn.sh start &lt;agent-id&gt;` for the selected candidate.</code>

```text
# Harness entry points: Claude and Pi resolve /learn to the SAME shared skill file

$ ls -l .claude/skills .pi
lrwxr-xr-x@ 1 eliran  staff  17 Jul 29 10:41 .claude/skills -> ../.agents/skills
total 0
drwxr-xr-x@ 6 eliran  staff  192 Jul 29 10:41 extensions

$ ls .agents/skills/learn && ls .claude/skills/learn
SKILL.md
SKILL.md

$ readlink -f .claude/skills/learn/SKILL.md ; readlink -f .agents/skills/learn/SKILL.md
/Users/eliran/.no-mistakes/worktrees/f8fa3bd9c3c8/01KYQFG316088X4FM1BK6ZBZ1J/.agents/skills/learn/SKILL.md
/Users/eliran/.no-mistakes/worktrees/f8fa3bd9c3c8/01KYQFG316088X4FM1BK6ZBZ1J/.agents/skills/learn/SKILL.md

$ shasum -a 256 .claude/skills/learn/SKILL.md .agents/skills/learn/SKILL.md   # identical file, one seam
d4f5231fbd9421c8175592a9ed5ed27ab3df82e1526aa80074fe9a913949ad8c  .claude/skills/learn/SKILL.md
d4f5231fbd9421c8175592a9ed5ed27ab3df82e1526aa80074fe9a913949ad8c  .agents/skills/learn/SKILL.md

$ sed -n 1,8p .agents/skills/learn/SKILL.md   # frontmatter the harness routes on
---
name: learn
description: Open a read-only learning session for one Firstmate agent record, whether the agent is still working or its task is already done or failed. Use when the captain invokes /learn or asks to learn from, inspect, understand, or study an agent's recorded work without changing it.
user-invocable: true
metadata:
  internal: true
---


$ grep -n "fm-learn.sh" .agents/skills/learn/SKILL.md   # skill body calls only the shared core
12:It uses the shared `bin/fm-learn.sh` core, so Claude and Pi use the same adapter seam.
16:1. Run `bin/fm-learn.sh list`.
20:5. Run `bin/fm-learn.sh start <agent-id>` for the selected candidate.

$ grep -rn "pane\|split-window" .agents/skills/learn/SKILL.md   # PR1 constraint: no pane placement reintroduced
.agents/skills/learn/SKILL.md:28:If a future learner becomes an agent, it must use the normal isolated spawn path and the primary session's one-window-per-agent behavior rather than introducing pane placement.
.agents/skills/learn/SKILL.md:34:No harness-specific extension or pane command is needed for this slice.
```
</details>
<details>
<summary>Evidence: tmux 3.7b endpoint-probe note (pre-existing, scope of live reproduction)</summary>

<code>$ tmux -V&#10;tmux 3.7b&#10;$ tmux display-message -p -t &#34;no-such-session:no-such-window&#34; &#34;#{pane_id}&#34; ; echo &#34;exit=$?&#34;&#10;&#10;exit=0&#10;$ tmux list-panes -t &#34;no-such-session:no-such-window&#34; ; echo &#34;exit=$?&#34; # a strict target lookup does fail&#10;can&#39;t find session: no-such-session&#10;exit=1</code>

```text
# tmux endpoint-probe note (pre-existing, unchanged by this branch)

fm_backend_target_exists (bin/fm-backend.sh:837, NOT touched by fm/learn-pr2) probes a tmux
endpoint with `tmux display-message -p -t <target>`. On the tmux installed here that command
succeeds for a target that does not exist, so endpoint.exists can never become false:

$ tmux -V
tmux 3.7b
$ tmux display-message -p -t "no-such-session:no-such-window" "#{pane_id}" ; echo "exit=$?"

exit=0
$ tmux list-panes -t "no-such-session:no-such-window" ; echo "exit=$?"   # a strict target lookup does fail
can't find session: no-such-session
exit=1

Effect on this branch: the new list_json `active` derivation still correctly reports false for
terminal/unknown states and for records with no recorded endpoint (endpoint.exists = null),
which is demonstrated live in 01-learn-list.txt. Only the "recorded tmux window is gone"
sub-case cannot be reproduced against real tmux on this host; tests/fm-learn.test.sh covers it
with a fake tmux (test_active_is_derived_and_inactive_stays_selectable, gone-agent fixture).
```
</details>
<details>
<summary>Evidence: tests/fm-learn.test.sh suite output</summary>

```text
ok - learning list reports an explicit empty candidate set in both contracts
ok - learning list enumerates active agents from the fleet snapshot
ok - active requires a known non-terminal state and endpoint while candidates stay selectable
ok - selected learning context is bounded, read-only, and does not read worktree content
ok - learning selection aliases and path-safe errors are covered
ok - help text frames candidates as records without contradicting selectability
ok - Pi and Claude share the tested skill entry point without harness-specific spawning
```
</details>
- Outcome: ⚠️ 2 issues (1 warning, 1 info) across 1 run (11m10s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `bin/backends/tmux.sh` - branch carries 4 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (5 file(s)) into the PR:
- c2efcbe Merge pull request #1 from elirantism/fm/primary-session-window
- d879016 no-mistakes(test): fix tmux client format separator so attached session resolves
- 1216792 no-mistakes(review): fix tmux session resolution fail-closed, test isolation, docs
- 59c76f9 feat(tmux): create task windows in the captain&#39;s current session

Push main to origin, or rebase your branch onto origin/main, before gating.

🔧 Fix applied.
1 warning still open:
- ⚠️ `bin/backends/tmux.sh` - branch carries 4 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (5 file(s)) into the PR:
- c2efcbe Merge pull request #1 from elirantism/fm/primary-session-window
- d879016 no-mistakes(test): fix tmux client format separator so attached session resolves
- 1216792 no-mistakes(review): fix tmux session resolution fail-closed, test isolation, docs
- 59c76f9 feat(tmux): create task windows in the captain&#39;s current session

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>🔧 **Review** - 7 issues found → auto-fixed (5) ✅</summary>

- ⚠️ `bin/fm-spawn.sh:1479` - The fail-closed metadata publish only detects a redirection-open failure, not a partial write, contradicting its own comment (&#34;absent or truncated record&#34;). The compound group&#39;s exit status is that of its last command, which is `if [ &#34;$KIND&#34; = secondmate ]; then ... fi`; when KIND is not secondmate that `if` returns 0, masking any earlier `echo` failure. Failure scenario: state/ hits ENOSPC mid-write on a normal ship spawn - the earlier echoes fail, the trailing false `if` yields 0, so the guard passes and fm-spawn reports &#34;spawned &lt;id&gt;&#34; with a truncated state/&lt;id&gt;.meta that fm-crew-state.sh, the fleet snapshot, and fm-learn.sh will all misread. Verified empirically that a failing command followed by a false-condition `if` inside the group yields status 0. Fix by building the record into a variable and writing it with a single `printf ... &gt; &#34;$STATE/$ID.meta&#34;`, whose exit status directly reflects the write failure (and drop the awkward `if ...; then :; else ...; fi` in favor of `|| { ...; exit 1; }` while you are there).
- ⚠️ `bin/fm-spawn.sh:1483` - The new `exit 1` on metadata-publish failure leaks the already-created backend container and worktree for every backend except orca. The tmux window is created at bin/fm-spawn.sh:953 and the treehouse worktree is entered by ~bin/fm-spawn.sh:1284, both well before this write; `spawn_abort_cleanup` (bin/fm-spawn.sh:256) only tears down herdr projection state and orca resources, and `ORCA_ABORT_CLEANUP` is not cleared until line 1485. Failure scenario: a tmux ship spawn whose state/&lt;id&gt;.meta cannot be written aborts, leaving a live `fm-&lt;id&gt;` window and a checked-out treehouse worktree with no metadata record - fm-teardown.sh keys off meta, and there is no orphan-window/worktree reaper anywhere in bin/, so the leak is permanent and manual to clean. Consider extending spawn_abort_cleanup to kill the created backend target and release the worktree on this path (or at least printing the exact window and worktree to clean up in the error message).
- ⚠️ `bin/fm-learn.sh:252` - fm-learn.sh checks the fleet-snapshot subprocess but never checks any jq exit status, and runs with `set -u` only (no `set -e`/`pipefail`), so a jq failure produces empty output with exit code 0. Failure scenario: `jq -n --argjson fleet_snapshot &#34;$SNAPSHOT&#34; ...` fails (E2BIG from a large fleet snapshot passed via argv, or any malformed --argjson); $SESSION becomes empty, execution continues, and `printf &#39;%s\n&#39; &#34;$SESSION&#34; | jq .` prints nothing and exits 0 (verified: `printf &#39;&#39; | jq .` exits 0 with no output). A caller of `fm-learn.sh start &lt;id&gt; --json` - including the future separate learner process this contract exists for - sees success with no data. The same applies to `list_json` at bin/fm-learn.sh:191 and the human renderers at lines 195 and 259. Add explicit `|| { echo ...; exit 1; }` on the jq invocations (the idiom already used by bin/fm-fleet-view.sh:29 and bin/fm-fleet-snapshot.sh:1294) and set `-o pipefail`.
- ℹ️ `bin/fm-learn.sh:200` - The `// &#34;unknown harness&#34;` and `// &#34;unknown project&#34;` fallbacks never fire, because bin/fm-fleet-snapshot.sh:520-524 emits `harness:($harness // &#34;&#34;)` and `project:($project // &#34;&#34;)` - empty strings, and jq&#39;s `//` only falls through on null/false. Failure scenario: a state/&lt;id&gt;.meta with no `harness=` line (hand-written, or a record from an older/partial write) renders the list line as `... - state working / pane -  / tmux - endpoint present` and the session header as `Harness and backend:  / tmux`, i.e. a blank where the deliberate &#34;unknown&#34; text was intended. Verified with jq. Same defect at bin/fm-learn.sh:262 and :264. Replace with an explicit empty-string test, e.g. `((.harness // &#34;&#34;) | if . == &#34;&#34; then &#34;unknown harness&#34; else . end)`.
- ℹ️ `bin/fm-learn.sh:113` - The `[ -z &#34;$ID&#34; ] ||` guard inside the agent-id validation case is dead code: neither pattern can match an empty string (`.*` requires a leading dot, `*[!A-Za-z0-9._-]*` requires at least one character), so the branch is only ever reached with a non-empty ID and the guard is always true. Failure scenario: none at runtime - this is a simplification finding. It reads as if empty IDs are a handled case, obscuring that the empty-ID path is already fully covered by the earlier per-command checks at lines 100-105. Collapse the branch body to the plain `echo &#34;fm-learn: invalid agent id&#34; &gt;&amp;2; exit 2`.
- ℹ️ `bin/fm-learn.sh:209` - The selection error says &#34;no active agent record for &#39;&lt;id&gt;&#39;&#34;, but docs/learn.md and the list contract deliberately establish that active and selectable are different things - an inactive (done/failed/unknown/endpoint-absent) record is still fully selectable, and tests/fm-learn.test.sh:test_active_is_derived_and_inactive_stays_selectable asserts exactly that. Failure scenario: a captain runs `/learn` on a done task id they mistyped, sees &#34;no active agent record&#34;, and concludes the record exists but is inactive (a documented, selectable state) rather than that no record exists at all - the opposite of what happened. The message means &#34;no record&#34;; wording it as &#34;no agent record for &#39;&lt;id&gt;&#39;&#34; would match the contract the rest of the slice is careful about.
- ℹ️ `bin/fm-learn.sh:88` - Bare subcommand words are matched before positional arguments, so an agent id that collides with a command name is parsed as a second command. Failure scenario: `fm-learn.sh start context` (a task literally named `context`, `list`, `agents`, `snapshot`, or `start`) fails with &#34;fm-learn: more than one command&#34; instead of selecting that agent. This is already mitigated by the `--agent &lt;agent-id&gt;` spelling documented in the usage text, and task ids in practice are compound slugs, so noting it rather than proposing a change.

🔧 Fix: release endpoint and worktree on meta publish abort
3 issues (1 warning, 2 infos) still open:
- ⚠️ `bin/fm-spawn.sh:269` - The new abort cleanup returns the treehouse worktree to the pool without removing this task&#39;s turn-end hook files, and without removing the token registry entries that only teardown otherwise cleans. bin/fm-teardown.sh:1146-1147 does exactly this removal before its own `treehouse return --force`, with the comment &#34;Remove our hook file so a reused pool worktree cannot fire signals for a dead task&#34;; those files are written at bin/fm-spawn.sh:1343 (.claude/settings.local.json), 1350 (.opencode/plugins/fm-turn-end.js), 1423 (.fm-grok-turnend) and 1438 (.fm-kimi-turnend), all before the meta write at line 1505, and exclude_path (line 1332) registers them in .git/info/exclude so a git clean will not take them. Failure scenario: a claude ship spawn aborts on meta-publish failure; spawn_release_created_resources returns the worktree with .claude/settings.local.json still containing `touch &#39;&lt;state&gt;/&lt;dead-id&gt;.turn-ended&#39;`; the pool re-leases that slot to a different task, whose Stop hook now fires turn-end signals for a task that no longer exists. Secondarily, because no meta record exists, fm-teardown.sh can never run for this id, so remove_grok_turnend_auth / remove_kimi_turnend_auth (bin/fm-teardown.sh:195-207) never fire and ~/.grok/hooks/fm-turn-end.d/&lt;token&gt;, ~/.kimi-code/fm-turn-end.d/&lt;token&gt;, $STATE/$ID.pi-ext.ts, $STATE/$ID.grok-turnend-token, $STATE/$ID.kimi-turnend-token and /tmp/fm-$ID are orphaned permanently. Mirror teardown&#39;s `rm -f` of the four worktree hook paths before the treehouse return, and drop the state-side token/extension files (and their $HOME registry entries) in the same block.
- ℹ️ `bin/fm-learn.sh:197` - The empty-list human output still says &#34;No active First Mate agents found.&#34;, which is the same active-vs-present conflation just corrected at bin/fm-learn.sh:209. The list enumerates every task metadata row as a selectable candidate regardless of `active`, so an empty result means there are no agent records at all, not that none are active. Failure scenario: a captain with a fleet of only done/failed tasks runs `/learn`, reads &#34;No active First Mate agents found&#34;, and concludes the inactive records exist but are being filtered out (the documented, selectable case) - when in fact the snapshot returned no task rows whatsoever. &#34;No First Mate agent records found.&#34; would match the contract docs/learn.md establishes and the wording now used for the selection error. Note tests/fm-learn.test.sh:test_empty_list_is_explicit only asserts the JSON shape, so this string is untested.
- ℹ️ `bin/fm-spawn.sh:269` - The abort&#39;s `treehouse return --force` discards treehouse&#39;s own stderr (`&gt;/dev/null 2&gt;&amp;1`), so the warning on line 270 tells the captain the return failed but never why. bin/fm-teardown.sh:599 captures it (`out=$( ( cd &#34;$cd_dir&#34; &amp;&amp; treehouse return --force &#34;$dir&#34; ) 2&gt;&amp;1 )`) precisely so it can classify the failure - its header documents a known transient `.git/index.lock` &#34;File exists&#34; race that treehouse_return_is_index_lock_error detects and retries. Failure scenario: the abort&#39;s one-shot return hits that transient lock race; the captain sees only &#34;could not return worktree &lt;path&gt;&#34; with no indication the suggested manual retry would have succeeded on a second attempt. Capture the output and include it in the warning.

🔧 Fix: report absent learn records instead of inactive agents
1 info still open:
- ℹ️ `.agents/skills/learn/SKILL.md:18` - The skill procedure still instructs &#34;If there are no candidates, say that no active agent is available and stop&#34;, which is the active-vs-present conflation this branch just removed from bin/fm-learn.sh:197 (&#34;No First Mate agent records found.&#34;) and bin/fm-learn.sh:209 (&#34;no agent record for &#39;&lt;id&gt;&#39;&#34;). The skill is the /learn entry point that decides what the captain actually reads, so the corrected CLI strings are overridden by this instruction at the surface that matters. Failure scenario: a captain whose fleet holds only done/failed tasks runs /learn; bin/fm-learn.sh correctly prints &#34;No First Mate agent records found.&#34;, but step 3 tells the agent to report that no *active* agent is available, so the captain concludes inactive records exist and are being filtered out - when docs/learn.md:14 guarantees inactive candidates are still listed and selectable, meaning the true state is that no task records exist at all. Reword step 3 to say no agent records are available (e.g. &#34;If there are no candidates, say that no First Mate agent records are available and stop&#34;); tests/fm-learn.test.sh:test_adapter_seam_is_shared_by_pi_and_claude does not assert this line, so the change is safe.

🔧 Fix: align learn skill empty-candidate wording with records
1 info still open:
- ℹ️ `docs/learn.md:3` - docs/learn.md opens with &#34;`/learn` opens a read-only conversation about one active Firstmate agent&#34;, but the same document formally defines `active` at line 12 (known non-terminal state plus present endpoint) and then guarantees at line 14 that &#34;A candidate that is not active is still listed and can still be selected.&#34; The document that owns the definition therefore contradicts itself in its first sentence. Failure scenario: a captain reads the doc&#39;s opening line, concludes /learn only covers live agents, and never runs it on the done/failed/unknown records it is explicitly designed to expose - the exact case docs/learn.md:12-13 calls out (&#34;learn from a recorded task that needs recovery&#34;). Since `active` is a defined term in this file, the opening should use the neutral framing the CLI now uses, e.g. &#34;about one Firstmate agent record&#34;. README.md:48 (&#34;exposes one active agent&#39;s fleet snapshot&#34;) and README.md:176 (&#34;for one active agent&#34;) carry the same framing and would be the companions in one pass. This is the last remaining instance in the branch - bin/fm-learn.sh, .agents/skills/learn/SKILL.md and the tests are now consistent.

🔧 Fix: use record framing for /learn docs and README
1 info still open:
- ℹ️ `.agents/skills/learn/SKILL.md:3` - Two surfaces still use active-agent framing after this commit normalized docs/learn.md and README.md to record framing, and these are the only two left. (1) .agents/skills/learn/SKILL.md:3 - the `description:` frontmatter reads &#34;Open a read-only learning session for one active Firstmate agent. Use when the captain invokes /learn or asks to learn from, inspect, understand, or study an active agent&#39;s work without changing it.&#34; This is functional rather than cosmetic: the description is the routing text the harness matches on to decide whether the skill fires. Failure scenario: a captain asks &#34;help me understand what that failed task was doing&#34;; the description scopes /learn to an *active* agent&#39;s work, so the skill is a weaker match and may not trigger - even though docs/learn.md:12-14 guarantees terminal and unknown-state records are listed and selectable, and docs/learn.md:12-13 names recovery of a recorded task as a motivating case. It also now contradicts step 3 of its own procedure, which this branch corrected to record framing in 44b7a49. (2) bin/fm-learn.sh:39 - the --help text opens &#34;Expose a read-only learning-session view of Firstmate&#39;s active agent records&#34;, contradicted four lines later at line 43 (&#34;Every candidate is selectable; active is true only for a record in a known non-terminal state...&#34;) - the same self-contradiction just removed from docs/learn.md. Neither string is asserted by any test: tests/fm-learn.test.sh has no help-output assertion and test_adapter_seam_is_shared_by_pi_and_claude checks only the body lines, not the frontmatter description, so both are safe to reword to agent-record framing.

🔧 Fix: frame learn skill and help around agent records
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `tests/fm-bearings-snapshot.test.sh` - Pre-existing, unrelated test failure: `tests/fm-bearings-snapshot.test.sh` reports `not ok - restoring the SSHHIP child did not clear only its narrow warning` (28 other assertions pass). `git diff --name-only 99533c5d..01ce3bb | grep -i bearings` is empty, so neither `bin/fm-bearings-snapshot.sh` nor its test is touched by fm/learn-pr2 - this is not a regression from the /learn work. Flagging it because it is a red test on the branch that someone should own separately.
- ℹ️ `bin/fm-backend.sh:837` - Endpoint-liveness probe cannot report absent on tmux 3.7b (pre-existing code, unchanged by this branch). `fm_backend_target_exists` probes tmux with `tmux display-message -p -t &lt;target&gt;`, which on tmux 3.7b exits 0 even for a session/window that does not exist (`tmux list-panes -t` on the same bogus target correctly fails with `can&#39;t find session`). The new `active` derivation reads `.endpoint.exists`, so on this tmux version the &#34;recorded window is gone&#34; path cannot be reproduced live; it is covered in the suite by the fake-tmux `gone-agent` fixture. The state-based half of the derivation (terminal/unknown -&gt; inactive) and the no-recorded-endpoint case were both demonstrated end-to-end. No change requested here - recorded so the maintainer can decide whether the shared probe should use a strict target lookup.
- <code>`bash tests/fm-learn.test.sh` - 7/7 pass (empty candidate set, snapshot enumeration, derived `active` matrix, read-only bounded context, aliases + path-safe ids, help framing, shared Pi/Claude skill seam)</code>
- <code>`bash tests/fm-backend-tmux-smoke.test.sh` - 11/11 pass against real tmux</code>
- <code>`bash tests/fm-spawn-meta-publish.test.sh` - 3/3 pass (endpoint + worktree released on meta publish abort)</code>
- <code>`bash tests/fm-fleet-snapshot-view.test.sh`, `tests/fm-backend.test.sh`, `tests/fm-spawn-batch.test.sh`, `tests/fm-spawn-worktree-settle.test.sh`, `tests/fm-spawn-dispatch-profile.test.sh`, `tests/fm-documentation-audiences.test.sh` - all pass, no regressions</code>
- <code>`bash tests/fm-bearings-snapshot.test.sh` - 28 ok, 1 pre-existing failure; `git diff --name-only 99533c5d..01ce3bb | grep -i bearings` is empty, confirming the branch does not touch bearings</code>
- <code>Manual E2E: built a demo `FM_HOME` with 4 task records and created **real** tmux windows (`firstmate:fm-alpha-login`, `firstmate:fm-beta-signup`) so `bin/fm-fleet-snapshot.sh` performed genuine endpoint and pane-state probes</code>
- <code>`FM_HOME=&lt;demo&gt; bin/fm-learn.sh list` and `bin/fm-learn.sh agents` - human candidate list plus documented alias</code>
- <code>`bin/fm-learn.sh list --json | jq &#39;{schema, read_only, agents: [.agents[] | {id, active, state, endpoint}]}&#39;` - `active:true` only for working+present; done, unknown-state, and endpoint-less records all `active:false` and still listed</code>
- <code>`bin/fm-learn.sh start alpha-login`, `bin/fm-learn.sh context beta-signup`, `bin/fm-learn.sh snapshot --agent delta-deploy` - human learning session for an active, a terminal, and an endpoint-less record</code>
- <code>`bin/fm-learn.sh start alpha-login --json | jq &#39;{schema, selected_id, learner, boundary}&#39;` - `fm-learning-session.v1` with the inline-delivery / separate-process / Obsidian-persistence seams and the read-only boundary flags</code>
- <code>`FM_LEARN_RECORD_LINES=2 bin/fm-learn.sh start alpha-login --json` - bounded excerpt reports `truncated:true` with original `lines:5`</code>
- <code>Read-only proof: sha256 of every file under `$FM_HOME` (15 files, incl. agent worktrees) diffed before/after 8 `/learn` invocations - no change; `tmux list-windows -a` diffed before/after - no endpoint created, killed, or steered</code>
- <code>Worktree-isolation proof: `bin/fm-learn.sh start alpha-login --json | grep -c &#39;secret worktree source&#39;` returns 0 for a string present in the selected agent&#39;s worktree README</code>
- <code>`bin/fm-learn.sh start ../../etc/passwd` -&gt; `invalid agent id` exit 2; `bin/fm-learn.sh start no-such-agent` -&gt; `no agent record for &#39;no-such-agent&#39;` exit 1</code>
- <code>Harness seam: `shasum -a 256 .claude/skills/learn/SKILL.md .agents/skills/learn/SKILL.md` identical, `.claude/skills -&gt; ../.agents/skills`, skill body invokes only `bin/fm-learn.sh`, no pane-placement command</code>
- <code>Captain-facing capture: ran the `/learn` skill procedure inside a real tmux pane and captured the pane with `tmux capture-pane -p`</code>
- <code>Cleanup verified: demo tmux server killed, temp fixtures removed, `git status --porcelain` empty</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `docs/learn.md:35` - docs/learn.md&#39;s &#34;Harness entry points&#34; section names only Claude and Pi as the /learn discovery paths, while README.md lists `/learn` in the built-in skills table whose preamble implies every supported harness can invoke it (slash form for Claude/grok, `$` for codex). Nothing in the change is harness-specific - the skill is a plain `.agents/skills` entry - so availability most likely follows the same generic mechanism as `/bearings` and `/stow`. I left the wording alone rather than asserting discovery behavior for grok, codex, opencode, and kimi that I could not verify in this repo. If /learn is in fact available on every harness, the section should say so; if the PR intends to claim only Claude and Pi are verified, it should say &#34;verified on&#34; explicitly.

🔧 Fix: scope /learn harness verification to Claude and Pi
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
