### PR TITLE
fix(bin): forbid AI co-author trailers in generated ship briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -394,7 +394,7 @@ When starting no-mistakes, make \`--intent\` preserve all relevant content from 
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
+- ask-user findings are never yours to answer: escalate to firstmate (rule 7) and stop.
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -42,8 +42,10 @@
 # recorded task metadata cannot drift apart.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # Ship briefs also forbid a co-author trailer naming an AI model or assistant on
-# any commit, while human co-author trailers stay allowed; scout briefs omit that
-# rule because their scratch commits are discarded at teardown.
+# any commit, and any AI-attribution line (such as a "Generated with Claude Code"
+# footer) in the pull request body or a pull request comment, while human
+# co-author trailers stay allowed; scout briefs omit that rule because their
+# scratch commits are discarded at teardown.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns approval decisions, so yolo is
@@ -431,7 +433,8 @@ If the top-level path is the primary checkout or not the worktree you were launc
 
 # Rules
 $RULE1
-2. Never add a co-author trailer naming an AI model or assistant (e.g. \`Co-authored-by: Claude ...\`) to any commit.
+2. Never add a co-author trailer naming an AI model or assistant (e.g. \`Co-authored-by: Claude ...\`) to any commit,
+   and never add an AI-attribution line (e.g. \`Generated with Claude Code\`) to the pull request body or any pull request comment.
    Human co-author trailers stay allowed.
 3. Stay inside this worktree; modify nothing outside it.
 4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -428,9 +428,11 @@ If the top-level path is the primary checkout or not the worktree you were launc
 
 # Rules
 $RULE1
-2. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
-4. Report status by appending one line:
+2. Never add a co-author trailer naming an AI model or assistant (e.g. \`Co-authored-by: Claude ...\`) to any commit.
+   Human co-author trailers stay allowed.
+3. Stay inside this worktree; modify nothing outside it.
+4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+5. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
@@ -443,11 +445,11 @@ $RULE1
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
-5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
+6. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
+7. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same [key=<slug>] if you opened it with one) as you resume.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -41,6 +41,9 @@
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Ship briefs also forbid a co-author trailer naming an AI model or assistant on
+# any commit, while human co-author trailers stay allowed; scout briefs omit that
+# rule because their scratch commits are discarded at teardown.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns approval decisions, so yolo is

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -214,6 +214,10 @@ test_ship_modes_generate_clean_briefs() {
       "$id: brief missing nonterminal working:/setup-complete gate protection"
     assert_grep "Never add a co-author trailer naming an AI model or assistant" "$brief" \
       "$id: brief missing the AI co-author trailer ban"
+    assert_grep "never add an AI-attribution line" "$brief" \
+      "$id: brief AI-attribution ban does not cover the pull request body and comments"
+    assert_grep "to the pull request body or any pull request comment" "$brief" \
+      "$id: brief missing the pull request body and comment coverage of the AI ban"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
@@ -701,6 +705,8 @@ test_scout_and_secondmate_scaffold() {
   assert_present "$brief" "scout brief was not scaffolded"
   assert_grep "SCOUT task" "$brief" "scout brief must declare itself a scout task"
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
+  assert_no_grep "AI-attribution" "$brief" \
+    "scout brief must omit the ship-only AI-attribution ban"
 
   FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
     FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-sm-q6 --secondmate alpha >/dev/null 2>&1 \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -212,6 +212,8 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
+    assert_grep "Never add a co-author trailer naming an AI model or assistant" "$brief" \
+      "$id: brief missing the AI co-author trailer ban"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"


### PR DESCRIPTION
## Intent

Close the source of AI model co-author trailers landing in project commits. AGENTS.md section 1 already states 'Never add an agent name as a commit co-author' for this repo, but nothing carried that rule to crewmates working in project repos, and bin/fm-brief.sh's generated ship brief never mentioned it. Added a new standing rule to the ship brief's Rules block: 'Never add a co-author trailer naming an AI model or assistant... to any commit. Human co-author trailers stay allowed.' Renumbered the following rules (previously 2-7, now 3-8) to keep the list sequential. Deliberately did not touch the scout brief's Rules block since scout tasks never land commits (their scratch commits are discarded at teardown). Also deliberately did not add a git hook or commit-message filter per explicit task constraint: a brief instruction is the intended low-machinery fix. Checked whether the secondmate charter scaffold (same file, --secondmate branch) needed its own copy of the rule; it does not, because a secondmate delegates all project commit work to its own crewmates via the same fm-brief.sh ship/scout generator, which already carries the fix.

## What Changed

- `bin/fm-brief.sh` ship briefs now carry a standing rule 2 banning co-author trailers that name an AI model or assistant on any commit, while keeping human co-author trailers allowed; the following rules renumber from 2-7 to 3-8 and the no-mistakes ask-user cross-reference updates from "(rule 6)" to "(rule 7)".
- Scout briefs and the secondmate charter are intentionally untouched: scout scratch commits are discarded at teardown, and a secondmate delegates project commits to crewmates generated by the same ship path.
- The same rule now extends to the pull request page: the ban covers an AI-attribution line in the pull request body or any pull request comment, not only the git history. A worker's default "Generated with Claude Code" footer reached a public pull request once and not three other times, so the behaviour was inconsistent as well as unwanted, and a reviewer could not tell whether its absence meant anything.
- `tests/fm-brief.test.sh` pins the new wording with an `assert_grep` across all three ship delivery modes (no-mistakes / direct-PR / local-only); the suite passes 20/20.

## Risk Assessment

✅ Low: Text-only change to one brief generator plus a matching test assertion; both round-1 findings are fixed and the rest of the diff matches the stated intent exactly.

## Testing

Ran the focused suite tests/fm-brief.test.sh (all 17 checks pass, including the newly pinned co-author assertion), then went beyond unit coverage by generating real ship, scout, and secondmate scaffolds with bin/fm-brief.sh and diffing the rendered Rules block against a replay of the pre-fix script at f7d0d0a: the ship brief gains the AI co-author ban as rule 2 with correct 1-8 renumbering and a fixed `(rule 7)` cross-reference, while the scout brief and secondmate charter are confirmed untouched exactly as the intent describes. A repo-wide grep confirms no stale rule-number references remain. This is a generated-markdown surface rather than a UI, so the reviewer-visible evidence is the actual generated brief files and a before/after Rules-block comparison instead of screenshots.

<details>
<summary>Evidence: Generated ship brief (end-user artifact a crewmate receives)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of acme-web, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-ship-001`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Never add a co-author trailer naming an AI model or assistant (e.g. `Co-authored-by: Claude ...`) to any commit.
   Human co-author trailers stay allowed.
