### PR TITLE
fix(afk): deliver away-mode escalations when the primary pane is unusable

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -111,6 +111,8 @@ If that submit cannot be confirmed, it raises a loud, rate-limited wedge alarm:
 an ERROR in the daemon log, a durable
 `state/.subsuper-inject-wedged` marker (surface it on the "while you were out"
 catch-up if present), a tmux status-line flash when applicable, and a configurable backend-independent active alert.
+Because no backend can write to an agent except through the composer the guard may be refusing, that active alert is the only channel left while the pane is unusable, so it carries the buffered escalations themselves plus the recorded cause and duration of the block.
+`state/.subsuper-delivery-blocked` records which guard is refusing and when it first refused; the clock restarts whenever the blocking state changes, so only an unchanging state accrues a reportable stall.
 `docs/wedge-alarm.md` owns the alert channel setup, and `docs/verification/supervision.md` "Wedge-alarm channels" owns active evidence.
 So a guard false-positive becomes a visible stall, never an unbounded silent no-op.
 
@@ -195,7 +197,8 @@ the operational prefix lets firstmate distinguish it from a real captain message
   normal flush, which still requires an idle pane and an affirmatively empty composer. If that
   cannot confirm a submit, it raises a loud, rate-limited wedge alarm: ERROR log,
   durable `state/.subsuper-inject-wedged` marker, a tmux status-line flash when
