### PR TITLE
docs: ground user-visible validation in design and runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 ### Validate
 
 For user-visible work, treat relevant Figma evidence as design ground truth and the actual applicable app running in an emulator, device, or browser as behavioral and rendered ground truth.
-When that evidence can inform the change, use available MCP tools to exercise real flows, inspect results, and iterate on every discrepancy; static tests never justify accepting even small unverified deviations.
+When that evidence can inform the change, require the crewmate to use available MCP tools to exercise relevant app flows, inspect runtime results, and iterate on every discrepancy; static tests never justify accepting even small unverified deviations.
 Do not require emulator, device, or browser work when runtime evidence cannot inform the change.
 
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,10 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
+For user-visible work, treat relevant Figma evidence as design ground truth and the actual applicable app running in an emulator, device, or browser as behavioral and rendered ground truth.
+When that evidence can inform the change, use available MCP tools to exercise real flows, inspect results, and iterate on every discrepancy; static tests never justify accepting even small unverified deviations.
+Do not require emulator, device, or browser work when runtime evidence cannot inform the change.
+
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.


### PR DESCRIPTION
## Intent

Add a concise, durable Firstmate instruction for crewmates doing user-visible work. Relevant Figma evidence is the design ground truth, while the actual applicable app running in an emulator, device, or browser is the behavioral and rendered ground truth. When that evidence can inform the work, crewmates must use available MCP tools to exercise real flows, inspect results, and iterate on discrepancies, without accepting even small unverified deviations merely because static tests pass. Do not require ceremonial runtime work when it cannot inform the change. Place only the smallest always-loaded rule in the single authoritative AGENTS.md lifecycle location, preserve one-owner and one-sentence-per-line discipline, validate documentation, and never merge.

## What Changed

- Define relevant Figma evidence and the running app as the design, behavioral, and rendered ground truths for user-visible work.
- Require crewmates to exercise real flows with available MCP tools and resolve all observed discrepancies instead of relying solely on static tests.
- Exempt changes that cannot benefit from emulator, device, or browser validation.

## Risk Assessment

✅ Low: Captain, the three-sentence documentation change is well-bounded, correctly placed, and fully conforms to the authoritative intent and repository ownership rules.

## Testing

No prior baseline results were supplied; the documentation inventory/link validator, focused regression test, policy-specific placement and sentence-discipline check, and browser inspection all passed, with transcript and screenshot evidence captured.

- Evidence: Browser-rendered AGENTS.md Validate section (local file: <code>/tmp/no-mistakes-evidence/01KYTAQ0B53ZZATZCA3XMPFE1Y/agents-validate-runtime-ground-truth.png</code>)
<details>
<summary>Evidence: Documentation validation and exact policy transcript</summary>

```text
$ bin/fm-doc-audience-check.sh
fm-doc-audience-check: ok surfaces=57 local_links=160

$ bash tests/fm-documentation-audiences.test.sh
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed

$ git diff --name-only <base>..<target>
AGENTS.md

$ sed -n /### Validate/,/### PR ready/p AGENTS.md | head -n 8
### Validate

For user-visible work, treat relevant Figma evidence as design ground truth and the actual applicable app running in an emulator, device, or browser as behavioral and rendered ground truth.
When that evidence can inform the change, require the crewmate to use available MCP tools to exercise relevant app flows, inspect runtime results, and iterate on every discrepancy; static tests never justify accepting even small unverified deviations.
Do not require emulator, device, or browser work when runtime evidence cannot inform the change.

For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.

$ focused policy placement and sentence-per-line check
ok - one changed authoritative file; three one-sentence policy lines cover design/runtime ground truth, MCP flow inspection and iteration, static-test insufficiency, and the no-ceremony exception
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-doc-audience-check.sh`
- `bash tests/fm-documentation-audiences.test.sh`
- `Focused shell assertion for authoritative single-file placement, three one-sentence policy lines, and all required policy clauses`
- <code>Opened the actual local `AGENTS.md` in Chrome and captured the complete new Validate policy at 1440×900</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
