### PR TITLE
test: reap leaked background processes on every suite ending

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -98,6 +98,7 @@ Run `bin/fm-doc-audience-check.sh`; it enforces classification, README setup rou
 - Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, and pinned shellcheck version) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
 - Tests must exercise behavior through an executable or public interface and must never assert implementation-source bytes, including through parsers, regexes, snapshots, or indirect wrappers.
+- Hand every background process a test launches to `fm_test_reap` as soon as its pid is known, because a case that only kills on its happy path orphans that process on every failing or signalled path.
 - A maintainer-verification record under `docs/verification/` records active empirical facts, not assumptions or task chronology.
 - Include the date, version, exact commands run, and exact output needed to support the current guarantee.
 - Keep incident chronology and delivery evidence in private task reports or PR evidence unless a concise rationale is required to maintain a current safety boundary.

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -33,8 +33,10 @@ test_singleton_start() {
   mark_pr_check_migration_complete "$state"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out1" &
   pid1=$!
+  fm_test_reap "$pid1"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out2" &
   pid2=$!
+  fm_test_reap "$pid2"
   i=0
   while [ "$i" -lt 50 ]; do
     live=0
@@ -71,6 +73,7 @@ test_stale_watch_lock_reclaimed() {
   printf '%s\n' "$dead_pid" > "$state/.watch.lock/pid"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
+  fm_test_reap "$pid"
   i=0
   live=0
   lock_pid=
@@ -189,6 +192,7 @@ test_lock_single_winner_under_concurrency() {
       fi
     ' _ "$LIB" "$lockdir" "$marker" &
     pids="$pids $!"
+    fm_test_reap "$!"
     i=$((i + 1))
   done
   for pid in $pids; do
@@ -239,6 +243,7 @@ test_lock_stale_steal_single_winner_under_concurrency() {
       fi
     ' _ "$LIB" "$lockdir" "$marker" &
     pids="$pids $!"
+    fm_test_reap "$!"
     i=$((i + 1))
   done
   for pid in $pids; do
@@ -266,6 +271,7 @@ test_lock_live_steal_mutex_is_not_reclaimed() {
     fm_lock_release "$2.steal"
   ' _ "$LIB" "$lockdir" "$holder_file" &
   holder=$!
+  fm_test_reap "$holder"
   i=0
   while [ "$i" -lt 50 ] && [ ! -s "$holder_file" ]; do
     sleep 0.1
@@ -296,6 +302,7 @@ test_lock_does_not_steal_live_lock() {
   lockdir="$state/.contend.lock"
   sleep 300 &
   live=$!
+  fm_test_reap "$live"
   mkdir "$lockdir"
   printf '%s\n' "$live" > "$lockdir/pid"
   out=$(FM_STATE_OVERRIDE="$state" bash -c '
@@ -408,6 +415,7 @@ test_watch_restart_rejects_reused_pid() {
   mark_pr_check_migration_complete "$state"
   sleep 300 &
   live=$!
+  fm_test_reap "$live"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$live" > "$state/.watch.lock/pid"
   printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
@@ -415,6 +423,7 @@ test_watch_restart_rejects_reused_pid() {
   printf '%s\n' "stale watcher identity" > "$state/.watch.lock/pid-identity"
   PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" --restart > "$out" &
   pid=$!
+  fm_test_reap "$pid"
   # The honest arm forks the fresh watcher as a tracked child and waits on it, so
   # the lock now names that child, not the arm invocation. The property is the
   # same: the stale reused-pid lock is replaced by a genuinely live watcher, which
@@ -446,6 +455,7 @@ test_watch_restart_attaches_to_healthy_peer() {
   mark_pr_check_migration_complete "$state"
   node -e 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 300000)' &
   peer=$!
+  fm_test_reap "$peer"
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"
@@ -455,6 +465,7 @@ test_watch_restart_attaches_to_healthy_peer() {
   touch "$state/.last-watcher-beat"
   PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_ATTACH_POLL=0.1 FM_ARM_CONFIRM_TIMEOUT=1 "$WATCH_ARM" --restart > "$out" &
   armpid=$!
+  fm_test_reap "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF "watcher: attached pid=$peer" "$out" 2>/dev/null && break
@@ -473,6 +484,92 @@ test_watch_restart_attaches_to_healthy_peer() {
   pass "watch restart attaches to a verified healthy peer and later surfaces a successor gap"
 }
 
+# Wait for <pid> to disappear, then fail with <label> if it is still there.
+assert_reaped() {  # <pid> <label>
+  local pid=$1 label=$2 i=0
+  while [ "$i" -lt 60 ]; do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.1
+    i=$((i + 1))
+  done
+  fail "$label (pid $pid) survived the harness teardown"
+}
+
+# Every case above launches real watchers and arms in the background, and any of
+# them can abort on a failed assertion or be killed while wedged. The harness
+# reaper must hold on all three endings, including the child a registered
+# process forked: an orphaned bin/fm-watch-arm.sh relaunches a successor watcher
+# whenever its child cycle ends, so a half-reaped tree does not stay dead. Such
+# an orphan keeps polling a deleted temp home forever, inflates the shell count
+# of whatever checkout ran the suite, and pollutes later liveness reads.
+test_harness_reaps_registered_process_tree_on_every_ending() {
+  local dir script mode kidfile parentfile parent kid fixture status i
+  dir=$(make_case harness-reaper)
+  script="$dir/registered.sh"
+  cat > "$script" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$FM_REAPER_LIB"
+# Fork a parent that owns its own long-lived child, the shape fm-watch-arm.sh
+# has when it supervises the watcher it started.
+bash -c 'sleep 300 & printf "%s\n" "$!" > "$1"; wait' _ "$FM_REAPER_KID_FILE" &
+parent=$!
+fm_test_reap "$parent"
+printf '%s\n' "$parent" > "$FM_REAPER_PARENT_FILE"
+i=0
+while [ "$i" -lt 80 ] && [ ! -s "$FM_REAPER_KID_FILE" ]; do
+  sleep 0.1
+  i=$((i + 1))
+done
+[ -s "$FM_REAPER_KID_FILE" ] || { printf 'fixture child never started\n' >&2; exit 3; }
+case "$FM_REAPER_MODE" in
+  abort) fail "deliberate abort with a registered process still live" ;;
+  hang) sleep 300 ;;
+esac
+SH
+  chmod +x "$script"
+  for mode in clean abort hang; do
+    kidfile="$dir/$mode.kid"
+    parentfile="$dir/$mode.parent"
+    : > "$kidfile"
+    : > "$parentfile"
+    if [ "$mode" = hang ]; then
+      FM_REAPER_LIB="$ROOT/tests/lib.sh" FM_REAPER_MODE="$mode" \
+        FM_REAPER_KID_FILE="$kidfile" FM_REAPER_PARENT_FILE="$parentfile" \
+        "$script" >/dev/null 2>&1 &
+      fixture=$!
+      fm_test_reap "$fixture"
+      i=0
+      while [ "$i" -lt 80 ] && { [ ! -s "$kidfile" ] || [ ! -s "$parentfile" ]; }; do
+        sleep 0.1
+        i=$((i + 1))
+      done
+      [ -s "$kidfile" ] && [ -s "$parentfile" ] || fail "hang fixture never published its pids"
+      # Exactly how timeout(1) stops a wedged suite: a bare EXIT trap would not run.
+      kill -TERM "$fixture" 2>/dev/null || true
+      wait_for_exit "$fixture" 80
+      status=$?
+      [ "$status" -eq 143 ] || fail "a signalled suite must exit 128+TERM after tearing down, got $status"
+    else
+      FM_REAPER_LIB="$ROOT/tests/lib.sh" FM_REAPER_MODE="$mode" \
+        FM_REAPER_KID_FILE="$kidfile" FM_REAPER_PARENT_FILE="$parentfile" \
+        "$script" >/dev/null 2>&1
+      status=$?
+      case "$mode" in
+        clean) [ "$status" -eq 0 ] || fail "clean fixture exited $status" ;;
+        abort) [ "$status" -eq 1 ] || fail "aborting fixture exited $status, expected fail()'s 1" ;;
+      esac
+    fi
+    parent=$(cat "$parentfile")
+    kid=$(cat "$kidfile")
+    [ -n "$parent" ] && [ -n "$kid" ] || fail "$mode fixture published no pids"
+    assert_reaped "$parent" "$mode: registered process"
+    assert_reaped "$kid" "$mode: child of the registered process"
+  done
+  pass "harness reaps a registered process and its child on a pass, an abort, and a signal"
+}
+
 test_watcher_self_evicts_on_lock_takeover() {
   local dir state fakebin out pid i lock_pid
   dir=$(make_case self-evict)
@@ -481,6 +578,7 @@ test_watcher_self_evicts_on_lock_takeover() {
   out="$dir/watch.out"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
+  fm_test_reap "$pid"
   i=0
   while [ "$i" -lt 80 ]; do
     [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] \
@@ -512,6 +610,7 @@ test_arm_self_eviction_is_loud_without_successor() {
   mark_pr_check_migration_complete "$state"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=1 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_reap "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
@@ -543,6 +642,7 @@ test_arm_attaches_and_waits_for_live_fresh_watcher() {
   # A genuinely live watcher with a fresh beacon already holds the singleton.
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   wpid=$!
+  fm_test_reap "$wpid"
   i=0
   while [ "$i" -lt 60 ]; do
     [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] && [ -e "$state/.last-watcher-beat" ] && break
@@ -554,6 +654,7 @@ test_arm_attaches_and_waits_for_live_fresh_watcher() {
   # exit while the seed still holds the healthy lock.
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_ARM_ATTACH_POLL=0.1 FM_ARM_CONFIRM_TIMEOUT=1 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_reap "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF "watcher: attached pid=$wpid" "$armout" 2>/dev/null && break
@@ -584,6 +685,7 @@ test_attached_arm_signal_is_recorded_in_cycle_ledger() {
   armout="$dir/arm.out"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   wpid=$!
+  fm_test_reap "$wpid"
   i=0
   while [ "$i" -lt 60 ]; do
     [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] && [ -e "$state/.last-watcher-beat" ] && break
@@ -593,6 +695,7 @@ test_attached_arm_signal_is_recorded_in_cycle_ledger() {
   [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] || fail "seed watcher did not take the lock"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_ARM_ATTACH_POLL=0.1 FM_ARM_CONFIRM_TIMEOUT=1 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_reap "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF "watcher: attached pid=$wpid" "$armout" 2>/dev/null && break
@@ -636,6 +739,7 @@ test_arm_starts_and_self_heals() {
     fi
     PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
     armpid=$!
+    fm_test_reap "$armpid"
     i=0
     while [ "$i" -lt 80 ]; do
       grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
@@ -664,6 +768,7 @@ test_arm_hup_cleans_child_and_temp_output() {
   armout="$dir/arm.out"
   PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_reap "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
@@ -723,6 +828,7 @@ test_arm_waits_for_peer_beacon_after_child_stands_down() {
   mark_pr_check_migration_complete "$state"
   sleep 300 &
   peer=$!
+  fm_test_reap "$peer"
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"
@@ -731,6 +837,7 @@ test_arm_waits_for_peer_beacon_after_child_stands_down() {
   printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
   PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=1 FM_ARM_ATTACH_POLL=0.1 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_reap "$armpid"
   # Synchronize on the owned child declining the live peer lock before making
   # the peer healthy. Sleeping for the same one-second budget as the arm made
   # this regression fixture race the confirmation deadline under full-suite
@@ -772,6 +879,7 @@ test_arm_fails_loud_when_no_fresh_watcher_confirmable() {
   mark_pr_check_migration_complete "$state"
   sleep 300 &
   live=$!
+  fm_test_reap "$live"
   # A live process holds the lock but is NOT a confirmable watcher (no identity),
   # and the beacon is stale. The fresh child cannot steal a LIVE lock, so no
   # watcher can ever be confirmed - the honest answer is FAILED, not healthy.
@@ -780,6 +888,7 @@ test_arm_fails_loud_when_no_fresh_watcher_confirmable() {
   touch -t 200001010000 "$state/.last-watcher-beat"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=3 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_reap "$armpid"
   wait_for_exit "$armpid" 120
   status=$?
   [ "$status" -ne 124 ] || fail "arm never returned for an unconfirmable watcher"
@@ -811,6 +920,7 @@ SH
 
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=0 FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
   first_arm=$!
+  fm_test_reap "$first_arm"
   wait "$first_arm" || fail "first ledger cycle did not surface its actionable wake"
   grep -q "arm_pid=$first_arm.*reason=actionable-check.*successor=none" "$state/.watch-cycle-exits.log" \
     || fail "first ledger record omitted its actionable classification"
@@ -819,6 +929,7 @@ SH
   armout="$dir/successor-arm.out"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_WATCH_PREDECESSOR_ARM_PID="$first_arm" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
   successor_arm=$!
+  fm_test_reap "$successor_arm"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
@@ -839,6 +950,7 @@ SH
     armout="$dir/bounded-$iteration.out"
     PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_WATCH_CYCLE_LOG_MAX_BYTES=1400 FM_WATCH_CYCLE_LOG_KEEP_LINES=2 FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
     successor_arm=$!
+    fm_test_reap "$successor_arm"
     i=0
     while [ "$i" -lt 80 ]; do
       grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
@@ -866,6 +978,7 @@ test_stopped_watcher_is_live_but_stale_then_exit_is_classified() {
   mark_pr_check_migration_complete "$state"
   PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  fm_test_reap "$armpid"
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
@@ -905,6 +1018,7 @@ test_pid_identity_is_locale_invariant() {
   local real_first real_second observed
   sleep 300 &
   live=$!
+  fm_test_reap "$live"
   no_proc="$TMP_ROOT/no-proc"
   fakebin="$TMP_ROOT/locale-ps"
   locale_log="$TMP_ROOT/locale-ps.observed"
@@ -1001,6 +1115,7 @@ test_msys_pid_identity_uses_proc() {
   esac
   sleep 300 &
   live=$!
+  fm_test_reap "$live"
   identity=$(bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$live" 2>/dev/null)
   kill "$live" 2>/dev/null || true
   wait "$live" 2>/dev/null || true
@@ -1011,6 +1126,9 @@ test_msys_pid_identity_uses_proc() {
   pass "MSYS process identity uses compatible /proc fields"
 }
 
+# First: every case below leaves real watchers and arms in the background and
+# relies on the harness reaping them, so prove the reaper before leaning on it.
+test_harness_reaps_registered_process_tree_on_every_ending
 test_singleton_start
 test_pid_identity_is_locale_invariant
 test_proc_pid_identity_ignores_wall_clock_and_detects_pid_reuse

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -525,7 +525,7 @@ done
 [ -s "$FM_REAPER_KID_FILE" ] || { printf 'fixture child never started\n' >&2; exit 3; }
 case "$FM_REAPER_MODE" in
   abort) fail "deliberate abort with a registered process still live" ;;
-  hang) sleep 300 ;;
+  hang) sleep 300 & fm_test_reap "$!"; wait ;;
 esac
 SH
   chmod +x "$script"

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # tests/fm-watcher-lock.test.sh - watcher singleton + lock-primitive races +
-# PID identity stability + watch-arm liveness + guard warnings. These are
-# safety-critical process invariants (a race bug may not reproduce through an
-# e2e), so they stay as focused real-process units.
+# PID identity stability + watch-arm liveness + guard warnings, plus the
+# harness-reaper regression that proves backgrounded processes are torn down on
+# every suite ending. These are safety-critical process invariants (a race bug
+# may not reproduce through an e2e), so they stay as focused real-process units.
 set -u
 
 # shellcheck source=tests/wake-helpers.sh

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -6,9 +6,10 @@
 #   . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 #
 # It provides the boilerplate every test file used to re-roll: ok/not-ok
-# reporters, a self-cleaning temp root, fakebin/PATH-shim helpers, deterministic
-# git identity and fixture builders, state/<id>.meta writers, and the common
-# string/exit-code/file assertions. It deliberately does NOT bundle the
+# reporters, a self-cleaning temp root, a reaper for background processes,
+# fakebin/PATH-shim helpers, deterministic git identity and fixture builders,
+# state/<id>.meta writers, and the common string/exit-code/file assertions.
+# It deliberately does NOT bundle the
 # behavior-specific fake tmux/treehouse/no-mistakes mocks: those encode terminal
 # and lifecycle assumptions that differ per suite and belong with the tests that
 # own them.
@@ -50,28 +51,113 @@ pass() {
   printf 'ok - %s\n' "$1"
 }
 
-# --- self-cleaning temp root ------------------------------------------------
+# --- self-cleaning temp root and background-process reaper -------------------
 #
-# fm_test_tmproot <prefix> echoes a fresh temp dir and registers it for removal
-# on EXIT. The first call installs the cleanup trap. A test file that needs
-# extra teardown (e.g. killing a daemon) should define its own EXIT trap and
-# call fm_test_cleanup from inside it so registered dirs are still removed.
+# fm_test_tmproot <prefix> echoes a fresh temp dir and registers it for removal.
+# fm_test_reap <pid>... registers a background process for teardown.
+# Both are torn down by fm_test_cleanup, which the first registration installs on
+# EXIT and on the signals that stop a wedged suite. A test file that needs extra
+# teardown (e.g. killing a daemon) should define its own EXIT trap and call
+# fm_test_cleanup from inside it so registered dirs and processes are still torn
+# down.
 
 FM_TEST_CLEANUP_DIRS=()
+FM_TEST_CLEANUP_PIDS=()
+
+# Install fm_test_cleanup for every way a suite can end, once per shell.
+# A bare EXIT trap does not run for a signalled shell, and timeout(1) stops a
+# hung suite with TERM, so EXIT alone would let a wedged case orphan its
+# background processes.
+fm_test_install_cleanup_trap() {
+  [ -z "${FM_TEST_CLEANUP_TRAP_INSTALLED:-}" ] || return 0
+  FM_TEST_CLEANUP_TRAP_INSTALLED=1
+  trap fm_test_cleanup EXIT
+  trap 'fm_test_cleanup_on_signal 1' HUP
+  trap 'fm_test_cleanup_on_signal 2' INT
+  trap 'fm_test_cleanup_on_signal 15' TERM
+}
+
+# Tear down, then exit with the conventional 128+signo so the runner still sees
+# the suite as signalled. Clearing the EXIT trap keeps teardown from running
+# twice; fm_test_cleanup is idempotent regardless.
+fm_test_cleanup_on_signal() {  # <signal-number>
+  fm_test_cleanup
+  trap - EXIT
+  exit "$((128 + $1))"
+}
+
+# fm_test_reap <pid> ...: register background processes for teardown on every
+# exit path - a clean pass, a fail() abort, or an abrupt signal. Register a pid
+# as soon as it is known, BEFORE the assertions that could abort: a case that
+# only kills on its happy path leaks on every other path.
+fm_test_reap() {
+  local pid
+  fm_test_install_cleanup_trap
+  for pid in "$@"; do
+    case "$pid" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    FM_TEST_CLEANUP_PIDS+=("$pid")
+  done
+}
+
+# Echo every given pid and its descendants, parents before children. A
+# registered process may have forked its own tracked child - bin/fm-watch-arm.sh
+# forks the watcher it supervises - and killing only the registered pid would
+# orphan that child. All roots share one process-table read so registering many
+# short-lived helpers stays cheap. Depth is bounded so a malformed process table
+# cannot loop forever.
+fm_test_process_tree() {  # <pid> ...
+  local rows generation next depth=0
+  [ "$#" -gt 0 ] || return 0
+  rows=$(ps -axo pid=,ppid= 2>/dev/null) || return 0
+  generation="$*"
+  while [ -n "$generation" ] && [ "$depth" -lt 8 ]; do
+    printf '%s\n' "$generation" | tr ' ' '\n' | grep -v '^$' || true
+    next=$(printf '%s\n' "$rows" | awk -v gen="$generation" '
+      BEGIN { n = split(gen, ids, " "); for (i = 1; i <= n; i += 1) parent[ids[i]] = 1 }
+      parent[$2] { printf "%s ", $1 }
+    ')
+    generation=${next% }
+    depth=$((depth + 1))
+  done
+}
+
+# Kill the given processes and every descendant they had at teardown time.
+# The snapshot is taken BEFORE the first kill because a dead parent's children
+# are reparented and can no longer be found by walking ppid. SIGKILL rather than
+# SIGTERM because the process this reaper exists for, bin/fm-watch-arm.sh,
+# deliberately launches a successor watcher when its child cycle ends: a
+# catchable signal would hand back a fresh process nothing ever recorded.
+fm_test_kill_tree() {  # <pid> ...
+  local p
+  while IFS= read -r p; do
+    case "$p" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    kill -KILL "$p" 2>/dev/null || true
+    wait "$p" 2>/dev/null || true
+  done <<<"$(fm_test_process_tree "$@")"
+}
 
 fm_test_cleanup() {
   local d
+  # Processes first: a live child must not keep writing into a directory that is
+  # about to be removed.
+  if [ "${#FM_TEST_CLEANUP_PIDS[@]}" -gt 0 ]; then
+    fm_test_kill_tree "${FM_TEST_CLEANUP_PIDS[@]}"
+  fi
+  FM_TEST_CLEANUP_PIDS=()
   for d in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
     [ -n "$d" ] && rm -rf "$d"
   done
+  FM_TEST_CLEANUP_DIRS=()
 }
 
 fm_test_tmproot() {
   local prefix=${1:-fm-test} root
   root=$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX")
-  if [ "${#FM_TEST_CLEANUP_DIRS[@]}" -eq 0 ]; then
-    trap fm_test_cleanup EXIT
-  fi
+  fm_test_install_cleanup_trap
   FM_TEST_CLEANUP_DIRS+=("$root")
   printf '%s\n' "$root"
 }

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -63,6 +63,7 @@ pass() {
 
 FM_TEST_CLEANUP_DIRS=()
 FM_TEST_CLEANUP_PIDS=()
+FM_TEST_CLEANUP_PID_IDENTITIES=()
 
 # Install fm_test_cleanup for every way a suite can end, once per shell.
 # A bare EXIT trap does not run for a signalled shell, and timeout(1) stops a
@@ -86,18 +87,32 @@ fm_test_cleanup_on_signal() {  # <signal-number>
   exit "$((128 + $1))"
 }
 
+# Read a process identity through the production primitive. It runs in a
+# throwaway bash rather than being sourced here: bin/fm-wake-lib.sh defines
+# every fm_ function and mkdirs its state dir at source time, and injecting
+# that into every shell that sources this harness could change unrelated
+# suites. Failure prints nothing and returns nonzero.
+fm_test_pid_identity() {  # <pid>
+  FM_STATE_OVERRIDE="${TMPDIR:-/tmp}" bash -c '. "$1" && fm_pid_identity "$2"' _ "$ROOT/bin/fm-wake-lib.sh" "$1" 2>/dev/null
+}
+
 # fm_test_reap <pid> ...: register background processes for teardown on every
 # exit path - a clean pass, a fail() abort, or an abrupt signal. Register a pid
 # as soon as it is known, BEFORE the assertions that could abort: a case that
-# only kills on its happy path leaks on every other path.
+# only kills on its happy path leaks on every other path. Each pid's identity
+# is recorded alongside it: the registry lives for the whole suite, so by
+# teardown a short-lived helper's pid can have been recycled to an unrelated
+# process, and a root is only killed when its identity still matches.
 fm_test_reap() {
-  local pid
+  local pid identity
   fm_test_install_cleanup_trap
   for pid in "$@"; do
     case "$pid" in
       ''|*[!0-9]*) continue ;;
     esac
+    identity=$(fm_test_pid_identity "$pid") || identity=
     FM_TEST_CLEANUP_PIDS+=("$pid")
+    FM_TEST_CLEANUP_PID_IDENTITIES+=("$identity")
   done
 }
 
@@ -110,7 +125,14 @@ fm_test_reap() {
 fm_test_process_tree() {  # <pid> ...
   local rows generation next depth=0
   [ "$#" -gt 0 ] || return 0
-  rows=$(ps -axo pid=,ppid= 2>/dev/null) || return 0
+  # A ps that cannot render the pid/ppid table (MSYS/Cygwin, some busybox
+  # builds) must not turn the reaper into a no-op: the identity-verified roots
+  # are still known good, so emit them even when their descendants cannot be
+  # discovered.
+  if ! rows=$(ps -axo pid=,ppid= 2>/dev/null); then
+    printf '%s\n' "$@"
+    return 0
+  fi
   generation="$*"
   while [ -n "$generation" ] && [ "$depth" -lt 8 ]; do
     printf '%s\n' "$generation" | tr ' ' '\n' | grep -v '^$' || true
@@ -141,13 +163,26 @@ fm_test_kill_tree() {  # <pid> ...
 }
 
 fm_test_cleanup() {
-  local d
+  local d i pid verified=()
   # Processes first: a live child must not keep writing into a directory that is
-  # about to be removed.
+  # about to be removed. Never kill what cannot be proven ours: a registered
+  # root is killed only when its identity read now matches the one recorded at
+  # registration, so a recycled pid belonging to an unrelated process is
+  # skipped and never enumerated as a tree root. Descendants found under a
+  # verified root need no gate - they are that live process's current children.
   if [ "${#FM_TEST_CLEANUP_PIDS[@]}" -gt 0 ]; then
-    fm_test_kill_tree "${FM_TEST_CLEANUP_PIDS[@]}"
+    for i in "${!FM_TEST_CLEANUP_PIDS[@]}"; do
+      pid=${FM_TEST_CLEANUP_PIDS[$i]}
+      [ -n "${FM_TEST_CLEANUP_PID_IDENTITIES[$i]:-}" ] || continue
+      [ "$(fm_test_pid_identity "$pid")" = "${FM_TEST_CLEANUP_PID_IDENTITIES[$i]}" ] || continue
+      verified+=("$pid")
+    done
+    if [ "${#verified[@]}" -gt 0 ]; then
+      fm_test_kill_tree "${verified[@]}"
+    fi
   fi
   FM_TEST_CLEANUP_PIDS=()
+  FM_TEST_CLEANUP_PID_IDENTITIES=()
   for d in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
     [ -n "$d" ] && rm -rf "$d"
   done

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -35,9 +35,9 @@ fi
 # Create the recorder dir with mktemp directly (not fm_test_tmproot, whose
 # first call installs an EXIT trap that, invoked inside a command-substitution
 # subshell, would delete the dir on subshell exit). Register it for the same
-# cleanup and install the trap in THIS shell if it is the first registration.
+# cleanup and install the trap in THIS shell; tests/lib.sh owns the trap set.
 _fm_wedge_rec_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-wedge-rec.XXXXXX")
-if [ "${#FM_TEST_CLEANUP_DIRS[@]}" -eq 0 ]; then trap fm_test_cleanup EXIT; fi
+fm_test_install_cleanup_trap
 FM_TEST_CLEANUP_DIRS+=("$_fm_wedge_rec_dir")
 cat > "$_fm_wedge_rec_dir/rec" <<'REC'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Intent

Goal: stop crewmate worktrees of the firstmate repo from self-arming phantom watchers. Phantom fm-watch-arm.sh --restart plus fm-watch.sh pairs were observed live in several treehouse task worktrees; effects were an inflated shell count, polluted liveness reads, and a test suite that can hang.

Important context the diff does not show. The task as originally briefed asked me to make the Claude Stop auto-arm eligibility check refuse to arm inside a linked git worktree. That premise was investigated and DISPROVEN: bin/fm-primary-scope-lib.sh already refuses when git rev-parse --git-dir differs from --git-common-dir, with a .fm-secondmate-home marker as the secondmate exemption, and tests/fm-claude-stop-autoarm.test.sh already covers all three cases (primary arms, marked secondmate home arms, linked child worktree stays inert) and passes. So no change was made to the auto-arm or to the scope predicate, deliberately - that would have been a no-op.

The real cause was traced to a leaking test. Every live phantom carried test-harness env (FM_HOME=/tmp/fm-watcher-lock-tests.<rand>/restart-healthy-peer), and the only producer of that case is tests/fm-watcher-lock.test.sh test_watch_restart_attaches_to_healthy_peer. It backgrounds a real arm and only kills it on its happy path, so when an assertion aborts the suite via fail(), or when timeout(1) kills a hung case, the arm and its child watcher are orphaned and keep polling an already-deleted temp home. Reproduced directly.

The supervising firstmate ruled to fix exactly this leak and explicitly NOT to expand into fixing the attach failure.

Decisions made, all deliberate:
- tests/lib.sh gains the reaper because it already owns the temp-root cleanup registry, keeping one owner for teardown.
- SIGKILL rather than SIGTERM is required, not sloppy: bin/fm-watch-arm.sh deliberately launches a successor watcher when its child cycle ends, so a catchable signal to the parent hands back a fresh process that was never registered. This is exactly why the original phantom respawned after being killed once.
- The process tree is snapshotted BEFORE the first kill because a dead parent leaves its children reparented and unreachable by a ppid walk.
- Cleanup is trapped on HUP, INT and TERM as well as EXIT because a bare EXIT trap does not run for a signalled shell, which is precisely why the hang path leaked.
- All roots share one ps read so registering many short-lived helpers stays cheap.
- Every background launch in tests/fm-watcher-lock.test.sh registers its pid at launch, including the short-lived lock contenders, for uniformity.
- The new regression case runs FIRST in the suite so it still executes even when a later case aborts, and it covers all three endings: a clean pass, a fail() abort, and a TERM. It was verified to FAIL against a deliberately neutered reaper, so it is not a tautology.

Known and deliberate non-goals, please do not flag these as omissions:
- test_watch_restart_attaches_to_healthy_peer still fails on this machine. That failure is pre-existing on main, upstream CI is green, and it was classified as a load-sensitive flaky fixture rather than a runtime defect: the identical scenario reproduced standalone against the same bin/fm-watch-arm.sh passes and prints the intended watcher: attached line. Fixing it was explicitly ruled out of scope for this change.
- fm_test_tmproot has a separate pre-existing quirk where a call inside command substitution loses its registration to the parent, so temp dirs accumulate. That is disk-only, affects every test file, and was intentionally left alone and reported instead.
- Nothing was added to AGENTS.md on purpose, to respect its size discipline; the durable convention went to the firstmate-coding-guidelines skill and to the tests/lib.sh header, which are the classified owners.

## What Changed

- `tests/lib.sh` now owns a process reaper alongside its temp-root registry: background pids are registered at launch, the process tree is snapshotted before killing so reparented children stay reachable, kills use SIGKILL (a catchable signal lets `fm-watch-arm.sh` respawn a successor watcher), each kill is gated by pid start-time identity to survive pid reuse and `ps` failures, and cleanup is trapped on HUP/INT/TERM as well as EXIT so a signalled or `timeout(1)`-killed shell still tears down. This closes the leak in `tests/fm-watcher-lock.test.sh` where `test_watch_restart_attaches_to_healthy_peer` orphaned a real `fm-watch-arm.sh --restart` + `fm-watch.sh` pair whenever the suite aborted or hung — the source of the phantom watchers seen in crewmate worktrees.
- `tests/fm-watcher-lock.test.sh` registers every background launch (including short-lived lock contenders) and adds a regression case that runs first in the suite, covering all three suite endings (clean pass, `fail()` abort, and TERM); it was verified to fail against a deliberately neutered reaper. The auto-arm eligibility check itself was left untouched — `bin/fm-primary-scope-lib.sh` already refuses to arm in linked worktrees and its existing tests pass.
- The reaper convention is documented in the `firstmate-coding-guidelines` skill and the `tests/lib.sh` header, with `tests/wake-helpers.sh` adjusted to match.

## Risk Assessment

✅ Low: The follow-up commit is tests-only and implements all three requested fixes exactly as instructed (interruptible hang fixture, identity-gated root kills via the production fm_pid_identity primitive through a subshell, and a roots-emitting ps-failure fallback) while preserving every declared design constraint, with the only residual behaviors being rare, fail-open identity-read races that match the chosen safety direction.

## Testing

Ran the changed watcher-lock suite via bin/fm-test-run.sh (all cases pass, new reaper regression case first, including the author's reportedly flaky peer-attach case which passed here), then demonstrated the fix end-to-end with a base-vs-branch comparison: a TERM'd wedged suite on the base harness orphans the exact phantom fm-watch-arm.sh + fm-watch.sh pair with the live-incident FM_HOME signature, while the fixed harness reaps every process and exits 128+TERM; a neutered-reaper run confirmed the regression test genuinely fails without the fix. No orphaned processes or temp scaffolding remain. No visual artifacts because this is a test-harness/CLI change with no rendered UI surface — CLI transcripts are the evidence.

<details>
<summary>Evidence: Full watcher-lock suite run on the branch (exit 0, reaper regression case first)</summary>

```text
FM_TEST_BEGIN 2026-07-30T03:18:54Z tests/fm-watcher-lock.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - harness reaps a registered process and its child on a pass, an abort, and a signal
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity real ps fallback is locale-invariant
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - /proc process identity ignores simulated btime changes
ok - /proc process identity detects pid reuse
ok - MSYS /proc process identity regression skipped on non-Windows host
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when fresh
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart refuses to signal a reused pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts+confirms a fresh watcher on a clean lock and self-heals a dead-pid lock (never healthy off a dead pid)
ok - arm cleans child watcher and temp output on HUP
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 2493486 but heartbeat is stale for 838678793s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
FM_TEST_END 2026-07-30T03:20:38Z tests/fm-watcher-lock.test.sh exit=0 duration_ms=103299 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=103333
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=103299 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-watcher-lock.test.sh duration_ms=103299
```
</details>
<details>
<summary>Evidence: Base-commit harness: TERM&#39;d wedged suite orphans the phantom watcher pair</summary>

<code>== baseline: suite shell pid=2568598 backgrounded real arm pid=2568614, now wedged ==&#10;-- sending SIGTERM to the suite shell (what timeout(1) does to a hung suite) --&#10;suite shell exited with status 143&#10;-- processes still alive from this run (tagged) --&#10;2568614 34 bash /tmp/fm-baseline-harness.yqMgjn/bin/fm-watch-arm.sh&#10;2568626 2568614 bash /tmp/fm-baseline-harness.yqMgjn/bin/fm-watch.sh&#10;ORPHANS: 4 process(es) survived the suite&#10;-- FM_HOME carried by the orphaned arm (matches the live-incident signature) --&#10;FM_HOME=/tmp/fm-watcher-lock-tests.fAKcHr/restart-healthy-peer</code>

```text
== baseline: suite shell pid=2568598 backgrounded real arm pid=2568614, now wedged ==
-- sending SIGTERM to the suite shell (what timeout(1) does to a hung suite) --
suite shell exited with status 143
-- processes still alive from this run (tagged FM_LEAK_DEMO_MARKER=leakdemo-base-01KYRF4B) --
2568614      34 bash /tmp/fm-baseline-harness.yqMgjn/bin/fm-watch-arm.sh
2568626 2568614 bash /tmp/fm-baseline-harness.yqMgjn/bin/fm-watch.sh
2568741 2568626 sleep 5
2568780      34 sleep 300
ORPHANS: 4 process(es) survived the suite, still polling FM_HOME under /tmp/fm-watcher-lock-tests.*
-- FM_HOME carried by the orphaned arm (matches the live-incident signature) --
FM_HOME=/tmp/fm-watcher-lock-tests.fAKcHr/restart-healthy-peer
```
</details>
<details>
<summary>Evidence: Fixed harness: identical TERM&#39;d wedged suite is fully reaped</summary>

<code>== fixed: suite shell pid=2604013 backgrounded real arm pid=2604061, now wedged ==&#10;-- sending SIGTERM to the suite shell (what timeout(1) does to a hung suite) --&#10;suite shell exited with status 143&#10;-- processes still alive from this run (tagged) --&#10;(none - every process from the aborted suite was reaped)</code>

```text
== fixed: suite shell pid=2604013 backgrounded real arm pid=2604061, now wedged ==
-- sending SIGTERM to the suite shell (what timeout(1) does to a hung suite) --
suite shell exited with status 143
-- processes still alive from this run (tagged FM_LEAK_DEMO_MARKER=leakdemo-fixed2-01KYRF4B) --
(none - every process from the aborted suite was reaped)
```
</details>
<details>
<summary>Evidence: Neutered-reaper run proving the regression test is not a tautology (fails immediately)</summary>

`not ok - clean: registered process (pid 2628696) survived the harness teardown`

```text
not ok - clean: registered process (pid 2628696) survived the harness teardown
```
</details>
<details>
<summary>Evidence: Reproduction scripts for the before/after leak demo</summary>

```text
#!/usr/bin/env bash
# Faithful reduction of test_watch_restart_attaches_to_healthy_peer's leak path:
# background a REAL bin/fm-watch-arm.sh, then wedge until timeout(1)-style TERM.
set -u
. "$TESTS_DIR/wake-helpers.sh"
TMP_ROOT=$(fm_test_tmproot fm-watcher-lock-tests)
dir="$TMP_ROOT/restart-healthy-peer"
fakebin="$dir/fakebin"
mkdir -p "$dir/state" "$fakebin"
printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/tmux"; chmod +x "$fakebin/tmux"
state="$dir/state"
printf '%s\n' fm-pr-check-migration-scan-v1 > "$state/.pr-check-migration-scan-v1"
printf '%s\n' fm-pr-check-migration-v1 > "$state/.pr-check-migration-v1"
chmod 0600 "$state/.pr-check-migration-scan-v1" "$state/.pr-check-migration-v1"
PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
  "$ROOT/bin/fm-watch-arm.sh" > "$dir/arm.out" 2>&1 &
armpid=$!
# The fixed harness registers the pid at launch; the base harness has no reaper.
if type fm_test_reap >/dev/null 2>&1; then fm_test_reap "$armpid"; fi
i=0
while [ "$i" -lt 100 ]; do
  grep -qE 'watcher: (started|attached) pid=' "$dir/arm.out" 2>/dev/null && break
  sleep 0.1; i=$((i + 1))
done
printf '%s\n' "$armpid" > "$FIXTURE_READY_FILE"
# Wedge, exactly like a hung case a runner stops with TERM.
sleep 300 &
if type fm_test_reap >/dev/null 2>&1; then fm_test_reap "$!"; fi
wait
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `tests/fm-watcher-lock.test.sh:528` - The hang-mode leg of the new regression test simulates a wedged suite with a foreground `sleep 300`, but bash defers a trapped TERM until the current foreground command completes (verified empirically: a `bash -c &#39;trap &#34;exit 143&#34; TERM; sleep 300&#39;` process stays alive after TERM). The leg only passes if the outer `kill -TERM` lands while the fixture is still inside its 0.1s poll loop; if the fixture has already dropped into `sleep 300` — which happens whenever the kid pidfile is written before the fixture&#39;s first poll check, and is more likely under full-suite load — the trap is deferred ~300s, `wait_for_exit` (tests/wake-helpers.sh:260) polls 8s then blocks in `wait` for the remaining ~292s, and returns 124 instead of 143, failing the assertion at line 553. Because this test deliberately runs first, the losing side of the race stalls the suite ~5 minutes and then aborts every subsequent case. Fix: make the wedge interruptible, e.g. `hang) sleep 300 &amp; fm_test_reap &#34;$!&#34;; wait ;;` — the `wait` builtin returns immediately on a trapped signal, making the TERM leg deterministic (and the extra sleep is reaped by the fixture&#39;s own cleanup).
- ⚠️ `tests/lib.sh:138` - FM_TEST_CLEANUP_PIDS accumulates every registered pid for the suite&#39;s whole lifetime and pids are never deregistered, even after a test explicitly `wait`s them (e.g. the lock-contender loops). At teardown fm_test_kill_tree unconditionally SIGKILLs each stale pid and also treats it as a tree root, so after pid wraparound (macOS pid space is ~99999; Linux pid_max is often 32768) a recycled pid can belong to an unrelated same-user process, which then gets SIGKILLed along with its descendants. The repo already has a pid-identity primitive (fm_pid_identity, used by test_watch_restart_rejects_reused_pid) that could gate the kill, or fm_test_kill_tree could skip pids whose start-time identity changed since registration. Flagging for the author because the intent declares registering short-lived contenders &#34;for uniformity&#34; a deliberate choice.
- ⚠️ `tests/lib.sh:113` - fm_test_process_tree bails out with empty output when `ps -axo pid=,ppid=` fails (`|| return 0`), so fm_test_kill_tree kills nothing at all — not even the registered root pids that the caller knows are valid. On platforms whose ps lacks BSD `-o` output selection (MSYS/Cygwin ps, some busybox builds — and this very suite carries an MSYS-specific case, test_msys_pid_identity_uses_proc), the reaper silently no-ops, reintroducing the leak there, and the new first-position regression test would then fail the entire suite on those platforms because assert_reaped finds the fixture parent still alive. Degrade gracefully by emitting the given root pids when the ps read fails, so at least the registered processes are killed.
- ℹ️ `tests/lib.sh:85` - fm_test_cleanup_on_signal runs `trap - EXIT` before exiting, so a test file that follows the pattern documented in this same header — define its own EXIT trap that does extra teardown (e.g. cleanup_all killing tmux sessions in the e2e suites) and calls fm_test_cleanup from inside — gets that extra teardown silently skipped on the signal path; only lib-registered dirs/pids are torn down. This is not a regression (previously nothing ran on a signalled shell) and fm_test_cleanup is idempotent per its own comment, so leaving the EXIT trap installed and simply exiting would run the file&#39;s custom teardown too at the cost of a harmless double cleanup. Noting as a design tradeoff.

🔧 Fix: gate reaper kills by identity and survives ps loss
1 info still open:
- ℹ️ `tests/lib.sh:96` - Residual fail-open race in the identity gate: fm_pid_identity&#39;s identity includes the full /proc cmdline (or ps `command=`), and fm_test_reap reads it immediately after fork - if the identity read (itself ~10ms: fork bash, source bin/fm-wake-lib.sh) ever completes before the just-forked child execs its command, the recorded pre-exec bash cmdline can never match the teardown re-read, so that process is skipped and leaks. The same design makes the reaper a full no-op on a platform with neither a readable compatible /proc nor a BSD-capable ps (identity reads fail, all roots skipped). Both are deliberate consequences of the instructed governing property (never kill what cannot be proven ours), fail in the safe direction, and the realistic platform set (Linux, macOS, MSYS/Cygwin with /proc) is covered - noting the tradeoff only.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-watcher-lock.test.sh` — full changed suite on the branch: exit 0, new reaper regression case runs first and passes (clean/abort/TERM endings), and a post-run /proc environ scan with a unique marker env var confirmed zero surviving background processes</code>
- `Manual leak reproduction on base commit a2d5f26: materialized base tests/ with shared bin/, ran a faithful reduction of test_watch_restart_attaches_to_healthy_peer (real backgrounded bin/fm-watch-arm.sh, then wedged), sent SIGTERM like timeout(1) — orphaned fm-watch-arm.sh + fm-watch.sh survived, carrying the incident's FM_HOME=/tmp/fm-watcher-lock-tests.*/restart-healthy-peer signature`
- `Same manual scenario against the fixed harness at HEAD: suite shell exited 143 (128+TERM per the new signal cleanup contract) and zero tagged processes survived`
- `Non-tautology check: neutered fm_test_kill_tree to a no-op in a temp copy of HEAD's tests and re-ran the suite — the new regression case immediately failed with 'registered process survived the harness teardown' (exit 1)`
- `Post-test hygiene: killed all marker-tagged demo/neutered-run leftovers without touching other lanes' live fm-watch processes, removed temp harness dirs, verified worktree clean`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
