### PR TITLE
feat(bin): add guarded retirement for out-of-registry project trees

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -105,4 +105,4 @@ The order that matters is:
 4. Execute only with the plan id that preflight printed, so evidence that changed in between refuses instead of removing a tree nobody approved.
 
 A refusal from that helper is a stop-and-report result, never an obstacle to route around: do not force, prune, stash, reset, or discard anything to make a check pass, and do not fall back to a raw removal command.
-Once the captain's approval is concrete and the helper's own checks pass, AGENTS.md hard rule 1's guarded project-retirement exception authorizes running it.
+Once the captain's approval is concrete and the helper's own checks pass, AGENTS.md hard rule 1's guarded out-of-registry project-tree retirement exception authorizes running it.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -78,21 +78,31 @@ If doctor reports an environment, authentication, or daemon problem, resolve tha
 ## Remove or retire
 
 Project removal is destructive, and so is retiring an out-of-registry legacy tree left behind by an earlier layout.
-Both follow the same path.
+Both start from the same preflight, and they differ only in what performs the removal.
 
 First obtain the captain's explicit removal decision, then inspect the current digest and authoritative repositories for in-flight or queued work, registered secondmate clones, linked worktrees, dirty files, unpushed commits, and any other unlanded work.
 If any dependency or unlanded work exists, stop and report it before changing anything.
 Never issue a raw removal command from Firstmate.
+When a clone has already been removed through an approved removal, or the registry is provably stale because no clone exists, remove its registry line so navigation matches reality.
 
-`bin/fm-project-retire.sh` is the single guarded owner of the removal itself.
+### Remove a registered project
+
+A project registered in `data/projects.md` and living under this home's `projects/` keeps its own path.
+Once that preflight confirms none of the above and the captain's approval is concrete, AGENTS.md hard rule 1's captain-approved project operation exception authorizes firstmate to remove the clone directly and update its registry entry to match.
+`bin/fm-project-retire.sh` does not cover this case: it refuses on any path inside this home's `projects/` or named by the registry, and that refusal is a deliberate scope boundary, not a step to work around.
+
+### Retire an out-of-registry tree
+
+A legacy tree outside `projects/`, such as an old clone plus its linked Treehouse pool left behind by an earlier layout, is retired only through the guarded helper.
+
+`bin/fm-project-retire.sh` is the single guarded owner of that removal itself.
 Its header and `--help` own the exact flags, the complete refusal list, the landing-proof ladder, and every mechanic; do not restate them here or anywhere else.
 The order that matters is:
 
 1. Get the captain's concrete approval for that specific tree.
-2. Retire the tree's registry line first, because the helper refuses while `data/projects.md` or `data/secondmates.md` still names the path; a registry line without a clone is navigable, a clone the registry still points at is not.
+2. Retire any stale registry line that still names the tree first, because the helper refuses while `data/projects.md` or `data/secondmates.md` names the path; a registry line without a clone is navigable, a clone the registry still points at is not. Never delete a live registered project's line to move it out of the helper's refusal list; that project uses the direct path above.
 3. Run the helper's preflight, read the printed plan end to end, and confirm it names exactly the tree and linked pool the captain approved.
 4. Execute only with the plan id that preflight printed, so evidence that changed in between refuses instead of removing a tree nobody approved.
 
 A refusal from that helper is a stop-and-report result, never an obstacle to route around: do not force, prune, stash, reset, or discard anything to make a check pass, and do not fall back to a raw removal command.
 Once the captain's approval is concrete and the helper's own checks pass, AGENTS.md hard rule 1's guarded project-retirement exception authorizes running it.
-When a clone has already been removed through an approved removal, or the registry is provably stale because no clone exists, remove its registry line so navigation matches reality.

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -2,9 +2,9 @@
 name: project-management
 description: >-
   Agent-only procedure for Firstmate project management.
-  Use before adding, creating, removing, or initializing a project.
+  Use before adding, creating, removing, or initializing a project, and before retiring an out-of-registry project tree.
   Cloning or registering a project is add intake and uses the same trigger.
-  Owns project add, create, clone, remove, initialization, registry, delivery-mode, autonomy, and outward-consent decisions.
+  Owns project add, create, clone, remove, retire, initialization, registry, delivery-mode, autonomy, and outward-consent decisions.
 user-invocable: false
 metadata:
   internal: true
@@ -12,7 +12,7 @@ metadata:
 
 # project-management
 
-Use this procedure before adding, creating, removing, or initializing a project.
+Use this procedure before adding, creating, removing, or initializing a project, and before retiring an out-of-registry project tree.
 Cloning or registering a project is add intake and uses the same trigger.
 This skill is the single owner of Firstmate's project-management procedure.
 It does not replace `secondmate-provisioning`, which owns project clones inside persistent secondmate homes.
@@ -75,11 +75,24 @@ Initialization configures the local gate and does not vendor a no-mistakes skill
 Do not create a commit merely because initialization ran.
 If doctor reports an environment, authentication, or daemon problem, resolve that blocker before dispatching work and never restart the shared daemon from a project operation.
 
-## Remove
+## Remove or retire
 
-Project removal is destructive.
+Project removal is destructive, and so is retiring an out-of-registry legacy tree left behind by an earlier layout.
+Both follow the same path.
+
 First obtain the captain's explicit removal decision, then inspect the current digest and authoritative repositories for in-flight or queued work, registered secondmate clones, linked worktrees, dirty files, unpushed commits, and any other unlanded work.
 If any dependency or unlanded work exists, stop and report it before changing anything.
 Never issue a raw removal command from Firstmate.
-Once that preflight confirms none of the above and the captain's approval is concrete, AGENTS.md hard rule 1's captain-approved project operation exception authorizes firstmate to remove the clone directly and update its registry entry to match.
+
+`bin/fm-project-retire.sh` is the single guarded owner of the removal itself.
+Its header and `--help` own the exact flags, the complete refusal list, the landing-proof ladder, and every mechanic; do not restate them here or anywhere else.
+The order that matters is:
+
+1. Get the captain's concrete approval for that specific tree.
+2. Retire the tree's registry line first, because the helper refuses while `data/projects.md` or `data/secondmates.md` still names the path; a registry line without a clone is navigable, a clone the registry still points at is not.
+3. Run the helper's preflight, read the printed plan end to end, and confirm it names exactly the tree and linked pool the captain approved.
+4. Execute only with the plan id that preflight printed, so evidence that changed in between refuses instead of removing a tree nobody approved.
+
+A refusal from that helper is a stop-and-report result, never an obstacle to route around: do not force, prune, stash, reset, or discard anything to make a check pass, and do not fall back to a raw removal command.
+Once the captain's approval is concrete and the helper's own checks pass, AGENTS.md hard rule 1's guarded project-retirement exception authorizes running it.
 When a clone has already been removed through an approved removal, or the registry is provably stale because no clone exists, remove its registry line so navigation matches reality.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Hard rules, in priority order:
 
 1. **Never write to a project.**
    Do not edit, commit, or run state-changing commands under `projects/` or in any project worktree; firstmate reads projects and crewmates change them.
-   The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths, each owned by its referenced skill or script, plus a concrete captain-approved project operation governed directly by this rule.
+   The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, guarded project retirement, and approved `local-only` merge paths, each owned by its referenced skill or script, plus a concrete captain-approved project operation governed directly by this rule.
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
    Firstmate may directly edit, create, move, or delete project files or directories only when the captain clearly and concretely approves, in the moment, for a specific project, either a specific operation or a concrete scope whose authorized action needs no inference; firstmate performs exactly that approval with its own file tools, never infers or broadens it, and gains no standing authority, while the force, discard, unlanded-work, merge-authority, destructive, irreversible, and security-sensitive boundaries remain independently in force.
 2. **Never merge a PR without the captain's explicit word.**
@@ -201,9 +201,9 @@ A restart must be a non-event because durable state and live backend inventory, 
 
 ## 6. Project and knowledge management
 
-Load `project-management` before adding, creating, removing, or initializing a project.
+Load `project-management` before adding, creating, removing, or initializing a project, and before retiring an out-of-registry project tree.
 Cloning or registering a project is add intake and uses the same trigger.
-That skill owns registry syntax, delivery-mode selection, outward-facing consent, clone and initialization procedure, safe rollback, and removal preflight.
+That skill owns registry syntax, delivery-mode selection, outward-facing consent, clone and initialization procedure, safe rollback, removal preflight, and the guarded retirement path.
 Project creation never authorizes an unmentioned remote, and project removal never bypasses that preflight or unlanded-work checks; hard rule 1's concrete captain-approved project operation exception remains available when its exact conditions are met.
 
 Load `secondmate-provisioning` before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
@@ -484,7 +484,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
-- `project-management` - load before adding, creating, removing, or initializing a project.
+- `project-management` - load before adding, creating, removing, or initializing a project, and before retiring an out-of-registry project tree.
   Cloning or registering a project is add intake and uses the same trigger.
 - `stuck-crewmate-recovery` - load when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Hard rules, in priority order:
 
 1. **Never write to a project.**
    Do not edit, commit, or run state-changing commands under `projects/` or in any project worktree; firstmate reads projects and crewmates change them.
-   The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, guarded project retirement, and approved `local-only` merge paths, each owned by its referenced skill or script, plus a concrete captain-approved project operation governed directly by this rule.
+   The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, guarded out-of-registry project-tree retirement, and approved `local-only` merge paths, each owned by its referenced skill or script, plus a concrete captain-approved project operation governed directly by this rule.
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
    Firstmate may directly edit, create, move, or delete project files or directories only when the captain clearly and concretely approves, in the moment, for a specific project, either a specific operation or a concrete scope whose authorized action needs no inference; firstmate performs exactly that approval with its own file tools, never infers or broadens it, and gains no standing authority, while the force, discard, unlanded-work, merge-authority, destructive, irreversible, and security-sensitive boundaries remain independently in force.
 2. **Never merge a PR without the captain's explicit word.**
@@ -203,7 +203,7 @@ A restart must be a non-event because durable state and live backend inventory, 
 
 Load `project-management` before adding, creating, removing, or initializing a project, and before retiring an out-of-registry project tree.
 Cloning or registering a project is add intake and uses the same trigger.
-That skill owns registry syntax, delivery-mode selection, outward-facing consent, clone and initialization procedure, safe rollback, removal preflight, and the guarded retirement path.
+That skill owns registry syntax, delivery-mode selection, outward-facing consent, clone and initialization procedure, safe rollback, removal preflight, and the guarded out-of-registry retirement path.
 Project creation never authorizes an unmentioned remote, and project removal never bypasses that preflight or unlanded-work checks; hard rule 1's concrete captain-approved project operation exception remains available when its exact conditions are met.
 
 Load `secondmate-provisioning` before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.

