### PR TITLE
feat(bin): verify a merged PR's issues actually closed post-merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,7 @@ Tear down a ship task only after landing is confirmed.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.
 Never force teardown without explicit discard authority.
 After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.
+As part of teardown, `bin/fm-issue-closure.sh` verifies a merged PR's issues actually closed and reports any GitHub left open despite a closing reference; surface such an `issue-closure:` discrepancy to the captain - it means the board misrepresents landed work.
 
 A secondmate is persistent and an empty queue is healthy.
 Retire one only on an explicit captain or main-firstmate decision, after loading `secondmate-provisioning`; its home must contain no work under way, and forced discard still requires explicit captain authority.

--- a/bin/fm-issue-closure.sh
+++ b/bin/fm-issue-closure.sh
@@ -25,6 +25,8 @@
 #     GitHub linked from commit messages even when the PR body is bare.
 #   - the task brief (--brief <path>), parsed with the same grammar, as a fallback
 #     for work whose PR body carried no parseable reference at all.
+# Issues and pull requests share one number space, so a candidate that resolves
+# to a pull request is skipped silently: it is not an issue to verify.
 # Usage: fm-issue-closure.sh <pr-url> [--brief <brief-path>]
 set -u
 
@@ -133,7 +135,8 @@ main() {
 
   while IFS= read -r n; do
     [ -n "$n" ] || continue
-    if ! state=$(gh issue view "$n" -R "$REPO_SLASH" --json state -q .state 2>/dev/null); then
+    if ! state=$(gh api "repos/$REPO_SLASH/issues/$n" \
+      -q 'if .pull_request then "pull-request" else (.state | ascii_upcase) end' 2>/dev/null); then
       echo "issue-closure: could not verify state of issue #$n for $PR_URL (gh lookup failed); the merge is unaffected." >&2
       continue
     fi

--- a/bin/fm-issue-closure.sh
+++ b/bin/fm-issue-closure.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Best-effort post-merge verification that the issues a merged GitHub PR was
+# meant to close are actually closed, reporting - never auto-closing - any GitHub
+# left open despite a closing reference.
+#
+# GitHub silently ignores some closing keywords even when the PR body carries a
+# verified one, so the work lands on the default branch and the issue stays open
+# with no error or signal. This re-derives the candidate issues the PR was meant
+# to close, checks each candidate's state, and prints a clear report naming the
+# PR and every still-open issue. It never closes anything: closing an issue on
+# inferred evidence is an outward-facing human decision, and a wrong auto-close
+# is worse than an open issue.
+#
+# It is best-effort and never blocks its caller: it always exits 0. A lookup
+# failure (network down, gh error, missing issue) is reported on stderr and the
+# merge is left unaffected. GitLab merge requests are out of scope and exit
+# silently; the measured failure mode is GitHub-specific.
+#
+# Candidate issue numbers are unioned and deduplicated, scoped to the PR's own
+# repository, from three sources:
+#   - the PR body, parsed for GitHub's closing-keyword grammar
+#     (close[sd]|fix(es|ed)?|resolve[ds]) followed by #N, owner/repo#N, or a full
+#     issue URL. GitHub may have silently ignored exactly these keywords.
+#   - GitHub's closingIssuesReferences for the PR, which captures references
+#     GitHub linked from commit messages even when the PR body is bare.
+#   - the task brief (--brief <path>), parsed with the same grammar, as a fallback
+#     for work whose PR body carried no parseable reference at all.
+# Usage: fm-issue-closure.sh <pr-url> [--brief <brief-path>]
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -ne 1 ] && [ "$#" -ne 3 ]; then
+  echo "usage: fm-issue-closure.sh <pr-url> [--brief <brief-path>]" >&2
+  exit 2
+fi
+
+PR_URL=$1
+BRIEF=
+if [ "$#" -eq 3 ]; then
+  if [ "$2" != "--brief" ]; then
+    echo "usage: fm-issue-closure.sh <pr-url> [--brief <brief-path>]" >&2
+    exit 2
+  fi
+  BRIEF=$3
+fi
+
+if ! fm_pr_url_parse "$PR_URL"; then
+  echo "issue-closure: not a valid PR URL: $PR_URL" >&2
+  exit 0
+fi
+
+# GitLab merge-request closure verification is out of scope; exit silently.
+[ "$FM_PR_PROVIDER" = github ] || exit 0
+
+OWNER=$FM_PR_OWNER
+REPO=$FM_PR_REPO
+REPO_SLASH="$OWNER/$REPO"
+
+# Emit same-repository issue numbers referenced as closable by GitHub's
+# closing-keyword grammar in the text on stdin, one number per line. The keyword
+# must begin at a word boundary so prose such as "prefixes" or "unresolved" does
+# not match. The reference may be a bare #N, an explicit owner/repo#N, or a full
+# issue URL; references for other repositories are deliberately not emitted,
+# since they cannot be resolved against this PR's repository.
+issue_refs_from_text() {
+  local boundary kw repo_re bare text
+  boundary='(^|[^[:alnum:]_])'
+  kw='(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]+'
+  repo_re=$(printf '%s' "$REPO_SLASH" | sed 's/[.]/\\./g')
+  bare="${boundary}${kw}"
+  # Buffer stdin once: the three pattern greps each need the whole text, but a
+  # bare { grep; grep; grep; } block would let the first grep consume all stdin.
+  text=$(cat)
+  {
+    printf '%s\n' "$text" | grep -oiE "${bare}#[0-9]+"
+    printf '%s\n' "$text" | grep -oiE "${bare}${repo_re}#[0-9]+"
+    printf '%s\n' "$text" | grep -oiE "${bare}https://github\.com/${repo_re}/issues/[0-9]+"
+  } | grep -oE '#[0-9]+|/issues/[0-9]+' | grep -oE '[0-9]+'
+}
+
+main() {
+  local pr_state body closing_refs brief_text candidates n state
+  # Confirm the PR is merged first: this runs after landing, and an unmerged PR's
+  # closing references are not this check's concern.
+  if ! pr_state=$(gh pr view "$PR_URL" --json state -q .state 2>/dev/null); then
+    echo "issue-closure: could not verify issue closure for $PR_URL (gh lookup failed); the merge is unaffected." >&2
+    return 0
+  fi
+  case "$pr_state" in
+    MERGED) ;;
+    *) return 0 ;;
+  esac
+
+  if ! body=$(gh pr view "$PR_URL" --json body -q .body 2>/dev/null); then
+    echo "issue-closure: could not read the body of $PR_URL (gh lookup failed); the merge is unaffected." >&2
+    return 0
+  fi
+
+  closing_refs=$(gh pr view "$PR_URL" --json closingIssuesReferences \
+    -q "[.closingIssuesReferences[] | select(.repository.owner.login == \"$OWNER\" and .repository.name == \"$REPO\") | .number] | unique | .[]" 2>/dev/null || true)
+
+  brief_text=
+  if [ -n "$BRIEF" ] && [ -f "$BRIEF" ]; then
+    brief_text=$(cat -- "$BRIEF" 2>/dev/null || true)
+  fi
+
+  candidates=$(
+    {
+      { printf '%s\n' "$body"; [ -z "$brief_text" ] || printf '%s\n' "$brief_text"; } | issue_refs_from_text
+      printf '%s\n' "$closing_refs" | grep -E '^[0-9]+$' || true
+    } | sort -n | uniq
+  )
+
+  # Nothing to verify: the PR deliberately closes nothing, so stay silent.
+  [ -n "$candidates" ] || return 0
+
+  while IFS= read -r n; do
+    [ -n "$n" ] || continue
+    if ! state=$(gh issue view "$n" -R "$REPO_SLASH" --json state -q .state 2>/dev/null); then
+      echo "issue-closure: could not verify state of issue #$n for $PR_URL (gh lookup failed); the merge is unaffected." >&2
+      continue
+    fi
+    case "$state" in
+      OPEN)
+        printf 'issue-closure: merged PR %s carried a closing reference for #%d (https://github.com/%s/issues/%d) but GitHub left it OPEN; it may need manual closing.\n' \
+          "$PR_URL" "$n" "$REPO_SLASH" "$n"
+        ;;
+    esac
+  done <<EOF
+$candidates
+EOF
+}
+
+# Always exit 0: a best-effort verification must never block teardown or any
+# post-merge path. Discrepancies are reported on stdout, lookup failures on
+# stderr, and silence means nothing actionable.
+main
+exit 0

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1235,5 +1235,16 @@ rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi
+# Best-effort: verify a merged PR's issues actually closed. GitHub silently
+# ignores some closing keywords, leaving an issue open after the work lands; this
+# reports any such discrepancy so firstmate can surface it. It never blocks
+# teardown and never auto-closes anything. See bin/fm-issue-closure.sh.
+if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ -n "$PR_URL" ]; then
+  if [ -f "$DATA/$ID/brief.md" ]; then
+    "$FM_ROOT/bin/fm-issue-closure.sh" "$PR_URL" --brief "$DATA/$ID/brief.md" || true
+  else
+    "$FM_ROOT/bin/fm-issue-closure.sh" "$PR_URL" || true
+  fi
+fi
 echo "teardown $ID complete (window $T, worktree $WT)"
 backlog_refresh_reminder

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -85,6 +85,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
+| `fm-issue-closure.sh`    | Best-effort post-merge report of issues a merged GitHub PR referenced for closing but GitHub left open |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared X-mode config, relay, and reply-threading helpers                             |

