### PR TITLE
fix(bin): name the PR gate first in the no-mistakes brief DOD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,7 +293,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
+For a no-mistakes ship, the worker starts validation itself after its implementation commit; trigger it on that same worker only when it did not, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -332,9 +332,9 @@ EOF
     RULE1='1. Never push to the default branch. Never merge a PR.'
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+The task is complete only when /no-mistakes has opened a PR and reported CI green: append \`done: PR {url} checks green\` to the status file and stop.
+That is the CI-ready return point and you are finished there - do not keep monitoring the run until merge.
+Committing on your branch is an intermediate step and never a stopping point: do not report \`done:\` for it, and start /no-mistakes yourself once it is committed.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -345,8 +345,6 @@ Two firstmate-specific rules layer on top of that guidance:
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
-
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
     ;;
 esac

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -266,12 +266,15 @@ test_no_mistakes_dod_wording() {
 
 # Four crewmates in a row (2026-07-26/27) reported `done:` as soon as their
 # implementation was committed with green project tests, never starting the
-# pipeline. They were following this section: it named the commit as the
-# completion condition and offered a `done:` gate there, deferring the pipeline
-# to a later firstmate steer fourteen lines below. A worker that stops reading
-# at its first stop condition stops at the commit. Pin the inverted order - the
-# PR with green checks is the first and only stop condition named, the commit is
-# explicitly intermediate - and pin that no earlier `done:` gate reappears.
+# pipeline. They were following this section: it opened by naming the commit as
+# the completion condition and offered a premature `done: {summary}` gate right
+# there, then handed the pipeline off to a firstmate steer. The real completion
+# gate - `done: PR {url} checks green` once /no-mistakes reports CI green - was
+# buried fourteen lines below at the end of the section. A worker that stops
+# reading at its first stop condition stops at the commit. Pin the inverted
+# order - the PR with green checks is the first and only stop condition named,
+# the commit is explicitly intermediate - and pin that no earlier `done:` gate
+# reappears.
 test_no_mistakes_dod_names_the_pr_gate_before_the_commit() {
   local home id brief gate_line commit_line
   home="$TMP_ROOT/dod-order-home"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -264,6 +264,70 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
 }
 
+# Four crewmates in a row (2026-07-26/27) reported `done:` as soon as their
+# implementation was committed with green project tests, never starting the
+# pipeline. They were following this section: it named the commit as the
+# completion condition and offered a `done:` gate there, deferring the pipeline
+# to a later firstmate steer fourteen lines below. A worker that stops reading
+# at its first stop condition stops at the commit. Pin the inverted order - the
+# PR with green checks is the first and only stop condition named, the commit is
+# explicitly intermediate - and pin that no earlier `done:` gate reappears.
+test_no_mistakes_dod_names_the_pr_gate_before_the_commit() {
+  local home id brief gate_line commit_line
+  home="$TMP_ROOT/dod-order-home"
+  write_registry "$home"
+  id="brief-dod-order-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+
+  gate_line=$(grep -nF 'The task is complete only when /no-mistakes has opened a PR and reported CI green' "$brief" | head -1 | cut -d: -f1)
+  [ -n "$gate_line" ] || fail "no-mistakes DOD must open with the PR-with-green-checks completion condition"
+  commit_line=$(grep -nF 'Committing on your branch is an intermediate step' "$brief" | head -1 | cut -d: -f1)
+  [ -n "$commit_line" ] || fail "no-mistakes DOD must mark the commit as an intermediate step"
+  [ "$gate_line" -lt "$commit_line" ] || \
+    fail "no-mistakes DOD regressed: the commit is named before the PR gate (gate line $gate_line, commit line $commit_line)"
+
+  assert_grep 'start /no-mistakes yourself once it is committed' "$brief" \
+    "no-mistakes DOD must have the worker start the pipeline itself"
+  assert_grep 'do not keep monitoring the run until merge' "$brief" \
+    "no-mistakes DOD lost the CI-ready return point"
+
+  # The exact defect: a second, earlier stop condition at the commit.
+  assert_no_grep 'The task is complete only when committed on your branch.' "$brief" \
+    "no-mistakes DOD regressed to naming the commit as the completion condition"
+  # shellcheck disable=SC2016  # literal backticks and braces must stay unexpanded
+  assert_no_grep 'append `done: {summary}`' "$brief" \
+    "no-mistakes DOD regressed to a premature done gate after the commit"
+  assert_no_grep 'Firstmate will then instruct you to run /no-mistakes' "$brief" \
+    "no-mistakes DOD regressed to deferring the pipeline to a firstmate steer"
+
+  # Safety wording the reordering must never disturb.
+  assert_grep 'ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.' "$brief" \
+    "no-mistakes DOD lost the ask-user escalation rule"
+  # shellcheck disable=SC2016  # literal backticks must stay unexpanded
+  assert_grep 'Avoid `--yes`: it would silently bypass' "$brief" \
+    "no-mistakes DOD lost the --yes prohibition"
+  # shellcheck disable=SC2016  # literal backticks must stay unexpanded
+  assert_grep 'Never stop, restart, or update the shared `no-mistakes` daemon' "$brief" \
+    "ship brief lost the shared-daemon prohibition"
+  assert_grep '**Verify isolation before anything else.**' "$brief" \
+    "ship brief lost the worktree-isolation assertion"
+
+  # The inversion is scoped to no-mistakes: direct-PR and local-only genuinely
+  # do complete at the commit, so their completion condition must stay put.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-dod-order-direct direct-proj >/dev/null 2>&1
+  assert_grep 'The task is complete only when committed on your branch.' \
+    "$home/data/brief-dod-order-direct/brief.md" \
+    "direct-PR DOD must keep the commit as its completion condition"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-dod-order-local local-proj >/dev/null 2>&1
+  # shellcheck disable=SC2016  # literal backticks must stay unexpanded
+  assert_grep 'The task is complete only when committed on your branch `fm/brief-dod-order-local`.' \
+    "$home/data/brief-dod-order-local/brief.md" \
+    "local-only DOD must keep the commit as its completion condition"
+  pass "fm-brief.sh: no-mistakes DOD names the PR gate first and the commit as intermediate"
+}
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
@@ -624,6 +688,7 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_no_mistakes_dod_names_the_pr_gate_before_the_commit
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

The developer needed to fix a defect in firstmate's brief generator: four out of four crewmates on no-mistakes projects had reported done: as soon as their implementation was committed with green project tests, never starting the no-mistakes pipeline that the brief names as the definition of done. They suspected the cause was ordering in the generated no-mistakes section of bin/fm-brief.sh, where the pipeline is mentioned only after the sentence saying the task is complete once committed on the branch, and asked that the hypothesis first be verified against the actually generated output and rejected with reasoning if the evidence did not support it. If it held, they wanted the stopping condition inverted so the PR with green checks is the first and only stated completion gate and the branch commit is explicitly an intermediate step, so that a worker reading only the first sentence reaches the right conclusion. Constraints: touch only the no-mistakes branch and leave direct-PR and local-only alone; keep it short since every added line lands in every future brief; preserve the section's safety wording verbatim (worktree isolation check, ban on self-answering ask-user findings, ban on --yes, never touching the shared no-mistakes daemon); only edit AGENTS.md if it genuinely contradicts the change; and add or extend a test pinning the ordering since nothing had caught this defect. They also asked for a closing report covering what changed, the before and after of the generated section, and whether the thesis was confirmed.

## What Changed

- `bin/fm-brief.sh`: inverted the no-mistakes "Definition of done" so `done: PR {url} checks green` is the first and only stated completion gate, with the CI-ready return point folded into it. The premature `done: {summary}` stop at the commit and the "Firstmate will then instruct you to run /no-mistakes" steer are gone; the branch commit is now explicitly an intermediate step after which the worker starts /no-mistakes itself. The section's safety wording (worktree isolation, ask-user escalation, no `--yes`, no touching the shared daemon) is unchanged, and direct-PR and local-only briefs are untouched.
- `AGENTS.md`: the Validate section now says the worker starts validation itself after its implementation commit, and firstmate triggers it on that worker only when it did not.
- `tests/fm-brief.test.sh`: added `test_no_mistakes_dod_names_the_pr_gate_before_the_commit`, which pins the PR gate ahead of the commit line by line number, asserts the three removed phrases stay absent, re-checks the preserved safety wording, and confirms the direct-PR and local-only briefs keep their own commit-based completion condition. The Test gate proved it red against base `79e62b8` and green at `c6a8f42`; Review auto-fixed the test's root-cause comment to describe the old section layout accurately.

## Risk Assessment

✅ Low: The only change since the previous round is a comment-only correction to the regression test's root-cause note, which I verified is now factually accurate against the pre-change file, and the functional parts of the change (bin/fm-brief.sh and AGENTS.md) are byte-identical to the already-reviewed, well-bounded prose reordering.

## Testing

Exercised the change at the product surface a crewmate actually reads: generated the real brief from both the base and target fm-brief.sh, diffed the no-mistakes Definition-of-done section, and audited the order of every `done:` stop instruction, which confirms the author's thesis - before the fix the first stop condition sat at the commit with a premature `done: {summary}` gate and the real gate was buried fourteen lines below; after it, the PR-with-green-checks gate is first and only and the commit is explicitly intermediate. Also confirmed the safety wording renders byte-identically, the direct-PR and local-only briefs are unaffected, and the new regression test genuinely bites by running it against the pre-fix script (red) and the fixed one (green); the AGENTS.md-touching documentation-audience test passes too. Visual evidence is a rendered side-by-side screenshot of the generated section, since this surface is generated markdown consumed by an agent rather than an interactive UI. No failures, no flakiness, worktree left clean.

- Evidence: Rendered before/after of the generated Definition-of-done section (local file: <code>/var/folders/9d/8w50jhgd79x63rgbq_5cyyvm0000gn/T/no-mistakes-evidence/01KYT0E5V72PE6F12KX87HHG1B/brief-dod-before-after.png</code>)
<details>
<summary>Evidence: Every `done:` stop instruction a crewmate reads, top-down (the defect and its fix)</summary>

<code>--- BEFORE (base 79e62b8) ---&#10;33: turn after it; continue the same stage until a defined `done:` gate under Definition of done.&#10;55:When you believe it is complete, append `done: {summary}` to the status file and stop.&#10;68:After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.&#10;&#10;--- AFTER (target c6a8f42) ---&#10;33: turn after it; continue the same stage until a defined `done:` gate under Definition of done.&#10;54:The task is complete only when /no-mistakes has opened a PR and reported CI green: append `done: PR {url} checks green` to the status file and stop.&#10;56:Committing on your branch is an intermediate step and never a stopping point: do not report `done:` for it, and start /no-mistakes yourself once it is committed.</code>

```text
### Every 'done:' stop instruction a crewmate reads, top-down (no-mistakes brief)

