### PR TITLE
fix(bin): harden worker spawn, locking, and briefs against recurring session failures

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -178,6 +178,7 @@ The shared symptom is a healthy-looking pane with no work in progress, so each a
 | Exit command | `/exit` |
 | Interrupt | single Escape |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`) |
+| Autonomy | Firstmate requests `bypassPermissions`; `fm-spawn` accepts Claude's verified `bypass permissions on` footer and warns without stopping the worker when the footer instead reports verified `auto mode on` or `manual mode on`, naming `permissions.disableBypassPermissionsMode` or organization policy as the likely cause. |
 
 First launch in a fresh worktree, or first ever on a machine, may show a trust or bypass-permissions confirmation.
 After every spawn, peek the pane within about 20 seconds.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/verification/runtime-backends.md](docs/verification/runtime-backends.md) - active maintainer verification for runtime backend guarantees.
 - [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - maintainer verification for GitLab merge watching on arbitrary instances.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's current "no turn ends blind" backstop, scope, loop safety, and compatibility limits.
-- [docs/verification/supervision.md](docs/verification/supervision.md) - active maintainer verification for session-start, guard, continuity, and wedge integrations.
+- [docs/verification/supervision.md](docs/verification/supervision.md) - active maintainer verification for the supervision integration guarantees it lists.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi and `pi-signed`, Grok, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [docs/documentation-audiences.md](docs/documentation-audiences.md) - documentation audiences and the machine-checked placement boundary.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -44,6 +44,11 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
+# Every ship and scout brief includes a short conditional evidence-integrity
+# section because the {TASK} body is filled only after scaffolding, so this
+# script cannot reliably select a visual or content-specific flag.
+# It requires built-static-output screenshots staged and verified under the
+# task temp directory, plus sources for factual user-facing content claims.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -247,6 +252,15 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+IFS= read -r -d '' EVIDENCE_SECTION <<EOF || true
+# Evidence integrity
+When visual verification is part of the task, capture the built static output, never a development server; Astro's development server injects a toolbar overlay that contaminates screenshots.
+\`chrome-devtools-axi screenshot\` can exit zero and print success while writing no file when the destination is anywhere under \`\$HOME\`.
+Write every screenshot first under the task temp directory \`/tmp/fm-$ID/\`, require \`test -s <capture>\` before using it, copy it to the deliverable location, and require \`test -s <deliverable>\` again.
+For every factual claim added to user-facing marketing or product content - including customer counts, ratings, awards, certifications, and performance numbers - cite its source in the task or PR evidence and never invent or extrapolate one.
+EOF
+EVIDENCE_SECTION=${EVIDENCE_SECTION%$'\n'}
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -256,6 +270,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 $HERDR_SECTION
 
+$EVIDENCE_SECTION
+
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 This is a SCOUT task: the deliverable is a written report, not a PR.
@@ -264,7 +280,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 
 # Rules
 1. Never push to any remote and never open a PR.
-2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
+2. Stay inside this worktree; the only files you may write outside it are the report, the status file below, and screenshots staged under \`/tmp/fm-$ID/\` as required above.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -364,6 +380,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 $HERDR_SECTION
 
+$EVIDENCE_SECTION
+
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 
@@ -375,7 +393,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 
 # Rules
 $RULE1
-2. Stay inside this worktree; modify nothing outside it.
+2. Stay inside this worktree; modify nothing outside it except screenshots staged under \`/tmp/fm-$ID/\` as required above.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -312,7 +312,7 @@ EOF
   while IFS=$'\t' read -r key _verb _summary; do
     [ -n "$key" ] || continue
     list_has_key "$keys" "$key" \
-      || fail "open structured decision $origin/$key has no captain-held inventory entry"
+      || fail "open structured decision $origin/$key has no captain-held inventory entry; register a captain hold for key '$key', or if the event has cleared append a matching 'resolved: <how it cleared>' status line (include [key=$key] when the opening event was keyed), then retry"
   done <<EOF
 $open
 EOF

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -33,7 +33,19 @@ if [ "${1:-}" = "status" ]; then
   exit 0
 fi
 
-me=$(fm_harness_ancestry_pid) || { echo "error: cannot locate harness process in ancestry" >&2; exit 1; }
+me=$(fm_harness_ancestry_pid)
+ancestry_status=$?
+case "$ancestry_status" in
+  0) ;;
+  2)
+    echo "error: process inspection is unavailable (ps failed for the current process); allow ps in the harness sandbox - for Claude Code, disable its sandbox for this firstmate session - then rerun session start; operate read-only until resolved" >&2
+    exit 1
+    ;;
+  *)
+    echo "error: process inspection ran but no supported harness process matched the ancestry; launch firstmate from a verified harness, then rerun session start; operate read-only until resolved" >&2
+    exit 1
+    ;;
+esac
 probe=$(mktemp "$STATE/.lock-write.XXXXXX" 2>/dev/null) || {
   echo "error: cannot write session lock; operate read-only until resolved" >&2
   exit 1

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -27,9 +27,15 @@ FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
 # as long as the session, unlike the transient subshell pid of any one tool
 # call.
 fm_harness_ancestry_pid() {
-  local pid=$$ comm args best='' bc extending=0 hit=0 is_claude=0
+  local pid=$$ comm args best='' bc extending=0 hit=0 is_claude=0 inspected=0
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || {
+      # Exit 2 distinguishes a sandbox or host that blocks process inspection
+      # entirely from a readable ancestry that contains no verified harness.
+      [ "$inspected" -eq 1 ] && break
+      return 2
+    }
+    inspected=1
     args=$(ps -o args= -p "$pid" 2>/dev/null)
     bc=$(basename -- "$comm")
     hit=0; is_claude=0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -111,6 +111,12 @@
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
+# Before every harness launch, the pane shell receives an idempotent PATH
+# guarantee for ${NPM_CONFIG_PREFIX:-$HOME/.npm-global}/bin so stale inherited
+# home-manager guards cannot hide the fleet npm tools from the worker.
+# After a verified template launch, spawn observes any empirically supported
+# autonomy footer without changing permissions or blocking the worker; currently
+# only Claude's bypass/auto/manual footer distinction is verified.
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -493,8 +499,10 @@ launch_template() {
   esac
 }
 
+LAUNCH_IS_TEMPLATE=1
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
+    LAUNCH_IS_TEMPLATE=0
     LAUNCH=$ARG3
     HARNESS=""
     for word in $LAUNCH; do
@@ -528,6 +536,11 @@ case "$ARG3" in
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
 esac
+
+REQUESTED_AUTONOMY_MODE=
+if [ "$LAUNCH_IS_TEMPLATE" -eq 1 ] && [ "$HARNESS" = claude ]; then
+  REQUESTED_AUTONOMY_MODE=bypassPermissions
+fi
 
 case "$HARNESS" in
   pi|pi-signed) LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH" ;;
@@ -582,6 +595,38 @@ shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
   printf "'"
+}
+
+fleet_toolchain_bin() {
+  local prefix=${NPM_CONFIG_PREFIX:-}
+  if [ -z "$prefix" ]; then
+    [ -n "${HOME:-}" ] || {
+      echo "error: HOME is unset, so the fleet toolchain directory cannot be resolved" >&2
+      return 1
+    }
+    prefix="$HOME/.npm-global"
+  else
+    case "$prefix" in
+      /*) ;;
+      *)
+        [ -n "${HOME:-}" ] || {
+          echo "error: HOME is unset, so the relative fleet toolchain prefix cannot be resolved" >&2
+          return 1
+        }
+        case "$prefix" in
+          \~) prefix=$HOME ;;
+          \~/*) prefix="$HOME/${prefix#\~/}" ;;
+          *) prefix="$HOME/$prefix" ;;
+        esac
+        ;;
+    esac
+  fi
+  [ -n "$prefix" ] || {
+    echo "error: the fleet toolchain prefix resolved empty" >&2
+    return 1
+  }
+  [ "$prefix" = / ] || prefix=${prefix%/}
+  printf '%s/bin\n' "$prefix"
 }
 
 resolve_kimi_binary() {
@@ -1243,6 +1288,47 @@ spawn_send_key() {  # <target> <key>
   esac
 }
 
+spawn_capture() {  # <lines>
+  fm_backend_capture "$BACKEND" "$T" "$1" "$W" 2>/dev/null || true
+}
+
+claude_observed_autonomy_mode() {  # <plain-pane-capture>
+  local mode_line
+  mode_line=$(printf '%s\n' "$1" \
+    | grep -iE 'bypass[[:space:]]+permissions[[:space:]]+on|auto[[:space:]]+mode[[:space:]]+on|manual[[:space:]]+mode[[:space:]]+on' \
+    | tail -1 || true)
+  case "$mode_line" in
+    *[Bb]ypass*[Pp]ermissions*[Oo]n*) printf '%s\n' bypassPermissions ;;
+    *[Aa]uto*[Mm]ode*[Oo]n*) printf '%s\n' auto ;;
+    *[Mm]anual*[Mm]ode*[Oo]n*) printf '%s\n' manual ;;
+  esac
+}
+
+verify_spawn_autonomy_mode() {
+  local pane observed i=0 max=${FM_SPAWN_AUTONOMY_POLLS:-10}
+  local interval=${FM_SPAWN_AUTONOMY_POLL_INTERVAL:-0.4}
+  [ "$REQUESTED_AUTONOMY_MODE" = bypassPermissions ] || return 0
+
+  pane=$(spawn_capture 120)
+  while [ "$i" -lt "$max" ]; do
+    observed=$(claude_observed_autonomy_mode "$pane")
+    case "$observed" in
+      bypassPermissions) return 0 ;;
+      auto|manual)
+        printf 'AUTONOMY WARNING: task %s requested mode=%s but observed mode=%s in the Claude worker; likely cause: permissions.disableBypassPermissionsMode is "disable" in effective Claude settings or organization policy. The worker remains launched; fix the authoritative setting or policy and relaunch it.\n' \
+          "$ID" "$REQUESTED_AUTONOMY_MODE" "$observed" >&2
+        return 0
+        ;;
+    esac
+    i=$((i + 1))
+    [ "$i" -ge "$max" ] || sleep "$interval"
+    pane=$(spawn_capture 120)
+  done
+  printf 'AUTONOMY WARNING: task %s requested mode=%s but observed mode=unverified in the Claude worker; likely cause: the worker UI did not render a verified status footer in time or the backend capture was unavailable. The worker remains launched; inspect its status line, correct the capture or startup problem, and relaunch it if bypass permissions is not on.\n' \
+    "$ID" "$REQUESTED_AUTONOMY_MODE" >&2
+  return 0
+}
+
 kimi_capture() {
   fm_backend_capture "$BACKEND" "$T" 120 "$W" 2>/dev/null || true
 }
@@ -1679,9 +1765,21 @@ if [ "$KIND" = secondmate ]; then
   sq_primary_home=$(shell_quote "$FM_HOME")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=$sq_primary_home FM_HOME=$sq_home $LAUNCH"
 fi
+# A login shell that predates a home-manager PATH change can export
+# __HM_SESS_VARS_SOURCED without the newer variables, making every descendant
+# skip the current session-vars file. Guarantee the npm fleet-tool directory in
+# the pane instead of trusting that poisoned parent PATH. NPM_CONFIG_PREFIX owns
+# a configured prefix; the fleet's user-owned HOME prefix is the fallback. The
+# shell case makes repeated spawns converge without duplicating the entry, and
+# the directory need not exist for PATH construction.
+FLEET_TOOLCHAIN_BIN=$(fleet_toolchain_bin) || exit 1
+sq_fleet_toolchain_bin=$(shell_quote "$FLEET_TOOLCHAIN_BIN")
+PATH_GUARANTEE="fm_spawn_toolchain_bin=$sq_fleet_toolchain_bin; case \":\${PATH-}:\" in *\":\${fm_spawn_toolchain_bin}:\"*) ;; *) export PATH=\"\${fm_spawn_toolchain_bin}\${PATH:+:\${PATH}}\" ;; esac; unset fm_spawn_toolchain_bin"
+spawn_send_text_line "$T" "$PATH_GUARANTEE"
+
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
-# the env is set when the agent starts; the brief sleep lets the export land.
+# the env is set when the agent starts; the brief sleep lets both exports land.
 spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 sleep 0.3
 spawn_send_literal "$T" "$LAUNCH"
@@ -1691,6 +1789,7 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
+verify_spawn_autonomy_mode
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -2,7 +2,7 @@
 
 Audience: maintainer verification.
 
-This record supports current session-start, turn-end, watcher-continuity, and wedge-alarm guarantees.
+This record supports current session-start, spawn-autonomy, busy-state, turn-end, watcher-continuity, and wedge-alarm guarantees.
 Operator behavior and active limits remain in the linked current guides.
 Task-specific chronology, temporary paths, run identifiers, and delivery transcripts remain in private reports or PR evidence.
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -60,6 +60,53 @@ The Ahoy first-message boundary was reverified on 2026-07-22 with Pi 0.81.1 and 
 Marked current operational input and the two exact legacy compatibility shapes selected Bearings, while genuine near-miss captain messages remained real boundaries.
 The detailed reconciliation and task chronology stay in the private audit report and PR evidence.
 
+## Spawn autonomy mode
+
+Claude's launch-time autonomy postcondition was verified on 2026-07-31 with Claude Code 2.1.220.
+
+```sh
+claude --version
+claude --dangerously-skip-permissions
+claude --dangerously-skip-permissions \
+  --settings '{"permissions":{"disableBypassPermissionsMode":"disable"}}'
+claude --dangerously-skip-permissions \
+  --settings '{"permissions":{"disableBypassPermissionsMode":"disable","defaultMode":"auto"}}'
+```
+
+The three interactive footer outcomes and the downgrade banner were:
+
+```text
+2.1.220 (Claude Code)
+⏵⏵ bypass permissions on (shift+tab to cycle)
+Bypass permissions mode was disabled by settings
+⏸ manual mode on · ← for agents
+Bypass permissions mode was disabled by settings
+⏵⏵ auto mode on (shift+tab to cycle) · ← for agents
+```
+
+`bin/fm-spawn.sh` therefore verifies only these empirically observed Claude renderings, accepts the bypass footer, and prints a non-blocking `AUTONOMY WARNING` with requested mode, observed mode, likely setting or policy cause, and relaunch remedy for the two downgraded footers.
+The same plain capture dispatch covers tmux, Herdr, Zellij, Orca, and cmux, while a Claude capture with no verified mode signal warns with `observed mode=unverified` instead of guessing a mode or silently accepting the missing postcondition.
+
+Codex was exercised on the same date with its real interactive launch flag:
+
+```sh
+codex --version
+codex --dangerously-bypass-approvals-and-sandbox
+```
+
+```text
+codex-cli 0.146.0
+```
+
+Its initial TUI exposed no stable approval or sandbox mode signal, so no Codex check was added.
+OpenCode, Pi, pi-signed, Grok, and Kimi were not installed in this environment and were deliberately left unchanged rather than inferred.
+
+Deterministic coverage drives the real spawn executable through a fake pane capture:
+
+```sh
+tests/fm-spawn-autonomy.test.sh
+```
+
 ## Semantic busy state
 
 The per-adapter semantic sources behind [`bin/fm-busy-lib.sh`](../../bin/fm-busy-lib.sh) were live-verified on 2026-07-28 against firstmate-launched workers wired exactly as `fm-spawn` writes them.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -281,6 +281,40 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+test_ship_and_scout_inherit_evidence_integrity_rules() {
+  local home kind id brief
+  home="$TMP_ROOT/evidence-integrity-home"
+  mkdir -p "$home/data"
+  for kind in ship scout; do
+    id="brief-evidence-$kind"
+    if [ "$kind" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" sample --scout >/dev/null 2>&1
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" sample >/dev/null 2>&1
+    fi
+    brief="$home/data/$id/brief.md"
+    assert_grep "# Evidence integrity" "$brief" \
+      "$kind brief did not inherit the conditional evidence rules"
+    assert_grep "capture the built static output, never a development server" "$brief" \
+      "$kind brief did not reject development-server overlays"
+    assert_grep "can exit zero and print success while writing no file" "$brief" \
+      "$kind brief still trusts screenshot command success"
+    assert_grep "under the task temp directory \`/tmp/fm-$id/\`" "$brief" \
+      "$kind brief did not stage browser captures in its task temp directory"
+    assert_grep "require \`test -s <capture>\`" "$brief" \
+      "$kind brief did not assert the staged screenshot postcondition"
+    assert_grep "require \`test -s <deliverable>\` again" "$brief" \
+      "$kind brief did not assert the copied screenshot postcondition"
+    assert_grep "customer counts, ratings, awards, certifications, and performance numbers" "$brief" \
+      "$kind brief did not enumerate factual user-facing claim classes"
+    assert_grep "cite its source in the task or PR evidence and never invent or extrapolate one" "$brief" \
+      "$kind brief did not require a source for factual user-facing claims"
+    assert_grep "screenshots staged under \`/tmp/fm-$id/\` as required above" "$brief" \
+      "$kind brief's write boundary conflicts with required screenshot staging"
+  done
+  pass "fm-brief.sh: every ship and scout inherits screenshot postconditions and sourced-claim rules"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -625,6 +659,7 @@ test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_ship_and_scout_inherit_evidence_integrity_rules
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -410,6 +410,30 @@ test_terminal_single_owner_status_decision_does_not_block_empty_inventory() {
   pass "terminal single-owner stale status decisions do not block empty inventory"
 }
 
+test_open_blocked_event_message_names_both_remedies() {
+  local home id
+  home=$(make_home open-blocked-remedy)
+  id=sample-cleared-blocker
+  mkdir -p "$home/data/$id"
+  tasks_in "$home" add "$id" "Review a cleared sample blocker" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create cleared-blocker origin"
+  write_origin_meta "$home" "$id"
+  printf 'blocked: sample dependency was unavailable\n' > "$home/state/$id.status"
+  printf '# Cleared blocker\n\nThe dependency is now available.\n' > "$home/data/$id/report.md"
+
+  if run_decisions "$home" complete "$id" --none \
+    > "$home/complete.out" 2> "$home/complete.err"; then
+    fail "an open blocked event passed completion without a hold or resolved status"
+  fi
+  assert_grep "open structured decision $id/default has no captain-held inventory entry" \
+    "$home/complete.err" "decision-hold refusal lost the open event identity"
+  assert_grep "register a captain hold for key 'default'" "$home/complete.err" \
+    "decision-hold refusal omitted the legitimate hold-registration remedy"
+  assert_grep "append a matching 'resolved: <how it cleared>' status line" "$home/complete.err" \
+    "decision-hold refusal omitted the cleared-event remedy"
+  pass "fm-decision-hold: an open blocked event refusal explains both legitimate remedies"
+}
+
 test_secondmate_hold_stays_in_authoritative_home() {
   local parent mate origin hold json
   parent=$(make_home main-routing)
@@ -558,5 +582,6 @@ test_origin_slug_validation_precedes_path_construction
 test_visual_review_uses_shared_completion_owner
 test_none_inventory_and_resolved_prose_do_not_create_holds
 test_terminal_single_owner_status_decision_does_not_block_empty_inventory
+test_open_blocked_event_message_names_both_remedies
 test_secondmate_hold_stays_in_authoritative_home
 test_resolve_matches_quoted_blocked_by_edges

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -64,7 +64,9 @@ case "${1:-}" in
     case "${4:-}" in
       fm_spawn_toolchain_bin=*)
         pane_command=$4
-        PATH="${FM_FAKE_INITIAL_PANE_PATH:-/usr/bin:/bin}" /bin/zsh -c \
+        # /bin/sh exists on every CI platform (zsh does not); the guarantee is
+        # POSIX shell, so sh exercises the same contract the pane shell runs.
+        PATH="${FM_FAKE_INITIAL_PANE_PATH:-/usr/bin:/bin}" /bin/sh -c \
           "$pane_command; $pane_command; printf '%s\\n' \"\$PATH\"" \
           > "$FM_FAKE_TOOLCHAIN_PATH_LOG"
         exit 0

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -61,6 +61,15 @@ case "${1:-}" in
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
   send-keys)
+    case "${4:-}" in
+      fm_spawn_toolchain_bin=*)
+        pane_command=$4
+        PATH="${FM_FAKE_INITIAL_PANE_PATH:-/usr/bin:/bin}" /bin/zsh -c \
+          "$pane_command; $pane_command; printf '%s\\n' \"\$PATH\"" \
+          > "$FM_FAKE_TOOLCHAIN_PATH_LOG"
+        exit 0
+        ;;
+    esac
     prev=
     literal=
     for arg in "$@"; do
@@ -164,6 +173,8 @@ run_spawn() {
     FM_FAKE_KIMI_SWALLOWED="$case_dir/kimi.swallowed" \
     FM_FAKE_KIMI_SWALLOW_FIRST="${FM_FAKE_KIMI_SWALLOW_FIRST:-no}" \
     FM_FAKE_TMUX_CALL_LOG="$case_dir/tmux-calls.log" \
+    FM_FAKE_TOOLCHAIN_PATH_LOG="$case_dir/toolchain-path.log" \
+    FM_FAKE_INITIAL_PANE_PATH="${FM_FAKE_INITIAL_PANE_PATH:-/usr/bin:/bin}" \
     FM_FAKE_BRIEF_REAL="$(cd "$home/data/$id" && pwd -P)/brief.md" \
     FM_KIMI_READY_POLLS=2 FM_KIMI_DELIVERY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
     PATH="$fakebin:$BASE_PATH" \
@@ -177,7 +188,7 @@ EOF
 }
 
 test_kimi_launch_then_send_is_verified() {
-  local id rec out rc launch pointer brief_real meta task_tmp
+  local id rec out rc launch pointer brief_real meta task_tmp toolchain_path toolchain_bin count
   id="kimi-success-z1-$$"
   task_tmp="/tmp/fm-$id"
   KIMI_RUNTIME_TASK_TMP=$task_tmp
@@ -209,6 +220,15 @@ test_kimi_launch_then_send_is_verified() {
   assert_present "$task_tmp/gotmp" "kimi spawn did not create its Go temp directory"
   assert_grep "export GOTMPDIR=$task_tmp/gotmp" "$CASE_DIR/tmux-calls.log" \
     "kimi spawn did not export its Go temp directory into the pane"
+  toolchain_path=$(cat "$CASE_DIR/toolchain-path.log")
+  toolchain_bin="$HOME_DIR/.npm-global/bin"
+  count=$(printf '%s\n' "$toolchain_path" | tr ':' '\n' | grep -Fxc "$toolchain_bin" || true)
+  [ "$count" -eq 1 ] \
+    || fail "two fleet-toolchain PATH guarantees left $count copies of $toolchain_bin in '$toolchain_path'"
+  case "$toolchain_path" in
+    "$toolchain_bin":/usr/bin:/bin) ;;
+    *) fail "fleet toolchain PATH guarantee clobbered or reordered the pane PATH: $toolchain_path" ;;
+  esac
   assert_grep 'BEGIN FIRSTMATE KIMI TURN-END HOOK' "$HOME_DIR/.kimi-code/config.toml" \
     "kimi spawn did not install its guarded global hook region"
   assert_grep 'token=' "$WT_DIR/.fm-kimi-turnend" "kimi spawn did not write its token pointer"

--- a/tests/fm-lock.test.sh
+++ b/tests/fm-lock.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Behavior tests for the public session-lock diagnostic when harness ancestry
+# cannot be established.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LOCK="$ROOT/bin/fm-lock.sh"
+TMP_ROOT=$(fm_test_tmproot fm-lock)
+BASE_PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+test_process_inspection_unavailable_is_distinct() {
+  local home fakebin out rc=0
+  home="$TMP_ROOT/inspection-unavailable"
+  fakebin=$(fm_fakebin "$home")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(FM_HOME="$home" PATH="$fakebin:$BASE_PATH" "$LOCK" 2>&1) || rc=$?
+  expect_code 1 "$rc" "fm-lock must fail closed when ps is unavailable"
+  assert_contains "$out" "process inspection is unavailable (ps failed for the current process)" \
+    "fm-lock did not distinguish a blocked process-inspection surface"
+  assert_contains "$out" "for Claude Code, disable its sandbox for this firstmate session" \
+    "fm-lock did not give the concrete sandbox remedy"
+  assert_contains "$out" "operate read-only until resolved" \
+    "fm-lock lost its read-only fail-closed instruction"
+  assert_absent "$home/state/.lock" "failed process inspection published a session lock"
+  pass "fm-lock: unavailable process inspection names the sandbox remedy and stays read-only"
+}
+
+test_readable_ancestry_without_harness_is_distinct() {
+  local home fakebin out rc=0
+  home="$TMP_ROOT/no-harness-match"
+  fakebin=$(fm_fakebin "$home")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$field" in
+  comm=) printf '%s\n' /bin/zsh ;;
+  args=) printf '%s\n' zsh ;;
+  ppid=) printf '%s\n' 1 ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(FM_HOME="$home" PATH="$fakebin:$BASE_PATH" "$LOCK" 2>&1) || rc=$?
+  expect_code 1 "$rc" "fm-lock must fail closed when no harness matches"
+  assert_contains "$out" "process inspection ran but no supported harness process matched the ancestry" \
+    "fm-lock confused a completed unmatched walk with unavailable process inspection"
+  assert_contains "$out" "launch firstmate from a verified harness" \
+    "fm-lock did not give the unmatched-ancestry remedy"
+  assert_not_contains "$out" "disable its sandbox" \
+    "fm-lock prescribed a sandbox change after process inspection succeeded"
+  assert_absent "$home/state/.lock" "unmatched harness ancestry published a session lock"
+  pass "fm-lock: a readable unmatched ancestry names the verified-harness remedy"
+}
+
+test_process_inspection_unavailable_is_distinct
+test_readable_ancestry_without_harness_is_distinct

--- a/tests/fm-spawn-autonomy.test.sh
+++ b/tests/fm-spawn-autonomy.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn's non-blocking, post-launch autonomy observation.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-autonomy)
+
+cleanup_autonomy_tests() {
+  rm -rf "/tmp/fm-autonomy-healthy-$$" "/tmp/fm-autonomy-auto-$$" \
+    "/tmp/fm-autonomy-manual-$$" "/tmp/fm-autonomy-unverified-$$" \
+    "/tmp/fm-autonomy-codex-$$"
+  fm_test_cleanup
+}
+trap cleanup_autonomy_tests EXIT
+
+make_fakebin() {  # <dir>
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "$FM_FAKE_PANE_PATH"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf '%s\n' firstmate ;;
+  list-windows|has-session|new-session|set-window-option|send-keys|kill-window) ;;
+  new-window) printf '%s\n' %1 ;;
+  capture-pane) printf '%s\n' "$FM_FAKE_PANE_CAPTURE" ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse claude codex gh gh-axi sleep
+  printf '%s\n' "$fakebin"
+}
+
+make_case() {  # <name> <harness> <id>
+  local name=$1 harness=$2 id=$3 dir home project worktree fakebin
+  dir="$TMP_ROOT/$name"
+  home="$dir/home"
+  project="$dir/project"
+  worktree="$dir/worktree"
+  fakebin=$(make_fakebin "$dir")
+  mkdir -p "$home/data/$id" "$home/state" "$home/config" "$home/projects"
+  printf '%s\n' "$harness" > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+  fm_git_worktree "$project" "$worktree" "wt-$name"
+  printf '%s\n' "$home|$project|$worktree|$fakebin"
+}
+
+run_spawn() {  # <home> <project> <worktree> <fakebin> <capture> <id> <harness>
+  local home=$1 project=$2 worktree=$3 fakebin=$4 capture=$5 id=$6 harness=$7
+  HOME="$home" FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$worktree" \
+    FM_FAKE_PANE_CAPTURE="$capture" FM_SPAWN_AUTONOMY_POLLS=1 \
+    FM_SPAWN_AUTONOMY_POLL_INTERVAL=0 TMUX='fake,1,0' \
+    PATH="$fakebin:$PATH" "$SPAWN" "$id" "$project" --harness "$harness" 2>&1
+}
+
+test_verified_claude_bypass_is_accepted() {
+  local id="autonomy-healthy-$$" rec home project worktree fakebin out rc=0
+  rec=$(make_case healthy claude "$id")
+  IFS='|' read -r home project worktree fakebin <<EOF
+$rec
+EOF
+  out=$(run_spawn "$home" "$project" "$worktree" "$fakebin" \
+    '⏵⏵ bypass permissions on (shift+tab to cycle)' "$id" claude) || rc=$?
+  expect_code 0 "$rc" "a verified Claude bypass launch must stay healthy"
+  assert_contains "$out" "spawned $id harness=claude" \
+    "healthy Claude autonomy observation blocked spawn completion"
+  assert_not_contains "$out" "AUTONOMY WARNING" \
+    "verified Claude bypass mode produced a false warning"
+  pass "fm-spawn: Claude's verified bypass footer satisfies the autonomy postcondition"
+}
+
+test_verified_claude_downgrades_warn_without_blocking() {
+  local mode id rec home project worktree fakebin capture out rc
+  for mode in auto manual; do
+    id="autonomy-$mode-$$"
+    rec=$(make_case "$mode" claude "$id")
+    IFS='|' read -r home project worktree fakebin <<EOF
+$rec
+EOF
+    capture="Bypass permissions mode was disabled by settings
+⏵⏵ $mode mode on (shift+tab to cycle)"
+    rc=0
+    out=$(run_spawn "$home" "$project" "$worktree" "$fakebin" "$capture" "$id" claude) || rc=$?
+    expect_code 0 "$rc" "a Claude $mode downgrade warning must not block the worker"
+    assert_contains "$out" "AUTONOMY WARNING: task $id requested mode=bypassPermissions but observed mode=$mode" \
+      "Claude $mode downgrade warning omitted requested or observed mode"
+    assert_contains "$out" 'permissions.disableBypassPermissionsMode is "disable"' \
+      "Claude $mode downgrade warning omitted the likely setting cause"
+    assert_contains "$out" "The worker remains launched" \
+      "Claude $mode downgrade warning did not preserve the warning-only boundary"
+    assert_contains "$out" "spawned $id harness=claude" \
+      "Claude $mode downgrade stopped an otherwise healthy spawn"
+  done
+  pass "fm-spawn: verified Claude auto/manual downgrades warn with cause and remain non-blocking"
+}
+
+test_unverified_claude_mode_warns_without_blocking() {
+  local id="autonomy-unverified-$$" rec home project worktree fakebin out rc=0
+  rec=$(make_case unverified claude "$id")
+  IFS='|' read -r home project worktree fakebin <<EOF
+$rec
+EOF
+  out=$(run_spawn "$home" "$project" "$worktree" "$fakebin" '' "$id" claude) || rc=$?
+  expect_code 0 "$rc" "an unverified Claude mode warning must not block the worker"
+  assert_contains "$out" "AUTONOMY WARNING: task $id requested mode=bypassPermissions but observed mode=unverified" \
+    "missing Claude mode signal degraded silently"
+  assert_contains "$out" "worker UI did not render a verified status footer in time or the backend capture was unavailable" \
+    "unverified Claude warning omitted its likely causes"
+  assert_contains "$out" "The worker remains launched" \
+    "unverified Claude warning did not preserve the warning-only boundary"
+  assert_contains "$out" "spawned $id harness=claude" \
+    "unverified Claude mode observation blocked an otherwise healthy spawn"
+  pass "fm-spawn: a missing Claude mode postcondition warns loudly without blocking"
+}
+
+test_unverified_codex_rendering_is_not_guessed() {
+  local id="autonomy-codex-$$" rec home project worktree fakebin out rc=0
+  rec=$(make_case codex codex "$id")
+  IFS='|' read -r home project worktree fakebin <<EOF
+$rec
+EOF
+  out=$(run_spawn "$home" "$project" "$worktree" "$fakebin" \
+    'auto mode on' "$id" codex) || rc=$?
+  expect_code 0 "$rc" "Codex spawn must remain unchanged without a verified mode signal"
+  assert_not_contains "$out" "AUTONOMY WARNING" \
+    "fm-spawn guessed a Codex mode from Claude-specific text"
+  assert_contains "$out" "spawned $id harness=codex" \
+    "unverified Codex mode observation blocked spawn completion"
+  pass "fm-spawn: adapters without a verified mode rendering are deliberately left alone"
+}
+
+test_verified_claude_bypass_is_accepted
+test_verified_claude_downgrades_warn_without_blocking
+test_unverified_claude_mode_warns_without_blocking
+test_unverified_codex_rendering_is_not_guessed


### PR DESCRIPTION
## Intent

Fold five recurring Firstmate session time sinks into shared tracked material: guarantee spawned workers inherit the fleet toolchain PATH, warn without blocking when Claude autonomy is downgraded or unverified, scaffold reliable static screenshot capture and sourced factual claims, distinguish lock failure causes, and make decision-hold recovery actionable without changing safety or approval boundaries.

## What Changed

- `bin/fm-spawn.sh` now sends every worker pane an idempotent PATH prepend of the fleet npm toolchain bin (`${NPM_CONFIG_PREFIX:-$HOME/.npm-global}/bin`) before launching the harness, and after a verified Claude template launch polls the pane footer, printing a non-blocking `AUTONOMY WARNING` when the requested bypass-permissions mode is observed downgraded to auto/manual or cannot be verified.
- Lock and hold diagnostics are now cause-specific: `fm-session-lock-lib.sh` returns a distinct code when `ps` is blocked outright versus when the ancestry walk finds no verified harness, `bin/fm-lock.sh` prints a tailored remedy for each, and `bin/fm-decision-hold.sh`'s unmatched-decision failure spells out both recovery paths (register a captain hold, or append a matching `resolved:` status line).
- `bin/fm-brief.sh` adds an evidence-integrity section to every ship and scout brief — screenshots must come from built static output, be staged under `/tmp/fm-<id>/` (a matching narrow widening of the worker write boundary) and pass `test -s` checks, and factual user-facing claims must cite sources — with new/extended coverage in `tests/` and updated verification lists in `docs/verification/supervision.md`.

## Five-item implementation and verification

1. Fleet toolchain PATH - `fm-spawn` derives `${NPM_CONFIG_PREFIX:-$HOME/.npm-global}/bin` and sends one convergent PATH update through the shared pre-launch dispatch, so it applies to every harness template and to tmux, Herdr, Zellij, Orca, and cmux.
   The executable behavior test drives the tmux/Kimi path twice against a poisoned PATH and proves one preserved prepend without requiring the directory to exist; the remaining backend arms were reviewed at their common dispatch boundary rather than claimed as real-runtime exercises.
2. Worker autonomy - real Claude Code 2.1.220 was exercised for `bypass permissions on`, `manual mode on`, and `auto mode on`, and deterministic spawn tests cover those modes plus a missing footer while preserving warning-only behavior.
   Codex 0.146.0 was exercised but exposed no stable approval/sandbox status signal, so it was deliberately left unchanged; OpenCode, Pi, pi-signed, Grok, and Kimi were unavailable for empirical autonomy verification and were also deliberately left unchanged.
   The existing capture implementations for tmux, Herdr, Zellij, Orca, and cmux were reviewed, but the rendered autonomy postcondition is intentionally Claude-only because no other harness signal was empirically verified.
3. Capture integrity - every ship and scout scaffold now requires built static output, `/tmp/fm-<id>/` staging, and non-empty assertions before and after copying.
   This is unconditional conditional guidance rather than a flag because `{TASK}` is inserted only after scaffold generation, leaving `fm-brief` no reliable signal that a task will need visual verification; `--herdr-lab` has an explicit lifecycle declaration available at generation time, while visual intent does not.
   Generated ship and scout briefs were verified; no harness or backend behavior changes for this item.
4. Actionable diagnostics - the lock executable now distinguishes process inspection being unavailable from a completed ancestry walk with no harness match, and decision-hold completion names both legitimate recovery paths.
   Public executable tests cover both lock cases and the unkeyed `default` decision-hold remedy; no harness autonomy or backend mutation is involved.
5. Factual claims - every ship and scout brief now requires a source for customer counts, ratings, awards, certifications, performance numbers, and similar user-facing claims and forbids invention or extrapolation.
   Generated brief tests verify the rule reaches both worker kinds; no harness or backend behavior changes for this item.


## Risk Assessment

✅ Low: All five intent items are implemented as warning-only or message/scaffolding changes with fail-closed lock behavior preserved, the new shell paths were verified safe under the scripts' actual set flags and backend argv shapes, deterministic tests cover each new behavior, and the only findings are two informational corner-case notes.

## Testing

Ran the five targeted test files that map one-to-one to the five folded session lessons (fm-lock, fm-spawn-autonomy, fm-brief, fm-decision-hold-lifecycle, fm-kimi-harness) — all pass — then manually drove the real bin/ scripts end-to-end with the suite's terminal fakes to capture reviewer-visible CLI transcripts: the generated brief's Evidence integrity section, both distinct fm-lock diagnostics, healthy/downgraded/unverified Claude spawn autonomy output (warnings never block, exit 0), the exact pane PATH-guarantee line proven idempotent against a poisoned PATH, and the decision-hold refusal naming both recovery remedies. No visual artifacts because every changed surface is CLI/shell text output, for which transcripts are the native end-user surface. Two suites initially skipped because tasks-axi was missing from PATH (the very gap this change fixes for workers); adding ~/.npm-global/bin for those invocations resolved it. No product failures found.

<details>
<summary>Evidence: Generated ship brief: Evidence integrity section and amended write boundary</summary>

```text
$ FM_HOME=... bin/fm-brief.sh demo-landing-refresh sample
--- generated data/demo-landing-refresh/brief.md (excerpts) ---

