### PR TITLE
feat(bin): add fm-verify-delivered.sh to check delivery claims against merged code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Hard rules, in priority order:
    Treat direct captain intervention in a crewmate window as authoritative and reconcile it at the next supervision review.
 5. **Report outcomes faithfully.**
    If work failed, say so plainly with the evidence.
+   Before reporting a capability as delivered or marking a task done, check the claim against the merged code with `bin/fm-verify-delivered.sh`, whose header owns its modes and exact outcomes; only exit 0 may be read as delivered.
 
 You may maintain this repo's private operational state directly.
 Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and public `skills/`.

--- a/bin/fm-verify-delivered.sh
+++ b/bin/fm-verify-delivered.sh
@@ -172,7 +172,7 @@ verify_brand_identity() {
     search_failed "cannot resolve rev '$REV' in $repo; nothing was searched"
   fi
 
-  printf '=== files deciding brand identity by STRING, no graph consultation ===\n'
+  printf '=== files referencing a brand-identity helper with NO graph identifier ===\n'
   printf '  repo: %s\n  rev:  %s\n  path: %s\n' "$repo" "$REV" "$BRAND_PATHSPEC"
 
   # Bug 1's shape: a pathspec that matches no files. git grep reports that as an
@@ -225,16 +225,16 @@ verify_brand_identity() {
     case "$st" in
       0) migrated=$((migrated + 1)) ;;
       1)
-        printf '  UNMIGRATED: %s\n' "${f#schema-generator/}"
+        printf '  NO GRAPH IDENTIFIER: %s\n' "${f#schema-generator/}"
         unmigrated=$((unmigrated + 1))
         ;;
-      *) search_failed "git grep for graph consultation failed on $f with status $st: $(tr '\n' ' ' <"$ERRLOG")" ;;
+      *) search_failed "git grep for a graph identifier failed on $f with status $st: $(tr '\n' ' ' <"$ERRLOG")" ;;
     esac
   done
 
   printf '  INSPECTED: %s candidate file(s) out of %s under %s\n' "$cand_n" "$scope_n" "$BRAND_PATHSPEC"
   if [ "$unmigrated" -gt 0 ]; then
-    printf 'VIOLATIONS: %s of %s inspected file(s) decide brand identity by string with no graph consultation.\n' \
+    printf 'VIOLATIONS: %s of %s inspected file(s) reference a brand-identity helper with no graph identifier anywhere in the file.\n' \
       "$unmigrated" "$cand_n"
     printf '  >>> DO NOT report brand-identity work as complete.\n'
     exit 1

--- a/bin/fm-verify-delivered.sh
+++ b/bin/fm-verify-delivered.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# fm-verify-delivered.sh - MECHANISM, not a promise.
+#
+# Firstmate repeatedly reported work as delivered without checking the merged
+# result against what was asked (2026-07-28/29: Stage 6 "every comparison
+# through NS" when 16 files still used strings; PR 657 merged with 11 files
+# still string-only after "solve every brand-related bug").
+#
+# Run this BEFORE telling the captain a PR delivered a capability, and BEFORE
+# marking a task done. It checks the CLAIM against the CODE, not the report.
+#
+# Usage:
+#   fm-verify-delivered.sh brand-identity [--no-fetch]
+#                                    who still decides brand identity by string
+#   fm-verify-delivered.sh <task-id>  acceptance claims in a brief, to check by hand
+#   fm-verify-delivered.sh --help     print this header
+#
+# The exit status is the verdict, and only 0 may be read as delivered:
+#   0  CLEAN              inspected one or more files and found no violation
+#                         (in task-id mode: acceptance claims were extracted,
+#                         which is a checklist to work through, not a verdict)
+#   1  VIOLATIONS         found violations, listed above the verdict line
+#   2  USAGE              bad invocation
+#   3  INSPECTED NOTHING  the search matched no files, so it proves nothing
+#   4  SEARCH FAILED      the search itself errored, so the answer is unknown
+#
+# Outcomes 3 and 4 exist because this verifier twice printed a clean result
+# while checking nothing. First its pathspec matched no files, and git grep
+# reports that as an ordinary no-match, so zero files inspected read as zero
+# violations found. Then a git grep no-match status aborted the whole run under
+# `set -o pipefail`, so it printed its header and stopped. A verifier that
+# cannot say "I do not know" converts unknown into clean, which is worse than
+# having no verifier at all. Every git search below therefore classifies its own
+# exit status, and every count of what was actually inspected is checked before
+# any clean verdict is allowed to print.
+#
+# tests/fm-verify-delivered.test.sh holds one regression test per outcome.
+#
+# Environment:
+#   FM_VERIFY_REPO  repo brand-identity inspects; overrides the repo path
+#                   recorded for inception in data/projects.md
+#   FM_VERIFY_REV   rev brand-identity inspects (default: origin/main)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+REV="${FM_VERIFY_REV:-origin/main}"
+
+# brand-identity's definition of the migration: which files are candidates, who
+# is allowed to own string comparison, and what counts as consulting the graph.
+BRAND_PATHSPEC="schema-generator/app"
+BRAND_CANDIDATE_RE='is_same_brand|normalize_entity|is_competitor_reference'
+BRAND_GRAPH_RE='graph_directives|brand_relations|ns_comparison|brand_graph|referability'
+
+SELF="$SCRIPT_DIR/fm-verify-delivered.sh"
+ERRLOG=""
+# shellcheck disable=SC2329 # Registered by the EXIT trap below.
+cleanup() { [ -z "$ERRLOG" ] || rm -f "$ERRLOG"; }
+trap cleanup EXIT
+
+# --- outcome emitters -------------------------------------------------------
+#
+# One function per outcome so no code path can invent a fifth one, and so a
+# clean verdict is only reachable from the single place that has already
+# counted what was inspected.
+
+usage_error() {
+  printf 'fm-verify-delivered.sh: %s\n' "$1" >&2
+  printf 'usage: fm-verify-delivered.sh brand-identity [--no-fetch] | fm-verify-delivered.sh <task-id>\n' >&2
+  exit 2
+}
+
+inspected_nothing() {
+  printf 'INSPECTED NOTHING: %s\n' "$1"
+  printf '  >>> NOT a clean result. The check examined no files, so it proved nothing.\n'
+  printf '  >>> Fix the search before reporting anything about this claim.\n'
+  exit 3
+}
+
+search_failed() {
+  printf 'SEARCH FAILED: %s\n' "$1"
+  printf '  >>> NOT a clean result. The answer is unknown, not negative.\n'
+  exit 4
+}
+
+# Any failure this script did not classify itself lands here rather than
+# escaping as some other status. An unhandled failure is an unknown answer.
+trap 'search_failed "unhandled command failure at line $LINENO"' ERR
+
+# --- helpers ---------------------------------------------------------------
+
+# Count the lines in a captured command substitution, where empty means zero
+# rather than one blank line.
+count_lines() {
+  [ -n "$1" ] || { printf '0\n'; return 0; }
+  printf '%s\n' "$1" | wc -l | tr -d '[:space:]'
+}
+
+# Resolve the repo brand-identity inspects: an explicit override first, then the
+# path data/projects.md records for inception, then the standard clone location.
+# No personal absolute path is baked into this shared script.
+resolve_brand_repo() {
+  local registry="$DATA/projects.md" from_registry=""
+  if [ -n "${FM_VERIFY_REPO:-}" ]; then
+    printf '%s\n' "$FM_VERIFY_REPO"
+    return 0
+  fi
+  if [ -f "$registry" ]; then
+    from_registry=$(sed -n 's/^- inception .*repo at \([^ ,)]*\).*$/\1/p' "$registry" | sed -n 1p)
+  fi
+  if [ -n "$from_registry" ]; then
+    printf '%s\n' "$from_registry"
+    return 0
+  fi
+  printf '%s\n' "$FM_HOME/projects/inception"
+}
+
+# --- brand-identity mode ---------------------------------------------------
+
+verify_brand_identity() {
+  local fetch=1 repo candidate_out st scope_out scope_n cand_n
+  local unmigrated=0 migrated=0 line f
+  local -a candidates=()
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --no-fetch) fetch=0 ;;
+      *) usage_error "unknown brand-identity option '$1'" ;;
+    esac
+    shift
+  done
+
+  repo=$(resolve_brand_repo)
+  ERRLOG=$(mktemp "${TMPDIR:-/tmp}/fm-verify-delivered.XXXXXX")
+
+  if ! git -C "$repo" rev-parse --git-dir >/dev/null 2>"$ERRLOG"; then
+    search_failed "$repo is not a git repository ($(tr '\n' ' ' <"$ERRLOG")); set FM_VERIFY_REPO"
+  fi
+  if [ "$fetch" -eq 1 ]; then
+    if ! git -C "$repo" fetch origin -q 2>"$ERRLOG"; then
+      printf 'WARNING: could not fetch origin in %s; %s may be stale.\n' "$repo" "$REV"
+    fi
+  fi
+  if ! git -C "$repo" rev-parse --verify --quiet "$REV^{commit}" >/dev/null 2>"$ERRLOG"; then
+    search_failed "cannot resolve rev '$REV' in $repo; nothing was searched"
+  fi
+
+  printf '=== files deciding brand identity by STRING, no graph consultation ===\n'
+  printf '  repo: %s\n  rev:  %s\n  path: %s\n' "$repo" "$REV" "$BRAND_PATHSPEC"
+
+  # Bug 1's shape: a pathspec that matches no files. git grep reports that as an
+  # ordinary no-match, so the scope has to be counted separately from the search.
+  st=0
+  scope_out=$(git -C "$repo" ls-tree -r --name-only "$REV" -- "$BRAND_PATHSPEC" 2>"$ERRLOG") || st=$?
+  if [ "$st" -ne 0 ]; then
+    search_failed "git ls-tree failed with status $st: $(tr '\n' ' ' <"$ERRLOG")"
+  fi
+  scope_n=$(count_lines "$scope_out")
+  if [ "$scope_n" -eq 0 ]; then
+    inspected_nothing "pathspec '$BRAND_PATHSPEC' matches no file at $REV in $repo"
+  fi
+
+  # git grep: 0 means matches, 1 means a legitimate no-match, anything higher is
+  # a real failure. Only the first two are results.
+  st=0
+  candidate_out=$(git -C "$repo" grep -lE "$BRAND_CANDIDATE_RE" "$REV" -- "$BRAND_PATHSPEC" 2>"$ERRLOG") || st=$?
+  case "$st" in
+    0 | 1) : ;;
+    *) search_failed "git grep for candidates failed with status $st: $(tr '\n' ' ' <"$ERRLOG")" ;;
+  esac
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    f=${line#"$REV:"}
+    # The two owners of string matching are allowed to compare strings.
+    case "$f" in
+      */name_matching.py | */competitor_guards.py) continue ;;
+    esac
+    candidates+=("$f")
+  done <<<"$candidate_out"
+
+  cand_n=${#candidates[@]}
+  if [ "$cand_n" -eq 0 ]; then
+    inspected_nothing "no file among the $scope_n under '$BRAND_PATHSPEC' matches /$BRAND_CANDIDATE_RE/; the candidate pattern found nothing to check"
+  fi
+
+  for f in "${candidates[@]}"; do
+    st=0
+    git -C "$repo" grep -qE "$BRAND_GRAPH_RE" "$REV" -- "$f" 2>"$ERRLOG" || st=$?
+    case "$st" in
+      0) migrated=$((migrated + 1)) ;;
+      1)
+        printf '  UNMIGRATED: %s\n' "${f#schema-generator/}"
+        unmigrated=$((unmigrated + 1))
+        ;;
+      *) search_failed "git grep for graph consultation failed on $f with status $st: $(tr '\n' ' ' <"$ERRLOG")" ;;
+    esac
+  done
+
+  printf '  INSPECTED: %s candidate file(s) out of %s under %s\n' "$cand_n" "$scope_n" "$BRAND_PATHSPEC"
+  if [ "$unmigrated" -gt 0 ]; then
+    printf 'VIOLATIONS: %s of %s inspected file(s) decide brand identity by string with no graph consultation.\n' \
+      "$unmigrated" "$cand_n"
+    printf '  >>> DO NOT report brand-identity work as complete.\n'
+    exit 1
+  fi
+  printf 'CLEAN: all %s inspected file(s) consult the graph; %s migrated, 0 unmigrated.\n' "$cand_n" "$migrated"
+  exit 0
+}
+
+# --- task-id mode ----------------------------------------------------------
+
+verify_task_claims() {
+  local id=$1 brief claims st=0
+  brief="$DATA/$id/brief.md"
+  [ -f "$brief" ] || usage_error "no brief for '$id' at $brief"
+
+  claims=$(grep -nE "^[0-9]+\.|^\*\*[0-9]|must |MUST |every |EVERY |all " "$brief") || st=$?
+  case "$st" in
+    0 | 1) : ;;
+    *) search_failed "grep over $brief failed with status $st" ;;
+  esac
+  if [ -z "$claims" ]; then
+    inspected_nothing "no acceptance-shaped line in $brief; the claim pattern extracted nothing to verify"
+  fi
+
+  printf '=== ACCEPTANCE CLAIMS in the brief for %s - verify EACH against merged main ===\n' "$id"
+  # sed, not head: head can close the pipe early, and under pipefail that turns
+  # a long claim list into a spurious failure.
+  printf '%s\n' "$claims" | sed -n '1,40p'
+  printf '\n'
+  printf '>>> For each line above: does merged main actually satisfy it? Check, do not assume.\n'
+  printf ">>> A worker's 'done' is a claim. The code is the evidence.\n"
+  printf 'CHECKLIST: %s claim line(s) extracted. This is a checklist, NOT a clean verdict.\n' "$(count_lines "$claims")"
+  exit 0
+}
+
+case "${1:-}" in
+  brand-identity)
+    shift
+    verify_brand_identity "$@"
+    ;;
+  -h | --help)
+    # Print this file's leading comment block, so the header stays the one owner
+    # of the usage text and no line range has to be kept in sync.
+    awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "$SELF"
+    exit 0
+    ;;
+  "")
+    usage_error "no mode given"
+    ;;
+  -*)
+    usage_error "unknown option '$1'"
+    ;;
+  *)
+    verify_task_claims "$1"
+    ;;
+esac

