### PR TITLE
fix: 按真实活跃任务启用监督

### DIFF
--- a/bin/fm-claude-stop-autoarm.sh
+++ b/bin/fm-claude-stop-autoarm.sh
@@ -18,8 +18,9 @@
 #   - AFK: while state/.afk exists the away daemon owns the watcher and triage;
 #     this hook exits 0 and NEVER rewakes the primary (checked again at
 #     translation time so a mid-cycle AFK transition is honored).
-#   - Need: arms only while work is in flight (state/*.meta) or X mode has a
-#     relay poll to run (state/x-watch.check.sh); an idle home exits 0.
+#   - Need: arms only while the shared supervision predicate finds actionable
+#     active work, or X mode has a relay poll to run (state/x-watch.check.sh);
+#     an idle home exits 0.
 #   - Single-flight: Claude does not dedupe async hooks, so a home-scoped owner
 #     lock (state/.claude-autoarm.lock) admits exactly one owner; every other
 #     concurrent firing exits 0 without translating, which keeps one event

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -5,7 +5,8 @@
 # First, always warn if the firstmate primary checkout (FM_ROOT) is on a named
 # non-default branch, because that means firstmate-on-itself work landed in the
 # primary instead of an isolated worktree.
-# Then, if any task is in flight (a state/<id>.meta exists) and the watcher's
+# Then, if the shared supervision predicate finds actionable active work and
+# the watcher's
 # liveness beacon (state/.last-watcher-beat, touched every poll cycle) is
 # missing or older than FM_GUARD_GRACE seconds, prints a loud, clearly delimited
 # banner so the agent cannot skim past it in the tool output of whatever it was

--- a/bin/fm-supervision-lib.sh
+++ b/bin/fm-supervision-lib.sh
@@ -2,14 +2,17 @@
 # Shared "supervision missing" predicate.
 # Usage: . bin/fm-supervision-lib.sh
 #
-# Reports whether a firstmate home needs supervision because it has in-flight
-# work (a state/<id>.meta exists) or an X-mode relay poll
+# Reports whether a firstmate home needs supervision because it has actionable
+# active work or an X-mode relay poll
 # (state/x-watch.check.sh), and whether its watcher has a fresh liveness beacon
 # (state/.last-watcher-beat, touched every poll cycle, within the grace window).
 # bin/fm-guard.sh keeps its task-specific grace-based warning predicate;
 # bin/fm-turnend-guard.sh uses the status fields here for its banner but performs
 # its end-of-turn block decision with the live watcher lock check in
 # bin/fm-wake-lib.sh.
+
+_FM_SUPERVISION_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)" || _FM_SUPERVISION_LIB_DIR="."
+FM_CREW_STATE_BIN="${FM_CREW_STATE_BIN:-$_FM_SUPERVISION_LIB_DIR/fm-crew-state.sh}"
 
 # Portable mtime; Linux stat lacks -f, macOS stat lacks -c.
 fm_sup_stat_mtime() {
@@ -20,9 +23,52 @@ fm_sup_stat_mtime() {
   fi
 }
 
+fm_sup_meta_value() {  # <meta> <key>
+  grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+fm_sup_current_state() {  # <id>
+  local line state
+  line=$("$FM_CREW_STATE_BIN" "$1" 2>/dev/null) || return 1
+  case "$line" in state:*) ;; *) return 1 ;; esac
+  state=${line#state: }
+  printf '%s\n' "${state%% *}"
+}
+
+# Return true when one metadata record still needs primary supervision.
+# Ordinary tasks stay active by default; only a trailing done event earns the
+# bounded authoritative current-state read that can disprove completion.
+# Secondmates are cheap to reconcile because fm-crew-state skips no-mistakes for
+# them, and their canonical unknown/none state means the persistent endpoint is
+# healthy and idle.
+# Missing or malformed evidence remains active so supervision still fails closed.
+fm_sup_meta_needs_supervision() {  # <state-dir> <meta>
+  local state=$1 meta=$2 id kind last current
+  id=${meta##*/}
+  id=${id%.meta}
+  kind=$(fm_sup_meta_value "$meta" kind)
+  [ -n "$kind" ] || kind=ship
+
+  if [ "$kind" = secondmate ]; then
+    current=$(fm_sup_current_state "$id") || return 0
+    case "$current" in
+      done|unknown) return 1 ;;
+      *) return 0 ;;
+    esac
+  fi
+
+  last=$(grep -v '^[[:space:]]*$' "$state/$id.status" 2>/dev/null | tail -1 || true)
+  case "$last" in done:*) ;; *) return 0 ;; esac
+  current=$(fm_sup_current_state "$id") || return 0
+  case "$current" in
+    done|unknown) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 # fm_supervision_status <state-dir> [grace-seconds]
 # Populates, for the state dir at $1:
-#   FM_SUP_IN_FLIGHT      count of state/*.meta (in-flight tasks)
+#   FM_SUP_IN_FLIGHT      count of tasks that still need primary supervision
 #   FM_SUP_NEEDED         true/false - in-flight work or an X-mode relay poll
 #   FM_SUP_WATCHER_FRESH  true/false - a watcher beacon within the grace window
 #   FM_SUP_BEACON_DESC    human-readable beacon age, for banners ("never" if absent)
@@ -39,6 +85,7 @@ fm_supervision_status() {
 
   for meta in "$state"/*.meta; do
     [ -e "$meta" ] || continue
+    fm_sup_meta_needs_supervision "$state" "$meta" || continue
     FM_SUP_IN_FLIGHT=$((FM_SUP_IN_FLIGHT + 1))
   done
   if [ "$FM_SUP_IN_FLIGHT" -gt 0 ] || [ -f "$state/x-watch.check.sh" ]; then

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -25,7 +25,9 @@ An unmarked checkout or invalid marker falls through to the git-dir check.
 That check keeps crewmate and scout linked worktrees inert because their git dir differs from their git common dir.
 It also requires `AGENTS.md`, `bin/`, and the effective state directory.
 
-For an in-scope primary, the guard counts in-flight work from `state/*.meta`.
+For an in-scope primary, the shared supervision predicate starts from `state/*.meta` and uses `bin/fm-crew-state.sh` only where a record may no longer require primary supervision.
+An ordinary task remains active unless it has a trailing `done:` event and current state provides no positive evidence that work resumed, while a persistent secondmate in its canonical `unknown · source: none` state is healthy and idle.
+A failed or malformed current-state read and any positive contradictory state remain active so the guard continues to fail closed.
 The default cross-harness mode exits silently with no work in flight.
 Claude's `--claude` mode also treats `state/x-watch.check.sh` as supervision need, so X-mode relay polling remains guarded without an in-flight task.
 Otherwise it calls `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] [home]` from `bin/fm-wake-lib.sh`, the same identity-matched lock and fresh-beacon check used by `bin/fm-watch-arm.sh`.
@@ -90,7 +92,8 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 ## Regression coverage
 
-`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
+`tests/fm-turnend-guard.test.sh` covers the active-work predicate including done ships, idle secondmates, and resumed ships, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
+`tests/fm-claude-stop-autoarm.test.sh` verifies that done ships and idle secondmates create no background watcher cycle while active work and X relay polling still arm normally.
 `tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -106,6 +106,26 @@ The direct and passive mechanisms were validated across all five harnesses on 20
 | Pi | 0.80.5 | Passive `agent_settled` callback | Exactly one guard follow-up ran for an unhealthy cycle, with no recursion across tool turns. |
 | Grok | 0.2.112 native and 0.2.73 pre-native | Running-payload adaptive `Stop` | Native false-to-true continuation stayed in one process with two model turns and zero resume launches; the field-absent pre-native process launched exactly one guarded resume. |
 
+The actionable-work eligibility was revalidated deterministically on 2026-07-31 with Bash 3.2.57(1)-release.
+
+```sh
+tests/fm-turnend-guard.test.sh
+tests/fm-claude-stop-autoarm.test.sh
+tests/fm-backend.test.sh
+```
+
+Observed boundary output:
+
+```text
+ok - fm_supervision_status: done ship without resumed-work evidence does not need supervision
+ok - fm_supervision_status: positive current work overrides a trailing done event
+ok - fm_supervision_status: unknown/none secondmate is healthy idle
+ok - fm_supervision_status: active ship still needs supervision
+ok - auto-arm: done ship and idle secondmate create no background watcher cycle
+ok - auto-arm: actionable close translates to exactly one exit-2 rewake with reason
+ok - auto-arm: X-mode poll need arms the cycle even with no tasks in flight
+```
+
 The Grok adaptive matrix ran on 2026-07-28 with separate scratch repositories and homes, dedicated tmux sockets, one target plus one control window, ambient tmux variables removed, and a socket-bound wrapper first in `PATH`.
 
 ```sh

--- a/tests/fm-claude-stop-autoarm.test.sh
+++ b/tests/fm-claude-stop-autoarm.test.sh
@@ -294,6 +294,25 @@ test_inert_when_fleet_idle() {
   pass "auto-arm: inert with nothing in flight and no X-mode need"
 }
 
+test_inert_with_only_done_ship_and_idle_secondmate() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/terminal-and-idle")
+  printf 'kind=ship\n' > "$dir/state/done-ship.meta"
+  printf 'done: ready for captain review\n' > "$dir/state/done-ship.status"
+  printf 'kind=secondmate\n' > "$dir/state/idle-mate.meta"
+  cat > "$dir/bin/fm-crew-state.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'state: unknown · source: none · no current-state source available\n'
+SH
+  chmod +x "$dir/bin/fm-crew-state.sh"
+  write_arm_fixture "$dir" actionable
+  out=$(run_autoarm "$dir" 2>/dev/null); status=$?
+  expect_code 0 "$status" "hook must exit 0 when metadata contains only terminal or idle records"
+  [ ! -e "$dir/state/arm-ran" ] || fail "hook armed for a done ship or idle secondmate"
+  [ ! -e "$dir/state/.claude-autoarm-epoch" ] || fail "hook wrote an epoch with no actionable active work"
+  pass "auto-arm: done ship and idle secondmate create no background watcher cycle"
+}
+
 # --- the armed cycle ----------------------------------------------------------
 
 test_actionable_close_rewakes_with_reason() {
@@ -424,6 +443,7 @@ test_inert_when_afk
 test_stale_lock_recovery_preserves_afk_and_need_gates
 test_resolves_outermost_claude_pid_in_nested_bgspare_chain
 test_inert_when_fleet_idle
+test_inert_with_only_done_ship_and_idle_secondmate
 test_actionable_close_rewakes_with_reason
 test_failed_close_rewakes_with_failure_banner
 test_clean_close_exits_silently

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -33,6 +33,67 @@ test_predicate_healthy_no_inflight() {
   pass "fm_supervision_unhealthy: false with no state/*.meta at all"
 }
 
+make_current_state_stub() {  # <path> <state>
+  local path=$1 state=$2
+  printf '#!/usr/bin/env bash\nprintf '\''state: %%s · source: test\\n'\'' %s\n' "$state" > "$path"
+  chmod +x "$path"
+}
+
+test_predicate_done_ship_not_counted() {
+  local dir="$TMP_ROOT/pred-done-ship" state reader
+  state="$dir/state"
+  reader="$dir/crew-state"
+  mkdir -p "$state"
+  printf 'kind=ship\n' > "$state/done-ship.meta"
+  printf 'done: ready for captain review\n' > "$state/done-ship.status"
+  make_current_state_stub "$reader" unknown
+  FM_CREW_STATE_BIN="$reader" fm_supervision_status "$state" 300
+  [ "$FM_SUP_IN_FLIGHT" -eq 0 ] || fail "done ship was still counted as in flight"
+  [ "$FM_SUP_NEEDED" = false ] || fail "done ship still required supervision"
+  pass "fm_supervision_status: done ship without resumed-work evidence does not need supervision"
+}
+
+test_predicate_resumed_ship_after_done_still_counted() {
+  local dir="$TMP_ROOT/pred-resumed-ship" state reader
+  state="$dir/state"
+  reader="$dir/crew-state"
+  mkdir -p "$state"
+  printf 'kind=ship\n' > "$state/resumed-ship.meta"
+  printf 'done: initial delivery finished\n' > "$state/resumed-ship.status"
+  make_current_state_stub "$reader" working
+  FM_CREW_STATE_BIN="$reader" fm_supervision_status "$state" 300
+  [ "$FM_SUP_IN_FLIGHT" -eq 1 ] || fail "ship with positive resumed-work evidence was not counted"
+  [ "$FM_SUP_NEEDED" = true ] || fail "resumed ship no longer required supervision"
+  pass "fm_supervision_status: positive current work overrides a trailing done event"
+}
+
+test_predicate_idle_secondmate_not_counted() {
+  local dir="$TMP_ROOT/pred-idle-secondmate" state reader
+  state="$dir/state"
+  reader="$dir/crew-state"
+  mkdir -p "$state"
+  printf 'kind=secondmate\n' > "$state/mate.meta"
+  make_current_state_stub "$reader" unknown
+  FM_CREW_STATE_BIN="$reader" fm_supervision_status "$state" 300
+  [ "$FM_SUP_IN_FLIGHT" -eq 0 ] || fail "idle secondmate was still counted as in flight"
+  [ "$FM_SUP_NEEDED" = false ] || fail "idle secondmate still required supervision"
+  pass "fm_supervision_status: unknown/none secondmate is healthy idle"
+}
+
+test_predicate_active_ship_still_counted() {
+  local dir="$TMP_ROOT/pred-active-ship" state reader
+  state="$dir/state"
+  reader="$dir/crew-state"
+  mkdir -p "$state"
+  printf 'kind=ship\n' > "$state/active-ship.meta"
+  printf 'working: implementation under way\n' > "$state/active-ship.status"
+  make_current_state_stub "$reader" working
+  FM_CREW_STATE_BIN="$reader" fm_supervision_status "$state" 300
+  [ "$FM_SUP_IN_FLIGHT" -eq 1 ] || fail "active ship was not counted as in flight"
+  [ "$FM_SUP_NEEDED" = true ] || fail "active ship no longer required supervision"
+  pass "fm_supervision_status: active ship still needs supervision"
+}
+
 test_predicate_unhealthy_no_beacon() {
   local state="$TMP_ROOT/pred-nobeat/state"
   mkdir -p "$state"
@@ -1105,6 +1166,10 @@ test_hook_claude_mode_secondmate_reblocks_like_primary() {
 }
 
 test_predicate_healthy_no_inflight
+test_predicate_done_ship_not_counted
+test_predicate_resumed_ship_after_done_still_counted
+test_predicate_idle_secondmate_not_counted
+test_predicate_active_ship_still_counted
 test_predicate_unhealthy_no_beacon
 test_predicate_unhealthy_stale_beacon
 test_predicate_healthy_fresh_beacon


### PR DESCRIPTION
## 概要

- 将监督 eligibility 收敛到共享 predicate，只统计真正需要 primary 监督的 active work。
- 排除尾部 `done:` 且没有恢复工作证据的 ship，以及 canonical `unknown` idle secondmate。
- 保持 active/resumed ship、X-mode relay、watcher fail-closed 与 wake 行为不变。
- 更新 turn-end owner 文档和监督验证记录。

## 验证

- `tests/fm-turnend-guard.test.sh`
- `tests/fm-claude-stop-autoarm.test.sh`
- `tests/fm-backend.test.sh`
- `bash -n bin/fm-supervision-lib.sh bin/fm-claude-stop-autoarm.sh bin/fm-guard.sh tests/fm-turnend-guard.test.sh tests/fm-claude-stop-autoarm.test.sh`
- `bin/fm-doc-audience-check.sh`
- `git diff --check`

`bin/fm-lint.sh` 未运行：当前环境缺少仓库要求的 ShellCheck 0.11.0。