# Evidence integrity
When visual verification is part of the task, capture the built static output, never a development server; Astro's development server injects a toolbar overlay that contaminates screenshots.
`chrome-devtools-axi screenshot` can exit zero and print success while writing no file when the destination is anywhere under `$HOME`.
Write every screenshot first under the task temp directory `/tmp/fm-demo-landing-refresh/`, require `test -s <capture>` before using it, copy it to the deliverable location, and require `test -s <deliverable>` again.
For every factual claim added to user-facing marketing or product content - including customer counts, ratings, awards, certifications, and performance numbers - cite its source in the task or PR evidence and never invent or extrapolate one.

2. Stay inside this worktree; modify nothing outside it except screenshots staged under `/tmp/fm-demo-landing-refresh/` as required above.
```
</details>
<details>
<summary>Evidence: fm-lock transcripts: distinct sandbox-blocked vs unmatched-ancestry diagnostics, both fail-closed</summary>

```text
$ bin/fm-lock.sh   # ps blocked by sandbox
error: process inspection is unavailable (ps failed for the current process); allow ps in the harness sandbox - for Claude Code, disable its sandbox for this firstmate session - then rerun session start; operate read-only until resolved
(exit 1)

$ bin/fm-lock.sh   # readable ancestry, no harness process
error: process inspection ran but no supported harness process matched the ancestry; launch firstmate from a verified harness, then rerun session start; operate read-only until resolved
(exit 1)
```
</details>
<details>
<summary>Evidence: fm-spawn transcripts: verified bypass silent; auto-mode downgrade and unverified footer warn with cause without blocking (exit 0)</summary>

```text
$ bin/fm-spawn.sh demo-bypass-42565 <project> --harness claude   # Claude footer: bypass permissions on
warn: no registry at /var/folders/v5/7v9100716xg8rk0np43zl_yc0000gn/T//demo-session-lessons.ojaJBF/healthy/home/data/projects.md; defaulting project to no-mistakes off
spawned demo-bypass-42565 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-bypass-42565 worktree=/var/folders/v5/7v9100716xg8rk0np43zl_yc0000gn/T//demo-session-lessons.ojaJBF/healthy/worktree
(exit 0)