--- a/bin/fm-project-retire.sh
+++ b/bin/fm-project-retire.sh
@@ -1,0 +1,833 @@
+#!/usr/bin/env bash
+# fm-project-retire.sh - the single guarded owner of retiring a captain-approved
+# project tree: a clone (or a small tree of clones) plus, optionally, the linked
+# Treehouse pool whose slots are worktrees of that tree.
+#
+# It exists because AGENTS.md hard rule 1 forbids a raw removal command under a
+# project tree, and the project-management skill's Remove procedure needs one
+# owner that PROVES, before any mutation, that nothing unlanded, still
+# referenced, or still in use would be destroyed. Every check below is a refusal
+# condition: an inability to prove a condition is a blocker, never a reason to
+# proceed.
+#
+# Usage:
+#   fm-project-retire.sh --root <abs> --boundary <abs> [--boundary <abs>]...
+#                        [--pool <abs>] --preflight
+#   fm-project-retire.sh --root <abs> --boundary <abs> [--boundary <abs>]...
+#                        [--pool <abs>] --execute
+#                        --confirm-root <abs> --confirm-plan <plan-id>
+#   fm-project-retire.sh --help
+#
+# Flags:
+#   --root <abs>     the retirement root. Must be absolute, normalized (no ".",
+#                    "..", "//", or trailing "/"), already canonical, an ordinary
+#                    non-symlink directory, and at least three path components
+#                    deep. It is NEVER inferred from the current directory, from
+#                    data/projects.md, or from any other default.
+#   --pool <abs>     the linked legacy Treehouse pool root, when the tree's
+#                    worktrees live outside the root. Same path rules as --root,
+#                    must be outside --root, and every checkout found under it
+#                    must prove it is a worktree of a repository inside --root.
+#                    Without --pool, any worktree outside --root is a refusal.
+#   --boundary <abs> an operator-approved retirement boundary. Required and
+#                    repeatable. Every removal target must be inside (or equal
+#                    to) at least one boundary, and no boundary may contain, be,
+#                    or sit inside a protected fleet path. Naming the envelope
+#                    separately is what turns a typo in --root into a refusal
+#                    instead of a deletion.
+#   --preflight      run every check, print the bounded removal plan and its plan
+#                    id, and remove nothing.
+#   --execute        run every check again from scratch and remove exactly the
+#                    planned paths.
+#   --confirm-root <abs>
+#                    must repeat --root byte for byte. Execute only.
+#   --confirm-plan <plan-id>
+#                    must repeat the plan id printed by --preflight. Execute
+#                    only. The plan id is a digest of the inspected evidence, so
+#                    any change to that evidence between approval and removal
+#                    refuses instead of removing a tree nobody approved.
+#
+# Refusal conditions (all of them, in this order):
+#   - a non-absolute, non-normalized, non-canonical, missing, symlinked,
+#     non-directory, or too-shallow root, pool, or boundary;
+#   - a root or pool that is, contains, or sits inside the primary firstmate
+#     home, the firstmate repository, a registered project, or a registered
+#     secondmate home;
+#   - a root or pool still named by a path reference in data/projects.md or
+#     data/secondmates.md;
+#   - a boundary that conflicts with any of those protected paths, or a removal
+#     target outside every boundary;
+#   - a root or pool still named by any recorded task (worktree=, project=, or
+#     home= in this home's or a registered secondmate home's state/<id>.meta);
+#   - a live process whose current directory is inside a removal target;
+#   - no git checkout under the root at all (this owner retires project trees,
+#     not arbitrary directories);
+#   - a checkout whose git toplevel does not canonically match its own path, or
+#     whose repository lives outside the retirement tree;
+#   - any dirty or untracked file in any checkout;
+#   - a linked worktree outside the root and the proven pool, any locked
+#     worktree, or any stale worktree registration whose path is gone;
+#   - a repository with no remote, a remote fetch failure, or no remote-tracking
+#     ref after the fetch (incomplete landing evidence);
+#   - a local branch, or an unreachable commit, whose work is not proven landed;
+#   - any ambiguous git result anywhere above.
+#
+# Landing proof (a matching commit subject is NEVER proof). In order:
+#   1. exact ancestry - the commit is an ancestor of a remote-tracking ref;
+#   2. content containment - a three-way merge of a remote-tracking ref with the
+#      commit yields that ref's exact tree, so the commit introduces nothing the
+#      authoritative merged upstream does not already have (this is how a squash
+#      merge or a rewritten history proves out);
+#   3. patch equivalence - every commit the work adds over the remote-tracking
+#      refs has a patch id that also appears upstream.
+# Step 3 scans upstream commits, so it is bounded by FM_RETIRE_PATCH_SCAN_LIMIT
+# (default 2000). Exceeding the bound is a refusal with an explicit message, not
+# a silent skip; raise the bound deliberately when the evidence needs it.
+#
+# Repository discovery finds both working checkouts (a `.git` file or directory)
+# and standalone repositories with no worktree (a bare repository or a detached
+# git directory), so objects that no checkout points at are still proven landed
+# before anything is removed.
+#
+# Evidence freshness: preflight and execute each run one non-pruning
+# `git fetch <remote>` per repository so landing evidence is current, and a fetch
+# failure refuses. That fetch, plus the throwaway trees `git merge-tree` writes
+# while proving containment, are the ONLY writes this owner makes before the
+# confirmed removal: both are purely additive, and nothing here ever prunes,
+# resets, stashes, forces, checks out, or discards anything.
+# Because the fetched remote-tracking refs are part of the plan id, an upstream
+# that moves between approval and removal also changes the plan id and refuses;
+# re-run --preflight and approve the new plan deliberately.
+#
+# Live-process coverage: the current-directory check reads FM_RETIRE_PROC_ROOT
+# (default /proc). Entries this user cannot read - other users' processes - are
+# not inspectable; the plan reports how many were inspected and how many were
+# not, so the gap is visible rather than assumed away.
+#
+# The mutation is exactly two `rm -rf --` calls on the two canonical paths named
+# in the plan, pool first so the authoritative repository survives longest. No
+# glob, no recursion into symlinks (`rm -rf` unlinks a symlink, never follows
+# it), and no cleanup beyond those two paths. Any removal error stops the run
+# immediately and reports precisely what was and was not removed.
+#
+# Exit codes: 0 success, 1 refusal or removal failure, 2 usage error,
+# 3 no-mistakes gate refusal (bin/fm-gate-refuse-lib.sh).
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+PROC_ROOT="${FM_RETIRE_PROC_ROOT:-/proc}"
+PATCH_SCAN_LIMIT="${FM_RETIRE_PATCH_SCAN_LIMIT:-2000}"
+
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+refuse() {
+  printf 'REFUSED: %s\n' "$1" >&2
+  exit 1
+}
+
+usage_error() {
+  printf 'error: %s\n' "$1" >&2
+  printf 'run %s --help for the full contract\n' "$(basename "$0")" >&2
+  exit 2
+}
+
+# --- argument parsing --------------------------------------------------------
+
+ROOT_ARG=
+POOL_ARG=
+MODE=
+CONFIRM_ROOT=
+CONFIRM_PLAN=
+BOUNDARY_ARGS=()
+
+require_value() {
+  [ "$2" -gt 0 ] || usage_error "$1 needs a value"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root) require_value --root "$(( $# - 1 ))"; [ -z "$ROOT_ARG" ] || usage_error "--root given twice"; ROOT_ARG=$2; shift 2 ;;
+    --pool) require_value --pool "$(( $# - 1 ))"; [ -z "$POOL_ARG" ] || usage_error "--pool given twice"; POOL_ARG=$2; shift 2 ;;
+    --boundary) require_value --boundary "$(( $# - 1 ))"; BOUNDARY_ARGS+=("$2"); shift 2 ;;
+    --confirm-root) require_value --confirm-root "$(( $# - 1 ))"; CONFIRM_ROOT=$2; shift 2 ;;
+    --confirm-plan) require_value --confirm-plan "$(( $# - 1 ))"; CONFIRM_PLAN=$2; shift 2 ;;
+    --preflight) [ -z "$MODE" ] || usage_error "choose exactly one of --preflight or --execute"; MODE=preflight; shift ;;
+    --execute) [ -z "$MODE" ] || usage_error "choose exactly one of --preflight or --execute"; MODE=execute; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage_error "unknown argument '$1'" ;;
+  esac
+done
+
+[ -n "$MODE" ] || usage_error "choose exactly one of --preflight or --execute"
+[ -n "$ROOT_ARG" ] || usage_error "--root <absolute path> is required and is never inferred"
+[ "${#BOUNDARY_ARGS[@]}" -gt 0 ] || usage_error "at least one --boundary <absolute path> is required"
+
+if [ "$MODE" = execute ]; then
+  [ -n "$CONFIRM_ROOT" ] || usage_error "--execute requires --confirm-root repeating --root exactly"
+  [ -n "$CONFIRM_PLAN" ] || usage_error "--execute requires --confirm-plan repeating the plan id from --preflight"
+  [ "$CONFIRM_ROOT" = "$ROOT_ARG" ] || usage_error "--confirm-root '$CONFIRM_ROOT' does not repeat --root '$ROOT_ARG'"
+else
+  [ -z "$CONFIRM_ROOT" ] || usage_error "--confirm-root is only valid with --execute"
+  [ -z "$CONFIRM_PLAN" ] || usage_error "--confirm-plan is only valid with --execute"
+fi
+
+case "$PATCH_SCAN_LIMIT" in
+  ''|*[!0-9]*) usage_error "FM_RETIRE_PATCH_SCAN_LIMIT must be a non-negative integer" ;;
+esac
+
+# Fail closed before any inspection or mutation: a no-mistakes gate agent must
+# never drive a fleet removal.
+fm_refuse_if_gate_agent
+
+# --- path primitives ---------------------------------------------------------
+
+canonical_dir() {
+  local p=$1
+  [ -n "$p" ] || return 1
+  [ -d "$p" ] || return 1
+  ( cd "$p" 2>/dev/null && pwd -P ) || return 1
+}
+
+path_equal_or_inside() {
+  local inner=$1 outer=$2
+  [ -n "$inner" ] && [ -n "$outer" ] || return 1
+  [ "$inner" = "$outer" ] && return 0
+  case "$inner" in "$outer"/*) return 0 ;; esac
+  return 1
+}
+
+paths_conflict() {
+  path_equal_or_inside "$1" "$2" && return 0
+  path_equal_or_inside "$2" "$1"
+}
+
+VALIDATED_PATH=
+validate_path_shape() {
+  local raw=$1 label=$2 canon
+  case "$raw" in
+    /*) ;;
+    *) usage_error "$label must be an absolute path (got '$raw')" ;;
+  esac
+  case "$raw" in
+    */) usage_error "$label must not end with '/' (got '$raw')" ;;
+    *//*|*/./*|*/../*|*/.|*/..) usage_error "$label must be normalized, without '.', '..', or empty components (got '$raw')" ;;
+  esac
+  case "$raw" in
+    /*/*/*) ;;
+    *) refuse "$label $raw is too close to the filesystem root to be an ordinary retirement path" ;;
+  esac
+  [ -e "$raw" ] || [ -L "$raw" ] || refuse "$label $raw does not exist"
+  [ ! -L "$raw" ] || refuse "$label $raw is a symlink; name the real directory instead"
+  [ -d "$raw" ] || refuse "$label $raw is not an ordinary directory"
+  canon=$(canonical_dir "$raw") || refuse "$label $raw cannot be resolved to a canonical directory"
+  [ "$canon" = "$raw" ] || refuse "$label $raw is not canonical; it resolves to $canon"
+  VALIDATED_PATH=$canon
+}
+
+# --- protected fleet paths ---------------------------------------------------
+
+PROTECTED_PATHS=()
+PROTECTED_LABELS=()
+SECONDMATE_STATE_DIRS=()
+
+add_protected() {
+  [ -n "$1" ] || return 0
+  PROTECTED_PATHS+=("${1%/}")
+  PROTECTED_LABELS+=("$2")
+}
+
+registry_home_for_line() {
+  sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p'
+}
+
+registry_id_for_line() {
+  local id=${1#- }
+  printf '%s\n' "${id%% *}"
+}
+
+collect_protected() {
+  local home_canon root_canon line id home canon
+
+  if home_canon=$(canonical_dir "$FM_HOME"); then :; else home_canon=${FM_HOME%/}; fi
+  add_protected "$home_canon" "the primary firstmate home"
+  add_protected "$home_canon/projects" "the primary firstmate project directory"
+  if root_canon=$(canonical_dir "$FM_ROOT"); then :; else root_canon=${FM_ROOT%/}; fi
+  add_protected "$root_canon" "the firstmate repository"
+
+  if [ -f "$DATA/projects.md" ]; then
+    while IFS= read -r line; do
+      case "$line" in "- "*) ;; *) continue ;; esac
+      id=$(registry_id_for_line "$line")
+      [ -n "$id" ] || continue
+      add_protected "$home_canon/projects/$id" "registered project $id"
+    done < "$DATA/projects.md"
+  fi
+
+  if [ -f "$DATA/secondmates.md" ]; then
+    while IFS= read -r line; do
+      case "$line" in "- "*) ;; *) continue ;; esac
+      id=$(registry_id_for_line "$line")
+      home=$(printf '%s\n' "$line" | registry_home_for_line)
+      [ -n "$home" ] || continue
+      if canon=$(canonical_dir "$home"); then home=$canon; else home=${home%/}; fi
+      add_protected "$home" "registered secondmate home for ${id:-an unnamed secondmate}"
+      SECONDMATE_STATE_DIRS+=("$home/state")
+    done < "$DATA/secondmates.md"
+  fi
+}
+
+assert_not_protected() {
+  local path=$1 label=$2 i
+  [ "${#PROTECTED_PATHS[@]}" -gt 0 ] || return 0
+  for i in "${!PROTECTED_PATHS[@]}"; do
+    if paths_conflict "$path" "${PROTECTED_PATHS[$i]}"; then
+      refuse "$label $path is, contains, or sits inside ${PROTECTED_LABELS[$i]} (${PROTECTED_PATHS[$i]})"
+    fi
+  done
+}
+
+assert_no_registry_reference() {
+  local path=$1 label=$2 file tokens token
+  for file in "$DATA/projects.md" "$DATA/secondmates.md"; do
+    [ -f "$file" ] || continue
+    tokens=$(grep -oE '/[^[:space:];)"'"'"']+' "$file" 2>/dev/null | sed 's:/*$::' | LC_ALL=C sort -u || true)
+    [ -n "$tokens" ] || continue
+    while IFS= read -r token; do
+      [ -n "$token" ] || continue
+      case "$token" in /*/*) ;; *) continue ;; esac
+      if paths_conflict "$path" "$token"; then
+        refuse "$label $path is still referenced by $file ($token); retire the registry entry first"
+      fi
+    done <<EOF
+$tokens
+EOF
+  done
+}
+
+assert_no_task_reference() {
+  local path=$1 label=$2 dirs dir meta id line value
+  dirs=("$STATE")
+  [ "${#SECONDMATE_STATE_DIRS[@]}" -eq 0 ] || dirs+=("${SECONDMATE_STATE_DIRS[@]}")
+  for dir in "${dirs[@]}"; do
+    [ -d "$dir" ] || continue
+    for meta in "$dir"/*.meta; do
+      [ -f "$meta" ] || continue
+      id=$(basename "$meta" .meta)
+      while IFS= read -r line; do
+        case "$line" in
+          worktree=*|project=*|home=*) value=${line#*=} ;;
+          *) continue ;;
+        esac
+        case "$value" in /*) ;; *) continue ;; esac
+        if paths_conflict "$path" "${value%/}"; then
+          refuse "$label $path is still referenced by recorded task $id ($meta: $line)"
+        fi
+      done < "$meta"
+    done
+  done
+}
+
+PROC_INSPECTED=0
+PROC_UNREADABLE=0
+assert_no_live_process_cwd() {
+  local path=$1 label=$2 entry pid cwd
+  [ -d "$PROC_ROOT" ] || refuse "cannot prove no live process is working inside $path: $PROC_ROOT is unavailable"
+  for entry in "$PROC_ROOT"/[0-9]*; do
+    [ -d "$entry" ] || continue
+    pid=$(basename "$entry")
+    if ! cwd=$(readlink "$entry/cwd" 2>/dev/null); then
+      PROC_UNREADABLE=$(( PROC_UNREADABLE + 1 ))
+      continue
+    fi
+    PROC_INSPECTED=$(( PROC_INSPECTED + 1 ))
+    cwd=${cwd% (deleted)}
+    case "$cwd" in /*) ;; *) continue ;; esac
+    if path_equal_or_inside "${cwd%/}" "$path"; then
+      refuse "$label $path is the current directory of live process $pid ($cwd)"
+    fi
+  done
+}
+
+# --- git inventory and landing proof ----------------------------------------
+
+CHECKOUTS=()
+
+collect_checkouts() {
+  local dir=$1 found marker workdir canon
+  found=$(find -P "$dir" -name .git -prune -print 2>/dev/null) || refuse "cannot inventory git checkouts under $dir"
+  [ -n "$found" ] || return 0
+  while IFS= read -r marker; do
+    [ -n "$marker" ] || continue
+    workdir=$(dirname "$marker")
+    canon=$(canonical_dir "$workdir") || refuse "cannot resolve checkout $workdir to a canonical directory"
+    CHECKOUTS+=("$canon")
+  done <<EOF
+$found
+EOF
+}
+
+BARE_REPOS=()
+
+# Standalone repositories have no `.git` marker for collect_checkouts to find:
+# a bare repository, or a detached git directory, is recognised by being its own
+# git common directory. Nested git directories (a worktree administrative dir, a
+# `.git/logs` directory) resolve to an enclosing common directory instead and are
+# left to the checkout that owns them.
+collect_bare_repos() {
+  local dir=$1 found head candidate canon bare common
+  found=$(find -P "$dir" -type f -name HEAD -print 2>/dev/null) \
+    || refuse "cannot inventory git repositories under $dir"
+  [ -n "$found" ] || return 0
+  while IFS= read -r head; do
+    [ -n "$head" ] || continue
+    candidate=$(dirname "$head")
+    canon=$(canonical_dir "$candidate") || continue
+    bare=$(git -C "$canon" rev-parse --is-bare-repository 2>/dev/null) || continue
+    [ "$bare" = true ] || continue
+    common=$(common_dir_of "$canon") || continue
+    [ "$common" = "$canon" ] || continue
+    BARE_REPOS+=("$canon")
+  done <<EOF
+$found
+EOF
+}
+
+common_dir_of() {
+  local workdir=$1 common
+  common=$(git -C "$workdir" rev-parse --git-common-dir 2>/dev/null) || return 1
+  [ -n "$common" ] || return 1
+  case "$common" in /*) ;; *) common="$workdir/$common" ;; esac
+  ( cd "$common" 2>/dev/null && pwd -P ) || return 1
+}
+
+patch_id_of() {
+  local workdir=$1 commit=$2
+  git -C "$workdir" show --pretty=medium --no-ext-diff "$commit" 2>/dev/null \
+    | git patch-id --stable 2>/dev/null \
+    | awk 'NR == 1 { print $1 }'
+}
+
+REPO_REMOTE_REFS=
+REPO_UPSTREAM_IDS=
+REPO_UPSTREAM_IDS_READY=0
+
+load_upstream_patch_ids() {
+  local workdir=$1 total commit
+  [ "$REPO_UPSTREAM_IDS_READY" -eq 0 ] || return 0
+  total=$(git -C "$workdir" rev-list --count --remotes 2>/dev/null) || return 1
+  case "$total" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$total" -le "$PATCH_SCAN_LIMIT" ] || return 2
+  REPO_UPSTREAM_IDS=$(
+    git -C "$workdir" rev-list --remotes 2>/dev/null | while IFS= read -r commit; do
+      patch_id_of "$workdir" "$commit"
+    done | sed '/^$/d' | LC_ALL=C sort -u
+  )
+  REPO_UPSTREAM_IDS_READY=1
+}
+
+LANDED_REASON=
+# Prove that everything reachable from <commit> and not already on a
+# remote-tracking ref has landed upstream. A matching commit subject is never
+# consulted; see the header's landing-proof ladder.
+work_is_landed() {
+  local workdir=$1 commit=$2 ref tree merged unique count entry pid rc
+
+  while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    if git -C "$workdir" merge-base --is-ancestor "$commit" "$ref" 2>/dev/null; then
+      LANDED_REASON="exact ancestry of $ref"
+      return 0
+    fi
+  done <<EOF
+$REPO_REMOTE_REFS
+EOF
+
+  while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    tree=$(git -C "$workdir" rev-parse -q --verify "$ref^{tree}" 2>/dev/null) || continue
+    [ -n "$tree" ] || continue
+    merged=$(git -C "$workdir" merge-tree --write-tree "$ref" "$commit" 2>/dev/null | head -1) || continue
+    if [ -n "$merged" ] && [ "$merged" = "$tree" ]; then
+      LANDED_REASON="content already contained in $ref"
+      return 0
+    fi
+  done <<EOF
+$REPO_REMOTE_REFS
+EOF
+
+  unique=$(git -C "$workdir" log --format=%H "$commit" --not --remotes -- 2>/dev/null) || {
+    LANDED_REASON="git could not list the commits it adds over the remote-tracking refs"
+    return 1
+  }
+  unique=$(printf '%s\n' "$unique" | sed '/^$/d')
+  if [ -z "$unique" ]; then
+    LANDED_REASON="adds nothing over the remote-tracking refs"
+    return 0
+  fi
+  count=$(printf '%s\n' "$unique" | wc -l | tr -d ' ')
+  if [ "$count" -gt "$PATCH_SCAN_LIMIT" ]; then
+    LANDED_REASON="adds $count commits, above the FM_RETIRE_PATCH_SCAN_LIMIT bound of $PATCH_SCAN_LIMIT"
+    return 1
+  fi
+
+  rc=0
+  load_upstream_patch_ids "$workdir" || rc=$?
+  if [ "$rc" -eq 2 ]; then
+    LANDED_REASON="upstream history is larger than the FM_RETIRE_PATCH_SCAN_LIMIT bound of $PATCH_SCAN_LIMIT, so patch equivalence cannot be proven"
+    return 1
+  fi
+  if [ "$rc" -ne 0 ]; then
+    LANDED_REASON="git could not enumerate the upstream commits needed for patch equivalence"
+    return 1
+  fi
+
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    pid=$(patch_id_of "$workdir" "$entry")
+    if [ -z "$pid" ]; then
+      LANDED_REASON="commit $entry has no computable patch id, so patch equivalence cannot be proven"
+      return 1
+    fi
+    if ! printf '%s\n' "$REPO_UPSTREAM_IDS" | grep -qxF "$pid"; then
+      LANDED_REASON="commit $entry is not patch-equivalent to any upstream commit"
+      return 1
+    fi
+  done <<EOF
+$unique
+EOF
+  LANDED_REASON="patch-equivalent to upstream for all $count added commits"
+  return 0
+}
+
+EVIDENCE=
+REPORT=
+add_evidence() {
+  EVIDENCE="$EVIDENCE$1"$'\n'
+}
+add_report() {
+  REPORT="$REPORT$1"$'\n'
+}
+
+# --- validation -------------------------------------------------------------
+
+validate_path_shape "$ROOT_ARG" "retirement root"
+ROOT=$VALIDATED_PATH
+POOL=
+if [ -n "$POOL_ARG" ]; then
+  validate_path_shape "$POOL_ARG" "legacy pool root"
+  POOL=$VALIDATED_PATH
+  [ "$POOL" != "$ROOT" ] || usage_error "--pool must not repeat --root"
+  ! path_equal_or_inside "$POOL" "$ROOT" || usage_error "--pool $POOL is inside --root $ROOT; the root removal already covers it"
+  ! path_equal_or_inside "$ROOT" "$POOL" || usage_error "--root $ROOT is inside --pool $POOL; name the outermost tree as --root"
+fi
+
+collect_protected
+assert_not_protected "$ROOT" "retirement root"
+assert_no_registry_reference "$ROOT" "retirement root"
+if [ -n "$POOL" ]; then
+  assert_not_protected "$POOL" "legacy pool root"
+  assert_no_registry_reference "$POOL" "legacy pool root"
+fi
+
+BOUNDARIES=()
+for boundary in "${BOUNDARY_ARGS[@]}"; do
+  validate_path_shape "$boundary" "retirement boundary"
+  assert_not_protected "$VALIDATED_PATH" "retirement boundary"
+  BOUNDARIES+=("$VALIDATED_PATH")
+done
+
+assert_inside_a_boundary() {
+  local path=$1 label=$2 boundary
+  for boundary in "${BOUNDARIES[@]}"; do
+    path_equal_or_inside "$path" "$boundary" && return 0
+  done
+  refuse "$label $path is outside every approved retirement boundary (${BOUNDARIES[*]})"
+}
+
+assert_inside_a_boundary "$ROOT" "retirement root"
+[ -z "$POOL" ] || assert_inside_a_boundary "$POOL" "legacy pool root"
+
+assert_no_task_reference "$ROOT" "retirement root"
+[ -z "$POOL" ] || assert_no_task_reference "$POOL" "legacy pool root"
+
+assert_no_live_process_cwd "$ROOT" "retirement root"
+[ -z "$POOL" ] || assert_no_live_process_cwd "$POOL" "legacy pool root"
+
+# --- inventory --------------------------------------------------------------
+
+collect_checkouts "$ROOT"
+ROOT_CHECKOUT_COUNT=${#CHECKOUTS[@]}
+[ -z "$POOL" ] || collect_checkouts "$POOL"
+[ "$ROOT_CHECKOUT_COUNT" -gt 0 ] \
+  || refuse "no git checkout found under retirement root $ROOT; this owner retires project trees, not arbitrary directories"
+if [ -n "$POOL" ] && [ "${#CHECKOUTS[@]}" -eq "$ROOT_CHECKOUT_COUNT" ]; then
+  refuse "legacy pool root $POOL holds no git checkout, so it cannot be proven linked to $ROOT"
+fi
+
+SORTED_CHECKOUTS=$(printf '%s\n' "${CHECKOUTS[@]}" | LC_ALL=C sort -u)
+
+REPO_COMMONS=()
+REPO_WORKDIRS=()
+
+remember_repo() {
+  local common=$1 workdir=$2 existing
+  for existing in ${REPO_COMMONS[@]+"${REPO_COMMONS[@]}"}; do
+    [ "$existing" = "$common" ] && return 0
+  done
+  REPO_COMMONS+=("$common")
+  REPO_WORKDIRS+=("$workdir")
+}
+
+while IFS= read -r checkout; do
+  [ -n "$checkout" ] || continue
+  toplevel=$(git -C "$checkout" rev-parse --show-toplevel 2>/dev/null) \
+    || refuse "checkout $checkout does not report a git toplevel; refusing on an ambiguous git result"
+  toplevel=$(canonical_dir "$toplevel") \
+    || refuse "checkout $checkout reports a git toplevel that cannot be resolved"
+  [ "$toplevel" = "$checkout" ] \
+    || refuse "checkout $checkout reports a different git toplevel $toplevel; refusing on an ambiguous git result"
+  common=$(common_dir_of "$checkout") \
+    || refuse "checkout $checkout does not report a resolvable git directory; refusing on an ambiguous git result"
+  path_equal_or_inside "$common" "$ROOT" \
+    || refuse "checkout $checkout belongs to repository $common outside the retirement root $ROOT"
+  status=$(git -C "$checkout" status --porcelain --untracked-files=all 2>/dev/null) \
+    || refuse "cannot inspect checkout $checkout for uncommitted work; refusing on an ambiguous git result"
+  [ -z "$status" ] \
+    || refuse "checkout $checkout has dirty or untracked files:"$'\n'"$(printf '%s\n' "$status" | head -10)"
+  head=$(git -C "$checkout" rev-parse --verify HEAD 2>/dev/null) \
+    || refuse "checkout $checkout has no resolvable HEAD; refusing on an ambiguous git result"
+  add_evidence "checkout $checkout head $head"
+  add_report "checkout $checkout at $head, clean"
+  remember_repo "$common" "$checkout"
+done <<EOF
+$SORTED_CHECKOUTS
+EOF
+
+collect_bare_repos "$ROOT"
+[ -z "$POOL" ] || collect_bare_repos "$POOL"
+for bare_repo in ${BARE_REPOS[@]+"${BARE_REPOS[@]}"}; do
+  path_equal_or_inside "$bare_repo" "$ROOT" \
+    || refuse "git repository $bare_repo has no worktree and lives outside the retirement root $ROOT"
+  remember_repo "$bare_repo" "$bare_repo"
+done
+
+for index in "${!REPO_COMMONS[@]}"; do
+  common=${REPO_COMMONS[$index]}
+  workdir=${REPO_WORKDIRS[$index]}
+  add_report "repository $common inspected from $workdir"
+
+  worktrees=$(git -C "$workdir" -c core.quotePath=false worktree list --porcelain 2>/dev/null) \
+    || refuse "cannot list the worktrees of repository $common; refusing on an ambiguous git result"
+  current_worktree=
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*)
+        current_worktree=${line#worktree }
+        current_worktree=$(canonical_dir "$current_worktree") \
+          || refuse "repository $common has a stale worktree registration for ${line#worktree }, whose path is gone; resolve that registration deliberately before retiring the tree"
+        if ! path_equal_or_inside "$current_worktree" "$ROOT" \
+          && { [ -z "$POOL" ] || ! path_equal_or_inside "$current_worktree" "$POOL"; }; then
+          refuse "repository $common has linked worktree $current_worktree outside the retirement tree"
+        fi
+        add_evidence "repo $common worktree $current_worktree"
+        add_report "  worktree $current_worktree"
+        ;;
+      "locked"|"locked "*)
+        refuse "repository $common has locked (in use) worktree ${current_worktree:-unknown}; ${line#locked}"
+        ;;
+    esac
+  done <<EOF
+$worktrees
+EOF
+
+  remotes=$(git -C "$workdir" remote 2>/dev/null) \
+    || refuse "cannot list the remotes of repository $common; refusing on an ambiguous git result"
+  remotes=$(printf '%s\n' "$remotes" | sed '/^$/d')
+  [ -n "$remotes" ] \
+    || refuse "repository $common has no remote, so no landing evidence exists for its branches"
+  while IFS= read -r remote; do
+    [ -n "$remote" ] || continue
+    git -C "$workdir" fetch --quiet --no-prune "$remote" 2>/dev/null \
+      || refuse "cannot refresh landing evidence for repository $common: git fetch $remote failed"
+  done <<EOF
+$remotes
+EOF
+
+  REPO_REMOTE_REFS=$(git -C "$workdir" for-each-ref --format='%(refname)' refs/remotes/ 2>/dev/null) \
+    || refuse "cannot list the remote-tracking refs of repository $common; refusing on an ambiguous git result"
+  REPO_REMOTE_REFS=$(printf '%s\n' "$REPO_REMOTE_REFS" | grep -v '/HEAD$' | sed '/^$/d' || true)
+  [ -n "$REPO_REMOTE_REFS" ] \
+    || refuse "repository $common has no remote-tracking ref after fetching, so its landing evidence is incomplete"
+  REPO_UPSTREAM_IDS=
+  REPO_UPSTREAM_IDS_READY=0
+
+  while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    sha=$(git -C "$workdir" rev-parse --verify "$ref" 2>/dev/null) \
+      || refuse "repository $common has unreadable ref $ref; refusing on an ambiguous git result"
+    add_evidence "repo $common ref $ref $sha"
+  done <<EOF
+$REPO_REMOTE_REFS
+EOF
+
+  branches=$(git -C "$workdir" for-each-ref --format='%(refname:short) %(objectname)' refs/heads/ 2>/dev/null) \
+    || refuse "cannot list the branches of repository $common; refusing on an ambiguous git result"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    branch=${line%% *}
+    sha=${line##* }
+    add_evidence "repo $common branch $branch $sha"
+    if work_is_landed "$workdir" "$sha"; then
+      add_report "  branch $branch landed ($LANDED_REASON)"
+    else
+      refuse "repository $common has unlanded branch $branch at $sha: $LANDED_REASON"
+    fi
+  done <<EOF
+$branches
+EOF
+
+  unreachable=$(git -C "$workdir" fsck --unreachable --no-reflogs --no-progress --connectivity-only 2>/dev/null \
+    | sed -n 's/^unreachable commit //p' | LC_ALL=C sort -u || true)
+  unreachable_count=0
+  while IFS= read -r sha; do
+    [ -n "$sha" ] || continue
+    unreachable_count=$(( unreachable_count + 1 ))
+    add_evidence "repo $common unreachable $sha"
+    if ! work_is_landed "$workdir" "$sha"; then
+      refuse "repository $common holds unreachable commit $sha whose work is not landed: $LANDED_REASON"
+    fi
+  done <<EOF
+$unreachable
+EOF
+  add_report "  $unreachable_count unreachable commits, all landed"
+done
+
+if [ -n "$POOL" ]; then
+  while IFS= read -r checkout; do
+    [ -n "$checkout" ] || continue
+    path_equal_or_inside "$checkout" "$POOL" || continue
+    common=$(common_dir_of "$checkout") \
+      || refuse "pool checkout $checkout does not report a resolvable git directory"
+    path_equal_or_inside "$common" "$ROOT" \
+      || refuse "pool checkout $checkout belongs to repository $common outside the retirement root $ROOT"
+  done <<EOF
+$SORTED_CHECKOUTS
+EOF
+fi
+
+# Top-level entries are part of the plan so the operator sees every non-checkout
+# file and directory the bounded removal would take with it.
+list_top_level() {
+  local dir=$1 label=$2 entry name
+  for entry in "$dir"/* "$dir"/.[!.]* "$dir"/..?*; do
+    [ -e "$entry" ] || [ -L "$entry" ] || continue
+    name=$(basename "$entry")
+    add_evidence "entry $label $name"
+    add_report "  contains $name"
+  done
+}
+
+add_report "retirement root $ROOT"
+list_top_level "$ROOT" "$ROOT"
+if [ -n "$POOL" ]; then
+  add_report "legacy pool root $POOL"
+  list_top_level "$POOL" "$POOL"
+fi
+
+# --- plan identity ----------------------------------------------------------
+
+digest_of_stdin() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{ print $1 }'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{ print $1 }'
+  else
+    return 1
+  fi
+}
+
+PLAN_ID=$(
+  {
+    printf 'root %s\n' "$ROOT"
+    printf 'pool %s\n' "${POOL:--}"
+    printf '%s' "$EVIDENCE" | LC_ALL=C sort
+  } | digest_of_stdin
+) || refuse "cannot compute a plan id: neither sha256sum nor shasum is available"
+[ -n "$PLAN_ID" ] || refuse "cannot compute a plan id from the inspected evidence"
+
+REMOVAL_TARGETS=()
+[ -z "$POOL" ] || REMOVAL_TARGETS+=("$POOL")
+REMOVAL_TARGETS+=("$ROOT")
+
+print_plan() {
+  printf 'PLAN: guarded retirement of %s\n' "$ROOT"
+  printf '%s' "$REPORT" | sed 's/^/PLAN:   /'
+  printf 'PLAN: inspected %s live process working directories (%s not inspectable by this user)\n' \
+    "$PROC_INSPECTED" "$PROC_UNREADABLE"
+  local step=0 target
+  for target in "${REMOVAL_TARGETS[@]}"; do
+    step=$(( step + 1 ))
+    printf 'PLAN: removal step %s: rm -rf -- %s\n' "$step" "$target"
+  done
+  printf 'PLAN-ID: %s\n' "$PLAN_ID"
+}
+
+if [ "$MODE" = preflight ]; then
+  print_plan
+  printf 'PREFLIGHT OK: every check passed and nothing was removed.\n'
+  printf 'To remove exactly this plan, re-run with:\n'
+  printf '  %s --root %s' "$0" "$ROOT"
+  [ -z "$POOL" ] || printf ' --pool %s' "$POOL"
+  for boundary in "${BOUNDARIES[@]}"; do
+    printf ' --boundary %s' "$boundary"
+  done
+  printf ' --execute --confirm-root %s --confirm-plan %s\n' "$ROOT" "$PLAN_ID"
+  exit 0
+fi
+
+# --- execute ----------------------------------------------------------------
+
+if [ "$CONFIRM_PLAN" != "$PLAN_ID" ]; then
+  printf 'REFUSED: the approved plan no longer matches the current evidence.\n' >&2
+  printf '  approved plan id: %s\n' "$CONFIRM_PLAN" >&2
+  printf '  current plan id:  %s\n' "$PLAN_ID" >&2
+  printf 'Nothing was removed. Re-run --preflight, review the new plan, and approve it deliberately.\n' >&2
+  exit 1
+fi
+
+print_plan
+
+for target in "${REMOVAL_TARGETS[@]}"; do
+  validate_path_shape "$target" "removal target"
+  [ "$VALIDATED_PATH" = "$target" ] || refuse "removal target $target changed identity after the plan was approved"
+  assert_not_protected "$target" "removal target"
+  assert_inside_a_boundary "$target" "removal target"
+done
+
+for target in "${REMOVAL_TARGETS[@]}"; do
+  if ! rm -rf -- "$target"; then
+    printf 'error: removing %s failed; stopping without any further removal\n' "$target" >&2
+    exit 1
+  fi
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    printf 'error: %s still exists after removal; stopping without any further removal\n' "$target" >&2
+    exit 1
+  fi
+  printf 'RETIRED: removed %s\n' "$target"
+done
+
+printf 'RETIRED: plan %s completed; %s removal target(s) gone, nothing else was touched.\n' \
+  "$PLAN_ID" "${#REMOVAL_TARGETS[@]}"

--- a/bin/fm-project-retire.sh
+++ b/bin/fm-project-retire.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 # fm-project-retire.sh - the single guarded owner of retiring a captain-approved
-# project tree: a clone (or a small tree of clones) plus, optionally, the linked
-# Treehouse pool whose slots are worktrees of that tree.
+# out-of-registry project tree: a legacy clone (or a small tree of clones) left
+# behind by an earlier layout, plus, optionally, the linked Treehouse pool whose
+# slots are worktrees of that tree.
 #
 # It exists because AGENTS.md hard rule 1 forbids a raw removal command under a
-# project tree, and the project-management skill's Remove procedure needs one
+# project tree, and the project-management skill's retirement procedure needs one
 # owner that PROVES, before any mutation, that nothing unlanded, still
 # referenced, or still in use would be destroyed. Every check below is a refusal
 # condition: an inability to prove a condition is a blocker, never a reason to
 # proceed.
+#
+# Scope: out-of-registry trees only. A registered project under this home's
+# `projects/` is deliberately out of scope and always refuses here; removing one
+# follows the project-management skill's registered-project path under hard
+# rule 1's captain-approved project operation exception instead.
 #
 # Usage:
 #   fm-project-retire.sh --root <abs> --boundary <abs> [--boundary <abs>]...

--- a/bin/fm-project-retire.sh
+++ b/bin/fm-project-retire.sh
@@ -73,13 +73,15 @@
 #   - any dirty or untracked file in any checkout;
 #   - a linked worktree outside the root and the proven pool, any locked
 #     worktree, or any stale worktree registration whose path is gone;
-#   - a repository with no remote, a remote fetch failure, or no remote-tracking
-#     ref after the fetch (incomplete landing evidence);
-#   - a remote whose URL resolves to a path inside a removal target, so the
-#     landing evidence would not survive the removal that cites it;
+#   - a repository with no remote, or a remote whose URL resolves to a path
+#     inside a removal target, so the landing evidence would not survive the
+#     removal that cites it;
+#   - a remote fetch failure, or no remote-tracking ref after the fetch
+#     (incomplete landing evidence);
+#   - a local branch whose work is not proven landed;
 #   - an object-store check (`git fsck`) that fails or cannot complete, so the
 #     repository's unreachable commits cannot be enumerated;
-#   - a local branch, or an unreachable commit, whose work is not proven landed;
+#   - an unreachable commit whose work is not proven landed;
 #   - any ambiguous git result anywhere above.
 #
 # Landing proof (a matching commit subject is NEVER proof). In order:
@@ -118,10 +120,11 @@
 # how many were inspected and how many were not, so the gap is visible rather
 # than assumed away.
 #
-# The mutation is exactly two `rm -rf --` calls on the two canonical paths named
-# in the plan, pool first so the authoritative repository survives longest. No
-# glob, no recursion into symlinks (`rm -rf` unlinks a symlink, never follows
-# it), and no cleanup beyond those two paths. Any removal error stops the run
+# The mutation is exactly one `rm -rf --` call per removal target named in the
+# plan - the root, preceded by the pool when `--pool` was given - so the
+# authoritative repository survives longest. No glob, no recursion into
+# symlinks (`rm -rf` unlinks a symlink, never follows it), and no cleanup
+# beyond the paths the plan names. Any removal error stops the run
 # immediately and reports precisely what was and was not removed.
 #
 # Exit codes: 0 success, 1 refusal or removal failure, 2 usage error,

--- a/bin/fm-project-retire.sh
+++ b/bin/fm-project-retire.sh
@@ -75,6 +75,10 @@
 #     worktree, or any stale worktree registration whose path is gone;
 #   - a repository with no remote, a remote fetch failure, or no remote-tracking
 #     ref after the fetch (incomplete landing evidence);
+#   - a remote whose URL resolves to a path inside a removal target, so the
+#     landing evidence would not survive the removal that cites it;
+#   - an object-store check (`git fsck`) that fails or cannot complete, so the
+#     repository's unreachable commits cannot be enumerated;
 #   - a local branch, or an unreachable commit, whose work is not proven landed;
 #   - any ambiguous git result anywhere above.
 #
@@ -91,9 +95,11 @@
 # a silent skip; raise the bound deliberately when the evidence needs it.
 #
 # Repository discovery finds both working checkouts (a `.git` file or directory)
-# and standalone repositories with no worktree (a bare repository or a detached
-# git directory), so objects that no checkout points at are still proven landed
-# before anything is removed.
+# and standalone repositories with no worktree, so objects that no checkout
+# points at are still proven landed before anything is removed. A standalone
+# repository is recognised by being its own git common directory, whether it is
+# bare or a detached non-bare git directory (a `--separate-git-dir` target, or a
+# `.git` directory whose worktree is gone); `core.bare` is never the test.
 #
 # Evidence freshness: preflight and execute each run one non-pruning
 # `git fetch <remote>` per repository so landing evidence is current, and a fetch
@@ -106,9 +112,11 @@
 # re-run --preflight and approve the new plan deliberately.
 #
 # Live-process coverage: the current-directory check reads FM_RETIRE_PROC_ROOT
-# (default /proc). Entries this user cannot read - other users' processes - are
-# not inspectable; the plan reports how many were inspected and how many were
-# not, so the gap is visible rather than assumed away.
+# (default /proc) exactly once, testing each process against every removal
+# target in that single pass so each process is counted once. Entries this user
+# cannot read - other users' processes - are not inspectable; the plan reports
+# how many were inspected and how many were not, so the gap is visible rather
+# than assumed away.
 #
 # The mutation is exactly two `rm -rf --` calls on the two canonical paths named
 # in the plan, pool first so the authoritative repository survives longest. No
@@ -255,8 +263,13 @@ add_protected() {
   PROTECTED_LABELS+=("$2")
 }
 
+# Match the (home: ...) field itself rather than requiring it to be the first
+# parenthesised group: summary and scope prose routinely carries its own
+# parentheticals, and a "^[^(]*" prefix would leave those entries looking like
+# they have no home - silently dropping that secondmate's state directory from
+# the recorded-task scan. Greedy prefix, so the last (home: ...) wins.
 registry_home_for_line() {
-  sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p'
+  sed -n 's/.*(home:[[:space:]]*\([^;)]*\);.*/\1/p' | sed 's/[[:space:]]*$//'
 }
 
 registry_id_for_line() {
@@ -348,9 +361,14 @@ assert_no_task_reference() {
 
 PROC_INSPECTED=0
 PROC_UNREADABLE=0
+# One pass over the process table for every removal target at once: walking it
+# per target would count each process once per target and report an inspected /
+# not-inspectable coverage gap that is a multiple of the real one.
 assert_no_live_process_cwd() {
-  local path=$1 label=$2 entry pid cwd
-  [ -d "$PROC_ROOT" ] || refuse "cannot prove no live process is working inside $path: $PROC_ROOT is unavailable"
+  local entry pid cwd i
+  [ "${#REMOVAL_TARGETS[@]}" -gt 0 ] || return 0
+  [ -d "$PROC_ROOT" ] \
+    || refuse "cannot prove no live process is working inside ${REMOVAL_TARGETS[*]}: $PROC_ROOT is unavailable"
   for entry in "$PROC_ROOT"/[0-9]*; do
     [ -d "$entry" ] || continue
     pid=$(basename "$entry")
@@ -361,9 +379,11 @@ assert_no_live_process_cwd() {
     PROC_INSPECTED=$(( PROC_INSPECTED + 1 ))
     cwd=${cwd% (deleted)}
     case "$cwd" in /*) ;; *) continue ;; esac
-    if path_equal_or_inside "${cwd%/}" "$path"; then
-      refuse "$label $path is the current directory of live process $pid ($cwd)"
-    fi
+    for i in "${!REMOVAL_TARGETS[@]}"; do
+      if path_equal_or_inside "${cwd%/}" "${REMOVAL_TARGETS[$i]}"; then
+        refuse "${REMOVAL_LABELS[$i]} ${REMOVAL_TARGETS[$i]} is the current directory of live process $pid ($cwd)"
+      fi
+    done
   done
 }
 
@@ -385,27 +405,42 @@ $found
 EOF
 }
 
-BARE_REPOS=()
+STANDALONE_REPOS=()
 
-# Standalone repositories have no `.git` marker for collect_checkouts to find:
-# a bare repository, or a detached git directory, is recognised by being its own
-# git common directory. Nested git directories (a worktree administrative dir, a
-# `.git/logs` directory) resolve to an enclosing common directory instead and are
-# left to the checkout that owns them.
-collect_bare_repos() {
-  local dir=$1 found head candidate canon bare common
+# A directory holding HEAD, objects/ and refs/ is git's own shape for a
+# repository directory. A worktree administrative directory or a stray HEAD file
+# elsewhere in the tree does not have all three, so this is what separates a
+# candidate repository from an ordinary directory that happens to contain a file
+# named HEAD.
+looks_like_git_dir() {
+  local dir=$1
+  [ -f "$dir/HEAD" ] && [ -d "$dir/objects" ] && [ -d "$dir/refs" ]
+}
+
+# Standalone repositories have no `.git` marker for collect_checkouts to find: a
+# repository directory is recognised by being its own git common directory,
+# whether it is bare or a detached non-bare git directory whose worktree is gone
+# or lives elsewhere. `core.bare` is deliberately not the test - a
+# `--separate-git-dir` target reports false and still holds objects nothing else
+# proves landed. Nested git directories (a worktree administrative dir) resolve
+# to an enclosing common directory instead and are left to the checkout that
+# owns them; a repository-shaped directory git cannot resolve is a refusal, not
+# a skip.
+collect_standalone_repos() {
+  local dir=$1 found head candidate canon common
   found=$(find -P "$dir" -type f -name HEAD -print 2>/dev/null) \
     || refuse "cannot inventory git repositories under $dir"
   [ -n "$found" ] || return 0
   while IFS= read -r head; do
     [ -n "$head" ] || continue
     candidate=$(dirname "$head")
-    canon=$(canonical_dir "$candidate") || continue
-    bare=$(git -C "$canon" rev-parse --is-bare-repository 2>/dev/null) || continue
-    [ "$bare" = true ] || continue
-    common=$(common_dir_of "$canon") || continue
+    looks_like_git_dir "$candidate" || continue
+    canon=$(canonical_dir "$candidate") \
+      || refuse "git repository directory $candidate cannot be resolved to a canonical directory; refusing on an ambiguous git result"
+    common=$(common_dir_of "$canon") \
+      || refuse "git repository directory $canon does not report a resolvable git directory; refusing on an ambiguous git result"
     [ "$common" = "$canon" ] || continue
-    BARE_REPOS+=("$canon")
+    STANDALONE_REPOS+=("$canon")
   done <<EOF
 $found
 EOF
@@ -417,6 +452,62 @@ common_dir_of() {
   [ -n "$common" ] || return 1
   case "$common" in /*) ;; *) common="$workdir/$common" ;; esac
   ( cd "$common" 2>/dev/null && pwd -P ) || return 1
+}
+
+# Echo the local filesystem path a remote URL names, or fail when the URL names
+# a network transport. Only local URLs can sit inside a removal target.
+remote_local_path() {
+  local workdir=$1 url=$2 path canon dir base
+  case "$url" in
+    file://localhost/*) path=${url#file://localhost} ;;
+    file:///*) path=${url#file://} ;;
+    *://*) return 1 ;;
+    /*) path=$url ;;
+    *)
+      # scp-like [user@]host:path carries its colon before any slash.
+      case "$url" in
+        */*) case "${url%%/*}" in *:*) return 1 ;; esac ;;
+        *:*) return 1 ;;
+      esac
+      path="$workdir/$url"
+      ;;
+  esac
+  [ -n "$path" ] || return 1
+  if canon=$(canonical_dir "$path"); then
+    printf '%s\n' "$canon"
+    return 0
+  fi
+  # A path that is not a directory right now still has to be placed: canonicalize
+  # the parent so a bare repository named but not yet resolvable still lands in
+  # the tree it belongs to.
+  dir=$(dirname "$path")
+  base=$(basename "$path")
+  if canon=$(canonical_dir "$dir"); then
+    printf '%s\n' "${canon%/}/$base"
+    return 0
+  fi
+  printf '%s\n' "${path%/}"
+}
+
+# Landing evidence has to outlive the removal that cites it. A remote pointing
+# at a mirror inside the retirement tree - or at the repository's own path -
+# fetches happily and makes every branch look like an exact ancestor of a ref
+# this same run destroys, so the proof proves nothing.
+assert_remote_evidence_survives() {
+  local common=$1 workdir=$2 remote=$3 urls url resolved i
+  urls=$(git -C "$workdir" remote get-url --all "$remote" 2>/dev/null) \
+    || refuse "cannot read the URL of remote $remote in repository $common; refusing on an ambiguous git result"
+  while IFS= read -r url; do
+    [ -n "$url" ] || continue
+    resolved=$(remote_local_path "$workdir" "$url") || continue
+    for i in "${!REMOVAL_TARGETS[@]}"; do
+      if path_equal_or_inside "$resolved" "${REMOVAL_TARGETS[$i]}"; then
+        refuse "repository $common takes its landing evidence from remote $remote ($url), which resolves to $resolved inside ${REMOVAL_LABELS[$i]} ${REMOVAL_TARGETS[$i]}; that evidence would be destroyed by this retirement, so it proves nothing"
+      fi
+    done
+  done <<EOF
+$urls
+EOF
 }
 
 patch_id_of() {
@@ -566,11 +657,24 @@ assert_inside_a_boundary() {
 assert_inside_a_boundary "$ROOT" "retirement root"
 [ -z "$POOL" ] || assert_inside_a_boundary "$POOL" "legacy pool root"
 
-assert_no_task_reference "$ROOT" "retirement root"
-[ -z "$POOL" ] || assert_no_task_reference "$POOL" "legacy pool root"
+# The removal targets are known as soon as the paths are validated, and every
+# later check - recorded tasks, live processes, and the remote URLs the landing
+# proof cites - is asked about all of them at once. Pool first, so the
+# authoritative repository is removed last.
+REMOVAL_TARGETS=()
+REMOVAL_LABELS=()
+if [ -n "$POOL" ]; then
+  REMOVAL_TARGETS+=("$POOL")
+  REMOVAL_LABELS+=("legacy pool root")
+fi
+REMOVAL_TARGETS+=("$ROOT")
+REMOVAL_LABELS+=("retirement root")
 
-assert_no_live_process_cwd "$ROOT" "retirement root"
-[ -z "$POOL" ] || assert_no_live_process_cwd "$POOL" "legacy pool root"
+for index in "${!REMOVAL_TARGETS[@]}"; do
+  assert_no_task_reference "${REMOVAL_TARGETS[$index]}" "${REMOVAL_LABELS[$index]}"
+done
+
+assert_no_live_process_cwd
 
 # --- inventory --------------------------------------------------------------
 
@@ -622,12 +726,12 @@ done <<EOF
 $SORTED_CHECKOUTS
 EOF
 
-collect_bare_repos "$ROOT"
-[ -z "$POOL" ] || collect_bare_repos "$POOL"
-for bare_repo in ${BARE_REPOS[@]+"${BARE_REPOS[@]}"}; do
-  path_equal_or_inside "$bare_repo" "$ROOT" \
-    || refuse "git repository $bare_repo has no worktree and lives outside the retirement root $ROOT"
-  remember_repo "$bare_repo" "$bare_repo"
+collect_standalone_repos "$ROOT"
+[ -z "$POOL" ] || collect_standalone_repos "$POOL"
+for standalone_repo in ${STANDALONE_REPOS[@]+"${STANDALONE_REPOS[@]}"}; do
+  path_equal_or_inside "$standalone_repo" "$ROOT" \
+    || refuse "git repository $standalone_repo has no worktree and lives outside the retirement root $ROOT"
+  remember_repo "$standalone_repo" "$standalone_repo"
 done
 
 for index in "${!REPO_COMMONS[@]}"; do
@@ -666,6 +770,7 @@ EOF
     || refuse "repository $common has no remote, so no landing evidence exists for its branches"
   while IFS= read -r remote; do
     [ -n "$remote" ] || continue
+    assert_remote_evidence_survives "$common" "$workdir" "$remote"
     git -C "$workdir" fetch --quiet --no-prune "$remote" 2>/dev/null \
       || refuse "cannot refresh landing evidence for repository $common: git fetch $remote failed"
   done <<EOF
@@ -705,8 +810,15 @@ EOF
 $branches
 EOF
 
-  unreachable=$(git -C "$workdir" fsck --unreachable --no-reflogs --no-progress --connectivity-only 2>/dev/null \
-    | sed -n 's/^unreachable commit //p' | LC_ALL=C sort -u || true)
+  # fsck's own exit status, not the pipeline's: piping it into sed would report
+  # a corrupt or unreadable object store as "no unreachable commits" and let the
+  # tree be deleted without its dangling objects ever being proven landed.
+  fsck_rc=0
+  fsck_output=$(git -C "$workdir" fsck --unreachable --no-reflogs --no-progress --connectivity-only 2>&1) \
+    || fsck_rc=$?
+  [ "$fsck_rc" -eq 0 ] \
+    || refuse "cannot check the object store of repository $common: git fsck exited $fsck_rc, so its unreachable commits cannot be enumerated:"$'\n'"$(printf '%s\n' "$fsck_output" | head -10)"
+  unreachable=$(printf '%s\n' "$fsck_output" | sed -n 's/^unreachable commit //p' | LC_ALL=C sort -u)
   unreachable_count=0
   while IFS= read -r sha; do
     [ -n "$sha" ] || continue
@@ -720,19 +832,6 @@ $unreachable
 EOF
   add_report "  $unreachable_count unreachable commits, all landed"
 done
-
-if [ -n "$POOL" ]; then
-  while IFS= read -r checkout; do
-    [ -n "$checkout" ] || continue
-    path_equal_or_inside "$checkout" "$POOL" || continue
-    common=$(common_dir_of "$checkout") \
-      || refuse "pool checkout $checkout does not report a resolvable git directory"
-    path_equal_or_inside "$common" "$ROOT" \
-      || refuse "pool checkout $checkout belongs to repository $common outside the retirement root $ROOT"
-  done <<EOF
-$SORTED_CHECKOUTS
-EOF
-fi
 
 # Top-level entries are part of the plan so the operator sees every non-checkout
 # file and directory the bounded removal would take with it.
@@ -773,10 +872,6 @@ PLAN_ID=$(
   } | digest_of_stdin
 ) || refuse "cannot compute a plan id: neither sha256sum nor shasum is available"
 [ -n "$PLAN_ID" ] || refuse "cannot compute a plan id from the inspected evidence"
-
-REMOVAL_TARGETS=()
-[ -z "$POOL" ] || REMOVAL_TARGETS+=("$POOL")
-REMOVAL_TARGETS+=("$ROOT")
 
 print_plan() {
   printf 'PLAN: guarded retirement of %s\n' "$ROOT"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,7 +131,7 @@ Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-
 
 Firstmate's own no-mistakes gate runs agents inside a checkout that also contains the fleet-captain identity in `AGENTS.md`, so gate execution needs an authority boundary separate from ordinary crewmate worktree isolation.
 The tracked `.no-mistakes.yaml` sets `disable_project_settings: true`; no-mistakes honors that setting only from the trusted default-branch copy, so a pushed branch cannot enable its own project instructions during validation.
-Independently, `fm-spawn.sh`, `fm-send.sh`, and `fm-teardown.sh` source `bin/fm-gate-refuse-lib.sh` and exit with status 3 before fleet mutation when the gate environment marker is present or the current checkout matches the default no-mistakes gate-repository topology.
+Independently, `fm-spawn.sh`, `fm-send.sh`, `fm-teardown.sh`, and `fm-project-retire.sh` source `bin/fm-gate-refuse-lib.sh` and exit with status 3 before fleet mutation when the gate environment marker is present or the current checkout matches the default no-mistakes gate-repository topology.
 A normal primary checkout or crewmate worktree has neither signal and remains unaffected.
 The helper's header owns the exact signal detection, relocated-home limitation, test-harness bypass, and relationship to no-mistakes' HEAD-continuity guard.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -49,7 +49,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live secondmates mid-session and send a pointer to the literal-content config reread when config changed |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
-| `fm-project-retire.sh`   | Guarded preflight-then-confirm retirement of an approved project tree and its proven linked pool |
+| `fm-project-retire.sh`   | Guarded preflight-then-confirm retirement of an approved out-of-registry project tree and its proven linked pool |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -49,6 +49,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live secondmates mid-session and send a pointer to the literal-content config reread when config changed |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
+| `fm-project-retire.sh`   | Guarded preflight-then-confirm retirement of an approved project tree and its proven linked pool |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |

--- a/tests/fm-project-retire.test.sh
+++ b/tests/fm-project-retire.test.sh
@@ -186,12 +186,41 @@ assert_contains "$OUT" "recorded task task-a" "task refusal names the task"
 pass "a live task reference refuses"
 
 new_fixture
+mkdir -p "$T/sm-home/state"
+printf -- '- sm - a second mate (id is legacy) covering x (home: %s; scope: y; added 2026-07-30)\n' \
+  "$T/sm-home" > "$T/home/data/secondmates.md"
+fm_write_meta "$T/sm-home/state/task-b.meta" \
+  "window=firstmate:fm-task-b" \
+  "worktree=$T/approved/pool/1/clone"
+preflight
+expect_code 1 "$RC" "a task recorded by a secondmate whose registry line has prose parentheses refuses"
+assert_contains "$OUT" "recorded task task-b" "the parenthetical registry line still yields its state directory"
+pass "a secondmate home is found even behind prose parentheses in its registry line"
+
+new_fixture
 mkdir -p "$T/proc/4242"
 ln -s "$T/approved/legacy/clone" "$T/proc/4242/cwd"
 preflight
 expect_code 1 "$RC" "a live process working inside the tree refuses"
 assert_contains "$OUT" "live process 4242" "process refusal names the pid"
+
+new_fixture
+mkdir -p "$T/proc/4243"
+ln -s "$T/approved/pool/1/clone" "$T/proc/4243/cwd"
+preflight
+expect_code 1 "$RC" "a live process working inside the proven pool refuses"
+assert_contains "$OUT" "legacy pool root" "the pool process refusal names the pool as the target"
 pass "a live process current directory refuses"
+
+new_fixture
+mkdir -p "$T/proc/11" "$T/proc/12" "$T/proc/13"
+ln -s "$T/seed" "$T/proc/11/cwd"
+ln -s "$T/home" "$T/proc/12/cwd"
+preflight
+expect_code 0 "$RC" "processes outside the retirement tree do not refuse"
+assert_contains "$OUT" "inspected 2 live process working directories (1 not inspectable" \
+  "the process table is walked once, so --pool does not double the reported coverage"
+pass "live-process coverage counts each process exactly once across every removal target"
 
 # --- git inventory ----------------------------------------------------------
 
@@ -242,7 +271,15 @@ preflight
 expect_code 1 "$RC" "a bare repository with no landing evidence refuses"
 assert_contains "$OUT" "orphan.git" "the bare repository is inventoried, not skipped"
 assert_contains "$OUT" "no remote" "the bare repository needs its own landing evidence"
-pass "a standalone repository with no checkout is still inventoried"
+
+new_fixture
+git init -q -b main --separate-git-dir "$T/approved/legacy/detached.git" "$T/approved/legacy/detached-work"
+rm -rf "$T/approved/legacy/detached-work"
+preflight
+expect_code 1 "$RC" "a detached non-bare git directory is inspected, not skipped"
+assert_contains "$OUT" "detached.git" "the detached git directory is inventoried"
+assert_contains "$OUT" "no remote" "the detached git directory needs its own landing evidence"
+pass "a standalone repository with no checkout is still inventoried, bare or not"
 
 new_fixture
 mkdir -p "$T/approved/pool/2"
@@ -278,6 +315,38 @@ preflight
 expect_code 1 "$RC" "a failed evidence refresh refuses"
 assert_contains "$OUT" "cannot refresh landing evidence" "stale-evidence refusal is explicit"
 pass "incomplete or unrefreshable landing evidence refuses"
+
+new_fixture
+git clone -q --bare "file://$T/upstream.git" "$T/approved/legacy/mirror.git"
+git -C "$T/approved/legacy/clone" remote set-url origin "file://$T/approved/legacy/mirror.git"
+preflight
+expect_code 1 "$RC" "landing evidence inside the retirement root refuses"
+assert_contains "$OUT" "would be destroyed by this retirement" "the doomed-evidence refusal explains itself"
+assert_contains "$OUT" "mirror.git" "the doomed-evidence refusal names the remote it distrusts"
+assert_present "$T/approved/legacy/clone" "nothing is removed when the evidence is doomed"
+
+new_fixture
+git -C "$T/approved/legacy/clone" remote set-url origin "$T/approved/legacy/clone"
+preflight
+expect_code 1 "$RC" "a self-remote is not landing evidence"
+assert_contains "$OUT" "would be destroyed by this retirement" "the self-remote refusal explains itself"
+
+new_fixture
+git -C "$T/approved/legacy/clone" remote set-url origin "file://$T/approved/pool/mirror.git"
+preflight
+expect_code 1 "$RC" "landing evidence inside the proven pool refuses"
+assert_contains "$OUT" "legacy pool root" "the pool-evidence refusal names the pool"
+pass "landing evidence that lives inside a removal target refuses"
+
+new_fixture
+mkdir -p "$T/approved/legacy/clone/.git/objects/ab"
+printf 'not an object at all' \
+  > "$T/approved/legacy/clone/.git/objects/ab/1234567890123456789012345678901234abcd"
+preflight
+expect_code 1 "$RC" "an unreadable object store refuses"
+assert_contains "$OUT" "cannot check the object store" "the fsck refusal is explicit"
+assert_present "$T/approved/legacy/clone" "a corrupt object store removes nothing"
+pass "a git fsck failure refuses instead of reporting no unreachable commits"
 
 new_fixture
 git -C "$T/approved/legacy/clone" checkout -q -b unlanded main

--- a/tests/fm-project-retire.test.sh
+++ b/tests/fm-project-retire.test.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# tests/fm-project-retire.test.sh - behavior tests for the guarded
+# project-retirement owner, bin/fm-project-retire.sh.
+#
+# Every fixture is built in a fresh temp root with its own fake firstmate home,
+# its own bare upstream, and its own fake /proc. No test reads, references, or
+# mutates any real project tree, Treehouse pool, or fleet home.
+set -eu
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+RETIRE="$ROOT/bin/fm-project-retire.sh"
+fm_git_identity
+
+T=
+OUT=
+RC=0
+
+# new_fixture: fresh temp root with
+#   $T/upstream.git       bare origin
+#   $T/seed               working clone used to publish upstream commits
+#   $T/home               fake firstmate home (FM_ROOT_OVERRIDE / FM_HOME)
+#   $T/approved           approved retirement boundary
+#   $T/approved/legacy    retirement root, holding clone/
+#   $T/approved/pool/1/clone   linked pool worktree of that clone
+#   $T/proc               fake process table (empty by default)
+new_fixture() {
+  T=$(fm_test_tmproot fm-project-retire)
+  mkdir -p "$T"
+  # fm_test_tmproot registers its cleanup inside a command-substitution subshell,
+  # so re-register in this shell and keep one EXIT trap that really fires.
+  FM_TEST_CLEANUP_DIRS+=("$T")
+  trap fm_test_cleanup EXIT
+  T=$(cd "$T" && pwd -P)
+  mkdir -p "$T/home/data" "$T/home/state" "$T/home/bin" "$T/approved/legacy" "$T/approved/pool" "$T/proc"
+  : > "$T/home/AGENTS.md"
+  git init -q --bare -b main "$T/upstream.git"
+  git init -q -b main "$T/seed"
+  printf 'seed\n' > "$T/seed/a.txt"
+  git -C "$T/seed" add a.txt
+  git -C "$T/seed" commit -qm initial
+  git -C "$T/seed" remote add origin "file://$T/upstream.git"
+  git -C "$T/seed" push -q origin main
+  git clone -q "file://$T/upstream.git" "$T/approved/legacy/clone"
+  git -C "$T/approved/legacy/clone" worktree add -q -b wt "$T/approved/pool/1/clone" main
+}
+
+# publish <subject> <file> <content>: land a commit on the bare upstream.
+publish() {
+  printf '%s\n' "$3" > "$T/seed/$2"
+  git -C "$T/seed" add "$2"
+  git -C "$T/seed" commit -qm "$1"
+  git -C "$T/seed" push -q origin main
+}
+
+run_retire() {
+  set +e
+  OUT=$(FM_ROOT_OVERRIDE="$T/home" FM_HOME="$T/home" FM_RETIRE_PROC_ROOT="$T/proc" \
+    "$RETIRE" "$@" 2>&1)
+  RC=$?
+  set -e
+}
+
+# preflight runs the fixture's standard flag set: root, proven pool, boundary.
+preflight() {
+  run_retire --root "$T/approved/legacy" --pool "$T/approved/pool" \
+    --boundary "$T/approved" --preflight
+}
+
+plan_id_of() {
+  printf '%s\n' "$OUT" | sed -n 's/^PLAN-ID: //p'
+}
+
+# --- usage contract ---------------------------------------------------------
+
+new_fixture
+run_retire --help
+expect_code 0 "$RC" "--help exits 0"
+assert_contains "$OUT" "the single guarded owner" "--help prints the contract"
+
+run_retire
+expect_code 2 "$RC" "no arguments is a usage error"
+
+run_retire --root approved/legacy --boundary "$T/approved" --preflight
+expect_code 2 "$RC" "a relative root is a usage error"
+assert_contains "$OUT" "must be an absolute path" "relative root names the absolute-path rule"
+
+run_retire --root "$T/approved/legacy/../legacy" --boundary "$T/approved" --preflight
+expect_code 2 "$RC" "an unnormalized root is a usage error"
+
+run_retire --root "$T/approved/legacy" --preflight
+expect_code 2 "$RC" "a missing boundary is a usage error"
+assert_contains "$OUT" "--boundary" "missing boundary names the flag"
+
+run_retire --root "$T/approved/legacy" --boundary "$T/approved" --execute --confirm-root "$T/approved/legacy"
+expect_code 2 "$RC" "--execute without --confirm-plan is a usage error"
+
+run_retire --root "$T/approved/legacy" --boundary "$T/approved" --execute \
+  --confirm-root "$T/approved" --confirm-plan deadbeef
+expect_code 2 "$RC" "--confirm-root must repeat --root exactly"
+assert_contains "$OUT" "does not repeat --root" "confirm-root mismatch is explicit"
+
+run_retire --root "$T/approved/legacy" --boundary "$T/approved" --preflight --execute
+expect_code 2 "$RC" "--preflight and --execute together is a usage error"
+pass "usage contract requires an explicit absolute root, boundary, and confirmations"
+
+# --- path safety ------------------------------------------------------------
+
+run_retire --root "$T/approved/missing" --boundary "$T/approved" --preflight
+expect_code 1 "$RC" "a missing root refuses"
+assert_contains "$OUT" "does not exist" "missing root says so"
+
+ln -s "$T/approved/legacy" "$T/approved/legacy-link"
+run_retire --root "$T/approved/legacy-link" --boundary "$T/approved" --preflight
+expect_code 1 "$RC" "a symlinked root refuses"
+assert_contains "$OUT" "is a symlink" "symlinked root says so"
+
+run_retire --root /tmp --boundary "$T/approved" --preflight
+expect_code 1 "$RC" "a shallow root refuses"
+assert_contains "$OUT" "too close to the filesystem root" "shallow root says so"
+pass "unsafe, symlinked, and non-canonical roots refuse"
+
+# --- protected fleet paths --------------------------------------------------
+
+new_fixture
+run_retire --root "$T/home" --boundary "$T" --preflight
+expect_code 1 "$RC" "the primary firstmate home refuses"
+assert_contains "$OUT" "the primary firstmate home" "home removal names the home"
+
+mkdir -p "$T/home/projects/alpha"
+printf -- '- alpha [no-mistakes] - a registered project (added 2026-07-30)\n' > "$T/home/data/projects.md"
+run_retire --root "$T/home/projects/alpha" --boundary "$T/home/projects" --preflight
+expect_code 1 "$RC" "a registered project clone inside the primary home refuses"
+assert_contains "$OUT" "the primary firstmate home" "nesting inside the home is the refusal"
+
+new_fixture
+mkdir -p "$T/approved/legacy/inner-home/state"
+: > "$T/approved/legacy/inner-home/AGENTS.md"
+OUT=$(FM_ROOT_OVERRIDE="$T/approved/legacy/inner-home" FM_HOME="$T/approved/legacy/inner-home" \
+  FM_RETIRE_PROC_ROOT="$T/proc" "$RETIRE" --root "$T/approved/legacy" \
+  --boundary "$T/approved" --preflight 2>&1) && RC=0 || RC=$?
+expect_code 1 "$RC" "a tree containing the primary home refuses"
+assert_contains "$OUT" "the primary firstmate home" "containment refusal names the home"
+pass "the primary home and anything nested in or containing it refuses"
+
+new_fixture
+printf -- '- sm - a second mate (home: %s; scope: x; projects: y; added 2026-07-30)\n' \
+  "$T/approved/legacy/sm-home" > "$T/home/data/secondmates.md"
+preflight
+expect_code 1 "$RC" "a tree containing a registered secondmate home refuses"
+assert_contains "$OUT" "registered secondmate home" "secondmate refusal names the registration"
+pass "registered secondmate homes inside the tree refuse"
+
+new_fixture
+printf -- '- alpha [local-only] - legacy copy at %s (added 2026-07-30)\n' \
+  "$T/approved/legacy/clone" > "$T/home/data/projects.md"
+preflight
+expect_code 1 "$RC" "a tree still named by the registry refuses"
+assert_contains "$OUT" "retire the registry entry first" "registry refusal says what to do"
+pass "a current registry reference refuses"
+
+# --- boundary contract ------------------------------------------------------
+
+new_fixture
+run_retire --root "$T/approved/legacy" --pool "$T/approved/pool" --boundary "$T" --preflight
+expect_code 1 "$RC" "a boundary containing the primary home refuses"
+assert_contains "$OUT" "retirement boundary" "boundary refusal names the boundary"
+
+mkdir -p "$T/elsewhere"
+run_retire --root "$T/approved/legacy" --pool "$T/approved/pool" --boundary "$T/elsewhere" --preflight
+expect_code 1 "$RC" "a root outside every boundary refuses"
+assert_contains "$OUT" "outside every approved retirement boundary" "boundary refusal is explicit"
+pass "the approved retirement boundary is enforced in both directions"
+
+# --- live references --------------------------------------------------------
+
+new_fixture
+fm_write_meta "$T/home/state/task-a.meta" \
+  "window=firstmate:fm-task-a" \
+  "worktree=$T/approved/pool/1/clone" \
+  "project=$T/approved/legacy/clone"
+preflight
+expect_code 1 "$RC" "a recorded task reference refuses"
+assert_contains "$OUT" "recorded task task-a" "task refusal names the task"
+pass "a live task reference refuses"
+
+new_fixture
+mkdir -p "$T/proc/4242"
+ln -s "$T/approved/legacy/clone" "$T/proc/4242/cwd"
+preflight
+expect_code 1 "$RC" "a live process working inside the tree refuses"
+assert_contains "$OUT" "live process 4242" "process refusal names the pid"
+pass "a live process current directory refuses"
+
+# --- git inventory ----------------------------------------------------------
+
+new_fixture
+mkdir -p "$T/approved/plain/sub"
+run_retire --root "$T/approved/plain" --boundary "$T/approved" --preflight
+expect_code 1 "$RC" "a tree with no checkout refuses"
+assert_contains "$OUT" "no git checkout found" "empty-tree refusal is explicit"
+
+new_fixture
+printf 'edited\n' >> "$T/approved/legacy/clone/a.txt"
+preflight
+expect_code 1 "$RC" "a dirty checkout refuses"
+assert_contains "$OUT" "dirty or untracked files" "dirty refusal is explicit"
+assert_contains "$OUT" "a.txt" "dirty refusal names the file"
+
+new_fixture
+printf 'scratch\n' > "$T/approved/pool/1/clone/scratch.txt"
+preflight
+expect_code 1 "$RC" "an untracked file refuses"
+assert_contains "$OUT" "scratch.txt" "untracked refusal names the file"
+pass "dirty and untracked files refuse"
+
+new_fixture
+run_retire --root "$T/approved/legacy" --boundary "$T/approved" --preflight
+expect_code 1 "$RC" "a linked worktree outside the root refuses without --pool"
+assert_contains "$OUT" "outside the retirement tree" "linked-worktree refusal is explicit"
+
+new_fixture
+git -C "$T/approved/legacy/clone" worktree lock "$T/approved/pool/1/clone"
+preflight
+expect_code 1 "$RC" "a locked worktree refuses"
+assert_contains "$OUT" "locked (in use) worktree" "locked-worktree refusal is explicit"
+pass "linked and in-use worktrees refuse"
+
+new_fixture
+git -C "$T/approved/legacy/clone" worktree add -q -b gone "$T/approved/legacy/gone" main
+rm -rf "$T/approved/legacy/gone"
+preflight
+expect_code 1 "$RC" "a stale worktree registration refuses"
+assert_contains "$OUT" "stale worktree registration" "stale-registration refusal is explicit"
+pass "a stale worktree registration refuses instead of being pruned away"
+
+new_fixture
+git init -q --bare -b main "$T/approved/legacy/orphan.git"
+git -C "$T/approved/legacy/orphan.git" fetch -q "file://$T/upstream.git" "main:refs/heads/main"
+preflight
+expect_code 1 "$RC" "a bare repository with no landing evidence refuses"
+assert_contains "$OUT" "orphan.git" "the bare repository is inventoried, not skipped"
+assert_contains "$OUT" "no remote" "the bare repository needs its own landing evidence"
+pass "a standalone repository with no checkout is still inventoried"
+
+new_fixture
+mkdir -p "$T/approved/pool/2"
+git init -q -b main "$T/outside-repo"
+printf 'x\n' > "$T/outside-repo/x.txt"
+git -C "$T/outside-repo" add x.txt
+git -C "$T/outside-repo" commit -qm outside
+git -C "$T/outside-repo" worktree add -q -b y "$T/approved/pool/2/outside" main
+preflight
+expect_code 1 "$RC" "a pool member of a foreign repository refuses"
+assert_contains "$OUT" "outside the retirement root" "foreign pool member refusal is explicit"
+
+new_fixture
+rm -rf "$T/approved/pool"
+mkdir -p "$T/approved/emptypool"
+run_retire --root "$T/approved/legacy" --pool "$T/approved/emptypool" \
+  --boundary "$T/approved" --preflight
+expect_code 1 "$RC" "an unproven pool refuses"
+assert_contains "$OUT" "cannot be proven linked" "unproven pool refusal is explicit"
+pass "the legacy pool must be proven linked to the retirement root"
+
+# --- landing evidence -------------------------------------------------------
+
+new_fixture
+git -C "$T/approved/legacy/clone" remote remove origin
+preflight
+expect_code 1 "$RC" "a repository with no remote refuses"
+assert_contains "$OUT" "no remote" "missing-remote refusal is explicit"
+
+new_fixture
+git -C "$T/approved/legacy/clone" remote set-url origin "file://$T/no-such-upstream.git"
+preflight
+expect_code 1 "$RC" "a failed evidence refresh refuses"
+assert_contains "$OUT" "cannot refresh landing evidence" "stale-evidence refusal is explicit"
+pass "incomplete or unrefreshable landing evidence refuses"
+
+new_fixture
+git -C "$T/approved/legacy/clone" checkout -q -b unlanded main
+printf 'only here\n' > "$T/approved/legacy/clone/local.txt"
+git -C "$T/approved/legacy/clone" add local.txt
+git -C "$T/approved/legacy/clone" commit -qm "local only work"
+git -C "$T/approved/legacy/clone" checkout -q main
+preflight
+expect_code 1 "$RC" "an unpushed, unlanded branch refuses"
+assert_contains "$OUT" "unlanded branch unlanded" "unlanded refusal names the branch"
+
+new_fixture
+publish "the real change" real.txt "authoritative"
+git -C "$T/approved/legacy/clone" checkout -q -b lookalike main
+printf 'something else entirely\n' > "$T/approved/legacy/clone/real.txt"
+git -C "$T/approved/legacy/clone" add real.txt
+git -C "$T/approved/legacy/clone" commit -qm "the real change"
+git -C "$T/approved/legacy/clone" checkout -q main
+preflight
+expect_code 1 "$RC" "a matching commit subject is not landing proof"
+assert_contains "$OUT" "unlanded branch lookalike" "subject-match refusal names the branch"
+assert_contains "$OUT" "not patch-equivalent" "subject-match refusal explains the real test"
+pass "unpushed work and lookalike subjects refuse"
+
+new_fixture
+git -C "$T/approved/legacy/clone" checkout -q -b scratch main
+printf 'lost work\n' > "$T/approved/legacy/clone/lost.txt"
+git -C "$T/approved/legacy/clone" add lost.txt
+git -C "$T/approved/legacy/clone" commit -qm "work in progress"
+git -C "$T/approved/legacy/clone" checkout -q main
+git -C "$T/approved/legacy/clone" branch -qD scratch
+preflight
+expect_code 1 "$RC" "an unreachable unique commit refuses"
+assert_contains "$OUT" "unreachable commit" "unreachable refusal is explicit"
+pass "an unreachable unique commit refuses"
+
+# --- successful preflight, including squash-landed history ------------------
+
+new_fixture
+git -C "$T/approved/legacy/clone" checkout -q -b feature main
+printf 'one\n' > "$T/approved/legacy/clone/f1.txt"
+git -C "$T/approved/legacy/clone" add f1.txt
+git -C "$T/approved/legacy/clone" commit -qm "feature part one"
+printf 'two\n' > "$T/approved/legacy/clone/f2.txt"
+git -C "$T/approved/legacy/clone" add f2.txt
+git -C "$T/approved/legacy/clone" commit -qm "feature part two"
+git -C "$T/approved/legacy/clone" checkout -q main
+printf 'one\n' > "$T/seed/f1.txt"
+printf 'two\n' > "$T/seed/f2.txt"
+git -C "$T/seed" add f1.txt f2.txt
+git -C "$T/seed" commit -qm "squashed feature"
+git -C "$T/seed" push -q origin main
+
+preflight
+expect_code 0 "$RC" "a clean, fully landed tree preflights"
+assert_contains "$OUT" "branch feature landed" "the squash-landed branch is proven"
+assert_contains "$OUT" "content already contained in" "squash landing uses content containment, not subjects"
+assert_contains "$OUT" "PREFLIGHT OK" "preflight reports success"
+assert_contains "$OUT" "rm -rf -- $T/approved/pool" "the plan names the pool removal"
+assert_contains "$OUT" "rm -rf -- $T/approved/legacy" "the plan names the root removal"
+assert_present "$T/approved/legacy/clone" "preflight removes nothing"
+assert_present "$T/approved/pool/1/clone" "preflight leaves the pool alone"
+PLAN_ID=$(plan_id_of)
+[ -n "$PLAN_ID" ] || fail "preflight must print a plan id"
+pass "preflight proves squash-landed history and removes nothing"
+
+# --- execution requires a matching second confirmation ----------------------
+
+run_retire --root "$T/approved/legacy" --pool "$T/approved/pool" --boundary "$T/approved" \
+  --execute --confirm-root "$T/approved/legacy" --confirm-plan "not-the-plan-id"
+expect_code 1 "$RC" "a wrong plan id refuses"
+assert_contains "$OUT" "no longer matches the current evidence" "plan mismatch is explicit"
+assert_present "$T/approved/legacy/clone" "a refused execution removes nothing"
+
+git -C "$T/approved/legacy/clone" branch -q raced main
+run_retire --root "$T/approved/legacy" --pool "$T/approved/pool" --boundary "$T/approved" \
+  --execute --confirm-root "$T/approved/legacy" --confirm-plan "$PLAN_ID"
+expect_code 1 "$RC" "evidence that changed after preflight refuses"
+assert_contains "$OUT" "Nothing was removed" "the race refusal says nothing was removed"
+assert_present "$T/approved/legacy/clone" "the raced tree survives"
+assert_present "$T/approved/pool/1/clone" "the raced pool survives"
+pass "execution refuses when evidence changed between approval and removal"
+
+# --- successful bounded execution -------------------------------------------
+
+preflight
+expect_code 0 "$RC" "re-preflight after the race succeeds"
+PLAN_ID=$(plan_id_of)
+run_retire --root "$T/approved/legacy" --pool "$T/approved/pool" --boundary "$T/approved" \
+  --execute --confirm-root "$T/approved/legacy" --confirm-plan "$PLAN_ID"
+expect_code 0 "$RC" "the re-approved plan executes"
+assert_contains "$OUT" "RETIRED: removed $T/approved/pool" "the pool is reported removed"
+assert_contains "$OUT" "RETIRED: removed $T/approved/legacy" "the root is reported removed"
+assert_absent "$T/approved/legacy" "the retirement root is gone"
+assert_absent "$T/approved/pool" "the proven pool is gone"
+assert_present "$T/approved" "the boundary itself is untouched"
+assert_present "$T/home/AGENTS.md" "the firstmate home is untouched"
+assert_present "$T/upstream.git" "the upstream repository is untouched"
+assert_present "$T/seed/a.txt" "unrelated neighbours are untouched"
+pass "execution removes exactly the approved tree and its proven pool"

--- a/tests/fm-project-retire.test.sh
+++ b/tests/fm-project-retire.test.sh
@@ -105,6 +105,27 @@ run_retire --root "$T/approved/legacy" --boundary "$T/approved" --preflight --ex
 expect_code 2 "$RC" "--preflight and --execute together is a usage error"
 pass "usage contract requires an explicit absolute root, boundary, and confirmations"
 
+# --- no-mistakes gate refusal -----------------------------------------------
+#
+# docs/architecture.md lists this owner alongside fm-spawn/fm-send/fm-teardown as
+# a bin/fm-gate-refuse-lib.sh caller. tests/lib.sh exports FM_GATE_REFUSE_BYPASS
+# for the whole suite, so strip it here and run from a neutral cwd to isolate the
+# env-marker signal: an otherwise perfectly valid retirement must still exit 3
+# before it inspects or removes anything.
+
+new_fixture
+set +e
+OUT=$(cd "$T" && env -u FM_GATE_REFUSE_BYPASS NO_MISTAKES_GATE=1 \
+  FM_ROOT_OVERRIDE="$T/home" FM_HOME="$T/home" FM_RETIRE_PROC_ROOT="$T/proc" \
+  "$RETIRE" --root "$T/approved/legacy" --pool "$T/approved/pool" \
+  --boundary "$T/approved" --preflight 2>&1)
+RC=$?
+set -e
+expect_code 3 "$RC" "a no-mistakes gate agent is refused"
+assert_contains "$OUT" "must not drive the fleet" "the gate refusal names its signal"
+assert_present "$T/approved/legacy/clone" "the gate refusal inspects and removes nothing"
+pass "a no-mistakes gate agent cannot drive a fleet removal"
+
 # --- path safety ------------------------------------------------------------
 
 run_retire --root "$T/approved/missing" --boundary "$T/approved" --preflight


### PR DESCRIPTION
## Intent

The developer, working as an autonomous agent under a Firstmate captain, had built bin/fm-project-retire.sh — a guarded removal command for retiring an out-of-registry legacy project tree — and was running it through the no-mistakes validation pipeline. At the review gate the pipeline raised one ask-user finding plus five auto-fix findings; the developer approved Option A for the ask-user finding, directing that the helper and project-management skill be scoped to approved out-of-registry trees only, that the separate registered-project removal rule be restored, that all primary-home and registered/active-home refusals be preserved, and that no registered-clone mode be added, supplying an exact axi respond command and forbidding --yes. After the run reached checks-passed on PR 1354 with the five auto-fix findings verifiably unfixed, the developer approved a fresh full validation run from the current reviewed head so the gate would re-raise and fix all five: reject landing evidence or remote URLs contained inside the deletion target, inspect rather than skip detached Git directories, treat git fsck failure as a hard refusal, eliminate process-use double counting when --pool is passed, and remove the redundant pool loop without weakening coverage. The developer explicitly constrained the work to preserve the existing branch and PR, keep the Option A out-of-registry-only scope intact, and forbade --yes, hand-edits during the run, forcing history, merging the current head, deleting the PR, or deferring any of the five findings, requiring every gate return be processed until a genuinely new decision or a fully green exact head.

## What Changed

- Adds `bin/fm-project-retire.sh`, a preflight-then-confirm owner for removing a captain-approved out-of-registry project tree and, optionally, its proven linked Treehouse pool. It refuses on protected fleet paths, registry- or task-referenced paths, dirty or unlanded work, foreign/locked/stale worktrees, live process working directories, remote URLs or landing evidence that resolve inside a removal target, and `git fsck` failures; it discovers standalone repositories by their own git common dir rather than `core.bare`; it walks `/proc` once so `--pool` runs report each process once; and `--execute` only proceeds when `--confirm-root` and the plan id from `--preflight` still match the inspected evidence. It also joins the other fleet entrypoints in sourcing `bin/fm-gate-refuse-lib.sh` to exit 3 under a no-mistakes gate.
- Splits the `project-management` skill's removal section into a registered-project path (unchanged, direct removal under AGENTS.md hard rule 1) and an out-of-registry retirement path that delegates flags, refusals, and mechanics to the helper's header, with the registry line retired before the tree.
- Registers the new authorization exception and skill trigger in `AGENTS.md`, and lists the script in `docs/scripts.md` and the gate-refusal entrypoints in `docs/architecture.md`. Adds `tests/fm-project-retire.test.sh` (24 checks) covering the refusal ladder, plan-id confirmation, and gate refusal.

## Risk Assessment

✅ Low: All six previously approved findings are correctly and completely fixed in a fail-closed direction with colocated tests, the settled out-of-registry-only scope and every existing guard are preserved, and the only remaining issue is an ordering inaccuracy in the header's refusal list.

## Testing

I ran the change's dedicated suite (`tests/fm-project-retire.test.sh`, 24 checks, all passing) and then drove the real script by hand against throwaway git fixtures to capture an operator-level CLI transcript, because unit-style pass lines say nothing about what an operator actually sees before deleting a project tree. The transcript shows the Option A scope holding (registered projects and registry-named trees refuse), all five hardened guards refusing with their real messages and leaving the tree intact, and the complete preflight → plan-id → execute path removing exactly the approved root and its proven pool while the upstream, boundary directory, seed clone and fleet home survive. I also closed one coverage gap: this change documents `fm-project-retire.sh` as a `fm-gate-refuse-lib.sh` caller in docs/architecture.md, but nothing tested it (the suite exports the bypass globally), so I added a focused case that strips the bypass and asserts the exit-3 refusal before any inspection. No visual artifacts apply — this is a shell CLI with no rendered surface, so the terminal transcript is the end-user experience. Everything passed; no actionable findings.

<details>
<summary>Evidence: Operator CLI transcript: guarded retirement refusals and full preflight→execute run</summary>

```text
fm-project-retire.sh - guarded retirement of an out-of-registry legacy project tree
demo root: /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo


=== SCOPE: a REGISTERED project under the fleet home is out of scope and always refuses ===

$ retire scope --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/scope/home/projects/alpha --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/scope/home/projects --preflight
REFUSED: retirement root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/scope/home/projects/alpha is, contains, or sits inside the primary firstmate home (/tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/scope/home)
[exit 1]


=== SCOPE: an out-of-registry tree still NAMED by data/projects.md refuses ===

$ retire named --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/named/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/named/approved/pool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/named/approved --preflight
REFUSED: retirement root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/named/approved/legacy is still referenced by /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/named/home/data/projects.md (/tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/named/approved/legacy/clone); retire the registry entry first
[exit 1]


=== UNLANDED WORK: a branch that exists nowhere upstream refuses ===

$ retire unlanded --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/unlanded/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/unlanded/approved/pool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/unlanded/approved --preflight
REFUSED: repository /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/unlanded/approved/legacy/clone/.git has unlanded branch wip at 1394baabed4d52be8ef5401085840f53ae862c3b: commit 1394baabed4d52be8ef5401085840f53ae862c3b is not patch-equivalent to any upstream commit
[exit 1]


=== FINDING 1: landing evidence that lives INSIDE the deletion target refuses ===

$ retire doomed --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/doomed/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/doomed/approved/pool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/doomed/approved --preflight
REFUSED: repository /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/doomed/approved/legacy/clone/.git takes its landing evidence from remote origin (file:///tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/doomed/approved/legacy/mirror.git), which resolves to /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/doomed/approved/legacy/mirror.git inside retirement root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/doomed/approved/legacy; that evidence would be destroyed by this retirement, so it proves nothing
[exit 1]

$ test -d /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/doomed/approved/legacy/clone && echo "clone still present"
clone still present


=== FINDING 2: a DETACHED git directory (no worktree) is inspected, not skipped ===

$ retire detached --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/detached/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/detached/approved/pool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/detached/approved --preflight
REFUSED: repository /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/detached/approved/legacy/detached.git has no remote, so no landing evidence exists for its branches
[exit 1]


=== FINDING 3: a git fsck failure is a hard refusal, never 'no unreachable commits' ===

$ retire corrupt --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/corrupt/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/corrupt/approved/pool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/corrupt/approved --preflight
REFUSED: cannot check the object store of repository /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/corrupt/approved/legacy/clone/.git: git fsck exited 128, so its unreachable commits cannot be enumerated:
error: inflate: data stream error (incorrect header check)
error: unable to unpack ab1234567890123456789012345678901234abcd header
error: inflate: data stream error (incorrect header check)
error: unable to unpack ab1234567890123456789012345678901234abcd header
fatal: loose object ab1234567890123456789012345678901234abcd (stored in .git/objects/ab/1234567890123456789012345678901234abcd) is corrupt
[exit 1]

$ test -d /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/corrupt/approved/legacy/clone && echo "clone still present"
clone still present


=== IN USE: a live process working inside the pool refuses ===

$ fm-project-retire.sh --root .../legacy --pool .../pool --boundary .../approved --preflight
REFUSED: legacy pool root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/inuse/approved/pool is the current directory of live process 4243 (/tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/inuse/approved/pool/1/clone)
[exit 1]


=== FINDING 4: with --pool the process table is walked ONCE (no double counting) ===

fake process table: 3 entries, 2 readable, 1 not inspectable

$ ... --pool ... --preflight | grep "inspected"
PLAN:   repository /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/count/approved/legacy/clone/.git inspected from /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/count/approved/legacy/clone
PLAN: inspected 2 live process working directories (1 not inspectable by this user)

$ ... (no --pool, single target) --preflight | grep "inspected"
PLAN:   repository /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/count/approved/legacy/clone/.git inspected from /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/count/approved/legacy/clone
PLAN: inspected 2 live process working directories (1 not inspectable by this user)


=== FINDING 5: pool coverage is undiminished - a pool is still checked in its own right ===

(a) landing evidence that would be destroyed with the POOL

$ retire poolev --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolev/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolev/approved/pool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolev/approved --preflight
REFUSED: repository /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolev/approved/legacy/clone/.git takes its landing evidence from remote origin (file:///tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolev/approved/pool/mirror.git), which resolves to /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolev/approved/pool/mirror.git inside legacy pool root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolev/approved/pool; that evidence would be destroyed by this retirement, so it proves nothing
[exit 1]

(b) a --pool that holds no checkout of the retired repository

$ retire poolunproven --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolunproven/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolunproven/approved/emptypool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolunproven/approved --preflight
REFUSED: legacy pool root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolunproven/approved/emptypool holds no git checkout, so it cannot be proven linked to /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolunproven/approved/legacy
[exit 1]

(c) the pool worktree exists but --pool was never approved

$ retire poolunnamed --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolunnamed/approved/legacy --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolunnamed/approved --preflight
REFUSED: repository /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolunnamed/approved/legacy/clone/.git has linked worktree /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/poolunnamed/approved/pool/1/clone outside the retirement tree
[exit 1]


=== HAPPY PATH: a clean, fully landed tree - preflight, approve, execute ===

$ ls /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved
legacy
pool

$ retire live --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved --preflight
PLAN: guarded retirement of /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy
PLAN:   checkout /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy/clone at 1fe686cac9a5c39ef52ddfae5b12fff6f9a182f2, clean
PLAN:   checkout /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool/1/clone at 1fe686cac9a5c39ef52ddfae5b12fff6f9a182f2, clean
PLAN:   repository /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy/clone/.git inspected from /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy/clone
PLAN:     worktree /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy/clone
PLAN:     worktree /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool/1/clone
PLAN:     branch feature landed (content already contained in refs/remotes/origin/main)
PLAN:     branch main landed (exact ancestry of refs/remotes/origin/main)
PLAN:     branch slot-1 landed (exact ancestry of refs/remotes/origin/main)
PLAN:     0 unreachable commits, all landed
PLAN:   retirement root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy
PLAN:     contains clone
PLAN:   legacy pool root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool
PLAN:     contains 1
PLAN: inspected 380 live process working directories (190 not inspectable by this user)
PLAN: removal step 1: rm -rf -- /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool
PLAN: removal step 2: rm -rf -- /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy
PLAN-ID: 1a63fcdadc4bcc3081265e18fc3fd25056aa5af6242ac2e0284a0c8fe432a7bd
PREFLIGHT OK: every check passed and nothing was removed.
To remove exactly this plan, re-run with:
  /home/exedev/.no-mistakes/worktrees/579deb6a33c1/01KYV1J14NXRCHYXRCJF336DTT/bin/fm-project-retire.sh --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved --execute --confirm-root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy --confirm-plan 1a63fcdadc4bcc3081265e18fc3fd25056aa5af6242ac2e0284a0c8fe432a7bd
[exit 0]


=== EXECUTE with a plan id nobody approved ===

$ retire live --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved --execute --confirm-root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy --confirm-plan not-the-plan-id
REFUSED: the approved plan no longer matches the current evidence.
  approved plan id: not-the-plan-id
  current plan id:  1a63fcdadc4bcc3081265e18fc3fd25056aa5af6242ac2e0284a0c8fe432a7bd
Nothing was removed. Re-run --preflight, review the new plan, and approve it deliberately.
[exit 1]


=== EXECUTE after the tree changed under the approved plan ===

$ retire live --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved --execute --confirm-root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy --confirm-plan 1a63fcdadc4bcc3081265e18fc3fd25056aa5af6242ac2e0284a0c8fe432a7bd
REFUSED: the approved plan no longer matches the current evidence.
  approved plan id: 1a63fcdadc4bcc3081265e18fc3fd25056aa5af6242ac2e0284a0c8fe432a7bd
  current plan id:  201c6a35dae9a97bee6251f8fb658e0a821f54872e3f3190070b0afbd72c58a1
Nothing was removed. Re-run --preflight, review the new plan, and approve it deliberately.
[exit 1]

$ ls /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved
legacy
pool


=== EXECUTE the freshly approved plan ===
newly approved plan id: 201c6a35dae9a97bee6251f8fb658e0a821f54872e3f3190070b0afbd72c58a1

$ retire live --root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy --pool /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool --boundary /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved --execute --confirm-root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy --confirm-plan 201c6a35dae9a97bee6251f8fb658e0a821f54872e3f3190070b0afbd72c58a1
PLAN: guarded retirement of /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy
PLAN:   checkout /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy/clone at 1fe686cac9a5c39ef52ddfae5b12fff6f9a182f2, clean
PLAN:   checkout /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool/1/clone at 1fe686cac9a5c39ef52ddfae5b12fff6f9a182f2, clean
PLAN:   repository /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy/clone/.git inspected from /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy/clone
PLAN:     worktree /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy/clone
PLAN:     worktree /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool/1/clone
PLAN:     branch feature landed (content already contained in refs/remotes/origin/main)
PLAN:     branch main landed (exact ancestry of refs/remotes/origin/main)
PLAN:     branch raced landed (exact ancestry of refs/remotes/origin/main)
PLAN:     branch slot-1 landed (exact ancestry of refs/remotes/origin/main)
PLAN:     0 unreachable commits, all landed
PLAN:   retirement root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy
PLAN:     contains clone
PLAN:   legacy pool root /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool
PLAN:     contains 1
PLAN: inspected 379 live process working directories (190 not inspectable by this user)
PLAN: removal step 1: rm -rf -- /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool
PLAN: removal step 2: rm -rf -- /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy
PLAN-ID: 201c6a35dae9a97bee6251f8fb658e0a821f54872e3f3190070b0afbd72c58a1
RETIRED: removed /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/pool
RETIRED: removed /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved/legacy
RETIRED: plan 201c6a35dae9a97bee6251f8fb658e0a821f54872e3f3190070b0afbd72c58a1 completed; 2 removal target(s) gone, nothing else was touched.
[exit 0]


=== AFTER: exactly the approved tree and its proven pool are gone ===

$ ls -A /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/approved
(empty listing above = both removal targets gone, boundary itself untouched)

$ ls /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live
approved
home
seed
upstream.git

$ git -C /tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo/live/upstream.git log --oneline -3
2936e25 squashed feature
1fe686c initial

(upstream, seed clone and the fleet home all survived untouched)
```
</details>
<details>
<summary>Evidence: Transcript driver (reproduces the evidence above)</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end demonstration of bin/fm-project-retire.sh as an operator
# experiences it. Builds throwaway fixtures under $DEMO, drives the real script,
# and prints the real stdout/stderr of every step.
set -eu

RETIRE=$1
DEMO=$2
export FM_GATE_REFUSE_BYPASS=1   # this transcript is captured from inside a
                                 # no-mistakes gate worktree, which the script
                                 # otherwise refuses outright (exit 3).
export GIT_AUTHOR_NAME=demo GIT_AUTHOR_EMAIL=demo@example.com
export GIT_COMMITTER_NAME=demo GIT_COMMITTER_EMAIL=demo@example.com
export GIT_CONFIG_GLOBAL=$DEMO/gitconfig GIT_CONFIG_SYSTEM=/dev/null
: > "$DEMO/gitconfig"

step() { printf '\n\n=== %s ===\n' "$*"; }
cmd() {
  printf '\n$ %s\n' "$*"
  set +e; "$@"; local rc=$?; set -e
  printf '[exit %s]\n' "$rc"
}

# fresh_tree <name>: a legacy out-of-registry project tree with one clone and a
# linked Treehouse-style pool worktree, plus a fake fleet home and a real bare
# upstream that holds the landed history.
fresh_tree() {
  local n=$1 t="$DEMO/$1"
  rm -rf "$t"; mkdir -p "$t/home/data" "$t/home/state" "$t/approved/legacy" "$t/approved/pool"
  : > "$t/home/AGENTS.md"
  git init -q --bare -b main "$t/upstream.git"
  git init -q -b main "$t/seed"
  printf 'seed\n' > "$t/seed/a.txt"
  git -C "$t/seed" add a.txt && git -C "$t/seed" commit -qm "initial"
  git -C "$t/seed" remote add origin "file://$t/upstream.git"
  git -C "$t/seed" push -q origin main
  git clone -q "file://$t/upstream.git" "$t/approved/legacy/clone"
  git -C "$t/approved/legacy/clone" worktree add -q -b slot-1 "$t/approved/pool/1/clone" main
}

# retire <tree> [args...]: run the real owner against fixture <tree>'s fake home.
retire() {
  local t="$DEMO/$1"; shift
  FM_ROOT_OVERRIDE="$t/home" FM_HOME="$t/home" "$RETIRE" "$@"
}

printf 'fm-project-retire.sh - guarded retirement of an out-of-registry legacy project tree\n'
printf 'demo root: %s\n' "$DEMO"

step "SCOPE: a REGISTERED project under the fleet home is out of scope and always refuses"
fresh_tree scope
mkdir -p "$DEMO/scope/home/projects/alpha"
printf -- '- alpha [no-mistakes] - a registered project (added 2026-07-30)\n' \
  > "$DEMO/scope/home/data/projects.md"
cmd retire scope --root "$DEMO/scope/home/projects/alpha" \
  --boundary "$DEMO/scope/home/projects" --preflight

step "SCOPE: an out-of-registry tree still NAMED by data/projects.md refuses"
fresh_tree named
printf -- '- alpha [local-only] - legacy copy at %s (added 2026-07-30)\n' \
  "$DEMO/named/approved/legacy/clone" > "$DEMO/named/home/data/projects.md"
cmd retire named --root "$DEMO/named/approved/legacy" --pool "$DEMO/named/approved/pool" \
  --boundary "$DEMO/named/approved" --preflight

step "UNLANDED WORK: a branch that exists nowhere upstream refuses"
fresh_tree unlanded
git -C "$DEMO/unlanded/approved/legacy/clone" checkout -q -b wip main
printf 'only here\n' > "$DEMO/unlanded/approved/legacy/clone/local.txt"
git -C "$DEMO/unlanded/approved/legacy/clone" add local.txt
git -C "$DEMO/unlanded/approved/legacy/clone" commit -qm "work in progress"
git -C "$DEMO/unlanded/approved/legacy/clone" checkout -q main
cmd retire unlanded --root "$DEMO/unlanded/approved/legacy" --pool "$DEMO/unlanded/approved/pool" \
  --boundary "$DEMO/unlanded/approved" --preflight

step "FINDING 1: landing evidence that lives INSIDE the deletion target refuses"
fresh_tree doomed
git clone -q --bare "file://$DEMO/doomed/upstream.git" "$DEMO/doomed/approved/legacy/mirror.git"
git -C "$DEMO/doomed/approved/legacy/clone" remote set-url origin \
  "file://$DEMO/doomed/approved/legacy/mirror.git"
cmd retire doomed --root "$DEMO/doomed/approved/legacy" --pool "$DEMO/doomed/approved/pool" \
  --boundary "$DEMO/doomed/approved" --preflight
printf '\n$ test -d %s && echo "clone still present"\n' "$DEMO/doomed/approved/legacy/clone"
test -d "$DEMO/doomed/approved/legacy/clone" && echo "clone still present"

step "FINDING 2: a DETACHED git directory (no worktree) is inspected, not skipped"
fresh_tree detached
git init -q -b main --separate-git-dir "$DEMO/detached/approved/legacy/detached.git" \
  "$DEMO/detached/approved/legacy/detached-work" >/dev/null
rm -rf "$DEMO/detached/approved/legacy/detached-work"
cmd retire detached --root "$DEMO/detached/approved/legacy" --pool "$DEMO/detached/approved/pool" \
  --boundary "$DEMO/detached/approved" --preflight

step "FINDING 3: a git fsck failure is a hard refusal, never 'no unreachable commits'"
fresh_tree corrupt
mkdir -p "$DEMO/corrupt/approved/legacy/clone/.git/objects/ab"
printf 'not an object at all' \
  > "$DEMO/corrupt/approved/legacy/clone/.git/objects/ab/1234567890123456789012345678901234abcd"
cmd retire corrupt --root "$DEMO/corrupt/approved/legacy" --pool "$DEMO/corrupt/approved/pool" \
  --boundary "$DEMO/corrupt/approved" --preflight
printf '\n$ test -d %s && echo "clone still present"\n' "$DEMO/corrupt/approved/legacy/clone"
test -d "$DEMO/corrupt/approved/legacy/clone" && echo "clone still present"

step "IN USE: a live process working inside the pool refuses"
fresh_tree inuse
mkdir -p "$DEMO/inuse/proc/4243"
ln -s "$DEMO/inuse/approved/pool/1/clone" "$DEMO/inuse/proc/4243/cwd"
printf '\n$ %s --root .../legacy --pool .../pool --boundary .../approved --preflight\n' \
  "$(basename "$RETIRE")"
set +e
FM_RETIRE_PROC_ROOT="$DEMO/inuse/proc" retire inuse --root "$DEMO/inuse/approved/legacy" \
  --pool "$DEMO/inuse/approved/pool" --boundary "$DEMO/inuse/approved" --preflight
printf '[exit %s]\n' "$?"
set -e

step "FINDING 4: with --pool the process table is walked ONCE (no double counting)"
fresh_tree count
mkdir -p "$DEMO/count/proc/11" "$DEMO/count/proc/12" "$DEMO/count/proc/13"
ln -s "$DEMO/count/seed" "$DEMO/count/proc/11/cwd"
ln -s "$DEMO/count/home" "$DEMO/count/proc/12/cwd"   # /13 has no cwd link: not inspectable
printf '\nfake process table: 3 entries, 2 readable, 1 not inspectable\n'
printf '\n$ ... --pool ... --preflight | grep "inspected"\n'
FM_RETIRE_PROC_ROOT="$DEMO/count/proc" retire count --root "$DEMO/count/approved/legacy" \
  --pool "$DEMO/count/approved/pool" --boundary "$DEMO/count/approved" --preflight \
  | grep 'inspected'
printf '\n$ ... (no --pool, single target) --preflight | grep "inspected"\n'
rm -rf "$DEMO/count/approved/pool"
git -C "$DEMO/count/approved/legacy/clone" worktree prune
FM_RETIRE_PROC_ROOT="$DEMO/count/proc" retire count --root "$DEMO/count/approved/legacy" \
  --boundary "$DEMO/count/approved" --preflight | grep 'inspected'

step "FINDING 5: pool coverage is undiminished - a pool is still checked in its own right"
fresh_tree poolev
git -C "$DEMO/poolev/approved/legacy/clone" remote set-url origin \
  "file://$DEMO/poolev/approved/pool/mirror.git"
printf '\n(a) landing evidence that would be destroyed with the POOL\n'
cmd retire poolev --root "$DEMO/poolev/approved/legacy" --pool "$DEMO/poolev/approved/pool" \
  --boundary "$DEMO/poolev/approved" --preflight

fresh_tree poolunproven
mkdir -p "$DEMO/poolunproven/approved/emptypool"
printf '\n(b) a --pool that holds no checkout of the retired repository\n'
cmd retire poolunproven --root "$DEMO/poolunproven/approved/legacy" \
  --pool "$DEMO/poolunproven/approved/emptypool" --boundary "$DEMO/poolunproven/approved" --preflight

fresh_tree poolunnamed
printf '\n(c) the pool worktree exists but --pool was never approved\n'
cmd retire poolunnamed --root "$DEMO/poolunnamed/approved/legacy" \
  --boundary "$DEMO/poolunnamed/approved" --preflight

step "HAPPY PATH: a clean, fully landed tree - preflight, approve, execute"
fresh_tree live
# a feature branch whose work landed upstream as a SQUASH (different commits,
# same content) - the case a subject match would get wrong.
git -C "$DEMO/live/approved/legacy/clone" checkout -q -b feature main
printf 'one\n' > "$DEMO/live/approved/legacy/clone/f1.txt"
git -C "$DEMO/live/approved/legacy/clone" add f1.txt
git -C "$DEMO/live/approved/legacy/clone" commit -qm "feature part one"
printf 'two\n' > "$DEMO/live/approved/legacy/clone/f2.txt"
git -C "$DEMO/live/approved/legacy/clone" add f2.txt
git -C "$DEMO/live/approved/legacy/clone" commit -qm "feature part two"
git -C "$DEMO/live/approved/legacy/clone" checkout -q main
printf 'one\n' > "$DEMO/live/seed/f1.txt"; printf 'two\n' > "$DEMO/live/seed/f2.txt"
git -C "$DEMO/live/seed" add f1.txt f2.txt
git -C "$DEMO/live/seed" commit -qm "squashed feature"
git -C "$DEMO/live/seed" push -q origin main

printf '\n$ ls %s\n' "$DEMO/live/approved"
ls "$DEMO/live/approved"

cmd retire live --root "$DEMO/live/approved/legacy" --pool "$DEMO/live/approved/pool" \
  --boundary "$DEMO/live/approved" --preflight

PLAN_ID=$(retire live --root "$DEMO/live/approved/legacy" --pool "$DEMO/live/approved/pool" \
  --boundary "$DEMO/live/approved" --preflight | sed -n 's/^PLAN-ID: //p')

step "EXECUTE with a plan id nobody approved"
cmd retire live --root "$DEMO/live/approved/legacy" --pool "$DEMO/live/approved/pool" \
  --boundary "$DEMO/live/approved" --execute --confirm-root "$DEMO/live/approved/legacy" \
  --confirm-plan not-the-plan-id

step "EXECUTE after the tree changed under the approved plan"
git -C "$DEMO/live/approved/legacy/clone" branch -q raced main
cmd retire live --root "$DEMO/live/approved/legacy" --pool "$DEMO/live/approved/pool" \
  --boundary "$DEMO/live/approved" --execute --confirm-root "$DEMO/live/approved/legacy" \
  --confirm-plan "$PLAN_ID"
printf '\n$ ls %s\n' "$DEMO/live/approved"
ls "$DEMO/live/approved"

step "EXECUTE the freshly approved plan"
PLAN_ID=$(retire live --root "$DEMO/live/approved/legacy" --pool "$DEMO/live/approved/pool" \
  --boundary "$DEMO/live/approved" --preflight | sed -n 's/^PLAN-ID: //p')
printf 'newly approved plan id: %s\n' "$PLAN_ID"
cmd retire live --root "$DEMO/live/approved/legacy" --pool "$DEMO/live/approved/pool" \
  --boundary "$DEMO/live/approved" --execute --confirm-root "$DEMO/live/approved/legacy" \
  --confirm-plan "$PLAN_ID"

step "AFTER: exactly the approved tree and its proven pool are gone"
printf '\n$ ls -A %s\n' "$DEMO/live/approved"
ls -A "$DEMO/live/approved" || true
printf '(empty listing above = both removal targets gone, boundary itself untouched)\n'
printf '\n$ ls %s\n' "$DEMO/live"
ls "$DEMO/live"
printf '\n$ git -C %s log --oneline -3\n' "$DEMO/live/upstream.git"
git -C "$DEMO/live/upstream.git" log --oneline -3
printf '\n(upstream, seed clone and the fleet home all survived untouched)\n'
```
</details>
<details>
<summary>Evidence: tests/fm-project-retire.test.sh run output</summary>

```text
ok - usage contract requires an explicit absolute root, boundary, and confirmations
ok - a no-mistakes gate agent cannot drive a fleet removal
ok - unsafe, symlinked, and non-canonical roots refuse
ok - the primary home and anything nested in or containing it refuses
ok - registered secondmate homes inside the tree refuse
ok - a current registry reference refuses
ok - the approved retirement boundary is enforced in both directions
ok - a live task reference refuses
ok - a secondmate home is found even behind prose parentheses in its registry line
ok - a live process current directory refuses
ok - live-process coverage counts each process exactly once across every removal target
ok - dirty and untracked files refuse
ok - linked and in-use worktrees refuse
ok - a stale worktree registration refuses instead of being pruned away
ok - a standalone repository with no checkout is still inventoried, bare or not
ok - the legacy pool must be proven linked to the retirement root
ok - incomplete or unrefreshable landing evidence refuses
ok - landing evidence that lives inside a removal target refuses
ok - a git fsck failure refuses instead of reporting no unreachable commits
ok - unpushed work and lookalike subjects refuse
ok - an unreachable unique commit refuses
ok - preflight proves squash-landed history and removes nothing
ok - execution refuses when evidence changed between approval and removal
ok - execution removes exactly the approved tree and its proven pool
```
</details>
<details>
<summary>Evidence: Happy path: preflight plan, plan-id approval, and bounded execution (excerpt)</summary>

```text
$ fm-project-retire.sh --root .../approved/legacy --pool .../approved/pool --boundary .../approved --preflight
PLAN: guarded retirement of .../approved/legacy
PLAN: checkout .../approved/legacy/clone at 1fe686ca..., clean
PLAN: checkout .../approved/pool/1/clone at 1fe686ca..., clean
PLAN: branch feature landed (content already contained in refs/remotes/origin/main)
PLAN: branch main landed (exact ancestry of refs/remotes/origin/main)
PLAN: 0 unreachable commits, all landed
PLAN: inspected 380 live process working directories (190 not inspectable by this user)
PLAN: removal step 1: rm -rf -- .../approved/pool
PLAN: removal step 2: rm -rf -- .../approved/legacy
PLAN-ID: 1a63fcda...
PREFLIGHT OK: every check passed and nothing was removed.
[exit 0]

$ ... --execute --confirm-plan not-the-plan-id
REFUSED: the approved plan no longer matches the current evidence.
Nothing was removed. Re-run --preflight, review the new plan, and approve it deliberately.
[exit 1]

$ ... --execute --confirm-plan 201c6a35... # freshly approved
RETIRED: removed .../approved/pool
RETIRED: removed .../approved/legacy
RETIRED: plan 201c6a35... completed; 2 removal target(s) gone, nothing else was touched.
[exit 0]

$ ls -A .../approved # boundary itself untouched, both targets gone
$ git -C .../upstream.git log --oneline -3
2936e25 squashed feature
1fe686c initial
```
</details>
<details>
<summary>Evidence: The five hardened guards refusing, with the tree left intact (excerpt)</summary>

```text
# evidence inside the deletion target
REFUSED: repository .../legacy/clone/.git takes its landing evidence from remote origin (file:///.../legacy/mirror.git), which resolves to .../legacy/mirror.git inside retirement root .../legacy; that evidence would be destroyed by this retirement, so it proves nothing
$ test -d .../legacy/clone && echo "clone still present" -> clone still present

# detached git directory inspected, not skipped
REFUSED: repository .../legacy/detached.git has no remote, so no landing evidence exists for its branches

# git fsck failure is a hard refusal
REFUSED: cannot check the object store of repository .../legacy/clone/.git: git fsck exited 128, so its unreachable commits cannot be enumerated:
fatal: loose object ab12345... is corrupt
$ test -d .../legacy/clone && echo "clone still present" -> clone still present

# no process-use double counting with --pool (fake table: 3 entries, 2 readable)
with --pool: PLAN: inspected 2 live process working directories (1 not inspectable by this user)
without --pool: PLAN: inspected 2 live process working directories (1 not inspectable by this user)

# pool coverage undiminished after the redundant loop was removed
REFUSED: ... resolves to .../pool/mirror.git inside legacy pool root .../pool ...
REFUSED: legacy pool root .../emptypool holds no git checkout, so it cannot be proven linked to .../legacy
REFUSED: repository .../legacy/clone/.git has linked worktree .../pool/1/clone outside the retirement tree
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `bin/fm-project-retire.sh:662` - Landing evidence is never checked for living inside the deletion target. Remotes are enumerated with `git remote` and fetched, but no remote URL is ever resolved or compared against --root/--pool. A legacy clone whose `origin` URL points at a sibling mirror inside --root (or at the clone&#39;s own path) fetches successfully, populates refs/remotes/origin/*, and every local branch then satisfies step 1 of the landing ladder (&#39;exact ancestry of &lt;ref&gt;&#39;) against a repository this same run removes with `rm -rf` at :827. The tool reports the work proven landed and destroys the only copy. Fix: for each remote, read `git remote get-url --all`, resolve file:// and filesystem-path URLs to a canonical path, and refuse when that path is equal to or inside any removal target — the proof must survive the removal.
- 🚨 `bin/fm-project-retire.sh:708` - `git fsck` failure is silently converted into &#39;no unreachable commits&#39;. Its exit status is lost twice: through the unset-pipefail pipeline into `sed`/`sort`, and again through the trailing `|| true`; stderr is sent to /dev/null. A repository with a corrupt or unreadable object store produces empty output, `unreachable_count` stays 0, the plan prints &#39;0 unreachable commits, all landed&#39; at :721, and execution proceeds to delete the tree without ever proving its dangling objects landed. This contradicts the header&#39;s own refusal condition at :79 (&#39;any ambiguous git result&#39;). Fix: capture fsck&#39;s exit status (e.g. run it into a temp var / use PIPESTATUS or a separate invocation) and refuse with an explicit message on non-zero.
- 🚨 `bin/fm-project-retire.sh:405` - Detached, non-bare git directories are silently skipped instead of inspected. `collect_bare_repos` drops every candidate whose `git rev-parse --is-bare-repository` is not exactly `true`, but a git directory with `core.bare=false` and no attached worktree (a `--separate-git-dir` target, or a `.git` directory moved aside under another name) reports `false`. Such a repository is never added to REPO_COMMONS, so its branches, refs and unreachable objects never go through landing proof, yet it sits inside --root and is removed by `rm -rf`. The header explicitly claims this case is covered at :94 and :391 (&#39;a bare repository, or a detached git directory&#39;). The adjacent `common=$(common_dir_of &#34;$canon&#34;) || continue` at :406 is the same silent-skip pattern. Fix: recognise a repository by its own git common dir (bare or not) and refuse rather than `continue` when a candidate looks like a repository but cannot be resolved.
- ⚠️ `bin/fm-project-retire.sh:259` - `registry_home_for_line` uses `s/^[^(]*(home: .../`, which only matches when the `home:` field is the first parenthesised group on the registry line. bin/fm-backlog-handoff.sh:65-69 documents this exact failure mode (&#39;Summary/scope prose often contains parentheticals ... ^[^(]* would leave those entries looking like &#34;has no home&#34;&#39;) and uses `s/.*(home:[[:space:]]*\([^;)]*\);.*/` instead. Here the consequence is a safety gap, not cosmetic: a secondmate whose one-sentence summary contains any parenthetical is skipped at :290, so its home never enters SECONDMATE_STATE_DIRS and `assert_no_task_reference` never scans its state/*.meta — a live recorded task whose `worktree=` points inside the retirement root goes undetected and its worktree is deleted. Fix: use the greedy-prefix pattern already proven in fm-backlog-handoff.sh.
- ⚠️ `bin/fm-project-retire.sh:573` - PROC_INSPECTED and PROC_UNREADABLE are file-scope counters incremented inside assert_no_live_process_cwd, which is called once for --root (:572) and again for --pool (:573) without being reset. With --pool the plan line at :784 reports roughly double the real number of inspected and non-inspectable process working directories, so the operator-facing evidence about the live-process coverage gap is wrong in exactly the case the header at :108-111 says it exists to make visible. The whole process table is also walked twice. Fix: walk /proc once, counting each pid once, and test the cwd against every removal target in that single pass.
- ℹ️ `bin/fm-project-retire.sh:724` - The pool re-check loop is unreachable-by-effect dead code. Every entry of SORTED_CHECKOUTS, pool members included, already passes through the main loop at :600-623, which refuses at :608-609 when common_dir_of fails and at :610-611 when the common dir is not inside $ROOT, with the message &#39;checkout ... belongs to repository ... outside the retirement root ...&#39;. That message already contains the &#39;outside the retirement root&#39; substring asserted by tests/fm-project-retire.test.sh:256, and the main loop reaches the foreign pool member first, so deleting :724-735 removes no coverage and no test signal.

🔧 Fix: harden retirement guards for evidence, fsck, and repo discovery
1 info still open:
- ℹ️ `bin/fm-project-retire.sh:78` - The header states &#39;Refusal conditions (all of them, in this order)&#39; at :56, but the two entries added by this commit are listed out of execution order. The remote-URL refusal is listed at :78-79 after &#39;a remote fetch failure, or no remote-tracking ref after the fetch&#39; (:76-77), yet assert_remote_evidence_survives runs at :773 before the fetch at :774 — a repository with both an in-tree remote URL and an unreachable remote reports the URL refusal, not the fetch failure. The fsck refusal is listed at :80-81 before &#39;a local branch, or an unreachable commit, whose work is not proven landed&#39; (:82), yet the branch landing loop runs at :797-811 and fsck only at :817. Because .agents/skills/project-management/SKILL.md delegates &#39;the complete refusal list ... and every mechanic&#39; to this header as the single contract, the ordered list should match: move the remote-URL bullet ahead of the fetch bullet, and move the fsck bullet after the branch-landing bullet (or split that bullet into branches-then-unreachable around it).

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-project-retire.test.sh` — full dedicated suite for the change under test, 24 checks, all ok</code>
- <code>Added and ran a new focused case in `tests/fm-project-retire.test.sh` (&#34;a no-mistakes gate agent cannot drive a fleet removal&#34;): strips the suite-wide `FM_GATE_REFUSE_BYPASS`, sets `NO_MISTAKES_GATE=1` on an otherwise valid retirement, asserts exit 3 and that the tree is untouched</code>
- <code>Manual end-to-end CLI transcript via `/tmp/no-mistakes-evidence/01KYV1J14NXRCHYXRCJF336DTT/demo.sh` driving the real `bin/fm-project-retire.sh` against fresh git fixtures (bare upstream + legacy clone + linked pool worktree + fake fleet home)</code>
- <code>Transcript scenario: `--root &lt;home&gt;/projects/alpha --preflight` — registered project under the fleet home refuses (Option A out-of-registry-only scope)</code>
- <code>Transcript scenario: tree still named by `data/projects.md` refuses with &#34;retire the registry entry first&#34;</code>
- `Transcript scenario: remote URL resolving inside the retirement root and inside the proven pool both refuse ("would be destroyed by this retirement"), clone left present`
- <code>Transcript scenario: `git init --separate-git-dir` detached git directory with its worktree deleted is inventoried and refused for missing landing evidence</code>
- <code>Transcript scenario: corrupted loose object → `git fsck exited 128` hard refusal, nothing removed</code>
- <code>Transcript scenario: `--pool` vs no `--pool` against a 3-entry fake `/proc` both report `inspected 2 live process working directories (1 not inspectable)` — no double counting</code>
- <code>Transcript scenario: live process cwd inside the pool refuses; unproven `--pool`; and a pool worktree with `--pool` unapproved refuses as an outside linked worktree</code>
- <code>Transcript scenario: happy path — preflight prints the plan and PLAN-ID (squash-landed branch proven by content containment), execute with a wrong plan id refuses, execute after the tree changed refuses with the new id, then the freshly approved plan removes pool-then-root; `ls` before/after plus `git log` on the upstream show only the two approved targets are gone</code>
- <code>Manual gate-refusal check: `env -u FM_GATE_REFUSE_BYPASS NO_MISTAKES_GATE=1 bin/fm-project-retire.sh ... --preflight` → exit 3; same from inside the gate worktree with the marker unset → exit 3 via the path backstop</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/configuration.md:405` - Judgment call, left as-is: the change adds two environment variables, FM_RETIRE_PATCH_SCAN_LIMIT (an operator-raisable landing-proof bound) and FM_RETIRE_PROC_ROOT (a test override), and neither appears in docs/configuration.md&#39;s &#34;Environment variables&#34; list. I did not add them because that list is a curated subset, not an exhaustive inventory - FM_BEARINGS_PR_LIMIT, FM_SESSION_START_BACKLOG_LIMIT, and the FM_SNAPSHOT_*_TIMEOUT knobs are equally absent - and firstmate-coding-guidelines placement rule 7 puts exact mechanics in the script header and --help, which already document both variables including the refusal message when the bound is exceeded. If the maintainers instead read that list as the operator-facing owner of every tunable knob, FM_RETIRE_PATCH_SCAN_LIMIT is the one that qualifies and would want a single line there.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
