### PR TITLE
fix(bin): require the exact recorded tmux window in fm_backend_target_exists

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -827,14 +827,73 @@ fm_backend_composer_state() {  # <backend> <target> -> empty|pending|pending-unp
 # probe). A gone tmux window or an unqueryable herdr pane (server down, pane
 # closed), missing zellij pane, or unreadable Orca terminal simply fails, which
 # IS "does not exist" for this purpose.
-# Mirrors fm-crew-state.sh's pane_readable check; exists here as one shared
-# primitive so callers that only need a fast alive/dead read (recovery
-# digests, the session-start fleet digest) do not re-derive it inline.
+# The one primitive behind every fast alive/dead read (recovery digests, the
+# session-start fleet digest, fm-crew-state.sh's pane_readable), so no caller
+# re-derives a liveness probe inline and drifts from this contract.
 fm_backend_target_exists() {  # <backend> <target> [expected-label]
-  local backend=$1 target=$2 expected_label=${3:-} session pane
+  local backend=$1 target=$2 expected_label=${3:-} session pane window idx name
   case "$backend" in
     tmux)
-      tmux display-message -p -t "$target" '#{pane_id}' >/dev/null 2>&1
+      # tmux display-message NEVER reliably fails for a bad target: a
+      # session:window whose window part does not match silently falls back
+      # to another window (exit 0, answering about the WRONG window), a gone
+      # %pane or @window id exits 0 too (empty or fallback answer). A bare
+      # exit-code read therefore cannot prove the recorded endpoint exists.
+      # Exact handles (%/@ ids) are verified by exact-answer equality, and a
+      # session:window name by requiring the exact recorded window in a
+      # successful session inventory - the same guarantee
+      # fm_backend_tmux_agent_state gives recovery, kept read-only and one
+      # tmux call for this cheap path.
+      case "$target" in
+        %*)
+          [ "$(tmux display-message -p -t "$target" '#{pane_id}' 2>/dev/null)" = "$target" ]
+          ;;
+        @*)
+          [ "$(tmux display-message -p -t "$target" '#{window_id}' 2>/dev/null)" = "$target" ]
+          ;;
+        *:*)
+          session=${target%%:*}
+          pane=${target#*:}
+          [ -n "$session" ] && [ -n "$pane" ] || return 1
+          # The window part may itself CONTAIN dots: a task id only has to be
+          # path-safe (fm_task_id_path_safe), so id `api.2` records window
+          # `fm-api.2`, and real tmux resolves that exact window name ahead of
+          # any pane-index split. Try the FULL window part first and keep the
+          # pane-index-stripped form only as a fallback, which is what still
+          # resolves a legacy `firstmate:0.1` supervisor target.
+          window=$pane
+          case "$pane" in
+            *.*)
+              # session:window.pane-index targets the window; a non-numeric
+              # suffix is part of the window name itself.
+              case "${pane##*.}" in
+                *[!0-9]*|'') : ;;
+                *) window=${pane%.*} ;;
+              esac
+              ;;
+          esac
+          # The window part may be a NAME or a numeric INDEX (e.g. the
+          # legacy firstmate:0 supervisor fallback): one inventory call
+          # listing both tab-separated, exact field match on either. Matched
+          # in-shell rather than through awk so this cheap probe stays a
+          # single fork and adds no new tool dependency to the many callers
+          # that source this library (the fm-crew-state.sh read path it now
+          # backs uses no awk today).
+          while IFS=$'\t' read -r idx name; do
+            case "$idx" in "$pane"|"$window") return 0 ;; esac
+            case "$name" in "$pane"|"$window") return 0 ;; esac
+          done < <(tmux list-windows -t "$session" -F '#{window_index}	#{window_name}' 2>/dev/null)
+          return 1
+          ;;
+        *)
+          # A colon-less target carries no session to inventory, so there is
+          # nothing to verify the recorded endpoint against: fail closed
+          # rather than resolve it against every session, which is exactly the
+          # "answered about some other window" false-alive this guards.
+          # fm_backend_validate_task_endpoint refuses this shape too.
+          return 1
+          ;;
+      esac
       ;;
     herdr)
       fm_backend_source herdr || return 1

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -141,13 +141,17 @@ LOG_VERB=$(status_line_verb "$LOG_LINE")
 # shell - so a finished crew whose endpoint has closed still reports its run-step
 # state (e.g. done) instead of being masked as unknown. Backend-aware
 # (fm_backend_of_meta defaults absent backend= to tmux, the P1 contract): a
