### PR TITLE
feat(bin): add hidden backlog triage view

### DIFF
--- a/bin/fm-backlog-list.sh
+++ b/bin/fm-backlog-list.sh
@@ -41,8 +41,8 @@ usage: fm-backlog-list.sh [--file path] [--limit N]
 
 List backlog task title lines with the hidden backlog category filtered.
 
-Default: omit items whose hold reason starts with "backlog:", and when any
-  were hidden print "N backlogged hidden - use bin/fm-backlog-list.sh --backlog to list".
+Default: omit items whose hold reason starts with "backlog:" and print the
+  shared hidden-count hint when any are omitted.
 --backlog: list only those hidden backlogged items.
 --include-backlog: list every title line, including backlogged ones.
 
@@ -96,92 +96,4 @@ if [ ! -f "$FILE" ]; then
   exit 1
 fi
 
-awk -v mode="$MODE" -v max="$LIMIT" '
-  function state_for_heading(line, heading) {
-    heading = line
-    sub(/^##[[:space:]]+/, "", heading)
-    sub(/[[:space:]]+$/, "", heading)
-    if (heading == "In flight") return "in_flight"
-    if (heading == "Queued") return "queued"
-    if (heading == "Done") return "done"
-    return ""
-  }
-  function is_backlogged(line) {
-    return line ~ /\(hold:[[:space:]]*backlog:/
-  }
-  function is_title(line) {
-    return line ~ /^[-*][[:space:]]+/
-  }
-  BEGIN {
-    shown = 0
-    total_visible = 0
-    total_backlogged = 0
-    printed_any = 0
-  }
-  /^##[[:space:]]+/ {
-    state = state_for_heading($0)
-    if (state != "") {
-      pending_heading = $0
-      heading_pending = 1
-    }
-    next
-  }
-  state != "" && is_title($0) {
-    bl = is_backlogged($0)
-    if (bl) total_backlogged++
-    keep = 0
-    if (mode == "backlog") {
-      keep = bl
-    } else if (mode == "include") {
-      keep = 1
-    } else {
-      keep = !bl
-    }
-    if (!keep) next
-    total_visible++
-    if (max > 0 && shown >= max) next
-    if (heading_pending) {
-      print pending_heading
-      heading_pending = 0
-      printed_any = 1
-    }
-    print $0
-    shown++
-    printed_any = 1
-    next
-  }
-  END {
-    if (mode == "backlog") {
-      if (total_backlogged == 0) {
-        print "(no backlogged items)"
-      } else if (max > 0 && total_visible > shown) {
-        printf "(shown %d of %d backlogged item title line(s))\n", shown, total_visible
-      } else {
-        printf "(shown %d backlogged item title line(s))\n", shown
-      }
-    } else if (mode == "include") {
-      if (total_visible == 0) {
-        print "(no backlog item title lines found)"
-      } else {
-        printf "(shown %d of %d backlog item title line(s); includes backlogged)\n", shown, total_visible
-        if (max > 0 && total_visible > shown) {
-          printf "(truncated %d item(s); increase --limit for a larger listing)\n", total_visible - shown
-        }
-      }
-    } else {
-      if (total_visible == 0 && total_backlogged == 0) {
-        print "(no backlog item title lines found)"
-      } else if (total_visible == 0) {
-        print "(no non-backlogged item title lines found)"
-      } else {
-        printf "(shown %d of %d non-backlogged item title line(s))\n", shown, total_visible
-        if (max > 0 && total_visible > shown) {
-          printf "(truncated %d item(s); increase --limit for a larger listing)\n", total_visible - shown
-        }
-      }
-      if (total_backlogged > 0) {
-        printf "%d backlogged hidden - use bin/fm-backlog-list.sh --backlog to list\n", total_backlogged
-      }
-    }
-  }
-' "$FILE"
+fm_backlog_render_title_lines "$FILE" "$MODE" "$LIMIT" status

--- a/bin/fm-backlog-list.sh
+++ b/bin/fm-backlog-list.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# fm-backlog-list.sh - routine and explicit backlog status listing.
+#
+# Captain triage vocabulary is do / defer / backlog / kill.
+# Items held with a reason that starts with "backlog:" are a hidden category:
+# they are omitted from every routine firstmate listing (this command's default
+# mode, session-start compact digest, fleet snapshot / fleet view / bearings)
+# and appear only when this command is invoked with --backlog (or the broader
+# --include-backlog which keeps ordinary rows and shows the hidden ones too).
+# Deferred (hold-until / hold-kind future) and parked (hold-kind parked without
+# the backlog: reason prefix) remain visible in the routine listing.
+#
+# This script is the explicit human status view for the hidden category and the
+# single owner of the title-line listing filter used when tasks-axi is not the
+# renderer. Predicate ownership lives in bin/fm-tasks-axi-lib.sh.
+#
+# Usage:
+#   fm-backlog-list.sh [--file path] [--limit N]
+#   fm-backlog-list.sh --backlog [--file path] [--limit N]
+#   fm-backlog-list.sh --include-backlog [--file path] [--limit N]
+#
+# Default mode prints non-backlogged title lines plus a one-line hidden count
+# hint when any were omitted. --backlog prints only backlogged title lines.
+# --include-backlog prints every title line (no hiding).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+DEFAULT_FILE="$DATA/backlog.md"
+# shellcheck source=bin/fm-tasks-axi-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+
+usage() {
+  cat <<'EOF'
+usage: fm-backlog-list.sh [--file path] [--limit N]
+       fm-backlog-list.sh --backlog [--file path] [--limit N]
+       fm-backlog-list.sh --include-backlog [--file path] [--limit N]
+
+List backlog task title lines with the hidden backlog category filtered.
+
+Default: omit items whose hold reason starts with "backlog:", and when any
+  were hidden print "N backlogged hidden - use bin/fm-backlog-list.sh --backlog to list".
+--backlog: list only those hidden backlogged items.
+--include-backlog: list every title line, including backlogged ones.
+
+Deferred and parked holds without the backlog: reason prefix stay in the default listing.
+Hold the item with: tasks-axi hold <id> --reason "backlog: <note>" [--kind parked|future|...]
+Revive with: tasks-axi unhold <id>
+EOF
+}
+
+MODE=routine
+FILE=$DEFAULT_FILE
+LIMIT=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --backlog)
+      [ "$MODE" = routine ] || { echo "fm-backlog-list: --backlog and --include-backlog are mutually exclusive" >&2; exit 2; }
+      MODE=backlog
+      shift
+      ;;
+    --include-backlog)
+      [ "$MODE" = routine ] || { echo "fm-backlog-list: --backlog and --include-backlog are mutually exclusive" >&2; exit 2; }
+      MODE=include
+      shift
+      ;;
+    --file)
+      [ $# -ge 2 ] || { echo "fm-backlog-list: --file requires a path" >&2; exit 2; }
+      FILE=$2
+      shift 2
+      ;;
+    --limit)
+      [ $# -ge 2 ] || { echo "fm-backlog-list: --limit requires a positive integer" >&2; exit 2; }
+      case "$2" in
+        ''|*[!0-9]*|0)
+          echo "fm-backlog-list: --limit requires a positive integer" >&2
+          exit 2
+          ;;
+      esac
+      LIMIT=$2
+      shift 2
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -f "$FILE" ]; then
+  echo "fm-backlog-list: backlog file not found: $FILE" >&2
+  exit 1
+fi
+
+awk -v mode="$MODE" -v max="$LIMIT" '
+  function state_for_heading(line, heading) {
+    heading = line
+    sub(/^##[[:space:]]+/, "", heading)
+    sub(/[[:space:]]+$/, "", heading)
+    if (heading == "In flight") return "in_flight"
+    if (heading == "Queued") return "queued"
+    if (heading == "Done") return "done"
+    return ""
+  }
+  function is_backlogged(line) {
+    return line ~ /\(hold:[[:space:]]*backlog:/
+  }
+  function is_title(line) {
+    return line ~ /^[-*][[:space:]]+/
+  }
+  BEGIN {
+    shown = 0
+    total_visible = 0
+    total_backlogged = 0
+    printed_any = 0
+  }
+  /^##[[:space:]]+/ {
+    state = state_for_heading($0)
+    if (state != "") {
+      pending_heading = $0
+      heading_pending = 1
+    }
+    next
+  }
+  state != "" && is_title($0) {
+    bl = is_backlogged($0)
+    if (bl) total_backlogged++
+    keep = 0
+    if (mode == "backlog") {
+      keep = bl
+    } else if (mode == "include") {
+      keep = 1
+    } else {
+      keep = !bl
+    }
+    if (!keep) next
+    total_visible++
+    if (max > 0 && shown >= max) next
+    if (heading_pending) {
+      print pending_heading
+      heading_pending = 0
+      printed_any = 1
+    }
+    print $0
+    shown++
+    printed_any = 1
+    next
+  }
+  END {
+    if (mode == "backlog") {
+      if (total_backlogged == 0) {
+        print "(no backlogged items)"
+      } else if (max > 0 && total_visible > shown) {
+        printf "(shown %d of %d backlogged item title line(s))\n", shown, total_visible
+      } else {
+        printf "(shown %d backlogged item title line(s))\n", shown
+      }
+    } else if (mode == "include") {
+      if (total_visible == 0) {
+        print "(no backlog item title lines found)"
+      } else {
+        printf "(shown %d of %d backlog item title line(s); includes backlogged)\n", shown, total_visible
+        if (max > 0 && total_visible > shown) {
+          printf "(truncated %d item(s); increase --limit for a larger listing)\n", total_visible - shown
+        }
+      }
+    } else {
+      if (total_visible == 0 && total_backlogged == 0) {
+        print "(no backlog item title lines found)"
+      } else if (total_visible == 0) {
+        print "(no non-backlogged item title lines found)"
+      } else {
+        printf "(shown %d of %d non-backlogged item title line(s))\n", shown, total_visible
+        if (max > 0 && total_visible > shown) {
+          printf "(truncated %d item(s); increase --limit for a larger listing)\n", total_visible - shown
+        }
+      }
+      if (total_backlogged > 0) {
+        printf "%d backlogged hidden - use bin/fm-backlog-list.sh --backlog to list\n", total_backlogged
+      }
+    }
+  }
+' "$FILE"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -837,7 +837,7 @@ else
 fi
 
 registry_secondmates_json() {
-  local reg="$DATA/secondmates.md" out rc reason mode script parse_filter output_filter
+  local hidden_ids=${1:-'[]'} reg="$DATA/secondmates.md" out rc reason mode script parse_filter output_filter
   if [ ! -f "$reg" ]; then
     jq -n --arg path "$reg" --arg observed "$SNAPSHOT_NOW" \
       '{present:false,available:true,complete:true,reason:null,provenance:"registered-table",path:$path,freshness:{status:"fresh",observed_at:$observed},records:[],input_truncated:false,records_truncated:false,reasons:[],lines_in_window:0,records_in_window:0}'
@@ -859,6 +859,7 @@ registry_secondmates_json() {
     observed=$6
     parse_filter=$7
     output_filter=$8
+    hidden_ids=$9
     content=$(LC_ALL=C head -c "$((max_bytes + 1))" "$f" || exit 3; printf "\036") || exit 3
     content=${content%$'\036'}
     bytes=$(printf "%s" "$content" | LC_ALL=C wc -c | tr -d " ")
@@ -886,7 +887,7 @@ registry_secondmates_json() {
     else
       lines_in_window=0
     fi
-    records=$(printf "%s\n" "$window" | jq -Rn "$parse_filter") || exit 3
+    records=$(printf "%s\n" "$window" | jq -Rn --argjson hidden "$hidden_ids" "$parse_filter") || exit 3
     records_in_window=$(printf "%s" "$records" | jq "length") || exit 3
     records_truncated=false
     if [ "$records_in_window" -gt "$max_records" ]; then records_truncated=true; fi
@@ -910,6 +911,7 @@ BASH
            registry_error:(if $home == null or ($home.home | length) == 0 then "registry entry has no home" else null end)} ]
       | group_by(.id)
       | map(if length > 1 then .[0] + {registry_error:"duplicate secondmate id in registry"} else .[0] end)
+      | map(select(.id as $id | $hidden | index($id) | not))
 JQ
   )
   output_filter=$(cat <<'JQ'
@@ -928,7 +930,7 @@ JQ
   out=$(run_timed "$FM_SNAPSHOT_REGISTRY_TIMEOUT" bash -c "$script" \
     fm-secondmate-registry "$reg" "$FM_SNAPSHOT_REGISTRY_LINES" \
     "$FM_SNAPSHOT_REGISTRY_BYTES" "$FM_SNAPSHOT_REGISTRY_RECORDS" "$reg" "$SNAPSHOT_NOW" \
-    "$parse_filter" "$output_filter" 2>/dev/null)
+    "$parse_filter" "$output_filter" "$hidden_ids" 2>/dev/null)
   rc=$?
   if [ "$rc" -eq 0 ] && printf '%s' "$out" | jq -e '
     .available == true and (.records | type) == "array"
@@ -1137,15 +1139,11 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
 }
 
 secondmate_current_json() {  # <parent-tasks-json> <hidden-ids-json>
-  local tasks=$1 hidden_ids=$2 registry registry_records union rows total_registered total shown truncated
+  local tasks=$1 hidden_ids=$2 registry union rows total_registered total shown truncated
   local row id home registered registry_error task status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
-  registry=$(registry_secondmates_json) || return 1
-  registry_records=$(printf '%s' "$registry" | jq -c '.records // []') || return 1
-  registry_records=$(filter_hidden_id_rows "$hidden_ids" "$registry_records") || return 1
-  registry=$(jq -n --argjson registry "$registry" --argjson records "$registry_records" \
-    '$registry | .records = $records') || return 1
+  registry=$(registry_secondmates_json "$hidden_ids") || return 1
   union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
     ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -11,7 +11,8 @@
 #   generated: UTC observation time for this fresh command execution.
 #   fm_home: resolved operational home.
 #   roots: resolved root/config/data/state/projects directories.
-#   backlog: {path,present,records[],hidden_backlogged_count,hidden_backlogged_hint}
+#   backlog: {path,present,records[],hidden_backlogged_ids,
+#     hidden_backlogged_count,hidden_backlogged_hint}
 #     where records are ordered as written in data/backlog.md and cover
 #     In flight, Queued, and Done.
 #     Canonical tasks-axi rows are structured; free-form non-empty lines in
@@ -273,19 +274,25 @@ first_pr_url_in_file() {  # <file>
 backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
   local backlog=${1:-$BACKLOG}
   local include_backlog_json=false
-  local hint_cmd='bin/fm-backlog-list.sh --backlog'
+  local parsed hidden_count hidden_hint backlogged_ids_json
   # jq treats numeric 0 as truthy; pass a real JSON boolean.
   if [ "${INCLUDE_BACKLOG:-0}" -eq 1 ]; then
     include_backlog_json=true
   fi
   if [ ! -f "$backlog" ]; then
     jq -n --arg path "$backlog" \
-      '{path:$path,present:false,records:[],hidden_backlogged_count:0,hidden_backlogged_hint:null}'
+      '{path:$path,present:false,records:[],hidden_backlogged_ids:[],hidden_backlogged_count:0,hidden_backlogged_hint:null}'
     return 0
   fi
 
+  backlogged_ids_json=$(fm_backlogged_ids_from_file "$backlog" \
+    | jq -Rsc 'split("\n") | map(select(. != "")) | unique') || return 1
+
   # shellcheck disable=SC2094
-  jq -Rn --arg path "$backlog" --argjson include_backlog "$include_backlog_json" --arg hint_cmd "$hint_cmd" '
+  parsed=$(jq -Rn \
+    --arg path "$backlog" \
+    --argjson include_backlog "$include_backlog_json" \
+    --argjson backlogged_ids "$backlogged_ids_json" '
     def trim: gsub("^[[:space:]]+|[[:space:]]+$"; "");
     def section_state:
       if . == "In flight" then "in_flight"
@@ -413,7 +420,7 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
               | $blocker
             ]
           | .backlogged =
-              (.hold_reason != null and (.hold_reason | startswith("backlog:")))
+              (.id as $id | $backlogged_ids | index($id) != null)
           | .current_role =
               (if .state == "in_flight" and .hold_reason != null and .hold_kind != null then "held"
                elif .state == "in_flight" and .kind == "program" then "program"
@@ -428,17 +435,37 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
         else
           .backlogged = false
         end)
-    | .hidden_backlogged_count = ([.records[] | select(.backlogged == true)] | length)
-    | .hidden_backlogged_hint =
-        (if .hidden_backlogged_count > 0 and ($include_backlog | not) then
-           "\(.hidden_backlogged_count) backlogged hidden - use \($hint_cmd) to list"
-         else null end)
+    | .hidden_backlogged_ids = $backlogged_ids
+    | .hidden_backlogged_count = (.hidden_backlogged_ids | length)
     | .records |=
         (if $include_backlog then .
          else map(select(.backlogged != true))
          end)
     | del(.section,.order)
-  ' < "$backlog"
+  ' < "$backlog") || return 1
+
+  hidden_count=$(printf '%s' "$parsed" | jq -r '.hidden_backlogged_count')
+  hidden_hint=$(fm_backlog_hidden_hint "$hidden_count")
+  jq -n \
+    --argjson parsed "$parsed" \
+    --argjson include_backlog "$include_backlog_json" \
+    --arg hidden_hint "$hidden_hint" \
+    '$parsed + {
+      hidden_backlogged_hint:
+        (if $include_backlog or $hidden_hint == "" then null else $hidden_hint end)
+    }'
+}
+
+filter_backlogged_tasks() {  # <backlog-json> <tasks-json>
+  if [ "${INCLUDE_BACKLOG:-0}" -eq 1 ]; then
+    printf '%s\n' "$2"
+    return 0
+  fi
+  jq -n \
+    --argjson backlog "$1" \
+    --argjson tasks "$2" '
+    $backlog.hidden_backlogged_ids as $hidden
+    | $tasks | map(select(.id as $id | $hidden | index($id) | not))'
 }
 
 task_json_lines() {
@@ -1336,6 +1363,8 @@ scout_report_lines() {
 
 BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" >&2; exit 1; }
 TASKS_JSON=$(task_json_lines) || { echo "fm-fleet-snapshot: task snapshot failed" >&2; exit 1; }
+TASKS_JSON=$(filter_backlogged_tasks "$BACKLOG_JSON" "$TASKS_JSON") \
+  || { echo "fm-fleet-snapshot: backlogged task filtering failed" >&2; exit 1; }
 
 if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
   secondmate_home_summary_json "$BACKLOG_JSON" "$TASKS_JSON" \

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -11,15 +11,23 @@
 #   generated: UTC observation time for this fresh command execution.
 #   fm_home: resolved operational home.
 #   roots: resolved root/config/data/state/projects directories.
-#   backlog: {path,present,records[]} where records are ordered as written in
-#     data/backlog.md and cover In flight, Queued, and Done.
+#   backlog: {path,present,records[],hidden_backlogged_count,hidden_backlogged_hint}
+#     where records are ordered as written in data/backlog.md and cover
+#     In flight, Queued, and Done.
 #     Canonical tasks-axi rows are structured; free-form non-empty lines in
 #     those sections are preserved as unstructured records.
 #     Structured rows preserve captain-hold metadata such as hold_kind and
 #     hold_reason when tasks-axi emits it. They also carry normalized current_role,
-#     requires_child_metadata, blocked_by_ids, unresolved_blocker_ids, and
-#     captain_actionable fields. Repeated blocker tokens remain ordered; a blocker
-#     resolves only when its structured record is Done, and missing ids stay open.
+#     requires_child_metadata, blocked_by_ids, unresolved_blocker_ids,
+#     captain_actionable, and backlogged fields. Repeated blocker tokens remain
+#     ordered; a blocker resolves only when its structured record is Done, and
+#     missing ids stay open.
+#     A structured hold whose reason starts with "backlog:" is the hidden
+#     backlog category (fm-tasks-axi-lib.sh): by default those rows are omitted
+#     from records, counted in hidden_backlogged_count, and summarized in
+#     hidden_backlogged_hint. Pass --include-backlog to keep them in records
+#     (still tagged backlogged:true). Explicit human listing is
+#     bin/fm-backlog-list.sh --backlog.
 #   tasks[]: one row per state/<id>.meta, sorted by id.
 #     current_state is parsed from bin/fm-crew-state.sh <id> and preserves
 #     state, source, detail, and raw line separately.
@@ -134,14 +142,23 @@ validate_positive_bound FM_SNAPSHOT_REGISTRY_TIMEOUT "$FM_SNAPSHOT_REGISTRY_TIME
 # shellcheck source=bin/fm-ff-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-ff-lib.sh"  # validate_secondmate_home: shared seeded-home boundary checks
+# shellcheck source=bin/fm-tasks-axi-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 
 usage() {
   cat <<'EOF'
-usage: fm-fleet-snapshot.sh --json
-       fm-fleet-snapshot.sh --secondmate-home-summary
+usage: fm-fleet-snapshot.sh --json [--include-backlog]
+       fm-fleet-snapshot.sh --secondmate-home-summary [--include-backlog]
 
 Print a read-only structured snapshot of the firstmate fleet.
 JSON is the stable machine-readable output contract.
+
+--include-backlog keeps structured rows whose hold reason starts with
+"backlog:" in backlog.records (they remain tagged backlogged:true).
+Without that flag those rows are render-hidden from records and counted in
+backlog.hidden_backlogged_count with a list hint; use bin/fm-backlog-list.sh
+--backlog for the human status view.
 
 --secondmate-home-summary emits the bounded structured summary used after a
 validated registered-home handoff. It is local-only, skips nested secondmate
@@ -165,12 +182,18 @@ EOF
 }
 
 OUTPUT_MODE=json
-case "${1:---json}" in
-  --json) ;;
-  --secondmate-home-summary) OUTPUT_MODE=secondmate-home-summary ;;
-  -h|--help) usage; exit 0 ;;
-  *) usage >&2; exit 2 ;;
-esac
+INCLUDE_BACKLOG=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json) OUTPUT_MODE=json; shift ;;
+    --secondmate-home-summary) OUTPUT_MODE=secondmate-home-summary; shift ;;
+    --include-backlog) INCLUDE_BACKLOG=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; exit 2 ;;
+  esac
+done
+# Default when invoked with no args matches the historical --json contract.
+[ $# -eq 0 ] || true
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; exit 1; }
 
