### PR TITLE
fix(bin): forbid Claude/AI attribution in every crewmate brief

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.
 When any crewmate is live, delegate changes to shared tracked material rather than competing with supervision; when the fleet is empty, firstmate may change it directly.
 This repo is a shared template, while `.env`, `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` are captain-private and gitignored.
 Ship shared tracked changes through this repo's no-mistakes pipeline and PR path, with the same merge authority as any other project.
-Never add an agent name as a commit co-author.
+Never add an agent name as a commit co-author, an AI-generated attribution footer on a PR, issue, or comment, or an AI-authorship indicator in code or docs.
 
 ## 2. Layout and state
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -283,6 +283,9 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Add no Claude or AI attribution to any output.
+   No \`Co-Authored-By\` trailer on commits, no "Generated with Claude Code" footer on PRs, issues, or comments, and no AI-authorship indicator in code or docs.
+   Commits stay signed regardless.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -397,6 +400,9 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Add no Claude or AI attribution to any output.
+   No \`Co-Authored-By\` trailer on commits, no "Generated with Claude Code" footer on PRs, issues, or comments, and no AI-authorship indicator in code or docs.
+   Commits stay signed regardless.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -598,6 +598,34 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+test_ship_and_scout_forbid_ai_attribution() {
+  local home brief
+  home="$TMP_ROOT/no-attribution-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-no-attribution-ship firstmate >/dev/null 2>&1
+  brief="$home/data/brief-no-attribution-ship/brief.md"
+  assert_grep "Add no Claude or AI attribution to any output." "$brief" \
+    "ship brief did not forbid Claude/AI attribution"
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_grep 'No `Co-Authored-By` trailer on commits' "$brief" \
+    "ship brief did not name the commit co-author trailer"
+  assert_grep "Commits stay signed regardless." "$brief" \
+    "ship brief dropped the signing requirement alongside the attribution guard"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-no-attribution-scout firstmate --scout >/dev/null 2>&1
+  brief="$home/data/brief-no-attribution-scout/brief.md"
+  assert_grep "Add no Claude or AI attribution to any output." "$brief" \
+    "scout brief did not forbid Claude/AI attribution"
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_grep 'No `Co-Authored-By` trailer on commits' "$brief" \
+    "scout brief did not name the commit co-author trailer"
+  assert_grep "Commits stay signed regardless." "$brief" \
+    "scout brief dropped the signing requirement alongside the attribution guard"
+
+  pass "fm-brief.sh: ship and scout briefs both forbid Claude/AI attribution while keeping commits signed"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -634,4 +662,5 @@ test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_ship_and_scout_forbid_ai_attribution
 test_scout_and_secondmate_scaffold


### PR DESCRIPTION
## Intent

The developer wanted to add a permanent, fleet-wide guard so no crewmate agent ever adds Claude/AI attribution to its output, closing a gap where a crewmate had added a Co-Authored-By: Claude trailer because the brief scaffold never forbade it. Change 1: in bin/fm-brief.sh, add a new numbered rule to the shared crewmate Rules block inherited by both ship and scout briefs, forbidding any Claude/AI attribution (no Co-Authored-By commit trailer, no "Generated with Claude Code" footer on PRs/issues/comments, and no AI-authorship indicator in code or docs) while explicitly preserving the requirement that commits stay signed. Change 2: in AGENTS.md section 1, extend the existing "Never add an agent name as a commit co-author" sentence (following a one-owner rule, not adding a competing statement) so it also forbids AI attribution footers on PRs/issues and AI-authorship indicators in code. They required following the firstmate coding-guidelines skill (one-sentence-per-line style, plain dashes not em dashes, shellcheck-clean), extending or adding a test that asserts the new rule through the fm-brief.sh executable interface for both a ship and scout brief rather than by asserting source bytes, and running bin/fm-lint.sh clean. They imposed strict scope discipline: limit the diff to those two files plus a test, with no scaffold refactor, rule reordering, or changes to project code.

## What Changed

- Added a new numbered rule (8) to the shared crewmate Rules block in `bin/fm-brief.sh`, so both the ship and scout briefs now forbid any Claude/AI attribution — no `Co-Authored-By` commit trailer, no "Generated with Claude Code" footer on PRs, issues, or comments, and no AI-authorship indicator in code or docs — while preserving the requirement that commits stay signed.
- Extended the one-owner co-author sentence in `AGENTS.md` section 1 so it also forbids AI-generated attribution footers on PRs, issues, and comments and AI-authorship indicators in code or docs.
- Added `test_ship_and_scout_forbid_ai_attribution` to `tests/fm-brief.test.sh`, asserting the new rule renders through the `fm-brief.sh` executable interface for both the ship and scout paths.

## Risk Assessment

✅ Low: The change is a small, well-bounded documentation/scaffold guard added identically to both brief paths with an executable-interface test covering ship and scout, no behavioral or product-code changes, and it preserves the existing signing requirement.

## Testing

Ran the targeted `tests/fm-brief.test.sh` suite (all pass, including the new attribution-guard test) and produced product-level evidence by generating actual ship and scout briefs from the fm-brief.sh executable, confirming both inherit the new rule 8 forbidding Claude/AI attribution while keeping "Commits stay signed regardless," and verified the AGENTS.md one-owner sentence was extended in place. I did not run bin/fm-lint.sh because this test phase forbids running linters/static-analysis tools; that verification is owned by the lint phase. Overall result: the user intent is demonstrated working end-to-end.

<details>
<summary>Evidence: Attribution-guard evidence (real ship + scout brief output and AGENTS.md sentence)</summary>

<code>### Generated SHIP brief - shared Rules block (real fm-brief.sh output)&#10;45:8. Add no Claude or AI attribution to any output.&#10;46- No `Co-Authored-By` trailer on commits, no &#34;Generated with Claude Code&#34; footer on PRs, issues, or comments, and no AI-authorship indicator in code or docs.&#10;47- Commits stay signed regardless.&#10;&#10;### Generated SCOUT brief - shared Rules block (real fm-brief.sh output)&#10;38:8. Add no Claude or AI attribution to any output.&#10;39- No `Co-Authored-By` trailer on commits, no &#34;Generated with Claude Code&#34; footer on PRs, issues, or comments, and no AI-authorship indicator in code or docs.&#10;40- Commits stay signed regardless.&#10;&#10;### AGENTS.md section 1 - one-owner sentence extended&#10;45:Never add an agent name as a commit co-author, an AI-generated attribution footer on a PR, issue, or comment, or an AI-authorship indicator in code or docs.</code>

```text
### Generated SHIP brief - shared Rules block (real fm-brief.sh output)
`` `
  44-   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
  45:8. Add no Claude or AI attribution to any output.
  46-   No `Co-Authored-By` trailer on commits, no "Generated with Claude Code" footer on PRs, issues, or comments, and no AI-authorship indicator in code or docs.
  47-   Commits stay signed regardless.
`` `

