### PR TITLE
fix(herdr): stop Broken-pipe stderr noise on every capability probe

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2556,8 +2556,13 @@ fm_backend_herdr_events_capable() {  # <session>
   case "$protocol" in ''|*[!0-9]*) return 1 ;; esac
   [ "$protocol" -ge "$FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL" ] || return 1
   schema=$(herdr api schema --json 2>/dev/null) || return 1
-  printf '%s' "$schema" | grep -Fq 'events.subscribe' || return 1
-  printf '%s' "$schema" | grep -Fq 'pane.agent_status_changed' || return 1
+  # In-memory substring tests, not `printf ... | grep -Fq`: grep -q exits on
+  # first match and closes the pipe while printf is still writing the large
+  # schema, which prints `printf: write error: Broken pipe` to stderr on every
+  # probe. A `case` glob matches the variable directly - no pipe, no reader to
+  # close early, and a literal substring test equivalent to grep -F.
+  case "$schema" in *events.subscribe*) ;; *) return 1 ;; esac
+  case "$schema" in *pane.agent_status_changed*) ;; *) return 1 ;; esac
   return 0
 }
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2856,6 +2856,85 @@ set_fake_agent() {  # <agent-dir> <window-or-pane> <status>
   printf '%s' "$status" > "$dir/$key.status"
 }
 
