### PR TITLE
fix(spawn): refuse pooled worktrees already claimed by another task's records

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -85,6 +85,15 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
+#   They also refuse a pooled worktree that any OTHER state/<id>.meta in this home
+#   already records as its worktree=. Those records are authoritative occupancy and
+#   outrank treehouse's process-based detection, which goes stale whenever a live
+#   crewmate's shell sits outside its worktree and is cleared entirely by a reboot.
+#   A refused slot is re-requested up to FM_SPAWN_WORKTREE_ATTEMPTS times (default 3,
+#   with FM_SPAWN_WORKTREE_POLLS/FM_SPAWN_WORKTREE_POLL_INTERVAL bounding each
+#   attempt's settle wait); an exhausted pool fails the spawn with every claiming task
+#   named. A claim whose task is no longer running is named the same way and is never
+#   discarded here - only fm-teardown.sh releases a claim.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -883,6 +892,70 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# --- worktree occupancy: fleet metadata is authoritative --------------------
+#
+# Treehouse decides a pooled worktree is free by looking for live processes whose
+# cwd is inside it. That signal is unreliable for firstmate's crewmates in both
+# directions: a working crewmate's shell frequently sits outside its own worktree,
+# and a reboot clears treehouse's occupancy state entirely while every recorded
+# worktree= under state/ survives untouched. A slot handed out through that gap
+# double-assigns: the second crewmate's first branch switch hijacks the live
+# crewmate's checkout and pipeline anchoring, and teardown then refuses to clean
+# either task up because the slot holds the other one's unpushed commits.
+#
+# So a path recorded as worktree= in ANY other state/<id>.meta of this home is
+# claimed until fm-teardown.sh removes that meta - across reboots, and regardless
+# of what treehouse reports. A claim whose task is no longer running is refused
+# here too and named for firstmate: releasing it means recovering or tearing down
+# that task, which is what protects its unlanded work. Spawn never discards
+# another task's record as a side effect of allocating a slot.
+#
+# Deliberately out of scope: Orca allocates a fresh worktree per task instead of
+# drawing from a shared pool, and two concurrent spawns of different ids can still
+# race between this read and their own meta write. Both are outside the incident
+# class this closes, which is a stale or reboot-cleared pool handing out a slot
+# firstmate's own records already own.
+worktree_meta_claim() {  # <candidate-real-path>; prints "<task-id>|<agent-state>|<recorded-path>"
+  local cand=$1 meta other recorded recorded_real backend target agent_state
+  [ -n "$cand" ] || return 1
+  [ -d "$STATE" ] || return 1
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] || continue
+    other=$(basename "$meta" .meta)
+    # A respawn of THIS task legitimately re-claims the worktree its own record
+    # already names; every other record is somebody else's claim.
+    [ "$other" != "$ID" ] || continue
+    recorded=$(fm_meta_get "$meta" worktree)
+    [ -n "$recorded" ] || continue
+    recorded_real=$(real_path_or_raw "$recorded")
+    [ "$recorded_real" = "$cand" ] || continue
+    backend=$(fm_backend_of_meta "$meta")
+    target=$(fm_backend_target_of_meta "$meta")
+    agent_state=unreadable
+    if [ -n "$target" ]; then
+      agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null || printf 'unreadable')
+    fi
+    printf '%s|%s|%s\n' "$other" "$agent_state" "$recorded"
+    return 0
+  done
+  return 1
+}
+
+# One reportable line per refused claim. The agent state only shapes the wording -
+# every state refuses the slot, because only fm-teardown.sh releases a claim.
+worktree_claim_line() {  # <claim-record>
+  local record=$1 claim_id claim_state claim_path note
+  IFS='|' read -r claim_id claim_state claim_path <<EOF
+$record
+EOF
+  case "$claim_state" in
+    alive) note="live worker" ;;
+    dead|missing) note="no live worker ($claim_state) - unreconciled record, left in place for recovery or cleanup" ;;
+    *) note="worker state $claim_state - treated as claimed" ;;
+  esac
+  printf '  claimed by %s (%s): %s\n' "$claim_id" "$note" "$claim_path"
+}
+
 herdr_projection_meta_field_exact() {  # <meta> <key>
   local meta=$1 key=$2 count
   [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
@@ -1259,34 +1332,69 @@ kimi_spawn_fail() {  # <detail>
 }
 
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  # Bounded re-acquire: a slot refused by the occupancy check below is asked for
+  # again rather than accepted or silently retargeted. The refused subshell is
+  # deliberately left in place while retrying, so treehouse's own process check
+  # now sees that slot as busy and offers a different one; the whole stack is
+  # released when the window dies. Polls stay per-attempt so a genuinely
+  # exhausted pool fails within a bounded time with the claimants named.
+  WT_ATTEMPTS=${FM_SPAWN_WORKTREE_ATTEMPTS:-3}
+  WT_POLLS=${FM_SPAWN_WORKTREE_POLLS:-60}
+  WT_POLL_INTERVAL=${FM_SPAWN_WORKTREE_POLL_INTERVAL:-1}
+  WT_REFUSED_PATHS=""
+  WT_REFUSED_REPORT=""
+  wt_attempt=0
 
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
-  # Target the stable window id, not the name: if the name is ever lost (e.g. an
-  # automatic-rename slips through), display-message -t <bad-name> falls back to the
-  # active client's window, which would misread firstmate's OWN pane path as the
-  # worktree and tangle a hook into the primary checkout. The window id never lies.
-  # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
-  # prefix would otherwise make the pane's OS-level cwd read differ from
-  # PROJ_ABS on the very first poll, before the pane has actually moved.
-  #
-  # A single read that already differs from PROJ_ABS_REAL is not proof the pane
-  # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
-  # transiently reports an unrelated stale path (seen live as another real git
-  # checkout entirely) before the shell catches up with treehouse get's cd. That
-  # stale path still passes the PROJ_ABS_REAL comparison and validate_spawn_worktree
-  # below (it resolves to a real, distinct worktree top-level too), so accepting it
-  # on one read alone silently records the wrong worktree= in state/<id>.meta. Require
-  # two consecutive reads to agree on the same non-project path before accepting it;
-  # a mismatch just becomes the new candidate rather than resetting the wait, so a
-  # pane that is already settled by the first real read only costs the one existing
-  # inter-poll sleep as confirmation, not a whole extra cycle on top.
-  candidate=""
-  for _ in $(seq 1 60); do
-    p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ]; then
-      p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
+  wt_path_refused() {  # <real-path>
+    [ -n "$WT_REFUSED_PATHS" ] || return 1
+    printf '%s\n' "$WT_REFUSED_PATHS" | grep -Fqx -- "$1"
+  }
+
+  wt_claim_refuse() {  # <why>
+    {
+      printf "error: refusing to launch %s: %s, and every worktree treehouse offered is already claimed by this home's task records.\n" "$ID" "$1"
+      printf '%s' "$WT_REFUSED_REPORT"
+      printf 'Those records are authoritative occupancy regardless of treehouse process detection, and spawn never discards one.\n'
+      printf 'Recover or tear down the named task(s) to release their worktrees, or widen the pool. Inspect target %s.\n' "$T"
+    } >&2
+  }
+
+  while :; do
+    wt_attempt=$((wt_attempt + 1))
+    spawn_send_text_line "$WT_TARGET" 'treehouse get'
+
+    # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+    # Target the stable window id, not the name: if the name is ever lost (e.g. an
+    # automatic-rename slips through), display-message -t <bad-name> falls back to the
+    # active client's window, which would misread firstmate's OWN pane path as the
+    # worktree and tangle a hook into the primary checkout. The window id never lies.
+    # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
+    # prefix would otherwise make the pane's OS-level cwd read differ from
+    # PROJ_ABS on the very first poll, before the pane has actually moved.
+    #
+    # A single read that already differs from PROJ_ABS_REAL is not proof the pane
+    # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
+    # transiently reports an unrelated stale path (seen live as another real git
+    # checkout entirely) before the shell catches up with treehouse get's cd. That
+    # stale path still passes the PROJ_ABS_REAL comparison and validate_spawn_worktree
+    # below (it resolves to a real, distinct worktree top-level too), so accepting it
+    # on one read alone silently records the wrong worktree= in state/<id>.meta. Require
+    # two consecutive reads to agree on the same non-project path before accepting it;
+    # a mismatch just becomes the new candidate rather than resetting the wait, so a
+    # pane that is already settled by the first real read only costs the one existing
+    # inter-poll sleep as confirmation, not a whole extra cycle on top.
+    # An already-refused path is treated exactly like the project path here: the pane
+    # is still sitting in the slot the previous attempt rejected, and that reading must
+    # never be mistaken for the new slot this attempt asked for.
+    candidate=""
+    WT=""
+    for _ in $(seq 1 "$WT_POLLS"); do
+      p=$(spawn_current_path "$WT_TARGET" || true)
+      p_real=""
+      if [ -n "$p" ]; then
+        p_real=$(real_path_or_raw "$p")
+      fi
+      if [ -n "$p_real" ] && [ "$p_real" != "$PROJ_ABS_REAL" ] && ! wt_path_refused "$p_real"; then
         if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
           WT="$p"
           break
@@ -1295,17 +1403,33 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
       else
         candidate=""
       fi
-    else
-      candidate=""
+      sleep "$WT_POLL_INTERVAL"
+    done
+    if [ -z "$WT" ]; then
+      # With claims already refused this spawn, a settle timeout is the pool telling
+      # us it has nothing else to offer - report it as the claim refusal it is.
+      if [ -n "$WT_REFUSED_REPORT" ]; then
+        wt_claim_refuse "treehouse offered no further worktree"
+        exit 1
+      fi
+      echo "error: treehouse get did not enter a worktree within $WT_POLLS polls; inspect window $T" >&2
+      exit 1
     fi
-    sleep 1
-  done
-  if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
-    exit 1
-  fi
 
-  validate_spawn_worktree "treehouse get" "$T"
+    validate_spawn_worktree "treehouse get" "$T"
+
+    # Metadata-verified occupancy, before the worktree is used for anything.
+    wt_real=$(real_path_or_raw "$WT")
+    wt_claim=$(worktree_meta_claim "$wt_real") || break
+    WT_REFUSED_PATHS="${WT_REFUSED_PATHS}${wt_real}"$'\n'
+    WT_REFUSED_REPORT="${WT_REFUSED_REPORT}$(worktree_claim_line "$wt_claim")"$'\n'
+    if [ "$wt_attempt" -ge "$WT_ATTEMPTS" ]; then
+      wt_claim_refuse "$WT_ATTEMPTS attempt(s) exhausted"
+      exit 1
+    fi
+    echo "warning: treehouse offered ${wt_real}, already recorded as another task's worktree; asking for a different slot (attempt $wt_attempt of $WT_ATTEMPTS)" >&2
+    WT=""
+  done
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -162,7 +162,8 @@ family_for_basename() {
       ;;
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
-    fm-spawn-dispatch-profile.test.sh|fm-spawn-worktree-settle.test.sh|\
+    fm-spawn-dispatch-profile.test.sh|fm-spawn-worktree-claim.test.sh|\
+    fm-spawn-worktree-settle.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,6 +115,8 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+Firstmate's own records are the authoritative occupancy signal for that pool: a path recorded as `worktree=` in any other `state/<id>.meta` stays claimed until `fm-teardown.sh` removes that record, so `fm-spawn.sh` refuses the slot and asks the pool for another one no matter what treehouse reports.
+Treehouse infers occupancy from processes cwd'd inside a worktree, which goes stale whenever a working crewmate's shell sits elsewhere and is cleared entirely by a reboot; a claim whose task is no longer running is named in the refusal for firstmate to recover or tear down, never released by another task's spawn.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,6 +442,9 @@ FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh t
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature
 FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=   # legacy alias for FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS when the new variable is unset
+FM_SPAWN_WORKTREE_ATTEMPTS=3       # treehouse get attempts before fm-spawn.sh fails a spawn whose every offered worktree is already claimed by another task's state/<id>.meta worktree= record (docs/architecture.md "Worktrees, not branches in your checkout")
+FM_SPAWN_WORKTREE_POLLS=60         # pane-settle polls per treehouse get attempt before fm-spawn.sh treats the pool as offering nothing further
+FM_SPAWN_WORKTREE_POLL_INTERVAL=1  # seconds between those settle polls
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3        # fetch retries after fm-fleet-sync.sh hits the orphaned .git/packed-refs.lock signature
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=1 # seconds fm-fleet-sync.sh waits before each of those retries
 FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=30       # min mtime age before fm-fleet-sync.sh treats a leftover packed-refs.lock as provably stale

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -19,8 +19,31 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+# FM_FAKE_PANE_PATH may carry SEVERAL paths, one per line: the pool then hands
+# out the nth on the nth `treehouse get`, clamped to the last line, so a batch
+# lands one task per slot exactly as a real pool does. A single-line value
+# behaves as it always did.
 case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"send-keys"*"treehouse get"*)
+    if [ -n "${FM_FAKE_PANE_COUNTFILE:-}" ]; then
+      n=0
+      [ -f "$FM_FAKE_PANE_COUNTFILE" ] && n=$(cat "$FM_FAKE_PANE_COUNTFILE")
+      printf '%s\n' "$((n + 1))" > "$FM_FAKE_PANE_COUNTFILE"
+    fi
+    exit 0
+    ;;
+  *"#{pane_current_path}"*)
+    n=1
+    if [ -n "${FM_FAKE_PANE_COUNTFILE:-}" ] && [ -f "$FM_FAKE_PANE_COUNTFILE" ]; then
+      n=$(cat "$FM_FAKE_PANE_COUNTFILE")
+      [ "$n" -ge 1 ] || n=1
+    fi
+    total=$(printf '%s\n' "${FM_FAKE_PANE_PATH:-}" | grep -c .)
+    [ "$total" -ge 1 ] || total=1
+    [ "$n" -le "$total" ] || n=$total
+    printf '%s\n' "${FM_FAKE_PANE_PATH:-}" | sed -n "${n}p"
+    exit 0
+    ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
@@ -84,6 +107,9 @@ run_spawn() {
   local home=$1 wt=$2 fakebin=$3 launchlog=$4
   shift 4
   : > "$launchlog"
+  # Pool cursor for the fake tmux above; reset per run so each case starts at
+  # the first slot. A batch run keeps it across its re-execed pairs.
+  : > "$launchlog.pane-count"
   # CLAUDE_CONFIG_DIR is forwarded onto claude launches by fm-spawn, so pin it
   # explicitly (empty by default) instead of leaking the invoking shell's value,
   # which would make launch assertions depend on the developer's environment.
@@ -91,7 +117,8 @@ run_spawn() {
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" FM_FAKE_PANE_COUNTFILE="$launchlog.pane-count" \
+    TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
@@ -570,14 +597,19 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
 }
 
 test_batch_forwards_shared_profile_flags() {
-  local rec id1 id2 out status
+  local rec id1 id2 wt2 out status
   id1=profile-batch-a-z9
   id2=profile-batch-b-z10
   rec=$(make_spawn_case profile-batch claude "$id1" "$id2")
   read_case_record "$rec"
   enable_dispatch_profile "$HOME_DIR"
+  # A two-task batch draws two pool slots. Handing both tasks the same worktree
+  # is the double-assignment fm-spawn now refuses, so the pool offers one slot
+  # per task, as it does live.
+  wt2="$CASE_DIR/wt-second"
+  git -C "$PROJ_DIR" worktree add --quiet -b wt-profile-batch-second "$wt2"
 
-  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR"$'\n'"$wt2" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
     "$id1=$PROJ_DIR" "$id2=$PROJ_DIR" --harness codex --model gpt-5 --effort high)
   status=$?
   expect_code 0 "$status" "batch spawn with shared profile flags should succeed"
@@ -585,6 +617,10 @@ test_batch_forwards_shared_profile_flags() {
   assert_contains "$out" "spawned $id2 harness=codex" "second batch task did not use shared harness"
   assert_meta_profile "$HOME_DIR/state/$id1.meta" codex gpt-5 high
   assert_meta_profile "$HOME_DIR/state/$id2.meta" codex gpt-5 high
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id1.meta" \
+    "first batch task did not record the first slot"
+  assert_grep "worktree=$wt2" "$HOME_DIR/state/$id2.meta" \
+    "second batch task did not take its own slot"
   pass "batch dispatch forwards shared --harness, --model, and --effort to every pair"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -185,7 +185,7 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
 }
 
 test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
-  local rec relative_id absolute_id out status launch home_real linked_home
+  local rec relative_id absolute_id out status launch home_real linked_home wt2
   relative_id=profile-relative-home-defaults-z1c
   absolute_id=profile-absolute-home-defaults-z1d
   rec=$(make_spawn_case profile-home-defaults pi "$relative_id" "$absolute_id")
@@ -213,12 +213,17 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
 
   linked_home="$CASE_DIR/home-link"
   ln -s "$HOME_DIR" "$linked_home"
+  # The first spawn's record still claims $WT_DIR, and reusing a claimed slot
+  # is the double assignment fm-spawn now refuses, so this second spawn draws
+  # its own slot, as it does live.
+  wt2="$CASE_DIR/wt-home-defaults-second"
+  git -C "$PROJ_DIR" worktree add --quiet -b wt-home-defaults-second "$wt2"
   : > "$LAUNCH_LOG"
   out=$(
     FM_ROOT_OVERRIDE='' FM_HOME="$linked_home" \
       FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
       FM_PROJECTS_OVERRIDE="$linked_home/projects" FM_CONFIG_OVERRIDE="$linked_home/config" \
-      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt2" TMUX="fake,1,0" \
       CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME="$linked_home/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
       "$SPAWN" "$absolute_id" "$PROJ_DIR" 2>&1

--- a/tests/fm-spawn-worktree-claim.test.sh
+++ b/tests/fm-spawn-worktree-claim.test.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Regression test for fm-spawn.sh's metadata-verified worktree occupancy check
+# (bin/fm-spawn.sh, worktree_meta_claim plus the bounded re-acquire loop around
+# `treehouse get`).
+#
+# Treehouse decides a pooled worktree is free from live processes cwd'd inside
+# it. That detection goes stale whenever a working crewmate's shell sits outside
+# its own worktree, and a reboot clears it entirely while every recorded
+# worktree= under state/ survives. Treehouse then hands a live task's checkout to
+# a second crewmate, whose first branch switch hijacks the first worker's
+# checkout and pipeline anchoring; teardown later refuses to clean up because the
+# slot holds another task's unpushed commits.
+#
+# These cases cover the observed incident shapes: a slot claimed by a live task
+# is refused, a retry lands on the next clean slot, a claim whose task is no
+# longer running is named but never discarded by spawn, an unclaimed slot still
+# spawns exactly as before, and a task's own record never blocks its respawn.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-worktree-claim)
+
+# make_claim_fakebin <dir> builds a fake tmux that models the treehouse pool as
+# an ordered list of slots (FM_FAKE_SLOTS_FILE, one absolute path per line):
+# `#{pane_current_path}` reports the slot matching how many `treehouse get`
+# sends the pane has received, clamped to the last line. Clamping IS the
+# pool-exhausted shape - a `treehouse get` with nothing left to hand out leaves
+# the pane exactly where it was.
+#
+# The occupant's liveness comes from the same fake: FM_FAKE_WINDOWS lists the
+# window names `list-windows` reports (an absent window is an authoritatively
+# missing endpoint), and FM_FAKE_COMMAND is the foreground command
+# `#{pane_current_command}` reports for a listed one.
+make_claim_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+countfile="${FM_FAKE_GET_COUNTFILE:?FM_FAKE_GET_COUNTFILE unset}"
+case "$*" in
+  *"send-keys"*"treehouse get"*)
+    n=0
+    [ -f "$countfile" ] && n=$(cat "$countfile")
+    printf '%s\n' "$((n + 1))" > "$countfile"
+    exit 0
+    ;;
+  *"#{pane_current_path}"*)
+    n=1
+    [ -f "$countfile" ] && n=$(cat "$countfile")
+    [ "$n" -ge 1 ] || n=1
+    total=$(grep -c . "${FM_FAKE_SLOTS_FILE:?}")
+    [ "$n" -le "$total" ] || n=$total
+    sed -n "${n}p" "$FM_FAKE_SLOTS_FILE"
+    exit 0
+    ;;
+  *"#{pane_current_command}"*)
+    printf '%s\n' "${FM_FAKE_COMMAND:-zsh}"
+    exit 0
+    ;;
+  *"#{window_id}"*)
+    printf '@7\n'
+    exit 0
+    ;;
+esac
+case "${1:-}" in
+  list-windows)
+    case "$*" in
+      *" -a "*) exit 0 ;;
+    esac
+    printf '%s' "${FM_FAKE_WINDOWS:-}"
+    exit 0
+    ;;
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# make_claim_case <name> <id> builds a home, a primary project, and two pooled
+# worktrees of it (slot A and slot B). The caller decides which slots treehouse
+# offers and which of them another task's record already claims.
+make_claim_case() {
+  local name=$1 id=$2 case_dir
+  CASE_DIR="$TMP_ROOT/$name"
+  HOME_DIR="$CASE_DIR/home"
+  PROJ_DIR="$CASE_DIR/project"
+  SLOT_A="$CASE_DIR/slot-a"
+  SLOT_B="$CASE_DIR/slot-b"
+  SLOTS_FILE="$CASE_DIR/slots"
+  COUNTFILE="$CASE_DIR/get-count"
+  case_dir=$CASE_DIR
+  FAKEBIN_DIR=$(make_claim_fakebin "$case_dir/fake")
+  mkdir -p "$HOME_DIR/data" "$HOME_DIR/projects" "$HOME_DIR/state" "$HOME_DIR/config"
+  printf 'codex\n' > "$HOME_DIR/config/crew-harness"
+  fm_git_worktree "$PROJ_DIR" "$SLOT_A" "slot-a-$name"
+  git -C "$PROJ_DIR" worktree add --quiet -b "slot-b-$name" "$SLOT_B"
+  mkdir -p "$HOME_DIR/data/$id"
+  printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+  touch "$HOME_DIR/state/.last-watcher-beat"
+}
+
+# offer_slots <path>...: the ordered slots treehouse hands out, one per
+# `treehouse get`.
+offer_slots() {
+  : > "$SLOTS_FILE"
+  printf '%s\n' "$@" >> "$SLOTS_FILE"
+}
+
+# claim_slot <task-id> <worktree> [backend]: record <worktree> as <task-id>'s
+# worktree, exactly as a live spawn would have. An explicit backend covers the
+# records whose runtime has no recovery-grade liveness classifier.
+claim_slot() {
+  local extra=()
+  [ -z "${3:-}" ] || extra=("backend=$3")
+  fm_write_meta "$HOME_DIR/state/$1.meta" \
+    "window=firstmate:fm-$1" \
+    "endpoint_task_id=$1" \
+    "worktree=$2" \
+    "project=$PROJ_DIR" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "yolo=off" \
+    ${extra+"${extra[@]}"}
+}
+
+run_claim_spawn() {  # <id> [windows] [command]
+  local id=$1 windows=${2:-} command=${3:-zsh}
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_SPAWN_WORKTREE_POLLS=3 FM_SPAWN_WORKTREE_POLL_INTERVAL=0.05 \
+    FM_FAKE_SLOTS_FILE="$SLOTS_FILE" FM_FAKE_GET_COUNTFILE="$COUNTFILE" \
+    FM_FAKE_WINDOWS="$windows" FM_FAKE_COMMAND="$command" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" 2>&1
+}
+
+# Incident shape 1: the pool offers a slot a live task already records as its
+# worktree. Metadata outranks treehouse's process detection, so the slot is
+# refused; with nothing else to offer, the spawn fails naming the claimant
+# instead of retargeting into the live worker's checkout.
+test_live_claim_is_refused() {
+  local id out status
+  id=claim-live-z1
+  make_claim_case claim-live "$id"
+  offer_slots "$SLOT_A"
+  claim_slot occupant-live "$SLOT_A"
+
+  out=$(run_claim_spawn "$id" "fm-occupant-live" claude)
+  status=$?
+  expect_code 1 "$status" "spawn should refuse a worktree a live task already claims"
+  assert_contains "$out" "refusing to launch $id" "refusal did not name the spawn it stopped"
+  assert_contains "$out" "claimed by occupant-live" "refusal did not name the claiming task"
+  assert_contains "$out" "live worker" "refusal did not report the claimant as live"
+  assert_contains "$out" "$SLOT_A" "refusal did not name the claimed worktree"
+  assert_absent "$HOME_DIR/state/$id.meta" "a refused spawn must not record metadata"
+  pass "a slot recorded by a live task is refused, naming the claimant"
+}
+
+# Incident shape 2: the first offered slot is claimed, the next one is clean.
+# The re-acquire lands on the clean slot and the spawn proceeds normally,
+# leaving the claimant's record untouched.
+test_retry_lands_on_clean_slot() {
+  local id out status
+  id=claim-retry-z2
+  make_claim_case claim-retry "$id"
+  offer_slots "$SLOT_A" "$SLOT_B"
+  claim_slot occupant-retry "$SLOT_A"
+
+  out=$(run_claim_spawn "$id" "fm-occupant-retry" claude)
+  status=$?
+  expect_code 0 "$status" "spawn should succeed once a clean slot is offered"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_contains "$out" "already recorded as another task's worktree" \
+    "the refused first slot was not reported"
+  assert_grep "worktree=$SLOT_B" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the clean slot"
+  assert_no_grep "worktree=$SLOT_A" "$HOME_DIR/state/$id.meta" \
+    "meta wrongly recorded the claimed slot"
+  assert_grep "worktree=$SLOT_A" "$HOME_DIR/state/occupant-retry.meta" \
+    "the claimant's own record was modified"
+  pass "a claimed slot is re-requested and the spawn takes the next clean one"
+}
+
+# Incident shape 3: the claiming task is genuinely gone (its endpoint is
+# authoritatively absent), which is exactly the reboot-cleared ghost that
+# treehouse recycles. Spawn still refuses the slot and names the record as
+# unreconciled - releasing it is firstmate's job, because that record is what
+# protects the unlanded work sitting in the slot.
+test_ghost_claim_is_named_not_discarded() {
+  local id out status before
+  id=claim-ghost-z3
+  make_claim_case claim-ghost "$id"
+  offer_slots "$SLOT_A"
+  claim_slot occupant-ghost "$SLOT_A"
+  before=$(cat "$HOME_DIR/state/occupant-ghost.meta")
+  printf 'unlanded work\n' > "$SLOT_A/unlanded.txt"
+
+  out=$(run_claim_spawn "$id" "" zsh)
+  status=$?
+  expect_code 1 "$status" "spawn should refuse a slot claimed by an unreconciled record"
+  assert_contains "$out" "claimed by occupant-ghost" "refusal did not name the ghost record"
+  assert_contains "$out" "no live worker (missing)" \
+    "refusal did not report the ghost record as having no live worker"
+  assert_contains "$out" "unreconciled record" \
+    "refusal did not mark the ghost record as needing reconciliation"
+  assert_present "$HOME_DIR/state/occupant-ghost.meta" \
+    "spawn discarded a ghost record it may only name"
+  [ "$(cat "$HOME_DIR/state/occupant-ghost.meta")" = "$before" ] \
+    || fail "spawn modified the ghost record it may only name"
+  assert_present "$SLOT_A/unlanded.txt" "spawn touched the unlanded work in the claimed slot"
+  assert_absent "$HOME_DIR/state/$id.meta" "a refused spawn must not record metadata"
+  pass "a ghost claim is named as unreconciled and left intact for firstmate"
+}
+
+# The clean path is unchanged: an unclaimed slot spawns on the first attempt,
+# with no refusal, even while other tasks hold unrelated worktrees.
+test_unclaimed_slot_spawns_unchanged() {
+  local id out status
+  id=claim-clean-z4
+  make_claim_case claim-clean "$id"
+  offer_slots "$SLOT_B"
+  claim_slot occupant-elsewhere "$SLOT_A"
+
+  out=$(run_claim_spawn "$id" "fm-occupant-elsewhere" claude)
+  status=$?
+  expect_code 0 "$status" "spawn should succeed on an unclaimed slot"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_not_contains "$out" "already recorded as another task's worktree" \
+    "an unclaimed slot must not report a refusal"
+  assert_grep "worktree=$SLOT_B" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the unclaimed slot"
+  [ "$(cat "$COUNTFILE")" = 1 ] || fail "an unclaimed slot took more than one treehouse get"
+  pass "an unclaimed slot spawns on the first attempt, unchanged"
+}
+
+# A respawn of the SAME task re-claims the worktree its own record names: the
+# check must refuse other tasks' records, never the task's own, or recovery
+# could never put a crewmate back in its own checkout.
+test_own_record_is_not_a_collision() {
+  local id out status
+  id=claim-self-z5
+  make_claim_case claim-self "$id"
+  offer_slots "$SLOT_A"
+  claim_slot "$id" "$SLOT_A"
+
+  out=$(run_claim_spawn "$id" "" zsh)
+  status=$?
+  expect_code 0 "$status" "a respawn should accept the worktree its own record names"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_grep "worktree=$SLOT_A" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the task's own worktree"
+  pass "a task's own record is not treated as a collision"
+}
+
+# A record whose runtime has no recovery-grade liveness classifier cannot prove
+# the claim is stale, so the slot is still refused. Occupancy comes from the
+# record, never from a liveness read that came back inconclusive.
+test_unclassifiable_claim_is_still_refused() {
+  local id out status
+  id=claim-unverified-z6
+  make_claim_case claim-unverified "$id"
+  offer_slots "$SLOT_A"
+  claim_slot occupant-unverified "$SLOT_A" zellij
+
+  out=$(run_claim_spawn "$id" "" zsh)
+  status=$?
+  expect_code 1 "$status" "spawn should refuse a claim whose liveness cannot be classified"
+  assert_contains "$out" "claimed by occupant-unverified" "refusal did not name the claiming task"
+  assert_contains "$out" "treated as claimed" "refusal did not report the inconclusive state as claimed"
+  assert_absent "$HOME_DIR/state/$id.meta" "a refused spawn must not record metadata"
+  pass "a claim with no classifiable liveness is refused, not assumed free"
+}
+
+test_live_claim_is_refused
+test_retry_lands_on_clean_slot
+test_ghost_claim_is_named_not_discarded
+test_unclaimed_slot_spawns_unchanged
+test_own_record_is_not_a_collision
+test_unclassifiable_claim_is_still_refused
+
+echo "# all fm-spawn-worktree-claim tests passed"