--- BEFORE (base 79e62b8) ---
33:   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
55:When you believe it is complete, append `done: {summary}` to the status file and stop.
68:After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

--- AFTER (target c6a8f42) ---
33:   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
54:The task is complete only when /no-mistakes has opened a PR and reported CI green: append `done: PR {url} checks green` to the status file and stop.
56:Committing on your branch is an intermediate step and never a stopping point: do not report `done:` for it, and start /no-mistakes yourself once it is committed.
```
</details>
<details>
<summary>Evidence: Regression proof: new test is red on the pre-fix script, green on the fix</summary>

<code>--- RED: tests/fm-brief.test.sh against the PRE-FIX bin/fm-brief.sh (base 79e62b8) ---&#10;not ok - no-mistakes DOD must open with the PR-with-green-checks completion condition&#10;test-file exit code: 1&#10;&#10;--- GREEN: same test against the FIXED bin/fm-brief.sh (target c6a8f42) ---&#10;ok - fm-brief.sh: no-mistakes DOD names the PR gate first and the commit as intermediate&#10;test-file exit code: 0</code>

```text
### Regression proof: tests/fm-brief.test.sh :: test_no_mistakes_dod_names_the_pr_gate_before_the_commit

--- RED: same test run against the PRE-FIX bin/fm-brief.sh (base 79e62b8) ---
not ok - no-mistakes DOD must open with the PR-with-green-checks completion condition
test-file exit code: 1

