### PR TITLE
fix(bin): close three merge and decision-hold papercuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
   captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
+  merged-prs.log     durable ledger of PRs merged after their task was cleaned up; LOCAL, gitignored; appended only by fm-pr-merge.sh, which owns its record shape; created lazily
   projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)
   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -37,6 +37,13 @@
 # It writes the captain decision and routed identities into the hold body, clears
 # those dependency edges, and only then marks the hold Done. A failure before the
 # final step leaves the captain hold open.
+#
+# A routed task that has already reached Done is accepted: the captain commonly
+# answers a decision after the dependent work shipped, and finished work carrying
+# the hold's dependency edge is stronger evidence of real routing than queued work.
+# The edge itself is never created here, because declaring the dependency is the
+# caller's deliberate act; a routed task with no edge is refused with the exact
+# `tasks-axi block` command that would declare it.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -368,7 +375,7 @@ EOF
 }
 
 command_resolve() {
-  local origin=${1:-} key=${2:-} decision_file='' id='' decision='' decision_digest='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0
+  local origin=${1:-} key=${2:-} decision_file='' id='' decision='' decision_digest='' body='' routed='' routed_csv='' dep show blocked hold_show hold_body
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   shift 2
   while [ "$#" -gt 0 ]; do
@@ -406,15 +413,11 @@ command_resolve() {
   case "$hold_body" in
     *"Resolution recorded by fm-decision-hold."*)
       verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv"
-      resolution_recorded=1
       ;;
   esac
 
   for dep in $routed; do
     show=$(task_show "$dep") || fail "routed task $dep does not exist in the active home"
-    state=$(show_field "$show" state)
-    [ "$state" != "done" ] || [ "$resolution_recorded" = 1 ] \
-      || fail "routed task $dep is already done"
     # tasks-axi quotes multi-entry blocked_by as "a,b,c"; strip so edge ids match.
     blocked=$(show_field "$show" blocked_by | tr -d '[:space:]')
     blocked=${blocked#\"}
@@ -424,7 +427,7 @@ command_resolve() {
       *)
         case "$hold_body" in
           *"Resolution recorded by fm-decision-hold."*"- $dep"*) : ;;
-          *) fail "routed task $dep is not durably blocked by $id" ;;
+          *) fail "routed task $dep is not durably blocked by $id; declare that dependency first with: tasks-axi block $dep --by $id" ;;
         esac
         ;;
     esac

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -12,10 +12,17 @@
 # merge keeps the guarded path instead of reaching around it to a raw merge
 # command. It requires the task metadata to be genuinely absent, refusing when
 # the task is still live so it can never be used to skip recording or the merge
-# poll for a task that has both. With no metadata to record into and no live
-# task for a merge poll to wake, the merge is recorded in the durable ledger
-# data/merged-prs.log as one <utc-timestamp><TAB><task-id><TAB><pr-url> line,
-# written before the merge exactly as pr= is on the ordinary path.
+# poll for a task that has both. Absent metadata alone is not enough, because an
+# invented or mistyped id has none either, so the flag also requires positive
+# evidence that the task existed and was cleaned up: either the
+# data/<task-id>/brief.md that teardown leaves in place, or a completed backlog
+# entry for the id in data/backlog.md or data/done-archive.md.
+# With no metadata to record into and no live task for a merge poll to wake, the
+# merge is recorded in the durable ledger data/merged-prs.log as one
+# <utc-timestamp><TAB><task-id><TAB><pr-url> line. The ledger path is validated
+# before the merge, but the line is appended only after gh-axi pr merge reports
+# success, so the ledger never asserts a merge that did not happen; a failed
+# merge writes no line and exits with the merge command's own status.
 # Usage: fm-pr-merge.sh [--torn-down] <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
 set -eu
 
@@ -79,25 +86,71 @@ reject_repo_overrides() {
 
 reject_repo_overrides "$@" || exit 1
 
+# Positive evidence that a torn-down task genuinely existed and was cleaned up:
+# teardown leaves data/<id>/brief.md in place, and the task's completed backlog
+# row survives in data/backlog.md until retention rolls it into the archive. A
+# row counts as completed when it is checked or sits under a Done heading.
+torn_down_task_recorded() {  # <task-id>
+  local id=$1 file
+  [ -f "$DATA/$id/brief.md" ] && return 0
+  for file in "$DATA/backlog.md" "$DATA/done-archive.md"; do
+    [ -f "$file" ] || continue
+    awk -v id="$id" '
+      /^##[ \t]+/ {
+        heading = $0
+        sub(/^##[ \t]+/, "", heading)
+        sub(/[ \t]+$/, "", heading)
+        in_done = (heading == "Done")
+        next
+      }
+      {
+        row = ""
+        checked = 0
+        if (match($0, /^[-*][ \t]+\[[ xX]\][ \t]+[^ \t]+[ \t]+-[ \t]+/)) {
+          row = substr($0, RSTART, RLENGTH)
+          checked = (row ~ /\[[xX]\]/)
+          sub(/^[-*][ \t]+\[[ xX]\][ \t]+/, "", row)
+          sub(/[ \t]+-[ \t]+$/, "", row)
+        } else if (match($0, /^[-*][ \t]+\*\*[^*]+\*\*[ \t]+-[ \t]+/)) {
+          row = substr($0, RSTART, RLENGTH)
+          sub(/^[-*][ \t]+\*\*/, "", row)
+          sub(/\*\*[ \t]+-[ \t]+$/, "", row)
+        }
+        if (row == id && (checked || in_done)) {
+          hit = 1
+          exit
+        }
+      }
+      END { exit(hit ? 0 : 1) }
+    ' "$file" && return 0
+  done
+  return 1
+}
+
 # Task-derived paths are constructed only after the canonical ID validation.
 META="$STATE/$ID.meta"
+LEDGER=
 if [ "$TORN_DOWN" = 1 ]; then
   if [ -e "$META" ] || [ -L "$META" ]; then
     echo "error: task $ID still has metadata; merge it without --torn-down" >&2
     exit 1
   fi
+  if ! torn_down_task_recorded "$ID"; then
+    echo "error: no record of a cleaned-up task $ID; --torn-down needs $DATA/$ID/brief.md or a completed $ID entry in $DATA/backlog.md" >&2
+    exit 1
+  fi
   LEDGER="$DATA/merged-prs.log"
+  umask 077
   mkdir -p "$DATA" || exit 1
   if [ -L "$LEDGER" ] || { [ -e "$LEDGER" ] && [ ! -f "$LEDGER" ]; }; then
     echo "error: merge ledger is unavailable" >&2
     exit 1
   fi
-  printf '%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ID" "$URL" >> "$LEDGER" || {
-    echo "error: merge ledger recording failed" >&2
-    exit 1
-  }
-  chmod 0600 "$LEDGER" || exit 1
 else
