### PR TITLE
fix(herdr): wait for shell readiness before project allocation

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1872,6 +1872,37 @@ fm_backend_herdr_target_ready() {  # <target>
   fm_backend_herdr_server_ensure "$FM_BACKEND_HERDR_SESSION" || return 1
 }
 
+# fm_backend_herdr_wait_for_shell_ready: wait for the exact newly-created pane
+# to expose its interactive shell before a spawn-time command is submitted.
+# Herdr can return a pane before that shell accepts Enter, so a command sent
+# earlier can remain in the shell buffer without running. Require ten
+# consecutive process-info samples whose sole foreground process is the shell,
+# sampled approximately 100ms apart, for a bounded 100-sample (10-second) wait.
+# This is intentionally separate from target_ready: the caller already proved
+# the named Herdr server while creating this exact pane, and this read must not
+# substitute another pane or infer one from a label.
+fm_backend_herdr_wait_for_shell_ready() {  # <session> <pane-id>
+  local session=$1 pane_id=$2 process_info ready_samples=0 poll
+  [ -n "$session" ] && [ -n "$pane_id" ] || return 1
+  for poll in $(seq 1 100); do
+    process_info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane_id" 2>/dev/null || true)
+    if printf '%s' "$process_info" | jq -e --arg pane "$pane_id" '
+      .result.type == "pane_process_info"
+      and .result.process_info.pane_id == $pane
+      and (.result.process_info.foreground_processes | type) == "array"
+      and (.result.process_info.foreground_processes | length) == 1
+      and .result.process_info.foreground_processes[0].pid == .result.process_info.shell_pid
+    ' >/dev/null 2>&1; then
+      ready_samples=$((ready_samples + 1))
+      [ "$ready_samples" -ge 10 ] && return 0
+    else
+      ready_samples=0
+    fi
+    [ "$poll" -ge 100 ] || sleep 0.1
+  done
+  return 1
+}
+
 # fm_backend_herdr_current_path: the live FOREGROUND process's cwd, or empty on
 # any error. Mirrors tmux's pane_current_path poll used for worktree-path
 # discovery after `treehouse get`.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -156,6 +156,30 @@ fm_backend_herdr_cli() {  # <session> <herdr-subcommand-and-args...>
   HERDR_SESSION="$session" herdr "$@" --session "$session"
 }
 