$ bin/fm-spawn.sh demo-auto-42565 <project> --harness claude   # Claude footer: auto mode on (bypass disabled by settings/policy)
warn: no registry at /var/folders/v5/7v9100716xg8rk0np43zl_yc0000gn/T//demo-session-lessons.ojaJBF/downgraded/home/data/projects.md; defaulting project to no-mistakes off
AUTONOMY WARNING: task demo-auto-42565 requested mode=bypassPermissions but observed mode=auto in the Claude worker; likely cause: permissions.disableBypassPermissionsMode is "disable" in effective Claude settings or organization policy. The worker remains launched; fix the authoritative setting or policy and relaunch it.
spawned demo-auto-42565 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-auto-42565 worktree=/var/folders/v5/7v9100716xg8rk0np43zl_yc0000gn/T//demo-session-lessons.ojaJBF/downgraded/worktree
(exit 0)

$ bin/fm-spawn.sh demo-unverified-42565 <project> --harness claude   # no Claude footer rendered in time
warn: no registry at /var/folders/v5/7v9100716xg8rk0np43zl_yc0000gn/T//demo-session-lessons.ojaJBF/unverified/home/data/projects.md; defaulting project to no-mistakes off
AUTONOMY WARNING: task demo-unverified-42565 requested mode=bypassPermissions but observed mode=unverified in the Claude worker; likely cause: the worker UI did not render a verified status footer in time or the backend capture was unavailable. The worker remains launched; inspect its status line, correct the capture or startup problem, and relaunch it if bypass permissions is not on.
spawned demo-unverified-42565 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-unverified-42565 worktree=/var/folders/v5/7v9100716xg8rk0np43zl_yc0000gn/T//demo-session-lessons.ojaJBF/unverified/worktree
(exit 0)
```
</details>
<details>
<summary>Evidence: Exact pane PATH-guarantee line fm-spawn sends, replayed twice against a poisoned PATH: fleet bin prepended exactly once</summary>

```text
# The exact PATH-guarantee line fm-spawn sends into the worker pane
# before launching the harness (HOME here is the demo fleet home):
fm_spawn_toolchain_bin='/var/folders/v5/7v9100716xg8rk0np43zl_yc0000gn/T//demo-session-lessons.ojaJBF/pathdemo/home/.npm-global/bin'; case ":${PATH-}:" in *":${fm_spawn_toolchain_bin}:"*) ;; *) export PATH="${fm_spawn_toolchain_bin}${PATH:+:${PATH}}" ;; esac; unset fm_spawn_toolchain_bin

