### PR TITLE
feat(secondmate): support local-only project work

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: secondmate-provisioning
 description: >-
-  Agent-only reference for persistent secondmate setup and retirement.
-  Use when creating, seeding, validating, launching, recovering, handing backlog to, pushing inherited local material into, or retiring a secondmate home, or when editing data/secondmates.md.
-  Covers home leases, transactional seeding, project clone restrictions, secondmate harness pins, inherited local-material push, idle charter, handoff helper, and teardown safety.
+  Agent-only reference for persistent secondmate lifecycle and routed work.
+  Use when creating, seeding, validating, launching, handing backlog to, routing or landing secondmate-owned local-only work, recovering, pushing inherited local material into, or retiring a secondmate home, or when editing data/secondmates.md.
+  Covers home leases, transactional seeding, project clone restrictions, local-only ready work and landing, secondmate harness pins, inherited local-material push, idle charter, handoff helper, and teardown safety.
 user-invocable: false
 metadata:
   internal: true
@@ -11,7 +11,7 @@ metadata:
 
 # secondmate-provisioning
 
-Use this reference before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a persistent secondmate, and before editing `data/secondmates.md`.
+Use this reference before creating, seeding, validating, launching, handing backlog to, routing or landing secondmate-owned `local-only` work, recovering, pushing inherited local material into, or retiring a persistent secondmate, and before editing `data/secondmates.md`.
 
 Keep the always-inline routing rules in `AGENTS.md` authoritative: route by natural-language `scope:`, only the main firstmate lands `local-only` work, and secondmates are idle by default.
 

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 Use this reference before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a persistent secondmate, and before editing `data/secondmates.md`.
 
-Keep the always-inline routing rules in `AGENTS.md` authoritative: route by natural-language `scope:`, local-only projects stay with the main firstmate, and secondmates are idle by default.
+Keep the always-inline routing rules in `AGENTS.md` authoritative: route by natural-language `scope:`, only the main firstmate lands `local-only` work, and secondmates are idle by default.
 
 ## Routing table
 
@@ -121,9 +121,38 @@ Run `bin/fm-home-seed.sh validate` when checking registry integrity; it refuses 
 Seeding is transactional.
 If validation, cloning, no-mistakes initialization, or registry update fails, generated briefs, new homes, new project clones, and registry edits are rolled back.
 
-Secondmate project lists may include `no-mistakes` and `direct-PR` projects only.
-`local-only` projects stay with the main firstmate.
+Secondmate project lists may include `no-mistakes`, `direct-PR`, and `local-only` projects.
+For `local-only`, seeding makes a normal local clone from the main home's authoritative checkout and records that checkout as the clone's `origin`.
+The clone checks out only committed Git state: tracked working-tree changes, untracked files, and ignored assets are not copied, stash refs are not exposed, and none of that state becomes a worker baseline.
+Project-owned ignored-asset staging and verification remain governed by that project's own instructions and tools.
 For `no-mistakes` projects, seeding initializes only projects newly cloned into a secondmate home and refuses to mutate a preexisting clone that is not already initialized.
+
+## Local-only ready work and landing
+
+A secondmate owns its `local-only` queue, briefs, workers, validation evidence, and restart recovery, but never the authoritative landing.
+Its worker stops on a clean `fm/<task-id>` branch and reports the full 40-character commit plus the validation commands and outcome required by the task and project instructions.
+Before routing that result to the main firstmate, record and validate it through the existing correlated parent path:
+
+```sh
+bin/fm-secondmate-report.sh --local-ready <parent-status-file> <corr-id> state/<task-id>.meta "<validation evidence>"
+```
+
+The helper verifies the marked secondmate home, `mode=local-only`, `kind=ship`, expected branch, exact branch and worktree HEAD, clean worktree, and non-empty single-line validation evidence.
+It records `ready_commit=`, `ready_branch=`, and `validation_evidence=` in the task's existing secondmate-home metadata, then appends one correlated result to the parent status route.
+This is the existing pending-reply contract, not a second coordination mechanism.
+Keep the worker, branch, metadata, and worktree intact after that report.
+
+After the configured merge authority approves, the main firstmate lands from its own home:
+
+```sh
+bin/fm-merge-local.sh <task-id> --secondmate <secondmate-id>
+```
+
+The landing helper resolves and validates the secondmate home from the main registry, reads the task metadata in place, re-verifies the exact ready branch, commit, worktree, and evidence, imports only that branch into the authoritative repository, and fast-forwards the authoritative default branch to that exact commit.
+It refuses immediately when the active home carries `.fm-secondmate-home`, so a secondmate cannot use the landing exception.
+It preserves the existing default-branch, clean-checkout, and strict-fast-forward refusals.
+When the authoritative checkout is dirty, the helper reports `ready, waiting`, leaves the ready task intact, and performs no fetch, checkout, stash, clean, commit, merge, or other project mutation.
+After landing, the secondmate clone's authoritative-path `origin` lets ordinary teardown verify that the exact content reached the authoritative default before cleanup.
 
 ## Backlog handoff
 
@@ -145,7 +174,7 @@ It accepts in-scope `## Queued` entries only and refuses `## In flight` and hist
 Done records stay with their home for pruning or archiving.
 It is idempotent; an item already in the secondmate backlog is skipped.
 It refuses any destination that is not a genuine seeded firstmate home with safe operational directories and a matching `.fm-secondmate-home` marker, so a move can never land in a project.
-Do not hand off `local-only` items.
+In-scope queued `local-only` items use the same handoff path as PR-based items; their landing authority does not move with the backlog item.
 
 ## Recovery
 
@@ -165,6 +194,8 @@ The main firstmate reconciles only direct reports.
 Each secondmate is a firstmate in its own home, so it runs recovery on startup and reconciles its own crewmates.
 A secondmate's recovery reconciles only work that is already its own and then idles.
 It never initiates a survey or audit during recovery.
+A ready but unlanded `local-only` task remains owned work after restart.
+Do not tear it down or report it landed until the main firstmate confirms the authoritative default contains its exact ready commit.
 
 ## Retirement and teardown
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ state/               volatile runtime signals; gitignored
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
   <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, endpoint_task_id=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
+  <id>.meta          written by fm-spawn: window=, endpoint_task_id=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-secondmate-report --local-ready records its exact ready result under secondmate-provisioning; fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
   <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
@@ -202,7 +202,7 @@ Cloning or registering a project is add intake and uses the same trigger.
 That skill owns registry syntax, delivery-mode selection, outward-facing consent, clone and initialization procedure, safe rollback, and removal preflight.
 Project creation never authorizes an unmentioned remote, and project removal never bypasses that preflight or unlanded-work checks; hard rule 1's concrete captain-approved project operation exception remains available when its exact conditions are met.
 
-Load `secondmate-provisioning` before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
+Load `secondmate-provisioning` for the complete secondmate-home and routed-work triggers in section 13.
 Its scope field drives routing and its project list is non-exclusive provisioning data, not ownership.
 A secondmate may manage `local-only` project work, but only the main firstmate may land its exact ready commit into the authoritative checkout.
 
@@ -483,7 +483,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `project-management` - load before adding, creating, removing, or initializing a project.
   Cloning or registering a project is add intake and uses the same trigger.
 - `stuck-crewmate-recovery` - load when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
-- `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
+- `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, routing or landing secondmate-owned `local-only` work, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Hard rules, in priority order:
 1. **Never write to a project.**
    Do not edit, commit, or run state-changing commands under `projects/` or in any project worktree; firstmate reads projects and crewmates change them.
    The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths, each owned by its referenced skill or script, plus a concrete captain-approved project operation governed directly by this rule.
+   Only the main firstmate may use the `local-only` merge exception; `bin/fm-merge-local.sh` refuses every marked secondmate home.
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
    Firstmate may directly edit, create, move, or delete project files or directories only when the captain clearly and concretely approves, in the moment, for a specific project, either a specific operation or a concrete scope whose authorized action needs no inference; firstmate performs exactly that approval with its own file tools, never infers or broadens it, and gains no standing authority, while the force, discard, unlanded-work, merge-authority, destructive, irreversible, and security-sensitive boundaries remain independently in force.
 2. **Never merge a PR without the captain's explicit word.**
@@ -203,7 +204,7 @@ Project creation never authorizes an unmentioned remote, and project removal nev
 
 Load `secondmate-provisioning` before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 Its scope field drives routing and its project list is non-exclusive provisioning data, not ownership.
-Keep `local-only` work in the main home.
+A secondmate may manage `local-only` project work, but only the main firstmate may land its exact ready commit into the authoritative checkout.
 
 A secondmate is idle by default and acts only on work routed by the main firstmate.
 It reconciles its own work under way after restart, then waits silently; an empty queue never authorizes a survey, audit, or self-directed improvement sweep.
@@ -234,7 +235,7 @@ An explicit project wins, a clear follow-up inherits its referent, and otherwise
 Proceed on one confident match while naming the project in plain language; ask one concise question when multiple or no projects plausibly match.
 
 Route by the nature of the work against each registered secondmate scope, not by a non-exclusive clone list.
-Keep `local-only` work in the main home.
+Load `secondmate-provisioning` before routing or landing ready `local-only` work owned by a secondmate.
 Send in-scope work to the fitting secondmate unless it is blocked or the captain explicitly redirects it; do not read the secondmate's chat because marked routed replies return through its status or referenced document.
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
 For one-off or infrequent operational work, start with the simplest direct end-to-end path.
@@ -278,7 +279,7 @@ The path's worker, automated gates, and captain approval remain authoritative:
 
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
 - **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
-- **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
+- **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before the main firstmate uses the guarded fast-forward merge path; a secondmate-owned task records and routes its exact ready commit plus validation evidence instead of landing.
 
 Delivery mode and `yolo` are orthogonal.
 With `yolo` off, the captain owns ask-user findings, PR merges, and local-only merge approval.