3. Stay inside this worktree; modify nothing outside it.
4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
5. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.bhENdgwigU/home/state/demo-ship-001.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
6. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
7. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
8. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/eduard/.no-mistakes/worktrees/025131ada156/01KYW11JBVRDGJDSGXDBKVQPA7/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/eduard/.no-mistakes/worktrees/025131ada156/01KYW11JBVRDGJDSGXDBKVQPA7/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 7) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Rules block before/after comparison</summary>

<code>After:&#10;1. Never push to the default branch. Never merge a PR.&#10;2. Never add a co-author trailer naming an AI model or assistant (e.g. `Co-authored-by: Claude ...`) to any commit.&#10;Human co-author trailers stay allowed.&#10;3. Stay inside this worktree; modify nothing outside it.&#10;4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.&#10;5. Report status by appending one line:&#10;6. If you hit the same obstacle twice ...&#10;7. If a decision belongs above the implementation worker ...&#10;8. Never stop, restart, or update the shared `no-mistakes` daemon ...&#10;&#10;- ask-user findings are never yours to answer: escalate to firstmate (rule 7) and stop.&#10;&#10;Before (f7d0d0a): no co-author rule at all; rules ran 1-7; cross-ref read &#34;(rule 6)&#34;.</code>

```text
# Ship brief Rules block: before (f7d0d0a) vs after (940dfb1)

## Before
`` `
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi ... chrome-devtools-axi ...
4. Report status by appending one line: ...
5. If you hit the same obstacle twice ...
6. If a decision belongs above the implementation worker ...
7. Never stop, restart, or update the shared no-mistakes daemon ...