# Replayed twice in a pane shell with a stale PATH=/usr/bin:/bin
# (simulating a poisoned __HM_SESS_VARS_SOURCED parent). Resulting PATH:
/var/folders/v5/7v9100716xg8rk0np43zl_yc0000gn/T//demo-session-lessons.ojaJBF/pathdemo/home/.npm-global/bin:/usr/bin:/bin
```
</details>
<details>
<summary>Evidence: fm-decision-hold refusal transcript naming both recovery remedies (register hold or append resolved line)</summary>

```text
$ bin/fm-decision-hold.sh complete demo-cleared-blocker --none   # open blocked event, no hold
fm-decision-hold: open structured decision demo-cleared-blocker/default has no captain-held inventory entry; register a captain hold for key 'default', or if the event has cleared append a matching 'resolved: <how it cleared>' status line (include [key=default] when the opening event was keyed), then retry
(exit 1)
```
</details>
<details>
<summary>Evidence: Reproducible demo script that generated the transcripts by driving the real bin/ scripts</summary>

```text
#!/usr/bin/env bash
# Manual-verification demo for the five session-lesson behaviors.
# Drives the real bin/ scripts with the same terminal fakes the test suite
# uses and records the user-visible transcripts as evidence artifacts.
set -u

WORKTREE=${WORKTREE:?}
EVID=${EVID:?}
export PATH="$HOME/.npm-global/bin:$PATH"   # tasks-axi lives here

