### PR TITLE
fix: ground user-visible work in project context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,9 +293,10 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-For user-visible work, treat relevant Figma evidence as design ground truth and the actual applicable app running in an emulator, device, or browser as behavioral and rendered ground truth.
-When that evidence can inform the change, require the crewmate to use available MCP tools to exercise relevant app flows, inspect runtime results, and iterate on every discrepancy; static tests never justify accepting even small unverified deviations.
-Do not require emulator, device, or browser work when runtime evidence cannot inform the change.
+For user-visible work, derive the relevant sources of truth and grounding targets from the project, current context, and user-provided evidence rather than assuming fixed tools, channels, or runtimes.
+Treat user-provided tool channel tokens as request-scoped; use only the current value and never reuse a prior one.
+When grounding can inform the change, require the crewmate to use available MCP tools to interact with the relevant artifacts or real flows, inspect results, and iterate on every discrepancy; static tests never justify accepting even small unverified deviations.
+Do not require grounding work when it cannot inform the change.
 
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 ### Validate
 
 For user-visible work, treat relevant Figma evidence as design ground truth and the actual applicable app running in an emulator, device, or browser as behavioral and rendered ground truth.
-When that evidence can inform the change, use available MCP tools to exercise real flows, inspect results, and iterate on every discrepancy; static tests never justify accepting even small unverified deviations.
+When that evidence can inform the change, require the crewmate to use available MCP tools to exercise relevant app flows, inspect runtime results, and iterate on every discrepancy; static tests never justify accepting even small unverified deviations.
 Do not require emulator, device, or browser work when runtime evidence cannot inform the change.
 
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,10 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
+For user-visible work, treat relevant Figma evidence as design ground truth and the actual applicable app running in an emulator, device, or browser as behavioral and rendered ground truth.
+When that evidence can inform the change, use available MCP tools to exercise real flows, inspect results, and iterate on every discrepancy; static tests never justify accepting even small unverified deviations.
+Do not require emulator, device, or browser work when runtime evidence cannot inform the change.
+
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.


### PR DESCRIPTION
## Intent

Preserve and validate commit cb7aff0 on the current unchanged fork/runtime-grounding branch. The durable Firstmate rule must require crewmates doing user-visible work to derive sources of truth and grounding targets from the project, current context, and user-provided evidence rather than hard-coding Figma, a fixed channel, a specific runtime, or another universal target. User-provided tool channel tokens are request-scoped: use only the current value and never reuse a prior one. When grounding can inform the change, crewmates use available MCP tools to interact with relevant artifacts or real flows, inspect results, and iterate even on small discrepancies rather than relying on static tests alone; do not require ceremonial grounding when it cannot inform the change. Preserve one-owner placement and one-sentence-per-line discipline. Run the full pipeline, push to the configured fork, create the appropriate PR if required, and never merge.

## What Changed

- Require user-visible work to derive grounding sources and targets from project context and current user evidence, without assuming fixed tools, channels, or runtimes.
- Scope user-provided tool channel tokens to the current request and prohibit reuse of prior values.
- Require MCP-backed artifact or real-flow inspection and iteration when grounding is informative, while avoiding ceremonial grounding when it is not.

## Risk Assessment

✅ Low: Captain, the focused documentation change fully matches the source-verifiable intent, preserves the original patch, and introduces no material standards or correctness concerns.

## Testing

The agent-consumed Markdown policy passed exact preserved-patch, ownership, grounding, request-scoped-token, MCP-iteration, no-ceremonial-grounding, forbidden-fixed-target, sentence-per-line, and clean-worktree checks. An initial whole-tree comparison was corrected to the exact patch boundary because the commit was rebased across unrelated base history. No screenshot was captured because this is an agent instruction surface rather than rendered UI; the actual loaded policy appears in the evidence transcript.

<details>
<summary>Evidence: Runtime grounding policy acceptance evidence</summary>

`22-line acceptance transcript; SHA-256: 40f7d247629caa29b7f5633459b8396c156aaae75e35fafa21f608df978996b3`

```text
Runtime grounding policy acceptance evidence
target=739f059e2b71e5816cd64e5fd933e8d712275458
preserved_commit=cb7aff0468fa4292c747263e601e90b422b6a857
PASS working tree unchanged before validation
PASS preserved commit patch: AGENTS.md 61514e18fa1fc5c47612046a370516a32340d210 -> 02f6f5708e3219aafc9f6ac4a2a1245ed6b3431b
PASS one-owner changed surface: AGENTS.md
PASS agent compatibility surface: CLAUDE.md -> AGENTS.md
PASS one sentence per policy line: 4/4
PASS derives truth and targets from project/context/user evidence
PASS forbids universal fixed tools/channels/runtimes
PASS channel tokens are current-request-only
PASS grounding uses MCP interaction, inspection, and discrepancy iteration
PASS non-informative ceremonial grounding is not required
PASS prior Figma/app/runtime-specific universal wording is absent
PASS each durable clause has one tracked Markdown owner
PASS working tree unchanged after validation

Actual agent-loaded Validate policy:
For user-visible work, derive the relevant sources of truth and grounding targets from the project, current context, and user-provided evidence rather than assuming fixed tools, channels, or runtimes.
Treat user-provided tool channel tokens as request-scoped; use only the current value and never reuse a prior one.
When grounding can inform the change, require the crewmate to use available MCP tools to interact with the relevant artifacts or real flows, inspect results, and iterate on every discrepancy; static tests never justify accepting even small unverified deviations.
Do not require grounding work when it cannot inform the change.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --unified=80 f0d7cbe91a4734f189a5d85b27d02d3ef58a7d23 739f059e2b71e5816cd64e5fd933e8d712275458 -- AGENTS.md`.</code>
- <code>Inspected `git show --format= --unified=40 cb7aff0468fa4292c747263e601e90b422b6a857 -- AGENTS.md`.</code>
- <code>Compared the preserved and target patches with `cmp &lt;(git diff cb7aff0^ cb7aff0 -- AGENTS.md) &lt;(git diff 739f059^ 739f059 -- AGENTS.md)`.</code>
- <code>Ran a focused Bash acceptance check covering exact patch preservation, single-owner placement, all required semantic clauses, removal of fixed-target wording, four one-sentence lines, the `CLAUDE.md -&gt; AGENTS.md` loaded surface, and clean-worktree preservation.</code>
- <code>Verified the evidence artifact with `wc -l`, `sha256sum`, and `sed -n &#39;1,80p&#39;`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
