### PR TITLE
fix(spawn): default non-UI reports to Markdown

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -62,7 +62,7 @@ It never tears down a task, merges a PR, dispatches new work, steers a worker, a
    - **Underway** - each live direct report making progress, with its current state, and the plans or main pickup pointers worth reopening (`data/<id>/report.md` files, `.lavish/*.html` boards).
    - **Charted Next** - queued or gated work, including any main-inventory integrity warning, with each item's blocker, date, or integrity reason.
    After writing the file, return the concise four-section chat digest and include the report path or link without adding a fifth section.
-   For a richer review surface, optionally offer a Lavish board with `lavish-axi` when the report has enough structure to deserve one, but only after the required digest is ready.
+   Apply `AGENTS.md` section 9's Lavish selection rule to any optional review surface; report structure alone is never a trigger.
 
 ## Chat-response contract
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -373,7 +373,8 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 | Composer | Bordered box with a bare `>` prompt glyph and no observed ghost or placeholder text. |
 | Effort | No reasoning-effort flag exists, so requested effort is recorded in task metadata but omitted from launch. |
 
-`fm-spawn.sh` launches Kimi bare, waits for the composer box or `Welcome to Kimi Code!`, sends the one-line output contract plus the exact absolute brief pointer for ordinary crewmates, and requires a cleared composer plus either the echoed `✨` submission or nonzero context before accepting delivery.
+`fm-spawn.sh` launches Kimi bare, waits for the composer box or `Welcome to Kimi Code!`, then sends one line: ordinary crewmates receive the output contract followed by `Read the brief at <absolute-path> and follow it exactly.`, while secondmates receive that exact absolute brief pointer alone.
+Delivery succeeds only after the composer clears and either the echoed `✨` submission or nonzero context appears.
 This launch-then-send shape is mandatory because Kimi rejects a positional brief as an unknown command.
 Sending before readiness was reproduced as a silent drop with a zero exit status, an empty composer, `context: 0%`, no echoed user message, and a healthy-looking idle pane.
 The brief path must be absolute because the brief lives outside the task worktree, and Kimi reads it there without `--add-dir`.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -278,7 +278,7 @@ Firstmate launches the selected executable name from `PATH`, records `pi-signed`
 The observed signed process tree is an exact `pi-signed` wrapper parent with the Pi application as its child, while tmux reports the foreground command as the exact `pi-launcher` name for both selected executables.
 The installed plain `pi` command also execs that signed launcher, so `FM_PI_HARNESS=pi-signed` is the authoritative selection marker and shared unmarked ancestry remains `pi`.
 Firstmate sets `FM_PI_HARNESS` explicitly for both worker launch identities, and a signed primary uses the README launch command to establish the same boundary.
-Keep the brief as one positional argument.
+Keep the combined ordinary-crewmate output contract and task brief as one positional argument; secondmates still receive their charter unchanged.
 Multiple positional args become separate queued messages; `fm-spawn`'s template already does this correctly.
 
 Project trust dialog can appear on the first pi run in any not-yet-trusted directory, observed even on clean worktrees.
@@ -300,7 +300,7 @@ When a secondmate is launched on Pi or pi-signed, `fm-spawn.sh --secondmate` lau
 ## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99; exit paths re-verified 2026-07-19 on grok 0.2.103)
 
 Grok Build TUI (`grok`), a Claude-Code-compatible CLI from xAI.
-Launch with a positional prompt: `grok --always-approve "$(cat <brief>)"`.
+Launch with one positional prompt containing the ordinary-crewmate output contract followed by the task brief; secondmates receive their charter unchanged.
 For Grok's supported reasoning-effort values and omission behavior, see the [launch-profile-axes table](#launch-profile-axes).
 
 | Fact | Value |

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -373,7 +373,7 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 | Composer | Bordered box with a bare `>` prompt glyph and no observed ghost or placeholder text. |
 | Effort | No reasoning-effort flag exists, so requested effort is recorded in task metadata but omitted from launch. |
 