### Generated SCOUT brief - shared Rules block (real fm-brief.sh output)
`` `
  37-   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
  38:8. Add no Claude or AI attribution to any output.
  39-   No `Co-Authored-By` trailer on commits, no "Generated with Claude Code" footer on PRs, issues, or comments, and no AI-authorship indicator in code or docs.
  40-   Commits stay signed regardless.
`` `

### AGENTS.md section 1 - one-owner sentence extended
`` `
45:Never add an agent name as a commit co-author, an AI-generated attribution footer on a PR, issue, or comment, or an AI-authorship indicator in code or docs.
`` `
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` — full fm-brief behavior suite passes, including the new `test_ship_and_scout_forbid_ai_attribution`</code>
- <code>Generated a real ship brief via `FM_HOME=... bin/fm-brief.sh evidence-ship firstmate` and confirmed rule 8 renders with the signing exception preserved</code>
- <code>Generated a real scout brief via `FM_HOME=... bin/fm-brief.sh evidence-scout firstmate --scout` and confirmed the same rule renders in the scout path</code>
- `Inspected AGENTS.md section 1 to confirm the one-owner co-author sentence was extended (not duplicated) to also forbid AI attribution footers and code/doc indicators`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `.agents/skills/firstmate-coding-guidelines/SKILL.md:96` - The change broadened AGENTS.md §1&#39;s co-author sentence to also forbid AI attribution footers and code/doc authorship indicators, but a narrower near-duplicate of the same rule remains at .agents/skills/firstmate-coding-guidelines/SKILL.md:96 (&#39;Never add an agent name as a commit co-author.&#39;). It is pre-existing and still true, so it is not stale, but the two copies of the same underlying rule now diverge. Consolidating it (reduce SKILL.md to a pointer at AGENTS.md, or keep it as a distinct code-style rule) is an out-of-scope, pre-existing duplication call left to the maintainer rather than synchronizing a second full copy here.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