--- a/bin/fm-backlog-handoff.sh
+++ b/bin/fm-backlog-handoff.sh
@@ -25,6 +25,9 @@
 #   - the multi-key classification and idempotent per-key reporting: a key
 #     already present in the secondmate backlog is reported and skipped, and if
 #     any key matches neither backlog nothing is moved.
+# Delivery mode does not change backlog ownership. In-scope queued local-only
+# items move through this same path, while main-only landing remains owned by
+# bin/fm-merge-local.sh and the secondmate-provisioning skill.
 #
 # What `tasks-axi mv <id>... --to <dest>` owns: moving each full item BLOCK
 # byte-exact (header, body lines, blank separators, and indented pseudo-headings

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -31,8 +31,9 @@
 # and AGENTS.md task lifecycle):
 #   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge (default)
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
-#   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
-#                captain approves, firstmate merges to local main
+#   local-only   implement on branch, stop and report ready (no push/PR);
+#                a secondmate-owned task includes exact commit + validation
+#                evidence and routes it to the main firstmate for landing
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Every scaffold's status protocol distinguishes the configured
@@ -81,6 +82,8 @@ resolve_directory_input() {
 
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME=$(resolve_directory_input FM_HOME "${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}") || exit 1
+IS_SECOND_MATE_HOME=0
+[ ! -f "$FM_HOME/.fm-secondmate-home" ] || IS_SECOND_MATE_HOME=1
 if [ -n "${FM_DATA_OVERRIDE:-}" ]; then
   DATA=$(resolve_directory_input FM_DATA_OVERRIDE "$FM_DATA_OVERRIDE") || exit 1
 else
@@ -317,7 +320,19 @@ EOF
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    IFS= read -r -d '' DOD <<EOF || true
+    if [ "$IS_SECOND_MATE_HOME" = 1 ]; then
+      IFS= read -r -d '' DOD <<EOF || true
+# Definition of done
+This project ships **local-only**: no remote, no PR, no pipeline.
+The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+Keep your branch a clean fast-forward onto the current default branch - if the default branch has advanced, rebase onto it so the eventual merge stays a fast-forward.
+Run the validation required by the task and project instructions.
+When it is implemented, committed, clean, and validated, append \`done: ready commit=<full 40-character HEAD> branch=fm/$ID validation=<commands and outcome>\` to the status file and stop.
+Your second mate records that exact ready commit and validation evidence, then routes it to the main firstmate.
+Only the main firstmate may run the guarded local landing.
+EOF
+    else
+      IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
@@ -325,6 +340,7 @@ Keep your branch a clean fast-forward onto the current default branch - if \`mai
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
+    fi
     ;;
   *)  # no-mistakes (default)
     SETUP2="

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -320,11 +320,13 @@ EOF
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    if [ "$IS_SECOND_MATE_HOME" = 1 ]; then
-      IFS= read -r -d '' DOD <<EOF || true
+    IFS= read -r -d '' DOD_HEAD <<EOF || true
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+EOF
+    if [ "$IS_SECOND_MATE_HOME" = 1 ]; then
+      IFS= read -r -d '' DOD_TAIL <<EOF || true
 Keep your branch a clean fast-forward onto the current default branch - if the default branch has advanced, rebase onto it so the eventual merge stays a fast-forward.
 Run the validation required by the task and project instructions.
 When it is implemented, committed, clean, and validated, append \`done: ready commit=<full 40-character HEAD> branch=fm/$ID validation=<commands and outcome>\` to the status file and stop.
@@ -332,15 +334,13 @@ Your second mate records that exact ready commit and validation evidence, then r
 Only the main firstmate may run the guarded local landing.
 EOF
     else
-      IFS= read -r -d '' DOD <<EOF || true
-# Definition of done
-This project ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+      IFS= read -r -d '' DOD_TAIL <<EOF || true
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     fi
+    DOD="$DOD_HEAD$DOD_TAIL"
     ;;
   *)  # no-mistakes (default)
     SETUP2="

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -7,8 +7,10 @@
 #       a fresh firstmate worktree via "treehouse get --lease", which durably
 #       leases the worktree under the secondmate <id> so the home survives with
 #       no live process and is never recycled until the lease is released with
-#       "treehouse return". Projects are cloned
-#       from the active home into the secondmate home's projects/ directory.
+#       "treehouse return". Projects are cloned from the active home into the
+#       secondmate home's projects/ directory. Remote-backed projects clone their
+#       existing origin; local-only projects clone only committed state from the
+#       active home's authoritative checkout and use that checkout as origin.
 #       That project list is non-exclusive provisioning data. Pass --no-projects
 #       instead of a project list to seed a project-less home for a domain whose
 #       subject is the firstmate repo itself; it is mutually exclusive with a
@@ -452,6 +454,10 @@ normalize_origin_url() {
 
 source_origin_url() {
   local project=$1 mode=$2 src=$3 url
+  if [ "$mode" = local-only ]; then
+    resolved_path "$src"
+    return
+  fi
   url=$(git -C "$src" remote get-url origin 2>/dev/null || true)
   [ -n "$url" ] || { echo "error: project $project is $mode but has no origin remote" >&2; return 1; }
   normalize_origin_url "$src" "$url"
@@ -542,10 +548,6 @@ clone_project() {
   read -r mode _ <<EOF
 $(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$FM_ROOT/bin/fm-project-mode.sh" "$project")
 EOF
-  if [ "$mode" = local-only ]; then
-    echo "error: project $project is local-only; secondmate routes support only no-mistakes and direct-PR projects" >&2
-    return 1
-  fi
   if [ -e "$dst" ]; then
     [ -d "$dst" ] || { echo "error: seeded project $project exists at $dst but is not a directory" >&2; return 1; }
     git -C "$dst" rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "error: seeded project $project at $dst is not a git repo" >&2; return 1; }
@@ -558,7 +560,11 @@ EOF
     return 0
   fi
   url=$(source_origin_url "$project" "$mode" "$src") || return 1
-  git clone --quiet "$url" "$dst"
+  if [ "$mode" = local-only ]; then
+    git clone --quiet --no-hardlinks "$url" "$dst"
+  else
+    git clone --quiet "$url" "$dst"
+  fi
 }
 
 validate_seed_project() {
@@ -569,10 +575,7 @@ validate_seed_project() {
   read -r mode _ <<EOF
 $(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$FM_ROOT/bin/fm-project-mode.sh" "$project")
 EOF
-  if [ "$mode" = local-only ]; then
-    echo "error: project $project is local-only; secondmate routes support only no-mistakes and direct-PR projects" >&2
-    return 1
-  fi
+  [ "$mode" != local-only ] || return 0
   url=$(git -C "$src" remote get-url origin 2>/dev/null || true)
   [ -n "$url" ] || { echo "error: project $project is $mode but has no origin remote" >&2; return 1; }
 }

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -9,20 +9,113 @@
 # auto-approves), and only as a clean fast-forward - it refuses a diverged branch
 # and tells you to have the crewmate rebase. See AGENTS.md prime directives,
 # project management, and task lifecycle.
-# Usage: fm-merge-local.sh <task-id>
+# A main-home task keeps the historical one-argument form.
+# A secondmate-owned task stays in that home's state and is selected explicitly:
+#   fm-merge-local.sh <task-id> --secondmate <secondmate-id>
+# The secondmate path requires the exact ready commit and validation evidence
+# recorded by fm-secondmate-report.sh --local-ready, imports only that branch,
+# and fast-forwards the main home's authoritative checkout to that exact commit.
+# A .fm-secondmate-home marker always refuses this script before any project
+# inspection or mutation.
+# Usage: fm-merge-local.sh <task-id> [--secondmate <secondmate-id>]
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+
+usage() {
+  echo "usage: fm-merge-local.sh <task-id> [--secondmate <secondmate-id>]" >&2
+  exit 2
+}
+
+[ $# -ge 1 ] || usage
+ID=$1
+shift
+SECOND_MATE_ID=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --secondmate)
+      [ $# -ge 2 ] || usage
+      SECOND_MATE_ID=$2
+      shift 2
+      ;;
+    *) usage ;;
+  esac
+done
+
+case "$ID" in
+  ''|.*|*[!A-Za-z0-9._-]*) usage ;;
+esac
+if [ -n "$SECOND_MATE_ID" ]; then
+  case "$SECOND_MATE_ID" in
+    ''|.*|*[!A-Za-z0-9._-]*) usage ;;
+  esac
+fi
+if [ -e "$FM_HOME/.fm-secondmate-home" ] || [ -L "$FM_HOME/.fm-secondmate-home" ]; then
+  echo "REFUSED: local landing is main-firstmate-only; $FM_HOME is marked as a secondmate home." >&2
+  exit 1
+fi
+
+meta_get() {
+  local meta=$1 key=$2
+  grep "^$key=" "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+canonical_dir() {
+  local dir=$1
+  [ -d "$dir" ] || return 1
+  cd "$dir" && pwd -P
+}
+
+secondmate_home() {
+  local id=$1 line home marker
+  [ -f "$DATA/secondmates.md" ] || {
+    echo "error: no secondmate registry at $DATA/secondmates.md" >&2
+    return 1
+  }
+  line=$(grep -E "^- $id( |$)" "$DATA/secondmates.md" | tail -1 || true)
+  [ -n "$line" ] || {
+    echo "error: secondmate $id is not registered in $DATA/secondmates.md" >&2
+    return 1
+  }
+  home=$(printf '%s\n' "$line" | sed -n 's/.*(home:[[:space:]]*\([^;)]*\);.*/\1/p' | sed 's/[[:space:]]*$//')
+  [ -n "$home" ] || {
+    echo "error: secondmate $id has no home in $DATA/secondmates.md" >&2
+    return 1
+  }
+  home=$(canonical_dir "$home") || {
+    echo "error: secondmate home does not exist or is not a directory: $home" >&2
+    return 1
+  }
+  [ -f "$home/.fm-secondmate-home" ] || {
+    echo "error: firstmate home $home is not a seeded secondmate home" >&2
+    return 1
+  }
+  marker=$(cat "$home/.fm-secondmate-home" 2>/dev/null || true)
+  [ "$marker" = "$id" ] || {
+    echo "error: firstmate home $home is marked for secondmate ${marker:-unknown}, expected $id" >&2
+    return 1
+  }
+  printf '%s\n' "$home"
+}
+
 "$FM_ROOT/bin/fm-guard.sh" || true
-ID=${1:?usage: fm-merge-local.sh <task-id>}
-META="$STATE/$ID.meta"
+SOURCE_HOME=
+if [ -n "$SECOND_MATE_ID" ]; then
+  SOURCE_HOME=$(secondmate_home "$SECOND_MATE_ID") || exit 1
+  META="$SOURCE_HOME/state/$ID.meta"
+else
+  META="$STATE/$ID.meta"
+fi
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
 
-PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
-MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
+SOURCE_PROJ=$(meta_get "$META" project)
+PROJ=$SOURCE_PROJ
+MODE=$(meta_get "$META" mode)
 [ "$MODE" = local-only ] || { echo "error: task $ID is mode=$MODE, not local-only; merge PR tasks with bin/fm-pr-merge.sh <id> <PR url> after approval" >&2; exit 1; }
 
 default_branch() {
@@ -42,7 +135,73 @@ default_branch() {
 }
 
 BRANCH="fm/$ID"
-git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $PROJ" >&2; exit 1; }
+READY_COMMIT=
+if [ -n "$SECOND_MATE_ID" ]; then
+  PROJECT_NAME=$(basename "$SOURCE_PROJ")
+  EXPECTED_SOURCE=$(canonical_dir "$SOURCE_HOME/projects/$PROJECT_NAME") || {
+    echo "error: secondmate project $PROJECT_NAME is missing under $SOURCE_HOME/projects" >&2
+    exit 1
+  }
+  SOURCE_PROJ=$(canonical_dir "$SOURCE_PROJ") || {
+    echo "error: task $ID project is missing: $SOURCE_PROJ" >&2
+    exit 1
+  }
+  [ "$SOURCE_PROJ" = "$EXPECTED_SOURCE" ] || {
+    echo "error: task $ID project $SOURCE_PROJ is not the registered secondmate clone $EXPECTED_SOURCE" >&2
+    exit 1
+  }
+  PROJ=$(canonical_dir "$PROJECTS/$PROJECT_NAME") || {
+    echo "error: authoritative project $PROJECT_NAME is missing under $PROJECTS" >&2
+    exit 1
+  }
+  read -r MAIN_MODE _ <<EOF
+$(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$FM_ROOT/bin/fm-project-mode.sh" "$PROJECT_NAME")
+EOF
+  [ "$MAIN_MODE" = local-only ] || {
+    echo "error: authoritative project $PROJECT_NAME is mode=$MAIN_MODE, not local-only" >&2
+    exit 1
+  }
+
+  READY_COMMIT=$(meta_get "$META" ready_commit)
+  READY_BRANCH=$(meta_get "$META" ready_branch)
+  VALIDATION_EVIDENCE=$(meta_get "$META" validation_evidence)
+  printf '%s\n' "$READY_COMMIT" | grep -Eq '^[0-9a-f]{40}$' || {
+    echo "error: task $ID has no valid exact ready_commit in $META; route it with bin/fm-secondmate-report.sh --local-ready first" >&2
+    exit 1
+  }
+  [ "$READY_BRANCH" = "$BRANCH" ] || {
+    echo "error: task $ID ready branch is ${READY_BRANCH:-missing}, expected $BRANCH" >&2
+    exit 1
+  }
+  [ -n "$VALIDATION_EVIDENCE" ] || {
+    echo "error: task $ID has no recorded validation evidence in $META" >&2
+    exit 1
+  }
+  SOURCE_BRANCH_COMMIT=$(git -C "$SOURCE_PROJ" rev-parse --verify "refs/heads/$BRANCH" 2>/dev/null || true)
+  [ "$SOURCE_BRANCH_COMMIT" = "$READY_COMMIT" ] || {
+    echo "error: ready branch $BRANCH moved after reporting; expected $READY_COMMIT, found ${SOURCE_BRANCH_COMMIT:-missing}" >&2
+    exit 1
+  }
+  WORKTREE=$(meta_get "$META" worktree)
+  WORKTREE_BRANCH=$(git -C "$WORKTREE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  WORKTREE_COMMIT=$(git -C "$WORKTREE" rev-parse --verify HEAD 2>/dev/null || true)
+  [ "$WORKTREE_BRANCH" = "$BRANCH" ] && [ "$WORKTREE_COMMIT" = "$READY_COMMIT" ] || {
+    echo "error: task $ID worktree no longer matches ready $BRANCH at $READY_COMMIT" >&2
+    exit 1
+  }
+  WORKTREE_DIRTY=$(git -C "$WORKTREE" status --porcelain 2>/dev/null \
+    | grep -vE '^\?\? (\.claude/|\.fm-(grok|kimi)-turnend$)' \
+    | head -1 || true)
+  [ -z "$WORKTREE_DIRTY" ] || {
+    echo "error: task $ID worktree became dirty after it was reported ready" >&2
+    exit 1
+  }
+else
+  git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || {
+    echo "error: branch $BRANCH does not exist in $PROJ" >&2
+    exit 1
+  }
+fi
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 
@@ -51,18 +210,38 @@ DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for 
 cur=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo "")
 [ "$cur" = "$DEFAULT" ] || { echo "error: $PROJ is on '$cur', expected default branch '$DEFAULT'; cannot merge safely" >&2; exit 1; }
 if [ -n "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ]; then
-  echo "error: $PROJ has a dirty working tree; refusing to merge into it" >&2
+  if [ -n "$SECOND_MATE_ID" ]; then
+    echo "ready, waiting: authoritative checkout $PROJ is dirty; commit $READY_COMMIT remains ready in secondmate $SECOND_MATE_ID task $ID" >&2
+  else
+    echo "error: $PROJ has a dirty working tree; refusing to merge into it" >&2
+  fi
   exit 1
 fi
 
+if [ -n "$SECOND_MATE_ID" ]; then
+  git -C "$PROJ" fetch --quiet --no-tags "$SOURCE_PROJ" "refs/heads/$BRANCH" || {
+    echo "error: cannot import ready branch $BRANCH from $SOURCE_PROJ" >&2
+    exit 1
+  }
+  git -C "$PROJ" rev-parse --verify --quiet "$READY_COMMIT^{commit}" >/dev/null || {
+    echo "error: imported branch did not provide ready commit $READY_COMMIT" >&2
+    exit 1
+  }
+fi
+
 # Clean fast-forward only: DEFAULT must be an ancestor of BRANCH.
-if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BRANCH"; then
-  echo "REFUSED: $BRANCH is not a fast-forward of $DEFAULT (it has diverged)." >&2
-  echo "Have the crewmate rebase $BRANCH onto $DEFAULT, then retry." >&2
+MERGE_TARGET=${READY_COMMIT:-$BRANCH}
+if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$MERGE_TARGET"; then
+  echo "REFUSED: $BRANCH at $MERGE_TARGET is not a fast-forward of $DEFAULT (it has diverged)." >&2
+  echo "Have the worker rebase $BRANCH onto $DEFAULT, record the new exact ready commit, then retry." >&2
   exit 1
 fi
 
 before=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
-git -C "$PROJ" merge --ff-only "$BRANCH" >/dev/null
+git -C "$PROJ" merge --ff-only "$MERGE_TARGET" >/dev/null
 after=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
-echo "merged $BRANCH into local $DEFAULT ($before -> $after) in $PROJ"
+if [ -n "$SECOND_MATE_ID" ]; then
+  echo "merged exact ready commit $READY_COMMIT from secondmate $SECOND_MATE_ID task $ID into local $DEFAULT ($before -> $after) in $PROJ"
+else
+  echo "merged $BRANCH into local $DEFAULT ($before -> $after) in $PROJ"
+fi

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -142,10 +142,11 @@ if [ -n "$SECOND_MATE_ID" ]; then
     echo "error: secondmate project $PROJECT_NAME is missing under $SOURCE_HOME/projects" >&2
     exit 1
   }
-  SOURCE_PROJ=$(canonical_dir "$SOURCE_PROJ") || {
-    echo "error: task $ID project is missing: $SOURCE_PROJ" >&2
+  RESOLVED_SOURCE_PROJ=$(canonical_dir "$SOURCE_PROJ") || {
+    echo "error: task $ID project is missing: ${SOURCE_PROJ:-<empty>}" >&2
     exit 1
   }
+  SOURCE_PROJ=$RESOLVED_SOURCE_PROJ
   [ "$SOURCE_PROJ" = "$EXPECTED_SOURCE" ] || {
     echo "error: task $ID project $SOURCE_PROJ is not the registered secondmate clone $EXPECTED_SOURCE" >&2
     exit 1
@@ -197,6 +198,11 @@ EOF
     exit 1
   }
 else
+  RESOLVED_PROJ=$(canonical_dir "$PROJ") || {
+    echo "error: task $ID project is missing: ${PROJ:-<empty>}" >&2
+    exit 1
+  }
+  PROJ=$RESOLVED_PROJ
   git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || {
     echo "error: branch $BRANCH does not exist in $PROJ" >&2
     exit 1

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -77,7 +77,7 @@ secondmate_home() {
     echo "error: no secondmate registry at $DATA/secondmates.md" >&2
     return 1
   }
-  line=$(grep -E "^- $id( |$)" "$DATA/secondmates.md" | tail -1 || true)
+  line=$(awk -v id="$id" '$1 == "-" && $2 == id { line=$0 } END { print line }' "$DATA/secondmates.md")
   [ -n "$line" ] || {
     echo "error: secondmate $id is not registered in $DATA/secondmates.md" >&2
     return 1
@@ -190,7 +190,11 @@ EOF
     echo "error: task $ID worktree no longer matches ready $BRANCH at $READY_COMMIT" >&2
     exit 1
   }
-  WORKTREE_DIRTY=$(git -C "$WORKTREE" status --porcelain 2>/dev/null \
+  if ! WORKTREE_STATUS=$(git -C "$WORKTREE" status --porcelain 2>/dev/null); then
+    echo "error: cannot inspect ready worktree status for task $ID: $WORKTREE" >&2
+    exit 1
+  fi
+  WORKTREE_DIRTY=$(printf '%s\n' "$WORKTREE_STATUS" \
     | grep -vE '^\?\? (\.claude/|\.fm-(grok|kimi)-turnend$)' \
     | head -1 || true)
   [ -z "$WORKTREE_DIRTY" ] || {

--- a/bin/fm-secondmate-report.sh
+++ b/bin/fm-secondmate-report.sh
@@ -128,7 +128,11 @@ if [ "$LOCAL_READY_MODE" = 1 ]; then
   PROJECT_COMMIT=$(git -C "$PROJECT" rev-parse --verify "refs/heads/$BRANCH" 2>/dev/null || true)
   [ "$PROJECT_COMMIT" = "$READY_COMMIT" ] \
     || { echo "error: local-ready branch $BRANCH does not resolve to worktree HEAD $READY_COMMIT in $PROJECT" >&2; exit 1; }
-  DIRTY=$(git -C "$WORKTREE" status --porcelain 2>/dev/null \
+  if ! WORKTREE_STATUS=$(git -C "$WORKTREE" status --porcelain 2>/dev/null); then
+    echo "error: cannot inspect local-ready worktree status: $WORKTREE" >&2
+    exit 1
+  fi
+  DIRTY=$(printf '%s\n' "$WORKTREE_STATUS" \
     | grep -vE '^\?\? (\.claude/|\.fm-(grok|kimi)-turnend$)' \
     | head -1 || true)
   [ -z "$DIRTY" ] \

--- a/bin/fm-secondmate-report.sh
+++ b/bin/fm-secondmate-report.sh
@@ -134,19 +134,20 @@ if [ "$LOCAL_READY_MODE" = 1 ]; then
   [ -z "$DIRTY" ] \
     || { echo "error: local-ready worktree is dirty: $WORKTREE" >&2; exit 1; }
 
-  META_TMP="$TASK_META.local-ready.tmp.$$"
-  awk -v commit="$READY_COMMIT" -v branch="$BRANCH" -v evidence="$VALIDATION_EVIDENCE" '
-    /^ready_commit=/ { next }
-    /^ready_branch=/ { next }
-    /^validation_evidence=/ { next }
-    { print }
-    END {
-      print "ready_commit=" commit
-      print "ready_branch=" branch
-      print "validation_evidence=" evidence
-    }
-  ' "$TASK_META" > "$META_TMP"
-  mv -f "$META_TMP" "$TASK_META"
+  META_TMP=
+  meta_tmp_cleanup() {
+    [ -z "$META_TMP" ] || rm -f -- "$META_TMP"
+  }
+  trap meta_tmp_cleanup EXIT
+  META_TMP=$(mktemp "$STATE_DIR/.$(basename "$TASK_META").local-ready.XXXXXX") \
+    || { echo "error: cannot stage local-ready metadata in $STATE_DIR" >&2; exit 1; }
+  { grep -vE '^ready_commit=|^ready_branch=|^validation_evidence=' "$TASK_META" || true; } > "$META_TMP" \
+    || { echo "error: cannot stage local-ready metadata for $TASK_META" >&2; exit 1; }
+  printf 'ready_commit=%s\n' "$READY_COMMIT" >> "$META_TMP" || exit 1
+  printf 'ready_branch=%s\n' "$BRANCH" >> "$META_TMP" || exit 1
+  printf 'validation_evidence=%s\n' "$VALIDATION_EVIDENCE" >> "$META_TMP" || exit 1
+  mv -f -- "$META_TMP" "$TASK_META" || exit 1
+  META_TMP=
   printf '%s [%s]: local-only ready task=%s commit=%s branch=%s validation=%s (via-helper)\n' \
     "$VERB" "$token" "$TASK_ID" "$READY_COMMIT" "$BRANCH" "$VALIDATION_EVIDENCE" >> "$STATUS_FILE"
 elif [ "$DOC_MODE" = 1 ]; then

--- a/bin/fm-secondmate-report.sh
+++ b/bin/fm-secondmate-report.sh
@@ -10,16 +10,23 @@
 # Usage:
 #   fm-secondmate-report.sh <status-file> <verb> <corr_id> <note...>
 #   fm-secondmate-report.sh --doc <status-file> <verb> <corr_id> <doc-path> <note...>
+#   fm-secondmate-report.sh --local-ready <status-file> <corr_id> <task-meta> <validation-evidence...>
 #
 # Examples:
 #   fm-secondmate-report.sh "$STATUS" done abcdef0123456789 "audit clean"
 #   fm-secondmate-report.sh --doc "$STATUS" done abcdef0123456789 data/x/report.md "see report"
+#   fm-secondmate-report.sh --local-ready "$STATUS" abcdef0123456789 state/fix.meta "scripts/gate.sh passed"
 #
 # The status file must be the absolute parent route from the secondmate charter
 # (state/<id>.status under the PARENT home), never a path relative to this
 # secondmate home. Writing under the wrong home is detected as supporting
 # evidence by the parent pending-reply guard and does not acknowledge the
 # request.
+#
+# --local-ready is the local-only ready-result path. It refuses unless task
+# metadata lives in a marked secondmate home and records a clean exact HEAD on
+# the expected fm/<id> branch plus non-empty validation evidence before it
+# reports that result to the parent. It never lands the work.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -31,21 +38,36 @@ usage() {
 Usage:
   fm-secondmate-report.sh <status-file> <verb> <corr_id> <note...>
   fm-secondmate-report.sh --doc <status-file> <verb> <corr_id> <doc-path> <note...>
+  fm-secondmate-report.sh --local-ready <status-file> <corr_id> <task-meta> <validation-evidence...>
 EOF
   exit 2
 }
 
 DOC_MODE=0
+LOCAL_READY_MODE=0
 if [ "${1:-}" = "--doc" ]; then
   DOC_MODE=1
   shift
+elif [ "${1:-}" = "--local-ready" ]; then
+  LOCAL_READY_MODE=1
+  shift
 fi
 
-[ $# -ge 4 ] || usage
-STATUS_FILE=$1
-VERB=$2
-CORR=$3
-shift 3
+if [ "$LOCAL_READY_MODE" = 1 ]; then
+  [ $# -ge 4 ] || usage
+  STATUS_FILE=$1
+  CORR=$2
+  TASK_META=$3
+  shift 3
+  VALIDATION_EVIDENCE=$*
+  VERB='done'
+else
+  [ $# -ge 4 ] || usage
+  STATUS_FILE=$1
+  VERB=$2
+  CORR=$3
+  shift 3
+fi
 
 case "$CORR" in
   corr=*) CORR=${CORR#corr=} ;;
@@ -68,7 +90,66 @@ if [ ! -d "$(dirname "$STATUS_FILE")" ]; then
 fi
 
 token=$(fm_pending_reply_corr_token "$CORR")
-if [ "$DOC_MODE" = 1 ]; then
+if [ "$LOCAL_READY_MODE" = 1 ]; then
+  case "$VALIDATION_EVIDENCE" in
+    ''|*$'\n'*|*$'\r'*)
+      echo "error: local-ready validation evidence must be one non-empty line" >&2
+      exit 1
+      ;;
+  esac
+  [ -f "$TASK_META" ] || { echo "error: local-ready task metadata not found: $TASK_META" >&2; exit 1; }
+  STATE_DIR=$(dirname "$TASK_META")
+  SECOND_MATE_HOME=$(dirname "$STATE_DIR")
+  [ "$(basename "$STATE_DIR")" = state ] \
+    || { echo "error: local-ready task metadata must live under a secondmate state directory: $TASK_META" >&2; exit 1; }
+  [ -f "$SECOND_MATE_HOME/.fm-secondmate-home" ] \
+    || { echo "error: local-ready task metadata is not in a marked secondmate home: $TASK_META" >&2; exit 1; }
+
+  TASK_ID=$(basename "$TASK_META" .meta)
+  MODE=$(fm_meta_get "$TASK_META" mode)
+  KIND=$(fm_meta_get "$TASK_META" kind)
+  WORKTREE=$(fm_meta_get "$TASK_META" worktree)
+  PROJECT=$(fm_meta_get "$TASK_META" project)
+  [ "$MODE" = local-only ] \
+    || { echo "error: local-ready task $TASK_ID is mode=${MODE:-unknown}, not local-only" >&2; exit 1; }
+  [ "$KIND" = ship ] \
+    || { echo "error: local-ready task $TASK_ID is kind=${KIND:-unknown}, not ship" >&2; exit 1; }
+  [ -d "$WORKTREE" ] \
+    || { echo "error: local-ready worktree is missing: ${WORKTREE:-<empty>}" >&2; exit 1; }
+  [ -d "$PROJECT" ] \
+    || { echo "error: local-ready project is missing: ${PROJECT:-<empty>}" >&2; exit 1; }
+
+  BRANCH="fm/$TASK_ID"
+  CURRENT_BRANCH=$(git -C "$WORKTREE" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  [ "$CURRENT_BRANCH" = "$BRANCH" ] \
+    || { echo "error: local-ready worktree is on ${CURRENT_BRANCH:-detached}, expected $BRANCH" >&2; exit 1; }
+  READY_COMMIT=$(git -C "$WORKTREE" rev-parse --verify HEAD 2>/dev/null) \
+    || { echo "error: cannot resolve local-ready HEAD in $WORKTREE" >&2; exit 1; }
+  PROJECT_COMMIT=$(git -C "$PROJECT" rev-parse --verify "refs/heads/$BRANCH" 2>/dev/null || true)
+  [ "$PROJECT_COMMIT" = "$READY_COMMIT" ] \
+    || { echo "error: local-ready branch $BRANCH does not resolve to worktree HEAD $READY_COMMIT in $PROJECT" >&2; exit 1; }
+  DIRTY=$(git -C "$WORKTREE" status --porcelain 2>/dev/null \
+    | grep -vE '^\?\? (\.claude/|\.fm-(grok|kimi)-turnend$)' \
+    | head -1 || true)
+  [ -z "$DIRTY" ] \
+    || { echo "error: local-ready worktree is dirty: $WORKTREE" >&2; exit 1; }
+
+  META_TMP="$TASK_META.local-ready.tmp.$$"
+  awk -v commit="$READY_COMMIT" -v branch="$BRANCH" -v evidence="$VALIDATION_EVIDENCE" '
+    /^ready_commit=/ { next }
+    /^ready_branch=/ { next }
+    /^validation_evidence=/ { next }
+    { print }
+    END {
+      print "ready_commit=" commit
+      print "ready_branch=" branch
+      print "validation_evidence=" evidence
+    }
+  ' "$TASK_META" > "$META_TMP"
+  mv -f "$META_TMP" "$TASK_META"
+  printf '%s [%s]: local-only ready task=%s commit=%s branch=%s validation=%s (via-helper)\n' \
+    "$VERB" "$token" "$TASK_ID" "$READY_COMMIT" "$BRANCH" "$VALIDATION_EVIDENCE" >> "$STATUS_FILE"
+elif [ "$DOC_MODE" = 1 ]; then
   [ $# -ge 1 ] || usage
   DOC_PATH=$1
   shift

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -410,6 +410,19 @@ content_in_default() {
   [ "$merged_tree" = "$default_tree" ]
 }
 
+ready_commit_in_origin_default() {
+  local ready evidence current name
+  ready=$(meta_value "$META" ready_commit)
+  evidence=$(meta_value "$META" validation_evidence)
+  [ -n "$ready" ] && [ -n "$evidence" ] || return 1
+  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
+  [ "$current" = "$ready" ] || return 1
+  name=$(default_branch) || return 1
+  git -C "$WT" remote get-url origin >/dev/null 2>&1 || return 1
+  git -C "$WT" fetch --quiet origin "+refs/heads/$name:refs/remotes/origin/$name" >/dev/null 2>&1 || return 1
+  git -C "$WT" merge-base --is-ancestor "$ready" "refs/remotes/origin/$name" 2>/dev/null
+}
+
 # Has the worktree's committed work actually LANDED, though its commits are not
 # reachable from any remote-tracking branch? True when a merged PR proves the
 # current local work is contained in the PR head, OR the content is already in the
@@ -705,7 +718,15 @@ validate_worktree_teardown_safety() {
       return 1
     fi
     unmerged=$(printf '%s\n' "$unmerged_raw" | head -5)
-    if [ -n "$dirty" ] || [ -n "$unmerged" ]; then
+    # A secondmate local-only clone points origin at the main home's
+    # authoritative checkout. After main-firstmate landing, refresh that
+    # committed default and accept only the exact recorded ready commit.
+    # Before landing, this remains false and cleanup refuses.
+    landed_in_authoritative=0
+    if [ -n "$unmerged" ] && ready_commit_in_origin_default; then
+      landed_in_authoritative=1
+    fi
+    if [ -n "$dirty" ] || { [ -n "$unmerged" ] && [ "$landed_in_authoritative" != 1 ]; }; then
       echo "REFUSED: local-only worktree $WT has work not yet merged into $DEFAULT and not on any remote." >&2
       [ -n "$dirty" ] && echo "uncommitted changes present" >&2
       [ -n "$unmerged" ] && printf 'commits not yet on %s:\n%s\n' "$DEFAULT" "$unmerged" >&2

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -363,6 +363,10 @@ select_lane() {
 run_coverage_guard() {
   local tmp missing extra a b
   local -a saved_scripts=()
+  # Every listing below is sorted in the C collation, so the comparisons must
+  # read them in the same collation or comm/uniq reject them as unsorted.
+  local LC_ALL=C
+  export LC_ALL
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-coverage.XXXXXX")
 
   all_repo_tests | LC_ALL=C sort -u >"$tmp/all"
@@ -653,7 +657,13 @@ families_for_changed_path() {
     bin/fm-gate-refuse*|bin/fm-lock*)
       printf '%s\n' session-bootstrap
       ;;
-    bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
+    bin/fm-merge-local.sh|bin/fm-teardown.sh)
+      printf '%s\n' pr-forge
+      # Their cross-home landing and secondmate-home safety paths are covered by
+      # the secondmate family, not by pr-forge.
+      printf '%s\n' secondmate
+      ;;
+    bin/fm-pr-*|bin/fm-review-diff.sh|\
     bin/fm-x-*|bin/fm-check*)
       printf '%s\n' pr-forge
       ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,7 +154,7 @@ That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and
 ## Optional secondmates
 
 `data/secondmates.md` records persistent secondmates with natural-language scopes, project clone lists, and home paths.
-`fm-home-seed.sh` provisions the isolated home, clones the listed PR-based projects into it, initializes newly cloned `no-mistakes` projects, copies the charter to `data/charter.md`, and `fm-spawn.sh --secondmate` launches it through the same session-provider and status-file path as any direct report.
+`fm-home-seed.sh` provisions the isolated home, clones the listed projects into it, initializes newly cloned `no-mistakes` projects, copies the charter to `data/charter.md`, and `fm-spawn.sh --secondmate` launches it through the same session-provider and status-file path as any direct report.
 For a domain whose subject is the firstmate repo itself, a deliberate `--no-projects` seed creates a project-less home whose crews take pooled worktrees of that repo instead of separate clones.
 The signal cannot be mixed with project names or omitted accidentally, and a populated home cannot be converted in place; the full seed contract is in [configuration.md](configuration.md#secondmate-routes-datasecondmatesmd).
 On the herdr backend, a secondmate launch lands in that secondmate home's labeled workspace, and crewmates spawned from that home land in the same workspace.
@@ -162,7 +162,7 @@ When seeded with `-`, the home is a durable treehouse lease under the secondmate
 Retirement or seed rollback returns the leased home; normal restart/recovery keeps it leased.
 If returning the lease fails during teardown, firstmate leaves the route and home intact instead of hiding a still-held lease.
 Seeding is transactional: if validation, cloning, initialization, or registry update fails, generated briefs, new homes, new project clones, and registry edits are rolled back.
-`local-only` projects stay with the main first mate because they merge into the main local checkout instead of a remote-backed PR path.
+`local-only` work may follow secondmate scope and backlog ownership, while the main first mate alone lands the exact reported ready commit; the [`secondmate-provisioning` skill](../.agents/skills/secondmate-provisioning/SKILL.md#local-only-ready-work-and-landing) owns the detailed seed, ready-result, restart, and landing contract.
 The same project may appear in multiple secondmate homes when their scopes differ, such as issue triage versus feature development.
 Secondmates are idle by default: after startup recovery reconciles only work already in their own home, an empty queue waits silently for routed tasks, and they never self-initiate surveys or audits.
 When called with `FM_HOME=<this-firstmate-home>` or when `FM_HOME` is already set to the active firstmate home, metadata-routed `fm-send.sh` requests to a live `kind=secondmate` use the live-charter-compatible `from-firstmate` carrier owned by `bin/fm-operational-input.sh`, so the secondmate returns terse answers through status lines and detailed answers through docs plus status pointers instead of replying only in its own chat.
@@ -189,7 +189,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 ## Project modes are explicit
 
 `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
-`no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
+`no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until the main first mate performs an approved fast-forward merge.
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,7 +150,8 @@ A project-less seed requires no existing project clones or `data/projects.md` en
 A preexisting project-bearing charter is also refused until it is re-scaffolded with `--no-projects` or removed.
 The lease is held under the secondmate id until explicit retirement or seed rollback returns it, so normal restarts do not free or recycle the home.
 Teardown of a leased home fails closed if `treehouse return` cannot release the lease; plain-clone homes with no treehouse pool slot are removed directly.
-Secondmate routes cover `no-mistakes` and `direct-PR` projects; `local-only` projects remain main-firstmate work.
+Secondmate routes cover all three delivery modes.
+For `local-only`, the secondmate manages isolated work and routes an exact validated ready commit back, while only the main first mate may land it into the authoritative checkout.
 For `no-mistakes` projects, seeding initializes only projects newly cloned into a secondmate home and refuses to mutate a preexisting clone that is not already initialized.
 After creating a secondmate, move existing main-backlog queued items that you have judged in-scope with `fm-backlog-handoff.sh <secondmate-id> <item-key>...`; it is idempotent and refuses In flight, Done, or non-secondmate homes.
 Set `FM_SECONDMATE_CHARTER` to seed from inline charter text when no filled charter brief exists; set `FM_SECONDMATE_SCOPE` when the routing scope should differ from the charter text.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -49,11 +49,11 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live secondmates mid-session and send a pointer to the literal-content config reread when config changed |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
-| `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
+| `fm-merge-local.sh`      | Land approved `local-only` work through the main home's guarded fast-forward          |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and one-shot escalation |
-| `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |
+| `fm-secondmate-report.sh` | Append correlated secondmate reports and record validated local-ready results          |
 | `fm-gate-refuse-lib.sh`  | Shared no-mistakes gate-context refusal for fleet lifecycle entrypoints               |
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with loud cycle endings and bounded lifecycle ledger |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -537,6 +537,30 @@ EOF
   pass "registry entry without (home: ...) fails cleanly with has no home"
 }
 