# shellcheck source=tests/lib.sh
. "$WORKTREE/tests/lib.sh"

BASE_PATH=/usr/bin:/bin:/usr/sbin:/sbin
TMP=$(fm_test_tmproot demo-session-lessons)

# ---------------------------------------------------------------- 1. fm-brief
home="$TMP/brief-home"
mkdir -p "$home/data"
FM_HOME="$home" "$ROOT/bin/fm-brief.sh" demo-landing-refresh sample >/dev/null 2>&1
{
  echo '$ FM_HOME=... bin/fm-brief.sh demo-landing-refresh sample'
  echo '--- generated data/demo-landing-refresh/brief.md (excerpts) ---'
  echo
  sed -n '/^# Evidence integrity/,/never invent or extrapolate one/p' \
    "$home/data/demo-landing-refresh/brief.md"
  echo
  grep '^2\. Stay inside this worktree' "$home/data/demo-landing-refresh/brief.md"
} > "$EVID/brief-evidence-integrity.txt"

# ----------------------------------------------------------------- 2. fm-lock
lockdemo() {  # <name> <ps-body>
  local d="$TMP/lock-$1" fakebin rc=0 out
  fakebin=$(fm_fakebin "$d")
  printf '#!/usr/bin/env bash\n%s\n' "$2" > "$fakebin/ps"
  chmod +x "$fakebin/ps"
  out=$(FM_HOME="$d" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || rc=$?
  printf '$ bin/fm-lock.sh   # %s\n%s\n(exit %s)\n' "$1" "$out" "$rc"
}
{
  lockdemo "ps blocked by sandbox" 'exit 1'
  echo
  lockdemo "readable ancestry, no harness process" '
field=
while [ "$#" -gt 0 ]; do
  case "$1" in
    -o) field=$2; shift 2 ;;
    -p) shift 2 ;;
    *) shift ;;
  esac
