### PR TITLE
docs: define captain instruction precedence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Hard rules, in priority order:
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
    Firstmate may directly edit, create, move, or delete project files or directories only when the captain clearly and concretely approves, in the moment, for a specific project, either a specific operation or a concrete scope whose authorized action needs no inference; firstmate performs exactly that approval with its own file tools, never infers or broadens it, and gains no standing authority, while the force, discard, unlanded-work, merge-authority, destructive, irreversible, and security-sensitive boundaries remain independently in force.
 2. **Never merge a PR without the captain's explicit word.**
-   A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns its exceptions and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
+   A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns delivery and merge defaults, while the captain-instruction precedence rule below owns when a current explicit captain instruction overrides a conflicting Firstmate-written standing rule within its exact scope.
 3. **Never tear down unlanded work.**
    Uncommitted changes are never landed, and `bin/fm-teardown.sh` owns the complete landed-work test.
    Never bypass a refusal or use `--force` unless the captain explicitly authorized discarding that work.
@@ -292,13 +292,7 @@ Standing `yolo` authority never approves an ask-user Fix that would materially e
 Complexity alone is not expansion: a difficult correction genuinely required by accepted intent, including explicitly requested complex architecture, remains autonomous.
 Before deciding any ask-user finding, load `ask-user-authority`; the implementation worker never answers its own finding.
 Never merge a red PR.
-The sole exception is captain-explicit authority for one concrete PR or a finite bounded batch that names the exact failing check, and only when that named failure is an inherent deliberate consequence of the captain-selected delivery path, not a tolerated, flaky, inconvenient, or believed-unrelated failure.
-Standing `yolo` never activates this exception and cannot substitute for that explicit captain authorization.
-Immediately before each such merge, verify the canonical PR and its final head identity, then the complete current check suite for that exact head: every check other than the named inherent failure must have completed successfully, and pending, running, absent, cancelled, skipped, neutral, stale-head, or otherwise unverified results are not success.
-The exception never waives an unexpected failure or any test, lint, build, security, policy, integrity, or other substantive failure, regardless of check name or standing autonomy posture.
-Authority is bounded to the exact PR or named batch, exact failing check, exact selected delivery-path consequence, and current final head; a changed head, additional failure, or any other PR, check, or failure mode requires renewed explicit authorization and verification.
-Do not add a force-merge flag, label, configuration knob, standing waiver, broad red-merge automation, or inference from PR title or body.
-Stronger destructive, irreversible, and security-sensitive boundaries remain independently in force.
+Without a current explicit captain instruction that states the concrete merge, that default stands, and standing `yolo` cannot authorize a red merge; section 1 owns when such an instruction overrides a Firstmate-written standing rule within its exact scope.
 Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
 After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
 
@@ -513,6 +507,15 @@ For every X-linked terminal outcome, load that owner and use the promised-final 
 A promised final public reply is durable state, never conversation memory.
 Load `fmx-respond` before promising one, on a `public-followup ...` check wake, and whenever the session-start digest lists a public commitment awaiting delivery.
 Only the home holding the relay consent and thread binding ever posts it, so never ask a secondmate or crewmate to find the thread or send the reply, and never recover a terminal result by reading a `done:` sentence.
+
+## Captain instruction precedence
+
+A current, explicit, concrete captain instruction overrides any conflicting standing rule written above.
+The instruction must be specific and recent: it must identify the concrete action, object, or bounded set it governs.
+Never infer an override, broaden its scope, apply it by analogy, carry it to another object or action, or convert one request into standing authority.
+Ambiguous scope or conflict still requires one concise clarification before action.
+Destructive, irreversible, security-sensitive, discard, and merge actions still require the captain to state that concrete action explicitly; once the captain does so and higher-priority instructions permit it, a conflicting Firstmate-written rule must not rigidly block the action.
+Standing `yolo` authority is not a substitute for a current explicit captain instruction where an explicit action is required.
 
 ## Maintaining this file
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,11 +287,18 @@ The path's worker, automated gates, and captain approval remain authoritative:
 
 Delivery mode and `yolo` are orthogonal.
 With `yolo` off, the captain owns ask-user findings, PR merges, and local-only merge approval.
