### PR TITLE
feat(fm-brief): add --group flag for browsable data/ grouping

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -30,8 +30,11 @@
 #   for browsing several related tasks (usually a project name, or an initiative
 #   spanning several tasks against the same project) as one folder. The authoritative
 #   path stays flat data/<task-id>/ - every other script keys off that path unchanged.
-#   Optional, not applicable to --secondmate. Refuses rather than overwriting an
-#   existing non-matching path at data/<name>/<task-id>.
+#   Optional, not applicable to --secondmate. <name> must be a single path component
+#   (not '.', '..', or containing '/') and must not equal the task id. Refuses rather
+#   than overwriting an existing non-matching path at data/<name>/<task-id>, refuses
+#   a <name> that already names a task's own directory, and refuses a task id that
+#   already names an existing --group folder.
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -121,6 +121,10 @@ if [ -n "$GROUP" ]; then
       exit 1
       ;;
   esac
+  if [ "$GROUP" = "$ID" ]; then
+    echo "error: --group=$GROUP must not equal the task id" >&2
+    exit 1
+  fi
 fi
 if [ -n "$GROUP" ] && [ "$KIND" = secondmate ]; then
   echo "error: --group does not apply to --secondmate charters" >&2
@@ -139,14 +143,19 @@ fi
 
 BRIEF="$DATA/$ID/brief.md"
 [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
+if [ -e "$DATA/$ID/.fm-group" ]; then
+  echo "error: $DATA/$ID is already used as a --group folder for other tasks, refusing to scaffold a task with this id" >&2
+  exit 1
+fi
+if [ -n "$GROUP" ] && { [ -e "$DATA/$GROUP/brief.md" ] || [ -e "$DATA/$GROUP/report.md" ]; }; then
+  echo "error: $DATA/$GROUP is itself a task directory (has brief.md or report.md), refusing to use it as a --group folder" >&2
+  exit 1
+fi
 mkdir -p "$DATA/$ID"
 
 if [ -n "$GROUP" ]; then
-  if [ -e "$DATA/$GROUP/brief.md" ] || [ -e "$DATA/$GROUP/report.md" ]; then
-    echo "error: $DATA/$GROUP is itself a task directory (has brief.md or report.md), refusing to use it as a --group folder" >&2
-    exit 1
-  fi
   mkdir -p "$DATA/$GROUP"
+  : > "$DATA/$GROUP/.fm-group"
   GROUP_LINK="$DATA/$GROUP/$ID"
   if [ -L "$GROUP_LINK" ] && [ "$(readlink "$GROUP_LINK")" = "../$ID" ]; then
     : # already correct, idempotent

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -142,6 +142,10 @@ BRIEF="$DATA/$ID/brief.md"
 mkdir -p "$DATA/$ID"
 
 if [ -n "$GROUP" ]; then
+  if [ -e "$DATA/$GROUP/brief.md" ] || [ -e "$DATA/$GROUP/report.md" ]; then
+    echo "error: $DATA/$GROUP is itself a task directory (has brief.md or report.md), refusing to use it as a --group folder" >&2
+    exit 1
+  fi
   mkdir -p "$DATA/$GROUP"
   GROUP_LINK="$DATA/$GROUP/$ID"
   if [ -L "$GROUP_LINK" ] && [ "$(readlink "$GROUP_LINK")" = "../$ID" ]; then

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -26,6 +26,12 @@
 #   The flag must be explicit because {TASK} is filled after scaffolding and the
 #   caller-supplied repo string cannot reliably identify this repo. Briefs made
 #   without it carry a loud declaration so an omitted contract cannot be silent.
+#   --group=<name> adds data/<name>/<task-id> as a relative symlink to data/<task-id>,
+#   for browsing several related tasks (usually a project name, or an initiative
+#   spanning several tasks against the same project) as one folder. The authoritative
+#   path stays flat data/<task-id>/ - every other script keys off that path unchanged.
+#   Optional, not applicable to --secondmate. Refuses rather than overwriting an
+#   existing non-matching path at data/<name>/<task-id>.
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):
@@ -94,6 +100,7 @@ fi
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0
+GROUP=""
 POS=()
 for a in "$@"; do
   case "$a" in
@@ -101,10 +108,24 @@ for a in "$@"; do
     --secondmate) KIND=secondmate ;;
     --herdr-lab) HERDR_LAB=1 ;;
     --no-projects) NO_PROJECTS=1 ;;
+    --group=*) GROUP="${a#--group=}" ;;
     *) POS+=("$a") ;;
   esac
 done
 ID=${POS[0]}