--- a/bin/fm-verify-delivered.sh
+++ b/bin/fm-verify-delivered.sh
@@ -34,11 +34,21 @@
 # exit status, and every count of what was actually inspected is checked before
 # any clean verdict is allowed to print.
 #
+# A rev nobody could refresh is unknown for the same reason. brand-identity
+# fetches origin before it reads $REV, and a fetch that was asked for and failed
+# is outcome 4, not a warning: the verdict would otherwise be computed against
+# whatever origin/main happens to be locally. --no-fetch is the honest opt-in for
+# inspecting a local ref on purpose, and it never errors.
+#
 # tests/fm-verify-delivered.test.sh holds one regression test per outcome.
 #
 # Environment:
-#   FM_VERIFY_REPO  repo brand-identity inspects; overrides the repo path
-#                   recorded for inception in data/projects.md
+#   FM_VERIFY_REPO  repo brand-identity inspects. Resolution order: this
+#                   variable, then the path data/projects.md records for
+#                   inception as `repo at <path>` on its `- inception ...` line
+#                   (this script parses that form directly; the registry's mode
+#                   field is fm-project-mode.sh's business), then
+#                   $FM_HOME/projects/inception. A miss is outcome 4, never clean.
 #   FM_VERIFY_REV   rev brand-identity inspects (default: origin/main)
 set -Eeuo pipefail
 
@@ -54,7 +64,7 @@ BRAND_PATHSPEC="schema-generator/app"
 BRAND_CANDIDATE_RE='is_same_brand|normalize_entity|is_competitor_reference'
 BRAND_GRAPH_RE='graph_directives|brand_relations|ns_comparison|brand_graph|referability'
 
-SELF="$SCRIPT_DIR/fm-verify-delivered.sh"
+SELF="${BASH_SOURCE[0]}"
 ERRLOG=""
 # shellcheck disable=SC2329 # Registered by the EXIT trap below.
 cleanup() { [ -z "$ERRLOG" ] || rm -f "$ERRLOG"; }
