### PR TITLE
test(herdr): gate real-Herdr tests on a provisionable lab, not on PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,9 @@ jobs:
           if-no-files-found: warn
 
   # Required real-Herdr lane: pinned install, serial real-herdr-gated family,
-  # hard-fail on "skip: herdr not found". Starts on Linux x86_64; if a genuine
+  # hard-fail on the lab gate's skip token (derived from bin/fm-herdr-lab.sh
+  # gate-token), which covers every unmet real-Herdr precondition including a
+  # missing binary. Starts on Linux x86_64; if a genuine
   # platform invariant fails (focus, cleanup, default-session tripwire), keep
   # the failure evidence and move the job to macOS rather than skip assertions.
   tests-herdr:
@@ -253,7 +255,6 @@ jobs:
             exit 1
           }
           bin/fm-test-run.sh --family real-herdr-gated \
-            --fail-on-gate-skip 'herdr not found' \
             --fail-on-gate-skip "$lab_token" \
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-herdr.json"
       - name: Cleanup job-owned Herdr lab sessions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,9 +245,16 @@ jobs:
           # the default session started above. Without this a gate could go green
           # by skipping everything. Live harness credential tests stay outside
           # this family (opt-in env only).
+          # The lab token comes from the helper that owns it, so renaming the
+          # constant propagates here instead of silently decoupling this guard.
+          lab_token=$(bin/fm-herdr-lab.sh gate-token)
+          [ -n "$lab_token" ] || {
+            echo "::error::fm-herdr-lab.sh gate-token printed no token; refusing to run with an unguarded gate"
+            exit 1
+          }
           bin/fm-test-run.sh --family real-herdr-gated \
             --fail-on-gate-skip 'herdr not found' \
-            --fail-on-gate-skip 'herdr lab unavailable' \
+            --fail-on-gate-skip "$lab_token" \
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-herdr.json"
       - name: Cleanup job-owned Herdr lab sessions
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,10 +239,15 @@ jobs:
         run: |
           set -eu
           mkdir -p "$RUNNER_TEMP/fm-test"
-          # Serial only. Fail if any script reports herdr not found. Live
-          # harness credential tests stay outside this family (opt-in env only).
+          # Serial only. This lane is where the real-Herdr bodies must actually
+          # RUN, so every gate skip that means an unmet Herdr precondition fails
+          # it: a missing binary, or a lab the helper could not provision against
+          # the default session started above. Without this a gate could go green
+          # by skipping everything. Live harness credential tests stay outside
+          # this family (opt-in env only).
           bin/fm-test-run.sh --family real-herdr-gated \
             --fail-on-gate-skip 'herdr not found' \
+            --fail-on-gate-skip 'herdr lab unavailable' \
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-herdr.json"
       - name: Cleanup job-owned Herdr lab sessions
         if: always()

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -5,6 +5,7 @@
 # Usage:
 #   fm-herdr-lab.sh name <label>
 #   fm-herdr-lab.sh gate [<session>]
+#   fm-herdr-lab.sh gate-token
 #   fm-herdr-lab.sh prepare <session>
 #   fm-herdr-lab.sh provision <session>
 #   fm-herdr-lab.sh run <session> <herdr arguments...>
@@ -18,6 +19,9 @@
 # exits 1 when it cannot.
 # It exists so callers gate on the precondition they actually need instead of
 # on "herdr" being on PATH, which proves nothing about session state.
+# The gate-token command prints the stable leading token of every gate reason so
+# callers such as the required CI Herdr lane derive it from this one owner rather
+# than hardcoding a copy that can silently drift.
 # The name command sanitizes the label, caps it at 16 characters, and appends
 # process/random suffixes to keep generated socket paths short.
 # Every Herdr call made here carries a trailing --session <session>.
@@ -65,11 +69,14 @@ fm_herdr_lab_session_list() { # <session>
   fm_herdr_lab_raw "$1" session list --json
 }
 
+# Exits 2 when the fleet cannot be read and 3 when it can be read but holds no
+# single running default session, so one Herdr call answers both questions and a
+# caller never has to re-probe to tell the two causes apart.
 fm_herdr_lab_fleet_state() { # <session>
   local name=$1 sessions snapshot
   sessions=$(fm_herdr_lab_session_list "$name" 2>/dev/null) || {
     fm_herdr_lab_error "cannot read Herdr sessions for the fleet-state tripwire"
-    return 1
+    return 2
   }
   snapshot=$(printf '%s' "$sessions" | jq -c '
     [.sessions[]? | select(.default == true)]
@@ -80,7 +87,7 @@ fm_herdr_lab_fleet_state() { # <session>
   ' 2>/dev/null)
   [ -n "$snapshot" ] || {
     fm_herdr_lab_error "fleet-state tripwire requires exactly one running default session"
-    return 1
+    return 3
   }
   printf '%s\n' "$snapshot"
 }
@@ -96,8 +103,12 @@ fm_herdr_lab_gate_reason() { # <cause>
   printf '%s: %s\n' "$FM_HERDR_LAB_GATE_TOKEN" "$1"
 }
 
+fm_herdr_lab_gate_token() {
+  printf '%s\n' "$FM_HERDR_LAB_GATE_TOKEN"
+}
+
 fm_herdr_lab_gate() { # [<session>]
-  local name=${1:-fm-lab-gate-probe}
+  local name=${1:-fm-lab-gate-probe} state=0
   fm_herdr_lab_validate_name "$name" 2>/dev/null || {
     fm_herdr_lab_gate_reason "invalid lab session name '$name'"
     return 1
@@ -110,15 +121,16 @@ fm_herdr_lab_gate() { # [<session>]
     fm_herdr_lab_gate_reason "jq not found (required by the Herdr lab helper)"
     return 1
   }
-  fm_herdr_lab_session_list "$name" >/dev/null 2>&1 || {
-    fm_herdr_lab_gate_reason "cannot list Herdr sessions"
-    return 1
-  }
-  fm_herdr_lab_fleet_state "$name" >/dev/null 2>&1 || {
-    fm_herdr_lab_gate_reason \
-      "no running default Herdr session for the lab fleet-state tripwire"
-    return 1
-  }
+  fm_herdr_lab_fleet_state "$name" >/dev/null 2>&1 || state=$?
+  case "$state" in
+    0) return 0 ;;
+    2) fm_herdr_lab_gate_reason "cannot list Herdr sessions" ;;
+    *)
+      fm_herdr_lab_gate_reason \
+        "no running default Herdr session for the lab fleet-state tripwire"
+      ;;
+  esac
+  return 1
 }
 
 fm_herdr_lab_prepare() { # <session>
@@ -342,7 +354,7 @@ fm_herdr_lab_name() { # <label>
 }
 
 fm_herdr_lab_usage() {
-  sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 fm_herdr_lab_main() {
@@ -355,6 +367,10 @@ fm_herdr_lab_main() {
     gate)
       [ "$#" -le 2 ] || { fm_herdr_lab_usage >&2; return 2; }
       fm_herdr_lab_gate "${2:-}"
+      ;;
+    gate-token)
+      [ "$#" -eq 1 ] || { fm_herdr_lab_usage >&2; return 2; }
+      fm_herdr_lab_gate_token
       ;;
     prepare)
       [ "$#" -eq 2 ] || { fm_herdr_lab_usage >&2; return 2; }

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -4,6 +4,7 @@
 #
 # Usage:
 #   fm-herdr-lab.sh name <label>
+#   fm-herdr-lab.sh gate [<session>]
 #   fm-herdr-lab.sh prepare <session>
 #   fm-herdr-lab.sh provision <session>
 #   fm-herdr-lab.sh run <session> <herdr arguments...>
@@ -11,6 +12,12 @@
 #   fm-herdr-lab.sh teardown <session>
 #
 # Session names must begin with "fm-lab-" and can never be "default".
+# The gate command answers whether this environment can host an isolated lab
+# session at all: it prints nothing and exits 0 when a lab can be provisioned,
+# or prints exactly one "herdr lab unavailable: <cause>" line to stdout and
+# exits 1 when it cannot.
+# It exists so callers gate on the precondition they actually need instead of
+# on "herdr" being on PATH, which proves nothing about session state.
 # The name command sanitizes the label, caps it at 16 characters, and appends
 # process/random suffixes to keep generated socket paths short.
 # Every Herdr call made here carries a trailing --session <session>.
@@ -76,6 +83,42 @@ fm_herdr_lab_fleet_state() { # <session>
     return 1
   }
   printf '%s\n' "$snapshot"
+}
+
+# Single owner of the "can a lab session be provisioned here?" question.
+# Every reason line begins with FM_HERDR_LAB_GATE_TOKEN so one gate-skip token
+# covers every cause (bin/fm-test-run.sh --fail-on-gate-skip, the required CI
+# Herdr lane). The verdict is derived from the same fleet-state check provision
+# performs, so the gate and provision can never disagree.
+FM_HERDR_LAB_GATE_TOKEN='herdr lab unavailable'
+
+fm_herdr_lab_gate_reason() { # <cause>
+  printf '%s: %s\n' "$FM_HERDR_LAB_GATE_TOKEN" "$1"
+}
+
+fm_herdr_lab_gate() { # [<session>]
+  local name=${1:-fm-lab-gate-probe}
+  fm_herdr_lab_validate_name "$name" 2>/dev/null || {
+    fm_herdr_lab_gate_reason "invalid lab session name '$name'"
+    return 1
+  }
+  command -v herdr >/dev/null 2>&1 || {
+    fm_herdr_lab_gate_reason "herdr not found"
+    return 1
+  }
+  command -v jq >/dev/null 2>&1 || {
+    fm_herdr_lab_gate_reason "jq not found (required by the Herdr lab helper)"
+    return 1
+  }
+  fm_herdr_lab_session_list "$name" >/dev/null 2>&1 || {
+    fm_herdr_lab_gate_reason "cannot list Herdr sessions"
+    return 1
+  }
+  fm_herdr_lab_fleet_state "$name" >/dev/null 2>&1 || {
+    fm_herdr_lab_gate_reason \
+      "no running default Herdr session for the lab fleet-state tripwire"
+    return 1
+  }
 }
 
 fm_herdr_lab_prepare() { # <session>
@@ -299,7 +342,7 @@ fm_herdr_lab_name() { # <label>
 }
 
 fm_herdr_lab_usage() {
-  sed -n '2,13p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 fm_herdr_lab_main() {
@@ -308,6 +351,10 @@ fm_herdr_lab_main() {
     name)
       [ "$#" -eq 2 ] || { fm_herdr_lab_usage >&2; return 2; }
       fm_herdr_lab_name "$2"
+      ;;
+    gate)
+      [ "$#" -le 2 ] || { fm_herdr_lab_usage >&2; return 2; }
+      fm_herdr_lab_gate "${2:-}"
       ;;
     prepare)
       [ "$#" -eq 2 ] || { fm_herdr_lab_usage >&2; return 2; }

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -33,9 +33,12 @@
 #                   dedicated required Herdr lane owns that coverage)
 #   --fail-on-gate-skip <token>
 #                   after each script, fail the run if any output line contains