-`fm-spawn.sh` launches Kimi bare, waits for the composer box or `Welcome to Kimi Code!`, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires a cleared composer plus either the echoed `✨` submission or nonzero context before accepting delivery.
+`fm-spawn.sh` launches Kimi bare, waits for the composer box or `Welcome to Kimi Code!`, sends the one-line output contract plus the exact absolute brief pointer for ordinary crewmates, and requires a cleared composer plus either the echoed `✨` submission or nonzero context before accepting delivery.
 This launch-then-send shape is mandatory because Kimi rejects a positional brief as an unknown command.
 Sending before readiness was reproduced as a silent drop with a zero exit status, an empty composer, `context: 0%`, no echoed user message, and a healthy-looking idle pane.
 The brief path must be absolute because the brief lives outside the task worktree, and Kimi reads it there without `--add-dir`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ When that section reports its checks still in progress it names exactly what is 
 
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
-Use `gh-axi` for GitHub, `chrome-devtools-axi` for browser work, and `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
+Use `gh-axi` for GitHub and `chrome-devtools-axi` for browser work; section 9 owns `lavish-axi` review selection, and current tool help owns exact flags.
 A silent bootstrap section needs no action; for any printed actionable diagnostic line, load `bootstrap-diagnostics` and follow its owner procedure.
 `BOOTSTRAP_INFO:` lines are completed no-action facts and do not require loading a skill.
 `secondmate-provisioning` owns startup secondmate sync, liveness, and inherited local-material convergence.
@@ -459,7 +459,8 @@ Reach the captain immediately for:
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
 When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.
-Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.
+Default non-UI engineering work to plain Markdown reports and chat; report complexity, technical structure, or multiple sections do not justify opening `lavish-axi`.
+Use `lavish-axi` only when the captain explicitly requests an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review; `bin/fm-spawn.sh` carries the corresponding ordinary-crewmate launch contract across every verified harness.
 Whenever a PR is mentioned, include its full `https://...` URL before any shorthand reference.
 Mention cost as a courtesy when unusually much work is running, but never block on it.
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -131,6 +131,8 @@
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
+#     __LAUNCHBRIEF__ command that encodes the charter unchanged for secondmates,
+#                  or prepends the ordinary-crewmate output contract for ship/scout
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -240,6 +242,10 @@ YOLO_SET=0
 TRACEPARENT_SET=0
 POS=()
 want_value=
+# AGENTS.md section 9 owns this policy. Launch-time reinforcement is deliberate:
+# unlike a scaffold-only rule, it also reaches custom briefs and never exposes or
+# parses captain-private preference files.
+CREWMATE_OUTPUT_CONTRACT='Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task explicitly requests an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'
 for a in "$@"; do
   if [ -n "$want_value" ]; then
     case "$a" in
@@ -826,20 +832,20 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__LAUNCHBRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__LAUNCHBRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__LAUNCHBRIEF__)"'
       fi
       ;;
-    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__LAUNCHBRIEF__)"' ;;
     pi|pi-signed)
       if [ "$kind" = secondmate ]; then
-        printf '%s%s' "$harness" ' __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s%s' "$harness" ' __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__LAUNCHBRIEF__)"'
       else
-        printf '%s%s' "$harness" ' __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s%s' "$harness" ' __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__LAUNCHBRIEF__)"'
       fi
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
@@ -849,7 +855,7 @@ launch_template() {
     # --dangerously-skip-permissions. grok's turn-end signal does NOT ride the
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
-    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__LAUNCHBRIEF__)"' ;;
     # Kimi Code rejects a positional prompt, so it launches bare and receives
     # only an absolute brief pointer after the TUI readiness gate below.
     # Its turn-end signal is a globally configured Stop hook plus a guarded