+  if [ ! -e "$META" ] && [ ! -L "$META" ]; then
+    echo "error: task metadata is unavailable; merge a cleaned-up task's PR with --torn-down" >&2
+    exit 1
+  fi
   if [ ! -f "$META" ] || [ -L "$META" ]; then
     echo "error: task metadata is unavailable" >&2
     exit 1
@@ -115,4 +168,15 @@ if ! caller_has_merge_method "$@"; then
   merge_args=(--squash)
 fi
 
-gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${merge_args[@]}"}" "$@"
+MERGE_RC=0
+gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${merge_args[@]}"}" "$@" \
+  || MERGE_RC=$?
+[ "$MERGE_RC" -eq 0 ] || exit "$MERGE_RC"
+
+if [ -n "$LEDGER" ]; then
+  printf '%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ID" "$URL" >> "$LEDGER" || {
+    echo "error: PR $URL merged but merge ledger recording failed" >&2
+    exit 1
+  }
+  chmod 0600 "$LEDGER" || exit 1
+fi

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -7,16 +7,32 @@
 # Merge method defaults to --squash when the caller passes none of --squash,
 # --merge, --rebase, or --method after the optional -- separator. Extra args
 # must not include --repo or -R because the repository comes only from the URL.
-# Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
+#
+# --torn-down merges a PR whose task has already been cleaned up, so a late
+# merge keeps the guarded path instead of reaching around it to a raw merge
+# command. It requires the task metadata to be genuinely absent, refusing when
+# the task is still live so it can never be used to skip recording or the merge
+# poll for a task that has both. With no metadata to record into and no live
+# task for a merge poll to wake, the merge is recorded in the durable ledger
+# data/merged-prs.log as one <utc-timestamp><TAB><task-id><TAB><pr-url> line,
+# written before the merge exactly as pr= is on the ordinary path.
+# Usage: fm-pr-merge.sh [--torn-down] <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+
+TORN_DOWN=0
+if [ "${1:-}" = "--torn-down" ]; then
+  TORN_DOWN=1
+  shift
+fi
 
 if [ "$#" -lt 2 ]; then
   echo "error: invalid PR merge request" >&2
@@ -65,16 +81,34 @@ reject_repo_overrides "$@" || exit 1
 
 # Task-derived paths are constructed only after the canonical ID validation.
 META="$STATE/$ID.meta"
-if [ ! -f "$META" ] || [ -L "$META" ]; then
-  echo "error: task metadata is unavailable" >&2
-  exit 1
-fi
+if [ "$TORN_DOWN" = 1 ]; then
+  if [ -e "$META" ] || [ -L "$META" ]; then
+    echo "error: task $ID still has metadata; merge it without --torn-down" >&2
+    exit 1
+  fi
+  LEDGER="$DATA/merged-prs.log"
+  mkdir -p "$DATA" || exit 1
+  if [ -L "$LEDGER" ] || { [ -e "$LEDGER" ] && [ ! -f "$LEDGER" ]; }; then
+    echo "error: merge ledger is unavailable" >&2
+    exit 1
+  fi
+  printf '%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ID" "$URL" >> "$LEDGER" || {
+    echo "error: merge ledger recording failed" >&2
+    exit 1
+  }
+  chmod 0600 "$LEDGER" || exit 1
+else
+  if [ ! -f "$META" ] || [ -L "$META" ]; then
+    echo "error: task metadata is unavailable" >&2
+    exit 1
+  fi
 
-"$SCRIPT_DIR/fm-pr-check.sh" "$ID" "$URL"
-grep -qxF "pr=$URL" "$META" || {
-  echo "error: PR metadata recording failed" >&2
-  exit 1
-}
+  "$SCRIPT_DIR/fm-pr-check.sh" "$ID" "$URL"
+  grep -qxF "pr=$URL" "$META" || {
+    echo "error: PR metadata recording failed" >&2
+    exit 1
+  }
+fi
 
 merge_args=()
 if ! caller_has_merge_method "$@"; then

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -12,17 +12,21 @@
 # merge keeps the guarded path instead of reaching around it to a raw merge
 # command. It requires the task metadata to be genuinely absent, refusing when
 # the task is still live so it can never be used to skip recording or the merge
-# poll for a task that has both. Absent metadata alone is not enough, because an
-# invented or mistyped id has none either, so the flag also requires positive
-# evidence that the task existed and was cleaned up: either the
-# data/<task-id>/brief.md that teardown leaves in place, or a completed backlog
-# entry for the id in data/backlog.md or data/done-archive.md.
+# poll for a task that has both. An irregular metadata path is refused by both
+# paths as something to inspect rather than merged around. Absent metadata alone
+# is not enough, because an invented or mistyped id has none either, so the flag
+# also requires positive evidence that the task genuinely existed: either the
+# data/<task-id>/brief.md that bin/fm-brief.sh writes at brief time and teardown
+# leaves in place, or a completed backlog entry for the id in data/backlog.md or
+# data/done-archive.md.
 # With no metadata to record into and no live task for a merge poll to wake, the
 # merge is recorded in the durable ledger data/merged-prs.log as one
 # <utc-timestamp><TAB><task-id><TAB><pr-url> line. The ledger path is validated
 # before the merge, but the line is appended only after gh-axi pr merge reports
 # success, so the ledger never asserts a merge that did not happen; a failed
