### PR TITLE
feat(bin): improve agent-loop cache efficiency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,7 @@ Handle actionable wakes as follows:
 1. For `signal:`, read the listed event lines first, then reconcile current state only where action depends on it.
 2. For `stale:`, inspect the recorded endpoint and load `stuck-crewmate-recovery` for a stopped, looping, confused, or unresponsive worker; a deep-inspection reason also requires current-state and validation-log inspection.
 3. For `check:`, act on the named poll result, including merges and X-mode events.
-4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
+4. For `heartbeat:`, review the whole fleet once from `bin/fm-fleet-view.sh` or `bin/fm-bearings-snapshot.sh`, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.
 When X-linked work reaches a milestone or terminal state, load `fmx-respond`; before terminal teardown, always post the final completion follow-up so the link clears even if earlier follow-ups were spent.

--- a/bin/fm-agent-loop-baseline.sh
+++ b/bin/fm-agent-loop-baseline.sh
@@ -141,6 +141,10 @@ from pathlib import Path
 root = Path(sys.argv[1]) / ".pi" / "extensions"
 total = 0
 count = 0
+tool_call = re.compile(
+    r"(?ms)^(?P<indent>[ \t]*)[^\n]*\bregisterTool(?:\?\.)?\(\s*\{"
+    r"(?P<body>.*?)^(?P=indent)\}\);\s*$"
+)
 def byte_len(s: str) -> int:
     try:
         return len(bytes(s, "utf-8").decode("unicode_escape").encode("utf-8"))
@@ -149,15 +153,17 @@ def byte_len(s: str) -> int:
 
 for path in sorted(root.rglob("*.ts")):
     text = path.read_text(encoding="utf-8", errors="replace")
-    # Match registerTool description / promptSnippet / promptGuidelines string literals.
-    for key in ("description", "promptSnippet"):
-        for m in re.finditer(rf"{key}:\s*\"((?:\\.|[^\"\\])*)\"", text):
-            total += byte_len(m.group(1))
-            if key == "description":
-                count += 1
-    for m in re.finditer(r"promptGuidelines:\s*\[(.*?)\]", text, re.S):
-        for sm in re.finditer(r"\"((?:\\.|[^\"\\])*)\"", m.group(1)):
-            total += byte_len(sm.group(1))
+    for tool in tool_call.finditer(text):
+        body = tool.group("body")
+        if not re.search(r"(?m)^\s*name\s*:", body):
+            continue
+        count += 1
+        for key in ("description", "promptSnippet"):
+            for m in re.finditer(rf"{key}:\s*\"((?:\\.|[^\"\\])*)\"", body):
+                total += byte_len(m.group(1))
+        for m in re.finditer(r"promptGuidelines:\s*\[(.*?)\]", body, re.S):
+            for sm in re.finditer(r"\"((?:\\.|[^\"\\])*)\"", m.group(1)):
+                total += byte_len(sm.group(1))
 print(f"{total} {count}")
 PY
 }