@@ -249,13 +272,20 @@ first_pr_url_in_file() {  # <file>
 
 backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
   local backlog=${1:-$BACKLOG}
+  local include_backlog_json=false
+  local hint_cmd='bin/fm-backlog-list.sh --backlog'
+  # jq treats numeric 0 as truthy; pass a real JSON boolean.
+  if [ "${INCLUDE_BACKLOG:-0}" -eq 1 ]; then
+    include_backlog_json=true
+  fi
   if [ ! -f "$backlog" ]; then
-    jq -n --arg path "$backlog" '{path:$path,present:false,records:[]}'
+    jq -n --arg path "$backlog" \
+      '{path:$path,present:false,records:[],hidden_backlogged_count:0,hidden_backlogged_hint:null}'
     return 0
   fi
 
   # shellcheck disable=SC2094
-  jq -Rn --arg path "$backlog" '
+  jq -Rn --arg path "$backlog" --argjson include_backlog "$include_backlog_json" --arg hint_cmd "$hint_cmd" '
     def trim: gsub("^[[:space:]]+|[[:space:]]+$"; "");
     def section_state:
       if . == "In flight" then "in_flight"
@@ -382,6 +412,8 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
               | select($resolved_ids[$blocker] != true)
               | $blocker
             ]
+          | .backlogged =
+              (.hold_reason != null and (.hold_reason | startswith("backlog:")))
           | .current_role =
               (if .state == "in_flight" and .hold_reason != null and .hold_kind != null then "held"
                elif .state == "in_flight" and .kind == "program" then "program"
@@ -391,8 +423,20 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
           | .requires_child_metadata = (.current_role == "worker")
           | .captain_actionable =
               (.state == "queued" and .kind == "captain" and .hold_kind == "captain"
-               and .hold_reason != null and (.unresolved_blocker_ids | length) == 0)
-        else . end)
+               and .hold_reason != null and (.unresolved_blocker_ids | length) == 0
+               and (.backlogged | not))
+        else
+          .backlogged = false
+        end)
+    | .hidden_backlogged_count = ([.records[] | select(.backlogged == true)] | length)
+    | .hidden_backlogged_hint =
+        (if .hidden_backlogged_count > 0 and ($include_backlog | not) then
+           "\(.hidden_backlogged_count) backlogged hidden - use \($hint_cmd) to list"
+         else null end)
+    | .records |=
+        (if $include_backlog then .
+         else map(select(.backlogged != true))
+         end)
     | del(.section,.order)
   ' < "$backlog"
 }

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -456,16 +456,11 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
     }'
 }
 