-#                   "skip: <token>" (e.g. --fail-on-gate-skip 'herdr not found').
-#                   The required Herdr CI lane uses this so a missing pin cannot
-#                   silently pass as a gate skip.
+#                   "skip: <token>" (e.g. --fail-on-gate-skip 'herdr lab
+#                   unavailable'). Repeatable; any listed token fails the run.
+#                   The required Herdr CI lane lists every token that means a
+#                   real-Herdr precondition went unmet, so neither a missing pin
+#                   nor a lab it could not provision can silently pass as a gate
+#                   skip.
 #   --jobs N        run the selected scripts with up to N concurrent workers.
 #                   Default is 1 (serial). N>1 is allowed only when every
 #                   selected script is in the proven-isolated set
@@ -79,7 +82,7 @@ BASE_REF=origin/main
 JSON_PATH=
 SCRIPTS=()
 EXCLUDE_FAMILIES=()
-FAIL_ON_GATE_SKIP=
+FAIL_ON_GATE_SKIP_TOKENS=()
 JOBS=1
 JOBS_MAX=8
 
@@ -986,12 +989,12 @@ while [ "$#" -gt 0 ]; do
       shift
       ;;
     --fail-on-gate-skip)
-      [ "$#" -gt 1 ] || die "--fail-on-gate-skip requires a token (e.g. 'herdr not found')"
-      FAIL_ON_GATE_SKIP=$2
+      [ "$#" -gt 1 ] || die "--fail-on-gate-skip requires a token (e.g. 'herdr lab unavailable')"
+      FAIL_ON_GATE_SKIP_TOKENS+=("$2")
       shift 2
       ;;
     --fail-on-gate-skip=*)
-      FAIL_ON_GATE_SKIP=${1#--fail-on-gate-skip=}
+      FAIL_ON_GATE_SKIP_TOKENS+=("${1#--fail-on-gate-skip=}")
       shift
       ;;
     -h|--help)
@@ -1092,8 +1095,8 @@ apply_exclude_families
 if [ "${#EXCLUDE_FAMILIES[@]}" -gt 0 ]; then
   SELECTION_DESC="${SELECTION_DESC};exclude-family=$(IFS=,; printf '%s' "${EXCLUDE_FAMILIES[*]}")"
 fi
-if [ -n "$FAIL_ON_GATE_SKIP" ]; then
-  SELECTION_DESC="${SELECTION_DESC};fail-on-gate-skip=$FAIL_ON_GATE_SKIP"
+if [ "${#FAIL_ON_GATE_SKIP_TOKENS[@]}" -gt 0 ]; then
+  SELECTION_DESC="${SELECTION_DESC};fail-on-gate-skip=$(IFS=,; printf '%s' "${FAIL_ON_GATE_SKIP_TOKENS[*]}")"
 fi
 if [ "$JOBS" -gt 1 ]; then
   SELECTION_DESC="${SELECTION_DESC};jobs=$JOBS"
@@ -1189,10 +1192,13 @@ record_script_result() {
   family=$(family_for_basename "$base")
   expected=$(expected_gate_skip_for_family "$family")
 
-  if [ -n "$FAIL_ON_GATE_SKIP" ] && detect_gate_skip_token "$out" "$FAIL_ON_GATE_SKIP"; then
-    log "required gate skip token seen in $script: skip: $FAIL_ON_GATE_SKIP"
-    rc=1
-  fi
+  local required
+  for required in "${FAIL_ON_GATE_SKIP_TOKENS[@]+"${FAIL_ON_GATE_SKIP_TOKENS[@]}"}"; do
+    if detect_gate_skip_token "$out" "$required"; then
+      log "required gate skip token seen in $script: skip: $required"
+      rc=1
+    fi
+  done
 
   gate_skip=false
   if [ "$rc" -eq 0 ] && detect_gate_skip "$out"; then

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -35,10 +35,13 @@
 #                   after each script, fail the run if any output line contains
 #                   "skip: <token>" (e.g. --fail-on-gate-skip 'herdr lab
 #                   unavailable'). Repeatable; any listed token fails the run.
+#                   The token must be non-empty: an empty one matches nothing and
+#                   would silently disable the guard the caller asked for.
 #                   The required Herdr CI lane lists every token that means a
 #                   real-Herdr precondition went unmet, so neither a missing pin
 #                   nor a lab it could not provision can silently pass as a gate
-#                   skip.
+#                   skip. It derives the lab token from the gate's own owner
+#                   (bin/fm-herdr-lab.sh gate-token) so the two cannot drift.
 #   --jobs N        run the selected scripts with up to N concurrent workers.
 #                   Default is 1 (serial). N>1 is allowed only when every
 #                   selected script is in the proven-isolated set
@@ -795,6 +798,13 @@ detect_gate_skip_token() {
   grep -F -q "skip: $token" "$file" 2>/dev/null
 }
 
+# An empty token matches nothing, so accepting one would silently disable the
+# guard the caller asked for. Callers derive tokens from other commands (the CI
+# Herdr lane uses bin/fm-herdr-lab.sh gate-token), so refuse it here instead.
+require_gate_skip_token() {
+  [ -n "$1" ] || die "--fail-on-gate-skip requires a non-empty token; an empty token would silently disable the guard"
+}
+
 apply_exclude_families() {
   local s fam keep ex
   local -a kept=()
@@ -990,10 +1000,12 @@ while [ "$#" -gt 0 ]; do
       ;;
     --fail-on-gate-skip)
       [ "$#" -gt 1 ] || die "--fail-on-gate-skip requires a token (e.g. 'herdr lab unavailable')"
+      require_gate_skip_token "$2"
       FAIL_ON_GATE_SKIP_TOKENS+=("$2")
       shift 2
       ;;
     --fail-on-gate-skip=*)
+      require_gate_skip_token "${1#--fail-on-gate-skip=}"
       FAIL_ON_GATE_SKIP_TOKENS+=("${1#--fail-on-gate-skip=}")
       shift
       ;;

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -252,6 +252,10 @@ It provisions only non-default names beginning with `fm-lab-`, appends an explic
 Immediately before every destructive call it re-queries the named session and refuses empty, missing, literal `default`, or `default:true` identities.
 Its before/after tripwire requires the live default-session snapshot to remain byte-identical.
 
+Because that tripwire needs a running default session, a machine with Herdr installed but no default session running cannot host a lab at all.
+The helper's `gate` command is the single owner of that verdict, so real-Herdr tests skip with the reason instead of failing on a precondition they cannot create.
+The required CI Herdr lane starts a default session and fails on those skip reasons, so the same gate can never turn the lane green by skipping the work.
+
 The helper's header and `--help` own exact commands.
 Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never duplicate the destructive policy.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -255,6 +255,7 @@ Its before/after tripwire requires the live default-session snapshot to remain b
 Because that tripwire needs a running default session, a machine with Herdr installed but no default session running cannot host a lab at all.
 The helper's `gate` command is the single owner of that verdict, so real-Herdr tests skip with the reason instead of failing on a precondition they cannot create.
 The required CI Herdr lane starts a default session and fails on those skip reasons, so the same gate can never turn the lane green by skipping the work.
+That lane reads the skip token from `bin/fm-herdr-lab.sh gate-token` rather than repeating a copy of it, so renaming the token can never leave the lane guarding a string the gate no longer prints.
 
 The helper's header and `--help` own exact commands.
 Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never duplicate the destructive policy.

--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -35,11 +35,13 @@ set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DAEMON="$ROOT/bin/fm-supervise-daemon.sh"
 
-command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
-command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
-
 # shellcheck source=tests/herdr-test-safety.sh
 . "$ROOT/tests/herdr-test-safety.sh"
