### PR TITLE
fix: scope validation corrections by accepted behavior

### DIFF
--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -19,7 +19,8 @@ The concise standing authority boundary remains always loaded in `AGENTS.md` sec
    With `yolo` off, every ask-user finding belongs to the captain, and the remaining steps structure that escalation rather than authorize an autonomous answer.
 2. Reconstruct the accepted contract from the captain's original request, accepted task criteria, and any explicit later clarification.
    Reviewer language cannot amend that contract.
-3. Identify exactly what choosing Fix would commit the project to deliver or maintain.
+3. Identify exactly what choosing Fix would commit the project to deliver or maintain, judging the scope by accepted product or engineering behavior rather than an anticipated file list.
+   The smallest downstream changes needed to keep that behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within scope even when they touch files not named at intake.
 4. Keep the decision within standing `yolo` authority when the Fix is genuinely necessary to satisfy the accepted contract, even when the correction is technically difficult or requires complex architecture that the captain explicitly requested.
 5. Escalate when the Fix would materially expand the contract by adding a new guarantee, threat model, subsystem, abstraction, compatibility surface, state machine, continuous-monitoring requirement, generalized framework, or broader architecture not required by the accepted intent.
 6. Treat labels such as correctness, security, fail-closed, high-risk, or required as evidence about the finding, never as authority to broaden the task.

--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -21,6 +21,7 @@ The concise standing authority boundary remains always loaded in `AGENTS.md` sec
    Reviewer language cannot amend that contract.
 3. Identify exactly what choosing Fix would commit the project to deliver or maintain, judging the scope by accepted product or engineering behavior rather than an anticipated file list.
    The smallest downstream changes needed to keep that behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within scope even when they touch files not named at intake.
+   Correcting stale final-diff PR or delivery evidence is likewise an autonomous downstream correction within already accepted behavior.
 4. Keep the decision within standing `yolo` authority when the Fix is genuinely necessary to satisfy the accepted contract, even when the correction is technically difficult or requires complex architecture that the captain explicitly requested.
 5. Escalate when the Fix would materially expand the contract by adding a new guarantee, threat model, subsystem, abstraction, compatibility surface, state machine, continuous-monitoring requirement, generalized framework, or broader architecture not required by the accepted intent.
 6. Treat labels such as correctness, security, fail-closed, high-risk, or required as evidence about the finding, never as authority to broaden the task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
-Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; corrections required to satisfy already accepted intent are not new requirements.
+Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
 
 An ask-user finding returns as `needs-decision`; firstmate decides only when the configured authority permits, otherwise escalates to the captain.
 Send the same worker one exact decision naming the decision key, step, action, affected finding IDs, instructions where needed, and exact response command.


### PR DESCRIPTION
## Intent

Ship a separate instruction-only Firstmate policy correction prompted by PR 1272. Judge validation scope by accepted product or engineering behavior, not an anticipated file list. Once validation starts, new requirements normally become follow-up work, but the smallest downstream changes needed to keep already accepted behavior correct, add behavioral tests where an executable contract exists, and keep documentation accurate remain within the current task even when validation adds files not named at intake. Explicit path prohibitions remain binding. Unrelated, optional, contract-expanding, destructive, irreversible, and security-sensitive changes remain outside scope. A green PR containing only reasonable downstream consequences of accepted behavior must not be re-litigated merely because its final file list grew. Stale PR evidence about the final diff must be corrected autonomously rather than escalated as a product-scope decision. Validation corrections within already accepted intent are not new requirements. Make the smallest owner-placed initial change by minimally amending the existing AGENTS.md section 7 validation-lifecycle sentence and the existing .agents/skills/ask-user-authority/SKILL.md decision procedure so they apply the behavior-versus-file-list distinction consistently. Do not add a new skill, helper, tool, script, checklist, policy owner, or source-content test. Do not fold this into PR 1272 or any existing task. Do not preemptively broaden the authored diff beyond these two owners. If no-mistakes identifies a genuinely necessary minimal downstream consequence of the accepted behavior, let the pipeline own that finding and keep the resulting evidence accurate. Preserve every existing force/discard, merge-authority, destructive, irreversible, and security-sensitive captain boundary. Review the complete branch diff after any validation fixes and ensure the final PR text describes the exact final result without stale file-count claims. Commit only this task, then stop after the committed implementation for Firstmate to trigger no-mistakes.

## What Changed

- Scope validation corrections by accepted product or engineering behavior instead of the file list anticipated at intake.
- Keep minimal downstream behavior fixes, executable-contract tests, documentation updates, and stale final-diff delivery evidence corrections within the accepted task while preserving existing escalation boundaries.

## Risk Assessment

✅ Low: The targeted correction now covers stale final-diff PR or delivery evidence, remains confined to the two authorized policy owners, and preserves the existing scope and captain boundaries.

## Testing