--- a/tests/fm-issue-closure.test.sh
+++ b/tests/fm-issue-closure.test.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-issue-closure.sh: the best-effort post-merge check
+# that the issues a merged GitHub PR was meant to close are actually closed.
+#
+# Two real GitHub failure modes motivate it:
+#   - GitHub silently ignores a closing keyword, so a merged PR leaves its
+#     issue open with no error. The body still carries the keyword, so the
+#     check re-parses the body, cross-references GitHub's own
+#     closingIssuesReferences, optionally mines the task brief, and reports any
+#     referenced issue that is still OPEN.
+#   - A PR carries no parseable reference at all. The check stays silent unless a
+#     brief (--brief) supplies a closing reference.
+#
+# What the check must DO (acceptance criteria), exercised behaviorally through a
+# mocked gh - never assertions about the script's source text:
+#   (a) merged PR + open issue         -> clear report naming the PR and issue
+#   (b) merged PR + closed issue       -> silent
+#   (c) merged PR + no reference       -> silent (deliberately closes nothing)
+#   (d) PR not merged                  -> silent
+#   (e) gh lookup fails                -> stderr warning, exit 0, no report
+#   (f) multiple issues, mixed states  -> report only the open ones
+#   (g) one issue lookup fails         -> warn on stderr, still report the rest
+#   (h) closingIssuesReferences source -> a commit-message-only ref is caught
+#   (i) brief source                   -> a reference only in the brief is caught
+#   (j) GitLab merge request           -> silent (out of scope)
+#   (k) word boundary                  -> "prefixes #5" is NOT a closing ref
+#   (l) cross-repo reference           -> ignored (not resolved against this repo)
+#   (m) owner/repo#N and full URL form -> same-repo forms are recognized
+#   (n) exit code                      -> always 0 (never blocks teardown)
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CLOSURE="$ROOT/bin/fm-issue-closure.sh"
+TMP_ROOT=$(fm_test_tmproot fm-issue-closure-tests)
+
+assert_present "$CLOSURE" "bin/fm-issue-closure.sh is missing"
+[ -x "$CLOSURE" ] || fail "bin/fm-issue-closure.sh must be executable"
+
+PR_URL='https://github.com/example/repo/pull/42'
+REPO_SLASH='example/repo'
+
+# Build a fakebin case dir. Echoes the case dir. The gh mock is written per test
+# via write_gh, which receives a heredoc body on stdin.
+make_case() {
+  local name=$1 case_dir fakebin
+  case_dir="$TMP_ROOT/$name"
+  fakebin="$case_dir/fakebin"
+  mkdir -p "$fakebin"
+  printf '%s\n' "$case_dir"
+}
+
+# write_gh <case_dir>: read a gh mock body from stdin and install it.
+write_gh() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/gh"
+  chmod +x "$case_dir/fakebin/gh"
+}
+
+# run_closure <case_dir> [args...]: run the script under the case's fakebin,
+# capturing stdout and stderr into files. Sets OUT, ERR, RC.
+run_closure() {
+  local case_dir=$1; shift
+  OUT=$(PATH="$case_dir/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_CLOSURE_DATA="$case_dir/data" "$CLOSURE" "$@" 2>"$case_dir/err")
+  RC=$?
+  ERR=$(cat "$case_dir/err")
+}
+
+# --- gh mock builders ------------------------------------------------------
+
+# A gh mock driven by simple data files in the case dir so a test declares the
+# PR state, body, closing refs, and per-issue states without rewriting shell.
+# Files (all optional):
+#   pr_state    one word: MERGED (default), OPEN, CLOSED
+#   pr_body     PR body text
+#   pr_refs     newline-separated same-repo closingIssuesReferences numbers
+#   fail        any content -> gh always exits 1 (lookup failure)
+#   issue_<n>   state for issue #<n> (OPEN/CLOSED); absent -> lookup fails
+gh_data_mock() {
+  local case_dir=$1
+  mkdir -p "$case_dir/data"
+  cat > "$case_dir/fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+set -u
+D="${FM_CLOSURE_DATA:?}"
+[ -f "$D/fail" ] && { echo "error: gh unavailable" >&2; exit 1; }
+state=MERGED
+[ -f "$D/pr_state" ] && state=$(cat "$D/pr_state")
+body=
+[ -f "$D/pr_body" ] && body=$(cat "$D/pr_body")
+case "${1:-} ${2:-}" in
+  "pr view")
+    case "$*" in
+      *"--json state -q"*) printf '%s\n' "$state"; exit 0 ;;
+      *"--json body -q"*) printf '%s\n' "$body"; exit 0 ;;
+      *"--json closingIssuesReferences"*)
+        [ -f "$D/pr_refs" ] && cat "$D/pr_refs" || true
+        exit 0 ;;
+    esac
+    ;;
+  "issue view")
+    n=
+    for a in "$@"; do
+      case "$a" in
+        [0-9]*) n=$a; break ;;
+      esac
+    done
+    [ -n "$n" ] || exit 1
+    if [ -f "$D/issue_$n" ]; then
+      printf '%s\n' "$(cat "$D/issue_$n")"
+      exit 0
+    fi
+    echo "error: issue not found" >&2
+    exit 1
+    ;;
+esac
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/gh"
+}
+
+# --- tests -----------------------------------------------------------------
+
+test_open_issue_is_reported() {
+  local case_dir
+  case_dir=$(make_case open-reported)
+  gh_data_mock "$case_dir"
+  printf 'MERGED\n' > "$case_dir/data/pr_state"
+  printf 'This fixes #7.\n' > "$case_dir/data/pr_body"
+  printf 'OPEN\n' > "$case_dir/data/issue_7"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "open-issue: the check must never exit non-zero"
+  assert_contains "$OUT" "issue-closure:" "open-issue: missing report line"
+  assert_contains "$OUT" "$PR_URL" "open-issue: report must name the PR URL"
+  assert_contains "$OUT" "#7" "open-issue: report must name the issue number"
+  assert_contains "$OUT" "github.com/$REPO_SLASH/issues/7" "open-issue: report must link the issue"
+  pass "a merged PR that left its issue open produces a report naming the PR and issue"
+}
+
+test_closed_issue_is_silent() {
+  local case_dir
+  case_dir=$(make_case closed-silent)
+  gh_data_mock "$case_dir"
+  printf 'This fixes #7.\n' > "$case_dir/data/pr_body"
+  printf 'CLOSED\n' > "$case_dir/data/issue_7"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "closed-issue: exit must be 0"
+  [ -z "$OUT" ] || fail "closed-issue: expected no report, got: $OUT"
+  pass "a merged PR whose issue did close produces no noise"
+}
+
+test_no_reference_is_silent() {
+  local case_dir
+  case_dir=$(make_case no-ref)
+  gh_data_mock "$case_dir"
+  printf 'Routine change. See #100 for context.\n' > "$case_dir/data/pr_body"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "no-ref: exit must be 0"
+  [ -z "$OUT" ] || fail "no-ref: 'See #100' is not a closing ref; expected silence, got: $OUT"
+  pass "a merged PR with no closing reference produces no noise"
+}
+
+test_not_merged_is_silent() {
+  local case_dir
+  case_dir=$(make_case not-merged)
+  gh_data_mock "$case_dir"
+  printf 'OPEN\n' > "$case_dir/data/pr_state"
+  printf 'This fixes #7.\n' > "$case_dir/data/pr_body"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "not-merged: exit must be 0"
+  [ -z "$OUT" ] || fail "not-merged: an unmerged PR should not be verified, got: $OUT"
+  pass "a PR that is not merged is not verified"
+}
+
+test_lookup_failure_is_reported_and_exits_zero() {
+  local case_dir
+  case_dir=$(make_case lookup-fail)
+  gh_data_mock "$case_dir"
+  : > "$case_dir/data/fail"
+  printf 'This fixes #7.\n' > "$case_dir/data/pr_body"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "lookup-fail: a gh failure must not break the post-merge path (exit 0)"
+  [ -z "$OUT" ] || fail "lookup-fail: no stdout report expected when the lookup fails, got: $OUT"
+  assert_contains "$ERR" "could not verify" "lookup-fail: lookup failure must be reported on stderr"
+  assert_contains "$ERR" "$PR_URL" "lookup-fail: warning must name the PR"
+  assert_contains "$ERR" "merge is unaffected" "lookup-fail: warning must say the merge is unaffected"
+  pass "failure of the issue lookup itself is reported and does not break the post-merge path"
+}
+
+test_multiple_issues_report_only_open() {
+  local case_dir
+  case_dir=$(make_case multi)
+  gh_data_mock "$case_dir"
+  printf 'fixes #1 and closes #2\n' > "$case_dir/data/pr_body"
+  printf 'CLOSED\n' > "$case_dir/data/issue_1"
+  printf 'OPEN\n' > "$case_dir/data/issue_2"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "multi: exit must be 0"
+  assert_contains "$OUT" "#2" "multi: the open issue #2 must be reported"
+  assert_not_contains "$OUT" "#1 " "multi: the closed issue #1 must not be reported"
+  pass "a merged PR closing several issues reports only the ones still open"
+}
+
+test_one_issue_lookup_failure_continues() {
+  local case_dir
+  case_dir=$(make_case partial-fail)
+  gh_data_mock "$case_dir"
+  printf 'fixes #30 closes #31\n' > "$case_dir/data/pr_body"
+  printf 'OPEN\n' > "$case_dir/data/issue_30"
+  # issue_31 intentionally absent -> lookup fails
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "partial-fail: exit must be 0"
+  assert_contains "$OUT" "#30" "partial-fail: the verifiable open issue #30 must still be reported"
+  assert_contains "$ERR" "#31" "partial-fail: the failed issue #31 must be warned on stderr"
+  pass "a per-issue lookup failure is warned about and does not stop the rest of the check"
+}
+
+test_closing_references_source_is_used() {
+  local case_dir
+  case_dir=$(make_case closing-refs)
+  gh_data_mock "$case_dir"
+  # Body has NO keyword; GitHub linked #5 from a commit message.
+  printf 'ship it\n' > "$case_dir/data/pr_body"
+  printf '5\n' > "$case_dir/data/pr_refs"
+  printf 'OPEN\n' > "$case_dir/data/issue_5"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "closing-refs: exit must be 0"
+  assert_contains "$OUT" "#5" "closing-refs: a GitHub-linked commit-message reference must be caught"
+  pass "GitHub's closingIssuesReferences supply candidates the body lacks"
+}
+
+test_brief_source_is_used() {
+  local case_dir
+  case_dir=$(make_case brief-src)
+  gh_data_mock "$case_dir"
+  printf 'ship it\n' > "$case_dir/data/pr_body"
+  printf 'Task: fixes #12 by refactoring.\n' > "$case_dir/brief.md"
+  printf 'OPEN\n' > "$case_dir/data/issue_12"
+  run_closure "$case_dir" "$PR_URL" --brief "$case_dir/brief.md"
+  expect_code 0 "$RC" "brief-src: exit must be 0"
+  assert_contains "$OUT" "#12" "brief-src: a reference present only in the brief must be caught"
+  pass "the task brief supplies candidates the PR body lacks"
+}
+
+test_brief_without_reference_is_silent() {
+  local case_dir
+  case_dir=$(make_case brief-silent)
+  gh_data_mock "$case_dir"
+  printf 'ship it\n' > "$case_dir/data/pr_body"
+  printf 'Investigate the build. Related: #44.\n' > "$case_dir/brief.md"
+  run_closure "$case_dir" "$PR_URL" --brief "$case_dir/brief.md"
+  expect_code 0 "$RC" "brief-silent: exit must be 0"
+  [ -z "$OUT" ] || fail "brief-silent: a non-closing 'Related: #44' must not be reported, got: $OUT"
+  pass "a brief without a closing-keyword reference produces no noise"
+}
+
+test_gitlab_is_silent() {
+  local case_dir
+  case_dir=$(make_case gitlab)
+  gh_data_mock "$case_dir"
+  run_closure "$case_dir" 'https://gitlab.example.com/group/proj/-/merge_requests/5'
+  expect_code 0 "$RC" "gitlab: exit must be 0"
+  [ -z "$OUT" ] || fail "gitlab: merge-request closure is out of scope, expected silence, got: $OUT"
+  pass "a GitLab merge request is out of scope and stays silent"
+}
+
+test_word_boundary_rejects_prose() {
+  local case_dir
+  case_dir=$(make_case word-boundary)
+  gh_data_mock "$case_dir"
+  printf 'Adds prefixes #5 and suffixes; unresolved #6 stays open.\n' > "$case_dir/data/pr_body"
+  printf 'OPEN\n' > "$case_dir/data/issue_5"
+  printf 'OPEN\n' > "$case_dir/data/issue_6"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "word-boundary: exit must be 0"
+  [ -z "$OUT" ] || fail "word-boundary: 'prefixes'/'suffixes'/'unresolved' are not keywords, expected silence, got: $OUT"
+  pass "prose containing keyword substrings is not mistaken for a closing reference"
+}
+
+test_cross_repo_reference_ignored() {
+  local case_dir
+  case_dir=$(make_case cross-repo)
+  gh_data_mock "$case_dir"
+  printf 'closes other/repo#9\n' > "$case_dir/data/pr_body"
+  printf 'OPEN\n' > "$case_dir/data/issue_9"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "cross-repo: exit must be 0"
+  [ -z "$OUT" ] || fail "cross-repo: a reference to another repo must be ignored, got: $OUT"
+  pass "cross-repository closing references are not resolved against this PR's repo"
+}
+
+test_ownerrepo_and_url_forms_recognized() {
+  local case_dir
+  case_dir=$(make_case forms)
+  gh_data_mock "$case_dir"
+  printf 'Fixes example/repo#20 and resolves https://github.com/example/repo/issues/77\n' > "$case_dir/data/pr_body"
+  printf 'OPEN\n' > "$case_dir/data/issue_20"
+  printf 'OPEN\n' > "$case_dir/data/issue_77"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "forms: exit must be 0"
+  assert_contains "$OUT" "#20" "forms: the owner/repo#N form must be recognized"
+  assert_contains "$OUT" "#77" "forms: the full issue-URL form must be recognized"
+  pass "owner/repo#N and full issue-URL closing references are recognized"
+}
+
+test_malformed_url_exits_zero() {
+  local case_dir
+  case_dir=$(make_case bad-url)
+  gh_data_mock "$case_dir"
+  run_closure "$case_dir" 'not-a-url'
+  expect_code 0 "$RC" "bad-url: a malformed URL must not break the post-merge path (exit 0)"
+  assert_contains "$ERR" "not a valid PR URL" "bad-url: the bad URL must be noted on stderr"
+  pass "a malformed PR URL is reported and exits zero"
+}
+
+test_exit_zero_on_discrepancy() {
+  local case_dir
+  case_dir=$(make_case discrepancy-exit)
+  gh_data_mock "$case_dir"
+  printf 'fixes #7\nfixes #8\n' > "$case_dir/data/pr_body"
+  printf 'OPEN\n' > "$case_dir/data/issue_7"
+  printf 'OPEN\n' > "$case_dir/data/issue_8"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "discrepancy-exit: reporting discrepancies must never exit non-zero"
+  pass "a discrepancy report is never an error exit (never blocks teardown)"
+}
+
+test_open_issue_is_reported
+test_closed_issue_is_silent
+test_no_reference_is_silent
+test_not_merged_is_silent
+test_lookup_failure_is_reported_and_exits_zero
+test_multiple_issues_report_only_open
+test_one_issue_lookup_failure_continues
+test_closing_references_source_is_used
+test_brief_source_is_used
+test_brief_without_reference_is_silent
+test_gitlab_is_silent
+test_word_boundary_rejects_prose
+test_cross_repo_reference_ignored
+test_ownerrepo_and_url_forms_recognized
+test_malformed_url_exits_zero
+test_exit_zero_on_discrepancy

