### PR TITLE
fix(scripts): refuse CLAUDE.md promotion when a repo guards it by literal path

### DIFF
--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -10,6 +10,13 @@
 # Refuses a case-variant real memory file such as a lowercase agents.md, whose
 # CLAUDE.md symlink would carry an uppercase literal target that dangles on a
 # case-sensitive filesystem (issue #389).
+# Refuses to promote CLAUDE.md when the repo's own tracked automation guards
+# it by literal path (a --disallowedTools entry naming CLAUDE.md) - promoting
+# would move the real content to AGENTS.md while that guard keeps matching
+# only the now-empty CLAUDE.md symlink, silently defeating the protection.
+# This is a narrow textual heuristic for that one known shape, not general
+# detection of every possible guard mechanism; a guard built from a variable,
+# a separate config file, or a non-CLI enforcement path can still slip through.
 # This is a worktree utility for crewmates, not a supervision script, so it does
 # not call fm-guard.sh.
 # Usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]
@@ -90,6 +97,30 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - Add durable project-specific notes here as they are discovered through real work.
 EOF
   ensure_maintenance_section
+}
+
+# Detects the one hazard class this script cannot safely paper over: a repo
+# whose own automation runs unattended agent turns against itself and guards
+# CLAUDE.md's real content by hardcoding its literal path in a
+# --disallowedTools list (rather than protecting "whichever file holds the
+# constitution"). Promoting CLAUDE.md into a symlink there would move the
+# real content to AGENTS.md while the guard keeps matching only the
+# now-empty CLAUDE.md path, silently defeating the protection - this is
+# exactly the regression a we-pack-together sibling caught and reverted by
+# hand in the brain vault (2026-07-30). Scoped to git-tracked files only
+# (git ls-files), and to files that mention BOTH markers together, so an
+# ordinary README/CONTRIBUTING mention of CLAUDE.md alone never trips it.
+has_disallowed_tools_guard_referencing_claude() {
+  command -v git >/dev/null 2>&1 || return 1
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+  local f
+  while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    if grep -q 'disallowedTools' "$f" 2>/dev/null && grep -q 'CLAUDE\.md' "$f" 2>/dev/null; then
+      return 0
+    fi
+  done < <(git ls-files 2>/dev/null)
+  return 1
 }
 
 is_correct_claude_symlink() {
@@ -183,6 +214,10 @@ fi
 
 if [ -e "$CLAUDE" ]; then
   if [ -f "$CLAUDE" ]; then
+    if has_disallowed_tools_guard_referencing_claude; then
+      echo "conflict: $DIR has its own automation that appears to guard CLAUDE.md by literal path (a --disallowedTools entry naming CLAUDE.md); promoting would move its real content into AGENTS.md while that guard still only matches the now-empty CLAUDE.md symlink, silently removing the protection. Update the repo's own guard to name AGENTS.md (or whichever file will hold the real content) before promoting, or promote manually with that fixed." >&2
+      exit 1
+    fi
     mv "$CLAUDE" "$AGENTS"
     ensure_maintenance_section
     ln -s "$AGENTS" "$CLAUDE"

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -200,6 +200,69 @@ test_lowercase_agents_md_refuses_case_fragile_symlink() {
   pass "fm-ensure-agents-md.sh: refuses a case-variant lowercase agents.md (issue #389)"
 }
 
+test_promotion_refuses_when_disallowed_tools_guards_claude_by_path() {
+  local repo out rc
+  repo="$TMP_ROOT/guarded-project"
+  mkdir -p "$repo/automation"
+  cat > "$repo/CLAUDE.md" <<'EOF'
+# Existing agent memory
+
+The constitution unattended turns must not edit.
+EOF
+  cat > "$repo/automation/bot.sh" <<'EOF'
+#!/usr/bin/env bash
+GUARDED=(CLAUDE.md settings.json)
+claude -p "$1" --disallowedTools "${GUARDED[@]}"
+EOF
+  (
+    cd "$repo" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    git add CLAUDE.md automation/bot.sh
+    git commit -q -m init
+  )
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "expected a non-zero exit when a --disallowedTools guard names CLAUDE.md by path"
+  assert_contains "$out" "conflict:" "guarded-repo refusal did not report a conflict"
+  assert_contains "$out" "disallowedTools" "guarded-repo refusal did not name the guard mechanism"
+  assert_absent "$repo/AGENTS.md" "promotion ran despite the path-based CLAUDE.md guard"
+  [ ! -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md was turned into a symlink despite the path-based guard"
+  assert_grep "The constitution unattended turns must not edit." "$repo/CLAUDE.md" \
+    "the real CLAUDE.md content was disturbed despite the refusal"
+  pass "fm-ensure-agents-md.sh: refuses to promote when a --disallowedTools guard names CLAUDE.md by literal path"
+}
+
+test_promotion_proceeds_when_claude_only_mentioned_in_docs() {
+  local repo out rc
+  repo="$TMP_ROOT/docs-mention-project"
+  mkdir -p "$repo"
+  cat > "$repo/CLAUDE.md" <<'EOF'
+# Existing agent memory
+
+Run tests with `make test`.
+EOF
+  cat > "$repo/README.md" <<'EOF'
+# Project
+
+See CLAUDE.md for agent conventions.
+EOF
+  (
+    cd "$repo" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    git add CLAUDE.md README.md
+    git commit -q -m init
+  )
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$repo" 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "an ordinary README mention of CLAUDE.md false-tripped the guard-detection heuristic: $out"
+  [ -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md was not promoted to a symlink for a repo with no real guard"
+  pass "fm-ensure-agents-md.sh: an ordinary doc mention of CLAUDE.md does not block promotion"
+}
+
 test_created_agents_md_includes_self_governance
 test_promoted_claude_md_includes_self_governance
 test_promoted_claude_md_without_trailing_newline_keeps_blank_separator
@@ -209,3 +272,5 @@ test_existing_agents_md_with_section_reports_unchanged
 test_existing_crlf_agents_md_with_section_stays_unchanged
 test_existing_crlf_agents_md_without_section_preserves_crlf
 test_lowercase_agents_md_refuses_case_fragile_symlink
+test_promotion_refuses_when_disallowed_tools_guards_claude_by_path
+test_promotion_proceeds_when_claude_only_mentioned_in_docs


### PR DESCRIPTION
## Summary
- `fm-ensure-agents-md.sh` promotes a bare `CLAUDE.md` into `AGENTS.md` (with a symlink left behind) whenever a project has only `CLAUDE.md` and no `AGENTS.md` yet.
- If that project's own tracked automation hardcodes a `--disallowedTools` entry naming `CLAUDE.md` by literal path (to stop unattended agent turns from editing their own "constitution"), promotion silently defeats that protection: the real content moves to `AGENTS.md`, but the guard keeps matching only the now-empty `CLAUDE.md` symlink.
- Found the hard way: caught and reverted by hand in a project after this exact regression happened.
- This adds a narrow, scoped detector (`has_disallowed_tools_guard_referencing_claude`) that refuses promotion when a git-tracked file mentions both `disallowedTools` and `CLAUDE.md` together, with an actionable error explaining the fix (point the guard at `AGENTS.md` instead, or promote manually).
- Deliberately narrow: this is a textual heuristic for the one confirmed pattern, not general guard-mechanism detection - a guard built from a variable, a separate config file, or a non-CLI enforcement path isn't caught. The header comment says so explicitly.

## Test plan
- [x] `bin/fm-lint.sh bin/fm-ensure-agents-md.sh tests/fm-ensure-agents-md.test.sh` (ShellCheck 0.11.0, pinned)
- [x] `bash tests/fm-ensure-agents-md.test.sh` - 11/11 passing, including two new tests: one confirming refusal when a `--disallowedTools` guard names `CLAUDE.md`, one confirming an ordinary README/CONTRIBUTING mention of `CLAUDE.md` alone does not false-trip the heuristic