+# make_herdr_schemafake: a herdr stub for the capability probe only - answers
+# `status --json` with an events-capable protocol and `api schema --json` by
+# emitting the contents of $FM_FAKE_SCHEMA_FILE verbatim. The schema file is
+# deliberately large so a naive `printf ... | grep -q` reader that closes the
+# pipe on first match would leave printf writing into a dead pipe (the EPIPE
+# these tests guard against).
+make_herdr_schemafake() {  # <dir> -> echoes fakebin dir
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+cmd=${1:-}; sub=${2:-}
+case "$cmd $sub" in
+  "status --json")
+    printf '{"client":{"version":"0.7.3","protocol":16},"server":{"running":true}}\n' ;;
+  "api schema")
+    cat "${FM_FAKE_SCHEMA_FILE:?}" ;;
+  *) : ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/herdr"
+  printf '%s\n' "$fb"
+}
+
+# write_big_schema: writes a >64KiB schema to <file> containing exactly the
+# tokens named in $2.. (space-joined) at the very front, followed by ~280KiB of
+# filler. Fronting the tokens makes an early-closing pipe reader (grep -q) match
+# on the first buffer while printf still has hundreds of KiB left to write. The
+# probe runs under `trap '' PIPE` (the disposition of the real watcher where
+# this noise surfaces): with SIGPIPE ignored, printf's blocked write to the
+# closed pipe returns EPIPE and prints `printf: write error: Broken pipe` to
+# stderr, which is exactly the regression these tests pin closed.
+write_big_schema() {  # <file> <token...>
+  local file=$1; shift
+  { printf '%s ' "$@"; yes 'padding-padding-padding-padding-padding-padding' | head -n 5000; } > "$file"
+}
+
+test_events_capable_detects_both_tokens_and_leaves_stderr_clean() {
+  local dir fb schema err rc
+  dir="$TMP_ROOT/ev-cap-both"; mkdir -p "$dir"
+  fb=$(make_herdr_schemafake "$dir")
+  schema="$dir/schema"; err="$dir/err"
+  write_big_schema "$schema" 'events.subscribe' 'pane.agent_status_changed'
+  rc=$(PATH="$fb:$PATH" FM_FAKE_SCHEMA_FILE="$schema" FM_BACKEND_HERDR_EVENT_READER=noop \
+    bash -c 'trap "" PIPE; . "$0/bin/backends/herdr.sh"; fm_backend_herdr_events_capable sess; echo $?' "$ROOT" 2>"$err" | tail -1)
+  [ "$rc" = 0 ] || fail "events_capable must report capable when both tokens are present, got $rc"
+  ! grep -q 'Broken pipe' "$err" || fail "capability probe emitted 'Broken pipe' on stderr: $(cat "$err")"
+  [ ! -s "$err" ] || fail "capability probe stderr must be clean, got: $(cat "$err")"
+  pass "fm_backend_herdr_events_capable: both tokens present -> capable, with no Broken-pipe stderr noise"
+}
+
+test_events_capable_not_capable_when_subscribe_token_missing() {
+  local dir fb schema err rc
+  dir="$TMP_ROOT/ev-cap-no-sub"; mkdir -p "$dir"
+  fb=$(make_herdr_schemafake "$dir")
+  schema="$dir/schema"; err="$dir/err"
+  write_big_schema "$schema" 'pane.agent_status_changed'
+  rc=$(PATH="$fb:$PATH" FM_FAKE_SCHEMA_FILE="$schema" FM_BACKEND_HERDR_EVENT_READER=noop \
+    bash -c 'trap "" PIPE; . "$0/bin/backends/herdr.sh"; fm_backend_herdr_events_capable sess; echo $?' "$ROOT" 2>"$err" | tail -1)
+  [ "$rc" = 1 ] || fail "events_capable must report NOT capable when events.subscribe is absent, got $rc"
+  ! grep -q 'Broken pipe' "$err" || fail "capability probe emitted 'Broken pipe' on stderr: $(cat "$err")"
+  pass "fm_backend_herdr_events_capable: missing events.subscribe -> not capable"
+}
+
+test_events_capable_not_capable_when_status_changed_token_missing() {
+  local dir fb schema err rc
+  dir="$TMP_ROOT/ev-cap-no-status"; mkdir -p "$dir"
+  fb=$(make_herdr_schemafake "$dir")
+  schema="$dir/schema"; err="$dir/err"
+  write_big_schema "$schema" 'events.subscribe'
+  rc=$(PATH="$fb:$PATH" FM_FAKE_SCHEMA_FILE="$schema" FM_BACKEND_HERDR_EVENT_READER=noop \
+    bash -c 'trap "" PIPE; . "$0/bin/backends/herdr.sh"; fm_backend_herdr_events_capable sess; echo $?' "$ROOT" 2>"$err" | tail -1)
+  [ "$rc" = 1 ] || fail "events_capable must report NOT capable when pane.agent_status_changed is absent, got $rc"
+  ! grep -q 'Broken pipe' "$err" || fail "capability probe emitted 'Broken pipe' on stderr: $(cat "$err")"
+  pass "fm_backend_herdr_events_capable: missing pane.agent_status_changed -> not capable"
+}
+
 test_normalize_event_leaves_from_empty() {
   local rec
   rec=$(bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_normalize_event wG:pQ wG blocked claude' "$ROOT")
@@ -3209,6 +3288,9 @@ test_dispatch_routes_herdr_backend
 test_dispatch_busy_state_unknown_for_tmux
 test_dispatch_composer_state_routes_by_backend
 test_scripts_route_explicit_target_through_meta_backend
+test_events_capable_detects_both_tokens_and_leaves_stderr_clean
+test_events_capable_not_capable_when_subscribe_token_missing
+test_events_capable_not_capable_when_status_changed_token_missing
 test_normalize_event_leaves_from_empty
 test_escalation_marker_keys_like_watcher
 test_apply_transition_blocked_requires_commit_to_dedupe


### PR DESCRIPTION
## Intent

Fix the 'printf: write error: Broken pipe' stderr noise the herdr backend writes on every capability check. Root cause: fm_backend_herdr_events_capable in bin/backends/herdr.sh piped the large API schema into 'grep -Fq'; grep -q exits on first match and closes the read end of the pipe while printf is still writing, so printf gets EPIPE and prints the broken-pipe message to stderr on essentially every watcher cycle. Fix: replace the two printf|grep -Fq lines with in-memory 'case $schema in *token*' substring globs - no subshell, no pipe, no early-closing reader, so no EPIPE, and faster. Behavior must NOT change: the case glob is semantically identical to grep -F (literal substring match), returning success only when BOTH events.subscribe and pane.agent_status_changed are present and return 1 otherwise; neither token contains a glob metacharacter so the match is equivalent - detection unchanged, not weakened. The one other pipe-into-grep in the file (a grep -qE regex on a single stripped terminal line) is a tiny buffer that never overflows the pipe, produces no such noise, and can't take the same substring fix, so it was left unchanged. Added three colocated regression tests in tests/fm-backend-herdr.test.sh proving both-tokens-present is capable, either-token-missing is not capable, and the probe leaves stderr clean; the clean-stderr test runs under 'trap "" PIPE' against a >64KiB schema and was verified to fail against the old grep-piped code and pass against the fix. Firstmate-repo change to shared tracked tooling following firstmate-coding-guidelines. Delivery is via the wameson/firstmate fork (no push access to upstream kunchenguid/firstmate); the PR must be opened by no-mistakes so it carries the required signature line.

## What Changed

- Replaced the two `printf '%s' "$schema" | grep -Fq ...` lines in `fm_backend_herdr_events_capable` (`bin/backends/herdr.sh`) with in-memory `case "$schema" in *token*` substring globs, so no subshell or pipe is created and `grep -q` can no longer close the read end early and trigger `printf: write error: Broken pipe` on stderr each watcher cycle. Detection is unchanged: the probe still succeeds only when both `events.subscribe` and `pane.agent_status_changed` are present.
- Added three colocated regression tests in `tests/fm-backend-herdr.test.sh` covering both-tokens-present (capable), a token missing (not capable), and a clean-stderr probe run under `trap "" PIPE` against a >64KiB schema; the stderr test was verified to fail against the old grep-piped code and pass against the fix.

## Risk Assessment

✅ Low: A well-bounded, single-purpose fix that replaces two pipe-into-grep substring checks with semantically identical in-memory case globs, with three colocated regression tests that correctly reproduce and pin the EPIPE noise.

## Testing

Exercised the herdr capability-probe fix end-to-end. The full `tests/fm-backend-herdr.test.sh` suite passes (exit 0) with the three new colocated regression tests. I proved the fix matters and the test is meaningful by reproducing the exact end-user symptom — a 240KiB schema under `trap "" PIPE` makes the old `printf | grep -Fq` path emit `printf: write error: Broken pipe` twice to stderr, while the new `case "$schema" in *TOKEN*` globs leave stderr clean — and by reverting herdr.sh to the old code, which flips the suite to a failing `not ok - capability probe emitted 'Broken pipe'` (exit 1). Detection is confirmed unchanged (capable iff both tokens present). This is a shell/CLI-only change with no user-visible UI surface, so a CLI/stderr transcript is the appropriate evidence rather than a screenshot. Worktree restored clean; no transient artifacts left behind.

<details>
<summary>Evidence: Old-vs-new stderr behavior (240KiB schema under trap &#39;&#39; PIPE)</summary>

```text
schema size (bytes): 240043

=== OLD code (printf | grep -Fq) ===
stderr: bash: printf: write error: Broken pipe (x2, one per token)

=== NEW code (case glob) ===
stderr: <empty (clean)>
```
</details>
<details>
<summary>Evidence: Regression test catches old code (suite run against reverted herdr.sh)</summary>

```text
suite exit=1
not ok - capability probe emitted 'Broken pipe' on stderr: .../bin/backends/herdr.sh: line 2559: printf: write error: Broken pipe
.../bin/backends/herdr.sh: line 2560: printf: write error: Broken pipe
```
</details>
<details>
<summary>Evidence: Full evidence transcript</summary>

```text
herdr Broken-pipe capability-probe fix — end-to-end evidence
============================================================

SYMPTOM REPRODUCTION (240KiB schema, under `trap "" PIPE` like the real watcher)

  OLD code — `printf '%s' "$schema" | grep -Fq TOKEN`:
    bash: line 3: printf: write error: Broken pipe
    bash: line 4: printf: write error: Broken pipe
      (one line PER token PER probe — emitted on essentially every watcher cycle)

  NEW code — `case "$schema" in *TOKEN*) ;; *) return 1 ;; esac`:
    <stderr empty — clean>

DETECTION UNCHANGED (bin/backends/herdr.sh fm_backend_herdr_events_capable):
  both tokens present            -> capable (rc 0)
  events.subscribe missing       -> not capable (rc 1)
  pane.agent_status_changed miss -> not capable (rc 1)

REGRESSION TEST VALIDATED BOTH DIRECTIONS (tests/fm-backend-herdr.test.sh):
  against the FIX  : ok - ...both tokens present -> capable, with no Broken-pipe stderr noise
                     ok - ...missing events.subscribe -> not capable
                     ok - ...missing pane.agent_status_changed -> not capable
                     (full suite exit 0)
  against OLD code : not ok - capability probe emitted 'Broken pipe' on stderr:
                       .../bin/backends/herdr.sh: line 2559: printf: write error: Broken pipe
                       .../bin/backends/herdr.sh: line 2560: printf: write error: Broken pipe
                     (full suite exit 1)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-backend-herdr.test.sh` — full suite passes (exit 0), including the three new `test_events_capable_*` cases</code>
- <code>Reverted herdr.sh to the old `printf | grep -Fq` code and re-ran the suite: it fails (exit 1) with `not ok - capability probe emitted &#39;Broken pipe&#39; on stderr`, proving the regression test catches the bug; then restored the fix and confirmed `git status --porcelain` clean</code>
- <code>Direct old-vs-new symptom reproduction under `trap &#34;&#34; PIPE` against a 240KiB schema: old code prints `printf: write error: Broken pipe` twice, new case-glob code produces empty/clean stderr</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
