### PR TITLE
fix: route new validation requirements to follow-up work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
+Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; corrections required to satisfy already accepted intent are not new requirements.
 
 An ask-user finding returns as `needs-decision`; firstmate decides only when the configured authority permits, otherwise escalates to the captain.
 Send the same worker one exact decision naming the decision key, step, action, affected finding IDs, instructions where needed, and exact response command.


### PR DESCRIPTION
## Intent

Ship only the one-sentence AGENTS.md section 7 rule that, once validation starts, new requirements normally become follow-up work rather than expanding the current task, except when a new requirement completely invalidates the work being validated, while corrections required to satisfy already accepted intent remain part of the current task. Preserve the minimal instruction-only scope: change only top-level AGENTS.md, add no helper, script, test, skill, duplicated policy, or unrelated wording, and do not merge the PR.

## What Changed

- Route new requirements raised during validation to follow-up work unless they completely invalidate the work being validated.
- Keep corrections required by already accepted intent within the current task.

## Risk Assessment

✅ Low: The change is a well-bounded, one-sentence addition to the authoritative top-level AGENTS.md and accurately preserves all required distinctions without unrelated changes or duplicated policy.

## Testing

Inspected the complete base-to-target diff and commit shape, ran focused structural and exact-copy assertions, rendered and visually inspected the affected Section 7 reading surface, and confirmed the worktree remained clean; all targeted checks passed.

- Evidence: Rendered AGENTS.md Section 7 validation rule (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KYR3WYK9ZVBATYG443AWWHFN/AGENTS-section-7-validation-rule.html.png</code>)
<details>
<summary>Evidence: Reviewer-visible rendered HTML evidence</summary>

```text
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <title>AGENTS.md - Section 7 Validate</title>
  <style>
    :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
    body { margin: 0; background: #f6f8fa; color: #1f2328; }
    main { max-width: 920px; margin: 48px auto; padding: 36px 44px; background: white; border: 1px solid #d0d7de; border-radius: 12px; box-shadow: 0 8px 24px rgba(140,149,159,.2); }
    .eyebrow { color: #57606a; font-size: 13px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; }
    h1 { margin: 8px 0 24px; padding-bottom: 12px; border-bottom: 1px solid #d8dee4; font-size: 28px; }
    p { font-size: 16px; line-height: 1.65; }
    code { padding: .15em .35em; background: #eff1f3; border-radius: 5px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .9em; }
    .new-rule { margin: 22px -16px; padding: 16px; background: #dafbe1; border-left: 4px solid #1a7f37; border-radius: 6px; }
    .legend { margin-top: 28px; color: #57606a; font-size: 13px; }
  </style>
</head>
<body>
  <main>
    <div class="eyebrow">AGENTS.md - Section 7</div>
    <h1>Validate</h1>
    <p>For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by <code>harness-adapters</code>.<br>
    The task worker that starts a no-mistakes run drives the pipeline and owns every <code>no-mistakes axi run</code> and <code>no-mistakes axi respond</code> call through the next gate or outcome.<br>
    Firstmate never invokes <code>no-mistakes axi respond</code> for a crew-owned run.</p>
    <p class="new-rule">Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; corrections required to satisfy already accepted intent are not new requirements.</p>
    <p>An ask-user finding returns as <code>needs-decision</code>; firstmate decides only when the configured authority permits, otherwise escalates to the captain.<br>
    Send the same worker one exact decision naming the decision key, step, action, affected finding IDs, instructions where needed, and exact response command.</p>
    <p class="legend">Green highlight marks the sole line added by commit 7cc9aacf71d76600e112070c69315c81639066ce.</p>
  </main>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-status c21bf547511cf983628eb07d5fb57f931baee21f 7cc9aacf71d76600e112070c69315c81639066ce`
- `git diff --stat c21bf547511cf983628eb07d5fb57f931baee21f 7cc9aacf71d76600e112070c69315c81639066ce`
- `git diff --unified=20 c21bf547511cf983628eb07d5fb57f931baee21f 7cc9aacf71d76600e112070c69315c81639066ce -- AGENTS.md`
- `Focused shell assertions verified the exact sentence, one-line/no-deletion delta, Section 7 placement, absence at base, single occurrence at target, and single-parent commit shape.`
- `qlmanage -t -s 1200 -o /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KYR3WYK9ZVBATYG443AWWHFN .../AGENTS-section-7-validation-rule.html`
- `Visually inspected the generated PNG at original resolution.`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
