### PR TITLE
feat(afk): make recurring composer deferrals record their own cause

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -110,6 +110,7 @@ If that submit cannot be confirmed, it raises a loud, rate-limited wedge alarm:
 an ERROR in the daemon log, a durable
 `state/.subsuper-inject-wedged` marker (surface it on the "while you were out"
 catch-up if present), a tmux status-line flash when applicable, and a configurable backend-independent active alert.
+A recurring identical composer verdict additionally records its own diagnostic into the marker, the daemon log, and the return catch-up evidence, so that wedge names its cause; `docs/wedge-alarm.md` "Recurring composer verdict diagnostic" owns that record.
 `docs/wedge-alarm.md` owns the alert channel setup, and `docs/verification/supervision.md` "Wedge-alarm channels" owns active evidence.
 So a guard false-positive becomes a visible stall, never an unbounded silent no-op.
 
@@ -230,6 +231,7 @@ the operational prefix lets firstmate distinguish it from a real captain message
 ## Stale-artifact lifecycle
 
 Treat `state/.subsuper-escalations`, its `.since` sidecar, and `state/.subsuper-inject-wedged` as session-scoped delivery artifacts, not as the durable work record.
+The recurring-composer-verdict diagnostic and streak files (`state/.subsuper-composer-defer-*`) are session-scoped too; `bin/fm-afk-return.sh` clears them with the other delivery artifacts on return, and `docs/wedge-alarm.md` owns the record.
 Always enter through `bin/fm-afk-launch.sh`, which clears prior-session artifacts only for a fresh entry and preserves the current session's buffer on refresh.
 Always exit through `bin/fm-afk-launch.sh stop`, which keeps `state/.afk` present through the daemon's shutdown flush and clears it last.
 `docs/herdr-backend.md` "Away-mode supervisor support" owns the current mechanism, and `docs/verification/runtime-backends.md` "Away-mode transport" owns active evidence.

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -231,7 +231,7 @@ the operational prefix lets firstmate distinguish it from a real captain message
 ## Stale-artifact lifecycle
 
 Treat `state/.subsuper-escalations`, its `.since` sidecar, and `state/.subsuper-inject-wedged` as session-scoped delivery artifacts, not as the durable work record.
-The recurring-composer-verdict diagnostic and streak files (`state/.subsuper-composer-defer-*`) are session-scoped too; `bin/fm-afk-return.sh` clears them with the other delivery artifacts on return, and `docs/wedge-alarm.md` owns the record.
+The recurring-composer-verdict diagnostic and streak files (`state/.subsuper-composer-defer-*`) are session-scoped too; `bin/fm-afk-return.sh` clears them with the other delivery artifacts on return, a fresh away entry clears any the return never saw, and `docs/wedge-alarm.md` owns the record.
 Always enter through `bin/fm-afk-launch.sh`, which clears prior-session artifacts only for a fresh entry and preserves the current session's buffer on refresh.
 Always exit through `bin/fm-afk-launch.sh stop`, which keeps `state/.afk` present through the daemon's shutdown flush and clears it last.
 `docs/herdr-backend.md` "Away-mode supervisor support" owns the current mechanism, and `docs/verification/runtime-backends.md` "Away-mode transport" owns active evidence.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2005,6 +2005,7 @@ EOF
   # shape only ever starts with an AGENT glyph (FM_BACKEND_HERDR_BARE_PROMPT_RE
   # is '^(❯|›)'), so a bare shell prompt never reaches here - it stays 'unknown'
   # via the no-composer-row path above, exactly as before.