### PR DESCRIPTION
## Intent

Prevent worktree double-leases in firstmate's crewmate spawn path by making firstmate's own fleet metadata the authoritative occupancy signal, with protection that survives a reboot.

Background and motivation: treehouse, the external worktree pool tool, decides a pooled worktree is free by looking for live processes cwd'd inside it. That detection is unreliable - a working crewmate's shell often sits outside its own worktree, and a reboot clears treehouse's lease state entirely while every recorded worktree= under state/ survives. On 2026-07-28 that produced four double-assignment incidents in one day: envy-forge slot 4 double-assigned during a bake-off; slot recycling against ghost records nearly discarded an unpushed commit; slot 1 handed to two live tasks so teardown refused because the slot held the other task's unpushed commits; and a third task's recorded lane was reclaimed mid-task. The consequence class is that the second worker's first branch switch hijacks the first worker's checkout and pipeline anchoring; teardown guards catch the data loss but the recovery laps burn hours of the validation constraint.

What this change does: in bin/fm-spawn.sh, after 'treehouse get --lease' resolves a worktree and before that worktree is used for anything, compare the resolved path against every other state/<id>.meta worktree= record in this home. A match refuses the slot and re-requests one, up to a bounded number of attempts. An exhausted pool fails the spawn loudly, naming every claiming task, instead of silently retargeting into an occupied checkout.

