### PR TITLE
docs: warn against liveness-only virtual displays

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,6 +112,13 @@ cmux is experimental, GUI-first, macOS-only, and can be selected explicitly or b
 cmux's container shape is one workspace per task with one surface, no per-home container split; workspace titles are scoped by the active home label plus a short hash of the resolved `FM_ROOT` path, and `--secondmate` spawns are refused, mirroring Orca.
 Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectable as a runtime backend.
 
+### Virtual-display launch safety
+
+A virtual display such as Xvfb can turn fail-fast startup into wait-forever behavior because software that would exit without a display may instead open an unrecoverable-error dialog and wait indefinitely once a display exists.
+Process liveness is not progress, so an alive process that has made no bounded startup or operational progress is not evidence that it is working.
+Before selecting a virtual display, determine what the application does on an unrecoverable error when a display exists; if it opens a dialog, any liveness-only launch check is invalid.
+Prefer the application's own no-GUI flag so rejected startup exits non-zero, and require a bounded startup or progress probe whose timeout fails the launch.
+
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.


### PR DESCRIPTION
## Intent

Record the general virtual-display safety hazard in Firstmate shared tracked documentation so future maintainers considering Xvfb or an equivalent do not mistake process liveness for progress. Use the documentation audience inventory and knowledge-placement tree to put the full warning in one authoritative maintainer-facing owner, without duplicating existing contracts or growing AGENTS.md unless an always-loaded trigger is truly required. State that a virtual display can turn fail-fast startup into an indefinite wait on an unrecoverable-error dialog, that liveness without bounded progress is not evidence of success, that a dialog makes liveness-only launch checks invalid, and that maintainers should prefer the application own no-GUI flag plus a bounded startup or progress probe whose timeout fails the launch. Keep Craftless and Fabric chronology and task evidence out of maintained documentation, and preserve one complete sentence per Markdown line with plain dashes. Validate the documentation audience inventory and all relevant focused documentation and link checks.

## What Changed

- Added a maintainer-facing warning that virtual displays can turn fail-fast startup into an indefinite wait on an unrecoverable-error dialog, making liveness-only launch checks invalid.
- Clarified that liveness without bounded progress is not evidence of success; maintainers should prefer the application's no-GUI flag and a bounded startup or progress probe whose timeout fails the launch.

## Risk Assessment

✅ Low: The change is a bounded documentation-only addition in the existing maintainer-architecture owner with no material issues identified.

## Testing

Validated the audience inventory, owner pointers, setup routing, local links, and maintainer-facing warning placement; manually inspected the required wording and style, with CLI evidence captured. No screenshot was needed for this Markdown-only change.

<details>
<summary>Evidence: Maintainer documentation excerpt and focused checks</summary>

```text
Firstmate maintainer documentation evidence
============================================

Source surface: docs/architecture.md
Audience owner: maintainer-architecture (docs/documentation-audiences.json)

End-user-facing excerpt (`nl -ba docs/architecture.md | sed -n '112,122p'`):

115	### Virtual-display launch safety
117	A virtual display such as Xvfb can turn fail-fast startup into wait-forever behavior because software that would exit without a display may instead open an unrecoverable-error dialog and wait indefinitely once a display exists.
118	Process liveness is not progress, so an alive process that has made no bounded startup or operational progress is not evidence that it is working.
119	Before selecting a virtual display, determine what the application does on an unrecoverable error when a display exists; if it opens a dialog, any liveness-only launch check is invalid.
120	Prefer the application's own no-GUI flag so rejected startup exits non-zero, and require a bounded startup or progress probe whose timeout fails the launch.

Focused inventory and link validation (`bin/fm-doc-audience-check.sh`):

fm-doc-audience-check: ok surfaces=57 local_links=160

Focused regression validation (`bash tests/fm-documentation-audiences.test.sh`):

ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-doc-audience-check.sh`
- `bash tests/fm-documentation-audiences.test.sh`
- `nl -ba docs/architecture.md | sed -n '112,122p'`
- <code>Focused search confirmed the hazard appears only in `docs/architecture.md`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