--- a/tests/fm-issue-closure.test.sh
+++ b/tests/fm-issue-closure.test.sh
@@ -27,6 +27,7 @@
 #   (l) cross-repo reference           -> ignored (not resolved against this repo)
 #   (m) owner/repo#N and full URL form -> same-repo forms are recognized
 #   (n) exit code                      -> always 0 (never blocks teardown)
+#   (o) reference to a PR number       -> silent (issues and PRs share numbers)
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -41,21 +42,14 @@ assert_present "$CLOSURE" "bin/fm-issue-closure.sh is missing"
 PR_URL='https://github.com/example/repo/pull/42'
 REPO_SLASH='example/repo'
 
-# Build a fakebin case dir. Echoes the case dir. The gh mock is written per test
-# via write_gh, which receives a heredoc body on stdin.
+# Build a fakebin case dir. Echoes the case dir. The gh mock is installed per
+# test via gh_data_mock.
 make_case() {
   local name=$1 case_dir fakebin
   case_dir="$TMP_ROOT/$name"
   fakebin="$case_dir/fakebin"
   mkdir -p "$fakebin"
   printf '%s\n' "$case_dir"
-}
-
-# write_gh <case_dir>: read a gh mock body from stdin and install it.
-write_gh() {
-  local case_dir=$1
-  cat > "$case_dir/fakebin/gh"
-  chmod +x "$case_dir/fakebin/gh"
 }
 
 # run_closure <case_dir> [args...]: run the script under the case's fakebin,