@@ -2235,10 +2241,17 @@ sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
+if [ "$KIND" = secondmate ]; then
+  LAUNCHBRIEF="$sq_opinput encode launch-brief < $sq_brief"
+else
+  sq_output_contract=$(shell_quote "$CREWMATE_OUTPUT_CONTRACT")
+  LAUNCHBRIEF="{ printf '%s\\n\\n' $sq_output_contract; cat $sq_brief; } | $sq_opinput encode launch-brief"
+fi
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
+LAUNCH=${LAUNCH//__LAUNCHBRIEF__/$LAUNCHBRIEF}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
@@ -2304,7 +2317,11 @@ if [ "$HARNESS" = kimi ]; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"
     exit 1
   fi
-  KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
+  if [ "$KIND" = secondmate ]; then
+    KIMI_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
+  else
+    KIMI_POINTER="$CREWMATE_OUTPUT_CONTRACT Read the brief at $BRIEF_REAL and follow it exactly."
+  fi
   KIMI_SUBMIT_RETRIES=${FM_KIMI_SUBMIT_RETRIES:-3}
   KIMI_SUBMIT_SLEEP=${FM_KIMI_SUBMIT_SLEEP:-${FM_KIMI_POLL_INTERVAL:-0.5}}
   KIMI_SUBMIT_SETTLE=${FM_KIMI_SUBMIT_SETTLE:-0}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -245,7 +245,7 @@ want_value=
 # AGENTS.md section 9 owns this policy. Launch-time reinforcement is deliberate:
 # unlike a scaffold-only rule, it also reaches custom briefs and never exposes or
 # parses captain-private preference files.
-CREWMATE_OUTPUT_CONTRACT='Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task explicitly requests an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'
+CREWMATE_OUTPUT_CONTRACT='Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'
 for a in "$@"; do
   if [ -n "$want_value" ]; then
     case "$a" in
@@ -857,7 +857,7 @@ launch_template() {
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__LAUNCHBRIEF__)"' ;;
     # Kimi Code rejects a positional prompt, so it launches bare and receives
-    # only an absolute brief pointer after the TUI readiness gate below.
+    # its output contract and absolute brief pointer after the TUI readiness gate.
     # Its turn-end signal is a globally configured Stop hook plus a guarded
     # per-task worktree token, so no launch placeholder belongs here.
     kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -108,6 +108,9 @@
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md task lifecycle); --secondmate records kind=secondmate and launches in a
 #   provisioned firstmate home; the default is kind=ship.
+#   Every ship/scout launch supplies AGENTS.md section 9's output contract ahead
+#   of the task instructions across all verified harnesses, including custom
+#   briefs. Secondmate launches encode their charter unchanged.
 #   Before a secondmate launch, the home is locally fast-forwarded to the primary
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,6 +171,8 @@ When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without 
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
 That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, grok, kimi, and muse while preserving the requested profile for later audit.
