### PR TITLE
feat(bin): wake-outcome ledger for measured coordinator attention cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
   projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)
   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
+  wake-ledger.tsv    append-only wake-outcome and terminal-task evidence; bin/fm-wake-ledger.sh owns its format, vocabulary, and append semantics
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
@@ -357,6 +358,8 @@ Handle actionable wakes as follows:
 2. For `stale:`, inspect the recorded endpoint and load `stuck-crewmate-recovery` for a stopped, looping, confused, or unresponsive worker; a deep-inspection reason also requires current-state and validation-log inspection.
 3. For `check:`, act on the named poll result, including merges and X-mode events.
 4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
+
+After handling each drained wake, record what it cost with `bin/fm-wake-ledger.sh outcome <token> <seq>`, using the wake's own queue sequence; that script owns the closed outcome vocabulary and its mechanics.
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.
 When X-linked work reaches a milestone or terminal state, load `fmx-respond`; before terminal teardown, use its promised-final reconciliation when a typed public commitment exists, otherwise post the final completion follow-up so the link clears even if earlier follow-ups were spent.

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1345,6 +1345,34 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
+# The wake-outcome ledger's terminal line, written while the task metadata still
+# exists: the removal just below deletes it, and this is the last moment the
+# harness/model/effort join for this task is available anywhere.
+# bin/fm-wake-ledger.sh owns the record format. Best effort by design - a
+# telemetry write must never stand between the fleet and cleanup.
+LEDGER_OUTCOME=landed
+if [ "$FORCE" = "--force" ]; then
+  LEDGER_OUTCOME=abandoned
+fi
+LEDGER_ESCALATED=$(meta_value "$META" escalated)
+case "$LEDGER_ESCALATED" in
+  yes|no) ;;
+  *) LEDGER_ESCALATED=unknown ;;
+esac
+FM_WAKE_LEDGER="${FM_WAKE_LEDGER:-$DATA/wake-ledger.tsv}" \
+"$SCRIPT_DIR/fm-wake-ledger.sh" task "$ID" \
+  --outcome "$LEDGER_OUTCOME" \
+  --harness "$(meta_value "$META" harness)" \
+  --model "$(meta_value "$META" model)" \
+  --effort "$(meta_value "$META" effort)" \
+  --mode "$MODE" \
+  --kind "$KIND" \
+  --project "$PROJ" \
+  --backend "$BACKEND" \
+  --route "$(meta_value "$META" route)" \
+  --escalated "$LEDGER_ESCALATED" \
+  --pr "$PR_URL" >/dev/null \
+  || echo "warning: wake ledger terminal line not recorded for $ID" >&2
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -133,8 +133,8 @@ family_for_basename() {
       ;;
     fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
     fm-supervision-events.test.sh|fm-turnend-guard.test.sh|fm-wake-daemon-lifecycle-e2e.test.sh|\
-    fm-wake-queue.test.sh|fm-watch-checkpoint.test.sh|fm-watch-triage.test.sh|\
-    fm-watcher-lock.test.sh)
+    fm-wake-ledger.test.sh|fm-wake-queue.test.sh|fm-watch-checkpoint.test.sh|\
+    fm-watch-triage.test.sh|fm-watcher-lock.test.sh)
       printf '%s\n' watcher-wake-lock
       ;;
     fm-afk-inject-herdr-e2e.test.sh|fm-afk-launch.test.sh|fm-backend-autodetect-smoke.test.sh|\

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Atomically drain durable watcher wake records, optionally annotate validated
-# signal status keys after raw consumption commits, then assert liveness.
+# Atomically drain durable watcher wake records, then after raw consumption
+# commits: optionally annotate validated signal status keys, record the
+# wake-outcome ledger's wake half (bin/fm-wake-ledger.sh), and assert liveness.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -26,6 +26,17 @@ assert_watcher_liveness() {
   "$SCRIPT_DIR/fm-guard.sh" || true
 }
 