-# herdr task is read through fm_backend_capture instead of a bare tmux probe.
+# herdr task is read through fm_backend_capture, and tmux through the shared
+# fm_backend_target_exists primitive rather than a bare `display-message`
+# probe, which never reliably fails - it silently answers about ANOTHER window
+# when the recorded one is gone, so a killed crew read as still alive here
+# (kunchenguid/firstmate#1130).
 TASK_BACKEND=$(fm_backend_of_meta "$META")
 BACKEND_TARGET=$(fm_backend_target_of_meta "$META")
 EXPECTED_LABEL="fm-$ID"
 pane_readable() {  # <target>
   case "$TASK_BACKEND" in
-    tmux) tmux display-message -p -t "$1" '#{pane_id}' >/dev/null 2>&1 ;;
+    tmux) fm_backend_target_exists tmux "$1" "$EXPECTED_LABEL" >/dev/null 2>&1 ;;
     *) fm_backend_capture "$TASK_BACKEND" "$1" 1 "$EXPECTED_LABEL" >/dev/null 2>&1 ;;
   esac
 }

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1396,8 +1396,10 @@ fm_super_main() {
   # --- validate supervisor target at startup (a missing target is a typo) ---
   # Dispatches through bin/fm-backend.sh instead of a raw `tmux display-message`
   # probe, so a herdr supervisor pane is checked via the herdr adapter; for
-  # backend=tmux this runs the exact same `tmux display-message -p -t "$TARGET"
-  # '#{pane_id}'` call as before.
+  # backend=tmux a session:window target is proved by an exact match in a
+  # successful `tmux list-windows` inventory (a bare display-message silently
+  # answers about another window - kunchenguid/firstmate#1130), so a typo'd
+  # target now really does fail here.
   if ! fm_backend_target_exists "$BACKEND" "$TARGET"; then
     echo "error: supervisor target '$TARGET' does not resolve to a $BACKEND pane; set FM_SUPERVISOR_TARGET" >&2
     log "startup failed: target '$TARGET' not found (backend=$BACKEND)"

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -44,7 +44,9 @@ Verify setup by spawning a small task and confirming its `fm-<id>` window appear
 
 ## Current behavior and safety
 
-A target-existence check proves only that the pane exists.
+A target-existence check proves only that the recorded endpoint still exists, never what runs in it.
+Because `tmux display-message` silently answers about another window instead of failing when the recorded one is gone, a `session:window` target is proved by an exact window-index or window-name match in a live session inventory, a `%pane` or `@window` handle by an exact-id answer, and a target carrying no session to inventory is refused.
+A window name may itself contain dots, so the full window part is matched before the pane-index-stripped form.
 The deeper tmux agent-liveness probe first verifies exact window membership, then reads `#{pane_current_command}` to distinguish a running harness process from a bare idle shell.
 It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, Grok, and Kimi process names as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
 Only `dead` and `missing` authorize recovery because a false dead result could launch a duplicate agent.

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -156,6 +156,70 @@ if fm_backend_tmux_resolve_bare_selector "no-such-window-xyz" 2>/dev/null; then
 fi
 pass "real tmux: fm_backend_tmux_resolve_bare_selector fails for a window that does not exist"
 
+# --- fm_backend_target_exists: a gone window of a LIVE session reads dead ---
+# Regression for kunchenguid/firstmate#1130: a bare `display-message -p -t`
+# silently falls back to another window when the window part of the target
+# does not match, so the cheap liveness read must require the exact recorded
+# window in a successful session inventory.
+
+fm_backend_target_exists tmux "$TARGET" \
+  || fail "fm_backend_target_exists should report the live window alive"
+if fm_backend_target_exists tmux "$SESSION:no-such-window-xyz" 2>/dev/null; then
+  fail "fm_backend_target_exists reported a nonexistent window of a live session alive"
+fi
+if fm_backend_target_exists tmux "no-such-session-xyz:$WINDOW" 2>/dev/null; then
+  fail "fm_backend_target_exists reported a window of a nonexistent session alive"
+fi
+pass "real tmux: fm_backend_target_exists reads the live window alive and a gone window of a live session dead"
+
+# A %pane / @window handle carries no session to inventory, so it is proved by
+# exact-answer equality instead: a gone id makes display-message exit 0 with an
+# EMPTY (or otherwise non-matching) answer, which only the comparison catches.
+live_pane=$(tmux display-message -p -t "$TARGET" '#{pane_id}') \
+  || fail "could not read the live pane id"
+live_window_id=$(tmux display-message -p -t "$TARGET" '#{window_id}') \
+  || fail "could not read the live window id"
+fm_backend_target_exists tmux "$live_pane" \
+  || fail "fm_backend_target_exists should report the live %pane id alive"
+fm_backend_target_exists tmux "$live_window_id" \
+  || fail "fm_backend_target_exists should report the live @window id alive"
+if fm_backend_target_exists tmux '%99999' 2>/dev/null; then
+  fail "fm_backend_target_exists reported a never-allocated %pane id alive"
+fi
+if fm_backend_target_exists tmux '@99999' 2>/dev/null; then
+  fail "fm_backend_target_exists reported a never-allocated @window id alive"
+fi
+pass "real tmux: fm_backend_target_exists reads live %pane/@window ids alive and never-allocated ones dead"
+
+# A window name may itself contain dots (a task id only has to be path-safe, so
+# id `api.2` records window `fm-api.2`): the pane-index strip must not report
+# that live window dead, and real tmux resolves the exact name the same way.
+DOTTED_WINDOW="fm-api.2"
+DOTTED_TARGET="$SESSION:$DOTTED_WINDOW"
+tmux new-window -d -t "$SESSION:" -n "$DOTTED_WINDOW" \
+  || fail "could not create the dotted-name window"
+fm_backend_target_exists tmux "$DOTTED_TARGET" \
+  || fail "fm_backend_target_exists reported the live dotted-name window dead"
+[ "$(tmux display-message -p -t "$DOTTED_TARGET" '#{window_name}')" = "$DOTTED_WINDOW" ] \
+  || fail "real tmux did not resolve '$DOTTED_TARGET' to the window literally named '$DOTTED_WINDOW'"
+# Kill by @id: tmux's own kill-window parses the trailing `.2` as a pane index
+# and cannot address this window by name - which is precisely why the liveness
+# read has to inventory the session rather than trust a per-target probe.
+dotted_id=$(tmux display-message -p -t "$DOTTED_TARGET" '#{window_id}') \
+  || fail "could not read the dotted-name window id"
+tmux kill-window -t "$dotted_id" || fail "could not kill the dotted-name window"
+if fm_backend_target_exists tmux "$DOTTED_TARGET" 2>/dev/null; then
+  fail "fm_backend_target_exists still reports the killed dotted-name window alive"
+fi
+pass "real tmux: fm_backend_target_exists reads a live dotted window name alive and dead once killed"
+
+# A colon-less target carries no session to inventory: fail closed rather than
+# resolve it against some other session's window.
+if fm_backend_target_exists tmux "$WINDOW" 2>/dev/null; then
+  fail "fm_backend_target_exists accepted a bare window name with no session"
+fi
+pass "real tmux: fm_backend_target_exists refuses a bare (colon-less) window name"
+
 # --- kill and recovery-grade missing-window classification ------------------
 
 fm_backend_tmux_kill "$TARGET"
@@ -165,6 +229,9 @@ fi
 state=$(fm_backend_agent_state tmux "$TARGET")
 [ "$state" = missing ] \
   || fail "a real missing window in a readable session should classify as missing, got '$state'"
+if fm_backend_target_exists tmux "$TARGET" 2>/dev/null; then
+  fail "fm_backend_target_exists still reports the killed window alive"
+fi
 # Best-effort contract: killing an already-gone window must not error.
 fm_backend_tmux_kill "$TARGET" || fail "fm_backend_tmux_kill on an already-dead target must stay best-effort (never fail)"
 pass "real tmux: kill removes the window and the readable session inventory authoritatively classifies it missing"

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -665,7 +665,10 @@ case "${1:-}" in
       printf '╭────╮\n│    │\n╰────╯\n'
     fi
     exit 0 ;;
-  list-windows) exit 0 ;;
+  # The explicit sess:win endpoint is live: a real list-windows inventory
+  # answers with the window name (fm_backend_target_exists requires this
+  # since the display-message fallback fix, kunchenguid/firstmate#1130).
+  list-windows) printf 'win\n'; exit 0 ;;
 esac
 exit 0
 SH