@@ -77,7 +71,8 @@ run_closure() {
 #   pr_body     PR body text
 #   pr_refs     newline-separated same-repo closingIssuesReferences numbers
 #   fail        any content -> gh always exits 1 (lookup failure)
-#   issue_<n>   state for issue #<n> (OPEN/CLOSED); absent -> lookup fails
+#   issue_<n>   state for issue #<n> (OPEN/CLOSED, or pull-request when #<n>
+#               is actually a PR); absent -> lookup fails
 gh_data_mock() {
   local case_dir=$1
   mkdir -p "$case_dir/data"
@@ -100,14 +95,11 @@ case "${1:-} ${2:-}" in
         exit 0 ;;
     esac
     ;;
-  "issue view")
-    n=
-    for a in "$@"; do
-      case "$a" in
-        [0-9]*) n=$a; break ;;
-      esac
-    done
-    [ -n "$n" ] || exit 1
+  "api repos/"*"/issues/"*)
+    n="${2##*/}"
+    case "$n" in
+      ''|*[!0-9]*) exit 1 ;;
+    esac
     if [ -f "$D/issue_$n" ]; then
       printf '%s\n' "$(cat "$D/issue_$n")"
       exit 0
@@ -305,6 +297,19 @@ test_ownerrepo_and_url_forms_recognized() {
   pass "owner/repo#N and full issue-URL closing references are recognized"
 }
 