+fm_backend_herdr_cli_timeout() {  # <timeout-seconds> <session> <herdr-subcommand-and-args...>
+  local timeout_seconds=$1 session=$2
+  shift 2
+  perl -MTime::HiRes=alarm -e '
+    my $timeout = shift;
+    my $pid = fork;
+    die "fork failed" unless defined $pid;
+    if (!$pid) {
+      setpgrp(0, 0);
+      exec @ARGV;
+    }
+    local $SIG{ALRM} = sub {
+      kill "TERM", -$pid;
+      kill "KILL", -$pid;
+      waitpid $pid, 0;
+      exit 124;
+    };
+    alarm $timeout;
+    waitpid $pid, 0;
+    alarm 0;
+    exit($? >> 8);
+  ' "$timeout_seconds" env HERDR_SESSION="$session" herdr "$@" --session "$session"
+}
+
 # fm_backend_herdr_tool_check: refuse loudly if herdr or jq is missing.
 fm_backend_herdr_tool_check() {
   command -v herdr >/dev/null 2>&1 || { echo "error: backend=herdr selected but the 'herdr' CLI is not installed (https://herdr.dev) (dual-licensed AGPL-3.0-or-later/commercial)" >&2; return 1; }
@@ -1877,15 +1901,21 @@ fm_backend_herdr_target_ready() {  # <target>
 # Herdr can return a pane before that shell accepts Enter, so a command sent
 # earlier can remain in the shell buffer without running. Require ten
 # consecutive process-info samples whose sole foreground process is the shell,
-# sampled approximately 100ms apart, for a bounded 100-sample (10-second) wait.
+# sampled approximately 100ms apart, within one ten-second wall-clock deadline.
 # This is intentionally separate from target_ready: the caller already proved
 # the named Herdr server while creating this exact pane, and this read must not
 # substitute another pane or infer one from a label.
 fm_backend_herdr_wait_for_shell_ready() {  # <session> <pane-id>
   local session=$1 pane_id=$2 process_info ready_samples=0 poll
+  local timeout_seconds=${FM_BACKEND_HERDR_READY_TIMEOUT_SECONDS:-10}
+  local started_at now remaining
   [ -n "$session" ] && [ -n "$pane_id" ] || return 1
+  started_at=$(perl -MTime::HiRes=time -e 'printf "%.6f", time') || return 1
   for poll in $(seq 1 100); do
-    process_info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane_id" 2>/dev/null || true)
+    now=$(perl -MTime::HiRes=time -e 'printf "%.6f", time') || return 1
+    remaining=$(awk -v start="$started_at" -v now="$now" -v limit="$timeout_seconds" 'BEGIN { printf "%.6f", limit - (now - start) }')
+    awk -v remaining="$remaining" 'BEGIN { exit !(remaining > 0) }' || return 1
+    process_info=$(fm_backend_herdr_cli_timeout "$remaining" "$session" pane process-info --pane "$pane_id" 2>/dev/null || true)
     if printf '%s' "$process_info" | jq -e --arg pane "$pane_id" '
       .result.type == "pane_process_info"
       and .result.process_info.pane_id == $pane
@@ -1898,7 +1928,12 @@ fm_backend_herdr_wait_for_shell_ready() {  # <session> <pane-id>
     else
       ready_samples=0
     fi
-    [ "$poll" -ge 100 ] || sleep 0.1
+    if [ "$poll" -lt 100 ]; then
+      now=$(perl -MTime::HiRes=time -e 'printf "%.6f", time') || return 1
+      remaining=$(awk -v start="$started_at" -v now="$now" -v limit="$timeout_seconds" 'BEGIN { printf "%.6f", limit - (now - start) }')
+      awk -v remaining="$remaining" 'BEGIN { exit !(remaining >= 0.1) }' || return 1
+      sleep 0.1
+    fi
   done
   return 1
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1199,6 +1199,15 @@ EOF
     T="$ORCA_TERMINAL"
     ;;
 esac
+if [ "$BACKEND" = herdr ] && [ "$KIND" != secondmate ]; then
+  if ! fm_backend_herdr_wait_for_shell_ready "$HERDR_SES" "$HERDR_PANE_ID"; then
+    # Preserve the exact new pane for diagnosis rather than invoking the
+    # presentation abort cleanup before any project command was submitted.
+    HERDR_PROJECTION_ABORT_CLEANUP=0
+    echo "error: herdr pane $HERDR_SES:$HERDR_PANE_ID did not reach shell-ready state within 10s; inspect window $T" >&2
+    exit 1
+  fi
+fi
 # #134 robustness: only tmux needs a worktree-detection target distinct from $T -
 # its rename-safe stable window id, set as WT_TARGET=$WID in the tmux branch above.
 # Every other backend addresses its pane/surface by the id already in $T, so default

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -186,6 +186,11 @@ On an already active or unreadable baseline, it falls back to conservative compo
 A fully unreadable target stops retrying and reports unknown.
 The poll density bounds the residual possibility of an extremely fast complete turn; a missed transition can cause only a redundant Enter on an empty composer, never duplicate message text.
 
+At project spawn, Firstmate waits on the exact pane returned by tab creation before submitting `treehouse get`.
+It queries `pane process-info` and requires exactly one foreground process whose PID equals the reported shell PID for ten consecutive samples approximately 100ms apart, with a bounded ten-second timeout.
+A timeout preserves the newly-created pane for diagnosis and submits no project-allocation command.
+This barrier covers the verified Herdr startup race in which tab creation can precede an interactive shell accepting Enter; `tests/fm-afk-inject-herdr-e2e.test.sh` carries the corresponding real-Herdr readiness evidence, and `tests/fm-backend-herdr.test.sh` covers the unit regression.
+
 `pane read --lines N` can return empty output when N is below the viewport height.
 The capture owner requests at least 200 lines from Herdr and trims locally to the caller's bound.
 This generous floor is required for small composer and peek reads.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1829,6 +1829,109 @@ test_current_path_reads_cwd() {
   pass "fm_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd"
 }
 
+# --- spawn shell readiness ----------------------------------------------------
+
+write_shell_ready_response() {  # <file> <ready|not-ready>
+  local file=$1 state=$2
+  if [ "$state" = ready ]; then
+    printf '%s\n' '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_processes":[{"pid":42}]}}}' > "$file"
+  else
+    printf '%s\n' '{"result":{"type":"pane_process_info","process_info":{"pane_id":"w1:p2","shell_pid":42,"foreground_processes":[{"pid":99}]}}}' > "$file"
+  fi
+}
+
+make_shell_ready_fake_sleep() {
+  local fb=$1
+  cat > "$fb/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fb/sleep"
+}
+
+test_shell_readiness_waits_for_not_ready_to_ready() {
+  local dir log resp fb out n
+  dir="$TMP_ROOT/shell-ready-transition"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  write_shell_ready_response "$resp/1.out" not-ready
+  for n in $(seq 2 11); do write_shell_ready_response "$resp/$n.out" ready; done
+  fb=$(make_herdr_fakebin "$dir"); make_shell_ready_fake_sleep "$fb"
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_wait_for_shell_ready fmtest w1:p2' "$ROOT" )
+  [ -z "$out" ] || fail "shell readiness should not print output, got '$out'"
+  [ "$(grep -c $'\x1f''pane'$'\x1f''process-info'$'\x1f''--pane'$'\x1f''w1:p2' "$log")" = 11 ] \
+    || fail "shell readiness did not query the exact pane for each scripted sample"
+  pass "fm_backend_herdr_wait_for_shell_ready: waits through a not-ready sample and accepts ten ready samples"
+}
+
+test_shell_readiness_resets_after_unstable_sample() {
+  local dir log resp fb status n
+  dir="$TMP_ROOT/shell-ready-reset"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  for n in $(seq 1 9); do write_shell_ready_response "$resp/$n.out" ready; done
+  write_shell_ready_response "$resp/10.out" not-ready
+  for n in $(seq 11 20); do write_shell_ready_response "$resp/$n.out" ready; done
+  fb=$(make_herdr_fakebin "$dir"); make_shell_ready_fake_sleep "$fb"
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_wait_for_shell_ready fmtest w1:p2' "$ROOT"
+  status=$?
+  expect_code 0 "$status" "a not-ready sample should reset the consecutive readiness count"
+  [ "$(grep -c $'\x1f''pane'$'\x1f''process-info'$'\x1f''--pane'$'\x1f''w1:p2' "$log")" = 20 ] \
+    || fail "shell readiness accepted nine samples before the required reset and ten new samples"
+  pass "fm_backend_herdr_wait_for_shell_ready: resets consecutive samples after a readiness regression"
+}
+
+test_shell_readiness_timeout_does_not_submit_a_command() {
+  local dir log resp fb status n
+  dir="$TMP_ROOT/shell-ready-timeout"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  for n in $(seq 1 100); do write_shell_ready_response "$resp/$n.out" not-ready; done
+  fb=$(make_herdr_fakebin "$dir"); make_shell_ready_fake_sleep "$fb"
+  if PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; if fm_backend_herdr_wait_for_shell_ready fmtest w1:p2; then exit 1; else exit 0; fi' "$ROOT"; then
+    status=0
+  else
+    status=$?
+  fi
+  expect_code 0 "$status" "shell readiness should time out after the bounded sample count"
+  [ "$(grep -c $'\x1f''pane'$'\x1f''process-info'$'\x1f''--pane'$'\x1f''w1:p2' "$log")" = 100 ] \
+    || fail "shell readiness did not stop at the bounded ten-second sample count"
+  assert_not_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''run' "a readiness timeout must not submit a pane command"
+  pass "fm_backend_herdr_wait_for_shell_ready: times out without submitting a command"
+}
+
+test_spawn_timeout_skips_treehouse_get() {
+  local dir home project log resp fb out status n treehouse_log id
+  id=herdr-ready-timeout-spawn
+  dir="$TMP_ROOT/spawn-shell-ready-timeout"; home="$dir/home"; project="$dir/project"
+  log="$dir/herdr.log"; resp="$dir/responses"; treehouse_log="$dir/treehouse.log"
+  mkdir -p "$home/data/$id" "$home/state" "$home/config" "$home/projects" "$resp"
+  printf 'test brief\n' > "$home/data/$id/brief.md"
+  git init -q "$project"
+  git -C "$project" config user.email test@example.invalid
+  git -C "$project" config user.name test
+  git -C "$project" commit --allow-empty -qm initial
+  printf '%s\n' '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"}]}}' > "$resp/1.out"
+  printf '%s\n' '{"result":{"tabs":[]}}' > "$resp/2.out"
+  printf '%s\n' '{"result":{"tab":{"tab_id":"w1:t2"},"root_pane":{"pane_id":"w1:p2"}}}' > "$resp/3.out"
+  for n in $(seq 4 103); do write_shell_ready_response "$resp/$n.out" not-ready; done
+  fb=$(make_herdr_fakebin "$dir"); make_shell_ready_fake_sleep "$fb"
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\\n' "\$*" >> "$treehouse_log"
+exit 0
+SH
+  chmod +x "$fb/treehouse"
+  out=$( FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_DATA_OVERRIDE="$home/data" FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    PATH="$fb:$PATH" "$ROOT/bin/fm-spawn.sh" "$id" "$project" codex --backend herdr 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "fm-spawn should refuse when the exact Herdr pane never becomes shell-ready"
+  assert_contains "$out" "did not reach shell-ready state" "spawn timeout did not explain the Herdr readiness refusal"
+  assert_not_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''run' "spawn submitted a pane command before Herdr shell readiness"
+  [ ! -s "$treehouse_log" ] || fail "spawn invoked treehouse after Herdr shell readiness timed out"
+  [ ! -e "$home/state/$id.meta" ] || fail "spawn wrote task metadata after Herdr shell readiness timed out"
+  pass "fm-spawn: a Herdr readiness timeout submits no treehouse command"
+}
+
 # --- busy_state (semantic agent state) ---------------------------------------
 
 test_busy_state_working_maps_to_busy() {
@@ -3164,6 +3267,10 @@ test_capture_preserves_pane_read_failure
 test_send_key_normalizes_and_targets_pane
 test_kill_is_best_effort
 test_current_path_reads_cwd
+test_shell_readiness_waits_for_not_ready_to_ready
+test_shell_readiness_resets_after_unstable_sample
+test_shell_readiness_timeout_does_not_submit_a_command
+test_spawn_timeout_skips_treehouse_get
 test_busy_state_working_maps_to_busy
 test_busy_state_done_and_blocked_map_to_idle
 test_busy_state_unknown_on_no_agent

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1897,6 +1897,28 @@ test_shell_readiness_timeout_does_not_submit_a_command() {
   pass "fm_backend_herdr_wait_for_shell_ready: times out without submitting a command"
 }
 
+test_shell_readiness_stalled_cli_obeys_wall_clock_timeout() {
+  local dir fb status started elapsed
+  dir="$TMP_ROOT/shell-ready-stalled"; mkdir -p "$dir/fakebin"; fb="$dir/fakebin"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+sleep 30
+SH
+  chmod +x "$fb/herdr"
+  started=$(perl -MTime::HiRes=time -e 'printf "%.6f", time')
+  if PATH="$fb:$PATH" FM_BACKEND_HERDR_READY_TIMEOUT_SECONDS=0.5 \
+    bash -c '. "$0/bin/backends/herdr.sh"; if fm_backend_herdr_wait_for_shell_ready fmtest w1:p2; then exit 1; else exit 0; fi' "$ROOT"; then
+    status=0
+  else
+    status=$?
+  fi
+  elapsed=$(perl -MTime::HiRes=time -e 'printf "%.3f", time - $ARGV[0]' "$started")
+  expect_code 0 "$status" "a stalled Herdr query should end at the readiness wall-clock deadline"
+  awk -v elapsed="$elapsed" 'BEGIN { exit !(elapsed < 2) }' \
+    || fail "a stalled Herdr query exceeded its 0.5-second readiness deadline: ${elapsed}s"
+  pass "fm_backend_herdr_wait_for_shell_ready: bounds a stalled CLI query by the wall clock"
+}
+
 test_spawn_timeout_skips_treehouse_get() {
   local dir home project log resp fb out status n treehouse_log id
   id=herdr-ready-timeout-spawn
@@ -3270,6 +3292,7 @@ test_current_path_reads_cwd
 test_shell_readiness_waits_for_not_ready_to_ready
 test_shell_readiness_resets_after_unstable_sample
 test_shell_readiness_timeout_does_not_submit_a_command
+test_shell_readiness_stalled_cli_obeys_wall_clock_timeout
 test_spawn_timeout_skips_treehouse_get
 test_busy_state_working_maps_to_busy
 test_busy_state_done_and_blocked_map_to_idle


### PR DESCRIPTION
## Intent

Fix the verified Herdr startup race that prevented BullSwing project allocation. After Herdr creates a pane, wait on the exact returned pane's process information until exactly one foreground process exists and its PID equals the shell PID for ten consecutive samples approximately 100ms apart, bounded by ten seconds, and refuse without submitting treehouse get on timeout. Keep this Herdr-only, preserve the existing post-submit two-sample project-copy cwd settlement check and all other backend behavior, do not change the default backend or broaden cleanup, document the empirical boundary in docs/herdr-backend.md, add focused readiness and non-regression tests, and validate and ship through the no-mistakes pipeline to a private Firstmate PR without merging it.

## What Changed

- Wait for the exact newly created Herdr pane to report ten consecutive shell-ready samples before submitting `treehouse get`.
- Enforce a ten-second wall-clock deadline, preserve timed-out panes for diagnosis, and refuse project allocation without submitting commands when readiness fails.
- Document the Herdr startup boundary and add focused coverage for readiness transitions, unstable samples, stalled CLI calls, timeouts, and spawn refusal.

## Risk Assessment

✅ Low: The follow-up enforces a wall-clock deadline around each exact-pane process query, retains the ten consecutive readiness samples, refuses before treehouse submission on timeout, and leaves the existing post-submit cwd settlement logic and other backends unchanged.

## Testing

Diff inspection, the focused fake-CLI Herdr suite, and an isolated real-Herdr E2E all passed; evidence demonstrates exact-pane readiness stabilization, reset after regression, bounded stalled/ordinary timeouts, and refusal without `treehouse get`. No screenshot was produced because this is a backend/CLI behavior with no rendered UI surface.

<details>
<summary>Evidence: Focused Herdr readiness transcript</summary>

<code>Readiness waited through instability, required ten consecutive shell-ready samples, honored the timeout, and `fm-spawn` submitted no `treehouse get` on failure.</code>

```text
ok - fm_backend_herdr_version_check: accepts the current protocol (14)
ok - fm_backend_herdr_version_check: refuses an old protocol loudly
ok - fm_backend_herdr_version_check: refuses loudly when herdr is not installed
ok - fm_backend_herdr_workspace_label: a primary home (no marker) resolves to 'firstmate'
ok - fm_backend_herdr_workspace_label: a secondmate home (.fm-secondmate-home) resolves to '2ndmate-<id>'
ok - fm_backend_herdr_workspace_label: trims whitespace around the marker's secondmate id
ok - fm_backend_herdr_workspace_label: an empty marker file falls back to the primary label 'firstmate'
ok - fm_backend_herdr_workspace_label: two different secondmate homes get two different, non-colliding labels
ok - fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call
ok - fm_backend_herdr_launcher_identity: a firstmate not running inside herdr has no launcher workspace to inherit
ok - fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent
ok - fm_backend_herdr_launcher_identity: resolves the launcher's exact workspace even when a same-labeled workspace sorts first
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane that names a different herdr session
ok - fm_backend_herdr_launcher_identity: refuses a claimed pane without exact server identity
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane whose injected socket belongs to another herdr server
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's own pane no longer resolves
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's pane and tab disagree about their workspace
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's workspace is gone from its own session
ok - fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one
ok - fm_backend_herdr_workspace_ensure: refuses to guess between two same-labeled home workspaces
ok - fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's
ok - fm_backend_herdr_container_ensure: surfaces the exact ambiguous-placement refusal instead of a generic failure
ok - fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id
ok - fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)
ok - fm_backend_herdr_container_ensure: workspace create passes --no-focus
ok - fm_backend_herdr_container_ensure: creates the workspace under the SECONDMATE home's own label, not 'firstmate'
ok - fm_backend_herdr_create_task: prunes exactly the seeded default tab container_ensure identified, once the first real task tab exists
ok - herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once
ok - fm_backend_herdr_create_task: an ADOPTED workspace's pre-existing tab is never pruned (the created-vs-adopted gate)
ok - fm_backend_herdr_create_task: the label-collision startup-workspace scenario (2026-07-02 incident) leaves the captain's live tab untouched
ok - fm_backend_herdr_workspace_prune_seeded_default_tab: refuses to close the seeded default tab when its pane reports a working agent (defense in depth)
ok - fm_backend_herdr_create_task: refuses a duplicate tab label (herdr's own tab create has no uniqueness check)
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - fm_backend_herdr_create_task: scans every same-labeled tab and refuses if any duplicate is live
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is dead (pane_not_found)
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is alive but hosts no registered agent (a restored plain shell)
ok - fm_backend_herdr_create_task: closes every confirmed same-labeled husk only after creating the replacement
ok - fm_backend_herdr_create_task: refuses success when a preexisting husk tab remains after replacement
ok - fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently
ok - fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse
ok - fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given
ok - fm_backend_herdr_create_task: tab create passes --no-focus
ok - herdr presentation journal: atomically publishes one non-authoritative 128-bit correlator and refuses overwrite
ok - herdr presentation journal: version 2 binds exact home/endpoint/parent identities and advances atomically
ok - herdr presentation create: exact response IDs yield one normal task pane with no workspace-close authority
ok - herdr presentation create: concurrent same-label tabs are never prune targets
ok - herdr presentation focus: snapshot requires one exact active workspace and tab
ok - herdr presentation focus: exact pane close restores the exact prior workspace and tab
ok - herdr presentation focus: cleanup refuses rather than close the captain's active tab
ok - herdr presentation focus: pane close fails when exact focus restoration fails
ok - herdr presentation reclaim: live agent state at the close boundary refuses mutation
ok - herdr presentation focus: projected seeded pruning refuses the active tab
ok - herdr presentation labels: └ concise-task · p:<full-token> for primary and secondmate children
ok - herdr presentation ordering: exact new workspace appends to the primary block while focus and relative orders stay stable
ok - herdr presentation ordering: secondmate children append under their owning parent block
ok - herdr presentation ordering: a foreign legacy child is warning-only and read-only
ok - herdr presentation ordering: intervening parent child blocks remain traversable
ok - herdr presentation ordering: only the exact new id moves; human spaces keep relative order
ok - herdr presentation ordering: move failure warns, returns success, and grants no cleanup authority
ok - herdr presentation ordering: an ambiguous existing worker block is warning-only and read-only
ok - herdr presentation ordering: the launcher's exact parent workspace id disambiguates a duplicated home label without moving anything
ok - herdr presentation ordering: a foreign new-format child is warning-only and read-only
ok - herdr presentation ordering: missing owning parent is warning-only and read-only
ok - herdr presentation lock: one path per session/socket across homes
ok - herdr presentation lock: null and missing socket paths fail closed
ok - herdr presentation ordering: malformed socket metadata is warning-only and read-only
ok - herdr presentation reclaim: legacy, cross-home, ambiguous, live/unknown, and focus-unknown cases refuse without mutation
ok - herdr presentation reclaim: exact agent-free husk survives duplicate parent labels while its sibling stays untouched
warning: 2 exact herdr presentation token matches for task-p3 are quarantined; inspecting only for duplicate-agent risk
warning: quarantined herdr presentation for task-p3 is dead or agent-free; exact bound reclaim may proceed, otherwise spawning flat
ok - herdr presentation recovery: duplicate-token inspection is read-only and live-agent risk refuses fallback
ok - fm_backend_herdr_workspace_find: matches only THIS home's own label among several coexisting workspaces
ok - fm_backend_herdr_list_live: scoped to this home's own workspace, never a sibling home's
ok - fm_backend_herdr_parse_target: splits '<session>:<pane_id>' on the FIRST colon (pane_id itself contains one)
ok - fm_backend_herdr_normalize_key: Enter/Escape/C-c map to herdr's verified enter/escape/ctrl+c
ok - fm_backend_herdr_capture: calls 'pane read <pane> --source recent --lines N' with the session set
ok - fm_backend_herdr_capture: works around the verified small-N '--lines' bug by over-fetching and trimming locally
ok - fm_backend_herdr_capture: ensures the session and preserves pane read failure
ok - fm_backend_herdr_send_key: normalizes the key and targets the right pane
ok - fm_backend_herdr_kill: calls pane close and stays best-effort on failure
ok - fm_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd
ok - fm_backend_herdr_wait_for_shell_ready: waits through a not-ready sample and accepts ten ready samples
ok - fm_backend_herdr_wait_for_shell_ready: resets consecutive samples after a readiness regression
ok - fm_backend_herdr_wait_for_shell_ready: times out without submitting a command
ok - fm_backend_herdr_wait_for_shell_ready: bounds a stalled CLI query by the wall clock
ok - fm-spawn: a Herdr readiness timeout submits no treehouse command
ok - fm_backend_herdr_busy_state: working -> busy
ok - fm_backend_herdr_busy_state: done -> idle, blocked -> idle (surfaced like a stale pane, not suppressed as busy)
ok - fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the regex-fallback cue
ok - fm_backend_herdr_composer_state: a bare '❯' composer row reads empty
ok - fm_backend_herdr_composer_state: the ghost placeholder text reads empty, not pending
ok - fm_backend_herdr_composer_state: real composer text reads pending
ok - fm_backend_herdr_composer_state: a slash-command popup's argument-hint placeholder still reads pending (the incident fix)
ok - fm_backend_herdr_composer_state: reports unknown when the pane cannot be captured
ok - fm_backend_herdr_composer_state: reports unknown for bare shell prompts with no composer row
ok - fm_backend_herdr_composer_state: a native idle Pi separator composer reads empty
ok - fm_backend_herdr_composer_state: real Pi composer text remains pending
ok - fm_backend_herdr_composer_state: an incomplete lower Pi separator cannot inherit a stale empty row
ok - fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯' prompt row (no border box in view) reads empty
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯ <text>' prompt row reads pending
ok - fm_backend_herdr_composer_state: a live unbordered prompt row below a stale bordered decorative box still wins (not misread as the box's own row)
ok - fm_backend_herdr_composer_state: claude's dim prompt-suggestion ghost (the overnight wedge shape) reads empty
ok - fm_backend_herdr_composer_state: real typed text on the same claude prompt row still reads pending
ok - fm_backend_herdr_composer_state: grok's dark-truecolor placeholder (the TRUECOLOR gap) reads empty
ok - fm_backend_herdr_composer_state: grok's real bright typed input still reads pending
ok - fm_backend_herdr_composer_state: a real-codex unbordered '›' prompt row reads empty
ok - fm_backend_herdr_composer_state: a faint real-codex ghost suggestion reads empty
ok - fm_backend_herdr_composer_state: non-faint codex prompt text still reads pending
ok - fm_backend_herdr_wait_for_working: reports 'busy' immediately on the first poll, without spending the rest of the budget
ok - fm_backend_herdr_wait_for_working: a slow transition landing on a later sample within one window is still caught (robust against the 'slow transition' failure direction)
ok - fm_backend_herdr_wait_for_working: spreads six samples across the full budget endpoint without a final trailing sleep
ok - fm_backend_herdr_send_text_submit: applies the herdr minimum confirmation budget before polling agent-state
ok - fm_backend_herdr_wait_for_working: reports 'idle' (readable, genuinely not yet working) when 'busy' never appears
ok - fm_backend_herdr_wait_for_working: reports 'unknown' (a hard read failure, not a timing race) only when EVERY poll in the window fails
ok - fm_backend_herdr_wait_for_working: treats blocked as submit-active for confirmation without changing watcher busy-state semantics
ok - fm_backend_herdr_send_text_submit: reports 'empty' once agent_status reports working after one Enter, without ever reading the composer
ok - fm_backend_herdr_send_text_submit: reports 'pending' when agent_status never reports working after retried Enters (swallowed)
ok - fm_backend_herdr_send_text_submit: a slash-command popup's placeholder fill on Enter #1 never flips agent_status to working, so it does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_herdr_send_text_submit: a post-Enter blocked state confirms delivery without retrying into the prompt
ok - fm_backend_herdr_send_text_submit: preexisting working is not accepted as submit proof when the composer still holds the message
ok - fm_backend_herdr_send_text_submit: confirms submission via native agent-state alone, immune to a codex-style dynamic idle-tip composer that would have misread as 'pending' under the old composer-based confirmation
ok - fm_backend_herdr_composer_state: a faint real-codex dynamic idle-tip composer row reads empty
ok - fm_backend_composer_state (herdr): the pre-injection empty-box guard still refuses a genuinely non-empty composer, unaffected by the submit-confirmation change
ok - fm_backend_herdr_send_text_submit: a slow transition landing on a later sample within one Enter's budget is confirmed WITHOUT sending a needless extra Enter
ok - fm_backend_herdr_send_text_submit: reports 'send-failed' when the literal send-text call itself errors
ok - fm_backend_herdr_send_text_submit: reports 'unknown' when the post-Enter agent-get read fails (never retries past an unreadable target)
ok - fm_backend_validate: herdr is a known backend (P2)
ok - fm_backend_busy_state: tmux (no native primitive) always reports unknown, preserving the P1 regex-only path
error: unknown backend 'bogus' (known: tmux herdr zellij orca cmux)
ok - fm_backend_composer_state dispatches tmux/herdr/orca to their named classifiers, unknown for zellij/unrecognized backends
ok - fm-peek/fm-send: explicit stale targets matching metadata use the recorded backend
ok - fm_backend_herdr_normalize_event routes through the shared record with an empty from_status
ok - fm_backend_herdr_escalation_marker keys the dedupe marker exactly like the watcher's .stale-<key>
ok - fm_backend_herdr_apply_transition: blocked dedupe starts only after explicit commit
ok - fm_backend_herdr_apply_transition: a working edge clears the marker so the next ->blocked re-escalates
ok - fm_backend_herdr_clear_transition removes task-owned dedupe state
ok - fm_backend_herdr_apply_transition: idle/done (defer) and unknown/empty (fallback) take no fast action
ok - fm_backend_herdr_wait_transition: a home with no herdr panes falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: below-capability protocol/schema falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: reconnect level-reconcile returns an uncommitted blocked pane
ok - fm_backend_herdr_wait_transition: subscribes before reconnect level-reconcile
ok - fm_backend_herdr_wait_transition: a still-blocked, already-escalated pane is not re-delivered on reconnect
ok - fm_backend_herdr_wait_transition: a streamed ->blocked edge returns the record sub-poll
ok - fm_backend_herdr_wait_transition: streamed working clears the marker, idle/done are deferred (clean timeout)
ok - fm_backend_herdr_wait_transition: a reader/subscribe failure falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: Bash 3.2-safe bad-ack path closes fd 9 and removes its FIFO
ok - fm_backend_herdr_wait_transition: stock macOS Bash clean timeout closes fd 9 and returns 1
```
</details>
<details>
<summary>Evidence: Real Herdr E2E transcript</summary>

`All isolated real-Herdr AFK injection scenarios passed, including swallowed-Enter handling.`

```text
ok - real herdr Scenario A: partial input defers injection; digest arrives clean after idle
ok - real herdr Scenario B: swallowed Enter (via the herdr shim) produces exactly one clean digest
ok - real herdr Scenario C: a normal captain status injects exactly one clean single-line sentinel digest
ok - real herdr Scenario D: a persistently pending composer raises the max-defer wedge alarm, preserves the buffer, and never crashes the daemon
all real-herdr afk injection e2e tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/backends/herdr.sh:1888` - The required “bounded by ten seconds” invariant is not enforced by the sample-count loop: every `fm_backend_herdr_cli ... process-info` call can take arbitrary time (the shared CLI helper applies no timeout), and even normally the 100 command runtimes are added to the 99 × 100 ms sleeps. A stalled Herdr CLI therefore leaves spawn blocked past ten seconds instead of refusing. Please enforce a wall-clock deadline/timeout at the earliest Herdr readiness boundary while retaining the ten consecutive samples.

🔧 Fix: Bound Herdr readiness by wall-clock deadline
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff f0d7cbe91a4734f189a5d85b27d02d3ef58a7d23..b415aa1aea5672cf8d9cbaec2e3f14d89ea0a571` for Herdr-only scope, preserved cwd settlement, documentation, and tests</code>
- `tests/fm-backend-herdr.test.sh`
- `tests/fm-afk-inject-herdr-e2e.test.sh`
- <code>`git status --short` after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