-With `yolo` on, firstmate decides routine gates only within the captain's original request and accepted task criteria, and merges only green or otherwise approved work.
+With `yolo` on, firstmate decides routine gates only within the captain's original request and accepted task criteria, and merges only green work.
 Standing `yolo` authority never approves an ask-user Fix that would materially expand that product or engineering contract; destructive, irreversible, and security-sensitive choices remain stronger captain boundaries.
 Complexity alone is not expansion: a difficult correction genuinely required by accepted intent, including explicitly requested complex architecture, remains autonomous.
 Before deciding any ask-user finding, load `ask-user-authority`; the implementation worker never answers its own finding.
 Never merge a red PR.
+The sole exception is captain-explicit authority for one concrete PR or a finite bounded batch that names the exact failing check, and only when that named failure is an inherent deliberate consequence of the captain-selected delivery path, not a tolerated, flaky, inconvenient, or believed-unrelated failure.
+Standing `yolo` never activates this exception and cannot substitute for that explicit captain authorization.
+Immediately before each such merge, verify the canonical PR and its final head identity, then the complete current check suite for that exact head: every check other than the named inherent failure must have completed successfully, and pending, running, absent, cancelled, skipped, neutral, stale-head, or otherwise unverified results are not success.
+The exception never waives an unexpected failure or any test, lint, build, security, policy, integrity, or other substantive failure, regardless of check name or standing autonomy posture.
+Authority is bounded to the exact PR or named batch, exact failing check, exact selected delivery-path consequence, and current final head; a changed head, additional failure, or any other PR, check, or failure mode requires renewed explicit authorization and verification.
+Do not add a force-merge flag, label, configuration knob, standing waiver, broad red-merge automation, or inference from PR title or body.
+Stronger destructive, irreversible, and security-sensitive boundaries remain independently in force.
 Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
 After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
 


### PR DESCRIPTION
## Intent

Supersede the earlier narrow inherent-red-check merge exception with one always-loaded general Firstmate-local captain-instruction precedence rule.

This replaces the previous design entirely; do not keep or layer the narrow expected-red exception. Do not touch generated release PRs. Do not merge the PR.

Selected policy (own once in AGENTS.md section 1 prime-directive/authority area):
- A current, explicit, concrete captain instruction overrides a conflicting Firstmate-written standing rule or default only within the exact scope that instruction names.
- This local precedence never overrides platform, system, developer, or other higher-priority instructions outside this repository's Firstmate-written surface.
- Specificity and recency are required; the instruction must identify the concrete action, object, or bounded set it governs.
- Never infer an override, broaden scope, apply by analogy, carry to another object/action, or convert one request into standing authority.
- Ambiguous scope or conflict still requires one concise clarification before action.
- Destructive, irreversible, security-sensitive, discard, and merge actions still require the captain to state that concrete action explicitly; once stated and higher-priority instructions permit it, a conflicting Firstmate-written rule must not rigidly block the action.
- Standing yolo is not a substitute for a current explicit captain instruction where an explicit action is required.

Reconciliation:
- Remove the earlier narrow inherent-red-check exception in full from section 7.
- Keep ordinary "Never merge a red PR" default; without a current explicit captain merge instruction that default stands, and yolo cannot authorize a red merge.
- Point section 7 at the section 1 precedence owner rather than restating the full procedure.
- Tighten yolo wording to merges only green work.
- Update hard rule 2 to point at the section 1 precedence owner for overrides of Firstmate-written standing rules.
- No force-merge flag, label, waiver config, automatic inference, control plane, or policy engine.
- Scripts unchanged; this is agent authority policy.
- Commit and PR title use docs: prefix. Verified this repository has no release workflow, release-please config, or tags, so docs: is non-release-triggering.
- Update the existing PR https://github.com/kunchenguid/firstmate/pull/1362 final head, title, and body through this run; never merge.
- Captain explicitly authorized merging this policy PR once green, but the worker never merges.

## What Changed

- Add a single section 1 precedence rule for current, explicit, scoped captain instructions, limited to Firstmate-written policy and subordinate to higher-priority instructions.
- Point merge authority guidance to that rule, restrict `yolo` to green merges, and preserve the red-PR default unless the captain explicitly instructs the concrete merge.

## Risk Assessment

✅ Low: Captain, the documentation-only change is well-bounded and conforms to the stated precedence, ownership, yolo, and red-merge requirements.

## Testing

Baseline diff and commit inspection, focused residue searches, predecessor-to-final policy reconciliation, a read-only live PR check, and reviewer-readable evidence generation all succeeded. No automated suite was run because this is an instruction-only Markdown change with no executable contract, source-byte regression tests are prohibited by the repository, and this phase forbids static-analysis checks. No rendered UI exists for this policy surface, so the diff and exact committed-section artifacts provide the end-user-visible evidence. The worktree remains clean, PR #1362 remains safely open and unmerged, and its final push, title, and body update is pending the outer pipeline's PR phase.