+  fm_composer_diag_record fm_backend_herdr_composer_state "$raw_match" "$stripped"
   fm_composer_classify_content "$bordered" "$stripped" "$FM_BACKEND_HERDR_IDLE_RE"
 }
 

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -362,11 +362,15 @@ fm_afk_launch_restore_backup() {  # <backup> <had-afk>
   rm -f "$FM_AFK_LAUNCH_STATE/.afk" \
     "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" \
     "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" \
-    "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged" || result=1
+    "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged" \
+    "$FM_AFK_LAUNCH_STATE/.subsuper-composer-defer-diag" \
+    "$FM_AFK_LAUNCH_STATE/.subsuper-composer-defer-streak" \
+    "$FM_AFK_LAUNCH_STATE/.subsuper-composer-defer-read" || result=1
   if [ "$had_afk" -eq 1 ]; then
     cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk" || result=1
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged \
+    .subsuper-composer-defer-diag .subsuper-composer-defer-streak .subsuper-composer-defer-read; do
     if [ -e "$backup/$artifact" ]; then
       cp -p "$backup/$artifact" "$FM_AFK_LAUNCH_STATE/$artifact" || result=1
     fi
@@ -489,7 +493,8 @@ fm_afk_launch_start() {
     had_afk=1
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged \
+    .subsuper-composer-defer-diag .subsuper-composer-defer-streak .subsuper-composer-defer-read; do
     if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
       cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
     fi
@@ -547,7 +552,8 @@ fm_afk_launch_start_native() {
     had_afk=1
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged \
+    .subsuper-composer-defer-diag .subsuper-composer-defer-streak .subsuper-composer-defer-read; do
     if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
       cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
     fi

--- a/bin/fm-afk-return.sh
+++ b/bin/fm-afk-return.sh
@@ -124,7 +124,10 @@ clear_delivery_artifacts() {
   rm -f \
     "$STATE/.subsuper-escalations" \
     "$STATE/.subsuper-escalations.since" \
-    "$STATE/.subsuper-inject-wedged"
+    "$STATE/.subsuper-inject-wedged" \
+    "$STATE/.subsuper-composer-defer-diag" \
+    "$STATE/.subsuper-composer-defer-streak" \
+    "$STATE/.subsuper-composer-defer-read"
 }
 
 return_guard() {
@@ -141,7 +144,7 @@ return_guard() {
 }
 
 return_reconcile() {
-  local evidence blockers drained wedge escalations lifecycle_ok=1
+  local evidence blockers drained wedge escalations defer_diag lifecycle_ok=1
   evidence=$(mktemp "$STATE/.afk-return-evidence.XXXXXX") || return 1
   blockers=$(mktemp "$STATE/.afk-return-blockers.XXXXXX") || { rm -f "$evidence"; return 1; }
   preserve_evidence "$evidence"
@@ -163,6 +166,14 @@ return_reconcile() {
   if [ -s "$STATE/.subsuper-inject-wedged" ]; then
     wedge=$(head -1 "$STATE/.subsuper-inject-wedged" 2>/dev/null || true)
     append_evidence wedge "$wedge" "$evidence"
+  fi
+  # A wedge whose cause was a recurring composer verdict already named that cause
+  # durably, so surface it here rather than leaving the return to rediscover it.
+  # The header plus the offending row is the actionable part; the full record,
+  # including any pane tail, stays in the wedge marker and the daemon log.
+  if [ -s "$STATE/.subsuper-composer-defer-diag" ]; then
+    defer_diag=$(head -3 "$STATE/.subsuper-composer-defer-diag" 2>/dev/null || true)
+    append_evidence composer-defer "$defer_diag" "$evidence"
   fi
   if [ -s "$STATE/.subsuper-escalations" ]; then
     escalations=$(cat "$STATE/.subsuper-escalations" 2>/dev/null || true)

--- a/bin/fm-afk-return.sh
+++ b/bin/fm-afk-return.sh
@@ -16,8 +16,9 @@
 #
 # The durable state/.afk-return-catchup file is written BEFORE daemon shutdown,
 # so a crash between stopping, draining, and blocker handling fails closed. It
-# retains the drained wake, buffered-escalation, and wedge-marker evidence until
-# every live open blocker is closed and `check` succeeds. Repeated begin/check
+# retains the drained wake, buffered-escalation, wedge-marker, and
+# recurring-composer-verdict diagnostic evidence until every live open blocker
+# is closed and `check` succeeds. Repeated begin/check
 # calls are idempotent. `guard` never mutates state and is suitable for ordinary
 # read entrypoints such as fm-bearings-snapshot.sh.
 set -u

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -7,7 +7,7 @@
 #   state/.supervise-daemon.lock, and:
 #     - prints "afk: daemon already running pid=<pid>" then exits 0 when that
 #       lock is held by a live daemon (a REFRESH: no stale-artifact clear);
-#     - otherwise clears any prior away session's stale escalation artifacts
+#     - otherwise clears any prior away session's stale session-scoped artifacts
 #       (fm_afk_clear_stale_artifacts) for a direct, non-prepared start, then
 #       execs bin/fm-supervise-daemon.sh in the foreground. A prepared start was
 #       already cleared transactionally by bin/fm-afk-launch.sh.
@@ -55,15 +55,23 @@ fm_afk_start_usage() {
 # escalation - the delivery buffer is a transient cache, and any condition still
 # true (a crew still blocked, a check still firing) is re-derived and re-escalated
 # fresh by the daemon's heartbeat catch-all scan and the durable
-# state/.wake-queue replay (see docs/herdr-backend.md "Away-mode stale-artifact
-# lifecycle" and bin/fm-supervise-daemon.sh's escalate_add/inject_wedge_alarm).
+# state/.wake-queue replay (see docs/herdr-backend.md "Away-mode supervisor
+# support" and bin/fm-supervise-daemon.sh's escalate_add/inject_wedge_alarm).
 # NOT called on a refresh (daemon already alive), so the current session's own
 # buffered escalations are preserved.
+# The composer-defer diagnostic, streak, and read files are session-scoped the
+# same way: bin/fm-afk-return.sh clears them on return, but when the return
+# never ran (crash, manual .afk removal) a fresh entry must drop them too, so a
+# stale diagnostic is never misread as the new session's and a carried-over
+# mid-wedge streak cannot trigger an early record against a prior verdict.
 fm_afk_clear_stale_artifacts() {  # <state-dir>
   local state=$1
   rm -f "$state/.subsuper-escalations" \
         "$state/.subsuper-escalations.since" \
-        "$state/.subsuper-inject-wedged" 2>/dev/null
+        "$state/.subsuper-inject-wedged" \
+        "$state/.subsuper-composer-defer-diag" \
+        "$state/.subsuper-composer-defer-streak" \
+        "$state/.subsuper-composer-defer-read" 2>/dev/null
 }
 
 daemon_lock_owner() {

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -270,8 +270,12 @@ fm_composer_diag_field() {  # <label> <text> -> "<label>_len=N <label>_hex=H <la
 
 # fm_composer_diag_record: append ONE candidate row's sanitised record. Adapters
 # that evaluate several rows per read (a bordered box) append one line each; the
-# daemon reports the LAST one, which is the deciding row because the readers
-# return on the first row that classifies non-empty.
+# daemon reports the LAST one. For a `pending` verdict that is the deciding row,
+# because the readers return on the first row that classifies non-empty. For the
+# geometry-ambiguous `unknown` verdict every box row classifies empty and the
+# verdict comes from the ambiguity flag instead, so the last record is simply the
+# last row evaluated, not an offending row; rows_evaluated plus the real pane
+# bytes keep the record diagnostic either way.
 fm_composer_diag_record() {  # <reader> <raw-row> <content>
   local reader=$1 raw=$2 content=$3
   [ -n "${FM_COMPOSER_DIAG_FILE:-}" ] || return 0

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -45,7 +45,9 @@
 # fm_composer_strip_ghost for the real-typed-content extraction, strips the box
 # borders, trims, and hands the result plus a <bordered> flag to
 # fm_composer_classify_content for the shared
-# empty|pending|unknown verdict. orca/cmux read a plain (unstyled) screen so
+# empty|pending|unknown verdict, optionally recording that row through
+# fm_composer_diag_record (the opt-in recurring-deferral diagnostic sink at the
+# foot of this file). orca/cmux read a plain (unstyled) screen so
 # they have no ghost styling to strip and rely on the idle-placeholder match
 # below. Re-sourcing is a cheap idempotent redefinition, so this file needs no
 # include guard (matching bin/fm-tmux-lib.sh).
@@ -221,4 +223,62 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
   fi
   # Real, unsubmitted content remains.
   printf 'pending'; return 0
+}
+
+# --- recurring-deferral diagnostic sink -------------------------------------
+# WHY THIS EXISTS (task composer-defer-diagnostic-fallback): a SYSTEMATIC
+# misclassification here defers away-mode escalation delivery forever, and the
+# away-mode daemon's max-defer escape can only retry the same guarded path and
+# alarm. The 2026-07-28/29 wedge deferred for 9.5 hours on one U+00A0 without
+# ever recording WHICH verdict recurred or WHAT the offending row held, so the
+# investigation had to start from scratch. This sink is what makes the next such
+# wedge self-diagnosing.
+#
+# It is OPT-IN: a no-op unless the caller exports FM_COMPOSER_DIAG_FILE, so every
+# production composer read on a healthy fleet costs nothing. The away-mode daemon
+# sets it only once it is already deep in an identical-verdict streak
+# (bin/fm-supervise-daemon.sh), which is also why the recorded row always comes
+# from the same read as the recorded verdict rather than a second one.
+#
+# Each adapter calls this once, where it already holds both the raw styled row
+# and the ghost-stripped content, immediately before delegating to
+# fm_composer_classify_content. This file owns the record format and the
+# sanitisation so neither can drift across adapters.
+FM_COMPOSER_DIAG_MAX_BYTES_DEFAULT=120
+
+# fm_composer_diag_field: one sanitised, bounded field triple for <text>.
+# Bytes are rendered as HEX because a composer row can contain the terminal's own
+# escape sequences, and a diagnostic record is read with `cat`: hex can never
+# replay an escape into the reader's terminal. The parallel printable-only
+# rendering (everything outside printable ASCII becomes '.') is for readability
+# and carries no escapes either. Both are bounded, because the row can hold the
+# captain's own draft text.
+fm_composer_diag_field() {  # <label> <text> -> "<label>_len=N <label>_hex=H <label>_text=T"
+  local label=$1 text=$2 max len bounded hex printable more=''
+  max=${FM_COMPOSER_DIAG_MAX_BYTES:-$FM_COMPOSER_DIAG_MAX_BYTES_DEFAULT}
+  case "$max" in ''|*[!0-9]*) max=$FM_COMPOSER_DIAG_MAX_BYTES_DEFAULT ;; esac
+  len=$(printf '%s' "$text" | LC_ALL=C wc -c | tr -d ' ')
+  bounded=$(printf '%s' "$text" | LC_ALL=C head -c "$max")
+  [ "$len" -gt "$max" ] && more=" (+$((len - max))_more)"
+  # -v is load-bearing: without it od collapses repeated 16-byte runs to a bare
+  # '*', which would silently elide bytes from a padded or repetitive row.
+  hex=$(printf '%s' "$bounded" | od -An -tx1 -v | tr -d '\n' | tr -s ' ' | sed 's/^ //;s/ *$//')
+  printable=$(printf '%s' "$bounded" | LC_ALL=C tr -c '\40-\176' '.')
+  printf '%s_len=%s %s_hex=%s%s %s_text=%s' \
+    "$label" "$len" "$label" "${hex:-none}" "$more" "$label" "${printable:-none}"
+}
+
+# fm_composer_diag_record: append ONE candidate row's sanitised record. Adapters
+# that evaluate several rows per read (a bordered box) append one line each; the
+# daemon reports the LAST one, which is the deciding row because the readers
+# return on the first row that classifies non-empty.
+fm_composer_diag_record() {  # <reader> <raw-row> <content>
+  local reader=$1 raw=$2 content=$3
+  [ -n "${FM_COMPOSER_DIAG_FILE:-}" ] || return 0
+  printf 'reader=%s %s %s\n' \
+    "$reader" \
+    "$(fm_composer_diag_field raw "$raw")" \
+    "$(fm_composer_diag_field content "$content")" \
+    >> "$FM_COMPOSER_DIAG_FILE" 2>/dev/null || true
+  return 0
 }

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1127,8 +1127,11 @@ composer_defer_diag_threshold() {  # -> N (0 disables)
 _composer_defer_streak_file() { printf '%s/.subsuper-composer-defer-streak' "$1"; }
 
 _composer_defer_streak_read() {  # <state> <field: count|verdict>
-  local count='' verdict=''
-  IFS=$'\t' read -r count verdict < "$(_composer_defer_streak_file "$1")" 2>/dev/null || true
+  local count='' verdict='' file
+  file=$(_composer_defer_streak_file "$1")
+  if [ -r "$file" ]; then
+    IFS=$'\t' read -r count verdict < "$file" || true
+  fi
   case "$2" in
     count)
       case "$count" in ''|*[!0-9]*) count=0 ;; esac

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -50,7 +50,10 @@
 #     Buffered escalation delivery also has a max-defer alarm: if a digest stays
 #     undelivered past FM_MAX_DEFER_SECS, the daemon retries a normal flush and
 #     writes state/.subsuper-inject-wedged and attempts a configurable active
-#     alert if submit still cannot be confirmed.
+#     alert if submit still cannot be confirmed. That retry uses the same guarded
+#     path, so it cannot clear a SYSTEMATIC composer misclassification; the
+#     recurring-deferral diagnostic below is what makes such a wedge name its own
+#     cause instead of only its duration.
 #   - Cheap heartbeat catch-all: every HEARTBEAT_SCAN_SECS the daemon greps all
 #     state/*.status for a captain-relevant line the per-wake classifier might
 #     have missed (e.g. a status verb outside CAPTAIN_RE) and escalates it.
@@ -104,6 +107,19 @@
 #                                   undelivered before one normal flush attempt;
 #                                   if that cannot confirm a submit, a wedge
 #                                   alarm fires (default 300; 0 disables)
+#          FM_COMPOSER_DEFER_DIAG_COUNT  consecutive IDENTICAL non-empty composer
+#                                   verdicts before the deferral is recorded as a
+#                                   distinguishable diagnostic - the verdict, the
+#                                   offending row's sanitised bytes, and the
+#                                   reader that produced it - in
+#                                   state/.subsuper-composer-defer-diag, the
+#                                   daemon log, and the wedge marker (default 20,
+#                                   about one FM_MAX_DEFER_SECS window of ticks,
+#                                   so a record is in place by the time the first
+#                                   wedge alarm fires; 0 disables). A retry cannot
+#                                   clear a systematic misclassification, so this
+#                                   is what stops the escape from being a bare
+#                                   alarm. See composer_defer_note below.
 #          FM_WEDGE_ALARM_CHANNEL   override config/wedge-alarm with a single
 #                                   active-alert directive for that wedge alarm
 #                                   (off|auto|osascript|herdr|command:<cmd>). An
@@ -873,7 +889,7 @@ wedge_alarm_notify() {  # <summary> <marker>
 # is lost - the buffer and the
 # wake-queue both survive - but the stall stops being invisible.
 inject_wedge_alarm() {  # <state> <age-seconds>
-  local state=$1 age=$2 marker target backend max_defer now notify=1
+  local state=$1 age=$2 marker target backend max_defer now notify=1 diag_summary
   marker="$state/.subsuper-inject-wedged"
   max_defer="${FM_MAX_DEFER_SECS:-$MAX_DEFER_SECS_DEFAULT}"
   # Re-alarm at most once per max-defer window so a long wedge does not spam.
@@ -881,16 +897,23 @@ inject_wedge_alarm() {  # <state> <age-seconds>
     return 0
   fi
   now=$(_now)
+  diag_summary=$(composer_defer_diag_summary "$state")
   if [ "$WEDGE_ALARM_LAST_EPOCH" -gt 0 ] && [ $((now - WEDGE_ALARM_LAST_EPOCH)) -lt "$max_defer" ]; then
     notify=0
   else
     WEDGE_ALARM_LAST_EPOCH=$now
-    log "ERROR: away-mode escalation undelivered ${age}s; inject could not confirm a submit (supervisor pane busy or wedged). Buffer + wake-queue preserved; alarm marker written."
+    log "ERROR: away-mode escalation undelivered ${age}s${diag_summary}; inject could not confirm a submit (supervisor pane busy or wedged). Buffer + wake-queue preserved; alarm marker written."
   fi
   {
     printf 'fm away-mode inject WEDGED: %ss undelivered as of %s\n' "$age" "$(date '+%Y-%m-%dT%H:%M:%S%z')"
     printf 'The supervisor pane could not accept an escalation. Buffered items:\n'
     cat "$state/.subsuper-escalations" 2>/dev/null
+    # The marker already carried WHAT was stuck; this is WHY, for the recurring
+    # composer-verdict case that no retry can clear.
+    if [ -s "$state/.subsuper-composer-defer-diag" ]; then
+      printf 'Recurring composer verdict diagnostic:\n'
+      cat "$state/.subsuper-composer-defer-diag" 2>/dev/null
+    fi
   } 2>/dev/null > "$marker" || true
   target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
   backend="${FM_SUPERVISOR_BACKEND:-$FM_SUPERVISOR_BACKEND_DEFAULT}"
@@ -907,7 +930,7 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   # incident fell through. Configurable and best-effort; the marker above stays
   # the durable record whether or not any channel fires.
   if [ "$notify" -eq 1 ]; then
-    wedge_alarm_notify "away-mode escalations WEDGED ${age}s undelivered - see $marker" "$marker"
+    wedge_alarm_notify "away-mode escalations WEDGED ${age}s undelivered${diag_summary} - see $marker" "$marker"
   fi
 }
 
@@ -1071,6 +1094,140 @@ window_for_task() {  # <task-key> [state]
   return 1
 }
 
+# --- recurring-deferral diagnostic ------------------------------------------
+# The max-defer escape below retries the SAME guarded path, so a systematic
+# composer misclassification defers identically forever and the escape can only
+# alarm. The 2026-07-28/29 wedge deferred 9.5 hours on one U+00A0 and recorded
+# neither the recurring verdict nor the offending row, so the follow-up
+# investigation started from zero. These helpers make that class self-diagnosing:
+# after COMPOSER_DEFER_DIAG_COUNT consecutive IDENTICAL non-empty verdicts they
+# record the verdict, the offending row's sanitised bytes, and the reader that
+# produced it.
+#
+# The pane is already proven not-busy by BOTH available signals before any of
+# this runs: inject_msg returns early on pane_is_busy, which consults the
+# backend's native busy state first and then the harness busy footer. The native
+# state is therefore RECORDED rather than gated on - it is only meaningful on
+# herdr, and requiring an affirmative native `idle` would make this diagnostic
+# never fire on tmux, which the diagnosed defect affected identically.
+#
+# Every non-`empty` verdict is eligible, including `unknown`: a dead-shell or
+# unreadable supervisor pane wedges delivery just as permanently as pending text.
+COMPOSER_DEFER_DIAG_COUNT_DEFAULT=20
+COMPOSER_DEFER_DIAG_TAIL_ROWS=12
+
+composer_defer_diag_threshold() {  # -> N (0 disables)
+  local n=${FM_COMPOSER_DEFER_DIAG_COUNT:-$COMPOSER_DEFER_DIAG_COUNT_DEFAULT}
+  case "$n" in ''|*[!0-9]*) n=$COMPOSER_DEFER_DIAG_COUNT_DEFAULT ;; esac
+  printf '%s' "$n"
+}
+
+# Streak state is durable (<count>TAB<verdict>) so a daemon restart mid-wedge
+# does not restart the count and hide an ongoing systematic misclassification.
+_composer_defer_streak_file() { printf '%s/.subsuper-composer-defer-streak' "$1"; }
+
+_composer_defer_streak_read() {  # <state> <field: count|verdict>
+  local count='' verdict=''
+  IFS=$'\t' read -r count verdict < "$(_composer_defer_streak_file "$1")" 2>/dev/null || true
+  case "$2" in
+    count)
+      case "$count" in ''|*[!0-9]*) count=0 ;; esac
+      printf '%s' "$count" ;;
+    *) printf '%s' "$verdict" ;;
+  esac
+}
+
+composer_defer_streak_reset() {  # <state>
+  rm -f "$(_composer_defer_streak_file "$1")"
+}
+
+# Bounded, sanitised pane tail for the case where the reader found NO candidate
+# composer row at all (the dead-shell / unreadable class). There is no offending
+# row to record, so the informative analogue is what IS on the pane.
+composer_defer_diag_tail() {  # <backend> <target>
+  local backend=$1 target=$2 cap line i=0 n
+  local -a tail_rows=()
+  cap=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null) || {
+    printf '  tail=unreadable\n'; return 0; }
+  while IFS= read -r line; do
+    [ -n "$(printf '%s' "$line" | tr -d '[:space:]')" ] || continue
+    tail_rows+=("$line")
+  done < <(printf '%s\n' "$cap")
+  n=${#tail_rows[@]}
+  [ "$n" -gt 0 ] || { printf '  tail=empty\n'; return 0; }
+  i=$((n - COMPOSER_DEFER_DIAG_TAIL_ROWS))
+  [ "$i" -lt 0 ] && i=0
+  while [ "$i" -lt "$n" ]; do
+    printf '  tail[%s] %s\n' "$i" "$(fm_composer_diag_field row "${tail_rows[$i]}")"
+    i=$((i + 1))
+  done
+}
+
+composer_defer_diag_write() {  # <state> <verdict> <count> <threshold> <target> <backend> <read-file>
+  local state=$1 verdict=$2 count=$3 threshold=$4 target=$5 backend=$6 read_file=$7
+  local out native rows=0 line
+  out="$state/.subsuper-composer-defer-diag"
+  native=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null || true)
+  if [ -n "$read_file" ] && [ -s "$read_file" ]; then
+    rows=$(wc -l < "$read_file" 2>/dev/null | tr -d ' ')
+  fi
+  {
+    printf 'composer-defer-diag %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')"
+    printf '  target=%s backend=%s verdict=%s streak=%s/%s native_busy=%s\n' \
+      "$target" "$backend" "$verdict" "$count" "$threshold" "${native:-unreadable}"
+    if [ "$rows" -gt 0 ]; then
+      printf '  rows_evaluated=%s %s\n' "$rows" "$(tail -1 "$read_file")"
+    else
+      printf '  rows_evaluated=0 reader=none no candidate composer row was found; pane tail follows\n'
+      composer_defer_diag_tail "$backend" "$target"
+    fi
+  } > "$out" 2>/dev/null || true
+  # Mirror into the daemon log line by line: the log is the durable trail that
+  # outlives this volatile state file, and stays greppable and timestamped. An
+  # unwritable state dir loses the record but must never break the daemon loop.
+  [ -s "$out" ] || return 0
+  while IFS= read -r line; do
+    log "$line"
+  done < "$out"
+}
+
+# composer_defer_note: fold one composer deferral into the streak, and record the
+# diagnostic when the streak first reaches the threshold and every N deferrals
+# after that, so a multi-hour wedge refreshes the bytes at a bounded cost instead
+# of writing thousands of records.
+composer_defer_note() {  # <state> <verdict> <target> <backend> <read-file>
+  local state=$1 verdict=$2 target=$3 backend=$4 read_file=$5 threshold count
+  threshold=$(composer_defer_diag_threshold)
+  # 0 disables the diagnostic entirely, streak bookkeeping included.
+  [ "$threshold" -gt 0 ] || return 0
+  count=$(_composer_defer_streak_read "$state" count)
+  if [ "$verdict" = "$(_composer_defer_streak_read "$state" verdict)" ]; then
+    count=$((count + 1))
+  else
+    count=1
+  fi
+  printf '%s\t%s\n' "$count" "$verdict" > "$(_composer_defer_streak_file "$state")" 2>/dev/null || true
+  [ "$count" -ge "$threshold" ] || return 0
+  [ $((count % threshold)) -eq 0 ] || return 0
+  composer_defer_diag_write "$state" "$verdict" "$count" "$threshold" "$target" "$backend" "$read_file"
+}
+
+# composer_defer_diag_summary: the ALARM-SAFE excerpt. The wedge alarm summary is
+# passed to an OS notifier or a configured command: directive, and the offending
+# row can hold the captain's own draft, so only the recurring verdict, the reader,
+# and the streak are ever exposed - never the row bytes. The character classes
+# keep the excerpt to internal identifiers, so no pane content, newline, or shell
+# metacharacter can reach a notifier argument through it.
+composer_defer_diag_summary() {  # <state> -> "" or " (composer verdict=X reader=Y streak=N/M)"
+  local f=$1/.subsuper-composer-defer-diag verdict streak reader
+  [ -s "$f" ] || return 0
+  verdict=$(grep -o 'verdict=[A-Za-z-]*' "$f" 2>/dev/null | head -1)
+  [ -n "$verdict" ] || return 0
+  reader=$(grep -o 'reader=[A-Za-z_]*' "$f" 2>/dev/null | head -1)
+  streak=$(grep -o 'streak=[0-9]*/[0-9]*' "$f" 2>/dev/null | head -1)
+  printf ' (composer %s %s %s)' "$verdict" "${reader:-reader=none}" "${streak:-streak=unknown}"
+}
+
 # --- injection --------------------------------------------------------------
 # inject_msg: send one escalation digest to the supervisor pane.
 # Returns 0 on successful inject (or empty buffer), non-zero if the pane is
@@ -1093,6 +1250,7 @@ window_for_task() {  # <task-key> [state]
 #     would merge with the human's text.
 inject_msg() {  # <message> [state]
   local msg=$1 state target backend retries sleep_s verdict composer encoded
+  local diag_threshold diag_read
   state="${2:-$(_state_root)}"
   # (1) Presence-gate: inject ONLY when afk is active. When afk is off, the
   # daemon self-handles and stays quiet; firstmate drives the normal always-on
@@ -1128,11 +1286,32 @@ inject_msg() {  # <message> [state]
   #      target - typing the escalation into a shell could execute it - so defer
   #      on anything that is not affirmatively 'empty'. A deferred escalation
   #      stays buffered for the next cycle or the catch-up flush.
-  composer=$(fm_backend_composer_state "$backend" "$target" 2>/dev/null)
+  #      A recurring identical verdict is the systematic-misclassification case
+  #      that wedged delivery for 9.5 hours, so instrument the read ONCE the
+  #      streak is already deep enough that this deferral could reach the
+  #      diagnostic threshold. Instrumenting here rather than re-reading later is
+  #      what makes the recorded row come from the same read as the recorded
+  #      verdict; on a healthy fleet the sink is never even armed.
+  #      The sink target is a FIXED name, not a mktemp: the daemon is a singleton,
+  #      so there is no concurrent writer, and a SIGKILL mid-read can then leave at
+  #      most that one known file, truncated by the next armed read, instead of
+  #      accumulating one leaked temp file per crash.
+  diag_threshold=$(composer_defer_diag_threshold)
+  diag_read=
+  if [ "$diag_threshold" -gt 0 ] \
+     && [ $(( $(_composer_defer_streak_read "$state" count) + 1 )) -ge "$diag_threshold" ]; then
+    diag_read="$state/.subsuper-composer-defer-read"
+    : > "$diag_read" 2>/dev/null || diag_read=
+  fi
+  composer=$(FM_COMPOSER_DIAG_FILE="$diag_read" fm_backend_composer_state "$backend" "$target" 2>/dev/null)
   if [ "$composer" != empty ]; then
+    composer_defer_note "$state" "$composer" "$target" "$backend" "$diag_read"
+    [ -n "$diag_read" ] && rm -f "$diag_read"
     log "inject deferred: supervisor composer not confirmed-empty (state=${composer:-unknown}: pending input, dead-shell prompt, or unreadable pane)"
     return 1
   fi
+  [ -n "$diag_read" ] && rm -f "$diag_read"
+  composer_defer_streak_reset "$state"
   # (4) Type the digest ONCE, then submit with Enter (retry Enter only, never
   # retype) via the shared submit primitive. Success = the backend confirms
   # submit. An unconfirmed/unknown pane does NOT count as delivered, so the

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -140,6 +140,7 @@ fm_tmux_composer_row_state() {  # <raw-row> [bordered] [allow-busy] -> empty|pen
      && printf '%s' "$stripped" | grep -qiE "${FM_BUSY_REGEX:-$FM_TMUX_BUSY_REGEX_DEFAULT}"; then
     printf 'empty'; return 0
   fi
+  fm_composer_diag_record fm_tmux_composer_row_state "$raw" "$stripped"
   fm_composer_classify_content "$bordered" "$stripped" "${FM_COMPOSER_IDLE_RE:-}" insensitive "$plain"
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,6 +82,7 @@ Composer-content classification has one shared owner, `bin/fm-composer-lib.sh`, 
 The daemon injects only into an affirmatively `empty` composer, so both `pending` and `unknown` defer and a bare dead-shell prompt cannot receive an escalation; the current boundary is in [Composer and injection safety](herdr-backend.md#composer-and-injection-safety).
 Unsupported supervisor backends refuse at daemon startup.
 Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts a configured backend-independent active alert after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
+Because that retry re-runs the same guarded path, a systematic composer misclassification instead records the recurring verdict, the offending row's sanitized bytes, and the reader that produced it, so the wedge names its own cause; the boundary is in [`wedge-alarm.md`](wedge-alarm.md).
 On an unmarked return, `bin/fm-afk-return.sh` owns ordered shutdown, durable catch-up evidence, and the fail-closed gate that keeps ordinary work behind every live firstmate-actionable blocker.
 `fm-send.sh` selects a pre-Enter popup-settle for slash commands and for codex `$...` skill invocations using metadata-routed target `harness=` values, then adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that post-submit pause.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,6 +116,12 @@ An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisel
 A missing or failing channel logs and falls through to the next, never crashing the daemon.
 See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
 
+A max-defer retry uses the same guarded delivery path, so it cannot clear a systematic composer misclassification that reports the same verdict on every poll.
+After `FM_COMPOSER_DEFER_DIAG_COUNT` consecutive identical non-empty verdicts, the daemon therefore records the recurring verdict, the offending composer row's sanitized bounded bytes, and the reader that produced it, so a wedge names its own cause instead of only its duration.
+The default is about one max-defer window of housekeeping ticks, so a record is in place by the time the first wedge alarm fires and the alarm can carry it.
+Bytes are recorded as hex and never reach an alert channel, because the row can hold the captain's own unsent draft; the alert summary carries only the verdict, the reader, and the streak.
+See [`wedge-alarm.md`](wedge-alarm.md) for where that record is surfaced.
+
 ## Gate defaults (.no-mistakes.yaml)
 
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
@@ -459,6 +465,7 @@ FM_SUPERVISOR_TARGET=              # optional supervisor pane target override; t
 FM_INJECT_SKIP=heartbeat           # |-prefixes force-self-handled bypassing classification; empty disables
 FM_ESCALATE_BATCH_SECS=90          # buffer window for batched escalation digests; 0 = flush immediately
 FM_MAX_DEFER_SECS=300              # max buffered escalation age before retry plus wedge alarm; 0 disables
+FM_COMPOSER_DEFER_DIAG_COUNT=20    # consecutive identical non-empty composer verdicts before the deferral records a diagnostic (verdict, offending row's sanitized bytes, reader) to state/.subsuper-composer-defer-diag, the daemon log, and the wedge marker; 0 disables
 FM_WEDGE_ALARM_CHANNEL=            # override config/wedge-alarm with one active-alert directive for the wedge alarm; off|auto|osascript|herdr|command:<cmd>; absent = auto (macOS -> an OS notification)
 FM_WEDGE_ALARM_EXEC=              # notifier seam: route every channel (osascript, herdr, command:) through this command as `<cmd> <channel> <summary>`; "discard" fires nothing; unset in production; the daemon defaults it to "discard" when sourced so no test posts a real notification (docs/wedge-alarm.md)
 FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum seconds for each osascript, herdr, override, or command: notifier before its watchdog terminates it and continues to the next channel; invalid or zero values use 10

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -38,6 +38,7 @@ When the reader found no candidate composer row, there is no offending row and a
 
 The record lands in `state/.subsuper-composer-defer-diag`, in the daemon log as the durable trail, and inside `state/.subsuper-inject-wedged` next to the buffered items the marker already carried.
 `bin/fm-afk-return.sh` surfaces it as return catch-up evidence and clears it with the other delivery artifacts.
+A fresh away entry also clears any record and streak the return never saw (a crash or manual `state/.afk` removal), so a stale diagnostic is never attributed to a later session.
 Row bytes are recorded as hex, so a record read with `cat` can never replay a pane's own escape sequences, and each field is bounded because the row can hold the captain's unsent draft.
 For the same reason the alert summary carries only the verdict, the reader, and the streak: it is passed to an OS notifier or a configured `command:` directive, and composer content must not leave the machine's local records.
 

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -28,6 +28,19 @@ On timeout or daemon shutdown, the notifier process group is terminated and the 
 AppleScript receives the summary as an argv item rather than interpolated source, so summary text cannot alter the script.
 See [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
 
+## Recurring composer verdict diagnostic
+
+The max-defer retry re-runs the same guarded delivery path, so it can clear a transient stall but never a systematic composer misclassification that returns the same verdict on every poll.
+That case previously produced an alarm reporting only how long delivery had been stuck, which is why a 9.5-hour wedge left its follow-up investigation with no starting point.
+After `FM_COMPOSER_DEFER_DIAG_COUNT` consecutive identical non-empty verdicts the daemon records the recurring verdict, the offending composer row's bytes, the reader that produced it, and the backend's own busy state.
+Every deferral reaching that point has already been proven not busy by both the backend's native busy state and the harness busy footer, so the recorded native state is evidence rather than a gate; that matters because only some backends expose a native busy state at all.
+When the reader found no candidate composer row, there is no offending row and a bounded pane tail is recorded instead, which is what makes the dead-shell and unreadable-pane class self-diagnosing.
+
+The record lands in `state/.subsuper-composer-defer-diag`, in the daemon log as the durable trail, and inside `state/.subsuper-inject-wedged` next to the buffered items the marker already carried.
+`bin/fm-afk-return.sh` surfaces it as return catch-up evidence and clears it with the other delivery artifacts.
+Row bytes are recorded as hex, so a record read with `cat` can never replay a pane's own escape sequences, and each field is bounded because the row can hold the captain's unsent draft.
+For the same reason the alert summary carries only the verdict, the reader, and the streak: it is passed to an OS notifier or a configured `command:` directive, and composer content must not leave the machine's local records.
+
 ## Test safety
 
 Every notifier routes through `FM_WEDGE_ALARM_EXEC` in `wedge_alarm_emit`.

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -41,7 +41,8 @@ GLOBAL_CLEANUP() {
 trap GLOBAL_CLEANUP EXIT
 
 # ---------------------------------------------------------------------------
-# UNIT 1: fm_afk_clear_stale_artifacts removes exactly the three stale artifacts.
+# UNIT 1: fm_afk_clear_stale_artifacts removes the session-scoped delivery and
+# composer-defer diagnostic artifacts, and nothing durable.
 # ---------------------------------------------------------------------------
 unit_clear_stale() {
   local st
@@ -50,6 +51,9 @@ unit_clear_stale() {
   : > "$st/state/.subsuper-escalations"
   : > "$st/state/.subsuper-escalations.since"
   : > "$st/state/.subsuper-inject-wedged"
+  : > "$st/state/.subsuper-composer-defer-diag"
+  : > "$st/state/.subsuper-composer-defer-streak"
+  : > "$st/state/.subsuper-composer-defer-read"
   : > "$st/state/.wake-queue"          # durable queue must be untouched
   # Source fm-afk-start.sh inside a child bash (it sets `set -eu` and would
   # otherwise leak that into this test shell) and call the clear helper.
@@ -57,8 +61,11 @@ unit_clear_stale() {
     bash -c '. "$1"; fm_afk_clear_stale_artifacts "$2"' _ "$START" "$st/state"
   if [ ! -e "$st/state/.subsuper-escalations" ] \
      && [ ! -e "$st/state/.subsuper-escalations.since" ] \
-     && [ ! -e "$st/state/.subsuper-inject-wedged" ]; then
-    pass "clear-stale: removes escalations buffer, sidecar, and wedge marker"
+     && [ ! -e "$st/state/.subsuper-inject-wedged" ] \
+     && [ ! -e "$st/state/.subsuper-composer-defer-diag" ] \
+     && [ ! -e "$st/state/.subsuper-composer-defer-streak" ] \
+     && [ ! -e "$st/state/.subsuper-composer-defer-read" ]; then
+    pass "clear-stale: removes escalations buffer, sidecar, wedge marker, and composer-defer diagnostics"
   else
     fail "clear-stale: stale artifacts survived"
   fi
@@ -66,6 +73,32 @@ unit_clear_stale() {
     pass "clear-stale: leaves the durable wake-queue intact (no pending work dropped)"
   else
     fail "clear-stale: removed the durable wake-queue"
+  fi
+  rm -rf "$st"
+}
+
+# ---------------------------------------------------------------------------
+# UNIT 1b: a fresh away ENTRY clears a prior session's composer-defer diagnostic,
+# streak, and read record through the launcher's executable interface. This is
+# the crash / manual-.afk-removal path where bin/fm-afk-return.sh never ran: a
+# stale diagnostic must not be misread as the new session's, and a carried-over
+# mid-wedge streak must not trigger an early record against a prior verdict.
+# ---------------------------------------------------------------------------
+unit_entry_clears_composer_defer_artifacts() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-defer-clear.XXXXXX")
+  mkdir -p "$st/state"
+  printf 'verdict=nonempty reader=tmux streak=17\n' > "$st/state/.subsuper-composer-defer-diag"
+  printf '17\n' > "$st/state/.subsuper-composer-defer-streak"
+  printf 'reader=tmux\n' > "$st/state/.subsuper-composer-defer-read"
+  if ! FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" start-native >/dev/null 2>&1; then
+    fail "entry defer-clear: fresh native entry failed"
+  elif [ ! -e "$st/state/.subsuper-composer-defer-diag" ] \
+    && [ ! -e "$st/state/.subsuper-composer-defer-streak" ] \
+    && [ ! -e "$st/state/.subsuper-composer-defer-read" ]; then
+    pass "entry defer-clear: fresh entry clears stale composer-defer diagnostic, streak, and read record"
+  else
+    fail "entry defer-clear: a prior session's composer-defer artifact survived a fresh entry"
   fi
   rm -rf "$st"
 }
@@ -217,15 +250,19 @@ unit_failed_start_rolls_back_state() {
   mkdir -p "$st/state"
   printf 'pending\n' > "$st/state/.subsuper-escalations"
   printf 'wedged\n' > "$st/state/.subsuper-inject-wedged"
+  printf 'verdict=nonempty reader=tmux streak=17\n' > "$st/state/.subsuper-composer-defer-diag"
+  printf '17\n' > "$st/state/.subsuper-composer-defer-streak"
   if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_TARGET=unused \
     FM_SUPERVISOR_BACKEND=unsupported "$LAUNCH" start >/dev/null 2>&1; then
     fail "failed start: unsupported backend unexpectedly succeeded"
   elif [ ! -e "$st/state/.afk" ] \
     && [ "$(cat "$st/state/.subsuper-escalations")" = pending ] \
-    && [ "$(cat "$st/state/.subsuper-inject-wedged")" = wedged ]; then
-    pass "failed start: away flag and delivery artifacts roll back"
+    && [ "$(cat "$st/state/.subsuper-inject-wedged")" = wedged ] \
+    && [ "$(cat "$st/state/.subsuper-composer-defer-streak")" = 17 ] \
+    && [ -s "$st/state/.subsuper-composer-defer-diag" ]; then
+    pass "failed start: away flag, delivery artifacts, and composer-defer diagnostics roll back"
   else
-    fail "failed start: left false away state or discarded delivery artifacts"
+    fail "failed start: left false away state or discarded delivery or diagnostic artifacts"
   fi
   rm -rf "$st"
 }
@@ -909,6 +946,7 @@ e2e_tmux() {
 }
 
 unit_clear_stale
+unit_entry_clears_composer_defer_artifacts
 unit_relative_paths_are_absolute_before_daemon_launch
 unit_fresh_vs_refresh
 unit_stop_ordering

--- a/tests/fm-afk-return.test.sh
+++ b/tests/fm-afk-return.test.sh
@@ -209,7 +209,51 @@ test_check_retries_recorded_terminal_teardown() {
   pass "check retries recorded terminal teardown and keeps catch-up gated until success"
 }
 
+# Task composer-defer-diagnostic-fallback: when delivery wedged on a recurring
+# composer verdict, the daemon named that cause durably. The return must surface
+# it rather than leave the captain's next investigation to rediscover it, and must
+# clear it with the other delivery artifacts so it cannot be misattributed to a
+# later away session.
+test_return_surfaces_and_clears_the_composer_defer_diagnostic() {
+  local dir out gate diag
+  dir="$TMP_ROOT/composer-defer-diag"
+  install_runner "$dir"
+  seed_live_blocker "$dir" tmux synthetic-dependency
+  diag="$dir/home/state/.subsuper-composer-defer-diag"
+  date +%s > "$dir/home/state/.afk"
+  printf 'repair-task.status: blocked synthetic dependency\n' > "$dir/home/state/.subsuper-escalations"
+  printf 'fm away-mode inject WEDGED: 34115s undelivered\n' > "$dir/home/state/.subsuper-inject-wedged"
+  printf '20\tpending\n' > "$dir/home/state/.subsuper-composer-defer-streak"
+  {
+    printf 'composer-defer-diag 2026-07-29T17:13:54-0400\n'
+    printf '  target=default:w11:p1 backend=herdr verdict=pending streak=20/20 native_busy=idle\n'
+    printf '  rows_evaluated=1 reader=fm_backend_herdr_composer_state content_hex=c2 a0\n'
+    printf '  tail[0] row_len=1 row_hex=24 row_text=$\n'
+  } > "$diag"
+
+  set +e
+  out=$(run_return "$dir" begin)
+  set -e
+  gate="$dir/home/state/.afk-return-catchup"
+  [ -s "$gate" ] || fail "return begin did not persist its catch-up gate"
+  grep -F $'evidence\tcomposer-defer\tcomposer-defer-diag 2026-07-29T17:13:54-0400' "$gate" >/dev/null \
+    || fail "the recurring-verdict diagnostic was not retained as return evidence"
+  grep -F 'verdict=pending streak=20/20' "$gate" >/dev/null \
+    || fail "return evidence lost the recurring verdict and streak"
+  grep -F 'reader=fm_backend_herdr_composer_state' "$gate" >/dev/null \
+    || fail "return evidence lost the reader that produced the verdict"
+  assert_contains "$out" 'catch-up composer-defer' "the return did not print the diagnostic to the captain's catch-up"
+
+  printf 'resolved [key=synthetic-dependency]: refreshed the synthetic token\n' >> "$dir/home/state/repair-task.status"
+  out=$(run_return "$dir" check) || fail "resolved blocker did not clear return catch-up: $out"
+  [ ! -e "$diag" ] || fail "successful check left the composer-defer diagnostic behind"
+  [ ! -e "$dir/home/state/.subsuper-composer-defer-streak" ] \
+    || fail "successful check left the identical-verdict streak behind"
+  pass "return catch-up surfaces the recurring-verdict diagnostic and clears it with the other delivery artifacts"
+}
+
 test_return_gate_orders_catchup_before_bearings
+test_return_surfaces_and_clears_the_composer_defer_diagnostic
 test_explicit_reclassification_requires_durable_reason
 test_captain_decision_does_not_masquerade_as_firstmate_blocker
 test_away_reentry_refuses_pending_return_gate

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -125,6 +125,94 @@ test_real_text_is_pending() {
   pass "fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)"
 }
 
+# --- recurring-deferral diagnostic sink -------------------------------------
+# Task composer-defer-diagnostic-fallback: a systematic misclassification defers
+# away-mode delivery forever, so the sink records WHICH verdict recurred and WHAT
+# the offending row held. These cover the record contract the daemon depends on.
+
+diag_tmp() { mktemp "${TMPDIR:-/tmp}/fm-composer-diag.XXXXXX"; }
+
+test_diag_record_is_a_noop_without_the_env_var() {
+  local out
+  # Unset is the production condition; empty is the daemon's own unarmed value.
+  out=$(unset FM_COMPOSER_DIAG_FILE; fm_composer_diag_record reader 'row' 'content' 2>&1)
+  [ -z "$out" ] || fail "the diagnostic sink wrote something with FM_COMPOSER_DIAG_FILE unset: '$out'"
+  out=$(FM_COMPOSER_DIAG_FILE='' fm_composer_diag_record reader 'row' 'content' 2>&1)
+  [ -z "$out" ] || fail "the diagnostic sink wrote something with an empty FM_COMPOSER_DIAG_FILE: '$out'"
+  fm_composer_diag_record reader 'row' 'content' \
+    || fail "the diagnostic sink must succeed as a no-op when unarmed"
+  pass "fm_composer_diag_record: inert unless FM_COMPOSER_DIAG_FILE is set"
+}
+
+test_diag_record_captures_the_offending_row_bytes() {
+  # The exact shape that wedged away mode for 9.5 hours: '❯' + U+00A0.
+  local file row content
+  file=$(diag_tmp)
+  row=$(printf '\xe2\x9d\xaf\xc2\xa0\r')
+  content=$(printf '\xe2\x9d\xaf\xc2\xa0')
+  FM_COMPOSER_DIAG_FILE="$file" fm_composer_diag_record my_reader "$row" "$content"
+  grep -Fq 'reader=my_reader' "$file" || fail "record omitted the reader: $(cat "$file")"
+  grep -Fq 'raw_len=6 raw_hex=e2 9d af c2 a0 0d' "$file" \
+    || fail "record did not carry the raw row's bytes: $(cat "$file")"
+  grep -Fq 'content_len=5 content_hex=e2 9d af c2 a0' "$file" \
+    || fail "record did not carry the classified content's bytes: $(cat "$file")"
+  [ "$(wc -l < "$file")" -eq 1 ] || fail "one row must produce exactly one record line"
+  rm -f "$file"
+  pass "fm_composer_diag_record: records the reader plus the offending row and content bytes"
+}
+
+test_diag_record_renders_no_replayable_escape() {
+  # A record is read with `cat`, and a composer row can carry the terminal's own
+  # escapes, so no raw ESC or control byte may survive into the record.
+  local file row esc
+  file=$(diag_tmp)
+  esc=$(printf '\033')
+  row="${esc}[31m> rm -rf x${esc}[0m$(printf '\a\b')"
+  FM_COMPOSER_DIAG_FILE="$file" fm_composer_diag_record r "$row" '> rm -rf x'
+  grep -q "$esc" "$file" && fail "a raw ESC byte survived into the record"
+  grep -Fq '1b 5b 33 31 6d' "$file" || fail "the escape was not preserved as hex: $(cat "$file")"
+  grep -Fq 'raw_text=.[31m> rm -rf x.[0m..' "$file" \
+    || fail "printable rendering did not neutralize control bytes: $(cat "$file")"
+  rm -f "$file"
+  pass "fm_composer_diag_record: bytes are recorded as hex, so no escape can replay into a reader's terminal"
+}
+
+test_diag_record_bounds_a_long_row() {
+  # The row can hold the captain's own draft, so both fields are bounded and the
+  # truncation is explicit rather than silent.
+  local file long hex rendered
+  file=$(diag_tmp)
+  long=$(printf 'x%.0s' $(seq 1 200))
+  FM_COMPOSER_DIAG_FILE="$file" FM_COMPOSER_DIAG_MAX_BYTES=120 \
+    fm_composer_diag_record r "$long" "$long"
+  grep -Fq 'raw_len=200' "$file" || fail "record lost the true row length: $(cat "$file")"
+  grep -Fq '(+80_more)' "$file" || fail "record truncated silently: $(cat "$file")"
+  hex=$(grep -o 'raw_hex=[0-9a-f ]*' "$file" | head -1 | sed 's/raw_hex=//')
+  [ "$(printf '%s' "$hex" | wc -w)" -eq 120 ] \
+    || fail "expected 120 bounded hex bytes, got $(printf '%s' "$hex" | wc -w)"
+  rendered=$(grep -o 'raw_text=x*' "$file" | head -1 | sed 's/raw_text=//')
+  [ "${#rendered}" -eq 120 ] \
+    || fail "expected the printable rendering bounded to 120 bytes, got ${#rendered}"
+  rm -f "$file"
+  pass "fm_composer_diag_record: bounds each field and marks the truncation explicitly"
+}
+
+test_diag_record_appends_one_line_per_row() {
+  # A bordered box makes the reader evaluate several rows; the daemon reports the
+  # LAST record, which is the deciding row.
+  local file
+  file=$(diag_tmp)
+  FM_COMPOSER_DIAG_FILE="$file" fm_composer_diag_record r 'first row' ''
+  FM_COMPOSER_DIAG_FILE="$file" fm_composer_diag_record r 'second row' 'deciding'
+  [ "$(wc -l < "$file")" -eq 2 ] || fail "expected one record line per evaluated row"
+  tail -1 "$file" | grep -Fq 'content_text=deciding' \
+    || fail "the last record is not the deciding row: $(tail -1 "$file")"
+  head -1 "$file" | grep -Fq 'content_hex=none' \
+    || fail "an empty field should read 'none', not blank: $(head -1 "$file")"
+  rm -f "$file"
+  pass "fm_composer_diag_record: appends one line per evaluated row, last is the deciding one"
+}
+
 test_bare_shell_glyphs_are_unknown
 test_stripped_unbordered_content_uses_plain_content
 test_bare_shell_prompt_with_command_is_not_empty
@@ -134,3 +222,8 @@ test_empty_content_is_empty
 test_idle_placeholder_is_empty
 test_idle_placeholder_case_mode_is_explicit
 test_real_text_is_pending
+test_diag_record_is_a_noop_without_the_env_var
+test_diag_record_captures_the_offending_row_bytes
+test_diag_record_renders_no_replayable_escape
+test_diag_record_bounds_a_long_row
+test_diag_record_appends_one_line_per_row

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1111,6 +1111,255 @@ test_max_defer_pending_composer_alarms_without_typing() {
   pass "max-defer on a pending composer alarms without typing"
 }
 
+# --- recurring-deferral diagnostic (task composer-defer-diagnostic-fallback) --
+# A SYSTEMATIC composer misclassification defers delivery identically forever, so
+# the max-defer escape's retry cannot clear it and the 2026-07-28/29 wedge left no
+# record of which verdict recurred or what the offending row held. These cover the
+# escape's diagnostic: the trigger, the record's content, and the safety
+# properties (nothing typed, no exposure of row bytes to a notifier).
+
+# defer_case: a supervisor pane whose composer holds <text> forever, with the
+# escalation buffer primed and away mode active. The fixture text is deliberately
+# NOT the U+00A0 that caused the diagnosed wedge: R1 normalises Unicode blanks in
+# the shared classifier, so an NBSP row will read `empty` once that lands and this
+# fixture would silently stop reproducing the condition. Stable non-blank content
+# models what R2 actually targets - the NEXT systematic misclassification.
+defer_case() {  # <name> <composer-text> -> <dir>
+  local name=$1 text=$2 dir state width border i=0
+  dir=$(make_bordered_case "$name"); state="$dir/state"
+  width=$(( ${#text} + 4 ))
+  border=
+  while [ "$i" -lt "$width" ]; do border="${border}─"; i=$((i + 1)); done
+  printf '╭%s╮\n│ > %s │\n╰%s╯\n' "$border" "$text" "$border" > "$dir/composer"
+  : > "$dir/sent.log"
+  escalate_add "$state" "needs-decision: pick A"
+  afk_enter "$state"
+  printf '%s\n' "$dir"
+}
+
+# defer_reads_present: did an instrumented composer read leak a temp file?
+defer_reads_present() {  # <state>
+  [ -e "$1/.subsuper-composer-defer-read" ]
+}
+
+# defer_poll: one inject attempt against that pane, as the daemon makes it.
+defer_poll() {  # <dir> <threshold>
+  local dir=$1 threshold=$2
+  PATH="$dir/fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$dir/sent.log" \
+    FM_COMPOSER_DEFER_DIAG_COUNT="$threshold" FM_INJECT_CONFIRM_SLEEP=0.05 \
+    inject_msg "the digest" "$dir/state" >/dev/null 2>&1
+}
+
+test_identical_verdict_streak_records_diagnostic_at_threshold() {
+  local dir state diag i
+  dir=$(defer_case defer-diag-threshold 'human draft'); state="$dir/state"
+  diag="$state/.subsuper-composer-defer-diag"
+
+  i=1
+  while [ "$i" -lt 5 ]; do
+    defer_poll "$dir" 5
+    [ ! -e "$diag" ] \
+      || fail "diagnostic recorded after only $i identical deferrals (threshold 5)"
+    [ "$(_composer_defer_streak_read "$state" count)" -eq "$i" ] \
+      || fail "streak count is $(_composer_defer_streak_read "$state" count), expected $i"
+    i=$((i + 1))
+  done
+
+  defer_poll "$dir" 5
+  [ -s "$diag" ] || fail "no diagnostic recorded once the identical verdict reached the threshold"
+  grep -Fq 'verdict=pending streak=5/5' "$diag" \
+    || fail "record did not name the recurring verdict and streak: $(cat "$diag")"
+  grep -Fq 'reader=fm_tmux_composer_row_state' "$diag" \
+    || fail "record did not name the reader that produced the verdict: $(cat "$diag")"
+  grep -Fq 'content_hex=3e 20 68 75 6d 61 6e 20 64 72 61 66 74' "$diag" \
+    || fail "record did not carry the offending row's bytes: $(cat "$diag")"
+  grep -Fq 'native_busy=' "$diag" \
+    || fail "record did not carry the backend's independent busy state: $(cat "$diag")"
+  [ ! -s "$dir/sent.log" ] || fail "the diagnostic path typed into a pane holding real input"
+  grep -Fq 'human draft' "$dir/composer" || fail "composer content changed"
+  pass "recurring identical composer verdicts record the verdict, offending bytes, and reader at the threshold"
+}
+
+test_identical_verdict_streak_refreshes_every_threshold() {
+  local dir state diag first i
+  dir=$(defer_case defer-diag-refresh 'human draft'); state="$dir/state"
+  diag="$state/.subsuper-composer-defer-diag"
+  i=0
+  while [ "$i" -lt 3 ]; do defer_poll "$dir" 3; i=$((i + 1)); done
+  first=$(cat "$diag")
+  grep -Fq 'streak=3/3' "$diag" || fail "expected the first record at the threshold: $first"
+  defer_poll "$dir" 3
+  [ "$(cat "$diag")" = "$first" ] || fail "record rewritten between threshold multiples"
+  defer_poll "$dir" 3
+  defer_poll "$dir" 3
+  grep -Fq 'streak=6/3' "$diag" \
+    || fail "a continuing wedge did not refresh its record at the next multiple: $(cat "$diag")"
+  pass "a long identical-verdict wedge refreshes its record once per threshold, not per deferral"
+}
+
+test_changed_verdict_resets_the_streak() {
+  local dir state
+  dir=$(defer_case defer-diag-reset 'human draft'); state="$dir/state"
+  defer_poll "$dir" 3
+  defer_poll "$dir" 3
+  [ "$(_composer_defer_streak_read "$state" count)" -eq 2 ] || fail "streak did not accumulate"
+  # An unreadable/structurally-ambiguous pane reads unknown: a DIFFERENT non-empty
+  # verdict, so the identical-verdict streak restarts rather than carrying the
+  # pending count over.
+  printf 'plain output line\n──────\n$ \n' > "$dir/composer"
+  defer_poll "$dir" 3
+  [ "$(_composer_defer_streak_read "$state" count)" -eq 1 ] \
+    || fail "a different verdict did not reset the streak to 1"
+  [ "$(_composer_defer_streak_read "$state" verdict)" = unknown ] \
+    || fail "streak did not record the new verdict: $(_composer_defer_streak_read "$state" verdict)"
+  [ ! -e "$state/.subsuper-composer-defer-diag" ] \
+    || fail "a reset streak still reached the diagnostic threshold"
+  pass "a changed composer verdict resets the identical-verdict streak"
+}
+
+test_streak_survives_a_daemon_restart() {
+  # The streak is durable so a restart mid-wedge cannot hide an ongoing
+  # systematic misclassification by restarting the count.
+  local dir state
+  dir=$(defer_case defer-diag-restart 'human draft'); state="$dir/state"
+  printf '4\tpending\n' > "$state/.subsuper-composer-defer-streak"
+  defer_poll "$dir" 5
+  [ -s "$state/.subsuper-composer-defer-diag" ] \
+    || fail "a streak inherited from before a restart did not reach the threshold"
+  grep -Fq 'streak=5/5' "$state/.subsuper-composer-defer-diag" \
+    || fail "inherited streak was not continued: $(cat "$state/.subsuper-composer-defer-diag")"
+  pass "the identical-verdict streak is durable across a daemon restart"
+}
+
+test_empty_composer_clears_the_streak() {
+  local dir state
+  dir=$(defer_case defer-diag-cleared 'human draft'); state="$dir/state"
+  defer_poll "$dir" 5
+  defer_poll "$dir" 5
+  [ -e "$state/.subsuper-composer-defer-streak" ] || fail "no streak recorded"
+  printf '╭─────╮\n│ >   │\n╰─────╯\n' > "$dir/composer"
+  defer_poll "$dir" 5
+  [ ! -e "$state/.subsuper-composer-defer-streak" ] \
+    || fail "streak survived a composer that read empty (delivery is no longer deferring)"
+  pass "a composer that reads empty clears the identical-verdict streak"
+}
+
+test_defer_diagnostic_can_be_disabled() {
+  local dir state i
+  dir=$(defer_case defer-diag-off 'human draft'); state="$dir/state"
+  i=0
+  while [ "$i" -lt 4 ]; do defer_poll "$dir" 0; i=$((i + 1)); done
+  [ ! -e "$state/.subsuper-composer-defer-diag" ] \
+    || fail "FM_COMPOSER_DEFER_DIAG_COUNT=0 still recorded a diagnostic"
+  if defer_reads_present "$state"; then
+    fail "the disabled diagnostic still armed the reader's sink"
+  fi
+  [ ! -e "$state/.subsuper-composer-defer-streak" ] \
+    || fail "the disabled diagnostic still kept streak bookkeeping"
+  pass "FM_COMPOSER_DEFER_DIAG_COUNT=0 disables the diagnostic entirely"
+}
+
+test_defer_diagnostic_leaves_no_temporary_reads() {
+  local dir state i
+  dir=$(defer_case defer-diag-tmp 'human draft'); state="$dir/state"
+  i=0
+  while [ "$i" -lt 6 ]; do defer_poll "$dir" 3; i=$((i + 1)); done
+  if defer_reads_present "$state"; then
+    fail "instrumented reads leaked temporary files into the state dir"
+  fi
+  pass "instrumented composer reads leave no temporary files behind"
+}
+
+test_unreadable_composer_records_a_bounded_pane_tail() {
+  # The dead-shell / unreadable class has no offending row at all, so the
+  # informative analogue is a bounded, sanitised tail of what IS on the pane.
+  local dir state diag
+  dir=$(defer_case defer-diag-norow 'human draft'); state="$dir/state"
+  diag="$state/.subsuper-composer-defer-diag"
+  printf 'plain output line\n──────\n$ \n' > "$dir/composer"
+  defer_poll "$dir" 2
+  defer_poll "$dir" 2
+  [ -s "$diag" ] || fail "a recurring unreadable composer recorded no diagnostic"
+  grep -Fq 'verdict=unknown' "$diag" || fail "record did not name the unknown verdict: $(cat "$diag")"
+  grep -Fq 'rows_evaluated=0' "$diag" || fail "record did not report that no candidate row was found"
+  grep -Fq 'tail[' "$diag" || fail "record carried no pane tail for the no-candidate-row case"
+  grep -Fq 'row_hex=70 6c 61 69 6e' "$diag" \
+    || fail "pane tail did not carry sanitised row bytes: $(cat "$diag")"
+  pass "a recurring unreadable composer records a bounded sanitised pane tail instead of a row"
+}
+
+test_recorded_pane_tail_is_row_bounded() {
+  # The tail must stay bounded: a long transcript cannot turn one diagnostic into
+  # an unbounded dump of the pane's scrollback. The recording path is covered
+  # above through inject_msg; this pins the bound itself, which needs a pane
+  # deeper than the fake reader's whole-capture fallback can represent.
+  local dir out i
+  dir=$(defer_case defer-diag-tail-bound 'human draft')
+  : > "$dir/composer"
+  i=0
+  while [ "$i" -lt 30 ]; do
+    printf 'transcript row %s\n' "$i" >> "$dir/composer"
+    printf '\n' >> "$dir/composer"
+    i=$((i + 1))
+  done
+  out=$(PATH="$dir/fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" \
+    composer_defer_diag_tail tmux fakepane)
+  [ "$(printf '%s\n' "$out" | grep -c '  tail\[')" -eq 12 ] \
+    || fail "expected exactly 12 bounded tail rows, got $(printf '%s\n' "$out" | grep -c '  tail\[')"
+  printf '%s\n' "$out" | grep -Fq 'row_text=transcript row 29' \
+    || fail "the bounded tail dropped the most recent row: $out"
+  printf '%s\n' "$out" | grep -Fq 'row_text=transcript row 0' \
+    && fail "the bounded tail reached back to the oldest transcript row"
+  printf '%s\n' "$out" | grep -Fq 'row_hex=74 72 61 6e 73 63 72 69 70 74' \
+    || fail "bounded tail rows were not recorded as sanitised bytes: $out"
+  pass "the recorded pane tail is bounded to the most recent rows and skips blank ones"
+}
+
+test_wedge_marker_carries_the_diagnostic() {
+  local dir state marker
+  dir=$(defer_case defer-diag-marker 'human draft'); state="$dir/state"
+  marker="$state/.subsuper-inject-wedged"
+  echo $(( $(date +%s) - 600 )) > "$state/.subsuper-escalations.since"
+  defer_poll "$dir" 2
+  defer_poll "$dir" 2
+  PATH="$dir/fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$dir/sent.log" \
+    FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 FM_COMPOSER_DEFER_DIAG_COUNT=2 \
+    FM_INJECT_CONFIRM_SLEEP=0.05 housekeeping "$state"
+  [ -s "$marker" ] || fail "no wedge marker raised"
+  grep -Fq 'Recurring composer verdict diagnostic:' "$marker" \
+    || fail "the wedge marker did not carry the diagnostic: $(cat "$marker")"
+  grep -Fq 'content_hex=3e 20 68 75 6d 61 6e' "$marker" \
+    || fail "the wedge marker did not carry the offending row's bytes: $(cat "$marker")"
+  grep -Fq 'needs-decision: pick A' "$marker" \
+    || fail "the wedge marker lost the buffered items it already carried"
+  pass "the wedge marker carries the recurring-verdict diagnostic alongside the buffered items"
+}
+
+test_wedge_alarm_summary_excludes_row_bytes() {
+  # The summary reaches an OS notifier or a configured command: directive, and the
+  # row can hold the captain's draft, so only identifiers may appear in it.
+  local dir state summary
+  dir=$(defer_case defer-diag-summary 'secret draft'); state="$dir/state"
+  defer_poll "$dir" 2
+  defer_poll "$dir" 2
+  summary=$(composer_defer_diag_summary "$state")
+  case "$summary" in
+    *'verdict=pending'*) : ;;
+    *) fail "alarm summary omitted the recurring verdict: '$summary'" ;;
+  esac
+  case "$summary" in
+    *'reader=fm_tmux_composer_row_state'*) : ;;
+    *) fail "alarm summary omitted the reader: '$summary'" ;;
+  esac
+  case "$summary" in
+    *secret*|*73\ 65\ 63*) fail "alarm summary leaked composer row content: '$summary'" ;;
+  esac
+  case "$summary" in
+    *$'\n'*) fail "alarm summary spans more than one line: '$summary'" ;;
+  esac
+  pass "the wedge alarm summary carries the verdict and reader but never the row's bytes"
+}
+
 test_normal_flush_clears_stale_wedge_marker() {
   local dir state fakebin sent
   dir=$(make_bordered_case normal-clears-wedge)
@@ -1825,6 +2074,17 @@ test_submit_ack_reports_pending_on_persistent_swallow
 test_max_defer_empty_swallow_types_once_and_alarms
 test_max_defer_flushes_empty_idle_pane
 test_max_defer_pending_composer_alarms_without_typing
+test_identical_verdict_streak_records_diagnostic_at_threshold
+test_identical_verdict_streak_refreshes_every_threshold
+test_changed_verdict_resets_the_streak
+test_streak_survives_a_daemon_restart
+test_empty_composer_clears_the_streak
+test_defer_diagnostic_can_be_disabled
+test_defer_diagnostic_leaves_no_temporary_reads
+test_unreadable_composer_records_a_bounded_pane_tail
+test_recorded_pane_tail_is_row_bounded
+test_wedge_marker_carries_the_diagnostic
+test_wedge_alarm_summary_excludes_row_bytes
 test_normal_flush_clears_stale_wedge_marker
 test_below_max_defer_does_nothing
 test_max_defer_afk_inactive_does_not_flush_or_alarm

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1180,6 +1180,23 @@ test_identical_verdict_streak_records_diagnostic_at_threshold() {
   pass "recurring identical composer verdicts record the verdict, offending bytes, and reader at the threshold"
 }
 
+test_deferral_without_streak_file_keeps_stderr_silent() {
+  # The streak file is absent on a healthy fleet and the arming check reads it on
+  # every inject attempt, so a missing file must not leak "No such file or
+  # directory" onto the daemon's stderr (its foreground pane).
+  local dir state err
+  dir=$(defer_case defer-diag-quiet 'human draft'); state="$dir/state"
+  err="$dir/stderr.log"
+  [ ! -e "$state/.subsuper-composer-defer-streak" ] || fail "fixture already has a streak file"
+  PATH="$dir/fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$dir/sent.log" \
+    FM_COMPOSER_DEFER_DIAG_COUNT=5 FM_INJECT_CONFIRM_SLEEP=0.05 \
+    inject_msg "the digest" "$state" >/dev/null 2>"$err" || true
+  [ ! -s "$err" ] || fail "a deferral with no streak file wrote to stderr: $(cat "$err")"
+  [ "$(_composer_defer_streak_read "$state" count)" -eq 1 ] \
+    || fail "the deferral did not still fold into the streak"
+  pass "a composer deferral with no streak file keeps stderr silent"
+}
+
 test_identical_verdict_streak_refreshes_every_threshold() {
   local dir state diag first i
   dir=$(defer_case defer-diag-refresh 'human draft'); state="$dir/state"
@@ -2075,6 +2092,7 @@ test_max_defer_empty_swallow_types_once_and_alarms
 test_max_defer_flushes_empty_idle_pane
 test_max_defer_pending_composer_alarms_without_typing
 test_identical_verdict_streak_records_diagnostic_at_threshold
+test_deferral_without_streak_file_keeps_stderr_silent
 test_identical_verdict_streak_refreshes_every_threshold
 test_changed_verdict_resets_the_streak
 test_streak_survives_a_daemon_restart


### PR DESCRIPTION
## Intent

Implement R2 from the completed away-mode escalation wedge diagnosis (data/away-injection-wedge-diagnosis/report.md): give the away-mode delivery guard's max-defer escape somewhere to escape to.

Background. Away mode buffers captain-relevant escalations and injects them into firstmate's own pane. The max-defer escape at bin/fm-supervise-daemon.sh retried the identical guarded delivery path and could only alarm. A 9.5-hour wedge (three consecutive occurrences) proved that a systematic composer misclassification defers forever with zero diagnostic value: the buffered escalation recorded no record of WHICH verdict recurred or WHAT the offending composer row contained, so the follow-up investigation had to start from scratch. The diagnosed root cause was Claude Code rendering its empty composer as the prompt glyph plus U+00A0, which bash's [[:space:]] trims cannot see.

Goal of THIS change. Make that class of wedge self-diagnosing. After N consecutive identical non-empty composer verdicts, record a distinguishable diagnostic: the verdict, the offending row's sanitized bounded bytes, and the reader that produced it, so the next investigation starts at the answer.

Deliberate decisions made and approved by the supervising firstmate in a mandatory design review before implementation (design at data/composer-defer-diagnostic-fallback/design.md). A reviewer reading only the diff would not know these were chosen on purpose:

1. NO fallback delivery route is implemented, deliberately. R2 offered either the diagnostic or a composer-independent delivery route. Six candidate routes were evaluated and every one violates the hard safety property that we never type into a pane that might hold real input: typing on a "provably chrome" verdict needs a general proof that does not exist; herdr agent prompt drives the same PTY so it either merges with or destroys the captain's draft; baseline identity is sound but can never arm in the wedge it would fix (proof needs a confirmed submit or an affirmative empty verdict, and the incident had zero of both across 9.5 hours); cross-pane identity against a crewmate pane rests on an assumption AGENTS.md hard rule 4 contradicts and ends in typing on a probabilistic argument; a fresh pane hosts a second firstmate that the per-home session lock refuses. R2 itself names the diagnostic alone as the accepted minimum in that case, and firstmate approved shipping exactly that. Do NOT flag the absence of a delivery route as incomplete work.

2. The diagnostic does NOT gate on the backend independently reporting idle, even though R2's wording mentions it. That needs no new gate: inject_msg already returns early on pane_is_busy, which consults the backend's native busy state before the harness busy footer, so every deferral reaching the composer guard is already proven not-busy by both signals. The native state is recorded as evidence instead, because only herdr exposes a real native busy state (tmux returns unknown) and gating on an affirmative idle would make the diagnostic never fire on the tmux reference backend, which the diagnosed defect affected identically.

3. The new test fixture deliberately does NOT use the U+00A0 that caused the diagnosed wedge. The root-cause fix (R1) is being shipped in parallel and normalizes Unicode blanks in the shared classifier, so once it lands an NBSP row reads empty and an NBSP fixture would silently stop reproducing the identical-verdict condition. Stable non-blank content models what R2 actually targets: the NEXT systematic misclassification, not the one R1 fixes. This change adds NO blank normalization of its own and must not duplicate R1's.

4. Row bytes are recorded as hex rather than raw, and every field is bounded to 120 bytes with an explicit truncation marker. Both are safety choices, not style: a composer row can contain the terminal's own escape sequences and a diagnostic record is read with cat, so hex can never replay an escape into the reader's terminal; and the row can hold the captain's own unsent draft, so it must be bounded. For the same reason the wedge alert summary carries only the verdict, reader, and streak and never the row bytes, because that string is passed to an OS notifier or a configured command: directive.

5. The diagnostic sink lives in bin/fm-composer-lib.sh and is opt-in via FM_COMPOSER_DIAG_FILE, inert otherwise. Each reader calls it once where it already holds both the raw styled row and the ghost-stripped content. This is to honor the repo's one-owner rule: re-deriving composer row location in the daemon would duplicate exactly the logic that has drifted across adapters twice before. The daemon arms the sink only once already deep in a streak, so the recorded row comes from the same read as the recorded verdict rather than a second read.

6. Scope also includes two additions firstmate explicitly approved beyond R2's literal wording: a bounded sanitized pane tail when the reader found no candidate composer row at all (the dead-shell / unreadable class, which has no offending row but wedges just as permanently), and surfacing the record as away-return catch-up evidence so the captain's next investigation does not have to rediscover it.

7. Only tmux and herdr can be supervisor panes (the daemon refuses others loudly at startup), so those two readers are the complete affected set. The orca, cmux, and zellij composer surfaces were inspected and deliberately left unchanged; the sink is inert without the env var so their behavior is unchanged bit for bit.

Verification already performed locally: bin/fm-lint.sh clean, bin/fm-doc-audience-check.sh clean, and 52 suites run. Sixteen new tests added across tests/fm-daemon.test.sh, tests/fm-composer-lib.test.sh, and tests/fm-afk-return.test.sh, all green. Four suites fail, and each was individually reproduced as identical at the base commit a2d5f26, so none is caused by this change: fm-calm-pi-extension, fm-pi-watch-extension, and fm-turnend-guard share one node ESM environment fault in the Pi tooling, and fm-watcher-lock is a watcher-singleton timing test perturbed by sibling firstmate lanes' live watchers on this host. tests/fm-backend-tmux-smoke.test.sh was excluded because it needs a real tmux server and hangs at the base commit too, and the real-herdr-gated family was excluded because this task's brief was scaffolded without the Herdr lab guard and must not drive Herdr lifecycle.

## What Changed

- The away-mode daemon (`bin/fm-supervise-daemon.sh`) now tracks consecutive identical non-empty composer verdicts across deferred escalation deliveries in a durable streak file that survives daemon restarts. After `FM_COMPOSER_DEFER_DIAG_COUNT` identical verdicts (default 20, `0` disables), it writes a diagnostic record — verdict, reader, streak, native busy state, and the offending row's sanitized bytes — to `state/.subsuper-composer-defer-diag`, the daemon log, and the wedge-alarm marker. The wedge alert summary carries only the verdict, reader, and streak, never row bytes; when the reader found no candidate row at all (dead-shell/unreadable pane), a bounded sanitized pane tail is recorded instead. Deliberately no fallback delivery route is added — the diagnostic alone is the approved scope.
- `bin/fm-composer-lib.sh` gains an opt-in diagnostic sink (`fm_composer_diag_record`, armed via `FM_COMPOSER_DIAG_FILE`, inert otherwise) that the tmux and herdr composer readers call at the point they already hold both the raw styled row and the ghost-stripped content. Row bytes are rendered as hex and every field is bounded to 120 bytes with an explicit truncation marker, so a record read with `cat` can never replay terminal escapes and never leaks an unbounded captain draft.
- Away-mode entry/return now manage the new artifacts: `fm-afk-return.sh` surfaces the diagnostic as catch-up evidence and clears it, and a fresh away entry clears stale diagnostics too, with the launcher's transactional backup/rollback extended to cover them. Docs (`docs/wedge-alarm.md`, `docs/configuration.md`, `docs/architecture.md`, the afk skill) describe the new behavior, and 16 new tests cover the threshold trigger, streak reset/restart survival, sanitization bounds, wedge-marker/alarm content, and return-side surfacing. The no-mistakes review pass also fixed a stderr leak from the streak-file read that would have printed on every healthy delivery.

## Risk Assessment

✅ Low: The round-1 fix commit resolves both prior findings precisely as instructed — a readability guard replacing the broken redirection-order suppression with identical fallback semantics plus a behavioral stderr regression test, and a comment-only correction of the diag sink contract — leaving the branch intent-conformant with no remaining issues.

## Testing

Ran the three touched suites (fm-composer-lib, fm-daemon, fm-afk-return — all green, covering the 16 new tests) and a manual end-to-end demo through the real daemon inject path: five identical pending deferrals build the durable streak, the diagnostic records at the threshold with verdict/reader/bounded hex row bytes and native busy state as evidence, nothing is typed into the pane holding the draft, the wedge marker and daemon log carry the record, the notifier summary carries only verdict/reader/streak (no row bytes), and away-return surfaces the record as catch-up evidence then clears it; diff checks confirmed no delivery route and no blank normalization were added.

<details>
<summary>Evidence: End-to-end wedge lifecycle transcript (deferrals → diagnostic → wedge alarm → return catch-up → clear)</summary>

<code>=== 5 daemon inject attempts (FM_COMPOSER_DEFER_DIAG_COUNT=5) ===&#10;attempt 1: deferred; streak file: [1 pending]; diagnostic: absent&#10;...&#10;attempt 5: deferred; streak file: [5 pending]; diagnostic: RECORDED&#10;&#10;=== state/.subsuper-composer-defer-diag ===&#10;composer-defer-diag 2026-07-29T23:47:21-0400&#10;target=firstmate:0 backend=tmux verdict=pending streak=5/5 native_busy=unknown&#10;rows_evaluated=1 reader=fm_tmux_composer_row_state raw_len=46 raw_hex=e2 94 82 20 3e 20 64 72 61 66 74 ... content_text=&gt; draft: reply to the board before 6pm&#10;&#10;=== nothing typed into the pane holding the draft ===&#10;sent.log bytes: 0&#10;&#10;--- summary handed to the OS notifier (no row bytes) ---&#10;osascript away-mode escalations WEDGED 600s undelivered (composer verdict=pending reader=fm_tmux_composer_row_state streak=5/5) - see .../.subsuper-inject-wedged&#10;&#10;=== fm-afk-return.sh begin ===&#10;catch-up composer-defer: composer-defer-diag 2026-07-29T23:47:21-0400&#10;...&#10;=== after resolved blocker -&gt; check ===&#10;.subsuper-composer-defer-diag: cleared&#10;.subsuper-composer-defer-streak: cleared&#10;.subsuper-composer-defer-read: cleared</code>

```text
=== supervisor pane (never changes: the captain left a draft in the composer) ===
╭────────────────────────────────────────╮
│ > draft: reply to the board before 6pm │
╰────────────────────────────────────────╯

=== 5 daemon inject attempts (FM_COMPOSER_DEFER_DIAG_COUNT=5) ===
attempt 1: deferred; streak file: [1 pending]; diagnostic: absent
attempt 2: deferred; streak file: [2 pending]; diagnostic: absent
attempt 3: deferred; streak file: [3 pending]; diagnostic: absent
attempt 4: deferred; streak file: [4 pending]; diagnostic: absent
attempt 5: deferred; streak file: [5 pending]; diagnostic: RECORDED

=== state/.subsuper-composer-defer-diag (the record the next investigation starts from) ===
composer-defer-diag 2026-07-29T23:47:21-0400
  target=firstmate:0 backend=tmux verdict=pending streak=5/5 native_busy=unknown
  rows_evaluated=1 reader=fm_tmux_composer_row_state raw_len=46 raw_hex=e2 94 82 20 3e 20 64 72 61 66 74 3a 20 72 65 70 6c 79 20 74 6f 20 74 68 65 20 62 6f 61 72 64 20 62 65 66 6f 72 65 20 36 70 6d 20 e2 94 82 raw_text=... > draft: reply to the board before 6pm ... content_len=38 content_hex=3e 20 64 72 61 66 74 3a 20 72 65 70 6c 79 20 74 6f 20 74 68 65 20 62 6f 61 72 64 20 62 65 66 6f 72 65 20 36 70 6d content_text=> draft: reply to the board before 6pm

=== nothing was ever typed into the pane holding the draft ===
sent.log bytes: 0

=== max-defer escape fires (housekeeping, FM_MAX_DEFER_SECS=60, digest 600s old) ===
--- wedge marker state/.subsuper-inject-wedged ---
fm away-mode inject WEDGED: 600s undelivered as of 2026-07-29T23:47:21-0400
The supervisor pane could not accept an escalation. Buffered items:
needs-decision: crewmate blocked on API key rotation
Recurring composer verdict diagnostic:
composer-defer-diag 2026-07-29T23:47:21-0400
  target=firstmate:0 backend=tmux verdict=pending streak=5/5 native_busy=unknown
  rows_evaluated=1 reader=fm_tmux_composer_row_state raw_len=46 raw_hex=e2 94 82 20 3e 20 64 72 61 66 74 3a 20 72 65 70 6c 79 20 74 6f 20 74 68 65 20 62 6f 61 72 64 20 62 65 66 6f 72 65 20 36 70 6d 20 e2 94 82 raw_text=... > draft: reply to the board before 6pm ... content_len=38 content_hex=3e 20 64 72 61 66 74 3a 20 72 65 70 6c 79 20 74 6f 20 74 68 65 20 62 6f 61 72 64 20 62 65 66 6f 72 65 20 36 70 6d content_text=> draft: reply to the board before 6pm
--- summary handed to the OS notifier (no row bytes, ever) ---
osascript	away-mode escalations WEDGED 600s undelivered (composer verdict=pending reader=fm_tmux_composer_row_state streak=5/5) - see /tmp/fm-defer-demo.lkQked/state/.subsuper-inject-wedged

--- daemon log trail (grep composer-defer) ---
    [2026-07-29T23:47:21-0400] composer-defer-diag 2026-07-29T23:47:21-0400
    [2026-07-29T23:47:21-0400] ERROR: away-mode escalation undelivered 600s (composer verdict=pending reader=fm_tmux_composer_row_state streak=5/5); inject could not confirm a submit (supervisor pane busy or wedged). Buffer + wake-queue preserved; alarm marker written.

=== captain returns: bin/fm-afk-return.sh begin surfaces the cause as catch-up evidence ===
fm-afk-return: catch-up must finish before the captain request
catch-up wedge: fm away-mode inject WEDGED: 600s undelivered as of 2026-07-29T23:47:21-0400
catch-up composer-defer: composer-defer-diag 2026-07-29T23:47:21-0400
catch-up composer-defer:   target=firstmate:0 backend=tmux verdict=pending streak=5/5 native_busy=unknown
catch-up composer-defer:   rows_evaluated=1 reader=fm_tmux_composer_row_state raw_len=46 raw_hex=e2 94 82 20 3e 20 64 72 61 66 74 3a 20 72 65 70 6c 79 20 74 6f 20 74 68 65 20 62 6f 61 72 64 20 62 65 66 6f 72 65 20 36 70 6d 20 e2 94 82 raw_text=... > draft: reply to the board before 6pm ... content_len=38 content_hex=3e 20 64 72 61 66 74 3a 20 72 65 70 6c 79 20 74 6f 20 74 68 65 20 62 6f 61 72 64 20 62 65 66 6f 72 65 20 36 70 6d content_text=> draft: reply to the board before 6pm
catch-up escalation: needs-decision: crewmate blocked on API key rotation
firstmate-actionable blocker: repair-task [key=api-key] firstmate can refresh the synthetic token
fm-afk-return: handle each blocker now, or close it with resolved [key=...] and append a durable reclassification reason, then run bin/fm-afk-return.sh check

=== blocker resolved -> return check clears the diagnostic with the delivery artifacts ===
.subsuper-composer-defer-diag: cleared
.subsuper-composer-defer-streak: cleared
.subsuper-composer-defer-read: cleared
```
</details>
<details>
<summary>Evidence: Demo script (reproducible manual verification)</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end demo of the recurring-deferral diagnostic
# (branch fm/composer-defer-diagnostic-fallback).
#
# Scenario: away mode is active, an escalation is buffered, and the supervisor
# pane's composer permanently holds a captain draft ("pending" on every poll) -
# the systematic-misclassification shape that wedged delivery for 9.5 hours.
# We drive the daemon's real inject path five times (threshold 5), then the
# max-defer housekeeping escape, then the away-return catch-up.
set -u
ROOT=${1:?repo root}
WORK=$(mktemp -d /tmp/fm-defer-demo.XXXXXX)
trap 'rm -rf "$WORK"' EXIT
state="$WORK/state"; fakebin="$WORK/fakebin"
mkdir -p "$state" "$fakebin"

DRAFT='draft: reply to the board before 6pm'

# Fake tmux: the pane's composer box forever holds the captain's draft.
cat > "$fakebin/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "${1:-}" in
  display-message)
    for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
    for a in "$@"; do [ "$a" = "-p" ] && { printf 'fakepane\n'; break; }; done
    exit 0 ;;
  capture-pane) cat "$FM_FAKE_COMPOSER" 2>/dev/null; exit 0 ;;
  list-windows) exit 0 ;;
  send-keys)
    shift; lit=0
    while [ "$#" -gt 0 ]; do
      case "$1" in
        -l) lit=1 ;;
        Enter) printf '[ENTER]\n' >> "$FM_FAKE_SENT" ;;
        -t) shift ;;
        *) [ "$lit" = 1 ] && printf '%s\n' "$1" >> "$FM_FAKE_SENT" ;;
      esac; shift
    done
    exit 0 ;;
esac
exit 1
SH
chmod +x "$fakebin/tmux"
width=$(( ${#DRAFT} + 4 )); border=; i=0
while [ "$i" -lt "$width" ]; do border="${border}─"; i=$((i+1)); done
printf '╭%s╮\n│ > %s │\n╰%s╯\n' "$border" "$DRAFT" "$border" > "$WORK/composer"
: > "$WORK/sent.log"

# Notifier seam recorder: what an OS notifier would have been handed.
cat > "$WORK/alarm-rec" <<'SH'
#!/usr/bin/env bash
printf '%s\t%s\n' "${1:-}" "${2:-}" >> "${DEMO_ALARM_LOG:?}"
SH
chmod +x "$WORK/alarm-rec"
export DEMO_ALARM_LOG="$WORK/alarm.log"
export FM_WEDGE_ALARM_EXEC="$WORK/alarm-rec"
export FM_WEDGE_ALARM_CHANNEL=osascript

export PATH="$fakebin:$PATH"
export FM_FAKE_COMPOSER="$WORK/composer" FM_FAKE_SENT="$WORK/sent.log"
export FM_INJECT_CONFIRM_SLEEP=0.05
export FM_COMPOSER_DEFER_DIAG_COUNT=5
export LOG="$WORK/daemon.log"

# shellcheck disable=SC1091
. "$ROOT/bin/fm-supervise-daemon.sh"

escalate_add "$state" "needs-decision: crewmate blocked on API key rotation"
afk_enter "$state"

echo '=== supervisor pane (never changes: the captain left a draft in the composer) ==='
cat "$WORK/composer"
echo
echo "=== 5 daemon inject attempts (FM_COMPOSER_DEFER_DIAG_COUNT=5) ==="
for i in 1 2 3 4 5; do
  inject_msg "away digest: needs-decision: crewmate blocked on API key rotation" "$state" >/dev/null 2>&1
  streak=$(cat "$state/.subsuper-composer-defer-streak" 2>/dev/null | tr '\t' ' ')
  diag_state=absent; [ -s "$state/.subsuper-composer-defer-diag" ] && diag_state=RECORDED
  printf 'attempt %s: deferred; streak file: [%s]; diagnostic: %s\n' "$i" "$streak" "$diag_state"
done
echo
echo '=== state/.subsuper-composer-defer-diag (the record the next investigation starts from) ==='
cat "$state/.subsuper-composer-defer-diag"
echo
echo '=== nothing was ever typed into the pane holding the draft ==='
printf 'sent.log bytes: %s\n' "$(wc -c < "$WORK/sent.log" | tr -d ' ')"
echo
echo '=== max-defer escape fires (housekeeping, FM_MAX_DEFER_SECS=60, digest 600s old) ==='
echo $(( $(date +%s) - 600 )) > "$state/.subsuper-escalations.since"
FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 housekeeping "$state" >/dev/null 2>&1
echo '--- wedge marker state/.subsuper-inject-wedged ---'
cat "$state/.subsuper-inject-wedged"
echo '--- summary handed to the OS notifier (no row bytes, ever) ---'
cat "$WORK/alarm.log"
echo
echo '--- daemon log trail (grep composer-defer) ---'
grep -E 'composer-defer|ERROR' "$WORK/daemon.log" | sed 's/^/    /'
echo
echo '=== captain returns: bin/fm-afk-return.sh begin surfaces the cause as catch-up evidence ==='
ret="$WORK/return"; mkdir -p "$ret/bin" "$ret/home/state" "$ret/home/data" "$ret/home/config"
cp "$ROOT/bin/fm-afk-return.sh" "$ROOT/bin/fm-wake-lib.sh" "$ROOT/bin/fm-classify-lib.sh" "$ret/bin/"
cat > "$ret/bin/fm-afk-launch.sh" <<'SH'
#!/usr/bin/env bash
[ "${1:-}" = stop ] || exit 2
rm -f "$FM_HOME/state/.afk" "$FM_HOME/state/.afk-daemon-terminal"
SH
cat > "$ret/bin/fm-wake-drain.sh" <<'SH'
#!/usr/bin/env bash
exit 0
SH
chmod +x "$ret/bin/"*.sh
# Carry the REAL artifacts the daemon just produced into the return's state.
cp "$state/.subsuper-escalations" "$state/.subsuper-inject-wedged" \
   "$state/.subsuper-composer-defer-diag" "$state/.subsuper-composer-defer-streak" \
   "$ret/home/state/" 2>/dev/null
date +%s > "$ret/home/state/.afk"
cat > "$ret/home/state/repair-task.meta" <<EOF
window=synthetic:fm-repair-task
backend=tmux
kind=ship
EOF
printf 'blocked [key=api-key]: firstmate can refresh the synthetic token\n' > "$ret/home/state/repair-task.status"
out=$(FM_HOME="$ret/home" FM_STATE_OVERRIDE="$ret/home/state" "$ret/bin/fm-afk-return.sh" begin 2>&1) || true
printf '%s\n' "$out"
echo
echo '=== blocker resolved -> return check clears the diagnostic with the delivery artifacts ==='
printf 'resolved [key=api-key]: refreshed the synthetic token\n' >> "$ret/home/state/repair-task.status"
FM_HOME="$ret/home" FM_STATE_OVERRIDE="$ret/home/state" "$ret/bin/fm-afk-return.sh" check >/dev/null 2>&1 || true
for f in .subsuper-composer-defer-diag .subsuper-composer-defer-streak .subsuper-composer-defer-read; do
  if [ -e "$ret/home/state/$f" ]; then printf '%s: STILL PRESENT\n' "$f"; else printf '%s: cleared\n' "$f"; fi
done
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-supervise-daemon.sh:1131` - In `_composer_defer_streak_read`, the redirection order `read -r count verdict &lt; &#34;$(_composer_defer_streak_file &#34;$1&#34;)&#34; 2&gt;/dev/null` does not suppress the error when the streak file is missing: bash processes redirections left to right, so the failed input redirect prints &#34;No such file or directory&#34; to the original stderr before `2&gt;/dev/null` takes effect (verified empirically). The arming check in inject_msg (line 1302) calls this on every inject attempt with the default threshold of 20, and the streak file is absent on a healthy fleet, so every normal escalation delivery emits an unsuppressed error line to the daemon&#39;s stderr (its foreground pane). Fix by reordering to `2&gt;/dev/null &lt; &#34;$file&#34;` or guarding with `[ -r &#34;$file&#34; ]` before the read.
- ℹ️ `bin/fm-composer-lib.sh:271` - The sink contract comment in fm_composer_diag_record says the daemon reports the LAST record because &#34;the readers return on the first row that classifies non-empty.&#34; That holds for `pending` (fm_tmux_composer_state returns immediately on a pending row) but not for the geometry-ambiguous `unknown` case: there every box row classifies `empty`, the verdict comes from the ambiguity flag, and `tail -1` in composer_defer_diag_write reports an innocuous last box row as the offending one. The record still carries rows_evaluated and real pane bytes, so it remains diagnostic; noting the nuance in case a future investigation reads the reported row as authoritative for verdict=unknown streaks.

🔧 Fix: silence missing-streak-file stderr leak; correct diag sink comment
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-composer-lib.test.sh` — 14 ok (5 new diag-sink tests: inert without env var, hex byte capture, no replayable escapes, 120-byte bounding with truncation marker, one line per row)</code>
- <code>`bash tests/fm-daemon.test.sh` — 111 ok, exit 0 (12 new tests: threshold trigger, stderr silence, refresh cadence, streak reset/restart-survival, disable via 0, no leaked temp reads, pane-tail for unreadable composer, wedge marker carries diagnostic, alarm summary excludes row bytes)</code>
- <code>`bash tests/fm-afk-return.test.sh` — 7 ok, exit 0 (new: return surfaces and clears the composer-defer diagnostic)</code>
- <code>Manual end-to-end demo (`defer-diag-demo.sh`): sourced the real daemon in library mode against a fake tmux pane whose composer forever holds a captain draft; drove 5 real `inject_msg` deferrals to the threshold, ran `housekeeping` past max-defer, then ran the real `bin/fm-afk-return.sh begin`/`check` against the daemon-produced artifacts</code>
- `Constraint checks against the diff: no fallback delivery route added, no blank/NBSP normalization added, diag sink opt-in via FM_COMPOSER_DIAG_FILE, daemon fixture uses non-blank content (not U+00A0)`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-afk-launch.sh:369` - fm_afk_clear_stale_artifacts in bin/fm-afk-launch.sh clears only .subsuper-escalations, .subsuper-escalations.since, and .subsuper-inject-wedged on a fresh away entry; the new .subsuper-composer-defer-diag/-streak/-read artifacts are cleared only by bin/fm-afk-return.sh, so a prior session&#39;s diagnostic or streak count can survive into a fresh away session if the return script never ran (crash or manual .afk removal). Effect is diagnostic-only, but a code follow-up may be warranted; documentation now attributes clearing to the return script, which matches current behavior.

🔧 Fix: clear composer-defer diagnostics on fresh away entry too
1 info still open:
- ℹ️ `bin/fm-afk-launch.sh:362` - Judgment call, already applied: the instruction literally asked only to extend fm_afk_clear_stale_artifacts (which lives in bin/fm-afk-start.sh, sourced by the launcher, not in bin/fm-afk-launch.sh as the instruction stated), but the launcher&#39;s transactional entry backs up and restores every artifact that clear removes, so the backup loops and fm_afk_launch_restore_backup were also extended with the three composer-defer artifacts. Without that, a failed away entry would restore the delivery artifacts yet permanently destroy the prior session&#39;s diagnostic evidence, breaking the launcher&#39;s existing rollback invariant. Signature, call sites, and away-entry ordering are unchanged, and the rollback regression test now covers the new artifacts.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
