### PR TITLE
fix(afk): alert on unexpected daemon death

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
-- [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
+- [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure active alerts for away-mode supervision failures.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - current setup and limits for the tmux reference backend.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - current setup, safety boundaries, and limits for the experimental Herdr backend.
 - [docs/zellij-backend.md](docs/zellij-backend.md) - current setup and limits for the experimental Zellij backend.

--- a/bin/fm-afk-death-lib.sh
+++ b/bin/fm-afk-death-lib.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Shared durable records for an away-mode daemon's intentional and unexpected
+# exit lifecycle.
+#
+# The stop intent is exact to one daemon process: pid plus fm_pid_identity.
+# A matching intent wins an exit race, because it was atomically published
+# before the lifecycle owner asked that exact daemon to stop.
+
+FM_AFK_STOP_INTENT_NAME=".supervise-daemon.stop-intent"
+FM_AFK_UNEXPECTED_EXIT_NAME=".supervise-daemon.unexpected-exit"
+
+fm_afk_stop_intent_path() { printf '%s/%s\n' "$1" "$FM_AFK_STOP_INTENT_NAME"; }
+
+fm_afk_unexpected_exit_path() { printf '%s/%s\n' "$1" "$FM_AFK_UNEXPECTED_EXIT_NAME"; }
+
+fm_afk_death_valid_identity() {
+  case "$1" in
+    ''|*$'\n'*|*$'\r'*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+fm_afk_stop_intent_publish() {  # <state> <pid> <pid-identity>
+  local state=$1 pid=$2 identity=$3 pending
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  fm_afk_death_valid_identity "$identity" || return 1
+  mkdir -p "$state" || return 1
+  pending=$(mktemp "$state/${FM_AFK_STOP_INTENT_NAME}.pending.XXXXXX") || return 1
+  {
+    printf 'pid=%s\n' "$pid"
+    printf 'pid_identity=%s\n' "$identity"
+    printf 'recorded_at=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  } > "$pending" || { rm -f "$pending"; return 1; }
+  mv "$pending" "$(fm_afk_stop_intent_path "$state")" || { rm -f "$pending"; return 1; }
+}
+
+fm_afk_stop_intent_matches() {  # <state> <pid> <pid-identity>
+  local state=$1 pid=$2 identity=$3 path line1 line2 line3 intent_pid intent_identity lines
+  path=$(fm_afk_stop_intent_path "$state")
+  [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  lines=$(awk 'END { print NR }' "$path" 2>/dev/null) || return 1
+  [ "$lines" = 3 ] || return 1
+  line1=$(sed -n '1p' "$path") || return 1
+  line2=$(sed -n '2p' "$path") || return 1
+  line3=$(sed -n '3p' "$path") || return 1
+  case "$line1" in pid=*) intent_pid=${line1#pid=} ;; *) return 1 ;; esac
+  case "$line2" in pid_identity=*) intent_identity=${line2#pid_identity=} ;; *) return 1 ;; esac
+  case "$line3" in recorded_at=????-??-??T??:??:??[+-]????) ;; *) return 1 ;; esac
+  [ "$intent_pid" = "$pid" ] && [ "$intent_identity" = "$identity" ]
+}
+
+fm_afk_stop_intent_retire() {  # <state> <pid> <pid-identity>
+  local state=$1 pid=$2 identity=$3 path
+  fm_afk_stop_intent_matches "$state" "$pid" "$identity" || return 1
+  path=$(fm_afk_stop_intent_path "$state")
+  rm -f "$path"
+}
+
+fm_afk_unexpected_exit_record() {  # <state> <signal> <pid> <pid-identity>
+  local state=$1 signal=$2 pid=$3 identity=$4 pending
+  case "$signal" in ''|*$'\n'*|*$'\r'*) return 1 ;; esac
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  fm_afk_death_valid_identity "$identity" || return 1
+  mkdir -p "$state" || return 1
+  pending=$(mktemp "$state/${FM_AFK_UNEXPECTED_EXIT_NAME}.pending.XXXXXX") || return 1
+  {
+    printf 'signal=%s\n' "$signal"
+    printf 'recorded_at=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')"
+    printf 'pid=%s\n' "$pid"
+    printf 'pid_identity=%s\n' "$identity"
+  } > "$pending" || { rm -f "$pending"; return 1; }
+  mv "$pending" "$(fm_afk_unexpected_exit_path "$state")" || { rm -f "$pending"; return 1; }
+}

--- a/bin/fm-afk-death-lib.sh
+++ b/bin/fm-afk-death-lib.sh
@@ -103,6 +103,13 @@ fm_afk_stop_intent_matches() {  # <state> <pid> <pid-identity>
     && [ "$FM_AFK_STOP_INTENT_IDENTITY" = "$identity" ]
 }
 
+fm_afk_stop_intent_publisher_alive() {
+  local current_identity
+  fm_pid_alive "$FM_AFK_STOP_INTENT_PUBLISHER_PID" || return 1
+  current_identity=$(fm_pid_identity "$FM_AFK_STOP_INTENT_PUBLISHER_PID" 2>/dev/null) || return 1
+  [ "$current_identity" = "$FM_AFK_STOP_INTENT_PUBLISHER_IDENTITY" ]
+}
+
 fm_afk_stop_intent_transition() {  # <state> <pid> <pid-identity> <from-phase> <to-phase>
   local state=$1 pid=$2 identity=$3 from_phase=$4 to_phase=$5 lock result=1
   lock="$state/${FM_AFK_STOP_INTENT_NAME}.transition.lock"
@@ -124,7 +131,28 @@ fm_afk_stop_intent_transition() {  # <state> <pid> <pid-identity> <from-phase> <
 }
 
 fm_afk_stop_intent_consume() {  # <state> <pid> <pid-identity>
-  fm_afk_stop_intent_transition "$1" "$2" "$3" published consumed
+  local state=$1 pid=$2 identity=$3 lock result=1 target_phase=abandoned
+  lock="$state/${FM_AFK_STOP_INTENT_NAME}.transition.lock"
+  fm_lock_acquire_wait "$lock" || return 1
+  if fm_afk_stop_intent_read "$state" \
+    && [ "$FM_AFK_STOP_INTENT_PID" = "$pid" ] \
+    && [ "$FM_AFK_STOP_INTENT_IDENTITY" = "$identity" ]; then
+    if [ "$FM_AFK_STOP_INTENT_PHASE" = consumed ]; then
+      result=0
+    elif [ "$FM_AFK_STOP_INTENT_PHASE" = published ]; then
+      if fm_afk_stop_intent_publisher_alive; then
+        target_phase=consumed
+      fi
+      if fm_afk_stop_intent_write "$state" "$target_phase" "$pid" "$identity" \
+        "$FM_AFK_STOP_INTENT_PUBLISHER_PID" "$FM_AFK_STOP_INTENT_PUBLISHER_IDENTITY" \
+        "$FM_AFK_STOP_INTENT_RECORDED_AT" \
+        && [ "$target_phase" = consumed ]; then
+        result=0
+      fi
+    fi
+  fi
+  fm_lock_release "$lock" 2>/dev/null || result=1
+  return "$result"
 }
 
 fm_afk_stop_intent_abandon() {  # <state> <pid> <pid-identity>

--- a/bin/fm-afk-death-lib.sh
+++ b/bin/fm-afk-death-lib.sh
@@ -8,6 +8,10 @@
 
 FM_AFK_STOP_INTENT_NAME=".supervise-daemon.stop-intent"
 FM_AFK_UNEXPECTED_EXIT_NAME=".supervise-daemon.unexpected-exit"
+FM_AFK_STOP_INTENT_PID=
+FM_AFK_STOP_INTENT_IDENTITY=
+FM_AFK_UNEXPECTED_EXIT_PID=
+FM_AFK_UNEXPECTED_EXIT_IDENTITY=
 
 fm_afk_stop_intent_path() { printf '%s/%s\n' "$1" "$FM_AFK_STOP_INTENT_NAME"; }
 
@@ -34,8 +38,10 @@ fm_afk_stop_intent_publish() {  # <state> <pid> <pid-identity>
   mv "$pending" "$(fm_afk_stop_intent_path "$state")" || { rm -f "$pending"; return 1; }
 }
 
-fm_afk_stop_intent_matches() {  # <state> <pid> <pid-identity>
-  local state=$1 pid=$2 identity=$3 path line1 line2 line3 intent_pid intent_identity lines
+fm_afk_stop_intent_read() {  # <state>
+  local state=$1 path line1 line2 line3 lines
+  FM_AFK_STOP_INTENT_PID=
+  FM_AFK_STOP_INTENT_IDENTITY=
   path=$(fm_afk_stop_intent_path "$state")
   [ -f "$path" ] && [ ! -L "$path" ] || return 1
   lines=$(awk 'END { print NR }' "$path" 2>/dev/null) || return 1
@@ -43,10 +49,18 @@ fm_afk_stop_intent_matches() {  # <state> <pid> <pid-identity>
   line1=$(sed -n '1p' "$path") || return 1
   line2=$(sed -n '2p' "$path") || return 1
   line3=$(sed -n '3p' "$path") || return 1
-  case "$line1" in pid=*) intent_pid=${line1#pid=} ;; *) return 1 ;; esac
-  case "$line2" in pid_identity=*) intent_identity=${line2#pid_identity=} ;; *) return 1 ;; esac
+  case "$line1" in pid=*) FM_AFK_STOP_INTENT_PID=${line1#pid=} ;; *) return 1 ;; esac
+  case "$line2" in pid_identity=*) FM_AFK_STOP_INTENT_IDENTITY=${line2#pid_identity=} ;; *) return 1 ;; esac
   case "$line3" in recorded_at=????-??-??T??:??:??[+-]????) ;; *) return 1 ;; esac
-  [ "$intent_pid" = "$pid" ] && [ "$intent_identity" = "$identity" ]
+  case "$FM_AFK_STOP_INTENT_PID" in ''|*[!0-9]*) return 1 ;; esac
+  fm_afk_death_valid_identity "$FM_AFK_STOP_INTENT_IDENTITY"
+}
+
+fm_afk_stop_intent_matches() {  # <state> <pid> <pid-identity>
+  local state=$1 pid=$2 identity=$3
+  fm_afk_stop_intent_read "$state" || return 1
+  [ "$FM_AFK_STOP_INTENT_PID" = "$pid" ] \
+    && [ "$FM_AFK_STOP_INTENT_IDENTITY" = "$identity" ]
 }
 
 fm_afk_stop_intent_retire() {  # <state> <pid> <pid-identity>
@@ -56,8 +70,10 @@ fm_afk_stop_intent_retire() {  # <state> <pid> <pid-identity>
   rm -f "$path"
 }
 
-fm_afk_unexpected_exit_matches() {  # <state> <pid> <pid-identity>
-  local state=$1 pid=$2 identity=$3 path line1 line2 line3 line4 exit_pid exit_identity lines
+fm_afk_unexpected_exit_read() {  # <state>
+  local state=$1 path line1 line2 line3 line4 lines
+  FM_AFK_UNEXPECTED_EXIT_PID=
+  FM_AFK_UNEXPECTED_EXIT_IDENTITY=
   path=$(fm_afk_unexpected_exit_path "$state")
   [ -f "$path" ] && [ ! -L "$path" ] || return 1
   lines=$(awk 'END { print NR }' "$path" 2>/dev/null) || return 1
@@ -68,15 +84,23 @@ fm_afk_unexpected_exit_matches() {  # <state> <pid> <pid-identity>
   line4=$(sed -n '4p' "$path") || return 1
   case "$line1" in signal=?*) ;; *) return 1 ;; esac
   case "$line2" in recorded_at=????-??-??T??:??:??[+-]????) ;; *) return 1 ;; esac
-  case "$line3" in pid=*) exit_pid=${line3#pid=} ;; *) return 1 ;; esac
-  case "$line4" in pid_identity=*) exit_identity=${line4#pid_identity=} ;; *) return 1 ;; esac
-  [ "$exit_pid" = "$pid" ] && [ "$exit_identity" = "$identity" ]
+  case "$line3" in pid=*) FM_AFK_UNEXPECTED_EXIT_PID=${line3#pid=} ;; *) return 1 ;; esac
+  case "$line4" in pid_identity=*) FM_AFK_UNEXPECTED_EXIT_IDENTITY=${line4#pid_identity=} ;; *) return 1 ;; esac
+  case "$FM_AFK_UNEXPECTED_EXIT_PID" in MISSING) ;; ''|*[!0-9]*) return 1 ;; esac
+  fm_afk_death_valid_identity "$FM_AFK_UNEXPECTED_EXIT_IDENTITY"
+}
+
+fm_afk_unexpected_exit_matches() {  # <state> <pid> <pid-identity>
+  local state=$1 pid=$2 identity=$3
+  fm_afk_unexpected_exit_read "$state" || return 1
+  [ "$FM_AFK_UNEXPECTED_EXIT_PID" = "$pid" ] \
+    && [ "$FM_AFK_UNEXPECTED_EXIT_IDENTITY" = "$identity" ]
 }
 
 fm_afk_unexpected_exit_record() {  # <state> <signal> <pid> <pid-identity>
   local state=$1 signal=$2 pid=$3 identity=$4 pending path
   case "$signal" in ''|*$'\n'*|*$'\r'*) return 1 ;; esac
-  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  case "$pid" in MISSING) ;; ''|*[!0-9]*) return 1 ;; esac
   fm_afk_death_valid_identity "$identity" || return 1
   mkdir -p "$state" || return 1
   pending=$(mktemp "$state/${FM_AFK_UNEXPECTED_EXIT_NAME}.pending.XXXXXX") || return 1
@@ -92,6 +116,6 @@ fm_afk_unexpected_exit_record() {  # <state> <signal> <pid> <pid-identity>
     return 0
   fi
   rm -f "$pending"
-  fm_afk_unexpected_exit_matches "$state" "$pid" "$identity" && return 2
+  fm_afk_unexpected_exit_read "$state" && return 2
   return 1
 }

--- a/bin/fm-afk-death-lib.sh
+++ b/bin/fm-afk-death-lib.sh
@@ -56,8 +56,25 @@ fm_afk_stop_intent_retire() {  # <state> <pid> <pid-identity>
   rm -f "$path"
 }
 
+fm_afk_unexpected_exit_matches() {  # <state> <pid> <pid-identity>
+  local state=$1 pid=$2 identity=$3 path line1 line2 line3 line4 exit_pid exit_identity lines
+  path=$(fm_afk_unexpected_exit_path "$state")
+  [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  lines=$(awk 'END { print NR }' "$path" 2>/dev/null) || return 1
+  [ "$lines" = 4 ] || return 1
+  line1=$(sed -n '1p' "$path") || return 1
+  line2=$(sed -n '2p' "$path") || return 1
+  line3=$(sed -n '3p' "$path") || return 1
+  line4=$(sed -n '4p' "$path") || return 1
+  case "$line1" in signal=?*) ;; *) return 1 ;; esac
+  case "$line2" in recorded_at=????-??-??T??:??:??[+-]????) ;; *) return 1 ;; esac
+  case "$line3" in pid=*) exit_pid=${line3#pid=} ;; *) return 1 ;; esac
+  case "$line4" in pid_identity=*) exit_identity=${line4#pid_identity=} ;; *) return 1 ;; esac
+  [ "$exit_pid" = "$pid" ] && [ "$exit_identity" = "$identity" ]
+}
+
 fm_afk_unexpected_exit_record() {  # <state> <signal> <pid> <pid-identity>
-  local state=$1 signal=$2 pid=$3 identity=$4 pending
+  local state=$1 signal=$2 pid=$3 identity=$4 pending path
   case "$signal" in ''|*$'\n'*|*$'\r'*) return 1 ;; esac
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac
   fm_afk_death_valid_identity "$identity" || return 1
@@ -69,5 +86,12 @@ fm_afk_unexpected_exit_record() {  # <state> <signal> <pid> <pid-identity>
     printf 'pid=%s\n' "$pid"
     printf 'pid_identity=%s\n' "$identity"
   } > "$pending" || { rm -f "$pending"; return 1; }
-  mv "$pending" "$(fm_afk_unexpected_exit_path "$state")" || { rm -f "$pending"; return 1; }
+  path=$(fm_afk_unexpected_exit_path "$state")
+  if ln "$pending" "$path" 2>/dev/null; then
+    rm -f "$pending"
+    return 0
+  fi
+  rm -f "$pending"
+  fm_afk_unexpected_exit_matches "$state" "$pid" "$identity" && return 2
+  return 1
 }

--- a/bin/fm-afk-death-lib.sh
+++ b/bin/fm-afk-death-lib.sh
@@ -8,14 +8,23 @@
 
 FM_AFK_STOP_INTENT_NAME=".supervise-daemon.stop-intent"
 FM_AFK_UNEXPECTED_EXIT_NAME=".supervise-daemon.unexpected-exit"
+FM_AFK_START_PENDING_NAME=".supervise-daemon.start-pending"
 FM_AFK_STOP_INTENT_PID=
 FM_AFK_STOP_INTENT_IDENTITY=
+FM_AFK_STOP_INTENT_PHASE=
+FM_AFK_STOP_INTENT_PUBLISHER_PID=
+FM_AFK_STOP_INTENT_PUBLISHER_IDENTITY=
+FM_AFK_STOP_INTENT_RECORDED_AT=
 FM_AFK_UNEXPECTED_EXIT_PID=
 FM_AFK_UNEXPECTED_EXIT_IDENTITY=
+FM_AFK_START_PENDING_RECORDED_AT=
+FM_AFK_START_PENDING_EXPIRES_AT=
 
 fm_afk_stop_intent_path() { printf '%s/%s\n' "$1" "$FM_AFK_STOP_INTENT_NAME"; }
 
 fm_afk_unexpected_exit_path() { printf '%s/%s\n' "$1" "$FM_AFK_UNEXPECTED_EXIT_NAME"; }
+
+fm_afk_start_pending_path() { printf '%s/%s\n' "$1" "$FM_AFK_START_PENDING_NAME"; }
 
 fm_afk_death_valid_identity() {
   case "$1" in
@@ -24,36 +33,67 @@ fm_afk_death_valid_identity() {
   esac
 }
 
-fm_afk_stop_intent_publish() {  # <state> <pid> <pid-identity>
-  local state=$1 pid=$2 identity=$3 pending
+fm_afk_stop_intent_write() {  # <state> <phase> <pid> <pid-identity> <publisher-pid> <publisher-identity> <recorded-at>
+  local state=$1 phase=$2 pid=$3 identity=$4 publisher_pid=$5 publisher_identity=$6 recorded_at=$7 pending
+  case "$phase" in published|consumed|abandoned) ;; *) return 1 ;; esac
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac
   fm_afk_death_valid_identity "$identity" || return 1
+  case "$publisher_pid" in ''|*[!0-9]*) return 1 ;; esac
+  fm_afk_death_valid_identity "$publisher_identity" || return 1
   mkdir -p "$state" || return 1
   pending=$(mktemp "$state/${FM_AFK_STOP_INTENT_NAME}.pending.XXXXXX") || return 1
   {
+    printf 'phase=%s\n' "$phase"
     printf 'pid=%s\n' "$pid"
     printf 'pid_identity=%s\n' "$identity"
-    printf 'recorded_at=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')"
+    printf 'publisher_pid=%s\n' "$publisher_pid"
+    printf 'publisher_identity=%s\n' "$publisher_identity"
+    printf 'recorded_at=%s\n' "$recorded_at"
+    printf 'phase_at=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')"
   } > "$pending" || { rm -f "$pending"; return 1; }
   mv "$pending" "$(fm_afk_stop_intent_path "$state")" || { rm -f "$pending"; return 1; }
 }
 