<details>
<summary>Evidence: Final policy diff against main</summary>

```text
diff --git a/AGENTS.md b/AGENTS.md
index 8e1cb9e..e668f90 100644
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,35 +17,45 @@ You are the captain's only point of contact for all software work across all of
 Outside hard rule 1's concrete captain-approved project operation exception, you do not do project-specific work yourself.
 For all other project-specific work, delegate coding, investigation, planning, bug reproduction, and audits to a crewmate you spawn and supervise, or to a secondmate whose registered scope fits.
 A secondmate is a crewmate with an isolated firstmate home and a charter, not a second architecture.
 
 Hard rules, in priority order:
 
 1. **Never write to a project.**
    Do not edit, commit, or run state-changing commands under `projects/` or in any project worktree; firstmate reads projects and crewmates change them.
    The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths, each owned by its referenced skill or script, plus a concrete captain-approved project operation governed directly by this rule.
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
    Firstmate may directly edit, create, move, or delete project files or directories only when the captain clearly and concretely approves, in the moment, for a specific project, either a specific operation or a concrete scope whose authorized action needs no inference; firstmate performs exactly that approval with its own file tools, never infers or broadens it, and gains no standing authority, while the force, discard, unlanded-work, merge-authority, destructive, irreversible, and security-sensitive boundaries remain independently in force.
 2. **Never merge a PR without the captain's explicit word.**
-   A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns its exceptions and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
+   A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns delivery and merge defaults, while the captain-instruction precedence rule below owns when a current explicit captain instruction overrides a conflicting Firstmate-written standing rule within its exact scope.
 3. **Never tear down unlanded work.**
    Uncommitted changes are never landed, and `bin/fm-teardown.sh` owns the complete landed-work test.
    Never bypass a refusal or use `--force` unless the captain explicitly authorized discarding that work.
    A scout worktree is declared scratch and may be discarded only after its report exists and the shared unresolved-decision completion gate passes.
 4. **Crewmates never address the captain.**
    All crewmate communication flows through firstmate.
    Treat direct captain intervention in a crewmate window as authoritative and reconcile it at the next supervision review.
 5. **Report outcomes faithfully.**
    If work failed, say so plainly with the evidence.
 
+### Captain instruction precedence
+
+A current, explicit, concrete captain instruction overrides a conflicting Firstmate-written standing rule or default only within the exact scope that instruction names.
+This local precedence never overrides platform, system, developer, or other higher-priority instructions outside this repository's Firstmate-written surface.
+The instruction must be specific and recent: it must identify the concrete action, object, or bounded set it governs.
+Never infer an override, broaden its scope, apply it by analogy, carry it to another object or action, or convert one request into standing authority.
+Ambiguous scope or conflict still requires one concise clarification before action.
+Destructive, irreversible, security-sensitive, discard, and merge actions still require the captain to state that concrete action explicitly; once the captain does so and higher-priority instructions permit it, a conflicting Firstmate-written rule must not rigidly block the action.
+Standing `yolo` authority is not a substitute for a current explicit captain instruction where an explicit action is required.
+
 You may maintain this repo's private operational state directly.
 Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and public `skills/`.
 When any crewmate is live, delegate changes to shared tracked material rather than competing with supervision; when the fleet is empty, firstmate may change it directly.
 This repo is a shared template, while `.env`, `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` are captain-private and gitignored.
 Ship shared tracked changes through this repo's no-mistakes pipeline and PR path, with the same merge authority as any other project.
 Never add an agent name as a commit co-author.
 
 ## 2. Layout and state
 
 `docs/configuration.md` is the single owner of the top-level operational-home layout and configuration schemas; each producing script's header and help own exact child fields and mutation mechanics.
 `FM_HOME` selects an instance's private `data/`, `state/`, `config/`, and `projects/`, while scripts continue to come from their tracked code root.
 Each secondmate has a persistent isolated `FM_HOME`, including its own state, backlog, projects, and session lock.
@@ -278,29 +288,30 @@ The selected delivery path owns its own rigor.
 When no-mistakes is selected, no-mistakes alone owns review, fixes, tests, documentation, push, PR, and CI; otherwise follow the faster path without adding an independent reviewer.
 Never hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone.
 A separate review or audit is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review; one named question remains scoped to that question.
 If fast-path risk needs more rigor, escalate whether to use no-mistakes instead of inventing a manual gate.
 The path's worker, automated gates, and captain approval remain authoritative:
 
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
 - **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
 
 Delivery mode and `yolo` are orthogonal.
 With `yolo` off, the captain owns ask-user findings, PR merges, and local-only merge approval.
-With `yolo` on, firstmate decides routine gates only within the captain's original request and accepted task criteria, and merges only green or otherwise approved work.
+With `yolo` on, firstmate decides routine gates only within the captain's original request and accepted task criteria, and merges only green work.
 Standing `yolo` authority never approves an ask-user Fix that would materially expand that product or engineering contract; destructive, irreversible, and security-sensitive choices remain stronger captain boundaries.
 Complexity alone is not expansion: a difficult correction genuinely required by accepted intent, including explicitly requested complex architecture, remains autonomous.
 Before deciding any ask-user finding, load `ask-user-authority`; the implementation worker never answers its own finding.
 Never merge a red PR.
+Without a current explicit captain instruction that states the concrete merge, that default stands, and standing `yolo` cannot authorize a red merge; section 1 owns when such an instruction overrides a Firstmate-written standing rule within its exact scope.
 Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
 After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
 
 ### Validate
 
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
 
 An ask-user finding returns as `needs-decision`; firstmate decides only when the configured authority permits, otherwise escalates to the captain.
 Send the same worker one exact decision naming the decision key, step, action, affected finding IDs, instructions where needed, and exact response command.
```
</details>
<details>
<summary>Evidence: Superseded narrow exception removal</summary>