+For every verified harness, the same launch path supplies the `AGENTS.md` section 9 output contract ahead of ordinary ship and scout task instructions while leaving secondmate charters unchanged.
+This launch-time boundary also covers custom task briefs without reading captain-private preference files; `tests/fm-spawn-dispatch-profile.test.sh` and `tests/fm-kimi-harness.test.sh` cover the streaming and readiness-gated adapter shapes.
 
 ## Optional secondmates
 

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -177,7 +177,7 @@ EOF
 }
 
 test_kimi_launch_then_send_is_verified() {
-  local id rec out rc launch pointer brief_real meta task_tmp
+  local id rec out rc launch pointer brief_real meta task_tmp output_contract
   id="kimi-success-z1-$$"
   task_tmp="/tmp/fm-$id"
   KIMI_RUNTIME_TASK_TMP=$task_tmp
@@ -200,8 +200,9 @@ test_kimi_launch_then_send_is_verified() {
 
   brief_real="$(cd "$HOME_DIR/data/$id" && pwd -P)/brief.md"
   pointer=$(cat "$CASE_DIR/pointer.log")
-  [ "$pointer" = "Read the brief at $brief_real and follow it exactly." ] \
-    || fail "kimi pointer was not the exact absolute-path-only instruction: $pointer"
+  output_contract="Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task explicitly requests an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review."
+  [ "$pointer" = "$output_contract Read the brief at $brief_real and follow it exactly." ] \
+    || fail "kimi pointer did not combine the shared output contract with the exact absolute brief path: $pointer"
   meta="$HOME_DIR/state/$id.meta"
   assert_grep 'model=kimi-code/k3' "$meta" "kimi meta lost the requested model"
   assert_grep 'effort=high' "$meta" "kimi meta did not retain the unsupported effort axis"

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -200,7 +200,7 @@ test_kimi_launch_then_send_is_verified() {
 
   brief_real="$(cd "$HOME_DIR/data/$id" && pwd -P)/brief.md"
   pointer=$(cat "$CASE_DIR/pointer.log")
-  output_contract="Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task explicitly requests an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review."
+  output_contract="Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review."
   [ "$pointer" = "$output_contract Read the brief at $brief_real and follow it exactly." ] \
     || fail "kimi pointer did not combine the shared output contract with the exact absolute brief path: $pointer"
   meta="$HOME_DIR/state/$id.meta"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -117,7 +117,7 @@ assert_meta_profile() {
 }
 
 test_no_profile_keeps_claude_profile_defaults() {
-  local rec id out status expected launch
+  local rec id out status expected launch output_contract
   id=profile-off-z1
   rec=$(make_spawn_case profile-off claude "$id")
   read_case_record "$rec"
@@ -129,9 +129,45 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  output_contract="Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task explicitly requests an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review."
+  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$({ printf '%s\\n\\n' '$output_contract'; cat '$HOME_DIR/data/$id/brief.md'; } | '${ROOT}/bin/fm-operational-input.sh' encode launch-brief)\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
+}
+
+test_verified_streaming_harnesses_receive_non_ui_markdown_default() {
+  local harness rec id out status launch brief
+  for harness in claude codex opencode pi pi-signed grok; do
+    id="output-contract-${harness}-z1"
+    rec=$(make_spawn_case "output-contract-$harness" "$harness" "$id")
+    read_case_record "$rec"
+    brief="$HOME_DIR/data/$id/brief.md"
+    cat > "$brief" <<'EOF'
+# Task
+
+Diagnose a non-UI engineering failure and write a technically structured report with multiple sections.
+EOF
+
+    out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --scout)
+    status=$?
+    expect_code 0 "$status" "$harness non-UI scout spawn should succeed"
+    assert_contains "$out" "spawned $id harness=$harness kind=scout" \
+      "$harness non-UI scout spawn did not report the expected adapter and kind"
+    launch=$(cat "$LAUNCH_LOG")
+    assert_contains "$launch" "Default non-UI engineering work to plain Markdown reports and chat." \
+      "$harness launch did not receive the Markdown default"
+    assert_contains "$launch" "Report complexity, technical structure, or multiple sections do not justify opening Lavish." \
+      "$harness launch treated report structure as a Lavish trigger"
+    assert_contains "$launch" "Use Lavish only when the task explicitly requests an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review." \
+      "$harness launch did not preserve explicit and genuinely visual Lavish use"
+    assert_not_contains "$launch" "lavish-axi for structured decisions or reports" \
+      "$harness launch retained the broad structured-report Lavish trigger"
+    assert_contains "$launch" "cat '$brief'" \
+      "$harness launch did not combine the output contract with its exact task brief"
+    assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
+      "$harness launch did not use the canonical launch-brief encoder"
+  done
+  pass "every verified streaming harness receives the shared non-UI Markdown launch default"
 }
 
 test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
@@ -158,7 +194,7 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$home_real/state/$id.pi-ext.ts'" \
     "relative FM_STATE_OVERRIDE leaked into Pi's cross-process extension path"
-  assert_contains "$launch" "< '$home_real/data/$id/brief.md'" \
+  assert_contains "$launch" "cat '$home_real/data/$id/brief.md'" \
     "relative FM_DATA_OVERRIDE leaked into the cross-process brief path"
   pass "relative home overrides ignore CDPATH and become absolute before spawn launch construction"
 }
@@ -187,7 +223,7 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$home_real/state/$relative_id.pi-ext.ts'" \
     "relative FM_HOME leaked into Pi's default cross-process extension path"
-  assert_contains "$launch" "< '$home_real/data/$relative_id/brief.md'" \
+  assert_contains "$launch" "cat '$home_real/data/$relative_id/brief.md'" \
     "relative FM_HOME leaked into the default cross-process brief path"
 
   linked_home="$CASE_DIR/home-link"
@@ -207,7 +243,7 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$linked_home/state/$absolute_id.pi-ext.ts'" \
     "absolute FM_HOME spelling changed in Pi's default cross-process extension path"
-  assert_contains "$launch" "< '$linked_home/data/$absolute_id/brief.md'" \
+  assert_contains "$launch" "cat '$linked_home/data/$absolute_id/brief.md'" \
     "absolute FM_HOME spelling changed in the default cross-process brief path"
   pass "FM_HOME defaults resolve relative paths and preserve absolute spellings"
 }
