### PR TITLE
feat(brief): bake no-agent-co-author commit rule into every scaffold

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -166,6 +166,7 @@ You are in an isolated firstmate home. The local \`AGENTS.md\` is your job descr
 $PROJECT_CLONES_NOTE
 Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
 Do not invent a second delegation system.
+Never add an agent name as a commit co-author: no "Co-authored-by" or "Generated with" trailer naming an agent, a model, or a tool, on any commit you make; your own generated crewmate briefs carry the same rule to your workers.
 You do not generate your own work.
 Act only on tasks the main firstmate routes to you.
 Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.
@@ -283,6 +284,10 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Never add an agent name as a commit co-author: no "Co-authored-by" or "Generated with"
+   trailer naming an agent, a model, or a tool, on any commit, including scratch commits.
+   Some worker harnesses append one silently by default, so check your first commit's
+   trailer and amend it out if present.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -397,6 +402,10 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Never add an agent name as a commit co-author: no "Co-authored-by" or "Generated with"
+   trailer naming an agent, a model, or a tool, on any commit.
+   Some worker harnesses append one silently by default, so check your first commit's
+   trailer and amend it out if present.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -598,6 +598,46 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+# Every generated variant must carry the no-agent-co-author commit rule, as a
+# numbered rule in ship and scout Rules lists and as an operating-model line in
+# the secondmate charter, so a harness's default trailer cannot land silently.
+test_all_variants_forbid_agent_commit_coauthor() {
+  local home kind id brief
+  home="$TMP_ROOT/coauthor-rule-home"
+  mkdir -p "$home/data"
+
+  for kind in ship scout secondmate; do
+    id="brief-coauthor-$kind"
+    case "$kind" in
+      ship)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate >/dev/null 2>&1
+        ;;
+      scout)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout >/dev/null 2>&1
+        ;;
+      secondmate)
+        FM_HOME="$home" FM_SECONDMATE_CHARTER='domain ops' \
+          "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1
+        ;;
+    esac
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind: brief was not scaffolded"
+    assert_grep 'Never add an agent name as a commit co-author' "$brief" \
+      "$kind brief omitted the no-agent-co-author commit rule"
+    assert_grep 'no "Co-authored-by" or "Generated with"' "$brief" \
+      "$kind brief omitted the concrete forbidden trailer forms"
+    assert_grep 'trailer naming an agent, a model, or a tool' "$brief" \
+      "$kind brief omitted the trailer-content scope (agent, model, tool)"
+    if [ "$kind" != secondmate ]; then
+      assert_grep '8. Never add an agent name as a commit co-author' "$brief" \
+        "$kind brief must carry the co-author rule as numbered rule 8, not loose prose"
+      assert_grep "append one silently by default, so check your first commit's" "$brief" \
+        "$kind brief lost the harness-default-trailer check instruction"
+    fi
+  done
+  pass "fm-brief.sh: every scaffold variant forbids agent commit co-author trailers"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -634,4 +674,5 @@ test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_all_variants_forbid_agent_commit_coauthor
 test_scout_and_secondmate_scaffold


### PR DESCRIPTION
Every generated brief variant now carries the no-agent-co-author commit rule, so it reaches every crewmate automatically instead of depending on firstmate pasting it into each brief by hand.
The rule was violated once (fruitflight commit a700d51, PR #3) because a brief omitted it and the worker harness appended the trailer by default.

Changes:
- Ship and scout scaffolds gain numbered rule 8: never add an agent name as a commit co-author, no "Co-authored-by" or "Generated with" trailer naming an agent, a model, or a tool, on any commit (scout wording also covers scratch commits, which can survive promotion).
- Both include a check-and-amend instruction, because the real failure mode is harnesses appending the trailer silently by default.
- The secondmate charter has no numbered Rules list, so the rule is a single Operating model line, noting that its own generated crewmate briefs carry the rule onward to its workers.
- The rule is appended as rule 8 rather than inserted earlier, because the Definition of done cross-references rule 6 and renumbering would break it.
- The rule text avoids backticks deliberately: all three scaffolds are unquoted heredocs where backticks would command-substitute at scaffold time.

Tests:
- tests/fm-brief.test.sh gains test_all_variants_forbid_agent_commit_coauthor, pinning the rule text in all three variants and the numbered-rule-8 form for ship and scout.
- Full test file passes (18/18) and bin/fm-lint.sh passes under the pinned ShellCheck 0.11.0.

Deliberately not included: a no-em-dash writing rule was considered and left out, since it is a captain-personal style preference rather than part of firstmate's shared contract in AGENTS.md; it was reported back as a recommendation instead.