-# merge writes no line and exits with the merge command's own status.
+# merge writes no line and exits with the merge command's own status. Every
+# failure after that successful merge names the merge as done and the recording
+# step that failed, so a non-zero exit is never read as an unmerged PR.
 # Usage: fm-pr-merge.sh [--torn-down] <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
 set -eu
 
@@ -86,10 +90,14 @@ reject_repo_overrides() {
 
 reject_repo_overrides "$@" || exit 1
 
-# Positive evidence that a torn-down task genuinely existed and was cleaned up:
-# teardown leaves data/<id>/brief.md in place, and the task's completed backlog
-# row survives in data/backlog.md until retention rolls it into the archive. A
-# row counts as completed when it is checked or sits under a Done heading.
+# Positive evidence that a torn-down task genuinely existed: bin/fm-brief.sh
+# writes data/<id>/brief.md at brief time and teardown leaves it in place, and
+# the task's completed backlog row survives in data/backlog.md until retention
+# rolls it into the archive. A row counts as completed when it is checked or sits
+# under a Done heading. The row shape matches backlog_key_section in
+# bin/fm-backlog-handoff.sh - the id is the first whitespace-delimited token
+# after the marker, compared whole - so a hand-edited row with no title
+# separator still counts and no other id's prefix can match.
 torn_down_task_recorded() {  # <task-id>
   local id=$1 file
   [ -f "$DATA/$id/brief.md" ] && return 0
@@ -106,15 +114,15 @@ torn_down_task_recorded() {  # <task-id>
       {
         row = ""
         checked = 0
-        if (match($0, /^[-*][ \t]+\[[ xX]\][ \t]+[^ \t]+[ \t]+-[ \t]+/)) {
-          row = substr($0, RSTART, RLENGTH)
-          checked = (row ~ /\[[xX]\]/)
-          sub(/^[-*][ \t]+\[[ xX]\][ \t]+/, "", row)
-          sub(/[ \t]+-[ \t]+$/, "", row)
-        } else if (match($0, /^[-*][ \t]+\*\*[^*]+\*\*[ \t]+-[ \t]+/)) {
+        if (match($0, /^[-*][ \t]+\[[ xX]\][ \t]+/)) {
+          checked = (substr($0, RSTART, RLENGTH) ~ /\[[xX]\]/)
+          row = substr($0, RSTART + RLENGTH)
+          sub(/[ \t].*$/, "", row)
+          sub(/\r$/, "", row)
+        } else if (match($0, /^[-*][ \t]+\*\*[^*]+\*\*/)) {
           row = substr($0, RSTART, RLENGTH)
           sub(/^[-*][ \t]+\*\*/, "", row)
-          sub(/\*\*[ \t]+-[ \t]+$/, "", row)
+          sub(/\*\*$/, "", row)
         }
         if (row == id && (checked || in_done)) {
           hit = 1
@@ -130,13 +138,20 @@ torn_down_task_recorded() {  # <task-id>
 # Task-derived paths are constructed only after the canonical ID validation.
 META="$STATE/$ID.meta"
 LEDGER=
+# A symlink, directory, or other irregular metadata path is neither live
+# metadata nor a cleaned-up task, so both paths refuse it as something to
+# inspect rather than sending the caller to a flag that also refuses.
+if [ -L "$META" ] || { [ -e "$META" ] && [ ! -f "$META" ]; }; then
+  echo "error: irregular task metadata at $META; inspect it before merging task $ID's PR" >&2
+  exit 1
+fi
 if [ "$TORN_DOWN" = 1 ]; then
-  if [ -e "$META" ] || [ -L "$META" ]; then
+  if [ -e "$META" ]; then
     echo "error: task $ID still has metadata; merge it without --torn-down" >&2
     exit 1
   fi
   if ! torn_down_task_recorded "$ID"; then
-    echo "error: no record of a cleaned-up task $ID; --torn-down needs $DATA/$ID/brief.md or a completed $ID entry in $DATA/backlog.md" >&2
+    echo "error: no record of a cleaned-up task $ID; --torn-down needs $DATA/$ID/brief.md or a completed $ID entry in $DATA/backlog.md or $DATA/done-archive.md" >&2
     exit 1
   fi
   LEDGER="$DATA/merged-prs.log"
@@ -147,12 +162,8 @@ if [ "$TORN_DOWN" = 1 ]; then
     exit 1
   fi
 else
-  if [ ! -e "$META" ] && [ ! -L "$META" ]; then
+  if [ ! -e "$META" ]; then
     echo "error: task metadata is unavailable; merge a cleaned-up task's PR with --torn-down" >&2
-    exit 1
-  fi
-  if [ ! -f "$META" ] || [ -L "$META" ]; then
-    echo "error: task metadata is unavailable" >&2
     exit 1
   fi
 
@@ -178,5 +189,8 @@ if [ -n "$LEDGER" ]; then
     echo "error: PR $URL merged but merge ledger recording failed" >&2
     exit 1
   }
-  chmod 0600 "$LEDGER" || exit 1
+  chmod 0600 "$LEDGER" || {
+    echo "error: PR $URL merged and recorded but tightening merge ledger permissions failed" >&2
+    exit 1
+  }
 fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,7 +194,8 @@ For target project repos shipped through their own no-mistakes pipeline, commits
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
 The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state; a well-formed GitLab merge request URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) is refused too, explicitly, rather than sent to the wrong forge.
-A late merge whose task has already been cleaned up keeps that same guarded path through the helper's `--torn-down` flag, which refuses while the task is still live and records the merge in the durable `data/merged-prs.log` ledger instead of task metadata, so a torn-down task never forces a raw merge command around the guards.
+A late merge whose task has already been cleaned up keeps that same guarded path through the helper's `--torn-down` flag, so a torn-down task never forces a raw merge command around the guards.
+The flag refuses while the task is still live, refuses an id with no surviving record of a cleaned-up task, and records the merge in the durable `data/merged-prs.log` ledger instead of task metadata only after the merge itself succeeds.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,6 +196,7 @@ PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and an
 The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state; a well-formed GitLab merge request URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) is refused too, explicitly, rather than sent to the wrong forge.
 A late merge whose task has already been cleaned up keeps that same guarded path through the helper's `--torn-down` flag, so a torn-down task never forces a raw merge command around the guards.
 The flag refuses while the task is still live, refuses an id with no surviving record of a cleaned-up task, and records the merge in the durable `data/merged-prs.log` ledger instead of task metadata only after the merge itself succeeds.
+An irregular metadata path is refused by both paths as something to inspect, and any recording failure after a successful merge names the merge as done so a non-zero exit is never read as an unmerged PR.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,6 +194,7 @@ For target project repos shipped through their own no-mistakes pipeline, commits
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
 The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state; a well-formed GitLab merge request URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) is refused too, explicitly, rather than sent to the wrong forge.
+A late merge whose task has already been cleaned up keeps that same guarded path through the helper's `--torn-down` flag, which refuses while the task is still live and records the merge in the durable `data/merged-prs.log` ledger instead of task metadata, so a torn-down task never forces a raw merge command around the guards.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ The shared orchestrator behavior lives in [`AGENTS.md`](../AGENTS.md) - edit it 
 
 This section is the single owner of the top-level operational-home layout; producer script headers and their help own exact child-file fields and mutation contracts.
 The tracked code root contains the shared instruction, skill, documentation, workflow, and `bin/` surfaces, while each effective `FM_HOME` contains private operational directories.
-`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, and scout reports.
+`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, scout reports, and the lazily created `merged-prs.log` ledger that `bin/fm-pr-merge.sh` appends when it merges a cleaned-up task's PR.
 `state/` holds volatile runtime records such as task metadata, append-only status events, endpoint signals, watcher and wake-queue coordination, away-mode state, generated X-mode artifacts, private secondmate config-reread generations with their retry and quarantine state, and parent-owned secondmate pending-reply records under `state/pending-replies/` (`bin/fm-pending-reply-lib.sh`).
 `config/` holds local gitignored operating choices, and `projects/` holds the local project clones that Firstmate reads but changes only through the guarded exceptions in `AGENTS.md`.
 

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -26,6 +26,8 @@ The `--force` path remains the explicit captain-approved discard escape hatch.
 The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
 It records the decision digest and routed task identities as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
 An exact retry can finish a partial routing operation, while a changed decision or routed-task set is rejected.
+A routed task that has already reached Done is accepted, because the captain commonly answers a decision after its dependent work shipped and finished work carrying the edge is stronger routing evidence than queued work.
+The edge itself is never created by `resolve`, and a routed task with no edge is refused with the exact `tasks-axi block <task> --by <hold>` command that declares it.
 A failed intermediate step leaves the hold open.
 
 ## Structured read surfaces
@@ -43,11 +45,13 @@ The projection remains read-only and does not inspect historical prose.
 Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Done-routed acceptance and remedy-naming refusal verification date: 2026-07-29.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
 The initial Bearings snapshot correctly has no open decision, and the new teardown gate refuses to erase the source.
 A later regression covers tasks-axi's quoted multi-entry `blocked_by` output so `resolve` matches the first, middle, and last ids and rejects a genuinely absent id.
+A further regression covers a Done routed task that still carries the hold's edge, and asserts that a routed task with no edge is refused with the exact `tasks-axi block` command naming both real ids.
 
 The final verification commands and their exact summarized outputs follow.
 
@@ -62,6 +66,7 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
+ok - resolve accepts Done routed work and names the block remedy for an undeclared edge
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -82,7 +82,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
-| `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
+| `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL; records into the durable merge ledger instead with `--torn-down` |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -550,6 +550,71 @@ test_resolve_matches_quoted_blocked_by_edges() {
   pass "resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id"
 }
 
+# The captain commonly answers a decision after the dependent work has already
+# shipped, which is the ordinary shape whenever a hold outlives its own work item.
+# Finished work still carrying the hold's dependency edge is real routing, so
+# resolve must close through the owner tool instead of forcing a hand edit. A
+# routed task with no edge at all stays refused, and that refusal must name the
+# exact command that declares the edge.
+test_resolve_accepts_done_routed_work_and_names_the_block_remedy() {
+  local home origin hold_shipped hold_unrouted show
+  home=$(make_home done-routed-work)
+  origin=sample-late-answer-review
+  mkdir -p "$home/data/$origin"
+  tasks_in "$home" add "$origin" "Late captain answer review" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create late-answer origin"
+  write_origin_meta "$home" "$origin"
+  printf 'done: report complete\n' > "$home/state/$origin.status"
+  printf '# Late answer review\n\nOne shipped route and one undeclared control.\n' > "$home/data/$origin/report.md"
+
+  hold_shipped=$(run_decisions "$home" hold "$origin" shipped \
+    --title "Choose the shipped route" --reason "captain shipped route pending" --repo sample) \
+    || fail "could not register shipped-route hold"
+  hold_unrouted=$(run_decisions "$home" hold "$origin" unrouted \
+    --title "Choose the unrouted control" --reason "captain unrouted control pending" --repo sample) \
+    || fail "could not register unrouted-control hold"
+
+  tasks_in "$home" add dep-shipped "Apply the shipped route" --kind ship --repo sample >/dev/null \
+    || fail "could not create shipped dependent"
+  tasks_in "$home" block dep-shipped --by "$hold_shipped" >/dev/null \
+    || fail "could not route shipped dependent behind its hold"
+  tasks_in "$home" "done" dep-shipped >/dev/null || fail "could not complete the shipped dependent"
+  show=$(tasks_in "$home" show dep-shipped --full)
+  assert_contains "$show" "state: done" "shipped fixture must be Done before resolve"
+  assert_contains "$show" "blocked_by: $hold_shipped" "shipped fixture must retain its durable routing edge"
+
+  printf 'Use the shipped route.\n' > "$home/shipped-decision.txt"
+  if ! run_decisions "$home" resolve "$origin" shipped --decision-file "$home/shipped-decision.txt" \
+    --routed-to dep-shipped > "$home/shipped.out" 2> "$home/shipped.err"; then
+    fail "resolve refused a Done routed task that carried the hold's edge: $(cat "$home/shipped.err")"
+  fi
+  show=$(tasks_in "$home" show "$hold_shipped" --full)
+  assert_contains "$show" "state: done" "hold routed to Done work did not close"
+  assert_contains "$show" "Resolution recorded by fm-decision-hold" "closed hold lost its decision record"
+  show=$(tasks_in "$home" show dep-shipped --full)
+  assert_contains "$show" "blocked: no" "resolve did not clear the Done dependent's routing edge"
+
+  run_decisions "$home" resolve "$origin" shipped --decision-file "$home/shipped-decision.txt" \
+    --routed-to dep-shipped >/dev/null 2>&1 \
+    || fail "identical Done-route resolution retry was not idempotent"
+
+  tasks_in "$home" add dep-unrouted "Apply the unrouted control" --kind ship --repo sample >/dev/null \
+    || fail "could not create unrouted dependent"
+  tasks_in "$home" "done" dep-unrouted >/dev/null || fail "could not complete the unrouted dependent"
+  printf 'Use the unrouted control.\n' > "$home/unrouted-decision.txt"
+  if run_decisions "$home" resolve "$origin" unrouted --decision-file "$home/unrouted-decision.txt" \
+    --routed-to dep-unrouted > "$home/unrouted.out" 2> "$home/unrouted.err"; then
+    fail "resolve accepted a routed task with no declared dependency edge"
+  fi
+  assert_grep "tasks-axi block dep-unrouted --by $hold_unrouted" "$home/unrouted.err" \
+    "the undeclared-edge refusal did not name the exact remedy command"
+  show=$(tasks_in "$home" show "$hold_unrouted" --full)
+  assert_contains "$show" "state: queued" "failed undeclared-edge resolve closed the hold"
+  assert_contains "$show" "held: yes" "failed undeclared-edge resolve released the hold"
+
+  pass "resolve accepts Done routed work and names the block remedy for an undeclared edge"
+}
+
 test_uninventoried_report_decision_refuses_completion
 
 test_scout_teardown_always_requires_inventory_verification
@@ -560,3 +625,4 @@ test_none_inventory_and_resolved_prose_do_not_create_holds
 test_terminal_single_owner_status_decision_does_not_block_empty_inventory
 test_secondmate_hold_stays_in_authoritative_home
 test_resolve_matches_quoted_blocked_by_edges
+test_resolve_accepts_done_routed_work_and_names_the_block_remedy

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -17,6 +17,9 @@
 #   (i) --torn-down merges a cleaned-up task's PR and records the durable ledger
 #   (j) --torn-down is refused while the task is still live, and its guards run
 #       before the ledger is written
+#   (k) --torn-down accepts a completed backlog entry as cleanup evidence
+#   (l) --torn-down is refused for an id with no surviving record of a task
+#   (m) --torn-down writes no ledger line when the merge itself fails
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -177,6 +180,8 @@ test_missing_meta_refuses_before_merge() {
   expect_code 1 "$rc" "missing-meta: fm-pr-merge should refuse"
   assert_grep 'error: task metadata is unavailable' "$case_dir/stderr" \
     "missing-meta: refusal did not explain missing meta"
+  assert_grep '--torn-down' "$case_dir/stderr" \
+    "missing-meta: refusal did not name --torn-down as the remedy for a cleaned-up task"
   [ ! -s "$case_dir/gh-axi.log" ] || fail "missing-meta: gh-axi pr merge was invoked"
   assert_absent "$case_dir/state/missing-x1.check.sh" \
     "missing-meta: fm-pr-check should not arm a poll for an unknown task"
@@ -305,6 +310,14 @@ test_parses_pr_url_for_gh_axi() {
   pass "fm-pr-merge parses a GitHub PR URL into gh-axi number and --repo arguments"
 }
 
+# Teardown leaves data/<id>/brief.md behind, so a torn-down task keeps that
+# proof it genuinely existed even after its metadata is gone. Args: case_dir id
+add_torn_down_brief() {
+  local case_dir=$1 id=$2
+  mkdir -p "$case_dir/data/$id"
+  printf '%s\n' "# Brief for $id" > "$case_dir/data/$id/brief.md"
+}
+
 # A late merge - a held PR, a rebase, a review that landed after cleanup - must
 # keep the guarded path rather than reaching around it to a raw merge command.
 # There is no meta to record into and no live task for a merge poll to wake, so
@@ -313,6 +326,7 @@ test_torn_down_merges_and_records_the_durable_ledger() {
   local case_dir rc
   case_dir="$TMP_ROOT/torn-down"
   mkdir -p "$case_dir/state" "$case_dir/fakebin"
+  add_torn_down_brief "$case_dir" gone-x1
   add_gh_mocks "$case_dir" aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee
   : > "$case_dir/gh-axi.log"
 
@@ -361,6 +375,7 @@ test_torn_down_guards_run_before_the_ledger() {
   local case_dir rc
   case_dir="$TMP_ROOT/torn-down-repo-override"
   mkdir -p "$case_dir/state" "$case_dir/fakebin"
+  add_torn_down_brief "$case_dir" gone-x2
   add_gh_mocks "$case_dir" 4444444455555555666666667777777788888888
   : > "$case_dir/gh-axi.log"
 
@@ -380,6 +395,102 @@ test_torn_down_guards_run_before_the_ledger() {
   pass "fm-pr-merge --torn-down runs its merge guards before writing the ledger"
 }
 
+# A brief can be gone while the task's completed backlog row is still there, so
+# the backlog row is evidence of a real cleaned-up task in its own right.
+test_torn_down_accepts_a_completed_backlog_entry() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/torn-down-backlog"
+  mkdir -p "$case_dir/state" "$case_dir/fakebin" "$case_dir/data"
+  cat > "$case_dir/data/backlog.md" <<'MD'
+# Backlog
+
+## In flight
+
+## Queued
+
+## Done
+- [x] gone-x3 - Land the late PR (kind: ship) (done 2026-07-30)
+MD
+  add_gh_mocks "$case_dir" bbbbbbbbccccccccddddddddeeeeeeeeffffffff
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" --torn-down gone-x3 https://github.com/example/repo/pull/37 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "torn-down-backlog: a completed backlog entry should satisfy --torn-down"
+  assert_grep "$(printf '\tgone-x3\thttps://github.com/example/repo/pull/37')" \
+    "$case_dir/data/merged-prs.log" "torn-down-backlog: the merge was not recorded in the durable ledger"
+  grep -qxF 'pr merge 37 --repo example/repo --squash' "$case_dir/gh-axi.log" \
+    || fail "torn-down-backlog: gh-axi pr merge was not invoked"
+  pass "fm-pr-merge --torn-down accepts a completed backlog entry as cleanup evidence"
+}
+
+# Absent metadata is equally true for an id that never existed, so a typo or an
+# invented id must never merge an arbitrary PR through the guarded path.
+test_torn_down_refused_without_a_task_record() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/torn-down-unknown"
+  mkdir -p "$case_dir/state" "$case_dir/fakebin" "$case_dir/data"
+  cat > "$case_dir/data/backlog.md" <<'MD'
+# Backlog
+
+## In flight
+
+## Queued
+- [ ] other-x9 - Some other queued task (kind: ship)
+
+## Done
+MD
+  add_gh_mocks "$case_dir" ccccccccddddddddeeeeeeeeffffffff00000000
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" --torn-down bogus-x9 https://github.com/example/repo/pull/39 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "torn-down-unknown: fm-pr-merge should refuse an id with no task record"
+  assert_grep 'no record of a cleaned-up task bogus-x9' "$case_dir/stderr" \
+    "torn-down-unknown: refusal did not name the unknown task"
+  assert_grep 'brief.md' "$case_dir/stderr" \
+    "torn-down-unknown: refusal did not name the missing evidence"
+  assert_absent "$case_dir/data/merged-prs.log" \
+    "torn-down-unknown: a ledger line was written for a task that never existed"
+  assert_no_grep 'pr merge' "$case_dir/gh-axi.log" \
+    "torn-down-unknown: gh-axi pr merge was invoked for a task that never existed"
+  pass "fm-pr-merge refuses --torn-down for an id with no surviving task record"
+}
+
+# The ledger's whole value is that it records merges that really happened, so a
+# refused or failed merge must leave no line claiming success.
+test_torn_down_merge_failure_writes_no_ledger_line() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/torn-down-merge-fails"
+  mkdir -p "$case_dir/state" "$case_dir/fakebin"
+  add_torn_down_brief "$case_dir" gone-x4
+  add_gh_mocks_merge_fails "$case_dir"
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" --torn-down gone-x4 https://github.com/example/repo/pull/41 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "torn-down-merge-fails: fm-pr-merge should propagate the gh-axi merge failure"
+  if [ -e "$case_dir/data/merged-prs.log" ]; then
+    assert_no_grep 'gone-x4' "$case_dir/data/merged-prs.log" \
+      "torn-down-merge-fails: the ledger claimed a merge that never happened"
+  fi
+  grep -qxF 'pr merge 41 --repo example/repo --squash' "$case_dir/gh-axi.log" \
+    || fail "torn-down-merge-fails: gh-axi pr merge was not attempted"
+  pass "fm-pr-merge --torn-down records no ledger line when the merge itself fails"
+}
+
 test_records_pr_and_head_before_merging
 test_merge_failure_propagates_after_recording
 test_extra_merge_args_forwarded
@@ -393,3 +504,6 @@ test_parses_pr_url_for_gh_axi
 test_torn_down_merges_and_records_the_durable_ledger
 test_torn_down_refused_while_task_is_live
 test_torn_down_guards_run_before_the_ledger
+test_torn_down_accepts_a_completed_backlog_entry
+test_torn_down_refused_without_a_task_record
+test_torn_down_merge_failure_writes_no_ledger_line

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -20,6 +20,9 @@
 #   (k) --torn-down accepts a completed backlog entry as cleanup evidence
 #   (l) --torn-down is refused for an id with no surviving record of a task
 #   (m) --torn-down writes no ledger line when the merge itself fails
+#   (n) a hand-edited Done row with no title separator is cleanup evidence
+#   (o) irregular task metadata is refused as itself, not as live metadata,
+#       so the caller is never bounced between two refusals
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -491,6 +494,112 @@ test_torn_down_merge_failure_writes_no_ledger_line() {
   pass "fm-pr-merge --torn-down records no ledger line when the merge itself fails"
 }
 
+# A home on the manual backlog backend hand-edits data/backlog.md, so a Done row
+# can carry a free-form title with no " - " separator after the id. That row is
+# still a completed task record, and the id stays a whole token so a longer id
+# sharing its prefix never counts as evidence for it.
+test_torn_down_accepts_a_separatorless_done_row() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/torn-down-backlog-freeform"
+  mkdir -p "$case_dir/state" "$case_dir/fakebin" "$case_dir/data"
+  cat > "$case_dir/data/backlog.md" <<'MD'
+# Backlog
+
+## Done
+- [x] gone-x5-late landed locally
+- [x] gone-x5 landed locally
+MD
+  add_gh_mocks "$case_dir" dddddddd11111111222222223333333344444444
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" --torn-down gone-x5 https://github.com/example/repo/pull/43 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "torn-down-backlog-freeform: a Done row with no title separator should satisfy --torn-down"
+  assert_grep "$(printf '\tgone-x5\thttps://github.com/example/repo/pull/43')" \
+    "$case_dir/data/merged-prs.log" "torn-down-backlog-freeform: the merge was not recorded in the durable ledger"
+  grep -qxF 'pr merge 43 --repo example/repo --squash' "$case_dir/gh-axi.log" \
+    || fail "torn-down-backlog-freeform: gh-axi pr merge was not invoked"
+  pass "fm-pr-merge --torn-down accepts a hand-edited Done row with no title separator"
+}
+
+# A Done row for a longer id must not satisfy --torn-down for a shorter id that
+# happens to be its prefix, or a typo could merge an arbitrary PR.
+test_torn_down_refuses_a_prefix_of_another_id() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/torn-down-backlog-prefix"
+  mkdir -p "$case_dir/state" "$case_dir/fakebin" "$case_dir/data"
+  cat > "$case_dir/data/backlog.md" <<'MD'
+# Backlog
+
+## Done
+- [x] gone-x6-real landed locally
+MD
+  add_gh_mocks "$case_dir" eeeeeeee55555555666666667777777788888888
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" --torn-down gone-x6 https://github.com/example/repo/pull/45 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "torn-down-backlog-prefix: a prefix of another id must not satisfy --torn-down"
+  assert_grep 'no record of a cleaned-up task gone-x6' "$case_dir/stderr" \
+    "torn-down-backlog-prefix: refusal did not name the unrecorded task"
+  assert_grep 'done-archive.md' "$case_dir/stderr" \
+    "torn-down-backlog-prefix: refusal did not name the archive it also consulted"
+  assert_absent "$case_dir/data/merged-prs.log" \
+    "torn-down-backlog-prefix: a ledger line was written for an unrecorded task"
+  assert_no_grep 'pr merge' "$case_dir/gh-axi.log" \
+    "torn-down-backlog-prefix: gh-axi pr merge was invoked for an unrecorded task"
+  pass "fm-pr-merge --torn-down refuses an id that is only a prefix of a completed row"
+}
+
+# A symlink at state/<id>.meta is neither live metadata nor a cleaned-up task.
+# Both paths must name it as the thing to inspect, so the caller is never sent
+# from one refusal to a flag that refuses too.
+test_irregular_meta_refused_as_itself() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/irregular-meta"
+  mkdir -p "$case_dir/state" "$case_dir/fakebin" "$case_dir/data"
+  ln -s "$case_dir/state/nowhere.meta" "$case_dir/state/gone-x7.meta"
+  add_gh_mocks "$case_dir" 99999999aaaaaaaabbbbbbbbccccccccdddddddd
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" --torn-down gone-x7 https://github.com/example/repo/pull/47 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "irregular-meta: --torn-down should refuse an irregular metadata path"
+  assert_grep 'irregular task metadata' "$case_dir/stderr" \
+    "irregular-meta: --torn-down refusal did not name the irregular metadata"
+  assert_no_grep 'merge it without --torn-down' "$case_dir/stderr" \
+    "irregular-meta: --torn-down refusal misdescribed a broken symlink as live metadata"
+
+  set +e
+  run_pr_merge "$case_dir" gone-x7 https://github.com/example/repo/pull/47 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr.ordinary"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "irregular-meta: the ordinary path should refuse an irregular metadata path"
+  assert_grep 'irregular task metadata' "$case_dir/stderr.ordinary" \
+    "irregular-meta: the ordinary refusal did not name the irregular metadata"
+  assert_no_grep 'with --torn-down' "$case_dir/stderr.ordinary" \
+    "irregular-meta: the ordinary refusal bounced the caller to --torn-down"
+  assert_absent "$case_dir/data/merged-prs.log" \
+    "irregular-meta: a ledger line was written for an irregular metadata path"
+  assert_no_grep 'pr merge' "$case_dir/gh-axi.log" \
+    "irregular-meta: gh-axi pr merge was invoked for an irregular metadata path"
+  pass "fm-pr-merge refuses irregular task metadata as itself on both paths"
+}
+
 test_records_pr_and_head_before_merging
 test_merge_failure_propagates_after_recording
 test_extra_merge_args_forwarded