+fm_afk_stop_intent_publish() {  # <state> <pid> <pid-identity> <publisher-pid> <publisher-identity>
+  local state=$1 lock result=0
+  lock="$state/${FM_AFK_STOP_INTENT_NAME}.transition.lock"
+  fm_lock_acquire_wait "$lock" || return 1
+  fm_afk_stop_intent_write "$state" published "$2" "$3" "$4" "$5" \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" || result=1
+  fm_lock_release "$lock" 2>/dev/null || result=1
+  return "$result"
+}
+
 fm_afk_stop_intent_read() {  # <state>
-  local state=$1 path line1 line2 line3 lines
+  local state=$1 path line1 line2 line3 line4 line5 line6 line7 lines
   FM_AFK_STOP_INTENT_PID=
   FM_AFK_STOP_INTENT_IDENTITY=
+  FM_AFK_STOP_INTENT_PHASE=
+  FM_AFK_STOP_INTENT_PUBLISHER_PID=
+  FM_AFK_STOP_INTENT_PUBLISHER_IDENTITY=
+  FM_AFK_STOP_INTENT_RECORDED_AT=
   path=$(fm_afk_stop_intent_path "$state")
   [ -f "$path" ] && [ ! -L "$path" ] || return 1
   lines=$(awk 'END { print NR }' "$path" 2>/dev/null) || return 1
-  [ "$lines" = 3 ] || return 1
+  [ "$lines" = 7 ] || return 1
   line1=$(sed -n '1p' "$path") || return 1
   line2=$(sed -n '2p' "$path") || return 1
   line3=$(sed -n '3p' "$path") || return 1
-  case "$line1" in pid=*) FM_AFK_STOP_INTENT_PID=${line1#pid=} ;; *) return 1 ;; esac
-  case "$line2" in pid_identity=*) FM_AFK_STOP_INTENT_IDENTITY=${line2#pid_identity=} ;; *) return 1 ;; esac
-  case "$line3" in recorded_at=????-??-??T??:??:??[+-]????) ;; *) return 1 ;; esac
+  line4=$(sed -n '4p' "$path") || return 1
+  line5=$(sed -n '5p' "$path") || return 1
+  line6=$(sed -n '6p' "$path") || return 1
+  line7=$(sed -n '7p' "$path") || return 1
+  case "$line1" in phase=published|phase=consumed|phase=abandoned) FM_AFK_STOP_INTENT_PHASE=${line1#phase=} ;; *) return 1 ;; esac
+  case "$line2" in pid=*) FM_AFK_STOP_INTENT_PID=${line2#pid=} ;; *) return 1 ;; esac
+  case "$line3" in pid_identity=*) FM_AFK_STOP_INTENT_IDENTITY=${line3#pid_identity=} ;; *) return 1 ;; esac
+  case "$line4" in publisher_pid=*) FM_AFK_STOP_INTENT_PUBLISHER_PID=${line4#publisher_pid=} ;; *) return 1 ;; esac
+  case "$line5" in publisher_identity=*) FM_AFK_STOP_INTENT_PUBLISHER_IDENTITY=${line5#publisher_identity=} ;; *) return 1 ;; esac
+  case "$line6" in recorded_at=????-??-??T??:??:??[+-]????) FM_AFK_STOP_INTENT_RECORDED_AT=${line6#recorded_at=} ;; *) return 1 ;; esac
+  case "$line7" in phase_at=????-??-??T??:??:??[+-]????) ;; *) return 1 ;; esac
   case "$FM_AFK_STOP_INTENT_PID" in ''|*[!0-9]*) return 1 ;; esac