+test_pr_number_reference_is_silent() {
+  local case_dir
+  case_dir=$(make_case pr-number-ref)
+  gh_data_mock "$case_dir"
+  printf 'This fixes #50.\n' > "$case_dir/data/pr_body"
+  printf 'pull-request\n' > "$case_dir/data/issue_50"
+  run_closure "$case_dir" "$PR_URL"
+  expect_code 0 "$RC" "pr-number-ref: exit must be 0"
+  [ -z "$OUT" ] || fail "pr-number-ref: #50 is a PR, not an issue; expected silence, got: $OUT"
+  [ -z "$ERR" ] || fail "pr-number-ref: a PR-numbered candidate must be skipped silently, got: $ERR"
+  pass "a closing reference to a PR number is not reported as an open issue"
+}
+
 test_malformed_url_exits_zero() {
   local case_dir
   case_dir=$(make_case bad-url)
@@ -341,5 +346,6 @@ test_gitlab_is_silent
 test_word_boundary_rejects_prose
 test_cross_repo_reference_ignored
 test_ownerrepo_and_url_forms_recognized
+test_pr_number_reference_is_silent
 test_malformed_url_exits_zero
 test_exit_zero_on_discrepancy

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -277,11 +277,8 @@ case "\${1:-} \${2:-}" in
       *"--json closingIssuesReferences"*) exit 0 ;;
     esac
     ;;