-  applicable, and a backend-independent active alert. A
+  applicable, and a backend-independent active alert carrying the escalations
+  plus the recorded cause and duration of the block. A
   composer false-positive surfaces as a visible stall, never an unbounded silent
   no-op.
 - **Verified type-once submit model** - the digest is typed once (`send-keys -l`
@@ -230,7 +233,8 @@ the operational prefix lets firstmate distinguish it from a real captain message
 
 ## Stale-artifact lifecycle
 
-Treat `state/.subsuper-escalations`, its `.since` sidecar, and `state/.subsuper-inject-wedged` as session-scoped delivery artifacts, not as the durable work record.
+Treat `state/.subsuper-escalations`, its `.since` sidecar, `state/.subsuper-inject-wedged`, and `state/.subsuper-delivery-blocked` as session-scoped delivery artifacts, not as the durable work record.
+`bin/fm-afk-artifacts-lib.sh` is the single owner of that set; add a new delivery artifact there rather than to any caller's own list.
 Always enter through `bin/fm-afk-launch.sh`, which clears prior-session artifacts only for a fresh entry and preserves the current session's buffer on refresh.
 Always exit through `bin/fm-afk-launch.sh stop`, which keeps `state/.afk` present through the daemon's shutdown flush and clears it last.
 `docs/herdr-backend.md` "Away-mode supervisor support" owns the current mechanism, and `docs/verification/runtime-backends.md` "Away-mode transport" owns active evidence.

--- a/bin/fm-afk-artifacts-lib.sh
+++ b/bin/fm-afk-artifacts-lib.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# fm-afk-artifacts-lib.sh - the ONE owner of the away-mode delivery-artifact set.
+#
+# These files are session-scoped DELIVERY state, not the durable work record:
+# the escalation buffer, its first-arrival sidecar, the wedge marker, and the
+# delivery-block record. The durable record is state/.wake-queue, which replays
+# independently, so clearing these on a fresh away-mode entry loses nothing.
+#
+# WHY THIS EXISTS: the set was spelled out literally in five places across
+# bin/fm-afk-start.sh, bin/fm-afk-launch.sh (clear, back up, restore), and
+# bin/fm-afk-return.sh. Adding a fifth artifact meant editing five lists, and a
+# list that must be edited in five places is a list that will be edited in four.
+# A delivery artifact that a launcher forgets to carry across a backup/restore
+# leaks stale state into the next away-mode session, which is exactly how a
+# wedge marker or a block record can appear to describe a stall that already
+# ended. Callers iterate FM_AFK_DELIVERY_ARTIFACTS or use the helpers below.
+#
+# No side effects on source. set -u / set -e safe.
+
+# The delivery artifacts, relative to a state directory. Order is not
+# significant; every consumer treats the set as a whole.
+FM_AFK_DELIVERY_ARTIFACTS='.subsuper-escalations
+.subsuper-escalations.since
+.subsuper-inject-wedged
+.subsuper-delivery-blocked'
+
+# fm_afk_artifacts_clear: drop every delivery artifact under <state-dir>.
+# Best-effort by contract: a missing artifact is the normal case, so absence is
+# never an error. Returns non-zero only when a present artifact could not be
+# removed, which a caller doing transactional restore must notice.
+fm_afk_artifacts_clear() {  # <state-dir>
+  local state=$1 artifact result=0
+  while IFS= read -r artifact; do
+    [ -n "$artifact" ] || continue
+    rm -f "$state/$artifact" 2>/dev/null || result=1
+  done <<EOF
+$FM_AFK_DELIVERY_ARTIFACTS
+EOF
+  return "$result"
+}
+
+# fm_afk_artifacts_copy: copy every PRESENT delivery artifact from <src-dir> to
+# <dst-dir>, preserving mtimes. Mtime preservation is load-bearing: the wedge
+# alarm's once-per-window throttle is derived from the marker's age, so a copy
+# that reset it would let a restored session re-alarm immediately.
+# Returns non-zero if any present artifact could not be copied.
+fm_afk_artifacts_copy() {  # <src-dir> <dst-dir>
+  local src=$1 dst=$2 artifact result=0
+  while IFS= read -r artifact; do
+    [ -n "$artifact" ] || continue
+    [ -e "$src/$artifact" ] || continue
+    cp -p "$src/$artifact" "$dst/$artifact" 2>/dev/null || result=1
+  done <<EOF
+$FM_AFK_DELIVERY_ARTIFACTS
+EOF
+  return "$result"
+}

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -358,19 +358,13 @@ fm_afk_launch_reconcile() {
 }
 
 fm_afk_launch_restore_backup() {  # <backup> <had-afk>
-  local backup=$1 had_afk=$2 artifact result=0
-  rm -f "$FM_AFK_LAUNCH_STATE/.afk" \
-    "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" \
-    "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" \
-    "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged" || result=1
+  local backup=$1 had_afk=$2 result=0
+  rm -f "$FM_AFK_LAUNCH_STATE/.afk" || result=1
+  fm_afk_artifacts_clear "$FM_AFK_LAUNCH_STATE" || result=1
   if [ "$had_afk" -eq 1 ]; then
     cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk" || result=1
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
-    if [ -e "$backup/$artifact" ]; then
-      cp -p "$backup/$artifact" "$FM_AFK_LAUNCH_STATE/$artifact" || result=1
-    fi
-  done
+  fm_afk_artifacts_copy "$backup" "$FM_AFK_LAUNCH_STATE" || result=1
   if [ "$result" -eq 0 ]; then
     rm -rf "$backup" || return 1
   else
@@ -461,7 +455,7 @@ fm_afk_launch_create_tmux() {  # <captain-target> <captain-backend>
 }
 
 fm_afk_launch_start() {
-  local captain_target captain_backend backup artifact had_afk=0 result
+  local captain_target captain_backend backup had_afk=0 result
   if [ -e "$FM_AFK_LAUNCH_STATE/.afk-return-catchup" ]; then
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"
     return 1
@@ -489,11 +483,7 @@ fm_afk_launch_start() {
     had_afk=1
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
-    if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
-      cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
-    fi
-  done
+  fm_afk_artifacts_copy "$FM_AFK_LAUNCH_STATE" "$backup" || { rm -rf "$backup"; return 1; }
   if ! fm_afk_launch_reconcile; then
     result=1
   else
@@ -530,7 +520,7 @@ fm_afk_launch_start() {
 }
 
 fm_afk_launch_start_native() {
-  local backup artifact had_afk=0 result=0
+  local backup had_afk=0 result=0
   mkdir -p "$FM_AFK_LAUNCH_STATE" || return 1
   if [ -e "$FM_AFK_LAUNCH_STATE/.afk-return-catchup" ]; then
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"
@@ -547,11 +537,7 @@ fm_afk_launch_start_native() {
     had_afk=1
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
-    if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
-      cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
-    fi
-  done
+  fm_afk_artifacts_copy "$FM_AFK_LAUNCH_STATE" "$backup" || { rm -rf "$backup"; return 1; }
   fm_afk_launch_reconcile || result=1
   if [ "$result" -eq 0 ]; then
     if ! fm_afk_clear_stale_artifacts "$FM_AFK_LAUNCH_STATE"; then

--- a/bin/fm-afk-return.sh
+++ b/bin/fm-afk-return.sh
@@ -29,6 +29,16 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 GATE="$STATE/.afk-return-catchup"
 LOCK="$STATE/.afk-return-catchup.lock"
 
+# The single owner of the away-mode delivery-artifact set. Sourcing failure is
+# fatal, not best-effort: silently continuing would leave this return path
+# believing it had cleared delivery state it never touched, so a stale wedge
+# marker or block record would describe the NEXT away-mode session.
+# shellcheck source=bin/fm-afk-artifacts-lib.sh
+if ! . "$SCRIPT_DIR/fm-afk-artifacts-lib.sh"; then
+  printf 'fm-afk-return: cannot load %s/fm-afk-artifacts-lib.sh\n' "$SCRIPT_DIR" >&2
+  exit 1
+fi
+
 usage() {
   sed -n '2,7p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
@@ -121,10 +131,8 @@ print_blockers() {  # <file>
 }
 
 clear_delivery_artifacts() {
-  rm -f \
-    "$STATE/.subsuper-escalations" \
-    "$STATE/.subsuper-escalations.since" \
-    "$STATE/.subsuper-inject-wedged"
+  # bin/fm-afk-artifacts-lib.sh owns the artifact set.
+  fm_afk_artifacts_clear "$STATE"
 }
 
 return_guard() {

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -41,6 +41,10 @@ FM_AFK_DAEMON="$FM_AFK_START_DIR/fm-supervise-daemon.sh"
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$FM_AFK_START_DIR/fm-wake-lib.sh"
+# The single owner of the away-mode delivery-artifact set (bin/fm-afk-launch.sh
+# sources this script, so it inherits the same owner).
+# shellcheck source=bin/fm-afk-artifacts-lib.sh
+. "$FM_AFK_START_DIR/fm-afk-artifacts-lib.sh"
 
 fm_afk_start_usage() {
   sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
@@ -59,11 +63,11 @@ fm_afk_start_usage() {
 # lifecycle" and bin/fm-supervise-daemon.sh's escalate_add/inject_wedge_alarm).
 # NOT called on a refresh (daemon already alive), so the current session's own
 # buffered escalations are preserved.
+# bin/fm-afk-artifacts-lib.sh owns the artifact set. The clear status propagates
+# unchanged: bin/fm-afk-launch.sh treats a failed clear as a reason to abort
+# entry rather than start a session on another session's delivery state.
 fm_afk_clear_stale_artifacts() {  # <state-dir>
-  local state=$1
-  rm -f "$state/.subsuper-escalations" \
-        "$state/.subsuper-escalations.since" \
-        "$state/.subsuper-inject-wedged" 2>/dev/null
+  fm_afk_artifacts_clear "$1"
 }
 
 daemon_lock_owner() {

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -50,7 +50,11 @@
 #     Buffered escalation delivery also has a max-defer alarm: if a digest stays
 #     undelivered past FM_MAX_DEFER_SECS, the daemon retries a normal flush and
 #     writes state/.subsuper-inject-wedged and attempts a configurable active
-#     alert if submit still cannot be confirmed.
+#     alert if submit still cannot be confirmed. Because no backend offers a
+#     write path that bypasses the composer, that alert is the ONLY channel that
+#     can reach an away captain when the pane itself is unusable, so it carries
+#     the escalations themselves plus the recorded cause and duration of the
+#     block (see the delivery-block tracking section below).
 #   - Cheap heartbeat catch-all: every HEARTBEAT_SCAN_SECS the daemon greps all
 #     state/*.status for a captain-relevant line the per-wake classifier might
 #     have missed (e.g. a status verb outside CAPTAIN_RE) and escalates it.
@@ -198,6 +202,11 @@ HOUSEKEEPING_TICK_DEFAULT=15
 # the normal flush path and, if that cannot confirm a submit, raises a loud wedge
 # alarm. The escape hatch makes a guard false-positive visible instead of silent.
 MAX_DEFER_SECS_DEFAULT=300
+# Cap on the escalation text the wedge alarm carries into a notifier. The alarm
+# is the only captain-reachable channel that needs no pane, so it carries the
+# items themselves; notifiers truncate long bodies, and the durable marker keeps
+# the full buffer regardless.
+WEDGE_SUMMARY_MAX_CHARS=280
 WEDGE_ALARM_TIMEOUT_SECS_DEFAULT=10
 WEDGE_ALARM_LAST_EPOCH=0
 WEDGE_ALARM_NOTIFIER_PID=
@@ -244,6 +253,16 @@ _file_age() {  # seconds since mtime; very large if missing
 _hash_text() {
   if command -v md5 >/dev/null 2>&1; then printf '%s' "$1" | md5 -q
   else printf '%s' "$1" | md5sum | cut -d ' ' -f1; fi
+}
+
+# _human_secs: compact captain-readable duration for alarm text (5h39m, 12m, 45s).
+_human_secs() {  # <seconds>
+  local s=$1 h m
+  case "$s" in ''|*[!0-9]*) printf 'an unknown time'; return 0 ;; esac
+  h=$(( s / 3600 )); m=$(( (s % 3600) / 60 ))
+  if [ "$h" -gt 0 ]; then printf '%dh%02dm' "$h" "$m"
+  elif [ "$m" -gt 0 ]; then printf '%dm' "$m"
+  else printf '%ds' "$s"; fi
 }
 
 # --- presence-gating helpers (PURE-ish: side-effect-free reads of state) -----
@@ -884,32 +903,130 @@ wedge_alarm_notify() {  # <summary> <marker>
   return 0
 }
 
+# --- delivery-block tracking -------------------------------------------------
+# WHY (task fm-afk-inject-wedge; overnight stalls 2026-07-21 and 2026-07-30, the
+# second logging the SAME line as the first): inject_msg's guards are each
+# individually correct - typing into a human's half-written line corrupts it, and
+# typing into a bare dead-shell prompt could EXECUTE the digest - but a refusal
+# carries no DURATION. A primary that parks in one blocking state therefore
+# blocks every injection for as long as it stays there. On 2026-07-30 that was
+# 5.6h of "composer not confirmed-empty (state=pending)" while four finished PRs
+# waited, with away mode still reporting itself armed.
+#
+# Nothing here relaxes a guard: there is no safe way to type into a composer
+# holding unsubmitted text, and no backend offers a write path that bypasses the
+# composer, so the guard must stay. What this adds is the missing evidence -
+# WHEN the current blocking state was first seen - so the wedge alarm can assert
+# "the primary composer has held unsent text for 5h39m" (proof this is not a
+# human mid-sentence) instead of guessing "busy or wedged". That evidence plus
+# the content-bearing summary in _wedge_summary turns the one channel that needs
+# no pane into an actual delivery path, which is what the guard's refusal owes
+# the captain.
+_delivery_block_file() { printf '%s/.subsuper-delivery-blocked' "$1"; }
+
+# delivery_block_record: note that delivery is blocked by <reason>, PRESERVING
+# the epoch the current reason was first seen. A CHANGED reason restarts the
+# clock: a pane moving pending -> unknown -> pending is a changing pane, not one
+# stuck state, and only an unchanging state proves nobody is at the keyboard.
+delivery_block_record() {  # <state> <reason>
+  local state=$1 reason=$2 f prev
+  f=$(_delivery_block_file "$state")
+  if [ -r "$f" ]; then
+    prev=$(cut -d' ' -f1 < "$f" 2>/dev/null || true)
+    [ "$prev" = "$reason" ] && return 0
+  fi
+  printf '%s %s\n' "$reason" "$(_now)" > "$f" 2>/dev/null || true
+}
+
+# delivery_block_clear: the blocking condition ended. Called the moment a guard
+# stops refusing, so a transient busy pane never accrues a misleading duration.
+delivery_block_clear() {  # <state>
+  rm -f "$(_delivery_block_file "$1")" 2>/dev/null || true
+}
+
+_describe_block_reason() {  # <reason> -> captain-readable cause
+  case "$1" in
+    busy) printf 'the primary has been mid-turn' ;;
+    pending) printf 'the primary composer has held unsent text' ;;
+    pending-unproven) printf 'the primary composer has held unsent text in an unrecognized layout' ;;
+    unknown) printf 'the primary pane has been unreadable or exited to a shell' ;;
+    submit-unconfirmed) printf 'the primary swallowed the send' ;;
+    *) printf 'the primary pane has been unavailable' ;;
+  esac
+}
+
+# delivery_block_describe: one evidence phrase for the alarm and marker, or
+# non-zero when delivery has not been observed blocked.
+delivery_block_describe() {  # <state>
+  local state=$1 f reason since age
+  f=$(_delivery_block_file "$state")
+  [ -r "$f" ] || return 1
+  reason=$(cut -d' ' -f1 < "$f" 2>/dev/null || true)
+  since=$(cut -d' ' -f2 < "$f" 2>/dev/null || true)
+  [ -n "$reason" ] || return 1
+  case "$since" in ''|*[!0-9]*) return 1 ;; esac
+  age=$(( $(_now) - since ))
+  [ "$age" -ge 0 ] || age=0
+  printf '%s for %s' "$(_describe_block_reason "$reason")" "$(_human_secs "$age")"
+}
+
+# _wedge_summary: the alarm's payload. The previous summary carried only how long
+# delivery had stalled, so the ONE channel that reaches a captain with no usable
+# pane delivered no news - the captain had to open the marker to learn that a PR
+# was waiting, which is exactly what an away captain cannot do. Carrying the
+# distilled escalations themselves makes the alert the pane-independent delivery
+# path. Bounded, because notifiers truncate: the durable marker keeps the full
+# buffer.
+_wedge_summary() {  # <state> <age-seconds>
+  local state=$1 age=$2 buf n items cause summary
+  buf="$state/.subsuper-escalations"
+  n=$(wc -l < "$buf" 2>/dev/null | tr -d ' ') || n=0
+  [ -n "$n" ] || n=0
+  items=$(awk 'NR>1{printf " | "} {printf "%s",$0} END{print ""}' "$buf" 2>/dev/null)
+  items=$(_collapse_newlines "$items")
+  if [ "${#items}" -gt "$WEDGE_SUMMARY_MAX_CHARS" ]; then
+    items="${items:0:$WEDGE_SUMMARY_MAX_CHARS}..."
+  fi
+  summary=$(printf 'fm away mode NOT DELIVERING for %s: %s undelivered - %s' \
+    "$(_human_secs "$age")" "$n" "$items")
+  if cause=$(delivery_block_describe "$state"); then
+    summary="$summary [$cause]"
+  fi
+  printf '%s' "$summary"
+}
+
 # Raise a loud, rate-limited alarm when escalations cannot be delivered after
 # max-defer (the supervisor pane is genuinely busy/wedged, or the submit's Enter
 # is swallowed). The daemon must NEVER silently wedge: this logs
 # an ERROR, drops a durable marker firstmate/recovery can surface, flashes
 # the tmux supervisor client's status line when applicable, and attempts a
-# configurable backend-independent active alert (wedge_alarm_notify). Nothing
-# is lost - the buffer and the
+# configurable backend-independent active alert (wedge_alarm_notify) that now
+# carries the escalations themselves. Nothing is lost - the buffer and the
 # wake-queue both survive - but the stall stops being invisible.
 inject_wedge_alarm() {  # <state> <age-seconds>
-  local state=$1 age=$2 marker target backend max_defer now notify=1
+  local state=$1 age=$2 marker target backend max_defer now notify=1 cause summary
   marker="$state/.subsuper-inject-wedged"
   max_defer="${FM_MAX_DEFER_SECS:-$MAX_DEFER_SECS_DEFAULT}"
   # Re-alarm at most once per max-defer window so a long wedge does not spam.
   if [ "$(_file_age "$marker")" -lt "$max_defer" ]; then
     return 0
   fi
+  # Recorded cause and duration, not a guess. The old text asserted "supervisor
+  # pane busy or wedged" for every failure, which is why the identical stall
+  # recurred nine days later without anyone learning which guard had refused.
+  cause=$(delivery_block_describe "$state") || cause="the cause was not recorded"
+  summary=$(_wedge_summary "$state" "$age")
   now=$(_now)
   if [ "$WEDGE_ALARM_LAST_EPOCH" -gt 0 ] && [ $((now - WEDGE_ALARM_LAST_EPOCH)) -lt "$max_defer" ]; then
     notify=0
   else
     WEDGE_ALARM_LAST_EPOCH=$now
-    log "ERROR: away-mode escalation undelivered ${age}s; inject could not confirm a submit (supervisor pane busy or wedged). Buffer + wake-queue preserved; alarm marker written."
+    log "ERROR: away-mode escalation undelivered ${age}s; delivery is blocked because ${cause}. Buffer + wake-queue preserved; alarm marker written."
   fi
   {
     printf 'fm away-mode inject WEDGED: %ss undelivered as of %s\n' "$age" "$(date '+%Y-%m-%dT%H:%M:%S%z')"
-    printf 'The supervisor pane could not accept an escalation. Buffered items:\n'
+    printf 'Cause: %s.\n' "$cause"
+    printf 'Away mode is NOT delivering; these items are still waiting:\n'
     cat "$state/.subsuper-escalations" 2>/dev/null
   } 2>/dev/null > "$marker" || true
   target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
@@ -919,7 +1036,7 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   # the primary, backend-independent signal, so a non-tmux backend just skips
   # this cosmetic extra rather than attempting an unsupported call.
   if [ "$backend" = tmux ]; then
-    tmux display-message -t "$target" "fm: away-mode escalations WEDGED ${age}s — see $marker" 2>/dev/null || true
+    tmux display-message -t "$target" "fm: away mode NOT delivering (${cause}) - see $marker" 2>/dev/null || true
   fi
   # Backend-independent active alert. Unlike the tmux flash above (skipped on
   # every non-tmux backend), this can reach the captain even when every pane and
@@ -927,7 +1044,7 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   # incident fell through. Configurable and best-effort; the marker above stays
   # the durable record whether or not any channel fires.
   if [ "$notify" -eq 1 ]; then
-    wedge_alarm_notify "away-mode escalations WEDGED ${age}s undelivered - see $marker" "$marker"
+    wedge_alarm_notify "$summary" "$marker"
   fi
 }
 
@@ -1136,6 +1253,7 @@ inject_msg() {  # <message> [state]
   # (3) Busy-guard: never inject into an in-use supervisor pane.
   if pane_is_busy "$target" "$backend"; then
     log "inject deferred: supervisor pane busy (agent mid-turn)"
+    delivery_block_record "$state" busy
     return 1
   fi
   #   b) Composer-guard: inject ONLY into a confirmed-empty GENUINE agent
@@ -1150,8 +1268,12 @@ inject_msg() {  # <message> [state]
   composer=$(fm_backend_composer_state "$backend" "$target" 2>/dev/null)
   if [ "$composer" != empty ]; then
     log "inject deferred: supervisor composer not confirmed-empty (state=${composer:-unknown}: pending input, dead-shell prompt, or unreadable pane)"
+    delivery_block_record "$state" "${composer:-unknown}"
     return 1
   fi
+  # Past every guard: whatever was blocking delivery has ended, so the recorded
+  # duration must not carry over into a later, unrelated block.
+  delivery_block_clear "$state"
   # (4) Type the digest ONCE, then submit with Enter (retry Enter only, never
   # retype) via the shared submit primitive. Success = the backend confirms
   # submit. An unconfirmed/unknown pane does NOT count as delivered, so the
@@ -1166,6 +1288,7 @@ inject_msg() {  # <message> [state]
     return 0  # Backend confirmed the submit.
   fi
   log "inject failed: submit unconfirmed after $retries retries (verdict=$verdict, text may be in composer)"
+  delivery_block_record "$state" submit-unconfirmed
   return 1
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,7 @@ Composer-content classification has one shared owner, `bin/fm-composer-lib.sh`, 
 The daemon injects only into an affirmatively `empty` composer, so both `pending` and `unknown` defer and a bare dead-shell prompt cannot receive an escalation; the current boundary is in [Composer and injection safety](herdr-backend.md#composer-and-injection-safety).
 Unsupported supervisor backends refuse at daemon startup.
 Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts a configured backend-independent active alert after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
+That alert carries the buffered escalations and the recorded cause and duration of the block, because no backend can write to an agent except through a composer that the delivery guards may be refusing.
 On an unmarked return, `bin/fm-afk-return.sh` owns ordered shutdown, durable catch-up evidence, and the fail-closed gate that keeps ordinary work behind every live firstmate-actionable blocker.
 `fm-send.sh` selects a pre-Enter popup-settle for slash commands and for codex `$...` skill invocations using metadata-routed target `harness=` values, then adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that post-submit pause.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,6 +109,8 @@ Selecting any other supervisor backend, including `zellij`, `orca`, or `cmux`, r
 
 When away-mode injection wedges past `FM_MAX_DEFER_SECS`, the sub-supervisor raises a loud, rate-limited alarm.
 Beyond the durable `state/.subsuper-inject-wedged` marker and the tmux status-line flash, it attempts a configured backend-independent active alert that can reach the captain even when every pane and its backend status-line is unreadable.
+Because every backend writes to an agent only through its composer, that alert is the sole channel available while the pane is unusable, so it carries the buffered escalations plus the recorded cause and duration of the block rather than only a marker path.
+The daemon records which guard is refusing delivery in `state/.subsuper-delivery-blocked`, restarting that clock whenever the blocking state changes, so an in-use pane is never reported as a long stall.
 `config/wedge-alarm` (local, gitignored) lists channel directives, one per non-empty, non-comment line; every listed non-`off` channel fires, best-effort.
 `FM_WEDGE_ALARM_CHANNEL` overrides the file with a single directive.
 Directives are `off` (a position-independent kill switch that disables every active alert), `auto`/`default`, `osascript` (macOS Notification Center banner), `herdr` (herdr UI notification), and `command:<cmd>` (run `<cmd>` via `sh -c`, summary on `$1` and stdin).

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -5,6 +5,12 @@ When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_a
 The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and cannot reach an unattended captain reliably.
 The durable marker and tmux flash remain as additional signals.
 
+No backend offers a way to send text to an agent except through its composer, and a composer holding unsubmitted text can never be typed into safely.
+The active alert is therefore the only channel that can reach an away captain while the pane itself is unusable, so it carries the buffered escalations themselves rather than a pointer to the marker file.
+It also names the recorded cause of the block and how long delivery has been blocked, for example `the primary composer has held unsent text for 5h39m`.
+A captain reading a phone notification can act on that; they cannot open a file path.
+The daemon caps the escalation text it passes to a notifier, and the durable marker keeps the full buffer regardless.
+
 ## Channels
 
 `config/wedge-alarm` is local and gitignored.

--- a/tests/fm-afk-return.test.sh
+++ b/tests/fm-afk-return.test.sh
@@ -19,6 +19,7 @@ install_runner() {  # <case-dir>
   cp "$ROOT/bin/fm-afk-return.sh" "$dir/bin/"
   cp "$ROOT/bin/fm-wake-lib.sh" "$dir/bin/"
   cp "$ROOT/bin/fm-classify-lib.sh" "$dir/bin/"
+  cp "$ROOT/bin/fm-afk-artifacts-lib.sh" "$dir/bin/"
   cat > "$dir/bin/fm-afk-launch.sh" <<'SH'
 #!/usr/bin/env bash
 [ "${1:-}" = stop ] || exit 2

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1538,8 +1538,12 @@ test_inject_wedge_alarm_fires_active_alert_on_non_tmux_backend() {
     inject_wedge_alarm "$state" 30600
   [ -s "$state/.subsuper-inject-wedged" ] || fail "inject_wedge_alarm did not write the durable marker"
   grep -F 'osascript' "$log" >/dev/null || fail "inject_wedge_alarm did not emit the active alert on a non-tmux backend: $(cat "$log")"
-  grep -F 'WEDGED 30600s' "$log" >/dev/null || fail "active alert missing the age and summary"
-  pass "inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)"
+  grep -F '8h30m' "$log" >/dev/null || fail "active alert missing the stall duration: $(cat "$log")"
+  # The alert must carry the ESCALATION ITSELF, not just a pointer to a marker
+  # file. This channel is the only one that reaches a captain whose pane is
+  # unusable, and a captain reading a phone notification cannot open a path.
+  grep -F 'needs-decision: pick A' "$log" >/dev/null || fail "active alert did not carry the buffered escalation: $(cat "$log")"
+  pass "inject_wedge_alarm writes the marker AND emits an escalation-carrying active alert with no tmux status-line (herdr backend)"
 }
 
 test_inject_wedge_alarm_throttles_when_marker_cannot_be_written() {
@@ -1924,5 +1928,127 @@ test_inject_msg_herdr_busy_guard_defers
 test_inject_msg_herdr_composer_guard_defers
 test_inject_msg_herdr_pane_gone_defers
 test_inject_msg_herdr_submits_through_backend_dispatch
+# --- overnight away-mode stall (task fm-afk-inject-wedge) -------------------
+# The 2026-07-21 and 2026-07-30 incidents were the SAME failure nine days apart:
+# the primary pane sat in one blocking composer state all night, every escalation
+# logged "composer not confirmed-empty (state=pending)", and four finished PRs
+# went unmerged. The guard was right to refuse - there is no safe way to type
+# into a composer holding unsubmitted text - but the refusal was silent, endless,
+# and told nobody WHICH guard had refused or for how long.
+#
+# These lock the guarantees the fix owes: the guard still refuses, the buffer
+# still survives, and the one channel that needs no pane carries the escalations
+# themselves plus the recorded cause and duration.
+
+# make_stalled_case: a state dir already in away mode with <n> escalations
+# buffered and their arrival backdated <age> seconds, so max-defer is due.
+make_stalled_case() {  # <name> <age-secs> <item>...
+  local name=$1 age=$2 dir state
+  shift 2
+  dir=$(make_supercase "$name"); state="$dir/state"
+  afk_enter "$state"
+  for item in "$@"; do escalate_add "$state" "$item"; done
+  printf '%s\n' "$(( $(_now) - age ))" > "$state/.subsuper-escalations.since"
+  printf '%s\n' "$dir"
+}
+
+test_overnight_stall_alarm_carries_escalations_and_recorded_cause() {
+  local dir state log alert
+  dir=$(make_stalled_case stall-overnight 20318 \
+    "done: PR 1361 checks green" "blocked: needs a credential")
+  state="$dir/state"; log="$dir/alert.log"
+  (
+    fm_backend_target_exists() { return 0; }
+    pane_is_busy() { return 1; }
+    # The exact 2026-07-30 observation: the primary composer holds unsent text
+    # and never changes.
+    fm_backend_composer_state() { printf 'pending'; }
+    fm_backend_send_text_submit() { fail "the composer guard must still refuse: typing into unsent text would corrupt it"; }
+    WEDGE_ALARM_LAST_EPOCH=0
+    export FM_MAX_DEFER_SECS=1 FM_ESCALATE_BATCH_SECS=0
+    export FM_SUPERVISOR_BACKEND=herdr FM_SUPERVISOR_TARGET="default:w1:p2"
+    export FM_WEDGE_ALARM_LOG="$log" FM_WEDGE_ALARM_CHANNEL=osascript
+    # First tick records the block; the marker is backdated so the second tick's
+    # throttle window is open and the alarm actually fires.
+    housekeeping "$state"
+    touch -t 200001010000 "$state/.subsuper-inject-wedged" 2>/dev/null || true
+    housekeeping "$state"
+  ) || fail "stalled-away-mode housekeeping subshell failed"
+
+  # Nothing is lost: the guard refused, so the buffer is still intact.
+  [ "$(wc -l < "$state/.subsuper-escalations" | tr -d ' ')" -eq 2 ] \
+    || fail "a refused injection must preserve the escalation buffer"
+  alert=$(cat "$log" 2>/dev/null)
+  # The alert must carry the WORK, not a path to a file an away captain cannot open.
+  case "$alert" in
+    *"done: PR 1361 checks green"*) ;;
+    *) fail "the pane-independent alert did not carry the buffered escalations: $alert" ;;
+  esac
+  # ...and the recorded cause, so the same stall is diagnosable the FIRST time.
+  case "$alert" in
+    *"composer has held unsent text"*) ;;
+    *) fail "the alert did not name the recorded cause of the block: $alert" ;;
+  esac
+  case "$alert" in
+    *5h38m*) ;;
+    *) fail "the alert did not report how long delivery had been blocked: $alert" ;;
+  esac
+  pass "overnight stall: the guard still refuses, the buffer survives, and the pane-independent alert carries the escalations plus the recorded cause and duration"
+}
+
+test_stall_duration_accrues_across_repeated_identical_defers() {
+  local dir state first second
+  dir=$(make_supercase stall-duration); state="$dir/state"
+  delivery_block_record "$state" pending
+  first=$(cut -d' ' -f2 < "$state/.subsuper-delivery-blocked")
+  sleep 1
+  delivery_block_record "$state" pending
+  second=$(cut -d' ' -f2 < "$state/.subsuper-delivery-blocked")
+  [ "$first" = "$second" ] \
+    || fail "an unchanged blocking state must keep its first-seen epoch, or the reported duration resets every poll ($first -> $second)"
+  pass "delivery block: an unchanged blocking state accrues real duration instead of resetting each poll"
+}
+
+test_stall_clock_restarts_when_the_pane_state_changes() {
+  local dir state first second
+  dir=$(make_supercase stall-changing); state="$dir/state"
+  delivery_block_record "$state" pending
+  first=$(cut -d' ' -f2 < "$state/.subsuper-delivery-blocked")
+  sleep 1
+  # A pane that MOVES between states is a pane someone is using; it must not
+  # inherit the previous state's accrued age and be reported as a long stall.
+  delivery_block_record "$state" busy
+  second=$(cut -d' ' -f2 < "$state/.subsuper-delivery-blocked")
+  [ "$first" != "$second" ] \
+    || fail "a changed blocking reason must restart the clock, not inherit the previous reason's age"
+  case "$(delivery_block_describe "$state")" in
+    *mid-turn*) ;;
+    *) fail "delivery_block_describe did not report the CURRENT reason: $(delivery_block_describe "$state")" ;;
+  esac
+  pass "delivery block: a changing pane restarts the clock, so an in-use pane is never reported as a long stall"
+}
+
+test_successful_delivery_clears_the_block_record() {
+  local dir state
+  dir=$(make_supercase stall-cleared); state="$dir/state"
+  afk_enter "$state"
+  delivery_block_record "$state" pending
+  (
+    fm_backend_target_exists() { return 0; }
+    pane_is_busy() { return 1; }
+    fm_backend_composer_state() { printf 'empty'; }
+    fm_backend_send_text_submit() { printf 'empty'; }
+    FM_SUPERVISOR_BACKEND=herdr FM_SUPERVISOR_TARGET="default:w1:p2" \
+      inject_msg "hello" "$state" || fail "inject_msg should deliver into a confirmed-empty composer"
+  ) || fail "cleared-block inject_msg subshell failed"
+  [ ! -e "$state/.subsuper-delivery-blocked" ] \
+    || fail "a delivered escalation must clear the block record, or a later unrelated block inherits this stall's age"
+  pass "delivery block: a successful delivery clears the record so no stale duration leaks into a later block"
+}
+
 test_inject_msg_defers_on_dead_shell_unknown
 test_inject_msg_defers_on_unrecognized_composer_state
+test_overnight_stall_alarm_carries_escalations_and_recorded_cause
+test_stall_duration_accrues_across_repeated_identical_defers
+test_stall_clock_restarts_when_the_pane_state_changes
+test_successful_delivery_clears_the_block_record


### PR DESCRIPTION
## The incident

Away mode stalled overnight twice with the identical log line — 2026-07-21 and 2026-07-30:

```
inject deferred: supervisor composer not confirmed-empty (state=pending)
```

The second occurrence buffered **every escalation for 5.6 hours** while four finished PRs waited to be merged, and the daemon still reported itself armed the whole time. Nothing was lost — the durable queue replayed everything on return — but the entire point of away mode (landing work unattended) did not happen.

**It reproduced a third time on 2026-07-31, within ten minutes of arming**, with a worker genuinely blocked and waiting:

```
fm away-mode inject WEDGED: 307s undelivered as of 2026-07-31T13:45:06+0200
```

So this is not intermittent bad luck. On a home where the primary sits in a state the shared classifier reads as `pending` or `unknown`, it reproduces on essentially every session.

## Why the guards are kept

The delivery guards are each correct and stay. There is no safe way to type into a composer holding unsubmitted text, and no backend offers a write path that bypasses the composer, so a refusal cannot be relaxed into an injection without risking a corrupted prompt.

**The defect was that a refusal carried no duration and no cause.** A primary parked in one blocking state blocked every injection indefinitely, while the only channel a captain could actually reach said nothing useful. The max-defer escape could not help either, because its one retry needs the same idle pane that is unavailable.

## The change

- **Record which guard is refusing, and when it first refused**, in `state/.subsuper-delivery-blocked`. A changed blocking state restarts the clock, so only an unchanging state accrues a reportable stall and a genuinely in-use pane is never misreported as wedged.
- **Make the pane-independent active alert an actual delivery path.** It now carries the buffered escalations themselves plus the recorded cause and duration — *"the primary composer has held unsent text for 5h39m"* — instead of pointing at a marker file an away captain cannot open. The durable marker keeps the full buffer and records the real cause rather than asserting "busy or wedged" for every failure.
- **Add `bin/fm-afk-artifacts-lib.sh`** as the single owner of the delivery-artifact set, which was previously spelled out literally in five places across three scripts. A failed source in the return path is now fatal rather than silently leaving delivery state uncleared.

## Testing

Regression coverage in `tests/fm-daemon.test.sh` reproduces the incident shape and **fails against the unfixed daemon**: the guard still refuses, the buffer survives, and the alert carries the work plus the cause and duration.

Full suite green (101 files, 0 failures).

## Notes for review

- No behaviour change when delivery is healthy — the new state file is only written on a refusal.
- The guards' refusal semantics are unchanged; this only adds observability and an alternate delivery path for the already-buffered work.
- Docs updated: `docs/architecture.md`, `docs/configuration.md`, `docs/wedge-alarm.md`, and the `afk` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
