### PR TITLE
fix: select OpenCode build agent for workers

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -245,7 +245,7 @@ If a pane shows the exit banner, relaunch with `--continue` to resume the sessio
 `--prompt` does not auto-submit alongside `--continue`, so send the next instruction via `fm-send` once the TUI is up.
 Firstmate names `--agent build` only for opencode ship and scout launches so workers do worker work even when the local `default_agent` is an officer.
 Secondmate launches omit `--agent build` so persistent firstmate homes keep primary-agent semantics.
-OpenCode 1.18.9 silently falls back to `default_agent` when an unknown `--agent` is supplied, so future removal or renaming of `build` would reintroduce the worker-as-officer defect without a CLI error.
+OpenCode 1.18.9 shows the TUI error `Agent not found: zzz-not-an-agent` and then falls back to `default_agent` when an unknown `--agent` is supplied, so future removal or renaming of `build` would reintroduce the worker-as-officer defect.
 The empirical A/B record lives in `docs/verification/harness-adapters.md`.
 
 **Busy-queued Enter (opencode 1.18.4, tmux backend fix, herdr known gap).**

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -125,7 +125,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
-| opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| opencode | `--model <provider/model>` and worker-only `--agent build` | none for firstmate's interactive launch | Verified on opencode 1.18.9. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
@@ -243,6 +243,10 @@ No trust dialog.
 Opencode can auto-upgrade itself in the background and the running TUI can exit mid-task, observed live from 1.15.7 to 1.17.3.
 If a pane shows the exit banner, relaunch with `--continue` to resume the session.
 `--prompt` does not auto-submit alongside `--continue`, so send the next instruction via `fm-send` once the TUI is up.
+Firstmate names `--agent build` only for opencode ship and scout launches so workers do worker work even when the local `default_agent` is an officer.
+Secondmate launches omit `--agent build` so persistent firstmate homes keep primary-agent semantics.
+OpenCode 1.18.9 silently falls back to `default_agent` when an unknown `--agent` is supplied, so future removal or renaming of `build` would reintroduce the worker-as-officer defect without a CLI error.
+The empirical A/B record lives in `docs/verification/harness-adapters.md`.
 
 **Busy-queued Enter (opencode 1.18.4, tmux backend fix, herdr known gap).**
 While opencode is mid-turn, the composer accepts Enter as a "send when the turn

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -727,7 +727,13 @@ launch_template() {
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
-    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    opencode)
+      if [ "$kind" = secondmate ]; then
+        printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      else
+        printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode --agent build __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      fi
+      ;;
     pi|pi-signed)
       if [ "$kind" = secondmate ]; then
         printf '%s%s' "$harness" ' __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -103,6 +103,10 @@
       "target": "docs/verification/runtime-backends.md"
     },
     {
+      "source": ".agents/skills/harness-adapters/SKILL.md",
+      "target": "docs/verification/harness-adapters.md"
+    },
+    {
       "source": "docs/trace-context.md",
       "target": "docs/verification/trace-context.md"
     }
