### PR TITLE
fix(bin): bind Codex session locks to thread identity

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -233,6 +233,8 @@ Each command shell is its own POSIX session and process-group leader, but remain
 Codex injects one stable `CODEX_THREAD_ID` into command children, including a distinct value for a nested Codex session.
 A nested Codex process can retain the outer thread id in its own inherited environment while its command children receive the nested id, so the child value rather than the parent environment is authoritative for the active thread.
 `bin/fm-session-lock-lib.sh` owns the resulting Codex thread-identity sidecar and fail-closed ownership contract while preserving the numeric harness pid used by every other verified adapter.
+Because the command child's parent link does resolve, the sidecar narrows harness ancestry rather than replacing it: ownership needs the thread id to match and any resolvable ancestry to still name the lock pid, so another harness nested inside a Codex session never inherits ownership from the environment.
+The numeric holder's own reacquisition rebinds a mismatched sidecar, so a Codex process that moves to another thread recovers through session start instead of staying read-only.
 [`docs/verification/supervision.md`](../../../docs/verification/supervision.md#codex-01460-session-lock-identity) records the exact live probe and scratch lock evidence.
 
 ## opencode (VERIFIED 2026-06-11, v1.15.7-1.17.6; 1.18.4 busy-queue re-verified 2026-07-20)

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -230,7 +230,7 @@ The checkpoint is deliberately foreground and bounded so Codex regains control r
 
 **Session-lock fact (verified 2026-07-29, codex-cli 0.146.0).**
 Each command shell is its own POSIX session and process-group leader, but remains a direct child of the Codex process in the same PID namespace.
-Codex injects one stable `CODEX_THREAD_ID` into command children, including a distinct value for a nested Codex session.
+Codex injects one stable lowercase-UUID `CODEX_THREAD_ID` into command children, including a distinct value for a nested Codex session.
 A nested Codex process can retain the outer thread id in its own inherited environment while its command children receive the nested id, so the child value rather than the parent environment is authoritative for the active thread.
 `bin/fm-session-lock-lib.sh` owns the resulting Codex thread-identity sidecar and fail-closed ownership contract while preserving the numeric harness pid used by every other verified adapter.
 Because the command child's parent link does resolve, the sidecar narrows harness ancestry rather than replacing it: ownership needs the thread id to match and any resolvable ancestry to still name the lock pid, so another harness nested inside a Codex session never inherits ownership from the environment.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -197,7 +197,7 @@ A project-level `.claude/settings.json` only takes effect when Claude Code's pro
 After those settings are loaded, hook command resolution is still cwd-sensitive because Claude Code runs commands through `/bin/sh` against the session's current cwd; keep the tracked commands anchored through `"$CLAUDE_PROJECT_DIR"/bin/...` and see `docs/turnend-guard.md` for the verified Stop-hook details.
 Claude Code's primary watcher protocol is Stop-owned: the auto-arm hook fires on every Stop and foregrounds `bin/fm-watch-arm.sh` when the home is eligible and still needs supervision, and its exit-2 `asyncRewake` rewake is the wake; the model drains and handles wakes but never runs a routine re-arm command.
 
-## codex (VERIFIED 2026-07-29, codex-cli 0.146.0)
+## codex (VERIFIED 2026-06-11, codex-cli 0.139.0; session-lock identity re-verified 2026-07-29 on codex-cli 0.146.0)
 
 | Fact | Value |
 |---|---|

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -197,7 +197,7 @@ A project-level `.claude/settings.json` only takes effect when Claude Code's pro
 After those settings are loaded, hook command resolution is still cwd-sensitive because Claude Code runs commands through `/bin/sh` against the session's current cwd; keep the tracked commands anchored through `"$CLAUDE_PROJECT_DIR"/bin/...` and see `docs/turnend-guard.md` for the verified Stop-hook details.
 Claude Code's primary watcher protocol is Stop-owned: the auto-arm hook fires on every Stop and foregrounds `bin/fm-watch-arm.sh` when the home is eligible and still needs supervision, and its exit-2 `asyncRewake` rewake is the wake; the model drains and handles wakes but never runs a routine re-arm command.
 
-## codex (VERIFIED 2026-06-11, codex-cli 0.139.0)
+## codex (VERIFIED 2026-07-29, codex-cli 0.146.0)
 
 | Fact | Value |
 |---|---|
@@ -227,6 +227,13 @@ Verified on 2026-07-08: Codex runs the Stop hook command with process PWD set to
 The tracked hook anchors to `pwd -P`, verifies that root is firstmate-shaped and hook-bearing, and then invokes `bin/fm-turnend-guard.sh` with the original payload.
 Codex's primary watcher protocol is `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`, not `bin/fm-watch-arm.sh`.
 The checkpoint is deliberately foreground and bounded so Codex regains control regularly to process user messages and queued wakes.
+
+**Session-lock fact (verified 2026-07-29, codex-cli 0.146.0).**
+Each command shell is its own POSIX session and process-group leader, but remains a direct child of the Codex process in the same PID namespace.
+Codex injects one stable `CODEX_THREAD_ID` into command children, including a distinct value for a nested Codex session.
+A nested Codex process can retain the outer thread id in its own inherited environment while its command children receive the nested id, so the child value rather than the parent environment is authoritative for the active thread.
+`bin/fm-session-lock-lib.sh` owns the resulting Codex thread-identity sidecar and fail-closed ownership contract while preserving the numeric harness pid used by every other verified adapter.
+[`docs/verification/supervision.md`](../../../docs/verification/supervision.md#codex-01460-session-lock-identity) records the exact live probe and scratch lock evidence.
 
 ## opencode (VERIFIED 2026-06-11, v1.15.7-1.17.6; 1.18.4 busy-queue re-verified 2026-07-20)
 

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -69,13 +69,11 @@ if [ -e "$LOCK" ] || [ -L "$LOCK" ]; then
     echo "error: another live firstmate session holds the lock (pid $old); operate read-only until resolved" >&2
     exit 1
   fi
-  if [ "$old" = "$me" ] \
-    && { [ -e "$STATE/.lock.codex-thread" ] || [ -L "$STATE/.lock.codex-thread" ]; } \
-    && ! fm_codex_lock_identity_matches "$STATE" "$old"; then
-    echo "error: live session lock has a different or malformed Codex thread identity; operate read-only until resolved" >&2
-    exit 1
-  fi
 fi
+# The recorded holder is now either this caller's own harness ancestor or no
+# longer a live harness, so publication below rebinds a mismatched, stale, or
+# reused-pid Codex sidecar to this command's thread instead of leaving the holder
+# read-only. Cross-session protection is the live other-holder refusal above.
 if ! fm_session_lock_publish_identity "$STATE" "$me"; then
   echo "error: cannot publish session lock identity; operate read-only until resolved" >&2
   exit 1

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -4,7 +4,11 @@
 # identity contract. Codex also writes a thread-identity sidecar because its
 # command children have isolated POSIX sessions/process groups.
 # Usage: fm-lock.sh           acquire; exit 1 unless ownership is verified
-#        fm-lock.sh status    print holder and liveness; always exits 0
+#        fm-lock.sh status    print holder, liveness, and - whenever a lock pid
+#                             is recorded - one Codex identity-sidecar line so a
+#                             live-holder-but-unverifiable read-only state is
+#                             diagnosable without hand-reading state files;
+#                             always exits 0
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -29,6 +33,7 @@ if [ "${1:-}" = "status" ]; then
     exit 0
   }
   if fm_harness_pid_alive "$old"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
+  fm_session_lock_identity_status "$STATE" "$old"
   exit 0
 fi
 

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Acquire or inspect the per-home firstmate session lock.
-# Writes the harness (agent) process PID found by walking the shell's ancestry,
-# which lives as long as the firstmate session - unlike the transient subshell
-# PID of any one tool call, which is dead moments after it is written.
+# Writes the live harness process PID resolved by the shared session-lock
+# identity contract. Codex also writes a thread-identity sidecar because its
+# command children have isolated POSIX sessions/process groups.
 # Usage: fm-lock.sh           acquire; exit 1 unless ownership is verified
 #        fm-lock.sh status    print holder and liveness; always exits 0
 set -u
@@ -17,9 +17,8 @@ mkdir -p "$STATE" 2>/dev/null || {
   exit 1
 }
 
-# Harness identity (FM_HARNESS_RE, ancestry walk, holder liveness) is owned by
-# the shared session-lock lib so the Claude Stop auto-arm applies the exact
-# same identity contract.
+# Harness identity, Codex's thread sidecar, holder liveness, and self-ownership
+# are owned by the shared session-lock lib so every caller applies one contract.
 # shellcheck source=bin/fm-session-lock-lib.sh
 . "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
@@ -70,6 +69,16 @@ if [ -e "$LOCK" ] || [ -L "$LOCK" ]; then
     echo "error: another live firstmate session holds the lock (pid $old); operate read-only until resolved" >&2
     exit 1
   fi
+  if [ "$old" = "$me" ] \
+    && { [ -e "$STATE/.lock.codex-thread" ] || [ -L "$STATE/.lock.codex-thread" ]; } \
+    && ! fm_codex_lock_identity_matches "$STATE" "$old"; then
+    echo "error: live session lock has a different or malformed Codex thread identity; operate read-only until resolved" >&2
+    exit 1
+  fi
+fi
+if ! fm_session_lock_publish_identity "$STATE" "$me"; then
+  echo "error: cannot publish session lock identity; operate read-only until resolved" >&2
+  exit 1
 fi
 if ! { printf '%s\n' "$me" > "$LOCK"; } 2>/dev/null; then
   echo "error: cannot write session lock; operate read-only until resolved" >&2
@@ -81,6 +90,10 @@ written=$(cat "$LOCK" 2>/dev/null) || {
 }
 if [ ! -f "$LOCK" ] || [ -L "$LOCK" ] || [ "$written" != "$me" ]; then
   echo "error: session lock ownership verification failed; operate read-only until resolved" >&2
+  exit 1
+fi
+if ! fm_session_lock_owned_by_self "$STATE"; then
+  echo "error: session lock identity verification failed; operate read-only until resolved" >&2
   exit 1
 fi
 release_claim_lock

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -14,8 +14,14 @@
 # A Codex acquisition therefore also publishes state/.lock.codex-thread as
 # "<lock-pid>:<thread-id>". When that sidecar exists, ownership requires its
 # regular non-symlink shape, its pid to match state/.lock, its thread id to match
-# the current command environment, and the numeric holder to remain a live
-# verified harness. A mismatch fails closed instead of falling back to ancestry.
+# the current command environment, the numeric holder to remain a live verified
+# harness, and any resolvable harness ancestry to still name that same holder.
+# The sidecar narrows ancestry instead of replacing it: only a command whose
+# harness ancestry cannot be resolved at all may rely on the thread id alone, so
+# an unrelated harness nested inside a Codex session never inherits ownership
+# from the environment. A mismatch fails closed instead of falling back to
+# ancestry, and the holder's own next acquisition rebinds the sidecar so a Codex
+# process that moved to another thread recovers instead of staying read-only.
 # Locks without the sidecar retain the verified ancestry behavior for older
 # Codex sessions and every other harness.
 # This file is sourced by scripts and has no side effects on source.
@@ -23,7 +29,9 @@
 # Known harness command names; extend when a new adapter is verified.
 FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
 
-# Print the validated Codex thread id inherited by command and hook children.
+# Print the validated Codex thread id. Command children are the empirically
+# verified carriers of this variable; any other child shape that never receives
+# it simply fails closed to the ancestry contract.
 # Codex uses lowercase UUID-shaped ids. Treat every other shape as absent so
 # malformed ambient state can never become lock authority.
 fm_codex_thread_id() {
@@ -149,6 +157,10 @@ fm_codex_lock_identity_matches() {
 # Publish or clear the Codex-specific identity sidecar for numeric lock pid $2.
 # The caller owns state/.lock.acquire. Publishing before state/.lock is safe:
 # readers require both files to name the same pid and otherwise fail closed.
+# This is also the recovery path for a mismatched sidecar: an acquisition that
+# the numeric holder itself may perform rebinds the file to the current thread,
+# and an acquisition with no Codex thread identity clears it, so no stale or
+# reused-pid sidecar can keep a live holder permanently read-only.
 fm_session_lock_publish_identity() {
   local state=$1 lock_pid=$2 identity_file thread_id tmp
   identity_file="$state/.lock.codex-thread"
@@ -168,9 +180,13 @@ fm_session_lock_publish_identity() {
 }
 
 # True when state dir $1 holds a session lock whose pid is the harness ancestor
-# of the current process, or whose Codex identity sidecar matches this command's
-# thread. A missing lock, a malformed or mismatched Codex identity, a lock held
-# by another live harness, or unresolved legacy ancestry all fail closed.
+# of the current process. When the Codex identity sidecar exists it must also
+# match this command's thread, and any harness ancestry that does resolve must
+# still name the lock pid; only a command with no resolvable harness ancestry may
+# rely on the sidecar alone, so a different harness nested inside the Codex
+# session cannot claim ownership from the inherited thread id. A missing lock, a
+# malformed or mismatched Codex identity, a lock held by another live harness, or
+# unresolved legacy ancestry all fail closed.
 fm_session_lock_owned_by_self() {
   local state=$1 lock_pid my_pid identity_file
   lock_pid=$(cat "$state/.lock" 2>/dev/null || true)
@@ -179,7 +195,9 @@ fm_session_lock_owned_by_self() {
   esac
   identity_file="$state/.lock.codex-thread"
   if [ -e "$identity_file" ] || [ -L "$identity_file" ]; then
-    fm_codex_lock_identity_matches "$state" "$lock_pid"
+    fm_codex_lock_identity_matches "$state" "$lock_pid" || return 1
+    my_pid=$(fm_harness_ancestry_pid) || return 0
+    [ "$my_pid" = "$lock_pid" ]
     return
   fi
   my_pid=$(fm_harness_ancestry_pid) || return 1

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -33,11 +33,12 @@ FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
 # verified carriers of this variable; any other child shape that never receives
 # it simply fails closed to the ancestry contract.
 # Codex uses lowercase UUID-shaped ids. Treat every other shape as absent so
-# malformed ambient state can never become lock authority.
+# malformed ambient state can never become lock authority. The match is anchored
+# against the whole value, not per line, so an embedded newline cannot smuggle a
+# UUID-shaped line past validation.
 fm_codex_thread_id() {
   local thread_id=${CODEX_THREAD_ID:-}
-  printf '%s' "$thread_id" \
-    | grep -Eq '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' \
+  [[ $thread_id =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] \
     || return 1
   printf '%s\n' "$thread_id"
 }
@@ -95,46 +96,45 @@ fm_harness_ancestry_pid() {
   return 1
 }
 
-# True if $1 is a live process that looks like a verified harness.
-fm_harness_pid_alive() {
-  local pid=$1 comm args
+# True if $1 is a live process whose command name matches ERE $2, or whose
+# script path matches it when the command is a bare interpreter. ONE owner of
+# the "is this pid still that harness?" probe, so the generic and Codex-specific
+# callers below cannot drift apart.
+fm_pid_alive_matching() {
+  local pid=$1 re=$2 comm args
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  if printf '%s' "$(basename -- "$comm")" | grep -qE "$FM_HARNESS_RE"; then
+  if printf '%s' "$(basename -- "$comm")" | grep -qE "$re"; then
     return 0
   fi
   case "$comm" in
     *node*|*python*)
       args=$(ps -o args= -p "$pid" 2>/dev/null)
-      printf '%s' "$args" | grep -qE "$FM_HARNESS_RE"
+      printf '%s' "$args" | grep -qE "$re"
       ;;
     *) return 1 ;;
   esac
+}
+
+# True if $1 is a live process that looks like a verified harness.
+fm_harness_pid_alive() {
+  fm_pid_alive_matching "$1" "$FM_HARNESS_RE"
 }
 
 # True if $1 is the live Codex harness process that may be paired with a
 # CODEX_THREAD_ID sidecar. A thread id inherited by another nested harness is
 # not enough to make that harness a Codex lock owner.
 fm_codex_pid_alive() {
-  local pid=$1 comm args
-  kill -0 "$pid" 2>/dev/null || return 1
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  if printf '%s' "$(basename -- "$comm")" | grep -qE 'codex'; then
-    return 0
-  fi
-  case "$comm" in
-    *node*|*python*)
-      args=$(ps -o args= -p "$pid" 2>/dev/null)
-      printf '%s' "$args" | grep -qE 'codex'
-      ;;
-    *) return 1 ;;
-  esac
+  fm_pid_alive_matching "$1" 'codex'
 }
 
-# True when $1/.lock.codex-thread securely binds numeric lock pid $2 to this
-# command's Codex thread id.
-fm_codex_lock_identity_matches() {
-  local state=$1 lock_pid=$2 identity_file identity identity_pid identity_thread thread_id
+# Print the "<pid>:<thread-id>" payload of state dir $1's Codex identity sidecar
+# when it is a usable regular file carrying exactly the published shape; fail
+# closed on anything else. ONE owner of the sidecar's on-disk format, so the
+# ownership predicate and the human-facing status line cannot disagree about
+# which files are well-formed.
+fm_codex_lock_identity_read() {
+  local state=$1 identity_file identity identity_pid
   identity_file="$state/.lock.codex-thread"
   [ -f "$identity_file" ] && [ ! -L "$identity_file" ] || return 1
   identity=$(cat "$identity_file" 2>/dev/null) || return 1
@@ -144,14 +144,66 @@ fm_codex_lock_identity_matches() {
     *) return 1 ;;
   esac
   identity_pid=${identity%%:*}
-  identity_thread=${identity#*:}
   case "$identity_pid" in
     ''|*[!0-9]*) return 1 ;;
   esac
+  printf '%s\n' "$identity"
+}
+
+# True when $1/.lock.codex-thread securely binds numeric lock pid $2 to this
+# command's Codex thread id.
+fm_codex_lock_identity_matches() {
+  local state=$1 lock_pid=$2 identity identity_pid identity_thread thread_id
+  identity=$(fm_codex_lock_identity_read "$state") || return 1
+  identity_pid=${identity%%:*}
+  identity_thread=${identity#*:}
   thread_id=$(fm_codex_thread_id) || return 1
   [ "$identity_pid" = "$lock_pid" ] \
     && [ "$identity_thread" = "$thread_id" ] \
     && fm_codex_pid_alive "$lock_pid"
+}
+
+# Print one human-facing line describing state dir $1's Codex identity sidecar
+# against numeric lock pid $2: whether it exists, whether its pid agrees with
+# state/.lock, and whether its thread id is this command's. Read-only diagnosis
+# of the state that makes ownership fail closed - it never grants ownership and
+# never changes any file, so callers still decide with
+# fm_session_lock_owned_by_self.
+fm_session_lock_identity_status() {
+  local state=$1 lock_pid=$2 identity_file identity identity_pid identity_thread thread_id
+  identity_file="$state/.lock.codex-thread"
+  if [ ! -e "$identity_file" ] && [ ! -L "$identity_file" ]; then
+    printf 'identity: codex sidecar absent; harness ancestry decides ownership\n'
+    return 0
+  fi
+  if ! identity=$(fm_codex_lock_identity_read "$state"); then
+    printf 'identity: codex sidecar unusable; ownership fails closed until reacquisition\n'
+    return 0
+  fi
+  identity_pid=${identity%%:*}
+  identity_thread=${identity#*:}
+  if [ "$identity_pid" != "$lock_pid" ]; then
+    printf 'identity: codex sidecar pid %s thread %s; pid does not match lock pid %s\n' \
+      "$identity_pid" "$identity_thread" "$lock_pid"
+    return 0
+  fi
+  if ! fm_codex_pid_alive "$identity_pid"; then
+    printf 'identity: codex sidecar pid %s thread %s; pid matches lock but is not a live codex process\n' \
+      "$identity_pid" "$identity_thread"
+    return 0
+  fi
+  if ! thread_id=$(fm_codex_thread_id); then
+    printf 'identity: codex sidecar pid %s thread %s; pid matches lock, this command has no codex thread id\n' \
+      "$identity_pid" "$identity_thread"
+    return 0
+  fi
+  if [ "$identity_thread" = "$thread_id" ]; then
+    printf 'identity: codex sidecar pid %s thread %s; pid matches lock, thread matches this command\n' \
+      "$identity_pid" "$identity_thread"
+  else
+    printf 'identity: codex sidecar pid %s thread %s; pid matches lock, thread differs from this command\n' \
+      "$identity_pid" "$identity_thread"
+  fi
 }
 
 # Publish or clear the Codex-specific identity sidecar for numeric lock pid $2.

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -4,12 +4,35 @@
 # ONE owner of the "which verified-harness process holds this home's session
 # lock, and does the current process descend from that same harness?" decision.
 # bin/fm-lock.sh uses it to acquire and inspect state/.lock;
+# bin/fm-sessionstart-nudge.sh uses it to recognize a completed session start;
 # bin/fm-claude-stop-autoarm.sh uses it to prove a Stop hook fires inside the
 # lock-owning primary session before it may arm or rewake.
+#
+# state/.lock remains one numeric harness pid for cross-harness liveness.
+# Codex 0.146.0 launches each command as a separate POSIX session/process-group
+# leader but injects a distinct stable CODEX_THREAD_ID into every command child.
+# A Codex acquisition therefore also publishes state/.lock.codex-thread as
+# "<lock-pid>:<thread-id>". When that sidecar exists, ownership requires its
+# regular non-symlink shape, its pid to match state/.lock, its thread id to match
+# the current command environment, and the numeric holder to remain a live
+# verified harness. A mismatch fails closed instead of falling back to ancestry.
+# Locks without the sidecar retain the verified ancestry behavior for older
+# Codex sessions and every other harness.
 # This file is sourced by scripts and has no side effects on source.
 
 # Known harness command names; extend when a new adapter is verified.
 FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+
+# Print the validated Codex thread id inherited by command and hook children.
+# Codex uses lowercase UUID-shaped ids. Treat every other shape as absent so
+# malformed ambient state can never become lock authority.
+fm_codex_thread_id() {
+  local thread_id=${CODEX_THREAD_ID:-}
+  printf '%s' "$thread_id" \
+    | grep -Eq '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' \
+    || return 1
+  printf '%s\n' "$thread_id"
+}
 
 # Walk the current process ancestry (up to 16 hops) and print a harness pid.
 # For every harness except Claude, the first match wins (innermost pid), which
@@ -81,16 +104,84 @@ fm_harness_pid_alive() {
   esac
 }
 
+# True if $1 is the live Codex harness process that may be paired with a
+# CODEX_THREAD_ID sidecar. A thread id inherited by another nested harness is
+# not enough to make that harness a Codex lock owner.
+fm_codex_pid_alive() {
+  local pid=$1 comm args
+  kill -0 "$pid" 2>/dev/null || return 1
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+  if printf '%s' "$(basename -- "$comm")" | grep -qE 'codex'; then
+    return 0
+  fi
+  case "$comm" in
+    *node*|*python*)
+      args=$(ps -o args= -p "$pid" 2>/dev/null)
+      printf '%s' "$args" | grep -qE 'codex'
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# True when $1/.lock.codex-thread securely binds numeric lock pid $2 to this
+# command's Codex thread id.
+fm_codex_lock_identity_matches() {
+  local state=$1 lock_pid=$2 identity_file identity identity_pid identity_thread thread_id
+  identity_file="$state/.lock.codex-thread"
+  [ -f "$identity_file" ] && [ ! -L "$identity_file" ] || return 1
+  identity=$(cat "$identity_file" 2>/dev/null) || return 1
+  case "$identity" in
+    *$'\n'*|*:*:*) return 1 ;;
+    *:*) ;;
+    *) return 1 ;;
+  esac
+  identity_pid=${identity%%:*}
+  identity_thread=${identity#*:}
+  case "$identity_pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  thread_id=$(fm_codex_thread_id) || return 1
+  [ "$identity_pid" = "$lock_pid" ] \
+    && [ "$identity_thread" = "$thread_id" ] \
+    && fm_codex_pid_alive "$lock_pid"
+}
+
+# Publish or clear the Codex-specific identity sidecar for numeric lock pid $2.
+# The caller owns state/.lock.acquire. Publishing before state/.lock is safe:
+# readers require both files to name the same pid and otherwise fail closed.
+fm_session_lock_publish_identity() {
+  local state=$1 lock_pid=$2 identity_file thread_id tmp
+  identity_file="$state/.lock.codex-thread"
+  if thread_id=$(fm_codex_thread_id) && fm_codex_pid_alive "$lock_pid"; then
+    tmp=$(mktemp "$state/.lock-codex-thread-write.XXXXXX" 2>/dev/null) || return 1
+    if ! printf '%s:%s\n' "$lock_pid" "$thread_id" > "$tmp" 2>/dev/null \
+      || ! mv -f "$tmp" "$identity_file" 2>/dev/null; then
+      rm -f "$tmp" 2>/dev/null || true
+      return 1
+    fi
+    [ -f "$identity_file" ] && [ ! -L "$identity_file" ] \
+      && fm_codex_lock_identity_matches "$state" "$lock_pid"
+    return
+  fi
+  rm -f "$identity_file" 2>/dev/null || return 1
+  [ ! -e "$identity_file" ] && [ ! -L "$identity_file" ]
+}
+
 # True when state dir $1 holds a session lock whose pid is the harness ancestor
-# of the current process: this script runs inside the session that owns the
-# home's fleet lock. A missing lock, a lock held by another live harness, or an
-# ancestry that cannot be resolved all fail closed.
+# of the current process, or whose Codex identity sidecar matches this command's
+# thread. A missing lock, a malformed or mismatched Codex identity, a lock held
+# by another live harness, or unresolved legacy ancestry all fail closed.
 fm_session_lock_owned_by_self() {
-  local state=$1 lock_pid my_pid
+  local state=$1 lock_pid my_pid identity_file
   lock_pid=$(cat "$state/.lock" 2>/dev/null || true)
   case "$lock_pid" in
     ''|*[!0-9]*) return 1 ;;
   esac
+  identity_file="$state/.lock.codex-thread"
+  if [ -e "$identity_file" ] || [ -L "$identity_file" ]; then
+    fm_codex_lock_identity_matches "$state" "$lock_pid"
+    return
+  fi
   my_pid=$(fm_harness_ancestry_pid) || return 1
   [ "$my_pid" = "$lock_pid" ]
 }

--- a/bin/fm-sessionstart-nudge.sh
+++ b/bin/fm-sessionstart-nudge.sh
@@ -16,27 +16,13 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-primary-scope-lib.sh"
 # shellcheck source=bin/fm-operational-input.sh
 . "$SCRIPT_DIR/fm-operational-input.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
 fm_is_gate_agent "$FM_ROOT" && exit 0
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
-lock_is_in_ancestry() {
-  local lock_pid pid=$$ _
-  [ -f "$STATE/.lock" ] || return 1
-  IFS= read -r lock_pid < "$STATE/.lock" 2>/dev/null || return 1
-  case "$lock_pid" in
-    ''|*[!0-9]*|1) return 1 ;;
-  esac
-  kill -0 "$lock_pid" 2>/dev/null || return 1
-  for _ in 1 2 3 4 5 6 7 8; do
-    [ "$pid" = "$lock_pid" ] && return 0
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
-  done
-  return 1
-}
-
-lock_is_in_ancestry && exit 0
+fm_session_lock_owned_by_self "$STATE" && exit 0
 nudge=
 fm_operational_input_encode session-start \
   "Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions." \

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -28,7 +28,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
-| `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
+| `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk, holder liveness, and the Codex thread-identity sidecar) for fm-lock.sh, the session-start nudge, and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -36,7 +36,7 @@ That alternative expands trust and writes outside this repository, so Firstmate 
 ## Regression coverage
 
 `tests/fm-sessionstart-nudge.test.sh` proves wrapper silence for both gate signals, an unmarked linked worktree, a missing state directory, an ancestry-owned lock, and a Codex thread-owned lock whose harness ancestry is unavailable.
-It also proves that a different Codex thread fails closed to the nudge.
+It also proves that a different Codex thread and a nested foreign harness holding an inherited Codex thread id both fail closed to the nudge.
 It proves exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output for a plain primary and a marked linked secondmate primary.
 `tests/fm-pi-primary-live-e2e.test.sh` and `tests/fm-opencode-primary-live-e2e.test.sh` exercise native startup paths with first-message and later-message Ahoy regressions.
 `tests/fm-turnend-guard.test.sh`, `tests/fm-pi-watch-extension.test.sh`, and `tests/fm-daemon.test.sh` cover marked guard, monitoring, and away-mode delivery.

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -12,8 +12,9 @@ It sources `bin/fm-gate-refuse-lib.sh` and stays silent for a no-mistakes gate a
 It shares `bin/fm-primary-scope-lib.sh` with `bin/fm-turnend-guard.sh`, so the hooks use one primary-detection owner.
 The Shared Predicate section of [`turnend-guard.md`](turnend-guard.md#shared-predicate) owns marker validation, plain-checkout detection, and required Firstmate-shaped paths.
 
-Before printing, the wrapper reads `state/.lock` and walks at most eight parents from its own pid in its own separate, hard-coded loop, independent of `bin/fm-lock.sh`'s ancestry walk (`fm_harness_ancestry_pid()` in `bin/fm-session-lock-lib.sh`, which now walks up to sixteen parents and can extend past a claude-named match to a still-more-ancestral one) and of Pi's `lockOwnership()`.
-If the lock names a live pid in that ancestry, session start already ran in this harness session and the wrapper stays silent.
+Before printing, the wrapper delegates ownership to `bin/fm-session-lock-lib.sh`, the same decision owner used by `bin/fm-lock.sh` and the Claude Stop auto-arm.
+That shared owner covers the verified harness ancestry rules and Codex's thread-identity sidecar without a second nudge-specific ancestry loop.
+If the shared owner verifies this session, session start already ran and the wrapper stays silent.
 Every path exits 0, including malformed state and adapter errors, because a Claude SessionStart exit 2 blocks session initialization.
 
 ## Harness transports
@@ -34,7 +35,8 @@ That alternative expands trust and writes outside this repository, so Firstmate 
 
 ## Regression coverage
 
-`tests/fm-sessionstart-nudge.test.sh` proves wrapper silence for both gate signals, an unmarked linked worktree, a missing state directory, and an already-owned lock.
+`tests/fm-sessionstart-nudge.test.sh` proves wrapper silence for both gate signals, an unmarked linked worktree, a missing state directory, an ancestry-owned lock, and a Codex thread-owned lock whose harness ancestry is unavailable.
+It also proves that a different Codex thread fails closed to the nudge.
 It proves exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output for a plain primary and a marked linked secondmate primary.
 `tests/fm-pi-primary-live-e2e.test.sh` and `tests/fm-opencode-primary-live-e2e.test.sh` exercise native startup paths with first-message and later-message Ahoy regressions.
 `tests/fm-turnend-guard.test.sh`, `tests/fm-pi-watch-extension.test.sh`, and `tests/fm-daemon.test.sh` cover marked guard, monitoring, and away-mode delivery.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -32,8 +32,9 @@ Otherwise it calls `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] 
 A stale beacon blocks even when a watcher pid is live.
 A fresh leftover beacon blocks when the lock is missing, dead, or identity-mismatched.
 
-Primary session-lock ownership is a separate decision this guard predicate never makes: `bin/fm-session-lock-lib.sh` owns it for every tracked shell caller, so no hook script repeats that ancestry walk itself.
-That owner includes the Codex 0.146.0 thread-identity path used by session start and the native session-start nudge.
+Primary session-lock ownership is a separate decision this guard predicate never makes: `bin/fm-session-lock-lib.sh` owns it for every tracked shell caller, so no shell hook repeats that ancestry walk itself.
+Pi's two tracked extensions and OpenCode's watch-arm plugin still resolve ownership in their own process rather than sourcing that library, and [`watcher-continuity.md`](watcher-continuity.md#ownership) owns their contract.
+That shared owner includes the Codex 0.146.0 thread-identity path used by session start and the native session-start nudge.
 [`verification/supervision.md`](verification/supervision.md#codex-01460-session-lock-identity) owns the dated empirical evidence.
 
 `FM_STATE_OVERRIDE` wins over `FM_HOME/state`, and `FM_HOME` wins over repository-root `state/`.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -32,7 +32,7 @@ Otherwise it calls `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] 
 A stale beacon blocks even when a watcher pid is live.
 A fresh leftover beacon blocks when the lock is missing, dead, or identity-mismatched.
 
-Primary session-lock ownership is a separate shared decision owned by `bin/fm-session-lock-lib.sh`, never by a harness hook or this guard predicate.
+Primary session-lock ownership is a separate decision this guard predicate never makes: `bin/fm-session-lock-lib.sh` owns it for every tracked shell caller, so no hook script repeats that ancestry walk itself.
 That owner includes the Codex 0.146.0 thread-identity path used by session start and the native session-start nudge.
 [`verification/supervision.md`](verification/supervision.md#codex-01460-session-lock-identity) owns the dated empirical evidence.
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -32,6 +32,10 @@ Otherwise it calls `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] 
 A stale beacon blocks even when a watcher pid is live.
 A fresh leftover beacon blocks when the lock is missing, dead, or identity-mismatched.
 
+Primary session-lock ownership is a separate shared decision owned by `bin/fm-session-lock-lib.sh`, never by a harness hook or this guard predicate.
+That owner includes the Codex 0.146.0 thread-identity path used by session start and the native session-start nudge.
+[`verification/supervision.md`](verification/supervision.md#codex-01460-session-lock-identity) owns the dated empirical evidence.
+
 `FM_STATE_OVERRIDE` wins over `FM_HOME/state`, and `FM_HOME` wins over repository-root `state/`.
 `FM_GUARD_GRACE` controls beacon freshness and defaults to 300 seconds.
 If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot safely read loop-guard fields.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -98,6 +98,7 @@ The process shape is therefore a new POSIX session and process group for each co
 The command remains a direct child of `codex`, while the child-scoped `CODEX_THREAD_ID` distinguishes a nested session from its outer session.
 An additional `/proc/<parent>/environ` probe showed that the nested Codex parent retained the outer thread id while its command child received the nested id.
 This is why `bin/fm-session-lock-lib.sh` uses the command child's validated thread id as the Codex sidecar authority and retains the numeric Codex pid for liveness.
+Because that parent link resolves, the sidecar narrows the verified ancestry contract instead of replacing it: only a caller whose harness ancestry cannot be resolved at all may rely on the thread id alone, and the numeric holder's own reacquisition rebinds a mismatched sidecar.
 The test also seeds a dead numeric holder and mismatched old sidecar before proving status reports it stale, acquisition replaces it, and the new thread verifies ownership.
 
 ## Turn-end guard

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -162,6 +162,7 @@ FM_GROK_STOP_LIVE_E2E=1 FM_GROK_NATIVE_BIN="$native_grok" FM_GROK_LEGACY_BIN="$p
 ## Watcher continuity
 
 The cross-harness evidence combines the 2026-07-17 live pass with Claude's replacement Stop-owned path revalidated on 2026-07-24, all against isolated project and home state.
+Codex's row was re-verified separately on 2026-07-29 with codex-cli 0.146.0 when its session-lock identity contract changed; [Codex 0.146.0 session-lock identity](#codex-01460-session-lock-identity) owns that evidence, and the versions below remain those of the 2026-07-17 pass.
 No credential material was copied into a fixture.
 
 ```text

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -60,6 +60,46 @@ The Ahoy first-message boundary was reverified on 2026-07-22 with Pi 0.81.1 and 
 Marked current operational input and the two exact legacy compatibility shapes selected Bearings, while genuine near-miss captain messages remained real boundaries.
 The detailed reconciliation and task chronology stay in the private audit report and PR evidence.
 
+## Codex 0.146.0 session-lock identity
+
+Codex 0.146.0 release notes did not identify a Unix command-process isolation change, so the installed binary and a real nested scratch session were treated as authoritative.
+The live pass ran on Linux on 2026-07-29 from a Codex parent session.
+
+```sh
+codex --version
+FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh
+```
+
+Observed command output:
+
+```text
+codex-cli 0.146.0
+ok - codex-cli 0.146.0 live E2E verified isolated-command lock ownership, stale recovery, and the one-second foreground checkpoint path
+```
+
+The generated scratch command transcript contained these bounded stable results:
+
+```text
+CODEX_THREAD_ID is set: yes
+CODEX_THREAD_ID differs from outer session: yes
+probe is its own PGID leader: yes
+probe is its own SID leader: yes
+probe parent is codex: yes
+probe PID namespace matches parent: yes
+fresh ownership verified: yes
+fresh sidecar pid matches lock: yes
+fresh sidecar thread matches command: yes
+lock: stale (pid 99999999 dead or not a harness)
+stale ownership verified after reacquisition: yes
+checkpoint: no actionable wake within 1s
+```
+
+The process shape is therefore a new POSIX session and process group for each command, not a separate PID namespace or a broken parent link.
+The command remains a direct child of `codex`, while the child-scoped `CODEX_THREAD_ID` distinguishes a nested session from its outer session.
+An additional `/proc/<parent>/environ` probe showed that the nested Codex parent retained the outer thread id while its command child received the nested id.
+This is why `bin/fm-session-lock-lib.sh` uses the command child's validated thread id as the Codex sidecar authority and retains the numeric Codex pid for liveness.
+The test also seeds a dead numeric holder and mismatched old sidecar before proving status reports it stale, acquisition replaces it, and the new thread verifies ownership.
+
 ## Turn-end guard
 
 The direct and passive mechanisms were validated across all five harnesses on 2026-07-08 through 2026-07-12, with Claude's replacement Stop-owned path revalidated on 2026-07-24.
@@ -134,7 +174,7 @@ grok 0.2.103 (89c3d36fb6f1) [stable]
 | Harness | Exact opt-in command | Observed guarantee |
 | --- | --- | --- |
 | Claude | `FM_CLAUDE_LIVE_E2E=1 tests/fm-claude-stop-autoarm-live-e2e.test.sh` | Session start reclaimed a stale owner before two Stop-owned cycles, and a competing live owner prevented arm, rewake, epoch write, or lock replacement. |
-| Codex | `FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh` | The one-second foreground checkpoint returned without switching to the arm wrapper. |
+| Codex | `FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh` | The isolated command acquired and verified a thread-bound session lock, replaced a stale dead holder, and returned from the one-second foreground checkpoint without switching to the arm wrapper. |
 | OpenCode | `FM_OPENCODE_LIVE_E2E=1 tests/fm-opencode-primary-live-e2e.test.sh` | A verified successor existed before prompt handling, with no model re-arm or turn-end fallback. |
 | Pi | `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` | One initial tool call led to extension-owned successors and clean child retirement on exit. |
 | Grok | `FM_GROK_LIVE_E2E=1 tests/fm-grok-continuity-live-e2e.test.sh` | Native task completion surfaced the actionable close and the cycle ledger recorded `reason=actionable-signal`. |

--- a/tests/fm-codex-continuity-live-e2e.test.sh
+++ b/tests/fm-codex-continuity-live-e2e.test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Opt-in credentialed Codex regression proving the continuity changes preserve
-# Codex's bounded foreground-checkpoint supervision path.
+# Opt-in credentialed Codex regression proving session-lock identity inside a
+# real command environment and the bounded foreground-checkpoint supervision
+# path.
 set -u
 
 if [ "${FM_CODEX_LIVE_E2E:-0}" != 1 ]; then
@@ -21,7 +22,11 @@ LAB="$ROOT/.codex-live-e2e.$$"
 PROJECT="$LAB/project"
 HOME_DIR="$LAB/fmhome"
 TRANSCRIPT="$LAB/codex.jsonl"
+PROBE="$PROJECT/codex-lock-probe.sh"
+LOCK_FRESH_HOME="$LAB/lock-fresh"
+LOCK_STALE_HOME="$LAB/lock-stale"
 CODEX_VERSION=$(codex --version)
+OUTER_THREAD_ID=${CODEX_THREAD_ID:-}
 
 cleanup() {
   rm -rf "$LAB"
@@ -30,14 +35,76 @@ trap cleanup EXIT
 
 mkdir -p "$LAB"
 git clone -q "$ROOT" "$PROJECT"
+cp "$ROOT/bin/fm-lock.sh" "$ROOT/bin/fm-session-lock-lib.sh" "$PROJECT/bin/"
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/config"
+cat > "$PROBE" <<'SH'
+#!/usr/bin/env bash
+set -u
+
+ROOT=${CODEX_PROBE_ROOT:?}
+FRESH=${CODEX_PROBE_FRESH_HOME:?}
+STALE=${CODEX_PROBE_STALE_HOME:?}
+
+yes_no() {
+  if "$@"; then printf '%s' yes; else printf '%s' no; fi
+}
+
+shell_pid=$$
+shell_pgid=$(ps -o pgid= -p "$shell_pid" | tr -d ' ')
+shell_sid=$(ps -o sid= -p "$shell_pid" | tr -d ' ')
+parent_comm=$(ps -o comm= -p "$PPID" | tr -d '[:space:]')
+thread_set=$(yes_no test -n "${CODEX_THREAD_ID:-}")
+thread_differs_from_outer=not-applicable
+if [ -n "${CODEX_PROBE_OUTER_THREAD_ID:-}" ]; then
+  thread_differs_from_outer=$(yes_no test "${CODEX_THREAD_ID:-}" != "$CODEX_PROBE_OUTER_THREAD_ID")
+fi
+pgid_leader=$(yes_no test "$shell_pid" = "$shell_pgid")
+sid_leader=$(yes_no test "$shell_pid" = "$shell_sid")
+parent_codex=$(yes_no test "$parent_comm" = codex)
+namespace_match=$(yes_no test "$(readlink "/proc/$shell_pid/ns/pid")" = "$(readlink "/proc/$PPID/ns/pid")")
+
+mkdir -p "$FRESH/state" "$STALE/state"
+FM_HOME="$FRESH" "$ROOT/bin/fm-lock.sh" >/dev/null
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$ROOT/bin/fm-session-lock-lib.sh"
+fresh_owned=no
+fm_session_lock_owned_by_self "$FRESH/state" && fresh_owned=yes
+fresh_lock=$(cat "$FRESH/state/.lock")
+fresh_identity=$(cat "$FRESH/state/.lock.codex-thread")
+fresh_pid_match=$(yes_no test "${fresh_identity%%:*}" = "$fresh_lock")
+fresh_thread_match=$(yes_no test "${fresh_identity#*:}" = "${CODEX_THREAD_ID:-}")
+
+printf '%s\n' 99999999 > "$STALE/state/.lock"
+printf '%s\n' '99999999:01900000-0000-7000-8000-000000000000' > "$STALE/state/.lock.codex-thread"
+stale_status=$(FM_HOME="$STALE" "$ROOT/bin/fm-lock.sh" status)
+FM_HOME="$STALE" "$ROOT/bin/fm-lock.sh" >/dev/null
+stale_owned=no
+fm_session_lock_owned_by_self "$STALE/state" && stale_owned=yes
+printf 'CODEX_THREAD_ID is set: %s\n' "$thread_set"
+printf 'CODEX_THREAD_ID differs from outer session: %s\n' "$thread_differs_from_outer"
+printf 'probe is its own PGID leader: %s\n' "$pgid_leader"
+printf 'probe is its own SID leader: %s\n' "$sid_leader"
+printf 'probe parent is codex: %s\n' "$parent_codex"
+printf 'probe PID namespace matches parent: %s\n' "$namespace_match"
+printf 'fresh ownership verified: %s\n' "$fresh_owned"
+printf 'fresh sidecar pid matches lock: %s\n' "$fresh_pid_match"
+printf 'fresh sidecar thread matches command: %s\n' "$fresh_thread_match"
+printf '%s\n' "$stale_status"
+printf 'stale ownership verified after reacquisition: %s\n' "$stale_owned"
+SH
+chmod +x "$PROBE"
 # shellcheck disable=SC2016 # Backticks are literal prompt markup.
-PROMPT='Run exactly `bin/fm-watch-checkpoint.sh --seconds 1` as one foreground shell call. Do not use a background task and do not run fm-watch-arm.sh. After the checkpoint returns, reply briefly.'
+PROMPT='Run exactly `exec ./codex-lock-probe.sh` as one foreground shell call. Then run exactly `bin/fm-watch-checkpoint.sh --seconds 1` as one foreground shell call. Do not use a background task and do not run fm-watch-arm.sh. After both commands return, reply briefly.'
 
 (
   cd "$PROJECT" || exit 1
   printf '%s\n' "$$" > "$HOME_DIR/state/.lock"
-  FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$PROJECT" codex exec \
+  FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$PROJECT" \
+    CODEX_PROBE_ROOT="$PROJECT" \
+    CODEX_PROBE_FRESH_HOME="$LOCK_FRESH_HOME" \
+    CODEX_PROBE_STALE_HOME="$LOCK_STALE_HOME" \
+    CODEX_PROBE_OUTER_THREAD_ID="$OUTER_THREAD_ID" \
+    codex exec \
     --dangerously-bypass-hook-trust \
     --dangerously-bypass-approvals-and-sandbox \
     --skip-git-repo-check \
@@ -46,10 +113,31 @@ PROMPT='Run exactly `bin/fm-watch-checkpoint.sh --seconds 1` as one foreground s
     "$PROMPT"
 ) > "$TRANSCRIPT" 2>&1 || fail "Codex credentialed checkpoint turn failed: $(tail -20 "$TRANSCRIPT")"
 
+for expected in \
+  'CODEX_THREAD_ID is set: yes' \
+  'probe is its own PGID leader: yes' \
+  'probe is its own SID leader: yes' \
+  'probe parent is codex: yes' \
+  'probe PID namespace matches parent: yes' \
+  'fresh ownership verified: yes' \
+  'fresh sidecar pid matches lock: yes' \
+  'fresh sidecar thread matches command: yes' \
+  'lock: stale (pid 99999999 dead or not a harness)' \
+  'stale ownership verified after reacquisition: yes'; do
+  grep -F "$expected" "$TRANSCRIPT" >/dev/null \
+    || fail "Codex transcript omitted '$expected': $(tail -20 "$TRANSCRIPT")"
+done
+if [ -n "$OUTER_THREAD_ID" ]; then
+  grep -F 'CODEX_THREAD_ID differs from outer session: yes' "$TRANSCRIPT" >/dev/null \
+    || fail "nested Codex command reused the outer thread identity: $(tail -20 "$TRANSCRIPT")"
+else
+  grep -F 'CODEX_THREAD_ID differs from outer session: not-applicable' "$TRANSCRIPT" >/dev/null \
+    || fail "top-level Codex probe did not report the absent outer session: $(tail -20 "$TRANSCRIPT")"
+fi
 grep -F 'checkpoint: no actionable wake within 1s' "$TRANSCRIPT" >/dev/null \
   || fail "Codex transcript omitted the real foreground checkpoint result"
 if grep -F 'watcher: started pid=' "$TRANSCRIPT" >/dev/null; then
   fail "Codex switched to the background arm path"
 fi
 
-printf 'ok - %s live E2E preserved the one-second foreground checkpoint path\n' "$CODEX_VERSION"
+printf 'ok - %s live E2E verified isolated-command lock ownership, stale recovery, and the one-second foreground checkpoint path\n' "$CODEX_VERSION"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -756,6 +756,7 @@ SH
 codex_owned_by_self() {
   local state=$1
   shift
+  # shellcheck disable=SC2016 # Variables must expand in the child shell, not this test shell.
   env "$@" HOME_STATE="$state" ROOT_UNDER_TEST="$ROOT" \
     bash -c '. "$ROOT_UNDER_TEST/bin/fm-session-lock-lib.sh"; fm_session_lock_owned_by_self "$HOME_STATE"'
 }

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -761,18 +761,22 @@ codex_owned_by_self() {
     bash -c '. "$ROOT_UNDER_TEST/bin/fm-session-lock-lib.sh"; fm_session_lock_owned_by_self "$HOME_STATE"'
 }
 
-test_codex_session_lock_uses_thread_identity() {
-  local rec root home fakebin codex_pid out status=0 lock_pid
-  local thread_id=019fb044-acd6-7c20-97a2-f3e227def5d2
-  local other_thread_id=019fb041-9ca2-76c1-a272-358bd63dfe7a
-  local nested_pid
-  rec=$(new_world codex-thread-lock)
-  IFS='|' read -r root home fakebin <<EOF
-$rec
-EOF
-  sleep 300 &
-  codex_pid=$!
-  nested_pid=$((codex_pid + 1))
+# codex_thread_id_accepted <value>: true when the shared validator treats <value>
+# as a usable Codex thread id, decided by the lib itself rather than a copy of
+# its shape rule here.
+codex_thread_id_accepted() {
+  # shellcheck disable=SC2016 # Variables must expand in the child shell, not this test shell.
+  env CODEX_THREAD_ID="$1" ROOT_UNDER_TEST="$ROOT" \
+    bash -c '. "$ROOT_UNDER_TEST/bin/fm-session-lock-lib.sh"; fm_codex_thread_id' >/dev/null 2>&1
+}
+
+# make_fake_ps_codex <fakebin>: the Codex ancestry shape. FM_FAKE_CODEX_PID is
+# the live codex harness and every other pid is a plain shell descending from
+# it, unless FM_FAKE_CODEX_ISOLATED=1 (the real command-child shape: no harness
+# resolvable in ancestry) or FM_FAKE_NESTED_HARNESS_PID names a foreign harness
+# nested between the caller and codex.
+make_fake_ps_codex() {
+  local fakebin=$1
   cat > "$fakebin/ps" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -807,6 +811,21 @@ case "$pid:$field" in
 esac
 SH
   chmod +x "$fakebin/ps"
+}
+
+test_codex_session_lock_uses_thread_identity() {
+  local rec root home fakebin codex_pid out status=0 lock_pid
+  local thread_id=019fb044-acd6-7c20-97a2-f3e227def5d2
+  local other_thread_id=019fb041-9ca2-76c1-a272-358bd63dfe7a
+  local nested_pid
+  rec=$(new_world codex-thread-lock)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  sleep 300 &
+  codex_pid=$!
+  nested_pid=$((codex_pid + 1))
+  make_fake_ps_codex "$fakebin"
 
   printf '%s\n' 9999999 > "$home/state/.lock"
   printf '%s\n' "9999999:$other_thread_id" > "$home/state/.lock.codex-thread"
@@ -874,6 +893,146 @@ SH
   assert_contains "$out" "lock: stale" \
     "dead Codex holder was not classified as a releasable stale lock"
   pass "Codex lock: thread identity survives isolated command ancestry, rebinds for the holder, and refuses nested harnesses"
+}
+
+# A UUID-shaped LINE inside a multi-line ambient value must never become lock
+# authority: grep's per-line anchoring would accept it, publish a sidecar the
+# reader then rejects, and wedge every caller read-only behind a malformed file.
+test_codex_thread_id_rejects_multiline_values() {
+  local rec root home fakebin codex_pid out status=0 value
+  local thread_id=019fb044-acd6-7c20-97a2-f3e227def5d2
+  rec=$(new_world codex-thread-multiline)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  sleep 300 &
+  codex_pid=$!
+  make_fake_ps_codex "$fakebin"
+
+  codex_thread_id_accepted "$thread_id" \
+    || fail "the validator rejected a well-formed Codex thread id"
+  if codex_thread_id_accepted "$thread_id"$'\nx'; then
+    fail "the validator accepted a multi-line value whose first line is UUID-shaped"
+  fi
+  if codex_thread_id_accepted $'x\n'"$thread_id"; then
+    fail "the validator accepted a multi-line value whose last line is UUID-shaped"
+  fi
+  if codex_thread_id_accepted "$thread_id"$'\n'; then
+    fail "the validator accepted a Codex thread id carrying a trailing newline"
+  fi
+
+  for value in "$thread_id"$'\nx' $'x\n'"$thread_id" "$thread_id"$'\n'; do
+    status=0
+    out=$(CODEX_THREAD_ID="$value" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+      PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+    expect_code 0 "$status" "acquisition under a multi-line CODEX_THREAD_ID"
+    assert_contains "$out" "lock acquired: harness pid $codex_pid" \
+      "a multi-line CODEX_THREAD_ID did not fall back to the verified ancestry contract"
+    if [ -e "$home/state/.lock.codex-thread" ] || [ -L "$home/state/.lock.codex-thread" ]; then
+      fail "a multi-line CODEX_THREAD_ID left an identity sidecar: $(cat "$home/state/.lock.codex-thread" 2>/dev/null)"
+    fi
+    [ "$(cat "$home/state/.lock")" = "$codex_pid" ] \
+      || fail "a multi-line CODEX_THREAD_ID did not record the live harness pid"
+  done
+
+  kill "$codex_pid" 2>/dev/null || true
+  wait "$codex_pid" 2>/dev/null || true
+  pass "a multi-line CODEX_THREAD_ID never becomes lock authority and never publishes a sidecar"
+}
+
+# `status` is the documented inspection path, so the state that makes a live
+# holder unverifiable - and therefore every caller read-only - must be readable
+# there instead of only by hand-reading state files.
+test_lock_status_reports_codex_identity() {
+  local rec root home fakebin codex_pid out sidecar before
+  local thread_id=019fb044-acd6-7c20-97a2-f3e227def5d2
+  local other_thread_id=019fb041-9ca2-76c1-a272-358bd63dfe7a
+  rec=$(new_world codex-lock-status)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  sleep 300 &
+  codex_pid=$!
+  make_fake_ps_codex "$fakebin"
+  sidecar="$home/state/.lock.codex-thread"
+
+  out=$(FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" PATH="$fakebin:$BASE_PATH" \
+    "$ROOT/bin/fm-lock.sh" status)
+  [ "$out" = "lock: free" ] \
+    || fail "a free lock gained an identity line it has no holder to describe: $out"
+
+  CODEX_THREAD_ID="$thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" >/dev/null \
+    || fail "Codex acquisition failed while seeding the status fixture"
+
+  out=$(CODEX_THREAD_ID="$thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid $codex_pid" \
+    "status lost its holder line"
+  assert_contains "$out" \
+    "identity: codex sidecar pid $codex_pid thread $thread_id; pid matches lock, thread matches this command" \
+    "status did not report the verifiable Codex identity"
+
+  # The read-only wedge itself: a live holder no current caller can verify.
+  out=$(CODEX_THREAD_ID="$other_thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid $codex_pid" \
+    "status stopped reporting a live holder once the thread diverged"
+  assert_contains "$out" \
+    "identity: codex sidecar pid $codex_pid thread $thread_id; pid matches lock, thread differs from this command" \
+    "status did not diagnose the diverged Codex thread"
+
+  out=$(FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" PATH="$fakebin:$BASE_PATH" \
+    "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "pid matches lock, this command has no codex thread id" \
+    "status did not distinguish an absent caller thread id from a diverged one"
+
+  before=$(cat "$sidecar")
+  [ "$before" = "$codex_pid:$thread_id" ] \
+    || fail "status mutated the identity sidecar it only inspects: $before"
+  [ "$(cat "$home/state/.lock")" = "$codex_pid" ] \
+    || fail "status mutated the session lock it only inspects"
+
+  printf '%s\n' "9999999:$thread_id" > "$sidecar"
+  out=$(CODEX_THREAD_ID="$thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" \
+    "identity: codex sidecar pid 9999999 thread $thread_id; pid does not match lock pid $codex_pid" \
+    "status did not report a sidecar bound to a different pid than the lock"
+
+  printf '%s\n' 'not-an-identity' > "$sidecar"
+  out=$(CODEX_THREAD_ID="$thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "identity: codex sidecar unusable" \
+    "status did not report a malformed identity sidecar"
+
+  printf '%s\n' "$codex_pid:$thread_id" > "$home/state/real-identity"
+  rm -f "$sidecar"
+  ln -s "$home/state/real-identity" "$sidecar"
+  out=$(CODEX_THREAD_ID="$thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "identity: codex sidecar unusable" \
+    "status trusted a symlinked identity sidecar that ownership refuses"
+
+  rm -f "$sidecar"
+  out=$(CODEX_THREAD_ID="$thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "identity: codex sidecar absent; harness ancestry decides ownership" \
+    "status did not report a lock governed by the ancestry contract alone"
+
+  # A sidecar whose pid was reused by some other live harness still fails closed,
+  # so the line must not claim a clean match.
+  printf '%s\n' "$codex_pid:$thread_id" > "$sidecar"
+  out=$(CODEX_THREAD_ID="$thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID=1 \
+    FM_FAKE_NESTED_HARNESS_PID="$codex_pid" PATH="$fakebin:$BASE_PATH" \
+    "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" \
+    "identity: codex sidecar pid $codex_pid thread $thread_id; pid matches lock but is not a live codex process" \
+    "status claimed a verifiable identity for a holder that is not a live codex process"
+
+  kill "$codex_pid" 2>/dev/null || true
+  wait "$codex_pid" 2>/dev/null || true
+  pass "fm-lock.sh status reports sidecar presence, pid agreement, and thread agreement"
 }
 
 # --- output ordering ----------------------------------------------------------
@@ -1533,6 +1692,8 @@ test_lock_refusal_read_only_path
 test_lock_write_failure_read_only_path
 test_session_lock_concurrent_single_winner
 test_codex_session_lock_uses_thread_identity
+test_codex_thread_id_rejects_multiline_values
+test_lock_status_reports_codex_identity
 test_output_ordering_diagnostics_lead
 test_herdr_backend_diagnostics_follow_real_session_start
 test_session_start_relaunches_missing_pi_secondmate

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -751,16 +751,27 @@ SH
   pass "concurrent session-lock acquisition admits exactly one live harness"
 }
 
+# codex_owned_by_self <state-dir> <env assignment>...: run the shared ownership
+# predicate in a child shell so the fake ps ancestry of that child decides.
+codex_owned_by_self() {
+  local state=$1
+  shift
+  env "$@" HOME_STATE="$state" ROOT_UNDER_TEST="$ROOT" \
+    bash -c '. "$ROOT_UNDER_TEST/bin/fm-session-lock-lib.sh"; fm_session_lock_owned_by_self "$HOME_STATE"'
+}
+
 test_codex_session_lock_uses_thread_identity() {
   local rec root home fakebin codex_pid out status=0 lock_pid
   local thread_id=019fb044-acd6-7c20-97a2-f3e227def5d2
   local other_thread_id=019fb041-9ca2-76c1-a272-358bd63dfe7a
+  local nested_pid
   rec=$(new_world codex-thread-lock)
   IFS='|' read -r root home fakebin <<EOF
 $rec
 EOF
   sleep 300 &
   codex_pid=$!
+  nested_pid=$((codex_pid + 1))
   cat > "$fakebin/ps" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -773,11 +784,17 @@ while [ "$#" -gt 0 ]; do
     *) shift ;;
   esac
 done
+nested=${FM_FAKE_NESTED_HARNESS_PID:-}
 case "$pid:$field" in
   "$FM_FAKE_CODEX_PID:comm=") printf '%s\n' codex ;;
   "$FM_FAKE_CODEX_PID:args=") printf '%s\n' codex ;;
+  "$nested:comm=") printf '%s\n' claude ;;
+  "$nested:args=") printf '%s\n' claude ;;
+  "$nested:ppid=") printf '%s\n' 1 ;;
   *:ppid=)
-    if [ "${FM_FAKE_CODEX_ISOLATED:-0}" = 1 ]; then
+    if [ -n "$nested" ]; then
+      printf '%s\n' "$nested"
+    elif [ "${FM_FAKE_CODEX_ISOLATED:-0}" = 1 ]; then
       printf '%s\n' 1
     else
       printf '%s\n' "$FM_FAKE_CODEX_PID"
@@ -803,31 +820,59 @@ SH
   assert_contains "$out" "lock acquired: harness pid $codex_pid" \
     "Codex acquisition did not report its live harness pid"
 
+  # A second thread of the SAME live Codex process must be able to rebind the
+  # sidecar; otherwise a thread change leaves that process permanently read-only.
   status=0
   out=$(CODEX_THREAD_ID="$other_thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
     PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
-  [ "$status" -ne 0 ] || fail "a different Codex thread replaced the live lock identity"
-  assert_contains "$out" "different or malformed Codex thread identity" \
-    "a different Codex thread did not fail closed with an ownership diagnostic"
+  expect_code 0 "$status" "same-pid Codex thread change"
+  [ "$(cat "$home/state/.lock")" = "$codex_pid" ] \
+    || fail "a same-pid Codex thread change lost the numeric lock holder"
+  [ "$(cat "$home/state/.lock.codex-thread")" = "$codex_pid:$other_thread_id" ] \
+    || fail "a same-pid Codex thread change did not rebind the lock identity"
+  if codex_owned_by_self "$home/state" CODEX_THREAD_ID="$thread_id" \
+    FM_FAKE_CODEX_PID="$codex_pid" PATH="$fakebin:$BASE_PATH"; then
+    fail "the replaced Codex thread still verified ownership after rebinding"
+  fi
+  status=0
+  out=$(CODEX_THREAD_ID="$thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  expect_code 0 "$status" "Codex thread rebind back"
   [ "$(cat "$home/state/.lock.codex-thread")" = "$codex_pid:$thread_id" ] \
-    || fail "a refused Codex thread changed the live lock identity"
+    || fail "Codex reacquisition did not rebind the lock identity back to its thread"
 
-  CODEX_THREAD_ID="$thread_id" FM_FAKE_CODEX_PID="$codex_pid" FM_FAKE_CODEX_ISOLATED=1 \
-    PATH="$fakebin:$BASE_PATH" HOME_STATE="$home/state" ROOT_UNDER_TEST="$ROOT" \
-    bash -c '. "$ROOT_UNDER_TEST/bin/fm-session-lock-lib.sh"; fm_session_lock_owned_by_self "$HOME_STATE"' \
+  codex_owned_by_self "$home/state" CODEX_THREAD_ID="$thread_id" \
+    FM_FAKE_CODEX_PID="$codex_pid" FM_FAKE_CODEX_ISOLATED=1 PATH="$fakebin:$BASE_PATH" \
     || fail "Codex thread identity did not verify ownership after ancestry became unavailable"
-  if CODEX_THREAD_ID="$other_thread_id" FM_FAKE_CODEX_PID="$codex_pid" FM_FAKE_CODEX_ISOLATED=1 \
-    PATH="$fakebin:$BASE_PATH" HOME_STATE="$home/state" ROOT_UNDER_TEST="$ROOT" \
-    bash -c '. "$ROOT_UNDER_TEST/bin/fm-session-lock-lib.sh"; fm_session_lock_owned_by_self "$HOME_STATE"'; then
+  if codex_owned_by_self "$home/state" CODEX_THREAD_ID="$other_thread_id" \
+    FM_FAKE_CODEX_PID="$codex_pid" FM_FAKE_CODEX_ISOLATED=1 PATH="$fakebin:$BASE_PATH"; then
     fail "a different Codex thread verified ownership of the live lock"
   fi
+
+  # A different harness nested inside the Codex session inherits CODEX_THREAD_ID,
+  # so the sidecar alone must never grant it ownership: its own resolvable
+  # ancestry is not the lock holder, and acquisition refuses it too.
+  if codex_owned_by_self "$home/state" CODEX_THREAD_ID="$thread_id" \
+    FM_FAKE_CODEX_PID="$codex_pid" FM_FAKE_NESTED_HARNESS_PID="$nested_pid" \
+    PATH="$fakebin:$BASE_PATH"; then
+    fail "a nested foreign harness verified ownership from an inherited Codex thread id"
+  fi
+  status=0
+  out=$(CODEX_THREAD_ID="$thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+    FM_FAKE_NESTED_HARNESS_PID="$nested_pid" PATH="$fakebin:$BASE_PATH" \
+    "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "a nested foreign harness acquired the live Codex lock"
+  assert_contains "$out" "another live firstmate session holds the lock (pid $codex_pid)" \
+    "a nested foreign harness did not fail closed with the live-owner diagnostic"
+  [ "$(cat "$home/state/.lock.codex-thread")" = "$codex_pid:$thread_id" ] \
+    || fail "a refused nested harness changed the live lock identity"
 
   kill "$codex_pid" 2>/dev/null || true
   wait "$codex_pid" 2>/dev/null || true
   out=$(FM_HOME="$home" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
   assert_contains "$out" "lock: stale" \
     "dead Codex holder was not classified as a releasable stale lock"
-  pass "Codex lock: thread identity survives isolated command ancestry and stale holders remain releasable"
+  pass "Codex lock: thread identity survives isolated command ancestry, rebinds for the holder, and refuses nested harnesses"
 }
 
 # --- output ordering ----------------------------------------------------------

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -751,10 +751,89 @@ SH
   pass "concurrent session-lock acquisition admits exactly one live harness"
 }
 
+test_codex_session_lock_uses_thread_identity() {
+  local rec root home fakebin codex_pid out status=0 lock_pid
+  local thread_id=019fb044-acd6-7c20-97a2-f3e227def5d2
+  local other_thread_id=019fb041-9ca2-76c1-a272-358bd63dfe7a
+  rec=$(new_world codex-thread-lock)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  sleep 300 &
+  codex_pid=$!
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+pid=
+field=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -p) pid=$2; shift 2 ;;
+    -o) field=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  "$FM_FAKE_CODEX_PID:comm=") printf '%s\n' codex ;;
+  "$FM_FAKE_CODEX_PID:args=") printf '%s\n' codex ;;
+  *:ppid=)
+    if [ "${FM_FAKE_CODEX_ISOLATED:-0}" = 1 ]; then
+      printf '%s\n' 1
+    else
+      printf '%s\n' "$FM_FAKE_CODEX_PID"
+    fi
+    ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  printf '%s\n' 9999999 > "$home/state/.lock"
+  printf '%s\n' "9999999:$other_thread_id" > "$home/state/.lock.codex-thread"
+  out=$(CODEX_THREAD_ID="$thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  expect_code 0 "$status" "Codex stale-lock recovery"
+  lock_pid=$(cat "$home/state/.lock")
+  [ "$lock_pid" = "$codex_pid" ] \
+    || fail "Codex stale-lock recovery recorded '$lock_pid', expected '$codex_pid'"
+  [ "$(cat "$home/state/.lock.codex-thread")" = "$codex_pid:$thread_id" ] \
+    || fail "Codex acquisition did not bind the lock pid to its thread id"
+  assert_contains "$out" "lock acquired: harness pid $codex_pid" \
+    "Codex acquisition did not report its live harness pid"
+
+  status=0
+  out=$(CODEX_THREAD_ID="$other_thread_id" FM_HOME="$home" FM_FAKE_CODEX_PID="$codex_pid" \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "a different Codex thread replaced the live lock identity"
+  assert_contains "$out" "different or malformed Codex thread identity" \
+    "a different Codex thread did not fail closed with an ownership diagnostic"
+  [ "$(cat "$home/state/.lock.codex-thread")" = "$codex_pid:$thread_id" ] \
+    || fail "a refused Codex thread changed the live lock identity"
+
+  CODEX_THREAD_ID="$thread_id" FM_FAKE_CODEX_PID="$codex_pid" FM_FAKE_CODEX_ISOLATED=1 \
+    PATH="$fakebin:$BASE_PATH" HOME_STATE="$home/state" ROOT_UNDER_TEST="$ROOT" \
+    bash -c '. "$ROOT_UNDER_TEST/bin/fm-session-lock-lib.sh"; fm_session_lock_owned_by_self "$HOME_STATE"' \
+    || fail "Codex thread identity did not verify ownership after ancestry became unavailable"
+  if CODEX_THREAD_ID="$other_thread_id" FM_FAKE_CODEX_PID="$codex_pid" FM_FAKE_CODEX_ISOLATED=1 \
+    PATH="$fakebin:$BASE_PATH" HOME_STATE="$home/state" ROOT_UNDER_TEST="$ROOT" \
+    bash -c '. "$ROOT_UNDER_TEST/bin/fm-session-lock-lib.sh"; fm_session_lock_owned_by_self "$HOME_STATE"'; then
+    fail "a different Codex thread verified ownership of the live lock"
+  fi
+
+  kill "$codex_pid" 2>/dev/null || true
+  wait "$codex_pid" 2>/dev/null || true
+  out=$(FM_HOME="$home" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: stale" \
+    "dead Codex holder was not classified as a releasable stale lock"
+  pass "Codex lock: thread identity survives isolated command ancestry and stale holders remain releasable"
+}
+
 # --- output ordering ----------------------------------------------------------
 
 test_output_ordering_diagnostics_lead() {
-  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line
+  local rec root home fakebin out mask lock_line boot_line wake_line context_line fleet_line next_line
   rec=$(new_world ordering)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -763,10 +842,19 @@ EOF
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
   rm -f "$fakebin/node"
+  mask="$home/mask-system-node.bash"
+  cat > "$mask" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = node ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+SH
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
   lock_line=$(printf '%s\n' "$out" | grep -n '^LOCK$' | head -1 | cut -d: -f1)
   boot_line=$(printf '%s\n' "$out" | grep -n '^BOOTSTRAP$' | head -1 | cut -d: -f1)
@@ -1037,7 +1125,7 @@ EOF
 # --- composition: real scripts run, not reimplemented ------------------------
 
 test_composition_invokes_real_scripts() {
-  local rec root home fakebin out
+  local rec root home fakebin out mask
   rec=$(new_world composition)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -1045,11 +1133,20 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   rm -f "$fakebin/node"
+  mask="$home/mask-system-node.bash"
+  cat > "$mask" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = node ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+SH
 
   printf 'needs-decision: pick a library\n' > "$home/state/task-z.status"
   append_wake "$home/state" signal task-z.status "needs-decision: pick a library"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
@@ -1389,6 +1486,7 @@ test_context_digest_absent_empty_present
 test_lock_refusal_read_only_path
 test_lock_write_failure_read_only_path
 test_session_lock_concurrent_single_winner
+test_codex_session_lock_uses_thread_identity
 test_output_ordering_diagnostics_lead
 test_herdr_backend_diagnostics_follow_real_session_start
 test_session_start_relaunches_missing_pi_secondmate

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -102,11 +102,85 @@ test_missing_state_is_silent() {
 }
 
 test_owned_lock_is_silent() {
-  local root="$TMP_ROOT/already-ran"
+  local root="$TMP_ROOT/already-ran" fakebin
   make_primary "$root"
   printf '%s\n' "$$" > "$root/state/.lock"
-  expect_silent_zero "owned lock nudge" run_nudge "$root"
+  fakebin=$(fm_fakebin "$root/fake")
+  cat > "$fakebin/ps" <<SH
+#!/usr/bin/env bash
+set -u
+pid=
+field=
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    -p) pid=\$2; shift 2 ;;
+    -o) field=\$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "\$pid:\$field" in
+  "$$:comm=") printf '%s\n' claude ;;
+  "$$:args=") printf '%s\n' claude ;;
+  *:ppid=) printf '%s\n' "$$" ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  expect_silent_zero "owned lock nudge" env PATH="$fakebin:/usr/bin:/bin" \
+    FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" "$NUDGE"
   pass "fm-sessionstart-nudge: a lock holder in process ancestry is already run"
+}
+
+test_codex_thread_identity_is_silent_without_lock_ancestry() {
+  local root="$TMP_ROOT/codex-thread-owned" fakebin holder out status=0
+  local thread_id=019fb044-acd6-7c20-97a2-f3e227def5d2
+  local other_thread_id=019fb041-9ca2-76c1-a272-358bd63dfe7a
+  make_primary "$root"
+  fakebin=$(fm_fakebin "$root/fake")
+  sleep 300 &
+  holder=$!
+  printf '%s\n' "$holder" > "$root/state/.lock"
+  printf '%s:%s\n' "$holder" "$thread_id" > "$root/state/.lock.codex-thread"
+  cat > "$fakebin/ps" <<SH
+#!/usr/bin/env bash
+set -u
+pid=
+field=
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    -p) pid=\$2; shift 2 ;;
+    -o) field=\$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "\$pid:\$field" in
+  "$holder:comm=") printf '%s\n' codex ;;
+  "$holder:args=") printf '%s\n' codex ;;
+  *:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(CODEX_THREAD_ID="$thread_id" PATH="$fakebin:/usr/bin:/bin" \
+    FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" "$NUDGE" 2>&1) \
+    || status=$?
+  expect_code 0 "$status" "Codex thread-owned nudge"
+  [ -z "$out" ] || fail "matching Codex thread identity must stay silent without lock ancestry: $out"
+
+  out=$(CODEX_THREAD_ID="$other_thread_id" PATH="$fakebin:/usr/bin:/bin" \
+    FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" "$NUDGE" 2>&1) \
+    || status=$?
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  expect_code 0 "$status" "mismatched Codex thread nudge"
+  [ "$out" = "$NUDGE_LINE" ] \
+    || fail "mismatched Codex thread identity did not fail closed to a nudge: $out"
+  pass "fm-sessionstart-nudge: Codex thread identity replaces ancestry without admitting another thread"
 }
 
 test_opencode_plugin_delivers_exact_nudge_once() {
@@ -155,4 +229,5 @@ test_unmarked_linked_worktree_is_silent
 test_linked_secondmate_primary_nudges
 test_missing_state_is_silent
 test_owned_lock_is_silent
+test_codex_thread_identity_is_silent_without_lock_ancestry
 test_opencode_plugin_delivers_exact_nudge_once

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -155,10 +155,20 @@ while [ "\$#" -gt 0 ]; do
     *) shift ;;
   esac
 done
+nested=\${FM_FAKE_NESTED_HARNESS_PID:-}
 case "\$pid:\$field" in
   "$holder:comm=") printf '%s\n' codex ;;
   "$holder:args=") printf '%s\n' codex ;;
-  *:ppid=) printf '%s\n' 1 ;;
+  "\$nested:comm=") printf '%s\n' claude ;;
+  "\$nested:args=") printf '%s\n' claude ;;
+  "\$nested:ppid=") printf '%s\n' 1 ;;
+  *:ppid=)
+    if [ -n "\$nested" ]; then
+      printf '%s\n' "\$nested"
+    else
+      printf '%s\n' 1
+    fi
+    ;;
   *:comm=) printf '%s\n' bash ;;
   *:args=) printf '%s\n' bash ;;
   *) exit 1 ;;
