### PR TITLE
feat: allow a lock-refused session to open an independent detached Paseo agent

### DIFF
--- a/.agents/skills/detached-paseo-agent/SKILL.md
+++ b/.agents/skills/detached-paseo-agent/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: detached-paseo-agent
+description: >-
+  Agent-only procedure for opening an independent detached Paseo root agent from a lock-refused firstmate session.
+  Use only when the captain explicitly asks to open an independent or detached agent or terminal as another tab in the current Paseo workspace, and the session cannot hold the fleet lock.
+  Owns the detached-only exception, the runtime-cwd safety gate, the independence prompt, and the strict boundary that this is never a firstmate fleet member.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# detached-paseo-agent
+
+Load this only when both hold:
+
+- The current session is lock-refused (another session owns the home's fleet lock, so this session is read-only under `AGENTS.md` section 3).
+- The captain explicitly asks to open an independent or detached agent, terminal, or tab in the current Paseo workspace.
+
+This is a single narrow exception to the read-only rule.
+It is NOT a delegation mailbox, a dispatch queue, or a way around the single-writer rule.
+It never uses `bin/fm-spawn.sh`, never creates a crewmate or secondmate, and never records anything in the backlog or `state/`.
+If the request is anything other than "open one independent agent in this Paseo tab", stop and stay read-only.
+
+## What the lock-refused session still may NOT do
+
+Everything section 3 forbids remains forbidden: no spawn, no crewmate or secondmate, no backlog or `state/` writes, no steering, no merges, no wake-queue drain, no supervision, no repair, no project-worktree mutation, no `--force`, and no lock stealing.
+Creating a detached Paseo agent grants none of those.
+It also cannot grant the new agent merge authority or any destructive or irreversible authority; those still require the captain through a session that holds the lock.
+
+## The one allowed action
+
+Create exactly one Paseo agent through `mcp__paseo__create_agent` with, and only with:
+
+- `relationship`: `{ "kind": "detached" }` - a new root agent, never `{ "kind": "subagent" }`.
+- `workspace`: `{ "kind": "current", "cwd": "<validated cwd>" }` - it stays visible as another tab in the caller's current Paseo workspace.
+- `provider`: a real provider/model pair. Call `mcp__paseo__list_providers` and `mcp__paseo__list_models` when unsure; do not guess.
+- `title`: a short (<= 60 char) captain-facing label, for example `Independent Codex agent`.
+- `initialPrompt`: the independence prompt below.
+
+Do not set `relationship.kind` to anything but `detached`.
+Do not use `workspace.kind` `existing` or `create`; the captain asked for another tab in THIS workspace.
+
+## Runtime cwd safety gate (mandatory, before create_agent)
+
+The new agent must start OUTSIDE every firstmate-owned directory so it can never read this home's private operational state.
+Do not eyeball this; run the deterministic gate:
+
+```
+bin/fm-detached-cwd-check.sh "<captain-supplied-or-default-cwd>"
+```
+
+- On exit 0 it prints `SAFE <canonical-path>`; pass that canonical path as `workspace.cwd`.
+- On any non-zero exit it prints `UNSAFE: <reason>`; REFUSE the request and tell the captain the concrete reason. Never silently rewrite an unsafe or ambiguous cwd into a safe one - ask the captain for an explicit safe directory instead.
+
+The gate refuses a cwd that equals or sits inside the firstmate code root, this home, `<home>/projects`, any registered project clone, or any active task worktree, and it resolves symlinks, `..` traversal, and alternate or case-insensitive spellings to the same real directory (`bin/fm-detached-cwd-check.sh` header owns the exact rules).
+A safe default when the captain gives no directory is `/Users/jacobcole/code` (or another user-named non-firstmate directory); still run it through the gate.
+
+## Independence prompt (initialPrompt)
+
+The first prompt must state, in plain language, that the new agent:
+
+- is an independent root agent the captain opened, not a firstmate crewmate, secondmate, or fleet member;
+- must not access, read, or modify firstmate's private operational state (the firstmate home, its `data/`, `state/`, `config/`, `.env`, or `projects/`);
+- must do any repository work in its own isolated clone or worktree, never in a firstmate-owned checkout;
+- carries no firstmate fleet responsibility, supervision duty, or merge authority.
+
+Template (adapt the specific task the captain names, keep every boundary):
+
+```
+You are an independent agent the captain opened directly. You are NOT a Firstmate
+crewmate, secondmate, or fleet member, and you carry no Firstmate supervision or
+merge responsibility. Do not access, read, or modify any Firstmate operational
+state (a Firstmate home and its data/, state/, config/, .env, or projects/). Do
+all repository work in your own isolated clone or worktree, never in a
+Firstmate-owned checkout. Your task: <captain's task>.
+```
+
+## After creation
+
+- Firstmate does not track, supervise, steer, recover, or tear down this agent. It is the captain's own tab.
+- Do not write a backlog item, a `state/<id>.meta`, a brief, or any wake for it.
+- Report to the captain in plain language that the independent agent is open in this Paseo workspace and that it is separate from the fleet.
+- Then return to read-only mode; the session is still lock-refused for everything else.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ An `ABSENT` captain, shared-captain, secondmate, or learnings file means the fir
 
 If the session lock cannot be acquired and verified, report its exact diagnostic and remain read-only; another active session is only one possible cause.
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
+The single narrow exception is that, only on the captain's explicit request, a lock-refused session may open one independent detached Paseo root agent in the current Paseo workspace with a runtime cwd outside every firstmate-owned directory; that agent is never a fleet member and gains no merge or destructive authority, and `detached-paseo-agent` owns the whole procedure and its safety gate.
 
 1. **Lock** - acquires the per-home session lock first, before anything mutates shared state.
 2. **Bootstrap** - detect-only checks (tool/version problems, GitHub auth, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
@@ -476,6 +477,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `detached-paseo-agent` - load only when a lock-refused session is explicitly asked to open one independent detached Paseo root agent in the current Paseo workspace; never for fleet work.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/bin/fm-detached-cwd-check.sh
+++ b/bin/fm-detached-cwd-check.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Validate a candidate runtime cwd for a detached Paseo root agent.
+#
+# The detached-paseo-agent skill is the only caller: it must never place an
+# independent agent inside firstmate's operational home, so this script is the
+# deterministic gate that decides whether a captain-supplied cwd is outside every
+# firstmate-owned directory. Instructions alone are not enough for a safety
+# boundary, so the refusal is enforced here rather than left to agent memory.
+#
+# Usage: fm-detached-cwd-check.sh <candidate-cwd>
+#   Prints "SAFE <canonical-path>" and exits 0 when the candidate is a real
+#   directory outside every firstmate-owned root.
+#   Prints "UNSAFE: <reason>" to stderr and exits 1 otherwise, including a
+#   missing, relative, unreadable, or ambiguous path. The caller must refuse the
+#   request rather than rewrite the cwd on any non-zero exit.
+#
+# Forbidden roots (the candidate may not equal or sit inside any of them):
+#   - FM_ROOT             the tracked firstmate code root
+#   - FM_HOME             the effective operational home
+#   - FM_HOME/projects    all registered project clones live here
+#   - every worktree=      recorded in FM_HOME/state/*.meta (active task worktrees)
+#
+# Containment is decided by device+inode identity walked up the candidate's real
+# ancestry, not by string prefix: this resolves symlinks, ".." traversal, and
+# case-insensitive or otherwise alternate spellings to the same directory a
+# forbidden root names. A candidate that merely CONTAINS firstmate (for example
+# the parent of the home) is allowed - only a candidate inside firstmate is
+# refused.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+unsafe() {
+  printf 'UNSAFE: %s\n' "$1" >&2
+  exit 1
+}
+
+CANDIDATE=${1-}
+[ -n "$CANDIDATE" ] || unsafe 'no candidate cwd given'
+case "$CANDIDATE" in
+  /*) ;;
+  *) unsafe "candidate cwd must be an absolute path, got: $CANDIDATE" ;;
+esac
+
+# Portable "dev:inode" identity for an existing directory.
+inode_key() {
+  if [ "$(uname)" = Darwin ]; then
+    stat -f '%d:%i' "$1" 2>/dev/null
+  else
+    stat -c '%d:%i' "$1" 2>/dev/null
+  fi
+}
+
+# Canonical physical path of an existing directory, or empty on failure.
+real_dir() {
+  ( cd "$1" 2>/dev/null && pwd -P ) 2>/dev/null
+}
+
+CANON=$(real_dir "$CANDIDATE")
+[ -n "$CANON" ] || unsafe "candidate cwd does not resolve to a real directory: $CANDIDATE"
+
+# Collect the device+inode identity of every firstmate-owned root that exists.
+FORBIDDEN_KEYS=""
+add_forbidden() {
+  local dir=$1 canon key
+  [ -n "$dir" ] || return 0
+  canon=$(real_dir "$dir") || return 0
+  [ -n "$canon" ] || return 0
+  key=$(inode_key "$canon")
+  [ -n "$key" ] || return 0
+  FORBIDDEN_KEYS="$FORBIDDEN_KEYS$key
+"
+}
+
+add_forbidden "$FM_ROOT"
+add_forbidden "$FM_HOME"
+add_forbidden "$FM_HOME/projects"
+
+if [ -d "$STATE" ]; then
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    while IFS= read -r line; do
+      case "$line" in
+        worktree=*) add_forbidden "${line#worktree=}" ;;
+      esac
+    done < "$meta"
+  done
+fi
+
+# Fail closed if we could not identify a single forbidden root: without the
+# firstmate roots there is nothing to protect the home with, so refuse.
+[ -n "$FORBIDDEN_KEYS" ] || unsafe 'could not resolve any firstmate-owned root to compare against'
+
+# Walk the candidate's real ancestry; refuse if any ancestor (including the
+# candidate itself) is one of the forbidden roots by device+inode identity.
+node="$CANON"
+i=0
+while [ "$i" -lt 100 ]; do
+  key=$(inode_key "$node")
+  if [ -n "$key" ] && printf '%s\n' "$FORBIDDEN_KEYS" | grep -Fxq "$key"; then
+    unsafe "candidate cwd is inside a firstmate-owned directory: $CANON"
+  fi
+  parent=$(dirname "$node")
+  [ "$parent" = "$node" ] && break
+  node="$parent"
+  i=$((i + 1))
+done
+
+printf 'SAFE %s\n' "$CANON"
+exit 0

--- a/bin/fm-detached-cwd-check.sh
+++ b/bin/fm-detached-cwd-check.sh
@@ -17,7 +17,9 @@
 # Forbidden roots (the candidate may not equal or sit inside any of them):
 #   - FM_ROOT             the tracked firstmate code root
 #   - FM_HOME             the effective operational home
-#   - FM_HOME/projects    all registered project clones live here
+#   - FM_PROJECTS_OVERRIDE or FM_HOME/projects
+#                         all registered project clones live here
+#   - every home: entry    recorded in FM_DATA_OVERRIDE or FM_HOME/data/secondmates.md
 #   - every worktree=      recorded in FM_HOME/state/*.meta (active task worktrees)
 #
 # Containment is decided by device+inode identity walked up the candidate's real
@@ -32,6 +34,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
 unsafe() {
   printf 'UNSAFE: %s\n' "$1" >&2
@@ -77,7 +81,15 @@ add_forbidden() {
 
 add_forbidden "$FM_ROOT"
 add_forbidden "$FM_HOME"
-add_forbidden "$FM_HOME/projects"
+add_forbidden "$PROJECTS"
+
+if [ -f "$DATA/secondmates.md" ]; then
+  while IFS= read -r line; do
+    home=$(printf '%s\n' "$line" | sed -n 's/.*(home:[[:space:]]*\([^;)]*\);.*/\1/p' | sed 's/[[:space:]]*$//')
+    [ -n "$home" ] || continue
+    add_forbidden "$home"
+  done < "$DATA/secondmates.md"
+fi
 
 if [ -d "$STATE" ]; then
   for meta in "$STATE"/*.meta; do

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -94,3 +94,33 @@ fm_session_lock_owned_by_self() {
   my_pid=$(fm_harness_ancestry_pid) || return 1
   [ "$my_pid" = "$lock_pid" ]
 }
+
+# Classify session-lock ownership for the home whose state dir is $1, using the
+# same harness-identity contract as fm_session_lock_owned_by_self. Prints exactly
+# one token and always returns 0:
+#   self       - the current process descends from the live lock-owning harness
+#   other-live - the lock names a different live harness process (a lock-refused
+#                read-only session); only this token proves another session owns
+#                the home, and only confidently, so callers may silence on it
+#   stale      - the lock names a dead or non-harness pid (a recoverable owner)
+#   free       - no lock, or an empty / malformed lock pid
+# Ancestry that cannot be resolved never yields "self"; it degrades toward
+# "other-live" only when a different pid is a confirmed live harness, so a caller
+# that acts on "self"/"stale"/"free" keeps its existing behavior under
+# uncertainty and never silences the real owner by mistake.
+fm_session_lock_ownership() {
+  local state=$1 lock_pid
+  if fm_session_lock_owned_by_self "$state"; then
+    printf 'self\n'
+    return 0
+  fi
+  lock_pid=$(cat "$state/.lock" 2>/dev/null || true)
+  case "$lock_pid" in
+    ''|*[!0-9]*) printf 'free\n'; return 0 ;;
+  esac
+  if fm_harness_pid_alive "$lock_pid"; then
+    printf 'other-live\n'
+    return 0
+  fi
+  printf 'stale\n'
+}

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -120,7 +120,7 @@ family_for_basename() {
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|fm-brief.test.sh|\
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
-    fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
+    fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|fm-detached-cwd-check.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -126,6 +126,8 @@ fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 # --- the actual predicate ----------------------------------------------------
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
 BUDGET_FILE="$STATE/.turnend-claude-blocks"
 budget_reset() {
@@ -146,6 +148,19 @@ else
   fi
 fi
 if fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
+  budget_reset
+  exit 0
+fi
+
+# A lock-refused read-only session is not responsible for this home's
+# supervision. When a DIFFERENT live harness owns the session lock, the owning
+# session (guarded here as "self") carries the repair; telling this read-only
+# session to resume supervision on another session's in-flight work is exactly
+# the wrong instruction, so exit silently. A "self", "stale", or "free" lock all
+# keep the existing block/recovery behavior below: the owner still blocks when
+# its supervision is unhealthy, and an absent or dead-owner lock still needs
+# recovery here.
+if [ "$(fm_session_lock_ownership "$STATE")" = other-live ]; then
   budget_reset
   exit 0
 fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,6 +69,7 @@ The drain script calls that guard after emptying the queue, which avoids repeati
 It leads with a prominent bordered tangle banner, while `bin/fm-guard.sh` owns the stale-watcher banner/reminder policy so repeated guarded commands stay noisy without reprinting the full watcher-down banner in the same episode.
 On every verified primary harness, tracked hook integration gives the primary session a push-based backstop: when work is in flight and no identity-matched watcher lock with a fresh beacon is live, direct Stop hooks block and passive turn-end hooks force one bounded follow-up.
 The guard covers the main primary and genuinely marked secondmate homes, exempts child crewmate/scout worktrees, is loop-safe per harness, and is documented in [turnend-guard.md](turnend-guard.md).
+When another live harness owns `state/.lock`, the guard treats the current session as lock-refused and exits silently instead of instructing it to supervise the lock owner's work.
 
 A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill starts it through the tracked foreground helper `bin/fm-afk-start.sh`, after which the watcher reverts to daemon-managed one-shot mode and the daemon self-handles routine wakes in bash.
 The watcher and daemon share `bin/fm-classify-lib.sh` for captain-relevant status verbs, declared-external-wait vocabulary, and status-scan primitives.
@@ -126,6 +127,7 @@ Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.
 `fm-guard.sh` prints the repair command on the next mutable fleet action, while `bin/fm-session-start.sh` reports the same condition through bootstrap as a `TANGLE:` line at session start.
 If another live session holds the fleet lock, both surfaces keep the alarm but switch to read-only wording with no repair command.
 Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>`, then stop with a blocked status if it landed in the primary checkout.
+The only lock-refused action path is the agent-only detached Paseo exception owned by [`detached-paseo-agent`](../.agents/skills/detached-paseo-agent/SKILL.md), with `bin/fm-detached-cwd-check.sh` enforcing that the new root agent starts outside Firstmate-owned directories.
 
 ## No-mistakes gate authority boundary
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -128,6 +128,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/detached-paseo-agent/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/diagnostic-reasoning/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -28,11 +28,12 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
-| `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
+| `fm-session-lock-lib.sh` | Shared session-lock harness identity, owner classification, ancestry walk, and holder liveness |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-kimi-turnend-hook.sh` | Surgically install or remove Kimi's guarded global crew turn-end hook                |
+| `fm-detached-cwd-check.sh` | Validate one detached Paseo root agent runtime cwd is outside Firstmate-owned directories |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |
 | `fm-subagent-pretool-check.sh` | Primary-home delegation-shape PreToolUse guard (docs/subagent-guard.md) |

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -32,6 +32,11 @@ Otherwise it calls `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] 
 A stale beacon blocks even when a watcher pid is live.
 A fresh leftover beacon blocks when the lock is missing, dead, or identity-mismatched.
 
+Once the guard has decided supervision is needed and no watcher is healthy, it classifies session-lock ownership through `fm_session_lock_ownership <state-dir>` in `bin/fm-session-lock-lib.sh`, the same harness-identity contract the Claude Stop auto-arm uses.
+A lock-refused read-only session (`other-live`: a different live harness owns `state/.lock`) exits silently, because supervising the lock owner's in-flight work is not its job and telling it to resume supervision would be the wrong instruction.
+Only a confidently different live harness owner silences the guard; a lock owned by this session (`self`), an absent or malformed lock (`free`), or a dead or non-harness owner (`stale`) all keep the existing block or recovery behavior, so the real owner still blocks when its supervision is unhealthy and an absent or dead-owner lock still triggers recovery.
+This preserves the loop guard and both main-home and secondmate-home behavior.
+
 `FM_STATE_OVERRIDE` wins over `FM_HOME/state`, and `FM_HOME` wins over repository-root `state/`.
 `FM_GUARD_GRACE` controls beacon freshness and defaults to 300 seconds.
 If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot safely read loop-guard fields.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -95,7 +95,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 ## Regression coverage
 
-`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
+`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, session-lock ownership classification for `self`, `other-live`, and `stale`, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
 `tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -94,6 +94,7 @@ The same run proved the Claude-compatible Stop entries stay inert under `GROK_AG
 The secondmate-home scope and manual-repair wake path were measured with Claude Code 2.1.207 on 2026-07-12, when a native background completion re-invoked the idle model with no human input.
 The current Stop-owned main/secondmate inclusion and child-worktree exclusion are covered deterministically by `tests/fm-claude-stop-autoarm.test.sh`.
 On 2026-07-28 with Claude Code 2.1.205, `fm_harness_ancestry_pid()` in `bin/fm-session-lock-lib.sh` was fixed to resolve the outermost pid of a contiguous nested-harness run instead of the first match, so the Stop auto-arm correctly reaches the session's true lock owner through Claude Code's multi-level `bg-spare` hook worker chain.
+The deterministic turn-end guard suite now also covers lock-refused read-only sessions by proving a different live harness owner exits silently in both main and secondmate homes, while self-owned and stale-owner locks keep the existing block or recovery path.
 
 The Claude product live path ran with Claude Code 2.1.219 on 2026-07-24:
 

--- a/tests/fm-detached-cwd-check.test.sh
+++ b/tests/fm-detached-cwd-check.test.sh
@@ -4,7 +4,8 @@
 # directory (the detached-paseo-agent skill is the only caller).
 #
 # All hermetic over temp dirs; the check is driven only through its executable
-# interface with FM_ROOT_OVERRIDE / FM_HOME / FM_STATE_OVERRIDE.
+# interface with FM_ROOT_OVERRIDE / FM_HOME / FM_STATE_OVERRIDE /
+# FM_PROJECTS_OVERRIDE / FM_DATA_OVERRIDE.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -22,17 +23,24 @@ CODE="$TMP_ROOT/fmcode"
 HOME_DIR="$TMP_ROOT/home"
 WT="$TMP_ROOT/wt/task1"
 SAFE="$TMP_ROOT/user/code"
+PROJECTS="$TMP_ROOT/relocated-projects"
+SECOND_HOME="$TMP_ROOT/secondmate-home"
 mkdir -p \
   "$CODE/bin" \
+  "$HOME_DIR/data" \
   "$HOME_DIR/state" \
   "$HOME_DIR/projects/alpha/src" \
+  "$PROJECTS/beta/src" \
+  "$SECOND_HOME/data/private" \
   "$WT/pkg" \
   "$SAFE/sub" \
   "$HOME_DIR/sub"
 printf 'worktree=%s\n' "$WT" > "$HOME_DIR/state/task1.meta"
+printf -- '- sm - registered idle secondmate (home: %s; scope: fixture; projects: beta; added 2026-07-30)\n' "$SECOND_HOME" > "$HOME_DIR/data/secondmates.md"
 
 run_check() {
   FM_ROOT_OVERRIDE="$CODE" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
+    FM_PROJECTS_OVERRIDE="$PROJECTS" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     bash "$CHECK" "$1" 2>&1
 }
 
@@ -83,11 +91,15 @@ test_refuse_inside_fm_home() {
 }
 
 test_refuse_projects_root() {
-  expect_unsafe "$HOME_DIR/projects" "the projects root is refused"
+  expect_unsafe "$PROJECTS" "the configured projects root is refused"
 }
 
-test_refuse_inside_registered_clone() {
-  expect_unsafe "$HOME_DIR/projects/alpha/src" "a directory inside a registered project clone is refused"
+test_refuse_inside_configured_projects_root() {
+  expect_unsafe "$PROJECTS/beta/src" "a directory inside the configured projects root is refused"
+}
+
+test_refuse_inside_registered_secondmate_home() {
+  expect_unsafe "$SECOND_HOME/data/private" "a directory inside a registered idle secondmate home is refused"
 }
 
 test_refuse_inside_active_worktree() {
@@ -143,7 +155,8 @@ test_refuse_inside_fm_root
 test_refuse_fm_home_itself
 test_refuse_inside_fm_home
 test_refuse_projects_root
-test_refuse_inside_registered_clone
+test_refuse_inside_configured_projects_root
+test_refuse_inside_registered_secondmate_home
 test_refuse_inside_active_worktree
 test_refuse_relative_path
 test_refuse_nonexistent_path

--- a/tests/fm-detached-cwd-check.test.sh
+++ b/tests/fm-detached-cwd-check.test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-detached-cwd-check.sh - the deterministic gate that
+# keeps a detached Paseo root agent's runtime cwd outside every firstmate-owned
+# directory (the detached-paseo-agent skill is the only caller).
+#
+# All hermetic over temp dirs; the check is driven only through its executable
+# interface with FM_ROOT_OVERRIDE / FM_HOME / FM_STATE_OVERRIDE.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CHECK="$ROOT/bin/fm-detached-cwd-check.sh"
+[ -x "$CHECK" ] || fail "bin/fm-detached-cwd-check.sh must be executable"
+
+TMP_ROOT=$(fm_test_tmproot fm-detached-cwd)
+
+# Fixture firstmate layout: a code root, a distinct operational home with a
+# projects tree and a registered clone, plus one active task worktree recorded in
+# state/<id>.meta. A "safe" tree and the shared parent live outside all of it.
+CODE="$TMP_ROOT/fmcode"
+HOME_DIR="$TMP_ROOT/home"
+WT="$TMP_ROOT/wt/task1"
+SAFE="$TMP_ROOT/user/code"
+mkdir -p \
+  "$CODE/bin" \
+  "$HOME_DIR/state" \
+  "$HOME_DIR/projects/alpha/src" \
+  "$WT/pkg" \
+  "$SAFE/sub" \
+  "$HOME_DIR/sub"
+printf 'worktree=%s\n' "$WT" > "$HOME_DIR/state/task1.meta"
+
+run_check() {
+  FM_ROOT_OVERRIDE="$CODE" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
+    bash "$CHECK" "$1" 2>&1
+}
+
+expect_safe() {
+  local candidate=$1 label=$2 out status
+  out=$(run_check "$candidate"); status=$?
+  expect_code 0 "$status" "$label: expected SAFE (exit 0)"
+  assert_contains "$out" "SAFE " "$label: output must announce SAFE"
+  pass "fm-detached-cwd-check: $label"
+}
+
+expect_unsafe() {
+  local candidate=$1 label=$2 out status
+  out=$(run_check "$candidate"); status=$?
+  expect_code 1 "$status" "$label: expected UNSAFE (exit 1)"
+  assert_contains "$out" "UNSAFE" "$label: output must announce UNSAFE"
+  pass "fm-detached-cwd-check: $label"
+}
+
+# --- safe candidates ---------------------------------------------------------
+
+test_safe_outside_directory() {
+  expect_safe "$SAFE" "a non-firstmate directory outside the home is permitted"
+}
+
+test_safe_parent_of_home_is_allowed() {
+  # A candidate that merely CONTAINS firstmate (like /Users/jacobcole/code) is
+  # allowed; only a candidate INSIDE firstmate is refused.
+  expect_safe "$TMP_ROOT" "the shared parent that contains the firstmate home is permitted"
+}
+
+# --- refused: inside firstmate-owned roots -----------------------------------
+
+test_refuse_fm_root_itself() {
+  expect_unsafe "$CODE" "the firstmate code root itself is refused"
+}
+
+test_refuse_inside_fm_root() {
+  expect_unsafe "$CODE/bin" "a directory inside the firstmate code root is refused"
+}
+
+test_refuse_fm_home_itself() {
+  expect_unsafe "$HOME_DIR" "the operational home itself is refused"
+}
+
+test_refuse_inside_fm_home() {
+  expect_unsafe "$HOME_DIR/state" "a directory inside the operational home is refused"
+}
+
+test_refuse_projects_root() {
+  expect_unsafe "$HOME_DIR/projects" "the projects root is refused"
+}
+
+test_refuse_inside_registered_clone() {
+  expect_unsafe "$HOME_DIR/projects/alpha/src" "a directory inside a registered project clone is refused"
+}
+
+test_refuse_inside_active_worktree() {
+  expect_unsafe "$WT" "an active task worktree is refused"
+  expect_unsafe "$WT/pkg" "a directory inside an active task worktree is refused"
+}
+
+# --- refused: bypass attempts ------------------------------------------------
+
+test_refuse_relative_path() {
+  expect_unsafe "relative/path" "a relative candidate path is refused (ambiguous)"
+}
+
+test_refuse_nonexistent_path() {
+  expect_unsafe "$TMP_ROOT/does-not-exist" "a nonexistent candidate is refused"
+}
+
+test_refuse_traversal_into_home() {
+  # A textually 'safe-looking' path whose .. segments escape back into the home.
+  expect_unsafe "$SAFE/../../home" "a .. traversal that lands inside the home is refused"
+}
+
+test_refuse_traversal_via_home_dotdot() {
+  expect_unsafe "$HOME_DIR/sub/.." "a .. traversal resolving to the home itself is refused"
+}
+
+test_refuse_symlink_into_fm_root() {
+  local link="$TMP_ROOT/evil-link"
+  ln -sf "$CODE" "$link"
+  expect_unsafe "$link" "a symlink pointing into the firstmate code root is refused"
+  rm -f "$link"
+}
+
+test_refuse_symlink_into_home() {
+  local link="$TMP_ROOT/evil-home-link"
+  ln -sf "$HOME_DIR/projects" "$link"
+  expect_unsafe "$link" "a symlink pointing into the projects tree is refused"
+  rm -f "$link"
+}
+
+test_refuse_alternate_case_spelling() {
+  # On a case-insensitive filesystem the OS resolves the mixed-case spelling to
+  # the real firstmate root (device+inode identity catches it); on a
+  # case-sensitive filesystem the path simply does not exist. Either way the
+  # candidate must be refused, so an alternate spelling can never bypass the gate.
+  expect_unsafe "$TMP_ROOT/FMCODE" "an alternate/case-variant spelling of the code root cannot bypass the gate"
+}
+
+test_safe_outside_directory
+test_safe_parent_of_home_is_allowed
+test_refuse_fm_root_itself
+test_refuse_inside_fm_root
+test_refuse_fm_home_itself
+test_refuse_inside_fm_home
+test_refuse_projects_root
+test_refuse_inside_registered_clone
+test_refuse_inside_active_worktree
+test_refuse_relative_path
+test_refuse_nonexistent_path
+test_refuse_traversal_into_home
+test_refuse_traversal_via_home_dotdot
+test_refuse_symlink_into_fm_root
+test_refuse_symlink_into_home
+test_refuse_alternate_case_spelling

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -107,6 +107,7 @@ install_guard_scripts() {
   cp "$ROOT/bin/fm-primary-scope-lib.sh" "$dir/bin/fm-primary-scope-lib.sh"
   cp "$ROOT/bin/fm-supervision-lib.sh" "$dir/bin/fm-supervision-lib.sh"
   cp "$ROOT/bin/fm-wake-lib.sh" "$dir/bin/fm-wake-lib.sh"
+  cp "$ROOT/bin/fm-session-lock-lib.sh" "$dir/bin/fm-session-lock-lib.sh"
   mkdir -p "$dir/docs"
   cp -R "$ROOT/docs/supervision-protocols" "$dir/docs/supervision-protocols"
   chmod +x "$dir/bin/fm-turnend-guard.sh" "$dir/bin/fm-turnend-guard-grok.sh" "$dir/bin/fm-operational-input.sh" "$dir/bin/fm-supervision-instructions.sh" "$dir/bin/fm-harness.sh"
@@ -354,6 +355,94 @@ test_hook_loop_guard_allows_retry() {
   expect_code 0 "$status" "hook must allow the stop when stop_hook_active is already true"
   [ -z "$out" ] || fail "hook produced output on the loop-guarded retry: $out"
   pass "fm-turnend-guard: stop_hook_active=true always allows the stop (never blocks twice in one turn)"
+}
+
+# --- session-lock ownership: a lock-refused read-only session stays silent -----
+#
+# The turn-end guard classifies session-lock ownership (bin/fm-session-lock-lib.sh)
+# before it may nag. Only a DIFFERENT live harness owner (a lock-refused read-only
+# session) is silenced; the real owner still blocks when its supervision is
+# unhealthy, and a free or stale-owner lock still triggers recovery.
+#
+# The guard resolves the current session's harness by walking its process
+# ancestry, so these fixtures run the guard as a child of a fake harness (a bash
+# symlink named "codex") exactly as the auto-arm tests do.
+
+# Run the guard as a child of a fake "codex" harness whose own pid is written to
+# the home's session lock, so the guard classifies the lock as owned by self.
+# shellcheck disable=SC2016 # $$/$rc/$? are deliberately literal: they expand inside the fake harness child, not here; only $dir/$home expand via the '"..."' concatenation.
+run_hook_owned_by_self() {
+  local dir=$1 fakebin home
+  home=$(cd "$dir" && pwd)
+  fakebin=$(fm_fakebin "$dir/fake-self")
+  ln -sf /bin/bash "$fakebin/codex"
+  printf '{"stop_hook_active":false}' | CLAUDECODE=1 FM_HOME="$home" "$fakebin/codex" -c '
+    printf "%s\n" "$$" > "'"$home"'/state/.lock"
+    bash "'"$dir"'/bin/fm-turnend-guard.sh"
+    rc=$?
+    exit "$rc"
+  ' 2>&1
+}
+
+# Start a detached fake "codex" harness process and echo its pid; the caller
+# writes it into state/.lock to simulate a different live session owning the home.
+start_other_harness() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir/fake-other")
+  ln -sf /bin/bash "$fakebin/codex"
+  "$fakebin/codex" -c 'sleep 60; :' >/dev/null 2>&1 &
+  printf '%s\n' "$!"
+}
+
+test_hook_silent_when_other_live_harness_owns_lock() {
+  local dir other out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-other-live")
+  : > "$dir/state/task1.meta"
+  other=$(start_other_harness "$dir")
+  printf '%s\n' "$other" > "$dir/state/.lock"
+  out=$(run_hook "$dir" false); status=$?
+  kill "$other" 2>/dev/null || true
+  wait "$other" 2>/dev/null || true
+  expect_code 0 "$status" "hook must stay silent when a different live harness owns the session lock"
+  [ -z "$out" ] || fail "lock-refused read-only session must not be told to supervise: $out"
+  pass "fm-turnend-guard: silent when another live session owns the home (lock-refused read-only session)"
+}
+
+test_hook_blocks_when_current_harness_owns_lock() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-self-owns")
+  : > "$dir/state/task1.meta"
+  out=$(run_hook_owned_by_self "$dir"); status=$?
+  expect_code 2 "$status" "the lock-owning session must still block when its own supervision is unhealthy"
+  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
+  assert_contains "$out" "TURN WOULD END BLIND" "block banner must read as an alarm"
+  pass "fm-turnend-guard: the session that owns the lock still blocks a blind turn end"
+}
+
+test_hook_blocks_when_lock_owner_is_stale() {
+  local dir dead out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-stale-owner")
+  : > "$dir/state/task1.meta"
+  dead=$(nonexistent_pid)
+  printf '%s\n' "$dead" > "$dir/state/.lock"
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 2 "$status" "a dead session-lock owner must still trigger recovery, not silence"
+  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
+  pass "fm-turnend-guard: a stale (dead-owner) session lock still blocks for recovery"
+}
+
+test_hook_silent_when_other_live_harness_owns_secondmate_lock() {
+  local dir other out status
+  dir=$(make_secondmate_dir "$TMP_ROOT/hook-other-live-sm")
+  : > "$dir/state/task1.meta"
+  other=$(start_other_harness "$dir")
+  printf '%s\n' "$other" > "$dir/state/.lock"
+  out=$(run_hook "$dir" false); status=$?
+  kill "$other" 2>/dev/null || true
+  wait "$other" 2>/dev/null || true
+  expect_code 0 "$status" "a secondmate home must also silence when a different live session owns its lock"
+  [ -z "$out" ] || fail "lock-refused secondmate session must not be told to supervise: $out"
+  pass "fm-turnend-guard: silent in a secondmate home when another live session owns its lock"
 }
 
 # A secondmate's OWN home runs a primary firstmate session and must be guarded
@@ -1121,6 +1210,10 @@ test_hook_x_mode_reason_sources_cadence
 test_hook_ignores_repo_state_when_fm_home_set
 test_hook_uses_state_override
 test_hook_loop_guard_allows_retry
+test_hook_silent_when_other_live_harness_owns_lock
+test_hook_blocks_when_current_harness_owns_lock
+test_hook_blocks_when_lock_owner_is_stale
+test_hook_silent_when_other_live_harness_owns_secondmate_lock
 test_hook_blocks_in_secondmate_own_home
 test_hook_silent_in_idle_secondmate_home
 test_hook_secondmate_loop_guard_allows_retry


### PR DESCRIPTION
## What

Adds one narrow exception to Firstmate's single-writer / lock-refused rule, plus a related turn-end-guard correctness fix.

A lock-refused, read-only session may now, **only on the captain's explicit request**, open **one independent detached Paseo root agent** as another tab in the current Paseo workspace, with a runtime cwd **outside** every Firstmate-owned directory. The new agent is a plain Paseo root agent (`relationship.kind=detached`, `workspace.kind=current`) — never a Firstmate crewmate or secondmate. It is not recorded in the backlog or `state/`, is never supervised, steered, merged, recovered, or torn down, and gains no merge or destructive authority. This is intentionally **not** a delegation mailbox or dispatch queue and does not touch `fm-spawn.sh`.

## Changes

- **New agent-only skill `detached-paseo-agent`** owns the full procedure: the real Paseo `create_agent` schema, the independence prompt, and refusal rules. `AGENTS.md` gets only a concise boundary in section 3 and a section-13 trigger (size-discipline / one-owner rules); registered in `docs/documentation-audiences.json`.
- **New `bin/fm-detached-cwd-check.sh`** — a deterministic gate (not left to agent memory) that refuses any candidate cwd equal to or inside the Firstmate code root, this home, the configured projects root, any registered project clone, any registered (even idle) secondmate home from `data/secondmates.md`, or any active task worktree. Containment is decided by device+inode identity walked up the candidate's real ancestry, so symlinks, `..` traversal, and alternate/case-insensitive spellings cannot bypass it; a directory that merely *contains* Firstmate (e.g. the parent) is allowed.
- **Turn-end guard fix (`bin/fm-turnend-guard.sh`)**: a lock-refused session is no longer told to resume supervision on another session's in-flight work. When a **different live harness** owns `state/.lock` (`other-live`), the guard exits silently. `self` / `free` / `stale` locks keep the existing block/recovery behavior, preserving the loop guard and both main-home and secondmate-home paths. Ownership is classified by a new `fm_session_lock_ownership` helper added to `bin/fm-session-lock-lib.sh`, reusing the existing harness-identity contract rather than parsing `fm-lock.sh` status text.
- Docs: `docs/turnend-guard.md`, `docs/architecture.md`, `docs/scripts.md`, `docs/verification/supervision.md` updated.

## Tests

- New `tests/fm-detached-cwd-check.test.sh` (safe/parent allowed; refuses code root, home, configured projects root, registered idle secondmate home, active worktree; refuses relative/nonexistent/traversal/symlink/alternate-case bypass).
- Four new lock-ownership cases in `tests/fm-turnend-guard.test.sh` (silent when another live harness owns the lock in main and secondmate homes; owner still blocks when unhealthy; stale-owner still recovers).
- Full turn-end-guard suite and the doc-audience structural check remain green; `bin/fm-lint.sh` clean.

## Notes

Delivered through the repo's no-mistakes pipeline (review, test, document, lint all green). The pipeline's review step surfaced and auto-fixed the registered-secondmate-home / configured-projects-root gap in the cwd gate. The relationship=detached-only, prompt-independence, and no-state-writes requirements are enforced as instructions in the skill (they are `create_agent` tool-call decisions with no Firstmate script to assert against), consistent with the repo's test-through-executable-interface guideline.