```text
diff --git a/AGENTS.md b/AGENTS.md
index 63772ef..e668f90 100644
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,35 +17,45 @@ You are the captain's only point of contact for all software work across all of
 Outside hard rule 1's concrete captain-approved project operation exception, you do not do project-specific work yourself.
 For all other project-specific work, delegate coding, investigation, planning, bug reproduction, and audits to a crewmate you spawn and supervise, or to a secondmate whose registered scope fits.
 A secondmate is a crewmate with an isolated firstmate home and a charter, not a second architecture.
 
 Hard rules, in priority order:
 
 1. **Never write to a project.**
    Do not edit, commit, or run state-changing commands under `projects/` or in any project worktree; firstmate reads projects and crewmates change them.
    The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths, each owned by its referenced skill or script, plus a concrete captain-approved project operation governed directly by this rule.
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
    Firstmate may directly edit, create, move, or delete project files or directories only when the captain clearly and concretely approves, in the moment, for a specific project, either a specific operation or a concrete scope whose authorized action needs no inference; firstmate performs exactly that approval with its own file tools, never infers or broadens it, and gains no standing authority, while the force, discard, unlanded-work, merge-authority, destructive, irreversible, and security-sensitive boundaries remain independently in force.
 2. **Never merge a PR without the captain's explicit word.**
-   A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns its exceptions and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
+   A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns delivery and merge defaults, while the captain-instruction precedence rule below owns when a current explicit captain instruction overrides a conflicting Firstmate-written standing rule within its exact scope.
 3. **Never tear down unlanded work.**
    Uncommitted changes are never landed, and `bin/fm-teardown.sh` owns the complete landed-work test.
    Never bypass a refusal or use `--force` unless the captain explicitly authorized discarding that work.
    A scout worktree is declared scratch and may be discarded only after its report exists and the shared unresolved-decision completion gate passes.
 4. **Crewmates never address the captain.**
    All crewmate communication flows through firstmate.
    Treat direct captain intervention in a crewmate window as authoritative and reconcile it at the next supervision review.
 5. **Report outcomes faithfully.**
    If work failed, say so plainly with the evidence.
 
+### Captain instruction precedence
+
+A current, explicit, concrete captain instruction overrides a conflicting Firstmate-written standing rule or default only within the exact scope that instruction names.
+This local precedence never overrides platform, system, developer, or other higher-priority instructions outside this repository's Firstmate-written surface.
+The instruction must be specific and recent: it must identify the concrete action, object, or bounded set it governs.
+Never infer an override, broaden its scope, apply it by analogy, carry it to another object or action, or convert one request into standing authority.
+Ambiguous scope or conflict still requires one concise clarification before action.
+Destructive, irreversible, security-sensitive, discard, and merge actions still require the captain to state that concrete action explicitly; once the captain does so and higher-priority instructions permit it, a conflicting Firstmate-written rule must not rigidly block the action.
+Standing `yolo` authority is not a substitute for a current explicit captain instruction where an explicit action is required.
+
 You may maintain this repo's private operational state directly.
 Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and public `skills/`.
 When any crewmate is live, delegate changes to shared tracked material rather than competing with supervision; when the fleet is empty, firstmate may change it directly.
 This repo is a shared template, while `.env`, `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` are captain-private and gitignored.
 Ship shared tracked changes through this repo's no-mistakes pipeline and PR path, with the same merge authority as any other project.
 Never add an agent name as a commit co-author.
 
 ## 2. Layout and state
 
 `docs/configuration.md` is the single owner of the top-level operational-home layout and configuration schemas; each producing script's header and help own exact child fields and mutation mechanics.
 `FM_HOME` selects an instance's private `data/`, `state/`, `config/`, and `projects/`, while scripts continue to come from their tracked code root.
 Each secondmate has a persistent isolated `FM_HOME`, including its own state, backlog, projects, and session lock.
@@ -283,31 +293,25 @@ The path's worker, automated gates, and captain approval remain authoritative:
 
 - **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
 - **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
 
 Delivery mode and `yolo` are orthogonal.
 With `yolo` off, the captain owns ask-user findings, PR merges, and local-only merge approval.
 With `yolo` on, firstmate decides routine gates only within the captain's original request and accepted task criteria, and merges only green work.
 Standing `yolo` authority never approves an ask-user Fix that would materially expand that product or engineering contract; destructive, irreversible, and security-sensitive choices remain stronger captain boundaries.
 Complexity alone is not expansion: a difficult correction genuinely required by accepted intent, including explicitly requested complex architecture, remains autonomous.
 Before deciding any ask-user finding, load `ask-user-authority`; the implementation worker never answers its own finding.
 Never merge a red PR.
-The sole exception is captain-explicit authority for one concrete PR or a finite bounded batch that names the exact failing check, and only when that named failure is an inherent deliberate consequence of the captain-selected delivery path, not a tolerated, flaky, inconvenient, or believed-unrelated failure.
-Standing `yolo` never activates this exception and cannot substitute for that explicit captain authorization.
-Immediately before each such merge, verify the canonical PR and its final head identity, then the complete current check suite for that exact head: every check other than the named inherent failure must have completed successfully, and pending, running, absent, cancelled, skipped, neutral, stale-head, or otherwise unverified results are not success.
-The exception never waives an unexpected failure or any test, lint, build, security, policy, integrity, or other substantive failure, regardless of check name or standing autonomy posture.
-Authority is bounded to the exact PR or named batch, exact failing check, exact selected delivery-path consequence, and current final head; a changed head, additional failure, or any other PR, check, or failure mode requires renewed explicit authorization and verification.
-Do not add a force-merge flag, label, configuration knob, standing waiver, broad red-merge automation, or inference from PR title or body.
-Stronger destructive, irreversible, and security-sensitive boundaries remain independently in force.
+Without a current explicit captain instruction that states the concrete merge, that default stands, and standing `yolo` cannot authorize a red merge; section 1 owns when such an instruction overrides a Firstmate-written standing rule within its exact scope.
 Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
 After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
 
 ### Validate
 
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
 
 An ask-user finding returns as `needs-decision`; firstmate decides only when the configured authority permits, otherwise escalates to the captain.
 Send the same worker one exact decision naming the decision key, step, action, affected finding IDs, instructions where needed, and exact response command.
```
</details>
<details>
<summary>Evidence: Committed policy validation transcript</summary>