Deliberate decisions a reviewer would not infer from the diff alone:
- Fleet metadata is authoritative occupancy REGARDLESS of what treehouse reports. This is intentional: treehouse's process detection is the thing being distrusted, so we never consult or defer to it for the occupancy question.
- A claim is released only by fm-teardown.sh removing the meta. Spawn deliberately never auto-discards a record, not even a ghost record whose task is genuinely dead. A ghost claim is refused and NAMED in the failure so firstmate can reconcile it; surfacing it is firstmate's job, not spawn's. This is a deliberate bias toward refusing rather than reclaiming, because the record is what protects another task's unlanded work.
- A claim whose runtime has no recovery-grade liveness classifier is also refused rather than assumed free - same fail-safe direction.
- The task's own record is explicitly not a collision, so recovery can put a crewmate back into its own checkout.
- Scope was deliberately kept inside firstmate's spawn path. The external treehouse tool is NOT patched. If a treehouse-side flag such as lease persistence would help, it belongs in the PR body as a follow-up rather than as a dependency of this fix.
- Orca is unaffected because it allocates a fresh worktree per task instead of drawing from a shared pool.
- tests/fm-spawn-dispatch-profile.test.sh's batch fixture was updated to hand each batched task its own slot, because handing both the same worktree is exactly the double assignment this change now refuses. That fixture change is intended, not collateral damage.

