### PR TITLE
fix: preserve Calm boat continuity across working periods

### DIFF
--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -42,6 +42,7 @@ import { installCalmAssistantLayout } from "./lib/fm-calm-assistant-layout.ts";
 import { installCalmOperationalUserLayout } from "./lib/fm-calm-operational-user-layout.ts";
 import {
   CALM_WORKING_SHIP_WIDGET_KEY,
+  createCalmWorkingShipAnimation,
   createCalmWorkingShipWidget,
 } from "./lib/fm-calm-working-ship.ts";
 import {
@@ -105,6 +106,10 @@ export default function (pi: ExtensionAPI) {
   // continuations, retries, or compaction that stay inside the same run.
   let agentRunActive = false;
   let workingShipShown = false;
+  // One animation instance per extension lifetime. Hiding the working widget freezes
+  // this state; the next working period resumes it. session_start resets it so a fresh
+  // Pi session starts at the normal initial position. Never module-global.
+  const workingShipAnimation = createCalmWorkingShipAnimation();
 
   // Single owner of Calm's working-row presentation choice. The widget is only created
   // or removed on a real transition, so repeated starts cannot duplicate its timer.
@@ -117,7 +122,9 @@ export default function (pi: ExtensionAPI) {
       workingShipShown = showShip;
       ui.setWidget(
         CALM_WORKING_SHIP_WIDGET_KEY,
-        showShip ? createCalmWorkingShipWidget : undefined,
+        showShip
+          ? (tui) => createCalmWorkingShipWidget(tui, workingShipAnimation)
+          : undefined,
       );
       ui.setWorkingVisible(!showShip);
     } else if (forceStockVisibility && !showShip) {
@@ -274,6 +281,8 @@ export default function (pi: ExtensionAPI) {
     publishPresentationState();
     agentRunActive = false;
     workingShipShown = false;
+    // A genuine new session lifetime starts the boat at the normal initial position.
+    workingShipAnimation.reset();
     applyWorkingPresentation(ctx.ui, true);
     ctx.ui.setHiddenThinkingLabel(calmPresentationIsActive() ? "" : undefined);
     ctx.ui.setStatus("firstmate-calm", undefined);

--- a/.pi/extensions/lib/fm-calm-working-ship.ts
+++ b/.pi/extensions/lib/fm-calm-working-ship.ts
@@ -2,10 +2,10 @@
 //
 // Calm replaces Pi's stock working row with a tiny SSHHIP-derived boat while one
 // logical agent run is active. This module owns only the sprite geometry, the bounce
-// track, the two animation cadences, and the temporary TUI widget;
-// `.pi/extensions/fm-calm.ts` owns when the presentation is installed and removed, and
-// stays the sole caller of setWorkingVisible(). docs/calm.md owns the captain-facing
-// contract.
+// track, the two animation cadences, the session-scoped freeze/resume state, and the
+// temporary TUI widget; `.pi/extensions/fm-calm.ts` owns when the presentation is
+// installed and removed, and stays the sole caller of setWorkingVisible().
+// docs/calm.md owns the captain-facing contract.
 //
 // Cadence: one scheduler drives two logically independent clocks. Every tick advances
 // the water phase, and only every CALM_WORKING_SHIP_TICKS_PER_MOVE-th tick moves the
@@ -13,11 +13,19 @@
 // itself reads as calm. Both clocks stop together when the widget is disposed. Ticks,
 // not wall-clock timestamps, drive every state change, so tests can seek time exactly.
 //
+// Continuity: one extension-owned animation instance survives hide/show within the same
+// Pi process and Calm extension lifetime. Disposing the widget freezes column,
+// direction, water phase, and tick cadence without advancing them for hidden wall
+// time. The next working period resumes from that exact logical state. A fresh session
+// or new extension lifetime calls reset() and starts at the normal initial position.
+// State is never a module-level or process-global singleton.
+//
 // Verified against Pi 0.81.1 declarations and the Pi 0.82.0 CLI, which expose
 // ExtensionUIContext.setWidget() with a component factory, per-widget dispose(), and
 // TUI.requestRender(). Pi renders a widget through Component.render(width), so this
 // module recomputes its track from that width on every frame instead of caching a
-// terminal size that a resize would invalidate.
+// terminal size that a resize would invalidate. A resize while the boat is hidden is
+// applied on the first resumed frame through the same clamp path.
 import type { Component, TUI } from "@earendil-works/pi-tui";
 
 // The hull is symmetric and replaces waves on its row rather than adding a third row.
@@ -51,6 +59,13 @@ export type CalmWorkingShipAnimation = {
   render(width: number): string[];
   /** Advance one scheduler tick: water every tick, boat on its slower cadence. */
   tick(): void;
+  /** Restore the normal initial column, direction, water phase, and cadence. */
+  reset(): void;
+  /**
+   * Clamp the frozen column and direction to `width` without advancing time.
+   * Used when a terminal resize lands while the working presentation is hidden.
+   */
+  clampToWidth(width: number): void;
   /** Current hull column, exposed for deterministic motion assertions. */
   position(): number;
   /** Current travel direction: 1 travelling right, -1 travelling left. */
@@ -81,6 +96,17 @@ export function createCalmWorkingShipAnimation(): CalmWorkingShipAnimation {
     else if (position <= 0) direction = 1;
   };
 
+  const applyWidth = (width: number): void => {
+    if (width <= 0) {
+      span = 0;
+      position = 0;
+      return;
+    }
+    span = trackSpan(width);
+    position = Math.min(position, span);
+    settleDirectionAtEdges();
+  };
+
   /** One colored run of water covering absolute columns [from, from + count). */
   const water = (from: number, count: number): string => {
     if (count <= 0) return "";
@@ -97,6 +123,18 @@ export function createCalmWorkingShipAnimation(): CalmWorkingShipAnimation {
     position: () => position,
     direction: () => direction,
     waterPhase: () => phase,
+
+    reset(): void {
+      position = 0;
+      direction = 1;
+      span = 0;
+      phase = 0;
+      ticks = 0;
+    },
+
+    clampToWidth(width: number): void {
+      applyWidth(width);
+    },
 
     tick(): void {
       ticks += 1;
@@ -115,9 +153,7 @@ export function createCalmWorkingShipAnimation(): CalmWorkingShipAnimation {
 
       // A resize lands here before the next frame, so recompute and clamp the track
       // immediately rather than trusting a position measured against the old width.
-      span = trackSpan(width);
-      position = Math.min(position, span);
-      settleDirectionAtEdges();
+      applyWidth(width);
 
       const sail = direction >= 0 ? SAIL_RIGHT : SAIL_LEFT;
 
@@ -146,13 +182,20 @@ export function createCalmWorkingShipAnimation(): CalmWorkingShipAnimation {
 }
 
 /**
- * Build the temporary Calm working widget. Pi disposes the previous component before
- * installing a replacement under the same key and when it clears extension widgets, so
- * the single scheduler driving both cadences cannot outlive the widget or duplicate.
+ * Build the temporary Calm working widget bound to one caller-owned animation.
+ * Pi disposes the previous component before installing a replacement under the same
+ * key and when it clears extension widgets, so the single scheduler driving both
+ * cadences cannot outlive the widget or duplicate. Disposing freezes the shared
+ * animation in place; the next widget bound to the same animation resumes without
+ * applying hidden wall time.
  */
-export function createCalmWorkingShipWidget(tui: TUI): Component & { dispose(): void } {
-  const animation = createCalmWorkingShipAnimation();
+export function createCalmWorkingShipWidget(
+  tui: TUI,
+  animation: CalmWorkingShipAnimation = createCalmWorkingShipAnimation(),
+): Component & { dispose(): void } {
+  let disposed = false;
   const timer = setInterval(() => {
+    if (disposed) return;
     animation.tick();
     tui.requestRender();
   }, CALM_WORKING_SHIP_TICK_MS);
@@ -163,6 +206,10 @@ export function createCalmWorkingShipWidget(tui: TUI): Component & { dispose(): 
     render: (width) => animation.render(width),
     // Every frame is rebuilt from fixed standard ANSI codes, so there is no cache.
     invalidate: () => {},
-    dispose: () => clearInterval(timer),
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      clearInterval(timer);
+    },
   };
 }

--- a/.pi/extensions/lib/fm-calm-working-ship.ts
+++ b/.pi/extensions/lib/fm-calm-working-ship.ts
@@ -59,6 +59,7 @@ export type CalmWorkingShipAnimation = {
   render(width: number): string[];
   /** Advance one scheduler tick: water every tick, boat on its slower cadence. */
   tick(): void;
+  restoreLastRendered(): void;
   /** Restore the normal initial column, direction, water phase, and cadence. */
   reset(): void;
   /**
@@ -87,6 +88,11 @@ export function createCalmWorkingShipAnimation(): CalmWorkingShipAnimation {
   let span = 0;
   let phase = 0;
   let ticks = 0;
+  let renderedPosition = position;
+  let renderedDirection = direction;
+  let renderedSpan = span;
+  let renderedPhase = phase;
+  let renderedTicks = ticks;
 
   // Reversing the moment the boat lands on an endpoint means the endpoint frame itself
   // already shows the new heading, so no frame at or after a bounce shows the old sail.
@@ -107,6 +113,22 @@ export function createCalmWorkingShipAnimation(): CalmWorkingShipAnimation {
     settleDirectionAtEdges();
   };
 
+  const commitRenderedState = (): void => {
+    renderedPosition = position;
+    renderedDirection = direction;
+    renderedSpan = span;
+    renderedPhase = phase;
+    renderedTicks = ticks;
+  };
+
+  const restoreLastRenderedState = (): void => {
+    position = renderedPosition;
+    direction = renderedDirection;
+    span = renderedSpan;
+    phase = renderedPhase;
+    ticks = renderedTicks;
+  };
+
   /** One colored run of water covering absolute columns [from, from + count). */
   const water = (from: number, count: number): string => {
     if (count <= 0) return "";
@@ -124,12 +146,15 @@ export function createCalmWorkingShipAnimation(): CalmWorkingShipAnimation {
     direction: () => direction,
     waterPhase: () => phase,
 
+    restoreLastRendered: restoreLastRenderedState,
+
     reset(): void {
       position = 0;
       direction = 1;
       span = 0;
       phase = 0;
       ticks = 0;
+      commitRenderedState();
     },
 
     clampToWidth(width: number): void {
@@ -157,26 +182,28 @@ export function createCalmWorkingShipAnimation(): CalmWorkingShipAnimation {
 
       const sail = direction >= 0 ? SAIL_RIGHT : SAIL_LEFT;
 
+      let frame: string[];
       if (width < SAIL_WIDTH) {
         // Too narrow for even the sail: a deterministic single row of water.
-        return [water(0, width)];
-      }
-
-      if (width < HULL_WIDTH) {
+        frame = [water(0, width)];
+      } else if (width < HULL_WIDTH) {
         // Too narrow for the hull: the sail alone rides the water row.
-        return [
+        frame = [
           water(0, position) +
             boat(sail) +
             water(position + SAIL_WIDTH, width - position - SAIL_WIDTH),
         ];
+      } else {
+        frame = [
+          " ".repeat(position + SAIL_OFFSET) + boat(sail),
+          water(0, position) +
+            boat(HULL) +
+            water(position + HULL_WIDTH, width - position - HULL_WIDTH),
+        ];
       }
 
-      return [
-        " ".repeat(position + SAIL_OFFSET) + boat(sail),
-        water(0, position) +
-          boat(HULL) +
-          water(position + HULL_WIDTH, width - position - HULL_WIDTH),
-      ];
+      commitRenderedState();
+      return frame;
     },
   };
 }
@@ -203,13 +230,14 @@ export function createCalmWorkingShipWidget(
   timer.unref?.();
 
   return {
-    render: (width) => animation.render(width),
+    render: (width) => (disposed ? [] : animation.render(width)),
     // Every frame is rebuilt from fixed standard ANSI codes, so there is no cache.
     invalidate: () => {},
     dispose: () => {
       if (disposed) return;
       disposed = true;
       clearInterval(timer);
+      animation.restoreLastRendered();
     },
   };
 }

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -8,7 +8,9 @@ The water fills the usable width in standard ANSI blue and the complete boat is 
 The boat is deliberately calm: it moves one column every 880ms, while the water ripples on its own faster cadence so the surface stays alive between boat steps.
 Its mainsail is directional, showing `<|` while travelling right and `|>` while travelling left, and it flips on the exact frame the boat turns at either edge.
 Every resize reflows the sprite without wrapping, and it disappears when the run settles, aborts, or fails.
-Within one Pi session, the next working period resumes the boat from that frozen column and travel direction rather than restarting at the left edge; a fresh Pi session starts at the normal initial position.
+Within one Pi session and Calm extension lifetime, the next working period resumes the boat from its last rendered column and travel direction rather than restarting at the left edge.
+Hidden elapsed time does not advance the animation, and a resize while hidden clamps the frozen boat to the new width without changing its valid travel direction.
+A fresh Pi session or new Calm extension lifetime starts at the normal initial position.
 Very narrow terminals fall back to a smaller deterministic sprite.
 While Calm is off, Pi's stock working row is left exactly as Pi renders it.
 Calm hides collapsed thinking labels, the shells for Pi's seven built-in tools, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -8,6 +8,7 @@ The water fills the usable width in standard ANSI blue and the complete boat is 
 The boat is deliberately calm: it moves one column every 880ms, while the water ripples on its own faster cadence so the surface stays alive between boat steps.
 Its mainsail is directional, showing `<|` while travelling right and `|>` while travelling left, and it flips on the exact frame the boat turns at either edge.
 Every resize reflows the sprite without wrapping, and it disappears when the run settles, aborts, or fails.
+Within one Pi session, the next working period resumes the boat from that frozen column and travel direction rather than restarting at the left edge; a fresh Pi session starts at the normal initial position.
 Very narrow terminals fall back to a smaller deterministic sprite.
 While Calm is off, Pi's stock working row is left exactly as Pi renders it.
 Calm hides collapsed thinking labels, the shells for Pi's seven built-in tools, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1928,6 +1928,7 @@ for (const width of [40, 16, 8, 6, 5, 4, 3, 2]) {
   const tui = { requestRender() {} };
   animation.render(40);
   for (let step = 0; step < CALM_WORKING_SHIP_TICKS_PER_MOVE * 7; step += 1) animation.tick();
+  animation.render(40);
   const frozenColumn = animation.position();
   const frozenDirection = animation.direction();
   const frozenPhase = animation.waterPhase();
@@ -1960,6 +1961,7 @@ for (const width of [40, 16, 8, 6, 5, 4, 3, 2]) {
   // Hidden resize clamps without needing a live widget, and preserves a valid heading.
   animation.render(80);
   while (animation.position() < 76) animation.tick();
+  animation.render(80);
   check(animation.position() === 76 && animation.direction() === -1, "endpoint setup failed before hidden resize");
   const beforeHiddenResize = { column: animation.position(), direction: animation.direction(), phase: animation.waterPhase() };
   animation.clampToWidth(20);
@@ -2009,6 +2011,7 @@ for (const width of [40, 16, 8, 6, 5, 4, 3, 2]) {
   ]) {
     const edge = createCalmWorkingShipAnimation();
     scenario.setup(edge);
+    edge.render(12);
     const frozen = { column: edge.position(), direction: edge.direction(), phase: edge.waterPhase() };
     const paused = createCalmWorkingShipWidget(tui, edge);
     paused.dispose();
@@ -2046,6 +2049,112 @@ for (const width of [40, 16, 8, 6, 5, 4, 3, 2]) {
   right.render(40);
   for (let step = 0; step < CALM_WORKING_SHIP_TICKS_PER_MOVE * 3; step += 1) left.tick();
   check(left.position() === 3 && right.position() === 0, "separate animations leaked motion state");
+}
+
+{
+  const realSetInterval = globalThis.setInterval;
+  const realClearInterval = globalThis.clearInterval;
+  const callbacks = [];
+  const handles = new Set();
+  globalThis.setInterval = (callback) => {
+    callbacks.push(callback);
+    const handle = { unref() {} };
+    handles.add(handle);
+    return handle;
+  };
+  globalThis.clearInterval = (handle) => {
+    handles.delete(handle);
+  };
+
+  try {
+    const tui = { renderRequests: 0, requestRender() { this.renderRequests += 1; } };
+    const animation = createCalmWorkingShipAnimation();
+    const first = createCalmWorkingShipWidget(tui, animation);
+    first.render(40);
+    callbacks[callbacks.length - 1]();
+    callbacks[callbacks.length - 1]();
+    check(tui.renderRequests === 2, "unpainted timer ticks did not request renders");
+    first.dispose();
+    check(handles.size === 0, "disposing the unpainted widget left its timer scheduled");
+    check(
+      animation.position() === 0 && animation.direction() === 1 && animation.waterPhase() === 0,
+      "dispose retained state from unpainted timer ticks",
+    );
+
+    const resumed = createCalmWorkingShipWidget(tui, animation);
+    resumed.render(40);
+    for (let step = 0; step < CALM_WORKING_SHIP_TICKS_PER_MOVE; step += 1) {
+      callbacks[callbacks.length - 1]();
+    }
+    resumed.render(40);
+    check(animation.position() === 1, "unpainted ticks leaked into the resumed cadence");
+    check(animation.waterPhase() === 0, "resumed cadence did not restore the rendered water phase");
+    resumed.dispose();
+
+    const committed = createCalmWorkingShipAnimation();
+    const progressing = createCalmWorkingShipWidget(tui, committed);
+    progressing.render(40);
+    callbacks[callbacks.length - 1]();
+    progressing.render(40);
+    const renderedPhase = committed.waterPhase();
+    callbacks[callbacks.length - 1]();
+    progressing.dispose();
+    check(committed.position() === 0, "dispose changed the committed column after an unpainted tick");
+    check(committed.waterPhase() === renderedPhase, "dispose changed the committed phase after an unpainted tick");
+
+    const committedResume = createCalmWorkingShipWidget(tui, committed);
+    committedResume.render(40);
+    for (let step = 0; step < CALM_WORKING_SHIP_TICKS_PER_MOVE - 2; step += 1) {
+      callbacks[callbacks.length - 1]();
+    }
+    check(committed.position() === 0, "serviced render did not preserve the committed cadence");
+    callbacks[callbacks.length - 1]();
+    committedResume.render(40);
+    check(committed.position() === 1, "serviced render did not commit progress for the next cadence");
+    committedResume.dispose();
+
+    const boundaryCases = [
+      [7, 1], [8, -1], [7, -1], [1, -1], [0, 1], [1, 1],
+    ];
+    for (const [targetPosition, targetDirection] of boundaryCases) {
+      const edge = createCalmWorkingShipAnimation();
+      edge.render(12);
+      let reached = false;
+      for (let step = 0; step < 160; step += 1) {
+        if (edge.position() === targetPosition && edge.direction() === targetDirection) {
+          edge.render(12);
+          reached = true;
+          break;
+        }
+        edge.tick();
+        edge.render(12);
+      }
+      check(reached, `could not prepare bounce state ${targetPosition}/${targetDirection}`);
+      const before = { position: edge.position(), direction: edge.direction(), phase: edge.waterPhase() };
+      const paused = createCalmWorkingShipWidget(tui, edge);
+      paused.render(12);
+      for (let step = 0; step < CALM_WORKING_SHIP_TICKS_PER_MOVE; step += 1) {
+        callbacks[callbacks.length - 1]();
+      }
+      paused.dispose();
+      check(
+        edge.position() === before.position &&
+          edge.direction() === before.direction &&
+          edge.waterPhase() === before.phase,
+        `unpainted bounce tick escaped ${targetPosition}/${targetDirection}`,
+      );
+      const resumedEdge = createCalmWorkingShipWidget(tui, edge);
+      resumedEdge.render(12);
+      check(
+        edge.position() === before.position && edge.direction() === before.direction,
+        `bounce state ${targetPosition}/${targetDirection} changed on resume`,
+      );
+      resumedEdge.dispose();
+    }
+  } finally {
+    globalThis.setInterval = realSetInterval;
+    globalThis.clearInterval = realClearInterval;
+  }
 }
 
 // --- Lifecycle through the Calm extension's registered handlers --------------------

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1646,6 +1646,7 @@ const {
   CALM_WORKING_SHIP_TICK_MS,
   CALM_WORKING_SHIP_TICKS_PER_MOVE,
   createCalmWorkingShipAnimation,
+  createCalmWorkingShipWidget,
 } = ship;
 
 const ESC = "\u001b";
@@ -1919,6 +1920,134 @@ for (const width of [40, 16, 8, 6, 5, 4, 3, 2]) {
   }
 }
 
+// --- Freeze/resume continuity on one shared animation instance ---------------------
+// Hiding the working presentation must freeze column and direction. The next widget
+// bound to the same animation resumes exactly there; hidden wall time must not jump.
+{
+  const animation = createCalmWorkingShipAnimation();
+  const tui = { requestRender() {} };
+  animation.render(40);
+  for (let step = 0; step < CALM_WORKING_SHIP_TICKS_PER_MOVE * 7; step += 1) animation.tick();
+  const frozenColumn = animation.position();
+  const frozenDirection = animation.direction();
+  const frozenPhase = animation.waterPhase();
+  check(frozenColumn > 0, `continuity setup never left the left edge: ${frozenColumn}`);
+
+  const first = createCalmWorkingShipWidget(tui, animation);
+  check(first.render(40) && animation.position() === frozenColumn, "binding a widget moved the frozen boat");
+  first.dispose();
+  // Dispose freezes; further wall time without ticks must not change logical state.
+  check(animation.position() === frozenColumn, "dispose changed the frozen column");
+  check(animation.direction() === frozenDirection, "dispose changed the frozen direction");
+  check(animation.waterPhase() === frozenPhase, "dispose changed the frozen water phase");
+
+  const resumed = createCalmWorkingShipWidget(tui, animation);
+  const firstFrame = resumed.render(40);
+  check(
+    animation.position() === frozenColumn && animation.direction() === frozenDirection,
+    `resume first frame left frozen state: col=${animation.position()} dir=${animation.direction()}`,
+  );
+  check(sailOf(firstFrame) === (frozenDirection >= 0 ? "<|" : "|>"), "resume first frame lost sail heading");
+  check(animation.waterPhase() === frozenPhase, "resume advanced water phase without a tick");
+  // After resume, motion continues from the frozen state rather than restarting.
+  for (let step = 0; step < CALM_WORKING_SHIP_TICKS_PER_MOVE; step += 1) animation.tick();
+  check(
+    animation.position() === frozenColumn + frozenDirection,
+    `post-resume motion did not continue from frozen column: ${animation.position()}`,
+  );
+  resumed.dispose();
+
+  // Hidden resize clamps without needing a live widget, and preserves a valid heading.
+  animation.render(80);
+  while (animation.position() < 76) animation.tick();
+  check(animation.position() === 76 && animation.direction() === -1, "endpoint setup failed before hidden resize");
+  const beforeHiddenResize = { column: animation.position(), direction: animation.direction(), phase: animation.waterPhase() };
+  animation.clampToWidth(20);
+  check(animation.position() === 16, `hidden shrink did not clamp: ${animation.position()}`);
+  check(animation.direction() === -1, "hidden shrink lost the leftward heading at the right edge");
+  check(animation.waterPhase() === beforeHiddenResize.phase, "hidden clamp advanced water phase");
+  // Growing while hidden must not invent motion either.
+  animation.clampToWidth(60);
+  check(animation.position() === 16, `hidden grow moved the boat: ${animation.position()}`);
+  check(animation.direction() === -1, "hidden grow changed direction without cause");
+
+  // Endpoint and bounce continuity: pause immediately before, at, and after each edge.
+  for (const scenario of [
+    { label: "before-right", setup(anim) {
+      anim.reset(); anim.render(12);
+      while (anim.position() < 7) anim.tick();
+      check(anim.position() === 7 && anim.direction() === 1, "before-right setup");
+    }},
+    { label: "at-right", setup(anim) {
+      anim.reset(); anim.render(12);
+      while (anim.position() < 8) anim.tick();
+      check(anim.position() === 8 && anim.direction() === -1, "at-right setup");
+    }},
+    { label: "after-right", setup(anim) {
+      anim.reset(); anim.render(12);
+      while (anim.position() < 8) anim.tick();
+      for (let step = 0; step < CALM_WORKING_SHIP_TICKS_PER_MOVE; step += 1) anim.tick();
+      check(anim.position() === 7 && anim.direction() === -1, "after-right setup");
+    }},
+    { label: "before-left", setup(anim) {
+      anim.reset(); anim.render(12);
+      while (anim.position() < 8) anim.tick();
+      while (!(anim.position() === 1 && anim.direction() === -1)) anim.tick();
+    }},
+    { label: "at-left", setup(anim) {
+      anim.reset(); anim.render(12);
+      while (anim.position() < 8) anim.tick();
+      while (!(anim.position() === 0 && anim.direction() === 1)) anim.tick();
+    }},
+    { label: "after-left", setup(anim) {
+      anim.reset(); anim.render(12);
+      while (anim.position() < 8) anim.tick();
+      while (!(anim.position() === 0 && anim.direction() === 1)) anim.tick();
+      for (let step = 0; step < CALM_WORKING_SHIP_TICKS_PER_MOVE; step += 1) anim.tick();
+      check(anim.position() === 1 && anim.direction() === 1, "after-left setup");
+    }},
+  ]) {
+    const edge = createCalmWorkingShipAnimation();
+    scenario.setup(edge);
+    const frozen = { column: edge.position(), direction: edge.direction(), phase: edge.waterPhase() };
+    const paused = createCalmWorkingShipWidget(tui, edge);
+    paused.dispose();
+    const again = createCalmWorkingShipWidget(tui, edge);
+    again.render(12);
+    check(
+      edge.position() === frozen.column && edge.direction() === frozen.direction && edge.waterPhase() === frozen.phase,
+      `${scenario.label} resume changed frozen edge state`,
+    );
+    for (let step = 0; step < CALM_WORKING_SHIP_TICKS_PER_MOVE; step += 1) edge.tick();
+    const expectedColumn = Math.min(8, Math.max(0, frozen.column + frozen.direction));
+    let expectedDirection = frozen.direction;
+    if (expectedColumn >= 8) expectedDirection = -1;
+    else if (expectedColumn <= 0) expectedDirection = 1;
+    check(
+      edge.position() === expectedColumn && edge.direction() === expectedDirection,
+      `${scenario.label} post-resume bounce drifted: col=${edge.position()} dir=${edge.direction()}`,
+    );
+    again.dispose();
+  }
+
+  // reset() returns a genuine fresh-session initial state.
+  animation.reset();
+  check(
+    animation.position() === 0 && animation.direction() === 1 && animation.waterPhase() === 0,
+    "reset() did not restore the normal initial boat state",
+  );
+  animation.render(40);
+  check(sailOf(animation.render(40)) === "<|", "reset() first frame was not the initial rightward sail");
+
+  // Two controller instances never share motion state.
+  const left = createCalmWorkingShipAnimation();
+  const right = createCalmWorkingShipAnimation();
+  left.render(40);
+  right.render(40);
+  for (let step = 0; step < CALM_WORKING_SHIP_TICKS_PER_MOVE * 3; step += 1) left.tick();
+  check(left.position() === 3 && right.position() === 0, "separate animations leaked motion state");
+}
+
 // --- Lifecycle through the Calm extension's registered handlers --------------------
 let liveTimers = 0;
 const realSetInterval = globalThis.setInterval;
@@ -2068,6 +2197,19 @@ check(shipWidget() === widget, "repeated starts replaced the running widget");
 }
 
 // --- Settling removes the boat, stops the animation, and restores the stock row ----
+// Drive the live widget far enough that a left-edge reset would be observable.
+{
+  const moving = shipWidget();
+  check(!!moving, "continuity setup lost the live working widget");
+  moving.render(40);
+  await new Promise((resolve) => setTimeout(resolve, CALM_WORKING_SHIP_TICK_MS * CALM_WORKING_SHIP_TICKS_PER_MOVE * 5 + 40));
+  moving.render(40);
+}
+const hullColumn = (widget) => strip(widget.render(40)[1]).indexOf("\\__/");
+const freezeColumn = hullColumn(shipWidget());
+const freezeSail = sailOf(shipWidget().render(40));
+check(freezeColumn > 0, `lifecycle continuity setup never left the left edge: ${freezeColumn}`);
+
 reset();
 await fire("agent_settled");
 check(
@@ -2085,12 +2227,49 @@ check(
 {
   // No stale rows survive the removal: the widget renders nothing once disposed.
   const renderRequestsAfterDispose = renderRequests;
-  await new Promise((resolve) => setTimeout(resolve, CALM_WORKING_SHIP_TICK_MS * 3));
+  await new Promise((resolve) => setTimeout(resolve, CALM_WORKING_SHIP_TICK_MS * CALM_WORKING_SHIP_TICKS_PER_MOVE * 3));
   check(
     renderRequests === renderRequestsAfterDispose,
     "the animation kept running after the widget was removed",
   );
 }
+
+// --- Later working period resumes the frozen column and direction -----------------
+reset();
+await fire("agent_start");
+check(liveTimers === 1, `resume start left ${liveTimers} animation timers instead of one`);
+check(ui.widgets.size === 1, "resume start did not install exactly one working widget");
+const resumedWidget = shipWidget();
+const resumeColumn = hullColumn(resumedWidget);
+const resumeSail = sailOf(resumedWidget.render(40));
+check(
+  resumeColumn === freezeColumn && resumeSail === freezeSail,
+  `resume reset the boat instead of continuing: froze ${freezeColumn}/${freezeSail}, resumed ${resumeColumn}/${resumeSail}`,
+);
+// Repeated start/settle cycles must not duplicate scheduler or widget ownership.
+for (let cycle = 0; cycle < 3; cycle += 1) {
+  await fire("agent_settled");
+  check(liveTimers === 0, `cycle ${cycle} settle left ${liveTimers} timers`);
+  check(ui.widgets.size === 0, `cycle ${cycle} settle left a residual widget`);
+  await fire("agent_start");
+  check(liveTimers === 1, `cycle ${cycle} start left ${liveTimers} timers`);
+  check(ui.widgets.size === 1, `cycle ${cycle} start left ${ui.widgets.size} widgets`);
+  check(
+    hullColumn(shipWidget()) >= freezeColumn,
+    `cycle ${cycle} lost continuity after repeated settle/start`,
+  );
+}
+await fire("agent_settled");
+check(liveTimers === 0 && ui.widgets.size === 0, "repeated continuity cycles did not finish clean");
+
+// A genuine fresh session resets to the normal initial position.
+reset();
+await fire("session_start", { reason: "new" });
+check(liveTimers === 0 && ui.widgets.size === 0, "fresh session left a stale boat");
+await fire("agent_start");
+check(hullColumn(shipWidget()) === 0, "fresh session did not restart at the left edge");
+check(sailOf(shipWidget().render(40)) === "<|", "fresh session lost the initial rightward sail");
+await fire("agent_settled");
 
 // --- Abort and failure share Pi's agent_settled path ------------------------------
 // Pi emits agent_settled from a finally block, so an aborted or failed run reaches
@@ -2173,11 +2352,11 @@ JS
   status=$?
   [ "$status" -eq 0 ] || fail "Pi Calm working-ship checks failed: $out"
   [ -z "$out" ] || fail "Pi Calm working-ship test printed output: $out"
-  pass "Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps resizes, falls back deterministically when narrow, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched"
+  pass "Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps visible and hidden resizes, falls back deterministically when narrow, freezes and resumes column/direction across settle/start without hidden-time jumps or duplicate timers, resets only on a fresh session, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched"
 }
 
 test_interactive_terminal_e2e() {
-  local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot export_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait boat_frame_one boat_frame_two boat_resized_snapshot boat_focus_snapshot boat_cleared_snapshot boat_hull_line boat_sail_line boat_column_one boat_column_two boat_line boat_color_snapshot boat_color_line boat_water_snapshot boat_water_line boat_water_first boat_water_changed boat_narrow_snapshot boat_narrow_sails
+  local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot export_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait boat_frame_one boat_frame_two boat_resized_snapshot boat_focus_snapshot boat_cleared_snapshot boat_hull_line boat_sail_line boat_column_one boat_column_two boat_line boat_color_snapshot boat_color_line boat_water_snapshot boat_water_line boat_water_first boat_water_changed boat_narrow_snapshot boat_narrow_sails boat_freeze_snapshot boat_resume_snapshot boat_freeze_column boat_freeze_sail boat_resume_column boat_resume_sail
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi calm interactive E2E"
     return 0
@@ -2208,6 +2387,8 @@ test_interactive_terminal_e2e() {
   boat_color_snapshot="$TMP_ROOT/boat-color.txt"
   boat_water_snapshot="$TMP_ROOT/boat-water.txt"
   boat_narrow_snapshot="$TMP_ROOT/boat-narrow.txt"
+  boat_freeze_snapshot="$TMP_ROOT/boat-freeze.txt"
+  boat_resume_snapshot="$TMP_ROOT/boat-resume.txt"
   restarted_snapshot="$TMP_ROOT/restarted.txt"
   resumed_restored_snapshot="$TMP_ROOT/resumed-restored.txt"
   mkdir -p "$project/.pi/extensions/lib" "$project/bin" "$project/state" "$config" "$home/config"
@@ -2828,6 +3009,19 @@ JS
     i=$((i + 1))
   done
 
+  # Capture the last on-screen column and sail before settling so the next working
+  # period in this same Pi session can prove freeze/resume continuity.
+  tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$boat_freeze_snapshot"
+  boat_freeze_column=$(awk 'index($0,"\\__/"){print index($0,"\\__/"); exit}' "$boat_freeze_snapshot")
+  boat_freeze_sail=$(grep -E '<\||\|>' "$boat_freeze_snapshot" | tail -1 || true)
+  case "$boat_freeze_sail" in
+    *'<|'*) boat_freeze_sail='<|' ;;
+    *'|>'*) boat_freeze_sail='|>' ;;
+    *) fail "could not read the freeze-frame sail heading" ;;
+  esac
+  [ -n "$boat_freeze_column" ] && [ "$boat_freeze_column" -gt 1 ] \
+    || fail "freeze frame never left the left edge (column '${boat_freeze_column:-empty}')"
+
   # Escape aborts the run, and the abort path removes the ship with no residue.
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Escape
   active_screen_wait=0
@@ -2842,6 +3036,50 @@ JS
   assert_not_contains "$(cat "$boat_cleared_snapshot")" '\__/' "Escape did not remove the working ship"
   assert_not_contains "$(cat "$boat_cleared_snapshot")" "CALM_WORKING_E2E_RESPONSE" "the long-delay fixture settled instead of aborting on Escape"
   assert_not_contains "$(cat "$boat_cleared_snapshot")" "FOCUSPROBE" "the editor kept the focus probe text after Escape"
+
+  # A later working period in the same Pi process must resume the frozen column and
+  # sail rather than recreating the boat at the left edge. Capture the first resumed
+  # frames quickly so the slow boat cadence cannot advance before the assertion.
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm-boat-e2e"
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
+  boat_resume_column=""
+  boat_resume_sail=""
+  active_screen_wait=0
+  while [ "$active_screen_wait" -lt 200 ]; do
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$boat_resume_snapshot"
+    if grep -Fq '\__/' "$boat_resume_snapshot"; then
+      boat_resume_column=$(awk 'index($0,"\\__/"){print index($0,"\\__/"); exit}' "$boat_resume_snapshot")
+      boat_resume_sail=$(grep -E '<\||\|>' "$boat_resume_snapshot" | tail -1 || true)
+      case "$boat_resume_sail" in
+        *'<|'*) boat_resume_sail='<|' ;;
+        *'|>'*) boat_resume_sail='|>' ;;
+      esac
+      break
+    fi
+    sleep 0.025
+    active_screen_wait=$((active_screen_wait + 1))
+  done
+  [ -n "$boat_resume_column" ] \
+    || fail "the second working period never showed the working ship"
+  [ "$boat_resume_column" -eq "$boat_freeze_column" ] \
+    || fail "the second working period reset the boat from column $boat_freeze_column to $boat_resume_column instead of resuming"
+  [ "$boat_resume_sail" = "$boat_freeze_sail" ] \
+    || fail "the second working period changed sail from $boat_freeze_sail to $boat_resume_sail"
+  assert_not_contains "$(cat "$boat_resume_snapshot")" "Working..." \
+    "the second working period left Pi's stock working row visible"
+
+  # Clear the resumed run before the Calm-off stock-row probe.
+  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Escape
+  active_screen_wait=0
+  while [ "$active_screen_wait" -lt 200 ]; do
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$boat_cleared_snapshot"
+    if ! grep -Fq '\__/' "$boat_cleared_snapshot"; then
+      break
+    fi
+    sleep 0.05
+    active_screen_wait=$((active_screen_wait + 1))
+  done
+  assert_not_contains "$(cat "$boat_cleared_snapshot")" '\__/' "Escape did not remove the resumed working ship"
 
   # Calm off restores Pi's stock working row and never shows the ship.
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
@@ -2923,7 +3161,7 @@ JS
   [ "$(cat "$home/config/calm")" = off ] || fail "/calm after restart did not persist the inactive choice"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/quit"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
-  pass "Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior"
+  pass "Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior"
 }
 
 test_home_resolution


### PR DESCRIPTION
## Intent

Implement and ship the captain-authorized Firstmate Calm boat continuity fix.

Within one Pi process/session and one Calm extension lifetime, hiding or pausing the working display must freeze the boat at its last rendered column and current travel direction. The next working period in that same session must resume from that exact logical column and direction without returning to the left edge. Hidden elapsed wall time must not advance animation state or create a jump on resume. Endpoint/bounce behavior must remain correct when pause occurs immediately before, at, and immediately after either boundary. Terminal resize while hidden must clamp the frozen column safely to the new width while preserving a valid direction; resize after resume keeps the existing bounce/clamp contract. Repeated start/settle cycles must create no duplicate scheduler, timer, widget, or render subscription, and every owned timer must be cleaned up on replacement, shutdown, and extension disposal. Calm-off behavior must remain stock Pi behavior and must not create, retain, or resume a hidden Calm boat. A genuinely fresh Pi session or new extension lifetime must start at the normal initial position. State must be scoped to one extension/session instance, not a module-level or process-global singleton. Do not add durable cross-process persistence and do not build a general animation-state framework.

This is a reported bug against the PR 1339 working-ship implementation: settling disposed the widget and destroyed animation state, so the next agent run recreated the boat at column 0. The fix keeps one extension-owned animation instance, binds disposable widgets to it, freezes on dispose, resumes on the next working period, and resets only on session_start. Deterministic behavioral coverage was added for continuity, hidden-time freeze, endpoint cases, hidden/visible resize, lifecycle, timer cleanup, Calm-off, and fresh-session reset, plus a real Pi TUI two-period continuity check. Maintained docs were updated only for the new captain-facing continuity contract in docs/calm.md.

## What Changed

- Keep one extension-owned Calm boat animation across widget replacement, freezing at the last rendered state and resuming the exact column and direction without hidden-time advancement.
- Clamp frozen state safely across hidden resizes, preserve boundary behavior, clean up timers on disposal, and reset only for fresh sessions while Calm-off remains stock Pi behavior.
- Add deterministic and live Pi coverage for continuity, hidden time and resize, boundaries, lifecycle cleanup, Calm-off, and fresh-session reset, with updated captain-facing documentation.

## Risk Assessment

✅ Low: The updated implementation now commits all continuity state after rendering and restores the last committed snapshot on disposal, with focused coverage for unpainted ticks, cadence, boundaries, and lifecycle paths.

## Testing

Ran the focused Calm Pi extension tests end to end. Deterministic renderer, endpoint, resize, lifecycle, timer cleanup, Calm-off, and fresh-session checks passed, as did the real tmux/Pi TUI continuity scenario. Captured reviewer-visible terminal evidence showing the boat resuming at the same column and direction after hidden time; the worktree remained clean.

<details>
<summary>Evidence: Calm boat continuity transcript</summary>

```text
FIRSTMATE CALM BOAT CONTINUITY - live animation transcript
single extension/session animation instance; widget timer disposed before hidden wait

before hide: column=5 terminal_column=6 direction=1 phase=0
      <|
~~-~~\__/~-~~~-~~~-~~~-~~~-~~~-~

after dispose: column=5 direction=1 phase=0
after 1100ms hidden wall time: column=5 direction=1 phase=0
resume first frame: column=5 terminal_column=6 direction=1 phase=0
      <|
~~-~~\__/~-~~~-~~~-~~~-~~~-~~~-~
resume exact-match: PASS

wide right edge before hidden resize: column=76 direction=-1
hidden resize to width=20: column=16 terminal_column=17 direction=-1 phase=0
                 |>
~~-~~~-~~~-~~~-~\__/
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.pi/extensions/lib/fm-calm-working-ship.ts:199` - `animation.tick()` mutates the shared state before `tui.requestRender()` schedules the actual paint. If settling occurs while that render is queued or coalesced, `dispose()` preserves the post-tick column and direction even though the terminal last showed the prior frame; the next widget then resumes one step ahead. This contradicts the required freeze at the last rendered column and direction. Commit a render-confirmed snapshot or otherwise make tick and rendered-state publication atomic.

🔧 Fix: Freeze Calm boat from last rendered state
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-calm-pi-extension.test.sh`
- `Live animation transcript covering disposal, 1100ms hidden time, exact resume, and hidden resize clamp`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