+
+# Gate on the precondition this test actually needs - an isolated lab session it
+# can provision - instead of on "herdr" being on PATH, which proves nothing about
+# session state (bin/fm-herdr-lab.sh owns the verdict and the reason text).
+herdr_lab_gate_or_skip 'herdr away-mode injection e2e' || exit 0
 
 fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -815,10 +815,12 @@ unit_flag_write_failure_aborts() {
 # E2E herdr: topology invariant.
 # ---------------------------------------------------------------------------
 e2e_herdr() {
-  command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found (herdr e2e)"; return 0; }
-  command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (herdr e2e)"; return 0; }
   # shellcheck source=tests/herdr-test-safety.sh
   . "$ROOT/tests/herdr-test-safety.sh"
+  # Gate on the precondition this case actually needs - an isolated lab session it
+  # can provision - instead of on "herdr" being on PATH, which proves nothing about
+  # session state (bin/fm-herdr-lab.sh owns the verdict and the reason text).
+  herdr_lab_gate_or_skip 'herdr e2e' || return 0
   # shellcheck source=/dev/null
   . "$ROOT/bin/fm-backend.sh"
 

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -37,9 +37,15 @@ assert_contains_local() {  # <haystack> <needle> <msg>
   esac
 }
 
-command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
-command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (required by fm-spawn.sh)"; exit 0; }
+# Gate on the precondition this test actually needs - an isolated lab session it
+# can provision - instead of on "herdr" being on PATH, which proves nothing about
+# session state (bin/fm-herdr-lab.sh owns the verdict and the reason text).
+HERDR_LAB_HELPER="$ROOT/bin/fm-herdr-lab.sh"
+if ! HERDR_LAB_GATE_REASON=$("$HERDR_LAB_HELPER" gate); then
+  echo "skip: $HERDR_LAB_GATE_REASON"
+  exit 0
+fi
 
 export FM_GATE_REFUSE_BYPASS=1
 
@@ -51,7 +57,6 @@ export FM_GATE_REFUSE_BYPASS=1
 # The dedicated regression is
 # tests/fm-backend.test.sh:test_spawn_symlinked_project_prefix_avoids_false_refusal.
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-backend-autodetect-smoke.XXXXXX")
-HERDR_LAB_HELPER="$ROOT/bin/fm-herdr-lab.sh"
 HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name fm-autodetect-smoke-concurrency-h3) || {
   rm -rf "$TMP_ROOT"
   fail "could not generate an isolated Herdr lab session name"

--- a/tests/fm-backend-herdr-eventwait-smoke.test.sh
+++ b/tests/fm-backend-herdr-eventwait-smoke.test.sh
@@ -18,12 +18,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
 
-command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
-command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
-command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found (required by the event subscriber)"; exit 0; }
-
 # shellcheck source=tests/herdr-test-safety.sh
 . "$ROOT/tests/herdr-test-safety.sh"
+
+command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found (required by the event subscriber)"; exit 0; }
+
+# Gate on the precondition this test actually needs - an isolated lab session it
+# can provision - instead of on "herdr" being on PATH, which proves nothing about
+# session state (bin/fm-herdr-lab.sh owns the verdict and the reason text).
+herdr_lab_gate_or_skip 'herdr event-wait smoke' || exit 0
 
 SESSION="fm-lab-eventwait-smoke-$$"
 export HERDR_SESSION="$SESSION"

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -12,10 +12,15 @@ HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
 
-command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
-command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
 command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found"; exit 0; }
 [ -x "$HERDR_LAB_HELPER" ] || { echo "skip: Herdr lab helper not executable at $HERDR_LAB_HELPER"; exit 0; }
+# Gate on the precondition this test actually needs - an isolated lab session it
+# can provision - instead of on "herdr" being on PATH, which proves nothing about
+# session state (bin/fm-herdr-lab.sh owns the verdict and the reason text).
+if ! HERDR_LAB_GATE_REASON=$("$HERDR_LAB_HELPER" gate); then
+  echo "skip: $HERDR_LAB_GATE_REASON"
+  exit 0
+fi
 
 REAL_HERDR=$(command -v herdr)
 REAL_TREEHOUSE=$(command -v treehouse)

--- a/tests/fm-backend-herdr-prune-safety-e2e.test.sh
+++ b/tests/fm-backend-herdr-prune-safety-e2e.test.sh
@@ -27,11 +27,13 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
 
-command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
-command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
-
 # shellcheck source=tests/herdr-test-safety.sh
 . "$ROOT/tests/herdr-test-safety.sh"
+
+# Gate on the precondition this test actually needs - an isolated lab session it
+# can provision - instead of on "herdr" being on PATH, which proves nothing about
+# session state (bin/fm-herdr-lab.sh owns the verdict and the reason text).
+herdr_lab_gate_or_skip 'herdr prune-safety e2e' || exit 0
 
 SESSION="fm-lab-prune-safety-e2e-$$"
 export HERDR_SESSION="$SESSION"

--- a/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
+++ b/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
@@ -39,11 +39,13 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
 
-command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
-command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
-
 # shellcheck source=tests/herdr-test-safety.sh
 . "$ROOT/tests/herdr-test-safety.sh"
+
+# Gate on the precondition this test actually needs - an isolated lab session it
+# can provision - instead of on "herdr" being on PATH, which proves nothing about
+# session state (bin/fm-herdr-lab.sh owns the verdict and the reason text).
+herdr_lab_gate_or_skip 'herdr respawn-idempotence e2e' || exit 0
 
 SESSION="fm-lab-respawn-idem-e2e-$$"
 export HERDR_SESSION="$SESSION"

--- a/tests/fm-backend-herdr-smoke.test.sh
+++ b/tests/fm-backend-herdr-smoke.test.sh
@@ -21,11 +21,13 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
 
-command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
-command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
-
 # shellcheck source=tests/herdr-test-safety.sh
 . "$ROOT/tests/herdr-test-safety.sh"
+
+# Gate on the precondition this test actually needs - an isolated lab session it
+# can provision - instead of on "herdr" being on PATH, which proves nothing about
+# session state (bin/fm-herdr-lab.sh owns the verdict and the reason text).
+herdr_lab_gate_or_skip 'herdr backend smoke' || exit 0
 
 SESSION="fm-lab-backend-smoke-$$"
 export HERDR_SESSION="$SESSION"

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -47,12 +47,15 @@ assert_not_contains_local() {  # <haystack> <needle> <msg>
   esac
 }
 
-command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
-command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
-command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (required by fm-spawn.sh)"; exit 0; }
-
 # shellcheck source=tests/herdr-test-safety.sh
 . "$ROOT/tests/herdr-test-safety.sh"
+
+command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (required by fm-spawn.sh)"; exit 0; }
+
+# Gate on the precondition this test actually needs - an isolated lab session it
+# can provision - instead of on "herdr" being on PATH, which proves nothing about
+# session state (bin/fm-herdr-lab.sh owns the verdict and the reason text).
+herdr_lab_gate_or_skip 'herdr workspace-per-home e2e' || exit 0
 
 # TMP_ROOT is physically resolved (mktemp -d "$(pwd -P)"-relative) for the same
 # low-noise scratch fixture shape used by

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -163,11 +163,10 @@ test_gate_tracks_actual_lab_availability() {
   expect_code 1 "$status" "gate must refuse an unsafe probe session name"
   assert_contains "$reason" "invalid lab session name" "unsafe probe name produced the wrong reason"
 
-  # The token is the contract the required CI Herdr lane keys on, so renaming it
-  # here without updating that lane must not pass quietly.
+  # Every reason shares the one token the required CI Herdr lane keys on, so a
+  # renamed cause can never escape that lane's over-skip guard. The runner-side
+  # enforcement of the token is proven behaviorally in tests/fm-test-run.test.sh.
   [ -n "$FM_HERDR_LAB_GATE_TOKEN" ] || fail "the gate token must be a named constant"
-  grep -Fq -- "--fail-on-gate-skip '$FM_HERDR_LAB_GATE_TOKEN'" "$ROOT/.github/workflows/ci.yml" \
-    || fail "the required Herdr CI lane does not fail on '$FM_HERDR_LAB_GATE_TOKEN' skips"
 
   pass "fm-herdr-lab: the gate mirrors real lab availability in both directions"
 }

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -31,15 +31,26 @@ default_socket=$(cat "$state/default-socket")
 lab_state=absent
 [ ! -f "$state/$session" ] || lab_state=$(cat "$state/$session")
 
+# The default session's own state is a fixture knob so the lab gate can be
+# proven in both directions: FM_FAKE_HERDR_DEFAULT_RUNNING=false is the ordinary
+# machine where herdr is installed and no default session runs,
+# FM_FAKE_HERDR_DEFAULT_ABSENT=1 has no default entry at all, and
+# FM_FAKE_HERDR_LIST_FAIL=1 cannot be read.
+default_running=${FM_FAKE_HERDR_DEFAULT_RUNNING:-true}
 case "$1 ${2:-}" in
   "session list")
-    if [ "$lab_state" = absent ] || [ "$lab_state" = deleted ]; then
-      jq -nc --arg socket "$default_socket" '{sessions:[{default:true,name:"default",running:true,socket_path:$socket}]}'
+    [ "${FM_FAKE_HERDR_LIST_FAIL:-}" != 1 ] || { echo "fake herdr: session list failed" >&2; exit 94; }
+    if [ "${FM_FAKE_HERDR_DEFAULT_ABSENT:-}" = 1 ]; then
+      printf '%s\n' '{"sessions":[]}'
+    elif [ "$lab_state" = absent ] || [ "$lab_state" = deleted ]; then
+      jq -nc --arg socket "$default_socket" --argjson default_running "$default_running" \
+        '{sessions:[{default:true,name:"default",running:$default_running,socket_path:$socket}]}'
     else
       running=false
       [ "$lab_state" = running ] && running=true
       jq -nc --arg socket "$default_socket" --arg name "$session" --argjson running "$running" \
-        '{sessions:[{default:true,name:"default",running:true,socket_path:$socket},{default:false,name:$name,running:$running,socket_path:("/tmp/" + $name + ".sock")}]}'
+        --argjson default_running "$default_running" \
+        '{sessions:[{default:true,name:"default",running:$default_running,socket_path:$socket},{default:false,name:$name,running:$running,socket_path:("/tmp/" + $name + ".sock")}]}'
     fi
     ;;
   "server --session")