-  "issue view")
-    case " \$* " in
-      *"view 7 "*) printf '%s\n' 'OPEN' ; exit 0 ;;
-    esac
-    ;;
+  "api repos/example/repo/issues/7")
+    printf '%s\n' 'OPEN' ; exit 0 ;;
 esac
 echo "error: pull request not found" >&2
 exit 1

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -250,6 +250,45 @@ append_pr_meta_url() {
   printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
 }
 
+# Override gh-axi/gh so the landed-work check sees merged PR 7 with <head>, AND
+# bin/fm-issue-closure.sh sees a merged PR whose body fixes #7 with #7 still OPEN.
+# This exercises the full post-merge issue-closure path through teardown: the
+# discrepancy report must surface and teardown must still complete.
+add_gh_issue_open_after_merge() {
+  local case_dir=$1 head=$2
+  cat > "$case_dir/fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr list")
+    printf '%s\n' "count: 1 (showing first 1)" "pull_requests[1]{number,state}:" "  7,merged" ; exit 0 ;;
+  "pr view")
+    printf '%s\n' "pull_request:" "  number: 7" "  state: merged" '  merged: "2026-06-26T00:00:00Z"' ; exit 0 ;;
+esac
+exit 0
+SH
+  cat > "$case_dir/fakebin/gh" <<SH
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+  "pr view")
+    case " \$* " in
+      *"state,headRefOid"*) printf '%s\t%s\n' 'MERGED' '$head' ; exit 0 ;;
+      *"--json state "*) printf '%s\n' 'MERGED' ; exit 0 ;;
+      *"--json body "*) printf '%s\n' 'This fixes #7.' ; exit 0 ;;
+      *"--json closingIssuesReferences"*) exit 0 ;;
+    esac
+    ;;
+  "issue view")
+    case " \$* " in
+      *"view 7 "*) printf '%s\n' 'OPEN' ; exit 0 ;;
+    esac
+    ;;
+esac
+echo "error: pull request not found" >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/gh-axi" "$case_dir/fakebin/gh"
+}
+
 commit_tree_from_wt_head() {
   local case_dir=$1 parent=$2 msg=$3 tree
   tree=$(git -C "$case_dir/wt" rev-parse "$parent^{tree}") || return 1
@@ -1377,6 +1416,59 @@ test_herdr_projection_teardown_retains_journal_when_close_unconfirmed() {
   pass "herdr projection teardown retains the stale journal and attempts no workspace cleanup when exact-pane close is unconfirmed"
 }
 
+# After a merged PR, teardown runs bin/fm-issue-closure.sh to verify the PR's
+# issues actually closed (GitHub silently ignores some closing keywords). The
+# discrepancy report must surface in teardown's output and must never block it.
+test_teardown_surfaces_open_issue_and_does_not_block() {
+  local case_dir rc local_head pr_head
+  case_dir=$(make_case issue-open-after-merge)
+  mkdir -p "$case_dir/data"
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  append_pr_meta_url "$case_dir"
+  local_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  pr_head=$(commit_tree_from_wt_head "$case_dir" "$local_head" "no-mistakes follow-up")
+  add_gh_issue_open_after_merge "$case_dir" "$pr_head"
+
+  set +e
+  FM_DATA_OVERRIDE="$case_dir/data" run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "issue-open: teardown must not be blocked by the issue-closure check"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "issue-open: teardown printed a REFUSED line"
+  grep -Fq "issue-closure:" "$case_dir/stdout" \
+    || fail "issue-open: teardown did not surface the issue-closure report in its output"
+  grep -Fq "#7" "$case_dir/stdout" \
+    || fail "issue-open: teardown did not name the still-open issue #7"
+  pass "teardown surfaces an issue a merged PR left open and never blocks on the check"
+}
+
+# An issue-closure lookup failure (gh unavailable / network) must not block or
+# fail teardown; the merge landed correctly and cleanup must proceed.
+test_teardown_issue_closure_lookup_failure_does_not_block() {
+  local case_dir rc local_head pr_head
+  case_dir=$(make_case issue-lookup-fail)
+  mkdir -p "$case_dir/data"
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  append_pr_meta_url "$case_dir"
+  local_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  pr_head=$(commit_tree_from_wt_head "$case_dir" "$local_head" "no-mistakes follow-up")
+  # Merged PR passes the landed-work check; issue-closure's extra gh probes hit
+  # the mock's fallthrough and fail, exercising the never-block guarantee.
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head"
+
+  set +e
+  FM_DATA_OVERRIDE="$case_dir/data" run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "issue-lookup-fail: teardown must not be blocked when the issue lookup fails"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "issue-lookup-fail: teardown printed a REFUSED line"
+  pass "teardown is not blocked when the issue-closure lookup itself fails"
+}
+
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
@@ -1409,3 +1501,5 @@ test_transient_index_lock_clears_after_first_attempt_and_retry_succeeds
 test_persistent_index_lock_exhausts_retries_and_refuses_loudly
 test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
+test_teardown_surfaces_open_issue_and_does_not_block
+test_teardown_issue_closure_lookup_failure_does_not_block


### PR DESCRIPTION
## Intent

Make firstmate verify that a merged PR actually closed its issue, and report it when it did not. Two measured GitHub failure modes motivate this: (1) GitHub silently ignores a closing keyword even when the PR body carries a verified one, so the work lands on main and the issue stays open with no signal; (2) PRs merge carrying no parseable closing reference at all.

Decisions and constraints: DETECT AND REPORT ONLY - never auto-close issues, because closing on inferred evidence is an outward-facing human decision and a wrong auto-close is worse than an open issue. The check must NEVER block or fail a teardown (a correctly landed merge must never be held up by an issue-lookup failure or network error); it always exits 0 and reports lookup failures separately. No new state files or registries - it reuses the existing task pr= meta and live gh lookups. It must work for a PR closing zero, one, or several issues, and stay silent for a PR that deliberately closes nothing.

Implementation: new bin/fm-issue-closure.sh, invoked best-effort from bin/fm-teardown.sh post-merge path (alongside fleet-sync, guarded by || true). Candidate issue numbers are unioned and deduplicated, scoped to the PR's own repo, from three sources: the PR body parsed for GitHub closing-keyword grammar (catches failure mode 1, where GitHub silently ignored the keyword), GitHub closingIssuesReferences (catches commit-message refs), and optionally the task brief (--brief, same grammar, fallback for PR bodies with no parseable reference). Each same-repo candidate's state is checked via gh issue view; any still OPEN is reported naming the PR and issue. GitLab merge requests are out of scope (silent). Scope is a verification+reporting change to the post-merge path: teardown, merge authority, and anything under projects/ are unchanged. The optional brief-scaffold change was intentionally left out (it would only help direct-PR mode since the pipeline owns the PR body in no-mistakes mode). Behavioral tests exercise the script through a mocked gh, not source-text assertions.

## What Changed

- New `bin/fm-issue-closure.sh` checks, after a PR merges, whether the issues it referenced actually closed: it unions candidate issue numbers from the PR body's closing-keyword grammar, GitHub `closingIssuesReferences`, and an optional `--brief` file, scopes them to the PR's own repo, looks each up via `gh api`, and reports any still open — detect-and-report only, always exiting 0 so a lookup failure can never block teardown. PR-numbered candidates are skipped (issues and PRs share a number space), and GitLab merge requests are silently out of scope.
- `bin/fm-teardown.sh` invokes the new script best-effort (`|| true`) on its post-merge path, alongside fleet-sync.
- Added `tests/fm-issue-closure.test.sh` (17 behavioral tests through a mocked `gh`) and two teardown integration tests, plus toolbelt inventory entries in `AGENTS.md` and `docs/scripts.md`.

## Risk Assessment

✅ Low: The final delta is the exact mechanical test-mock migration requested in round 2, verified by tracing the mocked gh invocation's argument vector; all prior findings are resolved and the additive, self-guarded feature conforms to every intent constraint.

## Testing

Ran the 17-case behavioral suite for bin/fm-issue-closure.sh and the full fm-teardown suite (35 tests, including the two new integration tests) — all pass; then demonstrated the product surface directly with a mocked-gh CLI transcript showing the exact discrepancy report (naming the PR and the still-open issue, exit 0) and a live run against real merged PR kunchenguid/firstmate#1093 whose three Fixes-referenced issues were verified closed via real gh lookups with correct silence, confirming detect-and-report-only, never-block, and silent-when-nothing-to-verify behavior end to end.

<details>
<summary>Evidence: Operator-facing discrepancy report (mocked gh demo of the silently-ignored-keyword failure mode)</summary>

<code>$ bin/fm-issue-closure.sh https://github.com/example/repo/pull/42&#10;(simulated: PR 42 merged with body &#34;This fixes #7 and closes #9.&#34;; GitHub closed #9 but silently left #7 open)&#10;issue-closure: merged PR https://github.com/example/repo/pull/42 carried a closing reference for #7 (https://github.com/example/repo/issues/7) but GitHub left it OPEN; it may need manual closing.&#10;exit code: 0</code>

```text
$ bin/fm-issue-closure.sh https://github.com/example/repo/pull/42
  (simulated: PR 42 merged with body "This fixes #7 and closes #9."; GitHub closed #9 but silently left #7 open)
issue-closure: merged PR https://github.com/example/repo/pull/42 carried a closing reference for #7 (https://github.com/example/repo/issues/7) but GitHub left it OPEN; it may need manual closing.
exit code: 0
```
</details>
<details>
<summary>Evidence: Live end-to-end run against real merged PR kunchenguid/firstmate#1093 (all referenced issues closed → correct silence, exit 0)</summary>

<code>$ gh api repos/kunchenguid/firstmate/issues/{958,1000,1017} -q .state # ground truth&#10;issue #958: closed&#10;issue #1000: closed&#10;issue #1017: closed&#10;&#10;$ bin/fm-issue-closure.sh https://github.com/kunchenguid/firstmate/pull/1093 # live run, real gh, merged PR with &#34;Fixes #958 / #1000 / #1017&#34;&#10;exit code: 0 (stdout above; silence = all closing references verified closed)</code>

```text
$ gh api repos/kunchenguid/firstmate/issues/{958,1000,1017} -q .state   # ground truth
  issue #958: closed
  issue #1000: closed
  issue #1017: closed

$ bin/fm-issue-closure.sh https://github.com/kunchenguid/firstmate/pull/1093   # live run, real gh, merged PR with "Fixes #958 / #1000 / #1017"
exit code: 0 (stdout above; silence = all closing references verified closed)
```
</details>
<details>
<summary>Evidence: fm-issue-closure behavioral test suite log (17/17 pass)</summary>

```text
ok - a merged PR that left its issue open produces a report naming the PR and issue
ok - a merged PR whose issue did close produces no noise
ok - a merged PR with no closing reference produces no noise
ok - a PR that is not merged is not verified
ok - failure of the issue lookup itself is reported and does not break the post-merge path
ok - a merged PR closing several issues reports only the ones still open
ok - a per-issue lookup failure is warned about and does not stop the rest of the check
ok - GitHub's closingIssuesReferences supply candidates the body lacks
ok - the task brief supplies candidates the PR body lacks
ok - a brief without a closing-keyword reference produces no noise
ok - a GitLab merge request is out of scope and stays silent
ok - prose containing keyword substrings is not mistaken for a closing reference
ok - cross-repository closing references are not resolved against this PR's repo
ok - owner/repo#N and full issue-URL closing references are recognized
ok - a closing reference to a PR number is not reported as an open issue
ok - a malformed PR URL is reported and exits zero
ok - a discrepancy report is never an error exit (never blocks teardown)
```
</details>
<details>
<summary>Evidence: fm-teardown test suite log (35/35 pass, incl. both new issue-closure integration tests)</summary>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
issue-closure: could not verify issue closure for https://github.com/example/repo/pull/7 (gh lookup failed); the merge is unaffected.
ok - teardown prompts tasks-axi backlog refresh when compatible
issue-closure: could not verify issue closure for https://github.com/example/repo/pull/7 (gh lookup failed); the merge is unaffected.
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains the stale journal and attempts no workspace cleanup when exact-pane close is unconfirmed
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
ok - fm-pr-check does not refresh PR head after HEAD moves
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
ok - teardown surfaces an issue a merged PR left open and never blocks on the check
ok - teardown is not blocked when the issue-closure lookup itself fails
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-issue-closure.sh:136` - `gh issue view` resolves pull-request numbers too (verified live: `gh issue view 1304 --json state -q .state` on this repo, where #1304 is a PR, returns `MERGED` with exit 0). Issues and PRs share one number space, so a PR body or brief containing `fixes #N` where #N is an open pull request makes the check report a false discrepancy claiming the merged PR &#34;carried a closing reference for #N ... but GitHub left it OPEN&#34;, linking an /issues/N URL that is actually a PR. Only the body/brief text sources can produce PR-numbered candidates (closingIssuesReferences contains real issues only). Fix locally in the per-candidate lookup: request `--json state,url` and only treat the candidate as a reportable issue when the returned url matches github.com/&lt;owner&gt;/&lt;repo&gt;/issues/&lt;n&gt;; otherwise skip silently.
- ℹ️ `tests/fm-issue-closure.test.sh:55` - The `write_gh` helper is defined but never used - every test installs its mock via `gh_data_mock` - and the `make_case` comment at line 44-45 still claims the gh mock &#34;is written per test via write_gh&#34;. Delete the dead helper and correct the comment.

🔧 Fix: skip PR-numbered closure candidates via gh api; drop dead helper
1 error still open:
- 🚨 `tests/fm-teardown.test.sh:280` - The round-1 fix switched bin/fm-issue-closure.sh from `gh issue view` to `gh api repos/&lt;owner&gt;/&lt;repo&gt;/issues/&lt;n&gt;`, but the teardown test&#39;s gh mock in `add_gh_issue_open_after_merge` was not updated: its `&#34;issue view&#34;)` case arm never matches the new invocation (`$1 $2` is now `api repos/example/repo/issues/7`), so the call falls through to `exit 1`. The closure script then emits only a stderr lookup-failure warning and no stdout report, making `test_teardown_surfaces_open_issue_and_does_not_block` fail deterministically on its `grep -Fq &#34;issue-closure:&#34; stdout` and `grep -Fq &#34;#7&#34; stdout` assertions - violating the round-1 instruction to keep all existing behavioral tests passing. Mechanical fix: replace the `&#34;issue view&#34;)` branch with a case arm matching the new key, e.g. `&#34;api repos/example/repo/issues/7&#34;) printf &#39;OPEN\n&#39;; exit 0 ;;`, mirroring how tests/fm-issue-closure.test.sh&#39;s gh_data_mock was updated. `test_teardown_issue_closure_lookup_failure_does_not_block` needs no change (it deliberately relies on the fallthrough failure).

🔧 Fix: migrate teardown test gh mock to gh api issue lookup
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-issue-closure.test.sh` — 17 behavioral tests through a mocked gh: open-issue report, closed/no-ref/not-merged silence, lookup-failure stderr + exit 0, mixed states, per-issue failure continuation, closingIssuesReferences and brief sources, GitLab silence, word-boundary, cross-repo ignore, owner/repo#N and URL forms, PR-number skip, always-exit-0</code>
- <code>`bash tests/fm-teardown.test.sh` — full teardown suite (35 tests) including the two new integration tests: teardown surfaces the issue-closure report for a merged PR whose issue stayed open, and an issue-closure gh lookup failure never blocks teardown</code>
- `Manual CLI demo with a mocked gh simulating the measured failure mode (merged PR body 'fixes #7 and closes #9', #7 left open): captured the exact operator-facing report line and exit 0, with the closed issue #9 correctly silent`
- <code>Live end-to-end run: `bin/fm-issue-closure.sh https://github.com/kunchenguid/firstmate/pull/1093` against real GitHub — merged PR with Fixes #958/#1000/#1017, all verified closed via live gh, correct silence and exit 0; ground-truth issue states captured alongside</code>
- `Verified detect-and-report-only: the gh mock exits 1 on any unexpected invocation, so an attempted auto-close would have failed the tests; the script issues only read operations`
- <code>`git status --porcelain` — worktree left clean, no transient test artifacts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