@@ -507,3 +616,6 @@ test_torn_down_guards_run_before_the_ledger
 test_torn_down_accepts_a_completed_backlog_entry
 test_torn_down_refused_without_a_task_record
 test_torn_down_merge_failure_writes_no_ledger_line
+test_torn_down_accepts_a_separatorless_done_row
+test_torn_down_refuses_a_prefix_of_another_id
+test_irregular_meta_refused_as_itself

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -14,6 +14,9 @@
 #   (f) malformed PR URL fails fast without calling gh-axi
 #   (g) explicit merge method is not overridden by the default --squash
 #   (h) repo override args fail fast because the repo comes from the URL
+#   (i) --torn-down merges a cleaned-up task's PR and records the durable ledger
+#   (j) --torn-down is refused while the task is still live, and its guards run
+#       before the ledger is written
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -88,6 +91,7 @@ run_pr_merge() {
   local case_dir=$1 rc; shift
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
   FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
   PATH="$case_dir/fakebin:$PATH" \
     "$PR_MERGE" "$@"
@@ -301,6 +305,81 @@ test_parses_pr_url_for_gh_axi() {
   pass "fm-pr-merge parses a GitHub PR URL into gh-axi number and --repo arguments"
 }
 
+# A late merge - a held PR, a rebase, a review that landed after cleanup - must
+# keep the guarded path rather than reaching around it to a raw merge command.
+# There is no meta to record into and no live task for a merge poll to wake, so
+# the durable ledger carries the merge record instead.
+test_torn_down_merges_and_records_the_durable_ledger() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/torn-down"
+  mkdir -p "$case_dir/state" "$case_dir/fakebin"
+  add_gh_mocks "$case_dir" aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" --torn-down gone-x1 https://github.com/example/repo/pull/31 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "torn-down: fm-pr-merge should merge a cleaned-up task's PR"
+  assert_grep "$(printf '\tgone-x1\thttps://github.com/example/repo/pull/31')" \
+    "$case_dir/data/merged-prs.log" "torn-down: the merge was not recorded in the durable ledger"
+  grep -qxF 'pr merge 31 --repo example/repo --squash' "$case_dir/gh-axi.log" \
+    || fail "torn-down: gh-axi pr merge was not invoked with number, --repo, and default --squash"
+  assert_absent "$case_dir/state/gone-x1.check.sh" \
+    "torn-down: a merge poll was armed for a task that no longer exists"
+  assert_absent "$case_dir/state/gone-x1.meta" \
+    "torn-down: task metadata was recreated for a cleaned-up task"
+  pass "fm-pr-merge --torn-down merges a cleaned-up task's PR and records the durable ledger"
+}
+
+test_torn_down_refused_while_task_is_live() {
+  local case_dir rc
+  case_dir=$(make_case torn-down-live)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks "$case_dir" ffffffff00000000111111112222222233333333
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" --torn-down task-x1 https://github.com/example/repo/pull/33 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "torn-down-live: fm-pr-merge should refuse --torn-down for a live task"
+  assert_grep 'still has metadata; merge it without --torn-down' "$case_dir/stderr" \
+    "torn-down-live: refusal did not name the ordinary path"
+  assert_absent "$case_dir/data/merged-prs.log" \
+    "torn-down-live: a ledger line was written for a live task"
+  assert_no_grep 'pr merge' "$case_dir/gh-axi.log" \
+    "torn-down-live: gh-axi pr merge was invoked for a live task"
+  pass "fm-pr-merge refuses --torn-down while the task is still live"
+}
+
+test_torn_down_guards_run_before_the_ledger() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/torn-down-repo-override"
+  mkdir -p "$case_dir/state" "$case_dir/fakebin"
+  add_gh_mocks "$case_dir" 4444444455555555666666667777777788888888
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" --torn-down gone-x2 https://github.com/right/repo/pull/35 -- --repo wrong/repo \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "torn-down-repo-override: fm-pr-merge should refuse repo override flags"
+  assert_grep 'extra merge arguments must not override the repository' "$case_dir/stderr" \
+    "torn-down-repo-override: refusal did not explain the repo override"
+  assert_absent "$case_dir/data/merged-prs.log" \
+    "torn-down-repo-override: a ledger line was written before the guards passed"
+  assert_no_grep 'pr merge' "$case_dir/gh-axi.log" \
+    "torn-down-repo-override: gh-axi pr merge was invoked despite repo override"
+  pass "fm-pr-merge --torn-down runs its merge guards before writing the ledger"
+}
+
 test_records_pr_and_head_before_merging
 test_merge_failure_propagates_after_recording
 test_extra_merge_args_forwarded