@@ -322,6 +326,10 @@
     },
     {
       "path": "docs/verification/dispatch-auth.md",
+      "audience": "maintainer-verification"
+    },
+    {
+      "path": "docs/verification/harness-adapters.md",
       "audience": "maintainer-verification"
     },
     {

--- a/docs/verification/harness-adapters.md
+++ b/docs/verification/harness-adapters.md
@@ -55,4 +55,4 @@ Applicability was reviewed across all five supported runtime backends.
 - Orca is not affected because backend routing receives the already-rendered launch command and does not interpret harness-specific `--agent` flags.
 - cmux is not affected because backend routing receives the already-rendered launch command and does not interpret harness-specific `--agent` flags.
 
-The regression coverage is `tests/fm-spawn-dispatch-profile.test.sh` for ship, scout, and secondmate launch commands, plus `tests/fm-kimi-harness.test.sh` for the byte-pinned adapter launch template inventory.
+The regression coverage is `tests/fm-spawn-dispatch-profile.test.sh` for ship, scout, and secondmate launch commands.

--- a/docs/verification/harness-adapters.md
+++ b/docs/verification/harness-adapters.md
@@ -8,33 +8,64 @@ Task chronology, temporary paths, branch names, and delivery transcripts stay in
 
 ## OpenCode worker agent selection
 
-OpenCode worker-agent selection was verified on 2026-07-29 with OpenCode 1.18.9 on the same interactive `--prompt` path that Firstmate launches.
-The probe used a scratch git repository, a throwaway tmux session, and the same injected `OPENCODE_CONFIG_CONTENT` prefix used by `bin/fm-spawn.sh`.
+OpenCode worker-agent selection was verified on 2026-07-31 with OpenCode 1.18.9 on the interactive startup path.
 The TUI footer rendered the active agent at startup, so the probe spent zero model tokens.
-The footer was rechecked after 25 seconds and 40 seconds.
 
-Command shapes:
+Exact command and output:
 
 ```sh
-OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --prompt '<throwaway prompt>'
-OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --agent build --prompt '<throwaway prompt>'
-OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --agent zzz-not-an-agent --prompt '<throwaway prompt>'
-opencode agent list
+opencode --version
 ```
-
-Observed output:
 
 ```text
-no --agent footer: Gentle-Orchestrator · GPT-5.6 Sol
---agent build footer: Build · GPT-5.6 Sol
---agent zzz-not-an-agent footer: Gentle-Orchestrator
-opencode agent list includes: build (primary)
+1.18.9
 ```
 
-The first row proves that an OpenCode launch without `--agent` inherits the configured `default_agent`.
-The second row proves that `--agent build` selects the built-in worker agent on the interactive launch path.
-The third row proves that an unknown `--agent` value silently falls back to `default_agent` instead of failing or warning.
-The fallback behavior is the critical residual risk: if a later OpenCode version removes or renames `build`, OpenCode crewmates would again launch as the configured default agent with no CLI signal.
+Exact command and relevant footer output:
+
+```sh
+OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode
+```
+
+```text
+Gentle-Orchestrator · GPT-5.6 Sol OpenAI
+```
+
+Exact command and relevant footer output:
+
+```sh
+OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --agent build
+```
+
+```text
+Build · GPT-5.6 Sol OpenAI
+```
+
+Exact command and popup plus relevant footer output:
+
+```sh
+OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --agent zzz-not-an-agent
+```
+
+```text
+Agent not found: zzz-not-an-agent
+Gentle-Orchestrator · GPT-5.6 Sol OpenAI
+```
+
+Exact command and output:
+
+```sh
+opencode agent list | python3 -c 'import sys; [print(line, end="") for line in sys.stdin if line.startswith("build ")]'
+```
+
+```text
+build (primary)
+```
+
+The default startup proves that an OpenCode launch without `--agent` inherits the configured `default_agent`.
+The explicit build startup proves that `--agent build` selects the built-in worker agent on the interactive launch path.
+The unknown-agent startup proves that OpenCode reports the unknown agent in the TUI and then uses the configured default agent without failing the process.
+The fallback behavior is the critical residual risk: if a later OpenCode version removes or renames `build`, OpenCode crewmates would again launch as the configured default agent after a TUI error.
 Firstmate therefore pins `--agent build` for OpenCode ship and scout launches, while secondmate launches omit it so persistent firstmate homes retain primary-agent semantics.
 
 Applicability was reviewed across all seven supported harnesses.

--- a/docs/verification/harness-adapters.md
+++ b/docs/verification/harness-adapters.md
@@ -1,0 +1,58 @@
+# Harness adapter verification
+
+Audience: maintainer verification.
+
+This record contains reusable version-scoped evidence for active harness launch guarantees.
+The `harness-adapters` skill owns current harness facts, and `bin/fm-spawn.sh` owns launch mechanics.
+Task chronology, temporary paths, branch names, and delivery transcripts stay in private reports or PR evidence.
+
+## OpenCode worker agent selection
+
+OpenCode worker-agent selection was verified on 2026-07-29 with OpenCode 1.18.9 on the same interactive `--prompt` path that Firstmate launches.
+The probe used a scratch git repository, a throwaway tmux session, and the same injected `OPENCODE_CONFIG_CONTENT` prefix used by `bin/fm-spawn.sh`.
+The TUI footer rendered the active agent at startup, so the probe spent zero model tokens.
+The footer was rechecked after 25 seconds and 40 seconds.
+
+Command shapes:
+
+```sh
+OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --prompt '<throwaway prompt>'
+OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --agent build --prompt '<throwaway prompt>'
+OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --agent zzz-not-an-agent --prompt '<throwaway prompt>'
+opencode agent list
+```
+
+Observed output:
+
+```text
+no --agent footer: Gentle-Orchestrator · GPT-5.6 Sol
+--agent build footer: Build · GPT-5.6 Sol
+--agent zzz-not-an-agent footer: Gentle-Orchestrator
+opencode agent list includes: build (primary)
+```
+
+The first row proves that an OpenCode launch without `--agent` inherits the configured `default_agent`.
+The second row proves that `--agent build` selects the built-in worker agent on the interactive launch path.
+The third row proves that an unknown `--agent` value silently falls back to `default_agent` instead of failing or warning.
+The fallback behavior is the critical residual risk: if a later OpenCode version removes or renames `build`, OpenCode crewmates would again launch as the configured default agent with no CLI signal.
+Firstmate therefore pins `--agent build` for OpenCode ship and scout launches, while secondmate launches omit it so persistent firstmate homes retain primary-agent semantics.
+
+Applicability was reviewed across all seven supported harnesses.
+
+- Claude is not affected because its launch template does not select OpenCode agents.
+- Codex is not affected because its launch template already branches on secondmate state for Codex-specific mechanics.
+- OpenCode is affected, and ship plus scout launches now add `--agent build` while secondmate launches omit it.
+- Pi is not affected because its launch template selects Pi extensions rather than OpenCode agents.
+- pi-signed is not affected because it shares Pi launch semantics under the signed wrapper identity.
+- Grok is not affected because its launch template has no OpenCode agent selection surface.
+- Kimi is not affected because it launches through its Kimi-specific readiness and pointer-delivery path.
+
+Applicability was reviewed across all five supported runtime backends.
+
+- Tmux is not affected because backend routing receives the already-rendered launch command and does not interpret harness-specific `--agent` flags.
+- Herdr is not affected because backend routing receives the already-rendered launch command and does not interpret harness-specific `--agent` flags.
+- Zellij is not affected because backend routing receives the already-rendered launch command and does not interpret harness-specific `--agent` flags.
+- Orca is not affected because backend routing receives the already-rendered launch command and does not interpret harness-specific `--agent` flags.
+- cmux is not affected because backend routing receives the already-rendered launch command and does not interpret harness-specific `--agent` flags.
+
+The regression coverage is `tests/fm-spawn-dispatch-profile.test.sh` for ship, scout, and secondmate launch commands, plus `tests/fm-kimi-harness.test.sh` for the byte-pinned adapter launch template inventory.

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -480,12 +480,53 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   expect_code 0 "$status" "opencode spawn with model and ignored effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" opencode anthropic/claude-sonnet-4-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "opencode --model 'anthropic/claude-sonnet-4-5' --prompt" \
-    "opencode launch did not thread model"
+  assert_contains "$launch" "opencode --agent build --model 'anthropic/claude-sonnet-4-5' --prompt" \
+    "opencode worker launch did not name the build agent and thread the model"
   assert_not_contains "$launch" "--effort" "opencode launch must not pass unsupported --effort"
   assert_not_contains "$launch" "--variant" "opencode launch must not pass run-only --variant"
   assert_not_contains "$launch" "--thinking" "opencode launch must not pass pi thinking flag"
-  pass "opencode receives --model and omits the unsupported effort axis"
+  pass "opencode workers name the build agent, receive --model, and omit the unsupported effort axis"
+}
+
+test_opencode_scout_names_build_agent() {
+  local rec id out status launch
+  id=profile-opencode-scout-z7b
+  rec=$(make_spawn_case profile-opencode-scout opencode "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --model openai/gpt-5.6-terra --scout)
+  status=$?
+  expect_code 0 "$status" "opencode scout spawn should succeed"
+  assert_contains "$out" "spawned $id harness=opencode kind=scout" \
+    "opencode scout spawn did not preserve its task kind"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "opencode --agent build --model 'openai/gpt-5.6-terra' --prompt" \
+    "opencode scout launch did not name the build agent and thread the model"
+  pass "opencode scouts name the build agent and preserve the selected model"
+}
+
+test_opencode_secondmate_preserves_officer_agent_selection() {
+  local rec id sm out status launch
+  id=profile-opencode-secondmate-z7c
+  rec=$(make_spawn_case profile-opencode-secondmate opencode "$id")
+  read_case_record "$rec"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+  sm=$(cd "$sm" && pwd -P)
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$sm" --model openai/gpt-5.6-sol --secondmate)
+  status=$?
+  expect_code 0 "$status" "opencode secondmate spawn should succeed"
+  assert_contains "$out" "spawned $id harness=opencode kind=secondmate" \
+    "opencode secondmate spawn did not preserve its officer task kind"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "opencode --model 'openai/gpt-5.6-sol' --prompt" \
+    "opencode secondmate launch did not preserve the selected model"
+  assert_not_contains "$launch" "--agent" \
+    "opencode secondmate launch must preserve its existing officer agent selection"
+  pass "opencode secondmates preserve officer agent selection while retaining the selected model"
 }
 
 test_pi_threads_model_and_max_effort() {
@@ -690,6 +731,8 @@ test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
+test_opencode_scout_names_build_agent
+test_opencode_secondmate_preserves_officer_agent_selection
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata


### PR DESCRIPTION
## What Changed

- Select OpenCode’s `build` agent for ship and scout workers while preserving default-agent semantics for secondmates.
- Add dispatch-profile coverage for OpenCode ship, scout, and secondmate launch commands.
- Document the launch behavior and version-scoped OpenCode 1.18.9 verification evidence.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, preserves secondmate semantics, covers both worker kinds, and aligns documentation with version-scoped evidence.

## Testing

The focused spawn suite passed for OpenCode worker, scout, and secondmate launch behavior; live OpenCode 1.18.9 capability output confirmed `build (primary)`, reviewer-visible transcript evidence was captured, the attempted TUI capture was unreadable due to terminal rendering, and the worktree remained clean.

<details>
<summary>Evidence: OpenCode worker-agent evidence</summary>

<code>Rendered launch behavior:&#10;ok - opencode workers name the build agent, receive --model, and omit the unsupported effort axis&#10;ok - opencode scouts name the build agent and preserve the selected model&#10;ok - opencode secondmates preserve officer agent selection while retaining the selected model&#10;&#10;OpenCode version: 1.18.9&#10;Build agent listing:&#10;build (primary)</code>

```text
Rendered launch behavior:
ok - opencode workers name the build agent, receive --model, and omit the unsupported effort axis
ok - opencode scouts name the build agent and preserve the selected model
ok - opencode secondmates preserve officer agent selection while retaining the selected model

OpenCode version: 1.18.9

Build agent listing:
build (primary)
```
</details>
<details>
<summary>Evidence: Focused test output</summary>

```text
ok - no --model/--effort records defaults and types the claude launch instructions
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - FM_HOME defaults resolve relative paths and preserve absolute spellings
ok - absolute override spellings are preserved in spawn launch paths
ok - unresolvable relative spawn overrides fail with named diagnostics
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex omits unsupported max effort instead of passing a bad config value
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - grok omits unsupported xhigh reasoning effort
ok - opencode workers name the build agent, receive --model, and omit the unsupported effort axis
ok - opencode scouts name the build agent and preserve the selected model
ok - opencode secondmates preserve officer agent selection while retaining the selected model
ok - pi receives --model and --thinking max profile flags
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed refuses safely and actionably when the selected executable is unavailable
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store
ok - claude omits the config-dir prefix when firstmate runs with the single-store default
ok - non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix
ok - active crew-dispatch profile does not block secondmate launches
# all fm-spawn-dispatch-profile tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `opencode --version`
- `timeout 10 opencode agent list | grep '^build '`
- <code>Attempted a 160×50 PTY startup capture with `opencode --agent build`; the raw TUI stream was not reviewer-readable in this terminal environment.</code>
- <code>`git status --short` confirmed testing left the worktree clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