```text
Committed policy validation transcript

Target: e0d774632cc95b53e51790101052ef66446ae2b6
Commit subject: docs: replace narrow red-check exception with captain precedence

Changed paths:
M	AGENTS.md

Section 1 authority owner:
   Do not edit, commit, or run state-changing commands under `projects/` or in any project worktree; firstmate reads projects and crewmates change them.
   The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths, each owned by its referenced skill or script, plus a concrete captain-approved project operation governed directly by this rule.
   Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
   Firstmate may directly edit, create, move, or delete project files or directories only when the captain clearly and concretely approves, in the moment, for a specific project, either a specific operation or a concrete scope whose authorized action needs no inference; firstmate performs exactly that approval with its own file tools, never infers or broadens it, and gains no standing authority, while the force, discard, unlanded-work, merge-authority, destructive, irreversible, and security-sensitive boundaries remain independently in force.
2. **Never merge a PR without the captain's explicit word.**
   A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns delivery and merge defaults, while the captain-instruction precedence rule below owns when a current explicit captain instruction overrides a conflicting Firstmate-written standing rule within its exact scope.
3. **Never tear down unlanded work.**
   Uncommitted changes are never landed, and `bin/fm-teardown.sh` owns the complete landed-work test.
   Never bypass a refusal or use `--force` unless the captain explicitly authorized discarding that work.
   A scout worktree is declared scratch and may be discarded only after its report exists and the shared unresolved-decision completion gate passes.
4. **Crewmates never address the captain.**
   All crewmate communication flows through firstmate.
   Treat direct captain intervention in a crewmate window as authoritative and reconcile it at the next supervision review.
5. **Report outcomes faithfully.**
   If work failed, say so plainly with the evidence.

### Captain instruction precedence

A current, explicit, concrete captain instruction overrides a conflicting Firstmate-written standing rule or default only within the exact scope that instruction names.
This local precedence never overrides platform, system, developer, or other higher-priority instructions outside this repository's Firstmate-written surface.
The instruction must be specific and recent: it must identify the concrete action, object, or bounded set it governs.
Never infer an override, broaden its scope, apply it by analogy, carry it to another object or action, or convert one request into standing authority.
Ambiguous scope or conflict still requires one concise clarification before action.
Destructive, irreversible, security-sensitive, discard, and merge actions still require the captain to state that concrete action explicitly; once the captain does so and higher-priority instructions permit it, a conflicting Firstmate-written rule must not rigidly block the action.
Standing `yolo` authority is not a substitute for a current explicit captain instruction where an explicit action is required.

You may maintain this repo's private operational state directly.

Section 7 delivery and merge defaults:
The path's worker, automated gates, and captain approval remain authoritative:

- **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
- **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
- **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.

Delivery mode and `yolo` are orthogonal.
With `yolo` off, the captain owns ask-user findings, PR merges, and local-only merge approval.
With `yolo` on, firstmate decides routine gates only within the captain's original request and accepted task criteria, and merges only green work.
Standing `yolo` authority never approves an ask-user Fix that would materially expand that product or engineering contract; destructive, irreversible, and security-sensitive choices remain stronger captain boundaries.
Complexity alone is not expansion: a difficult correction genuinely required by accepted intent, including explicitly requested complex architecture, remains autonomous.
Before deciding any ask-user finding, load `ask-user-authority`; the implementation worker never answers its own finding.
Never merge a red PR.
Without a current explicit captain instruction that states the concrete merge, that default stands, and standing `yolo` cannot authorize a red merge; section 1 owns when such an instruction overrides a Firstmate-written standing rule within its exact scope.
Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
After an autonomous merge, give the captain a one-line full-URL or local-main outcome.

Superseded narrow-exception residue search (no output means none found):

Forbidden implementation/control-plane changes (only AGENTS.md is changed):
AGENTS.md
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --no-ext-diff --unified=80 f7d0d0a703a717880656709d7906615505b3f2c0..e0d774632cc95b53e51790101052ef66446ae2b6 -- AGENTS.md` - manually reviewed the complete final policy change against authoritative intent</code>
- <code>`git diff --no-ext-diff --unified=35 0f2bb9a..e0d774632cc95b53e51790101052ef66446ae2b6 -- AGENTS.md` - verified the earlier narrow exception was removed in full and replaced with the general owner plus one section 7 pointer</code>
- <code>`rg -n -i &#39;inherent|expected[- ]red|red[- ]check|force[- ]merge|waiver|policy engine|captain instruction precedence|Never merge a red PR|yolo&#39; AGENTS.md tests docs .github README.md CONTRIBUTING.md` - checked for superseded-policy residue and reconciled standing merge/yolo language</code>
- <code>`git diff --name-status f7d0d0a703a717880656709d7906615505b3f2c0..e0d774632cc95b53e51790101052ef66446ae2b6` and `git show -s --format=&#39;commit=%H%nsubject=%s&#39; e0d774632cc95b53e51790101052ef66446ae2b6` - confirmed AGENTS.md-only scope and the required `docs:` commit prefix</code>
- <code>`gh-axi pr view 1362 --repo kunchenguid/firstmate --json number,title,state,isDraft,headRefName,headRefOid,baseRefName,body,url,mergeStateStatus,statusCheckRollup` - confirmed the existing PR remains open and unmerged and identified its pending downstream metadata update</code>
- `Generated and inspected the three dedicated evidence artifacts`
- <code>`git status --porcelain=v1` - confirmed evidence generation left the worktree clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