Regression coverage in tests/fm-spawn-worktree-claim.test.sh follows the existing tests/ patterns and covers the four incident shapes plus two guards: a live claim refused naming the claimant, a retry landing on the next clean slot, a ghost record named but left intact along with the unlanded work in its slot, an unclaimed slot spawning unchanged on the first attempt, a respawn re-claiming its own worktree, and an unclassifiable claim still refused.

Acceptance: a slot matching any live state/*.meta worktree= is never accepted for a new spawn; an exhausted pool fails loudly naming the collision rather than retargeting; existing clean-slot spawn behavior is unchanged and all existing tests stay green.

Delivery note: earlier runs of this branch reached push and failed with a 403 because origin (kunchenguid/firstmate) is not writable by this account. The gate is now configured with fork https://github.com/joshshaloo/firstmate.git, so branches push to the fork while the PR opens against origin.

## What Changed

- `bin/fm-spawn.sh` now treats firstmate's own fleet metadata as the authoritative occupancy signal for the treehouse pool: after `treehouse get --lease` resolves a worktree, the path is compared against every other `state/<id>.meta` `worktree=` record in the home. A claimed slot is refused and re-requested up to `FM_SPAWN_WORKTREE_ATTEMPTS` times, and an exhausted pool fails the spawn loudly, naming the claiming task instead of silently retargeting into an occupied checkout. Claims are only ever released by `fm-teardown.sh`: ghost records (task dead, work possibly unlanded) and claims without a recovery-grade liveness classifier are refused and named rather than reclaimed, while a task's own record is not a collision so recovery can respawn into its own checkout.
- Added `tests/fm-spawn-worktree-claim.test.sh` covering the four 2026-07-28 double-lease incident shapes plus guards (live claim refused naming the claimant, retry landing on a clean slot, ghost record named but left intact, unclaimed slot unchanged, own record accepted, unclassifiable claim refused), registered it in `bin/fm-test-run.sh`, and updated the `tests/fm-spawn-dispatch-profile.test.sh` fixtures so each spawned task draws its own pool slot - reusing one slot across tasks is exactly the double assignment now refused.
- Documented the new spawn claim tunables (`FM_SPAWN_WORKTREE_ATTEMPTS`, `FM_SPAWN_WORKTREE_POLLS`, `FM_SPAWN_WORKTREE_POLL_INTERVAL`) in `docs/configuration.md` and recorded the fleet-metadata-over-treehouse occupancy rule in `docs/architecture.md`.

Follow-up (deliberately not a dependency of this fix): treehouse itself is left unpatched; a treehouse-side persistent-lease option would let the pool's own lease state survive reboots and could further shrink the residual concurrent-spawn window noted in review.

## Risk Assessment

✅ Low: The change is a well-bounded, fail-closed guard on a single acquisition path that matches every source-verifiable acceptance criterion in the intent (authoritative fleet metadata, bounded re-acquire, loud exhaustion naming claimants, records never discarded, own-record exemption, unclassifiable liveness refused, clean-slot path unchanged, orca/secondmate/treehouse untouched), with regression tests mapping to the four incident shapes plus two guards; the only observations are two informational, author-acknowledged edge cases in diagnostics and a documented out-of-scope concurrent-spawn race.

## Testing

Ran the new fm-spawn-worktree-claim regression suite, the updated fm-spawn-dispatch-profile suite (confirming the round-1 fixture fix), and the sibling worktree-settle and batch suites - all green - then manually drove the real fm-spawn.sh through the three 2026-07-28 incident shapes and captured a CLI transcript showing the loud claimant-naming refusal, the retry onto a clean slot with the claimant record untouched, and the ghost record plus its unlanded work left intact; pre-existing kimi/secondmate harness failures on this host reproduce at the base commit and are unrelated.

<details>
<summary>Evidence: CLI transcript: fm-spawn refusing claimed slots across all three incident shapes</summary>

<code>error: refusing to launch demo-new-task: treehouse offered no further worktree, and every worktree treehouse offered is already claimed by this home&#39;s task records.&#10;claimed by occupant-live (live worker): .../live/slot-a&#10;Those records are authoritative occupancy regardless of treehouse process detection, and spawn never discards one.&#10;Recover or tear down the named task(s) to release their worktrees, or widen the pool.&#10;[ghost scenario] claimed by occupant-ghost (no live worker (missing) - unreconciled record, left in place for recovery or cleanup): .../ghost/slot-a&#10;[retry scenario] spawned demo-retry-task ... worktree=.../retry/slot-b (claimant&#39;s slot-a record untouched)</code>

```text

================================================================
SCENARIO 1 - the 2026-07-28 incident shape: treehouse offers a slot a LIVE task already records as its worktree, and the pool has nothing else. Before this change the second crewmate landed in the live worker's checkout; now:
================================================================

$ fm-spawn.sh demo-new-task <project>   # pool only has slot-a, claimed by live task occupant-live

warning: treehouse offered /private/var/folders/tf/xtzn3q5d2llgqv9scn2yh6th0000gn/T/fm-claim-manual-demo.VqdCpN/live/slot-a, already recorded as another task's worktree; asking for a different slot (attempt 1 of 3)
error: refusing to launch demo-new-task: treehouse offered no further worktree, and every worktree treehouse offered is already claimed by this home's task records.
  claimed by occupant-live (live worker): /var/folders/tf/xtzn3q5d2llgqv9scn2yh6th0000gn/T//fm-claim-manual-demo.VqdCpN/live/slot-a
Those records are authoritative occupancy regardless of treehouse process detection, and spawn never discards one.
Recover or tear down the named task(s) to release their worktrees, or widen the pool. Inspect target firstmate:fm-demo-new-task.

--> exit status: 1
--> state/demo-new-task.meta exists after refusal? NO (correct - refused spawn records nothing)

================================================================
SCENARIO 2 - same collision but the pool has a second, clean slot: the claimed slot is refused and the spawn retries onto the clean one.
================================================================

$ fm-spawn.sh demo-retry-task <project>   # slot-a claimed, slot-b clean

warning: treehouse offered /private/var/folders/tf/xtzn3q5d2llgqv9scn2yh6th0000gn/T/fm-claim-manual-demo.VqdCpN/retry/slot-a, already recorded as another task's worktree; asking for a different slot (attempt 1 of 3)
warn: no registry at /var/folders/tf/xtzn3q5d2llgqv9scn2yh6th0000gn/T//fm-claim-manual-demo.VqdCpN/retry/home/data/projects.md; defaulting project to no-mistakes off
spawned demo-retry-task harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-retry-task worktree=/var/folders/tf/xtzn3q5d2llgqv9scn2yh6th0000gn/T//fm-claim-manual-demo.VqdCpN/retry/slot-b

--> exit status: 0
--> worktree recorded for demo-retry-task: worktree=/var/folders/tf/xtzn3q5d2llgqv9scn2yh6th0000gn/T//fm-claim-manual-demo.VqdCpN/retry/slot-b
--> occupant-live record untouched:        worktree=/var/folders/tf/xtzn3q5d2llgqv9scn2yh6th0000gn/T//fm-claim-manual-demo.VqdCpN/retry/slot-a

================================================================
SCENARIO 3 - reboot-cleared ghost: the claiming task is dead (exactly what treehouse recycles after a reboot), and its slot holds unlanded work. Spawn refuses, NAMES the ghost, and leaves record + work intact.
================================================================

$ fm-spawn.sh demo-ghost-task <project>   # slot-a claimed by a task with no live worker

warning: treehouse offered /private/var/folders/tf/xtzn3q5d2llgqv9scn2yh6th0000gn/T/fm-claim-manual-demo.VqdCpN/ghost/slot-a, already recorded as another task's worktree; asking for a different slot (attempt 1 of 3)
error: refusing to launch demo-ghost-task: treehouse offered no further worktree, and every worktree treehouse offered is already claimed by this home's task records.
  claimed by occupant-ghost (no live worker (missing) - unreconciled record, left in place for recovery or cleanup): /var/folders/tf/xtzn3q5d2llgqv9scn2yh6th0000gn/T//fm-claim-manual-demo.VqdCpN/ghost/slot-a
Those records are authoritative occupancy regardless of treehouse process detection, and spawn never discards one.
Recover or tear down the named task(s) to release their worktrees, or widen the pool. Inspect target firstmate:fm-demo-ghost-task.

--> exit status: 1
--> ghost record still present? YES (correct - spawn never discards a claim)
--> unlanded work still present? YES (correct - protected)
```
</details>
<details>
<summary>Evidence: Manual demo script that produced the transcript (drives real bin/fm-spawn.sh via the repo&#39;s fake-tmux pool fixture)</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end demonstration of fm-spawn.sh's worktree occupancy check.
# Reuses the repo's own test fixtures (fake tmux modeling the treehouse pool)
# to drive the REAL bin/fm-spawn.sh and capture the operator-visible output
# verbatim for three scenarios matching the 2026-07-28 incident shapes.
set -u

REPO=${1:?usage: manual-demo.sh <repo-root>}
. "$REPO/tests/lib.sh"

SPAWN="$ROOT/bin/fm-spawn.sh"
TMP_ROOT=$(fm_test_tmproot fm-claim-manual-demo)

make_fakebin() {
  local dir=$1 fakebin
  fakebin=$(fm_fakebin "$dir")
  cat > "$fakebin/tmux" <<'SH'
#!/usr/bin/env bash
set -u
countfile="${FM_FAKE_GET_COUNTFILE:?}"
case "$*" in
  *"send-keys"*"treehouse get"*)
    n=0; [ -f "$countfile" ] && n=$(cat "$countfile")
    printf '%s\n' "$((n + 1))" > "$countfile"; exit 0 ;;
  *"#{pane_current_path}"*)
    n=1; [ -f "$countfile" ] && n=$(cat "$countfile")
    [ "$n" -ge 1 ] || n=1
    total=$(grep -c . "${FM_FAKE_SLOTS_FILE:?}")
    [ "$n" -le "$total" ] || n=$total
    sed -n "${n}p" "$FM_FAKE_SLOTS_FILE"; exit 0 ;;
  *"#{pane_current_command}"*) printf '%s\n' "${FM_FAKE_COMMAND:-zsh}"; exit 0 ;;
  *"#{window_id}"*) printf '@7\n'; exit 0 ;;
esac
case "${1:-}" in
  list-windows)
    case "$*" in *" -a "*) exit 0 ;; esac
    printf '%s' "${FM_FAKE_WINDOWS:-}"; exit 0 ;;
  display-message) printf 'firstmate\n'; exit 0 ;;
  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
esac
exit 0
SH
  chmod +x "$fakebin/tmux"
  fm_fake_exit0 "$fakebin" treehouse
  printf '%s\n' "$fakebin"
}

make_case() {
  local name=$1 id=$2
  CASE_DIR="$TMP_ROOT/$name"
  HOME_DIR="$CASE_DIR/home"
  PROJ_DIR="$CASE_DIR/project"
  SLOT_A="$CASE_DIR/slot-a"
  SLOT_B="$CASE_DIR/slot-b"
  SLOTS_FILE="$CASE_DIR/slots"
  COUNTFILE="$CASE_DIR/get-count"
  FAKEBIN_DIR=$(make_fakebin "$CASE_DIR/fake")
  mkdir -p "$HOME_DIR/data" "$HOME_DIR/projects" "$HOME_DIR/state" "$HOME_DIR/config"
  printf 'codex\n' > "$HOME_DIR/config/crew-harness"
  fm_git_worktree "$PROJ_DIR" "$SLOT_A" "slot-a-$name"
  git -C "$PROJ_DIR" worktree add --quiet -b "slot-b-$name" "$SLOT_B"
  mkdir -p "$HOME_DIR/data/$id"
  printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
  touch "$HOME_DIR/state/.last-watcher-beat"
}

claim_slot() {
  fm_write_meta "$HOME_DIR/state/$1.meta" \
    "window=firstmate:fm-$1" "endpoint_task_id=$1" "worktree=$2" \
    "project=$PROJ_DIR" "harness=codex" "kind=ship" "mode=no-mistakes" "yolo=off"
}

run_spawn() {
  local id=$1 windows=${2:-} command=${3:-zsh}
  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
    FM_SPAWN_WORKTREE_POLLS=3 FM_SPAWN_WORKTREE_POLL_INTERVAL=0.05 \
    FM_FAKE_SLOTS_FILE="$SLOTS_FILE" FM_FAKE_GET_COUNTFILE="$COUNTFILE" \
    FM_FAKE_WINDOWS="$windows" FM_FAKE_COMMAND="$command" \
    PATH="$FAKEBIN_DIR:$PATH" \
    "$SPAWN" "$id" "$PROJ_DIR" 2>&1
}

hr() { printf '\n================================================================\n%s\n================================================================\n' "$1"; }

hr "SCENARIO 1 - the 2026-07-28 incident shape: treehouse offers a slot a LIVE task already records as its worktree, and the pool has nothing else. Before this change the second crewmate landed in the live worker's checkout; now:"
make_case live demo-new-task
claim_slot occupant-live "$SLOT_A"
printf '%s\n' "$SLOT_A" > "$SLOTS_FILE"
printf '\n$ fm-spawn.sh demo-new-task <project>   # pool only has slot-a, claimed by live task occupant-live\n\n'
run_spawn demo-new-task "fm-occupant-live" claude
printf '\n--> exit status: %s\n' "$?"
printf -- '--> state/demo-new-task.meta exists after refusal? %s\n' "$([ -f "$HOME_DIR/state/demo-new-task.meta" ] && echo YES || echo "NO (correct - refused spawn records nothing)")"

hr "SCENARIO 2 - same collision but the pool has a second, clean slot: the claimed slot is refused and the spawn retries onto the clean one."
make_case retry demo-retry-task
claim_slot occupant-live "$SLOT_A"
printf '%s\n%s\n' "$SLOT_A" "$SLOT_B" > "$SLOTS_FILE"
printf '\n$ fm-spawn.sh demo-retry-task <project>   # slot-a claimed, slot-b clean\n\n'
run_spawn demo-retry-task "fm-occupant-live" claude
printf '\n--> exit status: %s\n' "$?"
printf -- '--> worktree recorded for demo-retry-task: %s\n' "$(grep '^worktree=' "$HOME_DIR/state/demo-retry-task.meta")"
printf -- '--> occupant-live record untouched:        %s\n' "$(grep '^worktree=' "$HOME_DIR/state/occupant-live.meta")"

hr "SCENARIO 3 - reboot-cleared ghost: the claiming task is dead (exactly what treehouse recycles after a reboot), and its slot holds unlanded work. Spawn refuses, NAMES the ghost, and leaves record + work intact."
make_case ghost demo-ghost-task
claim_slot occupant-ghost "$SLOT_A"
printf 'unpushed commit contents\n' > "$SLOT_A/unlanded.txt"
printf '%s\n' "$SLOT_A" > "$SLOTS_FILE"
printf '\n$ fm-spawn.sh demo-ghost-task <project>   # slot-a claimed by a task with no live worker\n\n'
run_spawn demo-ghost-task "" zsh
printf '\n--> exit status: %s\n' "$?"
printf -- '--> ghost record still present? %s\n' "$([ -f "$HOME_DIR/state/occupant-ghost.meta" ] && echo "YES (correct - spawn never discards a claim)" || echo NO)"
printf -- '--> unlanded work still present? %s\n' "$([ -f "$SLOT_A/unlanded.txt" ] && echo "YES (correct - protected)" || echo NO)"
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 2 runs (18m37s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-spawn.sh:939` - worktree_meta_claim returns on the first matching meta record, so when two state/&lt;id&gt;.meta records claim the same worktree path (the exact state the 2026-07-28 double-assignment incidents left behind), the refusal names only the alphabetically-first claimant. The slot is still correctly refused, but the intent&#39;s &#39;naming every claiming task&#39; holds only per first match per slot; the second claimant surfaces only after the first is reconciled and a new spawn retries. Optional follow-up: collect and print one claim line per matching record instead of returning on the first.
- ℹ️ `bin/fm-spawn.sh:1423` - Between the occupancy check (line 1423) and this spawn&#39;s own meta write (line 1583), another concurrent fm-spawn of a different id offered the same slot would pass the same check, leaving a residual double-lease window. The code comment at lines 913-917 explicitly declares this concurrent-spawn race out of scope of the incident class (stale/reboot-cleared pool vs existing records), and the per-ID spawn lock does not serialize different ids. If this ever needs closing, the earliest shared boundary is a home-scoped lock held across claim-check through meta-write, or writing a provisional claim record immediately after the check.

</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `tests/fm-spawn-dispatch-profile.test.sh:218` - Existing test test_home_defaults_preserve_absolute_or_resolve_relative_paths in tests/fm-spawn-dispatch-profile.test.sh failed under the new occupancy check: its fixture spawns two tasks sequentially in one home while reusing the same single pooled worktree, so the second spawn was (correctly) refused with &#39;refusing to launch ... already claimed by this home&#39;s task records&#39;, violating the intent&#39;s &#39;all existing tests stay green&#39; criterion. The author updated the batch fixture for exactly this but missed this second two-task fixture in the same file. Fixed by giving the second spawn its own pool slot (same treatment as the batch fixture); the file now passes all 26 cases.
- ℹ️ Pre-existing failures on this host, unrelated to this change (both reproduce identically at base commit daf6dce via a clean git-archive extract): tests/fm-kimi-harness.test.sh needs python3 with tomllib (&#39;refused: python3 with tomllib is required to validate config.toml&#39;), and tests/fm-secondmate-harness.test.sh fails macOS signed-wrapper ancestry resolution (&#34;unmarked shared signed-wrapper ancestry resolved &#39;claude&#39;, expected pi&#34;), same territory as open issue #1280. Not caused by and not blocking this change; remote CI remains the authority for these.
- <code>`bash tests/fm-spawn-worktree-claim.test.sh` - all 6 incident-shape cases pass (live claim refused naming claimant, retry lands on clean slot, ghost record named but left intact with unlanded work untouched, unclaimed slot unchanged, own record not a collision, unclassifiable claim refused)</code>
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` - failed at test_home_defaults_preserve_absolute_or_resolve_relative_paths (second spawn refused: fixture reused one pooled worktree for two tasks); fixed the fixture to draw its own slot, then all 26 cases pass including the author&#39;s updated batch fixture</code>
- <code>Manual E2E demo driving the real `bin/fm-spawn.sh` through the four 2026-07-28 incident shapes against a modeled treehouse pool, verifying refusal text, exit codes, persisted state/*.meta records, ghost record byte-identity, and unlanded-work preservation (transcript in evidence dir)</code>
- <code>`bash tests/fm-spawn-batch.test.sh`, `bash tests/fm-spawn-worktree-settle.test.sh`, `bash tests/fm-gate-refuse.test.sh`, `bash tests/fm-tangle-guard.test.sh`, `bash tests/fm-grok-harness.test.sh` - pass; `bash tests/fm-teardown-endpoint-safety.test.sh` self-skips (tmux not installed)</code>
- <code>`bash tests/fm-kimi-harness.test.sh` and `bash tests/fm-secondmate-harness.test.sh` fail on this host; reproduced identically at base commit daf6dce from a clean `git archive` extract - pre-existing environment issues (missing python3 tomllib; macOS ancestry resolution, cf. issue #1280), not caused by this change</code>

🔧 Fix: give second dispatch-profile fixture spawn its own worktree slot
✅ Re-checked - no issues remain.
- <code>`bash tests/fm-spawn-worktree-claim.test.sh` - new regression file, all 6 cases (live claim refused naming claimant, retry lands on clean slot, ghost named but never discarded, unclaimed slot unchanged, own record not a collision, unclassifiable claim refused)</code>
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` - all 26 cases including the round-1-fixed two-task fixture and the batch one-slot-per-task fixture</code>
- <code>`bash tests/fm-spawn-worktree-settle.test.sh` - restructured poll loop still rejects transient stale pane reads</code>
- <code>`bash tests/fm-spawn-batch.test.sh` - batch dispatch path unaffected</code>
- `Manual E2E: drove the real bin/fm-spawn.sh through three incident-shaped scenarios (exhausted pool with live claimant, claimed-then-clean retry, reboot-cleared ghost with unlanded work) via the repo's fake-tmux pool fixture and captured the operator-visible CLI transcript, verifying exit codes, refusal wording naming claimants, meta records, and preserved ghost record plus unlanded file`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
