### PR TITLE
fix(bin): isolate Treehouse pools by firstmate home

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -176,7 +176,7 @@ The safety check is the secondmate's own home.
 Teardown refuses while its `state/*.meta` contains in-flight work.
 When safe, teardown kills the direct tmux window, removes the `data/secondmates.md` route, clears the main home metadata, and removes the retired secondmate home.
 Removing a leased home releases its durable treehouse lease via `treehouse return`, so the pool slot is freed for reuse rather than left leased forever.
-A plain-clone home with no pool slot is simply removed.
+A plain-clone home has no home lease to return and is removed after the project-slot cleanup described below.
 If `treehouse return` fails for a leased home, teardown stops with state intact rather than raw-removing the directory and hiding a held lease.
 Before the home is removed, teardown also destroys every treehouse pool slot whose git common dir lies under the retiring home, and refuses the retirement when treehouse will not destroy one; `bin/fm-teardown.sh`'s header owns the exact scan and flag contract.
 

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -178,6 +178,7 @@ When safe, teardown kills the direct tmux window, removes the `data/secondmates.
 Removing a leased home releases its durable treehouse lease via `treehouse return`, so the pool slot is freed for reuse rather than left leased forever.
 A plain-clone home with no pool slot is simply removed.
 If `treehouse return` fails for a leased home, teardown stops with state intact rather than raw-removing the directory and hiding a held lease.
+Before the home is removed, teardown also destroys every treehouse pool slot whose git common dir lies under the retiring home, and refuses the retirement when treehouse will not destroy one; `bin/fm-teardown.sh`'s header owns the exact scan and flag contract.
 
 With `--force`, teardown is the explicit discard path.
 It kills child windows, discards child work and state inside the secondmate home, removes the route, releases the lease, and removes the retired secondmate home.

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -12,7 +12,13 @@
 #       That project list is non-exclusive provisioning data. Pass --no-projects
 #       instead of a project list to seed a project-less home for a domain whose
 #       subject is the firstmate repo itself; it is mutually exclusive with a
-#       project list, and omitting both still fails loudly. A project-less seed
+#       project list, and omitting both still fails loudly. Each cloned project
+#       also gets a repo-level treehouse.toml pinning treehouse's pool root
+#       inside the home (seed_treehouse_pool_root), because treehouse keys pools
+#       by origin URL under one shared root and a slot binds permanently to
+#       whichever clone created it; without isolation, two homes' clones of one
+#       remote share a pool and retiring one home orphans the other's slots.
+#       A project-less seed
 #       refuses a home with project clones or project-registry entries, so it
 #       never converts populated homes in place. The charter brief
 #       is copied to data/charter.md, newly cloned no-mistakes projects are
@@ -533,6 +539,34 @@ EOF
   return 1
 }
 
+# Pin a repo-level treehouse.toml into a freshly seeded project clone so every
+# "treehouse get" from this clone resolves pools under the home instead of the
+# default shared ~/.treehouse root. treehouse keys a pool by origin URL, so two
+# homes' clones of one remote would otherwise share a pool, and each slot stays
+# bound (git worktree add) to whichever clone created it - retiring one home
+# would then orphan the other's slots and poison the shared pool. A repo-level
+# treehouse.toml wins over user config for the root field (treehouse
+# internal/config/config.go Load), so this file is the isolation mechanism.
+seed_treehouse_pool_root() {  # <project> <dst> <home>
+  local project=$1 dst=$2 home=$3 cfg marker
+  cfg="$dst/treehouse.toml"
+  marker="# firstmate: seeded by fm-home-seed.sh"
+  if git -C "$dst" ls-files --error-unmatch treehouse.toml >/dev/null 2>&1; then
+    echo "error: project $project tracks treehouse.toml; cannot pin a home-scoped pool root for $dst without diverging from the repo's own treehouse config" >&2
+    return 1
+  fi
+  if [ -f "$cfg" ] && ! grep -qF "$marker" "$cfg" 2>/dev/null; then
+    echo "error: $cfg already exists without the firstmate seed marker; refusing to overwrite an operator's treehouse config" >&2
+    return 1
+  fi
+  cat > "$cfg" <<EOF
+$marker - keep this home's treehouse pools isolated from other firstmate
+# homes' clones of the same origin. treehouse appends .treehouse/<pool> under
+# this root, so pools land in data/treehouse-pools/.treehouse/ inside the home.
+root = "$home/data/treehouse-pools"
+EOF
+}
+
 clone_project() {
   local project=$1 home=$2 src dst url dst_url mode
   src="$PROJECTS/$project"
@@ -555,10 +589,12 @@ EOF
       echo "error: seeded project $project at $dst has origin $dst_url; expected $url" >&2
       return 1
     }
+    seed_treehouse_pool_root "$project" "$dst" "$home" || return 1
     return 0
   fi
   url=$(source_origin_url "$project" "$mode" "$src") || return 1
-  git clone --quiet "$url" "$dst"
+  git clone --quiet "$url" "$dst" || return 1
+  seed_treehouse_pool_root "$project" "$dst" "$home"
 }
 
 validate_seed_project() {

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -547,24 +547,49 @@ EOF
 # would then orphan the other's slots and poison the shared pool. A repo-level
 # treehouse.toml wins over user config for the root field (treehouse
 # internal/config/config.go Load), so this file is the isolation mechanism.
+toml_basic_string_escape() {
+  local value=$1
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\t'/\\t}
+  value=${value//$'\r'/\\r}
+  printf '%s\n' "$value"
+}
+
 seed_treehouse_pool_root() {  # <project> <dst> <home>
-  local project=$1 dst=$2 home=$3 cfg marker
+  local project=$1 dst=$2 home=$3 cfg marker exclude escaped_home
   cfg="$dst/treehouse.toml"
   marker="# firstmate: seeded by fm-home-seed.sh"
   if git -C "$dst" ls-files --error-unmatch treehouse.toml >/dev/null 2>&1; then
     echo "error: project $project tracks treehouse.toml; cannot pin a home-scoped pool root for $dst without diverging from the repo's own treehouse config" >&2
     return 1
   fi
+  if [ -L "$cfg" ]; then
+    echo "error: $cfg is a symlink; refusing to overwrite it" >&2
+    return 1
+  fi
   if [ -f "$cfg" ] && ! grep -qF "$marker" "$cfg" 2>/dev/null; then
     echo "error: $cfg already exists without the firstmate seed marker; refusing to overwrite an operator's treehouse config" >&2
     return 1
   fi
+  exclude=$(git -C "$dst" rev-parse --path-format=absolute --git-path info/exclude) || return 1
+  if ! seed_project_was_created "$dst"; then
+    seed_backup_project_file "$cfg" || return 1
+    seed_backup_project_file "$exclude" || return 1
+  fi
+  escaped_home=$(toml_basic_string_escape "$home")
   cat > "$cfg" <<EOF
 $marker - keep this home's treehouse pools isolated from other firstmate
 # homes' clones of the same origin. treehouse appends .treehouse/<pool> under
 # this root, so pools land in data/treehouse-pools/.treehouse/ inside the home.
-root = "$home/data/treehouse-pools"
+root = "$escaped_home/data/treehouse-pools"
 EOF
+  if ! grep -Fx '/treehouse.toml' "$exclude" >/dev/null 2>&1; then
+    if [ -s "$exclude" ] && [ "$(tail -c 1 "$exclude" 2>/dev/null || true)" != "" ]; then
+      printf '\n' >> "$exclude"
+    fi
+    printf '/treehouse.toml\n' >> "$exclude"
+  fi
 }
 
 clone_project() {
@@ -621,6 +646,8 @@ SEED_HOME_CREATED=0
 SEED_HOME_BACKED_UP=0
 SEED_BACKUP_DIR=
 SEED_CREATED_PROJECTS_FILE=
+SEED_PROJECT_FILES_BACKUP_DIR=
+SEED_PROJECT_FILES_BACKUP_COUNT=0
 SEED_PARENT_REG_EXISTED=0
 SEED_PARENT_BRIEF=
 SEED_PARENT_BRIEF_CREATED=0
@@ -721,6 +748,32 @@ seed_project_was_created() {
   grep -Fx -- "$project_path" "$SEED_CREATED_PROJECTS_FILE" >/dev/null 2>&1
 }
 
+seed_backup_project_file() {
+  local path=$1 record
+  SEED_PROJECT_FILES_BACKUP_COUNT=$((SEED_PROJECT_FILES_BACKUP_COUNT + 1))
+  record="$SEED_PROJECT_FILES_BACKUP_DIR/$SEED_PROJECT_FILES_BACKUP_COUNT"
+  mkdir -p "$record"
+  printf '%s\n' "$path" > "$record/path"
+  if [ -e "$path" ]; then
+    printf '1\n' > "$record/existed"
+    cp "$path" "$record/content"
+  else
+    printf '0\n' > "$record/existed"
+  fi
+}
+
+seed_restore_project_files() {
+  local record path existed
+  [ -n "${SEED_PROJECT_FILES_BACKUP_DIR:-}" ] || return 0
+  [ -d "$SEED_PROJECT_FILES_BACKUP_DIR" ] || return 0
+  for record in "$SEED_PROJECT_FILES_BACKUP_DIR"/*; do
+    [ -d "$record" ] || continue
+    path=$(cat "$record/path")
+    existed=$(cat "$record/existed")
+    restore_seed_file "$existed" "$record/content" "$path"
+  done
+}
+
 seed_rollback() {
   local project_path
   [ "${SEED_ROLLBACK_ACTIVE:-0}" = 1 ] || return 0
@@ -745,6 +798,7 @@ seed_rollback() {
           seed_remove_created_project "$project_path"
         done < "$SEED_CREATED_PROJECTS_FILE"
       fi
+      seed_restore_project_files
       if [ -n "${SEED_BACKUP_DIR:-}" ] && [ "${SEED_HOME_BACKED_UP:-0}" = 1 ]; then
         restore_seed_file "$SEED_MARKER_EXISTED" "$SEED_BACKUP_DIR/marker" "$SEED_HOME/$SUB_HOME_MARKER"
         restore_seed_file "$SEED_CHARTER_EXISTED" "$SEED_BACKUP_DIR/charter.md" "$SEED_HOME/data/charter.md"
@@ -935,6 +989,9 @@ seed_home() {
   SEED_BACKUP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-home-seed.XXXXXX")
   SEED_CREATED_PROJECTS_FILE="$SEED_BACKUP_DIR/created-projects"
   : > "$SEED_CREATED_PROJECTS_FILE"
+  SEED_PROJECT_FILES_BACKUP_DIR="$SEED_BACKUP_DIR/project-files"
+  SEED_PROJECT_FILES_BACKUP_COUNT=0
+  mkdir -p "$SEED_PROJECT_FILES_BACKUP_DIR"
   SEED_PARENT_REG_EXISTED=0
   SEED_PARENT_BRIEF="$DATA/$id/brief.md"
   SEED_PARENT_BRIEF_CREATED=0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1306,6 +1306,28 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+
+  # Cross-home pool-binding guard: treehouse keys a pool by origin URL under one
+  # root, so a reused slot may be permanently bound (git worktree add) to a
+  # different home's clone of the same remote. Working from such a slot means
+  # this task's object store, refs, and tool trust root live in another home
+  # that can be retired out from under it, so fail closed and hand the slot
+  # back. Equality of git common dirs is the exact test: a slot created from
+  # this home's project clone shares its object store; anything else is foreign.
+  # (Secondmate homes' clones pin a home-scoped pool root via treehouse.toml at
+  # seed time, so a healthy fleet never reaches this refusal.)
+  WT_COMMON_DIR=$(git -C "$WT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  PROJ_COMMON_DIR=$(git -C "$PROJ_ABS" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  WT_COMMON_DIR_REAL=$(real_path_or_raw "$WT_COMMON_DIR")
+  PROJ_COMMON_DIR_REAL=$(real_path_or_raw "$PROJ_COMMON_DIR")
+  if [ -z "$WT_COMMON_DIR" ] || [ -z "$PROJ_COMMON_DIR" ] || [ "$WT_COMMON_DIR_REAL" != "$PROJ_COMMON_DIR_REAL" ]; then
+    ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 \
+      || echo "warning: could not return foreign-bound pool slot $WT from $PROJ_ABS; destroy it with: treehouse destroy $WT --yes" >&2
+    echo "error: treehouse get acquired pool slot $WT bound to a different clone (git common dir ${WT_COMMON_DIR_REAL:-unknown}, expected $PROJ_COMMON_DIR_REAL)." >&2
+    echo "That slot's object store belongs to another home's clone of the same origin; continuing would tangle this task with that home and break when it retires." >&2
+    echo "Destroy the foreign-bound slot with: treehouse destroy $WT --yes  (then respawn). Inspect window $T" >&2
+    exit 1
+  fi
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -959,9 +959,9 @@ $HOME/.treehouse"
         slot_common=$(git -C "$slot" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
         [ -n "$slot_common" ] || continue
         slot_common_real=$(cd "$slot_common" 2>/dev/null && pwd -P) || continue
-        case "$slot_common_real" in
-          "$home_real"/*) printf '%s\n' "$slot" ;;
-        esac
+        if [ "${slot_common_real#"$home_real"/}" != "$slot_common_real" ]; then
+          printf '%s\n' "$slot"
+        fi
       done
     done
   )

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -48,7 +48,14 @@
 # Secondmates (kind=secondmate in meta) are retired explicitly. Normal
 # teardown refuses while their home has in-flight crewmate meta files; --force
 # is the approved discard path that prevalidates child removal targets, discards
-# child work, kills child runtime endpoints, and removes the retired home. Removing a
+# child work, kills child runtime endpoints, and removes the retired home. Before the
+# home is removed, teardown destroys every treehouse pool slot whose git common
+# dir lies under that home (destroy_home_bound_pool_slots), while the home's
+# project clones still exist: treehouse keys pools by origin URL under a shared
+# root, so slots created from the home's clones can live in pools other homes
+# use, and deleting the clones first would orphan those slots and poison the
+# pool. A slot treehouse will not destroy bare (in use, or unlanded without
+# --force) refuses the retirement loudly. Removing a
 # leased home releases its durable treehouse lease so the pool slot is freed,
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
@@ -919,6 +926,72 @@ EOF
   printf '%s\n' "$abs_home_path"
 }
 
+# Destroy every treehouse pool slot whose git common dir lies under the given
+# secondmate home, while the home's project clones still exist. treehouse keys
+# pools by origin URL under one root, so spawns from this home's clones can
+# leave slots in the shared default root (and, for homes seeded before
+# home-scoped pool roots were pinned, in roots other homes still use); deleting
+# the home without destroying those slots orphans them (broken gitdir pointers)
+# and poisons the pool toward its max_trees cap. Bare `treehouse destroy`
+# removes only genuinely disposable slots, so an in-use slot - possibly another
+# home's live task that acquired a slot created from this home's clone -
+# refuses the retirement instead of being torn down. --force adds
+# --include-unlanded because that flag is the captain's discard authority for
+# this home's own unlanded work; it never adds --include-in-use or
+# --include-leased, which could kill another home's live task or home lease.
+# FM_TEARDOWN_POOL_SCAN_ROOTS (newline-separated) overrides the scanned pool
+# roots for tests; the default scans the home-scoped root written by
+# fm-home-seed.sh and treehouse's default shared root.
+destroy_home_bound_pool_slots() {  # <home-abs-real>
+  local home_real=$1 roots root slot_git slot slot_common slot_common_real bound_slots
+  if [ -n "${FM_TEARDOWN_POOL_SCAN_ROOTS:-}" ]; then
+    roots=$FM_TEARDOWN_POOL_SCAN_ROOTS
+  else
+    roots="$home_real/data/treehouse-pools/.treehouse
+$HOME/.treehouse"
+  fi
+  bound_slots=$(
+    printf '%s\n' "$roots" | while IFS= read -r root; do
+      [ -d "$root" ] || continue
+      for slot_git in "$root"/*/*/*/.git; do
+        [ -f "$slot_git" ] || continue
+        slot=${slot_git%/.git}
+        slot_common=$(git -C "$slot" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+        [ -n "$slot_common" ] || continue
+        slot_common_real=$(cd "$slot_common" 2>/dev/null && pwd -P) || continue
+        case "$slot_common_real" in
+          "$home_real"/*) printf '%s\n' "$slot" ;;
+        esac
+      done
+    done
+  )
+  [ -n "$bound_slots" ] || return 0
+  command -v treehouse >/dev/null 2>&1 || {
+    echo "error: treehouse command not found; cannot destroy pool slots bound to $home_real before removing the home" >&2
+    return 1
+  }
+  while IFS= read -r slot; do
+    [ -n "$slot" ] || continue
+    echo "teardown: destroying pool slot $slot bound to retiring home $home_real" >&2
+    if [ "$FORCE" = "--force" ]; then
+      treehouse destroy "$slot" --yes --include-unlanded || {
+        echo "error: treehouse refused to destroy pool slot $slot bound to retiring home $home_real; refusing to remove the home" >&2
+        echo "Destroy the slot manually with: treehouse destroy $slot --yes  (then rerun teardown)" >&2
+        return 1
+      }
+    else
+      treehouse destroy "$slot" --yes || {
+        echo "error: treehouse refused to destroy pool slot $slot bound to retiring home $home_real; refusing to remove the home" >&2
+        echo "The slot is in use or holds unverified work - possibly another home's live task that acquired a slot created from this home's clone." >&2
+        echo "Drain that work, destroy the slot with: treehouse destroy $slot --yes  (then rerun teardown)" >&2
+        return 1
+      }
+    fi
+  done <<EOF
+$bound_slots
+EOF
+}
+
 remove_firstmate_home() {
   local home=$1 label=$2 expected_id=${3:-} abs_home_path
   [ -n "$home" ] || return 0
@@ -1219,6 +1292,11 @@ elif [ "$BACKEND" = herdr ] \
 fi
 if [ "$KIND" = secondmate ]; then
   [ -n "$HOME_PATH" ] || HOME_PATH=$WT
+  HOME_PATH_REAL=$(cd "$HOME_PATH" 2>/dev/null && pwd -P) || {
+    echo "error: secondmate home $HOME_PATH does not exist; cannot scan for bound pool slots" >&2
+    exit 1
+  }
+  destroy_home_bound_pool_slots "$HOME_PATH_REAL" || exit 1
   remove_firstmate_home "$HOME_PATH" "secondmate home" "$ID"
   remove_secondmate_registry_entry "$ID"
 fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,10 @@ A project-less seed requires no existing project clones or `data/projects.md` en
 A preexisting project-bearing charter is also refused until it is re-scaffolded with `--no-projects` or removed.
 The lease is held under the secondmate id until explicit retirement or seed rollback returns it, so normal restarts do not free or recycle the home.
 Teardown of a leased home fails closed if `treehouse return` cannot release the lease; plain-clone homes with no treehouse pool slot are removed directly.
+Each seeded project clone carries a repo-level `treehouse.toml` pinning treehouse's pool root inside the home under `data/treehouse-pools/`, because treehouse keys pools by origin URL under one shared root and each pool slot binds permanently to the clone that created it.
+Without that pin, the main home and a secondmate cloning the same remote share one pool, a spawn can receive a worktree whose object store belongs to another home, and retiring that home orphans those slots.
+`fm-spawn.sh` fail-closed refuses an acquired slot whose git common dir is not the spawning home's project clone, and `fm-teardown.sh` destroys every pool slot bound to a retiring secondmate home before removing the home.
+Homes seeded before this isolation may still hold slots in the shared `~/.treehouse` root; the spawn refusal and the retirement scan cover those legacy slots until they are destroyed.
 Secondmate routes cover `no-mistakes` and `direct-PR` projects; `local-only` projects remain main-firstmate work.
 For `no-mistakes` projects, seeding initializes only projects newly cloned into a secondmate home and refuses to mutate a preexisting clone that is not already initialized.
 After creating a secondmate, move existing main-backlog queued items that you have judged in-scope with `fm-backlog-handoff.sh <secondmate-id> <item-key>...`; it is idempotent and refuses In flight, Done, or non-secondmate homes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,8 +149,9 @@ It cannot be combined with a project list, and omitting both still fails loudly.
 A project-less seed requires no existing project clones or `data/projects.md` entries in the home, so it refuses a populated-home conversion without changing that home.
 A preexisting project-bearing charter is also refused until it is re-scaffolded with `--no-projects` or removed.
 The lease is held under the secondmate id until explicit retirement or seed rollback returns it, so normal restarts do not free or recycle the home.
-Teardown of a leased home fails closed if `treehouse return` cannot release the lease; plain-clone homes with no treehouse pool slot are removed directly.
+Teardown of a leased home fails closed if `treehouse return` cannot release the lease; a plain-clone home has no home lease to return and is removed after its bound project pool slots are destroyed.
 Each seeded project clone carries a repo-level `treehouse.toml` pinning treehouse's pool root inside the home under `data/treehouse-pools/`, because treehouse keys pools by origin URL under one shared root and each pool slot binds permanently to the clone that created it.
+The main home's project clones keep treehouse's default `~/.treehouse` root, while seeding a secondmate refuses rather than overwrite either a project's tracked `treehouse.toml` or an operator's untracked one.
 Without that pin, the main home and a secondmate cloning the same remote share one pool, a spawn can receive a worktree whose object store belongs to another home, and retiring that home orphans those slots.
 `fm-spawn.sh` fail-closed refuses an acquired slot whose git common dir is not the spawning home's project clone, and `fm-teardown.sh` destroys every pool slot bound to a retiring secondmate home before removing the home.
 Homes seeded before this isolation may still hold slots in the shared `~/.treehouse` root; the spawn refusal and the retirement scan cover those legacy slots until they are destroyed.

--- a/tests/fm-treehouse-pool-isolation.test.sh
+++ b/tests/fm-treehouse-pool-isolation.test.sh
@@ -1,0 +1,454 @@
+#!/usr/bin/env bash
+# tests/fm-treehouse-pool-isolation.test.sh - cross-home treehouse pool binding
+# guards (fm-treehouse-pool-root-audit): treehouse keys a pool by origin URL
+# under one shared root, so two homes' clones of one remote would share a pool,
+# and each slot stays bound (git worktree add) to whichever clone created it.
+# This suite covers the three shipped guards:
+#   1. fm-home-seed.sh pins a home-scoped pool root (repo-level treehouse.toml)
+#      into every secondmate project clone.
+#   2. fm-spawn.sh fail-closed refuses an acquired pool slot whose git common
+#      dir is not the spawning home's project clone, returning the slot.
+#   3. fm-teardown.sh destroys pool slots bound to a retiring secondmate home
+#      before removing the home, and refuses the retirement when treehouse
+#      will not destroy one.
+# Plus the report's end-to-end regression: with the pin in place, two temp
+# clones of one remote acquire slots from different pool roots.
+# Every fixture is a temp clone and a temp pool root; no live pool slot or real
+# home is ever touched.
+set -u
+
+# shellcheck source=tests/secondmate-helpers.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/secondmate-helpers.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-treehouse-pool-isolation)
+export FM_BACKEND=tmux
+
+# Seed the direct-PR project alpha into a secondmate home via the real
+# fm-home-seed.sh. Echoes "<main-home>|<secondmate-home>".
+make_seeded_home() {  # <name>
+  local name=$1 home smhome
+  home="$TMP_ROOT/$name-main"
+  smhome="$TMP_ROOT/$name-sm"
+  mkdir -p "$home/projects" "$home/data" "$home/state"
+  fm_git_init_commit "$home/projects/alpha"
+  fm_git_add_origin "$home/projects/alpha" "$TMP_ROOT/remotes/$name-alpha.git"
+  printf '%s\n' '- alpha [direct-PR] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='alpha domain' FM_SECONDMATE_SCOPE='alpha domain' \
+    "$ROOT/bin/fm-home-seed.sh" "sm-$name" "$smhome" alpha >/dev/null \
+    || fail "seed failed for $name"
+  printf '%s|%s\n' "$home" "$smhome"
+}
+
+read_pair() {  # <record>  -> sets PAIR_MAIN PAIR_SM
+  IFS='|' read -r PAIR_MAIN PAIR_SM <<EOF
+$1
+EOF
+}
+
+test_seed_pins_home_scoped_pool_root() {
+  local rec cfg sm_real
+  rec=$(make_seeded_home pin)
+  read_pair "$rec"
+  # fm-home-seed canonicalizes the home to its physical path before writing.
+  sm_real=$(cd "$PAIR_SM" && pwd -P)
+  cfg="$PAIR_SM/projects/alpha/treehouse.toml"
+  assert_present "$cfg" "seed did not write treehouse.toml into the secondmate project clone"
+  assert_grep '# firstmate: seeded by fm-home-seed.sh' "$cfg" "seeded treehouse.toml lacks the firstmate marker"
+  assert_grep "root = \"$sm_real/data/treehouse-pools\"" "$cfg" "seeded treehouse.toml does not pin the home-scoped pool root"
+  assert_absent "$PAIR_MAIN/projects/alpha/treehouse.toml" "seed wrote treehouse.toml into the main home clone"
+  if git -C "$PAIR_SM/projects/alpha" ls-files --error-unmatch treehouse.toml >/dev/null 2>&1; then
+    fail "seeded treehouse.toml is tracked in the clone; crewmates could commit it"
+  fi
+  pass "seed pins a home-scoped treehouse pool root into the secondmate clone only"
+}
+
+test_seed_pins_pool_root_for_preexisting_clone() {
+  local name=pre home smhome cfg
+  home="$TMP_ROOT/$name-main"
+  smhome="$TMP_ROOT/$name-sm"
+  mkdir -p "$home/projects" "$home/data" "$home/state" "$smhome/projects" "$smhome/data" "$smhome/state" "$smhome/config"
+  mark_firstmate_home "$smhome"
+  fm_git_init_commit "$home/projects/alpha"
+  fm_git_add_origin "$home/projects/alpha" "$TMP_ROOT/remotes/$name-alpha.git"
+  printf '%s\n' '- alpha [direct-PR] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
+  git clone --quiet "file://$(cd "$TMP_ROOT/remotes/$name-alpha.git" && pwd)" "$smhome/projects/alpha"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='alpha domain' FM_SECONDMATE_SCOPE='alpha domain' \
+    "$ROOT/bin/fm-home-seed.sh" "sm-$name" "$smhome" alpha >/dev/null \
+    || fail "seed failed for a preexisting project clone"
+  cfg="$smhome/projects/alpha/treehouse.toml"
+  assert_present "$cfg" "seed did not pin a pool root for a preexisting clone"
+  assert_grep "root = \"$(cd "$smhome" && pwd -P)/data/treehouse-pools\"" "$cfg" "preexisting clone got the wrong pool root"
+  pass "seed pins the pool root for a preexisting project clone too"
+}
+
+test_seed_refuses_project_that_tracks_treehouse_toml() {
+  local name=tracked home smhome err rc
+  home="$TMP_ROOT/$name-main"
+  smhome="$TMP_ROOT/$name-sm"
+  err="$TMP_ROOT/$name.err"
+  mkdir -p "$home/projects" "$home/data" "$home/state"
+  fm_git_init_commit "$home/projects/alpha"
+  printf 'max_trees = 4\n' > "$home/projects/alpha/treehouse.toml"
+  git -C "$home/projects/alpha" add treehouse.toml
+  git -C "$home/projects/alpha" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm 'add treehouse.toml'
+  fm_git_add_origin "$home/projects/alpha" "$TMP_ROOT/remotes/$name-alpha.git"
+  printf '%s\n' '- alpha [direct-PR] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
+  set +e
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='alpha domain' FM_SECONDMATE_SCOPE='alpha domain' \
+    "$ROOT/bin/fm-home-seed.sh" "sm-$name" "$smhome" alpha >/dev/null 2>"$err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "seed succeeded for a project that tracks treehouse.toml"
+  grep -F 'tracks treehouse.toml' "$err" >/dev/null || fail "seed refusal did not explain the tracked treehouse.toml"
+  pass "seed refuses to override a project's own tracked treehouse.toml"
+}
+
+test_seed_refuses_foreign_untracked_treehouse_toml() {
+  local name=foreigncfg home smhome err rc
+  home="$TMP_ROOT/$name-main"
+  smhome="$TMP_ROOT/$name-sm"
+  err="$TMP_ROOT/$name.err"
+  mkdir -p "$home/projects" "$home/data" "$home/state" "$smhome/projects" "$smhome/data" "$smhome/state" "$smhome/config"
+  mark_firstmate_home "$smhome"
+  fm_git_init_commit "$home/projects/alpha"
+  fm_git_add_origin "$home/projects/alpha" "$TMP_ROOT/remotes/$name-alpha.git"
+  printf '%s\n' '- alpha [direct-PR] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
+  git clone --quiet "file://$(cd "$TMP_ROOT/remotes/$name-alpha.git" && pwd)" "$smhome/projects/alpha"
+  printf 'root = "/somewhere/else"\n' > "$smhome/projects/alpha/treehouse.toml"
+  set +e
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='alpha domain' FM_SECONDMATE_SCOPE='alpha domain' \
+    "$ROOT/bin/fm-home-seed.sh" "sm-$name" "$smhome" alpha >/dev/null 2>"$err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "seed overwrote an operator's untracked treehouse.toml"
+  grep -F 'without the firstmate seed marker' "$err" >/dev/null || fail "seed refusal did not explain the foreign treehouse.toml"
+  assert_grep 'root = "/somewhere/else"' "$smhome/projects/alpha/treehouse.toml" "seed rewrote the operator's treehouse.toml"
+  pass "seed refuses to overwrite an untracked treehouse.toml it did not write"
+}
+
+# With the seeded pin, two clones of one remote must acquire slots from
+# different pool roots (the audit's end-to-end regression). Uses the real
+# treehouse binary against temp clones with HOME redirected to a temp dir, so
+# the captain's real ~/.treehouse is never touched.
+test_seeded_clones_do_not_share_pool_dirs() {
+  if ! command -v treehouse >/dev/null 2>&1; then
+    pass "treehouse not installed; skipped real-pool isolation check"
+    return
+  fi
+  local rec fakeuser wt_main wt_sm pool_main pool_sm common_main common_sm sm_real
+  rec=$(make_seeded_home pool)
+  read_pair "$rec"
+  sm_real=$(cd "$PAIR_SM" && pwd -P)
+  fakeuser="$TMP_ROOT/pool-fakeuser"
+  mkdir -p "$fakeuser"
+  wt_main=$(cd "$PAIR_MAIN/projects/alpha" && HOME="$fakeuser" treehouse get --lease 2>/dev/null) \
+    || fail "treehouse get --lease failed from the main clone"
+  wt_sm=$(cd "$PAIR_SM/projects/alpha" && HOME="$fakeuser" treehouse get --lease 2>/dev/null) \
+    || fail "treehouse get --lease failed from the secondmate clone"
+  # treehouse cleans paths lexically while the fixture TMPDIR may carry a
+  # trailing slash or symlink, so compare canonicalized paths throughout.
+  wt_main=$(cd "$wt_main" && pwd -P)
+  wt_sm=$(cd "$wt_sm" && pwd -P)
+  fakeuser=$(cd "$fakeuser" && pwd -P)
+  case "$wt_main" in
+    "$fakeuser"/.treehouse/*) : ;;
+    *) fail "main clone slot $wt_main did not land under the default pool root" ;;
+  esac
+  case "$wt_sm" in
+    "$sm_real"/data/treehouse-pools/.treehouse/*) : ;;
+    *) fail "secondmate clone slot $wt_sm did not land under the home-scoped pool root" ;;
+  esac
+  pool_main=$(dirname "$(dirname "$wt_main")")
+  pool_sm=$(dirname "$(dirname "$wt_sm")")
+  [ "$pool_main" != "$pool_sm" ] || fail "two homes' clones of one remote still share pool dir $pool_main"
+  # Same origin URL must still produce the same pool NAME; only the root moved.
+  [ "$(basename "$pool_main")" = "$(basename "$pool_sm")" ] \
+    || fail "expected identical origin-keyed pool names, got $(basename "$pool_main") vs $(basename "$pool_sm")"
+  common_main=$(git -C "$wt_main" rev-parse --path-format=absolute --git-common-dir)
+  common_sm=$(git -C "$wt_sm" rev-parse --path-format=absolute --git-common-dir)
+  [ "$(cd "$common_main" && pwd -P)" = "$(cd "$PAIR_MAIN/projects/alpha/.git" && pwd -P)" ] \
+    || fail "main slot is not bound to the main clone"
+  [ "$(cd "$common_sm" && pwd -P)" = "$(cd "$PAIR_SM/projects/alpha/.git" && pwd -P)" ] \
+    || fail "secondmate slot is not bound to the secondmate clone"
+  (cd "$PAIR_MAIN/projects/alpha" && HOME="$fakeuser" treehouse return --force "$wt_main" >/dev/null 2>&1) || true
+  (cd "$PAIR_SM/projects/alpha" && HOME="$fakeuser" treehouse return --force "$wt_sm" >/dev/null 2>&1) || true
+  pass "two clones of one remote acquire same-named pools under different roots"
+}
+
+# --- fm-spawn common-dir assert ----------------------------------------------
+
+# Fake tmux (pane_current_path settles immediately on the fixture worktree) and
+# a call-logging exit-0 treehouse. Echoes the fakebin dir.
+make_spawn_fakebin() {  # <dir>
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*)
+    printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+    exit 0
+    ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf 'treehouse %s\n' "$*" >> "${FM_FAKE_TREEHOUSE_LOG:-/dev/null}"
+exit 0
+SH
+  chmod +x "$fakebin/tmux" "$fakebin/treehouse"
+  printf '%s\n' "$fakebin"
+}
+
+# Build a spawn fixture whose settled pane path is a real worktree. With
+# binding=same the worktree belongs to the spawned project clone; with
+# binding=foreign it belongs to a second clone of the same origin (the exact
+# cross-home hazard). Echoes a pipe record.
+make_spawn_case() {  # <name> <id> <binding>
+  local name=$1 id=$2 binding=$3 case_dir home proj wt remote foreign fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  fm_git_init_commit "$proj"
+  fm_git_add_origin "$proj" "$case_dir/remote.git"
+  remote=$(cd "$case_dir/remote.git" && pwd)
+  if [ "$binding" = foreign ]; then
+    foreign="$case_dir/foreign-clone"
+    git clone --quiet "file://$remote" "$foreign"
+    git -C "$foreign" worktree add --quiet --detach "$wt"
+  else
+    git -C "$proj" worktree add --quiet --detach "$wt"
+  fi
+  mkdir -p "$home/data/$id"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
+}
+
+run_pool_spawn() {  # <record> <id>
+  local home proj wt fakebin
+  IFS='|' read -r _ home proj wt fakebin <<EOF
+$1
+EOF
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH="$wt" FM_FAKE_TREEHOUSE_LOG="$home/treehouse.log" \
+    PATH="$fakebin:$PATH" \
+    "$ROOT/bin/fm-spawn.sh" "$2" "$proj" 2>&1
+}
+
+test_spawn_accepts_slot_bound_to_own_clone() {
+  local id=pool-spawn-same rec out status home wt
+  rec=$(make_spawn_case spawn-same "$id" same)
+  IFS='|' read -r _ home _ wt _ <<EOF
+$rec
+EOF
+  out=$(run_pool_spawn "$rec" "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should accept a slot bound to the spawning clone"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_grep "worktree=$wt" "$home/state/$id.meta" "meta did not record the accepted worktree"
+  pass "spawn accepts a pool slot bound to the spawning home's own clone"
+}
+
+test_spawn_refuses_slot_bound_to_foreign_clone() {
+  local id=pool-spawn-foreign rec out status home wt
+  rec=$(make_spawn_case spawn-foreign "$id" foreign)
+  IFS='|' read -r _ home _ wt _ <<EOF
+$rec
+EOF
+  set +e
+  out=$(run_pool_spawn "$rec" "$id")
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "spawn accepted a pool slot bound to a foreign clone"
+  assert_contains "$out" "bound to a different clone" "spawn refusal did not explain the foreign binding"
+  assert_grep "treehouse return --force $wt" "$home/treehouse.log" "spawn did not return the foreign-bound slot to the pool"
+  if [ -e "$home/state/$id.meta" ]; then
+    assert_no_grep "worktree=$wt" "$home/state/$id.meta" "refused spawn still recorded the foreign worktree"
+  fi
+  pass "spawn fail-closed refuses a pool slot bound to another clone and returns it"
+}
+
+# --- secondmate retirement pool-slot destruction ------------------------------
+
+# Fake tmux plus a destroy-aware fake treehouse that logs every call, removes
+# the destroyed target, and fails when FM_FAKE_TREEHOUSE_DESTROY_FAIL is set.
+make_teardown_fakebin() {  # <dir>
+  local dir=$1 fakebin capture
+  fakebin=$(fm_fakebin "$dir")
+  capture="$dir/pane.txt"
+  printf 'idle prompt\n' > "$capture"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  has-session|new-session|new-window|send-keys|kill-window) exit 0 ;;
+  list-windows) exit 0 ;;
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane) cat "$FM_FAKE_TMUX_CAPTURE"; exit 0 ;;
+esac
+exit 0
+SH
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf 'treehouse %s\n' "$*" >> "${FM_FAKE_TREEHOUSE_LOG:-/dev/null}"
+case "${1:-}" in
+  destroy)
+    shift
+    [ -z "${FM_FAKE_TREEHOUSE_DESTROY_FAIL:-}" ] || exit 1
+    target=
+    for a in "$@"; do
+      case "$a" in -*) ;; *) target=$a ;; esac
+    done
+    [ -n "$target" ] && rm -rf -- "$target"
+    exit 0
+    ;;
+  return)
+    [ -z "${FM_FAKE_TREEHOUSE_RETURN_FAIL:-}" ] || exit 17
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux" "$fakebin/treehouse"
+  printf '%s\n' "$fakebin"
+}
+
+# A plain-clone secondmate home with a project clone, plus a temp pool holding
+# one slot bound to that clone and one slot bound to the main home's clone of
+# the same origin. Echoes a pipe record.
+make_teardown_case() {  # <name>
+  local name=$1 home subhome poolroot mainclone remote slot_bound slot_foreign fakebin
+  home="$TMP_ROOT/$name-home"
+  subhome="$TMP_ROOT/$name-subhome"
+  poolroot="$TMP_ROOT/$name-pools"
+  mainclone="$home/projects/alpha"
+  mkdir -p "$home/state" "$home/data" "$home/projects" "$subhome/state" "$subhome/projects"
+  mark_firstmate_home "$subhome"
+  printf 'domain\n' > "$subhome/.fm-secondmate-home"
+  fm_git_init_commit "$mainclone"
+  fm_git_add_origin "$mainclone" "$TMP_ROOT/remotes/td-$name.git"
+  remote=$(cd "$TMP_ROOT/remotes/td-$name.git" && pwd)
+  git clone --quiet "file://$remote" "$subhome/projects/alpha"
+  slot_bound="$poolroot/alpha-deadbeef/1/alpha"
+  slot_foreign="$poolroot/alpha-deadbeef/2/alpha"
+  mkdir -p "$(dirname "$slot_bound")" "$(dirname "$slot_foreign")"
+  git -C "$subhome/projects/alpha" worktree add --quiet --detach "$slot_bound"
+  git -C "$mainclone" worktree add --quiet --detach "$slot_foreign"
+  cat > "$home/state/domain.meta" <<EOF
+window=firstmate:fm-domain
+worktree=$subhome
+project=$subhome
+harness=echo
+kind=secondmate
+mode=secondmate
+yolo=off
+home=$subhome
+projects=alpha
+EOF
+  printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
+  fakebin=$(make_teardown_fakebin "$TMP_ROOT/$name-fake")
+  printf '%s\n' "$home|$subhome|$poolroot|$slot_bound|$slot_foreign|$fakebin"
+}
+
+run_pool_teardown() {  # <record> [extra-env...] -- runs fm-teardown domain
+  local home subhome poolroot slot_bound slot_foreign fakebin
+  IFS='|' read -r home subhome poolroot slot_bound slot_foreign fakebin <<EOF
+$1
+EOF
+  shift
+  env PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_TEARDOWN_POOL_SCAN_ROOTS="$poolroot" \
+    FM_FAKE_TMUX_CAPTURE="$(dirname "$fakebin")/pane.txt" \
+    FM_FAKE_TREEHOUSE_LOG="$home/treehouse.log" \
+    "$@" \
+    "$ROOT/bin/fm-teardown.sh" domain 2>&1
+}
+
+test_retirement_destroys_home_bound_pool_slots() {
+  local rec home subhome slot_bound slot_foreign out status
+  rec=$(make_teardown_case retire)
+  IFS='|' read -r home subhome _ slot_bound slot_foreign _ <<EOF
+$rec
+EOF
+  out=$(run_pool_teardown "$rec")
+  status=$?
+  expect_code 0 "$status" "retirement failed with disposable home-bound slots: $out"
+  assert_grep "treehouse destroy $slot_bound --yes" "$home/treehouse.log" "retirement did not destroy the home-bound pool slot"
+  assert_no_grep "destroy $slot_foreign" "$home/treehouse.log" "retirement destroyed a slot bound to another home"
+  assert_absent "$slot_bound" "home-bound pool slot survived retirement"
+  assert_present "$slot_foreign" "foreign-bound pool slot was removed"
+  assert_absent "$subhome" "retirement did not remove the secondmate home"
+  pass "secondmate retirement destroys exactly the pool slots bound to its own clones"
+}
+
+test_retirement_refuses_when_slot_not_disposable() {
+  local rec home subhome slot_bound slot_foreign out status
+  rec=$(make_teardown_case refuse)
+  IFS='|' read -r home subhome _ slot_bound slot_foreign _ <<EOF
+$rec
+EOF
+  set +e
+  out=$(run_pool_teardown "$rec" FM_FAKE_TREEHOUSE_DESTROY_FAIL=1)
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "retirement succeeded although treehouse refused to destroy a bound slot"
+  assert_contains "$out" "refused to destroy pool slot" "retirement did not report the refused destroy"
+  assert_present "$subhome" "retirement removed the home after a refused slot destroy"
+  assert_present "$home/state/domain.meta" "retirement cleared meta after a refused slot destroy"
+  assert_present "$slot_foreign" "foreign-bound pool slot was removed"
+  pass "secondmate retirement fails closed when a bound slot is not disposable"
+}
+
+test_force_retirement_includes_unlanded_but_never_in_use() {
+  local rec home subhome poolroot slot_bound slot_foreign fakebin out status
+  rec=$(make_teardown_case force)
+  IFS='|' read -r home subhome poolroot slot_bound slot_foreign fakebin <<EOF
+$rec
+EOF
+  set +e
+  out=$(env PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_TEARDOWN_POOL_SCAN_ROOTS="$poolroot" \
+    FM_FAKE_TMUX_CAPTURE="$(dirname "$fakebin")/pane.txt" \
+    FM_FAKE_TREEHOUSE_LOG="$home/treehouse.log" \
+    "$ROOT/bin/fm-teardown.sh" domain --force 2>&1)
+  status=$?
+  set -e
+  expect_code 0 "$status" "forced retirement failed: $out"
+  assert_grep "treehouse destroy $slot_bound --yes --include-unlanded" "$home/treehouse.log" \
+    "forced retirement did not pass --include-unlanded for the home's own slots"
+  assert_no_grep "--include-in-use" "$home/treehouse.log" "forced retirement passed --include-in-use"
+  assert_no_grep "--include-leased" "$home/treehouse.log" "forced retirement passed --include-leased"
+  assert_absent "$subhome" "forced retirement did not remove the secondmate home"
+  pass "forced retirement discards unlanded home-bound slots but never in-use or leased ones"
+}
+
+test_seed_pins_home_scoped_pool_root
+test_seed_pins_pool_root_for_preexisting_clone
+test_seed_refuses_project_that_tracks_treehouse_toml
+test_seed_refuses_foreign_untracked_treehouse_toml
+test_seeded_clones_do_not_share_pool_dirs
+test_spawn_accepts_slot_bound_to_own_clone
+test_spawn_refuses_slot_bound_to_foreign_clone
+test_retirement_destroys_home_bound_pool_slots
+test_retirement_refuses_when_slot_not_disposable
+test_force_retirement_includes_unlanded_but_never_in_use
+
+echo "# all fm-treehouse-pool-isolation tests passed"

--- a/tests/fm-treehouse-pool-isolation.test.sh
+++ b/tests/fm-treehouse-pool-isolation.test.sh
@@ -46,7 +46,7 @@ EOF
 }
 
 test_seed_pins_home_scoped_pool_root() {
-  local rec cfg sm_real
+  local rec cfg sm_real status
   rec=$(make_seeded_home pin)
   read_pair "$rec"
   # fm-home-seed canonicalizes the home to its physical path before writing.
@@ -59,6 +59,8 @@ test_seed_pins_home_scoped_pool_root() {
   if git -C "$PAIR_SM/projects/alpha" ls-files --error-unmatch treehouse.toml >/dev/null 2>&1; then
     fail "seeded treehouse.toml is tracked in the clone; crewmates could commit it"
   fi
+  status=$(git -C "$PAIR_SM/projects/alpha" status --short)
+  [ -z "$status" ] || fail "seeded project clone is dirty: $status"
   pass "seed pins a home-scoped treehouse pool root into the secondmate clone only"
 }
 
@@ -124,6 +126,54 @@ test_seed_refuses_foreign_untracked_treehouse_toml() {
   grep -F 'without the firstmate seed marker' "$err" >/dev/null || fail "seed refusal did not explain the foreign treehouse.toml"
   assert_grep 'root = "/somewhere/else"' "$smhome/projects/alpha/treehouse.toml" "seed rewrote the operator's treehouse.toml"
   pass "seed refuses to overwrite an untracked treehouse.toml it did not write"
+}
+
+test_seed_rolls_back_preexisting_project_configs() {
+  local name=rollback home smhome project err rc initial_exclude
+  home="$TMP_ROOT/$name-main"
+  smhome="$TMP_ROOT/$name-sm"
+  err="$TMP_ROOT/$name.err"
+  mkdir -p "$home/projects" "$home/data" "$home/state" "$smhome/projects" "$smhome/data" "$smhome/state" "$smhome/config"
+  mark_firstmate_home "$smhome"
+  for project in alpha gamma beta; do
+    fm_git_init_commit "$home/projects/$project"
+    fm_git_add_origin "$home/projects/$project" "$TMP_ROOT/remotes/$name-$project.git"
+    git clone --quiet "file://$(cd "$TMP_ROOT/remotes/$name-$project.git" && pwd)" "$smhome/projects/$project"
+    printf -- '- %s [direct-PR] - %s project (added 2026-06-22)\n' "$project" "$project" >> "$home/data/projects.md"
+  done
+  cat > "$smhome/projects/alpha/treehouse.toml" <<'EOF'
+# firstmate: seeded by fm-home-seed.sh - previous value
+root = "/previous/root"
+EOF
+  printf '# fixture exclude without newline' > "$smhome/projects/alpha/.git/info/exclude"
+  cp "$smhome/projects/alpha/.git/info/exclude" "$TMP_ROOT/$name-alpha-exclude"
+  initial_exclude=$(cat "$smhome/projects/gamma/.git/info/exclude")
+  printf 'root = "/operator/root"\n' > "$smhome/projects/beta/treehouse.toml"
+  set +e
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='rollback domain' FM_SECONDMATE_SCOPE='rollback domain' \
+    "$ROOT/bin/fm-home-seed.sh" "sm-$name" "$smhome" alpha gamma beta >/dev/null 2>"$err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "seed succeeded despite a later foreign treehouse.toml"
+  assert_grep 'root = "/previous/root"' "$smhome/projects/alpha/treehouse.toml" "rollback did not restore the prior seed-owned config"
+  cmp -s "$TMP_ROOT/$name-alpha-exclude" "$smhome/projects/alpha/.git/info/exclude" \
+    || fail "rollback did not restore the prior alpha info/exclude"
+  assert_absent "$smhome/projects/gamma/treehouse.toml" "rollback preserved a newly created config in a preexisting clone"
+  [ "$(cat "$smhome/projects/gamma/.git/info/exclude")" = "$initial_exclude" ] \
+    || fail "rollback did not restore gamma info/exclude"
+  pass "seed rollback restores configs and exclusions in preexisting clones"
+}
+
+test_seed_escapes_pool_root_for_toml() {
+  local name='escape"slash\home' rec cfg sm_real escaped
+  rec=$(make_seeded_home "$name")
+  read_pair "$rec"
+  sm_real=$(cd "$PAIR_SM" && pwd -P)
+  cfg="$PAIR_SM/projects/alpha/treehouse.toml"
+  escaped=${sm_real//\\/\\\\}
+  escaped=${escaped//\"/\\\"}
+  assert_grep "root = \"$escaped/data/treehouse-pools\"" "$cfg" "seed did not TOML-escape the home-scoped pool root"
+  pass "seed TOML-escapes quotes and backslashes in the pool root"
 }
 
 # With the seeded pin, two clones of one remote must acquire slots from
@@ -444,6 +494,8 @@ test_seed_pins_home_scoped_pool_root
 test_seed_pins_pool_root_for_preexisting_clone
 test_seed_refuses_project_that_tracks_treehouse_toml
 test_seed_refuses_foreign_untracked_treehouse_toml
+test_seed_rolls_back_preexisting_project_configs
+test_seed_escapes_pool_root_for_toml
 test_seeded_clones_do_not_share_pool_dirs
 test_spawn_accepts_slot_bound_to_own_clone
 test_spawn_refuses_slot_bound_to_foreign_clone


### PR DESCRIPTION
## Intent

Fix the cross-home treehouse pool binding hazard in firstmate, per the completed audit fm-treehouse-pool-root-audit. Treehouse keys its shared ~/.treehouse pool by origin URL, so main-home and secondmate clones of one remote share a pool and each slot binds permanently to whichever clone created it; deleting a secondmate home would orphan its slots and poison the pool. The ship scope, all implemented: (1) fm-home-seed.sh writes a repo-level treehouse.toml with a home-scoped pool root into each secondmate project clone so pools are isolated per home (refusing to clobber a project's own tracked treehouse.toml or an operator's untracked one); (2) fm-spawn.sh fail-closed refuses an acquired pool slot whose git common dir is not the spawning home's project clone, returning the slot with an actionable destroy message - this is a deliberate safety refusal, not a behavior regression; (3) fm-teardown.sh secondmate retirement destroys pool slots bound to the retiring home before removing it, refusing the retirement when treehouse will not destroy one, and --force adds --include-unlanded but deliberately never --include-in-use or --include-leased so another home's live task cannot be torn down; (4) docs in docs/configuration.md plus a one-line cross-reference in the secondmate-provisioning skill, and a new regression suite tests/fm-treehouse-pool-isolation.test.sh using temp fixtures only (never live pools or real homes). The main home intentionally keeps the default ~/.treehouse root; only secondmate clones get the pin. FM_TEARDOWN_POOL_SCAN_ROOTS is a deliberate test-only override of the scanned pool roots.

## What Changed

- Pin seeded secondmate project clones to home-scoped Treehouse pool roots without overwriting existing configs, while keeping seed writes escaped, ignored, and transactional.
- Reject pool slots bound to another home during spawn, and destroy home-bound slots before secondmate retirement with fail-closed safety checks.
- Document the pool-isolation lifecycle and add regression coverage for seeding, spawning, teardown, and legacy shared-pool handling.

## Risk Assessment

✅ Low: The amended change is well-bounded, satisfies the stated pool-isolation and teardown constraints, and resolves the prior cleanliness, rollback, and TOML-escaping defects without introducing a material new risk.

## Testing

Inspected the complete target diff and documentation, then exercised production seed, spawn, and teardown entry points using temporary Git fixtures, including a real `treehouse` run with redirected `HOME`; pool roots were isolated, foreign bindings failed closed, retirement preserved foreign/live slots, neighboring lifecycle regressions passed, the reviewer-visible CLI transcript was captured, and cleanup left the worktree unchanged.

<details>
<summary>Evidence: Treehouse pool isolation evidence</summary>

`End-to-end CLI transcript demonstrating isolated pools, foreign-slot refusal, safe retirement, and force-flag boundaries.`

```text
ok - seed pins a home-scoped treehouse pool root into the secondmate clone only
ok - seed pins the pool root for a preexisting project clone too
ok - seed refuses to override a project's own tracked treehouse.toml
ok - seed refuses to overwrite an untracked treehouse.toml it did not write
ok - seed rollback restores configs and exclusions in preexisting clones
ok - seed TOML-escapes quotes and backslashes in the pool root
ok - two clones of one remote acquire same-named pools under different roots
ok - spawn accepts a pool slot bound to the spawning home's own clone
ok - spawn fail-closed refuses a pool slot bound to another clone and returns it
ok - secondmate retirement destroys exactly the pool slots bound to its own clones
ok - secondmate retirement fails closed when a bound slot is not disposable
ok - forced retirement discards unlanded home-bound slots but never in-use or leased ones
# all fm-treehouse-pool-isolation tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-home-seed.sh:562` - The generated treehouse.toml remains visible to `git status`, so every seeded secondmate project clone is permanently dirty. `fm-fleet-sync.sh:338-367` consequently refuses its normal fast-forward path, leaving secondmate clones stale. Add the seed-owned file to the clone&#39;s git info/exclude after verifying it is safe to create or overwrite.
- ⚠️ `bin/fm-home-seed.sh:592` - Writing treehouse.toml into a preexisting clone is not tracked by the seed rollback. If a later project, no-mistakes initialization, or registry update fails, rollback preserves the newly added config despite the script&#39;s transactional contract. Record and remove newly created configs, and back up/restore an existing seed-owned config.
- ⚠️ `bin/fm-home-seed.sh:566` - The home path is interpolated into a TOML basic string without escaping. Supported paths containing `&#34;` or `\` produce invalid or altered configuration, so Treehouse will fail instead of using the isolated root. TOML-escape the path before emitting it or reject unsupported path characters explicitly.

🔧 Fix: Make seeded Treehouse configs clean, escaped, and transactional
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --unified=80 a2d5f264966f9b391899fa5286bd54acd8f2e877..ef4d64076aef6719a8cbf8f653378978a1e0eccd -- bin/fm-home-seed.sh bin/fm-spawn.sh bin/fm-teardown.sh tests/fm-treehouse-pool-isolation.test.sh docs/configuration.md .agents/skills/secondmate-provisioning/SKILL.md`
- `bash tests/fm-treehouse-pool-isolation.test.sh`
- `bash tests/fm-spawn-worktree-settle.test.sh`
- `bash tests/fm-teardown.test.sh`
- `bash tests/fm-secondmate-lifecycle-e2e.test.sh`
- `git status --porcelain=v1 --untracked-files=all`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