-  fm_afk_death_valid_identity "$FM_AFK_STOP_INTENT_IDENTITY"
+  fm_afk_death_valid_identity "$FM_AFK_STOP_INTENT_IDENTITY" || return 1
+  case "$FM_AFK_STOP_INTENT_PUBLISHER_PID" in ''|*[!0-9]*) return 1 ;; esac
+  fm_afk_death_valid_identity "$FM_AFK_STOP_INTENT_PUBLISHER_IDENTITY"
 }
 
 fm_afk_stop_intent_matches() {  # <state> <pid> <pid-identity>
@@ -63,11 +103,86 @@ fm_afk_stop_intent_matches() {  # <state> <pid> <pid-identity>
     && [ "$FM_AFK_STOP_INTENT_IDENTITY" = "$identity" ]
 }
 
+fm_afk_stop_intent_transition() {  # <state> <pid> <pid-identity> <from-phase> <to-phase>
+  local state=$1 pid=$2 identity=$3 from_phase=$4 to_phase=$5 lock result=1
+  lock="$state/${FM_AFK_STOP_INTENT_NAME}.transition.lock"
+  fm_lock_acquire_wait "$lock" || return 1
+  if fm_afk_stop_intent_read "$state" \
+    && [ "$FM_AFK_STOP_INTENT_PID" = "$pid" ] \
+    && [ "$FM_AFK_STOP_INTENT_IDENTITY" = "$identity" ]; then
+    if [ "$FM_AFK_STOP_INTENT_PHASE" = "$to_phase" ]; then
+      result=0
+    elif [ "$FM_AFK_STOP_INTENT_PHASE" = "$from_phase" ] \
+      && fm_afk_stop_intent_write "$state" "$to_phase" "$pid" "$identity" \
+        "$FM_AFK_STOP_INTENT_PUBLISHER_PID" "$FM_AFK_STOP_INTENT_PUBLISHER_IDENTITY" \
+        "$FM_AFK_STOP_INTENT_RECORDED_AT"; then
+      result=0
+    fi
+  fi
+  fm_lock_release "$lock" 2>/dev/null || result=1
+  return "$result"
+}
+
+fm_afk_stop_intent_consume() {  # <state> <pid> <pid-identity>
+  fm_afk_stop_intent_transition "$1" "$2" "$3" published consumed
+}
+
+fm_afk_stop_intent_abandon() {  # <state> <pid> <pid-identity>
+  fm_afk_stop_intent_transition "$1" "$2" "$3" published abandoned
+}
+
 fm_afk_stop_intent_retire() {  # <state> <pid> <pid-identity>
-  local state=$1 pid=$2 identity=$3 path
-  fm_afk_stop_intent_matches "$state" "$pid" "$identity" || return 1
+  local state=$1 pid=$2 identity=$3 path lock result=1
+  lock="$state/${FM_AFK_STOP_INTENT_NAME}.transition.lock"
+  fm_lock_acquire_wait "$lock" || return 1
   path=$(fm_afk_stop_intent_path "$state")
-  rm -f "$path"
+  if fm_afk_stop_intent_matches "$state" "$pid" "$identity" && rm -f "$path"; then
+    result=0
+  fi
+  fm_lock_release "$lock" 2>/dev/null || result=1
+  return "$result"
+}
+
+fm_afk_start_pending_publish() {  # <state>
+  local state=$1 seconds now pending
+  seconds=${FM_AFK_START_PENDING_SECS:-60}
+  case "$seconds" in ''|*[!0-9]*|0) return 1 ;; esac
+  now=$(date '+%s') || return 1
+  mkdir -p "$state" || return 1
+  pending=$(mktemp "$state/${FM_AFK_START_PENDING_NAME}.pending.XXXXXX") || return 1
+  {
+    printf 'recorded_at_epoch=%s\n' "$now"
+    printf 'expires_at_epoch=%s\n' "$((now + seconds))"
+  } > "$pending" || { rm -f "$pending"; return 1; }
+  mv "$pending" "$(fm_afk_start_pending_path "$state")" || { rm -f "$pending"; return 1; }
+}
+
+fm_afk_start_pending_read() {  # <state>
+  local state=$1 path line1 line2 lines
+  FM_AFK_START_PENDING_RECORDED_AT=
+  FM_AFK_START_PENDING_EXPIRES_AT=
+  path=$(fm_afk_start_pending_path "$state")
+  [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  lines=$(awk 'END { print NR }' "$path" 2>/dev/null) || return 1
+  [ "$lines" = 2 ] || return 1
+  line1=$(sed -n '1p' "$path") || return 1
+  line2=$(sed -n '2p' "$path") || return 1
+  case "$line1" in recorded_at_epoch=*) FM_AFK_START_PENDING_RECORDED_AT=${line1#recorded_at_epoch=} ;; *) return 1 ;; esac
+  case "$line2" in expires_at_epoch=*) FM_AFK_START_PENDING_EXPIRES_AT=${line2#expires_at_epoch=} ;; *) return 1 ;; esac
+  case "$FM_AFK_START_PENDING_RECORDED_AT" in ''|*[!0-9]*) return 1 ;; esac
+  case "$FM_AFK_START_PENDING_EXPIRES_AT" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$FM_AFK_START_PENDING_EXPIRES_AT" -ge "$FM_AFK_START_PENDING_RECORDED_AT" ]
+}
+
+fm_afk_start_pending_active() {  # <state>
+  local now
+  fm_afk_start_pending_read "$1" || return 1
+  now=$(date '+%s') || return 1
+  [ "$now" -le "$FM_AFK_START_PENDING_EXPIRES_AT" ]
+}
+
+fm_afk_start_pending_clear() {  # <state>
+  rm -f "$(fm_afk_start_pending_path "$1")"
 }
 
 fm_afk_unexpected_exit_read() {  # <state>

--- a/bin/fm-afk-death-lib.sh
+++ b/bin/fm-afk-death-lib.sh
@@ -5,6 +5,8 @@
 # The stop intent is exact to one daemon process: pid plus fm_pid_identity.
 # A matching intent wins an exit race, because it was atomically published
 # before the lifecycle owner asked that exact daemon to stop.
+# An unexpected-exit record durably captures signal, timestamp, pid, and
+# identity before the existing wedge-alarm channel is invoked.
 
 FM_AFK_STOP_INTENT_NAME=".supervise-daemon.stop-intent"
 FM_AFK_UNEXPECTED_EXIT_NAME=".supervise-daemon.unexpected-exit"

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -86,6 +86,8 @@ FM_AFK_LAUNCH_WS_LABEL="firstmate-afk-daemon"
 # shellcheck source=bin/fm-afk-start.sh
 . "$FM_AFK_LAUNCH_DIR/fm-afk-start.sh"
 set +e
+# shellcheck source=bin/fm-afk-death-lib.sh
+. "$FM_AFK_LAUNCH_DIR/fm-afk-death-lib.sh"
 
 fm_afk_launch_log() { printf 'fm-afk-launch: %s\n' "$*" >&2; }
 
@@ -153,6 +155,22 @@ fm_afk_launch_usage() {
 # daemon entry; a test overrides it with a harmless placeholder.
 fm_afk_launch_entry_cmd() {
   printf '%s' "${FM_AFK_LAUNCH_ENTRY:-$FM_ROOT/bin/fm-afk-start.sh}"
+}
+
+# tmux panes can inherit SIGTERM as ignored from their server process.
+# A short-lived native resetter restores the normal disposition before execing
+# the shell daemon, so its TERM/HUP cleanup traps remain observable.
+fm_afk_launch_daemon_cmd() {  # <captain-target> <captain-backend>
+  local captain_target=$1 captain_backend=$2 entry resetter
+  entry=$(fm_afk_launch_entry_cmd)
+  resetter=$(command -v perl 2>/dev/null) || {
+    fm_afk_launch_log "perl is required to reset inherited daemon signal dispositions"
+    return 1
+  }
+  printf 'exec %q -e %q -- env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q FM_WEDGE_ALARM_CHANNEL=%q FM_WEDGE_ALARM_EXEC=%q FM_WEDGE_ALARM_TIMEOUT_SECS=%q %q' \
+    "$resetter" '$SIG{TERM} = "DEFAULT"; $SIG{INT} = "DEFAULT"; $SIG{HUP} = "DEFAULT"; exec @ARGV or die "exec: $!\n";' \
+    "$FM_HOME" "$captain_target" "$captain_backend" "${FM_WEDGE_ALARM_CHANNEL:-}" \
+    "${FM_WEDGE_ALARM_EXEC:-}" "${FM_WEDGE_ALARM_TIMEOUT_SECS:-}" "$entry"
 }
 
 fm_afk_launch_record_write() {  # <backend> <target> <extra>
@@ -384,7 +402,7 @@ fm_afk_launch_restore_backup() {  # <backup> <had-afk>
 # dedicated background workspace (--no-focus) holds exactly one tab/pane; it
 # never touches the captain's active tab. Prints the record line on success.
 fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
-  local captain_target=$1 captain_backend=$2 session out wsid pane entry cmd label recovered create_result
+  local captain_target=$1 captain_backend=$2 session out wsid pane cmd label recovered create_result
   session=${captain_target%%:*}
   if [ -z "$session" ] || [ "$session" = "$captain_target" ]; then
     fm_afk_launch_log "cannot derive herdr session from captain target '$captain_target'"
@@ -415,9 +433,7 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
     }
     IFS=$'\t' read -r wsid pane <<< "$recovered"
   fi
-  entry=$(fm_afk_launch_entry_cmd)
-  cmd=$(printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %q' \
-    "$FM_HOME" "$captain_target" "$captain_backend" "$entry")
+  cmd=$(fm_afk_launch_daemon_cmd "$captain_target" "$captain_backend") || return 1
   if ! fm_afk_launch_record_write herdr "$session:$pane" "$wsid"; then
     fm_afk_launch_log "failed to persist herdr daemon terminal record; closing $session:$pane"
     fm_afk_launch_close_terminal herdr "$session:$pane"
@@ -438,13 +454,11 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
 # captain's window). tmux pane ids are server-global, so the daemon reaches the
 # captain pane by its %id from this separate session.
 fm_afk_launch_create_tmux() {  # <captain-target> <captain-backend>
-  local captain_target=$1 captain_backend=$2 session entry cmd hash nonce
+  local captain_target=$1 captain_backend=$2 session cmd hash nonce
   hash=$(printf '%s' "$FM_HOME" | cksum | cut -d' ' -f1)
   nonce="$$-${RANDOM:-0}-$(date '+%s')"
   session="fm-afk-daemon-$hash-$nonce"
-  entry=$(fm_afk_launch_entry_cmd)
-  cmd=$(printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %q' \
-    "$FM_HOME" "$captain_target" "$captain_backend" "$entry")
+  cmd=$(fm_afk_launch_daemon_cmd "$captain_target" "$captain_backend") || return 1
   if ! fm_afk_launch_record_write tmux "$session" ""; then
     fm_afk_launch_log "failed to persist planned tmux daemon session '$session'"
     return 1
@@ -590,7 +604,12 @@ fm_afk_launch_stop() {
     pid_identity=$(fm_pid_identity "$pid" 2>/dev/null) || return 1
   fi
   if [ -n "$pid" ]; then
+    if ! fm_afk_stop_intent_publish "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity"; then
+      fm_afk_launch_log "failed to publish the exact daemon stop intent; preserving lifecycle state"
+      return 1
+    fi
     if ! kill -TERM "$pid" 2>/dev/null; then
+      fm_afk_stop_intent_retire "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity" || true
       fm_afk_launch_log "failed to signal away-mode daemon pid=$pid"
       result=1
     fi

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -118,6 +118,8 @@ fm_afk_launch_stop_intent_abandon_if_live() {
 
 fm_afk_launch_signal_exit() {
   local code=$1
+  trap - HUP INT TERM
+  fm_lock_release "$FM_AFK_LAUNCH_STATE/${FM_AFK_STOP_INTENT_NAME}.transition.lock" 2>/dev/null || true
   fm_afk_launch_stop_intent_abandon_if_live || true
   exit "$code"
 }
@@ -125,13 +127,6 @@ fm_afk_launch_signal_exit() {
 fm_afk_launch_exit_cleanup() {
   fm_afk_launch_stop_intent_abandon_if_live || true
   fm_afk_launch_lock_release
-}
-
-fm_afk_launch_stop_publisher_alive() {
-  local current_identity
-  fm_pid_alive "$FM_AFK_STOP_INTENT_PUBLISHER_PID" || return 1
-  current_identity=$(fm_pid_identity "$FM_AFK_STOP_INTENT_PUBLISHER_PID" 2>/dev/null) || return 1
-  [ "$current_identity" = "$FM_AFK_STOP_INTENT_PUBLISHER_IDENTITY" ]
 }
 
 fm_afk_launch_lock_owned() {
@@ -406,7 +401,18 @@ fm_afk_launch_check_dead_daemon() {
   local owner pid identity current_identity marker record_result intent_applies=0
   [ -e "$FM_AFK_LAUNCH_STATE/.afk" ] || return 0
   fm_afk_unexpected_exit_read "$FM_AFK_LAUNCH_STATE" && return 0
-  daemon_lock_held_by_live_daemon && return 0
+  if daemon_lock_held_by_live_daemon; then
+    pid=$(daemon_lock_pid 2>/dev/null) || return 1
+    identity=$(fm_pid_identity "$pid" 2>/dev/null) || return 1
+    if fm_afk_stop_intent_read "$FM_AFK_LAUNCH_STATE" \
+      && [ "$FM_AFK_STOP_INTENT_PHASE" = published ] \
+      && [ "$FM_AFK_STOP_INTENT_PID" = "$pid" ] \
+      && [ "$FM_AFK_STOP_INTENT_IDENTITY" = "$identity" ] \
+      && ! fm_afk_stop_intent_publisher_alive; then
+      fm_afk_stop_intent_abandon "$FM_AFK_LAUNCH_STATE" "$pid" "$identity" || return 1
+    fi
+    return 0
+  fi
   fm_afk_start_pending_active "$FM_AFK_LAUNCH_STATE" && return 0
   owner=$(daemon_lock_owner 2>/dev/null || true)
   pid=
@@ -440,7 +446,7 @@ fm_afk_launch_check_dead_daemon() {
           return 0
           ;;
         published)
-          if fm_afk_launch_stop_publisher_alive; then
+          if fm_afk_stop_intent_publisher_alive; then
             return 0
           fi
           fm_afk_stop_intent_abandon "$FM_AFK_LAUNCH_STATE" \
@@ -479,10 +485,10 @@ fm_afk_launch_check_dead_daemon() {
 # owns it, close the leaked terminal by exact id and drop the record.
 fm_afk_launch_reconcile() {
   local read_result
+  fm_afk_launch_check_dead_daemon || return 1
   if daemon_lock_held_by_live_daemon; then
     return 0
   fi
-  fm_afk_launch_check_dead_daemon || return 1
   fm_afk_launch_record_read
   read_result=$?
   if [ "$read_result" -eq 0 ]; then
@@ -611,6 +617,7 @@ fm_afk_launch_start() {
 
   mkdir -p "$FM_AFK_LAUNCH_STATE"
 
+  fm_afk_launch_check_dead_daemon || return 1
   if daemon_lock_held_by_live_daemon; then
     fm_afk_launch_record_validate_if_present || return 1
     if ! fm_afk_launch_flag_write; then
@@ -621,7 +628,6 @@ fm_afk_launch_start() {
     return 0
   fi
 
-  fm_afk_launch_check_dead_daemon || return 1
   backup=$(mktemp -d "$FM_AFK_LAUNCH_STATE/.afk-launch-backup.XXXXXX") || return 1
   if [ -f "$FM_AFK_LAUNCH_STATE/.afk" ]; then
     had_afk=1
@@ -676,13 +682,13 @@ fm_afk_launch_start_native() {
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"
     return 1
   fi
+  fm_afk_launch_check_dead_daemon || return 1
   if daemon_lock_held_by_live_daemon; then
     fm_afk_launch_record_validate_if_present || return 1
     fm_afk_launch_flag_write || return 1
     fm_afk_launch_log "daemon already running; refreshed away-mode flag"
     return 0
   fi
-  fm_afk_launch_check_dead_daemon || return 1
   backup=$(mktemp -d "$FM_AFK_LAUNCH_STATE/.afk-launch-backup.XXXXXX") || return 1
   if [ -f "$FM_AFK_LAUNCH_STATE/.afk" ]; then
     had_afk=1
@@ -720,6 +726,7 @@ fm_afk_launch_start_native() {
 fm_afk_launch_stop() {
   local pid pid_identity current_identity publisher_pid publisher_identity result=0 read_result afk_cleared=0
   fm_afk_launch_stop_tracking_clear
+  fm_afk_launch_check_dead_daemon || return 1
   fm_afk_launch_record_read
   read_result=$?
   if [ "$read_result" -eq 2 ]; then

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -161,14 +161,15 @@ fm_afk_launch_entry_cmd() {
 # A short-lived native resetter restores the normal disposition before execing
 # the shell daemon, so its TERM/HUP cleanup traps remain observable.
 fm_afk_launch_daemon_cmd() {  # <captain-target> <captain-backend>
-  local captain_target=$1 captain_backend=$2 entry resetter
+  local captain_target=$1 captain_backend=$2 entry resetter perl_program
   entry=$(fm_afk_launch_entry_cmd)
   resetter=$(command -v perl 2>/dev/null) || {
     fm_afk_launch_log "perl is required to reset inherited daemon signal dispositions"
     return 1
   }
+  perl_program="\$SIG{TERM} = \"DEFAULT\"; \$SIG{INT} = \"DEFAULT\"; \$SIG{HUP} = \"DEFAULT\"; exec @ARGV or die \"exec: \$!\\n\";"
   printf 'exec %q -e %q -- env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q FM_WEDGE_ALARM_CHANNEL=%q FM_WEDGE_ALARM_EXEC=%q FM_WEDGE_ALARM_TIMEOUT_SECS=%q %q' \
-    "$resetter" '$SIG{TERM} = "DEFAULT"; $SIG{INT} = "DEFAULT"; $SIG{HUP} = "DEFAULT"; exec @ARGV or die "exec: $!\n";' \
+    "$resetter" "$perl_program" \
     "$FM_HOME" "$captain_target" "$captain_backend" "${FM_WEDGE_ALARM_CHANNEL:-}" \
     "${FM_WEDGE_ALARM_EXEC:-}" "${FM_WEDGE_ALARM_TIMEOUT_SECS:-}" "$entry"
 }
@@ -358,6 +359,45 @@ fm_afk_launch_herdr_recover_created() {  # <session> <label>
   return 1
 }
 
+fm_afk_launch_check_dead_daemon() {
+  local owner pid identity current_identity marker record_result
+  [ -e "$FM_AFK_LAUNCH_STATE/.afk" ] || return 0
+  daemon_lock_held_by_live_daemon && return 0
+  owner=$(daemon_lock_owner 2>/dev/null) || return 0
+  pid=$(cat "$owner/pid" 2>/dev/null || true)
+  identity=$(cat "$owner/pid-identity" 2>/dev/null || true)
+  case "$pid" in ''|*[!0-9]*) return 0 ;; esac
+  fm_afk_death_valid_identity "$identity" || return 0
+  if fm_pid_alive "$pid"; then
+    current_identity=$(fm_pid_identity "$pid" 2>/dev/null) || return 0
+    [ "$current_identity" != "$identity" ] || return 0
+  fi
+  if fm_afk_stop_intent_matches "$FM_AFK_LAUNCH_STATE" "$pid" "$identity"; then
+    fm_afk_stop_intent_retire "$FM_AFK_LAUNCH_STATE" "$pid" "$identity" || return 1
+    fm_afk_launch_log "expected daemon loss observed (pid=$pid)"
+    return 0
+  fi
+  marker=$(fm_afk_unexpected_exit_path "$FM_AFK_LAUNCH_STATE")
+  fm_afk_unexpected_exit_record "$FM_AFK_LAUNCH_STATE" UNTRAPPABLE "$pid" "$identity"
+  record_result=$?
+  case "$record_result" in
+    0)
+      fm_afk_launch_log "away-mode daemon loss detected (pid=$pid); alarm marker written"
+      "$FM_AFK_LAUNCH_DIR/fm-supervise-daemon.sh" --wedge-alarm-notify \
+        "away-mode daemon exited unexpectedly (signal=UNTRAPPABLE pid=$pid) - see $marker" "$marker"
+      ;;
+    2)
+      return 0
+      ;;
+    *)
+      fm_afk_launch_log "away-mode daemon loss detected (pid=$pid); failed to write alarm marker"
+      "$FM_AFK_LAUNCH_DIR/fm-supervise-daemon.sh" --wedge-alarm-notify \
+        "away-mode daemon exited unexpectedly (signal=UNTRAPPABLE pid=$pid) - durable marker write failed" "$marker"
+      return 1
+      ;;
+  esac
+}
+
 # Reconcile a recorded-but-dead terminal: if a record exists and no live daemon
 # owns it, close the leaked terminal by exact id and drop the record.
 fm_afk_launch_reconcile() {
@@ -365,6 +405,7 @@ fm_afk_launch_reconcile() {
   if daemon_lock_held_by_live_daemon; then
     return 0
   fi
+  fm_afk_launch_check_dead_daemon || return 1
   fm_afk_launch_record_read
   read_result=$?
   if [ "$read_result" -eq 0 ]; then
@@ -380,11 +421,14 @@ fm_afk_launch_restore_backup() {  # <backup> <had-afk>
   rm -f "$FM_AFK_LAUNCH_STATE/.afk" \
     "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" \
     "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" \
-    "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged" || result=1
+    "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged" \
+    "$FM_AFK_LAUNCH_STATE/.supervise-daemon.stop-intent" \
+    "$FM_AFK_LAUNCH_STATE/.supervise-daemon.unexpected-exit" || result=1
   if [ "$had_afk" -eq 1 ]; then
     cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk" || result=1
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged \
+    .supervise-daemon.stop-intent .supervise-daemon.unexpected-exit; do
     if [ -e "$backup/$artifact" ]; then
       cp -p "$backup/$artifact" "$FM_AFK_LAUNCH_STATE/$artifact" || result=1
     fi
@@ -410,6 +454,7 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
   fi
   fm_backend_source herdr || return 1
   fm_backend_herdr_server_ensure "$session" || { fm_afk_launch_log "herdr server not ready for session '$session'"; return 1; }
+  cmd=$(fm_afk_launch_daemon_cmd "$captain_target" "$captain_backend") || return 1
   label=${FM_AFK_LAUNCH_LABEL:-"$FM_AFK_LAUNCH_WS_LABEL-$$-${RANDOM:-0}-$(date '+%s')"}
   out=$(fm_backend_herdr_cli "$session" workspace create --cwd "$FM_HOME" --label "$label" --no-focus 2>/dev/null)
   create_result=$?
@@ -433,7 +478,6 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
     }
     IFS=$'\t' read -r wsid pane <<< "$recovered"
   fi
-  cmd=$(fm_afk_launch_daemon_cmd "$captain_target" "$captain_backend") || return 1
   if ! fm_afk_launch_record_write herdr "$session:$pane" "$wsid"; then
     fm_afk_launch_log "failed to persist herdr daemon terminal record; closing $session:$pane"
     fm_afk_launch_close_terminal herdr "$session:$pane"
@@ -498,12 +542,14 @@ fm_afk_launch_start() {
     return 0
   fi
 
+  fm_afk_launch_check_dead_daemon || return 1
   backup=$(mktemp -d "$FM_AFK_LAUNCH_STATE/.afk-launch-backup.XXXXXX") || return 1
   if [ -f "$FM_AFK_LAUNCH_STATE/.afk" ]; then
     had_afk=1
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged \
+    .supervise-daemon.stop-intent .supervise-daemon.unexpected-exit; do
     if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
       cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
     fi
@@ -556,12 +602,14 @@ fm_afk_launch_start_native() {
     fm_afk_launch_log "daemon already running; refreshed away-mode flag"
     return 0
   fi
+  fm_afk_launch_check_dead_daemon || return 1
   backup=$(mktemp -d "$FM_AFK_LAUNCH_STATE/.afk-launch-backup.XXXXXX") || return 1
   if [ -f "$FM_AFK_LAUNCH_STATE/.afk" ]; then
     had_afk=1
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged \
+    .supervise-daemon.stop-intent .supervise-daemon.unexpected-exit; do
     if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
       cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
     fi
@@ -609,7 +657,6 @@ fm_afk_launch_stop() {
       return 1
     fi
     if ! kill -TERM "$pid" 2>/dev/null; then
-      fm_afk_stop_intent_retire "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity" || true
       fm_afk_launch_log "failed to signal away-mode daemon pid=$pid"
       result=1
     fi
@@ -624,9 +671,14 @@ fm_afk_launch_stop() {
       return 1
     }
     if [ "$current_identity" = "$pid_identity" ]; then
+      fm_afk_stop_intent_retire "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity" || true
       fm_afk_launch_log "away-mode daemon did not exit after SIGTERM; preserving lifecycle state"
       return 1
     fi
+  fi
+  if [ -n "$pid" ] \
+    && fm_afk_stop_intent_matches "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity"; then
+    fm_afk_stop_intent_retire "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity" || result=1
   fi
   # (2) Close the daemon's own terminal by exact id.
   if [ "$read_result" -eq 0 ]; then
@@ -656,6 +708,7 @@ fm_afk_launch_main() {
     start-native) fm_afk_launch_start_native ;;
     stop) fm_afk_launch_stop ;;
     reconcile) fm_afk_launch_reconcile ;;
+    check-death) fm_afk_launch_check_dead_daemon ;;
     -h|--help|help) fm_afk_launch_usage ;;
     *) fm_afk_launch_usage >&2; return 2 ;;
   esac

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -20,21 +20,18 @@
 # FM_SUPERVISOR_TARGET/FM_SUPERVISOR_BACKEND explicitly.
 #
 # Usage:
-#   fm-afk-launch.sh start     Capture the captain pane, then (unless the daemon
-#                              is already running) launch the daemon in a fresh
-#                              non-visible terminal for the detected backend and
-#                              record it. Idempotent: an already-running daemon
-#                              just refreshes state/.afk; a recorded-but-dead
-#                              terminal is reconciled (closed by id) first.
+#   fm-afk-launch.sh start     Refresh a live daemon or reconcile a dead one,
+#                              then launch a fresh non-visible backend terminal.
 #   fm-afk-launch.sh start-native
 #                              Prepare lifecycle state for a harness-native
 #                              background job and record that no terminal exists.
-#   fm-afk-launch.sh stop      Correct-ordered exit: SIGTERM the daemon so its
-#                              cleanup flushes WHILE state/.afk is still present,
-#                              wait for it, close the recorded terminal by exact
-#                              id, then clear state/.afk last.
+#   fm-afk-launch.sh stop      Publish exact stop intent, SIGTERM the daemon,
+#                              flush while state/.afk remains, close the exact
+#                              terminal, then clear state/.afk last.
 #   fm-afk-launch.sh reconcile Close a recorded-but-dead daemon terminal by exact
 #                              id and drop the record (recovery after a crash).
+#   fm-afk-launch.sh check-death
+#                              Reconcile and alert on daemon loss while afk.
 #
 # Supported backends: herdr, tmux. Others (zellij, orca, cmux) have no verified
 # non-visible-launch primitive here yet and refuse loudly.

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -89,7 +89,43 @@ set +e
 # shellcheck source=bin/fm-afk-death-lib.sh
 . "$FM_AFK_LAUNCH_DIR/fm-afk-death-lib.sh"
 
+FM_AFK_LAUNCH_STOP_PID=
+FM_AFK_LAUNCH_STOP_IDENTITY=
+FM_AFK_LAUNCH_STOP_INTENT_ACTIVE=0
+
 fm_afk_launch_log() { printf 'fm-afk-launch: %s\n' "$*" >&2; }
+
+fm_afk_launch_stop_tracking_clear() {
+  FM_AFK_LAUNCH_STOP_PID=
+  FM_AFK_LAUNCH_STOP_IDENTITY=
+  FM_AFK_LAUNCH_STOP_INTENT_ACTIVE=0
+}
+
+fm_afk_launch_stop_intent_retract_if_live() {
+  local current_identity
+  [ "$FM_AFK_LAUNCH_STOP_INTENT_ACTIVE" -eq 1 ] || return 0
+  fm_pid_alive "$FM_AFK_LAUNCH_STOP_PID" || return 0
+  current_identity=$(fm_pid_identity "$FM_AFK_LAUNCH_STOP_PID" 2>/dev/null || true)
+  if [ -n "$current_identity" ] \
+    && [ "$current_identity" != "$FM_AFK_LAUNCH_STOP_IDENTITY" ]; then
+    return 0
+  fi
+  if fm_afk_stop_intent_retire "$FM_AFK_LAUNCH_STATE" \
+    "$FM_AFK_LAUNCH_STOP_PID" "$FM_AFK_LAUNCH_STOP_IDENTITY"; then
+    fm_afk_launch_stop_tracking_clear
+  fi
+}
+
+fm_afk_launch_signal_exit() {
+  local code=$1
+  fm_afk_launch_stop_intent_retract_if_live || true
+  exit "$code"
+}
+
+fm_afk_launch_exit_cleanup() {
+  fm_afk_launch_stop_intent_retract_if_live || true
+  fm_afk_launch_lock_release
+}
 
 fm_afk_launch_lock_owned() {
   local pid expected actual
@@ -362,37 +398,51 @@ fm_afk_launch_herdr_recover_created() {  # <session> <label>
 fm_afk_launch_check_dead_daemon() {
   local owner pid identity current_identity marker record_result
   [ -e "$FM_AFK_LAUNCH_STATE/.afk" ] || return 0
+  fm_afk_unexpected_exit_read "$FM_AFK_LAUNCH_STATE" && return 0
   daemon_lock_held_by_live_daemon && return 0
-  owner=$(daemon_lock_owner 2>/dev/null) || return 0
-  pid=$(cat "$owner/pid" 2>/dev/null || true)
-  identity=$(cat "$owner/pid-identity" 2>/dev/null || true)
-  case "$pid" in ''|*[!0-9]*) return 0 ;; esac
-  fm_afk_death_valid_identity "$identity" || return 0
-  if fm_pid_alive "$pid"; then
-    current_identity=$(fm_pid_identity "$pid" 2>/dev/null) || return 0
-    [ "$current_identity" != "$identity" ] || return 0
+  owner=$(daemon_lock_owner 2>/dev/null || true)
+  pid=
+  identity=MISSING
+  if [ -n "$owner" ]; then
+    pid=$(cat "$owner/pid" 2>/dev/null || true)
+    identity=$(cat "$owner/pid-identity" 2>/dev/null || true)
   fi
-  if fm_afk_stop_intent_matches "$FM_AFK_LAUNCH_STATE" "$pid" "$identity"; then
-    fm_afk_stop_intent_retire "$FM_AFK_LAUNCH_STATE" "$pid" "$identity" || return 1
-    fm_afk_launch_log "expected daemon loss observed (pid=$pid)"
-    return 0
+  if [ -z "$pid" ]; then
+    pid=$(cat "$FM_AFK_LAUNCH_STATE/.supervise-daemon.pid" 2>/dev/null || true)
+  fi
+  case "$pid" in ''|*[!0-9]*) pid=MISSING ;; esac
+  fm_afk_death_valid_identity "$identity" || identity=MISSING
+  if fm_pid_alive "$pid"; then
+    current_identity=$(fm_pid_identity "$pid" 2>/dev/null || true)
+    if [ "$identity" != MISSING ] && [ "$current_identity" = "$identity" ]; then
+      return 0
+    fi
+  fi
+  if fm_afk_stop_intent_read "$FM_AFK_LAUNCH_STATE"; then
+    if { [ "$identity" != MISSING ] \
+      && [ "$FM_AFK_STOP_INTENT_PID" = "$pid" ] \
+      && [ "$FM_AFK_STOP_INTENT_IDENTITY" = "$identity" ]; } \
+      || { [ -z "$owner" ] && [ "$pid" = MISSING ]; }; then
+      fm_afk_launch_log "expected daemon loss observed (pid=$FM_AFK_STOP_INTENT_PID)"
+      return 0
+    fi
   fi
   marker=$(fm_afk_unexpected_exit_path "$FM_AFK_LAUNCH_STATE")
   fm_afk_unexpected_exit_record "$FM_AFK_LAUNCH_STATE" UNTRAPPABLE "$pid" "$identity"
   record_result=$?
   case "$record_result" in
     0)
-      fm_afk_launch_log "away-mode daemon loss detected (pid=$pid); alarm marker written"
+      fm_afk_launch_log "away-mode daemon loss detected (pid=$pid identity=$identity); alarm marker written"
       "$FM_AFK_LAUNCH_DIR/fm-supervise-daemon.sh" --wedge-alarm-notify \
-        "away-mode daemon exited unexpectedly (signal=UNTRAPPABLE pid=$pid) - see $marker" "$marker"
+        "away-mode daemon exited unexpectedly (signal=UNTRAPPABLE pid=$pid identity=$identity) - see $marker" "$marker"
       ;;
     2)
       return 0
       ;;
     *)
-      fm_afk_launch_log "away-mode daemon loss detected (pid=$pid); failed to write alarm marker"
+      fm_afk_launch_log "away-mode daemon loss detected (pid=$pid identity=$identity); failed to write alarm marker"
       "$FM_AFK_LAUNCH_DIR/fm-supervise-daemon.sh" --wedge-alarm-notify \
-        "away-mode daemon exited unexpectedly (signal=UNTRAPPABLE pid=$pid) - durable marker write failed" "$marker"
+        "away-mode daemon exited unexpectedly (signal=UNTRAPPABLE pid=$pid identity=$identity) - durable marker write failed" "$marker"
       return 1
       ;;
   esac
@@ -635,7 +685,8 @@ fm_afk_launch_start_native() {
 }
 
 fm_afk_launch_stop() {
-  local pid pid_identity current_identity result=0 read_result
+  local pid pid_identity current_identity result=0 read_result afk_cleared=0
+  fm_afk_launch_stop_tracking_clear
   fm_afk_launch_record_read
   read_result=$?
   if [ "$read_result" -eq 2 ]; then
@@ -652,7 +703,11 @@ fm_afk_launch_stop() {
     pid_identity=$(fm_pid_identity "$pid" 2>/dev/null) || return 1
   fi
   if [ -n "$pid" ]; then
+    FM_AFK_LAUNCH_STOP_PID=$pid
+    FM_AFK_LAUNCH_STOP_IDENTITY=$pid_identity
+    FM_AFK_LAUNCH_STOP_INTENT_ACTIVE=1
     if ! fm_afk_stop_intent_publish "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity"; then
+      fm_afk_launch_stop_tracking_clear
       fm_afk_launch_log "failed to publish the exact daemon stop intent; preserving lifecycle state"
       return 1
     fi
@@ -667,18 +722,15 @@ fm_afk_launch_stop() {
   fi
   if [ -n "$pid" ] && fm_pid_alive "$pid"; then
     current_identity=$(fm_pid_identity "$pid" 2>/dev/null) || {
+      fm_afk_launch_stop_intent_retract_if_live || true
       fm_afk_launch_log "could not confirm away-mode daemon exit; preserving lifecycle state"
       return 1
     }
     if [ "$current_identity" = "$pid_identity" ]; then
-      fm_afk_stop_intent_retire "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity" || true
+      fm_afk_launch_stop_intent_retract_if_live || true
       fm_afk_launch_log "away-mode daemon did not exit after SIGTERM; preserving lifecycle state"
       return 1
     fi
-  fi
-  if [ -n "$pid" ] \
-    && fm_afk_stop_intent_matches "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity"; then
-    fm_afk_stop_intent_retire "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity" || result=1
   fi
   # (2) Close the daemon's own terminal by exact id.
   if [ "$read_result" -eq 0 ]; then
@@ -688,7 +740,14 @@ fm_afk_launch_stop() {
   if ! rm -f "$FM_AFK_LAUNCH_STATE/.afk"; then
     fm_afk_launch_log "failed to clear away-mode flag"
     result=1
+  else
+    afk_cleared=1
   fi
+  if [ "$afk_cleared" -eq 1 ] && [ -n "$pid" ] \
+    && fm_afk_stop_intent_matches "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity"; then
+    fm_afk_stop_intent_retire "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity" || result=1
+  fi
+  fm_afk_launch_stop_tracking_clear
   if [ "$result" -eq 0 ]; then
     fm_afk_launch_log "away mode stopped; daemon terminal torn down and .afk cleared"
   else
@@ -700,9 +759,10 @@ fm_afk_launch_stop() {
 fm_afk_launch_main() {
   local result
   fm_afk_launch_lock_acquire || return 1
-  trap fm_afk_launch_lock_release EXIT
-  trap 'exit 130' INT
-  trap 'exit 143' TERM
+  trap fm_afk_launch_exit_cleanup EXIT
+  trap 'fm_afk_launch_signal_exit 129' HUP
+  trap 'fm_afk_launch_signal_exit 130' INT
+  trap 'fm_afk_launch_signal_exit 143' TERM
   case "${1:-start}" in
     start) fm_afk_launch_start ;;
     start-native) fm_afk_launch_start_native ;;
@@ -713,8 +773,9 @@ fm_afk_launch_main() {
     *) fm_afk_launch_usage >&2; return 2 ;;
   esac
   result=$?
+  fm_afk_launch_stop_intent_retract_if_live || result=1
   fm_afk_launch_lock_release || result=1
-  trap - EXIT INT TERM
+  trap - EXIT HUP INT TERM
   return "$result"
 }
 

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -436,7 +436,8 @@ fm_afk_launch_check_dead_daemon() {
     if { [ "$identity" != MISSING ] \
       && [ "$FM_AFK_STOP_INTENT_PID" = "$pid" ] \
       && [ "$FM_AFK_STOP_INTENT_IDENTITY" = "$identity" ]; } \
-      || { [ -z "$owner" ] && [ "$pid" = MISSING ]; }; then
+      || { [ -z "$owner" ] && [ "$pid" = MISSING ] \
+        && [ "$FM_AFK_STOP_INTENT_PHASE" = consumed ]; }; then
       intent_applies=1
     fi
     if [ "$intent_applies" -eq 1 ]; then
@@ -452,7 +453,9 @@ fm_afk_launch_check_dead_daemon() {
           fm_afk_stop_intent_abandon "$FM_AFK_LAUNCH_STATE" \
             "$FM_AFK_STOP_INTENT_PID" "$FM_AFK_STOP_INTENT_IDENTITY" || true
           if fm_afk_stop_intent_read "$FM_AFK_LAUNCH_STATE" \
-            && [ "$FM_AFK_STOP_INTENT_PHASE" = consumed ]; then
+            && [ "$FM_AFK_STOP_INTENT_PHASE" = consumed ] \
+            && [ "$FM_AFK_STOP_INTENT_PID" = "$pid" ] \
+            && [ "$FM_AFK_STOP_INTENT_IDENTITY" = "$identity" ]; then
             fm_afk_launch_log "expected daemon loss observed (pid=$FM_AFK_STOP_INTENT_PID)"
             return 0
           fi

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -101,7 +101,7 @@ fm_afk_launch_stop_tracking_clear() {
   FM_AFK_LAUNCH_STOP_INTENT_ACTIVE=0
 }
 
-fm_afk_launch_stop_intent_retract_if_live() {
+fm_afk_launch_stop_intent_abandon_if_live() {
   local current_identity
   [ "$FM_AFK_LAUNCH_STOP_INTENT_ACTIVE" -eq 1 ] || return 0
   fm_pid_alive "$FM_AFK_LAUNCH_STOP_PID" || return 0
@@ -110,7 +110,7 @@ fm_afk_launch_stop_intent_retract_if_live() {
     && [ "$current_identity" != "$FM_AFK_LAUNCH_STOP_IDENTITY" ]; then
     return 0
   fi
-  if fm_afk_stop_intent_retire "$FM_AFK_LAUNCH_STATE" \
+  if fm_afk_stop_intent_abandon "$FM_AFK_LAUNCH_STATE" \
     "$FM_AFK_LAUNCH_STOP_PID" "$FM_AFK_LAUNCH_STOP_IDENTITY"; then
     fm_afk_launch_stop_tracking_clear
   fi
@@ -118,13 +118,20 @@ fm_afk_launch_stop_intent_retract_if_live() {
 
 fm_afk_launch_signal_exit() {
   local code=$1
-  fm_afk_launch_stop_intent_retract_if_live || true
+  fm_afk_launch_stop_intent_abandon_if_live || true
   exit "$code"
 }
 
 fm_afk_launch_exit_cleanup() {
-  fm_afk_launch_stop_intent_retract_if_live || true
+  fm_afk_launch_stop_intent_abandon_if_live || true
   fm_afk_launch_lock_release
+}
+
+fm_afk_launch_stop_publisher_alive() {
+  local current_identity
+  fm_pid_alive "$FM_AFK_STOP_INTENT_PUBLISHER_PID" || return 1
+  current_identity=$(fm_pid_identity "$FM_AFK_STOP_INTENT_PUBLISHER_PID" 2>/dev/null) || return 1
+  [ "$current_identity" = "$FM_AFK_STOP_INTENT_PUBLISHER_IDENTITY" ]
 }
 
 fm_afk_launch_lock_owned() {
@@ -396,10 +403,11 @@ fm_afk_launch_herdr_recover_created() {  # <session> <label>
 }
 
 fm_afk_launch_check_dead_daemon() {
-  local owner pid identity current_identity marker record_result
+  local owner pid identity current_identity marker record_result intent_applies=0
   [ -e "$FM_AFK_LAUNCH_STATE/.afk" ] || return 0
   fm_afk_unexpected_exit_read "$FM_AFK_LAUNCH_STATE" && return 0
   daemon_lock_held_by_live_daemon && return 0
+  fm_afk_start_pending_active "$FM_AFK_LAUNCH_STATE" && return 0
   owner=$(daemon_lock_owner 2>/dev/null || true)
   pid=
   identity=MISSING
@@ -423,8 +431,27 @@ fm_afk_launch_check_dead_daemon() {
       && [ "$FM_AFK_STOP_INTENT_PID" = "$pid" ] \
       && [ "$FM_AFK_STOP_INTENT_IDENTITY" = "$identity" ]; } \
       || { [ -z "$owner" ] && [ "$pid" = MISSING ]; }; then
-      fm_afk_launch_log "expected daemon loss observed (pid=$FM_AFK_STOP_INTENT_PID)"
-      return 0
+      intent_applies=1
+    fi
+    if [ "$intent_applies" -eq 1 ]; then
+      case "$FM_AFK_STOP_INTENT_PHASE" in
+        consumed)
+          fm_afk_launch_log "expected daemon loss observed (pid=$FM_AFK_STOP_INTENT_PID)"
+          return 0
+          ;;
+        published)
+          if fm_afk_launch_stop_publisher_alive; then
+            return 0
+          fi
+          fm_afk_stop_intent_abandon "$FM_AFK_LAUNCH_STATE" \
+            "$FM_AFK_STOP_INTENT_PID" "$FM_AFK_STOP_INTENT_IDENTITY" || true
+          if fm_afk_stop_intent_read "$FM_AFK_LAUNCH_STATE" \
+            && [ "$FM_AFK_STOP_INTENT_PHASE" = consumed ]; then
+            fm_afk_launch_log "expected daemon loss observed (pid=$FM_AFK_STOP_INTENT_PID)"
+            return 0
+          fi
+          ;;
+      esac
     fi
   fi
   marker=$(fm_afk_unexpected_exit_path "$FM_AFK_LAUNCH_STATE")
@@ -472,13 +499,15 @@ fm_afk_launch_restore_backup() {  # <backup> <had-afk>
     "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" \
     "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" \
     "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged" \
+    "$FM_AFK_LAUNCH_STATE/.supervise-daemon.start-pending" \
     "$FM_AFK_LAUNCH_STATE/.supervise-daemon.stop-intent" \
     "$FM_AFK_LAUNCH_STATE/.supervise-daemon.unexpected-exit" || result=1
   if [ "$had_afk" -eq 1 ]; then
     cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk" || result=1
   fi
   for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged \
-    .supervise-daemon.stop-intent .supervise-daemon.unexpected-exit; do
+    .supervise-daemon.start-pending .supervise-daemon.stop-intent \
+    .supervise-daemon.unexpected-exit; do
     if [ -e "$backup/$artifact" ]; then
       cp -p "$backup/$artifact" "$FM_AFK_LAUNCH_STATE/$artifact" || result=1
     fi
@@ -599,7 +628,8 @@ fm_afk_launch_start() {
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
   for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged \
-    .supervise-daemon.stop-intent .supervise-daemon.unexpected-exit; do
+    .supervise-daemon.start-pending .supervise-daemon.stop-intent \
+    .supervise-daemon.unexpected-exit; do
     if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
       cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
     fi
@@ -659,7 +689,8 @@ fm_afk_launch_start_native() {
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
   for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged \
-    .supervise-daemon.stop-intent .supervise-daemon.unexpected-exit; do
+    .supervise-daemon.start-pending .supervise-daemon.stop-intent \
+    .supervise-daemon.unexpected-exit; do
     if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
       cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
     fi
@@ -668,6 +699,8 @@ fm_afk_launch_start_native() {
   if [ "$result" -eq 0 ]; then
     if ! fm_afk_clear_stale_artifacts "$FM_AFK_LAUNCH_STATE"; then
       fm_afk_launch_log "failed to clear stale away-mode artifacts"
+      result=1
+    elif ! fm_afk_start_pending_publish "$FM_AFK_LAUNCH_STATE"; then
       result=1
     elif ! fm_afk_launch_flag_write; then
       result=1
@@ -685,7 +718,7 @@ fm_afk_launch_start_native() {
 }
 
 fm_afk_launch_stop() {
-  local pid pid_identity current_identity result=0 read_result afk_cleared=0
+  local pid pid_identity current_identity publisher_pid publisher_identity result=0 read_result afk_cleared=0
   fm_afk_launch_stop_tracking_clear
   fm_afk_launch_record_read
   read_result=$?
@@ -706,7 +739,13 @@ fm_afk_launch_stop() {
     FM_AFK_LAUNCH_STOP_PID=$pid
     FM_AFK_LAUNCH_STOP_IDENTITY=$pid_identity
     FM_AFK_LAUNCH_STOP_INTENT_ACTIVE=1
-    if ! fm_afk_stop_intent_publish "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity"; then
+    publisher_pid=${BASHPID:-$$}
+    publisher_identity=$(fm_pid_identity "$publisher_pid" 2>/dev/null) || {
+      fm_afk_launch_stop_tracking_clear
+      return 1
+    }
+    if ! fm_afk_stop_intent_publish "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity" \
+      "$publisher_pid" "$publisher_identity"; then
       fm_afk_launch_stop_tracking_clear
       fm_afk_launch_log "failed to publish the exact daemon stop intent; preserving lifecycle state"
       return 1
@@ -722,12 +761,12 @@ fm_afk_launch_stop() {
   fi
   if [ -n "$pid" ] && fm_pid_alive "$pid"; then
     current_identity=$(fm_pid_identity "$pid" 2>/dev/null) || {
-      fm_afk_launch_stop_intent_retract_if_live || true
+      fm_afk_launch_stop_intent_abandon_if_live || true
       fm_afk_launch_log "could not confirm away-mode daemon exit; preserving lifecycle state"
       return 1
     }
     if [ "$current_identity" = "$pid_identity" ]; then
-      fm_afk_launch_stop_intent_retract_if_live || true
+      fm_afk_launch_stop_intent_abandon_if_live || true
       fm_afk_launch_log "away-mode daemon did not exit after SIGTERM; preserving lifecycle state"
       return 1
     fi
@@ -742,6 +781,9 @@ fm_afk_launch_stop() {
     result=1
   else
     afk_cleared=1
+  fi
+  if [ "$afk_cleared" -eq 1 ]; then
+    fm_afk_start_pending_clear "$FM_AFK_LAUNCH_STATE" || result=1
   fi
   if [ "$afk_cleared" -eq 1 ] && [ -n "$pid" ] \
     && fm_afk_stop_intent_matches "$FM_AFK_LAUNCH_STATE" "$pid" "$pid_identity"; then
@@ -773,7 +815,7 @@ fm_afk_launch_main() {
     *) fm_afk_launch_usage >&2; return 2 ;;
   esac
   result=$?
-  fm_afk_launch_stop_intent_retract_if_live || result=1
+  fm_afk_launch_stop_intent_abandon_if_live || result=1
   fm_afk_launch_lock_release || result=1
   trap - EXIT HUP INT TERM
   return "$result"

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -7,7 +7,7 @@
 #   state/.supervise-daemon.lock, and:
 #     - prints "afk: daemon already running pid=<pid>" then exits 0 when that
 #       lock is held by a live daemon (a REFRESH: no stale-artifact clear);
-#     - otherwise clears any prior away session's stale escalation artifacts
+#     - otherwise clears any prior away session's stale session artifacts
 #       (fm_afk_clear_stale_artifacts) for a direct, non-prepared start, then
 #       execs bin/fm-supervise-daemon.sh in the foreground. A prepared start was
 #       already cleared transactionally by bin/fm-afk-launch.sh.

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -47,8 +47,8 @@ fm_afk_start_usage() {
 }
 
 # fm_afk_clear_stale_artifacts: on a FRESH away-session entry (the daemon is not
-# already running), drop the previous away session's leftover escalation-delivery
-# artifacts so they cannot surface as stale escalations under the new session.
+# already running), drop the previous away session's delivery and daemon
+# lifecycle artifacts so they cannot surface under the new session.
 # These are session-scoped by timing: a fresh entry owns a new supervision
 # session and the new daemon has not produced anything yet, so anything present
 # here belongs to a PRIOR session. This never drops a genuinely-pending
@@ -63,7 +63,9 @@ fm_afk_clear_stale_artifacts() {  # <state-dir>
   local state=$1
   rm -f "$state/.subsuper-escalations" \
         "$state/.subsuper-escalations.since" \
-        "$state/.subsuper-inject-wedged" 2>/dev/null
+        "$state/.subsuper-inject-wedged" \
+        "$state/.supervise-daemon.stop-intent" \
+        "$state/.supervise-daemon.unexpected-exit" 2>/dev/null
 }
 
 daemon_lock_owner() {

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -64,6 +64,7 @@ fm_afk_clear_stale_artifacts() {  # <state-dir>
   rm -f "$state/.subsuper-escalations" \
         "$state/.subsuper-escalations.since" \
         "$state/.subsuper-inject-wedged" \
+        "$state/.supervise-daemon.start-pending" \
         "$state/.supervise-daemon.stop-intent" \
         "$state/.supervise-daemon.unexpected-exit" 2>/dev/null
 }

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -12,6 +12,9 @@
 # doing - the one channel every harness has. The full banner is emitted once per
 # distinct staleness episode in this FM_HOME (keyed to beacon mtime or absence);
 # later guarded commands in the same episode print a one-line reminder instead.
+# While away mode remains active, normal mode also reconciles daemon liveness
+# and durably alerts on an unexpected loss; read-only mode only reports an
+# existing death marker.
 # Episode state lives only under state/.guard-watcher-stale-banner (volatile,
 # bounded). Independent alarms (queued wakes, worktree tangle) are never
 # suppressed by that dedup. Normal wake handling (watcher briefly down between a

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -41,6 +41,18 @@ STALE_BANNER_MARKER="$STATE/.guard-watcher-stale-banner"
 # shellcheck source=bin/fm-supervision-lib.sh
 . "$SCRIPT_DIR/fm-supervision-lib.sh"
 
+if [ -e "$STATE/.afk" ]; then
+  if [ "$READ_ONLY" -eq 1 ]; then
+    if [ -s "$STATE/.supervise-daemon.unexpected-exit" ]; then
+      printf 'CRITICAL: away-mode daemon death alarm is active - see %s\n' \
+        "$STATE/.supervise-daemon.unexpected-exit" >&2
+    fi
+  elif ! "$SCRIPT_DIR/fm-afk-launch.sh" check-death; then
+    printf 'CRITICAL: away-mode daemon liveness reconciliation failed; preserving %s\n' \
+      "$STATE/.afk" >&2
+  fi
+fi
+
 # Deterministic episode key from beacon state: same continuous stale beacon
 # (or continuous absence) shares a key; a recovered-then-restale beacon gets a
 # new mtime and therefore a new episode.

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1273,6 +1273,27 @@ trim_log() {
   tail -n "${FM_LOG_KEEP_LINES:-$LOG_KEEP_LINES_DEFAULT}" "$LOG" >"$tmp" 2>/dev/null && mv -f "$tmp" "$LOG"
 }
 
+fm_super_publish_daemon_identity() {  # <lock> <pidfile> <pid> <identity>
+  local lock=$1 pidfile=$2 pid=$3 identity=$4 published
+  if ! printf '%s\n' "$identity" > "$lock/pid-identity" 2>/dev/null; then
+    return 1
+  fi
+  published=$(cat "$lock/pid-identity" 2>/dev/null || true)
+  if [ "$published" != "$identity" ]; then
+    rm -f "$lock/pid-identity" 2>/dev/null || true
+    return 1
+  fi
+  if ! printf '%s\n' "$pid" > "$pidfile" 2>/dev/null; then
+    rm -f "$lock/pid-identity" 2>/dev/null || true
+    return 1
+  fi
+  published=$(cat "$pidfile" 2>/dev/null || true)
+  if [ "$published" != "$pid" ]; then
+    rm -f "$pidfile" "$lock/pid-identity" 2>/dev/null || true
+    return 1
+  fi
+}
+
 # ============================================================================
 # Everything below runs only when the script is EXECUTED, not sourced. The pure
 # classifiers above are sourceable for unit tests (tests/fm-daemon.test.sh).
@@ -1318,8 +1339,12 @@ fm_super_main() {
     fm_lock_release "$LOCK" 2>/dev/null || true
     exit 1
   }
-  echo "$DAEMON_PID" > "$PIDFILE"
-  printf '%s\n' "$DAEMON_IDENTITY" > "$LOCK/pid-identity" 2>/dev/null || true
+  if ! fm_super_publish_daemon_identity "$LOCK" "$PIDFILE" "$DAEMON_PID" "$DAEMON_IDENTITY"; then
+    echo "error: cannot publish away-mode daemon identity for pid $DAEMON_PID" >&2
+    rm -f "$PIDFILE" 2>/dev/null || true
+    fm_lock_release "$LOCK" 2>/dev/null || true
+    exit 1
+  fi
 
   # --- auto-discover the supervisor BACKEND (tmux vs herdr) first -----------
   # Priority: FM_SUPERVISOR_BACKEND override > $TMUX_PANE (tmux) > $HERDR_ENV=1
@@ -1407,7 +1432,6 @@ fm_super_main() {
     afk_active "$STATE" || return 0
     if [ -n "$DAEMON_IDENTITY" ] \
       && fm_afk_stop_intent_matches "$STATE" "$DAEMON_PID" "$DAEMON_IDENTITY"; then
-      fm_afk_stop_intent_retire "$STATE" "$DAEMON_PID" "$DAEMON_IDENTITY" || true
       log "daemon expected stop observed (signal=$signal pid=$DAEMON_PID)"
       return 0
     fi

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1345,6 +1345,12 @@ fm_super_main() {
     fm_lock_release "$LOCK" 2>/dev/null || true
     exit 1
   fi
+  if ! fm_afk_start_pending_clear "$STATE"; then
+    echo "error: cannot clear away-mode daemon pending-start state" >&2
+    rm -f "$PIDFILE" 2>/dev/null || true
+    fm_lock_release "$LOCK" 2>/dev/null || true
+    exit 1
+  fi
 
   # --- auto-discover the supervisor BACKEND (tmux vs herdr) first -----------
   # Priority: FM_SUPERVISOR_BACKEND override > $TMUX_PANE (tmux) > $HERDR_ENV=1
@@ -1431,7 +1437,7 @@ fm_super_main() {
     local signal=$1 marker record_result
     afk_active "$STATE" || return 0
     if [ -n "$DAEMON_IDENTITY" ] \
-      && fm_afk_stop_intent_matches "$STATE" "$DAEMON_PID" "$DAEMON_IDENTITY"; then
+      && fm_afk_stop_intent_consume "$STATE" "$DAEMON_PID" "$DAEMON_IDENTITY"; then
       log "daemon expected stop observed (signal=$signal pid=$DAEMON_PID)"
       return 0
     fi

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -51,6 +51,9 @@
 #     undelivered past FM_MAX_DEFER_SECS, the daemon retries a normal flush and
 #     writes state/.subsuper-inject-wedged and attempts a configurable active
 #     alert if submit still cannot be confirmed.
+#   - Durable daemon-death alarm: while state/.afk remains present, any exit
+#     without an exact consumed lifecycle stop intent records signal, timestamp,
+#     PID, and process identity before using the same active-alert channel.
 #   - Cheap heartbeat catch-all: every HEARTBEAT_SCAN_SECS the daemon greps all
 #     state/*.status for a captain-relevant line the per-wake classifier might
 #     have missed (e.g. a status verb outside CAPTAIN_RE) and escalates it.
@@ -105,7 +108,7 @@
 #                                   if that cannot confirm a submit, a wedge
 #                                   alarm fires (default 300; 0 disables)
 #          FM_WEDGE_ALARM_CHANNEL   override config/wedge-alarm with a single
-#                                   active-alert directive for that wedge alarm
+#                                   active-alert directive for away-mode alarms
 #                                   (off|auto|osascript|herdr|command:<cmd>). An
 #                                   absent file/var means auto: on macOS that is
 #                                   an OS-level notification, so the alarm is
@@ -137,9 +140,10 @@
 #          FM_STATE_OVERRIDE        alternate state dir (testing)
 #          Logs each wake to state/.supervise-daemon.log (size-capped). Single
 #          instance via portable lock on state/.supervise-daemon.lock. Trapped
-#          SIGTERM/SIGINT shut down within ~1s, flush escalations, release the
-#          lock. A crashing fm-watch.sh is logged and restarted, never killing
-#          the daemon; a tight crash-restart spin is detected and backed off.
+#          SIGTERM/SIGINT/SIGHUP record the exit outcome, shut down within ~1s,
+#          flush escalations, and release the lock. A crashing fm-watch.sh is
+#          logged and restarted, never killing the daemon; a tight crash-restart
+#          spin is detected and backed off.
 set -u
 
 FM_DAEMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1403,7 +1403,7 @@ fm_super_main() {
   # --- shutdown: flush buffered escalations, reap child, release lock -------
   local WATCHER_PID="" CUR_TMP=""
   record_daemon_exit() {  # <signal-or-exit>
-    local signal=$1 marker
+    local signal=$1 marker record_result
     afk_active "$STATE" || return 0
     if [ -n "$DAEMON_IDENTITY" ] \
       && fm_afk_stop_intent_matches "$STATE" "$DAEMON_PID" "$DAEMON_IDENTITY"; then
@@ -1412,13 +1412,21 @@ fm_super_main() {
       return 0
     fi
     marker=$(fm_afk_unexpected_exit_path "$STATE")
-    if fm_afk_unexpected_exit_record "$STATE" "$signal" "$DAEMON_PID" "$DAEMON_IDENTITY"; then
-      log "ERROR: away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID identity=$DAEMON_IDENTITY); alarm marker written"
-      wedge_alarm_notify "away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID) - see $marker" "$marker"
-    else
-      log "ERROR: away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID); failed to write alarm marker"
-      wedge_alarm_notify "away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID) - durable marker write failed" "$marker"
-    fi
+    fm_afk_unexpected_exit_record "$STATE" "$signal" "$DAEMON_PID" "$DAEMON_IDENTITY"
+    record_result=$?
+    case "$record_result" in
+      0)
+        log "ERROR: away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID identity=$DAEMON_IDENTITY); alarm marker written"
+        wedge_alarm_notify "away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID) - see $marker" "$marker"
+        ;;
+      2)
+        log "daemon unexpected exit already recorded (signal=$signal pid=$DAEMON_PID)"
+        ;;
+      *)
+        log "ERROR: away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID); failed to write alarm marker"
+        wedge_alarm_notify "away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID) - durable marker write failed" "$marker"
+        ;;
+    esac
   }
   cleanup() {
     local signal=${1:-EXIT}
@@ -1547,9 +1555,21 @@ fm_super_main() {
   done
 }
 
+fm_super_wedge_alarm_notify() {
+  [ "$#" -eq 2 ] || return 2
+  LOG="$(_state_root)/.supervise-daemon.log"
+  mkdir -p "$(dirname "$LOG")" || return 1
+  wedge_alarm_notify "$1" "$2"
+}
+
 # Run only when executed, not when sourced (tests source the classifiers).
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-  fm_super_main "$@"
+  if [ "${1:-}" = --wedge-alarm-notify ]; then
+    shift
+    fm_super_wedge_alarm_notify "$@"
+  else
+    fm_super_main "$@"
+  fi
 else
   # Library mode: these functions were SOURCED (only tests do this - production
   # execs the daemon, see bin/fm-afk-start.sh). Make it structurally impossible

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1287,6 +1287,8 @@ fm_super_main() {
   # Export FM_STATE_OVERRIDE so the lib resolves the same state dir.
   # shellcheck source=bin/fm-wake-lib.sh
   FM_STATE_OVERRIDE="$STATE" . "$FM_DAEMON_DIR/fm-wake-lib.sh"
+  # shellcheck source=bin/fm-afk-death-lib.sh
+  . "$FM_DAEMON_DIR/fm-afk-death-lib.sh"
 
   local WATCH="$FM_DAEMON_DIR/fm-watch.sh"
   local LOG="$STATE/.supervise-daemon.log"
@@ -1310,8 +1312,14 @@ fm_super_main() {
     fi
     exit 1
   fi
-  echo "$$" > "$PIDFILE"
-  fm_pid_identity "${BASHPID:-$$}" > "$LOCK/pid-identity" 2>/dev/null || true
+  local DAEMON_PID="${BASHPID:-$$}" DAEMON_IDENTITY
+  DAEMON_IDENTITY=$(fm_pid_identity "$DAEMON_PID" 2>/dev/null) || {
+    echo "error: cannot identify away-mode daemon pid $DAEMON_PID" >&2
+    fm_lock_release "$LOCK" 2>/dev/null || true
+    exit 1
+  }
+  echo "$DAEMON_PID" > "$PIDFILE"
+  printf '%s\n' "$DAEMON_IDENTITY" > "$LOCK/pid-identity" 2>/dev/null || true
 
   # --- auto-discover the supervisor BACKEND (tmux vs herdr) first -----------
   # Priority: FM_SUPERVISOR_BACKEND override > $TMUX_PANE (tmux) > $HERDR_ENV=1
@@ -1394,12 +1402,43 @@ fm_super_main() {
 
   # --- shutdown: flush buffered escalations, reap child, release lock -------
   local WATCHER_PID="" CUR_TMP=""
+  record_daemon_exit() {  # <signal-or-exit>
+    local signal=$1 marker
+    afk_active "$STATE" || return 0
+    if [ -n "$DAEMON_IDENTITY" ] \
+      && fm_afk_stop_intent_matches "$STATE" "$DAEMON_PID" "$DAEMON_IDENTITY"; then
+      fm_afk_stop_intent_retire "$STATE" "$DAEMON_PID" "$DAEMON_IDENTITY" || true
+      log "daemon expected stop observed (signal=$signal pid=$DAEMON_PID)"
+      return 0
+    fi
+    marker=$(fm_afk_unexpected_exit_path "$STATE")
+    if fm_afk_unexpected_exit_record "$STATE" "$signal" "$DAEMON_PID" "$DAEMON_IDENTITY"; then
+      log "ERROR: away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID identity=$DAEMON_IDENTITY); alarm marker written"
+      wedge_alarm_notify "away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID) - see $marker" "$marker"
+    else
+      log "ERROR: away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID); failed to write alarm marker"
+      wedge_alarm_notify "away-mode daemon exited unexpectedly (signal=$signal pid=$DAEMON_PID) - durable marker write failed" "$marker"
+    fi
+  }
   cleanup() {
-    trap - TERM INT
+    local signal=${1:-EXIT}
+    trap - TERM INT HUP
+    # Persist and emit before any best-effort flush or child reap can stall.
+    # The death signal must survive even when the watcher is itself wedged.
+    record_daemon_exit "$signal"
     wedge_alarm_stop_active_notifier
     escalate_flush "$STATE" 2>/dev/null || true
     if [ -n "${WATCHER_PID:-}" ]; then
       kill "$WATCHER_PID" 2>/dev/null || true
+      for _ in $(seq 1 20); do
+        fm_pid_alive "$WATCHER_PID" || break
+        sleep 0.05
+      done
+      # A watcher inherited from a detached terminal can itself ignore TERM.
+      # It is this daemon's exact child, so bounded reaping may escalate safely.
+      if fm_pid_alive "$WATCHER_PID"; then
+        kill -KILL "$WATCHER_PID" 2>/dev/null || true
+      fi
       wait "$WATCHER_PID" 2>/dev/null || true
     fi
     if [ -n "${CUR_TMP:-}" ]; then
@@ -1408,9 +1447,13 @@ fm_super_main() {
     fm_lock_release "$LOCK" 2>/dev/null || true
     rm -f "$PIDFILE" 2>/dev/null || true
     log "daemon shutting down"
+    trap - EXIT
     exit 0
   }
-  trap cleanup TERM INT
+  trap 'cleanup TERM' TERM
+  trap 'cleanup INT' INT
+  trap 'cleanup HUP' HUP
+  trap 'cleanup EXIT' EXIT
 
   # --- crash-loop guard -----------------------------------------------------
   local crash_times=() backoff_secs=$CRASH_NORMAL_SLEEP

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,14 +107,10 @@ Selecting any other supervisor backend, including `zellij`, `orca`, or `cmux`, r
 
 ## Away-mode wedge alarm channels (config/wedge-alarm)
 
-When away-mode injection wedges past `FM_MAX_DEFER_SECS`, the sub-supervisor raises a loud, rate-limited alarm.
-Beyond the durable `state/.subsuper-inject-wedged` marker and the tmux status-line flash, it attempts a configured backend-independent active alert that can reach the captain even when every pane and its backend status-line is unreadable.
-`config/wedge-alarm` (local, gitignored) lists channel directives, one per non-empty, non-comment line; every listed non-`off` channel fires, best-effort.
+`config/wedge-alarm` selects the backend-independent active-alert channels used by away-mode supervision alarms.
+The file is local and gitignored, with one channel directive per non-empty, non-comment line; every listed non-`off` channel fires best-effort.
 `FM_WEDGE_ALARM_CHANNEL` overrides the file with a single directive.
-Directives are `off` (a position-independent kill switch that disables every active alert), `auto`/`default`, `osascript` (macOS Notification Center banner), `herdr` (herdr UI notification), and `command:<cmd>` (run `<cmd>` via `sh -c`, summary on `$1` and stdin).
-An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisely so a wedged away-mode primary is never silent, and it fires at most once per max-defer window after a genuine wedge.
-A missing or failing channel logs and falls through to the next, never crashing the daemon.
-See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
+See [`wedge-alarm.md`](wedge-alarm.md) for the authoritative trigger and channel contract, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
 
 ## Gate defaults (.no-mistakes.yaml)
 
@@ -474,7 +470,7 @@ FM_SUPERVISOR_TARGET=              # optional supervisor pane target override; t
 FM_INJECT_SKIP=heartbeat           # |-prefixes force-self-handled bypassing classification; empty disables
 FM_ESCALATE_BATCH_SECS=90          # buffer window for batched escalation digests; 0 = flush immediately
 FM_MAX_DEFER_SECS=300              # max buffered escalation age before retry plus wedge alarm; 0 disables
-FM_WEDGE_ALARM_CHANNEL=            # override config/wedge-alarm with one active-alert directive for the wedge alarm; off|auto|osascript|herdr|command:<cmd>; absent = auto (macOS -> an OS notification)
+FM_WEDGE_ALARM_CHANNEL=            # override config/wedge-alarm with one active-alert directive for away-mode supervision alarms; off|auto|osascript|herdr|command:<cmd>; absent = auto (macOS -> an OS notification)
 FM_WEDGE_ALARM_EXEC=              # notifier seam: route every channel (osascript, herdr, command:) through this command as `<cmd> <channel> <summary>`; "discard" fires nothing; unset in production; the daemon defaults it to "discard" when sourced so no test posts a real notification (docs/wedge-alarm.md)
 FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum seconds for each osascript, herdr, override, or command: notifier before its watchdog terminates it and continues to the next channel; invalid or zero values use 10
 FM_INJECT_FAIL_SLEEP=30            # seconds to back off when the supervisor pane is unavailable

--- a/docs/examples/wedge-alarm
+++ b/docs/examples/wedge-alarm
@@ -1,11 +1,11 @@
-# config/wedge-alarm - active alert channels for the away-mode injection wedge
-# alarm (bin/fm-supervise-daemon.sh's inject_wedge_alarm). Copy this into a
-# local, gitignored config/wedge-alarm and edit. One channel directive per
-# non-empty, non-comment line; every listed non-off channel fires, best-effort.
+# config/wedge-alarm - active alert channels for away-mode supervision alarms.
+# Copy this into a local, gitignored config/wedge-alarm and edit. One channel
+# directive per non-empty, non-comment line; every listed non-off channel fires,
+# best-effort. See docs/wedge-alarm.md for the trigger and channel contract.
 #
 # Directives:
 #   off              position-independent kill switch: disable every active
-#                    alert (the durable marker and tmux status-line flash remain)
+#                    alert (durable markers and any applicable tmux flash remain)
 #   auto | default   platform default: macOS -> osascript; other platforms have
 #                    no built-in OS channel (configure a command: line instead)
 #   osascript        macOS Notification Center banner (backend-independent)
@@ -13,10 +13,9 @@
 #   command:<cmd>    run <cmd> via `sh -c`; the alarm summary is passed as $1 and
 #                    on stdin, so it can reach a phone/pager while you are away
 #
-# An ABSENT config/wedge-alarm behaves as `auto` (default-on on macOS): the
-# alarm exists precisely so a wedged away-mode primary is never silent.
+# An ABSENT config/wedge-alarm behaves as `auto` (default-on on macOS).
 #
-# Example: a macOS banner plus a push to a phone via ntfy.sh, so a wedge that
-# happens overnight reaches you even away from the machine.
+# Example: a macOS banner plus a push to a phone via ntfy.sh, so an away-mode
+# supervision failure reaches you even away from the machine.
 osascript
-command: curl -fsS -H "Title: firstmate wedge alarm" -d "$1" https://ntfy.sh/replace-with-your-topic
+command: curl -fsS -H "Title: firstmate away-mode alarm" -d "$1" https://ntfy.sh/replace-with-your-topic

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -26,7 +26,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
-| `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
+| `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and supervision liveness failures |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
@@ -59,10 +59,10 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
 | `fm-watch.sh`            | Singleton-safe always-on watcher: absorb benign wakes, queue and exit on actionable ones |
 | `fm-afk-start.sh`        | Run the common sourceable away-mode daemon entry in the foreground                      |
-| `fm-afk-launch.sh`       | Own away-mode entry, exit, rollback, and any backend terminal lifecycle                 |
+| `fm-afk-launch.sh`       | Own away-mode entry, exact-intent exit, daemon-loss reconciliation, and backend terminal lifecycle |
 | `fm-afk-return.sh`       | Own deterministic return shutdown, catch-up evidence, and the firstmate-actionable blocker gate |
 | `fm-supervisor-target-lib.sh` | Resolve the shared supervisor target and backend for the daemon and launcher       |
-| `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, escalate batched digests, alert on failed delivery |
+| `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, escalate batched digests, and alert on delivery wedges or unexpected exit |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -196,3 +196,4 @@ Observed output:
 ```
 
 The safe command-channel contract is covered without a notification by `tests/fm-daemon.test.sh`: the summary reaches both `$1` and stdin, every channel is process-group bounded, and a failed channel falls through.
+The daemon-loss lifecycle is covered by `tests/fm-afk-launch.test.sh`: deliberate launcher stop stays quiet, external `TERM` and untrappable loss record and alert once, exact consumed stop intent wins the exit race, and refresh reconciliation starts a replacement without repeating the alarm.

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -2,6 +2,7 @@
 
 The away-mode sub-supervisor (`bin/fm-supervise-daemon.sh`) buffers escalations and injects them into Firstmate's own pane.
 When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_alarm` raises a loud, rate-limited alarm so the stall never stays invisible.
+An away-mode daemon exit without its exact lifecycle stop intent raises this same channel and writes `state/.supervise-daemon.unexpected-exit` with the exit signal, timestamp, PID, and process identity.
 The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and cannot reach an unattended captain reliably.
 The durable marker and tmux flash remain as additional signals.
 

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -1,10 +1,11 @@
-# Away-mode injection wedge alarm
+# Away-mode active alarm channel
 
-The away-mode sub-supervisor (`bin/fm-supervise-daemon.sh`) buffers escalations and injects them into Firstmate's own pane.
-When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_alarm` raises a loud, rate-limited alarm so the stall never stays invisible.
-An away-mode daemon exit without its exact lifecycle stop intent raises this same channel and writes `state/.supervise-daemon.unexpected-exit` with the exit signal, timestamp, PID, and process identity.
-The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and cannot reach an unattended captain reliably.
-The durable marker and tmux flash remain as additional signals.
+The away-mode supervisor uses one pane-independent active-alert channel for two durable safety alarms.
+When escalation injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_alarm` writes `state/.subsuper-inject-wedged`, flashes the tmux status line when applicable, and raises a rate-limited alert so the stall never stays invisible.
+When the away-mode daemon exits while `state/.afk` remains present and no matching lifecycle stop intent was consumed, it writes `state/.supervise-daemon.unexpected-exit` with the exit signal, timestamp, PID, and process identity before raising the same alert channel.
+A deliberate `bin/fm-afk-launch.sh stop` publishes an intent bound to the daemon's exact PID and process identity before sending `SIGTERM`, so that exit does not alarm.
+Refresh and terminal reconciliation do not alert again for an already-recorded episode, and a fresh replacement retires the prior session's lifecycle artifacts.
+The active alert remains pane-independent because a terminal status signal cannot reliably reach an unattended captain or work across every backend.
 
 ## Channels
 
@@ -12,7 +13,7 @@ The durable marker and tmux flash remain as additional signals.
 It lists channel directives, one per non-empty, non-comment line, and every listed non-`off` channel fires best-effort.
 `FM_WEDGE_ALARM_CHANNEL` overrides the file with one directive for focused testing.
 
-- `off` disables every active alert while retaining the durable marker and tmux flash.
+- `off` disables every active alert while retaining the corresponding durable marker and, for an injection wedge, the tmux flash.
 - `auto` or `default` resolves to `osascript` on macOS.
   Other platforms have no built-in OS channel, so configure `command:` when a durable marker alone is insufficient.
 - `osascript` posts a macOS Notification Center banner outside the terminal pane.
@@ -20,7 +21,8 @@ It lists channel directives, one per non-empty, non-comment line, and every list
 - `command:<cmd>` runs `<cmd>` through `sh -c` with the alarm summary as `$1` and on stdin, allowing delivery to a phone or pager service.
 
 An absent `config/wedge-alarm` behaves as `auto`, which is default-on on macOS.
-This is deliberate because the alarm fires only after a genuine max-defer wedge and is rate-limited to at most once per max-defer window.
+This is deliberate because an alert requires either a genuine max-defer wedge or an unexpected daemon exit.
+Max-defer alerts are rate-limited to at most once per window, while a durable unexpected-exit record prevents the same daemon-loss episode from alerting again.
 
 Each channel is best-effort.
 A missing binary or non-zero exit logs a warning and continues to the next channel without crashing the daemon loop.
@@ -37,4 +39,5 @@ When the daemon is sourced as a library, that seam defaults to `discard`, so a t
 Production leaves the seam unset and uses the configured real channels.
 
 `tests/fm-daemon.test.sh` covers directive parsing, rate limiting, timeout and process-group cleanup, argv-safe dispatch, channel fallback, and safe `command:` summary delivery.
+`tests/fm-afk-launch.test.sh` covers deliberate stop, external and untrappable daemon loss, the stop-versus-exit race, and replacement reconciliation without repeat alerts.
 [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) records the bounded manual macOS and Herdr channel proof.

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -22,6 +22,7 @@ set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LAUNCH="$ROOT/bin/fm-afk-launch.sh"
 START="$ROOT/bin/fm-afk-start.sh"
+DAEMON="$ROOT/bin/fm-supervise-daemon.sh"
 
 FAILED=0
 fail() { printf 'not ok - %s\n' "$1" >&2; FAILED=1; }
@@ -310,6 +311,23 @@ unit_signal_exits_with_lock_cleanup() {
     pass "launcher signal: TERM exits and releases the lifecycle lock"
   else
     fail "launcher signal: interrupted lifecycle resumed or retained its lock"
+  fi
+  rm -rf "$st"
+}
+
+unit_daemon_identity_publication_is_mandatory() {
+  local st lock pidfile
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-identity-publish.XXXXXX")
+  lock="$st/state/.supervise-daemon.lock"
+  pidfile="$st/state/.supervise-daemon.pid"
+  mkdir -p "$lock/pid-identity"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    ! fm_super_publish_daemon_identity "$2" "$3" "$$" exact-identity
+  ' _ "$DAEMON" "$lock" "$pidfile" && [ ! -e "$pidfile" ]; then
+    pass "daemon startup: identity publication failure is fatal"
+  else
+    fail "daemon startup: identity publication failure was ignored"
   fi
   rm -rf "$st"
 }
@@ -744,6 +762,76 @@ unit_stop_confirms_daemon_exit() {
   rm -rf "$st"
 }
 
+unit_interrupted_stop_retracts_live_intent() {
+  local st daemon_pid launcher_pid
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-stop-interrupt.XXXXXX")
+  mkdir -p "$st/state/.supervise-daemon.lock"
+  : > "$st/state/.afk"
+  printf 'none\t-\tnative\n' > "$st/state/.afk-daemon-terminal"
+  bash -c 'trap "" TERM; while :; do sleep 1; done' &
+  daemon_pid=$!
+  printf '%s\n' "$daemon_pid" > "$st/state/.supervise-daemon.lock/pid"
+  ( . "$ROOT/bin/fm-wake-lib.sh"; fm_pid_identity "$daemon_pid" > "$st/state/.supervise-daemon.lock/pid-identity" )
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" stop >/dev/null 2>&1 &
+  launcher_pid=$!
+  for _ in $(seq 1 100); do
+    [ -s "$st/state/.supervise-daemon.stop-intent" ] && break
+    sleep 0.05
+  done
+  kill -TERM "$launcher_pid" 2>/dev/null || true
+  wait "$launcher_pid" 2>/dev/null || true
+  if kill -0 "$daemon_pid" 2>/dev/null \
+    && [ ! -e "$st/state/.supervise-daemon.stop-intent" ] \
+    && [ -e "$st/state/.afk" ] \
+    && [ -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "stop signal: interrupted stop retracts the live daemon intent"
+  else
+    fail "stop signal: interrupted stop left a stale live-daemon intent"
+  fi
+  kill -KILL "$daemon_pid" 2>/dev/null || true
+  wait "$daemon_pid" 2>/dev/null || true
+  rm -rf "$st"
+}
+
+unit_stop_identity_failure_retracts_live_intent() {
+  local st daemon_pid identity
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-stop-identity.XXXXXX")
+  mkdir -p "$st/state/.supervise-daemon.lock"
+  : > "$st/state/.afk"
+  printf 'none\t-\tnative\n' > "$st/state/.afk-daemon-terminal"
+  bash -c 'trap "" TERM; while :; do sleep 1; done' &
+  daemon_pid=$!
+  printf '%s\n' "$daemon_pid" > "$st/state/.supervise-daemon.lock/pid"
+  identity=$(FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    bash -c '. "$1"; fm_pid_identity "$2"' _ "$ROOT/bin/fm-wake-lib.sh" "$daemon_pid")
+  printf '%s\n' "$identity" > "$st/state/.supervise-daemon.lock/pid-identity"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" EXPECTED_IDENTITY="$identity" bash -c '
+    . "$1"
+    fm_pid_identity() {
+      if [ -e "$FM_AFK_LAUNCH_STATE/.supervise-daemon.stop-intent" ]; then
+        return 1
+      fi
+      printf "%s\n" "$EXPECTED_IDENTITY"
+    }
+    seq() { printf "1\n"; }
+    sleep() { :; }
+    kill() {
+      [ "${1:-}" = -TERM ] && return 0
+      command kill "$@"
+    }
+    ! fm_afk_launch_stop
+  ' _ "$LAUNCH" && kill -0 "$daemon_pid" 2>/dev/null \
+    && [ ! -e "$st/state/.supervise-daemon.stop-intent" ] \
+    && [ -e "$st/state/.afk" ]; then
+    pass "stop identity: failed confirmation retracts the live daemon intent"
+  else
+    fail "stop identity: failed confirmation left a stale live-daemon intent"
+  fi
+  kill -KILL "$daemon_pid" 2>/dev/null || true
+  wait "$daemon_pid" 2>/dev/null || true
+  rm -rf "$st"
+}
+
 unit_refresh_validates_record() {
   local st daemon_pid
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-refresh-record.XXXXXX")
@@ -940,8 +1028,8 @@ e2e_tmux() {
 # These run a real daemon in a disposable FM_HOME and target a uniquely named
 # tmux session, so no process or state outside this test home is touched.
 # ---------------------------------------------------------------------------
-death_test_start_daemon() {  # <home> <captain-session> <captain-pane>
-  local home=$1 captain_session=$2 captain_pane=$3 notifier pid
+death_test_configure_alarm() {  # <home>
+  local home=$1 notifier
   mkdir -p "$home/config"
   notifier="$home/record-alarm"
   cat > "$notifier" <<'SH'
@@ -950,6 +1038,12 @@ printf '%s\n' "${1:-}" >> "$(dirname "$0")/alarms"
 SH
   chmod +x "$notifier"
   printf 'command:%s\n' "$notifier" > "$home/config/wedge-alarm"
+}
+
+death_test_start_daemon() {  # <home> <captain-session> <captain-pane>
+  local home=$1 captain_session=$2 captain_pane=$3 notifier pid
+  death_test_configure_alarm "$home"
+  notifier="$home/record-alarm"
   FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_SUPERVISOR_TARGET="$captain_pane" \
     FM_SUPERVISOR_BACKEND=tmux FM_WEDGE_ALARM_EXEC="$notifier" "$LAUNCH" start >/dev/null 2>&1 || return 1
   for _ in $(seq 1 100); do
@@ -1052,6 +1146,73 @@ unit_untrappable_daemon_death_alarms_on_guard() {
   death_test_stop_home "$home" "$captain_session"
 }
 
+unit_missing_identity_daemon_death_alarms_on_guard() {
+  local home pid marker alarm_count
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-missing-identity.XXXXXX")
+  marker="$home/state/.supervise-daemon.unexpected-exit"
+  death_test_configure_alarm "$home"
+  mkdir -p "$home/state/.supervise-daemon.lock" "$home/root"
+  sleep 30 &
+  pid=$!
+  kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  : > "$home/state/.afk"
+  printf '%s\n' "$pid" > "$home/state/.supervise-daemon.pid"
+  printf '%s\n' "$pid" > "$home/state/.supervise-daemon.lock/pid"
+  FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
+  FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
+  alarm_count=0
+  [ ! -f "$home/alarms" ] || alarm_count=$(wc -l < "$home/alarms" | tr -d ' ')
+  if [ -s "$marker" ] \
+    && grep -F 'signal=UNTRAPPABLE' "$marker" >/dev/null \
+    && grep -F "pid=$pid" "$marker" >/dev/null \
+    && grep -F 'pid_identity=MISSING' "$marker" >/dev/null \
+    && [ "${alarm_count:-0}" = 1 ]; then
+    pass "daemon death: missing identity records available evidence and alarms once"
+  else
+    fail "daemon death: missing identity was silent or repeatedly alarmed"
+  fi
+  rm -rf "$home"
+}
+
+unit_expected_untrappable_death_survives_reconciliation() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (expected daemon KILL)"; return 0; }
+  local home captain_session captain_pane pid identity replacement_pid
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-expected-kill.XXXXXX")
+  captain_session="fm-afk-death-expected-kill-cap-$$"
+  tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "expected daemon KILL: captain session creation failed"; rm -rf "$home"; return 0; }
+  captain_pane=$(tmux display-message -p -t "$captain_session" '#{pane_id}')
+  if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
+    pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+    identity=$(cat "$home/state/.supervise-daemon.lock/pid-identity" 2>/dev/null || true)
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" bash -c \
+      '. "$1"; fm_afk_stop_intent_publish "$2" "$3" "$4"' _ \
+      "$ROOT/bin/fm-afk-death-lib.sh" "$home/state" "$pid" "$identity" \
+      && kill -KILL "$pid" 2>/dev/null || true
+    for _ in $(seq 1 100); do kill -0 "$pid" 2>/dev/null || break; sleep 0.05; done
+    mkdir -p "$home/root"
+    FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_SUPERVISOR_TARGET="$captain_pane" \
+      FM_SUPERVISOR_BACKEND=tmux FM_WEDGE_ALARM_EXEC="$home/record-alarm" \
+      "$LAUNCH" start >/dev/null 2>&1 || true
+    replacement_pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+  fi
+  if [ ! -e "$home/state/.supervise-daemon.unexpected-exit" ] \
+    && [ ! -s "$home/alarms" ] \
+    && [ ! -e "$home/state/.supervise-daemon.stop-intent" ] \
+    && [ -n "${replacement_pid:-}" ] \
+    && [ "$replacement_pid" != "$pid" ] \
+    && kill -0 "$replacement_pid" 2>/dev/null; then
+    pass "daemon death: expected untrappable loss reconciles without a false alarm"
+  else
+    fail "daemon death: expected untrappable loss lost evidence or falsely alarmed"
+  fi
+  death_test_stop_home "$home" "$captain_session"
+}
+
 unit_stop_intent_wins_exit_race() {
   command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon death race)"; return 0; }
   local home captain_session captain_pane pid identity
@@ -1068,12 +1229,15 @@ unit_stop_intent_wins_exit_race() {
       && kill -TERM "$pid" 2>/dev/null || true
     for _ in $(seq 1 100); do kill -0 "$pid" 2>/dev/null || break; sleep 0.05; done
   fi
+  mkdir -p "$home/root"
+  FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
   if [ ! -e "$home/state/.supervise-daemon.unexpected-exit" ] \
     && [ ! -s "$home/alarms" ] \
-    && [ ! -e "$home/state/.supervise-daemon.stop-intent" ]; then
-    pass "daemon death race: published exact intent wins a concurrent external TERM"
+    && [ -e "$home/state/.supervise-daemon.stop-intent" ]; then
+    pass "daemon death race: exact intent remains durable while away mode is active"
   else
-    fail "daemon death race: exact stop intent produced a false alarm or leaked"
+    fail "daemon death race: exact stop intent was consumed early or produced a false alarm"
   fi
   death_test_stop_home "$home" "$captain_session"
 }
@@ -1112,6 +1276,7 @@ unit_failed_start_rolls_back_state
 unit_concurrent_start_serialized
 unit_lock_initialization_grace
 unit_signal_exits_with_lock_cleanup
+unit_daemon_identity_publication_is_mandatory
 unit_herdr_command_failure_creates_no_workspace
 unit_herdr_partial_create_recovery
 unit_herdr_error_with_exact_ids_closes_exact
@@ -1131,9 +1296,13 @@ unit_stop_validates_before_signal
 unit_lock_requires_complete_metadata
 unit_stop_surfaces_afk_removal_failure
 unit_stop_confirms_daemon_exit
+unit_interrupted_stop_retracts_live_intent
+unit_stop_identity_failure_retracts_live_intent
 unit_expected_stop_does_not_alarm
 unit_external_daemon_term_alarms
 unit_untrappable_daemon_death_alarms_on_guard
+unit_missing_identity_daemon_death_alarms_on_guard
+unit_expected_untrappable_death_survives_reconciliation
 unit_stop_intent_wins_exit_race
 unit_refresh_and_reconcile_do_not_refire_death_alarm
 unit_refresh_validates_record

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -908,6 +908,136 @@ e2e_tmux() {
   rm -rf "$home_tmp" 2>/dev/null || true
 }
 
+# ---------------------------------------------------------------------------
+# UNIT 4: unexpected daemon death is durable and active, while a PID-and-
+# identity-scoped intent suppresses only the exact lifecycle stop it authorizes.
+# These run a real daemon in a disposable FM_HOME and target a uniquely named
+# tmux session, so no process or state outside this test home is touched.
+# ---------------------------------------------------------------------------
+death_test_start_daemon() {  # <home> <captain-session> <captain-pane>
+  local home=$1 captain_session=$2 captain_pane=$3 notifier pid
+  mkdir -p "$home/config"
+  notifier="$home/record-alarm"
+  cat > "$notifier" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-}" >> "$(dirname "$0")/alarms"
+SH
+  chmod +x "$notifier"
+  printf 'command:%s\n' "$notifier" > "$home/config/wedge-alarm"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_SUPERVISOR_TARGET="$captain_pane" \
+    FM_SUPERVISOR_BACKEND=tmux FM_WEDGE_ALARM_EXEC="$notifier" "$LAUNCH" start >/dev/null 2>&1 || return 1
+  for _ in $(seq 1 100); do
+    pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null \
+      && [ -d "$home/state/.supervise-daemon.lock" ]; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  return 1
+}
+
+death_test_stop_home() {  # <home> <captain-session>
+  FM_HOME="$1" FM_STATE_OVERRIDE="$1/state" "$LAUNCH" stop >/dev/null 2>&1 || true
+  tmux kill-session -t "$2" 2>/dev/null || true
+  rm -rf "$1" 2>/dev/null || true
+}
+
+unit_expected_stop_does_not_alarm() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon death stop)"; return 0; }
+  local home captain_session captain_pane
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-stop.XXXXXX")
+  captain_session="fm-afk-death-stop-cap-$$"
+  tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "daemon death stop: captain session creation failed"; rm -rf "$home"; return 0; }
+  captain_pane=$(tmux display-message -p -t "$captain_session" '#{pane_id}')
+  if death_test_start_daemon "$home" "$captain_session" "$captain_pane" \
+    && FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" "$LAUNCH" stop >/dev/null 2>&1 \
+    && [ ! -e "$home/state/.supervise-daemon.unexpected-exit" ] \
+    && [ ! -s "$home/alarms" ] \
+    && [ ! -e "$home/state/.supervise-daemon.stop-intent" ]; then
+    pass "daemon death: launcher stop records an exact intent and raises no alarm"
+  else
+    fail "daemon death: a deliberate launcher stop left an unexpected-exit alarm"
+  fi
+  death_test_stop_home "$home" "$captain_session"
+}
+
+unit_external_daemon_term_alarms() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon death TERM)"; return 0; }
+  local home captain_session captain_pane pid marker
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-term.XXXXXX")
+  captain_session="fm-afk-death-term-cap-$$"
+  tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "daemon death TERM: captain session creation failed"; rm -rf "$home"; return 0; }
+  captain_pane=$(tmux display-message -p -t "$captain_session" '#{pane_id}')
+  marker="$home/state/.supervise-daemon.unexpected-exit"
+  if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
+    pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+    kill -TERM "$pid" 2>/dev/null || true
+    for _ in $(seq 1 100); do [ -s "$marker" ] && break; sleep 0.05; done
+  fi
+  if [ -s "$marker" ] \
+    && grep -F 'signal=TERM' "$marker" >/dev/null \
+    && grep -Eq '^recorded_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T' "$marker" \
+    && grep -F "pid=$pid" "$marker" >/dev/null \
+    && grep -F 'pid_identity=' "$marker" >/dev/null; then
+    pass "daemon death: external TERM while afk writes identity marker and fires wedge alarm channel"
+  else
+    fail "daemon death: external TERM did not leave a durable active alarm"
+  fi
+  death_test_stop_home "$home" "$captain_session"
+}
+
+unit_stop_intent_wins_exit_race() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon death race)"; return 0; }
+  local home captain_session captain_pane pid identity
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-race.XXXXXX")
+  captain_session="fm-afk-death-race-cap-$$"
+  tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "daemon death race: captain session creation failed"; rm -rf "$home"; return 0; }
+  captain_pane=$(tmux display-message -p -t "$captain_session" '#{pane_id}')
+  if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
+    pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+    identity=$(cat "$home/state/.supervise-daemon.lock/pid-identity" 2>/dev/null || true)
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" bash -c \
+      '. "$1"; fm_afk_stop_intent_publish "$2" "$3" "$4"' _ \
+      "$ROOT/bin/fm-afk-death-lib.sh" "$home/state" "$pid" "$identity" \
+      && kill -TERM "$pid" 2>/dev/null || true
+    for _ in $(seq 1 100); do kill -0 "$pid" 2>/dev/null || break; sleep 0.05; done
+  fi
+  if [ ! -e "$home/state/.supervise-daemon.unexpected-exit" ] \
+    && [ ! -s "$home/alarms" ] \
+    && [ ! -e "$home/state/.supervise-daemon.stop-intent" ]; then
+    pass "daemon death race: published exact intent wins a concurrent external TERM"
+  else
+    fail "daemon death race: exact stop intent produced a false alarm or leaked"
+  fi
+  death_test_stop_home "$home" "$captain_session"
+}
+
+unit_refresh_and_reconcile_do_not_refire_death_alarm() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon death reconcile)"; return 0; }
+  local home captain_session captain_pane pid alarm_count
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-reconcile.XXXXXX")
+  captain_session="fm-afk-death-reconcile-cap-$$"
+  tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "daemon death reconcile: captain session creation failed"; rm -rf "$home"; return 0; }
+  captain_pane=$(tmux display-message -p -t "$captain_session" '#{pane_id}')
+  if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
+    pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+    kill -TERM "$pid" 2>/dev/null || true
+    for _ in $(seq 1 100); do [ -s "$home/alarms" ] && break; sleep 0.05; done
+    alarm_count=$(wc -l < "$home/alarms" 2>/dev/null | tr -d ' ')
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_SUPERVISOR_TARGET="$captain_pane" \
+      FM_SUPERVISOR_BACKEND=tmux "$LAUNCH" start >/dev/null 2>&1 || true
+  fi
+  if [ "${alarm_count:-0}" = 1 ] \
+    && [ "$(wc -l < "$home/alarms" 2>/dev/null | tr -d ' ')" = 1 ] \
+    && [ -s "$home/state/.supervise-daemon.pid" ]; then
+    pass "daemon death: refresh reconciles its terminal and starts a replacement without refiring"
+  else
+    fail "daemon death: refresh or terminal reconciliation refired the prior death alarm"
+  fi
+  death_test_stop_home "$home" "$captain_session"
+}
+
 unit_clear_stale
 unit_relative_paths_are_absolute_before_daemon_launch
 unit_fresh_vs_refresh
@@ -935,6 +1065,10 @@ unit_stop_validates_before_signal
 unit_lock_requires_complete_metadata
 unit_stop_surfaces_afk_removal_failure
 unit_stop_confirms_daemon_exit
+unit_expected_stop_does_not_alarm
+unit_external_daemon_term_alarms
+unit_stop_intent_wins_exit_race
+unit_refresh_and_reconcile_do_not_refire_death_alarm
 unit_refresh_validates_record
 unit_clear_failure_aborts_entry
 unit_confirmed_absence_succeeds

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -1285,6 +1285,48 @@ unit_missing_identity_daemon_death_alarms_on_guard() {
   rm -rf "$home"
 }
 
+unit_missing_evidence_published_intent_alarms_on_guard() {
+  local home publisher_pid marker alarm_count
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-missing-evidence.XXXXXX")
+  marker="$home/state/.supervise-daemon.unexpected-exit"
+  death_test_configure_alarm "$home"
+  mkdir -p "$home/state" "$home/root"
+  : > "$home/state/.afk"
+  mkfifo "$home/publisher-hold"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" bash -c '
+    . "$1"
+    . "$2"
+    publisher_pid=${BASHPID:-$$}
+    publisher_identity=$(fm_pid_identity "$publisher_pid") || exit 1
+    fm_afk_stop_intent_publish "$3" 424242 unseen-daemon-cycle \
+      "$publisher_pid" "$publisher_identity" || exit 1
+    : > "$4"
+    read -r _ < "$5"
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$ROOT/bin/fm-afk-death-lib.sh" \
+    "$home/state" "$home/intent-published" "$home/publisher-hold" &
+  publisher_pid=$!
+  for _ in $(seq 1 100); do [ -e "$home/intent-published" ] && break; sleep 0.05; done
+  FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
+  FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
+  kill -KILL "$publisher_pid" 2>/dev/null || true
+  wait "$publisher_pid" 2>/dev/null || true
+  alarm_count=0
+  [ ! -f "$home/alarms" ] || alarm_count=$(wc -l < "$home/alarms" | tr -d ' ')
+  if [ -s "$marker" ] \
+    && grep -F 'signal=UNTRAPPABLE' "$marker" >/dev/null \
+    && grep -F 'pid=MISSING' "$marker" >/dev/null \
+    && grep -F 'pid_identity=MISSING' "$marker" >/dev/null \
+    && grep -F 'phase=published' "$home/state/.supervise-daemon.stop-intent" >/dev/null \
+    && [ "${alarm_count:-0}" = 1 ]; then
+    pass "daemon death: missing evidence cannot promote publication into suppression"
+  else
+    fail "daemon death: published intent suppressed a missing-evidence alarm"
+  fi
+  rm -rf "$home"
+}
+
 unit_abandoned_published_intent_does_not_suppress_death() {
   command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (abandoned daemon stop)"; return 0; }
   local home captain_session captain_pane pid identity publisher_pid marker alarm_count
@@ -1506,6 +1548,7 @@ unit_untrappable_daemon_death_alarms_on_guard
 unit_stop_reconciles_untrappable_death_before_clear
 unit_stop_reconciles_expired_native_pending_before_clear
 unit_missing_identity_daemon_death_alarms_on_guard
+unit_missing_evidence_published_intent_alarms_on_guard
 unit_abandoned_published_intent_does_not_suppress_death
 unit_dead_publisher_cannot_be_consumed_at_death
 unit_unreadable_stop_intent_cannot_suppress_death

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -51,6 +51,7 @@ unit_clear_stale() {
   : > "$st/state/.subsuper-escalations"
   : > "$st/state/.subsuper-escalations.since"
   : > "$st/state/.subsuper-inject-wedged"
+  : > "$st/state/.supervise-daemon.start-pending"
   : > "$st/state/.supervise-daemon.stop-intent"
   : > "$st/state/.supervise-daemon.unexpected-exit"
   : > "$st/state/.wake-queue"          # durable queue must be untouched
@@ -61,6 +62,7 @@ unit_clear_stale() {
   if [ ! -e "$st/state/.subsuper-escalations" ] \
      && [ ! -e "$st/state/.subsuper-escalations.since" ] \
      && [ ! -e "$st/state/.subsuper-inject-wedged" ] \
+     && [ ! -e "$st/state/.supervise-daemon.start-pending" ] \
      && [ ! -e "$st/state/.supervise-daemon.stop-intent" ] \
      && [ ! -e "$st/state/.supervise-daemon.unexpected-exit" ]; then
     pass "clear-stale: removes prior-session delivery and daemon lifecycle artifacts"
@@ -526,7 +528,9 @@ unit_native_lifecycle() {
     fail "native lifecycle: state preparation or no-terminal record failed"
   fi
   FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" stop >/dev/null 2>&1
-  if [ ! -e "$st/state/.afk" ] && [ ! -e "$st/state/.afk-daemon-terminal" ]; then
+  if [ ! -e "$st/state/.afk" ] \
+    && [ ! -e "$st/state/.afk-daemon-terminal" ] \
+    && [ ! -e "$st/state/.supervise-daemon.start-pending" ]; then
     pass "native lifecycle: uniform stop clears state without closing a terminal"
   else
     fail "native lifecycle: uniform stop retained state"
@@ -751,9 +755,9 @@ unit_stop_confirms_daemon_exit() {
     ! fm_afk_launch_stop
   ' _ "$LAUNCH" && kill -0 "$daemon_pid" 2>/dev/null \
     && [ ! -e "$st/state/.supervise-daemon.lock" ] \
-    && [ ! -e "$st/state/.supervise-daemon.stop-intent" ] \
+    && grep -F 'phase=abandoned' "$st/state/.supervise-daemon.stop-intent" >/dev/null \
     && [ -e "$st/state/.afk" ] && [ -e "$st/state/.afk-daemon-terminal" ]; then
-    pass "stop liveness: failed stop retracts intent and preserves lifecycle state"
+    pass "stop liveness: failed stop abandons intent and preserves lifecycle state"
   else
     fail "stop liveness: lock release was mistaken for captured daemon exit"
   fi
@@ -762,7 +766,7 @@ unit_stop_confirms_daemon_exit() {
   rm -rf "$st"
 }
 
-unit_interrupted_stop_retracts_live_intent() {
+unit_interrupted_stop_abandons_live_intent() {
   local st daemon_pid launcher_pid
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-stop-interrupt.XXXXXX")
   mkdir -p "$st/state/.supervise-daemon.lock"
@@ -781,19 +785,19 @@ unit_interrupted_stop_retracts_live_intent() {
   kill -TERM "$launcher_pid" 2>/dev/null || true
   wait "$launcher_pid" 2>/dev/null || true
   if kill -0 "$daemon_pid" 2>/dev/null \
-    && [ ! -e "$st/state/.supervise-daemon.stop-intent" ] \
+    && grep -F 'phase=abandoned' "$st/state/.supervise-daemon.stop-intent" >/dev/null \
     && [ -e "$st/state/.afk" ] \
     && [ -e "$st/state/.afk-daemon-terminal" ]; then
-    pass "stop signal: interrupted stop retracts the live daemon intent"
+    pass "stop signal: interrupted stop abandons the live daemon intent"
   else
-    fail "stop signal: interrupted stop left a stale live-daemon intent"
+    fail "stop signal: interrupted stop left a published live-daemon intent"
   fi
   kill -KILL "$daemon_pid" 2>/dev/null || true
   wait "$daemon_pid" 2>/dev/null || true
   rm -rf "$st"
 }
 
-unit_stop_identity_failure_retracts_live_intent() {
+unit_stop_identity_failure_abandons_live_intent() {
   local st daemon_pid identity
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-stop-identity.XXXXXX")
   mkdir -p "$st/state/.supervise-daemon.lock"
@@ -821,11 +825,11 @@ unit_stop_identity_failure_retracts_live_intent() {
     }
     ! fm_afk_launch_stop
   ' _ "$LAUNCH" && kill -0 "$daemon_pid" 2>/dev/null \
-    && [ ! -e "$st/state/.supervise-daemon.stop-intent" ] \
+    && grep -F 'phase=abandoned' "$st/state/.supervise-daemon.stop-intent" >/dev/null \
     && [ -e "$st/state/.afk" ]; then
-    pass "stop identity: failed confirmation retracts the live daemon intent"
+    pass "stop identity: failed confirmation abandons the live daemon intent"
   else
-    fail "stop identity: failed confirmation left a stale live-daemon intent"
+    fail "stop identity: failed confirmation left a published live-daemon intent"
   fi
   kill -KILL "$daemon_pid" 2>/dev/null || true
   wait "$daemon_pid" 2>/dev/null || true
@@ -1040,6 +1044,17 @@ SH
   printf 'command:%s\n' "$notifier" > "$home/config/wedge-alarm"
 }
 
+death_test_publish_stop_intent() {  # <home> <daemon-pid> <daemon-identity>
+  FM_HOME="$1" FM_STATE_OVERRIDE="$1/state" bash -c '
+    . "$1"
+    . "$2"
+    publisher_pid=${BASHPID:-$$}
+    publisher_identity=$(fm_pid_identity "$publisher_pid") || exit 1
+    fm_afk_stop_intent_publish "$3" "$4" "$5" "$publisher_pid" "$publisher_identity"
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$ROOT/bin/fm-afk-death-lib.sh" \
+    "$1/state" "$2" "$3"
+}
+
 death_test_start_daemon() {  # <home> <captain-session> <captain-pane>
   local home=$1 captain_session=$2 captain_pane=$3 notifier pid
   death_test_configure_alarm "$home"
@@ -1061,6 +1076,40 @@ death_test_stop_home() {  # <home> <captain-session>
   FM_HOME="$1" FM_STATE_OVERRIDE="$1/state" "$LAUNCH" stop >/dev/null 2>&1 || true
   tmux kill-session -t "$2" 2>/dev/null || true
   rm -rf "$1" 2>/dev/null || true
+}
+
+unit_native_pending_start_is_bounded() {
+  local home marker alarm_count
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-native-pending.XXXXXX")
+  marker="$home/state/.supervise-daemon.unexpected-exit"
+  death_test_configure_alarm "$home"
+  mkdir -p "$home/root"
+  if FM_AFK_START_PENDING_SECS=1 FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$LAUNCH" start-native >/dev/null 2>&1; then
+    FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
+  fi
+  if [ -e "$home/state/.supervise-daemon.start-pending" ] \
+    && [ ! -e "$marker" ] \
+    && [ ! -s "$home/alarms" ]; then
+    sleep 2
+    FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
+    FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
+  fi
+  alarm_count=0
+  [ ! -f "$home/alarms" ] || alarm_count=$(wc -l < "$home/alarms" | tr -d ' ')
+  if [ -s "$marker" ] \
+    && grep -F 'signal=UNTRAPPABLE' "$marker" >/dev/null \
+    && grep -F 'pid=MISSING' "$marker" >/dev/null \
+    && grep -F 'pid_identity=MISSING' "$marker" >/dev/null \
+    && [ "${alarm_count:-0}" = 1 ]; then
+    pass "native pending start: preparation is quiet until its bounded window expires"
+  else
+    fail "native pending start: preparation alarmed early or expiry stayed silent"
+  fi
+  rm -rf "$home"
 }
 
 unit_expected_stop_does_not_alarm() {
@@ -1177,38 +1226,50 @@ unit_missing_identity_daemon_death_alarms_on_guard() {
   rm -rf "$home"
 }
 
-unit_expected_untrappable_death_survives_reconciliation() {
-  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (expected daemon KILL)"; return 0; }
-  local home captain_session captain_pane pid identity replacement_pid
-  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-expected-kill.XXXXXX")
-  captain_session="fm-afk-death-expected-kill-cap-$$"
-  tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "expected daemon KILL: captain session creation failed"; rm -rf "$home"; return 0; }
+unit_abandoned_published_intent_does_not_suppress_death() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (abandoned daemon stop)"; return 0; }
+  local home captain_session captain_pane pid identity publisher_pid marker alarm_count
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-abandoned.XXXXXX")
+  captain_session="fm-afk-death-abandoned-cap-$$"
+  tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "abandoned daemon stop: captain session creation failed"; rm -rf "$home"; return 0; }
   captain_pane=$(tmux display-message -p -t "$captain_session" '#{pane_id}')
+  marker="$home/state/.supervise-daemon.unexpected-exit"
   if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
     pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
     identity=$(cat "$home/state/.supervise-daemon.lock/pid-identity" 2>/dev/null || true)
-    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" bash -c \
-      '. "$1"; fm_afk_stop_intent_publish "$2" "$3" "$4"' _ \
-      "$ROOT/bin/fm-afk-death-lib.sh" "$home/state" "$pid" "$identity" \
-      && kill -KILL "$pid" 2>/dev/null || true
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" bash -c '
+      . "$1"
+      . "$2"
+      publisher_pid=${BASHPID:-$$}
+      publisher_identity=$(fm_pid_identity "$publisher_pid") || exit 1
+      fm_afk_stop_intent_publish "$3" "$4" "$5" "$publisher_pid" "$publisher_identity" || exit 1
+      : > "$6"
+      while :; do sleep 1; done
+    ' _ "$ROOT/bin/fm-wake-lib.sh" "$ROOT/bin/fm-afk-death-lib.sh" \
+      "$home/state" "$pid" "$identity" "$home/intent-published" &
+    publisher_pid=$!
+    for _ in $(seq 1 100); do [ -e "$home/intent-published" ] && break; sleep 0.05; done
+    kill -KILL "$publisher_pid" 2>/dev/null || true
+    wait "$publisher_pid" 2>/dev/null || true
+    kill -KILL "$pid" 2>/dev/null || true
     for _ in $(seq 1 100); do kill -0 "$pid" 2>/dev/null || break; sleep 0.05; done
     mkdir -p "$home/root"
     FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
       FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
-    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_SUPERVISOR_TARGET="$captain_pane" \
-      FM_SUPERVISOR_BACKEND=tmux FM_WEDGE_ALARM_EXEC="$home/record-alarm" \
-      "$LAUNCH" start >/dev/null 2>&1 || true
-    replacement_pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+    FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
   fi
-  if [ ! -e "$home/state/.supervise-daemon.unexpected-exit" ] \
-    && [ ! -s "$home/alarms" ] \
-    && [ ! -e "$home/state/.supervise-daemon.stop-intent" ] \
-    && [ -n "${replacement_pid:-}" ] \
-    && [ "$replacement_pid" != "$pid" ] \
-    && kill -0 "$replacement_pid" 2>/dev/null; then
-    pass "daemon death: expected untrappable loss reconciles without a false alarm"
+  alarm_count=0
+  [ ! -f "$home/alarms" ] || alarm_count=$(wc -l < "$home/alarms" | tr -d ' ')
+  if [ -s "$marker" ] \
+    && grep -F 'signal=UNTRAPPABLE' "$marker" >/dev/null \
+    && grep -F "pid=$pid" "$marker" >/dev/null \
+    && grep -F "pid_identity=$identity" "$marker" >/dev/null \
+    && grep -F 'phase=abandoned' "$home/state/.supervise-daemon.stop-intent" >/dev/null \
+    && [ "${alarm_count:-0}" = 1 ]; then
+    pass "daemon death: abandoned published intent cannot suppress a later real death"
   else
-    fail "daemon death: expected untrappable loss lost evidence or falsely alarmed"
+    fail "daemon death: abandoned published intent suppressed or repeated the alarm"
   fi
   death_test_stop_home "$home" "$captain_session"
 }
@@ -1223,9 +1284,7 @@ unit_stop_intent_wins_exit_race() {
   if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
     pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
     identity=$(cat "$home/state/.supervise-daemon.lock/pid-identity" 2>/dev/null || true)
-    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" bash -c \
-      '. "$1"; fm_afk_stop_intent_publish "$2" "$3" "$4"' _ \
-      "$ROOT/bin/fm-afk-death-lib.sh" "$home/state" "$pid" "$identity" \
+    death_test_publish_stop_intent "$home" "$pid" "$identity" \
       && kill -TERM "$pid" 2>/dev/null || true
     for _ in $(seq 1 100); do kill -0 "$pid" 2>/dev/null || break; sleep 0.05; done
   fi
@@ -1234,10 +1293,10 @@ unit_stop_intent_wins_exit_race() {
     FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
   if [ ! -e "$home/state/.supervise-daemon.unexpected-exit" ] \
     && [ ! -s "$home/alarms" ] \
-    && [ -e "$home/state/.supervise-daemon.stop-intent" ]; then
-    pass "daemon death race: exact intent remains durable while away mode is active"
+    && grep -F 'phase=consumed' "$home/state/.supervise-daemon.stop-intent" >/dev/null; then
+    pass "daemon death race: daemon durably consumes the exact stop intent"
   else
-    fail "daemon death race: exact stop intent was consumed early or produced a false alarm"
+    fail "daemon death race: exact stop intent was not consumed or produced a false alarm"
   fi
   death_test_stop_home "$home" "$captain_session"
 }
@@ -1296,13 +1355,14 @@ unit_stop_validates_before_signal
 unit_lock_requires_complete_metadata
 unit_stop_surfaces_afk_removal_failure
 unit_stop_confirms_daemon_exit
-unit_interrupted_stop_retracts_live_intent
-unit_stop_identity_failure_retracts_live_intent
+unit_interrupted_stop_abandons_live_intent
+unit_stop_identity_failure_abandons_live_intent
+unit_native_pending_start_is_bounded
 unit_expected_stop_does_not_alarm
 unit_external_daemon_term_alarms
 unit_untrappable_daemon_death_alarms_on_guard
 unit_missing_identity_daemon_death_alarms_on_guard
-unit_expected_untrappable_death_survives_reconciliation
+unit_abandoned_published_intent_does_not_suppress_death
 unit_stop_intent_wins_exit_race
 unit_refresh_and_reconcile_do_not_refire_death_alarm
 unit_refresh_validates_record

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -41,7 +41,7 @@ GLOBAL_CLEANUP() {
 trap GLOBAL_CLEANUP EXIT
 
 # ---------------------------------------------------------------------------
-# UNIT 1: fm_afk_clear_stale_artifacts removes exactly the three stale artifacts.
+# UNIT 1: fm_afk_clear_stale_artifacts removes prior-session artifacts.
 # ---------------------------------------------------------------------------
 unit_clear_stale() {
   local st
@@ -50,6 +50,8 @@ unit_clear_stale() {
   : > "$st/state/.subsuper-escalations"
   : > "$st/state/.subsuper-escalations.since"
   : > "$st/state/.subsuper-inject-wedged"
+  : > "$st/state/.supervise-daemon.stop-intent"
+  : > "$st/state/.supervise-daemon.unexpected-exit"
   : > "$st/state/.wake-queue"          # durable queue must be untouched
   # Source fm-afk-start.sh inside a child bash (it sets `set -eu` and would
   # otherwise leak that into this test shell) and call the clear helper.
@@ -57,8 +59,10 @@ unit_clear_stale() {
     bash -c '. "$1"; fm_afk_clear_stale_artifacts "$2"' _ "$START" "$st/state"
   if [ ! -e "$st/state/.subsuper-escalations" ] \
      && [ ! -e "$st/state/.subsuper-escalations.since" ] \
-     && [ ! -e "$st/state/.subsuper-inject-wedged" ]; then
-    pass "clear-stale: removes escalations buffer, sidecar, and wedge marker"
+     && [ ! -e "$st/state/.subsuper-inject-wedged" ] \
+     && [ ! -e "$st/state/.supervise-daemon.stop-intent" ] \
+     && [ ! -e "$st/state/.supervise-daemon.unexpected-exit" ]; then
+    pass "clear-stale: removes prior-session delivery and daemon lifecycle artifacts"
   else
     fail "clear-stale: stale artifacts survived"
   fi
@@ -306,6 +310,27 @@ unit_signal_exits_with_lock_cleanup() {
     pass "launcher signal: TERM exits and releases the lifecycle lock"
   else
     fail "launcher signal: interrupted lifecycle resumed or retained its lock"
+  fi
+  rm -rf "$st"
+}
+
+unit_herdr_command_failure_creates_no_workspace() {
+  local st created
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-herdr-command.XXXXXX")
+  created="$st/workspace-created"
+  mkdir -p "$st/state"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    CREATED=$2
+    . "$1"
+    fm_backend_source() { return 0; }
+    fm_backend_herdr_server_ensure() { return 0; }
+    fm_afk_launch_daemon_cmd() { return 1; }
+    fm_backend_herdr_cli() { : > "$CREATED"; return 1; }
+    ! fm_afk_launch_create_herdr "isolated:%1" herdr
+  ' _ "$LAUNCH" "$created" && [ ! -e "$created" ]; then
+    pass "herdr launch: command construction failure creates no workspace"
+  else
+    fail "herdr launch: command construction failure leaked a workspace"
   fi
   rm -rf "$st"
 }
@@ -708,8 +733,9 @@ unit_stop_confirms_daemon_exit() {
     ! fm_afk_launch_stop
   ' _ "$LAUNCH" && kill -0 "$daemon_pid" 2>/dev/null \
     && [ ! -e "$st/state/.supervise-daemon.lock" ] \
+    && [ ! -e "$st/state/.supervise-daemon.stop-intent" ] \
     && [ -e "$st/state/.afk" ] && [ -e "$st/state/.afk-daemon-terminal" ]; then
-    pass "stop liveness: captured live daemon preserves lifecycle state after lock release"
+    pass "stop liveness: failed stop retracts intent and preserves lifecycle state"
   else
     fail "stop liveness: lock release was mistaken for captured daemon exit"
   fi
@@ -964,7 +990,7 @@ unit_expected_stop_does_not_alarm() {
 
 unit_external_daemon_term_alarms() {
   command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon death TERM)"; return 0; }
-  local home captain_session captain_pane pid marker
+  local home captain_session captain_pane pid marker alarm_count
   home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-term.XXXXXX")
   captain_session="fm-afk-death-term-cap-$$"
   tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "daemon death TERM: captain session creation failed"; rm -rf "$home"; return 0; }
@@ -973,16 +999,55 @@ unit_external_daemon_term_alarms() {
   if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
     pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
     kill -TERM "$pid" 2>/dev/null || true
-    for _ in $(seq 1 100); do [ -s "$marker" ] && break; sleep 0.05; done
+    for _ in $(seq 1 100); do
+      [ -s "$marker" ] && [ -s "$home/alarms" ] && break
+      sleep 0.05
+    done
   fi
+  alarm_count=0
+  [ ! -f "$home/alarms" ] || alarm_count=$(wc -l < "$home/alarms" | tr -d ' ')
   if [ -s "$marker" ] \
     && grep -F 'signal=TERM' "$marker" >/dev/null \
     && grep -Eq '^recorded_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T' "$marker" \
     && grep -F "pid=$pid" "$marker" >/dev/null \
-    && grep -F 'pid_identity=' "$marker" >/dev/null; then
+    && grep -F 'pid_identity=' "$marker" >/dev/null \
+    && [ "${alarm_count:-0}" = 1 ]; then
     pass "daemon death: external TERM while afk writes identity marker and fires wedge alarm channel"
   else
     fail "daemon death: external TERM did not leave a durable active alarm"
+  fi
+  death_test_stop_home "$home" "$captain_session"
+}
+
+unit_untrappable_daemon_death_alarms_on_guard() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon death KILL)"; return 0; }
+  local home captain_session captain_pane pid identity marker alarm_count
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-kill.XXXXXX")
+  captain_session="fm-afk-death-kill-cap-$$"
+  tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "daemon death KILL: captain session creation failed"; rm -rf "$home"; return 0; }
+  captain_pane=$(tmux display-message -p -t "$captain_session" '#{pane_id}')
+  marker="$home/state/.supervise-daemon.unexpected-exit"
+  if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
+    pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+    identity=$(cat "$home/state/.supervise-daemon.lock/pid-identity" 2>/dev/null || true)
+    kill -KILL "$pid" 2>/dev/null || true
+    for _ in $(seq 1 100); do kill -0 "$pid" 2>/dev/null || break; sleep 0.05; done
+    mkdir -p "$home/root"
+    FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
+    FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+      FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
+  fi
+  alarm_count=0
+  [ ! -f "$home/alarms" ] || alarm_count=$(wc -l < "$home/alarms" | tr -d ' ')
+  if [ -s "$marker" ] \
+    && grep -F 'signal=UNTRAPPABLE' "$marker" >/dev/null \
+    && grep -F "pid=$pid" "$marker" >/dev/null \
+    && grep -F "pid_identity=$identity" "$marker" >/dev/null \
+    && [ "${alarm_count:-0}" = 1 ]; then
+    pass "daemon death: guard records and alarms once after untrappable loss"
+  else
+    fail "daemon death: guard missed or repeated an untrappable daemon alarm"
   fi
   death_test_stop_home "$home" "$captain_session"
 }
@@ -1047,6 +1112,7 @@ unit_failed_start_rolls_back_state
 unit_concurrent_start_serialized
 unit_lock_initialization_grace
 unit_signal_exits_with_lock_cleanup
+unit_herdr_command_failure_creates_no_workspace
 unit_herdr_partial_create_recovery
 unit_herdr_error_with_exact_ids_closes_exact
 unit_herdr_run_failure_preserves_unconfirmed_record
@@ -1067,6 +1133,7 @@ unit_stop_surfaces_afk_removal_failure
 unit_stop_confirms_daemon_exit
 unit_expected_stop_does_not_alarm
 unit_external_daemon_term_alarms
+unit_untrappable_daemon_death_alarms_on_guard
 unit_stop_intent_wins_exit_race
 unit_refresh_and_reconcile_do_not_refire_death_alarm
 unit_refresh_validates_record

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -1064,7 +1064,8 @@ death_test_start_daemon() {  # <home> <captain-session> <captain-pane>
   for _ in $(seq 1 100); do
     pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null \
-      && [ -d "$home/state/.supervise-daemon.lock" ]; then
+      && [ -d "$home/state/.supervise-daemon.lock" ] \
+      && [ -e "$home/state/.last-watcher-beat" ]; then
       return 0
     fi
     sleep 0.05
@@ -1195,6 +1196,64 @@ unit_untrappable_daemon_death_alarms_on_guard() {
   death_test_stop_home "$home" "$captain_session"
 }
 
+unit_stop_reconciles_untrappable_death_before_clear() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon death before stop)"; return 0; }
+  local home captain_session captain_pane pid identity marker alarm_count
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-before-stop.XXXXXX")
+  captain_session="fm-afk-death-before-stop-cap-$$"
+  tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "daemon death before stop: captain session creation failed"; rm -rf "$home"; return 0; }
+  captain_pane=$(tmux display-message -p -t "$captain_session" '#{pane_id}')
+  marker="$home/state/.supervise-daemon.unexpected-exit"
+  if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
+    pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+    identity=$(cat "$home/state/.supervise-daemon.lock/pid-identity" 2>/dev/null || true)
+    kill -KILL "$pid" 2>/dev/null || true
+    for _ in $(seq 1 100); do kill -0 "$pid" 2>/dev/null || break; sleep 0.05; done
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_WEDGE_ALARM_EXEC="$home/record-alarm" \
+      "$LAUNCH" stop >/dev/null 2>&1 || true
+  fi
+  alarm_count=0
+  [ ! -f "$home/alarms" ] || alarm_count=$(wc -l < "$home/alarms" | tr -d ' ')
+  if [ -s "$marker" ] \
+    && grep -F 'signal=UNTRAPPABLE' "$marker" >/dev/null \
+    && grep -F "pid=$pid" "$marker" >/dev/null \
+    && grep -F "pid_identity=$identity" "$marker" >/dev/null \
+    && [ ! -e "$home/state/.afk" ] \
+    && [ "${alarm_count:-0}" = 1 ]; then
+    pass "daemon death: stop records and alarms before clearing away state"
+  else
+    fail "daemon death: stop erased an unobserved death before alarming"
+  fi
+  death_test_stop_home "$home" "$captain_session"
+}
+
+unit_stop_reconciles_expired_native_pending_before_clear() {
+  local home marker alarm_count
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-native-expired-stop.XXXXXX")
+  marker="$home/state/.supervise-daemon.unexpected-exit"
+  death_test_configure_alarm "$home"
+  if FM_AFK_START_PENDING_SECS=1 FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$LAUNCH" start-native >/dev/null 2>&1; then
+    sleep 2
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_WEDGE_ALARM_EXEC="$home/record-alarm" \
+      "$LAUNCH" stop >/dev/null 2>&1 || true
+  fi
+  alarm_count=0
+  [ ! -f "$home/alarms" ] || alarm_count=$(wc -l < "$home/alarms" | tr -d ' ')
+  if [ -s "$marker" ] \
+    && grep -F 'signal=UNTRAPPABLE' "$marker" >/dev/null \
+    && grep -F 'pid=MISSING' "$marker" >/dev/null \
+    && grep -F 'pid_identity=MISSING' "$marker" >/dev/null \
+    && [ ! -e "$home/state/.afk" ] \
+    && [ ! -e "$home/state/.supervise-daemon.start-pending" ] \
+    && [ "${alarm_count:-0}" = 1 ]; then
+    pass "native pending start: stop alarms after expiry before clearing state"
+  else
+    fail "native pending start: stop erased expired supervision loss"
+  fi
+  rm -rf "$home"
+}
+
 unit_missing_identity_daemon_death_alarms_on_guard() {
   local home pid marker alarm_count
   home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-missing-identity.XXXXXX")
@@ -1237,6 +1296,7 @@ unit_abandoned_published_intent_does_not_suppress_death() {
   if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
     pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
     identity=$(cat "$home/state/.supervise-daemon.lock/pid-identity" 2>/dev/null || true)
+    mkfifo "$home/publisher-hold"
     FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" bash -c '
       . "$1"
       . "$2"
@@ -1244,25 +1304,29 @@ unit_abandoned_published_intent_does_not_suppress_death() {
       publisher_identity=$(fm_pid_identity "$publisher_pid") || exit 1
       fm_afk_stop_intent_publish "$3" "$4" "$5" "$publisher_pid" "$publisher_identity" || exit 1
       : > "$6"
-      while :; do sleep 1; done
+      read -r _ < "$7"
     ' _ "$ROOT/bin/fm-wake-lib.sh" "$ROOT/bin/fm-afk-death-lib.sh" \
-      "$home/state" "$pid" "$identity" "$home/intent-published" &
+      "$home/state" "$pid" "$identity" "$home/intent-published" "$home/publisher-hold" &
     publisher_pid=$!
     for _ in $(seq 1 100); do [ -e "$home/intent-published" ] && break; sleep 0.05; done
     kill -KILL "$publisher_pid" 2>/dev/null || true
     wait "$publisher_pid" 2>/dev/null || true
-    kill -KILL "$pid" 2>/dev/null || true
-    for _ in $(seq 1 100); do kill -0 "$pid" 2>/dev/null || break; sleep 0.05; done
     mkdir -p "$home/root"
     FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
       FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
-    FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
-      FM_WEDGE_ALARM_EXEC="$home/record-alarm" "$ROOT/bin/fm-guard.sh" >/dev/null 2>&1
+    if grep -F 'phase=abandoned' "$home/state/.supervise-daemon.stop-intent" >/dev/null \
+      && kill -0 "$pid" 2>/dev/null; then
+      kill -TERM "$pid" 2>/dev/null || true
+      for _ in $(seq 1 100); do
+        [ -s "$marker" ] && [ -s "$home/alarms" ] && break
+        sleep 0.05
+      done
+    fi
   fi
   alarm_count=0
   [ ! -f "$home/alarms" ] || alarm_count=$(wc -l < "$home/alarms" | tr -d ' ')
   if [ -s "$marker" ] \
-    && grep -F 'signal=UNTRAPPABLE' "$marker" >/dev/null \
+    && grep -F 'signal=TERM' "$marker" >/dev/null \
     && grep -F "pid=$pid" "$marker" >/dev/null \
     && grep -F "pid_identity=$identity" "$marker" >/dev/null \
     && grep -F 'phase=abandoned' "$home/state/.supervise-daemon.stop-intent" >/dev/null \
@@ -1274,9 +1338,73 @@ unit_abandoned_published_intent_does_not_suppress_death() {
   death_test_stop_home "$home" "$captain_session"
 }
 
+unit_dead_publisher_cannot_be_consumed_at_death() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (dead stop publisher)"; return 0; }
+  local home captain_session captain_pane pid identity marker alarm_count
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-dead-publisher.XXXXXX")
+  captain_session="fm-afk-death-dead-publisher-cap-$$"
+  tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "dead stop publisher: captain session creation failed"; rm -rf "$home"; return 0; }
+  captain_pane=$(tmux display-message -p -t "$captain_session" '#{pane_id}')
+  marker="$home/state/.supervise-daemon.unexpected-exit"
+  if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
+    pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+    identity=$(cat "$home/state/.supervise-daemon.lock/pid-identity" 2>/dev/null || true)
+    if death_test_publish_stop_intent "$home" "$pid" "$identity"; then
+      kill -TERM "$pid" 2>/dev/null || true
+      for _ in $(seq 1 100); do
+        [ -s "$marker" ] && [ -s "$home/alarms" ] && break
+        sleep 0.05
+      done
+    fi
+  fi
+  alarm_count=0
+  [ ! -f "$home/alarms" ] || alarm_count=$(wc -l < "$home/alarms" | tr -d ' ')
+  if [ -s "$marker" ] \
+    && grep -F 'signal=TERM' "$marker" >/dev/null \
+    && grep -F "pid=$pid" "$marker" >/dev/null \
+    && grep -F "pid_identity=$identity" "$marker" >/dev/null \
+    && grep -F 'phase=abandoned' "$home/state/.supervise-daemon.stop-intent" >/dev/null \
+    && [ "${alarm_count:-0}" = 1 ]; then
+    pass "daemon death: dead publisher cannot authorize suppression at exit"
+  else
+    fail "daemon death: dead publisher intent suppressed or repeated the exit alarm"
+  fi
+  death_test_stop_home "$home" "$captain_session"
+}
+
+unit_unreadable_stop_intent_cannot_suppress_death() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (unreadable stop intent)"; return 0; }
+  local home captain_session captain_pane pid marker alarm_count
+  home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-unreadable-intent.XXXXXX")
+  captain_session="fm-afk-death-unreadable-intent-cap-$$"
+  tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "unreadable stop intent: captain session creation failed"; rm -rf "$home"; return 0; }
+  captain_pane=$(tmux display-message -p -t "$captain_session" '#{pane_id}')
+  marker="$home/state/.supervise-daemon.unexpected-exit"
+  if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
+    pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+    printf 'phase=published\n' > "$home/state/.supervise-daemon.stop-intent"
+    kill -TERM "$pid" 2>/dev/null || true
+    for _ in $(seq 1 100); do
+      [ -s "$marker" ] && [ -s "$home/alarms" ] && break
+      sleep 0.05
+    done
+  fi
+  alarm_count=0
+  [ ! -f "$home/alarms" ] || alarm_count=$(wc -l < "$home/alarms" | tr -d ' ')
+  if [ -s "$marker" ] \
+    && grep -F 'signal=TERM' "$marker" >/dev/null \
+    && grep -F "pid=$pid" "$marker" >/dev/null \
+    && [ "${alarm_count:-0}" = 1 ]; then
+    pass "daemon death: unreadable stop intent cannot authorize suppression"
+  else
+    fail "daemon death: unreadable stop intent suppressed or repeated the alarm"
+  fi
+  death_test_stop_home "$home" "$captain_session"
+}
+
 unit_stop_intent_wins_exit_race() {
   command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon death race)"; return 0; }
-  local home captain_session captain_pane pid identity
+  local home captain_session captain_pane pid identity publisher_pid
   home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-race.XXXXXX")
   captain_session="fm-afk-death-race-cap-$$"
   tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "daemon death race: captain session creation failed"; rm -rf "$home"; return 0; }
@@ -1284,9 +1412,23 @@ unit_stop_intent_wins_exit_race() {
   if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
     pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
     identity=$(cat "$home/state/.supervise-daemon.lock/pid-identity" 2>/dev/null || true)
-    death_test_publish_stop_intent "$home" "$pid" "$identity" \
-      && kill -TERM "$pid" 2>/dev/null || true
+    mkfifo "$home/publisher-hold"
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" bash -c '
+      . "$1"
+      . "$2"
+      publisher_pid=${BASHPID:-$$}
+      publisher_identity=$(fm_pid_identity "$publisher_pid") || exit 1
+      fm_afk_stop_intent_publish "$3" "$4" "$5" "$publisher_pid" "$publisher_identity" || exit 1
+      : > "$6"
+      read -r _ < "$7"
+    ' _ "$ROOT/bin/fm-wake-lib.sh" "$ROOT/bin/fm-afk-death-lib.sh" \
+      "$home/state" "$pid" "$identity" "$home/intent-published" "$home/publisher-hold" &
+    publisher_pid=$!
+    for _ in $(seq 1 100); do [ -e "$home/intent-published" ] && break; sleep 0.05; done
+    kill -TERM "$pid" 2>/dev/null || true
     for _ in $(seq 1 100); do kill -0 "$pid" 2>/dev/null || break; sleep 0.05; done
+    kill -KILL "$publisher_pid" 2>/dev/null || true
+    wait "$publisher_pid" 2>/dev/null || true
   fi
   mkdir -p "$home/root"
   FM_ROOT_OVERRIDE="$home/root" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
@@ -1361,8 +1503,12 @@ unit_native_pending_start_is_bounded
 unit_expected_stop_does_not_alarm
 unit_external_daemon_term_alarms
 unit_untrappable_daemon_death_alarms_on_guard
+unit_stop_reconciles_untrappable_death_before_clear
+unit_stop_reconciles_expired_native_pending_before_clear
 unit_missing_identity_daemon_death_alarms_on_guard
 unit_abandoned_published_intent_does_not_suppress_death
+unit_dead_publisher_cannot_be_consumed_at_death
+unit_unreadable_stop_intent_cannot_suppress_death
 unit_stop_intent_wins_exit_race
 unit_refresh_and_reconcile_do_not_refire_death_alarm
 unit_refresh_validates_record

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -1487,22 +1487,43 @@ unit_stop_intent_wins_exit_race() {
 
 unit_refresh_and_reconcile_do_not_refire_death_alarm() {
   command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (daemon death reconcile)"; return 0; }
-  local home captain_session captain_pane pid alarm_count
+  local home captain_session captain_pane pid new_pid old_session new_session alarm_count old_exited=0
   home=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-death-reconcile.XXXXXX")
   captain_session="fm-afk-death-reconcile-cap-$$"
   tmux new-session -d -s "$captain_session" 2>/dev/null || { fail "daemon death reconcile: captain session creation failed"; rm -rf "$home"; return 0; }
   captain_pane=$(tmux display-message -p -t "$captain_session" '#{pane_id}')
+  new_pid=
+  old_session=
+  new_session=
   if death_test_start_daemon "$home" "$captain_session" "$captain_pane"; then
     pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+    old_session=$(cut -f2 "$home/state/.afk-daemon-terminal" 2>/dev/null || true)
     kill -TERM "$pid" 2>/dev/null || true
     for _ in $(seq 1 100); do [ -s "$home/alarms" ] && break; sleep 0.05; done
     alarm_count=$(wc -l < "$home/alarms" 2>/dev/null | tr -d ' ')
-    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_SUPERVISOR_TARGET="$captain_pane" \
-      FM_SUPERVISOR_BACKEND=tmux "$LAUNCH" start >/dev/null 2>&1 || true
+    for _ in $(seq 1 200); do
+      if ! kill -0 "$pid" 2>/dev/null && [ ! -e "$home/state/.supervise-daemon.pid" ]; then
+        old_exited=1
+        break
+      fi
+      sleep 0.05
+    done
+    if [ "$old_exited" -eq 1 ]; then
+      FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_SUPERVISOR_TARGET="$captain_pane" \
+        FM_SUPERVISOR_BACKEND=tmux "$LAUNCH" start >/dev/null 2>&1 || true
+      new_pid=$(cat "$home/state/.supervise-daemon.pid" 2>/dev/null || true)
+      new_session=$(cut -f2 "$home/state/.afk-daemon-terminal" 2>/dev/null || true)
+    fi
   fi
   if [ "${alarm_count:-0}" = 1 ] \
     && [ "$(wc -l < "$home/alarms" 2>/dev/null | tr -d ' ')" = 1 ] \
-    && [ -s "$home/state/.supervise-daemon.pid" ]; then
+    && [ "$old_exited" -eq 1 ] \
+    && [ -n "$new_pid" ] \
+    && [ "$new_pid" != "$pid" ] \
+    && kill -0 "$new_pid" 2>/dev/null \
+    && [ -n "$new_session" ] \
+    && [ "$new_session" != "$old_session" ] \
+    && ! tmux has-session -t "$old_session" 2>/dev/null; then
     pass "daemon death: refresh reconciles its terminal and starts a replacement without refiring"
   else
     fail "daemon death: refresh or terminal reconciliation refired the prior death alarm"


### PR DESCRIPTION
Adds durable away-mode daemon-death detection and active wedge alarms. Implements proven-only intentional-stop suppression, guard/session-start recovery for untrappable loss, bounded native-start preparation, and isolated lifecycle regression coverage.