@@ -684,7 +687,7 @@ run_send_case() {  # <bin-root> <fakebin> <log> <home> -- <send args...>
 
 strip_send_preflight() {  # <log>
   local preflight
-  preflight=$'tmux\x1fdisplay-message\x1f-p\x1f-t\x1fsess:win\x1f#{pane_id}'
+  preflight=$'tmux\x1flist-windows\x1f-t\x1fsess\x1f-F\x1f#{window_index}\t#{window_name}'
   awk -v preflight="$preflight" '$0 != preflight { print }' "$1"
 }
 
@@ -702,7 +705,7 @@ test_send_conformance_old_vs_new() {
   run_send_case "$ROOT" "$fb" "$log_new" "$home" -- "sess:win" --key Escape
   rc_new=$?
   expect_code "$rc_old" "$rc_new" "fm-send --key: old vs new exit code"
-  assert_contains "$(cat "$log_new")" $'\x1f''display-message'$'\x1f''-p'$'\x1f''-t'$'\x1f''sess:win'$'\x1f''#{pane_id}' \
+  assert_contains "$(cat "$log_new")" $'\x1flist-windows\x1f-t\x1fsess\x1f-F\x1f#{window_index}\t#{window_name}' \
     "fm-send --key did not verify the explicit tmux target before sending"
   strip_send_preflight "$log_old" > "$filtered_old"
   strip_send_preflight "$log_new" > "$filtered_new"

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -30,6 +30,29 @@ SH
 #!/usr/bin/env bash
 case "${1:-}" in
   display-message) case "$*" in *dead-*) exit 1 ;; *) printf '%%1\n' ;; esac ;;
