### PR TITLE
fix: ignore the entire config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,13 +8,4 @@ data/
 __pycache__/
 *.pyc
 .env
-config/crew-harness
-config/crew-dispatch.json
-config/secondmate-harness
-config/backlog-backend
-config/backend
-config/calm
-config/x-mode.env
-config/cmux-socket-password
-config/wedge-alarm
-config/herdr-presentation-spaces
+config/

--- a/tests/fm-gitignore-config.test.sh
+++ b/tests/fm-gitignore-config.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# .gitignore must ignore config/ as a directory, not by exact filename.
+#
+# A name-by-name list silently stops ignoring any new or home-local file under
+# config/ (fm-gitignore-config-name-by-name): an unrecognized file there makes
+# the working tree read as dirty, which then blocks guarded sync paths that
+# refuse to touch a dirty home.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+test_config_dir_ignored_as_category() {
+  local sample
+  for sample in config/anything config/nested/dir/file config/some-new-key.admin; do
+    git -C "$ROOT" check-ignore -q "$sample" \
+      || fail "git does not ignore $sample (config/ must be ignored as a directory)"
+  done
+  pass "config/ is ignored as a directory, covering unlisted paths"
+}
+
+test_config_not_ignored_by_name_by_name_list() {
+  # Regression guard: .gitignore must not go back to enumerating config/ entries
+  # by exact filename, since that reintroduces the same silent-drift failure.
+  grep -qE '^config/[^/]+$' "$ROOT/.gitignore" \
+    && fail ".gitignore lists config/ entries by exact filename instead of ignoring the directory"
+  pass "no name-by-name config/ entries remain in .gitignore"
+}
+
+test_config_dir_ignored_as_category
+test_config_not_ignored_by_name_by_name_list


### PR DESCRIPTION
## Intent

Fix firstmate's .gitignore so the whole config/ directory is ignored as a category instead of by exact filename (task fm-gitignore-config-name-by-name). Root cause: a secondmate home with a legitimate domain-local file under config/ (e.g. a per-instance admin-credential file) was not covered by any of the 10 name-by-name config/ entries, so git status reported it as an untracked/dirty file and every guarded sync and update step silently skipped that home. AGENTS.md section 2 already documents config/ as captain-private and gitignored as a category, so the ignore file was out of sync with that contract. Fix: replaced the 10 exact-filename config/ entries in .gitignore with a single directory-level config/ ignore (verified nothing under config/ is intentionally tracked, so no exceptions were needed). Swept data/, state/, projects/, .no-mistakes/ and confirmed they were already directory-level, so no further sweep was needed. Added tests/fm-gitignore-config.test.sh asserting arbitrary/unlisted config/ paths are ignored via git check-ignore, plus a regression guard against re-introducing a name-by-name config/ list.

## What Changed

- Replaces the exact-filename `config/` ignore entries with one directory-level rule that covers all current and future local configuration files.
- Adds regression coverage for arbitrary and nested `config/` paths and prevents reintroducing a name-by-name ignore list.

## Risk Assessment

✅ Low: The change is narrowly scoped, aligns .gitignore with the documented captain-private config/ contract, has no tracked config/ files at either reviewed commit, and adds an effective regression test that is automatically included in the portable serial CI lane.

## Testing

The focused regression test passed, and an end-to-end baseline comparison reproduced the former dirty-home symptom and showed that the target commit removes it while preserving visibility of an unrelated untracked control file; the transcript was captured and testing left the source worktree clean.

<details>
<summary>Evidence: End-to-end Git status transcript</summary>

<code>BASE: config credential files appear as untracked.&#10;TARGET: only the unrelated operator-note appears as untracked.&#10;Both config files resolve to `.gitignore:11:config/`.</code>

```text
END-TO-END REPRODUCTION
User action: add domain-local config files, then inspect Git status.

BASE COMMIT (old name-by-name rules)
?? config/nested/domain-local-secret
?? config/per-instance-admin-credential
?? operator-note

TARGET COMMIT (directory-level config/ rule)
?? operator-note

TARGET IGNORE EXPLANATION
.gitignore:11:config/	config/per-instance-admin-credential
.gitignore:11:config/	config/nested/domain-local-secret

COUNTERFACTUAL CONTROL
operator-note remains visible in target status, proving unrelated files are not hidden.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 3577a4b91147d0d37490e19a7bb66094f1d74eb9..5f4cdd10e46235020ea873308165cc75ec36e260 -- .gitignore tests/fm-gitignore-config.test.sh`</code>
- <code>Verified no config files are intentionally tracked with `git ls-files &#39;config/**&#39;`</code>
- <code>Ran `./tests/fm-gitignore-config.test.sh`</code>
- <code>Created paired Git fixtures from both commits and ran `git status --short --untracked-files=all` after adding unlisted and nested config files</code>
- <code>Ran `git check-ignore -v config/per-instance-admin-credential config/nested/domain-local-secret` in the target fixture</code>
- <code>Confirmed the working tree remained clean with `git status --short`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