-filter_backlogged_tasks() {  # <backlog-json> <tasks-json>
-  if [ "${INCLUDE_BACKLOG:-0}" -eq 1 ]; then
-    printf '%s\n' "$2"
-    return 0
-  fi
+filter_hidden_id_rows() {
   jq -n \
-    --argjson backlog "$1" \
+    --argjson hidden "$1" \
     --argjson tasks "$2" '
-    $backlog.hidden_backlogged_ids as $hidden
-    | $tasks | map(select(.id as $id | $hidden | index($id) | not))'
+    $tasks | map(select(.id as $id | $hidden | index($id) | not))'
 }
 
 task_json_lines() {
@@ -1141,12 +1136,16 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
        inconclusive:any(($activity_results + $decision_results)[]; .verdict == "inconclusive")}'
 }
 
-secondmate_current_json() {  # <parent-tasks-json>
-  local tasks=$1 registry union rows total_registered total shown truncated
+secondmate_current_json() {  # <parent-tasks-json> <hidden-ids-json>
+  local tasks=$1 hidden_ids=$2 registry registry_records union rows total_registered total shown truncated
   local row id home registered registry_error task status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
+  registry_records=$(printf '%s' "$registry" | jq -c '.records // []') || return 1
+  registry_records=$(filter_hidden_id_rows "$hidden_ids" "$registry_records") || return 1
+  registry=$(jq -n --argjson registry "$registry" --argjson records "$registry_records" \
+    '$registry | .records = $records') || return 1
   union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
     ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
@@ -1362,8 +1361,13 @@ scout_report_lines() {
 }
 
 BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" >&2; exit 1; }
+if [ "${INCLUDE_BACKLOG:-0}" -eq 1 ]; then
+  HIDDEN_IDS_JSON='[]'
+else
+  HIDDEN_IDS_JSON=$(printf '%s' "$BACKLOG_JSON" | jq -c '.hidden_backlogged_ids')
+fi
 TASKS_JSON=$(task_json_lines) || { echo "fm-fleet-snapshot: task snapshot failed" >&2; exit 1; }
-TASKS_JSON=$(filter_backlogged_tasks "$BACKLOG_JSON" "$TASKS_JSON") \
+TASKS_JSON=$(filter_hidden_id_rows "$HIDDEN_IDS_JSON" "$TASKS_JSON") \
   || { echo "fm-fleet-snapshot: backlogged task filtering failed" >&2; exit 1; }
 
 if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
@@ -1373,9 +1377,11 @@ if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
 fi
 
 SCOUT_REPORTS_JSON=$(scout_report_lines)
+SCOUT_REPORTS_JSON=$(filter_hidden_id_rows "$HIDDEN_IDS_JSON" "$SCOUT_REPORTS_JSON") \
+  || { echo "fm-fleet-snapshot: backlogged report filtering failed" >&2; exit 1; }
 MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON" "$TASKS_JSON") \
   || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
-SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
+SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON" "$HIDDEN_IDS_JSON") \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }

--- a/bin/fm-fleet-view.sh
+++ b/bin/fm-fleet-view.sh
@@ -10,23 +10,40 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'EOF'
-usage: fm-fleet-view.sh [--json]
+usage: fm-fleet-view.sh [--json] [--include-backlog]
 
 Render a human fleet view from fm-fleet-snapshot.sh.
 Use --json to print the underlying snapshot.
+Use --include-backlog to keep hidden backlog: holds in the snapshot/view
+(same flag as fm-fleet-snapshot.sh). Default routine view omits them and
+prints the hidden-count hint when any were filtered.
 EOF
 }
 
-case "${1:-}" in
-  -h|--help) usage; exit 0 ;;
-  --json) "$SCRIPT_DIR/fm-fleet-snapshot.sh" --json; exit $? ;;
-  "") ;;
-  *) usage >&2; exit 2 ;;
-esac
+JSON_ONLY=0
+INCLUDE_BACKLOG=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --json) JSON_ONLY=1; shift ;;
+    --include-backlog) INCLUDE_BACKLOG=1; shift ;;
+    *) usage >&2; exit 2 ;;
+  esac
+done
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-view: jq not found" >&2; exit 1; }
 
-SNAPSHOT=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json) || exit $?
+SNAP_ARGS=(--json)
+if [ "$INCLUDE_BACKLOG" -eq 1 ]; then
+  SNAP_ARGS+=(--include-backlog)
+fi
+
+if [ "$JSON_ONLY" -eq 1 ]; then
+  "$SCRIPT_DIR/fm-fleet-snapshot.sh" "${SNAP_ARGS[@]}"
+  exit $?
+fi
+
+SNAPSHOT=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" "${SNAP_ARGS[@]}") || exit $?
 
 printf '%s\n' "$SNAPSHOT" | jq -r '
   def dash($v): if $v == null or $v == "" then "-" else $v end;
@@ -81,6 +98,10 @@ printf '%s\n' "$SNAPSHOT" | jq -r '
     "| --- | --- | --- | --- | --- | --- |",
     (.backlog.records[] | select(.state == "queued") | backlog_row(.))
    end),