(cross-ref elsewhere in brief: 'escalate to firstmate (rule 6)')
`` `

## After
`` `
1. Never push to the default branch. Never merge a PR.
2. Never add a co-author trailer naming an AI model or assistant (e.g. `Co-authored-by: Claude ...`) to any commit.
   Human co-author trailers stay allowed.
3. Stay inside this worktree; modify nothing outside it.
4. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
5. Report status by appending one line:
6. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
7. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
8. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving

- ask-user findings are never yours to answer: escalate to firstmate (rule 7) and stop.
`` `
```
</details>
<details>
<summary>Evidence: Generated scout brief (deliberately unchanged)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of acme-web, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.bhENdgwigU/home/state/demo-scout-001.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/tmp/tmp.bhENdgwigU/home/data/demo-scout-001/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/home/eduard/.no-mistakes/worktrees/025131ada156/01KYW11JBVRDGJDSGXDBKVQPA7/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Generated secondmate charter (has no Rules block, so needs no copy)</summary>

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
Own release ops

# Routing scope
Own release ops

# Project clones
- acme-web

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
The projects above are local clones for work you supervise; they are not an exclusive ownership claim.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.bhENdgwigU/home/state/demo-second-001.status'`
States: working, needs-decision, blocked, paused, done, failed.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
When a decision you escalated is answered or a blocker clears and your domain resumes, append `resolved: {how it was decided or unblocked}` (keyed with `[key=<slug>]` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-brief.sh:344` - Renumbering left a stale cross-reference: the no-mistakes Definition of done still says &#34;ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop&#34;, but rule 6 is now &#34;If you hit the same obstacle twice, append `blocked: {why}` and stop&#34; — the needs-decision rule moved to 7. In the default no-mistakes mode, a crewmate that hits an ask-user gate finding follows the pointer and appends `blocked:` instead of `needs-decision:`, routing it to firstmate&#39;s stuck-worker help path rather than the configured-authority decision path. Change &#34;(rule 6)&#34; to &#34;(rule 7)&#34;.
- ℹ️ `tests/fm-brief.test.sh:210` - tests/fm-brief.test.sh asserts every other brief wording contract with assert_grep (nonterminal working: line, project-memory wording, authority wording), but nothing pins the new co-author rule, so a future edit to the Rules block can silently drop it. One assert_grep for &#34;Never add a co-author trailer naming an AI model or assistant&#34; in test_ship_modes_generate_clean_briefs matches the existing convention.

🔧 Fix: fix stale rule cross-reference, pin co-author rule in tests
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` (17/17 pass, includes the new `Never add a co-author trailer naming an AI model or assistant` assertion across all three ship delivery modes)</code>
- <code>Manual generation of a real ship brief: `FM_HOME=$tmp bin/fm-brief.sh demo-ship-001 acme-web` then inspected the rendered `# Rules` block</code>
- <code>Manual generation of the scout brief: `FM_HOME=$tmp bin/fm-brief.sh demo-scout-001 acme-web --scout` (confirmed no co-author rule, numbering untouched)</code>
- <code>Manual generation of the secondmate charter: `FM_HOME=$tmp FM_SECONDMATE_CHARTER=&#39;Own release ops&#39; bin/fm-brief.sh demo-second-001 --secondmate acme-web` (confirmed it has no Rules block, so no rule copy is needed)</code>
- <code>Baseline replay: generated a ship brief from `git show f7d0d0a:bin/fm-brief.sh` in a temp copy of bin/ — zero co-author mentions and cross-ref read `(rule 6)`, proving the new rule and renumbering are both real behavior changes</code>
- <code>`grep -rniE &#39;rule [2-8]\b&#39; bin/ skills/ docs/ AGENTS.md CLAUDE.md` — only one rule-number cross-reference exists repo-wide and it now correctly points at rule 7</code>
- <code>`git status --porcelain` — clean worktree after testing, no transient artifacts left behind</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