+# The deterministic half of the wake-outcome ledger: one durable wake record per
+# deduped row this drain handed to the coordinator, so measured attention cost
+# has a denominator that moves only when wakes actually happen.
+# bin/fm-wake-ledger.sh owns the format. Its one call site sits below the
+# authoritative print-and-delete boundary, with stdout discarded and failure
+# ignored, so the ledger can never block, delay, alter, or fail a wake.
+record_wake_ledger() {
+  [ -n "$RAW_ROWS" ] || return 0
+  printf '%s\n' "$RAW_ROWS" | "$SCRIPT_DIR/fm-wake-ledger.sh" drain-record >/dev/null || true
+}
+
 # shellcheck disable=SC2317,SC2329 # Invoked by trap handlers below.
 cleanup() {
   local status=$?
@@ -75,5 +86,6 @@ DRAIN_LOCK_HELD=false
 # Raw output and queue deletion are authoritative. Everything below is
 # best-effort and cannot restore, duplicate, hide, or fail the consumed rows.
 (fm_wake_print_annotations "$RAW_ROWS") || true
+record_wake_ledger
 assert_watcher_liveness
 exit 0

--- a/bin/fm-wake-ledger.sh
+++ b/bin/fm-wake-ledger.sh
@@ -1,0 +1,622 @@
+#!/usr/bin/env bash
+# Wake-outcome ledger: the durable record of what every supervision wake cost
+# the coordinator, and how every task ended.
+#
+# This file is the single owner of the ledger's record format, its closed
+# outcome vocabulary, and its append semantics.
+#
+# WHERE: data/wake-ledger.tsv in the firstmate home (FM_WAKE_LEDGER overrides
+# the full path). It lives under data/, not state/, because it is durable
+# evidence spanning weeks and teardown clears state/<id>.* for every task that
+# finishes.
+#
+# FORMAT: one record per line, tab-separated, three fixed positional fields
+# followed by a key=value tail:
+#
+#   <schema>\t<record>\t<epoch>\t<key>=<value>\t<key>=<value>...
+#
+# Position 1 is the schema token (v1), position 2 the record kind, position 3
+# the epoch seconds this record was written. Per-line versioning rather than a
+# file header keeps an append-only file readable across a format change; a
+# key=value tail lets the three record kinds carry different fields and lets a
+# consumer add fields without invalidating existing lines or parsers.
+#
+# THREE RECORD KINDS:
+#
+#   wake     one per deduped drained wake-queue row, written by
+#            bin/fm-wake-drain.sh. Deterministic - no judgment involved.
+#            Fields: seq (the wake-queue sequence, and the join key), kind,
+#            key, task, queued (epoch the watcher enqueued), latency (seconds
+#            the wake waited for the coordinator).
+#
+#   outcome  one per handled wake, written by the coordinator through this
+#            script's `outcome` subcommand and joined to its wake record on
+#            seq. Fields: seq, outcome, task, after (seconds since the wake
+#            record), and optional defect and note.
+#
+#   task     one terminal line per task, written by bin/fm-teardown.sh
+#            immediately before the task metadata is deleted - the last moment
+#            the harness/model/effort join exists. Fields: task, harness,
+#            model, effort, mode, kind, project, backend, outcome, route,
+#            escalated, findings, pr.
+#
+# The wake half is written deterministically and the outcome half by the
+# coordinator ON PURPOSE. A single coordinator-written line would make measured
+# attention cost fall whenever the coordinator skipped the recording step, so
+# the metric would move without the underlying quantity moving. The split gives
+# a denominator that is stable under no change and makes missing coverage a
+# reported number instead of a silent undercount.
+#
+# The wake count per task is deliberately NOT stored on the task record: it is
+# computed from that task's wake records, so the same fact is never serialized
+# twice and cannot drift.
+#
+# CLOSED OUTCOME VOCABULARY, in coordinator terms:
+#   absorbed        reached me and needed nothing
+#   inspected       I read deeper state
+#   steered         I sent the worker an instruction
+#   decided         I answered a gate or decision
+#   escalated       I took it to the captain
+#   repaired        I recovered a stuck or broken worker
+#   false-positive  the wake should not have fired
+# An unrecognized token is refused with exit 2 and nothing is written.
+#
+# APPEND SEMANTICS: every record is one printf appended with >> and no lock at
+# all. Each line is capped at 1024 characters, well under the 4096-byte
+# PIPE_BUF bound, so concurrent appends from the drain, a coordinator
+# invocation, and teardown interleave as whole lines on a local POSIX
+# filesystem. Every value is sanitized (tab, CR and LF collapse to a space,
+# control characters are stripped) and truncated to its field cap. Nothing ever
+# rewrites, rotates, or truncates the file.
+#
+# THE LEDGER MUST NEVER BLOCK OR DELAY A WAKE. Callers uphold that: the drain
+# invokes this script only after its authoritative boundary (raw rows printed,
+# drain temp deleted, queue lock released), with stdout discarded and the
+# failure ignored, so a ledger problem can change neither the drain's exit
+# status nor the raw rows the coordinator reads as its work queue. This script
+# takes no lock, so it cannot contend with fm_wake_append.
+#
+# Usage:
+#   fm-wake-ledger.sh drain-record
+#       Read deduped drained queue rows (epoch/seq/kind/key/payload TSV) on
+#       stdin and append one wake record each. Invalid rows are skipped.
+#   fm-wake-ledger.sh outcome <token> <seq> [<seq>...]
+#                     [--task <id>] [--defect <class>] [--note <text>]
+#       Append one outcome record per seq. task and after are resolved from the
+#       matching wake record when --task is not given.
+#   fm-wake-ledger.sh task <id> [--outcome landed|failed|abandoned]
+#                     [--harness H] [--model M] [--effort E] [--mode M]
+#                     [--kind K] [--project P] [--backend B] [--pr URL]
+#                     [--route R] [--escalated yes|no] [--findings N]
+#       Append one terminal task record. Absent facts record as unknown rather
+#       than being guessed. Called by teardown, which supplies them from the
+#       task metadata it is about to delete.
+#   fm-wake-ledger.sh report [--since-days <n>]
+#       Summarize the ledger: wake volume and coverage, response latency,
+#       outcome mix, terminal task outcomes, and the per-profile model join.
+#       The ledger file itself remains the machine interface.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# fm-wake-lib.sh owns FM_ROOT/FM_HOME/STATE resolution and the validated
+# status-key mapping this script reuses for task attribution.
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+# fm-pr-lib.sh owns fm_task_id_path_safe, the task-id path-safety predicate.
+# Reused rather than re-stated so there is one owner of that rule.
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+LEDGER="${FM_WAKE_LEDGER:-$DATA/wake-ledger.tsv}"
+LEDGER_SCHEMA=v1
+LEDGER_LINE_MAX=1024
+LEDGER_KEY_MAX=200
+LEDGER_NOTE_MAX=200
+LEDGER_ID_MAX=64
+LEDGER_SHORT_MAX=64
+# Bounded backward read for resolving an outcome's wake record. A coordinator
+# records an outcome within a turn or two of the drain, so the matching wake
+# record is always near the tail; the cap keeps the lookup constant-time.
+LEDGER_LOOKUP_TAIL=${FM_WAKE_LEDGER_LOOKUP_TAIL:-500}
+# Busiest-task rows the report prints before summarizing the remainder. The
+# report always states how many rows it left out - a silent cap would read as
+# "this is all of it".
+LEDGER_REPORT_TOP=${FM_WAKE_LEDGER_REPORT_TOP:-10}
+
+TAB=$(printf '\t')
+
+usage() {
+  LC_ALL=C awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$SCRIPT_DIR/fm-wake-ledger.sh"
+}
+
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 2
+}
+
+# --- serialization ----------------------------------------------------------
+
+ledger_sanitize() {  # <value> <cap>
+  local v=${1-} cap=$2
+  v=$(printf '%s' "$v" | LC_ALL=C tr '\t\r\n' '   ' | LC_ALL=C tr -d '[:cntrl:]')
+  [ "${#v}" -le "$cap" ] || v=${v:0:$cap}
+  printf '%s' "$v"
+}
+
+# One record: a single printf append, no lock, capped so the write stays within
+# the atomic-append bound. Returns nonzero on failure; every caller treats that
+# as best effort.
+ledger_append() {  # <epoch> <record> <field>...
+  local epoch=$1 record=$2 line field dir
+  shift 2
+  line="$LEDGER_SCHEMA$TAB$record$TAB$epoch"
+  for field in "$@"; do
+    line="$line$TAB$field"
+  done
+  [ "${#line}" -le "$LEDGER_LINE_MAX" ] || line=${line:0:$LEDGER_LINE_MAX}
+  dir=$(dirname "$LEDGER")
+  [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || return 1
+  printf '%s\n' "$line" >> "$LEDGER" 2>/dev/null || return 1
+}
+
+# --- task attribution -------------------------------------------------------
+
+# Resolve a live task endpoint (a tmux window, an Orca terminal) to its task id
+# through the recorded metadata, which is the only authority for that mapping.
+ledger_task_for_endpoint() {  # <endpoint>
+  local key=$1 meta id
+  [ -n "$key" ] || return 1
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    if grep -qxF -e "window=$key" -e "terminal=$key" "$meta" 2>/dev/null; then
+      id=$(basename "$meta" .meta)
+      fm_task_id_path_safe "$id" || return 1
+      printf '%s' "$id"
+      return 0
+    fi
+  done
+  # The tmux window convention is fm-<id>, applied only when that task's
+  # metadata actually exists so the convention can never invent an id.
+  case "$key" in
+    fm-*)
+      id=${key#fm-}
+      if fm_task_id_path_safe "$id" && [ -f "$STATE/$id.meta" ]; then
+        printf '%s' "$id"
+        return 0
+      fi
+      ;;
+  esac
+  return 1
+}
+
+# A task id wherever one is honestly derivable, "-" otherwise. Heartbeats are
+# fleet-wide and never carry one.
+ledger_task_for_key() {  # <kind> <key>
+  local kind=$1 key=$2 id
+  case "$kind" in
+    signal)
+      if fm_wake_status_key_map "$key"; then
+        id=${FM_WAKE_STATUS_KEY%.status}
+        printf '%s' "$id"
+        return 0
+      fi
+      ;;
+    check)
+      id=$(basename "$key")
+      case "$id" in
+        *.check.sh)
+          id=${id%.check.sh}
+          if fm_task_id_path_safe "$id"; then
+            printf '%s' "$id"
+            return 0
+          fi
+          ;;
+      esac
+      ;;
+    stale)
+      if id=$(ledger_task_for_endpoint "$key"); then
+        printf '%s' "$id"
+        return 0
+      fi
+      ;;
+  esac
+  printf '%s' -
+}
+
+# --- subcommands ------------------------------------------------------------
+
+cmd_drain_record() {
+  local now epoch seq kind key task latency
+  now=$(date +%s)
+  # Test-only latency seam, mirroring the drain's own enrichment seam: it proves
+  # that a slow ledger phase cannot delay or block a concurrent wake append.
+  case "${FM_WAKE_LEDGER_TEST_DELAY:-0}" in
+    0) ;;
+    ''|*[!0-9]*) ;;
+    *) sleep "$FM_WAKE_LEDGER_TEST_DELAY" ;;
+  esac
+  while IFS="$TAB" read -r epoch seq kind key _; do
+    case "$epoch" in ''|*[!0-9]*) continue ;; esac
+    case "$seq" in ''|*[!0-9]*) continue ;; esac
+    case "$kind" in
+      signal|stale|check|heartbeat) ;;
+      *) continue ;;
+    esac
+    task=$(ledger_task_for_key "$kind" "$key")
+    # A check key is an absolute script path. Only its basename identifies the
+    # check, and the home path has no business in durable evidence.
+    case "$key" in
+      /*) key=$(basename "$key") ;;
+    esac
+    latency=$((now - epoch))
+    [ "$latency" -ge 0 ] || latency=0
+    ledger_append "$now" wake \
+      "seq=$seq" \
+      "kind=$kind" \
+      "key=$(ledger_sanitize "$key" "$LEDGER_KEY_MAX")" \
+      "task=$task" \
+      "queued=$epoch" \
+      "latency=$latency" || return 0
+  done
+  return 0
+}
+
+# The wake record for <seq>, as "<epoch><TAB><task>", from a bounded tail read.
+ledger_lookup_wake() {  # <seq>
+  local seq=$1 found
+  [ -f "$LEDGER" ] || return 1
+  found=$(tail -n "$LEDGER_LOOKUP_TAIL" "$LEDGER" 2>/dev/null | LC_ALL=C awk -F '\t' \
+    -v want="seq=$seq" -v schema="$LEDGER_SCHEMA" '
+    $1 == schema && $2 == "wake" {
+      match_seq = 0
+      row_task = "-"
+      for (i = 4; i <= NF; i++) {
+        if ($i == want) match_seq = 1
+        else if (substr($i, 1, 5) == "task=") row_task = substr($i, 6)
+      }
+      if (match_seq) { ts = $3; task = row_task; hit = 1 }
+    }
+    END { if (hit) printf "%s\t%s", ts, task }
+  ') || return 1
+  [ -n "$found" ] || return 1
+  printf '%s' "$found"
+}
+
+cmd_outcome() {
+  local token='' task='' defect='' note='' now seq wake_row wake_ts wake_task after
+  local -a seqs=()
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --task) [ "$#" -ge 2 ] || die "--task needs a value"; task=$2; shift 2 ;;
+      --defect) [ "$#" -ge 2 ] || die "--defect needs a value"; defect=$2; shift 2 ;;
+      --note) [ "$#" -ge 2 ] || die "--note needs a value"; note=$2; shift 2 ;;
+      -h|--help) usage; exit 0 ;;
+      -*) die "unknown flag for outcome: $1" ;;
+      *)
+        if [ -z "$token" ]; then
+          token=$1
+        else
+          seqs+=("$1")
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  [ -n "$token" ] || die "outcome needs a token and at least one wake sequence"
+  case "$token" in
+    absorbed|inspected|steered|decided|escalated|repaired|false-positive) ;;
+    *) die "unknown outcome token: $token (absorbed inspected steered decided escalated repaired false-positive)" ;;
+  esac
+  [ "${#seqs[@]}" -gt 0 ] || die "outcome needs at least one wake sequence"
+  for seq in "${seqs[@]}"; do
+    case "$seq" in
+      ''|*[!0-9]*) die "wake sequence must be a number: $seq" ;;
+    esac
+  done
+  if [ -n "$task" ] && ! fm_task_id_path_safe "$task"; then
+    die "unsafe task id: $task"
+  fi
+  case "$defect" in
+    '') ;;
+    *[!A-Za-z0-9._-]*) die "defect class must be [A-Za-z0-9._-]: $defect" ;;
+  esac
+
+  now=$(date +%s)
+  for seq in "${seqs[@]}"; do
+    wake_task=$task
+    after=unknown
+    if wake_row=$(ledger_lookup_wake "$seq"); then
+      wake_ts=${wake_row%%"$TAB"*}
+      case "$wake_ts" in
+        ''|*[!0-9]*) wake_ts= ;;
+      esac
+      if [ -z "$wake_task" ]; then
+        wake_task=${wake_row#*"$TAB"}
+      fi
+      if [ -n "$wake_ts" ]; then
+        after=$((now - wake_ts))
+        [ "$after" -ge 0 ] || after=0
+      fi
+    fi
+    [ -n "$wake_task" ] || wake_task=-
+    set -- \
+      "seq=$seq" \
+      "outcome=$token" \
+      "task=$(ledger_sanitize "$wake_task" "$LEDGER_ID_MAX")" \
+      "after=$after"
+    [ -z "$defect" ] || set -- "$@" "defect=$(ledger_sanitize "$defect" "$LEDGER_SHORT_MAX")"
+    [ -z "$note" ] || set -- "$@" "note=$(ledger_sanitize "$note" "$LEDGER_NOTE_MAX")"
+    ledger_append "$now" outcome "$@" || {
+      printf 'error: could not append outcome record for wake %s to %s\n' "$seq" "$LEDGER" >&2
+      return 1
+    }
+  done
+  return 0
+}
+
+cmd_task() {
+  local id='' outcome=landed route=unknown escalated=unknown findings=unknown
+  local harness=unknown model=unknown effort=unknown mode=unknown kind=unknown
+  local project=unknown backend=unknown pr='' now
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --outcome) [ "$#" -ge 2 ] || die "--outcome needs a value"; outcome=$2; shift 2 ;;
+      --harness) [ "$#" -ge 2 ] || die "--harness needs a value"; harness=$2; shift 2 ;;
+      --model) [ "$#" -ge 2 ] || die "--model needs a value"; model=$2; shift 2 ;;
+      --effort) [ "$#" -ge 2 ] || die "--effort needs a value"; effort=$2; shift 2 ;;
+      --mode) [ "$#" -ge 2 ] || die "--mode needs a value"; mode=$2; shift 2 ;;
+      --kind) [ "$#" -ge 2 ] || die "--kind needs a value"; kind=$2; shift 2 ;;
+      --project) [ "$#" -ge 2 ] || die "--project needs a value"; project=$2; shift 2 ;;
+      --backend) [ "$#" -ge 2 ] || die "--backend needs a value"; backend=$2; shift 2 ;;
+      --pr) [ "$#" -ge 2 ] || die "--pr needs a value"; pr=$2; shift 2 ;;
+      --route) [ "$#" -ge 2 ] || die "--route needs a value"; route=$2; shift 2 ;;
+      --escalated) [ "$#" -ge 2 ] || die "--escalated needs a value"; escalated=$2; shift 2 ;;
+      --findings) [ "$#" -ge 2 ] || die "--findings needs a value"; findings=$2; shift 2 ;;
+      -h|--help) usage; exit 0 ;;
+      -*) die "unknown flag for task: $1" ;;
+      *) [ -z "$id" ] || die "task takes one task id"; id=$1; shift ;;
+    esac
+  done
+
+  [ -n "$id" ] || die "task needs a task id"
+  fm_task_id_path_safe "$id" || die "unsafe task id: $id"
+  case "$outcome" in
+    landed|failed|abandoned) ;;
+    *) die "unknown terminal outcome: $outcome (landed failed abandoned)" ;;
+  esac
+  case "$escalated" in
+    yes|no|unknown) ;;
+    *) die "--escalated must be yes, no, or unknown: $escalated" ;;
+  esac
+  case "$findings" in
+    unknown|'') findings=unknown ;;
+    *[!0-9]*) die "--findings must be a count or unknown: $findings" ;;
+  esac
+
+  # A project path never enters the ledger; only its basename identifies it.
+  project=$(basename "$project")
+
+  now=$(date +%s)
+  set -- \
+    "task=$(ledger_sanitize "$id" "$LEDGER_ID_MAX")" \
+    "harness=$(ledger_sanitize "${harness:-unknown}" "$LEDGER_SHORT_MAX")" \
+    "model=$(ledger_sanitize "${model:-unknown}" "$LEDGER_KEY_MAX")" \
+    "effort=$(ledger_sanitize "${effort:-unknown}" "$LEDGER_SHORT_MAX")" \
+    "mode=$(ledger_sanitize "${mode:-unknown}" "$LEDGER_SHORT_MAX")" \
+    "kind=$(ledger_sanitize "${kind:-unknown}" "$LEDGER_SHORT_MAX")" \
+    "project=$(ledger_sanitize "${project:-unknown}" "$LEDGER_SHORT_MAX")" \
+    "backend=$(ledger_sanitize "${backend:-unknown}" "$LEDGER_SHORT_MAX")" \
+    "outcome=$outcome" \
+    "route=$(ledger_sanitize "${route:-unknown}" "$LEDGER_SHORT_MAX")" \
+    "escalated=$escalated" \
+    "findings=$findings"
+  [ -z "$pr" ] || set -- "$@" "pr=$(ledger_sanitize "$pr" "$LEDGER_KEY_MAX")"
+  ledger_append "$now" task "$@" || {
+    printf 'error: could not append terminal record for task %s to %s\n' "$id" "$LEDGER" >&2
+    return 1
+  }
+  return 0
+}
+
+cmd_report() {
+  local since_days='' cutoff=0 tmp now
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --since-days) [ "$#" -ge 2 ] || die "--since-days needs a value"; since_days=$2; shift 2 ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "unknown flag for report: $1" ;;
+    esac
+  done
+  case "$since_days" in
+    '') ;;
+    *[!0-9]*) die "--since-days must be a number: $since_days" ;;
+    *)
+      now=$(date +%s)
+      cutoff=$((now - since_days * 86400))
+      ;;
+  esac
+
+  if [ ! -f "$LEDGER" ]; then
+    printf 'wake ledger: %s (absent - nothing recorded yet)\n' "$LEDGER"
+    return 0
+  fi
+
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-wake-ledger-report.XXXXXX") || die "cannot create a work directory"
+  trap 'rm -rf "$tmp"' EXIT
+
+  printf 'wake ledger: %s\n' "$LEDGER"
+  if [ -n "$since_days" ]; then
+    printf 'window: last %s day(s)\n' "$since_days"
+  else
+    printf 'window: all records\n'
+  fi
+  printf '\n'
+
+  LC_ALL=C awk -F '\t' \
+    -v schema="$LEDGER_SCHEMA" \
+    -v cutoff="$cutoff" \
+    -v top="$LEDGER_REPORT_TOP" \
+    -v latfile="$tmp/lat" '
+    function fieldset(   i, p) {
+      split("", f)
+      for (i = 4; i <= NF; i++) {
+        p = index($i, "=")
+        if (p > 0) f[substr($i, 1, p - 1)] = substr($i, p + 1)
+      }
+    }
+    $1 != schema { next }
+    $3 + 0 < cutoff { next }
+    {
+      fieldset()
+    }
+    $2 == "wake" {
+      seq = f["seq"]
+      # A drain crash inside its at-least-once micro-gap can replay a wake, so
+      # count distinct sequences rather than lines.
+      if (seq in wake_seen) next
+      wake_seen[seq] = 1
+      wakes++
+      by_kind[f["kind"]]++
+      t = f["task"]
+      if (t != "" && t != "-") { wakes_by_task[t]++; }
+      if (f["latency"] ~ /^[0-9]+$/) print f["latency"] > latfile
+      next
+    }
+    $2 == "outcome" {
+      seq = f["seq"]
+      if (seq in outcome_seen) next
+      outcome_seen[seq] = 1
+      outcomes++
+      by_outcome[f["outcome"]]++
+      t = f["task"]
+      if (t == "" || t == "-") { unattributed++; next }
+      outcome_by_task[t, f["outcome"]]++
+      next
+    }
+    $2 == "task" {
+      t = f["task"]
+      # The most recent terminal line wins if a task id was ever reused.
+      profile[t] = f["harness"] "/" f["model"] "/" f["effort"]
+      terminal[t] = f["outcome"]
+      next
+    }
+    END {
+      printf "wakes: %d total", wakes + 0
+      if (wakes > 0) {
+        covered = 0
+        for (s in wake_seen) if (s in outcome_seen) covered++
+        printf ", %d with a recorded outcome, %d unrecorded (%d%% coverage)",
+          covered, wakes - covered, int((covered * 100.0 / wakes) + 0.5)
+      }
+      printf "\n"
+      if (wakes > 0) {
+        printf "  by kind:"
+        split("signal stale check heartbeat", order, " ")
+        for (i = 1; i <= 4; i++) if (order[i] in by_kind) printf "  %s %d", order[i], by_kind[order[i]]
+        printf "\n"
+      }
+
+      printf "\noutcomes: %d recorded", outcomes + 0
+      if (unattributed > 0) printf " (%d not attributable to a task)", unattributed
+      printf "\n"
+      if (outcomes > 0) {
+        printf "  by token:"
+        split("absorbed inspected steered decided escalated repaired false-positive", ov, " ")
+        for (i = 1; i <= 7; i++) if (ov[i] in by_outcome) printf "  %s %d", ov[i], by_outcome[ov[i]]
+        printf "\n"
+      }
+
+      tasks = 0
+      for (t in terminal) { tasks++; term_count[terminal[t]]++ }
+      printf "\ntasks: %d terminal", tasks
+      if (tasks > 0) {
+        printf " ("
+        split("landed failed abandoned", tv, " ")
+        first = 1
+        for (i = 1; i <= 3; i++) if (tv[i] in term_count) {
+          printf "%s%s %d", (first ? "" : "  "), tv[i], term_count[tv[i]]
+          first = 0
+        }
+        printf ")"
+      }
+      printf "\n"
+
+      if (tasks > 0) {
+        printf "\nper profile (harness/model/effort):\n"
+        split("absorbed inspected steered decided escalated repaired false-positive", ov, " ")
+        for (t in terminal) {
+          p = profile[t]
+          p_tasks[p]++
+          p_wakes[p] += wakes_by_task[t] + 0
+          for (i = 1; i <= 7; i++) {
+            if ((t, ov[i]) in outcome_by_task) p_out[p, ov[i]] += outcome_by_task[t, ov[i]]
+          }
+        }
+        for (p in p_tasks) {
+          printf "  %-44s tasks %-4d wakes/task %-6.1f steered %-4d repaired %-4d escalated %-4d false-positive %d\n",
+            p, p_tasks[p], p_wakes[p] / p_tasks[p],
+            p_out[p, "steered"] + 0, p_out[p, "repaired"] + 0,
+            p_out[p, "escalated"] + 0, p_out[p, "false-positive"] + 0
+        }
+      }
+
+      shown = 0
+      omitted = 0
+      n = 0
+      for (t in wakes_by_task) { n++; keys[n] = t }
+      # Simple selection of the busiest tasks; n is small (tasks per window).
+      if (n > 0) {
+        printf "\nbusiest tasks by wake count:\n"
+        for (i = 1; i <= n; i++) {
+          for (j = i + 1; j <= n; j++) {
+            if (wakes_by_task[keys[j]] > wakes_by_task[keys[i]]) {
+              swap = keys[i]; keys[i] = keys[j]; keys[j] = swap
+            }
+          }
+        }
+        for (i = 1; i <= n; i++) {
+          if (shown >= top) { omitted++; continue }
+          printf "  %-36s %d\n", keys[i], wakes_by_task[keys[i]]
+          shown++
+        }
+        if (omitted > 0) printf "  (%d more task(s) not shown)\n", omitted
+      }
+    }
+  ' "$LEDGER"
+
+  if [ -s "$tmp/lat" ]; then
+    printf '\n'
+    LC_ALL=C sort -n "$tmp/lat" | LC_ALL=C awk '
+      { v[n++] = $1 + 0 }
+      END {
+        if (n == 0) exit
+        printf "coordinator response latency (queued -> drained), seconds: min %d  median %d  p90 %d  max %d\n",
+          v[0], v[int((n - 1) * 0.5)], v[int((n - 1) * 0.9)], v[n - 1]
+      }
+    '
+  fi
+
+  rm -rf "$tmp"
+  trap - EXIT
+  return 0
+}
+
+# --- entry ------------------------------------------------------------------
+
+[ "$#" -ge 1 ] || { usage; exit 2; }
+SUBCOMMAND=$1
+shift
+case "$SUBCOMMAND" in
+  drain-record) cmd_drain_record "$@" ;;
+  outcome) cmd_outcome "$@" ;;
+  task) cmd_task "$@" ;;
+  report) cmd_report "$@" ;;
+  -h|--help|help) usage ;;
+  *) die "unknown subcommand: $SUBCOMMAND (drain-record outcome task report)" ;;
+esac

--- a/bin/fm-wake-ledger.sh
+++ b/bin/fm-wake-ledger.sh
@@ -25,14 +25,21 @@
 #
 #   wake     one per deduped drained wake-queue row, written by
 #            bin/fm-wake-drain.sh. Deterministic - no judgment involved.
-#            Fields: seq (the wake-queue sequence, and the join key), kind,
-#            key, task, queued (epoch the watcher enqueued), latency (seconds
-#            the wake waited for the coordinator).
+#            Fields: seq (the wake-queue sequence), kind, key, task, queued
+#            (epoch the watcher enqueued), latency (seconds the wake waited
+#            for the coordinator).
 #
 #   outcome  one per handled wake, written by the coordinator through this
 #            script's `outcome` subcommand and joined to its wake record on
-#            seq. Fields: seq, outcome, task, after (seconds since the wake
-#            record), and optional defect and note.
+#            the (seq, queued) pair. Fields: seq, queued (copied from the
+#            matching wake record, or unknown when none is resolvable),
+#            outcome, task, after (seconds since the wake record), and
+#            optional defect and note.
+#
+# The durable join identity is the (seq, queued) pair, not seq alone: seq
+# comes from state/.wake-queue.seq, which restarts when state/ is wiped or a
+# home is rebuilt while this file survives, so queued disambiguates a reused
+# sequence.
 #
 #   task     one terminal line per task, written by bin/fm-teardown.sh
 #            immediately before the task metadata is deleted - the last moment
@@ -266,7 +273,8 @@ cmd_drain_record() {
   return 0
 }
 
-# The wake record for <seq>, as "<epoch><TAB><task>", from a bounded tail read.
+# The wake record for <seq>, as "<epoch><TAB><task><TAB><queued>", from a
+# bounded tail read.
 ledger_lookup_wake() {  # <seq>
   local seq=$1 found
   [ -f "$LEDGER" ] || return 1
@@ -275,20 +283,22 @@ ledger_lookup_wake() {  # <seq>
     $1 == schema && $2 == "wake" {
       match_seq = 0
       row_task = "-"
+      row_queued = ""
       for (i = 4; i <= NF; i++) {
         if ($i == want) match_seq = 1
         else if (substr($i, 1, 5) == "task=") row_task = substr($i, 6)
+        else if (substr($i, 1, 7) == "queued=") row_queued = substr($i, 8)
       }
-      if (match_seq) { ts = $3; task = row_task; hit = 1 }
+      if (match_seq) { ts = $3; task = row_task; queued = row_queued; hit = 1 }
     }
-    END { if (hit) printf "%s\t%s", ts, task }
+    END { if (hit) printf "%s\t%s\t%s", ts, task, queued }
   ') || return 1
   [ -n "$found" ] || return 1
   printf '%s' "$found"
 }
 
 cmd_outcome() {
-  local token='' task='' defect='' note='' now seq wake_row wake_ts wake_task after
+  local token='' task='' defect='' note='' now seq wake_row wake_rest wake_ts wake_task wake_queued after
   local -a seqs=()
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -330,15 +340,21 @@ cmd_outcome() {
   now=$(date +%s)
   for seq in "${seqs[@]}"; do
     wake_task=$task
+    wake_queued=unknown
     after=unknown
     if wake_row=$(ledger_lookup_wake "$seq"); then
       wake_ts=${wake_row%%"$TAB"*}
       case "$wake_ts" in
         ''|*[!0-9]*) wake_ts= ;;
       esac
+      wake_rest=${wake_row#*"$TAB"}
       if [ -z "$wake_task" ]; then
-        wake_task=${wake_row#*"$TAB"}
+        wake_task=${wake_rest%%"$TAB"*}
       fi
+      wake_queued=${wake_rest#*"$TAB"}
+      case "$wake_queued" in
+        ''|*[!0-9]*) wake_queued=unknown ;;
+      esac
       if [ -n "$wake_ts" ]; then
         after=$((now - wake_ts))
         [ "$after" -ge 0 ] || after=0
@@ -347,6 +363,7 @@ cmd_outcome() {
     [ -n "$wake_task" ] || wake_task=-
     set -- \
       "seq=$seq" \
+      "queued=$wake_queued" \
       "outcome=$token" \
       "task=$(ledger_sanitize "$wake_task" "$LEDGER_ID_MAX")" \
       "after=$after"
@@ -477,10 +494,18 @@ cmd_report() {
     }
     $2 == "wake" {
       seq = f["seq"]
+      q = f["queued"]
+      if (q == "") q = "unknown"
       # A drain crash inside its at-least-once micro-gap can replay a wake, so
-      # count distinct sequences rather than lines.
-      if (seq in wake_seen) next
-      wake_seen[seq] = 1
+      # count distinct (seq, queued) pairs rather than lines. seq alone is not
+      # identity: state/.wake-queue.seq restarts across a state wipe while this
+      # file survives, so a reused seq needs queued to disambiguate. An unknown
+      # queued cannot identify a record, so it never dedups - silently merging
+      # unidentifiable records is exactly the undercount this guards against.
+      if (q != "unknown") {
+        if ((seq, q) in wake_seen) next
+        wake_seen[seq, q] = 1
+      }
       wakes++
       by_kind[f["kind"]]++
       t = f["task"]
@@ -490,8 +515,13 @@ cmd_report() {
     }
     $2 == "outcome" {
       seq = f["seq"]
-      if (seq in outcome_seen) next
-      outcome_seen[seq] = 1
+      q = f["queued"]
+      if (q == "") q = "unknown"
+      # Same pair identity and same unknown rule as the wake records above.
+      if (q != "unknown") {
+        if ((seq, q) in outcome_seen) next
+        outcome_seen[seq, q] = 1
+      }
       outcomes++
       by_outcome[f["outcome"]]++
       t = f["task"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,6 +41,22 @@ For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema
 `bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
 The script header owns the exact JSON schema.
 
+### Wake-outcome ledger
+
+`data/wake-ledger.tsv` is the durable record of what supervision actually costs, so coordinator attention is measured rather than estimated.
+`bin/fm-wake-ledger.sh` is its single owner: record format, the closed outcome vocabulary, and append semantics all live in that script's header and `--help`.
+It carries three record kinds - one `wake` record per drained wake, one `outcome` record per handled wake joined to it on the wake-queue sequence, and one terminal `task` record per finished task.
+It lives under `data/` rather than `state/` because teardown clears `state/<id>.*` and this evidence must outlive the tasks it describes.
+
+The wake half is written deterministically by `bin/fm-wake-drain.sh` and the outcome half by the first mate.
+That split is the point rather than an accident: a single coordinator-written line would make measured attention cost fall whenever the recording step was skipped, so the metric would move without the underlying quantity moving.
+Splitting it gives a denominator that is stable under no change and turns missing coverage into a reported number instead of a silent undercount.
+
+The ledger can never block, delay, alter, or fail a wake.
+The drain calls it only after its authoritative print-and-delete boundary, with stdout discarded and failure ignored, and the ledger itself takes no lock and writes one capped line per record.
+`bin/fm-teardown.sh` writes the terminal record immediately before deleting the task metadata, which is the last moment that task's harness, model, and effort are recoverable.
+Watcher-absorbed wakes stay out of the ledger by design: they never reach the coordinator, so they are not part of the quantity being measured, and `state/.watch-triage.log` remains their disposable debug record.
+
 ### Registered secondmate current state
 
 A registered secondmate's validated home is the authority for bearings current state because it owns the child metadata inventory, each child's current-state result, endpoint observations, backlog holds and dependencies, keyed unresolved decisions, and recent Done baseline.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ The script header owns the exact JSON schema.
 
 `data/wake-ledger.tsv` is the durable record of what supervision actually costs, so coordinator attention is measured rather than estimated.
 `bin/fm-wake-ledger.sh` is its single owner: record format, the closed outcome vocabulary, and append semantics all live in that script's header and `--help`.
-It carries three record kinds - one `wake` record per drained wake, one `outcome` record per handled wake joined to it on the wake-queue sequence, and one terminal `task` record per finished task.
+It carries three record kinds - one `wake` record per drained wake, one `outcome` record per handled wake joined to it on the (seq, queued) pair, and one terminal `task` record per finished task.
 It lives under `data/` rather than `state/` because teardown clears `state/<id>.*` and this evidence must outlive the tasks it describes.
 
 The wake half is written deterministically by `bin/fm-wake-drain.sh` and the outcome half by the first mate.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ The shared orchestrator behavior lives in [`AGENTS.md`](../AGENTS.md) - edit it 
 
 This section is the single owner of the top-level operational-home layout; producer script headers and their help own exact child-file fields and mutation contracts.
 The tracked code root contains the shared instruction, skill, documentation, workflow, and `bin/` surfaces, while each effective `FM_HOME` contains private operational directories.
-`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, and scout reports.
+`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, scout reports, and the wake-outcome ledger.
 `state/` holds volatile runtime records such as task metadata, append-only status events, endpoint signals, watcher and wake-queue coordination, away-mode state, generated X-mode artifacts, private secondmate config-reread generations with their retry and quarantine state, and parent-owned secondmate pending-reply records under `state/pending-replies/` (`bin/fm-pending-reply-lib.sh`).
 `config/` holds local gitignored operating choices, and `projects/` holds the local project clones that Firstmate reads but changes only through the narrow guarded and concrete captain-approved exceptions in `AGENTS.md`.
 
@@ -451,6 +451,7 @@ FMX_X_THREAD_MAX=25     # maximum messages in one auto-split reply thread
 FMX_FOLLOWUP_MAX_AGE_SECS=604800   # local window for posting X-mode completion follow-ups (7 days)
 FMX_FOLLOWUP_MAX_COUNT=3   # local cap on X-mode completion follow-ups per linked mention
 FM_PF_RETRY_BACKOFF_SECS=900   # seconds before the next attempt after a retryable promised-public-reply delivery error
+FM_WAKE_LEDGER=         # alternate wake-outcome ledger path, default data/wake-ledger.tsv (bin/fm-wake-ledger.sh)
 FM_LOCK_STALE_AFTER=2   # seconds before dead-pid lock records can be reclaimed; mid-acquire locks keep at least 2s grace
 FM_GUARD_GRACE=300      # seconds before guard warnings, arm health checks, and the primary turn-end guard treat a watcher beacon as stale
 FM_CLAUDE_AUTOARM_SYNC_WAIT_MS=800   # milliseconds the --claude turn-end guard waits for the Stop auto-arm's claim, health, or fresh rewake epoch before re-blocking

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -72,7 +72,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor for the bootstrap diagnostic                  |
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |
-| `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, then assert watcher liveness |
+| `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, record the ledger's wake half, then assert watcher liveness |
+| `fm-wake-ledger.sh`      | Own the append-only wake-outcome and terminal-task evidence record, and summarize it |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
 | `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -72,7 +72,7 @@ make_case() {
   local name=$1 case_dir fakebin
   case_dir="$TMP_ROOT/$name"
   fakebin="$case_dir/fakebin"
-  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/config" "$case_dir/data" "$fakebin"
 
   # Mocks for the post-check teardown steps. Refuse logic exits before these
   # run; the ALLOW cases need them so the script can complete cleanly.
@@ -494,6 +494,7 @@ run_teardown() {
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
   FM_CONFIG_OVERRIDE="$case_dir/config" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
   PATH="$case_dir/fakebin:$PATH" \
     "$TEARDOWN" task-x1 "$@"
 }
@@ -1398,6 +1399,85 @@ test_herdr_projection_teardown_retains_journal_when_close_unconfirmed() {
   pass "herdr projection teardown retains the stale journal and attempts no workspace cleanup when exact-pane close is unconfirmed"
 }
 
+# Write a meta carrying the dispatch profile, so the ledger's terminal line has
+# a harness/model/effort join to capture before teardown deletes it.
+write_profiled_meta() {  # <case_dir> <mode>
+  local case_dir=$1 mode=$2
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=firstmate:fm-task-x1" \
+    "endpoint_task_id=task-x1" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=$mode" \
+    "harness=pi" \
+    "model=openai-codex/gpt-5.6-sol" \
+    "effort=medium"
+}
+
+test_teardown_records_the_terminal_ledger_line() {
+  local case_dir ledger
+  case_dir=$(make_case ledger-terminal)
+  write_profiled_meta "$case_dir" local-only
+  wt_commit "$case_dir" "fix the thing"
+  add_fork_with_pushed_branch "$case_dir"
+
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "ledger-terminal: teardown should succeed"
+
+  ledger="$case_dir/data/wake-ledger.tsv"
+  [ -f "$ledger" ] || fail "ledger-terminal: teardown wrote no terminal record"
+  grep -q "task=task-x1" "$ledger" || fail "ledger-terminal: task id missing"
+  grep -q "outcome=landed" "$ledger" || fail "ledger-terminal: terminal outcome missing"
+  # The model join must be captured BEFORE the meta is deleted; this is the last
+  # moment those facts exist anywhere.
+  grep -q "harness=pi" "$ledger" || fail "ledger-terminal: harness not captured from the meta"
+  grep -q "model=openai-codex/gpt-5.6-sol" "$ledger" || fail "ledger-terminal: model not captured"
+  grep -q "effort=medium" "$ledger" || fail "ledger-terminal: effort not captured"
+  grep -q "mode=local-only" "$ledger" || fail "ledger-terminal: delivery mode not captured"
+  [ ! -f "$case_dir/state/task-x1.meta" ] || fail "ledger-terminal: meta should be gone after teardown"
+  pass "teardown records the terminal ledger line with the meta's profile before deleting it"
+}
+
+test_teardown_force_records_abandoned() {
+  local case_dir
+  case_dir=$(make_case ledger-abandoned)
+  write_profiled_meta "$case_dir" local-only
+  wt_commit "$case_dir" "unpushed work"
+
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "ledger-abandoned: --force teardown should succeed"
+
+  grep -q "outcome=abandoned" "$case_dir/data/wake-ledger.tsv" \
+    || fail "ledger-abandoned: discarded work should record an abandoned outcome"
+  pass "a --force teardown records the task as abandoned rather than landed"
+}
+
+test_unwritable_ledger_never_fails_teardown() {
+  local case_dir rc
+  case_dir=$(make_case ledger-unwritable)
+  write_profiled_meta "$case_dir" local-only
+  wt_commit "$case_dir" "fix the thing"
+  add_fork_with_pushed_branch "$case_dir"
+
+  set +e
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_CONFIG_OVERRIDE="$case_dir/config" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
+  FM_WAKE_LEDGER="/dev/null/impossible/wake-ledger.tsv" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$TEARDOWN" task-x1 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "ledger-unwritable: a telemetry write must never fail a teardown"
+  [ ! -f "$case_dir/state/task-x1.meta" ] || fail "ledger-unwritable: cleanup did not complete"
+  grep -q "wake ledger terminal line not recorded" "$case_dir/stderr" \
+    || fail "ledger-unwritable: teardown should warn that the record was lost"
+  pass "an unwritable ledger warns but never fails or halts a teardown"
+}
+
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
@@ -1431,3 +1511,6 @@ test_transient_index_lock_clears_after_first_attempt_and_retry_succeeds
 test_persistent_index_lock_exhausts_retries_and_refuses_loudly
 test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
+test_teardown_records_the_terminal_ledger_line
+test_teardown_force_records_abandoned
+test_unwritable_ledger_never_fails_teardown

--- a/tests/fm-wake-ledger.test.sh
+++ b/tests/fm-wake-ledger.test.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+# tests/fm-wake-ledger.test.sh - the wake-outcome ledger's contract:
+# record format, the closed outcome vocabulary, sanitization, task attribution,
+# drain integration, the never-block guarantee, concurrent-append safety, and
+# the report's counts and coverage.
+#
+# The never-block guarantee is the safety-critical half. Two cases prove it:
+# an unwritable ledger leaves the drain's raw rows and exit status untouched,
+# and a deliberately slowed ledger phase never blocks a concurrent wake append.
+#
+# Teardown's terminal-record write is covered where teardown's own fixture
+# lives, in tests/fm-teardown.test.sh.
+set -u
+
+# shellcheck source=tests/wake-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+
+LEDGER="$ROOT/bin/fm-wake-ledger.sh"
+DRAIN="$ROOT/bin/fm-wake-drain.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-wake-ledger-tests)
+
+# A sandboxed home for one case: echoes its dir, with state/ and data/ ready.
+make_home() {
+  local name=$1 dir
+  dir="$TMP_ROOT/$name"
+  mkdir -p "$dir/state" "$dir/data"
+  touch "$dir/state/.last-watcher-beat"
+  printf '%s\n' "$dir"
+}
+
+# Run the ledger against <home>.
+ledger() {
+  local home=$1
+  shift
+  FM_ROOT_OVERRIDE="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    "$LEDGER" "$@"
+}
+
+ledger_file() {
+  printf '%s\n' "$1/data/wake-ledger.tsv"
+}
+
+# The value of <field> on the first line matching <record> kind, or empty.
+field_of() {  # <file> <record> <field>
+  LC_ALL=C awk -F '\t' -v want="$2" -v key="$3" '
+    $1 == "v1" && $2 == want {
+      for (i = 4; i <= NF; i++) {
+        p = index($i, "=")
+        if (p > 0 && substr($i, 1, p - 1) == key) { print substr($i, p + 1); exit }
+      }
+      exit
+    }
+  ' "$1"
+}
+
+
+test_record_format_for_all_three_kinds() {
+  local home file now
+  home=$(make_home format)
+  file=$(ledger_file "$home")
+  now=$(date +%s)
+
+  printf '%s\t7\tsignal\talpha.status\tsignal: alpha\n' "$((now - 12))" \
+    | ledger "$home" drain-record || fail "format: drain-record failed"
+  ledger "$home" outcome steered 7 || fail "format: outcome failed"
+  ledger "$home" task alpha --outcome landed --harness pi --model sol --effort medium \
+    || fail "format: task failed"
+
+  [ "$(wc -l < "$file" | tr -d ' ')" -eq 3 ] || fail "format: expected three records"
+  LC_ALL=C awk -F '\t' '$1 != "v1" || NF < 4 { bad = 1 } END { exit bad + 0 }' "$file" \
+    || fail "format: a record was not a well-formed v1 line"
+
+  [ "$(field_of "$file" wake seq)" = 7 ] || fail "format: wake seq not recorded"
+  [ "$(field_of "$file" wake kind)" = signal ] || fail "format: wake kind not recorded"
+  [ "$(field_of "$file" wake task)" = alpha ] || fail "format: wake task not attributed"
+  [ "$(field_of "$file" wake latency)" = 12 ] || fail "format: wake latency not computed"
+  [ "$(field_of "$file" wake queued)" = "$((now - 12))" ] || fail "format: queued epoch not recorded"
+
+  [ "$(field_of "$file" outcome outcome)" = steered ] || fail "format: outcome token not recorded"
+  [ "$(field_of "$file" outcome task)" = alpha ] || fail "format: outcome task not resolved from its wake"
+
+  [ "$(field_of "$file" task harness)" = pi ] || fail "format: task harness not recorded"
+  [ "$(field_of "$file" task model)" = sol ] || fail "format: task model not recorded"
+  [ "$(field_of "$file" task escalated)" = unknown ] || fail "format: absent escalation must record unknown"
+  # The wake count is computed from wake records, never serialized on the task.
+  [ -z "$(field_of "$file" task wakes)" ] || fail "format: task record must not store a wake count"
+  pass "each record kind writes a well-formed v1 line with its expected fields"
+}
+
+test_outcome_vocabulary_is_closed() {
+  local home file token
+  home=$(make_home vocabulary)
+  file=$(ledger_file "$home")
+
+  for token in absorbed inspected steered decided escalated repaired false-positive; do
+    ledger "$home" outcome "$token" 1 >/dev/null 2>&1 \
+      || fail "vocabulary: $token should be accepted"
+  done
+  [ "$(wc -l < "$file" | tr -d ' ')" -eq 7 ] || fail "vocabulary: expected seven accepted records"
+
+  for token in handled ignored '' STEERED steered-ish; do
+    if ledger "$home" outcome "$token" 1 >/dev/null 2>&1; then
+      fail "vocabulary: '$token' should have been refused"
+    fi
+  done
+  [ "$(wc -l < "$file" | tr -d ' ')" -eq 7 ] \
+    || fail "vocabulary: a refused token still wrote a record"
+  pass "the outcome vocabulary is closed and a refused token writes nothing"
+}
+
+test_terminal_outcome_and_escalation_are_validated() {
+  local home file
+  home=$(make_home terminal-validation)
+  file=$(ledger_file "$home")
+
+  ledger "$home" task alpha --outcome shipped >/dev/null 2>&1 \
+    && fail "terminal: an unknown terminal outcome should be refused"
+  ledger "$home" task alpha --escalated maybe >/dev/null 2>&1 \
+    && fail "terminal: an unknown escalation value should be refused"
+  ledger "$home" task alpha --findings lots >/dev/null 2>&1 \
+    && fail "terminal: a non-numeric findings count should be refused"
+  ledger "$home" task ../escape >/dev/null 2>&1 \
+    && fail "terminal: an unsafe task id should be refused"
+  [ ! -s "$file" ] || fail "terminal: a refused terminal record still wrote a line"
+
+  ledger "$home" task alpha --outcome abandoned --escalated yes --findings 3 \
+    || fail "terminal: a valid terminal record should be accepted"
+  [ "$(field_of "$file" task outcome)" = abandoned ] || fail "terminal: outcome not recorded"
+  [ "$(field_of "$file" task escalated)" = yes ] || fail "terminal: escalation not recorded"
+  [ "$(field_of "$file" task findings)" = 3 ] || fail "terminal: findings not recorded"
+  pass "terminal outcome, escalation, findings, and task id are validated"
+}
+
+test_sanitization_keeps_one_record_per_line() {
+  local home file lines project
+  home=$(make_home sanitize)
+  file=$(ledger_file "$home")
+
+  ledger "$home" outcome steered 1 --note "$(printf 'first\tsecond\nthird\rfourth')" \
+    || fail "sanitize: outcome with control characters should still record"
+  lines=$(wc -l < "$file" | tr -d ' ')
+  [ "$lines" -eq 1 ] || fail "sanitize: embedded newline split the record into $lines lines"
+  LC_ALL=C awk -F '\t' 'NF != 8 { bad = 1 } END { exit bad + 0 }' "$file" \
+    || fail "sanitize: embedded tabs added fields to the record"
+  grep -q "note=first second third fourth" "$file" \
+    || fail "sanitize: control characters were not collapsed to spaces"
+
+  : > "$file"
+  ledger "$home" task alpha --note-unsupported 2>/dev/null && fail "sanitize: unknown flag should be refused"
+  ledger "$home" task alpha --model "$(head -c 400 < /dev/zero | tr '\0' 'm')" \
+    || fail "sanitize: an over-long model should still record"
+  [ "$(wc -l < "$file" | tr -d ' ')" -eq 1 ] || fail "sanitize: over-long field split the record"
+  [ "$(awk 'END { print length($0) }' "$file")" -le 1024 ] \
+    || fail "sanitize: record exceeded the atomic-append line cap"
+
+  : > "$file"
+  ledger "$home" task alpha --project /home/somebody/projects/demo || fail "sanitize: project record failed"
+  project=$(field_of "$file" task project)
+  [ "$project" = demo ] || fail "sanitize: project recorded as '$project', not its basename"
+  pass "sanitization keeps one record per line, caps fields, and keeps paths out"
+}
+
+test_task_attribution_across_wake_kinds() {
+  local home file
+  home=$(make_home attribution)
+  file=$(ledger_file "$home")
+  fm_write_meta "$home/state/alpha.meta" "window=firstmate:fm-alpha" "backend=tmux"
+  fm_write_meta "$home/state/bravo.meta" "terminal=orca-term-9" "backend=orca"
+  : > "$home/state/charlie.meta"
+
+  {
+    printf '1000\t1\tsignal\talpha.status\tsignal\n'
+    printf '1000\t2\tsignal\tbravo.turn-ended\tsignal\n'
+    printf '1000\t3\tcheck\t%s/state/charlie.check.sh\tcheck\n' "$home"
+    printf '1000\t4\tstale\tfirstmate:fm-alpha\tstale\n'
+    printf '1000\t5\tstale\torca-term-9\tstale\n'
+    printf '1000\t6\tstale\tfm-charlie\tstale\n'
+    printf '1000\t7\tstale\tunknown-window\tstale\n'
+    printf '1000\t8\theartbeat\theartbeat\theartbeat\n'
+  } | ledger "$home" drain-record || fail "attribution: drain-record failed"
+
+  local seq expected actual
+  # seq -> expected task
+  while read -r seq expected; do
+    actual=$(LC_ALL=C awk -F '\t' -v want="seq=$seq" '
+      $2 == "wake" {
+        hit = 0; t = ""
+        for (i = 4; i <= NF; i++) {
+          if ($i == want) hit = 1
+          else if (substr($i, 1, 5) == "task=") t = substr($i, 6)
+        }
+        if (hit) { print t; exit }
+      }' "$file")
+    [ "$actual" = "$expected" ] \
+      || fail "attribution: wake $seq resolved to '$actual', expected '$expected'"
+  done <<EOF
+1 alpha
+2 bravo
+3 charlie
+4 alpha
+5 bravo
+6 charlie
+7 -
+8 -
+EOF
+  # A check key is a path; only its basename belongs in durable evidence.
+  grep -q "key=charlie.check.sh" "$file" || fail "attribution: check key kept its absolute path"
+  pass "task attribution covers status, turn-end, check, window, terminal, and unresolvable keys"
+}
+
+test_drain_records_one_wake_per_deduped_row() {
+  local home file out state
+  home=$(make_home drain)
+  file=$(ledger_file "$home")
+  state="$home/state"
+  out="$home/drain.out"
+
+  append_wake "$state" signal "alpha.status" "signal: alpha"
+  append_wake "$state" signal "alpha.status" "signal: alpha again"
+  append_wake "$state" heartbeat heartbeat heartbeat
+
+  FM_ROOT_OVERRIDE="$home" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$home/data" \
+    "$DRAIN" > "$out" 2>/dev/null || fail "drain: drain failed"
+
+  [ "$(grep -c . "$out")" -eq 2 ] || fail "drain: expected two deduped rows on stdout"
+  [ "$(LC_ALL=C awk -F '\t' '$2 == "wake" { n++ } END { print n + 0 }' "$file")" -eq 2 ] \
+    || fail "drain: expected one wake record per deduped row"
+  grep -q "kind=signal" "$file" || fail "drain: signal wake not recorded"
+  grep -q "kind=heartbeat" "$file" || fail "drain: heartbeat wake not recorded"
+  pass "the drain records one wake per deduped row it hands the coordinator"
+}
+
+test_unwritable_ledger_cannot_change_the_drain() {
+  local home state out_ok out_blocked rc_ok rc_blocked
+  home=$(make_home drain-unwritable)
+  state="$home/state"
+  out_ok="$home/ok.out"
+  out_blocked="$home/blocked.out"
+
+  append_wake "$state" signal "alpha.status" "signal: alpha"
+  FM_ROOT_OVERRIDE="$home" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$home/data" \
+    "$DRAIN" > "$out_ok" 2>/dev/null
+  rc_ok=$?
+
+  # Same wake, but the ledger cannot be written at all.
+  append_wake "$state" signal "alpha.status" "signal: alpha"
+  FM_ROOT_OVERRIDE="$home" FM_STATE_OVERRIDE="$state" \
+  FM_WAKE_LEDGER="/dev/null/impossible/wake-ledger.tsv" \
+    "$DRAIN" > "$out_blocked" 2>/dev/null
+  rc_blocked=$?
+
+  [ "$rc_ok" -eq 0 ] || fail "unwritable: baseline drain exited $rc_ok"
+  [ "$rc_blocked" -eq 0 ] \
+    || fail "unwritable: an unwritable ledger changed the drain's exit status to $rc_blocked"
+  # Only the queue epoch/sequence differ between the two runs; the wake payload must not.
+  cut -f 3,4,5 < "$out_ok" > "$home/ok.fields"
+  cut -f 3,4,5 < "$out_blocked" > "$home/blocked.fields"
+  cmp -s "$home/ok.fields" "$home/blocked.fields" \
+    || fail "unwritable: an unwritable ledger changed the drained wake payload"
+  pass "an unwritable ledger changes neither the drain's raw rows nor its exit status"
+}
+
+test_slow_ledger_never_blocks_a_wake_append() {
+  local home state out started elapsed drain_pid
+  home=$(make_home drain-slow)
+  state="$home/state"
+  out="$home/drain.out"
+
+  append_wake "$state" signal "alpha.status" "signal: alpha"
+  # The ledger phase runs far longer than any wake append should ever wait. The
+  # drain reaches it only after releasing the queue lock, so an append stays free.
+  FM_ROOT_OVERRIDE="$home" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$home/data" \
+  FM_WAKE_LEDGER_TEST_DELAY=5 \
+    "$DRAIN" > "$out" 2>/dev/null &
+  drain_pid=$!
+
+  # Let the drain reach its slow best-effort phase, then append a wake.
+  sleep 1
+  started=$(date +%s)
+  append_wake "$state" signal "bravo.status" "signal: bravo" \
+    || fail "slow ledger: the wake append itself failed"
+  elapsed=$(( $(date +%s) - started ))
+  [ "$elapsed" -le 2 ] \
+    || fail "slow ledger: a wake append waited ${elapsed}s behind the ledger phase"
+
+  wait "$drain_pid" || fail "slow ledger: drain failed"
+  grep -q "bravo.status" "$state/.wake-queue" \
+    || fail "slow ledger: the concurrent wake was not durably queued"
+  pass "a slowed ledger phase never delays or blocks a concurrent wake append"
+}
+
+test_concurrent_appends_stay_whole_lines() {
+  local home file pids pid i
+  home=$(make_home concurrent)
+  file=$(ledger_file "$home")
+  pids=
+  i=1
+  while [ "$i" -le 30 ]; do
+    ledger "$home" outcome steered "$i" --note "worker $i" &
+    pids="$pids $!"
+    i=$((i + 1))
+  done
+  for pid in $pids; do
+    wait "$pid" || fail "concurrent: an append failed"
+  done
+  [ "$(wc -l < "$file" | tr -d ' ')" -eq 30 ] || fail "concurrent: expected 30 records"
+  LC_ALL=C awk -F '\t' '$1 != "v1" || $2 != "outcome" || NF != 8 { bad = 1 } END { exit bad + 0 }' "$file" \
+    || fail "concurrent: appends interleaved into a malformed record"
+  pass "concurrent appends from many writers stay whole, well-formed lines"
+}
+
+test_report_counts_coverage_and_the_model_join() {
+  local home file out
+  home=$(make_home report)
+  file=$(ledger_file "$home")
+  fm_write_meta "$home/state/alpha.meta" "window=fm-alpha" "backend=tmux"
+
+  {
+    printf '1000\t1\tsignal\talpha.status\tsignal\n'
+    printf '1000\t2\tstale\tfm-alpha\tstale\n'
+    printf '1000\t3\theartbeat\theartbeat\theartbeat\n'
+  } | ledger "$home" drain-record || fail "report: drain-record failed"
+  # A replayed wake: the drain's at-least-once boundary can duplicate a record.
+  printf '1000\t1\tsignal\talpha.status\tsignal\n' | ledger "$home" drain-record \
+    || fail "report: replay drain-record failed"
+
+  ledger "$home" outcome steered 1 || fail "report: outcome failed"
+  # A heartbeat is fleet-wide, so its outcome carries no task to attribute.
+  ledger "$home" outcome absorbed 3 || fail "report: outcome failed"
+  ledger "$home" task alpha --outcome landed --harness pi --model sol --effort medium \
+    || fail "report: task failed"
+
+  out=$(ledger "$home" report) || fail "report: report failed"
+  printf '%s\n' "$out" | grep -q "wakes: 3 total" \
+    || fail "report: a replayed wake was counted twice:"$'\n'"$out"
+  printf '%s\n' "$out" | grep -q "2 with a recorded outcome, 1 unrecorded" \
+    || fail "report: coverage was not reported:"$'\n'"$out"
+  printf '%s\n' "$out" | grep -q "1 not attributable to a task" \
+    || fail "report: unattributable outcomes were not reported:"$'\n'"$out"
+  printf '%s\n' "$out" | grep -q "tasks: 1 terminal (landed 1)" \
+    || fail "report: terminal tasks were not reported:"$'\n'"$out"
+  printf '%s\n' "$out" | grep -q "pi/sol/medium" \
+    || fail "report: the per-profile model join is missing:"$'\n'"$out"
+  printf '%s\n' "$out" | grep -q "steered 1" \
+    || fail "report: per-profile outcome counts are missing:"$'\n'"$out"
+  printf '%s\n' "$out" | grep -q "coordinator response latency" \
+    || fail "report: response latency was not reported:"$'\n'"$out"
+
+  # An absent ledger reports its absence rather than failing.
+  rm -f "$file"
+  out=$(ledger "$home" report) || fail "report: an absent ledger should not fail"
+  printf '%s\n' "$out" | grep -q "absent" || fail "report: absence was not reported"
+  pass "the report counts distinct wakes, states coverage, and joins outcomes to profiles"
+}
+
+
+test_record_format_for_all_three_kinds
+test_outcome_vocabulary_is_closed
+test_terminal_outcome_and_escalation_are_validated
+test_sanitization_keeps_one_record_per_line
+test_task_attribution_across_wake_kinds
+test_drain_records_one_wake_per_deduped_row
+test_unwritable_ledger_cannot_change_the_drain
+test_slow_ledger_never_blocks_a_wake_append
+test_concurrent_appends_stay_whole_lines
+test_report_counts_coverage_and_the_model_join

--- a/tests/fm-wake-ledger.test.sh
+++ b/tests/fm-wake-ledger.test.sh
@@ -79,6 +79,8 @@ test_record_format_for_all_three_kinds() {
 
   [ "$(field_of "$file" outcome outcome)" = steered ] || fail "format: outcome token not recorded"
   [ "$(field_of "$file" outcome task)" = alpha ] || fail "format: outcome task not resolved from its wake"
+  [ "$(field_of "$file" outcome queued)" = "$((now - 12))" ] \
+    || fail "format: outcome queued not copied from its wake record"
 
   [ "$(field_of "$file" task harness)" = pi ] || fail "format: task harness not recorded"
   [ "$(field_of "$file" task model)" = sol ] || fail "format: task model not recorded"
@@ -141,7 +143,7 @@ test_sanitization_keeps_one_record_per_line() {
     || fail "sanitize: outcome with control characters should still record"
   lines=$(wc -l < "$file" | tr -d ' ')
   [ "$lines" -eq 1 ] || fail "sanitize: embedded newline split the record into $lines lines"
-  LC_ALL=C awk -F '\t' 'NF != 8 { bad = 1 } END { exit bad + 0 }' "$file" \
+  LC_ALL=C awk -F '\t' 'NF != 9 { bad = 1 } END { exit bad + 0 }' "$file" \
     || fail "sanitize: embedded tabs added fields to the record"
   grep -q "note=first second third fourth" "$file" \
     || fail "sanitize: control characters were not collapsed to spaces"
@@ -305,7 +307,7 @@ test_concurrent_appends_stay_whole_lines() {
     wait "$pid" || fail "concurrent: an append failed"
   done
   [ "$(wc -l < "$file" | tr -d ' ')" -eq 30 ] || fail "concurrent: expected 30 records"
-  LC_ALL=C awk -F '\t' '$1 != "v1" || $2 != "outcome" || NF != 8 { bad = 1 } END { exit bad + 0 }' "$file" \
+  LC_ALL=C awk -F '\t' '$1 != "v1" || $2 != "outcome" || NF != 9 { bad = 1 } END { exit bad + 0 }' "$file" \
     || fail "concurrent: appends interleaved into a malformed record"
   pass "concurrent appends from many writers stay whole, well-formed lines"
 }
@@ -354,6 +356,36 @@ test_report_counts_coverage_and_the_model_join() {
   pass "the report counts distinct wakes, states coverage, and joins outcomes to profiles"
 }
 
+test_seq_reuse_across_a_state_reset_never_collapses_records() {
+  local home file out
+  home=$(make_home seq-reset)
+  file=$(ledger_file "$home")
+
+  # An outcome whose wake record is unresolvable must say so explicitly.
+  ledger "$home" outcome absorbed 9 || fail "seq reset: unmatched outcome failed"
+  [ "$(field_of "$file" outcome queued)" = unknown ] \
+    || fail "seq reset: an unmatched outcome must record queued=unknown"
+  : > "$file"
+
+  # A state wipe restarts the wake-queue sequence while the ledger survives,
+  # so the same seq arrives twice with different queue epochs.
+  printf '1000\t1\tsignal\talpha.status\tsignal\n' | ledger "$home" drain-record \
+    || fail "seq reset: first drain-record failed"
+  ledger "$home" outcome steered 1 || fail "seq reset: first outcome failed"
+  printf '2000\t1\tsignal\talpha.status\tsignal\n' | ledger "$home" drain-record \
+    || fail "seq reset: second drain-record failed"
+  ledger "$home" outcome absorbed 1 || fail "seq reset: second outcome failed"
+
+  out=$(ledger "$home" report) || fail "seq reset: report failed"
+  printf '%s\n' "$out" | grep -q "wakes: 2 total" \
+    || fail "seq reset: distinct wakes sharing a seq were collapsed:"$'\n'"$out"
+  printf '%s\n' "$out" | grep -q "2 with a recorded outcome, 0 unrecorded" \
+    || fail "seq reset: coverage did not join on the (seq, queued) pair:"$'\n'"$out"
+  printf '%s\n' "$out" | grep -q "outcomes: 2 recorded" \
+    || fail "seq reset: distinct outcomes sharing a seq were collapsed:"$'\n'"$out"
+  pass "a reused wake-queue sequence never collapses distinct wakes or outcomes"
+}
+
 
 test_record_format_for_all_three_kinds
 test_outcome_vocabulary_is_closed
@@ -365,3 +397,4 @@ test_unwritable_ledger_cannot_change_the_drain
 test_slow_ledger_never_blocks_a_wake_append
 test_concurrent_appends_stay_whole_lines
 test_report_counts_coverage_and_the_model_join
+test_seq_reuse_across_a_state_reset_never_collapses_records


### PR DESCRIPTION
## Intent

Add a wake-outcome ledger so firstmate's coordinator attention cost becomes measurable rather than estimated, and so the dormant model-promotion system can activate.

Why: the captain's scheduling policy (config/crew-dispatch.json _scheduling.telemetry.must_answer) requires telemetry answering why work was queued or promoted, which threshold fired, wait times, and whether thresholds are tuned right - none of which was collectable. The dormant model-promotion design (data/model-onboarding-policy/report.md sections 10.1/10.3/10.6) names this ledger plus a terminal per-task outcome line as its single named first instrument, and requires that it use no second evidence store and that a later task extend this file format rather than define a competing one. The captain's instrumentation doctrine also governs: the required instrumentation is whatever makes the quantity verifiable after deployment, and a signal used to detect change must be stable under no change.

This work followed a mandatory design review: the design was written to data/wake-outcome-ledger/design.md, reviewed and APPROVED by firstmate before any implementation, with three decisions explicitly ruled. Those three are deliberate and must not be flagged as mistakes:
1. The ledger lives at data/wake-ledger.tsv, NOT under state/, deviating from the referenced report's suggestion. Ruled because teardown deletes state/<id>.* for every finished task and this evidence must outlive the tasks it describes; AGENTS.md section 2 defines data/ as durable and state/ as volatile.
2. TWO records per wake (a deterministic wake record written by the drain, plus a coordinator-written outcome record joined on the wake-queue sequence) rather than the report's single combined line. Ruled because one coordinator-written line would make measured attention cost fall whenever the coordinator skipped the recording step, so the metric would move without the underlying quantity moving. The split gives a denominator that is stable under no change and turns missing coverage into a reported number instead of a silent undercount. The extra join is the accepted cost.
3. Watcher-absorbed wakes are deliberately EXCLUDED. They never reach the coordinator, so they are not part of the quantity being measured, and recording them would mean touching seven call sites in the watcher's hot loop for a number no captain policy asks for. state/.watch-triage.log remains their disposable debug record.

Other deliberate choices a reviewer reading only the diff would not know:
- The ledger must never block, delay, alter, or fail a wake. Its only drain call site sits below the drain's authoritative print-and-delete boundary, with stdout discarded and failure ignored; the ledger takes no lock and writes one printf-appended line capped at 1024 characters, under the 4096-byte PIPE_BUF atomic-append bound. Two tests pin exactly this: an unwritable ledger leaves the drain's raw rows and exit status untouched, and a deliberately delayed ledger phase never blocks a concurrent wake append.
- FM_WAKE_LEDGER_TEST_DELAY is an intentional test-only latency seam, deliberately mirroring the existing FM_WAKE_ENRICH_TEST_DELAY seam in fm-wake-lib.sh rather than inventing a new pattern.
- Teardown writes the terminal record immediately before deleting the task metadata, because that is the last moment the task's harness, model, and effort are recoverable anywhere. That call is best effort on purpose: it warns on stderr but can never fail a teardown, since a telemetry write must never stand between the fleet and cleanup. A test pins that too.
- The wake count per task is deliberately NOT stored on the terminal record; it is computed from that task's wake records, per the report's no-duplication requirement.
- fm-wake-ledger.sh sources fm-pr-lib.sh solely to reuse fm_task_id_path_safe rather than restate that predicate, honoring the one-owner rule in the firstmate-coding-guidelines skill.
- The escalated field intentionally reads unknown until dispatch records it; the field exists and reads from task metadata so it fills in later with no format change. This limitation is stated in the approved design rather than hidden.
- No prune or rotation command in v1: growth is roughly 1-3 MB per year, and a prune that races an append can lose evidence.
- AGENTS.md deliberately gains only two lines (a layout entry and one wake-handling sentence) with all mechanics kept in the script header and --help, per the firstmate-coding-guidelines size-discipline and one-owner rules. No new skill was added because there is no situation-specific procedure to load. docs/supervision-protocols/* were deliberately left untouched because the recording step is harness-independent, so duplicating it into six harness files would violate the one-owner rule.

Verification already done locally: the new tests/fm-wake-ledger.test.sh passes all 10 cases; tests/fm-teardown.test.sh passes 35 cases including 3 new ledger cases; fm-backend old-vs-new teardown conformance, teardown-endpoint-safety, gotmp, test-run and lint suites all pass; bin/fm-lint.sh is clean at pinned ShellCheck 0.11.0; bin/fm-doc-audience-check.sh is clean; and the test coverage guard accepts the new test. Three watcher suites (fm-pi-watch-extension, fm-turnend-guard, fm-watcher-lock) fail or hang in this worktree, but that is a known pre-existing fleet defect: a Stop hook keeps re-arming a watcher from the worktree, and those suites are sensitive to an externally armed watcher. I proved this by reverting my drain change and re-running: they fail byte-identically at baseline, so they are unrelated to this change.

## What Changed

- New `bin/fm-wake-ledger.sh` maintains a durable append-only ledger at `data/wake-ledger.tsv` (deliberately outside volatile `state/`) with two records per wake: a deterministic wake record appended by `fm-wake-drain.sh` below its print-and-delete boundary, and a coordinator-written outcome record joined on `(seq, queued)` so distinct wakes stay distinct across state resets — the join key was widened from bare `seq` after the pipeline review flagged silent collapse after a sequence reset. The ledger enforces a closed outcome vocabulary, sanitizes fields, caps lines under the PIPE_BUF atomic-append bound, and can never block, alter, or fail a wake.
- `bin/fm-teardown.sh` now writes a best-effort terminal task record (`landed`/`abandoned`, with `--force` mapping to `abandoned`) immediately before deleting task metadata — the last moment harness/model/effort are recoverable; an unwritable ledger warns on stderr but never fails teardown. A `report` command surfaces coverage, latency percentiles, outcome mix, and per-profile joins, turning missed coordinator recordings into a reported number instead of a silent undercount.
- Added `tests/fm-wake-ledger.test.sh` (11 cases, including unwritable-ledger isolation, delayed-ledger non-blocking, concurrent-append integrity, and reused-seq joins) plus 3 new teardown ledger cases; docs updated in `AGENTS.md`, `docs/architecture.md`, `docs/configuration.md`, and `docs/scripts.md`. Watcher-absorbed wakes are deliberately excluded — they never reach the coordinator.

## Risk Assessment

✅ Low: The round-2 commit implements the requested (seq, queued) join fix exactly as instructed — write side, report dedup, coverage join, unknown-never-dedups rule, docs, and a targeted seq-reuse regression test — without touching the drain path or any captain-ruled decision, leaving no open findings.

## Testing

Ran the two targeted suites (tests/fm-wake-ledger.test.sh, tests/fm-teardown.test.sh) — all 47 cases pass including the never-block and best-effort-teardown guarantees — then demonstrated the full workflow end-to-end with the real production scripts, capturing a CLI transcript showing wake records written by the drain, coordinator outcome records joined on (seq, queued), the terminal task record, the durable TSV at data/wake-ledger.tsv, and a report that answers the scheduling policy's telemetry questions (wake volume, coverage with missing outcomes reported not hidden, latency, outcome mix, per-profile model join). No findings.

<details>
<summary>Evidence: End-to-end ledger workflow transcript (enqueue → drain → outcomes → terminal record → report)</summary>

<code>===== 2b. the drain wrote one deterministic wake record per deduped row =====&#10;v1 wake 1785379594 seq=2 kind=signal key=task-demo1.status task=task-demo1 queued=1785379592 latency=2&#10;v1 wake 1785379594 seq=3 kind=heartbeat key=heartbeat task=- queued=1785379592 latency=2&#10;v1 wake 1785379594 seq=4 kind=check key=task-demo2.check.sh task=task-demo2 queued=1785379594 latency=0&#10;&#10;===== 3. out-of-vocabulary token =====&#10;error: unknown outcome token: shrugged (absorbed inspected steered decided escalated repaired false-positive) -&gt; refused, exit 2&#10;&#10;===== 6. fm-wake-ledger.sh report =====&#10;wakes: 3 total, 2 with a recorded outcome, 1 unrecorded (67% coverage)&#10;outcomes: by token: absorbed 1 decided 1&#10;tasks: 1 terminal (landed 1)&#10;per profile: pi/openai-codex/gpt-5.6-sol/medium tasks 1 wakes/task 1.0&#10;coordinator response latency (queued -&gt; drained), seconds: min 0 median 2 p90 2 max 2</code>

```text

===== 1. Watcher enqueues three wakes (production fm_wake_append) =====
  queued: 1785379592	1	signal	task-demo1.status	signal: task-demo1 needs a decision
  queued: 1785379592	2	signal	task-demo1.status	signal: task-demo1 duplicate (dedupes)
  queued: 1785379592	3	heartbeat	heartbeat	heartbeat
  queued: 1785379594	4	check	task-demo2.check.sh	check: PR poll for task-demo2

===== 2. Coordinator wake: fm-wake-drain.sh drains the queue (rows the coordinator reads) =====
1785379592	2	signal	task-demo1.status	signal: task-demo1 duplicate (dedupes)
1785379592	3	heartbeat	heartbeat	heartbeat
1785379594	4	check	task-demo2.check.sh	check: PR poll for task-demo2

===== 2b. ...and the drain wrote one deterministic wake record per deduped row =====
v1	wake	1785379594	seq=2	kind=signal	key=task-demo1.status	task=task-demo1	queued=1785379592	latency=2
v1	wake	1785379594	seq=3	kind=heartbeat	key=heartbeat	task=-	queued=1785379592	latency=2
v1	wake	1785379594	seq=4	kind=check	key=task-demo2.check.sh	task=task-demo2	queued=1785379594	latency=0

===== 3. Coordinator records outcomes per AGENTS.md (one wake deliberately left uncovered) =====
  drained seqs: 2 3 4
  (seq 4 intentionally not recorded - coverage must report it, not hide it)
  a token outside the closed vocabulary is refused:
error: unknown outcome token: shrugged (absorbed inspected steered decided escalated repaired false-positive)
  -> refused, exit 2

===== 4. Teardown writes the terminal task record (same call bin/fm-teardown.sh makes) =====

===== 5. The ledger file itself (durable evidence, data/wake-ledger.tsv) =====
v1	wake	1785379594	seq=2	kind=signal	key=task-demo1.status	task=task-demo1	queued=1785379592	latency=2
v1	wake	1785379594	seq=3	kind=heartbeat	key=heartbeat	task=-	queued=1785379592	latency=2
v1	wake	1785379594	seq=4	kind=check	key=task-demo2.check.sh	task=task-demo2	queued=1785379594	latency=0
v1	outcome	1785379594	seq=2	queued=1785379592	outcome=decided	task=task-demo1	after=0	note=answered task-demo1 merge gate
v1	outcome	1785379594	seq=3	queued=1785379592	outcome=absorbed	task=-	after=0
v1	task	1785379594	task=task-demo1	harness=pi	model=openai-codex/gpt-5.6-sol	effort=medium	mode=local-only	kind=crewmate	project=demo-proj	backend=tmux	outcome=landed	route=direct	escalated=unknown	findings=unknown	pr=https://github.com/demo/repo/pull/42

===== 6. fm-wake-ledger.sh report - the telemetry the captain's policy asks for =====
wake ledger: /tmp/fm-ledger-e2e.ipd3IO/data/wake-ledger.tsv
window: all records

wakes: 3 total, 2 with a recorded outcome, 1 unrecorded (67% coverage)
  by kind:  signal 1  check 1  heartbeat 1

outcomes: 2 recorded (1 not attributable to a task)
  by token:  absorbed 1  decided 1

tasks: 1 terminal (landed 1)

per profile (harness/model/effort):
  pi/openai-codex/gpt-5.6-sol/medium           tasks 1    wakes/task 1.0    steered 0    repaired 0    escalated 0    false-positive 0

busiest tasks by wake count:
  task-demo1                           1
  task-demo2                           1

coordinator response latency (queued -> drained), seconds: min 0  median 2  p90 2  max 2
```
</details>
<details>
<summary>Evidence: Reproducible demo script</summary>

```text
#!/usr/bin/env bash
# End-to-end demonstration of the wake-outcome ledger, driving the real
# production scripts exactly as the fleet does:
#   1. watcher enqueues wakes (production fm_wake_append)
#   2. fm-wake-drain.sh hands them to the coordinator AND writes wake records
#   3. the coordinator records outcomes per AGENTS.md (fm-wake-ledger.sh outcome)
#   4. teardown-style terminal task record (fm-wake-ledger.sh task)
#   5. fm-wake-ledger.sh report answers the scheduling-telemetry questions
set -u
ROOT=$1
HOME_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-ledger-e2e.XXXXXX")
mkdir -p "$HOME_DIR/state" "$HOME_DIR/data"
touch "$HOME_DIR/state/.last-watcher-beat"
export FM_ROOT_OVERRIDE="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data"
LEDGER_FILE="$HOME_DIR/data/wake-ledger.tsv"

# A task's metadata, so signal keys attribute to a real task id.
cat > "$HOME_DIR/state/task-demo1.meta" <<'META'
window=fm-task-demo1
harness=pi
model=openai-codex/gpt-5.6-sol
effort=medium
META

step() { printf '\n===== %s =====\n' "$1"; }

step "1. Watcher enqueues three wakes (production fm_wake_append)"
enqueue() {
  FM_STATE_OVERRIDE="$HOME_DIR/state" bash -c '
    . "$1"; fm_wake_append "$2" "$3" "$4"' _ "$ROOT/bin/fm-wake-lib.sh" "$2" "$3" "$4"
}
enqueue s signal  "task-demo1.status" "signal: task-demo1 needs a decision"
enqueue s signal  "task-demo1.status" "signal: task-demo1 duplicate (dedupes)"
enqueue s heartbeat heartbeat heartbeat
sleep 2   # real wait so latency is a measured, nonzero number
enqueue s check "task-demo2.check.sh" "check: PR poll for task-demo2"
sed 's/^/  queued: /' "$HOME_DIR/state/.wake-queue"

step "2. Coordinator wake: fm-wake-drain.sh drains the queue (rows the coordinator reads)"
"$ROOT/bin/fm-wake-drain.sh" 2>/dev/null
step "2b. ...and the drain wrote one deterministic wake record per deduped row"
grep -P '\twake\t' "$LEDGER_FILE"

step "3. Coordinator records outcomes per AGENTS.md (one wake deliberately left uncovered)"
seqs=$(grep -oP 'seq=\K[0-9]+' "$LEDGER_FILE" | sort -n)
set -- $seqs
echo "  drained seqs: $*"
"$ROOT/bin/fm-wake-ledger.sh" outcome decided "$1" --note "answered task-demo1 merge gate"
"$ROOT/bin/fm-wake-ledger.sh" outcome absorbed "$2"
echo "  (seq $3 intentionally not recorded - coverage must report it, not hide it)"
echo "  a token outside the closed vocabulary is refused:"
"$ROOT/bin/fm-wake-ledger.sh" outcome shrugged "$1" 2>&1 && echo UNEXPECTED-ACCEPT || echo "  -> refused, exit $?"

step "4. Teardown writes the terminal task record (same call bin/fm-teardown.sh makes)"
"$ROOT/bin/fm-wake-ledger.sh" task task-demo1 --outcome landed \
  --harness pi --model openai-codex/gpt-5.6-sol --effort medium \
  --mode local-only --kind crewmate --project demo-proj --backend tmux \
  --route direct --escalated unknown --pr https://github.com/demo/repo/pull/42

step "5. The ledger file itself (durable evidence, data/wake-ledger.tsv)"
cat "$LEDGER_FILE"

step "6. fm-wake-ledger.sh report - the telemetry the captain's policy asks for"
"$ROOT/bin/fm-wake-ledger.sh" report

rm -rf "$HOME_DIR"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-wake-ledger.sh:482` - The durable ledger&#39;s identity/join key is the wake-queue sequence from state/.wake-queue.seq, but state/ is volatile while data/wake-ledger.tsv is durable evidence spanning weeks. After a state wipe or home rebuild, sequences restart and distinct wakes in the durable file share a seq. cmd_report dedups wake records by seq alone (wake_seen, line 482) and outcome records by seq alone (outcome_seen, line 493), so an all-records report silently collapses distinct wakes/outcomes across a seq reset — undercounting the very denominator the design requires to be stable under no change. The live outcome join is unaffected (the bounded tail read takes the newest matching wake), and wake records already carry queued= which could disambiguate report dedup (seq SUBSEP queued); outcome records carry no second key, so a complete fix would touch the approved seq-as-join-key ruling — hence ask-user rather than auto-fix.
- ℹ️ `bin/fm-teardown.sh:1237` - The terminal outcome vocabulary accepts landed|failed|abandoned, but the only caller (fm-teardown.sh) maps --force to abandoned and everything else to landed, so &#39;failed&#39; is currently unreachable vocabulary with no writer. This is coherent (teardown refuses un-landed work without --force), but worth confirming that reserving &#39;failed&#39; for a future caller is intended rather than a missed mapping.

🔧 Fix: join wake outcomes on (seq, queued) across state resets
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-wake-ledger.test.sh` — all 11 cases pass (record format, closed vocabulary, sanitization, task attribution, drain integration, unwritable-ledger never changes drain rows/exit, delayed ledger never blocks a concurrent wake append, concurrent-append integrity, report counts/coverage, reused-seq (seq,queued) join)</code>
- <code>`bash tests/fm-teardown.test.sh` — all 36 cases pass, including the 3 new ledger cases: terminal record with the meta&#39;s harness/model/effort written before metadata deletion, --force records outcome=abandoned, unwritable ledger warns on stderr but never fails or halts teardown</code>
- <code>Manual end-to-end demo (`/tmp/no-mistakes-evidence/01KYRDQ3AZH2SPJ0X4CEQ869N5/e2e-demo.sh`): enqueued wakes via production fm_wake_lib, drained with the real bin/fm-wake-drain.sh, recorded coordinator outcomes per the new AGENTS.md instruction, wrote the teardown-style terminal task record, verified an out-of-vocabulary token is refused with exit 2, and ran `fm-wake-ledger.sh report` showing coverage (67% with one deliberately unrecorded wake), latency percentiles, outcome mix, and the per-profile join</code>
- <code>`git status --porcelain` — worktree left clean, no transient test artifacts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
