### PR TITLE
fix(session-lock): guard basename against dash-prefixed login-shell comm

### DIFF
--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -31,7 +31,9 @@ fm_harness_ancestry_pid() {
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
-    bc=$(basename "$comm")
+    # -- guards against a login shell's leading-dash comm (e.g. "-zsh"),
+    # which basename would otherwise parse as an option flag.
+    bc=$(basename -- "$comm")
     hit=0; is_claude=0
     if printf '%s' "$bc" | grep -qE "$FM_HARNESS_RE"; then
       hit=1
@@ -69,7 +71,7 @@ fm_harness_pid_alive() {
   local pid=$1 comm args
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  if printf '%s' "$(basename "$comm")" | grep -qE "$FM_HARNESS_RE"; then
+  if printf '%s' "$(basename -- "$comm")" | grep -qE "$FM_HARNESS_RE"; then
     return 0
   fi
   case "$comm" in


### PR DESCRIPTION
## Summary
- `ps -o comm=` reports a login shell's command name with a leading dash (e.g. `-zsh`), which `basename` was parsing as an illegal option flag instead of a filename, printing `basename: illegal option -- z` on every harness-ancestry walk during session-lock acquire.
- Guard both call sites with `basename --` to stop option parsing.

## Test plan
- [x] `bin/fm-lint.sh bin/fm-session-lock-lib.sh` passes (ShellCheck 0.11.0)
- [x] `bin/fm-session-start.sh` no longer prints the `basename` error at the lock step
- [x] `bin/fm-test-run.sh --changed` run; the one flagged failure (`fm-secondmate-safety.test.sh`) reproduces as a pass in isolation (34s vs 235s under parallel contention in the full run) and exercises unrelated secondmate-provisioning code, not session-lock ancestry