+
+if [ -n "$GROUP" ]; then
+  case "$GROUP" in
+    */* | . | ..)
+      echo "error: --group=$GROUP must be a single path component, not '.', '..', or contain '/'" >&2
+      exit 1
+      ;;
+  esac
+fi
+if [ -n "$GROUP" ] && [ "$KIND" = secondmate ]; then
+  echo "error: --group does not apply to --secondmate charters" >&2
+  exit 1
+fi
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   echo "error: --herdr-lab applies only to crewmate ship or scout briefs" >&2
@@ -119,6 +140,19 @@ fi
 BRIEF="$DATA/$ID/brief.md"
 [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
 mkdir -p "$DATA/$ID"
+
+if [ -n "$GROUP" ]; then
+  mkdir -p "$DATA/$GROUP"
+  GROUP_LINK="$DATA/$GROUP/$ID"
+  if [ -L "$GROUP_LINK" ] && [ "$(readlink "$GROUP_LINK")" = "../$ID" ]; then
+    : # already correct, idempotent
+  elif [ -e "$GROUP_LINK" ] || [ -L "$GROUP_LINK" ]; then
+    echo "error: $GROUP_LINK already exists and is not the expected symlink to ../$ID" >&2
+    exit 1
+  else
+    ln -s "../$ID" "$GROUP_LINK"
+  fi
+fi
 
 shell_quote() {
   printf "'"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -672,6 +672,25 @@ test_group_symlink_behavior() {
   assert_present "$err" "group/task collision must print an error"
   [ -e "$home/data/existing-task/brief-group-e6" ] && fail "colliding --group must not graft a symlink into another task's directory"
 
+  # --group must not equal the task's own id: that would graft a
+  # self-referential symlink into the task's own authoritative directory.
+  err="$TMP_ROOT/group-self.err"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-group-e7 alpha --scout --group=brief-group-e7 >/dev/null 2>"$err"
+  status=$?
+  expect_code 1 "$status" "--group equal to the task's own id must be refused"
+  assert_present "$err" "self-referential --group must print an error"
+  [ -e "$home/data/brief-group-e7/brief-group-e7" ] && fail "self-referential --group must not graft a symlink into the task's own directory"
+
+  # A task id that collides with an existing --group-only folder must be
+  # refused in the reverse direction too, not silently merged into it.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-group-e8 alpha --scout --group=widget-initiative >/dev/null 2>&1
+  err="$TMP_ROOT/group-reverse-collision.err"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" widget-initiative alpha --scout >/dev/null 2>"$err"
+  status=$?
+  expect_code 1 "$status" "a task id colliding with an existing --group folder must be refused"
+  assert_present "$err" "reverse group/task collision must print an error"
+  [ -e "$home/data/widget-initiative/brief.md" ] && fail "reverse collision must not scaffold a brief into the existing --group folder"
+
   pass "fm-brief.sh: --group creates additive, idempotent-per-task symlinks without touching the flat data/<id> path"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -662,6 +662,16 @@ test_group_symlink_behavior() {
   status=$?
   expect_code 1 "$status" "--group combined with --secondmate must be refused"
 
+  # A --group name that collides with an existing task's own authoritative
+  # directory must be refused, not silently grafted into that task's dir.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" existing-task alpha --scout >/dev/null 2>&1
+  err="$TMP_ROOT/group-collision.err"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-group-e6 alpha --scout --group=existing-task >/dev/null 2>"$err"
+  status=$?
+  expect_code 1 "$status" "--group colliding with an existing task directory must be refused"
+  assert_present "$err" "group/task collision must print an error"
+  [ -e "$home/data/existing-task/brief-group-e6" ] && fail "colliding --group must not graft a symlink into another task's directory"
+
   pass "fm-brief.sh: --group creates additive, idempotent-per-task symlinks without touching the flat data/<id> path"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -618,6 +618,53 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# --group=<name> adds a relative symlink data/<name>/<id> -> ../<id>, without
+# changing the authoritative flat data/<id> path other scripts key off.
+test_group_symlink_behavior() {
+  local home id1 id2 link1 link2 status err
+  home="$TMP_ROOT/group-home"
+  mkdir -p "$home/data"
+
+  id1="brief-group-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id1" alpha --scout --group=my-initiative >/dev/null 2>&1
+  status=$?
+  expect_code 0 "$status" "fm-brief.sh with --group should exit 0"
+  assert_present "$home/data/$id1/brief.md" "grouped brief was not scaffolded at its authoritative flat path"
+  link1="$home/data/my-initiative/$id1"
+  [ -L "$link1" ] || fail "--group did not create a symlink at $link1"
+  [ "$(readlink "$link1")" = "../$id1" ] || fail "$link1 must be a relative symlink to ../$id1, got $(readlink "$link1")"
+
+  # A second task under the same --group must add a second symlink alongside
+  # the first, not fail or clobber it (the group directory already exists).
+  id2="brief-group-e2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id2" alpha --scout --group=my-initiative >/dev/null 2>&1
+  status=$?
+  expect_code 0 "$status" "a second task under the same --group should exit 0"
+  link2="$home/data/my-initiative/$id2"
+  [ -L "$link2" ] || fail "second --group task did not get its own symlink at $link2"
+  [ -L "$link1" ] || fail "second --group task removed the first task's symlink at $link1"
+
+  # Omitting --group must not create any grouping folder for that task.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-group-e3 alpha --scout >/dev/null 2>&1
+  [ -e "$home/data/ungrouped-should-not-exist" ] && fail "a task without --group unexpectedly created a group folder"
+
+  # An invalid group name (path separator, or . / ..) must refuse loudly.
+  err="$TMP_ROOT/group-invalid.err"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-group-e4 alpha --scout --group=../escape >/dev/null 2>"$err"
+  status=$?
+  expect_code 1 "$status" "--group with a path separator must be refused"
+  assert_present "$err" "invalid --group must print an error"
+
+  # --group is not applicable to --secondmate charters.
+  err="$TMP_ROOT/group-secondmate.err"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER=x \
+    "$ROOT/bin/fm-brief.sh" brief-group-e5 --secondmate --group=my-initiative alpha >/dev/null 2>"$err"
+  status=$?
+  expect_code 1 "$status" "--group combined with --secondmate must be refused"
+
+  pass "fm-brief.sh: --group creates additive, idempotent-per-task symlinks without touching the flat data/<id> path"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -635,3 +682,4 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_group_symlink_behavior


### PR DESCRIPTION
## Intent

Reorganize the data/ directory so that all generated reports are grouped under a folder matching their project name, matching the existing projects/ structure. The developer required this change be applied properly to firstmate's own shared scripts/AGENTS.md contract (not just moved as files), with lint and tests passing before committing.

## What Changed

- Added an optional `--group=<name>` flag to `bin/fm-brief.sh` that symlinks `data/<name>/<task-id>` to `data/<task-id>`, letting related tasks (e.g. tasks under the same project/initiative) be browsed together while keeping `data/<task-id>/` as the single authoritative path all other scripts key off.
- Added validation to prevent inconsistent or self-referential state: rejects malformed group names (`.`, `..`, containing `/`), a group name equal to the task's own id, `--group` combined with `--secondmate`, a group name that collides with an existing task's own directory, and a task id that collides with an existing `--group` folder (detected via a `.fm-group` sentinel file); existing correct symlinks are treated as idempotent no-ops.
- Updated the script header comment documenting `--group` usage and all refusal branches, and added test coverage in `tests/fm-brief.test.sh` for the new refusal paths.

## Risk Assessment

✅ Low: The two remaining test-coverage gaps from the prior round are now closed with tests that correctly exercise both new refusal branches (self-referential --group, reverse group/task collision) and match the established pattern in the file; the --group feature is now fully guarded and tested in both collision directions.

## Testing

`tests/fm-brief.test.sh passes in full, including the new test_group_symlink_behavior. data/ is gitignored so the real adrevila-v2 report move isn't in this commit; instead verified the mechanism manually in a scratch FM_HOME, producing symlinks data/adrevila-v2/{market-research,brd,trd} pointing to the flat data/<id> dirs.`

<details>
<summary>Evidence: CLI transcript of --group=adrevila-v2 demo</summary>

```text
=== Simulating adrevila-v2 report grouping via bin/fm-brief.sh --group ===

$ fm-brief.sh market-research adrevila --scout --group=adrevila-v2
scaffolded: /tmp/tmp.LkXHQepCeH/data/market-research/brief.md (scout; replace {TASK})
exit: 0

$ fm-brief.sh brd adrevila --scout --group=adrevila-v2
scaffolded: /tmp/tmp.LkXHQepCeH/data/brd/brief.md (scout; replace {TASK})
exit: 0

$ fm-brief.sh trd adrevila --scout --group=adrevila-v2
scaffolded: /tmp/tmp.LkXHQepCeH/data/trd/brief.md (scout; replace {TASK})
exit: 0

=== Resulting data/ layout (authoritative flat dirs + browsable group folder) ===
data
data/adrevila-v2
data/adrevila-v2/brd
data/adrevila-v2/.fm-group
data/adrevila-v2/market-research
data/adrevila-v2/trd
data/brd
data/brd/brief.md
data/market-research
data/market-research/brief.md
data/trd
data/trd/brief.md

=== Symlinks resolve to the authoritative flat task directories ===
data/adrevila-v2/market-research -> ../market-research
data/adrevila-v2/brd -> ../brd
data/adrevila-v2/trd -> ../trd
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-brief.sh:144` - The collision guard added in this branch only checks that `$DATA/$GROUP/brief.md` or `report.md` doesn&#39;t already exist. It runs after `mkdir -p &#34;$DATA/$ID&#34;` (line 142) has already created the new task&#39;s own directory, so when `--group` is passed the *same* value as the task id itself (e.g. `fm-brief.sh foo repo --scout --group=foo`), the check inspects `$DATA/foo/brief.md` — which doesn&#39;t exist yet because this invocation hasn&#39;t written it — and passes. The script then creates `$DATA/foo/foo` as a symlink to `../foo`, which resolves back to `$DATA/foo` itself: a self-referential symlink sitting inside the task&#39;s own authoritative directory. This is a simple oversight, not a product-behavior question — grouping a task under its own id is never meaningful, so it should just be rejected outright alongside the existing `*/* | . | ..` format check.
- ⚠️ `bin/fm-brief.sh:141` - The new guard (this branch&#39;s second commit) refuses `--group=&lt;name&gt;` when `&lt;name&gt;` is already an existing task&#39;s own directory, but does not guard the mirror direction: if `&lt;name&gt;` was previously created purely as a --group folder (via some other task&#39;s `--group=&lt;name&gt;`), and a later task is scaffolded with id `&lt;name&gt;` itself (no --group), nothing detects the collision. Concrete sequence: `fm-brief.sh a repo --scout --group=widget` creates `data/widget/a -&gt; ../a`; then `fm-brief.sh widget repo --scout` succeeds silently, and `data/widget/` becomes simultaneously task `widget`&#39;s own authoritative directory *and* still contains the stray symlink `a` pointing to an unrelated task. Nothing else in the script inspects directory contents at this shared boundary, so the merge goes unreported. Since group names are commonged from project/initiative names (per the intent behind this feature) and task ids share the same `data/` namespace, this is plausibly reachable. The earliest shared boundary to close this would be marking group-only directories (e.g. a sentinel file dropped by the `--group` branch) and checking for it wherever a new task id is about to claim `$DATA/$ID`.
- ℹ️ `bin/fm-brief.sh:144` - Every other flag-validation check in this script (format check at line 117, secondmate-incompatibility at line 125, herdr-lab/no-projects checks) runs before `BRIEF=...`/`mkdir -p &#34;$DATA/$ID&#34;`, so a refused invocation creates nothing. The new group-collision check added in this branch&#39;s second commit is the first validation to run after that `mkdir -p`, so when it refuses (target dir is an existing task&#39;s own directory), it leaves behind an empty stray `$DATA/$ID/` directory for the *new*, never-scaffolded task. Harmless for a retry (idempotent), but it&#39;s a needless side effect on an error path that could be avoided by moving this check up next to the other early validations, since it only depends on `$DATA`/`$GROUP` and not on `$ID`&#39;s own directory existing yet.

🔧 Fix: Reject self-referential --group ids and reverse group/task collisions in fm-brief
1 warning still open:
- ⚠️ `tests/fm-brief.test.sh:656` - This round&#39;s fix (bin/fm-brief.sh) adds two new refusal branches: rejecting `--group=&lt;id&gt;` when it equals the task&#39;s own id (line 123-126), and rejecting a new task whose id matches an existing `.fm-group`-sentinel folder (line 146-149). Neither path is exercised by `test_group_symlink_behavior` or any other test in tests/fm-brief.test.sh — the existing test only covers the original &#39;group name is an existing task&#39;s brief/report dir&#39; collision. Since this test function already asserts the sibling collision direction with the same pattern (create scenario, expect_code 1, assert error text, assert no symlink grafted), extending it with two more cases for these new branches is mechanical and mirrors what&#39;s already there.

🔧 Fix: Add test coverage for new fm-brief --group refusal branches
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh`
- `manual CLI demo of --group=adrevila-v2 grouping three scout tasks`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