done
case "$field" in
  comm=) printf "%s\n" /bin/zsh ;;
  args=) printf "%s\n" zsh ;;
  ppid=) printf "%s\n" 1 ;;
  *) exit 1 ;;
esac'
} > "$EVID/lock-diagnostics.txt"

# --------------------------------------------- 3+4. fm-spawn autonomy & PATH
make_fakebin() {  # <dir>
  local dir=$1 fakebin
  fakebin=$(fm_fakebin "$dir")
  cat > "$fakebin/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "$*" in
  *"#{pane_current_path}"*) printf '%s\n' "$FM_FAKE_PANE_PATH"; exit 0 ;;
esac
case "${1:-}" in
  display-message) printf '%s\n' firstmate ;;
  list-windows|has-session|new-session|set-window-option|kill-window) ;;
  send-keys)
    if [ -n "${FM_DEMO_TOOLCHAIN_LOG:-}" ]; then
      for a in "$@"; do
        case "$a" in
          fm_spawn_toolchain_bin=*) printf '%s\n' "$a" >> "$FM_DEMO_TOOLCHAIN_LOG" ;;
        esac
      done
    fi
    ;;
  new-window) printf '%s\n' %1 ;;
  capture-pane) printf '%s\n' "$FM_FAKE_PANE_CAPTURE" ;;