+  (if (.backlog.hidden_backlogged_hint // null) != null then
+    "",
+    .backlog.hidden_backlogged_hint
+   else empty end),
   "",
   "## Done",
   (if ([.backlog.records[]? | select(.state == "done")] | length) == 0 then

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -80,6 +80,9 @@
 # this script prints only backlog section headings and item title lines, so
 # title-line hold and blocked-by metadata remain visible while indented bodies
 # stay out of the startup digest.
+# Hold reasons that start with "backlog:" are the hidden backlog category
+# (predicate in fm-tasks-axi-lib.sh): they are omitted from this routine digest
+# with a one-line count hint; list them via bin/fm-backlog-list.sh --backlog.
 # Full bodies are targeted follow-up only: `tasks-axi show <id> --full` when
 # compatible tasks-axi is available, or `data/backlog.md` when the file body is
 # truly needed.
@@ -139,6 +142,68 @@ print_backlog_pointer() {
   printf 'Full task bodies remain available on demand: tasks-axi show <id> --full when compatible tasks-axi is available, or data/backlog.md.\n'
 }
 
+# Drop tasks-axi list TOON rows whose id is backlogged; rewrite count/header.
+# Shared predicate/ids come from fm-tasks-axi-lib.sh so the prefix is not forked.
+print_backlog_tasks_axi_filtered() {
+  local path=$1 raw=$2
+  local idfile hidden
+  hidden=$(fm_backlogged_count_from_file "$path")
+  if [ "${hidden:-0}" -eq 0 ]; then
+    printf '%s\n' "$raw"
+    return 0
+  fi
+  idfile=$(mktemp "${TMPDIR:-/tmp}/fm-backlog-hide.XXXXXX")
+  fm_backlogged_ids_from_file "$path" > "$idfile"
+  printf '%s\n' "$raw" | awk -v idfile="$idfile" '
+    BEGIN {
+      while ((getline line < idfile) > 0) {
+        gsub(/[[:space:]]+$/, "", line)
+        if (line != "") hide[line] = 1
+      }
+      close(idfile)
+      in_tasks = 0
+      shown = 0
+      flushed = 0
+    }
+    function flush_tasks(   h, i) {
+      if (flushed || header == "") return
+      h = header
+      sub(/__N__/, shown + 0, h)
+      print "count: " (shown + 0)
+      print h
+      for (i = 0; i < shown; i++) print body[i]
+      flushed = 1
+      header = ""
+    }
+    /^count:[[:space:]]*[0-9]+/ { next }
+    /^tasks\[[0-9]+\]/ {
+      header = $0
+      sub(/^tasks\[[0-9]+\]/, "tasks[__N__]", header)
+      in_tasks = 1
+      next
+    }
+    in_tasks && /^[[:space:]]+[^[:space:]]/ {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      id = line
+      sub(/,.*/, "", id)
+      if (hide[id]) next
+      body[shown++] = $0
+      next
+    }
+    {
+      if (in_tasks) {
+        flush_tasks()
+        in_tasks = 0
+      }
+      print
+    }
+    END { flush_tasks() }
+  '
+  rm -f "$idfile"
+  fm_backlog_hidden_hint "$hidden" "bin/fm-backlog-list.sh --backlog"
+}
+
 print_backlog_manual_compact() {
   local path=$1 reason=$2
   printf 'compact backlog listing (%s; max %s item(s); indented task bodies omitted)\n' "$reason" "$BACKLOG_LIMIT"
@@ -152,14 +217,28 @@ print_backlog_manual_compact() {
       if (heading == "Done") return "done"
       return ""
     }
+    function is_backlogged(line) {
+      return line ~ /\(hold:[[:space:]]*backlog:/
+    }
     /^##[[:space:]]+/ {
       state = state_for_heading($0)
-      if (state != "") print $0
+      if (state != "") {
+        pending_heading = $0
+        heading_pending = 1
+      }
       next
     }
     state != "" && /^[-*][[:space:]]+/ {
+      if (is_backlogged($0)) {
+        hidden++
+        next
+      }
       total++
       if (shown < max) {
+        if (heading_pending) {
+          print pending_heading
+          heading_pending = 0
+        }
         print $0
         shown++
       }
@@ -167,12 +246,19 @@ print_backlog_manual_compact() {
     }
     END {
       if (total == 0) {
-        print "(no backlog item title lines found)"
+        if (hidden > 0) {
+          print "(no non-backlogged item title lines found)"
+        } else {
+          print "(no backlog item title lines found)"
+        }
       } else {
         printf "(shown %d of %d backlog item title line(s))\n", shown, total
         if (total > shown) {
           printf "(truncated %d item(s); increase FM_SESSION_START_BACKLOG_LIMIT for a larger startup listing)\n", total - shown
         }
+      }
+      if (hidden > 0) {
+        printf "%d backlogged hidden - use bin/fm-backlog-list.sh --backlog to list\n", hidden
       }
     }
   ' "$path"
@@ -184,7 +270,7 @@ print_backlog_tasks_axi_compact() {
   out=$(tasks-axi list --file "$path" --limit "$BACKLOG_LIMIT" --fields blocked_by,hold_kind,hold_reason 2>&1)
   rc=$?
   if [ "$rc" -eq 0 ]; then
-    printf '%s\n' "$out"
+    print_backlog_tasks_axi_filtered "$path" "$out"
   else
     printf 'tasks-axi compact listing failed; falling back to title-line rendering.\n'
     printf '%s\n' "$out"

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -146,23 +146,20 @@ print_backlog_pointer() {
 # Shared predicate/ids come from fm-tasks-axi-lib.sh so the prefix is not forked.
 print_backlog_tasks_axi_filtered() {
   local path=$1 raw=$2
-  local idfile hidden
+  local hidden hidden_ids
   hidden=$(fm_backlogged_count_from_file "$path")
-  if [ "${hidden:-0}" -eq 0 ]; then
-    printf '%s\n' "$raw"
-    return 0
-  fi
-  idfile=$(mktemp "${TMPDIR:-/tmp}/fm-backlog-hide.XXXXXX")
-  fm_backlogged_ids_from_file "$path" > "$idfile"
-  printf '%s\n' "$raw" | awk -v idfile="$idfile" '
+  hidden_ids=$(fm_backlogged_ids_from_file "$path")
+  printf '%s\n' "$raw" | awk -v hidden_ids="$hidden_ids" -v max="$BACKLOG_LIMIT" '
     BEGIN {
-      while ((getline line < idfile) > 0) {
+      count = split(hidden_ids, lines, "\n")
+      for (i = 1; i <= count; i++) {
+        line = lines[i]
         gsub(/[[:space:]]+$/, "", line)
         if (line != "") hide[line] = 1
       }
-      close(idfile)
       in_tasks = 0
       shown = 0
+      visible = 0
       flushed = 0
     }
     function flush_tasks(   h, i) {
@@ -188,7 +185,8 @@ print_backlog_tasks_axi_filtered() {
       id = line
       sub(/,.*/, "", id)
       if (hide[id]) next
-      body[shown++] = $0
+      visible++
+      if (shown < max) body[shown++] = $0
       next
     }
     {
@@ -198,76 +196,28 @@ print_backlog_tasks_axi_filtered() {
       }
       print
     }
-    END { flush_tasks() }
+    END {
+      flush_tasks()
+      if (visible > shown) {
+        printf "(truncated %d item(s); increase FM_SESSION_START_BACKLOG_LIMIT for a larger startup listing)\n", visible - shown
+      }
+    }
   '
-  rm -f "$idfile"
-  fm_backlog_hidden_hint "$hidden" "bin/fm-backlog-list.sh --backlog"
+  fm_backlog_hidden_hint "$hidden"
 }
 
 print_backlog_manual_compact() {
   local path=$1 reason=$2
   printf 'compact backlog listing (%s; max %s item(s); indented task bodies omitted)\n' "$reason" "$BACKLOG_LIMIT"
-  awk -v max="$BACKLOG_LIMIT" '
-    function state_for_heading(line, heading) {
-      heading = line
-      sub(/^##[[:space:]]+/, "", heading)
-      sub(/[[:space:]]+$/, "", heading)
-      if (heading == "In flight") return "in_flight"
-      if (heading == "Queued") return "queued"
-      if (heading == "Done") return "done"
-      return ""
-    }
-    function is_backlogged(line) {
-      return line ~ /\(hold:[[:space:]]*backlog:/
-    }
-    /^##[[:space:]]+/ {
-      state = state_for_heading($0)
-      if (state != "") {
-        pending_heading = $0
-        heading_pending = 1
-      }
-      next
-    }
-    state != "" && /^[-*][[:space:]]+/ {
-      if (is_backlogged($0)) {
-        hidden++
-        next
-      }
-      total++
-      if (shown < max) {
-        if (heading_pending) {
-          print pending_heading
-          heading_pending = 0
-        }
-        print $0
-        shown++
-      }
-      next
-    }
-    END {
-      if (total == 0) {
-        if (hidden > 0) {
-          print "(no non-backlogged item title lines found)"
-        } else {
-          print "(no backlog item title lines found)"
-        }
-      } else {
-        printf "(shown %d of %d backlog item title line(s))\n", shown, total
-        if (total > shown) {
-          printf "(truncated %d item(s); increase FM_SESSION_START_BACKLOG_LIMIT for a larger startup listing)\n", total - shown
-        }
-      }
-      if (hidden > 0) {
-        printf "%d backlogged hidden - use bin/fm-backlog-list.sh --backlog to list\n", hidden
-      }
-    }
-  ' "$path"
+  fm_backlog_render_title_lines "$path" routine "$BACKLOG_LIMIT" session
 }
 
 print_backlog_tasks_axi_compact() {
-  local path=$1 out rc
+  local path=$1 out rc hidden fetch_limit
   printf 'compact backlog listing (tasks-axi; max %s item(s); task bodies omitted)\n' "$BACKLOG_LIMIT"
-  out=$(tasks-axi list --file "$path" --limit "$BACKLOG_LIMIT" --fields blocked_by,hold_kind,hold_reason 2>&1)
+  hidden=$(fm_backlogged_count_from_file "$path")
+  fetch_limit=$((BACKLOG_LIMIT + hidden))
+  out=$(tasks-axi list --file "$path" --limit "$fetch_limit" --fields blocked_by,hold_kind,hold_reason 2>&1)
   rc=$?
   if [ "$rc" -eq 0 ]; then
     print_backlog_tasks_axi_filtered "$path" "$out"

--- a/bin/fm-tasks-axi-lib.sh
+++ b/bin/fm-tasks-axi-lib.sh
@@ -10,6 +10,14 @@
 # backlog mutations, but validated secondmate handoffs always use `tasks-axi mv`.
 # Absent or any other value keeps the default tasks-axi backend path, falling
 # back to manual mutation when the tool is not compatible.
+#
+# Hidden backlog category (captain triage: do / defer / backlog / kill):
+# A structured hold whose reason starts with "backlog:" is render-hidden from
+# every routine status surface until revived (unhold) or listed explicitly.
+# This lib owns the predicate and the human hint text; listing surfaces call it
+# rather than re-stating the prefix. Explicit listing is bin/fm-backlog-list.sh
+# --backlog (see that script's header). Deferred (hold-until / future) and
+# parked (hold-kind parked without the backlog: reason prefix) stay visible.
 
 fm_tasks_axi_version_parts() {
   local output
@@ -73,4 +81,71 @@ fm_tasks_axi_backend_available() {
   local config_dir=$1
   fm_backlog_backend_manual "$config_dir" && return 1
   fm_tasks_axi_compatible
+}
+
+# True when a hold reason is the hidden backlog triage category.
+# Match is prefix-only and case-sensitive: "backlog: cold storage" matches;
+# "Backlog: ..." or "deferred backlog later" do not.
+fm_hold_reason_is_backlogged() {
+  case "${1:-}" in
+    backlog:*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# True when a markdown task title line carries (hold: backlog: ...).
+fm_backlog_title_line_is_backlogged() {
+  printf '%s\n' "${1:-}" | grep -E '\(hold:[[:space:]]*backlog:' >/dev/null
+}
+
+# Print the one-line routine-surface hint, or nothing when count is zero.
+# Callers pass the explicit list invocation operators should run (default is
+# the firstmate backlog status view).
+fm_backlog_hidden_hint() {
+  local count=${1:-0}
+  local how=${2:-'bin/fm-backlog-list.sh --backlog'}
+  case "$count" in
+    ''|*[!0-9]*) return 0 ;;
+    0) return 0 ;;
+  esac
+  printf '%d backlogged hidden - use %s to list\n' "$count" "$how"
+}
+
+# List structured task ids in a backlog markdown file whose hold reason starts
+# with "backlog:". One id per line, in file order. Free-form lines are ignored.
+fm_backlogged_ids_from_file() {
+  local path=$1
+  [ -f "$path" ] || return 0
+  awk '
+    function is_task_title(line) {
+      return line ~ /^[-*][[:space:]]+(\[[ xX]\][[:space:]]+)?[^[:space:]]+[[:space:]]+-[[:space:]]+/ \
+        || line ~ /^[-*][[:space:]]+\*\*[^*]+\*\*[[:space:]]+-[[:space:]]+/
+    }
+    function task_id(line,   rest, id) {
+      rest = line
+      sub(/^[-*][[:space:]]+/, "", rest)
+      if (rest ~ /^\[[ xX]\][[:space:]]+/) sub(/^\[[ xX]\][[:space:]]+/, "", rest)
+      if (rest ~ /^\*\*[^*]+\*\*/) {
+        sub(/^\*\*/, "", rest)
+        sub(/\*\*.*/, "", rest)
+        id = rest
+      } else {
+        id = rest
+        sub(/[[:space:]].*/, "", id)
+      }
+      return id
+    }
+    is_task_title($0) && /\(hold:[[:space:]]*backlog:/ {
+      id = task_id($0)
+      if (id != "") print id
+    }
+  ' "$path"
+}
+
+# Count structured backlogged title lines in a backlog markdown file.
+fm_backlogged_count_from_file() {
+  local path=$1
+  local n
+  n=$(fm_backlogged_ids_from_file "$path" | awk 'END { print NR+0 }')
+  printf '%s\n' "${n:-0}"
 }

--- a/bin/fm-tasks-axi-lib.sh
+++ b/bin/fm-tasks-axi-lib.sh
@@ -19,6 +19,9 @@
 # --backlog (see that script's header). Deferred (hold-until / future) and
 # parked (hold-kind parked without the backlog: reason prefix) stay visible.
 
+FM_BACKLOG_HOLD_PREFIX='backlog:'
+FM_BACKLOG_LIST_COMMAND='bin/fm-backlog-list.sh --backlog'
+
 fm_tasks_axi_version_parts() {
   local output
   command -v tasks-axi >/dev/null 2>&1 || return 1
@@ -88,14 +91,24 @@ fm_tasks_axi_backend_available() {
 # "Backlog: ..." or "deferred backlog later" do not.
 fm_hold_reason_is_backlogged() {
   case "${1:-}" in
-    backlog:*) return 0 ;;
+    "$FM_BACKLOG_HOLD_PREFIX"*) return 0 ;;
     *) return 1 ;;
   esac
 }
 
 # True when a markdown task title line carries (hold: backlog: ...).
 fm_backlog_title_line_is_backlogged() {
-  printf '%s\n' "${1:-}" | grep -E '\(hold:[[:space:]]*backlog:' >/dev/null
+  local line=${1:-} reason
+  case "$line" in
+    *"(hold:"*)
+      reason=${line#*"(hold:"}
+      reason=${reason#"${reason%%[![:space:]]*}"}
+      case "$reason" in
+        "$FM_BACKLOG_HOLD_PREFIX"*) return 0 ;;
+      esac
+      ;;
+  esac
+  return 1
 }
 
 # Print the one-line routine-surface hint, or nothing when count is zero.
@@ -103,12 +116,11 @@ fm_backlog_title_line_is_backlogged() {
 # the firstmate backlog status view).
 fm_backlog_hidden_hint() {
   local count=${1:-0}
-  local how=${2:-'bin/fm-backlog-list.sh --backlog'}
   case "$count" in
     ''|*[!0-9]*) return 0 ;;
     0) return 0 ;;
   esac
-  printf '%d backlogged hidden - use %s to list\n' "$count" "$how"
+  printf '%d backlogged hidden - use %s to list\n' "$count" "$FM_BACKLOG_LIST_COMMAND"
 }
 
 # List structured task ids in a backlog markdown file whose hold reason starts
@@ -116,7 +128,7 @@ fm_backlog_hidden_hint() {
 fm_backlogged_ids_from_file() {
   local path=$1
   [ -f "$path" ] || return 0
-  awk '
+  awk -v prefix="$FM_BACKLOG_HOLD_PREFIX" '
     function is_task_title(line) {
       return line ~ /^[-*][[:space:]]+(\[[ xX]\][[:space:]]+)?[^[:space:]]+[[:space:]]+-[[:space:]]+/ \
         || line ~ /^[-*][[:space:]]+\*\*[^*]+\*\*[[:space:]]+-[[:space:]]+/
@@ -135,7 +147,12 @@ fm_backlogged_ids_from_file() {
       }
       return id
     }
-    is_task_title($0) && /\(hold:[[:space:]]*backlog:/ {
+    function is_backlogged(line, reason) {
+      reason = line
+      sub(/^.*\(hold:[[:space:]]*/, "", reason)
+      return index(reason, prefix) == 1
+    }
+    is_task_title($0) && is_backlogged($0) {
       id = task_id($0)
       if (id != "") print id
     }
@@ -148,4 +165,95 @@ fm_backlogged_count_from_file() {
   local n
   n=$(fm_backlogged_ids_from_file "$path" | awk 'END { print NR+0 }')
   printf '%s\n' "${n:-0}"
+}
+
+# Render backlog title lines for the explicit status view or session-start.
+# This is the single owner of markdown classification, filtering, and hints.
+fm_backlog_render_title_lines() {  # <path> <routine|backlog|include> <max> <status|session>
+  local path=$1 mode=${2:-routine} max=${3:-0} style=${4:-status}
+  awk \
+    -v mode="$mode" \
+    -v max="$max" \
+    -v style="$style" \
+    -v prefix="$FM_BACKLOG_HOLD_PREFIX" \
+    -v list_command="$FM_BACKLOG_LIST_COMMAND" '
+    function state_for_heading(line, heading) {
+      heading = line
+      sub(/^##[[:space:]]+/, "", heading)
+      sub(/[[:space:]]+$/, "", heading)
+      if (heading == "In flight") return "in_flight"
+      if (heading == "Queued") return "queued"
+      if (heading == "Done") return "done"
+      return ""
+    }
+    function is_backlogged(line, reason) {
+      reason = line
+      sub(/^.*\(hold:[[:space:]]*/, "", reason)
+      return index(reason, prefix) == 1
+    }
+    /^##[[:space:]]+/ {
+      state = state_for_heading($0)
+      if (state != "") {
+        pending_heading = $0
+        heading_pending = 1
+      }
+      next
+    }
+    state != "" && /^[-*][[:space:]]+/ {
+      backlogged = is_backlogged($0)
+      if (backlogged) hidden++
+      keep = mode == "backlog" ? backlogged : (mode == "include" ? 1 : !backlogged)
+      if (!keep) next
+      total++
+      if (max > 0 && shown >= max) next
+      if (heading_pending) {
+        print pending_heading
+        heading_pending = 0
+      }
+      print $0
+      shown++
+      next
+    }
+    END {
+      if (mode == "backlog") {
+        if (hidden == 0) {
+          print "(no backlogged items)"
+        } else if (max > 0 && total > shown) {
+          printf "(shown %d of %d backlogged item title line(s))\n", shown, total
+        } else {
+          printf "(shown %d backlogged item title line(s))\n", shown
+        }
+      } else if (mode == "include") {
+        if (total == 0) {
+          print "(no backlog item title lines found)"
+        } else {
+          printf "(shown %d of %d backlog item title line(s); includes backlogged)\n", shown, total
+          if (max > 0 && total > shown) {
+            printf "(truncated %d item(s); increase --limit for a larger listing)\n", total - shown
+          }
+        }
+      } else {
+        if (total == 0) {
+          if (hidden > 0) {
+            print "(no non-backlogged item title lines found)"
+          } else {
+            print "(no backlog item title lines found)"
+          }
+        } else if (style == "session") {
+          printf "(shown %d of %d backlog item title line(s))\n", shown, total
+          if (total > shown) {
+            printf "(truncated %d item(s); increase FM_SESSION_START_BACKLOG_LIMIT for a larger startup listing)\n", total - shown
+          }
+        } else {
+          printf "(shown %d of %d non-backlogged item title line(s))\n", shown, total
+          if (max > 0 && total > shown) {
+            printf "(truncated %d item(s); increase --limit for a larger listing)\n", total - shown
+          }
+        }
+        if (hidden > 0) {
+          printf "%d backlogged hidden - use %s to list\n", hidden, list_command
+        }
+      }
+    }
+  ' "$path"
 }

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -172,7 +172,7 @@ family_for_basename() {
     fm-afk-inject-e2e.test.sh|fm-afk-return.test.sh)
       printf '%s\n' afk
       ;;
-    fm-bearings-snapshot.test.sh|fm-fleet-snapshot-view.test.sh)
+    fm-backlog-list.test.sh|fm-bearings-snapshot.test.sh|fm-fleet-snapshot-view.test.sh)
       printf '%s\n' snapshot-bearings
       ;;
     fm-backend-cmux.test.sh|fm-backend-cmux-smoke.test.sh)
@@ -662,7 +662,7 @@ families_for_changed_path() {
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit
       ;;
-    bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh)
+    bin/fm-backlog-list.sh|bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh)
       printf '%s\n' snapshot-bearings
       ;;
     bin/fm-install-herdr.sh|bin/fm-install-treehouse.sh|bin/fm-herdr-ci-cleanup.sh)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,11 +36,11 @@ This preference is local to each Firstmate home and is not part of secondmate in
 The tracked `.tasks.toml` pins the default `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
 When the default backend is selected and compatible `tasks-axi` is on `PATH`, firstmate uses its verbs for routine backlog mutations.
 Secondmate handoffs are separate and unconditional: `fm-backlog-handoff.sh` keeps only its own fleet-level validation and always delegates the item move to `tasks-axi mv`, the single owner of the backlog format.
-A hold reason that starts with `backlog:` is the hidden backlog triage category.
-Routine session-start, fleet snapshot, fleet view, and bearings surfaces omit those items and print a count hint.
-`bin/fm-backlog-list.sh --backlog` lists only them.
-Pass `--include-backlog` on the snapshot or fleet view to keep them in the structured records.
-The predicate and hint text live in `bin/fm-tasks-axi-lib.sh`.
+Captain triage uses `do`, `defer`, `backlog`, and `kill`; a hold reason that starts with the case-sensitive prefix `backlog:` selects the hidden backlog category.
+Routine session-start, fleet snapshot, fleet view, and bearings surfaces omit those items, while deferred `future`/`hold-until` holds retain their revisit trigger and remain visible, as do parked holds without that prefix.
+The default `bin/fm-backlog-list.sh`, session-start digest, and fleet view print a hidden-count hint, and the snapshot exposes the count and hint as structured fields for its consumers.
+`bin/fm-backlog-list.sh --backlog` lists only hidden backlog items, while `--include-backlog` on the snapshot or fleet view keeps them in those surfaces.
+The shared predicate and hint text live in `bin/fm-tasks-axi-lib.sh`; exact listing flags and snapshot fields are owned by the corresponding script help and headers.
 Hold with `tasks-axi hold <id> --reason "backlog: <note>"` and revive with `tasks-axi unhold <id>`.
 It moves in-scope `## Queued` items only and refuses `## In flight` and historical `## Done` records, which stay with their home for pruning or archiving.
 Handoff item bodies must use at least two leading spaces, and the helper refuses a selected item with a single-space or tab-indented continuation rather than risk orphaning it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,12 @@ This preference is local to each Firstmate home and is not part of secondmate in
 The tracked `.tasks.toml` pins the default `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
 When the default backend is selected and compatible `tasks-axi` is on `PATH`, firstmate uses its verbs for routine backlog mutations.
 Secondmate handoffs are separate and unconditional: `fm-backlog-handoff.sh` keeps only its own fleet-level validation and always delegates the item move to `tasks-axi mv`, the single owner of the backlog format.
+A hold reason that starts with `backlog:` is the hidden backlog triage category.
+Routine session-start, fleet snapshot, fleet view, and bearings surfaces omit those items and print a count hint.
+`bin/fm-backlog-list.sh --backlog` lists only them.
+Pass `--include-backlog` on the snapshot or fleet view to keep them in the structured records.
+The predicate and hint text live in `bin/fm-tasks-axi-lib.sh`.
+Hold with `tasks-axi hold <id> --reason "backlog: <note>"` and revive with `tasks-axi unhold <id>`.
 It moves in-scope `## Queued` items only and refuses `## In flight` and historical `## Done` records, which stay with their home for pruning or archiving.
 Handoff item bodies must use at least two leading spaces, and the helper refuses a selected item with a single-space or tab-indented continuation rather than risk orphaning it.
 Because bootstrap requires `tasks-axi` on `PATH` on every profile, that delegation works fleet-wide, and the `config/backlog-backend=manual` knob governs firstmate's own hand-editing of its backlog, not this validated helper.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -14,6 +14,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
+| `fm-backlog-list.sh`     | List backlog title lines; default hides `backlog:` holds, `--backlog` lists only them |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
@@ -69,7 +70,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |
-| `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
+| `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector, `tasks-axi` probe, and hidden `backlog:` hold predicate |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, then assert watcher liveness |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
 | `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |

--- a/tests/fm-backlog-list.test.sh
+++ b/tests/fm-backlog-list.test.sh
@@ -44,6 +44,8 @@ new_home() {
   home="$TMP_ROOT/$name"
   mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
   write_mixed_backlog "$home/data/backlog.md"
+  printf 'kind=ship\nproject=alpha\n' > "$home/state/cold-storage.meta"
+  printf 'kind=ship\nproject=alpha\n' > "$home/state/defer-later.meta"
   printf '%s\n' "$home"
 }
 
@@ -129,6 +131,9 @@ test_fleet_snapshot_hides_backlogged_by_default() {
     and ([.backlog.records[] | select(.id == "defer-later")] | length) == 1
     and ([.backlog.records[] | select(.id == "park-vendor")] | length) == 1
     and ([.backlog.records[] | select(.id == "active-do")] | length) == 1
+    and (.backlog.hidden_backlogged_ids == ["backlog-note", "cold-storage"])
+    and ([.tasks[] | select(.id == "cold-storage")] | length) == 0
+    and ([.tasks[] | select(.id == "defer-later")] | length) == 1
     and (.backlog.records[] | select(.id == "defer-later") | .backlogged == false)
     and (.backlog.records[] | select(.id == "park-vendor") | .hold_kind == "parked")
   ' >/dev/null \
@@ -154,6 +159,8 @@ test_fleet_snapshot_include_backlog_keeps_rows() {
     and ([.backlog.records[] | select(.id == "cold-storage" and .backlogged == true)] | length) == 1
     and ([.backlog.records[] | select(.id == "backlog-note" and .backlogged == true)] | length) == 1
     and ([.backlog.records[] | select(.id == "defer-later" and .backlogged == false)] | length) == 1
+    and ([.tasks[] | select(.id == "cold-storage" and .backlog.backlogged == true)] | length) == 1
+    and ([.tasks[] | select(.id == "defer-later" and .backlog.backlogged == false)] | length) == 1
     and ((.backlog.records[] | select(.id == "cold-storage") | .hold_reason) | startswith("backlog:"))
   ' >/dev/null \
     || fail "fleet snapshot --include-backlog did not keep tagged backlog: rows"
@@ -182,10 +189,10 @@ test_lib_predicate_helpers() {
     '- [ ] x - t (hold: waiting on vendor) (hold-kind: parked)'; then
     fail "title-line detector false-positive on parked"
   fi
-  hint=$(fm_backlog_hidden_hint 3 "bin/fm-backlog-list.sh --backlog")
+  hint=$(fm_backlog_hidden_hint 3)
   assert_contains "$hint" "3 backlogged hidden" "hint missing count"
   assert_contains "$hint" "bin/fm-backlog-list.sh --backlog" "hint missing list command"
-  empty=$(fm_backlog_hidden_hint 0 "x")
+  empty=$(fm_backlog_hidden_hint 0)
   [ -z "$empty" ] || fail "zero count must print no hint"
 
   pass "shared predicate and hint helpers match the backlog: contract"

--- a/tests/fm-backlog-list.test.sh
+++ b/tests/fm-backlog-list.test.sh
@@ -184,6 +184,23 @@ test_fleet_snapshot_include_backlog_keeps_rows() {
   pass "fleet snapshot --include-backlog retains backlogged rows with tags"
 }
 
+test_hidden_secondmates_do_not_consume_registry_cap() {
+  local home snap
+  home=$(new_home registry-cap)
+  snap=$(FM_HOME="$home" FM_SNAPSHOT_REGISTRY_RECORDS=1 "$SNAPSHOT" --json)
+
+  printf '%s' "$snap" | jq -e '
+    (.secondmate_current.registry.records | map(.id)) == ["defer-later"]
+    and (.secondmate_current.registry.records_in_window == 1)
+    and (.secondmate_current.registry.records_truncated == false)
+    and (.secondmate_current.registry.complete == true)
+    and (.secondmate_current.records | map(.id)) == ["defer-later"]
+  ' >/dev/null \
+    || fail "hidden secondmate consumed the visible registry cap or truncation accounting"
+
+  pass "hidden secondmates are filtered before registry bounds and accounting"
+}
+
 test_lib_predicate_helpers() {
   # shellcheck source=bin/fm-tasks-axi-lib.sh
   . "$ROOT/bin/fm-tasks-axi-lib.sh"
@@ -222,6 +239,7 @@ test_include_backlog_shows_everything
 test_empty_backlog_mode_is_explicit
 test_fleet_snapshot_hides_backlogged_by_default
 test_fleet_snapshot_include_backlog_keeps_rows
+test_hidden_secondmates_do_not_consume_registry_cap
 test_lib_predicate_helpers
 
 echo "ALL PASS: fm-backlog-list / hidden backlog category"

--- a/tests/fm-backlog-list.test.sh
+++ b/tests/fm-backlog-list.test.sh
@@ -44,6 +44,13 @@ new_home() {
   home="$TMP_ROOT/$name"
   mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
   write_mixed_backlog "$home/data/backlog.md"
+  mkdir -p "$home/data/backlog-note" "$home/data/defer-later"
+  printf '# Hidden report\n' > "$home/data/backlog-note/report.md"
+  printf '# Visible report\n' > "$home/data/defer-later/report.md"
+  printf '%s\n' \
+    '- cold-storage - fixture (home: ; scope: fixture; projects: alpha; added 2026-07-29)' \
+    '- defer-later - fixture (home: ; scope: fixture; projects: alpha; added 2026-07-29)' \
+    > "$home/data/secondmates.md"
   printf 'kind=ship\nproject=alpha\n' > "$home/state/cold-storage.meta"
   printf 'kind=ship\nproject=alpha\n' > "$home/state/defer-later.meta"
   printf '%s\n' "$home"
@@ -134,6 +141,11 @@ test_fleet_snapshot_hides_backlogged_by_default() {
     and (.backlog.hidden_backlogged_ids == ["backlog-note", "cold-storage"])
     and ([.tasks[] | select(.id == "cold-storage")] | length) == 0
     and ([.tasks[] | select(.id == "defer-later")] | length) == 1
+    and ([.scout_reports[] | select(.id == "backlog-note")] | length) == 0
+    and ([.scout_reports[] | select(.id == "defer-later")] | length) == 1
+    and ([.secondmate_current.records[] | select(.id == "cold-storage")] | length) == 0
+    and ([.secondmate_current.registry.records[] | select(.id == "cold-storage")] | length) == 0
+    and ([.secondmate_current.records[] | select(.id == "defer-later")] | length) == 1
     and (.backlog.records[] | select(.id == "defer-later") | .backlogged == false)
     and (.backlog.records[] | select(.id == "park-vendor") | .hold_kind == "parked")
   ' >/dev/null \
@@ -161,6 +173,10 @@ test_fleet_snapshot_include_backlog_keeps_rows() {
     and ([.backlog.records[] | select(.id == "defer-later" and .backlogged == false)] | length) == 1
     and ([.tasks[] | select(.id == "cold-storage" and .backlog.backlogged == true)] | length) == 1
     and ([.tasks[] | select(.id == "defer-later" and .backlog.backlogged == false)] | length) == 1
+    and ([.scout_reports[] | select(.id == "backlog-note")] | length) == 1
+    and ([.scout_reports[] | select(.id == "defer-later")] | length) == 1
+    and ([.secondmate_current.records[] | select(.id == "cold-storage")] | length) == 1
+    and ([.secondmate_current.registry.records[] | select(.id == "cold-storage")] | length) == 1
     and ((.backlog.records[] | select(.id == "cold-storage") | .hold_reason) | startswith("backlog:"))
   ' >/dev/null \
     || fail "fleet snapshot --include-backlog did not keep tagged backlog: rows"

--- a/tests/fm-backlog-list.test.sh
+++ b/tests/fm-backlog-list.test.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# tests/fm-backlog-list.test.sh - hidden backlog category listing and inheritance.
+#
+# Coverage:
+#   - hold reason starting with "backlog:" is hidden from routine listing
+#   - --backlog shows only those items
+#   - deferred (future/hold-until) and parked (non-backlog: reason) stay visible
+#   - routine surfaces print the hidden-count hint
+#   - fleet-snapshot / fleet-view inherit the hide via the shared backlog filter
+#   - --include-backlog keeps backlogged rows in the snapshot
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LIST="$ROOT/bin/fm-backlog-list.sh"
+SNAPSHOT="$ROOT/bin/fm-fleet-snapshot.sh"
+VIEW="$ROOT/bin/fm-fleet-view.sh"
+TMP_ROOT=$(fm_test_tmproot fm-backlog-list)
+FM_TEST_CLEANUP_DIRS+=("$TMP_ROOT")
+trap fm_test_cleanup EXIT
+
+write_mixed_backlog() {
+  local path=$1
+  cat > "$path" <<'EOF'
+# Backlog
+
+## In flight
+
+## Queued
+- [ ] active-do - Ready to ship (repo: alpha) (kind: ship) (since 2026-07-15)
+- [ ] defer-later - Defer until Monday (repo: alpha) (kind: ship) (since 2026-07-15) (hold: defer until Monday) (hold-kind: future) (hold-until: 2030-01-01)
+- [ ] park-vendor - Waiting on vendor (repo: alpha) (kind: ship) (since 2026-07-15) (hold: waiting on vendor) (hold-kind: parked)
+- [ ] cold-storage - Not now (repo: alpha) (kind: ship) (since 2026-07-15) (hold: backlog: cold storage) (hold-kind: parked)
+- [ ] backlog-note - Shelf it (repo: beta) (kind: scout) (since 2026-07-16) (hold: backlog: revisit after launch) (hold-kind: future)
+
+## Done
+- [x] finished-task - Finished work (repo: alpha) (kind: ship) (done 2026-07-10)
+EOF
+}
+
+new_home() {
+  local name=$1 home
+  home="$TMP_ROOT/$name"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
+  write_mixed_backlog "$home/data/backlog.md"
+  printf '%s\n' "$home"
+}
+
+# --- fm-backlog-list.sh ------------------------------------------------------
+
+test_routine_hides_backlogged_keeps_defer_and_parked() {
+  local home out
+  home=$(new_home routine-list)
+  out=$(FM_HOME="$home" "$LIST" --file "$home/data/backlog.md")
+
+  assert_contains "$out" "active-do" "routine listing dropped ready work"
+  assert_contains "$out" "defer-later" "routine listing hid a deferred (future) hold"
+  assert_contains "$out" "park-vendor" "routine listing hid a parked non-backlog hold"
+  assert_not_contains "$out" "cold-storage" "routine listing showed a backlog: hold"
+  assert_not_contains "$out" "backlog-note" "routine listing showed a second backlog: hold"
+  assert_contains "$out" "2 backlogged hidden - use bin/fm-backlog-list.sh --backlog to list" \
+    "routine listing omitted the hidden-count hint"
+  assert_contains "$out" "finished-task" "routine listing dropped a Done item"
+
+  pass "routine listing hides backlog: holds and keeps defer/parked visible"
+}
+
+test_explicit_backlog_mode_lists_only_hidden() {
+  local home out
+  home=$(new_home explicit-backlog)
+  out=$(FM_HOME="$home" "$LIST" --backlog --file "$home/data/backlog.md")
+
+  assert_contains "$out" "cold-storage" "explicit --backlog omitted a backlog: hold"
+  assert_contains "$out" "backlog-note" "explicit --backlog omitted the second backlog: hold"
+  assert_contains "$out" "(hold: backlog: cold storage)" "explicit --backlog dropped hold metadata"
+  assert_not_contains "$out" "active-do" "explicit --backlog included non-backlogged work"
+  assert_not_contains "$out" "defer-later" "explicit --backlog included a deferred item"
+  assert_not_contains "$out" "park-vendor" "explicit --backlog included a parked item"
+  assert_not_contains "$out" "backlogged hidden" "explicit --backlog printed the hide hint"
+  assert_contains "$out" "(shown 2 backlogged item title line(s))" \
+    "explicit --backlog did not report its count"
+
+  pass "explicit --backlog lists only hidden backlog: holds"
+}
+
+test_include_backlog_shows_everything() {
+  local home out
+  home=$(new_home include-all)
+  out=$(FM_HOME="$home" "$LIST" --include-backlog --file "$home/data/backlog.md")
+
+  assert_contains "$out" "active-do" "include mode dropped ready work"
+  assert_contains "$out" "cold-storage" "include mode dropped a backlog: hold"
+  assert_contains "$out" "defer-later" "include mode dropped a deferred hold"
+  assert_not_contains "$out" "backlogged hidden" "include mode printed a hide hint"
+  assert_contains "$out" "includes backlogged" "include mode omitted its accounting note"
+
+  pass "--include-backlog lists every title line without hiding"
+}
+
+test_empty_backlog_mode_is_explicit() {
+  local home out
+  home=$(new_home empty-backlog-mode)
+  cat > "$home/data/backlog.md" <<'EOF'
+# Backlog
+## Queued
+- [ ] only-active - Just do it (repo: alpha)
+## Done
+EOF
+  out=$(FM_HOME="$home" "$LIST" --backlog --file "$home/data/backlog.md")
+  assert_contains "$out" "(no backlogged items)" "empty --backlog mode lacked the empty marker"
+  pass "--backlog on a file with no backlog: holds is explicit about emptiness"
+}
+
+# --- fleet snapshot / view inheritance ---------------------------------------
+
+test_fleet_snapshot_hides_backlogged_by_default() {
+  local home snap view
+  home=$(new_home snap-hide)
+  snap=$(FM_HOME="$home" "$SNAPSHOT" --json)
+  view=$(FM_HOME="$home" "$VIEW")
+
+  printf '%s' "$snap" | jq -e '
+    (.backlog.hidden_backlogged_count == 2)
+    and (.backlog.hidden_backlogged_hint | test("2 backlogged hidden"))
+    and (.backlog.hidden_backlogged_hint | test("fm-backlog-list.sh --backlog"))
+    and ([.backlog.records[] | select(.id == "cold-storage")] | length) == 0
+    and ([.backlog.records[] | select(.id == "backlog-note")] | length) == 0
+    and ([.backlog.records[] | select(.id == "defer-later")] | length) == 1
+    and ([.backlog.records[] | select(.id == "park-vendor")] | length) == 1
+    and ([.backlog.records[] | select(.id == "active-do")] | length) == 1
+    and (.backlog.records[] | select(.id == "defer-later") | .backlogged == false)
+    and (.backlog.records[] | select(.id == "park-vendor") | .hold_kind == "parked")
+  ' >/dev/null \
+    || fail "fleet snapshot did not hide backlog: holds or preserve defer/parked"
+
+  assert_not_contains "$view" "cold-storage" "fleet view showed a hidden backlog: hold"
+  assert_contains "$view" "defer-later" "fleet view hid a deferred hold"
+  assert_contains "$view" "park-vendor" "fleet view hid a parked hold"
+  assert_contains "$view" "2 backlogged hidden - use bin/fm-backlog-list.sh --backlog to list" \
+    "fleet view omitted the hidden-count hint"
+
+  pass "fleet snapshot and view hide backlog: holds and keep defer/parked"
+}
+
+test_fleet_snapshot_include_backlog_keeps_rows() {
+  local home snap
+  home=$(new_home snap-include)
+  snap=$(FM_HOME="$home" "$SNAPSHOT" --json --include-backlog)
+
+  printf '%s' "$snap" | jq -e '
+    (.backlog.hidden_backlogged_count == 2)
+    and (.backlog.hidden_backlogged_hint == null)
+    and ([.backlog.records[] | select(.id == "cold-storage" and .backlogged == true)] | length) == 1
+    and ([.backlog.records[] | select(.id == "backlog-note" and .backlogged == true)] | length) == 1
+    and ([.backlog.records[] | select(.id == "defer-later" and .backlogged == false)] | length) == 1
+    and ((.backlog.records[] | select(.id == "cold-storage") | .hold_reason) | startswith("backlog:"))
+  ' >/dev/null \
+    || fail "fleet snapshot --include-backlog did not keep tagged backlog: rows"
+
+  pass "fleet snapshot --include-backlog retains backlogged rows with tags"
+}
+
+test_lib_predicate_helpers() {
+  # shellcheck source=bin/fm-tasks-axi-lib.sh
+  . "$ROOT/bin/fm-tasks-axi-lib.sh"
+  fm_hold_reason_is_backlogged "backlog: cold" || fail "prefix match failed"
+  fm_hold_reason_is_backlogged "backlog:" || fail "bare prefix should match"
+  if fm_hold_reason_is_backlogged "Backlog: cold"; then
+    fail "predicate must be case-sensitive"
+  fi
+  if fm_hold_reason_is_backlogged "waiting on vendor"; then
+    fail "parked reason must not match"
+  fi
+  if fm_hold_reason_is_backlogged "defer until Monday"; then
+    fail "deferred reason must not match"
+  fi
+  fm_backlog_title_line_is_backlogged \
+    '- [ ] x - t (hold: backlog: note) (hold-kind: parked)' \
+    || fail "title-line detector missed backlog: hold"
+  if fm_backlog_title_line_is_backlogged \
+    '- [ ] x - t (hold: waiting on vendor) (hold-kind: parked)'; then
+    fail "title-line detector false-positive on parked"
+  fi
+  hint=$(fm_backlog_hidden_hint 3 "bin/fm-backlog-list.sh --backlog")
+  assert_contains "$hint" "3 backlogged hidden" "hint missing count"
+  assert_contains "$hint" "bin/fm-backlog-list.sh --backlog" "hint missing list command"
+  empty=$(fm_backlog_hidden_hint 0 "x")
+  [ -z "$empty" ] || fail "zero count must print no hint"
+
+  pass "shared predicate and hint helpers match the backlog: contract"
+}
+
+# --- run ---------------------------------------------------------------------
+
+test_routine_hides_backlogged_keeps_defer_and_parked
+test_explicit_backlog_mode_lists_only_hidden
+test_include_backlog_shows_everything
+test_empty_backlog_mode_is_explicit
+test_fleet_snapshot_hides_backlogged_by_default
+test_fleet_snapshot_include_backlog_keeps_rows
+test_lib_predicate_helpers
+
+echo "ALL PASS: fm-backlog-list / hidden backlog category"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -117,11 +117,12 @@ case "${1:-}" in
         exit 9
         ;;
     esac
-    case "$*" in *'--limit 80'*) : ;; *) printf '%s\n' 'missing compact limit' >&2; exit 9 ;; esac
+    case "$*" in *'--limit 3'*) : ;; *) printf '%s\n' 'fetch limit must include hidden rows' >&2; exit 9 ;; esac
     case "$*" in *'--file '*) : ;; *) printf '%s\n' 'missing explicit backlog file' >&2; exit 9 ;; esac
     cat <<'OUT'
-count: 2
-tasks[2]{id,state,kind,repo,title,blocked_by,hold_kind,hold_reason}:
+count: 3
+tasks[3]{id,state,kind,repo,title,blocked_by,hold_kind,hold_reason}:
+  hidden-first,queued,ship,firstmate,Hidden before visible rows,none,parked,backlog: later
   compact-startup,in_flight,ship,firstmate,Compact startup digest,none,captain,captain choice pending
   blocked-followup,queued,scout,firstmate,Follow compact startup,compact-startup,"-","-"
 help[2]:
@@ -1075,6 +1076,7 @@ write_long_body_backlog() {
   Another long body line that should not be printed after the fix.
 
 ## Queued
+- [ ] hidden-first - Hidden before visible rows (repo: firstmate) (kind: ship) (since 2026-07-15) (hold: backlog: later) (hold-kind: parked)
 - [ ] blocked-followup - Follow compact startup blocked-by: compact-startup - waits for implementation (repo: firstmate) (kind: scout) (since 2026-07-15)
   QUEUED-BODY-LINE this is another long multiline note.
 
@@ -1097,9 +1099,10 @@ EOF
     > "$home/state/compact-startup.meta"
   log="$home/tasks-axi.log"
 
-  out=$(FM_FAKE_TASKS_AXI_LOG="$log" run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(FM_FAKE_TASKS_AXI_LOG="$log" FM_SESSION_START_BACKLOG_LIMIT=2 \
+    run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
-  assert_contains "$out" "compact backlog listing (tasks-axi; max 80 item(s); task bodies omitted)" \
+  assert_contains "$out" "compact backlog listing (tasks-axi; max 2 item(s); task bodies omitted)" \
     "compatible tasks-axi backend did not render the compact backlog listing"
   assert_contains "$out" "tasks[2]{id,state,kind,repo,title,blocked_by,hold_kind,hold_reason}:" \
     "tasks-axi compact listing omitted the expected structured field header"
@@ -1107,14 +1110,18 @@ EOF
     "tasks-axi compact listing omitted in-flight identity, state, or hold metadata"
   assert_contains "$out" 'blocked-followup,queued,scout,firstmate,Follow compact startup,compact-startup,"-","-"' \
     "tasks-axi compact listing omitted blocked-by metadata"
+  assert_not_contains "$out" "hidden-first,queued" \
+    "tasks-axi compact listing showed a hidden backlog item"
+  assert_contains "$out" "1 backlogged hidden - use bin/fm-backlog-list.sh --backlog to list" \
+    "tasks-axi compact listing omitted the shared hidden-count hint"
   assert_not_contains "$out" "OVERSIZED-BODY-LINE" "tasks-axi compact digest leaked an in-flight task body"
   assert_not_contains "$out" "QUEUED-BODY-LINE" "tasks-axi compact digest leaked a queued task body"
   assert_contains "$out" "--- compact-startup ---" "in-flight meta identity disappeared from startup recovery digest"
   assert_contains "$out" "worktree=$home/projects/firstmate" "in-flight recovery worktree identity disappeared from startup digest"
   assert_contains "$out" "Full task bodies remain available on demand: tasks-axi show <id> --full" \
     "compact digest omitted the full-body lookup pointer"
-  assert_grep "list --file $home/data/backlog.md --limit 80 --fields blocked_by,hold_kind,hold_reason" "$log" \
-    "session start did not ask tasks-axi for the bounded compact field set"
+  assert_grep "list --file $home/data/backlog.md --limit 3 --fields blocked_by,hold_kind,hold_reason" "$log" \
+    "session start did not fetch enough compact rows to fill the visible limit"
 
   pass "compatible tasks-axi backlog rendering is compact, bounded, and preserves recovery metadata"
 }


### PR DESCRIPTION
## Intent

Add a hidden "Backlog" triage category and explicit backlog status view to firstmate's task tooling.

Captain triage vocabulary is do / defer / backlog / kill. Items held with a reason that starts with "backlog:" must be render-hidden from every routine surface (session-start compact listing, fleet snapshot, fleet view, bearings) until revived, and listed only via an explicit "show backlog" path. This differs from deferred (listed, with a revisit trigger) and parked (visible).

Implementation choices made while doing the work:
- Shared predicate and hint text live in bin/fm-tasks-axi-lib.sh (hold reason prefix "backlog:", case-sensitive) so surfaces do not re-state the convention.
- Explicit human status view is bin/fm-backlog-list.sh: default hides backlogged items with a count hint ("N backlogged hidden - use bin/fm-backlog-list.sh --backlog to list"); --backlog lists only them; --include-backlog shows everything.
- Fleet snapshot filters backlogged rows out of backlog.records by default, exposes hidden_backlogged_count and hidden_backlogged_hint, tags backlogged:true when included via --include-backlog; fleet-view and bearings inherit without per-surface duplication.
- Session-start filters both the tasks-axi compact path and the manual title-line path with the same convention.
- Deferred (future/hold-until) and parked without the backlog: reason prefix remain visible.
- Tests in tests/fm-backlog-list.test.sh; registered under snapshot-bearings in fm-test-run.sh.
- Hold/revive still use tasks-axi hold/unhold; no change to tasks-axi itself (external package).

## What Changed

- Add a shared, case-sensitive `backlog:` hold classification that hides matching tasks from session-start, fleet snapshot/view, Bearings, scout reports, and secondmate projections while keeping deferred and ordinary parked holds visible.
- Add `fm-backlog-list.sh` with routine, backlog-only, and include-backlog views, plus hidden-count hints and structured snapshot metadata.
- Document the backlog triage workflow and add behavioral coverage for listing, filtering, limits, registry accounting, and explicit inclusion.

## Risk Assessment

✅ Low: The latest correction filters hidden secondmate IDs before applying the registry record cap and computes record truncation/completeness from the visible record set, resolving the remaining issue without introducing a material new risk.

## Testing

Confirmed the supplied target and clean baseline, then passed the backlog, fleet snapshot/view, bearings, and full session-start regression suites. End-to-end CLI fixtures demonstrated case-sensitive hiding, continued visibility for deferred and parked work, hidden-count hints, explicit backlog listing, and `backlogged: true` restoration through `--include-backlog`.

<details>
<summary>Evidence: Backlog list CLI modes</summary>

```text
^D+ FM_HOME=/var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KYRFD6QZAPS839CCBFB2NK3H/fixture
+ bin/fm-backlog-list.sh --file /var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KYRFD6QZAPS839CCBFB2NK3H/fixture/data/backlog.md
## Queued
- [ ] active-do - Ready to ship (repo: alpha) (kind: ship) (since 2026-07-15)
- [ ] defer-later - Revisit Monday (repo: alpha) (kind: ship) (since 2026-07-15) (hold: defer until Monday) (hold-kind: future) (hold-until: 2030-01-01)
- [ ] park-vendor - Waiting on vendor (repo: alpha) (kind: ship) (since 2026-07-15) (hold: waiting on vendor) (hold-kind: parked)
- [ ] case-sensitive - Visible uppercase prefix (repo: alpha) (kind: scout) (since 2026-07-16) (hold: Backlog: intentionally visible) (hold-kind: parked)
## Done
- [x] finished-task - Finished work (repo: alpha) (kind: ship) (done 2026-07-10)
(shown 5 of 5 non-backlogged item title line(s))
1 backlogged hidden - use bin/fm-backlog-list.sh --backlog to list
+ FM_HOME=/var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KYRFD6QZAPS839CCBFB2NK3H/fixture
+ bin/fm-backlog-list.sh --backlog --file /var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KYRFD6QZAPS839CCBFB2NK3H/fixture/data/backlog.md
## Queued
- [ ] cold-storage - Not now (repo: alpha) (kind: ship) (since 2026-07-15) (hold: backlog: cold storage) (hold-kind: parked)
(shown 1 backlogged item title line(s))
+ FM_HOME=/var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KYRFD6QZAPS839CCBFB2NK3H/fixture
+ bin/fm-backlog-list.sh --include-backlog --file /var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KYRFD6QZAPS839CCBFB2NK3H/fixture/data/backlog.md
## Queued
- [ ] active-do - Ready to ship (repo: alpha) (kind: ship) (since 2026-07-15)
- [ ] defer-later - Revisit Monday (repo: alpha) (kind: ship) (since 2026-07-15) (hold: defer until Monday) (hold-kind: future) (hold-until: 2030-01-01)
- [ ] park-vendor - Waiting on vendor (repo: alpha) (kind: ship) (since 2026-07-15) (hold: waiting on vendor) (hold-kind: parked)
- [ ] cold-storage - Not now (repo: alpha) (kind: ship) (since 2026-07-15) (hold: backlog: cold storage) (hold-kind: parked)
- [ ] case-sensitive - Visible uppercase prefix (repo: alpha) (kind: scout) (since 2026-07-16) (hold: Backlog: intentionally visible) (hold-kind: parked)
## Done
- [x] finished-task - Finished work (repo: alpha) (kind: ship) (done 2026-07-10)
(shown 6 of 6 backlog item title line(s); includes backlogged)
```
</details>
<details>
<summary>Evidence: Fleet snapshot comparison</summary>

```text
{
  "routine": {
    "visible_ids": [
      "active-do",
      "defer-later",
      "park-vendor",
      "case-sensitive",
      "finished-task"
    ],
    "hidden_backlogged_ids": [
      "cold-storage"
    ],
    "hidden_backlogged_count": 1,
    "hidden_backlogged_hint": "1 backlogged hidden - use bin/fm-backlog-list.sh --backlog to list",
    "tasks": [
      "defer-later"
    ],
    "scout_reports": [],
    "secondmates": [
      "defer-later"
    ]
  },
  "include_backlog": {
    "records": [
      {
        "id": "active-do",
        "backlogged": false,
        "hold_kind": null,
        "hold_reason": null
      },
      {
        "id": "defer-later",
        "backlogged": false,
        "hold_kind": "future",
        "hold_reason": "defer until Monday"
      },
      {
        "id": "park-vendor",
        "backlogged": false,
        "hold_kind": "parked",
        "hold_reason": "waiting on vendor"
      },
      {
        "id": "cold-storage",
        "backlogged": true,
        "hold_kind": "parked",
        "hold_reason": "backlog: cold storage"
      },
      {
        "id": "case-sensitive",
        "backlogged": false,
        "hold_kind": "parked",
        "hold_reason": "Backlog: intentionally visible"
      },
      {
        "id": "finished-task",
        "backlogged": false,
        "hold_kind": null,
        "hold_reason": null
      }
    ],
    "hidden_backlogged_count": 1,
    "hidden_backlogged_hint": null,
    "tasks": [
      {
        "id": "cold-storage",
        "backlogged": true
      },
      {
        "id": "defer-later",
        "backlogged": false
      }
    ],
    "secondmates": [
      "cold-storage",
      "defer-later"
    ]
  }
}
```
</details>
<details>
<summary>Evidence: Fleet view</summary>

```text
^D# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KYRFD6QZAPS839CCBFB2NK3H/fixture

## Under Way
| ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| defer-later | unknown / none | ship | alpha | tmux | unknown | - | - | bin/fm-peek.sh fm-defer-later |

## Queued
| ID | Title | Repo | Kind | Blocked By | Artifact |
| --- | --- | --- | --- | --- | --- |
| active-do | Ready to ship | alpha | ship | - | - |
| defer-later | Revisit Monday (repo: alpha) (kind: ship) (since 2026-07-15) (hold: defer until Monday) (hold-kind: future) (hold-until: 2030-01-01) | alpha | ship | - | - |
| park-vendor | Waiting on vendor | alpha | ship | - | - |
| case-sensitive | Visible uppercase prefix | alpha | scout | - | - |

1 backlogged hidden - use bin/fm-backlog-list.sh --backlog to list

## Done
| ID | Title | Repo | Kind | Blocked By | Artifact |
| --- | --- | --- | --- | --- | --- |
| finished-task | Finished work | alpha | ship | - | - |

## Secondmates
For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.
```
</details>
<details>
<summary>Evidence: Bearings</summary>

```text
^Dschema: fm-bearings.v1
home: 01KYRFD6QZAPS839CCBFB2NK3H/fixture
generated: "2026-07-30T03:29:15Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight[1]{id,kind,state,doing}:
  defer-later,ship,unknown,worktree gone (torn down?)
secondmates[1]{id,state,doing,provenance,freshness,age_seconds,contradiction,reason}:
  defer-later,unknown,registry entry has no home,unknown,unknown,null,false,registry entry has no home
decisions_open: []
landed[1]{id,what,artifact,owner}:
  finished-task,Finished work,"-",(main)
gates[4]{id,title,blocked_by,reason,owner}:
  active-do,Ready to ship,"-","-",(main)
  defer-later,"Revisit Monday (repo: alpha) (kind: ship) (since 2026-07-15)…","-",defer until Monday,(main)
  park-vendor,Waiting on vendor,"-",waiting on vendor,(main)
  case-sensitive,Visible uppercase prefix,"-","Backlog: intentionally visible",(main)
reports: []
recorded_prs: []
omitted[8]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  superseded queued items,"--all-queued"
  "secondmate home(s) with unreadable backlog: 1",inspect the listed secondmate home backlogs
  live PR discovery + checks,"--include-prs"
```
</details>
<details>
<summary>Evidence: Session-start compact backlog digest</summary>

```text
data/backlog.md
--------------------------------------------------------------------------------
compact backlog listing (manual backend; max 20 item(s); indented task bodies omitted)
## Queued
- [ ] active-do - Ready to ship (repo: alpha) (kind: ship) (since 2026-07-15)
- [ ] defer-later - Revisit Monday (repo: alpha) (kind: ship) (since 2026-07-15) (hold: defer until Monday) (hold-kind: future) (hold-until: 2030-01-01)
- [ ] park-vendor - Waiting on vendor (repo: alpha) (kind: ship) (since 2026-07-15) (hold: waiting on vendor) (hold-kind: parked)
- [ ] case-sensitive - Visible uppercase prefix (repo: alpha) (kind: scout) (since 2026-07-16) (hold: Backlog: intentionally visible) (hold-kind: parked)
## Done
- [x] finished-task - Finished work (repo: alpha) (kind: ship) (done 2026-07-10)
(shown 5 of 5 backlog item title line(s))
1 backlogged hidden - use bin/fm-backlog-list.sh --backlog to list
Full task bodies remain available on demand: tasks-axi show <id> --full when compatible tasks-axi is available, or data/backlog.md.

Work under way (state/*.meta)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-fleet-snapshot.sh:436` - Backlogged rows are removed only from backlog.records, while matching state/*.meta entries remain in tasks. Fleet view renders every task, and Bearings treats a task whose attached backlog is null as eligible, so an in-flight item held with &#34;backlog:&#34; remains visible on both routine surfaces. Preserve the hidden IDs/flag and exclude matching task projections by default. (Confidence: 9/10)
- ⚠️ `bin/fm-fleet-snapshot.sh:416` - The required criterion says, &#34;Shared predicate and hint text live in bin/fm-tasks-axi-lib.sh ... so surfaces do not re-state the convention,&#34; but this hunk reimplements startswith(&#34;backlog:&#34;) and the hint string. fm-backlog-list.sh and the manual session-start path also duplicate them, allowing routine surfaces to drift from the shared helpers. Route these surfaces through one shared implementation. (Confidence: 10/10)
- ⚠️ `bin/fm-session-start.sh:270` - The tasks-axi path applies --limit before removing hidden rows. If hidden items occupy the first N results, later visible work is omitted and the rewritten output can report zero tasks despite actionable items beyond the limit; the manual path correctly limits after filtering. Filter before applying the visible-item limit or fetch enough rows to fill it. (Confidence: 8/10)

🔧 Fix: Hide backlogged tasks consistently across routine surfaces
1 error still open:
- 🚨 `bin/fm-fleet-snapshot.sh:1366` - The accepted contract requires backlog-held items to be hidden from the entire routine fleet snapshot and Bearings, but filtering is applied only to tasks[]. scout_reports still publishes every data/&lt;id&gt;/report.md, and secondmate_current reconstructs filtered secondmate IDs from the registry, so backlogged scouts or secondmates remain visible. Apply hidden_backlogged_ids to every identity-bearing projection by default and retain them only with --include-backlog. (Confidence: 9/10)

🔧 Fix: Hide backlogged IDs from all snapshot projections
1 warning still open:
- ⚠️ `bin/fm-fleet-snapshot.sh:1146` - Hidden registry rows are filtered only after registry_secondmates_json has capped records at FM_SNAPSHOT_REGISTRY_RECORDS. Hidden entries can therefore consume the cap, leaving later visible secondmates missing or incorrectly marked registration-unknown; records_truncated/complete also still reflect hidden rows. Filter before the registry cap, or add hidden-count headroom as the session-start path does. (Confidence: 8/10)

🔧 Fix: Filter hidden secondmates before registry caps
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --short` and `git rev-parse HEAD`</code>
- `git diff --stat --name-status a2d5f264966f9b391899fa5286bd54acd8f2e877..3f2311c5bafd2083ce405403436e8f1318d0a85b`
- `bin/fm-test-run.sh --family snapshot-bearings`
- `bin/fm-test-run.sh tests/fm-session-start.test.sh`
- `FM_HOME=<fixture> bin/fm-backlog-list.sh --file <fixture>/data/backlog.md`
- `FM_HOME=<fixture> bin/fm-backlog-list.sh --backlog --file <fixture>/data/backlog.md`
- `FM_HOME=<fixture> bin/fm-backlog-list.sh --include-backlog --file <fixture>/data/backlog.md`
- <code>`FM_HOME=&lt;fixture&gt; bin/fm-fleet-snapshot.sh --json` and `--include-backlog`, compared with `jq`</code>
- `FM_HOME=<fixture> bin/fm-fleet-view.sh`
- `FM_HOME=<fixture> bin/fm-bearings-snapshot.sh`
- `FM_HOME=<fixture> FM_SESSION_START_BACKLOG_LIMIT=20 bin/fm-session-start.sh`
- <code>Evidence assertions using `jq`, `rg`, and shell exit checks</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