@@ -311,3 +390,6 @@ test_repo_override_args_refuse_before_recording
 test_explicit_merge_method_not_overridden
 test_method_equals_merge_method_not_overridden
 test_parses_pr_url_for_gh_axi
+test_torn_down_merges_and_records_the_durable_ledger
+test_torn_down_refused_while_task_is_live
+test_torn_down_guards_run_before_the_ledger


### PR DESCRIPTION
Three small papercuts in firstmate's own merge and decision-hold tooling, found by hitting each of
them in real operation. Offered upstream for review — I have no push access, so this comes from a fork.

## 1. `fm-pr-merge` refused a PR whose task was already torn down

A merge that arrives after teardown had no guarded path at all, so the operator's only option was to
reach past the guards to a raw merge command. Adds `--torn-down`.

**It requires positive evidence the task genuinely existed** — `data/<id>/brief.md`, or a Done entry
for that id in the backlog. Absent metadata alone is not enough, because a task id that never existed
is equally absent: without the evidence check, a typo would merge whatever PR URL was passed. The
whole point of the flag is to be the guarded path, and a guarded path that merges an arbitrary PR on a
typo has defeated itself.

The name `--torn-down` is also now mentioned in the ordinary refusal message, so the path is
discoverable at the moment you need it.

## 2. The merge ledger could assert a merge that never happened

The ledger line was written *before* the merge was attempted, so a failed merge left a permanent
record claiming success. Now the line is written only after the merge succeeds, and records the actual
outcome. The ledger's only job is to be a true record, and firstmate itself reads it.

Ledger files are also created with `umask 077`.

## 3. `fm-decision-hold resolve` refused a routed task that was already Done

A decision answered after its dependent work had finished could not be closed, leaving a captain hold
open forever with nothing left to route it to.

## Verification

Full local pipeline: review, tests, docs and lint all passed. The two behavioural changes above (1 and
2) came out of that review as findings and were both fixed rather than accepted.