+test_local_only_item_uses_normal_handoff_path() {
+  local home="$TMP_ROOT/local-only-main"
+  local sub="$TMP_ROOT/local-only-sub"
+  setup_homes "$home" "$sub" local-domain
+  printf '%s\n' '- alpha [local-only] - local project (added 2026-07-29)' > "$home/data/projects.md"
+  cat > "$home/data/backlog.md" <<'EOF'
+## Queued
+- [ ] local-feature - ready for isolated local work (repo: alpha)
+  Preserve this task body.
+
+## Done
+EOF
+
+  FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" local-domain local-feature >/dev/null \
+    || fail "local-only queued item was refused by the normal handoff path"
+  assert_no_grep 'local-feature' "$home/data/backlog.md" \
+    "local-only item remained in the main backlog"
+  assert_grep 'local-feature' "$sub/data/backlog.md" \
+    "local-only item did not arrive in the secondmate backlog"
+  assert_grep '  Preserve this task body.' "$sub/data/backlog.md" \
+    "local-only item body did not move intact"
+  pass "local-only queued items use the existing secondmate handoff path"
+}
+
 test_body_moves_when_followed_by_another_item
 test_body_moves_when_followed_by_section_heading
 test_multi_paragraph_body_with_internal_blanks_moves_whole
@@ -548,5 +572,6 @@ test_noncanonical_indented_continuations_refuse_without_changes
 test_indented_heading_is_not_section_boundary
 test_registry_home_with_pre_home_parentheses
 test_registry_home_missing_field_fails_cleanly