--- GREEN: same test run against the FIXED bin/fm-brief.sh (target c6a8f42) ---
ok - fm-brief.sh: no-mistakes DOD names the PR gate first and the commit as intermediate
test-file exit code: 0
```
</details>
<details>
<summary>Evidence: Generated no-mistakes DOD section - before (base 79e62b8)</summary>

```text
# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated no-mistakes DOD section - after (target c6a8f42)</summary>

<code># Definition of done&#10;The task is complete only when /no-mistakes has opened a PR and reported CI green: append `done: PR {url} checks green` to the status file and stop.&#10;That is the CI-ready return point and you are finished there - do not keep monitoring the run until merge.&#10;Committing on your branch is an intermediate step and never a stopping point: do not report `done:` for it, and start /no-mistakes yourself once it is committed.</code>

```text
# Definition of done
The task is complete only when /no-mistakes has opened a PR and reported CI green: append `done: PR {url} checks green` to the status file and stop.
That is the CI-ready return point and you are finished there - do not keep monitoring the run until merge.
Committing on your branch is an intermediate step and never a stopping point: do not report `done:` for it, and start /no-mistakes yourself once it is committed.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.
```
</details>
<details>
<summary>Evidence: Full generated brief - before (base 79e62b8)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-task`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/9d/8w50jhgd79x63rgbq_5cyyvm0000gn/T/no-mistakes-evidence/01KYT0E5V72PE6F12KX87HHG1B/scratch/before-home/state/demo-task.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/yelen/.no-mistakes/worktrees/548b8aa73bec/01KYT0E5V72PE6F12KX87HHG1B/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/yelen/.no-mistakes/worktrees/548b8aa73bec/01KYT0E5V72PE6F12KX87HHG1B/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Full generated brief - after (target c6a8f42)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-task`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/9d/8w50jhgd79x63rgbq_5cyyvm0000gn/T/no-mistakes-evidence/01KYT0E5V72PE6F12KX87HHG1B/scratch/after-home/state/demo-task.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/yelen/.no-mistakes/worktrees/548b8aa73bec/01KYT0E5V72PE6F12KX87HHG1B/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/yelen/.no-mistakes/worktrees/548b8aa73bec/01KYT0E5V72PE6F12KX87HHG1B/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when /no-mistakes has opened a PR and reported CI green: append `done: PR {url} checks green` to the status file and stop.
That is the CI-ready return point and you are finished there - do not keep monitoring the run until merge.
Committing on your branch is an intermediate step and never a stopping point: do not report `done:` for it, and start /no-mistakes yourself once it is committed.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.
```
</details>
<details>
<summary>Evidence: Side-by-side comparison (rendered HTML source)</summary>

```text
<!doctype html><html><head><meta charset="utf-8">
<style>
body{margin:0;background:#0d1117;color:#c9d1d9;font:14px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;padding:28px}
h1{font-size:19px;margin:0 0 4px;color:#f0f6fc}
.sub{color:#8b949e;font-size:13px;margin:0 0 22px}
.grid{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:20px}
.panel{background:#161b22;border:1px solid #30363d;border-radius:10px;overflow:hidden;min-width:0}
.hd{padding:10px 14px;font-weight:600;font-size:13px;border-bottom:1px solid #30363d}
.hd.b{background:#3d1d1d;color:#ffa198}.hd.a{background:#12291c;color:#7ee787}
.body{padding:10px 0;font:12px/1.65 ui-monospace,SFMono-Regular,Menlo,monospace}
.ln{display:flex;gap:10px;padding:1px 14px;white-space:pre-wrap;overflow-wrap:anywhere}
.no{color:#484f58;min-width:22px;text-align:right;flex:none;user-select:none}
.tx{min-width:0}
.bad{background:#3d1d1d33;border-left:3px solid #f85149;margin-left:-3px}
.bad .tx{color:#ffa198}
.late{background:#39280033;border-left:3px solid #d29922;margin-left:-3px}
.late .tx{color:#e3b341}
.good{background:#12291c55;border-left:3px solid #3fb950;margin-left:-3px}
.good .tx{color:#7ee787}
.legend{margin-top:18px;display:flex;gap:22px;flex-wrap:wrap;font-size:12px;color:#8b949e}
.key{display:inline-block;width:10px;height:10px;border-radius:2px;margin-right:6px;vertical-align:middle}
</style></head><body>
<h1>Generated crewmate brief - "Definition of done" (no-mistakes project)</h1>
<p class="sub">Actual output of <code>bin/fm-brief.sh &lt;id&gt; &lt;project&gt;</code>, base 79e62b8 vs target c6a8f42. Lines 6-14 (safety wording) are byte-identical in both.</p>
<div class="grid">
  <div class="panel"><div class="hd b">BEFORE - base 79e62b8</div><div class="body"><div class="ln "><span class="no">1</span><span class="tx"># Definition of done</span></div>
<div class="ln bad"><span class="no">2</span><span class="tx">The task is complete only when committed on your branch.</span></div>
<div class="ln bad"><span class="no">3</span><span class="tx">When you believe it is complete, append `done: {summary}` to the status file and stop.</span></div>
<div class="ln bad"><span class="no">4</span><span class="tx">Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.</span></div>
<div class="ln "><span class="no">5</span><span class="tx">&nbsp;</span></div>
<div class="ln "><span class="no">6</span><span class="tx">You drive no-mistakes by responding to its gates, not by implementing fixes.</span></div>
<div class="ln "><span class="no">7</span><span class="tx">Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.</span></div>
<div class="ln "><span class="no">8</span><span class="tx">Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.</span></div>
<div class="ln "><span class="no">9</span><span class="tx">&nbsp;</span></div>
<div class="ln "><span class="no">10</span><span class="tx">Two firstmate-specific rules layer on top of that guidance:</span></div>
<div class="ln "><span class="no">11</span><span class="tx">- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.</span></div>
<div class="ln "><span class="no">12</span><span class="tx">  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.</span></div>
<div class="ln "><span class="no">13</span><span class="tx">  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to &quot;the user&quot; or implement the fix yourself.</span></div>
<div class="ln "><span class="no">14</span><span class="tx">- Avoid `--yes`: it would silently bypass firstmate&#x27;s authority check and any required captain escalation.</span></div>
<div class="ln "><span class="no">15</span><span class="tx">&nbsp;</span></div>
<div class="ln late"><span class="no">16</span><span class="tx">After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.</span></div></div></div>
  <div class="panel"><div class="hd a">AFTER - target c6a8f42</div><div class="body"><div class="ln "><span class="no">1</span><span class="tx"># Definition of done</span></div>
<div class="ln good"><span class="no">2</span><span class="tx">The task is complete only when /no-mistakes has opened a PR and reported CI green: append `done: PR {url} checks green` to the status file and stop.</span></div>
<div class="ln good"><span class="no">3</span><span class="tx">That is the CI-ready return point and you are finished there - do not keep monitoring the run until merge.</span></div>
<div class="ln good"><span class="no">4</span><span class="tx">Committing on your branch is an intermediate step and never a stopping point: do not report `done:` for it, and start /no-mistakes yourself once it is committed.</span></div>
<div class="ln "><span class="no">5</span><span class="tx">&nbsp;</span></div>
<div class="ln "><span class="no">6</span><span class="tx">You drive no-mistakes by responding to its gates, not by implementing fixes.</span></div>
<div class="ln "><span class="no">7</span><span class="tx">Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.</span></div>
<div class="ln "><span class="no">8</span><span class="tx">Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.</span></div>
<div class="ln "><span class="no">9</span><span class="tx">&nbsp;</span></div>
<div class="ln "><span class="no">10</span><span class="tx">Two firstmate-specific rules layer on top of that guidance:</span></div>
<div class="ln "><span class="no">11</span><span class="tx">- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.</span></div>
<div class="ln "><span class="no">12</span><span class="tx">  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.</span></div>
<div class="ln "><span class="no">13</span><span class="tx">  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to &quot;the user&quot; or implement the fix yourself.</span></div>
<div class="ln "><span class="no">14</span><span class="tx">- Avoid `--yes`: it would silently bypass firstmate&#x27;s authority check and any required captain escalation.</span></div></div></div>
</div>
<div class="legend">
  <span><span class="key" style="background:#f85149"></span>First stop condition a worker hits = the commit, with a premature <code>done: {summary}</code> gate</span>
  <span><span class="key" style="background:#d29922"></span>Real completion gate, buried 14 lines below</span>
  <span><span class="key" style="background:#3fb950"></span>PR-with-green-checks is now the first and only stop condition; commit explicitly intermediate</span>
</div>
</body></html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-brief.test.sh:320` - The new scope guard pins `The task is complete only when committed on your branch.` as required for direct-PR, and the comment at lines 317-318 justifies it by claiming direct-PR &#34;genuinely does complete at the commit&#34;. That is not true: bin/fm-brief.sh:313 has direct-PR push, open a PR with gh-axi, and only then append `done: PR {url}`, and AGENTS.md:313 confirms direct-PR&#39;s ready signal is `done: PR &lt;url&gt;`. So the direct-PR DOD still has the exact defect shape this commit removes from the no-mistakes DOD - the first stated completion condition is the commit, while the real done gate is one sentence later - and a direct-PR crewmate that stops reading at its first stop condition commits, appends `done:`, and never pushes or opens the PR. local-only is genuinely commit-terminal, so only direct-PR is wrong. Beyond leaving the hazard reachable, the new assertion makes a future fix require editing this test with a comment that argues the wrong behavior is correct. The author explicitly scoped direct-PR out of this change, so this needs a captain decision: either narrow the scope guard to assert that the no-mistakes-specific phrases are absent from the direct-PR/local-only briefs (which is what the guard actually needs to prove) instead of requiring the misleading sentence, or extend the inversion to direct-PR as a follow-up.
- ℹ️ `tests/fm-brief.test.sh:271` - The root-cause comment says the old section was &#34;deferring the pipeline to a later firstmate steer fourteen lines below&#34;. In the pre-change text (79e62b8:bin/fm-brief.sh:334-336) the firstmate steer - `Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.` - was the line immediately after the premature `done: {summary}` gate. What sat roughly thirteen lines below was the real completion gate, `After /no-mistakes reports CI green ... append `done: PR {url} checks green` and stop.` Since this comment is the durable record of why the regression test exists, reword it to say the premature `done:` gate came first while the actual CI-green gate was buried at the end of the section.

🔧 Fix: correct regression-test comment about old DOD layout
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` - full file, 18 checks green including the new `test_no_mistakes_dod_names_the_pr_gate_before_the_commit`</code>
- <code>Red/green regression proof: ran the same test file against the pre-fix `bin/fm-brief.sh` (base 79e62b8) via a symlinked root - fails with `not ok - no-mistakes DOD must open with the PR-with-green-checks completion condition`, exit 1; passes at c6a8f42, exit 0</code>
- <code>E2E brief generation for a no-mistakes project with both base and target `bin/fm-brief.sh` (`FM_HOME=... bin/fm-brief.sh demo-task some-proj`), then diffed the full generated `brief.md`</code>
- <code>Audited every `done:` stop instruction in both generated briefs (`grep -n &#39;done:&#39; brief.md`) to confirm which gate a worker reads first</code>
- `Regenerated the direct-PR and local-only briefs from base and target and diffed them - identical apart from the injected FM_HOME path`
- <code>`bash tests/fm-documentation-audiences.test.sh` - run because the change edits AGENTS.md; passes, exit 0</code>
- <code>Repo-wide grep for leftovers of the old flow (`instruct you to run /no-mistakes`, `done: {summary}`, `The task is complete only when committed on your branch`) - only the intentional direct-PR/local-only occurrences and the new negative assertions remain</code>
- `Rendered the before/after Definition-of-done section to HTML and captured it with headless Chrome`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