esac
exit 0
SH
  chmod +x "$fakebin/tmux"
  fm_fake_exit0 "$fakebin" treehouse claude codex gh gh-axi sleep
  printf '%s\n' "$fakebin"
}

make_case() {  # <name> <harness> <id>
  local name=$1 harness=$2 id=$3 dir home project worktree fakebin
  dir="$TMP/$name"
  home="$dir/home"
  project="$dir/project"
  worktree="$dir/worktree"
  fakebin=$(make_fakebin "$dir")
  mkdir -p "$home/data/$id" "$home/state" "$home/config" "$home/projects"
  printf '%s\n' "$harness" > "$home/config/crew-harness"
  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
  touch "$home/state/.last-watcher-beat"
  fm_git_worktree "$project" "$worktree" "wt-$name"
  printf '%s\n' "$home|$project|$worktree|$fakebin"
}

run_spawn() {  # <home> <project> <worktree> <fakebin> <capture> <id> <harness>
  local home=$1 project=$2 worktree=$3 fakebin=$4 capture=$5 id=$6 harness=$7
  HOME="$home" FM_ROOT_OVERRIDE='' FM_HOME="$home" \
    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$worktree" \
    FM_FAKE_PANE_CAPTURE="$capture" FM_SPAWN_AUTONOMY_POLLS=1 \
    FM_SPAWN_AUTONOMY_POLL_INTERVAL=0 TMUX='fake,1,0' \
    PATH="$fakebin:$PATH" "$ROOT/bin/fm-spawn.sh" "$id" "$project" --harness "$harness" 2>&1
}