@@ -150,9 +160,12 @@ verify_brand_identity() {
   if ! git -C "$repo" rev-parse --git-dir >/dev/null 2>"$ERRLOG"; then
     search_failed "$repo is not a git repository ($(tr '\n' ' ' <"$ERRLOG")); set FM_VERIFY_REPO"
   fi
+  # A fetch that was asked for and failed leaves $REV at whatever is already on
+  # disk, so any verdict below would be about an unknown rev. That is outcome 4,
+  # not a warning; --no-fetch is how a caller accepts a local ref on purpose.
   if [ "$fetch" -eq 1 ]; then
     if ! git -C "$repo" fetch origin -q 2>"$ERRLOG"; then
-      printf 'WARNING: could not fetch origin in %s; %s may be stale.\n' "$repo" "$REV"
+      search_failed "git fetch origin failed in $repo ($(tr '\n' ' ' <"$ERRLOG")); '$REV' may be stale, so nothing was searched; pass --no-fetch to inspect the local ref on purpose"
     fi
   fi
   if ! git -C "$repo" rev-parse --verify --quiet "$REV^{commit}" >/dev/null 2>"$ERRLOG"; then
@@ -226,7 +239,12 @@ verify_brand_identity() {
     printf '  >>> DO NOT report brand-identity work as complete.\n'
     exit 1
   fi
-  printf 'CLEAN: all %s inspected file(s) consult the graph; %s migrated, 0 unmigrated.\n' "$cand_n" "$migrated"
+  # Wording limited to what the per-file grep above actually proves: a graph
+  # identifier appears in the file. It can appear in a comment or a docstring,
+  # and a file can still decide by string in some other branch, so this is not a
+  # claim that the file consults the graph.
+  printf 'CLEAN: all %s inspected file(s) reference a graph identifier somewhere in the file, comments and docstrings included, which is not proof they consult it; %s referencing, 0 with no graph reference.\n' \
+    "$cand_n" "$migrated"
   exit 0
 }
 

--- a/bin/fm-verify-delivered.sh
+++ b/bin/fm-verify-delivered.sh
@@ -40,7 +40,7 @@
 #   FM_VERIFY_REPO  repo brand-identity inspects; overrides the repo path
 #                   recorded for inception in data/projects.md
 #   FM_VERIFY_REV   rev brand-identity inspects (default: origin/main)
-set -euo pipefail
+set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
@@ -87,7 +87,19 @@ search_failed() {
 
 # Any failure this script did not classify itself lands here rather than
 # escaping as some other status. An unhandled failure is an unknown answer.
-trap 'search_failed "unhandled command failure at line $LINENO"' ERR
+# `-E` above is what carries this trap into the mode functions, where all the
+# work happens; without it bash would drop the trap at the function boundary and
+# an unclassified failure would escape as exit 1, which here means "violations".
+# BASH_COMMAND names the command that actually failed: LINENO inside a trap
+# resolves to the enclosing function's definition line, not the failing one.
+#
+# Only the top-level shell turns a failure into outcome 4. `-E` carries the trap
+# into command substitutions as well, and the searches below read a subshell's
+# exit status to tell a legitimate git grep no-match from a real error; firing
+# there would rewrite every no-match as a failure. Standing aside loses nothing:
+# a subshell that dies under `-e` still hands its status to the command that
+# captured it, which is either classified there or caught here.
+trap '[ "${BASH_SUBSHELL:-0}" -ne 0 ] || search_failed "unhandled command failure in ${FUNCNAME[0]:-main} (called at line ${BASH_LINENO[0]}): $BASH_COMMAND"' ERR
 
 # --- helpers ---------------------------------------------------------------
 
@@ -120,7 +132,7 @@ resolve_brand_repo() {
 # --- brand-identity mode ---------------------------------------------------
 
 verify_brand_identity() {
-  local fetch=1 repo candidate_out st scope_out scope_n cand_n
+  local fetch=1 repo candidate_out st scope_out scope_n cand_n matched_n
   local unmigrated=0 migrated=0 line f
   local -a candidates=()
 
@@ -171,6 +183,11 @@ verify_brand_identity() {
     *) search_failed "git grep for candidates failed with status $st: $(tr '\n' ' ' <"$ERRLOG")" ;;
   esac
 
+  # Counted before the owner exclusion below, so an empty candidate list can say
+  # which of the two ways it got there: the pattern matched nothing at all, or
+  # everything it matched is a file allowed to compare strings.
+  matched_n=$(count_lines "$candidate_out")
+
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     f=${line#"$REV:"}
@@ -182,8 +199,11 @@ verify_brand_identity() {
   done <<<"$candidate_out"
 
   cand_n=${#candidates[@]}
+  if [ "$cand_n" -eq 0 ] && [ "$matched_n" -eq 0 ]; then
+    inspected_nothing "no file among the $scope_n under '$BRAND_PATHSPEC' matches /$BRAND_CANDIDATE_RE/; the candidate pattern matched nothing in scope, so it found nothing to check"
+  fi
   if [ "$cand_n" -eq 0 ]; then
-    inspected_nothing "no file among the $scope_n under '$BRAND_PATHSPEC' matches /$BRAND_CANDIDATE_RE/; the candidate pattern found nothing to check"
+    inspected_nothing "all $matched_n file(s) under '$BRAND_PATHSPEC' matching /$BRAND_CANDIDATE_RE/ are name_matching.py or competitor_guards.py; every file it matched is an allowed string-matching owner, so it found nothing to check"
   fi
 
   for f in "${candidates[@]}"; do

--- a/bin/fm-verify-delivered.sh
+++ b/bin/fm-verify-delivered.sh
@@ -11,15 +11,17 @@
 #
 # Usage:
 #   fm-verify-delivered.sh brand-identity [--no-fetch]
-#                                    who still decides brand identity by string
+#      which files reference a brand-identity helper with no graph identifier
 #   fm-verify-delivered.sh <task-id>  acceptance claims in a brief, to check by hand
 #   fm-verify-delivered.sh --help     print this header
 #
 # The exit status is the verdict, and only 0 may be read as delivered:
-#   0  CLEAN              inspected one or more files and found no violation
+#   0  CLEAN              inspected one or more files, every one of them
+#                         referencing a graph identifier
 #                         (in task-id mode: acceptance claims were extracted,
 #                         which is a checklist to work through, not a verdict)
-#   1  VIOLATIONS         found violations, listed above the verdict line
+#   1  VIOLATIONS         inspected files with no graph identifier anywhere in
+#                         them, listed above the verdict line
 #   2  USAGE              bad invocation
 #   3  INSPECTED NOTHING  the search matched no files, so it proves nothing
 #   4  SEARCH FAILED      the search itself errored, so the answer is unknown
@@ -59,7 +61,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 REV="${FM_VERIFY_REV:-origin/main}"
 
 # brand-identity's definition of the migration: which files are candidates, who
-# is allowed to own string comparison, and what counts as consulting the graph.
+# is allowed to own string comparison, and which identifiers count as a graph
+# reference.
 BRAND_PATHSPEC="schema-generator/app"
 BRAND_CANDIDATE_RE='is_same_brand|normalize_entity|is_competitor_reference'
 BRAND_GRAPH_RE='graph_directives|brand_relations|ns_comparison|brand_graph|referability'

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -51,6 +51,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
+| `fm-verify-delivered.sh` | Check a delivery claim against the merged code, reporting "inspected nothing" and "search failed" as their own non-clean outcomes |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and one-shot escalation |
 | `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -51,7 +51,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
-| `fm-verify-delivered.sh` | Check a delivery claim against the merged code, reporting "inspected nothing" and "search failed" as their own non-clean outcomes |
+| `fm-verify-delivered.sh` | Check a delivery claim against merged code, or list a brief's acceptance claims, with "inspected nothing" and "search failed" as their own non-clean outcomes |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and one-shot escalation |
 | `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |

--- a/tests/fm-verify-delivered.test.sh
+++ b/tests/fm-verify-delivered.test.sh
@@ -544,6 +544,13 @@ test_help_prints_the_outcome_contract() {
   assert_contains "$OUT" "INSPECTED NOTHING" "--help does not document the empty-search outcome"
   assert_contains "$OUT" "SEARCH FAILED" "--help does not document the failed-search outcome"
   assert_contains "$OUT" "only 0 may be read as delivered" "--help does not state the exit-status contract"
+  # --help is generated from the header block, so it is also where an overclaim
+  # survives longest. It must describe what the two searches establish, never
+  # assert that a candidate decides brand identity by string.
+  assert_contains "$OUT" "which files reference a brand-identity helper with no graph identifier" \
+    "--help does not describe brand-identity mode by what its searches establish"
+  assert_not_contains "$OUT" "decides brand identity by string" \
+    "--help states the inference as fact"
   pass "fm-verify-delivered.sh: --help documents the four outcomes"
 }
 

--- a/tests/fm-verify-delivered.test.sh
+++ b/tests/fm-verify-delivered.test.sh
@@ -64,13 +64,15 @@ fm_verify_commit() {
 
 # fm_verify_broken_origin <name>: a fixture repo holding one string-only
 # candidate whose 'origin' points at a local path that does not exist, so
-# `git fetch origin` fails without touching the network. Echoes the repo path.
+# `git fetch origin` fails without touching the network. Echoes the repo path;
+# the unfetchable remote is "<repo>-no-such-remote.git", which a caller can
+# derive and assert instead of asserting git's own English failure sentence.
 fm_verify_broken_origin() {
   local name=$1 repo
   repo=$(fm_verify_fixture "$name" schema-generator/app)
   fm_verify_write_source "$repo" schema-generator/app/legacy.py string
   fm_verify_commit "$repo"
-  git -C "$repo" remote add origin "$TMP_ROOT/$name-no-such-remote.git"
+  git -C "$repo" remote add origin "$repo-no-such-remote.git"
   printf '%s\n' "$repo"
 }
 
@@ -141,8 +143,18 @@ test_violation_is_reported_and_fails() {
 
   run_verify "$repo"
   expect_code 1 "$RC" "a known violation must fail"
-  assert_contains "$OUT" "UNMIGRATED: app/legacy.py" "the violating file was not named"
+  assert_contains "$OUT" "NO GRAPH IDENTIFIER: app/legacy.py" "the violating file was not named"
   assert_contains "$OUT" "VIOLATIONS:" "the violation verdict is missing"
+  # The report may only claim what its two greps prove: the file matched the
+  # candidate pattern, and no graph identifier appears in it. "Decides brand
+  # identity by string" is an inference, and the candidate set knowingly holds a
+  # re-export that decides nothing, so no line may state it as fact.
+  assert_contains "$OUT" "reference a brand-identity helper with no graph identifier anywhere in the file" \
+    "the violation verdict does not state what the searches actually proved"
+  assert_not_contains "$OUT" "decide brand identity by string" \
+    "the violation verdict claims more than the candidate grep proves"
+  assert_not_contains "$OUT" "graph consultation" \
+    "the report still asserts the files were checked for consulting the graph"
   assert_contains "$OUT" "DO NOT report brand-identity work as complete" "the refusal line is missing"
   assert_not_contains "$OUT" "CLEAN:" "a tree with a violation printed a clean verdict"
   assert_contains "$OUT" "INSPECTED: 2 candidate file(s)" "the inspected count is missing or wrong"
@@ -166,7 +178,7 @@ test_clean_tree_reports_clean() {
     "the clean verdict is missing or miscounted"
   assert_contains "$OUT" "not proof they consult it" "the clean verdict does not qualify what the search proved"
   assert_not_contains "$OUT" "consult the graph" "the clean verdict claims more than the per-file search proves"
-  assert_not_contains "$OUT" "UNMIGRATED" "a clean tree named a violation"
+  assert_not_contains "$OUT" "NO GRAPH IDENTIFIER" "a clean tree named a violation"
   assert_not_contains "$OUT" "INSPECTED NOTHING" "a clean tree claimed it inspected nothing"
   pass "fm-verify-delivered.sh: a tree with no violation reports clean and exits 0"
 }
@@ -290,7 +302,11 @@ test_failed_fetch_reports_search_failed() {
   expect_code 4 "$RC" "a failed fetch must report a failed search, not a verdict"
   assert_contains "$OUT" "SEARCH FAILED:" "a failed fetch is not reported as a failed search"
   assert_contains "$OUT" "git fetch origin failed" "the failed-fetch reason is missing"
-  assert_contains "$OUT" "does not appear to be a git repository" \
+  # The proof that git's stderr was carried through is the unfetchable remote
+  # path, which appears nowhere in this script's own message. Asserting git's
+  # English sentence instead would make the suite fail under a localised git for
+  # no defect, and a drift-catching suite must not be flaky by construction.
+  assert_contains "$OUT" "$repo-no-such-remote.git" \
     "the failed-fetch report drops git's own stderr, so the reader cannot tell why"
   assert_contains "$OUT" "--no-fetch" "the failed-fetch report does not name the opt-in for a local ref"
   assert_not_contains "$OUT" "CLEAN:" "a failed fetch printed a clean verdict"
@@ -308,7 +324,7 @@ test_no_fetch_still_reaches_a_verdict_on_an_unfetchable_repo() {
 
   run_verify "$repo"
   expect_code 1 "$RC" "--no-fetch must still reach a verdict when origin is unfetchable"
-  assert_contains "$OUT" "UNMIGRATED: app/legacy.py" "--no-fetch did not inspect the local ref"
+  assert_contains "$OUT" "NO GRAPH IDENTIFIER: app/legacy.py" "--no-fetch did not inspect the local ref"
   assert_contains "$OUT" "VIOLATIONS: 1 of 1 inspected file(s)" "--no-fetch did not reach its verdict"
   assert_not_contains "$OUT" "SEARCH FAILED:" "--no-fetch turned an accepted local ref into an error"
   pass "fm-verify-delivered.sh: --no-fetch still reaches a verdict when origin is unfetchable"
@@ -327,7 +343,7 @@ test_registry_recorded_repo_is_inspected() {
   run_env "FM_HOME=$home" FM_VERIFY_REV=checkme -- brand-identity --no-fetch
   expect_code 1 "$RC" "the registry-recorded repo was not inspected"
   assert_contains "$OUT" "repo: $repo" "the path recorded as 'repo at <path>' was not resolved"
-  assert_contains "$OUT" "UNMIGRATED: app/legacy.py" "the resolved path was printed but not inspected"
+  assert_contains "$OUT" "NO GRAPH IDENTIFIER: app/legacy.py" "the resolved path was printed but not inspected"
   pass "fm-verify-delivered.sh: the repo recorded in data/projects.md is resolved and inspected"
 }
 
@@ -434,7 +450,7 @@ test_no_match_is_a_result_not_a_fatal() {
 
   run_verify "$repo"
   expect_code 1 "$RC" "a single unmigrated file must exit 1 as a violation"
-  assert_contains "$OUT" "UNMIGRATED: app/legacy.py" "the run died before classifying the file"
+  assert_contains "$OUT" "NO GRAPH IDENTIFIER: app/legacy.py" "the run died before classifying the file"
   assert_contains "$OUT" "VIOLATIONS: 1 of 1 inspected file(s)" "the run died before its verdict"
   pass "fm-verify-delivered.sh: a git grep no-match is a result, not a fatal under pipefail"
 }

--- a/tests/fm-verify-delivered.test.sh
+++ b/tests/fm-verify-delivered.test.sh
@@ -340,6 +340,28 @@ EOF
   pass "fm-verify-delivered.sh: task-id mode extracts acceptance claims"
 }
 
+# Bug 2's class in the other mode. The claim list is truncated for display, and
+# `head` closes the pipe as soon as it has its lines; once the list outgrows the
+# pipe buffer the writer is cut off mid-write and pipefail turns that into a
+# fatal, so a brief with many claims fails while a short one passes. The brief
+# below is sized past the buffer on purpose: at ~40 claims the `head` spelling
+# still passes, so a smaller fixture would assert nothing.
+test_task_mode_long_claim_list_is_truncated_not_fatal() {
+  local home="$TMP_ROOT/home-long-claims"
+  mkdir -p "$home/data/fm-long"
+  awk 'BEGIN {
+    for (i = 1; i <= 1200; i++)
+      printf "%d. Every call site number %d must consult the graph and satisfy the acceptance criteria on this line.\n", i, i
+  }' > "$home/data/fm-long/brief.md"
+
+  run_env "FM_HOME=$home" -- fm-long
+  expect_code 0 "$RC" "a long claim list must not turn a truncated display into a failure"
+  assert_contains "$OUT" "CHECKLIST: 1200 claim line(s) extracted" "the count reports the truncated display, not every claim found"
+  assert_contains "$OUT" "40:40. Every call site number 40 " "the display stopped short of its 40-line cap"
+  assert_not_contains "$OUT" "41:41. Every call site number 41 " "the display printed past its 40-line cap"
+  pass "fm-verify-delivered.sh: a long claim list is truncated for display, not fatal"
+}
+
 # The same no-match hazard in the other mode: a brief whose claims do not parse
 # is an unverified brief, not an approved one.
 test_task_mode_without_claims_reports_inspected_nothing() {
@@ -404,6 +426,7 @@ test_erroring_git_grep_reports_search_failed
 test_unclassified_failure_in_a_mode_function_reports_search_failed
 test_no_match_is_a_result_not_a_fatal
 test_task_mode_extracts_claims
+test_task_mode_long_claim_list_is_truncated_not_fatal
 test_task_mode_without_claims_reports_inspected_nothing
 test_task_mode_missing_brief_is_usage_error
 test_no_mode_is_usage_error

--- a/tests/fm-verify-delivered.test.sh
+++ b/tests/fm-verify-delivered.test.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-verify-delivered.sh.
+#
+# This verifier has twice reported a clean result while checking nothing, so its
+# whole value is that "no violations", "inspected no files", and "the search
+# failed" stay three distinguishable outcomes. Every test below asserts the exit
+# status as well as the wording, because the status is the contract callers act
+# on, and the two regression tests named below are the reason this file exists:
+#
+#   test_zero_file_pathspec_reports_inspected_nothing
+#     Bug 1 (2026-07-28): the pathspec matched no files, git grep reported that
+#     as an ordinary no-match, and zero files inspected printed as zero
+#     violations found.
+#   test_no_match_is_a_result_not_a_fatal
+#     Bug 2 (2026-07-29): git grep's no-match status aborted the run under
+#     `set -o pipefail`, so the script printed its header and exited 1 on any
+#     input. That status is now only reachable from a real violation.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-verify-delivered)
+VERIFY="$ROOT/bin/fm-verify-delivered.sh"
+
+# --- fixtures ---------------------------------------------------------------
+
+# fm_verify_assert_tmp <path>: refuse any fixture path outside this run's temp
+# root. Without this, a helper handed an empty or unexpanded path would run
+# `git -C ""` against whatever repo the suite happens to sit in, and `git add -A`
+# plus `git commit` would land a fixture commit in the real checkout. An earlier
+# draft of this file did exactly that, so the guard is load-bearing.
+fm_verify_assert_tmp() {
+  [ -n "${TMP_ROOT:-}" ] || fail "TMP_ROOT is unset; refusing to build a fixture"
+  case "${1:-}" in
+    "$TMP_ROOT"/?*) : ;;
+    *) fail "fixture path '${1:-}' is not inside $TMP_ROOT; refusing to touch a real repo" ;;
+  esac
+}
+
+# fm_verify_fixture <name> <subdir>: a git repo whose brand-identity source will
+# live under <subdir>. Echoes the repo path. <subdir> is what lets a test point
+# the scoped pathspec at nothing.
+fm_verify_fixture() {
+  local name=$1 subdir=$2
+  local repo="$TMP_ROOT/$name"
+  fm_verify_assert_tmp "$repo"
+  mkdir -p "$repo/$subdir"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.name 'Firstmate Tests'
+  git -C "$repo" config user.email 'tests@example.invalid'
+  printf '%s\n' "$repo"
+}
+
+# fm_verify_commit <repo>: commit the fixture tree and name it "checkme", the
+# branch every run below inspects instead of a remote-tracking ref.
+fm_verify_commit() {
+  local repo=${1:-}
+  fm_verify_assert_tmp "$repo"
+  git -C "$repo" add -A
+  git -C "$repo" commit -qm fixture
+  git -C "$repo" branch -f checkme main
+}
+
+# fm_verify_write_source <repo> <path> graph|string: a candidate file that
+# decides brand identity, consulting the graph only when told to.
+fm_verify_write_source() {
+  local repo=${1:-} path=$2 graph=$3
+  fm_verify_assert_tmp "$repo"
+  mkdir -p "$repo/$(dirname "$path")"
+  {
+    printf 'def compare(a, b):\n'
+    printf '    return is_same_brand(a, b)\n'
+    [ "$graph" != graph ] || printf '    # resolved through brand_relations in the graph\n'
+  } > "$repo/$path"
+}
+
+# run_verify <repo> [args...]: run brand-identity against <repo> at the fixture
+# branch with no network fetch. Sets OUT to the combined output and RC to the
+# exit status. Both are globals on purpose: capturing the run in a command
+# substitution would leave its exit status in a subshell the caller cannot read,
+# and the exit status is most of what these tests assert.
+RC=0
+OUT=
+run_verify() {
+  local repo=$1
+  shift
+  OUT=$(FM_VERIFY_REPO="$repo" FM_VERIFY_REV=checkme "$VERIFY" brand-identity --no-fetch "$@" 2>&1)
+  RC=$?
+}
+
+# run_env <name=value>... -- <args>...: run the script under an explicit
+# environment, setting OUT and RC the same way.
+run_env() {
+  local -a env_kv=()
+  while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
+    env_kv+=("$1")
+    shift
+  done
+  shift
+  OUT=$(env "${env_kv[@]}" "$VERIFY" "$@" 2>&1)
+  RC=$?
+}
+
+# --- outcome 1: violations --------------------------------------------------
+
+test_violation_is_reported_and_fails() {
+  local repo
+  repo=$(fm_verify_fixture violation schema-generator/app)
+  fm_verify_write_source "$repo" schema-generator/app/migrated.py graph
+  fm_verify_write_source "$repo" schema-generator/app/legacy.py string
+  fm_verify_commit "$repo"
+
+  run_verify "$repo"
+  expect_code 1 "$RC" "a known violation must fail"
+  assert_contains "$OUT" "UNMIGRATED: app/legacy.py" "the violating file was not named"
+  assert_contains "$OUT" "VIOLATIONS:" "the violation verdict is missing"
+  assert_contains "$OUT" "DO NOT report brand-identity work as complete" "the refusal line is missing"
+  assert_not_contains "$OUT" "CLEAN:" "a tree with a violation printed a clean verdict"
+  assert_contains "$OUT" "INSPECTED: 2 candidate file(s)" "the inspected count is missing or wrong"
+  pass "fm-verify-delivered.sh: a known violation is reported and exits 1"
+}
+
+# --- outcome 2: clean -------------------------------------------------------
+
+test_clean_tree_reports_clean() {
+  local repo
+  repo=$(fm_verify_fixture clean schema-generator/app)
+  fm_verify_write_source "$repo" schema-generator/app/one.py graph
+  fm_verify_write_source "$repo" schema-generator/app/two.py graph
+  fm_verify_commit "$repo"
+
+  run_verify "$repo"
+  expect_code 0 "$RC" "a tree with no violation must pass"
+  assert_contains "$OUT" "CLEAN: all 2 inspected file(s) consult the graph" "the clean verdict is missing or miscounted"
+  assert_not_contains "$OUT" "UNMIGRATED" "a clean tree named a violation"
+  assert_not_contains "$OUT" "INSPECTED NOTHING" "a clean tree claimed it inspected nothing"
+  pass "fm-verify-delivered.sh: a tree with no violation reports clean and exits 0"
+}
+
+# The string-matching owners are allowed to compare strings, and excluding them
+# must narrow the candidate list without turning the check vacuous.
+test_owner_files_are_excluded_from_candidates() {
+  local repo
+  repo=$(fm_verify_fixture owners schema-generator/app)
+  fm_verify_write_source "$repo" schema-generator/app/name_matching.py string
+  fm_verify_write_source "$repo" schema-generator/app/competitor_guards.py string
+  fm_verify_write_source "$repo" schema-generator/app/caller.py graph
+  fm_verify_commit "$repo"
+
+  run_verify "$repo"
+  expect_code 0 "$RC" "excluded owner files must not count as violations"
+  assert_contains "$OUT" "INSPECTED: 1 candidate file(s) out of 3" "owner exclusion did not narrow the candidates"
+  assert_not_contains "$OUT" "name_matching.py" "an excluded owner file was reported"
+  pass "fm-verify-delivered.sh: string-matching owners are excluded from candidates"
+}
+
+# --- outcome 3: inspected nothing (regression for bug 1) --------------------
+
+test_zero_file_pathspec_reports_inspected_nothing() {
+  local repo
+  # The source lives somewhere else entirely, so the scoped pathspec resolves to
+  # no file. That is exactly bug 1: git grep calls it a no-match, and the old
+  # script called a no-match clean.
+  repo=$(fm_verify_fixture empty-pathspec other-place)
+  fm_verify_write_source "$repo" other-place/legacy.py string
+  fm_verify_commit "$repo"
+
+  run_verify "$repo"
+  expect_code 3 "$RC" "a pathspec matching zero files must not exit 0"
+  assert_contains "$OUT" "INSPECTED NOTHING:" "the empty-scope outcome is not distinguishable"
+  assert_contains "$OUT" "matches no file" "the empty-scope reason is missing"
+  assert_contains "$OUT" "NOT a clean result" "the empty-scope outcome was not called out as not-clean"
+  assert_not_contains "$OUT" "CLEAN:" "a pathspec matching zero files printed a clean verdict"
+  pass "fm-verify-delivered.sh: a pathspec matching zero files reports inspected nothing, not clean"
+}
+
+# The same collapse one layer in: the scope holds files, but the candidate
+# pattern matches none of them, so nothing was examined for the violation.
+test_zero_candidates_reports_inspected_nothing() {
+  local repo
+  repo=$(fm_verify_fixture no-candidates schema-generator/app)
+  printf 'def unrelated():\n    return 1\n' > "$repo/schema-generator/app/unrelated.py"
+  fm_verify_commit "$repo"
+
+  run_verify "$repo"
+  expect_code 3 "$RC" "zero candidate files must not exit 0"
+  assert_contains "$OUT" "INSPECTED NOTHING:" "the zero-candidate outcome is not distinguishable"
+  assert_contains "$OUT" "found nothing to check" "the zero-candidate reason is missing"
+  assert_not_contains "$OUT" "CLEAN:" "zero candidate files printed a clean verdict"
+  pass "fm-verify-delivered.sh: zero candidate files reports inspected nothing, not clean"
+}
+
+# --- outcome 4: search failed -----------------------------------------------
+
+test_unresolvable_rev_reports_search_failed() {
+  local repo
+  repo=$(fm_verify_fixture bad-rev schema-generator/app)
+  fm_verify_write_source "$repo" schema-generator/app/legacy.py string
+  fm_verify_commit "$repo"
+
+  run_env "FM_VERIFY_REPO=$repo" FM_VERIFY_REV=no-such-rev -- brand-identity --no-fetch
+  expect_code 4 "$RC" "an unresolvable rev must report a failed search"
+  assert_contains "$OUT" "SEARCH FAILED:" "the failed-search outcome is not distinguishable"
+  assert_contains "$OUT" "cannot resolve rev 'no-such-rev'" "the failed-search reason is missing"
+  assert_not_contains "$OUT" "CLEAN:" "an unresolvable rev printed a clean verdict"
+  assert_not_contains "$OUT" "INSPECTED NOTHING" "a failed search was reported as an empty search"
+  pass "fm-verify-delivered.sh: an unresolvable rev reports a failed search, not clean"
+}
+
+test_missing_repo_reports_search_failed() {
+  run_env "FM_VERIFY_REPO=$TMP_ROOT/not-a-repo" FM_VERIFY_REV=checkme -- brand-identity --no-fetch
+  expect_code 4 "$RC" "a missing repo must report a failed search"
+  assert_contains "$OUT" "SEARCH FAILED:" "a missing repo is not reported as a failed search"
+  assert_contains "$OUT" "is not a git repository" "the missing-repo reason is missing"
+  assert_not_contains "$OUT" "CLEAN:" "a missing repo printed a clean verdict"
+  pass "fm-verify-delivered.sh: a missing repo reports a failed search, not clean"
+}
+
+# git grep itself erroring mid-search, not a pre-check refusing to start. The
+# shim fails only `git grep`, so the repo, the rev, and the scope all resolve
+# first and the run reaches the search before it breaks.
+test_erroring_git_grep_reports_search_failed() {
+  local repo fakebin real_git
+  repo=$(fm_verify_fixture grep-error schema-generator/app)
+  fm_verify_write_source "$repo" schema-generator/app/legacy.py string
+  fm_verify_commit "$repo"
+
+  real_git=$(command -v git)
+  fakebin=$(fm_fakebin "$TMP_ROOT/grep-error-shim")
+  cat > "$fakebin/git" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  if [ "\$arg" = grep ]; then
+    printf 'fatal: simulated git grep failure\\n' >&2
+    exit 128
+  fi
+done
+exec "$real_git" "\$@"
+SH
+  chmod +x "$fakebin/git"
+
+  run_env "PATH=$fakebin:$PATH" "FM_VERIFY_REPO=$repo" FM_VERIFY_REV=checkme -- brand-identity --no-fetch
+  expect_code 4 "$RC" "an erroring search must not exit 0, 1, or 3"
+  assert_contains "$OUT" "SEARCH FAILED:" "an erroring git grep is not reported as a failed search"
+  assert_contains "$OUT" "status 128" "the underlying grep status is missing from the report"
+  assert_not_contains "$OUT" "CLEAN:" "an erroring search printed a clean verdict"
+  assert_not_contains "$OUT" "INSPECTED NOTHING" "an erroring search was reported as an empty search"
+  pass "fm-verify-delivered.sh: an erroring git grep reports a failed search, not clean"
+}
+
+# --- bug 2 regression: a no-match must survive `set -o pipefail` ------------
+
+test_no_match_is_a_result_not_a_fatal() {
+  local repo
+  # Bug 2's observed behaviour was header-only output and exit 1 on any input,
+  # because git grep's no-match status aborted the run. This tree ends on a
+  # graph no-match, the exact status that used to be fatal, so reaching the
+  # verdict line at all is the regression assertion.
+  repo=$(fm_verify_fixture pipefail schema-generator/app)
+  fm_verify_write_source "$repo" schema-generator/app/legacy.py string
+  fm_verify_commit "$repo"
+
+  run_verify "$repo"
+  expect_code 1 "$RC" "a single unmigrated file must exit 1 as a violation"
+  assert_contains "$OUT" "UNMIGRATED: app/legacy.py" "the run died before classifying the file"
+  assert_contains "$OUT" "VIOLATIONS: 1 of 1 inspected file(s)" "the run died before its verdict"
+  pass "fm-verify-delivered.sh: a git grep no-match is a result, not a fatal under pipefail"
+}
+
+# --- task-id mode -----------------------------------------------------------
+
+test_task_mode_extracts_claims() {
+  local home="$TMP_ROOT/home-claims"
+  mkdir -p "$home/data/fm-example"
+  cat > "$home/data/fm-example/brief.md" <<'EOF'
+# Task
+1. Fix the thing.
+2. Every call site must consult the graph.
+EOF
+  run_env "FM_HOME=$home" -- fm-example
+  expect_code 0 "$RC" "a brief with acceptance claims must exit 0"
+  assert_contains "$OUT" "ACCEPTANCE CLAIMS in the brief for fm-example" "the claims header is missing"
+  assert_contains "$OUT" "Every call site must consult the graph." "an acceptance claim was dropped"
+  assert_contains "$OUT" "NOT a clean verdict" "task-id mode did not disclaim being a verdict"
+  pass "fm-verify-delivered.sh: task-id mode extracts acceptance claims"
+}
+
+# The same no-match hazard in the other mode: a brief whose claims do not parse
+# is an unverified brief, not an approved one.
+test_task_mode_without_claims_reports_inspected_nothing() {
+  local home="$TMP_ROOT/home-no-claims"
+  mkdir -p "$home/data/fm-bare"
+  printf 'nothing here looks like an acceptance criterion\n' > "$home/data/fm-bare/brief.md"
+  run_env "FM_HOME=$home" -- fm-bare
+  expect_code 3 "$RC" "a brief with no parseable claims must not exit 0"
+  assert_contains "$OUT" "INSPECTED NOTHING:" "an unparseable brief is not reported as an empty search"
+  assert_contains "$OUT" "extracted nothing to verify" "the empty-claims reason is missing"
+  pass "fm-verify-delivered.sh: a brief with no parseable claims reports inspected nothing"
+}
+
+test_task_mode_missing_brief_is_usage_error() {
+  local home="$TMP_ROOT/home-missing"
+  mkdir -p "$home/data"
+  run_env "FM_HOME=$home" -- fm-absent
+  expect_code 2 "$RC" "a missing brief must be a usage error"
+  assert_contains "$OUT" "no brief for 'fm-absent'" "the missing-brief reason is missing"
+  pass "fm-verify-delivered.sh: a missing brief is a usage error"
+}
+
+# --- invocation contract ----------------------------------------------------
+
+test_no_mode_is_usage_error() {
+  OUT=$("$VERIFY" 2>&1)
+  RC=$?
+  expect_code 2 "$RC" "no mode must be a usage error"
+  assert_contains "$OUT" "no mode given" "the no-mode reason is missing"
+  pass "fm-verify-delivered.sh: no mode is a usage error"
+}
+
+# --- the suite's own safety guard -------------------------------------------
+
+test_fixture_guard_refuses_paths_outside_the_temp_root() {
+  # Run in a subshell so the guard's fail() aborts only the probe. An empty path
+  # is the dangerous one: `git -C ""` means "the current repo".
+  OUT=$(fm_verify_assert_tmp "" 2>&1) && fail "the fixture guard accepted an empty path"
+  assert_contains "$OUT" "refusing to touch a real repo" "the guard's refusal reason is missing"
+  OUT=$(fm_verify_assert_tmp "$ROOT" 2>&1) && fail "the fixture guard accepted the firstmate checkout"
+  OUT=$(fm_verify_assert_tmp "$TMP_ROOT/ok" 2>&1) || fail "the fixture guard rejected a valid temp path"
+  pass "fm-verify-delivered.sh: the fixture guard refuses paths outside the temp root"
+}
+
+test_help_prints_the_outcome_contract() {
+  OUT=$("$VERIFY" --help 2>&1) || fail "--help must exit 0"
+  assert_contains "$OUT" "INSPECTED NOTHING" "--help does not document the empty-search outcome"
+  assert_contains "$OUT" "SEARCH FAILED" "--help does not document the failed-search outcome"
+  assert_contains "$OUT" "only 0 may be read as delivered" "--help does not state the exit-status contract"
+  pass "fm-verify-delivered.sh: --help documents the four outcomes"
+}
+
+test_violation_is_reported_and_fails
+test_clean_tree_reports_clean
+test_owner_files_are_excluded_from_candidates
+test_zero_file_pathspec_reports_inspected_nothing
+test_zero_candidates_reports_inspected_nothing
+test_unresolvable_rev_reports_search_failed
+test_missing_repo_reports_search_failed
+test_erroring_git_grep_reports_search_failed
+test_no_match_is_a_result_not_a_fatal
+test_task_mode_extracts_claims
+test_task_mode_without_claims_reports_inspected_nothing
+test_task_mode_missing_brief_is_usage_error
+test_no_mode_is_usage_error
+test_fixture_guard_refuses_paths_outside_the_temp_root
+test_help_prints_the_outcome_contract

--- a/tests/fm-verify-delivered.test.sh
+++ b/tests/fm-verify-delivered.test.sh
@@ -62,6 +62,34 @@ fm_verify_commit() {
   git -C "$repo" branch -f checkme main
 }
 
+# fm_verify_broken_origin <name>: a fixture repo holding one string-only
+# candidate whose 'origin' points at a local path that does not exist, so
+# `git fetch origin` fails without touching the network. Echoes the repo path.
+fm_verify_broken_origin() {
+  local name=$1 repo
+  repo=$(fm_verify_fixture "$name" schema-generator/app)
+  fm_verify_write_source "$repo" schema-generator/app/legacy.py string
+  fm_verify_commit "$repo"
+  git -C "$repo" remote add origin "$TMP_ROOT/$name-no-such-remote.git"
+  printf '%s\n' "$repo"
+}
+
+# fm_verify_registry_home <name> <repo>: an FM_HOME whose data/projects.md
+# records <repo> for inception in the `repo at <path>` form this script parses.
+# The line shape is the coupling under test: if the registry format moves, the
+# tests that use this helper fail instead of the parse silently going dead.
+fm_verify_registry_home() {
+  local name=$1 repo=$2
+  local home="$TMP_ROOT/$name"
+  fm_verify_assert_tmp "$home"
+  mkdir -p "$home/data"
+  {
+    printf '# Projects\n\n'
+    printf -- '- inception [build] - SEO schema tool (repo at %s, added 2026-07-01)\n' "$repo"
+  } > "$home/data/projects.md"
+  printf '%s\n' "$home"
+}
+
 # fm_verify_write_source <repo> <path> graph|string: a candidate file that
 # decides brand identity, consulting the graph only when told to.
 fm_verify_write_source() {
@@ -132,7 +160,12 @@ test_clean_tree_reports_clean() {
 
   run_verify "$repo"
   expect_code 0 "$RC" "a tree with no violation must pass"
-  assert_contains "$OUT" "CLEAN: all 2 inspected file(s) consult the graph" "the clean verdict is missing or miscounted"
+  # The fixture's own graph marker is a comment, which is why the verdict may
+  # only claim the identifier appears in the file, not that the file consults it.
+  assert_contains "$OUT" "CLEAN: all 2 inspected file(s) reference a graph identifier somewhere in the file" \
+    "the clean verdict is missing or miscounted"
+  assert_contains "$OUT" "not proof they consult it" "the clean verdict does not qualify what the search proved"
+  assert_not_contains "$OUT" "consult the graph" "the clean verdict claims more than the per-file search proves"
   assert_not_contains "$OUT" "UNMIGRATED" "a clean tree named a violation"
   assert_not_contains "$OUT" "INSPECTED NOTHING" "a clean tree claimed it inspected nothing"
   pass "fm-verify-delivered.sh: a tree with no violation reports clean and exits 0"
@@ -240,8 +273,92 @@ test_missing_repo_reports_search_failed() {
   expect_code 4 "$RC" "a missing repo must report a failed search"
   assert_contains "$OUT" "SEARCH FAILED:" "a missing repo is not reported as a failed search"
   assert_contains "$OUT" "is not a git repository" "the missing-repo reason is missing"
+  assert_contains "$OUT" "set FM_VERIFY_REPO" "the missing-repo report is not actionable"
   assert_not_contains "$OUT" "CLEAN:" "a missing repo printed a clean verdict"
   pass "fm-verify-delivered.sh: a missing repo reports a failed search, not clean"
+}
+
+# A fetch that was asked for and failed leaves the rev at whatever is on disk, so
+# any verdict below it would be about an unknown rev. That is the same
+# "unknown reads as clean" collapse the outcome table exists to prevent, so it is
+# outcome 4 and not a warning. The broken origin is a local path, so no network.
+test_failed_fetch_reports_search_failed() {
+  local repo
+  repo=$(fm_verify_broken_origin failed-fetch)
+
+  run_env "FM_VERIFY_REPO=$repo" FM_VERIFY_REV=checkme -- brand-identity
+  expect_code 4 "$RC" "a failed fetch must report a failed search, not a verdict"
+  assert_contains "$OUT" "SEARCH FAILED:" "a failed fetch is not reported as a failed search"
+  assert_contains "$OUT" "git fetch origin failed" "the failed-fetch reason is missing"
+  assert_contains "$OUT" "does not appear to be a git repository" \
+    "the failed-fetch report drops git's own stderr, so the reader cannot tell why"
+  assert_contains "$OUT" "--no-fetch" "the failed-fetch report does not name the opt-in for a local ref"
+  assert_not_contains "$OUT" "CLEAN:" "a failed fetch printed a clean verdict"
+  assert_not_contains "$OUT" "VIOLATIONS:" "a failed fetch reached a violations verdict against a stale rev"
+  assert_not_contains "$OUT" "WARNING" "a failed fetch was downgraded to a warning"
+  pass "fm-verify-delivered.sh: a failed fetch reports a failed search, not a verdict"
+}
+
+# The other half of that contract: --no-fetch is the deliberate escape hatch for
+# inspecting a local ref, so on the very same unfetchable repo it must still
+# reach a real verdict rather than becoming an error.
+test_no_fetch_still_reaches_a_verdict_on_an_unfetchable_repo() {
+  local repo
+  repo=$(fm_verify_broken_origin no-fetch-hatch)
+
+  run_verify "$repo"
+  expect_code 1 "$RC" "--no-fetch must still reach a verdict when origin is unfetchable"
+  assert_contains "$OUT" "UNMIGRATED: app/legacy.py" "--no-fetch did not inspect the local ref"
+  assert_contains "$OUT" "VIOLATIONS: 1 of 1 inspected file(s)" "--no-fetch did not reach its verdict"
+  assert_not_contains "$OUT" "SEARCH FAILED:" "--no-fetch turned an accepted local ref into an error"
+  pass "fm-verify-delivered.sh: --no-fetch still reaches a verdict when origin is unfetchable"
+}
+
+# --- repo resolution --------------------------------------------------------
+
+# The script parses data/projects.md for `repo at <path>` itself. data/ is
+# gitignored, so nothing in-repo would notice that form drifting; this test is
+# what notices. It fails if the recorded form changes or the parse is removed.
+test_registry_recorded_repo_is_inspected() {
+  local repo home
+  repo=$(fm_verify_broken_origin registry-repo)
+  home=$(fm_verify_registry_home home-registry "$repo")
+
+  run_env "FM_HOME=$home" FM_VERIFY_REV=checkme -- brand-identity --no-fetch
+  expect_code 1 "$RC" "the registry-recorded repo was not inspected"
+  assert_contains "$OUT" "repo: $repo" "the path recorded as 'repo at <path>' was not resolved"
+  assert_contains "$OUT" "UNMIGRATED: app/legacy.py" "the resolved path was printed but not inspected"
+  pass "fm-verify-delivered.sh: the repo recorded in data/projects.md is resolved and inspected"
+}
+
+test_explicit_repo_overrides_the_registry() {
+  local registry_repo clean_repo home
+  registry_repo=$(fm_verify_broken_origin registry-loser)
+  clean_repo=$(fm_verify_fixture registry-winner schema-generator/app)
+  fm_verify_write_source "$clean_repo" schema-generator/app/one.py graph
+  fm_verify_commit "$clean_repo"
+  home=$(fm_verify_registry_home home-precedence "$registry_repo")
+
+  run_env "FM_HOME=$home" "FM_VERIFY_REPO=$clean_repo" FM_VERIFY_REV=checkme -- brand-identity --no-fetch
+  expect_code 0 "$RC" "FM_VERIFY_REPO must win over the registry-recorded path"
+  assert_contains "$OUT" "repo: $clean_repo" "FM_VERIFY_REPO was not the repo inspected"
+  assert_not_contains "$OUT" "$registry_repo" "the registry-recorded path outranked the explicit override"
+  pass "fm-verify-delivered.sh: FM_VERIFY_REPO outranks the registry-recorded path"
+}
+
+# No override and no registry: resolution falls through to the standard clone
+# location, and a miss there is still outcome 4 with an actionable message.
+test_unresolvable_repo_falls_through_to_search_failed() {
+  local home="$TMP_ROOT/home-no-registry"
+  mkdir -p "$home/data"
+
+  run_env "FM_HOME=$home" FM_VERIFY_REV=checkme -- brand-identity --no-fetch
+  expect_code 4 "$RC" "an unresolvable repo must not exit 0"
+  assert_contains "$OUT" "$home/projects/inception is not a git repository" \
+    "resolution did not fall through to the standard clone location"
+  assert_contains "$OUT" "set FM_VERIFY_REPO" "the fall-through report is not actionable"
+  assert_not_contains "$OUT" "CLEAN:" "an unresolvable repo printed a clean verdict"
+  pass "fm-verify-delivered.sh: an unresolvable repo falls through to a failed search"
 }
 
 # git grep itself erroring mid-search, not a pre-check refusing to start. The
@@ -422,6 +539,11 @@ test_zero_candidates_reports_inspected_nothing
 test_only_owner_candidates_reports_inspected_nothing
 test_unresolvable_rev_reports_search_failed
 test_missing_repo_reports_search_failed
+test_failed_fetch_reports_search_failed
+test_no_fetch_still_reaches_a_verdict_on_an_unfetchable_repo
+test_registry_recorded_repo_is_inspected
+test_explicit_repo_overrides_the_registry
+test_unresolvable_repo_falls_through_to_search_failed
 test_erroring_git_grep_reports_search_failed
 test_unclassified_failure_in_a_mode_function_reports_search_failed
 test_no_match_is_a_result_not_a_fatal

--- a/tests/fm-verify-delivered.test.sh
+++ b/tests/fm-verify-delivered.test.sh
@@ -187,8 +187,35 @@ test_zero_candidates_reports_inspected_nothing() {
   expect_code 3 "$RC" "zero candidate files must not exit 0"
   assert_contains "$OUT" "INSPECTED NOTHING:" "the zero-candidate outcome is not distinguishable"
   assert_contains "$OUT" "found nothing to check" "the zero-candidate reason is missing"
+  assert_contains "$OUT" "matched nothing in scope" "the zero-candidate reason does not say the pattern itself matched nothing"
+  assert_not_contains "$OUT" "allowed string-matching owner" "a tree with no pattern match blamed the owner exclusion"
   assert_not_contains "$OUT" "CLEAN:" "zero candidate files printed a clean verdict"
   pass "fm-verify-delivered.sh: zero candidate files reports inspected nothing, not clean"
+}
+
+# Same outcome, different cause, and the report has to tell them apart. Here the
+# pattern did match files; every one of them is an owner allowed to compare
+# strings, so the exclusion emptied the candidate list. Saying "the pattern
+# matched nothing" here would be a false statement from a script whose only job
+# is honest reporting of what it inspected.
+test_only_owner_candidates_reports_inspected_nothing() {
+  local repo
+  repo=$(fm_verify_fixture owners-only schema-generator/app)
+  fm_verify_write_source "$repo" schema-generator/app/name_matching.py string
+  fm_verify_write_source "$repo" schema-generator/app/competitor_guards.py string
+  printf 'def unrelated():\n    return 1\n' > "$repo/schema-generator/app/unrelated.py"
+  fm_verify_commit "$repo"
+
+  run_verify "$repo"
+  expect_code 3 "$RC" "an owners-only tree must not exit 0"
+  assert_contains "$OUT" "INSPECTED NOTHING:" "the owners-only outcome is not distinguishable"
+  assert_contains "$OUT" "every file it matched is an allowed string-matching owner" \
+    "the owners-only reason does not say the exclusion emptied the candidate list"
+  assert_contains "$OUT" "all 2 file(s)" "the owners-only reason does not count the pre-exclusion matches"
+  assert_not_contains "$OUT" "matched nothing in scope" \
+    "an owners-only tree falsely claimed the candidate pattern matched nothing"
+  assert_not_contains "$OUT" "CLEAN:" "an owners-only tree printed a clean verdict"
+  pass "fm-verify-delivered.sh: an owners-only tree says the exclusion emptied the candidates"
 }
 
 # --- outcome 4: search failed -----------------------------------------------
@@ -247,6 +274,33 @@ SH
   assert_not_contains "$OUT" "CLEAN:" "an erroring search printed a clean verdict"
   assert_not_contains "$OUT" "INSPECTED NOTHING" "an erroring search was reported as an empty search"
   pass "fm-verify-delivered.sh: an erroring git grep reports a failed search, not clean"
+}
+
+# The ERR trap, which is the catch-all the other three outcome-4 tests bypass by
+# exercising branches the script classifies for itself. A failure nobody wrote a
+# branch for must still land on "unknown", never on exit 1, which in this
+# script's vocabulary means "violations found".
+#
+# The failure is forced with an unusable TMPDIR, so the run dies on its own
+# mktemp inside verify_brand_identity with the repo, rev and pathspec all valid.
+# That location is the point: bash does not carry an ERR trap into a function
+# without `set -E`, so without it this exits 1 with no SEARCH FAILED line at all.
+test_unclassified_failure_in_a_mode_function_reports_search_failed() {
+  local repo
+  repo=$(fm_verify_fixture errtrace schema-generator/app)
+  fm_verify_write_source "$repo" schema-generator/app/legacy.py string
+  fm_verify_commit "$repo"
+
+  run_env "TMPDIR=$TMP_ROOT/errtrace-no-such-tmpdir" "FM_VERIFY_REPO=$repo" FM_VERIFY_REV=checkme \
+    -- brand-identity --no-fetch
+  expect_code 4 "$RC" "an unclassified failure must report a failed search, not violations"
+  assert_contains "$OUT" "SEARCH FAILED:" "the ERR trap did not fire inside the mode function"
+  assert_contains "$OUT" "unhandled command failure" "the unclassified-failure reason is missing"
+  assert_contains "$OUT" "in verify_brand_identity" "the report does not name the function that failed"
+  assert_contains "$OUT" "ERRLOG=" "the report does not name the command that actually failed"
+  assert_not_contains "$OUT" "CLEAN:" "an unclassified failure printed a clean verdict"
+  assert_not_contains "$OUT" "VIOLATIONS:" "an unclassified failure was reported as violations"
+  pass "fm-verify-delivered.sh: an unclassified failure inside a mode function reports a failed search"
 }
 
 # --- bug 2 regression: a no-match must survive `set -o pipefail` ------------
@@ -343,9 +397,11 @@ test_clean_tree_reports_clean
 test_owner_files_are_excluded_from_candidates
 test_zero_file_pathspec_reports_inspected_nothing
 test_zero_candidates_reports_inspected_nothing
+test_only_owner_candidates_reports_inspected_nothing
 test_unresolvable_rev_reports_search_failed
 test_missing_repo_reports_search_failed
 test_erroring_git_grep_reports_search_failed
+test_unclassified_failure_in_a_mode_function_reports_search_failed
 test_no_match_is_a_result_not_a_fatal
 test_task_mode_extracts_claims
 test_task_mode_without_claims_reports_inspected_nothing


### PR DESCRIPTION
## What Changed

- New `bin/fm-verify-delivered.sh` with two modes: `brand-identity`, which greps a fetched rev (`origin/main` by default, `FM_VERIFY_REPO`/`FM_VERIFY_REV` to override) for files that reference a brand-identity helper with no graph identifier, and `<task-id>`, which extracts a brief's acceptance claims as a checklist. Exit status is the verdict — 0 clean, 1 violations, 2 usage, 3 inspected nothing, 4 search failed — with one emitter function per outcome so a clean verdict is only reachable after counting what was actually inspected.
- Unknown results fail closed instead of reading as clean: a zero-file search is outcome 3, a git error or a failed `origin` fetch is outcome 4 (`--no-fetch` is the explicit opt-in for inspecting a local ref), an `ERR` trap classifies otherwise-unhandled failures rather than letting them surface as exit 1 (violations), and git's stderr is carried into the reported message. Report and `--help` wording states only what the grep proves (references a helper / no graph identifier) rather than asserting intent.
- Added `tests/fm-verify-delivered.test.sh` covering each outcome, plus documentation: a `fm-verify-delivered.sh` row in the `docs/scripts.md` toolbelt table and an AGENTS.md hard-rule-5 line requiring the check before reporting a capability delivered or marking a task done.

## Risk Assessment

✅ Low: This round touched only header comment text and added two test assertions, leaving matching, counts, control flow, and exit statuses byte-identical, and a full sweep of every emitted string found no remaining overclaim to close.

## Testing

Ran the repo's targeted suite for this script (tests/fm-verify-delivered.test.sh, 23 checks, all green), then — since a passing suite does not show what the CLI actually prints, which is this tool's entire product — drove the real script by hand against throwaway git fixtures and captured a full end-user CLI transcript covering all five outcomes with their exit statuses, plus a reconstruction of the pre-fix pipeline printing "TOTAL UNMIGRATED: 0 / ALL CLEAR" at exit 0 on the very same zero-file fixture where the fixed script now reports INSPECTED NOTHING at exit 3. The transcript confirms the three zero-inspection collapses are reported with distinct reasons, a failed fetch withholds the verdict rather than degrading to a warning, --no-fetch still reaches a real verdict on an unfetchable repo, and the sole clean verdict qualifies that a graph identifier in a file is not proof the file consults it. This is a CLI-only change with no rendered UI surface, so the reviewer-visible artifact is the terminal transcript rather than a screenshot. Fixtures were built and removed under a temp root, the suite's own path guard was exercised, and the worktree is clean with no leftover artifacts.

<details>
<summary>Evidence: End-user CLI transcript: all five outcomes, plus the pre-fix false clean for contrast</summary>

<code># reconstructed pre-fix shape, source outside the scanned pathspec&#10;TOTAL UNMIGRATED: 0&#10;ALL CLEAR - brand identity migration complete&#10;[exit status: 0] &lt;-- FALSE CLEAN: it inspected nothing and said clean&#10;&#10;# ...and the same repo through the script under test:&#10;=== files referencing a brand-identity helper with NO graph identifier ===&#10;INSPECTED NOTHING: pathspec &#39;schema-generator/app&#39; matches no file at checkme in &lt;fixture&gt;&#10;&gt;&gt;&gt; NOT a clean result. The check examined no files, so it proved nothing.&#10;&gt;&gt;&gt; Fix the search before reporting anything about this claim.&#10;[exit status: 3]&#10;&#10;# failed fetch withholds the verdict instead of computing it against a stale rev&#10;SEARCH FAILED: git fetch origin failed in &lt;fixture&gt; (...); &#39;checkme&#39; may be stale, so nothing was&#10;searched; pass --no-fetch to inspect the local ref on purpose&#10;[exit status: 4]&#10;&#10;# the only exit-0 verdict, hedged to what the grep proves&#10;CLEAN: all 2 inspected file(s) reference a graph identifier somewhere in the file, comments and&#10;docstrings included, which is not proof they consult it; 2 referencing, 0 with no graph reference.&#10;[exit status: 0]</code>

```text
############################################################
# 1. THE BUG: source lives outside the scanned pathspec, so
#    the search matches zero files. Pre-fix this printed a
#    clean result. Reconstructed pre-fix shape first:
############################################################

$ # legacy shape: one grep pipeline, no scope check, no status classification
$ git -C <repo> grep -lE 'is_same_brand|...' checkme -- schema-generator/app | grep -v ... | wc -l
TOTAL UNMIGRATED: 0
ALL CLEAR - brand identity migration complete
[exit status: 0]   <-- FALSE CLEAN: it inspected nothing and said clean

############################################################
# ...and the same repo through the script under test:
############################################################

$ FM_VERIFY_REPO=/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/bug-shape FM_VERIFY_REV=checkme fm-verify-delivered.sh brand-identity --no-fetch
=== files referencing a brand-identity helper with NO graph identifier ===
  repo: /var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/bug-shape
  rev:  checkme
  path: schema-generator/app
INSPECTED NOTHING: pathspec 'schema-generator/app' matches no file at checkme in /var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/bug-shape
  >>> NOT a clean result. The check examined no files, so it proved nothing.
  >>> Fix the search before reporting anything about this claim.
[exit status: 3]   <-- outcome 3, INSPECTED NOTHING (was a false clean)

############################################################
# 2. Scope has files but none match the candidate pattern
############################################################

$ FM_VERIFY_REPO=/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/no-candidates FM_VERIFY_REV=checkme fm-verify-delivered.sh brand-identity --no-fetch
=== files referencing a brand-identity helper with NO graph identifier ===
  repo: /var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/no-candidates
  rev:  checkme
  path: schema-generator/app
INSPECTED NOTHING: no file among the 1 under 'schema-generator/app' matches /is_same_brand|normalize_entity|is_competitor_reference/; the candidate pattern matched nothing in scope, so it found nothing to check
  >>> NOT a clean result. The check examined no files, so it proved nothing.
  >>> Fix the search before reporting anything about this claim.
[exit status: 3]   <-- outcome 3, INSPECTED NOTHING (nothing matched)

############################################################
# 3. Everything matched is a file allowed to compare strings
#    -- same outcome, different reason, stated as such
############################################################

$ FM_VERIFY_REPO=/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/owners-only FM_VERIFY_REV=checkme fm-verify-delivered.sh brand-identity --no-fetch
=== files referencing a brand-identity helper with NO graph identifier ===
  repo: /var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/owners-only
  rev:  checkme
  path: schema-generator/app
INSPECTED NOTHING: all 2 file(s) under 'schema-generator/app' matching /is_same_brand|normalize_entity|is_competitor_reference/ are name_matching.py or competitor_guards.py; every file it matched is an allowed string-matching owner, so it found nothing to check
  >>> NOT a clean result. The check examined no files, so it proved nothing.
  >>> Fix the search before reporting anything about this claim.
[exit status: 3]   <-- outcome 3, INSPECTED NOTHING (exclusion emptied the list)

############################################################
# 4. A real violation: one file references the helper with
#    no graph identifier anywhere in it
############################################################

$ FM_VERIFY_REPO=/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/violation FM_VERIFY_REV=checkme fm-verify-delivered.sh brand-identity --no-fetch
=== files referencing a brand-identity helper with NO graph identifier ===
  repo: /var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/violation
  rev:  checkme
  path: schema-generator/app
  NO GRAPH IDENTIFIER: app/legacy.py
  INSPECTED: 2 candidate file(s) out of 2 under schema-generator/app
VIOLATIONS: 1 of 2 inspected file(s) reference a brand-identity helper with no graph identifier anywhere in the file.
  >>> DO NOT report brand-identity work as complete.
[exit status: 1]   <-- outcome 1, VIOLATIONS

############################################################
# 5. A genuinely clean tree -- the only exit 0 verdict, and
#    it says what the grep does and does not prove
############################################################

$ FM_VERIFY_REPO=/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/clean FM_VERIFY_REV=checkme fm-verify-delivered.sh brand-identity --no-fetch
=== files referencing a brand-identity helper with NO graph identifier ===
  repo: /var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/clean
  rev:  checkme
  path: schema-generator/app
  INSPECTED: 2 candidate file(s) out of 2 under schema-generator/app
CLEAN: all 2 inspected file(s) reference a graph identifier somewhere in the file, comments and docstrings included, which is not proof they consult it; 2 referencing, 0 with no graph reference.
[exit status: 0]   <-- outcome 0, CLEAN

############################################################
# 6. Unknown answers: bad rev, missing repo, failed fetch
############################################################

$ FM_VERIFY_REPO=/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/clean FM_VERIFY_REV=no-such-rev fm-verify-delivered.sh brand-identity --no-fetch
SEARCH FAILED: cannot resolve rev 'no-such-rev' in /var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/clean; nothing was searched
  >>> NOT a clean result. The answer is unknown, not negative.
[exit status: 4]   <-- outcome 4, SEARCH FAILED (unresolvable rev)

$ FM_VERIFY_REPO=/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/not-a-repo FM_VERIFY_REV=checkme fm-verify-delivered.sh brand-identity --no-fetch
SEARCH FAILED: /var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/not-a-repo is not a git repository (fatal: cannot change to '/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/not-a-repo': No such file or directory ); set FM_VERIFY_REPO
  >>> NOT a clean result. The answer is unknown, not negative.
[exit status: 4]   <-- outcome 4, SEARCH FAILED (repo does not exist)

$ FM_VERIFY_REPO=/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/failed-fetch FM_VERIFY_REV=checkme fm-verify-delivered.sh brand-identity
SEARCH FAILED: git fetch origin failed in /var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/failed-fetch (fatal: '/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/failed-fetch-no-such-remote.git' does not appear to be a git repository fatal: Could not read from remote repository.  Please make sure you have the correct access rights and the repository exists. ); 'checkme' may be stale, so nothing was searched; pass --no-fetch to inspect the local ref on purpose
  >>> NOT a clean result. The answer is unknown, not negative.
[exit status: 4]   <-- outcome 4, SEARCH FAILED (fetch failed, verdict withheld)

$ FM_VERIFY_REPO=/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/failed-fetch FM_VERIFY_REV=checkme fm-verify-delivered.sh brand-identity --no-fetch
=== files referencing a brand-identity helper with NO graph identifier ===
  repo: /var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/failed-fetch
  rev:  checkme
  path: schema-generator/app
  NO GRAPH IDENTIFIER: app/legacy.py
  INSPECTED: 1 candidate file(s) out of 1 under schema-generator/app
VIOLATIONS: 1 of 1 inspected file(s) reference a brand-identity helper with no graph identifier anywhere in the file.
  >>> DO NOT report brand-identity work as complete.
[exit status: 1]   <-- outcome 1, --no-fetch is the honest opt-in and still verdicts

############################################################
# 7. Task-id mode: a checklist, explicitly not a verdict
############################################################

$ FM_HOME=/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/home fm-verify-delivered.sh fm-example
=== ACCEPTANCE CLAIMS in the brief for fm-example - verify EACH against merged main ===
2:1. Fix the thing.
3:2. Every call site must consult the graph.

>>> For each line above: does merged main actually satisfy it? Check, do not assume.
>>> A worker's 'done' is a claim. The code is the evidence.
CHECKLIST: 2 claim line(s) extracted. This is a checklist, NOT a clean verdict.
[exit status: 0]   <-- outcome 0, CHECKLIST (not a clean verdict)

$ FM_HOME=/var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/home fm-verify-delivered.sh fm-bare
INSPECTED NOTHING: no acceptance-shaped line in /var/folders/pj/563x6y950m9ccbkkgrt5h3y00000gn/T//fm-verify-demo.22m0Os/home/data/fm-bare/brief.md; the claim pattern extracted nothing to verify
  >>> NOT a clean result. The check examined no files, so it proved nothing.
  >>> Fix the search before reporting anything about this claim.
[exit status: 3]   <-- outcome 3, INSPECTED NOTHING (brief parsed to nothing)

############################################################
# 8. --help states the exit-status contract
############################################################

$ fm-verify-delivered.sh --help
fm-verify-delivered.sh - MECHANISM, not a promise.

Firstmate repeatedly reported work as delivered without checking the merged
result against what was asked (2026-07-28/29: Stage 6 "every comparison
through NS" when 16 files still used strings; PR 657 merged with 11 files
still string-only after "solve every brand-related bug").

Run this BEFORE telling the captain a PR delivered a capability, and BEFORE
marking a task done. It checks the CLAIM against the CODE, not the report.

Usage:
  fm-verify-delivered.sh brand-identity [--no-fetch]
     which files reference a brand-identity helper with no graph identifier
  fm-verify-delivered.sh <task-id>  acceptance claims in a brief, to check by hand
  fm-verify-delivered.sh --help     print this header

The exit status is the verdict, and only 0 may be read as delivered:
  0  CLEAN              inspected one or more files, every one of them
                        referencing a graph identifier
                        (in task-id mode: acceptance claims were extracted,
                        which is a checklist to work through, not a verdict)
  1  VIOLATIONS         inspected files with no graph identifier anywhere in
                        them, listed above the verdict line
  2  USAGE              bad invocation
  3  INSPECTED NOTHING  the search matched no files, so it proves nothing
  4  SEARCH FAILED      the search itself errored, so the answer is unknown

Outcomes 3 and 4 exist because this verifier twice printed a clean result
while checking nothing. First its pathspec matched no files, and git grep
reports that as an ordinary no-match, so zero files inspected read as zero
violations found. Then a git grep no-match status aborted the whole run under
`set -o pipefail`, so it printed its header and stopped. A verifier that
cannot say "I do not know" converts unknown into clean, which is worse than
having no verifier at all. Every git search below therefore classifies its own
exit status, and every count of what was actually inspected is checked before
any clean verdict is allowed to print.

A rev nobody could refresh is unknown for the same reason. brand-identity
fetches origin before it reads $REV, and a fetch that was asked for and failed
is outcome 4, not a warning: the verdict would otherwise be computed against
whatever origin/main happens to be locally. --no-fetch is the honest opt-in for
inspecting a local ref on purpose, and it never errors.

tests/fm-verify-delivered.test.sh holds one regression test per outcome.

Environment:
  FM_VERIFY_REPO  repo brand-identity inspects. Resolution order: this
                  variable, then the path data/projects.md records for
                  inception as `repo at <path>` on its `- inception ...` line
                  (this script parses that form directly; the registry's mode
                  field is fm-project-mode.sh's business), then
                  $FM_HOME/projects/inception. A miss is outcome 4, never clean.
  FM_VERIFY_REV   rev brand-identity inspects (default: origin/main)
[exit status: 0]
```
</details>
<details>
<summary>Evidence: Reproducible driver used to produce the transcript</summary>

```text
#!/usr/bin/env bash
# Hand-driven end-user transcript for bin/fm-verify-delivered.sh.
# Builds throwaway fixture repos under a temp root and runs the real script.
set -u

VERIFY="$1"
ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-verify-demo.XXXXXX")

mkrepo() { # mkrepo <name> <subdir>
  local r="$ROOT/$1"
  mkdir -p "$r/$2"
  git -C "$r" init -q -b main
  git -C "$r" config user.name demo
  git -C "$r" config user.email demo@example.invalid
  printf '%s\n' "$r"
}
src() { # src <repo> <path> graph|string
  mkdir -p "$1/$(dirname "$2")"
  { printf 'def compare(a, b):\n    return is_same_brand(a, b)\n'
    [ "$3" != graph ] || printf '    # resolved through brand_relations in the graph\n'
  } > "$1/$2"
}
commit() { git -C "$1" add -A; git -C "$1" commit -qm fixture; git -C "$1" branch -f checkme main; }

run() { # run <label> <env-assignments...> -- <args...>
  local label=$1; shift
  local -a kv=()
  while [ "$1" != "--" ]; do kv+=("$1"); shift; done; shift
  printf '\n$ %s %s\n' "${kv[*]}" "fm-verify-delivered.sh $*"
  env "${kv[@]}" "$VERIFY" "$@" 2>&1
  printf '[exit status: %s]   <-- %s\n' "$?" "$label"
}

echo "############################################################"
echo "# 1. THE BUG: source lives outside the scanned pathspec, so"
echo "#    the search matches zero files. Pre-fix this printed a"
echo "#    clean result. Reconstructed pre-fix shape first:"
echo "############################################################"
r=$(mkrepo bug-shape other-place); src "$r" other-place/legacy.py string; commit "$r"
printf '\n$ # legacy shape: one grep pipeline, no scope check, no status classification\n'
printf '$ git -C <repo> grep -lE '"'"'is_same_brand|...'"'"' checkme -- schema-generator/app | grep -v ... | wc -l\n'
n=$(git -C "$r" grep -lE 'is_same_brand|normalize_entity|is_competitor_reference' checkme -- schema-generator/app 2>/dev/null | grep -vE 'name_matching.py|competitor_guards.py' | wc -l | tr -d ' ')
printf 'TOTAL UNMIGRATED: %s\n' "$n"
printf 'ALL CLEAR - brand identity migration complete\n'
printf '[exit status: 0]   <-- FALSE CLEAN: it inspected nothing and said clean\n'

echo
echo "############################################################"
echo "# ...and the same repo through the script under test:"
echo "############################################################"
run "outcome 3, INSPECTED NOTHING (was a false clean)" "FM_VERIFY_REPO=$r" FM_VERIFY_REV=checkme -- brand-identity --no-fetch

echo
echo "############################################################"
echo "# 2. Scope has files but none match the candidate pattern"
echo "############################################################"
r=$(mkrepo no-candidates schema-generator/app)
printf 'def unrelated():\n    return 1\n' > "$r/schema-generator/app/unrelated.py"; commit "$r"
run "outcome 3, INSPECTED NOTHING (nothing matched)" "FM_VERIFY_REPO=$r" FM_VERIFY_REV=checkme -- brand-identity --no-fetch

echo
echo "############################################################"
echo "# 3. Everything matched is a file allowed to compare strings"
echo "#    -- same outcome, different reason, stated as such"
echo "############################################################"
r=$(mkrepo owners-only schema-generator/app)
src "$r" schema-generator/app/name_matching.py string
src "$r" schema-generator/app/competitor_guards.py string
commit "$r"
run "outcome 3, INSPECTED NOTHING (exclusion emptied the list)" "FM_VERIFY_REPO=$r" FM_VERIFY_REV=checkme -- brand-identity --no-fetch

echo
echo "############################################################"
echo "# 4. A real violation: one file references the helper with"
echo "#    no graph identifier anywhere in it"
echo "############################################################"
r=$(mkrepo violation schema-generator/app)
src "$r" schema-generator/app/migrated.py graph
src "$r" schema-generator/app/legacy.py string
commit "$r"
run "outcome 1, VIOLATIONS" "FM_VERIFY_REPO=$r" FM_VERIFY_REV=checkme -- brand-identity --no-fetch

echo
echo "############################################################"
echo "# 5. A genuinely clean tree -- the only exit 0 verdict, and"
echo "#    it says what the grep does and does not prove"
echo "############################################################"
r=$(mkrepo clean schema-generator/app)
src "$r" schema-generator/app/one.py graph
src "$r" schema-generator/app/two.py graph
commit "$r"
run "outcome 0, CLEAN" "FM_VERIFY_REPO=$r" FM_VERIFY_REV=checkme -- brand-identity --no-fetch

echo
echo "############################################################"
echo "# 6. Unknown answers: bad rev, missing repo, failed fetch"
echo "############################################################"
run "outcome 4, SEARCH FAILED (unresolvable rev)" "FM_VERIFY_REPO=$r" FM_VERIFY_REV=no-such-rev -- brand-identity --no-fetch
run "outcome 4, SEARCH FAILED (repo does not exist)" "FM_VERIFY_REPO=$ROOT/not-a-repo" FM_VERIFY_REV=checkme -- brand-identity --no-fetch

r=$(mkrepo failed-fetch schema-generator/app)
src "$r" schema-generator/app/legacy.py string; commit "$r"
git -C "$r" remote add origin "$r-no-such-remote.git"
run "outcome 4, SEARCH FAILED (fetch failed, verdict withheld)" "FM_VERIFY_REPO=$r" FM_VERIFY_REV=checkme -- brand-identity
run "outcome 1, --no-fetch is the honest opt-in and still verdicts" "FM_VERIFY_REPO=$r" FM_VERIFY_REV=checkme -- brand-identity --no-fetch

echo
echo "############################################################"
echo "# 7. Task-id mode: a checklist, explicitly not a verdict"
echo "############################################################"
h="$ROOT/home"; mkdir -p "$h/data/fm-example"
cat > "$h/data/fm-example/brief.md" <<'EOF'
# Task
1. Fix the thing.
2. Every call site must consult the graph.
EOF
run "outcome 0, CHECKLIST (not a clean verdict)" "FM_HOME=$h" -- fm-example
mkdir -p "$h/data/fm-bare"
printf 'nothing here looks like an acceptance criterion\n' > "$h/data/fm-bare/brief.md"
run "outcome 3, INSPECTED NOTHING (brief parsed to nothing)" "FM_HOME=$h" -- fm-bare

echo
echo "############################################################"
echo "# 8. --help states the exit-status contract"
echo "############################################################"
printf '\n$ fm-verify-delivered.sh --help\n'
"$VERIFY" --help 2>&1
printf '[exit status: %s]\n' "$?"

rm -rf "$ROOT"
```
</details>
<details>
<summary>Evidence: Targeted test suite output</summary>

```text
ok - fm-verify-delivered.sh: a known violation is reported and exits 1
ok - fm-verify-delivered.sh: a tree with no violation reports clean and exits 0
ok - fm-verify-delivered.sh: string-matching owners are excluded from candidates
ok - fm-verify-delivered.sh: a pathspec matching zero files reports inspected nothing, not clean
ok - fm-verify-delivered.sh: zero candidate files reports inspected nothing, not clean
ok - fm-verify-delivered.sh: an owners-only tree says the exclusion emptied the candidates
ok - fm-verify-delivered.sh: an unresolvable rev reports a failed search, not clean
ok - fm-verify-delivered.sh: a missing repo reports a failed search, not clean
ok - fm-verify-delivered.sh: a failed fetch reports a failed search, not a verdict
ok - fm-verify-delivered.sh: --no-fetch still reaches a verdict when origin is unfetchable
ok - fm-verify-delivered.sh: the repo recorded in data/projects.md is resolved and inspected
ok - fm-verify-delivered.sh: FM_VERIFY_REPO outranks the registry-recorded path
ok - fm-verify-delivered.sh: an unresolvable repo falls through to a failed search
ok - fm-verify-delivered.sh: an erroring git grep reports a failed search, not clean
ok - fm-verify-delivered.sh: an unclassified failure inside a mode function reports a failed search
ok - fm-verify-delivered.sh: a git grep no-match is a result, not a fatal under pipefail
ok - fm-verify-delivered.sh: task-id mode extracts acceptance claims
ok - fm-verify-delivered.sh: a long claim list is truncated for display, not fatal
ok - fm-verify-delivered.sh: a brief with no parseable claims reports inspected nothing
ok - fm-verify-delivered.sh: a missing brief is a usage error
ok - fm-verify-delivered.sh: no mode is a usage error
ok - fm-verify-delivered.sh: the fixture guard refuses paths outside the temp root
ok - fm-verify-delivered.sh: --help documents the four outcomes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed (3) ✅</summary>

- ⚠️ `bin/fm-verify-delivered.sh:154` - A failed `git fetch` only prints a WARNING and the run continues, so the verdict (including `CLEAN` with exit 0) is computed against whatever `origin/main` happens to be locally. This is the same &#34;unknown reported as clean&#34; shape the outcome table exists to prevent: the header promises exit 0 means &#34;inspected one or more files and found no violation&#34;, with no mention that the inspected rev may not be merged main. Recommend routing fetch failure to `search_failed` (outcome 4) unless staleness was explicitly accepted — `--no-fetch` already exists as the intentional escape hatch, so failing closed loses no capability.
- ℹ️ `bin/fm-verify-delivered.sh:155` - The fetch failure captures git&#39;s stderr into `$ERRLOG` but the WARNING line discards it, unlike every other error path here which reports `$(tr &#39;\n&#39; &#39; &#39; &lt;&#34;$ERRLOG&#34;)`. The reader is told the check may be stale but not why (offline, auth, no `origin`), which makes the one non-fatal degraded path the least diagnosable.
- ℹ️ `bin/fm-verify-delivered.sh:229` - `CLEAN: all N inspected file(s) consult the graph` asserts more than the per-file `git grep -qE &#34;$BRAND_GRAPH_RE&#34;` at line 211 verifies: any mention of a graph identifier anywhere in the file counts as migrated. A candidate that still decides identity by string in one branch while referencing `brand_relations` elsewhere — or only in a comment or docstring, which is exactly what the test fixture&#39;s graph marker is (tests/fm-verify-delivered.test.sh:74) — is counted as migrated, so `CLEAN` can print with a real violation present. The grep heuristic is a reasonable mechanism; the verdict wording should state what it actually checked (each candidate also references the graph API) rather than that the file consults the graph.
- ℹ️ `bin/fm-verify-delivered.sh:257` - Task-id mode exits 0 for merely extracting a checklist, which collides with the header&#39;s own contract line &#34;only 0 may be read as delivered&#34; (the parenthetical at line 20 discloses it, and the printed text says &#34;NOT a clean verdict&#34;, so the output is honest — the status is not). `--help` also exits 0. No automated caller exists today, but the tests state the status is the contract callers act on; a distinct status for checklist mode would keep exit 0 meaning exactly one thing.
- ℹ️ `bin/fm-verify-delivered.sh:123` - This makes the script a second parser of `data/projects.md`, which AGENTS.md:82 records as &#34;parsed by fm-project-mode.sh&#34;, and the `repo at &lt;path&gt;` substring it depends on appears in no documented registry line format (`- &lt;name&gt; [&lt;mode&gt;] - &lt;desc&gt; (added &lt;date&gt;)`, bin/fm-project-mode.sh:6-9). `data/` is gitignored so the pattern is unverifiable and untested in-repo; if it never matches, the branch is dead and resolution silently falls through to `$FM_HOME/projects/inception`. Also `[^ ,)]*` cannot express a path containing spaces, and a registry-recorded `~/...` is not expanded, surfacing as &#34;is not a git repository&#34;. Worth documenting the convention alongside the mode format, or dropping the branch in favour of FM_VERIFY_REPO plus the standard clone location.
- ℹ️ `bin/fm-verify-delivered.sh:57` - `SELF=&#34;$SCRIPT_DIR/fm-verify-delivered.sh&#34;` re-derives the script&#39;s own path by re-hardcoding its filename, when `${BASH_SOURCE[0]}` (already used for SCRIPT_DIR) is exactly that path. As written, a rename or a symlinked invocation makes `--help` awk a nonexistent file and exit 4 instead of printing the contract.

🔧 Fix: fail closed on failed fetch, stop overclaiming graph use
2 infos still open:
- ℹ️ `bin/fm-verify-delivered.sh:237` - The clean verdict is now carefully hedged, but the two other claim-bearing lines still assert the unhedged version: the VIOLATIONS line says the files &#34;decide brand identity by string with no graph consultation&#34;, and the run title (line 175) says &#34;files deciding brand identity by STRING, no graph consultation&#34;. The no-graph-identifier direction is sound, but &#34;decides brand identity by string&#34; is inferred purely from BRAND_CANDIDATE_RE matching, which the captain has already accepted includes the schema-generator/app/utils/__init__.py re-export that decides nothing. Wording-only symmetry with the new CLEAN line (e.g. &#34;reference a brand-identity helper and no graph identifier&#34;) would keep the whole report at the level the grep proves; no matching change is implied or wanted.
- ℹ️ `tests/fm-verify-delivered.test.sh:293` - The new failed-fetch test proves git&#39;s stderr is carried by asserting git&#39;s own English sentence &#34;does not appear to be a git repository&#34;, which is a translated, version-dependent message rather than part of this script&#39;s contract. I confirmed the wording on the host&#39;s git 2.50.1 (and that Apple git does not localise it), but a git built with NLS under a non-C locale would fail this assertion for no real defect. The unfetchable remote path (&#34;$TMP_ROOT/&lt;name&gt;-no-such-remote.git&#34;) appears only via git&#39;s stderr and never in the script&#39;s own message, so asserting that path proves exactly the same thing while being locale- and version-independent.

🔧 Fix: hedge violation wording, assert own message not git&#39;s
1 info still open:
- ℹ️ `bin/fm-verify-delivered.sh:14` - The sweep hedged the run title, the per-file label, the VIOLATIONS line, and the mid-search failure message, but the usage line printed by `--help` still describes brand-identity mode as showing &#34;who still decides brand identity by string&#34; — now the only place in user-visible output that states the inference as fact, i.e. the same asymmetry the captain ruled against, one line up. A phrasing matching the new report vocabulary (e.g. &#34;which files reference a brand-identity helper with no graph identifier&#34;) closes it; no matching, count, or exit-status change is implied, and test_help_prints_the_outcome_contract pins only the outcome table, not this line.

🔧 Fix: hedge help text, sweep remaining overclaimed strings
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-verify-delivered.test.sh` — 23 checks, all pass, exit 0</code>
- <code>Manual CLI transcript: real script driven against throwaway git fixtures for every outcome — `fm-verify-delivered.sh brand-identity --no-fetch` against a repo whose source sits outside the pathspec (exit 3, INSPECTED NOTHING), a scope with no pattern match (exit 3), an owners-only tree (exit 3, distinct reason), a violating tree (exit 1), a clean tree (exit 0), `FM_VERIFY_REV=no-such-rev` (exit 4), a nonexistent repo (exit 4), an unfetchable origin with and without `--no-fetch` (exit 4 vs exit 1)</code>
- <code>Manual CLI: task-id mode via `FM_HOME=&lt;fixture&gt; fm-verify-delivered.sh fm-example` (checklist, exit 0) and `fm-bare` with an unparseable brief (exit 3)</code>
- <code>Manual CLI: `fm-verify-delivered.sh --help` renders the five-outcome exit-status contract from the script header</code>
- `Reconstructed the pre-fix grep-pipeline shape against the identical zero-file fixture to show the false clean the change removes`
- <code>`git status --porcelain` after the run — no fixture commit or transient file landed in the worktree</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `docs/configuration.md:372` - Judgment call: FM_VERIFY_REPO and FM_VERIFY_REV are documented only in bin/fm-verify-delivered.sh&#39;s header, not in docs/configuration.md&#39;s environment-variable block. docs/scripts.md states each script&#39;s header is the authoritative description of its behavior, flags, and contracts, and the configuration.md block is a curated runtime-tuning list rather than an exhaustive inventory (many script-scoped FM_* variables are absent from it), so adding a copy there would create a second location to drift. Left as-is deliberately; if configuration.md is intended to be the exhaustive operator-facing env inventory, that is a broader consolidation worth a separate change.

🔧 Fix: point AGENTS.md hard rule 5 at fm-verify-delivered.sh
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