@@ -82,8 +93,83 @@ run_with_fake() {
     FM_FAKE_HERDR_SERVER_DELAY="${FM_FAKE_HERDR_SERVER_DELAY:-0}" \
     FM_FAKE_HERDR_FAST_POLL="${FM_FAKE_HERDR_FAST_POLL:-}" \
     FM_FAKE_HERDR_DELETE_FAIL="${FM_FAKE_HERDR_DELETE_FAIL:-}" \
+    FM_FAKE_HERDR_DEFAULT_RUNNING="${FM_FAKE_HERDR_DEFAULT_RUNNING:-true}" \
+    FM_FAKE_HERDR_DEFAULT_ABSENT="${FM_FAKE_HERDR_DEFAULT_ABSENT:-}" \
+    FM_FAKE_HERDR_LIST_FAIL="${FM_FAKE_HERDR_LIST_FAIL:-}" \
     FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
     "$@"
+}
+
+# The gate exists because "command -v herdr" proves a binary is on PATH and
+# proves nothing about session state, so every real-Herdr test hard-failed on an
+# ordinary machine with herdr installed and no default session running. Both
+# directions matter: a gate that always skipped would hide the same regressions
+# a red suite does, so these cases prove the gate LETS WORK THROUGH whenever a
+# lab is actually provisionable, and that its verdict always agrees with what
+# provisioning would really do.
+test_gate_tracks_actual_lab_availability() {
+  local status=0 reason nobin jqless name
+
+  # Direction 1: a running default session - gate passes silently AND provision
+  # really succeeds, so nothing skips when the precondition is met.
+  reason=$(run_with_fake fm_herdr_lab_gate) || status=$?
+  expect_code 0 "$status" "gate must pass when a running default session exists"
+  [ -z "$reason" ] || fail "a passing gate must print nothing, got: $reason"
+  name="fm-lab-gate-agrees-$$"
+  run_with_fake fm_herdr_lab_provision "$name" \
+    || fail "gate passed but provision failed; the gate and the tripwire disagree"
+  run_with_fake fm_herdr_lab_teardown "$name" || fail "teardown after the agreeing provision failed"
+
+  # Direction 2: the ordinary machine - herdr installed, default session stopped.
+  status=0
+  reason=$(FM_FAKE_HERDR_DEFAULT_RUNNING=false run_with_fake fm_herdr_lab_gate) || status=$?
+  expect_code 1 "$status" "gate must refuse when the default session is stopped"
+  assert_contains "$reason" "herdr lab unavailable" "gate reason lost its stable skip token"
+  assert_contains "$reason" "no running default Herdr session" "gate reason did not name the missing precondition"
+  [ "$(printf '%s\n' "$reason" | wc -l | tr -d ' ')" = 1 ] || fail "gate must print exactly one reason line, got: $reason"
+  status=0
+  name="fm-lab-gate-agrees-stopped-$$"
+  FM_FAKE_HERDR_DEFAULT_RUNNING=false run_with_fake fm_herdr_lab_provision "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "gate refused but provision succeeded; the gate and the tripwire disagree"
+  assert_absent "$TRIPWIRES/$name.fleet-state.json" "refused provision must leave no tripwire behind"
+
+  # Remaining causes each get their own reason, all under the same token.
+  status=0
+  reason=$(FM_FAKE_HERDR_DEFAULT_ABSENT=1 run_with_fake fm_herdr_lab_gate) || status=$?
+  expect_code 1 "$status" "gate must refuse when no default session exists at all"
+  assert_contains "$reason" "no running default Herdr session" "absent default produced the wrong reason"
+  status=0
+  reason=$(FM_FAKE_HERDR_LIST_FAIL=1 run_with_fake fm_herdr_lab_gate) || status=$?
+  expect_code 1 "$status" "gate must refuse when the session list cannot be read"
+  assert_contains "$reason" "cannot list Herdr sessions" "unreadable fleet produced the wrong reason"
+
+  nobin="$TMP_ROOT/gate-nobin"
+  mkdir -p "$nobin"
+  status=0
+  reason=$(PATH="$nobin" FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" fm_herdr_lab_gate) || status=$?
+  expect_code 1 "$status" "gate must refuse when herdr is not installed"
+  assert_contains "$reason" "herdr not found" "missing herdr produced the wrong reason"
+
+  jqless="$TMP_ROOT/gate-jqless"
+  mkdir -p "$jqless"
+  ln -sf "$FAKEBIN/herdr" "$jqless/herdr"
+  status=0
+  reason=$(PATH="$jqless" FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" fm_herdr_lab_gate) || status=$?
+  expect_code 1 "$status" "gate must refuse when jq is missing"
+  assert_contains "$reason" "jq not found" "missing jq produced the wrong reason"
+
+  status=0
+  reason=$(run_with_fake fm_herdr_lab_gate default) || status=$?
+  expect_code 1 "$status" "gate must refuse an unsafe probe session name"
+  assert_contains "$reason" "invalid lab session name" "unsafe probe name produced the wrong reason"
+
+  # The token is the contract the required CI Herdr lane keys on, so renaming it
+  # here without updating that lane must not pass quietly.
+  [ -n "$FM_HERDR_LAB_GATE_TOKEN" ] || fail "the gate token must be a named constant"
+  grep -Fq -- "--fail-on-gate-skip '$FM_HERDR_LAB_GATE_TOKEN'" "$ROOT/.github/workflows/ci.yml" \
+    || fail "the required Herdr CI lane does not fail on '$FM_HERDR_LAB_GATE_TOKEN' skips"
+
+  pass "fm-herdr-lab: the gate mirrors real lab availability in both directions"
 }
 
 test_refuses_unsafe_names() {
@@ -235,6 +321,7 @@ SH
 }
 
 test_refuses_unsafe_names
+test_gate_tracks_actual_lab_availability
 test_provision_run_and_guarded_teardown
 test_missing_tripwire_blocks_destruction
 test_changed_default_trips_after_teardown

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -108,13 +108,18 @@ run_with_fake() {
 # lab is actually provisionable, and that its verdict always agrees with what
 # provisioning would really do.
 test_gate_tracks_actual_lab_availability() {
-  local status=0 reason nobin jqless name
+  local status=0 reason nobin jqless name token
 
   # Direction 1: a running default session - gate passes silently AND provision
   # really succeeds, so nothing skips when the precondition is met.
+  : > "$FAKE_LOG"
   reason=$(run_with_fake fm_herdr_lab_gate) || status=$?
   expect_code 0 "$status" "gate must pass when a running default session exists"
   [ -z "$reason" ] || fail "a passing gate must print nothing, got: $reason"
+  # One Herdr call per verdict: a second probe could disagree with the first and
+  # report the wrong cause when the fleet changes between them.
+  [ "$(wc -l < "$FAKE_LOG" | tr -d ' ')" = 1 ] \
+    || fail "gate must reach Herdr exactly once: $(cat "$FAKE_LOG")"
   name="fm-lab-gate-agrees-$$"
   run_with_fake fm_herdr_lab_provision "$name" \
     || fail "gate passed but provision failed; the gate and the tripwire disagree"
@@ -122,8 +127,11 @@ test_gate_tracks_actual_lab_availability() {
 
   # Direction 2: the ordinary machine - herdr installed, default session stopped.
   status=0
+  : > "$FAKE_LOG"
   reason=$(FM_FAKE_HERDR_DEFAULT_RUNNING=false run_with_fake fm_herdr_lab_gate) || status=$?
   expect_code 1 "$status" "gate must refuse when the default session is stopped"
+  [ "$(wc -l < "$FAKE_LOG" | tr -d ' ')" = 1 ] \
+    || fail "a refusing gate must also reach Herdr exactly once: $(cat "$FAKE_LOG")"
   assert_contains "$reason" "herdr lab unavailable" "gate reason lost its stable skip token"
   assert_contains "$reason" "no running default Herdr session" "gate reason did not name the missing precondition"
   [ "$(printf '%s\n' "$reason" | wc -l | tr -d ' ')" = 1 ] || fail "gate must print exactly one reason line, got: $reason"
@@ -163,10 +171,21 @@ test_gate_tracks_actual_lab_availability() {
   expect_code 1 "$status" "gate must refuse an unsafe probe session name"
   assert_contains "$reason" "invalid lab session name" "unsafe probe name produced the wrong reason"
 
-  # Every reason shares the one token the required CI Herdr lane keys on, so a
-  # renamed cause can never escape that lane's over-skip guard. The runner-side
-  # enforcement of the token is proven behaviorally in tests/fm-test-run.test.sh.
-  [ -n "$FM_HERDR_LAB_GATE_TOKEN" ] || fail "the gate token must be a named constant"
+  # Every reason shares the one token the required CI Herdr lane keys on, and the
+  # lane asks this helper for that token instead of hardcoding a copy, so a
+  # rename cannot silently decouple the two. Both sides come from the executable
+  # here: gate-token must be exactly the prefix of a real refusal's reason line.
+  # The runner-side enforcement of that token is proven behaviorally in
+  # tests/fm-test-run.test.sh.
+  token=$("$ROOT/bin/fm-herdr-lab.sh" gate-token) || fail "gate-token must succeed"
+  [ -n "$token" ] || fail "gate-token must print a non-empty token"
+  status=0
+  reason=$("$ROOT/bin/fm-herdr-lab.sh" gate default) || status=$?
+  expect_code 1 "$status" "the refusing gate subprocess must exit 1"
+  case "$reason" in
+    "$token: "?*) : ;;
+    *) fail "gate-token '$token' is not the prefix of the real gate reason: $reason" ;;
+  esac
 
   pass "fm-herdr-lab: the gate mirrors real lab availability in both directions"
 }

--- a/tests/fm-herdr-session-cleanup-e2e.test.sh
+++ b/tests/fm-herdr-session-cleanup-e2e.test.sh
@@ -10,10 +10,15 @@ HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
 
-command -v herdr >/dev/null 2>&1 || { echo 'skip: herdr not found'; exit 0; }
-command -v jq >/dev/null 2>&1 || { echo 'skip: jq not found'; exit 0; }
 command -v python3 >/dev/null 2>&1 || { echo 'skip: python3 not found'; exit 0; }
 [ -x "$HERDR_LAB_HELPER" ] || { echo "skip: Herdr lab helper not executable at $HERDR_LAB_HELPER"; exit 0; }
+# Gate on the precondition this test actually needs - an isolated lab session it
+# can provision - instead of on "herdr" being on PATH, which proves nothing about
+# session state (bin/fm-herdr-lab.sh owns the verdict and the reason text).
+if ! HERDR_LAB_GATE_REASON=$("$HERDR_LAB_HELPER" gate); then
+  echo "skip: $HERDR_LAB_GATE_REASON"
+  exit 0
+fi
 
 REAL_HERDR=$(command -v herdr)
 HERDR_ORIGINAL_PATH=$PATH

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -159,28 +159,37 @@ esac
 SH
   chmod +x "$fakebin/ps"
 
-  got=$(PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true "$ROOT/bin/fm-harness.sh")
+  # The fake ps above stubs the ancestry layer, but bin/fm-harness.sh consults its
+  # env markers FIRST, so the harness running this suite would otherwise decide the
+  # result: under claude CLAUDECODE=1 wins before the Pi branch is reached, and an
+  # ambient PI_CODING_AGENT would satisfy the "no Pi family marker" case for the
+  # wrong reason. Drop every marker on each call and set only the ones the case is
+  # about, so what is asserted is the resolver's contract and not the host harness.
+  # Same idiom as tests/fm-session-start.test.sh's run_session_start.
+  local -a nomarkers=(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT)
+
+  got=$("${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi ] || fail "unmarked shared signed-wrapper ancestry resolved '$got', expected pi"
-  got=$(PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed "$ROOT/bin/fm-harness.sh")
+  got=$("${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi-signed ] || fail "selected signed wrapper resolved '$got', expected pi-signed"
-  got=$(PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_PI_HARNESS=pi "$ROOT/bin/fm-harness.sh")
+  got=$("${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_PI_HARNESS=pi "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi ] || fail "selected plain Pi resolved '$got', expected pi"
-  got=$(PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed-helper "$ROOT/bin/fm-harness.sh")
+  got=$("${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed-helper "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi ] || fail "inexact signed selection marker resolved '$got', expected pi"
-  got=$(PATH="$fakebin:$BASE_PATH" FM_PI_HARNESS=pi-signed "$ROOT/bin/fm-harness.sh")
+  got=$("${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" FM_PI_HARNESS=pi-signed "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi ] || fail "signed selection marker without Pi's family marker resolved '$got', expected pi"
-  got=$(PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_TEST_SIGNED_SHAPE=plain "$ROOT/bin/fm-harness.sh")
+  got=$("${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_TEST_SIGNED_SHAPE=plain "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi ] || fail "plain Pi marker resolved '$got', expected pi"
-  got=$(PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_TEST_SIGNED_SHAPE=helper "$ROOT/bin/fm-harness.sh")
+  got=$("${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_TEST_SIGNED_SHAPE=helper "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi ] || fail "unrelated pi-signed-helper ancestry resolved '$got', expected pi"
 
-  got=$(PATH="$fakebin:$BASE_PATH" bash -c \
+  got=$("${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" bash -c \
     '. "$0/bin/fm-session-lock-lib.sh"; fm_harness_ancestry_pid' "$ROOT")
   [ "$got" = 100 ] || fail "session-lock ancestry selected '$got', expected the inner Pi engine pid 100"
-  PATH="$fakebin:$BASE_PATH" bash -c \
+  "${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" bash -c \
     '. "$0/bin/fm-session-lock-lib.sh"; kill() { return 0; }; fm_harness_pid_alive 200' "$ROOT" \
     || fail "session-lock liveness rejected exact pi-signed holder"
-  if PATH="$fakebin:$BASE_PATH" FM_TEST_SIGNED_SHAPE=helper bash -c \
+  if "${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" FM_TEST_SIGNED_SHAPE=helper bash -c \
     '. "$0/bin/fm-session-lock-lib.sh"; kill() { return 0; }; fm_harness_pid_alive 200' "$ROOT"; then
     fail "session-lock liveness accepted unrelated pi-signed-helper"
   fi

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -183,12 +183,16 @@ SH
   got=$("${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_TEST_SIGNED_SHAPE=helper "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi ] || fail "unrelated pi-signed-helper ancestry resolved '$got', expected pi"
 
+  # shellcheck disable=SC2016 # single quotes are deliberate: the bash -c body is a
+  # literal, and its $0 is the "$ROOT" operand passed after it
   got=$("${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" bash -c \
     '. "$0/bin/fm-session-lock-lib.sh"; fm_harness_ancestry_pid' "$ROOT")
   [ "$got" = 100 ] || fail "session-lock ancestry selected '$got', expected the inner Pi engine pid 100"
+  # shellcheck disable=SC2016 # as above: literal bash -c bodies, $0 is the operand
   "${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" bash -c \
     '. "$0/bin/fm-session-lock-lib.sh"; kill() { return 0; }; fm_harness_pid_alive 200' "$ROOT" \
     || fail "session-lock liveness rejected exact pi-signed holder"
+  # shellcheck disable=SC2016 # as above: literal bash -c bodies, $0 is the operand
   if "${nomarkers[@]}" PATH="$fakebin:$BASE_PATH" FM_TEST_SIGNED_SHAPE=helper bash -c \
     '. "$0/bin/fm-session-lock-lib.sh"; kill() { return 0; }; fm_harness_pid_alive 200' "$ROOT"; then
     fail "session-lock liveness accepted unrelated pi-signed-helper"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -410,14 +410,22 @@ SH
 # codex and opencode have no env markers (ancestry only). Without this, a local
 # claude/pi/grok session fails cases that pin a different fake harness while CI
 # (no ambient markers) still passes.
+# HERDR_SESSION is dropped for the same reason one layer down: it is the runtime
+# backend's ambient session selection (bin/backends/herdr.sh
+# fm_backend_herdr_session, deliberately mirroring tmux's $TMUX), so a firstmate
+# running inside a NAMED herdr session would otherwise make every fake-herdr
+# fixture resolve that operator session instead of the "default" its recorded
+# metadata and assertions pin.
 run_session_start() {
   local home=$1 root=$2 path=$3 pi_harness=${4:-}
   if [ -n "$pi_harness" ]; then
-    env -u CLAUDECODE -u GROK_AGENT PI_CODING_AGENT=true FM_PI_HARNESS="$pi_harness" \
+    env -u CLAUDECODE -u GROK_AGENT -u HERDR_SESSION \
+      PI_CODING_AGENT=true FM_PI_HARNESS="$pi_harness" \
       FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
       "$SESSION_START"
   else
     env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+      -u HERDR_SESSION \
       FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
       "$SESSION_START"
   fi

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -336,6 +336,48 @@ SH
   pass "fail-on-gate-skip converts herdr-not-found into a hard failure"
 }
 
+# The required Herdr CI lane must fail on EVERY skip that means an unmet Herdr
+# precondition, so a single token is not enough: an over-skipping gate would
+# otherwise turn that lane green without running a single real-Herdr body.
+test_fail_on_gate_skip_is_repeatable() {
+  local tmp skip_f out rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-fail-skip-multi.XXXXXX")
+  skip_f="$tmp/skip.test.sh"
+  out="$tmp/out.txt"
+  cat >"$skip_f" <<'SH'
+#!/usr/bin/env bash
+echo "skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire"
+exit 0
+SH
+  chmod +x "$skip_f"
+  set +e
+  "$RUNNER" --fail-on-gate-skip 'herdr not found' \
+    --fail-on-gate-skip 'herdr lab unavailable' "$skip_f" >"$out" 2>"$tmp/err.txt"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "a second --fail-on-gate-skip token must also be enforced"
+  grep -q 'FM_TEST_SUMMARY total=1 failed=1' "$out" \
+    || fail "summary must report failed=1 for the later token: $(grep FM_TEST_SUMMARY "$out")"
+  grep -Fq 'skip: herdr lab unavailable' "$tmp/err.txt" \
+    || fail "runner must log which required token was seen"
+  # A skip that matches none of the listed tokens stays a legitimate skip.
+  cat >"$skip_f" <<'SH'
+#!/usr/bin/env bash
+echo "skip: python3 not found"
+exit 0
+SH
+  set +e
+  "$RUNNER" --fail-on-gate-skip 'herdr not found' \
+    --fail-on-gate-skip 'herdr lab unavailable' "$skip_f" >"$out" 2>"$tmp/err.txt"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "an unlisted skip token must remain a passing gate skip"
+  grep -q 'FM_TEST_SUMMARY total=1 failed=0 skipped_gate=1' "$out" \
+    || fail "unlisted skip must still count as a gate skip: $(grep FM_TEST_SUMMARY "$out")"
+  rm -rf "$tmp"
+  pass "fail-on-gate-skip is repeatable and only the listed tokens fail"
+}
+
 test_exclude_family() {
   local listed
   listed=$("$RUNNER" --list --all --exclude-family real-herdr-gated)
@@ -577,6 +619,7 @@ test_timing_markers_and_json
 test_aggregate_exit_behavior
 test_gate_skip_accounting
 test_fail_on_gate_skip_token
+test_fail_on_gate_skip_is_repeatable
 test_exclude_family
 test_portable_shard_union_and_coverage_guard
 test_jobs_requires_proven_isolated

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -374,8 +374,25 @@ SH
   [ "$rc" -eq 0 ] || fail "an unlisted skip token must remain a passing gate skip"
   grep -q 'FM_TEST_SUMMARY total=1 failed=0 skipped_gate=1' "$out" \
     || fail "unlisted skip must still count as a gate skip: $(grep FM_TEST_SUMMARY "$out")"
+  # Bind the runner's enforcement to the reason the real gate really prints: run
+  # bin/fm-herdr-lab.sh gate where no lab can exist, feed its exact output to the
+  # runner as a skip line, and require the token to catch it. A renamed cause or
+  # token then fails here instead of silently going green in the Herdr CI lane.
+  # An unsafe probe name is the one refusal that is deterministic everywhere,
+  # including the CI Herdr lane where a default session really is running.
+  local real_reason
+  real_reason=$("$ROOT/bin/fm-herdr-lab.sh" gate default) \
+    && fail "the lab gate must refuse an unsafe probe session name"
+  [ -n "$real_reason" ] || fail "the lab gate printed no reason to enforce"
+  printf '#!/usr/bin/env bash\necho %s\nexit 0\n' "$(printf '%q' "skip: $real_reason")" >"$skip_f"
+  set +e
+  "$RUNNER" --fail-on-gate-skip "$(printf '%s' "$real_reason" | cut -d: -f1)" "$skip_f" \
+    >"$out" 2>"$tmp/err.txt"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "the real gate reason escaped the runner's required-token guard"
   rm -rf "$tmp"
-  pass "fail-on-gate-skip is repeatable and only the listed tokens fail"
+  pass "fail-on-gate-skip is repeatable and catches the real lab-gate reason"
 }
 
 test_exclude_family() {

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -380,17 +380,34 @@ SH
   # token then fails here instead of silently going green in the Herdr CI lane.
   # An unsafe probe name is the one refusal that is deterministic everywhere,
   # including the CI Herdr lane where a default session really is running.
-  local real_reason
+  # The token is taken from the gate's own gate-token interface, exactly as the
+  # CI lane takes it, so neither side can be renamed without the other.
+  local real_reason real_token
   real_reason=$("$ROOT/bin/fm-herdr-lab.sh" gate default) \
     && fail "the lab gate must refuse an unsafe probe session name"
   [ -n "$real_reason" ] || fail "the lab gate printed no reason to enforce"
+  real_token=$("$ROOT/bin/fm-herdr-lab.sh" gate-token) \
+    || fail "the lab gate must publish its skip token"
   printf '#!/usr/bin/env bash\necho %s\nexit 0\n' "$(printf '%q' "skip: $real_reason")" >"$skip_f"
   set +e
-  "$RUNNER" --fail-on-gate-skip "$(printf '%s' "$real_reason" | cut -d: -f1)" "$skip_f" \
-    >"$out" 2>"$tmp/err.txt"
+  "$RUNNER" --fail-on-gate-skip "$real_token" "$skip_f" >"$out" 2>"$tmp/err.txt"
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "the real gate reason escaped the runner's required-token guard"
+  # An empty token matches nothing, so accepting one would turn the CI lane's
+  # guard off without a word. It must be a loud argument error instead.
+  set +e
+  "$RUNNER" --fail-on-gate-skip '' "$skip_f" >"$out" 2>"$tmp/err.txt"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "an empty --fail-on-gate-skip token must not silently disable the guard"
+  grep -q 'non-empty token' "$tmp/err.txt" \
+    || fail "the runner must say why an empty gate-skip token is refused: $(cat "$tmp/err.txt")"
+  set +e
+  "$RUNNER" --fail-on-gate-skip= "$skip_f" >"$out" 2>"$tmp/err.txt"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "the equals form of an empty gate-skip token must be refused too"
   rm -rf "$tmp"
   pass "fail-on-gate-skip is repeatable and catches the real lab-gate reason"
 }

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -14,6 +14,20 @@ HERDR_TEST_SAFETY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=/dev/null
 . "$HERDR_TEST_SAFETY_DIR/bin/fm-herdr-lab.sh"
 
+# Print the suite's skip line and return 1 when this environment cannot host an
+# isolated lab session; print nothing and return 0 when it can. The verdict comes
+# from bin/fm-herdr-lab.sh's gate, so a test never gates on "herdr" being on PATH
+# (which proves nothing about session state) and never hard-fails on a
+# precondition it cannot create. Callers decide whether to exit 0 or return 0.
+# The context label names the gated work, which a file with more than one gate
+# needs and a suite log always benefits from.
+herdr_lab_gate_or_skip() { # <context>
+  local reason
+  reason=$(fm_herdr_lab_gate) && return 0
+  printf 'skip: %s (%s)\n' "$reason" "${1:-real-herdr lab}"
+  return 1
+}
+
 herdr_refuse_if_default() { # <session>
   fm_herdr_lab_refuse_if_default "$1"
 }


### PR DESCRIPTION
## Intent

Make firstmate's own test suite green on an ordinary developer machine by fixing how 12 tests gate on their preconditions. These tests were red for environmental reasons, not because any production code was broken, and a suite that is red by default trains everyone to ignore red - which is exactly when a real regression slips through.

CAUSE 1 (11 tests): the real-Herdr tests gated on 'command -v herdr', which PASSES whenever the binary is on PATH but proves nothing about session state. They then required a running default Herdr session and HARD-FAILED when there wasn't one. The bug was the gate, not the environment. Fix: gate on whether an isolated lab can actually be provisioned, via a new 'gate' command on bin/fm-herdr-lab.sh. Its verdict is derived from the SAME fleet-state check that provisioning itself performs, so the gate and the provisioning tripwire can never disagree. Tests now skip with a reason naming the missing precondition instead of failing on something they cannot create.

CAUSE 2 (1 test): fm-secondmate-harness asserted the specific harness name 'pi' and got 'claude', because resolution reads the ACTUAL process ancestry of whatever harness runs the suite. An earlier partial fix stubbed ancestry via a fake 'ps', but that was insufficient: bin/fm-harness.sh consults its ENV MARKERS FIRST, so CLAUDECODE=1 decided the result before the ancestry stub was ever reached, and an ambient PI_CODING_AGENT would have satisfied the 'no Pi marker' case for the wrong reason. Fix: drop every ambient marker per call and set only the ones each case is about, so the test asserts the resolver's contract rather than the host runtime's identity. tests/fm-session-start.test.sh had the same class of ambient coupling (a named herdr session overriding its pinned fake fixture) and is corrected the same way in the same commit.

DELIBERATE DECISIONS A REVIEWER WOULD NOT SEE IN THE DIFF:
- No test was disabled, deleted, or weakened to reach green. Weakening coverage to get a green light is the same failure as ignoring red, one step earlier.
- BOTH directions of the gate are proven, not just the skip. The pass direction is proven locally with a fake-Herdr fixture (deterministic, and it never touches the captain's live 'default' session, which is a hard safety constraint). It is additionally enforced for real in CI: the required Herdr lane starts a default session and FAILS on the gate-skip tokens, so the gate can never turn that lane green by skipping the work.
- The CI lane derives the skip token from 'bin/fm-herdr-lab.sh gate-token' rather than repeating a string literal, so renaming the token cannot silently leave the lane guarding a string the gate no longer prints. bin/fm-test-run.sh rejects an empty --fail-on-gate-skip token, because an empty token matches nothing and would silently disable the guard the caller asked for.
- An earlier revision asserted this by grepping ci.yml's source. That was removed on purpose: upstream #1282 forbids asserting implementation-source bytes. The guarantee now runs through executables instead - the real gate produces a real refusal reason and the real runner must fail on it under the token.

ALREADY-RULED-ON SCOPE (do not re-litigate): a prior review round raised that the gate, the runner's token guard, and the CI lane remain coupled. The captain reviewed this and ruled: land these three fixes now, and file the coupling redesign SEPARATELY as its own task, because the patch-twice-rethink-at-three trigger exists to stop future patching rather than to hold finished value hostage, and the redesign starts from the improved state. So a coupling-redesign finding here is out of scope by explicit decision.

VERIFICATION ALREADY PERFORMED LOCALLY: with these commits rebased onto current origin/main, the full suite is green on a machine with Herdr installed and NO running default session (the ordinary state) - 95 total, 0 failed, 21 gate skips, of which 10 are the Herdr lab gate reporting its reason. One unrelated failure seen while still based on the older main (tests/fm-afk-inject-e2e.test.sh Scenario C) was diagnosed as upstream's own supervision-daemon bug already fixed in origin/main commit 56a7ac6; it is not caused by this branch and passes once rebased onto current origin/main. Please rebase onto origin/main (NOT the stale fork/main, which is 8 commits behind and lacks that fix) before running tests.

DELIVERY CONSTRAINT: the PR route is the fork remote 'fork', configured in ALIAS form (ssh://git@github.com-personal/...). It must NOT be rewritten to a plain URL - the plain form breaks the validation mirror's identity and authentication.

## What Changed

- `bin/fm-herdr-lab.sh` gains `gate` and `gate-token` commands that own the "can an isolated lab be provisioned here?" verdict, derived from the same fleet-state check provisioning performs; the 11 real-Herdr tests now call `herdr_lab_gate_or_skip` (new wrapper in `tests/herdr-test-safety.sh`) and skip with a reason naming the missing precondition instead of gating on `command -v herdr` and hard-failing when no default session is running.
- `bin/fm-test-run.sh --fail-on-gate-skip` is now repeatable and refuses an empty token (an empty token matches nothing and would silently disable the guard), and the required CI Herdr lane reads its token from `bin/fm-herdr-lab.sh gate-token` instead of a hardcoded copy, dropping the now-dead `herdr not found` literal.
- `tests/fm-secondmate-harness.test.sh` and `tests/fm-session-start.test.sh` clear every ambient harness/session marker per invocation (`CLAUDECODE`, `PI_CODING_AGENT`, `FM_PI_HARNESS`, `GROK_AGENT`, `HERDR_SESSION`) and set only the ones each case is about, so they assert the resolver's contract rather than the identity of whatever harness runs the suite; `docs/herdr-backend.md` records why a lab requires a running default session and how the CI lane stays honest.

## Risk Assessment

✅ Low: The only change since the last round is a two-line CI comment correction plus removal of a provably unmatchable gate-skip token, leaving the derived `$lab_token` guard - which already covers every gate reason including the missing-binary cause - fully intact, and the underlying branch was reviewed clean in round 1.

## Testing

Reproduced the red baseline and verified the green result on the exact machine state the intent targets - herdr on PATH with no running default session. At base commit a2d5f26 the real-herdr-gated family was 10/10 hard failures; at HEAD it is 0 failures with 10 skip lines that name the missing precondition. The two ambient-coupling tests were made to fail at base under a claude harness and inside a named herdr session, and both pass at HEAD under that same environment. The CI guarantee was exercised through the real executables rather than by inspecting ci.yml: the token derived from bin/fm-herdr-lab.sh gate-token makes the required lane fail on all ten skips here, gate-token is exactly the prefix of a real refusal reason, and the runner rejects an empty token with exit 2. No assertions were removed by the branch, no Herdr sessions or lab tripwires were left behind, and the worktree is clean. This change is CLI and test-infrastructure only with no rendered surface, so the evidence is command transcripts rather than screenshots. Per the targeted-validation boundary I did not run the full suite; broad regression stays with CI.

<details>
<summary>Evidence: Before/after: real-Herdr family on an ordinary developer machine</summary>

<code>BEFORE (base a2d5f26) - family=real-herdr-gated:&#10;not ok - could not prepare isolated Herdr lab session&#10;not ok - herdr e2e: could not prepare isolated lab session&#10;not ok - could not provision isolated Herdr lab session&#10;not ok - could not prepare the isolated Herdr lab session&#10;not ok - could not provision the isolated Herdr lab&#10;not ok - could not prepare isolated Herdr lab session (x4)&#10;not ok - could not create focus anchor&#10;FM_TEST_SUMMARY total=10 failed=10 skipped_gate=0&#10;&#10;AFTER (HEAD 8ac3b87) - same machine, same family:&#10;skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr away-mode injection e2e)&#10;skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr e2e)&#10;skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr event-wait smoke)&#10;skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr prune-safety e2e)&#10;skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr respawn-idempotence e2e)&#10;skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr backend smoke)&#10;skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr workspace-per-home e2e)&#10;... 10 skip lines total&#10;FM_TEST_SUMMARY total=10 failed=0 skipped_gate=9</code>

```text
BEFORE (base a2d5f26) - tests/*.test.sh family=real-herdr-gated, ordinary machine:
not ok - could not prepare isolated Herdr lab session
not ok - herdr e2e: could not prepare isolated lab session
not ok - could not provision isolated Herdr lab session
not ok - could not prepare the isolated Herdr lab session
not ok - could not provision the isolated Herdr lab
not ok - could not prepare isolated Herdr lab session
not ok - could not prepare isolated Herdr lab session
not ok - could not prepare isolated Herdr lab session
not ok - could not prepare isolated Herdr lab session
not ok - could not create focus anchor
FM_TEST_SUMMARY total=10 failed=10 skipped_gate=0 duration_ms=32596

AFTER (HEAD 8ac3b87) - same machine, same family:
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr away-mode injection e2e)
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr e2e)
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr event-wait smoke)
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr prune-safety e2e)
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr respawn-idempotence e2e)
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr backend smoke)
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr workspace-per-home e2e)
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire
FM_TEST_SUMMARY total=10 failed=0 skipped_gate=9 duration_ms=32512
```
</details>
<details>
<summary>Evidence: The required CI Herdr lane cannot be greened by skipping</summary>

<code>$ lab_token=$(bin/fm-herdr-lab.sh gate-token)&#10;lab_token=&#39;herdr lab unavailable&#39;&#10;$ bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip &#34;$lab_token&#34;&#10;lane exit=1&#10;FM_TEST_SUMMARY total=10 failed=10 skipped_gate=0 duration_ms=32511&#10;--- runner log (why it failed) ---&#10;fm-test-run: required gate skip token seen in tests/fm-afk-inject-herdr-e2e.test.sh: skip: herdr lab unavailable&#10;fm-test-run: required gate skip token seen in tests/fm-afk-launch.test.sh: skip: herdr lab unavailable&#10;fm-test-run: required gate skip token seen in tests/fm-backend-autodetect-smoke.test.sh: skip: herdr lab unavailable&#10;fm-test-run: required gate skip token seen in tests/fm-backend-herdr-eventwait-smoke.test.sh: skip: herdr lab unavailable&#10;total scripts flagged: 10</code>

```text
### Simulating the required CI Herdr lane on a machine WITHOUT a running default session ###
$ lab_token=$(bin/fm-herdr-lab.sh gate-token)
lab_token='herdr lab unavailable'
$ bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip "$lab_token"
lane exit=1
FM_TEST_SUMMARY total=10 failed=10 skipped_gate=0 duration_ms=32511
--- runner log (why it failed) ---
fm-test-run: required gate skip token seen in tests/fm-afk-inject-herdr-e2e.test.sh: skip: herdr lab unavailable
fm-test-run: required gate skip token seen in tests/fm-afk-launch.test.sh: skip: herdr lab unavailable
fm-test-run: required gate skip token seen in tests/fm-backend-autodetect-smoke.test.sh: skip: herdr lab unavailable
fm-test-run: required gate skip token seen in tests/fm-backend-herdr-eventwait-smoke.test.sh: skip: herdr lab unavailable
...
total scripts flagged: 10
```
</details>
<details>
<summary>Evidence: Developer-facing CLI transcript: gate verdict, token derivation, empty-token refusal</summary>

<code>$ herdr session list --json | jq -c &#39;[.sessions[]|{name,running,default}]&#39;&#10;[{&#34;name&#34;:&#34;default&#34;,&#34;running&#34;:false,&#34;default&#34;:true},{&#34;name&#34;:&#34;1&#34;,&#34;running&#34;:true,&#34;default&#34;:false},{&#34;name&#34;:&#34;co-captain&#34;,&#34;running&#34;:true,&#34;default&#34;:false}]&#10;&#10;$ bin/fm-herdr-lab.sh gate&#10;herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire&#10;exit=1&#10;&#10;$ bin/fm-test-run.sh --fail-on-gate-skip &#39;&#39; tests/fm-herdr-lab.test.sh&#10;fm-test-run: --fail-on-gate-skip requires a non-empty token; an empty token would silently disable the guard&#10;exit=2&#10;$ bin/fm-test-run.sh --fail-on-gate-skip= tests/fm-herdr-lab.test.sh&#10;fm-test-run: --fail-on-gate-skip requires a non-empty token; an empty token would silently disable the guard&#10;exit=2&#10;&#10;$ bin/fm-herdr-lab.sh gate-token&#10;herdr lab unavailable&#10;$ bin/fm-herdr-lab.sh gate default&#10;herdr lab unavailable: invalid lab session name &#39;default&#39;&#10;exit=1</code>

```text
### 1. What a developer sees on an ordinary machine (herdr installed, no running default session)
$ herdr session list --json | jq -c '[.sessions[]|{name,running,default}]'
[{"name":"default","running":false,"default":true},{"name":"1","running":true,"default":false},{"name":"co-captain","running":true,"default":false}]

$ bin/fm-herdr-lab.sh gate
herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire
exit=1

### 2. The runner refuses an empty gate-skip token instead of silently disabling the guard
$ bin/fm-test-run.sh --fail-on-gate-skip '' tests/fm-herdr-lab.test.sh
fm-test-run: --fail-on-gate-skip requires a non-empty token; an empty token would silently disable the guard
exit=2
$ bin/fm-test-run.sh --fail-on-gate-skip= tests/fm-herdr-lab.test.sh
fm-test-run: --fail-on-gate-skip requires a non-empty token; an empty token would silently disable the guard
exit=2

### 3. gate-token is exactly the prefix of a real refusal reason (no hardcoded copy in CI)
$ bin/fm-herdr-lab.sh gate-token
herdr lab unavailable
$ bin/fm-herdr-lab.sh gate default   # deterministic refusal, works even where a default session runs
herdr lab unavailable: invalid lab session name 'default'
exit=1
```
</details>
<details>
<summary>Evidence: Before/after: ambient host-runtime coupling (CLAUDECODE / HERDR_SESSION)</summary>

<code>BEFORE (base a2d5f26), run by a claude harness (CLAUDECODE=1):&#10;$ bash tests/fm-secondmate-harness.test.sh&#10;not ok - unmarked shared signed-wrapper ancestry resolved &#39;claude&#39;, expected pi (exit 1)&#10;&#10;BEFORE (base a2d5f26), from inside a NAMED herdr session (HERDR_SESSION=co-captain):&#10;$ bash tests/fm-session-start.test.sh&#10;not ok - the later fleet read did not confirm the relaunched Herdr endpoint&#10;(missing: &#39;endpoint: alive (backend=herdr window=default:p-new)&#39;) (exit 1)&#10;&#10;AFTER (HEAD 8ac3b87), same hostile ambient env for both:&#10;tests/fm-secondmate-harness.test.sh -&gt; # all fm-secondmate-harness tests passed, exit=0&#10;tests/fm-session-start.test.sh -&gt; exit=0</code>

```text
CAUSE 2 - ambient host-runtime coupling

BEFORE (base a2d5f26), run by a claude harness (CLAUDECODE=1):
  $ bash tests/fm-secondmate-harness.test.sh
  not ok - unmarked shared signed-wrapper ancestry resolved 'claude', expected pi   (exit 1)

BEFORE (base a2d5f26), run from inside a NAMED herdr session (HERDR_SESSION=co-captain):
  $ bash tests/fm-session-start.test.sh
  not ok - the later fleet read did not confirm the relaunched Herdr endpoint
           (missing: 'endpoint: alive (backend=herdr window=default:p-new)')   (exit 1)

AFTER (HEAD 8ac3b87), same hostile ambient env for both:
### FIXED: same ambient hostility (CLAUDECODE=1, HERDR_SESSION=co-captain) ###
--- tests/fm-secondmate-harness.test.sh ---
ok - B17 config reread skips unchanged homes and reads destination post-write bytes
ok - B18 bootstrap config reread path works; spawn flexibility remains defaults-only
ok - B19 bootstrap respawns before inherited-config reread
ok - B25 spawn quarantines stale rereads without blocking relaunch
ok - B24 bootstrap detect-only mode remains filesystem read-only
# all fm-secondmate-harness tests passed
exit=0
--- tests/fm-session-start.test.sh (tail) ---
ok - session start rejects stale Pi loaded markers
ok - session start accepts current Pi markers written before lock acquisition
ok - session start rejects Pi sessions missing the turn-end guard marker
ok - session start rejects Pi loaded markers from previous sessions
exit=0
```
</details>
<details>
<summary>Evidence: Full AFTER run log for the real-Herdr family</summary>

```text
FM_TEST_BEGIN 2026-07-30T08:32:43Z tests/fm-afk-inject-herdr-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr away-mode injection e2e)
FM_TEST_END 2026-07-30T08:32:43Z tests/fm-afk-inject-herdr-e2e.test.sh exit=0 duration_ms=15 gate_skip=true
FM_TEST_BEGIN 2026-07-30T08:32:43Z tests/fm-afk-launch.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - launcher paths: relative home and state ignore CDPATH before daemon command construction
ok - launcher paths: absolute symlink spellings are preserved
ok - launcher paths: unresolved relative FM_HOME fails loudly
ok - launcher paths: unresolved relative FM_STATE_OVERRIDE fails loudly
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
ok - concurrent start: one serialized daemon terminal remains tracked
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-544035451-1332624-22390-1785400395'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-2924873949-1332655-18076-1785400395'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /tmp/fm-afk-restore-fail.vuBrRU/state/.afk-launch-backup.dGX5qo
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr e2e)
ok - tmux e2e: captain window pane count unchanged after start (no split-window)
ok - tmux e2e: daemon launched in a separate detached session
ok - tmux e2e: captain window pane count unchanged after stop
ok - tmux e2e: daemon session killed by exact id on stop
ok - tmux e2e: record + .afk cleared on stop
FM_TEST_END 2026-07-30T08:33:16Z tests/fm-afk-launch.test.sh exit=0 duration_ms=32244 gate_skip=false
FM_TEST_BEGIN 2026-07-30T08:33:16Z tests/fm-backend-autodetect-smoke.test.sh family=real-herdr-gated expected_gate_skip=herdr
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire
FM_TEST_END 2026-07-30T08:33:16Z tests/fm-backend-autodetect-smoke.test.sh exit=0 duration_ms=15 gate_skip=true
FM_TEST_BEGIN 2026-07-30T08:33:16Z tests/fm-backend-herdr-eventwait-smoke.test.sh family=real-herdr-gated expected_gate_skip=herdr
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr event-wait smoke)
FM_TEST_END 2026-07-30T08:33:16Z tests/fm-backend-herdr-eventwait-smoke.test.sh exit=0 duration_ms=15 gate_skip=true
FM_TEST_BEGIN 2026-07-30T08:33:16Z tests/fm-backend-herdr-presentation-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire
FM_TEST_END 2026-07-30T08:33:16Z tests/fm-backend-herdr-presentation-e2e.test.sh exit=0 duration_ms=15 gate_skip=true
FM_TEST_BEGIN 2026-07-30T08:33:16Z tests/fm-backend-herdr-prune-safety-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr prune-safety e2e)
FM_TEST_END 2026-07-30T08:33:16Z tests/fm-backend-herdr-prune-safety-e2e.test.sh exit=0 duration_ms=14 gate_skip=true
FM_TEST_BEGIN 2026-07-30T08:33:16Z tests/fm-backend-herdr-respawn-idem-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr respawn-idempotence e2e)
FM_TEST_END 2026-07-30T08:33:16Z tests/fm-backend-herdr-respawn-idem-e2e.test.sh exit=0 duration_ms=15 gate_skip=true
FM_TEST_BEGIN 2026-07-30T08:33:16Z tests/fm-backend-herdr-smoke.test.sh family=real-herdr-gated expected_gate_skip=herdr
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr backend smoke)
FM_TEST_END 2026-07-30T08:33:16Z tests/fm-backend-herdr-smoke.test.sh exit=0 duration_ms=15 gate_skip=true
FM_TEST_BEGIN 2026-07-30T08:33:16Z tests/fm-backend-herdr-workspace-per-home-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire (herdr workspace-per-home e2e)
FM_TEST_END 2026-07-30T08:33:16Z tests/fm-backend-herdr-workspace-per-home-e2e.test.sh exit=0 duration_ms=14 gate_skip=true
FM_TEST_BEGIN 2026-07-30T08:33:16Z tests/fm-herdr-session-cleanup-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire
FM_TEST_END 2026-07-30T08:33:16Z tests/fm-herdr-session-cleanup-e2e.test.sh exit=0 duration_ms=16 gate_skip=true
FM_TEST_SUMMARY total=10 failed=0 skipped_gate=9 duration_ms=32512
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=10 duration_ms=32378 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-afk-launch.test.sh duration_ms=32244
FM_TEST_SLOWEST rank=2 script=tests/fm-herdr-session-cleanup-e2e.test.sh duration_ms=16
FM_TEST_SLOWEST rank=3 script=tests/fm-afk-inject-herdr-e2e.test.sh duration_ms=15
FM_TEST_SLOWEST rank=4 script=tests/fm-backend-autodetect-smoke.test.sh duration_ms=15
FM_TEST_SLOWEST rank=5 script=tests/fm-backend-herdr-eventwait-smoke.test.sh duration_ms=15
FM_TEST_SLOWEST rank=6 script=tests/fm-backend-herdr-presentation-e2e.test.sh duration_ms=15
FM_TEST_SLOWEST rank=7 script=tests/fm-backend-herdr-respawn-idem-e2e.test.sh duration_ms=15
FM_TEST_SLOWEST rank=8 script=tests/fm-backend-herdr-smoke.test.sh duration_ms=15
FM_TEST_SLOWEST rank=9 script=tests/fm-backend-herdr-prune-safety-e2e.test.sh duration_ms=14
FM_TEST_SLOWEST rank=10 script=tests/fm-backend-herdr-workspace-per-home-e2e.test.sh duration_ms=14
```
</details>
- Outcome: ⚠️ 1 info across 1 run (8m48s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `.github/workflows/ci.yml:256` - The hardcoded `--fail-on-gate-skip &#39;herdr not found&#39;` token in the required Herdr lane can no longer match anything, and the lane&#39;s header comment at ci.yml:151 still names it as the guard. Every real-Herdr precondition skip now routes through `fm_herdr_lab_gate`, which prefixes every reason with `herdr lab unavailable: ` (bin/fm-herdr-lab.sh:103), while `detect_gate_skip_token` matches with `grep -F &#34;skip: $token&#34;` (bin/fm-test-run.sh:798) - so the literal `skip: herdr not found` is never produced. I grepped every file in the real-herdr-gated family plus fm-supervise-daemon.sh, fm-herdr-session-cleanup.sh and fm-herdr-ci-cleanup.sh and found no remaining producer. There is no functional gap (the derived `$lab_token` fully covers the missing-binary cause), but this literal is precisely the hardcoded-copy drift the gate-token derivation was introduced to prevent, and ci.yml:151 now misstates what the required lane enforces. Retaining it as belt-and-suspenders is a defensible call, hence the author&#39;s decision rather than an auto-fix.

🔧 Fix: drop dead herdr-not-found gate token from CI lane
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-afk-inject-e2e.test.sh` - This worktree&#39;s base is 6ec5e08, which is this repo&#39;s origin/main tip here. The intent references an upstream origin/main commit 56a7ac6 (supervision-daemon fix for tests/fm-afk-inject-e2e.test.sh Scenario C) that does not exist in this repository, so the branch is not sitting on the newer main the author described. I did not run that test (out of the targeted scope), but if CI reports a Scenario C failure it is the known unrelated upstream bug, not this branch.
- <code>`bin/fm-herdr-lab.sh gate` and `bin/fm-herdr-lab.sh gate-token` on a machine with herdr installed and no running default session</code>
- <code>`bin/fm-test-run.sh --family real-herdr-gated` at HEAD (total=10 failed=0 skipped_gate=9, 10 named skip lines)</code>
- <code>Baseline comparison: same `bin/fm-test-run.sh --family real-herdr-gated` against a `git archive` checkout of base commit a2d5f26 (total=10 failed=10)</code>
- <code>`bash tests/fm-secondmate-harness.test.sh` at base (fails: resolved &#39;claude&#39;, expected pi) and at HEAD with `CLAUDECODE=1 HERDR_SESSION=co-captain` (passes)</code>
- <code>`bash tests/fm-session-start.test.sh` at base with `HERDR_SESSION=co-captain` (fails on the pinned fake-herdr endpoint) and at HEAD with the same env (passes)</code>
- <code>`bin/fm-test-run.sh tests/fm-herdr-lab.test.sh tests/fm-test-run.test.sh` (both green, including `ok - fm-herdr-lab: the gate mirrors real lab availability in both directions` and `ok - fail-on-gate-skip is repeatable and catches the real lab-gate reason`)</code>
- <code>CI-lane simulation: `lab_token=$(bin/fm-herdr-lab.sh gate-token); bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip &#34;$lab_token&#34;` -&gt; exit 1, total=10 failed=10, all 10 logged `required gate skip token seen`</code>
- <code>`bin/fm-test-run.sh --fail-on-gate-skip &#39;&#39; ...` and `--fail-on-gate-skip= ...` -&gt; exit 2 with the non-empty-token refusal</code>
- <code>Coverage-weakening check: `git diff a2d5f26..HEAD -- tests/` filtered for removed assertion lines (only one fixture conditional removed, no assertions)</code>
- <code>Cleanup verification: `herdr session list --json` unchanged (default, 1, co-captain), lab tripwire state dir empty, `git status --porcelain` clean, temporary baseline checkout removed</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/verification/runtime-backends.md:153` - Judgment call, deliberately not edited: the Herdr reproduction blocks in this maintainer-verification record (lines ~157-200) now skip instead of hard-failing when no default Herdr session is running, because the gated tests moved to the lab gate. I did not add a precondition line here. The gate prints a self-naming reason (&#39;skip: herdr lab unavailable: no running default Herdr session for the lab fleet-state tripwire&#39;), so a maintainer re-running the commands is already told exactly what is missing, and docs/herdr-backend.md#destructive-lab-safety is the one owner of that rationale - a copy here would be the duplication the one-owner rule forbids. Flagging so a reviewer can overrule if they want the precondition restated at the repro site.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