spawn_demo() {  # <case> <harness> <id> <capture> <label>
  local rec home project worktree fakebin out rc=0
  rec=$(make_case "$1" "$2" "$3")
  IFS='|' read -r home project worktree fakebin <<EOF
$rec
EOF
  out=$(run_spawn "$home" "$project" "$worktree" "$fakebin" "$4" "$3" "$2") || rc=$?
  printf '$ bin/fm-spawn.sh %s <project> --harness %s   # %s\n%s\n(exit %s)\n' "$3" "$2" "$5" "$out" "$rc"
}

{
  spawn_demo healthy claude "demo-bypass-$$" \
    '⏵⏵ bypass permissions on (shift+tab to cycle)' \
    'Claude footer: bypass permissions on'
  echo
  spawn_demo downgraded claude "demo-auto-$$" \
    '⏵⏵ auto mode on (shift+tab to cycle)' \
    'Claude footer: auto mode on (bypass disabled by settings/policy)'
  echo
  spawn_demo unverified claude "demo-unverified-$$" '' \
    'no Claude footer rendered in time'
} > "$EVID/spawn-autonomy-warning.txt"
rm -rf "/tmp/fm-demo-bypass-$$" "/tmp/fm-demo-auto-$$" "/tmp/fm-demo-unverified-$$"

# PATH guarantee: capture the exact line fm-spawn sends into the pane, then
# replay it twice in a shell whose PATH lacks the fleet toolchain dir.
rec=$(make_case pathdemo claude "demo-path-$$")
IFS='|' read -r home project worktree fakebin <<EOF
$rec
EOF
tclog="$TMP/pathdemo/toolchain.log"
FM_DEMO_TOOLCHAIN_LOG="$tclog" run_spawn "$home" "$project" "$worktree" "$fakebin" \
  '⏵⏵ bypass permissions on (shift+tab to cycle)' "demo-path-$$" claude >/dev/null 2>&1
rm -rf "/tmp/fm-demo-path-$$"
guarantee=$(head -1 "$tclog")
{
  echo '# The exact PATH-guarantee line fm-spawn sends into the worker pane'
  echo '# before launching the harness (HOME here is the demo fleet home):'
  printf '%s\n' "$guarantee"
  echo
  echo '# Replayed twice in a pane shell with a stale PATH=/usr/bin:/bin'
  echo '# (simulating a poisoned __HM_SESS_VARS_SOURCED parent). Resulting PATH:'
  env -i HOME="$home" PATH=/usr/bin:/bin /bin/sh -c \
    "$guarantee; $guarantee; printf '%s\n' \"\$PATH\""
} > "$EVID/spawn-path-guarantee.txt"

# -------------------------------------------------------- 5. fm-decision-hold
home="$TMP/decision-home"
mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
cp "$ROOT/.tasks.toml" "$home/.tasks.toml"
printf '## In flight\n\n## Queued\n\n## Done\n' > "$home/data/backlog.md"
fakebin=$(fm_fakebin "$home")
fm_fake_exit0 "$fakebin" tmux treehouse no-mistakes gh gh-axi
id=demo-cleared-blocker
mkdir -p "$home/data/$id"
(cd "$home" && tasks-axi add "$id" "Review a cleared sample blocker" --kind scout --repo sample --start >/dev/null)
fm_write_meta "$home/state/$id.meta" \
  "window=firstmate:fm-$id" \
  "worktree=$home/projects/missing-$id" \
  "project=$home/projects/sample" \
  "harness=codex" \
  "kind=scout" \
  "mode=scout"
printf 'blocked: sample dependency was unavailable\n' > "$home/state/$id.status"
printf '# Cleared blocker\n\nThe dependency is now available.\n' > "$home/data/$id/report.md"
rc=0
out=$(PATH="$fakebin:$PATH" REAL_TASKS_AXI="$(command -v tasks-axi)" \
  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
  FM_CONFIG_OVERRIDE="$home/config" "$ROOT/bin/fm-decision-hold.sh" complete "$id" --none 2>&1) || rc=$?
printf '$ bin/fm-decision-hold.sh complete %s --none   # open blocked event, no hold\n%s\n(exit %s)\n' \
  "$id" "$out" "$rc" > "$EVID/decision-hold-remedy.txt"

echo "demo complete"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-brief.sh:283` - The ship/scout brief write boundary is widened from &#34;report and status file only&#34; to also permit writes under /tmp/fm-&lt;id&gt;/ for screenshot staging. This is the enabling mechanism for the required screenshot postconditions and is bounded to the task temp directory fm-spawn already creates (it already hosts GOTMPDIR), so it reads as consistent with the intent&#39;s &#34;without changing safety or approval boundaries&#34; — but it is technically a declared write-surface expansion for workers and worth the author&#39;s conscious acknowledgment.
- ℹ️ `bin/fm-session-lock-lib.sh:35` - fm_harness_ancestry_pid only returns the new &#34;inspection unavailable&#34; code 2 when ps fails on the very first pid ($$). If ps succeeds for the current process but fails mid-walk before any harness match (e.g. an ancestor exits between the ppid read and the ps call, or a sandbox that permits self-inspection only), the function breaks and returns 1, so fm-lock.sh reports &#34;process inspection ran but no supported harness process matched the ancestry&#34; and prescribes the verified-harness remedy even though the walk never completed. This corner is rare and still fails closed; the two new diagnostics remain a strict improvement over the old single generic message.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-lock.test.sh` (2/2 pass: sandbox-blocked ps vs unmatched-ancestry diagnostics)</code>
- <code>`bash tests/fm-spawn-autonomy.test.sh` (4/4 pass: verified bypass, auto/manual downgrade warnings, unverified warning, Codex untouched)</code>
- <code>`bash tests/fm-brief.test.sh` (18/18 pass, incl. new evidence-integrity inheritance test)</code>
- <code>`PATH=&#34;$HOME/.npm-global/bin:$PATH&#34; bash tests/fm-decision-hold-lifecycle.test.sh` (10/10 pass, incl. new both-remedies refusal test)</code>
- <code>`PATH=&#34;$HOME/.npm-global/bin:$PATH&#34; bash tests/fm-kimi-harness.test.sh` (15/15 pass, incl. pane PATH-guarantee idempotence and ordering assertions)</code>
- <code>Manual end-to-end demo driving real `bin/fm-brief.sh`, `bin/fm-lock.sh`, `bin/fm-spawn.sh`, and `bin/fm-decision-hold.sh` with the suite&#39;s terminal fakes, capturing user-visible transcripts for all five behaviors (script and outputs in the evidence directory)</code>
- <code>Replayed the exact fm-spawn PATH-guarantee pane line twice in a poisoned `PATH=/usr/bin:/bin` shell to confirm single idempotent prepend of the fleet toolchain bin</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>