@@ -175,12 +185,21 @@ SH
   out=$(CODEX_THREAD_ID="$other_thread_id" PATH="$fakebin:/usr/bin:/bin" \
     FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" "$NUDGE" 2>&1) \
     || status=$?
-  kill "$holder" 2>/dev/null || true
-  wait "$holder" 2>/dev/null || true
   expect_code 0 "$status" "mismatched Codex thread nudge"
   [ "$out" = "$NUDGE_LINE" ] \
     || fail "mismatched Codex thread identity did not fail closed to a nudge: $out"
-  pass "fm-sessionstart-nudge: Codex thread identity replaces ancestry without admitting another thread"
+
+  status=0
+  out=$(CODEX_THREAD_ID="$thread_id" FM_FAKE_NESTED_HARNESS_PID="$((holder + 1))" \
+    PATH="$fakebin:/usr/bin:/bin" \
+    FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" "$NUDGE" 2>&1) \
+    || status=$?
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  expect_code 0 "$status" "nested foreign harness nudge"
+  [ "$out" = "$NUDGE_LINE" ] \
+    || fail "a nested foreign harness with an inherited Codex thread id was not nudged: $out"
+  pass "fm-sessionstart-nudge: Codex thread identity admits neither another thread nor a nested foreign harness"
 }
 
 test_opencode_plugin_delivers_exact_nudge_once() {


### PR DESCRIPTION
api_response:
  body: "## What Changed\n\n- `bin/fm-session-lock-lib.sh` now owns a Codex thread-identity sidecar (`state/.lock.codex-thread`, written as `<lock-pid>:<thread-id>`) alongside the numeric `state/.lock` pid: ownership requires the sidecar's pid to match the lock, the holder to still be a live `codex` process, the validated `CODEX_THREAD_ID` of the current command to match, and any harness ancestry that does resolve to still name that same lock pid — so a nested foreign harness cannot inherit ownership from the environment. Mismatched, malformed, or multi-line identities fail closed, and the numeric holder's own reacquisition rebinds the sidecar instead of leaving it read-only. Thread-id validation uses a whole-value `[[ =~ ]]` match, and the harness/Codex liveness probes were collapsed into one `fm_pid_alive_matching` helper.\n- `bin/fm-lock.sh` publishes the identity sidecar during acquisition (clearing it when no Codex thread id is present), verifies self-ownership after writing the lock, and `fm-lock.sh status` prints one `identity:` line describing sidecar presence, pid agreement, holder liveness, and thread match so a live-holder-but-unverifiable state is diagnosable without hand-reading state files.\n- `bin/fm-sessionstart-nudge.sh` drops its own eight-hop ancestry loop and delegates to `fm_session_lock_owned_by_self`, making the shared lib the single ownership owner for the nudge, `fm-lock.sh`, and the Claude Stop auto-arm; regression coverage was extended in `tests/fm-session-start.test.sh`, `tests/fm-sessionstart-nudge.test.sh`, and the opt-in `tests/fm-codex-continuity-live-e2e.test.sh`, with the codex-cli 0.146.0 process-shape and thread-id evidence recorded in `docs/verification/supervision.md` and the harness-adapters skill.\n\n## Risk Assessment\n\n⚠️ Medium: The three requested fixes landed correctly with focused tests and no behavior regressions I can find, but the branch as a whole still reshapes the shared session-lock ownership primitive that gates three hooks across all five harnesses — the session-start nudge predicate is now strictly stricter with only fake-`ps` coverage for non-Codex ancestry shapes — so it is safe to merge with the remaining informational items as follow-ups.\n\n## Testing\n\nNo baseline test commands preceded this phase, so I ran the targeted set myself: the session-start suite carrying the three new Codex lock tests, the session-start-nudge suite, and the Claude Stop auto-arm suite as the other consumer of the changed ownership predicate — all pass. Because unit tests use a fake `ps` ancestry, I also proved the intent on the real codex-cli 0.146.0 installed on this machine: the opt-in live E2E passes both standalone and re-run from inside a Codex session (so outer vs nested thread ids were real), and a purpose-written probe executed inside an actual Codex command child produced a CLI transcript showing the sidecar bound to a thread id identical to that session's printed session id, a second thread of the same live Codex pid held read-only, `fm-lock.sh status` naming each failure mode, stale-holder rebinding on reacquisition, a live `claude`-named holder and a nested foreign harness both refused, a multi-line `CODEX_THREAD_ID` refusing to become lock authority, and the session-start nudge silent for the owning thread but printing its single marked line for a new thread and a nested harness. This change is shell/CLI only with no rendered surface, so the reviewer-visible evidence is the Codex session transcript and probe output rather than screenshots. The worktree is clean and all scratch homes and helper processes created during testing were removed.\n\n<details>\n<summary>Evidence: Real codex-cli 0.146.0 lock-identity probe output (run inside an actual Codex command child)</summary>\n\n<code>=== 1. real Codex 0.146.0 command-child process shape ===&#10;codex --version : codex-cli 0.146.0&#10;probe pid / codex command child : 3521918 / 3521917&#10;command child pid/pgid/sid : 3521917 / 3521917 / 3521917&#10;own "
  truncated: true
  original_length: 34467

## OpenCode topology-sensitive test context

`tests/fm-pi-watch-extension.test.sh` had one OpenCode ownership assertion fail only in the disposable linked worktree used for this task. The identical unchanged plugin and test content passed from a plain clean clone at the same HEAD. This is merge-authority context; the result appears topology-sensitive rather than a regression introduced by this change.