+test_local_only_item_uses_normal_handoff_path
 
 echo "ALL TESTS PASSED"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -237,6 +237,24 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
+test_secondmate_local_only_brief_records_exact_ready_evidence() {
+  local home brief
+  home="$TMP_ROOT/secondmate-local-only-brief"
+  write_registry "$home"
+  printf '%s\n' design > "$home/.fm-secondmate-home"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" local-ready-a5 local-proj >/dev/null 2>&1 \
+    || fail "secondmate-home local-only brief failed"
+  brief="$home/data/local-ready-a5/brief.md"
+  assert_grep 'done: ready commit=<full 40-character HEAD> branch=fm/local-ready-a5 validation=<commands and outcome>' "$brief" \
+    "secondmate local-only brief did not require exact commit plus validation evidence"
+  assert_grep 'Only the main firstmate may run the guarded local landing.' "$brief" \
+    "secondmate local-only brief lost the main-only landing boundary"
+  assert_no_grep "The configured merge authority approves the ready branch, then firstmate merges it into local \`main\`" "$brief" \
+    "secondmate local-only brief retained the main-home landing wording"
+  pass "fm-brief.sh: secondmate local-only tasks report an exact validated ready commit"
+}
+
 # Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
 # reference must render as plain prose with no dangling apostrophe artifact.
 test_no_mistakes_dod_wording() {
@@ -623,6 +641,7 @@ test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
+test_secondmate_local_only_brief_records_exact_ready_evidence
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -2,7 +2,8 @@
 # tests/fm-secondmate-safety.test.sh - secondmate home safety invariants:
 # the path-boundary matrices (seed/spawn/teardown), registry/charter/origin
 # validation, treehouse lease handling, no-mistakes initialization of new
-# clones, child-worktree protection, and backlog-handoff safety. The happy-path
+# clones, local-only ready routing and main-only landing, child-worktree
+# protection, and backlog-handoff safety. The happy-path
 # operator flow lives in fm-secondmate-lifecycle-e2e.test.sh; this file keeps the
 # destructive-invariant coverage that an e2e run cannot deterministically reach.
 set -u
@@ -684,22 +685,183 @@ test_home_seed_refuses_missing_projects_without_signal() {
   pass "home seeding fails loudly on accidental project omission and rejects mixed --no-projects"
 }
 
-test_home_seed_refuses_local_only_project() {
-  local home subhome err
+test_home_seed_allows_local_only_project_without_copying_dirty_state() {
+  local home subhome source status_before head_before tracked_before untracked_before origin
   home="$TMP_ROOT/local-only-seed-home"
   subhome="$TMP_ROOT/local-only-seed-subhome"
-  err="$TMP_ROOT/local-only-seed.err"
   mkdir -p "$home/projects" "$home/data" "$home/state"
   fm_git_init_commit "$home/projects/alpha"
+  source="$home/projects/alpha"
+  printf '%s\n' 'committed baseline' > "$source/tracked.txt"
+  git -C "$source" add tracked.txt
+  git -C "$source" commit -qm 'add tracked baseline'
+  printf '%s\n' 'intentional tracked edit' > "$source/tracked.txt"
+  mkdir -p "$source/godot/assets/extracted"
+  printf '%s\n' 'intentional untracked bytes' > "$source/untracked.bin"
+  printf '%s\n' 'ignored-style overlay bytes' > "$source/godot/assets/extracted/overlay.bin"
   printf '%s\n' '- alpha [local-only] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
 
-  if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" design "$subhome" alpha >/dev/null 2>"$err"; then
-    fail "seed allowed a local-only project into a secondmate home"
+  status_before=$(git -C "$source" status --porcelain=v1 -uall)
+  head_before=$(git -C "$source" rev-parse HEAD)
+  tracked_before=$(git hash-object "$source/tracked.txt")
+  untracked_before=$(git hash-object "$source/untracked.bin")
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='local-only feature work' \
+    FM_SECONDMATE_SCOPE='local-only feature work' \
+    "$ROOT/bin/fm-home-seed.sh" design "$subhome" alpha >/dev/null \
+    || fail "seed refused a local-only project"
+
+  origin=$(git -C "$subhome/projects/alpha" remote get-url origin)
+  [ "$origin" = "$(cd "$source" && pwd -P)" ] \
+    || fail "local-only clone origin did not point at the authoritative checkout"
+  [ "$(cat "$subhome/projects/alpha/tracked.txt")" = 'committed baseline' ] \
+    || fail "local-only seed copied the authoritative checkout's tracked working-tree edit"
+  assert_absent "$subhome/projects/alpha/untracked.bin" \
+    "local-only seed copied an authoritative untracked file"
+  assert_absent "$subhome/projects/alpha/godot/assets/extracted/overlay.bin" \
+    "local-only seed copied an authoritative ignored-style overlay"
+  [ "$(git -C "$source" status --porcelain=v1 -uall)" = "$status_before" ] \
+    || fail "local-only seed changed authoritative dirty status"
+  [ "$(git -C "$source" rev-parse HEAD)" = "$head_before" ] \
+    || fail "local-only seed changed the authoritative commit"
+  [ "$(git hash-object "$source/tracked.txt")" = "$tracked_before" ] \
+    || fail "local-only seed changed tracked working-tree bytes"
+  [ "$(git hash-object "$source/untracked.bin")" = "$untracked_before" ] \
+    || fail "local-only seed changed untracked bytes"
+  [ "$(FM_HOME="$subhome" "$ROOT/bin/fm-project-mode.sh" alpha)" = 'local-only off' ] \
+    || fail "local-only delivery mode was not preserved in the secondmate home"
+  pass "home seeding clones committed local-only state without touching authoritative dirt"
+}
+
+test_secondmate_home_cannot_land_local_only_work() {
+  local home err
+  home="$TMP_ROOT/local-only-direct-landing-subhome"
+  err="$TMP_ROOT/local-only-direct-landing.err"
+  mkdir -p "$home"
+  printf '%s\n' design > "$home/.fm-secondmate-home"
+
+  if FM_HOME="$home" "$ROOT/bin/fm-merge-local.sh" task-a 2>"$err"; then
+    fail "marked secondmate home landed local-only work directly"
   fi
-  grep -F 'project alpha is local-only; secondmate routes support only no-mistakes and direct-PR projects' "$err" >/dev/null \
-    || fail "seed did not explain local-only project rejection"
-  [ ! -e "$subhome" ] || fail "seed created a subhome before rejecting a local-only project"
-  pass "home seeding refuses local-only projects"
+  assert_grep 'local landing is main-firstmate-only' "$err" \
+    "direct secondmate landing refusal did not explain the main-only boundary"
+  pass "marked secondmate homes cannot invoke the local landing path"
+}
+
+test_secondmate_ready_route_and_main_exact_landing_wait_on_dirty_checkout() {
+  local main sub source wt meta corr rec ready out rc
+  local status_before head_before dirty_hash stash_before
+  main="$TMP_ROOT/local-ready-main"
+  sub="$TMP_ROOT/local-ready-sub"
+  source="$main/projects/alpha"
+  wt="$TMP_ROOT/local-ready-worktree"
+  meta="$sub/state/feature-a.meta"
+  mkdir -p "$main/projects" "$main/data" "$main/state" "$sub/projects" "$sub/state"
+  touch "$main/state/.last-watcher-beat"
+  fm_git_init_commit "$source"
+  git -C "$source" branch -m main
+  printf '%s\n' '- alpha [local-only] - alpha project (added 2026-07-29)' > "$main/data/projects.md"
+  git clone --quiet --no-hardlinks "$source" "$sub/projects/alpha"
+  printf '%s\n' design > "$sub/.fm-secondmate-home"
+  printf -- '- design - local work (home: %s; scope: local work; projects: alpha; added 2026-07-29)\n' \
+    "$(cd "$sub" && pwd -P)" > "$main/data/secondmates.md"
+
+  git -C "$sub/projects/alpha" worktree add --quiet -b fm/feature-a "$wt" main
+  printf '%s\n' 'ready change' > "$wt/feature.txt"
+  git -C "$wt" add feature.txt
+  git -C "$wt" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm 'add ready change'
+  fm_write_meta "$meta" \
+    'window=firstmate:fm-feature-a' \
+    'endpoint_task_id=feature-a' \
+    "worktree=$wt" \
+    "project=$sub/projects/alpha" \
+    'harness=echo' \
+    'kind=ship' \
+    'mode=local-only' \
+    'yolo=off'
+
+  # shellcheck source=bin/fm-pending-reply-lib.sh disable=SC1091
+  . "$ROOT/bin/fm-pending-reply-lib.sh"
+  corr=$(fm_pending_reply_create "$main" "$main/state" design 'implement feature-a')
+  fm_pending_reply_mark_delivered "$main/state" "$corr" \
+    || fail "could not mark the routed request delivered"
+  "$ROOT/bin/fm-secondmate-report.sh" --local-ready \
+    "$main/state/design.status" "$corr" "$meta" 'dotnet test tests/: passed' \
+    || fail "local-ready result did not route through the existing report helper"
+  fm_pending_reply_try_resolve "$main/state" "$corr" \
+    || fail "correlated local-ready result did not resolve the parent pending reply"
+  rec=$(fm_pending_reply_path "$main/state" "$corr")
+  [ "$(fm_pending_reply_get "$rec" resolved_via)" = helper ] \
+    || fail "local-ready route did not resolve through the existing helper path"
+
+  ready=$(git -C "$wt" rev-parse HEAD)
+  assert_grep "ready_commit=$ready" "$meta" "local-ready metadata did not record the exact commit"
+  assert_grep 'ready_branch=fm/feature-a' "$meta" "local-ready metadata did not record the branch"
+  assert_grep 'validation_evidence=dotnet test tests/: passed' "$meta" \
+    "local-ready metadata did not record validation evidence"
+  assert_grep "local-only ready task=feature-a commit=$ready" "$main/state/design.status" \
+    "local-ready result was not routed to the main status channel"
+
+  printf '%s\n' 'intentional untracked state' > "$source/keep-untracked.bin"
+  status_before=$(git -C "$source" status --porcelain=v1 -uall)
+  head_before=$(git -C "$source" rev-parse HEAD)
+  dirty_hash=$(git hash-object "$source/keep-untracked.bin")
+  stash_before=$(git -C "$source" stash list)
+  rc=0
+  out=$(FM_HOME="$main" FM_GUARD_GRACE=999999 \
+    "$ROOT/bin/fm-merge-local.sh" feature-a --secondmate design 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "cross-home local landing ignored the authoritative dirty checkout"
+  assert_contains "$out" 'ready, waiting:' \
+    "dirty authoritative checkout did not surface the ready-waiting outcome"
+  [ "$(git -C "$source" status --porcelain=v1 -uall)" = "$status_before" ] \
+    || fail "dirty landing refusal changed authoritative status"
+  [ "$(git -C "$source" rev-parse HEAD)" = "$head_before" ] \
+    || fail "dirty landing refusal changed authoritative HEAD"
+  [ "$(git hash-object "$source/keep-untracked.bin")" = "$dirty_hash" ] \
+    || fail "dirty landing refusal changed intentional untracked bytes"
+  [ "$(git -C "$source" stash list)" = "$stash_before" ] \
+    || fail "dirty landing refusal changed the authoritative stash"
+
+  rm "$source/keep-untracked.bin"
+  out=$(FM_HOME="$main" FM_GUARD_GRACE=999999 \
+    "$ROOT/bin/fm-merge-local.sh" feature-a --secondmate design 2>&1) \
+    || fail "main firstmate could not land the secondmate's exact ready commit"
+  assert_contains "$out" "merged exact ready commit $ready" \
+    "cross-home landing did not report the exact commit"
+  [ "$(git -C "$source" rev-parse main)" = "$ready" ] \
+    || fail "authoritative main did not fast-forward to the exact ready commit"
+  pass "local-ready work routes through pending reply and main-only landing waits cleanly on dirt"
+}
+
+test_main_home_local_only_landing_keeps_historical_path() {
+  local home project wt ready
+  home="$TMP_ROOT/local-ready-main-home-legacy"
+  project="$home/projects/alpha"
+  wt="$TMP_ROOT/local-ready-main-home-worktree"
+  mkdir -p "$home/projects" "$home/data" "$home/state"
+  touch "$home/state/.last-watcher-beat"
+  fm_git_init_commit "$project"
+  git -C "$project" branch -m main
+  git -C "$project" worktree add --quiet -b fm/main-task "$wt" main
+  printf '%s\n' 'main-home change' > "$wt/main-home.txt"
+  git -C "$wt" add main-home.txt
+  git -C "$wt" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm 'add main-home change'
+  ready=$(git -C "$wt" rev-parse HEAD)
+  fm_write_meta "$home/state/main-task.meta" \
+    "worktree=$wt" \
+    "project=$project" \
+    'kind=ship' \
+    'mode=local-only' \
+    'yolo=off'
+
+  FM_HOME="$home" FM_GUARD_GRACE=999999 \
+    "$ROOT/bin/fm-merge-local.sh" main-task >/dev/null \
+    || fail "historical main-home local-only landing path regressed"
+  [ "$(git -C "$project" rev-parse main)" = "$ready" ] \
+    || fail "main-home local-only landing did not fast-forward to the ready branch"
+  pass "main-home local-only tasks retain the historical one-argument landing path"
 }
 
 test_home_seed_refuses_registry_delimiter_home() {
@@ -2186,7 +2348,10 @@ test_home_seed_refuses_projectless_home_with_symlinked_projects
 test_home_seed_refuses_projectless_home_with_non_directory_projects
 test_home_seed_refuses_projectless_home_with_uninspectable_registry
 test_home_seed_refuses_missing_projects_without_signal
-test_home_seed_refuses_local_only_project
+test_home_seed_allows_local_only_project_without_copying_dirty_state
+test_secondmate_home_cannot_land_local_only_work
+test_secondmate_ready_route_and_main_exact_landing_wait_on_dirty_checkout
+test_main_home_local_only_landing_keeps_historical_path
 test_home_seed_refuses_registry_delimiter_home
 test_home_seed_refuses_active_home_and_root
 test_home_seed_refuses_home_marked_for_another_id

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -749,22 +749,29 @@ test_secondmate_home_cannot_land_local_only_work() {
 }
 
 test_secondmate_ready_route_and_main_exact_landing_wait_on_dirty_checkout() {
-  local main sub source wt meta corr rec ready out rc
-  local status_before head_before dirty_hash stash_before
+  local main sub other_sub source wt meta corr rec ready out rc
+  local status_before head_before dirty_hash stash_before git_bin real_git meta_before
   main="$TMP_ROOT/local-ready-main"
   sub="$TMP_ROOT/local-ready-sub"
+  other_sub="$TMP_ROOT/local-ready-other-sub"
   source="$main/projects/alpha"
   wt="$TMP_ROOT/local-ready-worktree"
   meta="$sub/state/feature-a.meta"
-  mkdir -p "$main/projects" "$main/data" "$main/state" "$sub/projects" "$sub/state"
+  git_bin="$TMP_ROOT/local-ready-git-bin"
+  mkdir -p "$main/projects" "$main/data" "$main/state" "$sub/projects" "$sub/state" "$other_sub" "$git_bin"
   touch "$main/state/.last-watcher-beat"
   fm_git_init_commit "$source"
   git -C "$source" branch -m main
   printf '%s\n' '- alpha [local-only] - alpha project (added 2026-07-29)' > "$main/data/projects.md"
   git clone --quiet --no-hardlinks "$source" "$sub/projects/alpha"
-  printf '%s\n' design > "$sub/.fm-secondmate-home"
-  printf -- '- design - local work (home: %s; scope: local work; projects: alpha; added 2026-07-29)\n' \
-    "$(cd "$sub" && pwd -P)" > "$main/data/secondmates.md"
+  printf '%s\n' 'a.b' > "$sub/.fm-secondmate-home"
+  printf '%s\n' axb > "$other_sub/.fm-secondmate-home"
+  {
+    printf -- '- a.b - local work (home: %s; scope: local work; projects: alpha; added 2026-07-29)\n' \
+      "$(cd "$sub" && pwd -P)"
+    printf -- '- axb - other work (home: %s; scope: other work; projects: alpha; added 2026-07-29)\n' \
+      "$(cd "$other_sub" && pwd -P)"
+  } > "$main/data/secondmates.md"
 
   git -C "$sub/projects/alpha" worktree add --quiet -b fm/feature-a "$wt" main
   printf '%s\n' 'ready change' > "$wt/feature.txt"
@@ -781,13 +788,41 @@ test_secondmate_ready_route_and_main_exact_landing_wait_on_dirty_checkout() {
     'mode=local-only' \
     'yolo=off'
 
+  real_git=$(command -v git)
+  cat > "$git_bin/git" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = -C ] && [ "${2:-}" = "${FM_TEST_FAIL_STATUS_WORKTREE:-}" ] \
+  && [ "${3:-}" = status ]; then
+  exit 42
+fi
+exec "$FM_TEST_REAL_GIT" "$@"
+EOF
+  chmod +x "$git_bin/git"
+
   # shellcheck source=bin/fm-pending-reply-lib.sh disable=SC1091
   . "$ROOT/bin/fm-pending-reply-lib.sh"
-  corr=$(fm_pending_reply_create "$main" "$main/state" design 'implement feature-a')
+  corr=$(fm_pending_reply_create "$main" "$main/state" 'a.b' 'implement feature-a')
   fm_pending_reply_mark_delivered "$main/state" "$corr" \
     || fail "could not mark the routed request delivered"
+  meta_before=$(cat "$meta")
+  rc=0
+  out=$(PATH="$git_bin:$PATH" FM_TEST_REAL_GIT="$real_git" FM_TEST_FAIL_STATUS_WORKTREE="$wt" \
+    "$ROOT/bin/fm-secondmate-report.sh" --local-ready \
+    "$main/state/a.b.status" "$corr" "$meta" 'dotnet test tests/: passed' 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "local-ready reporting accepted a failed worktree status inspection"
+  assert_contains "$out" 'cannot inspect local-ready worktree status' \
+    "local-ready status inspection failure did not stop safely"
+  [ "$(cat "$meta")" = "$meta_before" ] \
+    || fail "failed local-ready status inspection changed task metadata"
+  assert_no_grep '^ready_commit=' "$meta" \
+    "failed local-ready status inspection recorded a ready commit"
+  if [ -f "$main/state/a.b.status" ]; then
+    assert_no_grep 'local-only ready task=' "$main/state/a.b.status" \
+      "failed local-ready status inspection routed a ready result"
+  fi
+
   "$ROOT/bin/fm-secondmate-report.sh" --local-ready \
-    "$main/state/design.status" "$corr" "$meta" 'dotnet test tests/: passed' \
+    "$main/state/a.b.status" "$corr" "$meta" 'dotnet test tests/: passed' \
     || fail "local-ready result did not route through the existing report helper"
   fm_pending_reply_try_resolve "$main/state" "$corr" \
     || fail "correlated local-ready result did not resolve the parent pending reply"
@@ -800,8 +835,19 @@ test_secondmate_ready_route_and_main_exact_landing_wait_on_dirty_checkout() {
   assert_grep 'ready_branch=fm/feature-a' "$meta" "local-ready metadata did not record the branch"
   assert_grep 'validation_evidence=dotnet test tests/: passed' "$meta" \
     "local-ready metadata did not record validation evidence"
-  assert_grep "local-only ready task=feature-a commit=$ready" "$main/state/design.status" \
+  assert_grep "local-only ready task=feature-a commit=$ready" "$main/state/a.b.status" \
     "local-ready result was not routed to the main status channel"
+
+  head_before=$(git -C "$source" rev-parse HEAD)
+  rc=0
+  out=$(PATH="$git_bin:$PATH" FM_TEST_REAL_GIT="$real_git" FM_TEST_FAIL_STATUS_WORKTREE="$wt" \
+    FM_HOME="$main" FM_GUARD_GRACE=999999 \
+    "$ROOT/bin/fm-merge-local.sh" feature-a --secondmate 'a.b' 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "cross-home local landing accepted a failed ready-worktree status inspection"
+  assert_contains "$out" 'cannot inspect ready worktree status' \
+    "ready-worktree status inspection failure did not stop landing safely"
+  [ "$(git -C "$source" rev-parse HEAD)" = "$head_before" ] \
+    || fail "failed ready-worktree status inspection changed authoritative HEAD"
 
   printf '%s\n' 'intentional untracked state' > "$source/keep-untracked.bin"
   status_before=$(git -C "$source" status --porcelain=v1 -uall)
@@ -810,7 +856,7 @@ test_secondmate_ready_route_and_main_exact_landing_wait_on_dirty_checkout() {
   stash_before=$(git -C "$source" stash list)
   rc=0
   out=$(FM_HOME="$main" FM_GUARD_GRACE=999999 \
-    "$ROOT/bin/fm-merge-local.sh" feature-a --secondmate design 2>&1) || rc=$?
+    "$ROOT/bin/fm-merge-local.sh" feature-a --secondmate 'a.b' 2>&1) || rc=$?
   [ "$rc" -ne 0 ] || fail "cross-home local landing ignored the authoritative dirty checkout"
   assert_contains "$out" 'ready, waiting:' \
     "dirty authoritative checkout did not surface the ready-waiting outcome"
@@ -825,7 +871,7 @@ test_secondmate_ready_route_and_main_exact_landing_wait_on_dirty_checkout() {
 
   rm "$source/keep-untracked.bin"
   out=$(FM_HOME="$main" FM_GUARD_GRACE=999999 \
-    "$ROOT/bin/fm-merge-local.sh" feature-a --secondmate design 2>&1) \
+    "$ROOT/bin/fm-merge-local.sh" feature-a --secondmate 'a.b' 2>&1) \
     || fail "main firstmate could not land the secondmate's exact ready commit"
   assert_contains "$out" "merged exact ready commit $ready" \
     "cross-home landing did not report the exact commit"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -38,17 +38,19 @@
 #   (o) fm-pr-check rerun after HEAD moved                      -> no stale pr_head
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
+#   (r) secondmate local-only ready branch before main landing  -> REFUSE across restart
+#       and ALLOW only after the authoritative checkout contains it
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
-#   (r) provably-stale index.lock (old mtime, no live holder) -> lock removed, ALLOW
-#   (s) index.lock with a live holder, any age                -> lock kept, REFUSE
-#   (t) lsof error while checking index.lock                  -> lock kept, REFUSE
-#   (u) dirty worktree after stale lock cleanup               -> lock removed, REFUSE
-#   (v) non-linked repo index.lock                            -> lock removed, ALLOW
-#   (w) index.lock mtime read failure                         -> lock kept, REFUSE
-#   (x) transient lock cleared after first failed return      -> retry ALLOW
-#   (y) persistent lock (never clears, not provably stale)    -> REFUSE loudly
+#   (s) provably-stale index.lock (old mtime, no live holder) -> lock removed, ALLOW
+#   (t) index.lock with a live holder, any age                -> lock kept, REFUSE
+#   (u) lsof error while checking index.lock                  -> lock kept, REFUSE
+#   (v) dirty worktree after stale lock cleanup               -> lock removed, REFUSE
+#   (w) non-linked repo index.lock                            -> lock removed, ALLOW
+#   (x) index.lock mtime read failure                         -> lock kept, REFUSE
+#   (y) transient lock cleared after first failed return      -> retry ALLOW
+#   (z) persistent lock (never clears, not provably stale)    -> REFUSE loudly
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -587,6 +589,51 @@ test_local_only_merged_to_local_main_allows() {
   expect_code 0 "$rc" "merged-main: teardown should succeed when work is merged into local main"
   ! grep -q REFUSED "$case_dir/stderr" || fail "merged-main: teardown printed a REFUSED line"
   pass "local-only worktree with work merged into local main is torn down (no regression)"
+}
+
+test_secondmate_local_only_ready_survives_restart_until_authoritative_landing() {
+  local case_dir auth ready rc
+  case_dir=$(make_case secondmate-local-ready)
+  auth="$case_dir/authoritative"
+  write_meta "$case_dir" local-only ship
+  wt_commit_file "$case_dir" ready.txt 'ready content' 'secondmate ready work'
+  ready=$(git -C "$case_dir/wt" rev-parse HEAD)
+  printf '%s\n' \
+    "ready_commit=$ready" \
+    'ready_branch=fm/task-x1' \
+    'validation_evidence=focused test passed' >> "$case_dir/state/task-x1.meta"
+
+  git clone -q "$case_dir/origin.git" "$auth"
+  git -C "$case_dir/project" remote set-url origin "$auth"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/first.stdout" 2> "$case_dir/first.stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "secondmate-ready: cleanup should refuse before authoritative landing"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "secondmate-ready: first refusal removed task metadata"
+  [ "$(git -C "$case_dir/wt" rev-parse HEAD)" = "$ready" ] \
+    || fail "secondmate-ready: first refusal changed the ready commit"
+
+  # Simulate a restarted secondmate reconciling the same durable task.
+  set +e
+  run_teardown "$case_dir" > "$case_dir/restart.stdout" 2> "$case_dir/restart.stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "secondmate-ready: restarted reconciliation should still refuse cleanup"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "secondmate-ready: restarted refusal removed task metadata"
+  [ "$(git -C "$case_dir/wt" symbolic-ref --short HEAD)" = fm/task-x1 ] \
+    || fail "secondmate-ready: restarted refusal detached or changed the ready branch"
+
+  git -C "$auth" fetch -q "$case_dir/project" refs/heads/fm/task-x1
+  git -C "$auth" merge -q --ff-only "$ready"
+  run_teardown "$case_dir" > "$case_dir/landed.stdout" 2> "$case_dir/landed.stderr" \
+    || fail "secondmate-ready: cleanup refused after authoritative landing"
+  assert_absent "$case_dir/state/task-x1.meta" \
+    "secondmate-ready: landed cleanup retained task metadata"
+  pass "secondmate local-only ready work survives restart and cleans up only after authoritative landing"
 }
 
 test_no_mistakes_origin_remote_allows() {
@@ -1382,6 +1429,7 @@ test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
+test_secondmate_local_only_ready_survives_restart_until_authoritative_landing
 test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed


### PR DESCRIPTION
## Summary

- allow second mates to own local-only project context and dispatch isolated workers
- record an exact validated ready commit and route it back through the existing cross-home reply path
- reserve guarded local landing for the main firstmate, including deterministic refusal from marked second-mate homes
- let the main home resolve second-mate task metadata without relocating it

## Safety

- preserves the existing clean-default-branch and strict-fast-forward landing checks
- leaves dirty authoritative checkouts untouched and keeps ready work waiting
- refuses cleanup while an exact ready commit remains unlanded or changes identity
- leaves PR-based second-mate behavior unchanged

## Validation

- focused tests passed: fm-secondmate-safety, fm-teardown, fm-brief, fm-backlog-handoff, and fm-test-run
- end-to-end CLI evidence passed for seed, isolated worker commit, correlated ready report, dirty-checkout refusal, restart recovery, exact main-home landing, and cleanup
- refusal evidence passed for dirty workers, moved ready commits, and non-fast-forward landing
- bin/fm-lint.sh passed with pinned ShellCheck 0.11.0
- bin/fm-doc-audience-check.sh passed