+  # A real tmux answers list-windows with the queried session's live windows,
+  # which fm_backend_target_exists reads to prove the recorded window still
+  # exists (kunchenguid/firstmate#1130). Inventory this home's recorded
+  # windows, keeping the fixture's alive/absent convention: every window is
+  # live except the *dead-* ones this suite models as gone.
+  list-windows)
+    session=""
+    prev=""
+    for a in "$@"; do
+      [ "$prev" = "-t" ] && session=$a
+      prev=$a
+    done
+    for m in "${FM_STATE_OVERRIDE:-${FM_HOME:?}/state}"/*.meta; do
+      [ -f "$m" ] || continue
+      w=$(sed -n 's/^window=//p' "$m")
+      case "$w" in
+        "$session":*) w=${w#*:} ;;
+        *) continue ;;
+      esac
+      case "$w" in ''|*dead-*) continue ;; esac
+      printf '%s\n' "$w"
+    done
+    ;;
   capture-pane)
     case "$*" in
       *fm-domain-alpha*) printf 'stale terminal summary: Phase 7 started\n> \n' ;;

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -16,7 +16,8 @@
 #   (e) cross-branch attribution: this branch's own run found via list lookup
 #   (f) no run + semantic busy                                    -> pane
 #   (g) no run + semantic idle falls to the status-log verb       -> status-log
-#   (h) dead pane: no run -> unknown/none; with a run -> run-step (not the shell)
+#   (h) dead pane: no run -> unknown/none; with a run -> run-step (not the shell);
+#       a window gone from a still-LIVE session reads dead too (#1130)
 #   (i) kind=scout skips the run lookup                           -> pane/status-log
 #   (j) torn-down worktree / missing meta                         -> unknown/none
 #   (k) crew_is_provably_working end-to-end over the REAL helper (not a canned
@@ -86,6 +87,20 @@ case "${1:-}" in
   display-message)
     [ "${FM_FAKE_TMUX_MISSING:-0}" = 1 ] && exit 1
     printf '%%1\n' ;;
+  # pane_readable's tmux arm now goes through fm_backend_target_exists, which
+  # proves the recorded window against a real list-windows inventory instead
+  # of a bare display-message probe (kunchenguid/firstmate#1130). Answer with
+  # this home's recorded windows, so FM_FAKE_TMUX_MISSING keeps modelling a
+  # gone endpoint exactly as it does for the probes above.
+  # FM_FAKE_TMUX_WINDOW_GONE models the narrower, real #1130 shape instead: the
+  # SESSION is alive, so display-message and capture-pane still succeed (real
+  # tmux silently falls back to another window), and only the inventory shows
+  # the recorded window is gone.
+  list-windows)
+    [ "${FM_FAKE_TMUX_MISSING:-0}" = 1 ] && exit 1
+    [ "${FM_FAKE_TMUX_WINDOW_GONE:-0}" = 1 ] && { printf 'other-window\n'; exit 0; }
+    sed -n 's/^window=[^:]*://p' "${FM_STATE_OVERRIDE:?}"/*.meta 2>/dev/null
+    ;;
   capture-pane)
     [ "${FM_FAKE_TMUX_MISSING:-0}" = 1 ] && exit 1
     if [ "${FM_FAKE_BUSY:-0}" = 1 ]; then printf 'work in progress\n%s\n' "${FM_FAKE_BUSY_TEXT:-esc to interrupt}"
@@ -166,11 +181,13 @@ reset_fakes() {
   FM_FAKE_BUSY=0
   FM_FAKE_BUSY_TEXT=
   FM_FAKE_TMUX_MISSING=0
+  FM_FAKE_TMUX_WINDOW_GONE=0
   FM_FAKE_HERDR_BUSY=0
   FM_FAKE_HERDR_MISSING=0
   FM_FAKE_HERDR_AGENT_STATUS=""
   FM_FAKE_CI_LOGS=""
   export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
+  export FM_FAKE_TMUX_WINDOW_GONE
   export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
 }
 
@@ -1047,6 +1064,32 @@ test_dead_window_ignores_stale_status_log() {
   pass "dead window ignores stale status log"
 }
 
+# Regression for kunchenguid/firstmate#1130 at THIS helper's read path: the
+# crew's window is gone but its SESSION is still alive, so the bare
+# `tmux display-message -p -t sess:win '#{pane_id}'` pane_readable used to run
+# silently answers about ANOTHER window and exits 0 - reporting a killed crew
+# as still alive and letting the stale status log through as current state.
+# Routing the tmux arm through fm_backend_target_exists (which proves the
+# recorded window against a real list-windows inventory) is what makes this
+# read `unknown · none`.
+test_gone_window_in_live_session_ignores_stale_status_log() {
+  reset_fakes
+  local d; d=$(new_case gone-window-live-session)
+  make_repo_on_branch "$d/wt" fm/feat-gone
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-gone.meta" "window=fm:fm-feat-gone" "worktree=$d/wt" "kind=ship"
+  printf 'working: implementing the widget\n' > "$d/state/feat-gone.status"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_TMUX_WINDOW_GONE=1   # session alive, this crew's window gone
+  local out; out=$(run_crew_state "$d" feat-gone)
+  assert_contains "$out" "state: unknown" "gone window in a live session -> unknown"
+  assert_contains "$out" "source: none" "gone window in a live session -> none source"
+  assert_contains "$out" "backend target gone" "gone window in a live session reports the dead endpoint"
+  assert_not_contains "$out" "source: status-log" "a gone window must not let the stale log read as current"
+  pass "a gone window of a LIVE session ignores the stale status log (no display-message fallback false-alive)"
+}
+
 # A closed/unreadable pane must NOT mask an authoritative run-step: judge by the
 # run-step, not the shell. The common case is a finished crew whose agent has
 # exited and closed its window (the normal gap between completion and teardown) -
@@ -1345,6 +1388,7 @@ test_no_run_idle_pane_paused
 test_no_run_idle_pane_custom_paused_verb
 test_no_run_idle_secondmate_resolved_event_not_state
 test_dead_window_ignores_stale_status_log
+test_gone_window_in_live_session_ignores_stale_status_log
 test_dead_window_still_reports_terminal_run_step
 test_dead_window_still_reports_active_run_step
 test_no_timeout_uses_perl_bound

--- a/tests/fm-send-popup-settle.test.sh
+++ b/tests/fm-send-popup-settle.test.sh
@@ -53,7 +53,10 @@ case "${1:-}" in
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
-  list-windows) exit 0 ;;
+  # The explicit sess:win endpoint is live: a real list-windows inventory
+  # answers with the window name (fm_backend_target_exists requires this
+  # since the display-message fallback fix, kunchenguid/firstmate#1130).
+  list-windows) printf 'win\n'; exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-send-secondmate-marker.test.sh
+++ b/tests/fm-send-secondmate-marker.test.sh
@@ -56,7 +56,22 @@ case "${1:-}" in
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
-  list-windows) exit 0 ;;
+  # The explicit endpoints these tests send to (other:win, outside:window)
+  # are live: a real list-windows inventory answers with the queried
+  # session's window (fm_backend_target_exists requires this since the
+  # display-message fallback fix, kunchenguid/firstmate#1130).
+  list-windows)
+    target=""
+    prev=""
+    for a in "$@"; do
+      [ "$prev" = "-t" ] && target="$a"
+      prev="$a"
+    done
+    case "$target" in
+      other) printf 'win\n' ;;
+      outside) printf 'window\n' ;;
+    esac
+    exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-send-settle.test.sh
+++ b/tests/fm-send-settle.test.sh
@@ -41,7 +41,10 @@ case "${1:-}" in
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
-  list-windows) exit 0 ;;
+  # The explicit sess:win endpoint is live: a real list-windows inventory
+  # answers with the window name (fm_backend_target_exists requires this
+  # since the display-message fallback fix, kunchenguid/firstmate#1130).
+  list-windows) printf 'win\n'; exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -197,25 +197,31 @@ SH
   chmod +x "$fakebin/ps"
 }
 
-# make_fake_tmux <fakebin> <live-target>: display-message succeeds only for
-# the given "session:window" target - the exact primitive
-# fm_backend_target_exists uses for a tmux endpoint liveness read.
+# make_fake_tmux <fakebin> <live-target>: models REAL tmux behavior around
+# the given live "session:window" target for the two primitives a tmux
+# endpoint liveness read can use. display-message SILENTLY FALLS BACK to the
+# live window when the window part of the target does not match (exit 0,
+# answering about the wrong window) and fails only when the session itself is
+# gone; list-windows inventories exactly the live window. The earlier
+# exit-1-for-anything-but-the-live-target fixture encoded the
+# fm_backend_target_exists false-alive bug (kunchenguid/firstmate#1130) as
+# expected behavior.
 make_fake_tmux() {
   local fakebin=$1 live=$2
+  local live_session=${live%%:*} live_window=${live#*:}
   cat > "$fakebin/tmux" <<SH
 #!/usr/bin/env bash
 set -u
+target=""
+prev=""
+for a in "\$@"; do
+  [ "\$prev" = "-t" ] && target="\$a"
+  prev="\$a"
+done
+[ "\${target%%:*}" = "$live_session" ] || exit 1
 case "\${1:-}" in
-  display-message)
-    target=""
-    prev=""
-    for a in "\$@"; do
-      [ "\$prev" = "-t" ] && target="\$a"
-      prev="\$a"
-    done
-    [ "\$target" = "$live" ] && { printf '%%1\n'; exit 0; }
-    exit 1
-    ;;
+  display-message) printf '%%1\n'; exit 0 ;;
+  list-windows) printf '%s\n' "$live_window"; exit 0 ;;
 esac
 exit 1
 SH

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -136,7 +136,11 @@ case "${1:-}" in
     [ "$_print" = 1 ] && printf 'fakepane\n'
     exit 0 ;;
   list-windows)
-    [ -n "${FM_FAKE_TMUX_WINDOW:-}" ] && printf '%s\n' "$FM_FAKE_TMUX_WINDOW"
+    # Default to the supervisor pane's window (firstmate:0) so the cheap
+    # inventory-based fm_backend_target_exists read sees a live supervisor
+    # endpoint, matching what FM_FAKE_TMUX_PANE_ALIVE=1 already models for
+    # display-message (kunchenguid/firstmate#1130).
+    printf '%s\n' "${FM_FAKE_TMUX_WINDOW:-0}"
     exit 0 ;;
   capture-pane)
     # Honor a single-line band capture (-S N -E M, both non-negative) for the
@@ -224,7 +228,22 @@ case "${1:-}" in
     [ "$print" = 1 ] && printf 'fakepane\n'
     exit 0 ;;
   capture-pane) cat "$COMPOSER" 2>/dev/null; exit 0 ;;
-  list-windows) exit 0 ;;
+  # The supervisor pane (firstmate:0) and the explicit fm-send endpoint
+  # (sess:win) are live: a real list-windows inventory answers with the
+  # queried session's window, which the inventory-based
+  # fm_backend_target_exists requires (kunchenguid/firstmate#1130).
+  list-windows)
+    target=""
+    prev=""
+    for a in "$@"; do
+      [ "$prev" = "-t" ] && target=$a
+      prev="$a"
+    done
+    case "$target" in
+      firstmate) printf '0\n' ;;
+      *) printf 'win\n' ;;
+    esac
+    exit 0 ;;
   send-keys)
     shift
     text=""; is_enter=0; lit=0


### PR DESCRIPTION
Fixes #1130.

> Context: this fix was produced by a firstmate crew (a crewmate agent supervised by a first mate) running the no-mistakes pipeline end-to-end, during a pilot of firstmate itself. The change was reviewed and approved by a human captain at the review gate and test gate, and the full CI matrix passed on the fork (bsorescu/firstmate#1: lint, coverage guard, repo invariants, all portable shards, Herdr, macOS bash compatibility — 9/9 green). One pre-existing gap surfaced during review and was deliberately kept out of scope: `fm_backend_tmux_kill` cannot address a window whose name contains a dot (e.g. `fm-api.2`), and its best-effort contract swallows the failure — happy to file that as a separate issue/PR.

## Intent

Fix fm_backend_target_exists (bin/fm-backend.sh) reporting a gone tmux window as alive - upstream issue kunchenguid/firstmate#1130. The tmux arm used a bare display-message probe that silently falls back to another window; it now requires the exact recorded window/pane via inventory or exact-answer equality, with fixtures corrected to model real tmux and red-first regression tests.

## What Changed

- `fm_backend_target_exists` (bin/fm-backend.sh) no longer trusts a bare `tmux display-message -p -t` probe, which exits 0 while silently answering about another window when the recorded one is gone (kunchenguid/firstmate#1130). A `session:window` target is now proved by an exact window-index or window-name match in a `tmux list-windows` inventory of that session, a `%pane`/`@window` handle by exact-answer id equality, and a colon-less target — carrying no session to inventory against — fails closed. The window part is matched in full before the pane-index-stripped form, so a dotted window name like `fm-api.2` is not mistaken for `fm-api` + pane index while `firstmate:0.1` still resolves.
- `bin/fm-crew-state.sh`'s `pane_readable` now routes its tmux arm through that shared primitive instead of duplicating the unsound probe, so a killed crew window reports `unknown / none / backend target gone` rather than a stale status-log-derived state. This also extends the fail-closed rule to tmux metas whose `window=` field has no session prefix, which now read gone. The stale comments in `bin/fm-supervise-daemon.sh` startup validation and `docs/tmux-backend.md` were updated to describe the inventory contract.
- Tests: new red-first regression coverage in `tests/fm-backend-tmux-smoke.test.sh` (live vs. gone window, `%pane`/`@window` ids, dotted window names, colon-less refusal) and a `FM_FAKE_TMUX_WINDOW_GONE` case in `tests/fm-crew-state.test.sh`; fake-tmux fixtures across the backend, bearings, session-start, send, and wake suites gained the `list-windows` inventory arm real tmux answers with. `tests/fm-fleet-snapshot-view.test.sh` could not be run locally — it hangs identically on this branch and on the base commit, on an unrelated cmux stdin wedge — so that caller's suite needs remote CI to confirm.

## Risk Assessment

✅ Low: This round changes only two lines of comment text to a claim I verified directly (fm-crew-state.sh contains no awk), leaves the already-verified implementation byte-identical, and every earlier finding has been applied or explicitly decided by the captain.

## Testing

I exercised the fix at the product surface rather than only in unit form: with a real tmux server on a private socket, bin/fm-crew-state.sh reports a killed crew window in a still-live session as \"unknown · none · backend target gone\" on the target commit, whereas the same scenario on base b6e351d still reports \"working · status-log\" because the bare display-message probe exits 0 answering about a decoy window. The change's new real-tmux smoke test is genuinely red-first (it fails on the pre-fix tree at the false-alive assertion), and all fixture-updated suites plus the remaining fm_backend_target_exists callers pass: fm-backend, fm-crew-state, fm-bearings-snapshot, fm-session-start, the three fm-send suites, fm-daemon, fm-send-strict and fm-secondmate-liveness. I found bin/fm-crew-state.sh's routing change had no test that would fail if reverted, so I added one focused regression case (plus a fixture arm modelling the real session-alive/window-gone shape) and confirmed it is red on base and green on the fix. One caller suite, fm-fleet-snapshot-view, hangs on this host in an unrelated cmux workspace lookup and hangs identically on the base commit, so it is pre-existing and left to CI; transient temp checkouts, logs and tmux sockets from my runs were removed and the only working-tree change left is the added regression case.

<details>
<summary>Evidence: Real-tmux end-to-end: gone crew window read as alive on base vs dead after the fix (fm-crew-state.sh)</summary>

<code>=== BEFORE the fix (base b6e351d) ===&#10;--- recorded endpoint: demo:fm-crew-1 (live) ---&#10;window 1: other-window&#10;window 2: fm-crew-1&#10;$ fm-crew-state.sh crew-1&#10;state: working · source: status-log · implementing the widget&#10;&#10;--- crew window killed (crewmate is gone) ---&#10;window 1: other-window&#10;raw probe: tmux display-message -p -t demo:fm-crew-1 &#39;#{pane_id}&#39; -&gt; %0 (exit 0) -- answered about window &#39;other-window&#39;&#10;$ fm-crew-state.sh crew-1&#10;state: working · source: status-log · implementing the widget&#10;&#10;=== AFTER the fix (69de64e) ===&#10;--- recorded endpoint: demo:fm-crew-1 (live) ---&#10;window 1: other-window&#10;window 2: fm-crew-1&#10;$ fm-crew-state.sh crew-1&#10;state: working · source: status-log · implementing the widget&#10;&#10;--- crew window killed (crewmate is gone) ---&#10;window 1: other-window&#10;raw probe: tmux display-message -p -t demo:fm-crew-1 &#39;#{pane_id}&#39; -&gt; %0 (exit 0) -- answered about window &#39;other-window&#39;&#10;$ fm-crew-state.sh crew-1&#10;state: unknown · source: none · backend target gone: demo:fm-crew-1</code>

```text
=== BEFORE the fix (base b6e351d) ===
--- recorded endpoint: demo:fm-crew-1 (live) ---
  window 1: other-window
  window 2: fm-crew-1
$ fm-crew-state.sh crew-1
  state: working · source: status-log · implementing the widget

--- crew window killed (crewmate is gone) ---
  window 1: other-window
  raw probe: tmux display-message -p -t demo:fm-crew-1 '#{pane_id}' -> %0 (exit 0) -- answered about window 'other-window'
$ fm-crew-state.sh crew-1
  state: working · source: status-log · implementing the widget

=== AFTER the fix (69de64e) ===
--- recorded endpoint: demo:fm-crew-1 (live) ---
  window 1: other-window
  window 2: fm-crew-1
$ fm-crew-state.sh crew-1
  state: working · source: status-log · implementing the widget

--- crew window killed (crewmate is gone) ---
  window 1: other-window
  raw probe: tmux display-message -p -t demo:fm-crew-1 '#{pane_id}' -> %0 (exit 0) -- answered about window 'other-window'
$ fm-crew-state.sh crew-1
  state: unknown · source: none · backend target gone: demo:fm-crew-1
```
</details>
<details>
<summary>Evidence: Red-first: the new tmux smoke test fails on the pre-fix code</summary>

<code># Red-first check: the NEW tmux smoke test run against the PRE-FIX code (base b6e351d)&#10;ok - real tmux: fm_backend_tmux_create_task creates a window and refuses a duplicate&#10;ok - real tmux: fm_backend_tmux_send_text_line sends literal text and submits with Enter&#10;ok - real tmux: fm_backend_tmux_send_literal + fm_backend_tmux_send_key Enter submit as two separate steps&#10;ok - real tmux: fm_backend_tmux_capture&#39;s -S -N bound trims old history for a small window and reaches it for a large one&#10;ok - real tmux: fm_backend_tmux_resolve_bare_selector (list-live) finds the created window by name&#10;ok - real tmux: fm_backend_tmux_resolve_bare_selector fails for a window that does not exist&#10;not ok - fm_backend_target_exists reported a nonexistent window of a live session alive&#10;exit=1</code>

```text
# Red-first check: the NEW tmux smoke test run against the PRE-FIX code (base b6e351d)
@1
ok - real tmux: fm_backend_tmux_create_task creates a window and refuses a duplicate
ok - real tmux: fm_backend_tmux_send_text_line sends literal text and submits with Enter
ok - real tmux: fm_backend_tmux_send_literal + fm_backend_tmux_send_key Enter submit as two separate steps
ok - real tmux: fm_backend_tmux_capture's -S -N bound trims old history for a small window and reaches it for a large one
ok - real tmux: fm_backend_tmux_resolve_bare_selector (list-live) finds the created window by name
ok - real tmux: fm_backend_tmux_resolve_bare_selector fails for a window that does not exist
not ok - fm_backend_target_exists reported a nonexistent window of a live session alive
exit=1
```
</details>
<details>
<summary>Evidence: Red-first: the added fm-crew-state regression case fails on the pre-fix code</summary>

<code># New fm-crew-state case run against PRE-FIX bin/ (base b6e351d)&#10;not ok - gone window in a live session -&gt; unknown (missing: &#39;state: unknown&#39;)</code>

```text
# New fm-crew-state case run against PRE-FIX bin/ (base b6e351d)
ok - terminal failed run is authoritative
not ok - gone window in a live session -> unknown (missing: 'state: unknown')
exit=
```
</details>
<details>
<summary>Evidence: Pre-existing hang: fm-fleet-snapshot-view wedges identically on base and target</summary>

<code>fixed tree (69de64e): rc=143 (killed by watchdog), last output:&#10;ok - empty fleet snapshot and view use explicit absence markers&#10;base tree (b6e351d): rc=143 (killed by watchdog), last output:&#10;ok - empty fleet snapshot and view use explicit absence markers&#10;&#10;blocked descendant when hung (cmux workspace lookup, bin/backends/cmux.sh:415 - not the tmux path):&#10;jq -r --arg id workspace &#39;.workspaces[]? | select(.id == $id) | .title&#39; &lt;- blocked on stdin</code>

```text
# tests/fm-fleet-snapshot-view.test.sh hangs identically on BOTH trees (pre-existing, not this change)
# 240s watchdog, same last-passing case, same blocked child process on each tree.

fixed tree (69de64e): rc=143 (killed by watchdog), last output:
  ok - empty fleet snapshot and view use explicit absence markers
base tree  (b6e351d): rc=143 (killed by watchdog), last output:
  ok - empty fleet snapshot and view use explicit absence markers

blocked descendant when hung (cmux workspace lookup, bin/backends/cmux.sh:415 - not the tmux path):
  jq -r --arg id workspace '.workspaces[]? | select(.id == $id) | .title'   <- blocked on stdin
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (44m49s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed (2) ✅</summary>

- 🚨 `tests/fm-bearings-snapshot.test.sh:32` - The fake tmux in make_fakebin handles only display-message and capture-pane; an unmatched `list-windows` falls through to `exit 0` with no output. Since fm_backend_target_exists now reads the session inventory, every tmux endpoint in this suite reads absent. Concretely: test_domain_alpha_stale_parent_event_does_not_become_current_work asserts `.terminal_evidence.captured == true` (line 225), but terminal_evidence_json (bin/fm-fleet-snapshot.sh:971) short-circuits to captured:false when `.endpoint.exists == false` for window=firstmate:fm-domain-alpha; and line 345 asserts `.endpoint.exists == true` for the child meta window=firstmate:fm-phase8 (bin/fm-fleet-snapshot.sh:472). Five sibling fixtures were updated for the inventory read; this one was missed. Add a `list-windows` arm that answers with the queried home&#39;s window names (e.g. `sed -n &#39;s/^window=[^:]*://p&#39; &#34;$FM_HOME&#34;/state/*.meta`, excluding the `*dead-*` ids the fixture deliberately models as gone) so the fixture keeps its existing alive/absent convention.
- ⚠️ `bin/fm-crew-state.sh:148` - The authorized failure this change fixes remains reachable through a sibling path. pane_readable&#39;s tmux arm is the exact bare probe the new comment declares unsound: `tmux display-message -p -t &#34;$1&#34; &#39;#{pane_id}&#39; &gt;/dev/null 2&gt;&amp;1`. Verified against real tmux 3.7b: for a gone window in a live session that call exits 0 while answering about a different window. So line 605 (`pane_readable &#34;$BACKEND_TARGET&#34; || emit unknown none &#34;backend target gone&#34;`) never fires for a killed task window; crew-state then falls through crew_pane_is_busy (capture-pane, which does fail correctly) to the status-log fallback and reports a stale state (e.g. working) for a crew whose endpoint is gone - the same false-alive class, feeding the watcher&#39;s provably-working triage. fm-crew-state.sh already sources bin/fm-backend.sh (line 62), so the earliest supported shared boundary is calling `fm_backend_target_exists tmux &#34;$1&#34;` here instead of duplicating a third symptom patch. Related: bin/fm-backend.sh:830 still says the function &#34;Mirrors fm-crew-state.sh&#39;s pane_readable check&#34;, which this change makes false.
- ⚠️ `bin/fm-backend.sh:862` - The pane-index strip can report a live window dead. Task ids legitimately contain dots (fm_task_id_path_safe, bin/fm-pr-lib.sh:97, rejects only a leading dot), so id `api.2` yields window `fm-api.2` and target `sess:fm-api.2` (bin/fm-spawn.sh:942,946). The numeric-suffix branch strips `.2`, the inventory is searched for `fm-api`, and the live endpoint reads dead. Verified against real tmux 3.7b: `display-message -p -t &#39;sess:fm-api.2&#39; &#39;#{window_name}&#39;` resolves to the window actually named `fm-api.2`, and fm_backend_tmux_agent_state (bin/backends/tmux.sh:185) matches that exact name - so the two liveness readers now contradict each other for the same target. Fix without losing the intended `firstmate:0.1` support: match the full window part first and only fall back to the stripped form (awk `$1 == w || $2 == w || $1 == ws || $2 == ws`).
- ℹ️ `bin/fm-supervise-daemon.sh:1375` - The startup-validation comment now misdescribes the code: it claims &#34;for backend=tmux this runs the exact same `tmux display-message -p -t \&#34;$TARGET\&#34; &#39;#{pane_id}&#39;` call as before&#34;, which is exactly the probe this change replaced. For a session:window supervisor target it is now a list-windows inventory read. Update the comment so the next reader does not trust a primitive that is no longer used.
- ℹ️ `tests/fm-backend-tmux-smoke.test.sh:165` - The new %pane and @window exact-answer arms (bin/fm-backend.sh:849,852) have no test anywhere, yet they carry the subtlest premise of the fix: a gone id makes display-message exit 0 with EMPTY output (confirmed on tmux 3.7b), so only the equality comparison distinguishes it from a live handle. This smoke test already holds a real live pane and window id, so the regression is two lines next to the existing block: assert alive for `$(tmux display-message -p -t &#34;$TARGET&#34; &#39;#{pane_id}&#39;)` and dead for a never-allocated id such as %99999/@99999. The bare-name rejection arm (line 874) is likewise untested.
- ℹ️ `bin/fm-backend.sh:874` - The catch-all `return 1` makes a colon-less tmux target unconditionally dead. This is a supported recorded shape elsewhere: fm_backend_meta_for_window and fm_backend_resolve_selector accept a meta whose window field is a bare name (fixture `window=custom-window`, tests/fm-backend.test.sh:613), and fm-session-start.sh:360 probes `${target:-$window}` straight from that field. Such an endpoint previously always read alive (via the fallback bug) and now always reads dead - neither is correct. If bare-window metas are still supported, the accurate read is the all-sessions inventory that fm_backend_tmux_resolve_bare_selector (bin/backends/tmux.sh:31) already performs; if they are not, the hard refusal matches fm_backend_validate_task_endpoint (bin/fm-backend.sh:448) and only the doc comment needs to say so.

🔧 Fix: route crew-state through fixed target_exists, fix dotted windows
3 infos still open:
- ℹ️ `bin/fm-backend.sh:880` - The rationale for matching in-shell instead of through awk asserts something I could not substantiate: &#34;fm-crew-state.sh&#39;s fallback path, which runs under a deliberately minimal PATH, has none today&#34;. fm-crew-state.sh sets no PATH itself, and both of its callers - bin/fm-fleet-snapshot.sh:206 and bin/fm-classify-lib.sh:337 (FM_CREW_STATE_BIN) - invoke it with the ambient PATH; no caller scrubs it. The rest of the justification holds (the loop is one fork, and fm-crew-state.sh genuinely uses no awk today - only grep/sed/cut/head/tail), so the fix is to drop or correct the minimal-PATH clause rather than change the code. Worth correcting because this codebase treats these rationale comments as contracts - the &#34;Mirrors fm-crew-state.sh&#39;s pane_readable check&#34; line was repaired this round for exactly that reason.
- ℹ️ `bin/backends/tmux.sh:135` - Pre-existing and NOT introduced by this change - flagging only because the new smoke fixture creates such a window and its comment documents half of it. fm_backend_tmux_kill runs `tmux kill-window -t &#34;=$session:=$window&#34;`; verified on tmux 3.7b that for a window named `fm-api.2` both the plain form (`can&#39;t find pane: 2`) and the exact-match form (`can&#39;t find window: fm-api`) fail, and the deliberate `|| true` best-effort contract swallows the failure. Since task ids only have to be path-safe (fm_task_id_path_safe, bin/fm-pr-lib.sh:97), id `api.2` spawns window `fm-api.2` (bin/fm-spawn.sh:942), passes fm_backend_validate_task_endpoint (bin/fm-backend.sh:448 requires exactly `fm-$id`), and now correctly reads alive - but teardown removes the metadata while the tmux window survives. Addressing it would need a kill by stable @window id (fm_backend_tmux_create_task already captures one) and is a separate change; nothing here should block on it.
- ℹ️ `bin/fm-crew-state.sh:609` - Note for the PR description the captain planned for the accepted fail-closed decision (colon-less tmux targets are dead by design, bin/fm-backend.sh:874): routing pane_readable through the shared primitive widens that decision&#39;s blast radius beyond the digests named in round 1. A tmux meta whose window field has no session prefix (a shape fm_backend_meta_for_window and fm_backend_resolve_selector still accept - fixture `window=custom-window`, tests/fm-backend.test.sh:613) now makes fm-crew-state.sh emit `unknown / none / backend target gone` instead of a status-log-derived state, which also propagates to fm-fleet-snapshot&#39;s current_state (bin/fm-fleet-snapshot.sh:206) and to the watcher&#39;s crew_is_provably_working predicate. No code change requested - this is the deliberate, already-approved semantics; it just deserves a line in the write-up.

🔧 Fix: drop unsubstantiated minimal-PATH clause from inventory comment
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-fleet-snapshot-view.test.sh` - tests/fm-fleet-snapshot-view.test.sh could not be run to completion locally: it hangs after its first case on both the target commit and the base commit b6e351d (240s watchdog, identical last-passing case, identical blocked child). The wedge is a cmux workspace lookup piped into jq (bin/backends/cmux.sh:415) that blocks on stdin, not the tmux liveness path this change touches; wedged fm-fleet-snapshot.sh processes from an unrelated checkout were already present on the host before this run. bin/fm-fleet-snapshot.sh:472 is one of the fm_backend_target_exists callers, so that caller&#39;s suite is unverified locally - its fake tmux does already provide a list-windows inventory arm, which statically satisfies the new probe. Remote CI needs to confirm it.
- <code>`bash bin/fm-test-run.sh tests/fm-backend-tmux-smoke.test.sh` (real tmux on a private socket; the new fm_backend_target_exists cases for gone window, %pane/@window ids, dotted window names, and colon-less refusal)</code>
- <code>Manual end-to-end: real tmux session with a recorded crew window plus a decoy window, then `bin/fm-crew-state.sh crew-1` before and after killing the crew window, run against both the target tree and a temp checkout of base b6e351d</code>
- <code>Red-first: `tests/fm-backend-tmux-smoke.test.sh` copied onto the base b6e351d tree -&gt; fails at `fm_backend_target_exists reported a nonexistent window of a live session alive`</code>
- <code>Added `test_gone_window_in_live_session_ignores_stale_status_log` + `FM_FAKE_TMUX_WINDOW_GONE` fixture arm to `tests/fm-crew-state.test.sh`; verified red on base b6e351d and green on the target commit</code>
- `bash bin/fm-test-run.sh tests/fm-backend.test.sh tests/fm-crew-state.test.sh tests/fm-bearings-snapshot.test.sh tests/fm-session-start.test.sh`
- `bash bin/fm-test-run.sh tests/fm-send-settle.test.sh tests/fm-send-popup-settle.test.sh tests/fm-send-secondmate-marker.test.sh`
- <code>`bash bin/fm-test-run.sh tests/fm-daemon.test.sh tests/fm-send-strict.test.sh tests/fm-secondmate-liveness.test.sh` (the other fm_backend_target_exists callers)</code>
- <code>`bash tests/fm-fleet-snapshot-view.test.sh` under a 240s watchdog on both the target tree and a base b6e351d checkout (hangs identically on both)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

