### PR TITLE
fix(spawn): use --auto-approve for Kimi crewmates

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -474,7 +474,7 @@ launch_template() {
     # only an absolute brief pointer after the TUI readiness gate below.
     # Its turn-end signal is a globally configured Stop hook plus a guarded
     # per-task worktree token, so no launch placeholder belongs here.
-    kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
+    kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto-approve' ;;
     *) return 1 ;;
   esac
 }


### PR DESCRIPTION
The installed Kimi CLI (1.49.0) does not accept `--auto`; the correct auto-approval flag is `--auto-approve`. Without this change, `fm-spawn.sh` refuses to launch Kimi crewmates with an unknown option error.