### PR TITLE
fix(crew-state): honor a declared pause while a run sits on the ci step

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -327,7 +327,9 @@ signal_reason_is_actionable() {  # <file> ...
 #             torn-down/unknown crew, or an unreadable verdict).
 # One fm-crew-state.sh read serves BOTH absorb reasons at once. Reading the state
 # authoritatively (not the status log) is what keeps run-step precedence: a crew
-# that appended paused: but then STARTED a run reports working, never paused.
+# that appended paused: but then STARTED a run reports working, never paused -
+# except on the run's ci step, where fm-crew-state.sh honors the declared pause
+# (that step is a merge wait, not pipeline work; it owns that rule in full).
 # NOT a pure read: fm-crew-state.sh may make a bounded no-mistakes call, so callers
 # run it only on no-verb signal and first-sighting stale paths, never every wake.
 # FM_CREW_STATE_BIN lets tests stub the verdict.

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -34,7 +34,12 @@
 #      the active step is ci, `axi status` alone cannot tell "still waiting on
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
 #      a ci-step log-tail check overrides working -> done once checks read
-#      green, so a green PR is never silently read as still-validating.
+#      green, so a green PR is never silently read as still-validating. And a
+#      crew that declared `paused:` while the run sits on the ci step reads
+#      paused, not working (see the ci-step declared-pause block below): the ci
+#      step is the one step with no pipeline work in it, only a merge wait of up
+#      to 168h, so treating it as working turns every declared pause there into
+#      a repeating stale escalation. Any other step keeps working.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
@@ -575,6 +580,33 @@ if [ "$HAVE_RUN" = 1 ]; then
     fi
     if [ "$CI_LOG_STATE" != not-ready ]; then
       emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
+    fi
+  fi
+
+  # ci-step declared pause. The ci step is the ONE run step with no pipeline work
+  # in it: it monitors the PR until merge or close, up to 168h, so a crew that
+  # correctly declared `paused:` there is not hiding activity - it is describing
+  # the same wait the run is in. Without this, every such crew reads working, its
+  # idle pane looks like a possible wedge, and the supervisor re-escalates
+  # `stale` every few minutes (verified 2026-07-30 on a crew parked on a green
+  # PR: four consecutive stale escalations, the last demanding deep inspection).
+  # Scope is deliberately narrow:
+  #   - only while the ci step is `running` (a ci step `fixing`, or any earlier
+  #     step, IS real pipeline work and must keep reading working, so a crew's
+  #     pause never hides it from supervision);
+  #   - only from RUN_STATE=working, so the checks-green -> done override above
+  #     still wins (a reviewable PR outranks a declared wait);
+  #   - only for the paused verb - needs-decision/blocked are captain-relevant
+  #     and keep their existing reconciliation below.
+  # The detail keeps both truths visible: the run is alive on ci, and the crew
+  # declared a pause with its reason.
+  # The coarse runs-list path is excluded: $RUN_OUT there belongs to ANOTHER
+  # branch's run, so its ci rows say nothing about this crew's step.
+  if [ "$RUN_STATE" = working ] && [ "$RUN_SOURCE" = full ] && status_is_paused "$LOG_LINE"; then
+    [ -n "$CI_STEP_STATUS" ] || CI_STEP_STATUS=$(nm_effective_ci_step_status)
+    if [ "$CI_STEP_STATUS" = running ]; then
+      RUN_STATE=paused
+      RUN_DETAIL="$RUN_DETAIL${SEP}ci monitoring PR${SEP}crew declared pause: $(status_line_note "$LOG_LINE")"
     fi
   fi
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ Crew status files are append-only wake-event logs, not current-state fields.
 The script header owns the exact run-head ancestry rules.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
+Because that `ci,running` step is a merge wait with no pipeline work in it, a crew that declared `paused:` while the run sits there reports `paused` rather than working, so a deliberate wait is not re-escalated as a possible wedge; any other step, and a ci step that is `fixing`, keeps the declared pause from hiding real activity.
 Only when no matching run exists does it fall back to the pane busy-signature and then a status-log event whose verb maps to a recognized run-state; a dead pane without a run reports unknown instead of trusting a stale log.
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -632,6 +632,115 @@ test_top_level_fixing_ci_running_after_green_stays_working() {
   pass "top-level fixing is not overridden by a stale ci running row"
 }
 
+# A crew that declared `paused:` while its run sits on the ci step is describing
+# the SAME wait the run is in (the ci step monitors the PR until merge/close and
+# does no pipeline work), so the declared pause must survive the run-step path.
+# Reading it as working is what made the supervisor re-escalate `stale` on a crew
+# that had correctly announced its wait.
+test_ci_running_declared_pause_reads_paused() {
+  reset_fakes
+  local d; d=$(new_case ci-paused)
+  make_repo_on_branch "$d/wt" fm/feat-cipaused
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cipaused.meta" "window=fm:fm-feat-cipaused" "worktree=$d/wt" "kind=ship"
+  printf 'paused: waiting on checks and the owner sign-off for PR #109\n' > "$d/state/feat-cipaused.status"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-cipaused)"
+  FM_FAKE_CI_LOGS="CI checks running, waiting for results..."
+  local out; out=$(run_crew_state "$d" feat-cipaused)
+  assert_contains "$out" "state: paused" "declared pause on the ci step -> paused"
+  assert_contains "$out" "source: run-step" "ci pause stays run-step sourced"
+  assert_contains "$out" "ci monitoring PR" "ci pause detail still shows the live run"
+  assert_contains "$out" "waiting on checks and the owner sign-off" "ci pause detail keeps the crew's reason"
+  assert_not_contains "$out" "state: working" "declared pause on ci must not read as working"
+  pass "declared pause on the ci step reads paused"
+}
+
+# Same top-level `status: ci` shape, no steps table - the other way a run reports
+# it is on the ci step.
+test_top_level_ci_declared_pause_reads_paused() {
+  reset_fakes
+  local d; d=$(new_case top-level-ci-paused)
+  make_repo_on_branch "$d/wt" fm/feat-topcipaused
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-topcipaused.meta" "window=fm:fm-feat-topcipaused" "worktree=$d/wt" "kind=ship"
+  printf 'paused: waiting on the merge decision\n' > "$d/state/feat-topcipaused.status"
+  FM_FAKE_AXI_STATUS="$(run_top_level_ci fm/feat-topcipaused)"
+  FM_FAKE_CI_LOGS="CI checks running, waiting for results..."
+  local out; out=$(run_crew_state "$d" feat-topcipaused)
+  assert_contains "$out" "state: paused" "top-level ci with declared pause -> paused"
+  assert_contains "$out" "source: run-step" "top-level ci pause stays run-step sourced"
+  assert_not_contains "$out" "state: working" "top-level ci pause must not read as working"
+  pass "top-level ci status honors a declared pause"
+}
+
+# BOUNDARY: on any step other than ci the run really is working, so a crew's
+# declared pause must NOT hide that from supervision.
+test_non_ci_step_declared_pause_stays_working() {
+  reset_fakes
+  local d; d=$(new_case noncipaused)
+  make_repo_on_branch "$d/wt" fm/feat-noncipaused
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-noncipaused.meta" "window=fm:fm-feat-noncipaused" "worktree=$d/wt" "kind=ship"
+  printf 'paused: waiting on the owner sign-off\n' > "$d/state/feat-noncipaused.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-noncipaused)"
+  local out; out=$(run_crew_state "$d" feat-noncipaused)
+  assert_contains "$out" "state: working" "declared pause off the ci step stays working"
+  assert_contains "$out" "source: run-step" "non-ci pause stays run-step sourced"
+  assert_not_contains "$out" "state: paused" "an active non-ci step must not read as paused"
+  pass "declared pause on a non-ci step stays working"
+}
+
+# BOUNDARY: a ci step that is FIXING is real pipeline work, not a merge wait.
+test_ci_fixing_declared_pause_stays_working() {
+  reset_fakes
+  local d; d=$(new_case ci-fixing-paused)
+  make_repo_on_branch "$d/wt" fm/feat-cifixingpaused
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cifixingpaused.meta" "window=fm:fm-feat-cifixingpaused" "worktree=$d/wt" "kind=ship"
+  printf 'paused: waiting on the owner sign-off\n' > "$d/state/feat-cifixingpaused.status"
+  FM_FAKE_AXI_STATUS="$(run_ci_fixing fm/feat-cifixingpaused)"
+  local out; out=$(run_crew_state "$d" feat-cifixingpaused)
+  assert_contains "$out" "state: working" "a fixing ci step stays working despite a declared pause"
+  assert_not_contains "$out" "state: paused" "ci fixing must not read as paused"
+  pass "declared pause during ci fixing stays working"
+}
+
+# BOUNDARY: needs-decision and blocked are captain-relevant verbs; the ci step
+# must keep their existing reconciliation instead of absorbing them as a pause.
+test_ci_running_needs_decision_unchanged() {
+  reset_fakes
+  local d; d=$(new_case ci-needsdecision)
+  make_repo_on_branch "$d/wt" fm/feat-cineeds
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cineeds.meta" "window=fm:fm-feat-cineeds" "worktree=$d/wt" "kind=ship"
+  printf 'needs-decision: merge now or wait for the owner\n' > "$d/state/feat-cineeds.status"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-cineeds)"
+  FM_FAKE_CI_LOGS="CI checks running, waiting for results..."
+  local out; out=$(run_crew_state "$d" feat-cineeds)
+  assert_contains "$out" "state: working" "needs-decision on the ci step keeps its prior state"
+  assert_contains "$out" "status-log superseded by active run" "needs-decision keeps its supersede annotation"
+  assert_not_contains "$out" "state: paused" "needs-decision must never be absorbed as a pause"
+  pass "needs-decision on the ci step is unchanged"
+}
+
+# BOUNDARY: a reviewable green PR outranks a declared wait - the checks-green
+# override still wins over the ci pause.
+test_ci_green_declared_pause_still_done() {
+  reset_fakes
+  local d; d=$(new_case ci-green-paused)
+  make_repo_on_branch "$d/wt" fm/feat-cigreenpaused
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cigreenpaused.meta" "window=fm:fm-feat-cigreenpaused" "worktree=$d/wt" "kind=ship"
+  printf 'paused: waiting on the owner sign-off\n' > "$d/state/feat-cigreenpaused.status"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-cigreenpaused)"
+  FM_FAKE_CI_LOGS="all CI checks passed - still monitoring until merged or closed"
+  local out; out=$(run_crew_state "$d" feat-cigreenpaused)
+  assert_contains "$out" "state: done" "green checks outrank a declared ci pause"
+  assert_contains "$out" "checks green" "green ci detail is preserved under a pause"
+  assert_not_contains "$out" "state: paused" "a reviewable green PR must not read as paused"
+  pass "checks-green still outranks a declared ci pause"
+}
+
 test_top_level_fixing_done_log_stays_working() {
   reset_fakes
   local d; d=$(new_case top-level-fixing-done-log)
@@ -1250,6 +1359,12 @@ test_ci_ready_done_log_relapse_stays_working
 test_ci_fixing_after_green_stays_working
 test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
+test_ci_running_declared_pause_reads_paused
+test_top_level_ci_declared_pause_reads_paused
+test_non_ci_step_declared_pause_stays_working
+test_ci_fixing_declared_pause_stays_working
+test_ci_running_needs_decision_unchanged
+test_ci_green_declared_pause_still_done
 test_terminal_passed
 test_terminal_failed
 test_cross_branch_attribution_via_runs_list


### PR DESCRIPTION
## Intent

Fix a supervision defect in firstmate: the fleet supervisor did not honor a crew that had deliberately declared a pause when its no-mistakes pipeline run was sitting on the ci step, so it re-escalated a stale/possible-wedge alarm every few minutes and each alarm cost firstmate a mandatory turn.

bin/fm-crew-state.sh treats the pipeline run step as authoritative over the append-only status event log, which is correct on every step EXCEPT ci: the ci step performs no pipeline work, it only monitors the PR until merge or close for up to 168 hours. So a crew that correctly appended a `paused:` line there was still read as `working`.

Requested change: on the authoritative run-step path, when the current run step is ci and the last status-log verb is the declared-pause verb, the state must read `paused` instead of `working`, while the emitted detail stays truthful about BOTH facts - the run is alive and monitoring the PR, and the crew declared a pause with its reason.

Deliberate scope decisions made while implementing, which a reviewer reading only the diff would not know:
- The override fires ONLY while the ci step status is `running`. A ci step in `fixing` is real pipeline work, as is any earlier step (review/test/document/lint/push/pr), and there a crew pause must NOT hide activity from supervision. This boundary was explicitly requested.
- It fires only from RUN_STATE=working, so the pre-existing checks-green -> done override still wins: a reviewable green PR outranks a declared wait. Explicitly requested that this branch not change.
- It fires only for the pause verb. needs-decision and blocked are captain-relevant verbs and keep their existing reconciliation (they still read working with the "status-log superseded by active run" annotation). Explicitly requested that this not change.
- It is excluded on the coarse runs-list attribution path, because there the captured run output belongs to another branch and its ci rows say nothing about this crew.
- The existing log_reports_ci_ready branch (a crew that reported a green PR reads done) is untouched, as requested.

Ownership: fm-crew-state.sh was verified to be the single owner of this decision. fm-classify-lib.sh consumes its one output line and already maps `state: paused` from any source, so it received only a one-line cross-reference correcting a now-stale comment, deliberately NOT a second copy of the rule (the repo one-owner rule).

Verification performed: six tests were added to the existing tests/fm-crew-state.test.sh (extending it, not creating a new runner). The two fix tests were proven to fail on unpatched code. The four boundary tests pass on unpatched code by design, so each was separately proven load-bearing by deliberately widening the fix in three ways and observing the matching boundary test fail. bin/fm-lint.sh exits 0 and shellcheck is clean; the crew-state and watch-triage suites pass, including under a bare `env -i` environment. The scenario was also confirmed on live data: a real task in this home flipped from `state: working` to `state: paused` with the pause reason preserved in the detail.

## What Changed

- `bin/fm-crew-state.sh`: on the authoritative run-step path, override `working` to `paused` when the current run step is `ci` in `running` status and the last status-log verb is the declared-pause verb; the emitted detail still reports both that the run is alive and monitoring the PR and the crew's declared pause reason. Scoped narrowly — only from `RUN_STATE=working`, only the `ci` step in `running` (not `fixing` or any earlier step), only the pause verb (needs-decision/blocked keep their existing reconciliation), and excluded on the coarse runs-list attribution path.
- `bin/fm-classify-lib.sh`: one-line cross-reference correcting a now-stale comment; no duplicate copy of the rule, since it already maps `state: paused` from any source.
- `tests/fm-crew-state.test.sh`: six cases added covering the two ci-pause fix scenarios (proven to fail on unpatched code) and four boundary cases (fixing step, earlier steps, other verbs, runs-list path).
- `docs/architecture.md`: documents the ci-step declared-pause override.

## Risk Assessment

✅ Low: A tightly-scoped, well-commented single-owner fix to one shell conditional, guarded on four documented boundaries and covered by two fix tests (proven to fail unpatched) plus four load-bearing boundary tests.

## Testing

Ran the targeted `tests/fm-crew-state.test.sh` suite (all cases pass, including the two fix tests and four boundary guards). Confirmed the two fix tests fail on the unpatched helper. Produced product-level CLI evidence by capturing the helper's actual emitted state line: unpatched the ci-running+paused crew reads `state: working · source: run-step · validating (running)` (the supervision-wedge bug), and patched it reads `state: paused · … · ci monitoring PR · crew declared pause: waiting on checks and the owner sign-off for PR #109` — both facts truthful. Top-level `status: ci` + paused likewise flips to paused. This is a CLI/state-string change with no rendered UI surface, so screenshots are not applicable; the emitted-line transcript is the reviewer-visible artifact. Worktree left clean.

<details>
<summary>Evidence: Emitted crew-state line: unpatched (working) vs patched (paused)</summary>

<code>PATCHED:&#10;[ci-running-paused] state: paused · source: run-step · validating (running) · ci monitoring PR · crew declared pause: waiting on checks and the owner sign-off for PR #109&#10;[top-level-ci-paused] state: paused · source: run-step · ci running · ci monitoring PR · crew declared pause: waiting on the merge decision&#10;UNPATCHED:&#10;[ci-running-paused] state: working · source: run-step · validating (running)</code>

```text
===== PATCHED (target commit) =====
[EMITTED ci-running-paused] state: paused · source: run-step · validating (running) · ci monitoring PR · crew declared pause: waiting on checks and the owner sign-off for PR #109
[EMITTED top-level-ci-paused] state: paused · source: run-step · ci running · ci monitoring PR · crew declared pause: waiting on the merge decision
===== UNPATCHED (base commit) =====
[EMITTED ci-running-paused] state: working · source: run-step · validating (running)
```
</details>
<details>
<summary>Evidence: Fix test fails on unpatched code</summary>

`not ok - declared pause on the ci step -> paused (missing: 'state: paused')`

```text
=== fix tests against UNPATCHED bin/fm-crew-state.sh ===
not ok - declared pause on the ci step -> paused (missing: 'state: paused')
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-crew-state.test.sh` (full suite, all pass including the 6 new ci-pause cases)</code>
- <code>Reverted `bin/fm-crew-state.sh` to base and re-ran: fix test `declared pause on the ci step -&gt; paused` fails with `missing: &#39;state: paused&#39;`, proving it load-bearing</code>
- `Captured the real emitted state line for both ci-pause scenarios patched vs unpatched to show the working→paused flip`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