@@ -235,7 +271,7 @@ test_absolute_override_spelling_is_preserved_in_launch_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$linked_home/state/$id.pi-ext.ts'" \
     "absolute FM_STATE_OVERRIDE spelling changed in Pi's cross-process extension path"
-  assert_contains "$launch" "< '$linked_home/data/$id/brief.md'" \
+  assert_contains "$launch" "cat '$linked_home/data/$id/brief.md'" \
     "absolute FM_DATA_OVERRIDE spelling changed in the cross-process brief path"
   pass "absolute override spellings are preserved in spawn launch paths"
 }
@@ -443,8 +479,10 @@ test_grok_omits_invalid_max_reasoning_effort() {
   expect_code 0 "$status" "grok spawn with unsupported max reasoning effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < " \
-    "grok launch did not preserve the model flag and typed brief when max effort was omitted"
+  assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$({ printf" \
+    "grok launch did not preserve the model flag and shared launch contract when max effort was omitted"
+  assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
+    "grok launch did not preserve the typed brief when max effort was omitted"
   assert_not_contains "$launch" "--reasoning-effort" "grok launch must omit unsupported max reasoning effort"
   assert_not_contains "$launch" "--effort" "grok launch must not fall back to --effort for reasoning effort"
   pass "grok omits unsupported max reasoning effort"
@@ -462,8 +500,10 @@ test_grok_omits_invalid_xhigh_reasoning_effort() {
   expect_code 0 "$status" "grok spawn with unsupported xhigh reasoning effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 xhigh
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < " \
-    "grok launch did not preserve the model flag and typed brief when xhigh effort was omitted"
+  assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$({ printf" \
+    "grok launch did not preserve the model flag and shared launch contract when xhigh effort was omitted"
+  assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
+    "grok launch did not preserve the typed brief when xhigh effort was omitted"
   assert_not_contains "$launch" "--reasoning-effort" "grok launch must omit unsupported xhigh reasoning effort"
   assert_not_contains "$launch" "--effort" "grok launch must not fall back to --effort for reasoning effort"
   pass "grok omits unsupported xhigh reasoning effort"
@@ -674,6 +714,7 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
 }
 
 test_no_profile_keeps_claude_profile_defaults
+test_verified_streaming_harnesses_receive_non_ui_markdown_default
 test_relative_home_overrides_launch_with_absolute_cross_process_paths
 test_home_defaults_preserve_absolute_or_resolve_relative_paths
 test_absolute_override_spelling_is_preserved_in_launch_paths

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -129,7 +129,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  output_contract="Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task explicitly requests an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review."
+  output_contract="Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review."
   expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$({ printf '%s\\n\\n' '$output_contract'; cat '$HOME_DIR/data/$id/brief.md'; } | '${ROOT}/bin/fm-operational-input.sh' encode launch-brief)\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
@@ -158,8 +158,8 @@ EOF
       "$harness launch did not receive the Markdown default"
     assert_contains "$launch" "Report complexity, technical structure, or multiple sections do not justify opening Lavish." \
       "$harness launch treated report structure as a Lavish trigger"
-    assert_contains "$launch" "Use Lavish only when the task explicitly requests an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review." \
-      "$harness launch did not preserve explicit and genuinely visual Lavish use"
+    assert_contains "$launch" "Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review." \
+      "$harness launch did not require explicit captain intent or preserve genuinely visual Lavish use"
     assert_not_contains "$launch" "lavish-axi for structured decisions or reports" \
       "$harness launch retained the broad structured-report Lavish trigger"
     assert_contains "$launch" "cat '$brief'" \


### PR DESCRIPTION
## Intent

The developer, acting as captain, wanted Firstmate to default non-UI reports to Markdown instead of Lavish. Lavish should be allowed only when the captain explicitly requested an interactive or visual review, or when genuine UI or visual work materially benefits from a visual surface. The change should keep AGENTS.md section 9 as the single policy owner, reinforce that rule in launch behavior and interface tests, preserve the Bearings pointer, and narrowly document Kimi's one-line output plus exact absolute brief-pointer contract without duplicating policy. They also expected the existing crewmate to remain supervised through no-mistakes validation, documentation checks, PR creation, and CI, without incorrectly treating it as dead or requiring unrelated GitHub authentication.

## What Changed

- Default ordinary ship and scout launches to Markdown/chat for non-UI reports across every verified harness, reserving Lavish for explicit captain requests or genuinely visual work.
- Preserve secondmate charters and Kimi’s readiness-gated absolute brief pointer contract.
- Align the policy, architecture, and harness documentation, with expanded spawn and Kimi adapter coverage.

## Risk Assessment

✅ Low: Captain, the change is well-bounded, preserves existing launch envelopes and secondmate behavior, and introduces no substantiated material risks.

## Testing

Session startup acquired the lock without a GitHub-auth blocker, all focused spawn, Kimi, documentation, and secondmate regressions passed, direct transcripts demonstrate Markdown-first ordinary launches and unchanged secondmate charters, and no visual screenshot was applicable because this is a non-UI CLI policy change.

<details>
<summary>Evidence: Decoded ordinary and secondmate launch brief bodies</summary>

```text
ORDINARY CREWMATE - decoded launch-brief body
Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.

# Task

Diagnose a non-UI engineering failure and write a technically structured report with multiple sections.

SECONDMATE - decoded launch-brief body
Persistent secondmate charter, unchanged.
```
</details>
<details>
<summary>Evidence: Streaming harness launch commands</summary>

```text
+ launch='CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-off/home/data/profile-off-z1/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ output_contract='Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'
+ expected='CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-off/home/data/profile-off-z1/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/output-contract-claude/home/data/output-contract-claude-z1/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/output-contract-codex/home/state/output-contract-codex-z1.turn-ended'\''\"]" "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/output-contract-codex/home/data/output-contract-codex-z1/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode --prompt "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/output-contract-opencode/home/data/output-contract-opencode-z1/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='FM_PI_HARNESS=pi pi -e '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/output-contract-pi/home/state/output-contract-pi-z1.pi-ext.ts'\'' "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/output-contract-pi/home/data/output-contract-pi-z1/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='FM_PI_HARNESS=pi-signed pi-signed -e '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/output-contract-pi-signed/home/state/output-contract-pi-signed-z1.pi-ext.ts'\'' "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/output-contract-pi-signed/home/data/output-contract-pi-signed-z1/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='grok --always-approve "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/output-contract-grok/home/data/output-contract-grok-z1/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
ok - every verified streaming harness receives the shared non-UI Markdown launch default
+ launch='FM_PI_HARNESS=pi pi -e '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-relative-paths/home/state/profile-relative-paths-z1b.pi-ext.ts'\'' "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-relative-paths/home/data/profile-relative-paths-z1b/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='FM_PI_HARNESS=pi pi -e '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-home-defaults/home/state/profile-relative-home-defaults-z1c.pi-ext.ts'\'' "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-home-defaults/home/data/profile-relative-home-defaults-z1c/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='FM_PI_HARNESS=pi pi -e '\''/tmp/fm-spawn-dispatch-profile.

... [4550 bytes truncated] ...

ustify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-codex-max/home/data/profile-codex-max-z4/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='grok --always-approve --model '\''grok-4'\'' --reasoning-effort '\''high'\'' "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-grok/home/data/profile-grok-z5/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='grok --always-approve --model '\''grok-4'\'' "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-grok-max/home/data/profile-grok-max-z6/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='grok --always-approve --model '\''grok-4'\'' "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-grok-xhigh/home/data/profile-grok-xhigh-z6b/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode --model '\''anthropic/claude-sonnet-4-5'\'' --prompt "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-opencode/home/data/profile-opencode-z7/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='FM_PI_HARNESS=pi pi --model '\''openai-codex/gpt-5.6-sol'\'' --thinking '\''max'\'' -e '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-pi/home/state/profile-pi-z8.pi-ext.ts'\'' "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-pi/home/data/profile-pi-z8/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='FM_PI_HARNESS=pi-signed pi-signed --model '\''openai-codex/gpt-5.6-sol'\'' --thinking '\''max'\'' -e '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-pi-signed/home/state/profile-pi-signed-z8b.pi-ext.ts'\'' "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-pi-signed/home/data/profile-pi-signed-z8b/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME='\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-pi-signed-secondmate/secondmate-home'\'' FM_PI_HARNESS=pi-signed pi-signed -e '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-pi-signed-secondmate/secondmate-home/.pi/extensions/fm-primary-turnend-guard.ts'\'' -e '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-pi-signed-secondmate/secondmate-home/.pi/extensions/fm-primary-pi-watch.ts'\'' "$('\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief < '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-pi-signed-secondmate/secondmate-home/data/charter.md'\'')"'
+ launch='CLAUDE_CONFIG_DIR='\''/opt/test/claude-work'\'' CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-claude-cfgdir/home/data/profile-claude-cfgdir-z17/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-claude-nocfgdir/home/data/profile-claude-nocfgdir-z18/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
+ launch='codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-codex-nocfgdir/home/state/profile-codex-nocfgdir-z19.turn-ended'\''\"]" "$({ printf '\''%s\n\n'\'' '\''Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'\''; cat '\''/tmp/fm-spawn-dispatch-profile.cVBJoj/profile-codex-nocfgdir/home/data/profile-codex-nocfgdir-z19/brief.md'\''; } | '\''/home/ch/.no-mistakes/worktrees/3ebf64bd3ecf/01KYT2X1AFZXVFSBGDAKSSVXF9/bin/fm-operational-input.sh'\'' encode launch-brief)"'
# all fm-spawn-dispatch-profile tests passed
```
</details>
<details>
<summary>Evidence: Kimi absolute brief-pointer delivery</summary>

```text
+ brief_real=/tmp/fm-kimi-harness.NOS4zN/success/home/data/kimi-success-z1-98652/brief.md
+ pointer='Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review. Read the brief at /tmp/fm-kimi-harness.NOS4zN/success/home/data/kimi-success-z1-98652/brief.md and follow it exactly.'
+ output_contract='Default non-UI engineering work to plain Markdown reports and chat. Report complexity, technical structure, or multiple sections do not justify opening Lavish. Use Lavish only when the task brief states that the captain explicitly requested an interactive or visual review, or for genuine UI or visual work when a visual surface materially improves review.'
ok - fm-spawn: kimi launches, delivers its brief, and registers a guarded turn-end token
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-session-start.sh`
- `tests/fm-spawn-dispatch-profile.test.sh`
- `tests/fm-kimi-harness.test.sh`
- `tests/fm-documentation-audiences.test.sh`
- `tests/fm-secondmate-harness.test.sh`
- <code>Traced `tests/fm-spawn-dispatch-profile.test.sh` to capture generated commands for Claude, Codex, OpenCode, Pi, Pi Signed, and Grok</code>
- <code>Traced `tests/fm-kimi-harness.test.sh` to capture Kimi&#39;s readiness-gated one-line output contract and absolute brief pointer</code>
- <code>Round-tripped representative ordinary-crewmate and secondmate payloads through `bin/fm-operational-input.sh encode launch-brief` and `body`</code>
- <code>Verified the Bearings skill still points to `AGENTS.md` section 9 and does not treat report structure as a Lavish trigger</code>
- <code>Verified `HEAD` is `c87a578b859c13d1605ebbd54732f200dee7d165` and `git status --short` is empty</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
