### PR TITLE
test: replace gitignore source assertion with behavioral coverage

### DIFF
--- a/tests/fm-gitignore-config.test.sh
+++ b/tests/fm-gitignore-config.test.sh
@@ -18,22 +18,30 @@ pass() {
   printf 'ok - %s\n' "$1"
 }
 
+random_leaf() {
+  printf '%s-%s' "$1" "$$-$RANDOM-$RANDOM"
+}
+
 test_config_dir_ignored_as_category() {
-  local sample
-  for sample in config/anything config/nested/dir/file config/some-new-key.admin; do
+  local direct nested sample
+  direct="$(random_leaf config/unlisted-key)"
+  nested="config/$(random_leaf nested-dir)/$(random_leaf deep-file)"
+  for sample in "$direct" "$nested" config/some-new-key.admin; do
     git -C "$ROOT" check-ignore -q "$sample" \
       || fail "git does not ignore $sample (config/ must be ignored as a directory)"
   done
-  pass "config/ is ignored as a directory, covering unlisted paths"
+  pass "config/ is ignored as a directory, covering unlisted and nested paths"
 }
 
-test_config_not_ignored_by_name_by_name_list() {
-  # Regression guard: .gitignore must not go back to enumerating config/ entries
-  # by exact filename, since that reintroduces the same silent-drift failure.
-  grep -qE '^config/[^/]+$' "$ROOT/.gitignore" \
-    && fail ".gitignore lists config/ entries by exact filename instead of ignoring the directory"
-  pass "no name-by-name config/ entries remain in .gitignore"
+test_unrelated_path_stays_visible() {
+  # Control: a path outside config/ must remain visible to Git, so the
+  # coverage above is proven by contrast rather than an always-ignoring rule.
+  local sibling
+  sibling="$(random_leaf not-config)"
+  git -C "$ROOT" check-ignore -q "$sibling" \
+    && fail "git unexpectedly ignores $sibling (outside config/)"
+  pass "an unrelated path outside config/ remains visible to git"
 }
 
 test_config_dir_ignored_as_category
-test_config_not_ignored_by_name_by_name_list
+test_unrelated_path_stays_visible


### PR DESCRIPTION
## Intent

Ship the captain-authorized bounded Firstmate test correction identified by the completed source-content-test audit at `/Users/kunchen/github/kunchenguid/firstmate/data/nm-source-content-tests-audit-r1/report.md`.

Remove only the brittle source-content assertion added by Firstmate PR 1261 from `tests/fm-gitignore-config.test.sh`. The test must never inspect `.gitignore` source bytes, line spelling, regex matches, parser proxies, snapshots, or other implementation-source text. Retain and strengthen real behavior coverage by invoking Git's public `check-ignore` consumer against generated unpredictable direct and nested paths under `config/`, plus a generated unrelated-path control that must remain visible. The coverage must accept semantically equivalent ignore patterns such as `config/` and `config/**`, preserve shell portability and existing test style, and include regression counterfactual evidence that it fails when arbitrary config paths become visible while passing with equivalent semantic patterns.

Keep the change limited to `tests/fm-gitignore-config.test.sh`. Do not edit `.gitignore`, AGENTS.md, documentation, product code, generated files, unrelated tests, or conduct broader source-content-test cleanup. Follow `firstmate-coding-guidelines`, run the focused test and relevant repository lint/test checks, and require a clean no-mistakes review, PR, and green CI. Never merge the PR from the worker.

## What Changed

- Replace the `.gitignore` source-text assertion with behavioral checks through Git's `check-ignore` interface.
- Exercise generated direct and nested paths under `config/`, plus an unrelated-path control that must remain visible.

## Risk Assessment

✅ Low: The change is tightly scoped to the requested test, replaces source-text inspection with Git behavior checks, covers generated direct and nested config paths plus an unrelated-path control, and remains compatible with semantically equivalent ignore patterns.

## Testing

The focused test passed under Bash 3.2 and the current Bash, while isolated end-to-end Git fixtures proved canonical and equivalent ignore patterns accept generated direct and nested config paths, the generated unrelated control remains visible, and visible arbitrary config paths trigger the expected regression failure.

<details>
<summary>Evidence: Git ignore semantic matrix</summary>

<code>`config/` and `config/**` both passed. With no config ignore rule, the test failed on a generated `config/unlisted-key-*` path as expected.</code>

```text
CASE: canonical semantic pattern config/
ok - config/ is ignored as a directory, covering unlisted and nested paths
ok - an unrelated path outside config/ remains visible to git
RESULT: PASS

CASE: equivalent semantic pattern config/**
ok - config/ is ignored as a directory, covering unlisted and nested paths
ok - an unrelated path outside config/ remains visible to git
RESULT: PASS

CASE: counterfactual with arbitrary config paths visible
not ok - git does not ignore config/unlisted-key-74752-14478-18949 (config/ must be ignored as a directory)
RESULT: EXPECTED FAILURE
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff e595611291247368b982eb729097c54f2b45aa78..93dc5355be26bfb8be260293bd6217f991e34e18 -- tests/fm-gitignore-config.test.sh`</code>
- `bash tests/fm-gitignore-config.test.sh`
- <code>`/bin/bash tests/fm-gitignore-config.test.sh` using macOS-compatible GNU Bash 3.2.57</code>
- <code>Ran the committed test unchanged in isolated Git repositories using `config/`, equivalent `config/**`, and an unrelated-only ignore rule</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
