### PR TITLE
fix(herdr): prevent nested processes from starting competing servers

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -457,13 +457,13 @@ fm_backend_herdr_presentation_lock_namespace_valid() {
   [ "$owner" = "$expected_uid" ] && [ "$mode" = 700 ]
 }
 
-# Resolve the one verified running named-session socket path as an absolute
-# string. Requires JSON string type and non-empty length (jq -r is never used:
-# it would turn JSON null into the literal string "null"). Canonicalizes the
-# parent directory when that directory exists so symlink parents such as /tmp
-# -> /private/tmp cannot yield two lock identities for the same socket.
+# Resolve the one verified running named-session socket path as the exact
+# absolute string advertised by Herdr. Requires JSON string type and non-empty
+# length (jq -r is never used: it would turn JSON null into the literal string
+# "null"). The lexical path is transport authority because Unix socket clients
+# can reject a physical-path rewrite of Herdr's advertised symlinked path.
 fm_backend_herdr_presentation_session_socket_path() {  # <session>
-  local session=$1 sessions socket sock_dir sock_base
+  local session=$1 sessions socket
   [ -n "$session" ] || return 1
   sessions=$(fm_backend_herdr_cli "$session" session list --json 2>/dev/null) || return 1
   socket=$(printf '%s' "$sessions" | jq -er --arg want "$session" '
@@ -479,24 +479,28 @@ fm_backend_herdr_presentation_session_socket_path() {  # <session>
     /*) ;;
     *) return 1 ;;
   esac
-  sock_dir=$(dirname "$socket")
-  sock_base=$(basename "$socket")
-  [ -n "$sock_dir" ] && [ -n "$sock_base" ] || return 1
-  if [ -d "$sock_dir" ]; then
-    sock_dir=$(cd "$sock_dir" 2>/dev/null && pwd -P) || return 1
-    socket="$sock_dir/$sock_base"
-  fi
   printf '%s' "$socket"
 }
 
 fm_backend_herdr_presentation_session_lock_path() {  # <session>
-  local session=$1 socket key dir hash
+  local session=$1 socket lock_socket sock_dir sock_base key dir hash
   [ -n "$session" ] || return 1
   socket=$(fm_backend_herdr_presentation_session_socket_path "$session") || return 1
+  lock_socket=$socket
+  sock_dir=$(dirname "$socket")
+  sock_base=$(basename "$socket")
+  [ -n "$sock_dir" ] && [ -n "$sock_base" ] || return 1
+  # Canonicalize only the lock identity so aliases such as /tmp and
+  # /private/tmp cannot create two locks for the same socket. The mover keeps
+  # the exact server-advertised path returned above.
+  if [ -d "$sock_dir" ]; then
+    sock_dir=$(cd "$sock_dir" 2>/dev/null && pwd -P) || return 1
+    lock_socket="$sock_dir/$sock_base"
+  fi
   if command -v shasum >/dev/null 2>&1; then
-    hash=$(printf '%s\0%s' "$session" "$socket" | shasum -a 256 2>/dev/null | awk '{print $1}')
+    hash=$(printf '%s\0%s' "$session" "$lock_socket" | shasum -a 256 2>/dev/null | awk '{print $1}')
   elif command -v sha256sum >/dev/null 2>&1; then
-    hash=$(printf '%s\0%s' "$session" "$socket" | sha256sum 2>/dev/null | awk '{print $1}')
+    hash=$(printf '%s\0%s' "$session" "$lock_socket" | sha256sum 2>/dev/null | awk '{print $1}')
   else
     return 1
   fi
@@ -802,15 +806,31 @@ fm_backend_herdr_projection_order_best_effort() {  # <session> <created-workspac
   return 0
 }
 
-# fm_backend_herdr_server_ensure: start the herdr server for <session>
-# headless (no TUI client) if not already running, mirroring tmux's `tmux
-# has-session || tmux new-session -d`. Verified: a bare socket CLI call does
-# NOT auto-start the server, so this must run before any workspace/tab/pane
-# call. Bounded poll for the server to report running.
+# fm_backend_herdr_server_ensure: attach to the already-running <session>, or
+# start it headless only when this process is outside Herdr and can be the
+# server owner. A nested process inherits HERDR_ENV=1 and its owning session
+# identity (HERDR_SESSION for a named session, implicit "default" otherwise).
+# It may use only that exact session and never starts a server after a status
+# miss: starting from a pane can replace the shared socket path while the old
+# UI remains attached to its original process, splitting fleet visibility
+# between two servers. A bare socket CLI call does not auto-start the server,
+# so an outside owner still uses the bounded start-and-poll path below before
+# any workspace/tab/pane call.
 fm_backend_herdr_server_ensure() {  # <session>
-  local session=$1 running out i
+  local session=$1 running out i nested_session
+  if [ "${HERDR_ENV:-}" = 1 ]; then
+    nested_session=$(fm_backend_herdr_session)
+    if [ "$session" != "$nested_session" ]; then
+      echo "error: Herdr target session '$session' differs from this pane's owning session '$nested_session' (HERDR_ENV=1); refusing cross-session CLI selection" >&2
+      return 1
+    fi
+  fi
   running=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null)
   [ "$running" = "true" ] && return 0
+  if [ "${HERDR_ENV:-}" = 1 ]; then
+    echo "error: Herdr session '$session' is not reachable as running from inside Herdr session '$nested_session' (pane ${HERDR_PANE_ID:-unknown}, socket ${HERDR_SOCKET_PATH:-unknown}); refusing to start a competing server. Start or repair the named session from its outer Herdr owner, then retry." >&2
+    return 1
+  fi
   ( fm_backend_herdr_cli "$session" server >/dev/null 2>&1 & ) || return 1
   for i in $(seq 1 20); do
     running=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null)
@@ -2341,8 +2361,8 @@ fm_backend_herdr_events_capable() {  # <session>
   case "$protocol" in ''|*[!0-9]*) return 1 ;; esac
   [ "$protocol" -ge "$FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL" ] || return 1
   schema=$(herdr api schema --json 2>/dev/null) || return 1
-  printf '%s' "$schema" | grep -Fq 'events.subscribe' || return 1
-  printf '%s' "$schema" | grep -Fq 'pane.agent_status_changed' || return 1
+  grep -Fq 'events.subscribe' <<< "$schema" || return 1
+  grep -Fq 'pane.agent_status_changed' <<< "$schema" || return 1
   return 0
 }
 

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -185,12 +185,13 @@ fm_backend_herdr_version_check() {
   return 0
 }
 
-# fm_backend_herdr_session: resolve which named herdr session this normal
-# spawn/op uses. HERDR_SESSION mirrors tmux's $TMUX ambient-selection for
-# adapter workspace/tab/pane operations: an operator (or firstmate's own
-# isolated test harness) sets it explicitly; absent means herdr's own
-# "default" session. Do not use HERDR_SESSION alone for destructive test
-# cleanup; tests/herdr-test-safety.sh documents and guards that path.
+# fm_backend_herdr_session: resolve the named Herdr session identity for a
+# normal spawn or operation. Outside Herdr, an operator or isolated test
+# harness selects it with HERDR_SESSION. Inside a HERDR_ENV=1 pane, the
+# inherited value identifies that pane's owning named session and the guarded
+# server path refuses a different target. An absent value means Herdr's
+# implicit "default" session. HERDR_SESSION alone never authorizes destructive
+# test cleanup; bin/fm-herdr-lab.sh owns that path.
 fm_backend_herdr_session() {
   printf '%s' "${HERDR_SESSION:-default}"
 }

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -209,19 +209,20 @@ fm_backend_zellij_cli() {  # <session> <action-subcommand-and-args...>
 }
 
 # fm_backend_zellij_session_exists: passive, READ-ONLY liveness check - never
-# starts or creates a session (unlike herdr's target_ready, which DOES
-# auto-start its server: a herdr server restart is non-destructive and
-# recovers persisted state, but zellij's `kill-session` is destructive and
-# recreating an unrelated target session under the same name would silently
-# orphan whatever the caller actually meant to reach). Every op below calls
-# this first and fails rather than guessing.
+# starts or creates a session (unlike herdr's target_ready, which may start its
+# server only for an outside owner and refuses a nested status miss). A herdr
+# server restart is non-destructive and recovers persisted state, but zellij's
+# `kill-session` is destructive and recreating an unrelated target session
+# under the same name would silently orphan whatever the caller actually meant
+# to reach. Every op below calls this first and fails rather than guessing.
 fm_backend_zellij_session_exists() {  # <session>
   zellij list-sessions --short --no-formatting 2>/dev/null | grep -qxF "$1"
 }
 
 # fm_backend_zellij_server_ensure: create the named session in the background,
 # headless (no attached client), if it does not already exist - mirrors
-# tmux's `tmux has-session || tmux new-session -d` and herdr's server_ensure.
+# tmux's `tmux has-session || tmux new-session -d` and herdr's outside-owner
+# server_ensure path.
 # Verified: `zellij attach -b <name>` with stdin redirected from /dev/null and
 # no controlling TTY creates the session and returns promptly (it cannot
 # actually attach without a TTY, so it exits after creating); running it again

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -821,12 +821,12 @@ fm_backend_composer_state() {  # <backend> <target> -> empty|pending|pending-unp
 # fm_backend_target_exists: cheap, READ-ONLY existence check - does the
 # recorded TARGET endpoint still exist on BACKEND? Never starts a server or
 # session: for herdr this deliberately queries the pane directly instead of
-# going through fm_backend_herdr_target_ready (which auto-starts the herdr
-# server as a side effect via fm_backend_herdr_server_ensure - fine for an
-# operation that is about to use the pane, wrong for a passive liveness
-# probe). A gone tmux window or an unqueryable herdr pane (server down, pane
-# closed), missing zellij pane, or unreadable Orca terminal simply fails, which
-# IS "does not exist" for this purpose.
+# going through fm_backend_herdr_target_ready (which may start the Herdr server
+# when the caller is an outside owner, and refuses a nested start). Either
+# side effect is wrong for a passive liveness probe. A gone tmux window or an
+# unqueryable herdr pane (server down, pane closed), missing zellij pane, or
+# unreadable Orca terminal simply fails, which IS "does not exist" for this
+# purpose.
 # Mirrors fm-crew-state.sh's pane_readable check; exists here as one shared
 # primitive so callers that only need a fast alive/dead read (recovery
 # digests, the session-start fleet digest) do not re-derive it inline.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -336,13 +336,16 @@ trap spawn_abort_cleanup EXIT
 # One bounded lock per live Herdr session/socket, shared across all homes.
 # <session> is required so secondmate and primary spawns serialize against the
 # same session without writing any other home's state directory.
-spawn_herdr_presentation_order_lock_acquire() {
-  local session=${1:-} attempt lock_path
+spawn_herdr_presentation_order_lock_acquire() {  # [session] [max-attempts]
+  local session=${1:-} max_attempts=${2:-50} attempt lock_path
   [ -n "$session" ] || session=$(fm_backend_herdr_session)
+  case "$max_attempts" in
+    ''|*[!0-9]*|0) return 1 ;;
+  esac
   lock_path=$(fm_backend_herdr_presentation_session_lock_path "$session") || return 1
   HERDR_PRESENTATION_ORDER_LOCK="$lock_path"
   attempt=0
-  while [ "$attempt" -lt 50 ]; do
+  while [ "$attempt" -lt "$max_attempts" ]; do
     if fm_lock_try_acquire "$HERDR_PRESENTATION_ORDER_LOCK"; then
       HERDR_PRESENTATION_ORDER_LOCK_HELD=1
       return 0
@@ -999,7 +1002,10 @@ case "$BACKEND" in
           echo "error: herdr presentation recovery could not ensure its exact named session" >&2
           exit 1
         }
-        spawn_herdr_presentation_order_lock_acquire "$HERDR_SES" || {
+        # A recovery owns exact live identities and cannot fall back flat.
+        # Give a concurrent recovery enough bounded time to finish its guarded
+        # Herdr mutations while ordinary best-effort ordering keeps 5 seconds.
+        spawn_herdr_presentation_order_lock_acquire "$HERDR_SES" 300 || {
           echo "error: herdr presentation recovery could not acquire its session lock; refusing a concurrent resume" >&2
           exit 1
         }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,8 @@ By default, Herdr workspaces are derived from `FM_HOME`: the primary home uses `
 The default-container spawn, list-live, and recovery paths read that label from the active home, so a secondmate's own crewmates stay inside that secondmate home's herdr space.
 The optional local `config/herdr-presentation-spaces` presence flag instead enables Herdr's default-off disposable single-task visual projection; [Optional presentation spaces](herdr-backend.md#optional-presentation-spaces) owns its behavior, safety limits, recovery contract, and narrow locked session-start cleanup of exact restored idle-shell children.
 The flag is default-off and inherited into secondmate homes under the primary-authoritative contract owned by [`secondmate-provisioning`](../.agents/skills/secondmate-provisioning/SKILL.md).
-For normal herdr operations, `HERDR_SESSION` selects the named session, but destructive test cleanup must not rely on `HERDR_SESSION` alone.
+Outside Herdr, `HERDR_SESSION` selects the named session for normal operations; inside a Herdr pane it identifies the inherited owning session and cannot authorize cross-session selection.
+[`docs/herdr-backend.md`](herdr-backend.md#setup) owns the nested single-server guard and its fail-closed limits.
 Use the explicit guarded cleanup path described in [`docs/herdr-backend.md`](herdr-backend.md) instead of `herdr server stop`.
 For normal zellij operations, `FM_ZELLIJ_SESSION` selects the named session and defaults to `firstmate`.
 Zellij has no per-home workspace split: primary and secondmate tasks share that one session, and visible tab titles are scoped by the active `FM_HOME` readable label plus a short hash of the resolved `FM_ROOT` path as `fm-<home-label>-<id>`.
@@ -378,7 +379,7 @@ FM_PROJECTS_OVERRIDE=    # alternate projects dir, mainly for tests
 FM_CONFIG_OVERRIDE=      # alternate config dir, mainly for tests
 FM_PROC_ROOT_OVERRIDE=   # alternate /proc root for the Linux process-identity read in fm-wake-lib.sh, mainly for tests
 FM_BACKEND=             # optional runtime backend override for new spawns; tmux/herdr/zellij/orca/cmux support ship/scout spawns, codex-app is not accepted
-HERDR_SESSION=default  # herdr-only: named session for normal backend ops; not enough for destructive cleanup (docs/herdr-backend.md)
+HERDR_SESSION=default  # herdr-only: selected session outside Herdr, inherited owner inside a Herdr pane; not enough for destructive cleanup (docs/herdr-backend.md)
 FM_BACKEND_HERDR_COMPOSER_LINES=20  # herdr-only: tail lines scanned by composer-state guard/fallback paths; idle-baseline submit confirmation uses agent-state
 FM_BACKEND_HERDR_IDLE_RE='^Type a message\.\.\.$'  # herdr-only: empty-composer placeholder regex after shared ghost extraction plus border and prompt stripping
 FM_BACKEND_HERDR_BARE_PROMPT_RE='^(❯|›)'  # herdr-only: verified agent glyphs recognized as an UNBORDERED (bare) composer row, e.g. Claude's ❯ or Codex's ›; an alternation, not a `[...]` bracket expression, so a C-locale byte-decomposed match can never misfire on an unrelated multibyte glyph; shell glyphs remain unknown rather than empty, and de-emphasised ghost/placeholder text reads empty through shared fm_composer_strip_ghost (docs/herdr-backend.md "Composer and injection safety")

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -27,6 +27,14 @@ An auto-detected Herdr spawn prints an opt-out notice.
 Spawn stops before creating a Herdr container or acquiring a task worktree when `herdr`, `jq`, or the protocol floor is unavailable.
 No separate first-run provisioning is required.
 
+Server startup has one owner.
+A process outside Herdr may start its selected named session through the bounded backend path.
+A process inheriting `HERDR_ENV=1` from a Herdr pane may use only that pane's owning session, which is `HERDR_SESSION` for a named session and implicit `default` when the variable is absent.
+The nested path attaches only when an explicitly scoped status call reports that exact session running.
+A session mismatch is refused before any CLI call, and a scoped status miss is refused before `herdr server` can replace or claim the shared socket.
+The diagnostic names the requested session, inherited owner, pane, and socket as available and directs the operator to repair the session from its outer owner.
+Because this ownership gate is inside the shared backend adapter, it covers Pi, Claude, Codex, Grok, secondmate launches, child spawns, watcher-driven recovery, and away-mode Herdr terminals without harness-specific branches.
+
 The required CI lane uses the pinned installers in `bin/fm-install-herdr.sh` and `bin/fm-install-treehouse.sh`.
 Those script headers own release assets, checksums, download bounds, and post-install gates.
 Real harness credential tests remain opt-in rather than part of default CI.
@@ -73,6 +81,8 @@ An ambiguous response grants no mutation or cleanup authority.
 
 Protocol 16 exposes `workspace.move` over the named session socket but no CLI subcommand.
 `bin/backends/herdr-workspace-move.py` sends only that whitelisted method and verifies the complete returned workspace order.
+The mover uses the exact absolute socket path advertised by the named session because Herdr 0.7.3 can reject an equivalent physical-path rewrite through a symlinked config directory.
+Only the per-session lock identity canonicalizes the socket parent, which keeps aliases on one lock without changing the transport target.
 Projected children are placed in one contiguous block immediately after their owning home when the session layout, protocol, socket, `python3`, and machine-private per-session lock are all verifiable.
 Existing legacy child labels may extend an already adjacent block read-only but are never renamed or migrated.
 A foreign, ambiguous, detached, or manually interleaved child makes ordering skip with a warning rather than rewriting the layout.
@@ -89,6 +99,7 @@ If lock, snapshot, pane identity, or restoration is ambiguous, cleanup warns and
 Recovery is deliberately conservative and presentation-only.
 An existing journal suppresses another projected create.
 Before any recovery mutation, Firstmate holds both the task spawn lock and the named-session presentation lock.
+Concurrent exact recoveries wait up to 30 seconds for that shared session lock, while ordinary best-effort ordering keeps its 5-second fallback budget.
 A same-identity version 2 binding may replace one exact agent-free restart husk in place only when the physical home, session, metadata endpoint, unique token match, workspace shape and labels, parent identity and placement, and non-target focus snapshot all agree.
 The replacement tab and pane are created and verified before the old pane is rechecked and closed, then the journal advances atomically to the replacement endpoint before metadata publication.
 The reclaim path never moves, closes, deletes, or renames a workspace and never touches a parent, sibling, captain, or foreign pane.
@@ -156,7 +167,8 @@ Workspace and tab ids support verification and cleanup but are not inferred from
 
 ## Current transport behavior
 
-The adapter starts and polls a named server before workspace, tab, pane, or agent calls.
+The adapter attaches to and polls the exact named server before workspace, tab, pane, or agent calls.
+Only an outside owner may start a missing server.
 Every Herdr invocation goes through `fm_backend_herdr_cli`, which sets the environment and passes an explicit trailing `--session <name>`.
 An environment variable alone is not reliable when another Herdr server is running.
 
@@ -258,6 +270,9 @@ Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never 
 ## Active limits
 
 - Herdr remains experimental.
+- Herdr 0.7.3 does not expose a stable server-process identity that lets Firstmate prove which process an already-attached UI client owns.
+  The ownership gate prevents a new split but cannot automatically identify, merge, or repair servers that were already split before the fix.
+  An existing split still requires a separate controlled runtime repair that preserves the chosen owner's live panes before retiring the competing process.
 - Presentation ordering needs protocol 16 and Python and is best-effort only.
 - Mutable labels can collide; they are never destructive authority.
 - Ghost and placeholder recognition depends on ANSI de-emphasis and fails safely to pending when unavailable.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -153,6 +153,41 @@ The CLI matrix was checked directly:
 All destructive verification used `bin/fm-herdr-lab.sh` with a non-default `fm-lab-` name and a byte-identical default-session tripwire.
 No ambient `herdr server stop` command is a supported test operation.
 
+### Single-server ownership
+
+The nested ownership guard was verified on 2026-07-30 with Herdr 0.7.3 and protocol 16.
+The deterministic adapter suite covered the implicit `default` environment inherited by a secondmate watcher, an already-running named-session attach, a cross-session target mismatch, and a standalone outside owner that remains allowed to start a missing server.
+The real lab suite created an actual named-session pane, confirmed its inherited `HERDR_ENV`, session, pane, workspace, and socket values, then substituted a status-miss CLI and proved the nested process returned a refusal without invoking `server`.
+
+```sh
+tests/fm-backend-herdr.test.sh
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
+  tests/fm-backend-autodetect-smoke.test.sh
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
+  tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
+  bin/fm-test-run.sh --family real-herdr-gated \
+  --fail-on-gate-skip 'herdr not found'
+```
+
+Observed ownership output:
+
+```text
+ok - fm_backend_herdr_server_ensure: a secondmate watcher inheriting the implicit default session refuses a competing same-socket server start
+ok - fm_backend_herdr_server_ensure: a nested caller safely attaches to its already-running inherited named session
+ok - fm_backend_herdr_server_ensure: a nested caller refuses a different target session before any CLI selection
+ok - real herdr: a secondmate-watcher-shaped process inside a named lab pane refuses a competing same-socket server start
+ok - real herdr: isolated lab session removed and default fleet session unchanged
+ok - real herdr E2E: a --secondmate spawn by the PRIMARY lands in the SECONDMATE's own labeled workspace, distinct from the primary's
+ok - real herdr E2E: a crewmate spawned FROM the secondmate-shaped home lands in the secondmate's OWN workspace - falls out of per-home resolution, no glue needed
+FM_TEST_SUMMARY total=10 failed=0 skipped_gate=0
+```
+
+All primary, secondmate, and secondmate-child metadata in the topology test recorded the same generated `herdr_session`.
+The server-start primitive exists only in the shared Herdr adapter and the guarded lab lifecycle owner, so Pi, Claude, Codex, and Grok launch strings cannot bypass the nested ownership decision.
+The mandatory real-Herdr family completed with the default-session tripwire intact.
+The same run also verified that presentation transport preserves Herdr's advertised lexical socket path through the symlinked config directory, while its shared lock uses the canonical socket identity.
+
 ### Prune and respawn
 
 The real label-collision reproduction is owned by:

--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -2,10 +2,9 @@
 # tests/fm-afk-inject-herdr-e2e.test.sh - real-herdr end-to-end test for the
 # away-mode daemon's herdr transport (bin/fm-supervise-daemon.sh), the herdr
 # counterpart of tests/fm-afk-inject-e2e.test.sh's private-socket tmux e2e.
-# Mirrors tests/fm-backend-herdr-smoke.test.sh and tests/herdr-test-safety.sh's
-# isolation patterns: everything runs on a throwaway, named, NEVER-default
-# HERDR_SESSION, torn down with herdr_safe_stop_and_delete. Skips cleanly when
-# herdr or jq is not installed.
+# Mirrors tests/fm-backend-herdr-smoke.test.sh's isolation pattern: everything
+# runs on a throwaway, named, NEVER-default HERDR_SESSION owned by
+# bin/fm-herdr-lab.sh. Skips cleanly when herdr or jq is not installed.
 #
 # Unlike the tmux e2e (which redirects a bare `tmux` PATH shim to a private
 # socket), herdr already supports named-session isolation via --session, so no
@@ -38,12 +37,10 @@ DAEMON="$ROOT/bin/fm-supervise-daemon.sh"
 command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 
-# shellcheck source=tests/herdr-test-safety.sh
-. "$ROOT/tests/herdr-test-safety.sh"
-
 fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
 
+LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 SESSION="fm-lab-afk-herdr-e2e-$$"
 export HERDR_SESSION="$SESSION"
 STATE_DIR=
@@ -60,12 +57,12 @@ cleanup_all() {
     kill "$DAEMON_PID" 2>/dev/null || true
     wait "$DAEMON_PID" 2>/dev/null || true
   fi
-  herdr_safe_stop_and_delete "$SESSION" 2>/dev/null || true
+  "$LAB_HELPER" teardown "$SESSION" 2>/dev/null || true
   rm -rf "${HERDR_SHIM_DIR:-}" 2>/dev/null || true
   rm -rf "${STATE_DIR:-}" 2>/dev/null || true
 }
 trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+"$LAB_HELPER" provision "$SESSION" || fail "could not provision isolated Herdr lab session"
 
 # --- source the daemon (for afk_enter/afk_exit/FM_INJECT_MARK) + the backend -
 # shellcheck source=/dev/null
@@ -150,10 +147,11 @@ cat > "$LOOP_SCRIPT" <<'LOOP'
 #!/usr/bin/env bash
 MARK=$'\xE2\x81\xA3'
 LOG="$1"
+LAB_HELPER="$2"
 AGENT_SOURCE=fm-test-supervisor
 AGENT_LABEL=fm-test-supervisor
 report_agent_state() {  # <idle|working>
-  herdr pane report-agent "$HERDR_PANE_ID" --source "$AGENT_SOURCE" --agent "$AGENT_LABEL" --state "$1" --session "$HERDR_SESSION" >/dev/null 2>&1
+  "$LAB_HELPER" run "$HERDR_SESSION" pane report-agent "$HERDR_PANE_ID" --source "$AGENT_SOURCE" --agent "$AGENT_LABEL" --state "$1" >/dev/null 2>&1
 }
 OLD_STTY=$(stty -g 2>/dev/null || true)
 [ -z "$OLD_STTY" ] || stty -echo -icanon min 1 time 0 2>/dev/null || true
@@ -223,7 +221,7 @@ done
 LOOP
 chmod +x "$LOOP_SCRIPT"
 
-fm_backend_herdr_send_text_line "$SUPERVISOR_TARGET" "bash '$LOOP_SCRIPT' '$LOG_FILE'" \
+fm_backend_herdr_send_text_line "$SUPERVISOR_TARGET" "bash '$LOOP_SCRIPT' '$LOG_FILE' '$LAB_HELPER'" \
   || fail "could not start the supervisor-loop script in the scratch herdr pane"
 sleep 1  # let the loop start and settle
 

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -817,25 +817,23 @@ unit_flag_write_failure_aborts() {
 e2e_herdr() {
   command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found (herdr e2e)"; return 0; }
   command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (herdr e2e)"; return 0; }
-  # shellcheck source=tests/herdr-test-safety.sh
-  . "$ROOT/tests/herdr-test-safety.sh"
   # shellcheck source=/dev/null
   . "$ROOT/bin/fm-backend.sh"
 
-  local SESSION home_tmp cap_ws cap_tab cap_pane target
+  local SESSION home_tmp cap_ws cap_tab cap_pane target lab_helper
   local before during after ws_before ws_during ws_after out dtgt dtab
+  lab_helper=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
   SESSION="fm-lab-afk-launch-e2e-$$"
   export HERDR_SESSION="$SESSION"
   home_tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-e2e-home.XXXXXX")
   E2E_HERDR_CLEANUP() {
     FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" \
       FM_SUPERVISOR_TARGET="$target" FM_SUPERVISOR_BACKEND=herdr "$LAUNCH" stop >/dev/null 2>&1 || true
-    herdr_safe_stop_and_delete "$SESSION" >/dev/null 2>&1 || true
+    "$lab_helper" teardown "$SESSION" >/dev/null 2>&1 || true
     rm -rf "$home_tmp" 2>/dev/null || true
   }
-  fm_herdr_lab_prepare "$SESSION" || { fail "herdr e2e: could not prepare isolated lab session"; return 0; }
+  "$lab_helper" provision "$SESSION" || { fail "herdr e2e: could not provision isolated lab session"; return 0; }
   fm_backend_source herdr || { E2E_HERDR_CLEANUP; fail "herdr e2e: fm_backend_source herdr failed"; return 0; }
-  fm_backend_herdr_server_ensure "$SESSION" || { E2E_HERDR_CLEANUP; fail "herdr e2e: lab server did not start"; return 0; }
 
   out=$(fm_backend_herdr_cli "$SESSION" workspace create --cwd "$ROOT" --label captain --no-focus 2>/dev/null)
   cap_ws=$(printf '%s' "$out" | jq -r '.result.workspace.workspace_id // empty')

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -51,7 +51,7 @@ export FM_GATE_REFUSE_BYPASS=1
 # The dedicated regression is
 # tests/fm-backend.test.sh:test_spawn_symlinked_project_prefix_avoids_false_refusal.
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-backend-autodetect-smoke.XXXXXX")
-HERDR_LAB_HELPER="$ROOT/bin/fm-herdr-lab.sh"
+HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name fm-autodetect-smoke-concurrency-h3) || {
   rm -rf "$TMP_ROOT"
   fail "could not generate an isolated Herdr lab session name"
@@ -154,6 +154,84 @@ if "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane get "$PANE" >/dev/null 2>&1
 fi
 WT=
 pass "real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)"
+
+# --- nested secondmate-watcher environment cannot claim another server -----
+
+NESTED_HOME="$TMP_ROOT/nested-secondmate-home"
+NESTED_FAKEBIN="$TMP_ROOT/nested-fakebin"
+NESTED_LOG="$TMP_ROOT/nested-herdr.log"
+NESTED_ENV_OUT="$TMP_ROOT/nested-env.out"
+NESTED_RESULT="$TMP_ROOT/nested-result.out"
+NESTED_STATUS="$TMP_ROOT/nested-status.out"
+NESTED_PROBE="$TMP_ROOT/nested-probe.sh"
+mkdir -p "$NESTED_HOME" "$NESTED_FAKEBIN"
+printf 'nested-sm\n' > "$NESTED_HOME/.fm-secondmate-home"
+cat > "$NESTED_FAKEBIN/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+{
+  printf 'HERDR_SESSION=%s' "${HERDR_SESSION:-}"
+  for arg in "$@"; do
+    printf '\037%s' "$arg"
+  done
+  printf '\n'
+} >> "${FM_NESTED_LOG:?}"
+printf '{"server":{"running":false}}\n'
+SH
+chmod +x "$NESTED_FAKEBIN/herdr"
+cat > "$NESTED_PROBE" <<'SH'
+#!/usr/bin/env bash
+set -u
+{
+  printf 'FM_HOME=%s\n' "${FM_HOME:-}"
+  printf 'HERDR_ENV=%s\n' "${HERDR_ENV:-}"
+  printf 'HERDR_SESSION=%s\n' "${HERDR_SESSION:-}"
+  printf 'HERDR_PANE_ID=%s\n' "${HERDR_PANE_ID:-}"
+  printf 'HERDR_WORKSPACE_ID=%s\n' "${HERDR_WORKSPACE_ID:-}"
+  printf 'HERDR_SOCKET_PATH=%s\n' "${HERDR_SOCKET_PATH:-}"
+} > "${FM_NESTED_ENV_OUT:?}"
+PATH="${FM_NESTED_FAKEBIN:?}:$PATH" FM_NESTED_LOG="${FM_NESTED_LOG:?}" \
+  bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure "${HERDR_SESSION:-default}"' \
+    "${FM_NESTED_ROOT:?}" > "${FM_NESTED_RESULT:?}" 2>&1
+printf '%s\n' "$?" > "${FM_NESTED_STATUS:?}"
+SH
+chmod +x "$NESTED_PROBE"
+
+NESTED_CREATE=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" \
+  workspace create --cwd "$ROOT" --label nested-single-server-guard --no-focus) || \
+  fail "could not create the isolated nested-server guard pane"
+NESTED_PANE=$(printf '%s' "$NESTED_CREATE" | jq -r '.result.root_pane.pane_id // empty')
+[ -n "$NESTED_PANE" ] || fail "nested-server guard fixture did not return a pane id"
+sleep 1
+printf -v NESTED_COMMAND \
+  'FM_HOME=%q FM_NESTED_ROOT=%q FM_NESTED_FAKEBIN=%q FM_NESTED_LOG=%q FM_NESTED_ENV_OUT=%q FM_NESTED_RESULT=%q FM_NESTED_STATUS=%q %q' \
+  "$NESTED_HOME" "$ROOT" "$NESTED_FAKEBIN" "$NESTED_LOG" "$NESTED_ENV_OUT" \
+  "$NESTED_RESULT" "$NESTED_STATUS" "$NESTED_PROBE"
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane run "$NESTED_PANE" "$NESTED_COMMAND" || \
+  fail "could not run the nested-server guard probe inside the isolated Herdr pane"
+for _ in $(seq 1 100); do
+  [ -s "$NESTED_STATUS" ] && break
+  sleep 0.1
+done
+[ -s "$NESTED_STATUS" ] || fail "nested-server guard probe did not finish"
+[ "$(cat "$NESTED_STATUS")" -ne 0 ] || \
+  fail "nested-server guard probe accepted a competing server start"
+assert_contains_local "$(cat "$NESTED_ENV_OUT")" "FM_HOME=$NESTED_HOME" \
+  "nested probe did not carry the secondmate watcher's home"
+assert_contains_local "$(cat "$NESTED_ENV_OUT")" "HERDR_ENV=1" \
+  "real Herdr pane did not supply the nested-runtime marker"
+assert_contains_local "$(cat "$NESTED_ENV_OUT")" "HERDR_SESSION=$HERDR_LAB_SESSION" \
+  "real Herdr pane did not inherit its exact named session"
+assert_contains_local "$(cat "$NESTED_ENV_OUT")" "HERDR_PANE_ID=$NESTED_PANE" \
+  "real Herdr pane did not inherit its exact pane identity"
+assert_contains_local "$(cat "$NESTED_RESULT")" "refusing to start a competing server" \
+  "nested-server guard did not return its actionable refusal"
+assert_contains_local "$(cat "$NESTED_LOG")" $'\037status\037--json\037--session\037'"$HERDR_LAB_SESSION" \
+  "nested-server guard did not check the exact inherited named session"
+case "$(cat "$NESTED_LOG")" in
+  *$'\037server'*) fail "nested-server guard invoked a competing server after the scoped status miss" ;;
+esac
+pass "real herdr: a secondmate-watcher-shaped process inside a named lab pane refuses a competing same-socket server start"
 
 if ! cleanup_all; then
   trap - EXIT

--- a/tests/fm-backend-herdr-eventwait-smoke.test.sh
+++ b/tests/fm-backend-herdr-eventwait-smoke.test.sh
@@ -7,10 +7,9 @@
 # that the watcher's handle_push_transition lands a stale record in a scratch
 # state/.wake-queue. Skips cleanly when herdr, jq, or python3 is missing.
 #
-# Safety (2026-07-02 incident, tests/herdr-test-safety.sh): cleanup uses ONLY
-# herdr_safe_stop_and_delete on a private fm-lab-* session, never a bare/ambient
-# `herdr server stop`. Every lifecycle op goes through bin/fm-herdr-lab.sh, which
-# refuses the default session and verifies the fleet-state tripwire.
+# Safety (2026-07-02 incident): every lifecycle op goes through
+# bin/fm-herdr-lab.sh, which refuses the default session and verifies the
+# fleet-state tripwire.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -22,18 +21,16 @@ command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found (required by the event subscriber)"; exit 0; }
 
-# shellcheck source=tests/herdr-test-safety.sh
-. "$ROOT/tests/herdr-test-safety.sh"
-
+LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 SESSION="fm-lab-eventwait-smoke-$$"
 export HERDR_SESSION="$SESSION"
 SCRATCH=
 cleanup_all() {
   [ -n "$SCRATCH" ] && rm -rf "$SCRATCH"
-  herdr_safe_stop_and_delete "$SESSION"
+  "$LAB_HELPER" teardown "$SESSION"
 }
 trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare the isolated Herdr lab session"
+"$LAB_HELPER" provision "$SESSION" || fail "could not provision the isolated Herdr lab session"
 
 # The dispatcher is a separately linted production boundary. Its dynamic
 # adapter source edges stop at each independently linted canonical adapter.
@@ -81,7 +78,7 @@ SOCK=$(fm_backend_herdr_socket_path "$SESSION")
 # report-agent is herdr's documented primitive for a non-built-in process to
 # report its own agent state (docs/herdr-backend.md); routed through the lab
 # helper's guarded `run` so it carries the trailing --session.
-fm_herdr_lab_cli "$SESSION" pane report-agent "$PANE_ID" --source fm-evwait-test --agent claude --state idle >/dev/null 2>&1 \
+"$LAB_HELPER" run "$SESSION" pane report-agent "$PANE_ID" --source fm-evwait-test --agent claude --state idle >/dev/null 2>&1 \
   || fail "could not register the pane's agent as idle"
 
 OUT="$SCRATCH/out"; RCF="$SCRATCH/rc"
@@ -93,7 +90,7 @@ WPID=$!
 sleep 0.5   # let it connect, subscribe, and reconcile the idle baseline
 
 START=$(python3 -c 'import time; print(time.time())')
-fm_herdr_lab_cli "$SESSION" pane report-agent "$PANE_ID" --source fm-evwait-test --agent claude --state blocked >/dev/null 2>&1 \
+"$LAB_HELPER" run "$SESSION" pane report-agent "$PANE_ID" --source fm-evwait-test --agent claude --state blocked >/dev/null 2>&1 \
   || fail "could not drive the pane's agent to blocked"
 wait "$WPID"
 END=$(python3 -c 'import time; print(time.time())')

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -684,7 +684,7 @@ ORDER_LIST=$(lab workspace list) || fail "could not inspect concurrent presentat
 CREATED_LABELS=$(projection_labels_from_log "$PROJECTION_ORDER_START")
 EXPECTED_LABELS=$(printf 'firstmate\n%s\n%s\n2ndmate-alpha\n2ndmate-bravo' "$PROJECTED_LABEL" "$CREATED_LABELS")
 ACTUAL_LABELS=$(printf '%s' "$ORDER_LIST" | jq -r '.result.workspaces[].label')
-[ "$ACTUAL_LABELS" = "$EXPECTED_LABELS" ] || fail "workspace order was not firstmate, stable primary block, secondmates: $ACTUAL_LABELS"
+[ "$ACTUAL_LABELS" = "$EXPECTED_LABELS" ] || fail "workspace order was not firstmate, stable primary block, secondmates: actual=$ACTUAL_LABELS expected=$EXPECTED_LABELS moves=$(cat "$MOVE_CALL_LOG")"
 PRIMARY_IDS=$(printf '%s' "$ORDER_LIST" | jq -r '
   .result.workspaces[]
   | select((.label | startswith("└ ")) or (.label | startswith("firstmate/")))

--- a/tests/fm-backend-herdr-prune-safety-e2e.test.sh
+++ b/tests/fm-backend-herdr-prune-safety-e2e.test.sh
@@ -16,10 +16,8 @@
 # fm-<id> task tab), mirroring tests/fm-backend-herdr-smoke.test.sh's broader
 # coverage but scoped tightly to this one safety property.
 #
-# Safety (tests/herdr-test-safety.sh): cleanup uses ONLY
-# herdr_safe_stop_and_delete, never a bare/inline-prefixed `herdr server
-# stop` - the exact category of unscoped destructive call that caused the
-# 2026-07-02 incident in the first place.
+# Safety: bin/fm-herdr-lab.sh owns provisioning and teardown and refuses the
+# default session immediately before every destructive lifecycle call.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -30,18 +28,19 @@ pass() { printf 'ok - %s\n' "$1"; }
 command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 
-# shellcheck source=tests/herdr-test-safety.sh
-. "$ROOT/tests/herdr-test-safety.sh"
-
+LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 SESSION="fm-lab-prune-safety-e2e-$$"
 export HERDR_SESSION="$SESSION"
 SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-herdr-prune-safety.XXXXXX")
+FM_HOME="$SCRATCH/primary-home"
+mkdir -p "$FM_HOME"
+export FM_HOME
 cleanup_all() {
-  herdr_safe_stop_and_delete "$SESSION"
+  "$LAB_HELPER" teardown "$SESSION"
   rm -rf "$SCRATCH"
 }
 trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+"$LAB_HELPER" provision "$SESSION" || fail "could not provision isolated Herdr lab session"
 
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
@@ -58,8 +57,6 @@ fm_backend_herdr_version_check || fail "version_check failed against the real in
 LIVE_CWD="$SCRATCH/firstmate"
 mkdir -p "$LIVE_CWD"
 
-fm_backend_herdr_server_ensure "$SESSION" || fail "could not start the isolated session's server"
-
 CREATE_OUT=$(fm_backend_herdr_cli "$SESSION" workspace create --cwd "$LIVE_CWD" --label firstmate --no-focus) \
   || fail "could not create the label-collision startup workspace"
 LIVE_WSID=$(printf '%s' "$CREATE_OUT" | jq -r '.result.workspace.workspace_id // empty')
@@ -69,7 +66,7 @@ if [ -z "$LIVE_WSID" ] || [ -z "$LIVE_TAB_ID" ] || [ -z "$LIVE_PANE_ID" ]; then
   fail "could not parse the startup workspace's ids from workspace create: $CREATE_OUT"
 fi
 
-LIVE_LABEL=$(herdr workspace list --session "$SESSION" 2>&1 | jq -r --arg id "$LIVE_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
+LIVE_LABEL=$("$LAB_HELPER" run "$SESSION" workspace list 2>&1 | jq -r --arg id "$LIVE_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
 [ "$LIVE_LABEL" = firstmate ] || fail "the startup workspace label should be 'firstmate', got '$LIVE_LABEL' - repro setup is wrong"
 pass "repro setup: a pre-existing workspace labeled 'firstmate' collides with the primary home's own label"
 
@@ -127,7 +124,7 @@ fi
 
 # --- 3. assert the live pane survived untouched -----------------------------
 
-if ! herdr pane get "$LIVE_PANE_ID" --session "$SESSION" >/dev/null 2>&1; then
+if ! "$LAB_HELPER" run "$SESSION" pane get "$LIVE_PANE_ID" >/dev/null 2>&1; then
   fail "REGRESSION (2026-07-02 self-kill): the live startup-workspace pane was CLOSED by create_task"
 fi
 sleep 2
@@ -136,7 +133,7 @@ AFTER_COUNT=$(wc -l < "$MARKER" | tr -d '[:space:]')
   || fail "REGRESSION: the live heartbeat process stopped writing after create_task ran - it was killed even though its pane object survived"
 pass "fixed: the live pane (and its live process) survived create_task untouched - the exact 2026-07-02 self-kill incident does not reproduce"
 
-LIVE_TABS_AFTER=$(herdr tab list --workspace "$LIVE_WSID" --session "$SESSION" 2>&1)
+LIVE_TABS_AFTER=$("$LAB_HELPER" run "$SESSION" tab list --workspace "$LIVE_WSID" 2>&1)
 printf '%s' "$LIVE_TABS_AFTER" | jq -e --arg t "$LIVE_TAB_ID" '.result.tabs[] | select(.tab_id == $t)' >/dev/null 2>&1 \
   || fail "REGRESSION: the startup workspace's original live tab is gone from tab list"
 pass "fixed: the startup workspace's original live tab is still present in tab list after the spawn"
@@ -162,7 +159,7 @@ EOF
 [ -n "$HAPPY_PANE" ] || fail "happy-path create_task did not return a pane id"
 
 HAPPY_WSID=${HAPPY_CONTAINER#*:}
-HAPPY_TABS=$(herdr tab list --workspace "$HAPPY_WSID" --session "$SESSION" 2>&1)
+HAPPY_TABS=$("$LAB_HELPER" run "$SESSION" tab list --workspace "$HAPPY_WSID" 2>&1)
 HAPPY_COUNT=$(printf '%s' "$HAPPY_TABS" | jq -r '.result.tabs? // [] | length')
 [ "$HAPPY_COUNT" = 1 ] || fail "happy path: expected exactly 1 tab (seeded default pruned) after the first real task tab, got $HAPPY_COUNT: $HAPPY_TABS"
 printf '%s' "$HAPPY_TABS" | jq -e --arg t "$HAPPY_SEEDED" '.result.tabs[] | select(.tab_id == $t)' >/dev/null 2>&1 \

--- a/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
+++ b/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
@@ -26,12 +26,8 @@
 # question of whether treehouse itself supports re-acquiring a worktree for
 # an id that already has one checked out (a separate, out-of-scope concern).
 #
-# Safety (tests/herdr-test-safety.sh): cleanup uses ONLY
-# herdr_safe_stop_and_delete, never a bare/inline-prefixed `herdr server
-# stop` - the exact category of unscoped destructive call that caused the
-# 2026-07-02 incident. Every herdr lifecycle call in this file targets this
-# test's own isolated $SESSION explicitly via --session; the live `default`
-# session is never touched.
+# Safety: bin/fm-herdr-lab.sh owns every lifecycle call, refuses the default
+# session, and verifies the default fleet tripwire.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -42,18 +38,16 @@ pass() { printf 'ok - %s\n' "$1"; }
 command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 
-# shellcheck source=tests/herdr-test-safety.sh
-. "$ROOT/tests/herdr-test-safety.sh"
-
+LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 SESSION="fm-lab-respawn-idem-e2e-$$"
 export HERDR_SESSION="$SESSION"
 SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-herdr-respawn-idem.XXXXXX")
 cleanup_all() {
-  herdr_safe_stop_and_delete "$SESSION"
+  "$LAB_HELPER" teardown "$SESSION"
   rm -rf "$SCRATCH"
 }
 trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+"$LAB_HELPER" provision "$SESSION" || fail "could not provision isolated Herdr lab session"
 
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
@@ -105,15 +99,15 @@ pass "repro setup: two real fm-<id> task tabs exist (crewmate-shaped and secondm
 # underlying process (a fresh shell) and its agent_status to unknown - the
 # exact husk shape a restored task tab comes back in.
 
-fm_herdr_lab_stop "$SESSION" >/dev/null 2>&1 \
+"$LAB_HELPER" stop "$SESSION" >/dev/null 2>&1 \
   || fail "could not stop the isolated session for the restart"
 sleep 0.5
-fm_backend_herdr_server_ensure "$SESSION" || fail "the isolated session's server did not come back up after the restart"
+"$LAB_HELPER" provision "$SESSION" || fail "the isolated session's server did not come back up after the restart"
 
-if ! herdr pane get "$CREW_PANE_ID" --session "$SESSION" >/dev/null 2>&1; then
+if ! "$LAB_HELPER" run "$SESSION" pane get "$CREW_PANE_ID" >/dev/null 2>&1; then
   fail "repro setup is wrong: the crewmate-shaped pane should survive a session restart alive (docs/herdr-backend.md 'ID stability'), but it is gone"
 fi
-if herdr agent get "$CREW_PANE_ID" --session "$SESSION" >/dev/null 2>&1; then
+if "$LAB_HELPER" run "$SESSION" agent get "$CREW_PANE_ID" >/dev/null 2>&1; then
   fail "repro setup is wrong: the restored pane should have NO registered agent (agent_not_found expected)"
 fi
 pass "repro confirmed: after a real session restart, both task panes survive alive but with no registered agent - the restored-layout husk"
@@ -129,7 +123,7 @@ if [ -z "$NEW_CREW_TAB_ID" ] || [ -z "$NEW_CREW_PANE_ID" ]; then
   fail "husk respawn (crewmate-shaped) did not return new tab/pane ids"
 fi
 [ "$NEW_CREW_PANE_ID" != "$CREW_PANE_ID" ] || fail "husk respawn (crewmate-shaped) returned the SAME pane id - nothing was actually replaced"
-if herdr pane get "$CREW_PANE_ID" --session "$SESSION" >/dev/null 2>&1; then
+if "$LAB_HELPER" run "$SESSION" pane get "$CREW_PANE_ID" >/dev/null 2>&1; then
   fail "REGRESSION: the old crewmate-shaped husk pane should have been closed by close-and-replace, but it still exists"
 fi
 pass "fixed: create_task closes and replaces the crewmate-shaped restored husk instead of refusing - no manual pane close needed"
@@ -143,12 +137,12 @@ if [ -z "$NEW_SM_TAB_ID" ] || [ -z "$NEW_SM_PANE_ID" ]; then
   fail "husk respawn (secondmate-shaped) did not return new tab/pane ids"
 fi
 [ "$NEW_SM_PANE_ID" != "$SM_PANE_ID" ] || fail "husk respawn (secondmate-shaped) returned the SAME pane id - nothing was actually replaced"
-if herdr pane get "$SM_PANE_ID" --session "$SESSION" >/dev/null 2>&1; then
+if "$LAB_HELPER" run "$SESSION" pane get "$SM_PANE_ID" >/dev/null 2>&1; then
   fail "REGRESSION: the old secondmate-shaped husk pane should have been closed by close-and-replace, but it still exists"
 fi
 pass "fixed: create_task closes and replaces the secondmate-shaped restored husk instead of refusing - same fix, same function, both spawn shapes"
 
-WS_TABS=$(herdr tab list --workspace "$WSID" --session "$SESSION" 2>&1)
+WS_TABS=$("$LAB_HELPER" run "$SESSION" tab list --workspace "$WSID" 2>&1)
 WS_COUNT=$(printf '%s' "$WS_TABS" | jq -r '.result.tabs? // [] | length')
 [ "$WS_COUNT" = 2 ] || fail "expected exactly 2 tabs (the two replacements, husks closed, no leaks), got $WS_COUNT: $WS_TABS"
 pass "fixed: the workspace holds exactly the 2 replacement tabs after both respawns - no leaked husk tabs, no destroyed workspace"
@@ -159,13 +153,13 @@ pass "fixed: the workspace holds exactly the 2 replacement tabs after both respa
 # attempt refuses exactly as before - the husk fix must never touch a pane
 # that actually has something registered in it.
 
-herdr pane report-agent "$NEW_CREW_PANE_ID" --source fm-respawn-e2e --agent fm-respawn-live-agent --state idle --session "$SESSION" >/dev/null 2>&1 \
+"$LAB_HELPER" run "$SESSION" pane report-agent "$NEW_CREW_PANE_ID" --source fm-respawn-e2e --agent fm-respawn-live-agent --state idle >/dev/null 2>&1 \
   || fail "could not register a live agent on the respawned crewmate-shaped pane"
 
 if fm_backend_herdr_create_task "$CONTAINER" "$CREW_LABEL" "$PROJ_CWD" >/dev/null 2>&1; then
   fail "REGRESSION: create_task should refuse a same-labeled tab whose pane hosts a genuinely live registered agent"
 fi
-if ! herdr pane get "$NEW_CREW_PANE_ID" --session "$SESSION" >/dev/null 2>&1; then
+if ! "$LAB_HELPER" run "$SESSION" pane get "$NEW_CREW_PANE_ID" >/dev/null 2>&1; then
   fail "REGRESSION: the live-agent pane should have survived the refused create_task call untouched"
 fi
 pass "fixed: a genuinely live duplicate (a real registered agent) still refuses exactly as before - the husk fix never closes a live pane"

--- a/tests/fm-backend-herdr-smoke.test.sh
+++ b/tests/fm-backend-herdr-smoke.test.sh
@@ -9,11 +9,8 @@
 # captain's real herdr usage. Skips cleanly when herdr (or jq) is not
 # installed, so CI/dev machines without herdr are unaffected.
 #
-# Safety (2026-07-02 incident, see tests/herdr-test-safety.sh): cleanup uses
-# ONLY herdr_safe_stop_and_delete, never a bare/ambient `herdr server stop` -
-# that command killed the captain's live default herdr server twice in
-# production because HERDR_SESSION-based targeting (env var OR inline prefix)
-# is not reliably honored once another herdr server is already running.
+# Safety (2026-07-02 incident): bin/fm-herdr-lab.sh owns every lifecycle call,
+# refuses the default session, and verifies the default fleet tripwire.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -24,18 +21,21 @@ pass() { printf 'ok - %s\n' "$1"; }
 command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 
-# shellcheck source=tests/herdr-test-safety.sh
-. "$ROOT/tests/herdr-test-safety.sh"
-
+LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 SESSION="fm-lab-backend-smoke-$$"
 export HERDR_SESSION="$SESSION"
+PRIMARY_SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-herdr-smoke-primary.XXXXXX")
+FM_HOME="$PRIMARY_SCRATCH/primary-home"
+mkdir -p "$FM_HOME"
+export FM_HOME
 SM_SCRATCH=
 cleanup_all() {
   [ -n "$SM_SCRATCH" ] && rm -rf "$SM_SCRATCH"
-  herdr_safe_stop_and_delete "$SESSION"
+  rm -rf "$PRIMARY_SCRATCH"
+  "$LAB_HELPER" teardown "$SESSION"
 }
 trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+"$LAB_HELPER" provision "$SESSION" || fail "could not provision isolated Herdr lab session"
 
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
@@ -89,7 +89,7 @@ TARGET="$SESSION:$PANE_ID"
 # The happy path: a fresh workspace's seeded default tab (label "1") must be
 # pruned once the first real task tab is created alongside it, leaving
 # exactly one clean fm-<id> task tab.
-POST_CREATE_TABS=$(herdr tab list --workspace "${CONTAINER#*:}" --session "$SESSION" 2>&1)
+POST_CREATE_TABS=$("$LAB_HELPER" run "$SESSION" tab list --workspace "${CONTAINER#*:}" 2>&1)
 POST_CREATE_COUNT=$(printf '%s' "$POST_CREATE_TABS" | jq -r '.result.tabs? // [] | length')
 [ "$POST_CREATE_COUNT" = 1 ] || fail "expected exactly 1 tab (the seeded default pruned) after the first real task tab, got $POST_CREATE_COUNT: $POST_CREATE_TABS"
 printf '%s' "$POST_CREATE_TABS" | jq -e --arg t "$SEEDED_TAB_ID" '.result.tabs[] | select(.tab_id == $t)' >/dev/null 2>&1 \
@@ -124,12 +124,12 @@ EOF
 if [ -z "$LIVE_DUP_TAB_ID" ] || [ -z "$LIVE_DUP_PANE_ID" ]; then
   fail "live-duplicate scenario tab creation did not return ids"
 fi
-herdr pane report-agent "$LIVE_DUP_PANE_ID" --source fm-smoke-test --agent fm-smoke-live-agent --state idle --session "$SESSION" >/dev/null 2>&1 \
+"$LAB_HELPER" run "$SESSION" pane report-agent "$LIVE_DUP_PANE_ID" --source fm-smoke-test --agent fm-smoke-live-agent --state idle >/dev/null 2>&1 \
   || fail "could not register a live agent on the live-duplicate scenario's pane"
 if fm_backend_herdr_create_task "$CONTAINER" "$LIVE_DUP_LABEL" /tmp >/dev/null 2>&1; then
   fail "REGRESSION: create_task should refuse a duplicate label whose pane hosts a genuinely live registered agent (idle counts as live)"
 fi
-herdr pane get "$LIVE_DUP_PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
+"$LAB_HELPER" run "$SESSION" pane get "$LIVE_DUP_PANE_ID" >/dev/null 2>&1 \
   || fail "REGRESSION: the live-duplicate scenario's pane should have survived the refused create_task call untouched"
 pass "real herdr: create_task refuses a same-labeled tab whose pane hosts a genuinely live registered agent (unchanged behavior)"
 fm_backend_herdr_kill "$SESSION:$LIVE_DUP_PANE_ID"
@@ -144,7 +144,7 @@ EOF
 if [ -z "$HUSK_TAB_ID" ] || [ -z "$HUSK_PANE_ID" ]; then
   fail "husk-simulation tab creation did not return ids"
 fi
-herdr agent get "$HUSK_PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
+"$LAB_HELPER" run "$SESSION" agent get "$HUSK_PANE_ID" >/dev/null 2>&1 \
   && fail "husk-simulation setup is wrong: this pane should have NO registered agent yet"
 REPLACED_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "$HUSK_LABEL" /tmp) \
   || fail "REGRESSION: create_task should close-and-replace a same-labeled tab whose pane hosts no registered agent, not refuse it"
@@ -155,10 +155,10 @@ if [ -z "$NEW_HUSK_TAB_ID" ] || [ -z "$NEW_HUSK_PANE_ID" ]; then
   fail "husk close-and-replace did not return new tab/pane ids"
 fi
 [ "$NEW_HUSK_PANE_ID" != "$HUSK_PANE_ID" ] || fail "husk close-and-replace returned the SAME pane id - it did not actually replace anything"
-if herdr pane get "$HUSK_PANE_ID" --session "$SESSION" >/dev/null 2>&1; then
+if "$LAB_HELPER" run "$SESSION" pane get "$HUSK_PANE_ID" >/dev/null 2>&1; then
   fail "REGRESSION: the old husk pane should have been closed by close-and-replace, but it still exists"
 fi
-HUSK_WS_TABS=$(herdr tab list --workspace "${CONTAINER#*:}" --session "$SESSION" 2>&1)
+HUSK_WS_TABS=$("$LAB_HELPER" run "$SESSION" tab list --workspace "${CONTAINER#*:}" 2>&1)
 printf '%s' "$HUSK_WS_TABS" | jq -e --arg t "$NEW_HUSK_TAB_ID" '.result.tabs[] | select(.tab_id == $t)' >/dev/null 2>&1 \
   || fail "REGRESSION: the replacement tab is missing from the workspace's own tab list"
 pass "real herdr: create_task closes and replaces a same-labeled tab whose pane hosts no registered agent (the restored-husk shape), leaving the workspace intact"
@@ -189,7 +189,7 @@ esac
 pass "real herdr: a secondmate-shaped home (.fm-secondmate-home) gets its OWN herdr workspace, distinct from the primary's, in the SAME session"
 
 SM_WSID=${SM_CONTAINER#*:}
-SM_LABEL_REAL=$(herdr workspace list --session "$SESSION" 2>&1 | jq -r --arg id "$SM_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
+SM_LABEL_REAL=$("$LAB_HELPER" run "$SESSION" workspace list 2>&1 | jq -r --arg id "$SM_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
 [ "$SM_LABEL_REAL" = "2ndmate-smoketest-sm1" ] || fail "the secondmate workspace's real herdr label should be 2ndmate-smoketest-sm1, got '$SM_LABEL_REAL'"
 pass "real herdr: the secondmate-shaped home's workspace is labeled 2ndmate-<secondmate-id> in herdr itself"
 
@@ -224,20 +224,20 @@ pass "real herdr: list_live stays scoped to each home's own workspace - neither 
 # still resolve, unchanged, after a `session stop` + fresh server restart, all
 # scoped to this suite's OWN isolated $SESSION - never the default session.
 
-fm_herdr_lab_stop "$SESSION" >/dev/null 2>&1 \
+"$LAB_HELPER" stop "$SESSION" >/dev/null 2>&1 \
   || fail "could not stop the isolated session for the restart-stability check"
 sleep 0.5
-fm_backend_herdr_server_ensure "$SESSION" || fail "the isolated session's server did not come back up after the stop"
+"$LAB_HELPER" provision "$SESSION" || fail "the isolated session's server did not come back up after the stop"
 
-POST_LIST=$(herdr workspace list --session "$SESSION" 2>&1)
+POST_LIST=$("$LAB_HELPER" run "$SESSION" workspace list 2>&1)
 POST_PRIMARY_ID=$(printf '%s' "$POST_LIST" | jq -r '.result.workspaces[]? | select(.label == "firstmate") | .workspace_id')
 POST_SM_ID=$(printf '%s' "$POST_LIST" | jq -r --arg l "2ndmate-smoketest-sm1" '.result.workspaces[]? | select(.label == $l) | .workspace_id')
-[ "$POST_PRIMARY_ID" = "${CONTAINER#*:}" ] || fail "the primary workspace id did not survive the restart: before=${CONTAINER#*:} after=$POST_PRIMARY_ID"
+[ "$POST_PRIMARY_ID" = "${CONTAINER#*:}" ] || fail "the primary workspace id did not survive the restart: before=${CONTAINER#*:} after=$POST_PRIMARY_ID list=$POST_LIST"
 [ "$POST_SM_ID" = "$SM_WSID" ] || fail "the secondmate workspace id did not survive the restart: before=$SM_WSID after=$POST_SM_ID"
 
-POST_PANE=$(herdr pane get "$PANE_ID" --session "$SESSION" 2>/dev/null | jq -r '.result.pane.pane_id // empty')
+POST_PANE=$("$LAB_HELPER" run "$SESSION" pane get "$PANE_ID" 2>/dev/null | jq -r '.result.pane.pane_id // empty')
 [ "$POST_PANE" = "$PANE_ID" ] || fail "the primary task's pane id did not survive the restart: before=$PANE_ID after=$POST_PANE"
-POST_SM_PANE=$(herdr pane get "$SM_PANE_ID" --session "$SESSION" 2>/dev/null | jq -r '.result.pane.pane_id // empty')
+POST_SM_PANE=$("$LAB_HELPER" run "$SESSION" pane get "$SM_PANE_ID" 2>/dev/null | jq -r '.result.pane.pane_id // empty')
 [ "$POST_SM_PANE" = "$SM_PANE_ID" ] || fail "the secondmate task's pane id did not survive the restart: before=$SM_PANE_ID after=$POST_SM_PANE"
 pass "real herdr: BOTH workspace ids/labels AND both tasks' pane ids survive a session stop + fresh server restart (multi-workspace shape)"
 
@@ -314,7 +314,7 @@ fi
 # --- kill -----------------------------------------------------------------
 
 fm_backend_herdr_kill "$TARGET"
-if herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1; then
+if "$LAB_HELPER" run "$SESSION" pane get "$PANE_ID" >/dev/null 2>&1; then
   fail "kill did not remove the pane"
 fi
 # Best-effort contract: killing an already-gone pane must not error.

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -13,9 +13,8 @@
 # convention: a private throwaway HERDR_SESSION (never the captain's
 # default), scratch FM_HOME(s), and scratch local-only projects.
 #
-# Safety (2026-07-02 incident, see tests/herdr-test-safety.sh): cleanup uses
-# ONLY herdr_safe_stop_and_delete, never a bare/inline-prefixed `herdr server
-# stop`.
+# Safety (2026-07-02 incident): every direct Herdr operation and all lifecycle
+# ownership use bin/fm-herdr-lab.sh with a trailing non-default named session.
 #
 # Covers, at minimum (per the task brief):
 #   - a primary-shaped home (no .fm-secondmate-home marker) spawning a
@@ -51,9 +50,6 @@ command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (required by fm-spawn.sh)"; exit 0; }
 
-# shellcheck source=tests/herdr-test-safety.sh
-. "$ROOT/tests/herdr-test-safety.sh"
-
 # TMP_ROOT is physically resolved (mktemp -d "$(pwd -P)"-relative) for the same
 # low-noise scratch fixture shape used by
 # tests/fm-backend-autodetect-smoke.test.sh.
@@ -61,17 +57,21 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (requi
 # canonicalized project and backend cwd comparisons in the worktree-discovery
 # poll.
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-herdr-e2e.XXXXXX")
-SESSION="fm-lab-herdr-e2e-$$"
+HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+SESSION=$("$HERDR_LAB_HELPER" name fm-herdr-workspace-per-home-e2e) || {
+  rm -rf "$TMP_ROOT"
+  fail "could not generate an isolated Herdr lab session name"
+}
 export HERDR_SESSION="$SESSION"
 WT1=; WT2=
 cleanup_all() {
   [ -n "$WT1" ] && command -v treehouse >/dev/null 2>&1 && treehouse return --force "$WT1" >/dev/null 2>&1
   [ -n "$WT2" ] && command -v treehouse >/dev/null 2>&1 && treehouse return --force "$WT2" >/dev/null 2>&1
-  herdr_safe_stop_and_delete "$SESSION"
+  "$HERDR_LAB_HELPER" teardown "$SESSION"
   rm -rf "$TMP_ROOT"
 }
 trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+"$HERDR_LAB_HELPER" provision "$SESSION" || fail "could not provision isolated Herdr lab session"
 
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-backend.sh"
@@ -114,6 +114,7 @@ rc=$?
 CM1_META="$PRIMARY_HOME/state/cm1.meta"
 [ -f "$CM1_META" ] || fail "no meta written for cm1"
 assert_contains_local "$(cat "$CM1_META")" "backend=herdr" "cm1 meta missing backend=herdr"
+assert_contains_local "$(cat "$CM1_META")" "herdr_session=$SESSION" "cm1 meta did not retain the fleet's named Herdr session owner"
 WT1=$(grep '^worktree=' "$CM1_META" | cut -d= -f2-)
 CM1_PANE=$(grep '^herdr_pane_id=' "$CM1_META" | cut -d= -f2-)
 [ -n "$CM1_PANE" ] || fail "cm1 meta missing herdr_pane_id"
@@ -123,9 +124,9 @@ sleep 1
 CM1_CAPTURE=$(fm_backend_herdr_capture "$SESSION:$CM1_PANE" 30) || fail "capture failed on cm1's pane"
 assert_contains_local "$CM1_CAPTURE" "primary-crew-ok" "cm1's raw launch command did not run in its herdr pane"
 
-CM1_WSID=$(herdr pane get "$CM1_PANE" --session "$SESSION" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
+CM1_WSID=$("$HERDR_LAB_HELPER" run "$SESSION" pane get "$CM1_PANE" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
 [ -n "$CM1_WSID" ] || fail "could not read cm1's pane workspace_id"
-CM1_WS_LABEL=$(herdr workspace list --session "$SESSION" 2>&1 | jq -r --arg id "$CM1_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
+CM1_WS_LABEL=$("$HERDR_LAB_HELPER" run "$SESSION" workspace list 2>&1 | jq -r --arg id "$CM1_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
 [ "$CM1_WS_LABEL" = "firstmate" ] || fail "a primary-shaped home's crewmate should land in the 'firstmate' workspace, got '$CM1_WS_LABEL'"
 pass "real herdr E2E: the primary-shaped home's crewmate landed in the 'firstmate' workspace"
 
@@ -144,15 +145,16 @@ SM_META="$PRIMARY_HOME/state/e2esm1.meta"
 [ -f "$SM_META" ] || fail "no meta written for e2esm1 (recorded in the PRIMARY's own state dir, since the primary did the spawning)"
 assert_contains_local "$(cat "$SM_META")" "kind=secondmate" "e2esm1 meta missing kind=secondmate"
 assert_contains_local "$(cat "$SM_META")" "backend=herdr" "e2esm1 meta missing backend=herdr"
+assert_contains_local "$(cat "$SM_META")" "herdr_session=$SESSION" "e2esm1 meta did not retain the fleet's named Herdr session owner"
 assert_contains_local "$(cat "$SM_META")" "home=$SM_HOME" "e2esm1 meta does not record its own home"
 SM_PANE=$(grep '^herdr_pane_id=' "$SM_META" | cut -d= -f2-)
 [ -n "$SM_PANE" ] || fail "e2esm1 meta missing herdr_pane_id"
 pass "real herdr E2E: the primary spawns a --secondmate task on the herdr backend"
 
-SM_WSID=$(herdr pane get "$SM_PANE" --session "$SESSION" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
+SM_WSID=$("$HERDR_LAB_HELPER" run "$SESSION" pane get "$SM_PANE" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
 [ -n "$SM_WSID" ] || fail "could not read e2esm1's pane workspace_id"
 [ "$SM_WSID" != "$CM1_WSID" ] || fail "the secondmate's tab must NOT land in the primary's workspace, but it shares $CM1_WSID"
-SM_WS_LABEL=$(herdr workspace list --session "$SESSION" 2>&1 | jq -r --arg id "$SM_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
+SM_WS_LABEL=$("$HERDR_LAB_HELPER" run "$SESSION" workspace list 2>&1 | jq -r --arg id "$SM_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
 [ "$SM_WS_LABEL" = "2ndmate-e2esm1" ] || fail "a --secondmate spawn should land in '2ndmate-<id>', got '$SM_WS_LABEL'"
 pass "real herdr E2E: a --secondmate spawn by the PRIMARY lands in the SECONDMATE's own labeled workspace, distinct from the primary's"
 
@@ -169,6 +171,7 @@ rc=$?
 CM2_META="$SM_HOME/state/cm2.meta"
 [ -f "$CM2_META" ] || fail "no meta written for cm2 (recorded in the SECONDMATE's own state dir - it did its own spawning)"
 assert_contains_local "$(cat "$CM2_META")" "backend=herdr" "cm2 meta missing backend=herdr"
+assert_contains_local "$(cat "$CM2_META")" "herdr_session=$SESSION" "cm2 meta did not retain the fleet's named Herdr session owner"
 WT2=$(grep '^worktree=' "$CM2_META" | cut -d= -f2-)
 CM2_PANE=$(grep '^herdr_pane_id=' "$CM2_META" | cut -d= -f2-)
 [ -n "$CM2_PANE" ] || fail "cm2 meta missing herdr_pane_id"
@@ -178,7 +181,7 @@ sleep 1
 CM2_CAPTURE=$(fm_backend_herdr_capture "$SESSION:$CM2_PANE" 30) || fail "capture failed on cm2's pane"
 assert_contains_local "$CM2_CAPTURE" "sm-crew-ok" "cm2's raw launch command did not run in its herdr pane"
 
-CM2_WSID=$(herdr pane get "$CM2_PANE" --session "$SESSION" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
+CM2_WSID=$("$HERDR_LAB_HELPER" run "$SESSION" pane get "$CM2_PANE" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
 [ "$CM2_WSID" = "$SM_WSID" ] || fail "a crewmate spawned FROM the secondmate home should land in the SAME workspace as the secondmate's own task ($SM_WSID), got '$CM2_WSID'"
 [ "$CM2_WSID" != "$CM1_WSID" ] || fail "a crewmate spawned FROM the secondmate home must NOT land in the primary's workspace"
 pass "real herdr E2E: a crewmate spawned FROM the secondmate-shaped home lands in the secondmate's OWN workspace - falls out of per-home resolution, no glue needed"
@@ -206,13 +209,13 @@ FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$PRIMARY_HOME/state" FM_DATA_OVERRID
 rc=$?
 [ "$rc" -eq 0 ] || fail "fm-teardown.sh failed for the primary-shaped crewmate cm1"$'\n'"$(cat "$TD1_OUT")"
 [ -f "$CM1_META" ] && fail "fm-teardown.sh did not remove cm1's meta"
-if herdr pane get "$CM1_PANE" --session "$SESSION" >/dev/null 2>&1; then
+if "$HERDR_LAB_HELPER" run "$SESSION" pane get "$CM1_PANE" >/dev/null 2>&1; then
   fail "fm-teardown.sh did not close cm1's pane"
 fi
-if ! herdr pane get "$SM_PANE" --session "$SESSION" >/dev/null 2>&1; then
+if ! "$HERDR_LAB_HELPER" run "$SESSION" pane get "$SM_PANE" >/dev/null 2>&1; then
   fail "tearing down cm1 must not have closed the secondmate's OWN pane (wrong tab closed)"
 fi
-if ! herdr pane get "$CM2_PANE" --session "$SESSION" >/dev/null 2>&1; then
+if ! "$HERDR_LAB_HELPER" run "$SESSION" pane get "$CM2_PANE" >/dev/null 2>&1; then
   fail "tearing down cm1 must not have closed cm2's pane (wrong tab closed)"
 fi
 WT1=
@@ -225,10 +228,10 @@ FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$SM_HOME/state" FM_DATA_OVERRIDE="$S
 rc=$?
 [ "$rc" -eq 0 ] || fail "fm-teardown.sh failed for the secondmate-owned crewmate cm2"$'\n'"$(cat "$TD2_OUT")"
 [ -f "$CM2_META" ] && fail "fm-teardown.sh did not remove cm2's meta"
-if herdr pane get "$CM2_PANE" --session "$SESSION" >/dev/null 2>&1; then
+if "$HERDR_LAB_HELPER" run "$SESSION" pane get "$CM2_PANE" >/dev/null 2>&1; then
   fail "fm-teardown.sh did not close cm2's pane"
 fi
-if ! herdr pane get "$SM_PANE" --session "$SESSION" >/dev/null 2>&1; then
+if ! "$HERDR_LAB_HELPER" run "$SESSION" pane get "$SM_PANE" >/dev/null 2>&1; then
   fail "tearing down cm2 must not have closed the secondmate's OWN pane (wrong tab closed)"
 fi
 WT2=

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -15,7 +15,14 @@ set -u
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 
+# Keep standalone server-owner tests independent from the Herdr pane that may
+# be hosting the test runner itself.
+unset HERDR_ENV HERDR_PANE_ID HERDR_SOCKET_PATH HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SESSION
+
 TMP_ROOT=$(fm_test_tmproot fm-backend-herdr-tests)
+TEST_PRIMARY_HOME="$TMP_ROOT/primary-home"
+mkdir -p "$TEST_PRIMARY_HOME"
+export FM_HOME="$TEST_PRIMARY_HOME"
 export FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP=0
 
 # make_herdr_fakebin: a `herdr` stub that logs every invocation (one line,
@@ -307,6 +314,61 @@ test_container_ensure_starts_server_and_workspace() {
   assert_contains "$(cat "$log")" $'\x1f''workspace'$'\x1f''create'$'\x1f''--cwd'$'\x1f''/tmp'$'\x1f''--label'$'\x1f''firstmate' \
     "container_ensure did not create the firstmate workspace with the given cwd"
   pass "fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id"
+}
+
+test_server_ensure_nested_default_status_miss_refuses_competing_start() {
+  local dir log resp fb out status home
+  dir="$TMP_ROOT/nested-default-status-miss"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  home="$dir/secondmate-home"; mkdir -p "$home"
+  printf 'design\n' > "$home/.fm-secondmate-home"
+  printf '{"server":{"running":false}}\n' > "$resp/1.out"
+  printf '{"server":{"running":true}}\n' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_HERDR_SCRIPT_STATUS=1 HERDR_ENV=1 HERDR_PANE_ID=w1:p7 \
+    HERDR_WORKSPACE_ID=w1 HERDR_SOCKET_PATH=/tmp/herdr.sock \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure default' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a secondmate watcher inside the implicit default Herdr session must not start a competing server after a scoped status miss"
+  assert_contains "$out" "refusing to start a competing server" \
+    "nested default-session refusal did not explain the single-server ownership boundary"
+  assert_not_contains "$(cat "$log")" $'\x1f''server' \
+    "nested default-session status miss attempted to start a competing Herdr server"
+  pass "fm_backend_herdr_server_ensure: a secondmate watcher inheriting the implicit default session refuses a competing same-socket server start"
+}
+
+test_server_ensure_nested_named_session_attaches_when_running() {
+  local dir log resp fb
+  dir="$TMP_ROOT/nested-named-running"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"server":{"running":true}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+    HERDR_ENV=1 HERDR_SESSION=fm-lab-owned HERDR_PANE_ID=w1:p3 \
+    HERDR_WORKSPACE_ID=w1 HERDR_SOCKET_PATH=/tmp/fm-lab-owned.sock \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure fm-lab-owned' "$ROOT" \
+    || fail "a nested caller should attach when its exact inherited named session reports running"
+  assert_not_contains "$(cat "$log")" $'\x1f''server' \
+    "healthy nested named-session attach attempted a server start"
+  pass "fm_backend_herdr_server_ensure: a nested caller safely attaches to its already-running inherited named session"
+}
+
+test_server_ensure_nested_session_mismatch_refuses_cross_session_target() {
+  local dir log resp fb out status
+  dir="$TMP_ROOT/nested-session-mismatch"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"server":{"running":true}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+    HERDR_ENV=1 HERDR_SESSION=owned HERDR_PANE_ID=w1:p4 \
+    HERDR_WORKSPACE_ID=w1 HERDR_SOCKET_PATH=/tmp/owned.sock \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure other' "$ROOT" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a nested caller must not silently target a session other than its inherited owner"
+  assert_contains "$out" "target session 'other'" \
+    "nested cross-session refusal did not name the requested session"
+  assert_contains "$out" "owning session 'owned'" \
+    "nested cross-session refusal did not name the inherited owner session"
+  [ ! -s "$log" ] || fail "nested cross-session mismatch should refuse before contacting any Herdr server"
+  pass "fm_backend_herdr_server_ensure: a nested caller refuses a different target session before any CLI selection"
 }
 
 test_container_ensure_reuses_existing_workspace() {
@@ -933,8 +995,8 @@ SH
   status=$?
   [ "$status" -eq 0 ] || fail "best-effort projection ordering must not fail the spawn"
   [ -z "$out" ] || fail "successful projection ordering emitted a warning: $out"
-  [ "$(cat "$mover_log")" = "$(cd /tmp && pwd -P)/fmtest.sock"$'\t'"w5"$'\t'"2" ] \
-    || fail "projection ordering did not move only the exact new response id to the owning-parent append index"
+  [ "$(cat "$mover_log")" = "/tmp/fmtest.sock"$'\t'"w5"$'\t'"2" ] \
+    || fail "projection ordering did not preserve the server-advertised socket path or move only the exact new response id"
   assert_not_contains "$(cat "$log")" $'workspace\x1fclose' "projection ordering called workspace close"
   assert_not_contains "$(cat "$log")" $'session\x1fdelete' "projection ordering called session delete"
   assert_not_contains "$(cat "$log")" $'workspace\x1frename' "projection ordering called a label-based workspace mutation"
@@ -965,7 +1027,7 @@ SH
   status=$?
   [ "$status" -eq 0 ] || fail "secondmate parent ordering must not fail the spawn: $out"
   [ -z "$out" ] || fail "successful secondmate ordering emitted a warning: $out"
-  [ "$(cat "$mover_log")" = "$(cd /tmp && pwd -P)/fmtest.sock"$'\t'"w6"$'\t'"4" ] \
+  [ "$(cat "$mover_log")" = "/tmp/fmtest.sock"$'\t'"w6"$'\t'"4" ] \
     || fail "secondmate child was not inserted after its parent block: $(cat "$mover_log")"
   assert_not_contains "$(cat "$log")" $'workspace\x1frename' "secondmate ordering renamed a legacy child"
   pass "herdr presentation ordering: secondmate children append under their owning parent block"
@@ -1019,7 +1081,7 @@ SH
   status=$?
   [ "$status" -eq 0 ] || fail "intervening parent ordering must not fail the spawn: $out"
   [ -z "$out" ] || fail "legitimate intervening parent ordering emitted a warning: $out"
-  [ "$(cat "$mover_log")" = "$(cd /tmp && pwd -P)/fmtest.sock"$'\t'"w6"$'\t'"2" ] \
+  [ "$(cat "$mover_log")" = "/tmp/fmtest.sock"$'\t'"w6"$'\t'"2" ] \
     || fail "intervening parent block prevented the owning-parent insertion: $(cat "$mover_log")"
   pass "herdr presentation ordering: intervening parent child blocks remain traversable"
 }
@@ -1046,7 +1108,7 @@ SH
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_projection_focus_snapshot() { printf "w2\tw2:t1"; }; fm_backend_herdr_projection_focus_restore() { return 0; }; fm_backend_herdr_projection_order_best_effort fmtest w3 firstmate' "$ROOT" 2>&1)
   status=$?
   [ "$status" -eq 0 ] || fail "human-interleaved ordering must not fail: $out"
-  [ "$(cat "$mover_log")" = "$(cd /tmp && pwd -P)/fmtest.sock"$'\t'"w3"$'\t'"2" ] \
+  [ "$(cat "$mover_log")" = "/tmp/fmtest.sock"$'\t'"w3"$'\t'"2" ] \
     || fail "human spaces changed the move target or insert index: $(cat "$mover_log")"
   pass "herdr presentation ordering: only the exact new id moves; human spaces keep relative order"
 }
@@ -2831,6 +2893,9 @@ test_workspace_label_empty_marker_falls_back_to_primary
 test_workspace_label_different_secondmates_get_different_labels
 test_cli_helper_sets_env_and_appends_trailing_session_flag
 test_container_ensure_starts_server_and_workspace
+test_server_ensure_nested_default_status_miss_refuses_competing_start
+test_server_ensure_nested_named_session_attaches_when_running
+test_server_ensure_nested_session_mismatch_refuses_cross_session_target
 test_container_ensure_reuses_existing_workspace
 test_container_ensure_creates_with_no_focus_flag
 test_container_ensure_uses_secondmate_home_label

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -14,6 +14,8 @@ set -u
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-batch)
+EMPTY_CONFIG="$TMP_ROOT/empty-config"
+mkdir -p "$EMPTY_CONFIG"
 export FM_BACKEND=tmux
 
 # Clear ambient firstmate overrides so the behavior test owns its environment.
@@ -23,7 +25,7 @@ run_spawn() {
     FM_STATE_OVERRIDE='' \
     FM_DATA_OVERRIDE='' \
     FM_PROJECTS_OVERRIDE='' \
-    FM_CONFIG_OVERRIDE='' \
+    FM_CONFIG_OVERRIDE="$EMPTY_CONFIG" \
     FM_SPAWN_NO_GUARD=1 \
     "$SPAWN" "$@" 2>&1
 }
@@ -79,12 +81,12 @@ test_projects_path_scoping() {
     projects="$TMP_ROOT/$id projects"
     mkdir -p "$home/data" "$projects/alpha"
     if [ "$use_override" = yes ]; then
-      out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
+      out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_CONFIG_OVERRIDE="$EMPTY_CONFIG" \
         FM_HOME="$home" FM_PROJECTS_OVERRIDE="$projects" FM_SPAWN_NO_GUARD=1 \
         "$SPAWN" "$id" projects/alpha codex 2>&1)
     else
       mkdir -p "$home/projects/alpha"
-      out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
+      out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE="$EMPTY_CONFIG" \
         FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
         "$SPAWN" "$id" projects/alpha codex 2>&1)
     fi


### PR DESCRIPTION
## Intent

Validate and ship the committed long-term Firstmate Herdr single-server ownership fix for the split-brain fleet visibility failure reproduced on 2026-07-30. Prevent every Firstmate-launched process already inside a Herdr pane, including primary agents, secondmates, child agents, watchers, recovery, and AFK paths across Pi, Claude, Codex, and Grok, from starting or silently claiming a competing default Herdr server or shared socket. Such a process must attach only to its exact inherited named session through the guarded backend path when that session reports running, or stop safely with a clear actionable diagnostic before any cross-session selection or server start. Preserve one shared visible session and the primary Pi UI, all secondmate and unlanded work, and keep F03-F12 workflow records historical and unchanged. Use only isolated non-default named Herdr labs for lifecycle validation, preserve the default-session tripwire, and verify the current live runtime separately without destructive broad process termination, implicit-session lifecycle commands, silent fallback, or automatic repair of the already-existing split. Retain the documented limit that an existing split requires a separate controlled runtime repair, and leave the secondary custom number-tab bindings outside this ownership fix.

## What Changed

- Make nested Herdr processes attach only to their inherited running session, rejecting cross-session targets and missing servers instead of starting a competing server.
- Preserve Herdr's advertised socket path for transport while canonicalizing lock identity, and extend exact presentation recovery lock waits to 30 seconds.
- Add nested-process and isolated named-lab coverage, plus documentation for server ownership and the manual repair requirement for existing splits.

## Risk Assessment

🚨 High: Captain, the server-start path is protected, but the authoritative requirement also forbids cross-session selection, which several required runtime paths can still perform without the guard.

## Testing

Inspected the committed ownership diff and historical scope, ran the deterministic adapter suite and the complete isolated real-Herdr family, corrected and retried one validator-environment-blocked multi-home test, captured a direct actionable-refusal transcript proving zero server starts, and separately confirmed the live default runtime, primary focus, tripwire, lab cleanup, and clean worktree; all product behavior passed.

<details>
<summary>Evidence: Actionable nested-process refusal with zero server starts</summary>

<code>nested_probe_exit=1&#10;diagnostic=error: Herdr session &#39;fm-lab-evidence&#39; is not reachable as running from inside Herdr session &#39;fm-lab-evidence&#39; (pane w9:p9, socket /tmp/fm-lab-evidence.sock); refusing to start a competing server. Start or repair the named session from its outer Herdr owner, then retry.&#10;server_call_count=0</code>

```text
nested_probe_exit=1
diagnostic=error: Herdr session 'fm-lab-evidence' is not reachable as running from inside Herdr session 'fm-lab-evidence' (pane w9:p9, socket /tmp/fm-lab-evidence.sock); refusing to start a competing server. Start or repair the named session from its outer Herdr owner, then retry. 
cli_calls=HERDR_SESSION=fm-lab-evidencestatus--json--sessionfm-lab-evidence;
server_call_count=0
```
</details>
<details>
<summary>Evidence: Real split-brain reproduction</summary>

`Real named-pane reproduction covering auto-detected spawn, exact inherited-session targeting, competing-server refusal, teardown, and default-session tripwire preservation.`

```text
ok - real herdr: fm-spawn.sh auto-detects herdr from HERDR_ENV=1 (no explicit config) and prints the loud notice
ok - real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta
ok - real herdr: the auto-detected spawn's launch command actually ran in the herdr pane
ok - real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)
ok - real herdr: a secondmate-watcher-shaped process inside a named lab pane refuses a competing same-socket server start
ok - real herdr: isolated lab session removed and default fleet session unchanged
```
</details>
<details>
<summary>Evidence: Complete guarded real-Herdr lifecycle run</summary>

`Complete guarded lifecycle family covering AFK, watcher events, presentation locking, restart/recovery, pruning, respawn, multi-home behavior, and cleanup. One validator-environment block was retried separately and passed.`

```text
FM_TEST_BEGIN 2026-07-30T15:49:27Z tests/fm-afk-inject-herdr-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - real herdr Scenario A: partial input defers injection; digest arrives clean after idle
ok - real herdr Scenario B: swallowed Enter (via the herdr shim) produces exactly one clean digest
ok - real herdr Scenario C: a normal captain status injects exactly one clean single-line sentinel digest
ok - real herdr Scenario D: a persistently pending composer raises the max-defer wedge alarm, preserves the buffer, and never crashes the daemon
all real-herdr afk injection e2e tests passed
FM_TEST_END 2026-07-30T15:50:32Z tests/fm-afk-inject-herdr-e2e.test.sh exit=0 duration_ms=64282 gate_skip=false
FM_TEST_BEGIN 2026-07-30T15:50:32Z tests/fm-afk-launch.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - launcher paths: relative home and state ignore CDPATH before daemon command construction
ok - launcher paths: absolute symlink spellings are preserved
ok - launcher paths: unresolved relative FM_HOME fails loudly
ok - launcher paths: unresolved relative FM_STATE_OVERRIDE fails loudly
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
ok - concurrent start: one serialized daemon terminal remains tracked
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-254831595-83607-11070-1785426665'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-3597013958-83639-20106-1785426665'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T//fm-afk-restore-fail.woWpiQ/state/.afk-launch-backup.VUvGRW
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
ok - herdr e2e: captain tab pane count unchanged after start (no split)
ok - herdr e2e: daemon launched in a separate non-visible workspace
ok - herdr e2e: daemon pane is NOT in the captain's tab
ok - herdr e2e: daemon terminal scoped to the lab session
ok - herdr e2e: captain tab pane count restored after stop
ok - herdr e2e: daemon workspace removed by exact id on stop
ok - herdr e2e: record + .afk cleared on stop
ok - tmux e2e: captain window pane count unchanged after start (no split-window)
ok - tmux e2e: daemon launched in a separate detached session
ok - tmux e2e: captain window pane count unchanged after stop
ok - tmux e2e: daemon session killed by exact id on stop
ok - tmux e2e: record + .afk cleared on stop
FM_TEST_END 2026-07-30T15:51:07Z tests/fm-afk-launch.test.sh exit=0 duration_ms=35587 gate_skip=false
FM_TEST_BEGIN 2026-07-30T15:51:07Z tests/fm-backend-autodetect-smoke.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - real herdr: fm-spawn.sh auto-detects herdr from HERDR_ENV=1 (no explicit config) and prints the loud notice
ok - real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta
ok - real herdr: the auto-detected spawn's launch command actually ran in the herdr pane
ok - real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)
ok - real herdr: a secondmate-watcher-shaped process inside a named lab pane refuses a competing same-socket server start
ok - real herdr: isolated lab session removed and default fleet session unchanged
FM_TEST_END 2026-07-30T15:51:22Z tests/fm-backend-autodetect-smoke.test.sh exit=0 duration_ms=14264 gate_skip=false
FM_TEST_BEGIN 2026-07-30T15:51:22Z tests/fm-backend-herdr-eventwait-smoke.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - real herdr (herdr 0.7.3): events.subscribe capability gate passes (protocol >= 16, events surface present in api schema)
ok - real herdr (herdr 0.7.3): a driven idle->blocked transition returns the blocked record in 0.183s (pane w1:p2)
ok - real herdr: the watcher fast-path enqueues a stale wake naming the task window from the live blocked transition
FM_TEST_END 2026-07-30T15:51:24Z tests/fm-backend-herdr-eventwait-smoke.test.sh exit=0 duration_ms=1986 gate_skip=false
FM_TEST_BEGIN 2026-07-30T15:51:24Z tests/fm-backend-herdr-presentation-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - real Herdr lab: flag-off sp

... [1483 bytes truncated] ...

ab: concurrent primary/A/B spawns preserve parent order and exact focus
ok - real Herdr lab: session lock contention from a secondmate home falls back flat with no journal
ok - real Herdr lab: Hi Bit and Wheelhouse-style same-identity restarts reclaim one nested space with exact focus and idempotence
ok - real Herdr lab: secondmate restart binding and reclaim stay isolated to the exact child home and parent
ok - real Herdr lab: concurrent cross-home recoveries replace exact husks under one session lock with no focus drift
ok - real Herdr lab: legacy projection labels and flat secondmate tabs are left unmigrated
ok - real Herdr lab: multi-home exact-pane teardowns restore captain focus without workspace close authority
warning: no exact herdr presentation token match for missing1; leaving any stale space untouched and spawning flat
warning: no exact herdr presentation token match for renamed1; leaving any stale space untouched and spawning flat
warning: 2 exact herdr presentation token matches for duplicate1 are quarantined; inspecting only for duplicate-agent risk
warning: quarantined herdr presentation for duplicate1 is dead or agent-free; exact bound reclaim may proceed, otherwise spawning flat
warning: 2 exact herdr presentation token matches for duplicate1 are quarantined; inspecting only for duplicate-agent risk
error: quarantined herdr presentation for duplicate1 has a live pane; refusing duplicate launch
ok - real Herdr lab: missing, renamed, and duplicate tokens trigger zero destructive or adoptive calls, and live duplicate risk refuses launch
ok - real Herdr lab validation completed on Herdr 0.7.3 with the default-session tripwire intact
FM_TEST_END 2026-07-30T15:57:57Z tests/fm-backend-herdr-presentation-e2e.test.sh exit=0 duration_ms=393214 gate_skip=false
FM_TEST_BEGIN 2026-07-30T15:57:57Z tests/fm-backend-herdr-prune-safety-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - repro setup: a pre-existing workspace labeled 'firstmate' collides with the primary home's own label
ok - repro setup: a live long-running process is running in the startup workspace's single tab (label '1'), heartbeating to a marker file
ok - fixed: container_ensure adopts the label-colliding startup workspace and reports NO seeded default tab (never a prune candidate)
ok - fixed: the live pane (and its live process) survived create_task untouched - the exact 2026-07-02 self-kill incident does not reproduce
ok - fixed: the startup workspace's original live tab is still present in tab list after the spawn
ok - happy path: a genuinely fresh workspace's seeded default tab is still pruned, leaving exactly one clean fm-<id> task tab
FM_TEST_END 2026-07-30T15:58:06Z tests/fm-backend-herdr-prune-safety-e2e.test.sh exit=0 duration_ms=8942 gate_skip=false
FM_TEST_BEGIN 2026-07-30T15:58:06Z tests/fm-backend-herdr-respawn-idem-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - repro setup: two real fm-<id> task tabs exist (crewmate-shaped and secondmate-shaped), neither with a registered agent
ok - repro confirmed: after a real session restart, both task panes survive alive but with no registered agent - the restored-layout husk
ok - fixed: create_task closes and replaces the crewmate-shaped restored husk instead of refusing - no manual pane close needed
ok - fixed: create_task closes and replaces the secondmate-shaped restored husk instead of refusing - same fix, same function, both spawn shapes
ok - fixed: the workspace holds exactly the 2 replacement tabs after both respawns - no leaked husk tabs, no destroyed workspace
ok - fixed: a genuinely live duplicate (a real registered agent) still refuses exactly as before - the husk fix never closes a live pane
FM_TEST_END 2026-07-30T15:58:09Z tests/fm-backend-herdr-respawn-idem-e2e.test.sh exit=0 duration_ms=2625 gate_skip=false
FM_TEST_BEGIN 2026-07-30T15:58:09Z tests/fm-backend-herdr-smoke.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - real herdr: version_check accepts the installed binary's protocol
ok - real herdr: container_ensure starts the isolated session's server, creates the firstmate workspace (fm-lab-backend-smoke-28312:w1), and reports its seeded default tab id (w1:t1)
ok - real herdr: container_ensure is idempotent (reuses/adopts the existing firstmate workspace, reports no seeded default tab on adoption)
ok - real herdr: create_task prunes the freshly-created workspace's seeded default tab, leaving exactly one clean fm-<id> task tab
ok - real herdr: create_task refuses a same-labeled tab whose pane hosts a genuinely live registered agent (unchanged behavior)
ok - real herdr: create_task closes and replaces a same-labeled tab whose pane hosts no registered agent (the restored-husk shape), leaving the workspace intact
ok - real herdr: a secondmate-shaped home (.fm-secondmate-home) gets its OWN herdr workspace, distinct from the primary's, in the SAME session
ok - real herdr: the secondmate-shaped home's workspace is labeled 2ndmate-<secondmate-id> in herdr itself
ok - real herdr: a task spawned into the secondmate-shaped home lands as a tab inside the secondmate's OWN workspace
ok - real herdr: list_live stays scoped to each home's own workspace - neither home sees the other's tasks
ok - real herdr: BOTH workspace ids/labels AND both tasks' pane ids survive a session stop + fresh server restart (multi-workspace shape)
ok - real herdr: send_text_line runs a command atomically (pane run) and its output is capturable
ok - real herdr: send_literal + send_key Enter submit as two separate steps (verified: send-text does NOT auto-submit)
ok - real herdr: current_path reads the pane's live cwd
note: FM_HERDR_SMOKE_REAL_CLAUDE=1 not set; skipping the real-agent busy_state check
ok - real herdr: kill removes the pane and is idempotent/best-effort
ok - real herdr: list_live discovers a live task tab by fm-<id> label
FM_TEST_END 2026-07-30T15:58:14Z tests/fm-backend-herdr-smoke.test.sh exit=0 duration_ms=5086 gate_skip=false
FM_TEST_BEGIN 2026-07-30T15:58:14Z tests/fm-backend-herdr-workspace-per-home-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
not ok - primary-shaped crewmate spawn failed
--- stdout ---

--- stderr ---
error: no-mistakes gate agent must not drive the fleet (NO_MISTAKES_GATE set)
fm-herdr-lab: missing fleet-state tripwire for 'fm-lab-fm-herdr-workspa-30027-21629'; refusing destructive calls
FM_TEST_END 2026-07-30T15:58:15Z tests/fm-backend-herdr-workspace-per-home-e2e.test.sh exit=1 duration_ms=987 gate_skip=false
FM_TEST_BEGIN 2026-07-30T15:58:15Z tests/fm-herdr-session-cleanup-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - real named lab reproduced the exact restored one-tab one-pane childless no-agent shell shape
ok - real named lab cleanup closes only the exact stale pane and preserves exact focus
ok - real named lab cleanup is idempotent and leaves the default fleet session to the teardown tripwire
evidence: herdr=0.7.3 protocol=16 default-session-tripwire=armed
FM_TEST_END 2026-07-30T15:58:22Z tests/fm-herdr-session-cleanup-e2e.test.sh exit=0 duration_ms=7519 gate_skip=false
FM_TEST_SUMMARY total=10 failed=1 skipped_gate=0 duration_ms=534978
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=10 duration_ms=534492 failed=1
FM_TEST_SLOWEST rank=1 script=tests/fm-backend-herdr-presentation-e2e.test.sh duration_ms=393214
FM_TEST_SLOWEST rank=2 script=tests/fm-afk-inject-herdr-e2e.test.sh duration_ms=64282
FM_TEST_SLOWEST rank=3 script=tests/fm-afk-launch.test.sh duration_ms=35587
FM_TEST_SLOWEST rank=4 script=tests/fm-backend-autodetect-smoke.test.sh duration_ms=14264
FM_TEST_SLOWEST rank=5 script=tests/fm-backend-herdr-prune-safety-e2e.test.sh duration_ms=8942
FM_TEST_SLOWEST rank=6 script=tests/fm-herdr-session-cleanup-e2e.test.sh duration_ms=7519
FM_TEST_SLOWEST rank=7 script=tests/fm-backend-herdr-smoke.test.sh duration_ms=5086
FM_TEST_SLOWEST rank=8 script=tests/fm-backend-herdr-respawn-idem-e2e.test.sh duration_ms=2625
FM_TEST_SLOWEST rank=9 script=tests/fm-backend-herdr-eventwait-smoke.test.sh duration_ms=1986
FM_TEST_SLOWEST rank=10 script=tests/fm-backend-herdr-workspace-per-home-e2e.test.sh duration_ms=987
```
</details>
<details>
<summary>Evidence: Multi-home topology retry</summary>

`Primary, secondmate, and secondmate-child spawns shared the named session while remaining home-scoped; exact teardown preserved sibling work.`

```text
ok - real herdr E2E: a primary-shaped home spawns a crewmate on the herdr backend
ok - real herdr E2E: the primary-shaped home's crewmate landed in the 'firstmate' workspace
ok - real herdr E2E: the primary spawns a --secondmate task on the herdr backend
ok - real herdr E2E: a --secondmate spawn by the PRIMARY lands in the SECONDMATE's own labeled workspace, distinct from the primary's
ok - real herdr E2E: a crewmate spawns successfully FROM a secondmate-shaped home's own fm-spawn.sh process
ok - real herdr E2E: a crewmate spawned FROM the secondmate-shaped home lands in the secondmate's OWN workspace - falls out of per-home resolution, no glue needed
ok - real herdr E2E: list_live from the primary's own context sees only the primary's own task
ok - real herdr E2E: list_live from the secondmate's own context sees only tasks in the secondmate's own workspace (both its own tab and its crewmate's)
ok - real herdr E2E: tearing down cm1 closes only its own tab - the secondmate's and cm2's tabs survive untouched
ok - real herdr E2E: tearing down cm2 closes only its own tab - the secondmate's own tab (same workspace) survives untouched
```
</details>
<details>
<summary>Evidence: Read-only live runtime snapshot</summary>

<code>Default server remained running on protocol 16, with one visible default session and the focused `firstmate` workspace plus three secondmate workspaces.</code>

```text
LIVE_RUNTIME_READ_ONLY
status={"client_protocol":16,"server_running":true,"server_protocol":16}
default_session=[{"name":"default","default":true,"running":true,"socket_path":"/Users/james/.config/herdr/herdr.sock"}]
visible_sessions=[{"name":"default","default":true,"running":true}]
focused_workspace=[{"workspace_id":"w1S","label":"firstmate","active_tab_id":"w1S:t3"}]
workspace_summary={"count":4,"labels":["firstmate","2ndmate-design-tako","2ndmate-reliability-tako","2ndmate-tax-thailand-tako"]}
```
</details>
<details>
<summary>Evidence: Herdr adapter suite</summary>

Source: Herdr adapter suite (local file: <code>/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T/no-mistakes-evidence/01KYSTFF0AC95XSXA08X82N3S9/fm-backend-herdr-unit.log</code>)

```text
Deterministic coverage for implicit-default refusal, exact inherited named-session attachment, cross-session refusal before CLI selection, and shared socket locking.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `bin/backends/herdr.sh:821` - The required criterion says a nested process must use only its inherited session or stop &#34;before any cross-session selection or server start.&#34; The new ownership check exists only inside `fm_backend_herdr_server_ensure`, so direct CLI paths bypass it: recovery/liveness deliberately selects the metadata session directly in `fm_backend_target_exists`, AFK paths do likewise, and watcher capability checks use bare `herdr status` and `herdr api schema`. Stale or cross-session metadata can therefore select another session before this guard runs. Move inherited-owner validation to the shared CLI boundary, or apply a common no-start guard to every direct path, with coverage for watcher, liveness, recovery, and AFK calls.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-status a53ffc17fe5b4c6c2ba0de80e82adbbf16ec9253..8881ad9fd251ff88eac18a8afeb71da78096953b` and focused diff inspection against the authoritative intent</code>
- `bash -o pipefail -c 'bash tests/fm-backend-herdr.test.sh 2>&1 | tee .../fm-backend-herdr-unit.log'`
- `bash -o pipefail -c 'bash tests/fm-backend-autodetect-smoke.test.sh 2>&1 | tee .../fm-backend-autodetect-smoke.log'`
- `HERDR_LAB_HELPER=bin/fm-herdr-lab.sh bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip 'herdr not found'`
- <code>`env -u NO_MISTAKES_GATE HERDR_LAB_HELPER=bin/fm-herdr-lab.sh bash tests/fm-backend-herdr-workspace-per-home-e2e.test.sh` - confirmed the remaining gate-worktree setup blocker</code>
- <code>`env -u NO_MISTAKES_GATE FM_GATE_REFUSE_BYPASS=1 HERDR_LAB_HELPER=bin/fm-herdr-lab.sh bash tests/fm-backend-herdr-workspace-per-home-e2e.test.sh` - setup-corrected retry</code>
- <code>Manual nested status-miss probe with `HERDR_ENV=1`, an exact named session, and a fake scoped CLI; recorded the diagnostic and verified `server_call_count=0`</code>
- <code>Read-only live checks: `herdr status --json --session default`, `herdr session list --json --session default`, and `herdr workspace list --session default`</code>
- <code>Cleanup checks: no remaining `fm-lab-*` sessions, `git status --short` empty, and `HEAD` equals target commit `8881ad9fd251ff88eac18a8afeb71da78096953b`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
