### PR TITLE
feat(bin): captain-facing kanban board generated from live fleet state

### DIFF
--- a/bin/fm-board.sh
+++ b/bin/fm-board.sh
@@ -1,0 +1,488 @@
+#!/usr/bin/env bash
+# fm-board.sh - captain-facing kanban board renderer over fm-fleet-snapshot.sh.
+#
+# Renders the live fleet as one self-contained HTML board for visual review in
+# Lavish Editor (lavish-axi). Like fm-fleet-view.sh and fm-bearings-snapshot.sh
+# it intentionally does not parse fleet state itself: backlog rows (all states
+# including captain holds), live task rows (recorded harness/model/effort and
+# current stage), and recorded PR links all come from the canonical
+# `fm-fleet-snapshot.sh --json` contract. The only extra input is the
+# hand-maintained effort maps under data/maps/*.md, which no snapshot surface
+# owns; each map contributes a top-band card (destination, decided and open
+# decision counts, fog, out of scope).
+#
+# Columns are the ordered pipeline steps Decide / Queued / Building / Review /
+# Landed:
+#   Decide   - captain-held backlog rows plus live tasks with open keyed
+#              decisions; each card carries an approval panel (radio options
+#              plus a free-text override) that queues exactly one Lavish prompt
+#              per submit.
+#   Queued   - queued backlog rows without a captain hold.
+#   Building - in-flight work with no recorded PR yet.
+#   Review   - work whose PR is recorded in task meta or backlog (the same
+#              recording fm-pr-check.sh makes when it arms the merge poll), so
+#              a Review card always links the PR.
+#   Landed   - Done backlog rows.
+#
+# The board never mutates fleet state: approval submits and card drags queue
+# Lavish prompts that come back to firstmate as exact orders, and the captain
+# releases them with Send to Agent. Approval panels are rendered as siblings
+# AFTER each card's todo <ul>, never inside it - nesting <details> inside the
+# list is the known clipping bug shape.
+#
+# Output: $FM_HOME/.lavish/fleet-board.html by default; --out overrides.
+# The file is a generated view - regenerate rather than edit it.
+#
+# usage: fm-board.sh [--out <path>]
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+OUT="$FM_HOME/.lavish/fleet-board.html"
+
+usage() {
+  cat <<'EOF'
+usage: fm-board.sh [--out <path>]
+
+Generate the captain-facing kanban board (Decide / Queued / Building /
+Review / Landed) from the live fleet snapshot plus data/maps/*.md.
+Writes $FM_HOME/.lavish/fleet-board.html unless --out overrides it.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --out)
+      [ $# -ge 2 ] || { usage >&2; exit 2; }
+      OUT=$2; shift 2 ;;
+    *) usage >&2; exit 2 ;;
+  esac
+done
+
+command -v python3 >/dev/null 2>&1 || { echo "fm-board: python3 not found" >&2; exit 1; }
+
+SNAP_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-board.XXXXXX") || exit 1
+trap 'rm -f "$SNAP_FILE"' EXIT
+
+"$SCRIPT_DIR/fm-fleet-snapshot.sh" --json > "$SNAP_FILE" \
+  || { echo "fm-board: fleet snapshot failed" >&2; exit 1; }
+
+mkdir -p "$(dirname "$OUT")" || exit 1
+
+python3 - "$SNAP_FILE" "$DATA/maps" "$OUT" <<'PY'
+import html
+import json
+import os
+import re
+import sys
+
+snap_path, maps_dir, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(snap_path, encoding="utf-8") as f:
+    snap = json.load(f)
+
+records = snap.get("backlog", {}).get("records", [])
+tasks = {t.get("id"): t for t in snap.get("tasks", [])}
+
+
+def esc(value):
+    return html.escape(str(value or ""), quote=True)
+
+
+def slugify(value):
+    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", str(value or "")).strip("-")
+    return slug[:80] or "decision"
+
+
+def clip(text, limit):
+    text = str(text or "").strip()
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def decision_key(record, task):
+    for line in (record or {}).get("body_lines", []) or []:
+        match = re.match(r"\s*Decision key:\s*(\S+)", line)
+        if match:
+            return slugify(match.group(1))
+    for dec in ((task or {}).get("hints", {}) or {}).get("open_decisions", []) or []:
+        if dec.get("key"):
+            return slugify(dec["key"])
+    return slugify((record or {}).get("id") or (task or {}).get("id"))
+
+
+def pr_url(record, task):
+    url = ((task or {}).get("pr", {}) or {}).get("url")
+    return url or (record or {}).get("pr_url")
+
+
+# --- classify every backlog row and live task into one pipeline column ------
+decide, queued, building, review, landed = [], [], [], [], []
+seen_task_ids = set()
+
+for record in records:
+    task = tasks.get(record.get("id")) if record.get("structured") else None
+    if task:
+        seen_task_ids.add(record["id"])
+    state = record.get("state")
+    if not record.get("structured"):
+        target = landed if state == "done" else (queued if state == "queued" else building)
+        target.append((record, None))
+        continue
+    hints = (task or {}).get("hints", {}) or {}
+    if state == "done":
+        landed.append((record, task))
+    elif record.get("hold_kind") == "captain" or hints.get("open_decisions"):
+        decide.append((record, task))
+    elif state == "queued":
+        queued.append((record, task))
+    elif pr_url(record, task):
+        review.append((record, task))
+    else:
+        building.append((record, task))
+
+for task_id in sorted(tasks):
+    task = tasks[task_id]
+    if task_id in seen_task_ids or task.get("kind") == "secondmate":
+        continue
+    if (task.get("hints", {}) or {}).get("open_decisions"):
+        decide.append((None, task))
+    elif pr_url(None, task):
+        review.append((None, task))
+    else:
+        building.append((None, task))
+
+
+# --- effort maps under data/maps/ -------------------------------------------
+def parse_map(path):
+    info = {
+        "title": os.path.basename(path)[:-3],
+        "destination": "",
+        "decided": 0,
+        "open": 0,
+        "fog": [],
+        "out_of_scope": [],
+    }
+    section = None
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip()
+            if line.startswith("# "):
+                match = re.match(r"#\s*(?:Effort map:\s*)?(.+)", line)
+                if match:
+                    info["title"] = match.group(1).strip()
+            elif line.startswith("## "):
+                heading = line[3:].strip().lower()
+                if heading.startswith("destination"):
+                    section = "destination"
+                elif heading.startswith("decisions"):
+                    section = "decided"
+                elif heading.startswith("open"):
+                    section = "open"
+                elif heading.startswith("not yet"):
+                    section = "fog"
+                elif heading.startswith("out of scope"):
+                    section = "out_of_scope"
+                else:
+                    section = None
+            elif section == "destination" and line.strip():
+                joiner = " " if info["destination"] else ""
+                info["destination"] += joiner + line.strip()
+            elif line.lstrip().startswith("- "):
+                item = line.lstrip()[2:].strip()
+                if section == "decided":
+                    info["decided"] += 1
+                elif section == "open":
+                    info["open"] += 1
+                elif section == "fog":
+                    info["fog"].append(item)
+                elif section == "out_of_scope":
+                    info["out_of_scope"].append(item)
+    return info
+
+
+maps = []
+if os.path.isdir(maps_dir):
+    for name in sorted(os.listdir(maps_dir)):
+        if name.endswith(".md"):
+            try:
+                maps.append(parse_map(os.path.join(maps_dir, name)))
+            except OSError:
+                continue
+
+
+# --- card rendering ----------------------------------------------------------
+def stage_of(record, task):
+    if task:
+        current = task.get("current_state", {}) or {}
+        state = current.get("state") or "unknown"
+        detail = current.get("detail") or ""
+        return f"{state} - {detail}" if detail else state
+    if record and record.get("hold_kind") == "captain":
+        return "awaiting decision"
+    if record and record.get("blocked_by"):
+        return f"blocked by {record['blocked_by']}"
+    if record and record.get("state") == "done":
+        verb = (record.get("completion", {}) or {}).get("verb") or "done"
+        date = (record.get("completion", {}) or {}).get("date") or ""
+        return f"{verb} {date}".strip()
+    return "no live worker yet"
+
+
+def crew_badge(task):
+    if not task:
+        return ""
+    parts = [task.get("harness") or "?"]
+    if task.get("model") and task["model"] != "default":
+        parts.append(task["model"])
+    if task.get("effort"):
+        parts.append(f"{task['effort']} effort")
+    return " · ".join(parts)
+
+
+def todo_lines(record):
+    lines = []
+    for line in (record or {}).get("body_lines", []) or []:
+        line = line.strip()
+        if line:
+            lines.append(clip(line, 160))
+        if len(lines) == 4:
+            break
+    return lines
+
+
+def approval_panel(record, task):
+    key = decision_key(record, task)
+    reason = (record or {}).get("hold_reason") or ""
+    if not reason:
+        for dec in ((task or {}).get("hints", {}) or {}).get("open_decisions", []) or []:
+            if dec.get("summary"):
+                reason = dec["summary"]
+                break
+    parts = [f'<details class="approval" data-lavish-question="{esc(key)}">']
+    parts.append("<summary>⚑ YOUR APPROVAL - click for options</summary>")
+    if reason:
+        parts.append(f'<p class="text-xs opacity-80">{esc(clip(reason, 320))}</p>')
+    parts.append(f'<form data-question="{esc(key)}" onsubmit="return fbDecide(event)">')
+    options = [
+        ("approve - proceed as recommended", True),
+        ("hold for now", False),
+        ("more detail first - report back before acting", False),
+    ]
+    for value, recommended in options:
+        label = f"<b>{esc(value.capitalize())}</b>" if recommended else esc(value.capitalize())
+        parts.append(
+            f'<label><input type="radio" name="{esc(key)}" value="{esc(value)}"> {label}</label>'
+        )
+    parts.append(
+        '<textarea name="freetext" rows="1" class="textarea textarea-bordered textarea-xs"'
+        ' placeholder="…or write your own answer"></textarea>'
+    )
+    parts.append('<button type="submit" class="btn btn-warning btn-xs mt-1">Queue this answer</button>')
+    parts.append(
+        '<span class="queued-note">✓ queued - press Send to Agent when done choosing</span>'
+    )
+    parts.append("</form></details>")
+    return "".join(parts)
+
+
+TICKET_CLASS = {
+    "decide": "t-captain",
+    "queued": "t-queued",
+    "building": "t-flight",
+    "review": "t-upstream",
+    "landed": "t-done",
+}
+
+
+def card(record, task, column):
+    title = (record or {}).get("title") or (record or {}).get("raw") or (task or {}).get("id") or "untitled"
+    url = pr_url(record, task)
+    heading = f'<a class="link" href="{esc(url)}">{esc(clip(title, 140))}</a>' if url else esc(clip(title, 140))
+    badges = []
+    repo = (record or {}).get("repo")
+    if repo:
+        badges.append(f'<span class="badge badge-xs badge-ghost">{esc(repo)}</span>')
+    kind = (record or {}).get("kind") or (task or {}).get("kind")
+    if kind:
+        badges.append(f'<span class="badge badge-xs badge-ghost">{esc(kind)}</span>')
+    crew = crew_badge(task)
+    if crew:
+        badges.append(f'<span class="badge badge-xs badge-info badge-outline">crew: {esc(crew)}</span>')
+    badges.append(f'<span class="badge badge-xs badge-ghost">stage: {esc(clip(stage_of(record, task), 90))}</span>')
+    blocked_by = (record or {}).get("blocked_by")
+    if blocked_by:
+        badges.append(f'<span class="badge badge-xs badge-warning badge-outline">blocked-by: {esc(blocked_by)}</span>')
+
+    parts = [
+        '<div draggable="true" ondragstart="fbDrag(event, this)"'
+        ' ondragend="this.classList.remove(\'dragging\')"'
+        f' class="card card-compact bg-base-100 ticket {TICKET_CLASS[column]} shadow"'
+        f' data-board-id="{esc((record or {}).get("id") or (task or {}).get("id") or "")}">',
+        '<div class="card-body">',
+        f'<h3 class="font-semibold text-sm">{heading}</h3>',
+        f'<div class="meta-row">{"".join(badges)}</div>',
+    ]
+    lines = todo_lines(record)
+    if not lines and task:
+        note = ((task.get("hints", {}) or {}).get("last_event_text")) or ""
+        if note:
+            lines = [clip(note, 160)]
+    if lines:
+        items = "".join(f"<li>{esc(line)}</li>" for line in lines)
+        parts.append(f'<ul class="todos opacity-80">{items}</ul>')
+    # The approval panel is a SIBLING of the todo list on purpose: a <details>
+    # inside the <ul> is the prototype's clipping bug.
+    if column == "decide":
+        parts.append(approval_panel(record, task))
+    parts.append("</div></div>")
+    return "".join(parts)
+
+
+def column_html(key, number, emoji, title, accent, entries):
+    cards = "".join(card(record, task, key) for record, task in entries)
+    if not cards:
+        cards = '<div class="text-xs opacity-50 italic p-2">nothing here</div>'
+    return (
+        '<section class="col" ondragover="event.preventDefault(); this.classList.add(\'dropover\')"'
+        ' ondragleave="this.classList.remove(\'dropover\')" ondrop="fbDrop(event, this)">'
+        f'<h2 class="font-semibold mb-2 {accent}">{number} · {emoji} {title}</h2>'
+        f'<div class="flex flex-col gap-3">{cards}</div>'
+        "</section>"
+    )
+
+
+def map_card(info):
+    badges = [
+        f'<span class="badge badge-xs badge-success">{info["decided"]} decided</span>',
+        f'<span class="badge badge-xs badge-warning">{info["open"]} open</span>',
+    ]
+    fog = clip("; ".join(info["fog"]), 120) if info["fog"] else "none - remaining work is sharp"
+    badges.append(f'<span class="badge badge-xs badge-ghost">fog: {esc(fog)}</span>')
+    if info["out_of_scope"]:
+        badges.append(
+            f'<span class="badge badge-xs badge-ghost">out of scope: {esc(clip("; ".join(info["out_of_scope"]), 120))}</span>'
+        )
+    return (
+        '<div class="card card-compact bg-base-100 shadow border-l-4" style="border-left-color: oklch(78% 0.14 200);">'
+        '<div class="card-body">'
+        f'<h3 class="font-semibold text-sm">\U0001f5fa️ Effort: {esc(info["title"])}</h3>'
+        f'<p class="text-xs opacity-80"><b>Destination:</b> {esc(clip(info["destination"], 320))}</p>'
+        f'<div class="meta-row">{"".join(badges)}</div>'
+        "</div></div>"
+    )
+
+
+generated = snap.get("generated") or ""
+date = generated[:10]
+counts = [
+    ("badge-warning", f"Your call: {len(decide)}"),
+    ("badge-accent", f"Queued: {len(queued)}"),
+    ("badge-info", f"Building: {len(building)}"),
+    ("badge-secondary", f"Review: {len(review)}"),
+    ("badge-success", f"Landed: {len(landed)}"),
+]
+count_html = "".join(
+    f'<span class="badge {cls} badge-outline">{esc(text)}</span>' for cls, text in counts
+)
+maps_html = ""
+if maps:
+    maps_html = (
+        '<div class="mb-4 grid grid-cols-1 md:grid-cols-2 gap-3">'
+        + "".join(map_card(m) for m in maps)
+        + "</div>"
+    )
+
+columns = "".join(
+    [
+        column_html("decide", 1, "⚓", "Decide", "text-warning", decide),
+        column_html("queued", 2, "\U0001f9ed", "Queued", "text-accent", queued),
+        column_html("building", 3, "⛵", "Building", "text-info", building),
+        column_html("review", 4, "\U0001f30a", "Review", "text-secondary", review),
+        column_html("landed", 5, "\U0001f3c1", "Landed", "text-success", landed),
+    ]
+)
+
+page = f"""<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Fleet Board — {esc(date)}</title>
+<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+<link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css">
+<style>
+  .col {{ min-width: 0; }}
+  .card-compact .card-body {{ padding: 0.85rem; }}
+  .ticket {{ border-left: 4px solid transparent; overflow: visible; }}
+  .card, .card-body, .todos, .todos li, details, summary {{ overflow: visible !important; max-height: none !important; height: auto !important; }}
+  .t-captain {{ border-left-color: oklch(75% 0.18 60); }}
+  .t-flight  {{ border-left-color: oklch(70% 0.15 250); }}
+  .t-queued  {{ border-left-color: oklch(70% 0.12 180); }}
+  .t-upstream{{ border-left-color: oklch(72% 0.14 300); }}
+  .t-done    {{ border-left-color: oklch(72% 0.17 145); }}
+  .todos {{ font-size: 0.72rem; line-height: 1.35; }}
+  .todos li {{ list-style: none; }}
+  .meta-row {{ display:flex; flex-wrap:wrap; gap:0.3rem; margin:0.25rem 0; }}
+  .approval {{ background: oklch(30% 0.06 60 / 0.4); border: 1px solid oklch(75% 0.18 60 / 0.7); border-radius: 0.4rem; padding: 0.25rem 0.45rem; margin: 0.25rem 0; }}
+  .approval summary {{ font-weight: 700; color: oklch(85% 0.16 70); cursor: pointer; font-size: 0.7rem; }}
+  .approval textarea {{ width:100%; font-size:0.7rem; margin-top:0.2rem; }}
+  .approval label {{ display:block; font-size:0.7rem; padding:0.1rem 0; cursor:pointer; }}
+  .approval .queued-note {{ display:none; font-size:0.7rem; color: oklch(80% 0.15 145); font-weight:600; }}
+  .dragging {{ opacity: 0.4; }}
+  .col.dropover {{ outline: 2px dashed oklch(70% 0.15 250); outline-offset: 4px; border-radius: 0.5rem; }}
+</style>
+</head>
+<body class="bg-base-200 min-h-screen p-4 md:p-6">
+<div class="max-w-[1700px] mx-auto">
+  <header class="mb-5 flex flex-wrap items-end justify-between gap-2">
+    <div>
+      <h1 class="text-2xl font-bold">Fleet Board</h1>
+      <p class="text-sm opacity-70">snapshot {esc(generated)} · regenerate with bin/fm-board.sh; say “refresh the board” anytime</p>
+    </div>
+    <div class="flex gap-2 text-xs">{count_html}</div>
+  </header>
+  {maps_html}
+  <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4">
+{columns}
+  </div>
+  <footer class="mt-6 text-xs opacity-60">Static snapshot — answer Decide cards or drag tickets, then press Send to Agent; firstmate dispatches from this board.</footer>
+</div>
+<script>
+let fbDragged=null;
+function fbDrag(ev, el){{ fbDragged=el; el.classList.add('dragging'); ev.dataTransfer.effectAllowed='move'; }}
+function fbDrop(ev, colEl){{
+  ev.preventDefault(); colEl.classList.remove('dropover');
+  if(!fbDragged) return;
+  const ticket=(fbDragged.querySelector('h3')||{{}}).innerText||'ticket';
+  const stage=(colEl.querySelector('h2')||{{}}).innerText||'column';
+  colEl.querySelector('.flex.flex-col').appendChild(fbDragged);
+  if(window.lavish && window.lavish.queuePrompt){{
+    window.lavish.queuePrompt('Move ticket "'+ticket.trim()+'" to stage "'+stage.trim()+'" - advance it accordingly', {{ tag:'move', text:ticket.trim()+' -> '+stage.trim(), element: fbDragged, queueKey:'move-'+ticket.trim() }});
+  }}
+  fbDragged=null;
+}}
+function fbDecide(ev){{
+  ev.preventDefault();
+  const form=ev.currentTarget;
+  const key=form.dataset.question;
+  const fd=new FormData(form);
+  const c=((fd.get('freetext')||'').trim()) || fd.get(key);
+  if(c && window.lavish && window.lavish.queuePrompt){{
+    window.lavish.queuePrompt('Decision '+key+': '+c, {{ tag:'choice', text:key+': '+c, element: form, queueKey:key, data:{{question:key, answer:c}} }});
+    form.querySelector('.queued-note').style.display='block';
+  }}
+  return false;
+}}
+</script>
+</body>
+</html>
+"""
+
+with open(out_path, "w", encoding="utf-8") as f:
+    f.write(page)
+PY
+rc=$?
+[ "$rc" -eq 0 ] || { echo "fm-board: render failed" >&2; exit "$rc"; }
+printf 'board: %s\n' "$OUT"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -21,6 +21,8 @@
 #     captain_actionable fields. Repeated blocker tokens remain ordered; a blocker
 #     resolves only when its structured record is Done, and missing ids stay open.
 #   tasks[]: one row per state/<id>.meta, sorted by id.
+#     harness, model, and effort mirror the recorded dispatch profile from the
+#     meta file ("" when unrecorded).
 #     current_state is parsed from bin/fm-crew-state.sh <id> and preserves
 #     state, source, detail, and raw line separately.
 #     paths.status_log.last_event is historical wake-event data only, never
@@ -398,7 +400,7 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
 }
 
 task_json_lines() {
-  local meta id kind harness mode yolo project worktree home projects backend target status_log report_path
+  local meta id kind harness model effort mode yolo project worktree home projects backend target status_log report_path
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
@@ -409,6 +411,8 @@ task_json_lines() {
     kind=$(meta_value "$meta" kind)
     [ -n "$kind" ] || kind=ship
     harness=$(meta_value "$meta" harness)
+    model=$(meta_value "$meta" model)
+    effort=$(meta_value "$meta" effort)
     mode=$(meta_value "$meta" mode)
     yolo=$(meta_value "$meta" yolo)
     project=$(meta_value "$meta" project)
@@ -491,6 +495,8 @@ task_json_lines() {
       --arg id "$id" \
       --arg kind "$kind" \
       --arg harness "$harness" \
+      --arg model "$model" \
+      --arg effort "$effort" \
       --arg mode "$mode" \
       --arg yolo "$yolo" \
       --arg project "$project" \
@@ -519,6 +525,8 @@ task_json_lines() {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
+        model:($model // ""),
+        effort:($effort // ""),
         mode:($mode // ""),
         yolo:($yolo // ""),
         project:($project // ""),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ Decision-only events such as `resolved` never become current state or leak their
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.
 The semantic branch reports working only on an exact busy verdict and names the source that produced it; an unknown verdict never becomes working, never permits the status-log fallback, and never becomes a silent idle.
 For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, and secondmate return-channel guidance.
-`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
+`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, and `bin/fm-board.sh` renders the captain-facing kanban board ([board.md](board.md)), so all three views consume one structured contract instead of reparsing raw fleet files.
 The script header owns the exact JSON schema.
 
 ### Registered secondmate current state

--- a/docs/board.md
+++ b/docs/board.md
@@ -1,0 +1,34 @@
+# Fleet board
+
+The fleet board is a captain-facing kanban view of everything under way, generated on demand from live fleet state.
+It is a review and decision surface, never a second tracker: the backlog remains the single queue, and firstmate remains the dispatcher.
+
+## Generate
+
+Run `bin/fm-board.sh`.
+It renders the canonical fleet snapshot (`bin/fm-fleet-snapshot.sh --json`) plus the hand-maintained effort maps under `data/maps/*.md` into one self-contained HTML file, `$FM_HOME/.lavish/fleet-board.html` by default (`--out` overrides).
+The script's header and `--help` own the exact flags and column-routing rules.
+
+## Read
+
+The top band shows one card per effort map: the destination, decided and open decision counts, fog (what is not yet specified), and what is out of scope.
+Below it, every backlog row and live task lands in exactly one of five ordered pipeline columns:
+
+1. **Decide** - captain-held items and live tasks parked on an open decision.
+2. **Queued** - queued work waiting on dispatch or a blocker.
+3. **Building** - in-flight work with no pull request recorded yet, with the assigned worker runtime, model, and effort on the card.
+4. **Review** - work whose pull request is recorded and being watched for merge; the card title links the PR.
+5. **Landed** - recently completed work.
+
+## Review and decide
+
+Open the board for visual review with `lavish-axi "$FM_HOME/.lavish/fleet-board.html"`.
+Every interaction queues a prompt instead of mutating anything:
+
+- Each Decide card carries an approval panel: pick a radio option or write a free-text answer, and one prompt per submitted decision is queued.
+- Dragging a card to another column queues a move order for that ticket.
+
+Pressing Send to Agent delivers the queued prompts to firstmate as exact orders; firstmate then applies its normal authority rules before acting on them.
+Nothing on the board bypasses merge authority, captain holds, or any other approval boundary.
+
+The board is a static snapshot: regenerate it with `bin/fm-board.sh` (say "refresh the board") rather than editing the generated file.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -200,6 +200,10 @@
       "audience": "maintainer-architecture"
     },
     {
+      "path": "docs/board.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/calm-mode-feasibility.md",
       "audience": "maintainer-verification"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -15,6 +15,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
+| `fm-board.sh`            | Render the fleet snapshot plus `data/maps/` as the captain-facing kanban board HTML ([board.md](board.md)) |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |

--- a/tests/fm-board.test.sh
+++ b/tests/fm-board.test.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Behavior tests for the captain-facing kanban board generator (bin/fm-board.sh).
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BOARD="$ROOT/bin/fm-board.sh"
+TMP_ROOT=$(fm_test_tmproot fm-board)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found"; exit 0; }
+
+make_fakebin() {  # <dir>
+  local fb
+  fb=$(fm_fakebin "$1")
+  cat > "$fb/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  list-windows)
+    sed -n 's/^window=[^:]*://p' "${FM_HOME:?}"/state/*.meta
+    ;;
+  display-message)
+    case "$*" in
+      *pane_current_command*) printf 'codex\n' ;;
+      *) printf '%%1\n' ;;
+    esac
+    ;;
+  capture-pane)
+    printf 'work in progress\nesc to interrupt\n'
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/no-mistakes" "$fb/tmux"
+  printf '%s\n' "$fb"
+}
+
+make_home() {  # <name>
+  local home=$TMP_ROOT/$1
+  mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config"
+  printf '%s\n' "$home"
+}
+
+write_fixture() {  # <home>
+  local home=$1
+  mkdir -p "$home/projects/build-worktree" "$home/projects/review-worktree" "$home/data/maps"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] build-task - Build The Widget (repo: alpha) (kind: ship) (since 2026-07-29)
+  Widget assembly in progress.
+- [ ] review-task - Review The Rudder (repo: alpha) (kind: ship) (since 2026-07-29)
+
+## Queued
+- [ ] decide-task - Pick The Mast Color (repo: alpha) (kind: captain) (since 2026-07-30) (hold: Two finishes fit; captain picks one) (hold-kind: captain)
+  Decision key: mast-color
+- [ ] queued-task - Queued Chore blocked-by: build-task (repo: alpha) (kind: ship) (since 2026-07-30)
+
+## Done
+- [x] landed-task - Landed Improvement https://github.com/kunchenguid/firstmate/pull/7 (repo: alpha) (kind: ship) (merged 2026-07-28)
+EOF
+  fm_write_meta "$home/state/build-task.meta" \
+    "window=firstmate:fm-build-task" \
+    "worktree=$home/projects/build-worktree" \
+    "project=alpha" \
+    "harness=codex" \
+    "model=opus" \
+    "effort=high" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "yolo=off"
+  printf 'working: assembling the widget\n' > "$home/state/build-task.status"
+  fm_write_meta "$home/state/review-task.meta" \
+    "window=firstmate:fm-review-task" \
+    "worktree=$home/projects/review-worktree" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "yolo=off" \
+    "pr=https://github.com/kunchenguid/firstmate/pull/9"
+  printf 'done: PR https://github.com/kunchenguid/firstmate/pull/9 checks green\n' > "$home/state/review-task.status"
+  cat > "$home/data/maps/alpha-refit.md" <<'EOF'
+# Effort map: alpha refit
+
+## Destination
+Alpha sails clean: refit landed and every mast decision settled.
+
+## Decisions so far
+- keel shape approved
+- sail cut approved
+
+## Not yet specified
+- rigging vendor
+
+## Out of scope
+- new hull
+
+## Open captain decisions (live tickets)
+- mast color
+EOF
+}
+
+test_board_renders_columns_and_cards() {
+  local home fakebin out html
+  home=$(make_home fixture)
+  write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  out="$home/board.html"
+  PATH="$fakebin:$PATH" FM_HOME="$home" "$BOARD" --out "$out" >/dev/null \
+    || fail "board generation failed"
+  [ -f "$out" ] || fail "board output file missing"
+  html=$(cat "$out")
+
+  local col
+  for col in Decide Queued Building Review Landed; do
+    assert_contains "$html" "$col" "board must contain the $col column"
+  done
+
+  assert_contains "$html" "Pick The Mast Color" "captain hold card must land in the board"
+  assert_contains "$html" 'data-lavish-question="mast-color"' \
+    "approval panel must carry the decision key from the backlog body"
+  assert_contains "$html" 'type="radio"' "approval panel must offer radio options"
+  assert_contains "$html" 'name="freetext"' "approval panel must offer a free-text override"
+  assert_contains "$html" "window.lavish.queuePrompt" "interactions must queue Lavish prompts"
+
+  assert_contains "$html" "Build The Widget" "in-flight card must render"
+  assert_contains "$html" "crew: codex · opus · high effort" \
+    "building card must show the assigned harness, model, and effort"
+  assert_contains "$html" "Queued Chore" "queued card must render"
+  assert_contains "$html" "blocked-by: build-task" "queued card must surface its blocker"
+  assert_contains "$html" 'href="https://github.com/kunchenguid/firstmate/pull/9"' \
+    "review card must link the armed PR"
+  assert_contains "$html" "Landed Improvement" "done card must render in Landed"
+
+  assert_contains "$html" "Alpha sails clean" "effort-map destination must render in the top band"
+  assert_contains "$html" "2 decided" "effort-map decided count must render"
+  assert_contains "$html" "1 open" "effort-map open count must render"
+
+  assert_contains "$html" 'draggable="true"' "cards must be draggable"
+  assert_contains "$html" "fbDrop" "columns must accept drops that queue move orders"
+  pass "board renders all five columns, cards, decision panels, and effort maps"
+}
+
+test_review_and_decide_routing() {
+  local home fakebin out html
+  home=$(make_home routing)
+  write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  out="$home/board.html"
+  PATH="$fakebin:$PATH" FM_HOME="$home" "$BOARD" --out "$out" >/dev/null \
+    || fail "board generation failed"
+  html=$(cat "$out")
+  # Column routing: the PR-recorded task reaches Review, the hold reaches
+  # Decide, and each card appears exactly once on the board.
+  local review_col decide_col
+  review_col=${html#*"🌊 Review"}
+  assert_contains "$review_col" "Review The Rudder" "PR-recorded card must be in or after the Review column"
+  decide_col=${html%%"🧭 Queued"*}
+  assert_contains "$decide_col" "Pick The Mast Color" "captain hold must be in the Decide column"
+  case "$html" in
+    *"Review The Rudder"*"Review The Rudder"*) fail "cards must appear exactly once" ;;
+  esac
+  pass "captain holds route to Decide and PR-recorded work routes to Review"
+}
+
+test_approval_panels_stay_out_of_lists() {
+  local home fakebin out
+  home=$(make_home clipping)
+  write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  out="$home/board.html"
+  PATH="$fakebin:$PATH" FM_HOME="$home" "$BOARD" --out "$out" >/dev/null \
+    || fail "board generation failed"
+  python3 - "$out" <<'PY' || fail "an approval details block is nested inside a list (clipping bug)"
+import sys
+from html.parser import HTMLParser
+
+class Check(HTMLParser):
+    VOID = {"meta", "link", "input", "br", "img", "progress", "hr"}
+    def __init__(self):
+        super().__init__()
+        self.stack = []
+        self.bad = False
+    def handle_starttag(self, tag, attrs):
+        if tag == "details" and "ul" in self.stack:
+            self.bad = True
+        if tag not in self.VOID:
+            self.stack.append(tag)
+    def handle_endtag(self, tag):
+        if self.stack and self.stack[-1] == tag:
+            self.stack.pop()
+
+check = Check()
+with open(sys.argv[1], encoding="utf-8") as f:
+    check.feed(f.read())
+sys.exit(1 if check.bad else 0)
+PY
+  pass "approval panels are siblings of the todo list, never nested in it"
+}
+
+test_default_output_path_and_empty_home() {
+  local home fakebin
+  home=$(make_home empty)
+  fakebin=$(make_fakebin "$home")
+  PATH="$fakebin:$PATH" FM_HOME="$home" "$BOARD" >/dev/null \
+    || fail "board generation must succeed on an empty home"
+  [ -f "$home/.lavish/fleet-board.html" ] \
+    || fail "default output must land in \$FM_HOME/.lavish/fleet-board.html"
+  assert_contains "$(cat "$home/.lavish/fleet-board.html")" "nothing here" \
+    "empty columns must render an explicit placeholder"
+  pass "default output path works and an empty fleet renders explicit placeholders"
+}
+
+test_board_renders_columns_and_cards
+test_review_and_decide_routing
+test_approval_panels_stay_out_of_lists
+test_default_output_path_and_empty_home


### PR DESCRIPTION
## Intent

Build the captain-facing kanban board INTO firstmate as a standing feature, productizing the hand-built .lavish/fleet-board.html prototype the captain has been using (its behaviors are the spec). Deliverables per the brief: (1) bin/fm-board.sh generating the board HTML from live fleet state - the tasks-axi backlog including captain holds, state/*.meta + status (assigned harness/model/effort, current stage), armed PR merge polls as links, and effort maps under data/maps/ rendered as a top band (destination, decided/open counts, fog, out-of-scope) - output to .lavish/fleet-board.html with columns as ordered pipeline steps Decide/Queued/Building/Review/Landed; (2) interactivity exactly as the prototype: per-decision approval panels with radio options plus a free-text override queueing exactly one prompt per submit via window.lavish.queuePrompt, draggable cards whose drop queues a move order, compact styling, and deliberately keeping approval details blocks OUT of ul lists to avoid the clipping bug the prototype hit (a test enforces this structurally); (3) a board section in the docs with one owner (docs/board.md, classified operator-current in docs/documentation-audiences.json, plus a docs/scripts.md toolbelt row) describing generate via bin/fm-board.sh, review via lavish-axi, and decisions flowing back as exact orders; (4) a colocated behavioral test tests/fm-board.test.sh (fixture backlog -> generated HTML asserts columns, cards, decision panels, PR links, effort maps). Deliberate design decisions: fm-board.sh follows the repo's established renderer convention (like fm-fleet-view.sh and fm-bearings-snapshot.sh) - it consumes the canonical fm-fleet-snapshot.sh --json contract instead of re-parsing state files, so bin/fm-fleet-snapshot.sh was extended additively to expose the recorded model and effort meta fields on task rows (schema fm-fleet-snapshot.v1, additive and backward compatible; existing snapshot and bearings suites verified green). The only non-snapshot input is data/maps/*.md because no snapshot surface owns effort maps. The generator is dependency-free (bash + python3 stdlib); Tailwind/DaisyUI via CDN in the generated HTML is the established look and was requested. Approval-panel option lists are generic (approve/hold/more-detail plus free text) because backlog holds carry no structured option lists; the decision key comes from the record's 'Decision key:' body line when present. Interactions only QUEUE Lavish prompts - the board never mutates fleet state, preserving firstmate's authority boundaries. Constraint from the brief: the pinned shellcheck is linux-only, so locally-unrunnable lint is expected, not failure.

## What Changed

- New `bin/fm-board.sh` renders `.lavish/fleet-board.html` from the canonical `fm-fleet-snapshot.sh --json` contract (plus `data/maps/*.md` for effort maps): Decide/Queued/Building/Review/Landed pipeline columns, per-decision approval panels (radio options + free-text override) that queue exactly one prompt per submit via `window.lavish.queuePrompt`, draggable cards whose drop queues a move order, armed PR merge polls as links, and an effort-map top band. Interactions only queue Lavish prompts — the board never mutates fleet state — and approval details blocks are kept out of `ul` lists to avoid the prototype's clipping bug.
- `bin/fm-fleet-snapshot.sh` additively exposes the recorded `model` and `effort` meta fields on task rows (schema `fm-fleet-snapshot.v1`, backward compatible; existing snapshot and bearings suites remain green).
- Adds `tests/fm-board.test.sh` (fixture backlog → generated HTML, asserting columns, cards, decision panels, PR links, effort maps, and the structural details-not-in-ul guard) and docs: `docs/board.md` (classified operator-current in `docs/documentation-audiences.json`), a `docs/scripts.md` toolbelt row, and `docs/architecture.md` now counting `fm-board.sh` among the fleet-snapshot renderers.

## Risk Assessment

✅ Low: A well-bounded additive feature — a new read-only renderer that consumes the verified fm-fleet-snapshot.v1 contract, purely additive snapshot fields with no strict-key consumers, faithful prototype-parity interactivity that only queues prompts and never mutates fleet state, plus docs and a colocated behavioral test covering every required behavior; the sole finding is a minor robustness nit.

## Testing

Ran the colocated fm-board behavioral suite plus the fleet-snapshot and bearings suites (all green), verified the fm-fleet-snapshot.v1 JSON contract additively exposes model/effort, then generated a board from a realistic fixture home and drove it in a real browser: screenshots show the effort-map top band, all five ordered pipeline columns with correctly routed cards, crew/blocker/PR details, and the expanded approval panel; interaction checks proved one queued Lavish prompt per decision submit and per drag-drop move with no fleet-state mutation, and the docs deliverables validate via fm-doc-audience-check.

- Evidence: Fleet board overview (five columns, effort-map band, routed cards) (local file: <code>/var/folders/gp/phywrkfd3kj2jp2f764xmldw0000gn/T/no-mistakes-evidence/01KYVAWPYEYE3PT7S33Y5Q97HV/fleet-board-overview.png</code>)
- Evidence: Approval panel expanded (radio options + free-text override, no clipping) (local file: <code>/var/folders/gp/phywrkfd3kj2jp2f764xmldw0000gn/T/no-mistakes-evidence/01KYVAWPYEYE3PT7S33Y5Q97HV/fleet-board-approval-panel.png</code>)
- Evidence: After interactions: decision queued (✓ note) and card dragged to Building (local file: <code>/var/folders/gp/phywrkfd3kj2jp2f764xmldw0000gn/T/no-mistakes-evidence/01KYVAWPYEYE3PT7S33Y5Q97HV/fleet-board-after-interactions.png</code>)
<details>
<summary>Evidence: Generated board HTML from fixture fleet state</summary>

```text
<!doctype html>
<html lang="en" data-theme="dark">
<head>
<meta charset="utf-8">
<meta name="viewport" content="width=device-width, initial-scale=1">
<title>Fleet Board — 2026-07-31</title>
<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
<link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css">
<style>
  .col { min-width: 0; }
  .card-compact .card-body { padding: 0.85rem; }
  .ticket { border-left: 4px solid transparent; overflow: visible; }
  .card, .card-body, .todos, .todos li, details, summary { overflow: visible !important; max-height: none !important; height: auto !important; }
  .t-captain { border-left-color: oklch(75% 0.18 60); }
  .t-flight  { border-left-color: oklch(70% 0.15 250); }
  .t-queued  { border-left-color: oklch(70% 0.12 180); }
  .t-upstream{ border-left-color: oklch(72% 0.14 300); }
  .t-done    { border-left-color: oklch(72% 0.17 145); }
  .todos { font-size: 0.72rem; line-height: 1.35; }
  .todos li { list-style: none; }
  .meta-row { display:flex; flex-wrap:wrap; gap:0.3rem; margin:0.25rem 0; }
  .approval { background: oklch(30% 0.06 60 / 0.4); border: 1px solid oklch(75% 0.18 60 / 0.7); border-radius: 0.4rem; padding: 0.25rem 0.45rem; margin: 0.25rem 0; }
  .approval summary { font-weight: 700; color: oklch(85% 0.16 70); cursor: pointer; font-size: 0.7rem; }
  .approval textarea { width:100%; font-size:0.7rem; margin-top:0.2rem; }
  .approval label { display:block; font-size:0.7rem; padding:0.1rem 0; cursor:pointer; }
  .approval .queued-note { display:none; font-size:0.7rem; color: oklch(80% 0.15 145); font-weight:600; }
  .dragging { opacity: 0.4; }
  .col.dropover { outline: 2px dashed oklch(70% 0.15 250); outline-offset: 4px; border-radius: 0.5rem; }
</style>
</head>
<body class="bg-base-200 min-h-screen p-4 md:p-6">
<div class="max-w-[1700px] mx-auto">
  <header class="mb-5 flex flex-wrap items-end justify-between gap-2">
    <div>
      <h1 class="text-2xl font-bold">Fleet Board</h1>
      <p class="text-sm opacity-70">snapshot 2026-07-31T05:45:13Z · regenerate with bin/fm-board.sh; say “refresh the board” anytime</p>
    </div>
    <div class="flex gap-2 text-xs"><span class="badge badge-warning badge-outline">Your call: 1</span><span class="badge badge-accent badge-outline">Queued: 1</span><span class="badge badge-info badge-outline">Building: 1</span><span class="badge badge-secondary badge-outline">Review: 1</span><span class="badge badge-success badge-outline">Landed: 1</span></div>
  </header>
  <div class="mb-4 grid grid-cols-1 md:grid-cols-2 gap-3"><div class="card card-compact bg-base-100 shadow border-l-4" style="border-left-color: oklch(78% 0.14 200);"><div class="card-body"><h3 class="font-semibold text-sm">🗺️ Effort: alpha refit</h3><p class="text-xs opacity-80"><b>Destination:</b> Alpha sails clean: refit landed and every mast decision settled.</p><div class="meta-row"><span class="badge badge-xs badge-success">2 decided</span><span class="badge badge-xs badge-warning">1 open</span><span class="badge badge-xs badge-ghost">fog: rigging vendor</span><span class="badge badge-xs badge-ghost">out of scope: new hull</span></div></div></div></div>
  <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4">
<section class="col" ondragover="event.preventDefault(); this.classList.add('dropover')" ondragleave="this.classList.remove('dropover')" ondrop="fbDrop(event, this)"><h2 class="font-semibold mb-2 text-warning">1 · ⚓ Decide</h2><div class="flex flex-col gap-3"><div draggable="true" ondragstart="fbDrag(event, this)" ondragend="this.classList.remove('dragging')" class="card card-compact bg-base-100 ticket t-captain shadow" data-board-id="decide-task"><div class="card-body"><h3 class="font-semibold text-sm">Pick The Mast Color</h3><div class="meta-row"><span class="badge badge-xs badge-ghost">alpha</span><span class="badge badge-xs badge-ghost">captain</span><span class="badge badge-xs badge-ghost">stage: awaiting decision</span></div><ul class="todos opacity-80"><li>Decision key: mast-color</li></ul><details class="approval" data-lavish-question="mast-color"><summary>⚑ YOUR APPROVAL - click for options</summary><p class="text-xs opacity-80">Two finishes fit; captain picks one</p><form data-question="mast-color" onsubmit="return fbDecide(event)"><label><input type="radio" name="mast-color" value="approve - proceed as recommended"> <b>Approve - proceed as recommended</b></label><label><input type="radio" name="mast-color" value="hold for now"> Hold for now</label><label><input type="radio" name="mast-color" value="more detail first - report back before acting"> More detail first - report back before acting</label><textarea name="freetext" rows="1" class="textarea textarea-bordered textarea-xs" placeholder="…or write your own answer"></textarea><button type="submit" class="btn btn-warning btn-xs mt-1">Queue this answer</button><span class="queued-note">✓ queued - press Send to Agent when done choosing</span></form></details></div></div></div></section><section class="col" ondragover="event.preventDefault(); this.classList.add('dropover')" ondragleave="this.classList.remove('dropover')" ondrop="fbDrop(event, this)"><h2 class="font-semibold mb-2 text-accent">2 · 🧭 Queued</h2><div class="flex flex-col gap-3"><div draggable="true" ondragstart="fbDrag(event, this)" ondragend="this.classList.remove('dragging')" class="card card-compact bg-base-100 ticket t-queued shadow" data-board-id="queued-task"><div class="card-body"><h3 class="font-semibold text-sm">Queued Chore</h3><div class="meta-row"><span class="badge badge-xs badge-ghost">alpha</span><span class="badge badge-xs badge-ghost">ship</span><span class="badge badge-xs badge-ghost">stage: blocked by build-task</span><span class="badge badge-xs badge-warning badge-outline">blocked-by: build-task</span></div></div></div></div></section><section class="col" ondragover="event.preventDefault(); this.classList.add('dropover')" ondragleave="this.classList.remove('dropover')" ondrop="fbDrop(event, this)"><h2 class="font-semibold mb-2 text-info">3 · ⛵ Building</h2><div class="flex flex-col gap-3"><div draggable="true" ondragstart="fbDrag(event, this)" ondragend="this.classList.remove('dragging')" class="card card-compact bg-base-100 ticket t-flight shadow" data-board-id="build-task"><div class="card-body"><h3 class="font-semibold text-sm">Build The Widget</h3><div class="meta-row"><span class="badge badge-xs badge-ghost">alpha</span><span class="badge badge-xs badge-ghost">ship</span><span class="badge badge-xs badge-info badge-outline">crew: codex · opus · high effort</span><span class="badge badge-xs badge-ghost">stage: unknown - harness state unavailable (unknown codex-unverified)</span></div><ul class="todos opacity-80"><li>Widget assembly in progress.</li></ul></div></div></div></section><section class="col" ondragover="event.preventDefault(); this.classList.add('dropover')" ondragleave="this.classList.remove('dropover')" ondrop="fbDrop(event, this)"><h2 class="font-semibold mb-2 text-secondary">4 · 🌊 Review</h2><div class="flex flex-col gap-3"><div draggable="true" ondragstart="fbDrag(event, this)" ondragend="this.classList.remove('dragging')" class="card card-compact bg-base-100 ticket t-upstream shadow" data-board-id="review-task"><div class="card-body"><h3 class="font-semibold text-sm"><a class="link" href="https://github.com/kunchenguid/firstmate/pull/9">Review The Rudder</a></h3><div class="meta-row"><span class="badge badge-xs badge-ghost">alpha</span><span class="badge badge-xs badge-ghost">ship</span><span class="badge badge-xs badge-info badge-outline">crew: claude</span><span class="badge badge-xs badge-ghost">stage: unknown - harness state unavailable (unknown missing)</span></div><ul class="todos opacity-80"><li>done: PR https://github.com/kunchenguid/firstmate/pull/9 checks green</li></ul></div></div></div></section><section class="col" ondragover="event.preventDefault(); this.classList.add('dropover')" ondragleave="this.classList.remove('dropover')" ondrop="fbDrop(event, this)"><h2 class="font-semibold mb-2 text-success">5 · 🏁 Landed</h2><div class="flex flex-col gap-3"><div draggable="true" ondragstart="fbDrag(event, this)" ondragend="this.classList.remove('dragging')" class="card card-compact bg-base-100 ticket t-done shadow" data-board-id="landed-task"><div class="card-body"><h3 class="font-semibold text-sm"><a class="link" href="https://github.com/kunchenguid/firstmate/pull/7">Landed Improvement</a></h3><div class="meta-row"><span class="badge badge-xs badge-ghost">alpha</span><span class="badge badge-xs badge-ghost">ship</span><span class="badge badge-xs badge-ghost">stage: merged 2026-07-28</span></div></div></div></div></section>
  </div>
  <footer class="mt-6 text-xs opacity-60">Static snapshot — answer Decide cards or drag tickets, then press Send to Agent; firstmate dispatches from this board.</footer>
</div>
<script>
let fbDragged=null;
function fbDrag(ev, el){ fbDragged=el; el.classList.add('dragging'); ev.dataTransfer.effectAllowed='move'; }
function fbDrop(ev, colEl){
  ev.preventDefault(); colEl.classList.remove('dropover');
  if(!fbDragged) return;
  const ticket=(fbDragged.querySelector('h3')||{}).innerText||'ticket';
  const stage=(colEl.querySelector('h2')||{}).innerText||'column';
  colEl.querySelector('.flex.flex-col').appendChild(fbDragged);
  if(window.lavish && window.lavish.queuePrompt){
    window.lavish.queuePrompt('Move ticket "'+ticket.trim()+'" to stage "'+stage.trim()+'" - advance it accordingly', { tag:'move', text:ticket.trim()+' -> '+stage.trim(), element: fbDragged, queueKey:'move-'+ticket.trim() });
  }
  fbDragged=null;
}
function fbDecide(ev){
  ev.preventDefault();
  const form=ev.currentTarget;
  const key=form.dataset.question;
  const fd=new FormData(form);
  const c=((fd.get('freetext')||'').trim()) || fd.get(key);
  if(c && window.lavish && window.lavish.queuePrompt){
    window.lavish.queuePrompt('Decision '+key+': '+c, { tag:'choice', text:key+': '+c, element: form, queueKey:key, data:{question:key, answer:c} });
    form.querySelector('.queued-note').style.display='block';
  }
  return false;
}
</script>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Queued-prompt interaction transcript</summary>

```text
stub: window.lavish.queuePrompt installed
radio 'Approve - proceed as recommended' + click 'Queue this answer' → __calls = ["Decision mast-color: approve - proceed as recommended"] (exactly 1)
drag 'Queued Chore' → drop on Building column → __calls = ["Move ticket \"Queued Chore\" to stage \"3 · ⛵ Building\" - advance it accordingly"] (exactly 1)
snapshot contract: fm-fleet-snapshot.sh --json → {"schema":"fm-fleet-snapshot.v1","build_task":{"harness":"codex","model":"opus","effort":"high"}}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-board.sh:211` - parse_map&#39;s per-map error handling catches only OSError, so a single non-UTF-8 byte in any hand-maintained data/maps/*.md raises UnicodeDecodeError inside the loop and aborts the entire board render (&#39;fm-board: render failed&#39;), while the surrounding try/except-continue clearly intends unreadable maps to be skipped so the board stays available. Broadening the except (or opening maps with errors=&#39;replace&#39;) would match that intent.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-board.test.sh` — 4/4 behavioral tests pass (columns, cards, decision panels, PR links, effort maps; Decide/Review routing; structural details-not-inside-ul clipping guard; default output path + empty-home placeholders)</code>
- <code>`bash tests/fm-fleet-snapshot-view.test.sh` — 15/15 pass, confirming the additive snapshot change regresses nothing</code>
- <code>`bash tests/fm-bearings-snapshot.test.sh` — 10/10 pass</code>
- <code>Manual contract check: fixture home → `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` with new `model`/`effort` fields on task rows</code>
- <code>Manual E2E: `bin/fm-board.sh --out` generated the board from a realistic fixture (captain hold + decision key, building task, PR-armed review task, blocked queued task, landed PR, effort map); rendered in Chrome via chrome-devtools-axi and screenshotted</code>
- <code>Browser interaction check with stubbed `window.lavish.queuePrompt`: radio select + &#34;Queue this answer&#34; queued exactly one prompt (`Decision mast-color: approve - proceed as recommended`); drag-drop of a card onto the Building column queued exactly one move-order prompt and moved the card; inline script confirms interactions only queue prompts and never mutate fleet state</code>
- <code>`bin/fm-doc-audience-check.sh` — ok; `docs/board.md` present and classified operator-current, `docs/scripts.md` toolbelt row present</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