@@ -169,10 +175,16 @@ supervision_doc_bytes() {
 
 supervision_render_bytes() {
   local harness=$1
-  local out
-  out=$("$SCRIPT_DIR/fm-supervision-instructions.sh" \
-    --harness "$harness" --read-only 0 --afk 0 --x-mode 0 2>/dev/null || true)
-  printf '%s' "$out" | wc -c | tr -d ' '
+  local out bytes
+  out=$(mktemp "${TMPDIR:-/tmp}/fm-supervision-render.XXXXXX") || return 1
+  if ! "$SCRIPT_DIR/fm-supervision-instructions.sh" \
+    --harness "$harness" --read-only 0 --afk 0 --x-mode 0 > "$out"; then
+    rm -f "$out"
+    return 1
+  fi
+  bytes=$(file_bytes "$out")
+  rm -f "$out"
+  printf '%s\n' "$bytes"
 }
 
 discover_openai_compaction() {
@@ -252,21 +264,27 @@ EOF
   # Hold the session lock as this process so the digest is lock-held.
   printf '%s\n' "$$" > "$home/state/.lock"
   out="$tmp/digest.txt"
-  env PATH="$fakebin:/usr/bin:/bin" \
+  if ! env PATH="$fakebin:/usr/bin:/bin" \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$FM_ROOT" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_CONFIG_OVERRIDE="$home/config" \
     FM_BOOTSTRAP_DETECT_ONLY=1 \
-    "$SCRIPT_DIR/fm-session-start.sh" > "$out" 2>/dev/null || true
+    "$SCRIPT_DIR/fm-session-start.sh" > "$out" 2>/dev/null; then
+    rm -rf "$tmp"
+    return 1
+  fi
   printf '%s\n' "$(file_bytes "$out")"
   # Determinism: second run must match excluding lock/bootstrap noise if any.
   local out2="$tmp/digest2.txt"
-  env PATH="$fakebin:/usr/bin:/bin" \
+  if ! env PATH="$fakebin:/usr/bin:/bin" \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$FM_ROOT" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_CONFIG_OVERRIDE="$home/config" \
     FM_BOOTSTRAP_DETECT_ONLY=1 \
-    "$SCRIPT_DIR/fm-session-start.sh" > "$out2" 2>/dev/null || true
+    "$SCRIPT_DIR/fm-session-start.sh" > "$out2" 2>/dev/null; then
+    rm -rf "$tmp"
+    return 1
+  fi
   if cmp -s "$out" "$out2"; then
     printf 'true\n'
   else
@@ -334,31 +352,53 @@ fi
 NOTES='Firstmate controls AGENTS.md, skill descriptions, supervision renders, session-start digests, and tracked Pi extension tools. Provider WebSocket/delta tokenization and GPU inference are outside Firstmate. Code Mode was not added: existing shell aggregates (fm-fleet-snapshot, fm-bearings-snapshot, fm-session-start) already batch fleet inspection. Sol/Terra/Luna dispatch is unchanged without measured same-task evidence. Single OpenAI compaction path remains operator-installed pi-openai-server-compaction at compactThreshold when present.'
 
 if [ "$JSON" -eq 1 ]; then
-  python3 - <<PY
+  FM_BASELINE_JSON_MEASURED_AT=$MEASURED_AT \
+  FM_BASELINE_JSON_AGENTS_BYTES=$AGENTS_BYTES \
+  FM_BASELINE_JSON_AGENTS_TOKENS=$AGENTS_TOKENS \
+  FM_BASELINE_JSON_SKILL_DESC_BYTES=$SKILL_DESC_BYTES \
+  FM_BASELINE_JSON_SKILL_DESC_COUNT=$SKILL_DESC_COUNT \
+  FM_BASELINE_JSON_SKILL_BODY_BYTES=$SKILL_BODY_BYTES \
+  FM_BASELINE_JSON_PI_TOOL_BYTES=$PI_TOOL_BYTES \
+  FM_BASELINE_JSON_PI_TOOL_COUNT=$PI_TOOL_COUNT \
+  FM_BASELINE_JSON_SUP_DOC=$SUP_DOC_JSON \
+  FM_BASELINE_JSON_SUP_RENDER=$SUP_RENDER_JSON \
+  FM_BASELINE_JSON_SESSION_BYTES=$SESSION_FIXTURE_BYTES \
+  FM_BASELINE_JSON_SESSION_DETERMINISTIC=$SESSION_FIXTURE_DETERMINISTIC \
+  FM_BASELINE_JSON_SESSION_SORTED=$SESSION_FIXTURE_SORTED \
+  FM_BASELINE_JSON_COMPACTION_STATE=$COMPACTION_STATE \
+  FM_BASELINE_JSON_COMPACT_THRESHOLD=$COMPACT_THRESHOLD \
+  FM_BASELINE_JSON_USE_PREV_RESP=$USE_PREV_RESP \
+  FM_BASELINE_JSON_PI_CACHE_RETENTION=$PI_CACHE_RETENTION_ENV \
+  FM_BASELINE_JSON_CODEX_MODELS=$CODEX_MODELS \
+  FM_BASELINE_JSON_LUNA_AVAILABLE=$LUNA_AVAILABLE \
+  FM_BASELINE_JSON_NOTES=$NOTES \
+  python3 - <<'PY'
 import json
+import os
+value = os.environ.__getitem__
 print(json.dumps({
   "schema": "fm-agent-loop-baseline.v1",
-  "measured_at": "$MEASURED_AT",
-  "agents_md_bytes": int("$AGENTS_BYTES"),
-  "agents_md_approx_tokens": int("$AGENTS_TOKENS"),
-  "skill_description_bytes": int("$SKILL_DESC_BYTES"),
-  "skill_description_count": int("$SKILL_DESC_COUNT"),
-  "skill_body_bytes": int("$SKILL_BODY_BYTES"),
-  "pi_extension_tool_description_bytes": int("$PI_TOOL_BYTES"),
-  "pi_extension_tool_count": int("$PI_TOOL_COUNT"),
-  "supervision_doc_bytes": json.loads('''$SUP_DOC_JSON'''),
-  "supervision_render_bytes": json.loads('''$SUP_RENDER_JSON'''),
-  "session_start_fixture_bytes": int("$SESSION_FIXTURE_BYTES"),
-  "session_start_fixture_deterministic": "$SESSION_FIXTURE_DETERMINISTIC",
-  "session_start_fixture_sorted_ids": "$SESSION_FIXTURE_SORTED",
-  "openai_server_compaction": "$COMPACTION_STATE",
-  "openai_compact_threshold": "$COMPACT_THRESHOLD",
-  "openai_use_previous_response_id": "$USE_PREV_RESP",
-  "pi_cache_retention_env": "$PI_CACHE_RETENTION_ENV",
-  "openai_codex_models": "$CODEX_MODELS",
-  "luna_available": "$LUNA_AVAILABLE",
+  "measured_at": value("FM_BASELINE_JSON_MEASURED_AT"),
+  "agents_md_bytes": int(value("FM_BASELINE_JSON_AGENTS_BYTES")),
+  "agents_md_approx_tokens": int(value("FM_BASELINE_JSON_AGENTS_TOKENS")),
+  "skill_description_bytes": int(value("FM_BASELINE_JSON_SKILL_DESC_BYTES")),
+  "skill_description_count": int(value("FM_BASELINE_JSON_SKILL_DESC_COUNT")),
+  "skill_body_bytes": int(value("FM_BASELINE_JSON_SKILL_BODY_BYTES")),
+  "pi_extension_tool_description_bytes": int(value("FM_BASELINE_JSON_PI_TOOL_BYTES")),
+  "pi_extension_tool_count": int(value("FM_BASELINE_JSON_PI_TOOL_COUNT")),
+  "supervision_doc_bytes": json.loads(value("FM_BASELINE_JSON_SUP_DOC")),
+  "supervision_render_bytes": json.loads(value("FM_BASELINE_JSON_SUP_RENDER")),
+  "session_start_fixture_bytes": int(value("FM_BASELINE_JSON_SESSION_BYTES")),
+  "session_start_fixture_deterministic": value("FM_BASELINE_JSON_SESSION_DETERMINISTIC"),
+  "session_start_fixture_sorted_ids": value("FM_BASELINE_JSON_SESSION_SORTED"),
+  "openai_server_compaction": value("FM_BASELINE_JSON_COMPACTION_STATE"),
+  "openai_compact_threshold": value("FM_BASELINE_JSON_COMPACT_THRESHOLD"),
+  "openai_use_previous_response_id": value("FM_BASELINE_JSON_USE_PREV_RESP"),
+  "pi_cache_retention_env": value("FM_BASELINE_JSON_PI_CACHE_RETENTION"),
+  "openai_codex_models": value("FM_BASELINE_JSON_CODEX_MODELS"),
+  "luna_available": value("FM_BASELINE_JSON_LUNA_AVAILABLE"),
   "code_mode_embedded_runtime": "absent",
-  "notes": """$NOTES""",
+  "notes": value("FM_BASELINE_JSON_NOTES"),
 }, indent=2, sort_keys=True))
 PY
   exit 0

--- a/bin/fm-agent-loop-baseline.sh
+++ b/bin/fm-agent-loop-baseline.sh
@@ -318,7 +318,7 @@ LUNA_AVAILABLE=$(printf '%s
 ' "$CODEX_RAW" | sed -n '2p')
 
 if [ -z "${PI_CACHE_RETENTION+x}" ]; then
-  PI_CACHE_RETENTION_ENV=unset
+  PI_CACHE_RETENTION_ENV="unset"
 else
   PI_CACHE_RETENTION_ENV=$PI_CACHE_RETENTION
 fi

--- a/bin/fm-agent-loop-baseline.sh
+++ b/bin/fm-agent-loop-baseline.sh
@@ -82,21 +82,6 @@ file_bytes() {
   fi
 }
 
-sha_file() {
-  local path=$1
-  if [ ! -f "$path" ]; then
-    printf '\n'
-    return 0
-  fi
-  if command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "$path" | awk '{print $1}'
-  elif command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$path" | awk '{print $1}'
-  else
-    printf '\n'
-  fi
-}
-
 # Skill frontmatter description bytes (always-discoverable cost).
 skill_description_stats() {
   local total=0 count=0 path desc
@@ -224,16 +209,11 @@ PY
 }
 
 run_session_fixture() {
-  local tmp root home fakebin out
+  local tmp home fakebin out
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-agent-loop-baseline.XXXXXX")
-  root="$tmp/root"
   home="$tmp/home"
   fakebin="$tmp/fakebin"
-  mkdir -p "$home/state" "$home/data" "$home/config" "$fakebin" "$root"
-  # Minimal git root so tangle checks stay quiet.
-  git init -q -b main "$root" 2>/dev/null || true
-  git -C "$root" -c user.email=fm@example.invalid -c user.name=fm \
-    commit -q --allow-empty -m init 2>/dev/null || true
+  mkdir -p "$home/state" "$home/data" "$home/config" "$fakebin"
   # Quiet toolchain stubs.
   for cmd in tmux node gh gh-axi chrome-devtools-axi lavish-axi treehouse no-mistakes; do
     printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/$cmd"
@@ -337,7 +317,11 @@ CODEX_MODELS=$(printf '%s
 LUNA_AVAILABLE=$(printf '%s
 ' "$CODEX_RAW" | sed -n '2p')
 
-PI_CACHE_RETENTION_ENV=${PI_CACHE_RETENTION:-unset}
+if [ -z "${PI_CACHE_RETENTION+x}" ]; then
+  PI_CACHE_RETENTION_ENV=unset
+else
+  PI_CACHE_RETENTION_ENV=$PI_CACHE_RETENTION
+fi
 
 SESSION_FIXTURE_BYTES=0
 SESSION_FIXTURE_DETERMINISTIC=unknown

--- a/bin/fm-agent-loop-baseline.sh
+++ b/bin/fm-agent-loop-baseline.sh
@@ -4,8 +4,8 @@
 # Measures Firstmate-controlled always-loaded surfaces and deterministic render
 # contracts. It does not call model APIs and does not invent provider-side
 # inference claims. Provider cache/usage telemetry, WebSocket transport, and
-# server-side compaction remain outside Firstmate control except where a
-# documented operator package is already installed.
+# server-side compaction remain outside Firstmate control. Package and config
+# fields below are local inventory only, not proof of runtime activation.
 #
 # Output schema (stdout, key=value unless --json):
 #   schema=fm-agent-loop-baseline.v1
@@ -17,13 +17,13 @@
 #   supervision_<harness>_bytes for each docs/supervision-protocols/*.md
 #   supervision_render_<harness>_bytes for fm-supervision-instructions.sh output
 #   session_start_fixture_bytes (optional; requires --with-session-fixture)
-#   openai_server_compaction=<present|absent>
-#   openai_compact_threshold=<int or empty>
-#   openai_use_previous_response_id=<true|false|unknown>
-#   pi_cache_retention_env=<value or unset>
-#   openai_codex_models=<comma list when discoverable>
-#   luna_available=<true|false|unknown>
-#   code_mode_embedded_runtime=<absent>
+#   openai_server_compaction=<present|absent> (global config-file inventory)
+#   openai_compact_threshold=<configured int or empty>
+#   openai_use_previous_response_id=<configured true|false|unknown>
+#   pi_cache_retention_env=<ambient value or unset>
+#   openai_codex_models=<local model-store comma list when discoverable>
+#   luna_available=<true|false|unknown> (local model-store inventory)
+#   code_mode_embedded_runtime=<absent> (declared boundary, not runtime detection)
 #   notes=...
 #
 # Usage:

--- a/bin/fm-agent-loop-baseline.sh
+++ b/bin/fm-agent-loop-baseline.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+# fm-agent-loop-baseline.sh - reproducible Firstmate agent-loop overhead baseline.
+#
+# Measures Firstmate-controlled always-loaded surfaces and deterministic render
+# contracts. It does not call model APIs and does not invent provider-side
+# inference claims. Provider cache/usage telemetry, WebSocket transport, and
+# server-side compaction remain outside Firstmate control except where a
+# documented operator package is already installed.
+#
+# Output schema (stdout, key=value unless --json):
+#   schema=fm-agent-loop-baseline.v1
+#   measured_at=<UTC ISO8601 or FM_BASELINE_NOW>
+#   agents_md_bytes / agents_md_approx_tokens
+#   skill_description_bytes / skill_description_count
+#   skill_body_bytes (full SKILL.md bodies; loaded on demand, not always-on)
+#   pi_extension_tool_description_bytes / pi_extension_tool_count
+#   supervision_<harness>_bytes for each docs/supervision-protocols/*.md
+#   supervision_render_<harness>_bytes for fm-supervision-instructions.sh output
+#   session_start_fixture_bytes (optional; requires --with-session-fixture)
+#   openai_server_compaction=<present|absent>
+#   openai_compact_threshold=<int or empty>
+#   openai_use_previous_response_id=<true|false|unknown>
+#   pi_cache_retention_env=<value or unset>
+#   openai_codex_models=<comma list when discoverable>
+#   luna_available=<true|false|unknown>
+#   code_mode_embedded_runtime=<absent>
+#   notes=...
+#
+# Usage:
+#   fm-agent-loop-baseline.sh [--json] [--with-session-fixture]
+#   fm-agent-loop-baseline.sh --help
+#
+# --with-session-fixture builds an isolated fake home, runs fm-session-start.sh
+# once under lock-held conditions with a quiet toolchain, and records digest
+# bytes. It never touches the live fleet home.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+# shellcheck source=bin/fm-prompt-stable-lib.sh
+. "$SCRIPT_DIR/fm-prompt-stable-lib.sh"
+
+JSON=0
+WITH_FIXTURE=0
+MEASURED_AT=${FM_BASELINE_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json) JSON=1; shift ;;
+    --with-session-fixture) WITH_FIXTURE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      printf 'fm-agent-loop-baseline: unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+approx_tokens() {
+  # Rough 4-byte heuristic used only for relative baselines, not billing.
+  local bytes=$1
+  printf '%s\n' $(( (bytes + 3) / 4 ))
+}
+
+file_bytes() {
+  local path=$1
+  if [ -f "$path" ]; then
+    wc -c < "$path" | tr -d ' '
+  else
+    printf '0\n'
+  fi
+}
+
+sha_file() {
+  local path=$1
+  if [ ! -f "$path" ]; then
+    printf '\n'
+    return 0
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+  else
+    printf '\n'
+  fi
+}
+
+# Skill frontmatter description bytes (always-discoverable cost).
+skill_description_stats() {
+  local total=0 count=0 path desc
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    desc=$(python3 - "$path" <<'PY'
+import re, sys
+from pathlib import Path
+text = Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace")
+m = re.search(r"^---\n(.*?)\n---", text, re.S)
+if not m:
+    print(0)
+    raise SystemExit
+block = m.group(1)
+dm = re.search(r"(?m)^description:\s*(?:[|>][+-]?\s*)?(.*?)(?=\n[A-Za-z0-9_-]+:|\Z)", block, re.S)
+if not dm:
+    print(0)
+    raise SystemExit
+print(len(dm.group(1).strip().encode("utf-8")))
+PY
+)
+    total=$((total + desc))
+    count=$((count + 1))
+  done < <(find "$FM_ROOT/.agents/skills" "$FM_ROOT/skills" -type f -name 'SKILL.md' 2>/dev/null | LC_ALL=C sort)
+  printf '%s %s\n' "$total" "$count"
+}
+
+skill_body_bytes() {
+  local total=0 path
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    total=$((total + $(file_bytes "$path")))
+  done < <(find "$FM_ROOT/.agents/skills" "$FM_ROOT/skills" -type f -name 'SKILL.md' 2>/dev/null | LC_ALL=C sort)
+  printf '%s\n' "$total"
+}
+
+# Firstmate-owned Pi tool description / prompt metadata bytes.
+pi_tool_stats() {
+  python3 - "$FM_ROOT" <<'PY'
+import re, sys
+from pathlib import Path
+root = Path(sys.argv[1]) / ".pi" / "extensions"
+total = 0
+count = 0
+def byte_len(s: str) -> int:
+    try:
+        return len(bytes(s, "utf-8").decode("unicode_escape").encode("utf-8"))
+    except Exception:
+        return len(s.encode("utf-8"))
+
+for path in sorted(root.rglob("*.ts")):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    # Match registerTool description / promptSnippet / promptGuidelines string literals.
+    for key in ("description", "promptSnippet"):
+        for m in re.finditer(rf"{key}:\s*\"((?:\\.|[^\"\\])*)\"", text):
+            total += byte_len(m.group(1))
+            if key == "description":
+                count += 1
+    for m in re.finditer(r"promptGuidelines:\s*\[(.*?)\]", text, re.S):
+        for sm in re.finditer(r"\"((?:\\.|[^\"\\])*)\"", m.group(1)):
+            total += byte_len(sm.group(1))
+print(f"{total} {count}")
+PY
+}
+
+supervision_doc_bytes() {
+  local harness=$1
+  file_bytes "$FM_ROOT/docs/supervision-protocols/${harness}.md"
+}
+
+supervision_render_bytes() {
+  local harness=$1
+  local out
+  out=$("$SCRIPT_DIR/fm-supervision-instructions.sh" \
+    --harness "$harness" --read-only 0 --afk 0 --x-mode 0 2>/dev/null || true)
+  printf '%s' "$out" | wc -c | tr -d ' '
+}
+
+discover_openai_compaction() {
+  local cfg="${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}/openai-server-compaction.json"
+  if [ -f "$cfg" ]; then
+    python3 - "$cfg" <<'PY'
+import json, sys
+from pathlib import Path
+cfg = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print("present")
+print(cfg.get("compactThreshold", ""))
+print("true" if cfg.get("usePreviousResponseId") else "false")
+PY
+  else
+    printf 'absent\n\nunknown\n'
+  fi
+}
+
+discover_codex_models() {
+  local store="${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}/models-store.json"
+  if [ ! -f "$store" ]; then
+    printf 'unknown\nfalse\n'
+    return 0
+  fi
+  python3 - "$store" <<'PY'
+import json, sys
+from pathlib import Path
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+models = []
+for m in data.get("openai-codex", {}).get("models", []):
+    mid = m.get("id") or ""
+    if mid:
+        models.append(mid)
+print(",".join(models) if models else "none")
+print("true" if any(x == "gpt-5.6-luna" for x in models) else "false")
+PY
+}
+
+run_session_fixture() {
+  local tmp root home fakebin out
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-agent-loop-baseline.XXXXXX")
+  root="$tmp/root"
+  home="$tmp/home"
+  fakebin="$tmp/fakebin"
+  mkdir -p "$home/state" "$home/data" "$home/config" "$fakebin" "$root"
+  # Minimal git root so tangle checks stay quiet.
+  git init -q -b main "$root" 2>/dev/null || true
+  git -C "$root" -c user.email=fm@example.invalid -c user.name=fm \
+    commit -q --allow-empty -m init 2>/dev/null || true
+  # Quiet toolchain stubs.
+  for cmd in tmux node gh gh-axi chrome-devtools-axi lavish-axi treehouse no-mistakes; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/$cmd"
+    chmod +x "$fakebin/$cmd"
+  done
+  printf 'manual\n' > "$home/config/backlog-backend"
+  printf 'alpha\n' > "$home/data/captain.md"
+  # Two tasks in reverse create order; listing must still be alpha-sorted.
+  cat > "$home/state/zulu.meta" <<'EOF'
+window=tmux:zulu
+harness=pi
+kind=ship
+mode=no-mistakes
+yolo=off
+EOF
+  cat > "$home/state/alpha.meta" <<'EOF'
+window=tmux:alpha
+harness=pi
+kind=ship
+mode=no-mistakes
+yolo=off
+EOF
+  printf 'working: start\n' > "$home/state/zulu.status"
+  printf 'working: start\n' > "$home/state/alpha.status"
+  # Fresh beacon keeps the session-start watcher banner from alternating between
+  # first-sighting and same-episode wording across two fixture runs.
+  : > "$home/state/.last-watcher-beat"
+  # Hold the session lock as this process so the digest is lock-held.
+  printf '%s\n' "$$" > "$home/state/.lock"
+  out="$tmp/digest.txt"
+  env PATH="$fakebin:/usr/bin:/bin" \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$FM_ROOT" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 \
+    "$SCRIPT_DIR/fm-session-start.sh" > "$out" 2>/dev/null || true
+  printf '%s\n' "$(file_bytes "$out")"
+  # Determinism: second run must match excluding lock/bootstrap noise if any.
+  local out2="$tmp/digest2.txt"
+  env PATH="$fakebin:/usr/bin:/bin" \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$FM_ROOT" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 \
+    "$SCRIPT_DIR/fm-session-start.sh" > "$out2" 2>/dev/null || true
+  if cmp -s "$out" "$out2"; then
+    printf 'true\n'
+  else
+    printf 'false\n'
+  fi
+  # Meta section order must list alpha before zulu.
+  if awk '
+    /Work under way/ {inmeta=1}
+    inmeta && /^--- alpha ---$/ {a=1}
+    inmeta && /^--- zulu ---$/ {z=1; if(a) ok=1}
+    END { exit ok ? 0 : 1 }
+  ' "$out"; then
+    printf 'true\n'
+  else
+    printf 'false\n'
+  fi
+  rm -rf "$tmp"
+}
+
+AGENTS_BYTES=$(file_bytes "$FM_ROOT/AGENTS.md")
+AGENTS_TOKENS=$(approx_tokens "$AGENTS_BYTES")
+read -r SKILL_DESC_BYTES SKILL_DESC_COUNT < <(skill_description_stats)
+SKILL_BODY_BYTES=$(skill_body_bytes)
+read -r PI_TOOL_BYTES PI_TOOL_COUNT < <(pi_tool_stats)
+
+SUP_HARNESSES="claude codex grok kimi opencode pi unknown"
+SUP_DOC_JSON=""
+SUP_RENDER_JSON=""
+for h in $SUP_HARNESSES; do
+  db=$(supervision_doc_bytes "$h")
+  rb=$(supervision_render_bytes "$h")
+  eval "SUP_DOC_${h}=$db"
+  eval "SUP_RENDER_${h}=$rb"
+  SUP_DOC_JSON="${SUP_DOC_JSON}\"${h}\":${db},"
+  SUP_RENDER_JSON="${SUP_RENDER_JSON}\"${h}\":${rb},"
+done
+SUP_DOC_JSON="{${SUP_DOC_JSON%,}}"
+SUP_RENDER_JSON="{${SUP_RENDER_JSON%,}}"
+
+COMPACTION_RAW=$(discover_openai_compaction)
+COMPACTION_STATE=$(printf '%s
+' "$COMPACTION_RAW" | sed -n '1p')
+COMPACT_THRESHOLD=$(printf '%s
+' "$COMPACTION_RAW" | sed -n '2p')
+USE_PREV_RESP=$(printf '%s
+' "$COMPACTION_RAW" | sed -n '3p')
+CODEX_RAW=$(discover_codex_models)
+CODEX_MODELS=$(printf '%s
+' "$CODEX_RAW" | sed -n '1p')
+LUNA_AVAILABLE=$(printf '%s
+' "$CODEX_RAW" | sed -n '2p')
+
+PI_CACHE_RETENTION_ENV=${PI_CACHE_RETENTION:-unset}
+
+SESSION_FIXTURE_BYTES=0
+SESSION_FIXTURE_DETERMINISTIC=unknown
+SESSION_FIXTURE_SORTED=unknown
+if [ "$WITH_FIXTURE" -eq 1 ]; then
+  fixture_out=$(run_session_fixture)
+  SESSION_FIXTURE_BYTES=$(printf '%s\n' "$fixture_out" | sed -n '1p')
+  SESSION_FIXTURE_DETERMINISTIC=$(printf '%s\n' "$fixture_out" | sed -n '2p')
+  SESSION_FIXTURE_SORTED=$(printf '%s\n' "$fixture_out" | sed -n '3p')
+fi
+
+NOTES='Firstmate controls AGENTS.md, skill descriptions, supervision renders, session-start digests, and tracked Pi extension tools. Provider WebSocket/delta tokenization and GPU inference are outside Firstmate. Code Mode was not added: existing shell aggregates (fm-fleet-snapshot, fm-bearings-snapshot, fm-session-start) already batch fleet inspection. Sol/Terra/Luna dispatch is unchanged without measured same-task evidence. Single OpenAI compaction path remains operator-installed pi-openai-server-compaction at compactThreshold when present.'
+
+if [ "$JSON" -eq 1 ]; then
+  python3 - <<PY
+import json
+print(json.dumps({
+  "schema": "fm-agent-loop-baseline.v1",
+  "measured_at": "$MEASURED_AT",
+  "agents_md_bytes": int("$AGENTS_BYTES"),
+  "agents_md_approx_tokens": int("$AGENTS_TOKENS"),
+  "skill_description_bytes": int("$SKILL_DESC_BYTES"),
+  "skill_description_count": int("$SKILL_DESC_COUNT"),
+  "skill_body_bytes": int("$SKILL_BODY_BYTES"),
+  "pi_extension_tool_description_bytes": int("$PI_TOOL_BYTES"),
+  "pi_extension_tool_count": int("$PI_TOOL_COUNT"),
+  "supervision_doc_bytes": json.loads('''$SUP_DOC_JSON'''),
+  "supervision_render_bytes": json.loads('''$SUP_RENDER_JSON'''),
+  "session_start_fixture_bytes": int("$SESSION_FIXTURE_BYTES"),
+  "session_start_fixture_deterministic": "$SESSION_FIXTURE_DETERMINISTIC",
+  "session_start_fixture_sorted_ids": "$SESSION_FIXTURE_SORTED",
+  "openai_server_compaction": "$COMPACTION_STATE",
+  "openai_compact_threshold": "$COMPACT_THRESHOLD",
+  "openai_use_previous_response_id": "$USE_PREV_RESP",
+  "pi_cache_retention_env": "$PI_CACHE_RETENTION_ENV",
+  "openai_codex_models": "$CODEX_MODELS",
+  "luna_available": "$LUNA_AVAILABLE",
+  "code_mode_embedded_runtime": "absent",
+  "notes": """$NOTES""",
+}, indent=2, sort_keys=True))
+PY
+  exit 0
+fi
+
+cat <<EOF
+schema=fm-agent-loop-baseline.v1
+measured_at=$MEASURED_AT
+agents_md_bytes=$AGENTS_BYTES
+agents_md_approx_tokens=$AGENTS_TOKENS
+skill_description_bytes=$SKILL_DESC_BYTES
+skill_description_count=$SKILL_DESC_COUNT
+skill_body_bytes=$SKILL_BODY_BYTES
+pi_extension_tool_description_bytes=$PI_TOOL_BYTES
+pi_extension_tool_count=$PI_TOOL_COUNT
+EOF
+
+for h in $SUP_HARNESSES; do
+  eval "db=\$SUP_DOC_${h}"
+  eval "rb=\$SUP_RENDER_${h}"
+  printf 'supervision_%s_doc_bytes=%s\n' "$h" "$db"
+  printf 'supervision_%s_render_bytes=%s\n' "$h" "$rb"
+done
+
+cat <<EOF
+session_start_fixture_bytes=$SESSION_FIXTURE_BYTES
+session_start_fixture_deterministic=$SESSION_FIXTURE_DETERMINISTIC
+session_start_fixture_sorted_ids=$SESSION_FIXTURE_SORTED
+openai_server_compaction=$COMPACTION_STATE
+openai_compact_threshold=$COMPACT_THRESHOLD
+openai_use_previous_response_id=$USE_PREV_RESP
+pi_cache_retention_env=$PI_CACHE_RETENTION_ENV
+openai_codex_models=$CODEX_MODELS
+luna_available=$LUNA_AVAILABLE
+code_mode_embedded_runtime=absent
+notes=$NOTES
+EOF

--- a/bin/fm-prompt-stable-lib.sh
+++ b/bin/fm-prompt-stable-lib.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# fm-prompt-stable-lib.sh - shared helpers for cache-stable Firstmate renders.
+#
+# Prompt-cache reuse requires exact prefix matches. Firstmate-controlled digests
+# and instruction blocks must therefore:
+#   1. emit static sections in a fixed order,
+#   2. list multi-entry state with deterministic (LC_ALL=C) id order,
+#   3. keep volatile runtime observations after the stable material they annotate.
+#
+# This library owns only the shared listing/ordering primitives. Each caller owns
+# its section layout and which fields are treated as volatile.
+#
+# Sourced only. Not a CLI.
+
+# fm_prompt_stable_list_ids <dir> <suffix>
+# Print basenames under <dir> matching *.<suffix>, one per line, sorted with
+# LC_ALL=C. Missing directories and empty matches print nothing.
+fm_prompt_stable_list_ids() {
+  local dir=$1 suffix=$2
+  local path id
+  [ -d "$dir" ] || return 0
+  # Prefer find for stable enumeration; fall back to a sorted glob when find is
+  # unavailable in tightly faked PATH fixtures.
+  if command -v find >/dev/null 2>&1; then
+    # -print0 / sort -z keep odd characters safe; strip the dotted suffix after.
+    while IFS= read -r -d '' path; do
+      id=$(basename "$path")
+      id=${id%."$suffix"}
+      printf '%s\n' "$id"
+    done < <(find "$dir" -maxdepth 1 -type f -name "*.${suffix}" -print0 2>/dev/null | LC_ALL=C sort -z)
+    return 0
+  fi
+  local old_nullglob
+  old_nullglob=$(shopt -p nullglob || true)
+  shopt -s nullglob
+  for path in "$dir"/*."$suffix"; do
+    id=$(basename "$path")
+    id=${id%."$suffix"}
+    printf '%s\n' "$id"
+  done | LC_ALL=C sort
+  eval "$old_nullglob" 2>/dev/null || true
+}
+
+# fm_prompt_stable_split_prefix_suffix <full-text-file> <volatile-marker-regex>
+# Print two records to stdout as:
+#   PREFIX_BYTES=<n>
+#   SUFFIX_BYTES=<n>
+#   PREFIX_SHA256=<hex>
+#   SUFFIX_SHA256=<hex>
+# The first line matching the extended regex starts the volatile suffix; when no
+# line matches, the whole file is prefix.
+fm_prompt_stable_split_stats() {
+  local file=$1 marker_re=$2
+  local prefix_file suffix_file line hit=0
+  prefix_file=$(mktemp) || return 1
+  suffix_file=$(mktemp) || { rm -f "$prefix_file"; return 1; }
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ "$hit" -eq 0 ] && printf '%s\n' "$line" | grep -E -q -- "$marker_re"; then
+      hit=1
+    fi
+    if [ "$hit" -eq 1 ]; then
+      printf '%s\n' "$line" >> "$suffix_file"
+    else
+      printf '%s\n' "$line" >> "$prefix_file"
+    fi
+  done < "$file"
+  printf 'PREFIX_BYTES=%s\n' "$(wc -c < "$prefix_file" | tr -d ' ')"
+  printf 'SUFFIX_BYTES=%s\n' "$(wc -c < "$suffix_file" | tr -d ' ')"
+  if command -v shasum >/dev/null 2>&1; then
+    printf 'PREFIX_SHA256=%s\n' "$(shasum -a 256 "$prefix_file" | awk '{print $1}')"
+    printf 'SUFFIX_SHA256=%s\n' "$(shasum -a 256 "$suffix_file" | awk '{print $1}')"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf 'PREFIX_SHA256=%s\n' "$(sha256sum "$prefix_file" | awk '{print $1}')"
+    printf 'SUFFIX_SHA256=%s\n' "$(sha256sum "$suffix_file" | awk '{print $1}')"
+  else
+    printf 'PREFIX_SHA256=\n'
+    printf 'SUFFIX_SHA256=\n'
+  fi
+  rm -f "$prefix_file" "$suffix_file"
+}

--- a/bin/fm-prompt-stable-lib.sh
+++ b/bin/fm-prompt-stable-lib.sh
@@ -5,9 +5,9 @@
 # and instruction blocks must therefore:
 #   1. emit static sections in a fixed order,
 #   2. list multi-entry state with deterministic (LC_ALL=C) id order,
-#   3. keep volatile runtime observations after the stable material they annotate.
+#   3. keep volatile runtime observations after all stable material in the block.
 #
-# This library owns only the shared listing/ordering primitives. Each caller owns
+# This library owns only the shared listing/ordering primitive. Each caller owns
 # its section layout and which fields are treated as volatile.
 #
 # Sourced only. Not a CLI.
@@ -39,42 +39,4 @@ fm_prompt_stable_list_ids() {
     printf '%s\n' "$id"
   done | LC_ALL=C sort
   eval "$old_nullglob" 2>/dev/null || true
-}
-
-# fm_prompt_stable_split_prefix_suffix <full-text-file> <volatile-marker-regex>
-# Print two records to stdout as:
-#   PREFIX_BYTES=<n>
-#   SUFFIX_BYTES=<n>
-#   PREFIX_SHA256=<hex>
-#   SUFFIX_SHA256=<hex>
-# The first line matching the extended regex starts the volatile suffix; when no
-# line matches, the whole file is prefix.
-fm_prompt_stable_split_stats() {
-  local file=$1 marker_re=$2
-  local prefix_file suffix_file line hit=0
-  prefix_file=$(mktemp) || return 1
-  suffix_file=$(mktemp) || { rm -f "$prefix_file"; return 1; }
-  while IFS= read -r line || [ -n "$line" ]; do
-    if [ "$hit" -eq 0 ] && printf '%s\n' "$line" | grep -E -q -- "$marker_re"; then
-      hit=1
-    fi
-    if [ "$hit" -eq 1 ]; then
-      printf '%s\n' "$line" >> "$suffix_file"
-    else
-      printf '%s\n' "$line" >> "$prefix_file"
-    fi
-  done < "$file"
-  printf 'PREFIX_BYTES=%s\n' "$(wc -c < "$prefix_file" | tr -d ' ')"
-  printf 'SUFFIX_BYTES=%s\n' "$(wc -c < "$suffix_file" | tr -d ' ')"
-  if command -v shasum >/dev/null 2>&1; then
-    printf 'PREFIX_SHA256=%s\n' "$(shasum -a 256 "$prefix_file" | awk '{print $1}')"
-    printf 'SUFFIX_SHA256=%s\n' "$(shasum -a 256 "$suffix_file" | awk '{print $1}')"
-  elif command -v sha256sum >/dev/null 2>&1; then
-    printf 'PREFIX_SHA256=%s\n' "$(sha256sum "$prefix_file" | awk '{print $1}')"
-    printf 'SUFFIX_SHA256=%s\n' "$(sha256sum "$suffix_file" | awk '{print $1}')"
-  else
-    printf 'PREFIX_SHA256=\n'
-    printf 'SUFFIX_SHA256=\n'
-  fi
-  rm -f "$prefix_file" "$suffix_file"
 }

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -39,9 +39,10 @@
 #                       data/captain-shared.md, data/learnings.md: read-only,
 #                       always safe, always runs.
 #   5. fleet digest   - a compact data/backlog.md identity/metadata listing,
-#                       every state/*.meta, a bounded state/*.status tail,
-#                       state/.afk, and a cheap per-task endpoint-liveness read:
-#                       read-only, always runs.
+#                       every state/*.meta in LC_ALL=C id order (stable meta
+#                       bytes before each task's volatile endpoint/status lines),
+#                       orphan status tails, state/.afk, and a cheap per-task
+#                       endpoint-liveness read: read-only, always runs.
 #   6. closing reminder - prints the context-specific watcher next step; this
 #                       script points back to the emitted harness supervision
 #                       block and deliberately never arms the watcher itself.
@@ -103,6 +104,8 @@ PRIMARY_HARNESS=$("$SCRIPT_DIR/fm-harness.sh" 2>/dev/null || printf unknown)
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-prompt-stable-lib.sh
+. "$SCRIPT_DIR/fm-prompt-stable-lib.sh"
 
 STATUS_TAIL=${FM_SESSION_START_STATUS_TAIL:-5}
 case "$STATUS_TAIL" in ''|*[!0-9]*) STATUS_TAIL=5 ;; esac
@@ -345,11 +348,15 @@ section "FLEET STATE"
 print_backlog_compact "$DATA/backlog.md" "data/backlog.md"
 
 subsection "Work under way (state/*.meta)"
+# Stable material (meta bytes) prints before volatile endpoint/status observations
+# for each task, and tasks themselves are LC_ALL=C id-ordered so repeated digests
+# keep a cache-stable multi-entry layout (bin/fm-prompt-stable-lib.sh).
 META_FOUND=0
-for meta in "$STATE"/*.meta; do
+while IFS= read -r id; do
+  [ -n "$id" ] || continue
+  meta="$STATE/$id.meta"
   [ -f "$meta" ] || continue
   META_FOUND=1
-  id=$(basename "$meta" .meta)
   printf '\n--- %s ---\n' "$id"
   cat "$meta"
 
@@ -372,19 +379,20 @@ for meta in "$STATE"/*.meta; do
   else
     printf 'status tail: (no status file yet: %s)\n' "$status"
   fi
-done
+done < <(fm_prompt_stable_list_ids "$STATE" meta)
 [ "$META_FOUND" -eq 1 ] || printf '(none)\n'
 
 subsection "Orphan status logs (state/*.status without matching .meta)"
 ORPHAN_STATUS_FOUND=0
-for status in "$STATE"/*.status; do
+while IFS= read -r id; do
+  [ -n "$id" ] || continue
+  status="$STATE/$id.status"
   [ -f "$status" ] || continue
-  id=$(basename "$status" .status)
   [ -f "$STATE/$id.meta" ] && continue
   ORPHAN_STATUS_FOUND=1
   printf '\n--- %s ---\n' "$id"
   print_status_tail "$status"
-done
+done < <(fm_prompt_stable_list_ids "$STATE" status)
 [ "$ORPHAN_STATUS_FOUND" -eq 1 ] || printf '(none)\n'
 
 subsection "AFK"
@@ -437,6 +445,8 @@ history is actually needed. Re-reading everything defeats the entire point
 of this command. Re-read a file only if this digest flagged it ABSENT (then
 rebuild or create it per AGENTS.md), its contents looked unparseable/corrupt,
 or an individual full status log is needed for older wake-event history.
+For whole-fleet heartbeat or catch-up reviews, use bin/fm-fleet-view.sh or
+bin/fm-bearings-snapshot.sh once instead of serial per-task inspection loops.
 EOF
 
 exit 0

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -39,10 +39,10 @@
 #                       data/captain-shared.md, data/learnings.md: read-only,
 #                       always safe, always runs.
 #   5. fleet digest   - a compact data/backlog.md identity/metadata listing,
-#                       every state/*.meta in LC_ALL=C id order (stable meta
-#                       bytes before each task's volatile endpoint/status lines),
-#                       orphan status tails, state/.afk, and a cheap per-task
-#                       endpoint-liveness read: read-only, always runs.
+#                       every state/*.meta in LC_ALL=C id order (all stable meta
+#                       bytes before any volatile endpoint/status lines), orphan
+#                       status tails, state/.afk, and a cheap per-task endpoint-
+#                       liveness read: read-only, always runs.
 #   6. closing reminder - prints the context-specific watcher next step; this
 #                       script points back to the emitted harness supervision
 #                       block and deliberately never arms the watcher itself.
@@ -347,10 +347,10 @@ print_file_or_absent "$DATA/learnings.md" "data/learnings.md"
 section "FLEET STATE"
 print_backlog_compact "$DATA/backlog.md" "data/backlog.md"
 
-subsection "Work under way (state/*.meta)"
-# Stable material (meta bytes) prints before volatile endpoint/status observations
-# for each task, and tasks themselves are LC_ALL=C id-ordered so repeated digests
-# keep a cache-stable multi-entry layout (bin/fm-prompt-stable-lib.sh).
+subsection "Work under way - stable metadata (state/*.meta)"
+# Tasks are staged once in LC_ALL=C id order. Every stable metadata record prints
+# before the separate volatile endpoint/status section.
+META_IDS=$(fm_prompt_stable_list_ids "$STATE" meta)
 META_FOUND=0
 while IFS= read -r id; do
   [ -n "$id" ] || continue
@@ -359,7 +359,19 @@ while IFS= read -r id; do
   META_FOUND=1
   printf '\n--- %s ---\n' "$id"
   cat "$meta"
+done <<EOF
+$META_IDS
+EOF
+[ "$META_FOUND" -eq 1 ] || printf '(none)\n'
 
+subsection "Work under way - volatile endpoint and status observations"
+VOLATILE_FOUND=0
+while IFS= read -r id; do
+  [ -n "$id" ] || continue
+  meta="$STATE/$id.meta"
+  [ -f "$meta" ] || continue
+  VOLATILE_FOUND=1
+  printf '\n--- %s endpoint/status ---\n' "$id"
   window=$(fm_meta_get "$meta" window)
   target=$(fm_backend_target_of_meta "$meta")
   if [ -n "$window" ]; then
@@ -379,8 +391,10 @@ while IFS= read -r id; do
   else
     printf 'status tail: (no status file yet: %s)\n' "$status"
   fi
-done < <(fm_prompt_stable_list_ids "$STATE" meta)
-[ "$META_FOUND" -eq 1 ] || printf '(none)\n'
+done <<EOF
+$META_IDS
+EOF
+[ "$VOLATILE_FOUND" -eq 1 ] || printf '(none)\n'
 
 subsection "Orphan status logs (state/*.status without matching .meta)"
 ORPHAN_STATUS_FOUND=0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -102,6 +102,9 @@
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
+#   pi and pi-signed launches also prefix FM_PI_HARNESS=<harness> and, when the
+#   operator has not set PI_CACHE_RETENTION, PI_CACHE_RETENTION=long for extended
+#   provider prompt caching where the installed Pi build supports it.
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -516,7 +519,16 @@ case "$ARG3" in
 esac
 
 case "$HARNESS" in
-  pi|pi-signed) LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH" ;;
+  pi|pi-signed)
+    # Prefer long provider prompt-cache retention when the operator has not set
+    # PI_CACHE_RETENTION already. Documented by Pi environment-variables.md;
+    # providers that ignore the flag stay unchanged.
+    if [ -z "${PI_CACHE_RETENTION+x}" ] || [ -z "${PI_CACHE_RETENTION}" ]; then
+      LAUNCH="PI_CACHE_RETENTION=long FM_PI_HARNESS=$HARNESS $LAUNCH"
+    else
+      LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH"
+    fi
+    ;;
 esac
 
 # pi-signed is an explicitly selected executable identity, not an alias that may

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -102,9 +102,8 @@
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
-#   pi and pi-signed launches also prefix FM_PI_HARNESS=<harness> and, when the
-#   operator has not set PI_CACHE_RETENTION, PI_CACHE_RETENTION=long for extended
-#   provider prompt caching where the installed Pi build supports it.
+#   pi and pi-signed launches always forward a shell-quoted PI_CACHE_RETENTION.
+#   An unset value selects long; explicit values, including empty, are preserved.
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -520,13 +519,10 @@ esac
 
 case "$HARNESS" in
   pi|pi-signed)
-    # Prefer long provider prompt-cache retention when the operator has not set
-    # PI_CACHE_RETENTION already. Documented by Pi environment-variables.md;
-    # providers that ignore the flag stay unchanged.
-    if [ -z "${PI_CACHE_RETENTION+x}" ] || [ -z "${PI_CACHE_RETENTION}" ]; then
-      LAUNCH="PI_CACHE_RETENTION=long FM_PI_HARNESS=$HARNESS $LAUNCH"
+    if [ -z "${PI_CACHE_RETENTION+x}" ]; then
+      PI_CACHE_RETENTION_VALUE=long
     else
-      LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH"
+      PI_CACHE_RETENTION_VALUE=$PI_CACHE_RETENTION
     fi
     ;;
 esac
@@ -1523,6 +1519,11 @@ LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
+case "$HARNESS" in
+  pi|pi-signed)
+    LAUNCH="PI_CACHE_RETENTION=$(shell_quote "$PI_CACHE_RETENTION_VALUE") FM_PI_HARNESS=$HARNESS $LAUNCH"
+    ;;
+esac
 # Crewmate panes are created by a long-lived tmux/herdr daemon that does not
 # inherit firstmate's current environment, so a bare `claude` in the pane falls
 # back to the default ~/.claude store even when firstmate itself runs under a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ The default path remains local-only; live GitHub enrichment exists only behind t
 Optional X mode integrates with the watcher only after explicit opt-in; [configuration.md](configuration.md#x-mode-env) owns its generated-artifact and dispatch mechanics.
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
-Firstmate-controlled prompt construction keeps multi-entry fleet digests in deterministic id order with volatile endpoint observations after stable meta bytes.
+Firstmate-controlled prompt construction keeps multi-entry fleet digests in deterministic id order with every stable task metadata record before any volatile endpoint/status observation.
 `bin/fm-prompt-stable-lib.sh` owns the shared listing primitive.
 `bin/fm-agent-loop-baseline.sh` owns the reproducible overhead baseline.
 [Agent-loop efficiency verification](verification/agent-loop-efficiency.md) records measured boundaries for deferred tool discovery, Code Mode, transport, compaction, and Sol/Terra/Luna routing.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,10 @@ The default path remains local-only; live GitHub enrichment exists only behind t
 Optional X mode integrates with the watcher only after explicit opt-in; [configuration.md](configuration.md#x-mode-env) owns its generated-artifact and dispatch mechanics.
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
+Firstmate-controlled prompt construction keeps multi-entry fleet digests in deterministic id order with volatile endpoint observations after stable meta bytes.
+`bin/fm-prompt-stable-lib.sh` owns the shared listing primitive.
+`bin/fm-agent-loop-baseline.sh` owns the reproducible overhead baseline.
+[Agent-loop efficiency verification](verification/agent-loop-efficiency.md) records measured boundaries for deferred tool discovery, Code Mode, transport, compaction, and Sol/Terra/Luna routing.
 That block owns the live wait shape for the running primary harness: Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
 `bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints an honest `started`, `attached`, or nonzero `FAILED` status.
 On `attached` it stays live across identity-matched successors, and an unexplained clean child close either attaches to a verified healthy successor or becomes the typed nonzero `watcher: FAILED - cycle ended without an actionable reason` result.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,10 +55,10 @@ The default path remains local-only; live GitHub enrichment exists only behind t
 Optional X mode integrates with the watcher only after explicit opt-in; [configuration.md](configuration.md#x-mode-env) owns its generated-artifact and dispatch mechanics.
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
-Firstmate-controlled prompt construction keeps multi-entry fleet digests in deterministic id order with every stable task metadata record before any volatile endpoint/status observation.
-`bin/fm-prompt-stable-lib.sh` owns the shared listing primitive.
-`bin/fm-agent-loop-baseline.sh` owns the reproducible overhead baseline.
-[Agent-loop efficiency verification](verification/agent-loop-efficiency.md) records measured boundaries for deferred tool discovery, Code Mode, transport, compaction, and Sol/Terra/Luna routing.
+The `bin/fm-session-start.sh` header owns its digest ordering and stable-versus-volatile section boundary.
+`bin/fm-prompt-stable-lib.sh` owns the shared deterministic id-listing primitive.
+The `bin/fm-agent-loop-baseline.sh` header owns the baseline schema and measurement mechanics.
+[Agent-loop efficiency verification](verification/agent-loop-efficiency.md) records version-scoped observations and non-adoption boundaries for deferred tool discovery, Code Mode, transport, compaction, and Sol/Terra/Luna routing.
 That block owns the live wait shape for the running primary harness: Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
 `bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints an honest `started`, `attached`, or nonzero `FAILED` status.
 On `attached` it stays live across identity-matched successors, and an unexplained clean child close either attaches to a verified healthy successor or becomes the typed nonzero `watcher: FAILED - cycle ended without an actionable reason` result.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -304,6 +304,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/verification/agent-loop-efficiency.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/verification/runtime-backends.md",
       "audience": "maintainer-verification"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -8,7 +8,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | Script                   | Purpose                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------ |
 | `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
-| `fm-prompt-stable-lib.sh` | Shared deterministic listing helpers for cache-stable Firstmate digests |
+| `fm-prompt-stable-lib.sh` | Shared deterministic listing helper for cache-stable Firstmate digests |
 | `fm-agent-loop-baseline.sh` | Measure Firstmate-controlled agent-loop overhead and cache/compaction boundaries |
 | `fm-sessionstart-nudge.sh` | Print the native session-start hook nudge when the primary has not already run the digest |
 | `fm-operational-input.sh` | Construct and parse the canonical cross-language operational-input protocol |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -8,8 +8,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | Script                   | Purpose                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------ |
 | `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
-| `fm-prompt-stable-lib.sh` | Shared deterministic listing helper for cache-stable Firstmate digests |
-| `fm-agent-loop-baseline.sh` | Measure Firstmate-controlled agent-loop overhead and cache/compaction boundaries |
+| `fm-prompt-stable-lib.sh` | Provide the deterministic id-listing primitive used by cache-stable Firstmate digests |
+| `fm-agent-loop-baseline.sh` | Report Firstmate prompt-surface sizes, deterministic fixture results, and local operator inventory |
 | `fm-sessionstart-nudge.sh` | Print the native session-start hook nudge when the primary has not already run the digest |
 | `fm-operational-input.sh` | Construct and parse the canonical cross-language operational-input protocol |
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -8,6 +8,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | Script                   | Purpose                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------ |
 | `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
+| `fm-prompt-stable-lib.sh` | Shared deterministic listing helpers for cache-stable Firstmate digests |
+| `fm-agent-loop-baseline.sh` | Measure Firstmate-controlled agent-loop overhead and cache/compaction boundaries |
 | `fm-sessionstart-nudge.sh` | Print the native session-start hook nudge when the primary has not already run the digest |
 | `fm-operational-input.sh` | Construct and parse the canonical cross-language operational-input protocol |
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |

--- a/docs/verification/agent-loop-efficiency.md
+++ b/docs/verification/agent-loop-efficiency.md
@@ -1,0 +1,108 @@
+# Agent-loop efficiency verification
+
+Audience: maintainer verification.
+
+This record supports current Firstmate-controlled agent-loop overhead baselines, cache-stable digest construction, deferred-discovery boundaries, bounded fleet inspection, Code Mode non-adoption, transport and compaction ownership, and Sol/Terra/Luna routing non-change.
+Task chronology, AIDE candidate scoring, and delivery transcripts stay in private task or PR evidence.
+
+## Baseline command
+
+```sh
+bin/fm-agent-loop-baseline.sh --json --with-session-fixture
+```
+
+Measured on 2026-07-30 against this branch tip with Pi-installed operator surfaces available on the host:
+
+| Field | Observed |
+| --- | --- |
+| `schema` | `fm-agent-loop-baseline.v1` |
+| `agents_md_bytes` | 54986 |
+| `skill_description_bytes` | 7251 (19 skills) |
+| `skill_body_bytes` | 202200 (on-demand bodies, not always-loaded) |
+| `pi_extension_tool_description_bytes` | 884 |
+| `pi_extension_tool_count` | 3 description strings matched in tracked extensions |
+| `session_start_fixture_deterministic` | `true` |
+| `session_start_fixture_sorted_ids` | `true` |
+| `openai_server_compaction` | `present` |
+| `openai_compact_threshold` | `260000` |
+| `openai_use_previous_response_id` | `true` |
+| `luna_available` | `true` via `openai-codex/gpt-5.6-luna` |
+| `code_mode_embedded_runtime` | `absent` |
+
+Re-run the command after material always-loaded surface changes and replace the table with fresh output.
+Approximate tokens are a 4-byte heuristic for relative comparison only.
+
+## Cache-stable prompt construction
+
+Owner scripts:
+
+- `bin/fm-prompt-stable-lib.sh` - deterministic `LC_ALL=C` id listing
+- `bin/fm-session-start.sh` - stable meta bytes before volatile endpoint/status lines; sorted task and orphan status ids
+- `bin/fm-supervision-instructions.sh` - pure function of harness and flag inputs
+
+Regression entry point:
+
+```sh
+bin/fm-test-run.sh tests/fm-agent-loop-efficiency.test.sh
+```
+
+The suite compares public rendered outputs under fixed inputs, proves single-variable captain-file sensitivity, and proves sorted multi-entry task order.
+
+## Deferred discovery boundary
+
+Pi documents dynamic tool registration and additive `setActiveTools` deferred loading in its extensions guide.
+Firstmate's tracked Pi tools keep core fleet arming immediately available (`fm_watch_arm_pi`).
+Firstmate does not install an opaque tool proxy or Code Mode runtime.
+Conditional agent skills remain progressive-disclosure descriptions with on-demand bodies.
+External packages such as Linear tools stay outside Firstmate's launch contract.
+
+## Bounded fleet inspection
+
+Whole-fleet reviews use existing aggregates rather than serial per-task loops:
+
+- `bin/fm-fleet-snapshot.sh` / `bin/fm-fleet-view.sh`
+- `bin/fm-bearings-snapshot.sh`
+- session-start compact backlog plus sorted meta dump
+
+`AGENTS.md` heartbeat handling names those aggregate commands explicitly.
+Safety-critical status tails and errors remain untruncated beyond existing bound helpers.
+
+## Code Mode evaluation
+
+No embedded Code Mode runtime was added.
+Existing shell aggregates and parallel tool calls already batch the highest-volume fleet inspection paths.
+The baseline schema reports `code_mode_embedded_runtime=absent` so a later regression cannot silently introduce a second orchestration layer without updating this record.
+
+## Transport and compaction
+
+| Concern | Firstmate control | Current evidence |
+| --- | --- | --- |
+| `PI_CACHE_RETENTION=long` default on pi/pi-signed spawn | Yes, when unset | `tests/fm-agent-loop-efficiency.test.sh` spawn capture |
+| OpenAI `previous_response_id` / WebSocket stream | Operator Pi package only | `pi-openai-server-compaction` when installed; `openai/*` yes, `openai-codex/*` retains built-in transport per package README |
+| Server-side compaction threshold | Operator config | `compactThreshold=260000` when `~/.pi/agent/openai-server-compaction.json` is present |
+| Competing Firstmate compactors | None | Do not add a second path |
+| GPU / KV / speculative decode | None | Outside Firstmate |
+
+Do not create a custom provider solely to imitate OpenAI internals.
+
+## Sol / Terra / Luna routing
+
+Luna is discoverable on the verified Pi `openai-codex` path alongside Sol and Terra.
+Vendor benchmarks alone do not authorize a dispatch change.
+Default `docs/examples/crew-dispatch.json` and standing dispatch policy remain unchanged until identical real integration-style tasks produce measured Firstmate evidence favoring a route.
+The baseline reports `luna_available` for host inventory only.
+
+## Integration with integration-evidence policy
+
+Integration-evidence attestation for ship tasks is owned by the concurrent `integration-evidence` skill and `bin/fm-integration-evidence.sh` work when present.
+This efficiency change does not duplicate that contract.
+End-to-end coverage here runs through public script interfaces in `tests/fm-agent-loop-efficiency.test.sh`.
+
+## Related tests
+
+```sh
+bin/fm-test-run.sh tests/fm-agent-loop-efficiency.test.sh
+bin/fm-test-run.sh tests/fm-session-start.test.sh
+bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh
+bin/fm-test-run.sh tests/fm-supervision-instructions.test.sh
+```

--- a/docs/verification/agent-loop-efficiency.md
+++ b/docs/verification/agent-loop-efficiency.md
@@ -19,8 +19,8 @@ Measured on 2026-07-30 against this branch tip with Pi-installed operator surfac
 | `agents_md_bytes` | 54986 |
 | `skill_description_bytes` | 7251 (19 skills) |
 | `skill_body_bytes` | 202200 (on-demand bodies, not always-loaded) |
-| `pi_extension_tool_description_bytes` | 884 |
-| `pi_extension_tool_count` | 3 description strings matched in tracked extensions |
+| `pi_extension_tool_description_bytes` | 727 |
+| `pi_extension_tool_count` | 1 named LLM-callable tool registered in tracked extensions |
 | `session_start_fixture_deterministic` | `true` |
 | `session_start_fixture_sorted_ids` | `true` |
 | `openai_server_compaction` | `present` |
@@ -37,7 +37,7 @@ Approximate tokens are a 4-byte heuristic for relative comparison only.
 Owner scripts:
 
 - `bin/fm-prompt-stable-lib.sh` - deterministic `LC_ALL=C` id listing
-- `bin/fm-session-start.sh` - stable meta bytes before volatile endpoint/status lines; sorted task and orphan status ids
+- `bin/fm-session-start.sh` - every sorted stable metadata record before any volatile endpoint/status line; sorted orphan status ids
 - `bin/fm-supervision-instructions.sh` - pure function of harness and flag inputs
 
 Regression entry point:
@@ -46,7 +46,7 @@ Regression entry point:
 bin/fm-test-run.sh tests/fm-agent-loop-efficiency.test.sh
 ```
 
-The suite compares public rendered outputs under fixed inputs, proves single-variable captain-file sensitivity, and proves sorted multi-entry task order.
+The suite compares public rendered outputs under fixed inputs, proves single-variable captain-file sensitivity, proves sorted multi-entry task order, and keeps the complete stable prefix byte-identical across a single volatile status change.
 
 ## Deferred discovery boundary
 
@@ -77,7 +77,7 @@ The baseline schema reports `code_mode_embedded_runtime=absent` so a later regre
 
 | Concern | Firstmate control | Current evidence |
 | --- | --- | --- |
-| `PI_CACHE_RETENTION=long` default on pi/pi-signed spawn | Yes, when unset | `tests/fm-agent-loop-efficiency.test.sh` spawn capture |
+| `PI_CACHE_RETENTION` on pi/pi-signed spawn | Always forwarded; `long` only when unset, while explicit empty/nonempty values are preserved | `tests/fm-agent-loop-efficiency.test.sh` spawn capture |
 | OpenAI `previous_response_id` / WebSocket stream | Operator Pi package only | `pi-openai-server-compaction` when installed; `openai/*` yes, `openai-codex/*` retains built-in transport per package README |
 | Server-side compaction threshold | Operator config | `compactThreshold=260000` when `~/.pi/agent/openai-server-compaction.json` is present |
 | Competing Firstmate compactors | None | Do not add a second path |

--- a/docs/verification/agent-loop-efficiency.md
+++ b/docs/verification/agent-loop-efficiency.md
@@ -2,8 +2,8 @@
 
 Audience: maintainer verification.
 
-This record supports current Firstmate-controlled agent-loop overhead baselines, cache-stable digest construction, deferred-discovery boundaries, bounded fleet inspection, Code Mode non-adoption, transport and compaction ownership, and Sol/Terra/Luna routing non-change.
-Task chronology, AIDE candidate scoring, and delivery transcripts stay in private task or PR evidence.
+This record supports current Firstmate-controlled agent-loop overhead evidence, cache-stable digest verification, deferred-discovery boundaries, bounded fleet inspection, Code Mode non-adoption, transport and compaction ownership, and Sol/Terra/Luna routing non-change.
+Task chronology and delivery transcripts stay in private task or PR evidence.
 
 ## Baseline command
 
@@ -11,7 +11,7 @@ Task chronology, AIDE candidate scoring, and delivery transcripts stay in privat
 bin/fm-agent-loop-baseline.sh --json --with-session-fixture
 ```
 
-Measured on 2026-07-30 against this branch tip with Pi-installed operator surfaces available on the host:
+Measured on 2026-07-30 at Firstmate commit `0564a48daa0b9afc34ef812d9256dfd67321a835` with Pi 0.83.0 and `pi-openai-server-compaction` 0.1.0 at commit `8a3de2f3b0c178fdd6f73f2f94172dfc3943e466` available on the host:
 
 | Field | Observed |
 | --- | --- |
@@ -26,19 +26,21 @@ Measured on 2026-07-30 against this branch tip with Pi-installed operator surfac
 | `openai_server_compaction` | `present` |
 | `openai_compact_threshold` | `260000` |
 | `openai_use_previous_response_id` | `true` |
+| `openai_codex_models` | `gpt-5.3-codex-spark,gpt-5.4,gpt-5.4-mini,gpt-5.5,gpt-5.6-luna,gpt-5.6-sol,gpt-5.6-terra` |
 | `luna_available` | `true` via `openai-codex/gpt-5.6-luna` |
 | `code_mode_embedded_runtime` | `absent` |
 
 Re-run the command after material always-loaded surface changes and replace the table with fresh output.
 Approximate tokens are a 4-byte heuristic for relative comparison only.
+Host-dependent package, config, and model-store fields are inventory, not proof that a provider path was active during the measurement.
 
 ## Cache-stable prompt construction
 
-Owner scripts:
+The script headers own their respective contracts:
 
-- `bin/fm-prompt-stable-lib.sh` - deterministic `LC_ALL=C` id listing
-- `bin/fm-session-start.sh` - every sorted stable metadata record before any volatile endpoint/status line; sorted orphan status ids
-- `bin/fm-supervision-instructions.sh` - pure function of harness and flag inputs
+- `bin/fm-prompt-stable-lib.sh` - shared id-listing order
+- `bin/fm-session-start.sh` - digest layout and stable-versus-volatile classification
+- `bin/fm-supervision-instructions.sh` - render inputs and layout
 
 Regression entry point:
 
@@ -50,8 +52,8 @@ The suite compares public rendered outputs under fixed inputs, proves single-var
 
 ## Deferred discovery boundary
 
-Pi documents dynamic tool registration and additive `setActiveTools` deferred loading in its extensions guide.
-Firstmate's tracked Pi tools keep core fleet arming immediately available (`fm_watch_arm_pi`).
+Pi 0.83.0 documents dynamic registration and additive `setActiveTools` loading in its [Dynamic Tool Loading guide](https://github.com/earendil-works/pi/blob/v0.83.0/packages/coding-agent/docs/extensions.md#dynamic-tool-loading).
+Firstmate's tracked Pi watch extension keeps core fleet arming immediately available as `fm_watch_arm_pi`.
 Firstmate does not install an opaque tool proxy or Code Mode runtime.
 Conditional agent skills remain progressive-disclosure descriptions with on-demand bodies.
 External packages such as Linear tools stay outside Firstmate's launch contract.
@@ -65,40 +67,37 @@ Whole-fleet reviews use existing aggregates rather than serial per-task loops:
 - session-start compact backlog plus sorted meta dump
 
 `AGENTS.md` heartbeat handling names those aggregate commands explicitly.
-Safety-critical status tails and errors remain untruncated beyond existing bound helpers.
+Existing bound helpers remain the only truncation applied to safety-critical status tails and errors.
 
 ## Code Mode evaluation
 
-No embedded Code Mode runtime was added.
-Existing shell aggregates and parallel tool calls already batch the highest-volume fleet inspection paths.
-The baseline schema reports `code_mode_embedded_runtime=absent` so a later regression cannot silently introduce a second orchestration layer without updating this record.
+Tracked Firstmate material contains no embedded Code Mode runtime.
+Existing shell aggregates already batch the highest-volume fleet inspection paths.
+The baseline's `code_mode_embedded_runtime=absent` field records this declared boundary; it is not an automated source or runtime detector.
 
 ## Transport and compaction
 
 | Concern | Firstmate control | Current evidence |
 | --- | --- | --- |
-| `PI_CACHE_RETENTION` on pi/pi-signed spawn | Always forwarded; `long` only when unset, while explicit empty/nonempty values are preserved | `tests/fm-agent-loop-efficiency.test.sh` spawn capture |
-| OpenAI `previous_response_id` / WebSocket stream | Operator Pi package only | `pi-openai-server-compaction` when installed; `openai/*` yes, `openai-codex/*` retains built-in transport per package README |
-| Server-side compaction threshold | Operator config | `compactThreshold=260000` when `~/.pi/agent/openai-server-compaction.json` is present |
+| Pi spawn cache retention | `bin/fm-spawn.sh` header | Public spawn capture covers unset, explicit empty, and explicit nonempty `PI_CACHE_RETENTION` inputs for pi and pi-signed |
+| OpenAI `previous_response_id` / WebSocket stream | Operator Pi package only | The version-scoped [package README](https://github.com/algal/pi-openai-server-compaction/blob/8a3de2f3b0c178fdd6f73f2f94172dfc3943e466/README.md) records direct `openai/*` support and retained built-in transport for `openai-codex/*` |
+| Server-side compaction threshold | Operator package and config | The baseline observed `compactThreshold=260000` and `usePreviousResponseId=true` in the global operator config |
 | Competing Firstmate compactors | None | Do not add a second path |
 | GPU / KV / speculative decode | None | Outside Firstmate |
 
-Do not create a custom provider solely to imitate OpenAI internals.
+Firstmate does not add or own a custom OpenAI provider.
+Provider transport remains with Pi or the operator-installed compaction package.
 
 ## Sol / Terra / Luna routing
 
-Luna is discoverable on the verified Pi `openai-codex` path alongside Sol and Terra.
+The measured local Pi model store lists Luna alongside Sol and Terra on `openai-codex`.
 Vendor benchmarks alone do not authorize a dispatch change.
 Default `docs/examples/crew-dispatch.json` and standing dispatch policy remain unchanged until identical real integration-style tasks produce measured Firstmate evidence favoring a route.
 The baseline reports `luna_available` for host inventory only.
 
-## Integration with integration-evidence policy
-
-Integration-evidence attestation for ship tasks is owned by the concurrent `integration-evidence` skill and `bin/fm-integration-evidence.sh` work when present.
-This efficiency change does not duplicate that contract.
-End-to-end coverage here runs through public script interfaces in `tests/fm-agent-loop-efficiency.test.sh`.
-
 ## Related tests
+
+End-to-end coverage here runs through public script interfaces in `tests/fm-agent-loop-efficiency.test.sh`.
 
 ```sh
 bin/fm-test-run.sh tests/fm-agent-loop-efficiency.test.sh

--- a/tests/fm-agent-loop-efficiency.test.sh
+++ b/tests/fm-agent-loop-efficiency.test.sh
@@ -257,15 +257,18 @@ EOF
 }
 
 test_baseline_schema_and_fixture() {
-  local json kv weird_now render_file render_bytes
+  local json empty_json kv weird_now render_file render_bytes
   weird_now=$'measured"\\value\nsecond line'
   render_file="$TMP_ROOT/supervision-render.out"
   FM_ROOT_OVERRIDE="$ROOT" \
     "$SUPERVISION" --harness pi --read-only 0 --afk 0 --x-mode 0 > "$render_file" \
     || fail "direct supervision render failed"
   render_bytes=$(wc -c < "$render_file" | tr -d ' ')
-  json=$(FM_ROOT_OVERRIDE="$ROOT" FM_BASELINE_NOW="$weird_now" \
-    "$BASELINE" --json --with-session-fixture) \
+  json=$(
+    unset PI_CACHE_RETENTION
+    FM_ROOT_OVERRIDE="$ROOT" FM_BASELINE_NOW="$weird_now" \
+      "$BASELINE" --json --with-session-fixture
+  ) \
     || fail "baseline --json --with-session-fixture failed"
   printf '%s\n' "$json" | python3 -c '
 import json
@@ -274,8 +277,16 @@ data = json.load(sys.stdin)
 assert data["measured_at"] == sys.argv[1]
 assert data["pi_extension_tool_count"] == 1
 assert data["supervision_render_bytes"]["pi"] == int(sys.argv[2])
+assert data["pi_cache_retention_env"] == "unset"
 ' "$weird_now" "$render_bytes" \
     || fail "baseline JSON did not preserve strings, count LLM tools, or measure exact render bytes"
+  empty_json=$(PI_CACHE_RETENTION='' FM_ROOT_OVERRIDE="$ROOT" "$BASELINE" --json) \
+    || fail "baseline --json with empty PI_CACHE_RETENTION failed"
+  printf '%s\n' "$empty_json" | python3 -c '
+import json
+import sys
+assert json.load(sys.stdin)["pi_cache_retention_env"] == ""
+' || fail "baseline JSON did not preserve empty PI_CACHE_RETENTION"
   printf '%s\n' "$json" | grep -q '"schema": "fm-agent-loop-baseline.v1"' \
     || fail "baseline json missing schema"
   printf '%s\n' "$json" | grep -q '"agents_md_bytes"' \

--- a/tests/fm-agent-loop-efficiency.test.sh
+++ b/tests/fm-agent-loop-efficiency.test.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# tests/fm-agent-loop-efficiency.test.sh - public-interface coverage for
+# Firstmate agent-loop efficiency surfaces:
+#   - bin/fm-prompt-stable-lib.sh deterministic id listing
+#   - bin/fm-agent-loop-baseline.sh baseline schema and fixture measurement
+#   - bin/fm-session-start.sh cache-stable task ordering and bounded-output reminder
+#   - bin/fm-supervision-instructions.sh byte-stable renders under fixed inputs
+#   - bin/fm-spawn.sh PI_CACHE_RETENTION default for pi launches
+#
+# Exercises real scripts through their public CLI / sourced helpers against
+# isolated fake homes. Does not call model APIs.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/wake-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+
+SESSION_START="$ROOT/bin/fm-session-start.sh"
+BASELINE="$ROOT/bin/fm-agent-loop-baseline.sh"
+SUPERVISION="$ROOT/bin/fm-supervision-instructions.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+TMP_ROOT=$(fm_test_tmproot fm-agent-loop-efficiency-tests)
+FM_TEST_CLEANUP_DIRS+=("$TMP_ROOT")
+trap fm_test_cleanup EXIT
+fm_git_identity fmtest fmtest@example.invalid
+
+# shellcheck source=bin/fm-prompt-stable-lib.sh
+. "$ROOT/bin/fm-prompt-stable-lib.sh"
+
+new_world() {
+  local name=$1 w root home fakebin
+  w="$TMP_ROOT/$name"
+  root="$w/root"
+  home="$w/home"
+  fakebin="$w/fakebin"
+  mkdir -p "$home/state" "$home/data" "$home/config" "$fakebin"
+  git init -q -b main "$root"
+  git -C "$root" commit -q --allow-empty -m init
+  printf '%s|%s|%s\n' "$root" "$home" "$fakebin"
+}
+
+make_quiet_toolchain() {
+  local fakebin=$1
+  fm_fake_exit0 "$fakebin" tmux node gh-axi chrome-devtools-axi lavish-axi
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/no-mistakes"
+}
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse pi pi-signed
+  printf '%s\n' "$fakebin"
+}
+
+run_spawn_capture() {
+  local home=$1 wt=$2 fakebin=$3 launchlog=$4
+  shift 4
+  : > "$launchlog"
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$launchlog" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$@" 2>&1
+}
+
+test_prompt_stable_list_ids_sorted() {
+  local dir="$TMP_ROOT/stable-ids"
+  mkdir -p "$dir"
+  : > "$dir/zulu.meta"
+  : > "$dir/alpha.meta"
+  : > "$dir/mike.meta"
+  : > "$dir/noise.txt"
+  got=$(fm_prompt_stable_list_ids "$dir" meta)
+  expected=$'alpha\nmike\nzulu'
+  [ "$got" = "$expected" ] || fail "expected sorted ids, got: $got"
+  pass "fm-prompt-stable-lib lists state ids in LC_ALL=C order"
+}
+
+test_supervision_render_byte_stable() {
+  local a b c
+  a=$("$SUPERVISION" --harness pi --read-only 0 --afk 0 --x-mode 0)
+  b=$("$SUPERVISION" --harness pi --read-only 0 --afk 0 --x-mode 0)
+  [ "$a" = "$b" ] || fail "supervision render was not byte-stable under fixed flags"
+  a=$("$SUPERVISION" --harness claude --read-only 1 --afk 0 --x-mode 0)
+  b=$("$SUPERVISION" --harness claude --read-only 1 --afk 0 --x-mode 0)
+  [ "$a" = "$b" ] || fail "claude supervision render was not byte-stable"
+  c=$("$SUPERVISION" --harness claude --read-only 0 --afk 0 --x-mode 0)
+  [ "$a" != "$c" ] || fail "read-only flag should change supervision render"
+  pass "fm-supervision-instructions renders are byte-stable and input-sensitive"
+}
+
+test_session_start_sorted_and_bounded_reminder() {
+  local root home fakebin out out2 path_alpha path_zulu
+  IFS='|' read -r root home fakebin < <(new_world sess-order)
+  make_quiet_toolchain "$fakebin"
+  printf 'manual\n' > "$home/config/backlog-backend"
+  printf 'prefs\n' > "$home/data/captain.md"
+  cat > "$home/state/zulu.meta" <<'EOF'
+window=tmux:zulu
+harness=pi
+kind=ship
+mode=no-mistakes
+yolo=off
+EOF
+  cat > "$home/state/alpha.meta" <<'EOF'
+window=tmux:alpha
+harness=pi
+kind=ship
+mode=no-mistakes
+yolo=off
+EOF
+  printf 'working: a\n' > "$home/state/alpha.status"
+  printf 'working: z\n' > "$home/state/zulu.status"
+  : > "$home/state/.last-watcher-beat"
+  printf '%s\n' "$$" > "$home/state/.lock"
+
+  out=$(
+    env PATH="$fakebin:$BASE_PATH" \
+      FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+      FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+      FM_CONFIG_OVERRIDE="$home/config" \
+      FM_BOOTSTRAP_DETECT_ONLY=1 \
+      "$SESSION_START"
+  ) || fail "session-start failed"
+
+  path_alpha=$(printf '%s\n' "$out" | grep -n '^--- alpha ---$' | head -1 | cut -d: -f1)
+  path_zulu=$(printf '%s\n' "$out" | grep -n '^--- zulu ---$' | head -1 | cut -d: -f1)
+  [ -n "$path_alpha" ] && [ -n "$path_zulu" ] || fail "missing meta headers in digest"
+  [ "$path_alpha" -lt "$path_zulu" ] || fail "meta order was not alpha before zulu ($path_alpha >= $path_zulu)"
+
+  printf '%s\n' "$out" | grep -q 'fm-fleet-view.sh' \
+    || fail "session-start closing reminder omitted fleet-view aggregate pointer"
+  printf '%s\n' "$out" | grep -q 'fm-bearings-snapshot.sh' \
+    || fail "session-start closing reminder omitted bearings aggregate pointer"
+
+  out2=$(
+    env PATH="$fakebin:$BASE_PATH" \
+      FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+      FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+      FM_CONFIG_OVERRIDE="$home/config" \
+      FM_BOOTSTRAP_DETECT_ONLY=1 \
+      "$SESSION_START"
+  ) || fail "second session-start failed"
+  [ "$out" = "$out2" ] || fail "session-start digest was not byte-identical across two fixed runs"
+
+  pass "session-start orders tasks stably, reminds aggregates, and is byte-stable"
+}
+
+test_session_start_single_variable_changes_expected_region() {
+  local root home fakebin out_a out_b
+  IFS='|' read -r root home fakebin < <(new_world sess-var)
+  make_quiet_toolchain "$fakebin"
+  printf 'manual\n' > "$home/config/backlog-backend"
+  printf 'stable-captain\n' > "$home/data/captain.md"
+  cat > "$home/state/only.meta" <<'EOF'
+window=tmux:only
+harness=pi
+kind=ship
+mode=no-mistakes
+yolo=off
+EOF
+  printf 'working: one\n' > "$home/state/only.status"
+  : > "$home/state/.last-watcher-beat"
+  printf '%s\n' "$$" > "$home/state/.lock"
+
+  out_a=$(
+    env PATH="$fakebin:$BASE_PATH" \
+      FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+      FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+      FM_CONFIG_OVERRIDE="$home/config" \
+      FM_BOOTSTRAP_DETECT_ONLY=1 \
+      "$SESSION_START"
+  )
+
+  printf 'stable-captain-changed\n' > "$home/data/captain.md"
+  out_b=$(
+    env PATH="$fakebin:$BASE_PATH" \
+      FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+      FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+      FM_CONFIG_OVERRIDE="$home/config" \
+      FM_BOOTSTRAP_DETECT_ONLY=1 \
+      "$SESSION_START"
+  )
+
+  [ "$out_a" != "$out_b" ] || fail "captain.md change should alter digest"
+  printf '%s\n' "$out_a" | grep -q 'stable-captain' || fail "original captain content missing"
+  printf '%s\n' "$out_b" | grep -q 'stable-captain-changed' || fail "updated captain content missing"
+  printf '%s\n' "$out_a" | grep -q '^--- only ---$' || fail "task header missing in a"
+  printf '%s\n' "$out_b" | grep -q '^--- only ---$' || fail "task header missing in b"
+  pass "session-start single-variable captain change affects digest without dropping tasks"
+}
+
+test_baseline_schema_and_fixture() {
+  local json kv
+  json=$("$BASELINE" --json --with-session-fixture) \
+    || fail "baseline --json --with-session-fixture failed"
+  printf '%s\n' "$json" | grep -q '"schema": "fm-agent-loop-baseline.v1"' \
+    || fail "baseline json missing schema"
+  printf '%s\n' "$json" | grep -q '"agents_md_bytes"' \
+    || fail "baseline json missing agents_md_bytes"
+  printf '%s\n' "$json" | grep -q '"code_mode_embedded_runtime": "absent"' \
+    || fail "baseline must report Code Mode runtime absent"
+  printf '%s\n' "$json" | grep -q '"session_start_fixture_deterministic": "true"' \
+    || fail "fixture digest was not deterministic: $json"
+  printf '%s\n' "$json" | grep -q '"session_start_fixture_sorted_ids": "true"' \
+    || fail "fixture digest did not sort ids: $json"
+
+  kv=$("$BASELINE") || fail "baseline kv mode failed"
+  printf '%s\n' "$kv" | grep -q '^schema=fm-agent-loop-baseline.v1$' \
+    || fail "kv baseline missing schema line"
+  printf '%s\n' "$kv" | grep -q '^openai_server_compaction=' \
+    || fail "kv baseline missing compaction discovery"
+
+  pass "fm-agent-loop-baseline reports schema, fixture determinism, and boundaries"
+}
+
+test_spawn_pi_cache_retention_default() {
+  local case_dir home proj wt fakebin launchlog id out status launch
+  id=loop-eff-pi-cache
+  case_dir="$TMP_ROOT/spawn-pi-cache"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  launchlog="$case_dir/launch.log"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data/$id" "$home/data/${id}-keep" "$home/projects" "$home/state" "$home/config"
+  printf 'pi\n' > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-pi-cache"
+  touch "$home/state/.last-watcher-beat"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  printf 'brief for %s\n' "${id}-keep" > "$home/data/${id}-keep/brief.md"
+
+  out=$(
+    unset PI_CACHE_RETENTION
+    run_spawn_capture "$home" "$wt" "$fakebin" "$launchlog" \
+      "$id" "$proj" pi
+  )
+  status=$?
+  expect_code 0 "$status" "pi spawn for cache-retention default should succeed: $out"
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "PI_CACHE_RETENTION=long" \
+    "pi launch missing default PI_CACHE_RETENTION=long"
+  assert_contains "$launch" "FM_PI_HARNESS=pi" \
+    "pi launch missing FM_PI_HARNESS"
+
+  out=$(
+    PI_CACHE_RETENTION=short \
+      run_spawn_capture "$home" "$wt" "$fakebin" "$launchlog" \
+      "${id}-keep" "$proj" pi
+  )
+  status=$?
+  expect_code 0 "$status" "pi spawn with operator retention should succeed: $out"
+  launch=$(cat "$launchlog")
+  assert_not_contains "$launch" "PI_CACHE_RETENTION=long" \
+    "operator PI_CACHE_RETENTION must not be overridden to long"
+  assert_contains "$launch" "FM_PI_HARNESS=pi" \
+    "pi launch missing FM_PI_HARNESS when retention preset"
+
+  pass "fm-spawn defaults PI_CACHE_RETENTION=long for pi and preserves operator overrides"
+}
+
+test_prompt_stable_list_ids_sorted
+test_supervision_render_byte_stable
+test_session_start_sorted_and_bounded_reminder
+test_session_start_single_variable_changes_expected_region
+test_baseline_schema_and_fixture
+test_spawn_pi_cache_retention_default
+
+echo "ALL TESTS PASSED"

--- a/tests/fm-agent-loop-efficiency.test.sh
+++ b/tests/fm-agent-loop-efficiency.test.sh
@@ -3,7 +3,7 @@
 # Firstmate agent-loop efficiency surfaces:
 #   - bin/fm-prompt-stable-lib.sh deterministic id listing
 #   - bin/fm-agent-loop-baseline.sh baseline schema and fixture measurement
-#   - bin/fm-session-start.sh cache-stable task ordering and bounded-output reminder
+#   - bin/fm-session-start.sh stable metadata prefix and bounded-output reminder
 #   - bin/fm-supervision-instructions.sh byte-stable renders under fixed inputs
 #   - bin/fm-spawn.sh PI_CACHE_RETENTION default for pi launches
 #
@@ -137,7 +137,8 @@ test_supervision_render_byte_stable() {
 }
 
 test_session_start_sorted_and_bounded_reminder() {
-  local root home fakebin out out2 path_alpha path_zulu
+  local root home fakebin out out2 out3 path_alpha path_zulu path_volatile
+  local stable_prefix_a stable_prefix_b
   IFS='|' read -r root home fakebin < <(new_world sess-order)
   make_quiet_toolchain "$fakebin"
   printf 'manual\n' > "$home/config/backlog-backend"
@@ -172,8 +173,11 @@ EOF
 
   path_alpha=$(printf '%s\n' "$out" | grep -n '^--- alpha ---$' | head -1 | cut -d: -f1)
   path_zulu=$(printf '%s\n' "$out" | grep -n '^--- zulu ---$' | head -1 | cut -d: -f1)
+  path_volatile=$(printf '%s\n' "$out" | grep -n '^Work under way - volatile endpoint and status observations$' | cut -d: -f1)
   [ -n "$path_alpha" ] && [ -n "$path_zulu" ] || fail "missing meta headers in digest"
+  [ -n "$path_volatile" ] || fail "missing volatile endpoint/status section"
   [ "$path_alpha" -lt "$path_zulu" ] || fail "meta order was not alpha before zulu ($path_alpha >= $path_zulu)"
+  [ "$path_zulu" -lt "$path_volatile" ] || fail "volatile observations appeared before every stable metadata record"
 
   printf '%s\n' "$out" | grep -q 'fm-fleet-view.sh' \
     || fail "session-start closing reminder omitted fleet-view aggregate pointer"
@@ -190,7 +194,22 @@ EOF
   ) || fail "second session-start failed"
   [ "$out" = "$out2" ] || fail "session-start digest was not byte-identical across two fixed runs"
 
-  pass "session-start orders tasks stably, reminds aggregates, and is byte-stable"
+  printf 'working: a changed\n' > "$home/state/alpha.status"
+  out3=$(
+    env PATH="$fakebin:$BASE_PATH" \
+      FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+      FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+      FM_CONFIG_OVERRIDE="$home/config" \
+      FM_BOOTSTRAP_DETECT_ONLY=1 \
+      "$SESSION_START"
+  ) || fail "session-start after volatile status change failed"
+  [ "$out2" != "$out3" ] || fail "volatile status change did not alter the digest"
+  stable_prefix_a=$(printf '%s\n' "$out2" | sed '/^Work under way - volatile endpoint and status observations$/,$d')
+  stable_prefix_b=$(printf '%s\n' "$out3" | sed '/^Work under way - volatile endpoint and status observations$/,$d')
+  [ "$stable_prefix_a" = "$stable_prefix_b" ] \
+    || fail "volatile status change altered the stable metadata prefix"
+
+  pass "session-start preserves its complete stable prefix across volatile changes"
 }
 
 test_session_start_single_variable_changes_expected_region() {
@@ -238,9 +257,25 @@ EOF
 }
 
 test_baseline_schema_and_fixture() {
-  local json kv
-  json=$("$BASELINE" --json --with-session-fixture) \
+  local json kv weird_now render_file render_bytes
+  weird_now=$'measured"\\value\nsecond line'
+  render_file="$TMP_ROOT/supervision-render.out"
+  FM_ROOT_OVERRIDE="$ROOT" \
+    "$SUPERVISION" --harness pi --read-only 0 --afk 0 --x-mode 0 > "$render_file" \
+    || fail "direct supervision render failed"
+  render_bytes=$(wc -c < "$render_file" | tr -d ' ')
+  json=$(FM_ROOT_OVERRIDE="$ROOT" FM_BASELINE_NOW="$weird_now" \
+    "$BASELINE" --json --with-session-fixture) \
     || fail "baseline --json --with-session-fixture failed"
+  printf '%s\n' "$json" | python3 -c '
+import json
+import sys
+data = json.load(sys.stdin)
+assert data["measured_at"] == sys.argv[1]
+assert data["pi_extension_tool_count"] == 1
+assert data["supervision_render_bytes"]["pi"] == int(sys.argv[2])
+' "$weird_now" "$render_bytes" \
+    || fail "baseline JSON did not preserve strings, count LLM tools, or measure exact render bytes"
   printf '%s\n' "$json" | grep -q '"schema": "fm-agent-loop-baseline.v1"' \
     || fail "baseline json missing schema"
   printf '%s\n' "$json" | grep -q '"agents_md_bytes"' \
@@ -252,7 +287,7 @@ test_baseline_schema_and_fixture() {
   printf '%s\n' "$json" | grep -q '"session_start_fixture_sorted_ids": "true"' \
     || fail "fixture digest did not sort ids: $json"
 
-  kv=$("$BASELINE") || fail "baseline kv mode failed"
+  kv=$(FM_ROOT_OVERRIDE="$ROOT" "$BASELINE") || fail "baseline kv mode failed"
   printf '%s\n' "$kv" | grep -q '^schema=fm-agent-loop-baseline.v1$' \
     || fail "kv baseline missing schema line"
   printf '%s\n' "$kv" | grep -q '^openai_server_compaction=' \
@@ -270,12 +305,14 @@ test_spawn_pi_cache_retention_default() {
   wt="$case_dir/wt"
   launchlog="$case_dir/launch.log"
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
-  mkdir -p "$home/data/$id" "$home/data/${id}-keep" "$home/projects" "$home/state" "$home/config"
+  mkdir -p "$home/data/$id" "$home/data/${id}-keep" "$home/data/${id}-empty" \
+    "$home/projects" "$home/state" "$home/config"
   printf 'pi\n' > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-pi-cache"
   touch "$home/state/.last-watcher-beat"
   printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
   printf 'brief for %s\n' "${id}-keep" > "$home/data/${id}-keep/brief.md"
+  printf 'brief for %s\n' "${id}-empty" > "$home/data/${id}-empty/brief.md"
 
   out=$(
     unset PI_CACHE_RETENTION
@@ -285,7 +322,7 @@ test_spawn_pi_cache_retention_default() {
   status=$?
   expect_code 0 "$status" "pi spawn for cache-retention default should succeed: $out"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "PI_CACHE_RETENTION=long" \
+  assert_contains "$launch" "PI_CACHE_RETENTION='long'" \
     "pi launch missing default PI_CACHE_RETENTION=long"
   assert_contains "$launch" "FM_PI_HARNESS=pi" \
     "pi launch missing FM_PI_HARNESS"
@@ -298,12 +335,29 @@ test_spawn_pi_cache_retention_default() {
   status=$?
   expect_code 0 "$status" "pi spawn with operator retention should succeed: $out"
   launch=$(cat "$launchlog")
-  assert_not_contains "$launch" "PI_CACHE_RETENTION=long" \
-    "operator PI_CACHE_RETENTION must not be overridden to long"
+  assert_contains "$launch" "PI_CACHE_RETENTION='short'" \
+    "operator PI_CACHE_RETENTION=short was not forwarded"
+  assert_not_contains "$launch" "PI_CACHE_RETENTION='long'" \
+    "operator PI_CACHE_RETENTION=short was overridden to long"
   assert_contains "$launch" "FM_PI_HARNESS=pi" \
     "pi launch missing FM_PI_HARNESS when retention preset"
 
-  pass "fm-spawn defaults PI_CACHE_RETENTION=long for pi and preserves operator overrides"
+  out=$(
+    PI_CACHE_RETENTION='' \
+      run_spawn_capture "$home" "$wt" "$fakebin" "$launchlog" \
+      "${id}-empty" "$proj" pi-signed
+  )
+  status=$?
+  expect_code 0 "$status" "pi-signed spawn with empty retention should succeed: $out"
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "PI_CACHE_RETENTION=''" \
+    "explicit empty PI_CACHE_RETENTION was not forwarded"
+  assert_not_contains "$launch" "PI_CACHE_RETENTION='long'" \
+    "explicit empty PI_CACHE_RETENTION was treated as unset"
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed" \
+    "pi-signed launch missing FM_PI_HARNESS"
+
+  pass "fm-spawn forwards quoted unset, nonempty, and empty Pi retention values"
 }
 
 test_prompt_stable_list_ids_sorted


### PR DESCRIPTION
## Intent

Implement useful workflow-level agent-loop efficiency recommendations from the GPT-5.6 efficiency article and ByteByteGo agent-loop post in Firstmate shared tracked material. Deliver cache-stable Firstmate-controlled prompt construction (deterministic ordering, stable meta before volatile endpoint/status), a reproducible overhead baseline command, Pi long prompt-cache retention default on spawn when unset, bounded fleet-review pointers to existing aggregate commands, and documented boundaries that refuse Code Mode embedded runtimes, custom OpenAI providers, competing compactors (preserve 260k server-compaction contract), and Sol/Terra/Luna dispatch changes without measured same-task evidence. Keep deferred discovery on documented Pi capabilities only with core fleet arming immediately available. Integrate with concurrent integration-evidence policy by not duplicating its owner. Add end-to-end public-interface tests and maintainer verification evidence. AIDE evidence retained privately; work/ scratch removed.

## What Changed

- Make session-start prompts cache-stable by sorting task IDs, emitting stable metadata before volatile endpoint/status observations, and directing fleet reviews to existing aggregate commands.
- Add a reproducible agent-loop overhead baseline and default Pi spawns to long cache retention only when unset, preserving explicit values.
- Document deferred-discovery, Code Mode, provider/compaction, and model-routing boundaries, backed by public-interface tests and maintainer verification evidence.

## Risk Assessment

✅ Low: The latest fix resolves the prior retention-state and dead-scaffolding findings, with no remaining material correctness, security, performance, simplification, or intent-conformance risks found.

## Testing

At exact target 0564a48, the focused agent-loop suite and directly affected documentation, session-start, and dispatch-profile regressions passed; two public baseline runs were byte-identical and matched the recorded cache, compaction, model-routing, and Code Mode boundaries, while the worktree remained clean.

<details>
<summary>Evidence: Public baseline JSON</summary>

`Deterministic and sorted session fixture; 260000 compaction threshold; previous-response reuse enabled; Luna available; Code Mode runtime absent. SHA-256: e22233c5c1b9270d3667b9c13a58ab454fff078f161693d3087d62a3a665f0b0`

```text
{
  "agents_md_approx_tokens": 13747,
  "agents_md_bytes": 54986,
  "code_mode_embedded_runtime": "absent",
  "luna_available": "true",
  "measured_at": "2026-07-30T14:18:37Z",
  "notes": "Firstmate controls AGENTS.md, skill descriptions, supervision renders, session-start digests, and tracked Pi extension tools. Provider WebSocket/delta tokenization and GPU inference are outside Firstmate. Code Mode was not added: existing shell aggregates (fm-fleet-snapshot, fm-bearings-snapshot, fm-session-start) already batch fleet inspection. Sol/Terra/Luna dispatch is unchanged without measured same-task evidence. Single OpenAI compaction path remains operator-installed pi-openai-server-compaction at compactThreshold when present.",
  "openai_codex_models": "gpt-5.3-codex-spark,gpt-5.4,gpt-5.4-mini,gpt-5.5,gpt-5.6-luna,gpt-5.6-sol,gpt-5.6-terra",
  "openai_compact_threshold": "260000",
  "openai_server_compaction": "present",
  "openai_use_previous_response_id": "true",
  "pi_cache_retention_env": "unset",
  "pi_extension_tool_count": 1,
  "pi_extension_tool_description_bytes": 727,
  "schema": "fm-agent-loop-baseline.v1",
  "session_start_fixture_bytes": 6423,
  "session_start_fixture_deterministic": "true",
  "session_start_fixture_sorted_ids": "true",
  "skill_body_bytes": 202200,
  "skill_description_bytes": 7251,
  "skill_description_count": 19,
  "supervision_doc_bytes": {
    "claude": 3009,
    "codex": 1359,
    "grok": 2786,
    "kimi": 0,
    "opencode": 1753,
    "pi": 2957,
    "unknown": 846
  },
  "supervision_render_bytes": {
    "claude": 3676,
    "codex": 1952,
    "grok": 3539,
    "kimi": 1355,
    "opencode": 2266,
    "pi": 3968,
    "unknown": 1355
  }
}
```
</details>
<details>
<summary>Evidence: Baseline reproducibility replay</summary>

`Byte-identical replay using the same measurement timestamp and SHA-256.`

```text
{
  "agents_md_approx_tokens": 13747,
  "agents_md_bytes": 54986,
  "code_mode_embedded_runtime": "absent",
  "luna_available": "true",
  "measured_at": "2026-07-30T14:18:37Z",
  "notes": "Firstmate controls AGENTS.md, skill descriptions, supervision renders, session-start digests, and tracked Pi extension tools. Provider WebSocket/delta tokenization and GPU inference are outside Firstmate. Code Mode was not added: existing shell aggregates (fm-fleet-snapshot, fm-bearings-snapshot, fm-session-start) already batch fleet inspection. Sol/Terra/Luna dispatch is unchanged without measured same-task evidence. Single OpenAI compaction path remains operator-installed pi-openai-server-compaction at compactThreshold when present.",
  "openai_codex_models": "gpt-5.3-codex-spark,gpt-5.4,gpt-5.4-mini,gpt-5.5,gpt-5.6-luna,gpt-5.6-sol,gpt-5.6-terra",
  "openai_compact_threshold": "260000",
  "openai_server_compaction": "present",
  "openai_use_previous_response_id": "true",
  "pi_cache_retention_env": "unset",
  "pi_extension_tool_count": 1,
  "pi_extension_tool_description_bytes": 727,
  "schema": "fm-agent-loop-baseline.v1",
  "session_start_fixture_bytes": 6423,
  "session_start_fixture_deterministic": "true",
  "session_start_fixture_sorted_ids": "true",
  "skill_body_bytes": 202200,
  "skill_description_bytes": 7251,
  "skill_description_count": 19,
  "supervision_doc_bytes": {
    "claude": 3009,
    "codex": 1359,
    "grok": 2786,
    "kimi": 0,
    "opencode": 1753,
    "pi": 2957,
    "unknown": 846
  },
  "supervision_render_bytes": {
    "claude": 3676,
    "codex": 1952,
    "grok": 3539,
    "kimi": 1355,
    "opencode": 2266,
    "pi": 3968,
    "unknown": 1355
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-session-start.sh:355` - The required “cache-stable Firstmate-controlled prompt construction … stable meta before volatile endpoint/status” invariant is not met globally. This single loop emits `alpha.meta`, then alpha’s volatile endpoint/status, and only then `zulu.meta`; an alpha liveness change therefore invalidates the exact prefix before later stable records. Stage the sorted IDs once, emit all metadata first, then all endpoint/status observations. The current test checks only sorted order under unchanged state. [OpenAI confirms variable content must follow static prefix content.](https://openai.com/index/unrolling-the-codex-agent-loop/)
- 🚨 `bin/fm-spawn.sh:526` - The required “Pi long prompt-cache retention default on spawn when unset” behavior is contradicted here: empty-but-set is treated as unset, while a nonempty caller value is omitted from `LAUNCH`. Because daemon-owned panes do not reliably inherit the caller environment, `PI_CACHE_RETENTION=short` can be lost—for example when the target pane already has `long`. Distinguish set from unset and prefix the shell-quoted selected value in both branches; require `short` in the captured-launch test. [Pi resolves literal `long` as extended retention and otherwise defaults to `short`.](https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/providers/openai-completions.ts)
- ⚠️ `bin/fm-agent-loop-baseline.sh:153` - `pi_tool_stats` counts every TypeScript `description:` property, so the documented count of three includes two `registerCommand` UI descriptions and only one LLM-callable tool. This overstates prompt overhead. Restrict measurement to actual `registerTool` definitions or the rendered active-tool prompt, then refresh the evidence. [Pi documents commands and LLM tools as distinct surfaces.](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md)
- ⚠️ `bin/fm-agent-loop-baseline.sh:337` - The unquoted heredoc substitutes environment- and config-derived values directly into Python string literals. Quotes, backslashes, or newlines can invalidate `--json`, and crafted model/config text becomes executable Python source. Pass values through argv/environment/stdin to a quoted heredoc and let `json.dumps` serialize them. [Bash expands unquoted heredocs](https://www.gnu.org/software/bash/manual/bash.html#Here-Documents); [Python provides JSON serialization](https://docs.python.org/3/tutorial/inputoutput.html#saving-structured-data-with-json).
- ⚠️ `bin/fm-agent-loop-baseline.sh:173` - This metric is not the byte count of the public renderer output: command substitution strips trailing newlines, and `|| true` converts renderer failures into plausible partial or zero counts. Capture output to a temporary file, require successful rendering, and measure that file directly.
- ℹ️ `bin/fm-prompt-stable-lib.sh:52` - `fm_prompt_stable_split_stats` adds 37 lines of temporary-file and hashing behavior but has no caller or test in the target tree; only `fm_prompt_stable_list_ids` is used. Remove the dormant helper, or wire it into the baseline contract and cover it if it is intentional.

🔧 Fix: Fix agent-loop cache and baseline invariants
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-agent-loop-baseline.sh:340` - `${PI_CACHE_RETENTION:-unset}` collapses explicitly empty and truly unset into the same value; [Bash documents that `:-` tests both unset and null](https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion). The baseline therefore reports `unset` while `fm-spawn.sh` forwards `PI_CACHE_RETENTION=&#39;&#39;`. Reuse the spawn existence check and preserve empty as an empty baseline value.
- ℹ️ `bin/fm-agent-loop-baseline.sh:85` - `sha_file` has no caller, while the temporary Git root created at lines 229–236 is never used or passed to session-start. Remove both dead scaffolds to simplify the baseline without changing behavior.

🔧 Fix: Preserve empty retention and remove baseline scaffolding
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-agent-loop-efficiency.test.sh`
- `bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh`
- `bin/fm-test-run.sh tests/fm-session-start.test.sh`
- `bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh`
- `env -u PI_CACHE_RETENTION FM_ROOT_OVERRIDE=/Users/leebarry/.no-mistakes/worktrees/f0199aaf840b/01KYSKQ4MWX70S6327ZF97W30G bin/fm-agent-loop-baseline.sh --json --with-session-fixture`
- <code>Replayed the baseline with `FM_BASELINE_NOW=2026-07-30T14:18:37Z` and compared both JSON files using `cmp -s` and SHA-256.</code>
- `Checked the target diff for tracked scratch/AIDE evidence, dispatch-policy paths, and integration-evidence ownership changes; none were introduced.`
- <code>`git status --short --branch` confirmed testing left the target worktree clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Quote unset cache retention literal for ShellCheck
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