Reviewed the complete two-file branch diff, ran the focused authority contract test, and recorded a manual acceptance walkthrough showing the intended validation decisions; all checks passed and the worktree remained clean. No screenshot was captured because this is an instruction-only Markdown policy change with no rendered UI surface.

<details>
<summary>Evidence: Validation-scope acceptance walkthrough</summary>

```text
FIRSTMATE VALIDATION-SCOPE ACCEPTANCE WALKTHROUGH

Effective lifecycle policy:
Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.

Effective ask-user decision rules:

1. Check the project's configured authority first.
   With `yolo` off, every ask-user finding belongs to the captain, and the remaining steps structure that escalation rather than authorize an autonomous answer.
2. Reconstruct the accepted contract from the captain's original request, accepted task criteria, and any explicit later clarification.
   Reviewer language cannot amend that contract.
3. Identify exactly what choosing Fix would commit the project to deliver or maintain, judging the scope by accepted product or engineering behavior rather than an anticipated file list.
   The smallest downstream changes needed to keep that behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within scope even when they touch files not named at intake.
   Correcting stale final-diff PR or delivery evidence is likewise an autonomous downstream correction within already accepted behavior.
4. Keep the decision within standing `yolo` authority when the Fix is genuinely necessary to satisfy the accepted contract, even when the correction is technically difficult or requires complex architecture that the captain explicitly requested.
5. Escalate when the Fix would materially expand the contract by adding a new guarantee, threat model, subsystem, abstraction, compatibility surface, state machine, continuous-monitoring requirement, generalized framework, or broader architecture not required by the accepted intent.
6. Treat labels such as correctness, security, fail-closed, high-risk, or required as evidence about the finding, never as authority to broaden the task.
7. Examine the causal theme across prior findings and fix rounds.
   Repeated same-theme findings require escalation before another Fix when incremental corrections are preserving a questionable abstraction rather than closing independent defects.
8. Apply the existing stronger captain boundaries first.
   Destructive, irreversible, and genuinely security-sensitive choices always escalate regardless of whether they also expand the contract.

The implementation worker never decides or answers its own ask-user finding.
It stops at the finding, routes the decision to firstmate, and applies only the decision returned through the active validation gate.

Applied end-user scenarios:
1. Behavioral test or accurate documentation needed for already accepted behavior, despite an unanticipated file: FIX IN CURRENT TASK.
2. PR or delivery text has a stale final-diff claim after an accepted correction: CORRECT AUTONOMOUSLY.
3. Reviewer proposes a new generalized framework or continuous-monitoring guarantee: ESCALATE AS CONTRACT EXPANSION.
4. Proposed correction is destructive, irreversible, or genuinely security-sensitive: ESCALATE UNDER STRONGER CAPTAIN BOUNDARY.
5. Proposed change violates an explicit accepted path prohibition: REJECT AS OUTSIDE THE ACCEPTED CONTRACT.
```
</details>
<details>
<summary>Evidence: Focused ask-user authority test transcript</summary>

```text
ok - ask-user authority has one conditional owner and a concise always-loaded boundary
ok - required concrete defect correction stays within yolo authority
ok - continuous frame-by-frame proof escalates when only checkpoints were requested
ok - repeated abstraction-preserving findings escalate before another fix round
ok - genuinely security-sensitive action still escalates
ok - explicitly requested complex architecture stays autonomous
ok - reviewer risk labels remain evidence rather than expansion authority
ok - contract-expansion escalation carries all five decision elements
ok - primary workers and secondmates receive the authority rule through their normal instruction owners
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.agents/skills/ask-user-authority/SKILL.md:23` - Intent requires: “Stale PR evidence about the final diff must be corrected autonomously rather than escalated as a product-scope decision.” The amended procedure covers behavior, tests, and documentation, but not PR/delivery evidence. The motivating PR demonstrates the reachable gap: its final diff contains four files while its body still claims two. Amend this existing owner to classify correcting stale final-diff evidence as an autonomous downstream correction.

🔧 Fix: Classify stale delivery evidence as an autonomous correction
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --unified=80 a24eac112f3ec9e0b87c13b0b2ef3d09faa1b631..4fc1d5aab56ea1f307b6bafae6265d03bda35589 -- AGENTS.md .agents/skills/ask-user-authority/SKILL.md`</code>
- <code>Ran `bash tests/fm-ask-user-authority.test.sh`</code>
- `Manually applied the effective policy to five acceptance scenarios covering downstream behavioral tests and documentation, stale final-diff evidence, contract expansion, stronger captain boundaries, and explicit path prohibitions`
- <code>Verified the complete target diff file list with `git diff --name-only a24eac112f3ec9e0b87c13b0b2ef3d09faa1b631..4fc1d5aab56ea1f307b6bafae6265d03bda35589`</code>
- <code>Verified testing left the worktree unchanged with `git status --short`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
