### PR TITLE
feat(cursor): Cursor Cloud agent view, steering, and creation

### DIFF
--- a/.agents/skills/firstmate-cursor-cloud/SKILL.md
+++ b/.agents/skills/firstmate-cursor-cloud/SKILL.md
@@ -42,6 +42,15 @@ A finished agent stays `ACTIVE` indefinitely until somebody archives it, so a fl
 Never report agent lifecycle as though it were activity.
 Take the run status from the latest run, which `bin/fm-cursor.sh list` resolves and reports as its primary column: `CREATING` and `RUNNING` mean work is in flight, and `FINISHED`, `ERROR`, `CANCELLED`, and `EXPIRED` are terminal.
 
+That enum is not the whole column, and the two values outside it are the ones most likely to be misread.
+`unknown` is a third category that is neither in flight nor terminal: it means resolving that agent's latest run failed, so its real state was never observed.
+`unresolved` is the same absence by choice rather than by failure, and appears only under `--no-runs`, which skips resolution entirely.
+Never read either value as idle, finished, or terminal, and never fold an `unknown` row into a "nothing running" count.
+The honest report is "could not tell for that agent, and here is why", because guessing at an unobserved state is the same fleet misread this whole environment-and-run-status design exists to prevent.
+Only the affected rows degrade: every other row in the same listing was resolved normally.
+`list` prints the reasons grouped under its unresolved count, and `--json` carries each one in `runStatusReason` alongside a `runStatusSource` of `resolution-failed`, which distinguishes a failed resolution from the `latestRunId` fast path, the `runs-list` fallback, and the `skipped` case under `--no-runs`.
+A rate limit and a rejected key therefore read differently, so use the reason rather than retrying blind.
+
 ## Reading the fleet
 
 1. `bin/fm-cursor.sh list` for the current picture, or `--json` when you need to compute over it.
@@ -67,6 +76,7 @@ When the captain asks about "the environment" without naming one, the configured
 Run status resolution prefers a `latestRunId` field that list items carry in practice but that is **not** in Cursor's published schema, falling back to a per-agent runs lookup.
 `--json` records which source answered in `runStatusSource`.
 If the fast path ever disappears the fallback keeps working, so treat a change there as a Cursor-side change rather than a firstmate defect.
+The fallback is always attempted when the fast path fails, and neither `list` nor `show` aborts when both fail: a stale run id says nothing about the agent, which the helper has usually just fetched successfully, so the run alone degrades to `unknown` with its reason.
 
 ## What this surface cannot do
 
@@ -92,4 +102,5 @@ Include the full Cursor Web URL when the captain will want to open the agent, ex
 - Helper reports it is not configured: the home has no `CURSOR_API_KEY` in its `.env`. Relay that and the dashboard link; do not go looking for a key in a keychain or another tool's credential store.
 - Helper reports the key was rejected: the key is wrong, revoked, or belongs to another account. Ask the captain to regenerate it; never fall back to another credential source.
 - Helper reports rate limiting: back off rather than retrying in a loop, and prefer `--limit` or `--no-runs` to shrink the request count.
+- Helper reports `RUN` unknown for some rows: read the grouped reasons printed under that count, because they say whether Cursor throttled the run lookups, rejected the key, or no longer has those runs. Report which it was, and never present those rows as idle.
 - Every listed agent reads terminal but the captain expects work in flight: check whether he is looking at a different Cursor account, since this view is per-user.

--- a/.agents/skills/firstmate-cursor-cloud/SKILL.md
+++ b/.agents/skills/firstmate-cursor-cloud/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: firstmate-cursor-cloud
+description: >-
+  Agent-only playbook for reading the captain's own Cursor Cloud agents without pretending they are a selectable runtime backend or a harness.
+  Use before reporting on Cursor Cloud agent activity, before answering what a cloud agent is doing or concluded, and before responding to requests to make Cursor Cloud native to firstmate.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# firstmate-cursor-cloud
+
+## Overview
+
+Use this playbook when the captain asks what his Cursor Cloud agents are doing, what one of them concluded, or what they have consumed.
+The current supported shape is a read-only view through `bin/fm-cursor.sh`, not a `cursor` value in `FM_BACKEND` and not an eighth harness.
+
+`bin/fm-cursor.sh --help` owns the exact subcommands, flags, environment variables, and exit codes.
+[`docs/configuration.md`](../../../docs/configuration.md) owns the `.env` activation contract.
+This skill owns only the judgment: what the numbers mean, what this surface cannot do, and how to report it.
+
+## Boundary
+
+Cursor Cloud agents are a companion surface, the same boundary [`firstmate-codexapp`](../firstmate-codexapp/SKILL.md) draws for Codex Desktop threads.
+They are not a runtime backend and not a harness, for concrete reasons rather than taste.
+
+- A runtime backend must supply bounded pane capture, a composer, special-key sends, and a local worktree path.
+  A cloud agent has none of these, so most of the adapter contract in `bin/fm-backend.sh` could only be stubbed with lies.
+- A harness is a local interactive CLI that `bin/fm-spawn.sh` launches into a pane and `bin/fm-harness.sh` detects in the process tree.
+  A cloud agent has no local process at all.
+- A ship spawn must pass the worktree-isolation assertion in `bin/fm-spawn.sh`, which no cloud agent can satisfy.
+  Bypassing that assertion for a whole backend class would weaken a safety invariant to fit a remote executor.
+
+If the captain asks to make Cursor Cloud a native backend, relay that boundary and the increment path below rather than inventing an adapter.
+
+## The one fact that is easy to get wrong
+
+An agent's `status` field is lifecycle only: the enum is `ACTIVE|ARCHIVED`, and Cursor documents execution status as living on runs instead.
+`ACTIVE` means "not archived". It does not mean the agent is working.
+A finished agent stays `ACTIVE` indefinitely until somebody archives it, so a fleet of thirty `ACTIVE` agents can have nothing running at all.
+
+Never report agent lifecycle as though it were activity.
+Take the run status from the latest run, which `bin/fm-cursor.sh list` resolves and reports as its primary column: `CREATING` and `RUNNING` mean work is in flight, and `FINISHED`, `ERROR`, `CANCELLED`, and `EXPIRED` are terminal.
+
+## Reading the fleet
+
+1. `bin/fm-cursor.sh list` for the current picture, or `--json` when you need to compute over it.
+2. `bin/fm-cursor.sh show <agent-id>` for one agent's repositories, environment, and Cursor Web URL.
+3. `bin/fm-cursor.sh runs <agent-id>` for its history, including any PR URL a run produced.
+4. `bin/fm-cursor.sh usage <agent-id>` for token consumption.
+
+Two properties of the data change how you read it.
+
+**The environment is the unit of work, not the repository.**
+A Cursor agent is the task and its environment is the project: a named, multi-repo, secret-bearing context that `POST /v1/agents` accepts instead of a bare repository list, the two being mutually exclusive in the API.
+A change spanning a front end and a back end is therefore one agent in one environment, not several tasks, and there is no multi-repo case to restrict.
+`list` and `show` lead with the environment name for that reason.
+Never describe an agent as working "in maverick-ui" when it runs in an environment that contains maverick-ui; name the environment.
+Never assume a run's PR URL belongs to any particular repository in that environment - take the URL as given.
+An agent created from a bare repository list has no environment name and displays as ad-hoc; it also carries none of a named environment's predefined secrets, which is worth saying when a captain wonders why an ad-hoc agent behaved differently from one in the shared environment.
+
+**This home may declare a default environment** in `config/cursor-environment`, which `list` marks with `*` and `show` calls out.
+The default is the intended target for a future operation that needs an environment; it deliberately does not filter what `list` shows, because hiding the agents outside it would misrepresent the fleet.
+Use `--env` to narrow to the default or `--env <name>` for another environment, and read the filtered footer, which reports matches against the fetched page rather than against the whole fleet.
+When the captain asks about "the environment" without naming one, the configured default is the sensible referent; say which one you used.
+
+Run status resolution prefers a `latestRunId` field that list items carry in practice but that is **not** in Cursor's published schema, falling back to a per-agent runs lookup.
+`--json` records which source answered in `runStatusSource`.
+If the fast path ever disappears the fallback keeps working, so treat a change there as a Cursor-side change rather than a firstmate defect.
+
+## What this surface cannot do
+
+- **It cannot steer.** There is no `send`, `cancel`, `create`, `archive`, or `delete` verb, by design for this increment.
+  When the captain wants to steer a cloud agent, hand him the agent's Cursor Web URL from `show` and say plainly that firstmate cannot send the follow-up itself yet.
+- **It cannot show a live run's progress.** The Cloud Agents API has no conversation or messages endpoint, so there is no cheap bounded read of an in-flight run.
+  A terminal run's final text is available through the API; for anything mid-run, escalate the URL rather than guessing.
+- **It cannot report money.** `usage` returns token counts only, because the Cloud Agents API exposes no price or charge field.
+  Report tokens and run counts, say that cost is unavailable, and never estimate spend from token counts and a public price list.
+- **It sees only this operator's own agents.** A user API key is scoped to its own user, so this is not a company-wide fleet view.
+  `GET /v1/agents` is documented as listing agents for the authenticated user and offers no team or user filter.
+  Team-wide visibility would need a service account key that only a Cursor team admin can create, and it is not established that such a key enumerates agents created by other people rather than only its own.
+  Do not promise a fleet-wide view on that basis; say what this key can see.
+
+## Reporting to the captain
+
+Translate through `AGENTS.md` section 9 as usual, and prefer the captain's nouns: the cloud agent, the run, the pull request, the repository.
+Report activity from run status, never from lifecycle, and say "nothing running" rather than "35 active" when that is what the data means.
+Include the full Cursor Web URL when the captain will want to open the agent, exactly as PR URLs are always given in full.
+
+## Failure signals
+
+- Helper reports it is not configured: the home has no `CURSOR_API_KEY` in its `.env`. Relay that and the dashboard link; do not go looking for a key in a keychain or another tool's credential store.
+- Helper reports the key was rejected: the key is wrong, revoked, or belongs to another account. Ask the captain to regenerate it; never fall back to another credential source.
+- Helper reports rate limiting: back off rather than retrying in a loop, and prefer `--limit` or `--no-runs` to shrink the request count.
+- Every listed agent reads terminal but the captain expects work in flight: check whether he is looking at a different Cursor account, since this view is per-user.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ README.md            public overview and development notes
 .claude/skills       symlink to .agents/skills for claude compatibility
 skills/              standalone public installer-facing skills, committed; not loaded by firstmate
 bin/                 helper scripts, committed; read each script's header before first use
-.env                 optional X-mode pairing token; LOCAL, gitignored; presence-gates section 14
+.env                 optional X-mode pairing token and Cursor Cloud API key; LOCAL, gitignored; the pairing token presence-gates section 14, and CURSOR_API_KEY presence-gates the read-only Cursor Cloud agent view, which reads it from this file only (docs/configuration.md "Cursor Cloud agent view")
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (section 4)
 config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (section 4). Inherited by secondmate homes
 config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
@@ -73,6 +73,7 @@ config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inhe
 config/startup-memory-budget     primary-authoritative per-home startup-memory budget; LOCAL, gitignored, materialized as 7,500 estimated tokens by locked primary bootstrap and inherited into secondmate homes; see docs/configuration.md "Startup memory budget"
 config/herdr-presentation-spaces  optional presence flag for Herdr's default-off disposable single-task visual projection; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Optional presentation spaces"
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
+config/cursor-environment  optional default Cursor Cloud environment name for the read-only agent view; LOCAL, gitignored; absent means no default, and the default never filters that view implicitly; see docs/configuration.md "Default Cursor environment"
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,6 +491,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
+- `firstmate-cursor-cloud` - load before reporting on Cursor Cloud agent activity, before answering what one of the captain's cloud agents is doing or concluded, and before responding to requests to make Cursor Cloud a native backend or harness.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 
 ## 14. X mode

--- a/bin/fm-cursor.sh
+++ b/bin/fm-cursor.sh
@@ -72,12 +72,18 @@
 # `runs?limit=1` fallback covers both its absence AND a fast path whose request
 # fails, and the JSON output records which source answered in `runStatusSource`:
 # `latestRunId`, `runs-list`, `resolution-failed`, or `skipped` for --no-runs.
-# Per-agent resolution inside `list` is deliberately NON-FATAL, because it is the
-# one place a single request failure could discard an otherwise good answer: a 404
-# on a stale run id, or a 429 partway through 1+N serial requests, degrades that
-# one agent's RUN to `unknown` and the rest of the listing still prints. Every
-# other fetch - the list call itself, and all of `show`, `runs`, and `usage` -
-# still fails loudly, because there a failed request leaves nothing worth showing.
+# Run resolution is deliberately NON-FATAL, in `show` exactly as in `list`. The
+# fast path is reached through that undocumented field, so a stale value there
+# says nothing about whether the agent exists, and exiting with "not found" for an
+# agent whose own GET just succeeded would be actively misleading. A failed fast
+# path therefore ALWAYS falls through to the fallback, and when both fail the run
+# is reported as `unknown` WITH its reason - the HTTP status and the API's own
+# message - so a 429 mid-listing can never be mistaken for a rejected key or for
+# runs that are simply gone. `list` groups those reasons into its footer and
+# degrades only the rows that failed; `--json` carries one per agent in
+# `runStatusReason`. What still fails loudly is the TOP-LEVEL request of each
+# subcommand - the agent list, one agent, its runs, its usage - because there a
+# non-200 means the operation itself failed and nothing is left to show.
 #
 # Activation: read-only, and inert until this home opts in by putting a non-empty
 # CURSOR_API_KEY in its gitignored .env, mirroring how X mode gates on
@@ -235,6 +241,13 @@ api_try_get() {  # <path>
     429) API_ERROR="rate limited by the Cursor API (HTTP 429)$(api_message). Retry in a minute" ;;
     *) API_ERROR="the Cursor API returned HTTP $code$(api_message)" ;;
   esac
+  # Collapse to one line here, at the single point every explanation is built:
+  # callers carry it through newline- and unit-separator-delimited records, and
+  # the API's `message` field is data this helper does not control.
+  API_ERROR=${API_ERROR//$'\n'/ }
+  API_ERROR=${API_ERROR//$'\r'/ }
+  API_ERROR=${API_ERROR//$'\t'/ }
+  API_ERROR=${API_ERROR//$'\037'/ }
   return 1
 }
 
@@ -277,40 +290,55 @@ valid_timeout() {  # <seconds>
   esac
 }
 
-# Latest run status for one agent. Echoes "<status> <runId> <source>".
+# One resolution record: status, run id, provenance, and the reason the status is
+# `unknown`, joined by unit separators so a reason containing spaces survives.
+run_status_record() {  # <status> <run-id> <source> [reason]
+  printf '%s\037%s\037%s\037%s' "$1" "$2" "$3" "${4:-}"
+}
+RUN_STATUS=
+RUN_ID=
+RUN_SOURCE=
+RUN_REASON=
+
+# Read one record back into RUN_STATUS, RUN_ID, RUN_SOURCE, and RUN_REASON.
+read_run_status_record() {  # <record>
+  IFS=$(printf '\037') read -r RUN_STATUS RUN_ID RUN_SOURCE RUN_REASON <<EOF
+$1
+EOF
+}
+
+# Latest run status for one agent, as a run_status_record.
 # Prefers the caller-supplied latestRunId, falls back to the runs list, and
-# reports "none none none" for an agent that has no run yet.
+# reports "none" for an agent that has no run yet.
 #
-# A failed fast-path request falls THROUGH to the runs-list fallback: the
+# A failed fast-path request ALWAYS falls through to the runs-list fallback: the
 # latestRunId that drove it is not in Cursor's published schema, so a stale or
-# removed run id answering 404 is an expected shape, not a fatal one. When the
-# fallback fails too, resolution degrades to "unknown none resolution-failed" so
-# one bad request costs one row rather than the whole view. Pass strict=1 for a
-# single-agent view, where an unresolvable latest run is the answer being asked
-# for and hiding the reason would be worse than failing.
-latest_run_status() {  # <agent-id> <latest-run-id-or-empty> [strict]
-  local agent=$1 run=$2 strict=${3:-0} status
+# removed run id answering 404 says nothing about the agent itself. When the
+# fallback fails too, resolution reports `unknown` with the reason attached and
+# never exits, in every caller: `list` degrades that one row and keeps going, and
+# `show` renders the agent it already fetched successfully rather than dying with
+# a status that would read as "no such agent".
+latest_run_status() {  # <agent-id> <latest-run-id-or-empty>
+  local agent=$1 run=$2 status
   if [ -n "$run" ] && [ "$run" != null ]; then
     if valid_agent_id "$run"; then
       if api_try_get "/v1/agents/$agent/runs/$run"; then
         status=$(jq -r '.status // "none"' "$BODY")
-        printf '%s %s %s' "$status" "$run" latestRunId
+        run_status_record "$status" "$run" latestRunId
         return 0
       fi
-      [ "$strict" -eq 0 ] || die 4 "$API_ERROR"
     fi
   fi
   if ! api_try_get "/v1/agents/$agent/runs?limit=1"; then
-    [ "$strict" -eq 0 ] || die 4 "$API_ERROR"
-    printf 'unknown none resolution-failed'
+    run_status_record unknown none resolution-failed "$API_ERROR"
     return 0
   fi
   status=$(jq -r '(.items // [])[0].status // "none"' "$BODY")
   run=$(jq -r '(.items // [])[0].id // "none"' "$BODY")
   if [ "$status" = none ]; then
-    printf 'none none none'
+    run_status_record none none none
   else
-    printf '%s %s %s' "$status" "$run" runs-list
+    run_status_record "$status" "$run" runs-list
   fi
 }
 
@@ -402,33 +430,37 @@ cmd_list() {
 
   # Resolve each agent's latest run one at a time. Serial on purpose: a burst of
   # parallel requests is the fastest way to meet the API's rate limiter. The ids
-  # come out of one jq pass and the resolved triples are stitched back on in one
+  # come out of one jq pass and the resolved records are stitched back on in one
   # more, rather than rebuilding the whole accumulating array once per agent.
   local resolved='[]'
   if [ "$resolve_runs" -eq 1 ]; then
-    local statuses='' agent_id run_id triple
+    local statuses='' agent_id run_id record
     while IFS=$(printf '\t') read -r agent_id run_id; do
-      # One triple per line, unconditionally: the stitch below matches triples to
+      # One record per line, unconditionally: the stitch below matches records to
       # agents by position, so skipping an unusable row would shift every status
       # after it onto the wrong agent.
       if valid_agent_id "$agent_id"; then
-        triple=$(latest_run_status "$agent_id" "$run_id")
+        record=$(latest_run_status "$agent_id" "$run_id")
       else
-        triple='none none none'
+        record=$(run_status_record none none none)
       fi
-      statuses="$statuses$triple"$'\n'
+      statuses="$statuses$record"$'\n'
     done <<EOF
 $(printf '%s' "$agents" | jq -r '.[] | [.id, .latestRunId] | @tsv')
 EOF
     resolved=$(printf '%s' "$agents" | jq -c --arg statuses "$statuses" '
-      ($statuses | split("\n") | map(select(length > 0) | split(" "))) as $t
+      ($statuses | split("\n") | map(select(length > 0) | split("\u001f"))) as $t
       | to_entries
       | map(.value + {
-          runStatus: $t[.key][0], runId: $t[.key][1], runStatusSource: $t[.key][2]
+          runStatus: $t[.key][0], runId: $t[.key][1], runStatusSource: $t[.key][2],
+          runStatusReason: (if ($t[.key][3] // "") == "" then null else $t[.key][3] end)
         })')
   else
     resolved=$(printf '%s' "$agents" | jq -c \
-      'map(. + {runStatus: "unresolved", runId: "", runStatusSource: "skipped"})')
+      'map(. + {
+        runStatus: "unresolved", runId: "", runStatusSource: "skipped",
+        runStatusReason: null
+      })')
   fi
 
   if [ "$json" -eq 1 ]; then
@@ -540,6 +572,13 @@ EOF
     if [ "$unresolved" -gt 0 ]; then
       printf 'RUN is unknown for %s agent(s) whose latest run could not be fetched; every other row is unaffected.\n' \
         "$unresolved"
+      # Name the reasons, grouped, so a mid-listing 429 reads as rate limiting and
+      # can never look identical to a rejected key or to runs that are simply gone.
+      printf '%s' "$resolved" | jq -r '
+        [.[] | select(.runStatusSource == "resolution-failed")
+             | (.runStatusReason // "no reason reported")]
+        | group_by(.) | map({reason: .[0], n: length}) | sort_by(-.n)[]
+        | "  " + (.n | tostring) + " of them: " + .reason'
     fi
   else
     echo 'RUN was not resolved (--no-runs), so nothing here says whether work is happening.'
@@ -579,17 +618,20 @@ cmd_show() {
   valid_agent_id "$agent" || die 2 "not a valid agent id: $agent"
 
   api_get "/v1/agents/$agent"
-  local agent_json triple
+  local agent_json
   agent_json=$(jq -c '.' "$BODY")
-  triple=$(latest_run_status "$agent" "$(printf '%s' "$agent_json" | jq -r '.latestRunId // ""')" 1)
-  # shellcheck disable=SC2086  # triple is three space-free tokens by construction
-  set -- $triple
+  read_run_status_record \
+    "$(latest_run_status "$agent" "$(printf '%s' "$agent_json" | jq -r '.latestRunId // ""')")"
 
   if [ "$json" -eq 1 ]; then
     printf '%s' "$agent_json" | jq \
-      --arg s "$1" --arg r "$2" --arg src "$3" '{
+      --arg s "$RUN_STATUS" --arg r "$RUN_ID" --arg src "$RUN_SOURCE" \
+      --arg reason "$RUN_REASON" '{
         schema: "fm-cursor-show.v1",
-        latestRun: {status: $s, id: $r, source: $src},
+        latestRun: {
+          status: $s, id: $r, source: $src,
+          reason: (if $reason == "" then null else $reason end)
+        },
         agent: .
       }'
     return 0
@@ -603,7 +645,11 @@ cmd_show() {
   printf '%s\n' "$(printf '%s' "$agent_json" | jq -r '.name // "(unnamed)"')"
   printf '  id           %s\n' "$(printf '%s' "$agent_json" | jq -r '.id')"
   printf '  environment  %s (%s)\n' "$(env_label "$env_name" "$env_type")" "${env_type:-unknown}"
-  printf '  latest run   %s\n' "$1"
+  if [ -n "$RUN_REASON" ]; then
+    printf '  latest run   %s (%s)\n' "$RUN_STATUS" "$RUN_REASON"
+  else
+    printf '  latest run   %s\n' "$RUN_STATUS"
+  fi
   printf '  lifecycle    %s\n' "$(printf '%s' "$agent_json" | jq -r '.status // "UNKNOWN" | ascii_downcase')"
   printf '  created      %s\n' "$(printf '%s' "$agent_json" | jq -r '.createdAt // "-"')"
   printf '  updated      %s\n' "$(printf '%s' "$agent_json" | jq -r '.updatedAt // "-"')"
@@ -622,6 +668,9 @@ cmd_show() {
     echo 'This agent was created from a repository list rather than a named environment, so it carries no predefined environment secrets.'
   fi
   echo 'lifecycle active means "not archived"; the latest run status above is what says whether work is happening.'
+  if [ -n "$RUN_REASON" ]; then
+    echo 'That latest run status is unknown because the request for it failed, not because the agent is idle; everything above it came back fine.'
+  fi
 }
 
 cmd_runs() {

--- a/bin/fm-cursor.sh
+++ b/bin/fm-cursor.sh
@@ -69,8 +69,15 @@
 # (CREATING|RUNNING|FINISHED|ERROR|CANCELLED|EXPIRED) as the primary column.
 # Resolution prefers the `latestRunId` field that list items carry in practice;
 # that field is NOT in Cursor's published schema, so a per-agent
-# `runs?limit=1` fallback covers its absence and the JSON output records which
-# source answered in `runStatusSource`.
+# `runs?limit=1` fallback covers both its absence AND a fast path whose request
+# fails, and the JSON output records which source answered in `runStatusSource`:
+# `latestRunId`, `runs-list`, `resolution-failed`, or `skipped` for --no-runs.
+# Per-agent resolution inside `list` is deliberately NON-FATAL, because it is the
+# one place a single request failure could discard an otherwise good answer: a 404
+# on a stale run id, or a 429 partway through 1+N serial requests, degrades that
+# one agent's RUN to `unknown` and the rest of the listing still prints. Every
+# other fetch - the list call itself, and all of `show`, `runs`, and `usage` -
+# still fails loudly, because there a failed request leaves nothing worth showing.
 #
 # Activation: read-only, and inert until this home opts in by putting a non-empty
 # CURSOR_API_KEY in its gitignored .env, mirroring how X mode gates on
@@ -101,12 +108,14 @@
 #   FM_CURSOR_ENV_FILE    read the key from this .env-style file instead
 #   FM_CONFIG_OVERRIDE    read config/ from this directory instead
 #   FM_CURSOR_API_BASE    API base URL (default https://api.cursor.com)
-#   FM_CURSOR_TIMEOUT     per-request timeout in seconds (default 30)
+#   FM_CURSOR_TIMEOUT     per-request timeout in seconds, a whole number from 1
+#                         to 3600 (default 30)
 #
 # Exit status:
 #   0  success
 #   2  usage error
-#   3  not configured (no CURSOR_API_KEY) or a required tool is missing
+#   3  not configured (no CURSOR_API_KEY), misconfigured (a key or timeout this
+#      helper refuses to hand to curl), or a required tool is missing
 #   4  the API rejected or failed the request
 set -eu
 
@@ -192,6 +201,13 @@ arm_auth() {
     *[!A-Za-z0-9._~+/=-]*)
       die 3 "the CURSOR_API_KEY in $env_file contains unexpected characters; re-copy it from https://cursor.com/dashboard/api" ;;
   esac
+  # The same config file carries the bearer header, and curl config syntax is one
+  # directive per line, so an unvalidated timeout is an injection point: a value
+  # holding a newline would append arbitrary directives (proxy, url, output) next
+  # to the key. Digits only, and a range, so a typo also fails legibly instead of
+  # degrading into an opaque "could not reach" error.
+  valid_timeout "$TIMEOUT" \
+    || die 3 "FM_CURSOR_TIMEOUT must be a whole number of seconds from 1 to 3600"
   umask 077
   CFG=$(mktemp "${TMPDIR:-/tmp}/.fm-cursor-auth.XXXXXX") \
     || die 3 "could not create a private file for the API key"
@@ -202,19 +218,30 @@ arm_auth() {
     || die 3 "could not create a response file"
 }
 
-# GET <path>; leaves the response body in $BODY. Fails loudly with the API's own
-# message, never with raw headers.
-api_get() {  # <path>
+# GET <path>; leaves the response body in $BODY. Returns 0 only on HTTP 200, and
+# otherwise returns non-zero with the explanation in $API_ERROR instead of
+# exiting, so a caller can choose between dying and degrading one row of a view.
+# The explanation carries the status and the API's own message, never raw headers.
+API_ERROR=
+api_try_get() {  # <path>
   local path=$1 code
+  API_ERROR=
   code=$(curl --config "$CFG" -o "$BODY" -w '%{http_code}' "$API_BASE$path" 2>/dev/null) || code=000
   case $code in
     200) return 0 ;;
-    000) die 4 "could not reach ${API_BASE} (network, proxy, or timeout after ${TIMEOUT}s)" ;;
-    401|403) die 4 "the Cursor API rejected the key (HTTP $code)$(api_message). Check CURSOR_API_KEY, or regenerate it at https://cursor.com/dashboard/api" ;;
-    404) die 4 "not found (HTTP 404)$(api_message)" ;;
-    429) die 4 "rate limited by the Cursor API (HTTP 429)$(api_message). Retry in a minute" ;;
-    *) die 4 "the Cursor API returned HTTP $code$(api_message)" ;;
+    000) API_ERROR="could not reach ${API_BASE} (network, proxy, or timeout after ${TIMEOUT}s)" ;;
+    401|403) API_ERROR="the Cursor API rejected the key (HTTP $code)$(api_message). Check CURSOR_API_KEY, or regenerate it at https://cursor.com/dashboard/api" ;;
+    404) API_ERROR="not found (HTTP 404)$(api_message)" ;;
+    429) API_ERROR="rate limited by the Cursor API (HTTP 429)$(api_message). Retry in a minute" ;;
+    *) API_ERROR="the Cursor API returned HTTP $code$(api_message)" ;;
   esac
+  return 1
+}
+
+# GET <path> or die. The right shape for a fetch whose failure leaves nothing to
+# show: every top-level fetch, including the `list` page itself.
+api_get() {  # <path>
+  api_try_get "$1" || die 4 "$API_ERROR"
 }
 
 # The API's own error text, when the body is JSON carrying one. Never the body
@@ -241,20 +268,43 @@ valid_limit() {  # <n>
   esac
 }
 
+# Digits only, then a range. The 5-or-more-digit pattern is refused before any
+# arithmetic so an absurd value cannot reach `[ -ge ]` at all.
+valid_timeout() {  # <seconds>
+  case $1 in
+    '' | *[!0-9]* | ?????*) return 1 ;;
+    *) [ "$1" -ge 1 ] && [ "$1" -le 3600 ] ;;
+  esac
+}
+
 # Latest run status for one agent. Echoes "<status> <runId> <source>".
 # Prefers the caller-supplied latestRunId, falls back to the runs list, and
 # reports "none none none" for an agent that has no run yet.
-latest_run_status() {  # <agent-id> <latest-run-id-or-empty>
-  local agent=$1 run=$2 status
+#
+# A failed fast-path request falls THROUGH to the runs-list fallback: the
+# latestRunId that drove it is not in Cursor's published schema, so a stale or
+# removed run id answering 404 is an expected shape, not a fatal one. When the
+# fallback fails too, resolution degrades to "unknown none resolution-failed" so
+# one bad request costs one row rather than the whole view. Pass strict=1 for a
+# single-agent view, where an unresolvable latest run is the answer being asked
+# for and hiding the reason would be worse than failing.
+latest_run_status() {  # <agent-id> <latest-run-id-or-empty> [strict]
+  local agent=$1 run=$2 strict=${3:-0} status
   if [ -n "$run" ] && [ "$run" != null ]; then
     if valid_agent_id "$run"; then
-      api_get "/v1/agents/$agent/runs/$run"
-      status=$(jq -r '.status // "none"' "$BODY")
-      printf '%s %s %s' "$status" "$run" latestRunId
-      return 0
+      if api_try_get "/v1/agents/$agent/runs/$run"; then
+        status=$(jq -r '.status // "none"' "$BODY")
+        printf '%s %s %s' "$status" "$run" latestRunId
+        return 0
+      fi
+      [ "$strict" -eq 0 ] || die 4 "$API_ERROR"
     fi
   fi
-  api_get "/v1/agents/$agent/runs?limit=1"
+  if ! api_try_get "/v1/agents/$agent/runs?limit=1"; then
+    [ "$strict" -eq 0 ] || die 4 "$API_ERROR"
+    printf 'unknown none resolution-failed'
+    return 0
+  fi
   status=$(jq -r '(.items // [])[0].status // "none"' "$BODY")
   run=$(jq -r '(.items // [])[0].id // "none"' "$BODY")
   if [ "$status" = none ]; then
@@ -276,12 +326,16 @@ env_label() {  # <env-name> <env-type>
   fi
 }
 
-trunc() {  # <string> <width>
-  local s=$1 w=$2
-  if [ "${#s}" -gt "$w" ]; then
-    printf '%s...' "${s:0:$((w - 3))}"
-  else
-    printf '%s' "$s"
+# Footer for an --env-narrowed view. Emitted whatever the match count is,
+# including zero: Cursor's list endpoint has no environment filter, so --limit
+# bounds the FETCH and a missing match may simply be on the next page. Reporting
+# only "none found" would read as "this home has no cloud agents".
+filtered_footer() {  # <matched> <fetched> <env-name>
+  printf 'Filtered to environment %s: %s of %s fetched agent(s) match. --limit bounds the fetch, not the matches, so raise it if a match is missing.\n' \
+    "$3" "$1" "$2"
+  if [ "$1" -eq 0 ] && [ "$2" -gt 0 ]; then
+    printf 'Agents were fetched, so this is not an empty fleet: none of the %s fetched is in %s. Drop --env to see every environment.\n' \
+      "$2" "$3"
   fi
 }
 
@@ -347,28 +401,31 @@ cmd_list() {
   fi
 
   # Resolve each agent's latest run one at a time. Serial on purpose: a burst of
-  # parallel requests is the fastest way to meet the API's rate limiter.
+  # parallel requests is the fastest way to meet the API's rate limiter. The ids
+  # come out of one jq pass and the resolved triples are stitched back on in one
+  # more, rather than rebuilding the whole accumulating array once per agent.
   local resolved='[]'
   if [ "$resolve_runs" -eq 1 ]; then
-    local n i row agent_id run_id triple
-    n=$(printf '%s' "$agents" | jq 'length')
-    i=0
-    while [ "$i" -lt "$n" ]; do
-      row=$(printf '%s' "$agents" | jq -c ".[$i]")
-      agent_id=$(printf '%s' "$row" | jq -r '.id')
-      run_id=$(printf '%s' "$row" | jq -r '.latestRunId')
+    local statuses='' agent_id run_id triple
+    while IFS=$(printf '\t') read -r agent_id run_id; do
+      # One triple per line, unconditionally: the stitch below matches triples to
+      # agents by position, so skipping an unusable row would shift every status
+      # after it onto the wrong agent.
       if valid_agent_id "$agent_id"; then
         triple=$(latest_run_status "$agent_id" "$run_id")
       else
         triple='none none none'
       fi
-      # shellcheck disable=SC2086  # triple is three space-free tokens by construction
-      set -- $triple
-      resolved=$(printf '%s' "$resolved" | jq -c \
-        --argjson row "$row" --arg s "$1" --arg r "$2" --arg src "$3" \
-        '. + [$row + {runStatus: $s, runId: $r, runStatusSource: $src}]')
-      i=$((i + 1))
-    done
+      statuses="$statuses$triple"$'\n'
+    done <<EOF
+$(printf '%s' "$agents" | jq -r '.[] | [.id, .latestRunId] | @tsv')
+EOF
+    resolved=$(printf '%s' "$agents" | jq -c --arg statuses "$statuses" '
+      ($statuses | split("\n") | map(select(length > 0) | split(" "))) as $t
+      | to_entries
+      | map(.value + {
+          runStatus: $t[.key][0], runId: $t[.key][1], runStatusSource: $t[.key][2]
+        })')
   else
     resolved=$(printf '%s' "$agents" | jq -c \
       'map(. + {runStatus: "unresolved", runId: "", runStatusSource: "skipped"})')
@@ -403,10 +460,25 @@ cmd_list() {
     return 0
   fi
 
-  local count
-  count=$(printf '%s' "$resolved" | jq 'length')
+  # One pass for every count the footer needs, rather than one jq per number.
+  local counts count running named unresolved
+  counts=$(printf '%s' "$resolved" | jq -r '[
+      length,
+      ([.[] | select(.runStatus == "RUNNING" or .runStatus == "CREATING")] | length),
+      ([.[] | select(.envName != "") | .envName] | unique | length),
+      ([.[] | select(.runStatusSource == "resolution-failed")] | length)
+    ] | @tsv')
+  IFS=$(printf '\t') read -r count running named unresolved <<EOF
+$counts
+EOF
+
   if [ "$count" -eq 0 ]; then
     echo "No Cursor Cloud agents found."
+    # An empty FILTERED view is a different fact from an empty fleet, and the
+    # --limit caveat matters most exactly here: the match may be one page away.
+    if [ "$filtering" -eq 1 ]; then
+      filtered_footer "$count" "$fetched" "$env_filter"
+    fi
     return 0
   fi
 
@@ -421,49 +493,54 @@ cmd_list() {
     # shellcheck disable=SC2059
     printf "$row_fmt" AGENT RUN UPDATED ENVIRONMENT REPOS NAME
   fi
-  local i=0 row
-  while [ "$i" -lt "$count" ]; do
-    row=$(printf '%s' "$resolved" | jq -c ".[$i]")
-    local id run life upd envl repos name
-    id=$(printf '%s' "$row" | jq -r '.id')
-    run=$(printf '%s' "$row" | jq -r '.runStatus')
-    life=$(printf '%s' "$row" | jq -r '.lifecycle | ascii_downcase')
-    upd=$(printf '%s' "$row" | jq -r '.updatedAt' | tr T ' ' | cut -c1-16)
-    local env_name
-    env_name=$(printf '%s' "$row" | jq -r '.envName')
-    envl=$(env_label "$env_name" "$(printf '%s' "$row" | jq -r '.envType')")
-    # Truncate first, then append the default marker, so a long environment name
-    # can never swallow the marker the way it would if the assembled label were
-    # cut to width.
-    envl=$(trunc "$envl" 18)
-    if [ -n "$default_env" ] && [ "$env_name" = "$default_env" ]; then
-      envl="$envl *"
-    fi
-    repos=$(printf '%s' "$row" | jq -r '.repos | length')
-    name=$(printf '%s' "$row" | jq -r '.name')
+  # One jq pass renders every cell, including the environment label, its
+  # truncation, and the default marker, then the read loop only pads columns.
+  # A unit separator rather than a tab, because tab is IFS whitespace to `read`
+  # and an empty middle cell - an agent with no updatedAt - would collapse the
+  # row by one column.
+  local sep
+  sep=$(printf '\037')
+  # Truncate the environment label first, then append the default marker, so a
+  # long environment name can never swallow the marker the way it would if the
+  # assembled label were cut to width.
+  printf '%s' "$resolved" | jq -r --arg defaultEnv "$default_env" '
+    def trunc($w): if length > $w then .[0:($w - 3)] + "..." else . end;
+    .[]
+    | ((if .envName != "" then .envName
+        else "(ad-hoc " + (if .envType != "" then .envType else "cloud" end) + ")" end)
+       | trunc(18)) as $envl
+    | [
+        .id,
+        .runStatus,
+        (.lifecycle | ascii_downcase),
+        (.updatedAt | gsub("T"; " ") | .[0:16]),
+        (if $defaultEnv != "" and .envName == $defaultEnv then $envl + " *" else $envl end),
+        (.repos | length | tostring),
+        (.name | trunc(34))
+      ] | join("\u001f")' |
+  while IFS="$sep" read -r id run life upd envl repos name; do
     if [ "$include_archived" = true ]; then
       # shellcheck disable=SC2059
-      printf "$row_fmt" "${id: -8}" "$run" "$life" "$upd" "$envl" "$repos" "$(trunc "$name" 34)"
+      printf "$row_fmt" "${id: -8}" "$run" "$life" "$upd" "$envl" "$repos" "$name"
     else
       # shellcheck disable=SC2059
-      printf "$row_fmt" "${id: -8}" "$run" "$upd" "$envl" "$repos" "$(trunc "$name" 34)"
+      printf "$row_fmt" "${id: -8}" "$run" "$upd" "$envl" "$repos" "$name"
     fi
-    i=$((i + 1))
   done
 
-  local running named
-  running=$(printf '%s' "$resolved" | jq '[.[] | select(.runStatus == "RUNNING" or .runStatus == "CREATING")] | length')
-  named=$(printf '%s' "$resolved" | jq -r '[.[] | select(.envName != "") | .envName] | unique | length')
   echo
   printf '%s agent(s) shown, %s with a run in flight' "$count" "$running"
   [ "$named" -eq 0 ] || printf ', across %s named environment(s)' "$named"
   printf '.\n'
   if [ "$filtering" -eq 1 ]; then
-    printf 'Filtered to environment %s: %s of %s fetched agent(s) match. --limit bounds the fetch, not the matches, so raise it if a match is missing.\n' \
-      "$env_filter" "$count" "$fetched"
+    filtered_footer "$count" "$fetched" "$env_filter"
   fi
   if [ "$resolve_runs" -eq 1 ]; then
     echo 'RUN is the latest run status and is what says whether work is happening.'
+    if [ "$unresolved" -gt 0 ]; then
+      printf 'RUN is unknown for %s agent(s) whose latest run could not be fetched; every other row is unaffected.\n' \
+        "$unresolved"
+    fi
   else
     echo 'RUN was not resolved (--no-runs), so nothing here says whether work is happening.'
   fi
@@ -504,7 +581,7 @@ cmd_show() {
   api_get "/v1/agents/$agent"
   local agent_json triple
   agent_json=$(jq -c '.' "$BODY")
-  triple=$(latest_run_status "$agent" "$(printf '%s' "$agent_json" | jq -r '.latestRunId // ""')")
+  triple=$(latest_run_status "$agent" "$(printf '%s' "$agent_json" | jq -r '.latestRunId // ""')" 1)
   # shellcheck disable=SC2086  # triple is three space-free tokens by construction
   set -- $triple
 

--- a/bin/fm-cursor.sh
+++ b/bin/fm-cursor.sh
@@ -1,0 +1,668 @@
+#!/usr/bin/env bash
+# fm-cursor.sh - read-only view of THIS operator's own Cursor Cloud agents.
+#
+# Cursor Cloud agents run on Cursor's infrastructure, not in a firstmate
+# worktree or terminal endpoint, so they are deliberately NOT a runtime backend
+# (bin/fm-backend.sh) and NOT a harness (bin/fm-harness.sh): there is no pane to
+# capture, no composer to submit into, and no local checkout to isolate. This
+# helper is the companion-surface pattern instead, the same boundary
+# docs/codex-app-backend.md draws for Codex Desktop threads. It creates no task
+# records and registers no watcher check, so no supervision path can mistake a
+# cloud agent for a stalled local crewmate.
+#
+# The mapping onto firstmate's own nouns is: a Cursor AGENT is a task, and a
+# Cursor ENVIRONMENT is the project. An environment is a named, multi-repo,
+# secret-bearing context, and `POST /v1/agents` accepts either a named `env` or a
+# bare `repos` list - the API documents them as mutually exclusive. An agent
+# therefore belongs to its environment, never to one of the repositories inside
+# it, and a change spanning a front end and a back end is one agent in one
+# environment rather than several tasks. Both `list` and `show` lead with the
+# environment for that reason; an agent created from a bare repo list has no
+# environment name and is shown as the ad-hoc case.
+#
+# Usage:
+#   fm-cursor.sh list  [--json] [--all] [--limit <n>] [--no-runs] [--env [<name>]]
+#   fm-cursor.sh show  <agent-id> [--json]
+#   fm-cursor.sh runs  <agent-id> [--json] [--limit <n>]
+#   fm-cursor.sh usage <agent-id> [--json]
+#   fm-cursor.sh -h | --help
+#
+# Subcommands:
+#   list   Agents newest-first, each with its ENVIRONMENT and the status of its
+#          LATEST RUN. Archived agents are hidden unless --all is passed.
+#   show   One agent's detail: its environment, every repository in that
+#          environment, and the status of its latest run.
+#   runs   Run history for one agent: status, start, duration, and any PR URL.
+#   usage  Token usage for one agent, totalled and per run.
+#
+# Options:
+#   --json        Emit a stable JSON document instead of the human table.
+#                 Schemas: fm-cursor-list.v1, fm-cursor-show.v1,
+#                 fm-cursor-runs.v1, fm-cursor-usage.v1.
+#   --all         list only: include ARCHIVED agents.
+#   --limit <n>   list: agents to fetch, 1-100, default 20.
+#                 runs: runs to fetch, 1-100, default 20.
+#   --no-runs     list only: skip latest-run resolution. One API call instead of
+#                 1+N, at the cost of the only column that says what is actually
+#                 running.
+#   --env [<name>]
+#                 list only: show only agents in that environment. A bare --env
+#                 means this home's default from config/cursor-environment, and
+#                 fails when no default is configured. Cursor's list endpoint has
+#                 no environment filter, so this narrows the fetched page
+#                 client-side: --limit bounds the FETCH, not the matches, and the
+#                 footer reports both counts. Filtering happens before run
+#                 resolution, so a narrow --env costs far fewer requests.
+#
+# The default environment never filters implicitly. `list` always shows every
+# environment and marks the default with `*`, because silently hiding most of the
+# fleet would misrepresent it; the default is the intended TARGET for a future
+# operation that needs an environment, not a view preference.
+#
+# Why list resolves runs by default: an agent's own `status` field is LIFECYCLE
+# only - the enum is ACTIVE|ARCHIVED and the Cursor API documents it as "agent
+# lifecycle state; execution status lives on runs". ACTIVE therefore means "not
+# archived", NOT "currently running": a finished agent stays ACTIVE until
+# somebody archives it. Reporting agent status as if it were execution status is
+# the single easiest way to misread this fleet, so `list` resolves each agent's
+# latest run and reports the run status enum
+# (CREATING|RUNNING|FINISHED|ERROR|CANCELLED|EXPIRED) as the primary column.
+# Resolution prefers the `latestRunId` field that list items carry in practice;
+# that field is NOT in Cursor's published schema, so a per-agent
+# `runs?limit=1` fallback covers its absence and the JSON output records which
+# source answered in `runStatusSource`.
+#
+# Activation: read-only, and inert until this home opts in by putting a non-empty
+# CURSOR_API_KEY in its gitignored .env, mirroring how X mode gates on
+# FMX_PAIRING_TOKEN. The key is read from that file ONLY. This helper never
+# consults the macOS keychain, `cursor-agent`'s stored credentials, or an ambient
+# CURSOR_API_KEY in the environment: an undocumented credential lifted from
+# another tool's store is not a supported Cursor credential, and an ambient
+# variable would silently change which account firstmate speaks for.
+#
+# Credential handling: the key is passed to curl through a mode-0600 config file
+# that is removed on every exit path, never through argv, because a process
+# argument is world-readable via `ps`. The key is never printed, never logged,
+# and never included in an error message; HTTP failures report the status code
+# and the API's own `message` field only.
+#
+# Every call is a GET. This helper has no verb that creates, steers, cancels,
+# archives, or deletes anything, so it cannot alter the operator's fleet.
+#
+# Files:
+#   $FM_HOME/.env                     CURSOR_API_KEY, the activation gate
+#   $FM_HOME/config/cursor-environment
+#                                     optional default environment name: the
+#                                     first non-empty, non-comment line, trimmed,
+#                                     used verbatim. Absent means no default.
+#
+# Environment:
+#   FM_HOME               home whose .env and config/ are read (default: this checkout)
+#   FM_CURSOR_ENV_FILE    read the key from this .env-style file instead
+#   FM_CONFIG_OVERRIDE    read config/ from this directory instead
+#   FM_CURSOR_API_BASE    API base URL (default https://api.cursor.com)
+#   FM_CURSOR_TIMEOUT     per-request timeout in seconds (default 30)
+#
+# Exit status:
+#   0  success
+#   2  usage error
+#   3  not configured (no CURSOR_API_KEY) or a required tool is missing
+#   4  the API rejected or failed the request
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+# fmx_env_get is the repo's single .env-style reader (last assignment wins,
+# tolerates `export ` and one layer of quotes). Reuse it rather than rolling a
+# second parser; bin/fm-public-followup-lib.sh depends on it the same way.
+# shellcheck source=bin/fm-x-lib.sh
+. "$SCRIPT_DIR/fm-x-lib.sh"
+
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+API_BASE=${FM_CURSOR_API_BASE:-https://api.cursor.com}
+API_BASE=${API_BASE%/}
+TIMEOUT=${FM_CURSOR_TIMEOUT:-30}
+
+# This home's default environment, from config/cursor-environment: the first
+# non-empty, non-comment line with surrounding whitespace trimmed, matching how
+# bin/fm-harness.sh reads config/secondmate-harness. Absent file, or a file with
+# only blank and comment lines, means this home has no default. The name is used
+# verbatim otherwise, because Cursor environment names contain spaces and are
+# case-sensitive.
+default_environment() {
+  local line
+  [ -f "$CONFIG/cursor-environment" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -n "$line" ] || continue
+    case "$line" in
+      '#'*) continue ;;
+    esac
+    printf '%s' "$line"
+    return 0
+  done < "$CONFIG/cursor-environment"
+}
+
+CFG=
+BODY=
+cleanup() {
+  [ -z "$CFG" ] || rm -f -- "$CFG"
+  [ -z "$BODY" ] || rm -f -- "$BODY"
+}
+trap cleanup EXIT HUP INT TERM
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+die() {  # <exit-code> <message...>
+  local code=$1
+  shift
+  printf 'fm-cursor: %s\n' "$*" >&2
+  exit "$code"
+}
+
+require_tools() {
+  local tool
+  for tool in curl jq; do
+    command -v "$tool" >/dev/null 2>&1 \
+      || die 3 "$tool is required (install: brew install $tool  # or the platform's package manager)"
+  done
+}
+
+# Arm curl with the operator's key in a mode-0600 config file. The key never
+# reaches argv, so it is not visible in `ps`.
+arm_auth() {
+  local env_file token
+  env_file=${FM_CURSOR_ENV_FILE:-$FM_HOME/.env}
+  token=$(fmx_env_get CURSOR_API_KEY "$env_file")
+  if [ -z "$token" ]; then
+    die 3 "Cursor Cloud is not configured for this home. Put a non-empty CURSOR_API_KEY in $env_file (create the key at https://cursor.com/dashboard/api). Until then this helper does nothing."
+  fi
+  # Refuse a key carrying characters that curl config quoting would mangle or
+  # that could inject a second directive. Real keys are URL-safe base64.
+  case $token in
+    *[!A-Za-z0-9._~+/=-]*)
+      die 3 "the CURSOR_API_KEY in $env_file contains unexpected characters; re-copy it from https://cursor.com/dashboard/api" ;;
+  esac
+  umask 077
+  CFG=$(mktemp "${TMPDIR:-/tmp}/.fm-cursor-auth.XXXXXX") \
+    || die 3 "could not create a private file for the API key"
+  chmod 600 "$CFG" || die 3 "could not restrict permissions on the API key file"
+  printf 'header = "Authorization: Bearer %s"\nsilent\nshow-error\nmax-time = %s\n' \
+    "$token" "$TIMEOUT" > "$CFG" || die 3 "could not write the API key file"
+  BODY=$(mktemp "${TMPDIR:-/tmp}/.fm-cursor-body.XXXXXX") \
+    || die 3 "could not create a response file"
+}
+
+# GET <path>; leaves the response body in $BODY. Fails loudly with the API's own
+# message, never with raw headers.
+api_get() {  # <path>
+  local path=$1 code
+  code=$(curl --config "$CFG" -o "$BODY" -w '%{http_code}' "$API_BASE$path" 2>/dev/null) || code=000
+  case $code in
+    200) return 0 ;;
+    000) die 4 "could not reach ${API_BASE} (network, proxy, or timeout after ${TIMEOUT}s)" ;;
+    401|403) die 4 "the Cursor API rejected the key (HTTP $code)$(api_message). Check CURSOR_API_KEY, or regenerate it at https://cursor.com/dashboard/api" ;;
+    404) die 4 "not found (HTTP 404)$(api_message)" ;;
+    429) die 4 "rate limited by the Cursor API (HTTP 429)$(api_message). Retry in a minute" ;;
+    *) die 4 "the Cursor API returned HTTP $code$(api_message)" ;;
+  esac
+}
+
+# The API's own error text, when the body is JSON carrying one. Never the body
+# wholesale, so a surprise payload cannot spill into a log.
+api_message() {
+  local msg
+  msg=$(jq -r 'if type == "object" and (.message? | type) == "string" then .message else empty end' \
+    "$BODY" 2>/dev/null) || return 0
+  [ -n "$msg" ] || return 0
+  printf ': %s' "$msg"
+}
+
+valid_agent_id() {  # <id>
+  case $1 in
+    '' | *[!A-Za-z0-9_-]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+valid_limit() {  # <n>
+  case $1 in
+    '' | *[!0-9]*) return 1 ;;
+    *) [ "$1" -ge 1 ] && [ "$1" -le 100 ] ;;
+  esac
+}
+
+# Latest run status for one agent. Echoes "<status> <runId> <source>".
+# Prefers the caller-supplied latestRunId, falls back to the runs list, and
+# reports "none none none" for an agent that has no run yet.
+latest_run_status() {  # <agent-id> <latest-run-id-or-empty>
+  local agent=$1 run=$2 status
+  if [ -n "$run" ] && [ "$run" != null ]; then
+    if valid_agent_id "$run"; then
+      api_get "/v1/agents/$agent/runs/$run"
+      status=$(jq -r '.status // "none"' "$BODY")
+      printf '%s %s %s' "$status" "$run" latestRunId
+      return 0
+    fi
+  fi
+  api_get "/v1/agents/$agent/runs?limit=1"
+  status=$(jq -r '(.items // [])[0].status // "none"' "$BODY")
+  run=$(jq -r '(.items // [])[0].id // "none"' "$BODY")
+  if [ "$status" = none ]; then
+    printf 'none none none'
+  else
+    printf '%s %s %s' "$status" "$run" runs-list
+  fi
+}
+
+# Display label for the agent's environment, which is where the work actually
+# lives. A named environment prints its name; an agent created from a bare repo
+# list has no name, so it prints as the ad-hoc case rather than as a blank that
+# would read like missing data.
+env_label() {  # <env-name> <env-type>
+  if [ -n "$1" ]; then
+    printf '%s' "$1"
+  else
+    printf '(ad-hoc %s)' "${2:-cloud}"
+  fi
+}
+
+trunc() {  # <string> <width>
+  local s=$1 w=$2
+  if [ "${#s}" -gt "$w" ]; then
+    printf '%s...' "${s:0:$((w - 3))}"
+  else
+    printf '%s' "$s"
+  fi
+}
+
+cmd_list() {
+  local json=0 include_archived=false limit=20 resolve_runs=1 env_filter='' filtering=0
+  local default_env
+  default_env=$(default_environment)
+  while [ "$#" -gt 0 ]; do
+    case $1 in
+      --json) json=1 ;;
+      --all) include_archived=true ;;
+      --no-runs) resolve_runs=0 ;;
+      --env)
+        # Optional argument: a bare --env means "this home's default".
+        filtering=1
+        if [ "$#" -ge 2 ] && [ -n "$2" ] && [ "${2#-}" = "$2" ]; then
+          env_filter=$2
+          shift
+        elif [ "$#" -ge 2 ] && [ -z "$2" ]; then
+          # An empty name would quietly select the ad-hoc agents, whose envName is
+          # "". Refuse instead of guessing which of the two was meant.
+          die 2 "--env needs a non-empty environment name; omit the name to use this home's default"
+        else
+          [ -n "$default_env" ] || die 2 "--env with no name needs a default environment in $CONFIG/cursor-environment; pass --env <name> instead"
+          env_filter=$default_env
+        fi
+        ;;
+      --env=*)
+        filtering=1
+        env_filter=${1#--env=}
+        [ -n "$env_filter" ] || die 2 "--env= needs a name"
+        ;;
+      --limit)
+        [ "$#" -ge 2 ] || die 2 "--limit needs a value"
+        valid_limit "$2" || die 2 "--limit must be a whole number from 1 to 100"
+        limit=$2
+        shift
+        ;;
+      --limit=*)
+        valid_limit "${1#--limit=}" || die 2 "--limit must be a whole number from 1 to 100"
+        limit=${1#--limit=}
+        ;;
+      *) die 2 "unknown option for list: $1" ;;
+    esac
+    shift
+  done
+
+  api_get "/v1/agents?limit=$limit&includeArchived=$include_archived"
+  local agents fetched
+  agents=$(jq -c '[(.items // [])[] | {
+      id, name: (.name // ""), lifecycle: (.status // "UNKNOWN"),
+      latestRunId: (.latestRunId // ""), createdAt: (.createdAt // ""),
+      updatedAt: (.updatedAt // ""), url: (.url // ""),
+      envType: (.env.type // ""), envName: (.env.name // ""),
+      repos: [(.repos // [])[] | .url]
+    }]' "$BODY")
+  fetched=$(printf '%s' "$agents" | jq 'length')
+
+  # Filter BEFORE resolving runs: run resolution costs one request per agent, so
+  # narrowing first is the difference between one extra request and N.
+  if [ "$filtering" -eq 1 ]; then
+    agents=$(printf '%s' "$agents" | jq -c --arg e "$env_filter" 'map(select(.envName == $e))')
+  fi
+
+  # Resolve each agent's latest run one at a time. Serial on purpose: a burst of
+  # parallel requests is the fastest way to meet the API's rate limiter.
+  local resolved='[]'
+  if [ "$resolve_runs" -eq 1 ]; then
+    local n i row agent_id run_id triple
+    n=$(printf '%s' "$agents" | jq 'length')
+    i=0
+    while [ "$i" -lt "$n" ]; do
+      row=$(printf '%s' "$agents" | jq -c ".[$i]")
+      agent_id=$(printf '%s' "$row" | jq -r '.id')
+      run_id=$(printf '%s' "$row" | jq -r '.latestRunId')
+      if valid_agent_id "$agent_id"; then
+        triple=$(latest_run_status "$agent_id" "$run_id")
+      else
+        triple='none none none'
+      fi
+      # shellcheck disable=SC2086  # triple is three space-free tokens by construction
+      set -- $triple
+      resolved=$(printf '%s' "$resolved" | jq -c \
+        --argjson row "$row" --arg s "$1" --arg r "$2" --arg src "$3" \
+        '. + [$row + {runStatus: $s, runId: $r, runStatusSource: $src}]')
+      i=$((i + 1))
+    done
+  else
+    resolved=$(printf '%s' "$agents" | jq -c \
+      'map(. + {runStatus: "unresolved", runId: "", runStatusSource: "skipped"})')
+  fi
+
+  if [ "$json" -eq 1 ]; then
+    printf '%s' "$resolved" | jq \
+      --arg base "$API_BASE" --argjson archived "$include_archived" \
+      --arg defaultEnv "$default_env" --arg envFilter "$env_filter" \
+      --argjson fetched "$fetched" \
+      --argjson resolvedRuns "$([ "$resolve_runs" -eq 1 ] && echo true || echo false)" '{
+        schema: "fm-cursor-list.v1",
+        base: $base,
+        archivedIncluded: $archived,
+        runsResolved: $resolvedRuns,
+        defaultEnvironment: (if $defaultEnv == "" then null else $defaultEnv end),
+        environmentFilter: (if $envFilter == "" then null else $envFilter end),
+        fetched: $fetched,
+        count: length,
+        summary: {
+          running: [.[] | select(.runStatus == "RUNNING" or .runStatus == "CREATING")] | length,
+          multiRepo: [.[] | select((.repos | length) > 1)] | length,
+          namedEnvironments: ([.[] | select(.envName != "") | .envName] | unique),
+          byLifecycle: (group_by(.lifecycle) | map({key: .[0].lifecycle, value: length}) | from_entries),
+          byRunStatus: (group_by(.runStatus) | map({key: .[0].runStatus, value: length}) | from_entries),
+          byEnvironment: (group_by(.envName)
+            | map({key: (if .[0].envName == "" then "(ad-hoc)" else .[0].envName end), value: length})
+            | from_entries)
+        },
+        agents: .
+      }'
+    return 0
+  fi
+
+  local count
+  count=$(printf '%s' "$resolved" | jq 'length')
+  if [ "$count" -eq 0 ]; then
+    echo "No Cursor Cloud agents found."
+    return 0
+  fi
+
+  # LIFECYCLE earns a column only with --all: without it every listed agent is
+  # ACTIVE by construction, so the column would be a constant.
+  local row_fmt='%-9s %-10s %-16s %-20s %5s  %s\n'
+  if [ "$include_archived" = true ]; then
+    row_fmt='%-9s %-10s %-9s %-16s %-20s %5s  %s\n'
+    # shellcheck disable=SC2059  # row_fmt is a trusted local format string
+    printf "$row_fmt" AGENT RUN LIFECYCLE UPDATED ENVIRONMENT REPOS NAME
+  else
+    # shellcheck disable=SC2059
+    printf "$row_fmt" AGENT RUN UPDATED ENVIRONMENT REPOS NAME
+  fi
+  local i=0 row
+  while [ "$i" -lt "$count" ]; do
+    row=$(printf '%s' "$resolved" | jq -c ".[$i]")
+    local id run life upd envl repos name
+    id=$(printf '%s' "$row" | jq -r '.id')
+    run=$(printf '%s' "$row" | jq -r '.runStatus')
+    life=$(printf '%s' "$row" | jq -r '.lifecycle | ascii_downcase')
+    upd=$(printf '%s' "$row" | jq -r '.updatedAt' | tr T ' ' | cut -c1-16)
+    local env_name
+    env_name=$(printf '%s' "$row" | jq -r '.envName')
+    envl=$(env_label "$env_name" "$(printf '%s' "$row" | jq -r '.envType')")
+    # Truncate first, then append the default marker, so a long environment name
+    # can never swallow the marker the way it would if the assembled label were
+    # cut to width.
+    envl=$(trunc "$envl" 18)
+    if [ -n "$default_env" ] && [ "$env_name" = "$default_env" ]; then
+      envl="$envl *"
+    fi
+    repos=$(printf '%s' "$row" | jq -r '.repos | length')
+    name=$(printf '%s' "$row" | jq -r '.name')
+    if [ "$include_archived" = true ]; then
+      # shellcheck disable=SC2059
+      printf "$row_fmt" "${id: -8}" "$run" "$life" "$upd" "$envl" "$repos" "$(trunc "$name" 34)"
+    else
+      # shellcheck disable=SC2059
+      printf "$row_fmt" "${id: -8}" "$run" "$upd" "$envl" "$repos" "$(trunc "$name" 34)"
+    fi
+    i=$((i + 1))
+  done
+
+  local running named
+  running=$(printf '%s' "$resolved" | jq '[.[] | select(.runStatus == "RUNNING" or .runStatus == "CREATING")] | length')
+  named=$(printf '%s' "$resolved" | jq -r '[.[] | select(.envName != "") | .envName] | unique | length')
+  echo
+  printf '%s agent(s) shown, %s with a run in flight' "$count" "$running"
+  [ "$named" -eq 0 ] || printf ', across %s named environment(s)' "$named"
+  printf '.\n'
+  if [ "$filtering" -eq 1 ]; then
+    printf 'Filtered to environment %s: %s of %s fetched agent(s) match. --limit bounds the fetch, not the matches, so raise it if a match is missing.\n' \
+      "$env_filter" "$count" "$fetched"
+  fi
+  if [ "$resolve_runs" -eq 1 ]; then
+    echo 'RUN is the latest run status and is what says whether work is happening.'
+  else
+    echo 'RUN was not resolved (--no-runs), so nothing here says whether work is happening.'
+  fi
+  if [ "$include_archived" = true ]; then
+    echo 'LIFECYCLE active means "not archived" - a finished agent stays active until archived.'
+  else
+    echo 'Every agent listed is unarchived, which says nothing about whether it ran; pass --all to include archived ones.'
+  fi
+  echo 'ENVIRONMENT is where the work runs and carries that environment'"'"'s repositories and secrets; REPOS is how many repositories it spans.'
+  echo 'An agent belongs to its environment, not to any single repository; use show for the repository list.'
+  if [ -n "$default_env" ]; then
+    if [ "$filtering" -eq 1 ]; then
+      printf '* marks this home'"'"'s default environment, %s, from config/cursor-environment.\n' "$default_env"
+    else
+      printf '* marks this home'"'"'s default environment, %s, from config/cursor-environment; every environment is still listed.\n' "$default_env"
+      printf 'Pass --env to narrow to %s, or --env <name> for another environment.\n' "$default_env"
+    fi
+  fi
+  printf 'Agent ids are shown short; use the full id from --json with show, runs, or usage.\n'
+}
+
+cmd_show() {
+  local json=0 agent=''
+  while [ "$#" -gt 0 ]; do
+    case $1 in
+      --json) json=1 ;;
+      -*) die 2 "unknown option for show: $1" ;;
+      *)
+        [ -z "$agent" ] || die 2 "show takes exactly one agent id"
+        agent=$1
+        ;;
+    esac
+    shift
+  done
+  [ -n "$agent" ] || die 2 "show needs an agent id (see: fm-cursor.sh list)"
+  valid_agent_id "$agent" || die 2 "not a valid agent id: $agent"
+
+  api_get "/v1/agents/$agent"
+  local agent_json triple
+  agent_json=$(jq -c '.' "$BODY")
+  triple=$(latest_run_status "$agent" "$(printf '%s' "$agent_json" | jq -r '.latestRunId // ""')")
+  # shellcheck disable=SC2086  # triple is three space-free tokens by construction
+  set -- $triple
+
+  if [ "$json" -eq 1 ]; then
+    printf '%s' "$agent_json" | jq \
+      --arg s "$1" --arg r "$2" --arg src "$3" '{
+        schema: "fm-cursor-show.v1",
+        latestRun: {status: $s, id: $r, source: $src},
+        agent: .
+      }'
+    return 0
+  fi
+
+  local env_name env_type repo_count
+  env_name=$(printf '%s' "$agent_json" | jq -r '.env.name // ""')
+  env_type=$(printf '%s' "$agent_json" | jq -r '.env.type // ""')
+  repo_count=$(printf '%s' "$agent_json" | jq '(.repos // []) | length')
+
+  printf '%s\n' "$(printf '%s' "$agent_json" | jq -r '.name // "(unnamed)"')"
+  printf '  id           %s\n' "$(printf '%s' "$agent_json" | jq -r '.id')"
+  printf '  environment  %s (%s)\n' "$(env_label "$env_name" "$env_type")" "${env_type:-unknown}"
+  printf '  latest run   %s\n' "$1"
+  printf '  lifecycle    %s\n' "$(printf '%s' "$agent_json" | jq -r '.status // "UNKNOWN" | ascii_downcase')"
+  printf '  created      %s\n' "$(printf '%s' "$agent_json" | jq -r '.createdAt // "-"')"
+  printf '  updated      %s\n' "$(printf '%s' "$agent_json" | jq -r '.updatedAt // "-"')"
+  printf '  url          %s\n' "$(printf '%s' "$agent_json" | jq -r '.url // "-"')"
+  printf '  repositories %s in this environment\n' "$repo_count"
+  printf '%s' "$agent_json" | jq -r '(.repos // [])[] | "                 " + .url'
+  echo
+  if [ -n "$env_name" ]; then
+    printf 'This agent runs in the %s environment, which carries its own repositories and secrets; it does not belong to any single repository.\n' "$env_name"
+    local default_env
+    default_env=$(default_environment)
+    if [ -n "$default_env" ] && [ "$env_name" = "$default_env" ]; then
+      echo 'That is this home'"'"'s default environment from config/cursor-environment.'
+    fi
+  else
+    echo 'This agent was created from a repository list rather than a named environment, so it carries no predefined environment secrets.'
+  fi
+  echo 'lifecycle active means "not archived"; the latest run status above is what says whether work is happening.'
+}
+
+cmd_runs() {
+  local json=0 agent='' limit=20
+  while [ "$#" -gt 0 ]; do
+    case $1 in
+      --json) json=1 ;;
+      --limit)
+        [ "$#" -ge 2 ] || die 2 "--limit needs a value"
+        valid_limit "$2" || die 2 "--limit must be a whole number from 1 to 100"
+        limit=$2
+        shift
+        ;;
+      --limit=*)
+        valid_limit "${1#--limit=}" || die 2 "--limit must be a whole number from 1 to 100"
+        limit=${1#--limit=}
+        ;;
+      -*) die 2 "unknown option for runs: $1" ;;
+      *)
+        [ -z "$agent" ] || die 2 "runs takes exactly one agent id"
+        agent=$1
+        ;;
+    esac
+    shift
+  done
+  [ -n "$agent" ] || die 2 "runs needs an agent id (see: fm-cursor.sh list)"
+  valid_agent_id "$agent" || die 2 "not a valid agent id: $agent"
+
+  api_get "/v1/agents/$agent/runs?limit=$limit"
+  if [ "$json" -eq 1 ]; then
+    jq --arg a "$agent" '{
+      schema: "fm-cursor-runs.v1",
+      agentId: $a,
+      count: ((.items // []) | length),
+      runs: [(.items // [])[] | {
+        id, status, createdAt, updatedAt, durationMs,
+        branches: [(.git.branches // [])[] | {repoUrl, branch, prUrl}]
+      }]
+    }' "$BODY"
+    return 0
+  fi
+
+  local count
+  count=$(jq '(.items // []) | length' "$BODY")
+  if [ "$count" -eq 0 ]; then
+    echo "No runs on this agent yet."
+    return 0
+  fi
+  printf '%-9s %-10s %-16s %-9s %s\n' RUN STATUS STARTED DURATION PR
+  jq -r '
+    def dur: if . == null then "-"
+      else (. / 1000 | floor) as $s
+        | if $s < 60 then ($s | tostring) + "s"
+          else (($s / 60 | floor) | tostring) + "m" + (($s % 60) | tostring) + "s" end
+      end;
+    (.items // [])[] | [
+      (.id // "-"), (.status // "-"), (.createdAt // "-"), (.durationMs | dur),
+      ([(.git.branches // [])[] | .prUrl // empty] | if length == 0 then "-" else join(" ") end)
+    ] | @tsv' "$BODY" |
+  while IFS=$(printf '\t') read -r rid status started dur pr; do
+    printf '%-9s %-10s %-16s %-9s %s\n' \
+      "${rid: -8}" "$status" "$(printf '%s' "$started" | tr T ' ' | cut -c1-16)" "$dur" "$pr"
+  done
+  echo
+  echo 'Each follow-up prompt to an agent is a new run; only one run can be active at a time.'
+  echo 'A PR URL belongs to the pull request itself, not necessarily to the first repository listed for the agent.'
+  echo 'Run ids are shown short; use --json for the full ids.'
+}
+
+cmd_usage() {
+  local json=0 agent=''
+  while [ "$#" -gt 0 ]; do
+    case $1 in
+      --json) json=1 ;;
+      -*) die 2 "unknown option for usage: $1" ;;
+      *)
+        [ -z "$agent" ] || die 2 "usage takes exactly one agent id"
+        agent=$1
+        ;;
+    esac
+    shift
+  done
+  [ -n "$agent" ] || die 2 "usage needs an agent id (see: fm-cursor.sh list)"
+  valid_agent_id "$agent" || die 2 "not a valid agent id: $agent"
+
+  api_get "/v1/agents/$agent/usage"
+  if [ "$json" -eq 1 ]; then
+    # costAvailable is a capability fact, not an opinion: the Cloud Agents API
+    # exposes no price or charge field anywhere, so a consumer should not hunt
+    # for one. Money lives only on the Admin API, behind an admin-only key.
+    jq --arg a "$agent" '{
+      schema: "fm-cursor-usage.v1",
+      agentId: $a,
+      costAvailable: false,
+      totalUsage: (.totalUsage // {}),
+      runs: [(.runs // [])[] | {id, usage}]
+    }' "$BODY"
+    return 0
+  fi
+
+  printf 'Token usage for %s across %s run(s)\n' "$agent" "$(jq '(.runs // []) | length' "$BODY")"
+  jq -r '(.totalUsage // {}) | to_entries[] | [.key, (.value | tostring)] | @tsv' "$BODY" |
+  while IFS=$(printf '\t') read -r label value; do
+    printf '  %-17s %s\n' "$label" "$value"
+  done
+  echo
+  echo 'Cursor reports tokens only; this API exposes no cost figure, so firstmate cannot report spend here.'
+}
+
+[ "$#" -ge 1 ] || { usage >&2; exit 2; }
+SUB=$1
+shift
+case $SUB in
+  -h|--help|help) usage; exit 0 ;;
+  list|show|runs|usage) ;;
+  *) die 2 "unknown subcommand: $SUB (expected list, show, runs, or usage)" ;;
+esac
+
+require_tools
+arm_auth
+"cmd_$SUB" "$@"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -315,7 +315,8 @@ A user API key sees only that user's own agents, so this view is per-operator ra
 
 The key is read from that `.env` file only.
 Unlike X mode, an ambient `CURSOR_API_KEY` in the environment does not activate this helper and does not override the file, because an inherited variable would silently change which Cursor account firstmate speaks for.
-`FM_CURSOR_ENV_FILE` can point the helper at another `.env`-style file, which is how its tests stay hermetic.
+`FM_CURSOR_ENV_FILE` can point the helper at another `.env`-style file, and that file takes precedence over `$FM_HOME/.env`.
+Its behavior tests stay hermetic by a different mechanism: a fake `curl` on `PATH` serves canned fixtures against a fixture `FM_HOME`, so no test reaches api.cursor.com and none needs a real key.
 The helper never reads the macOS keychain or `cursor-agent`'s stored credentials: those are undocumented, are not supported Cursor API credentials, and grant no access beyond the documented user key.
 
 Every subcommand is a GET, so this surface cannot create, steer, cancel, archive, or delete an agent.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -316,7 +316,6 @@ A user API key sees only that user's own agents, so this view is per-operator ra
 The key is read from that `.env` file only.
 Unlike X mode, an ambient `CURSOR_API_KEY` in the environment does not activate this helper and does not override the file, because an inherited variable would silently change which Cursor account firstmate speaks for.
 `FM_CURSOR_ENV_FILE` can point the helper at another `.env`-style file, and that file takes precedence over `$FM_HOME/.env`.
-Its behavior tests stay hermetic by a different mechanism: a fake `curl` on `PATH` serves canned fixtures against a fixture `FM_HOME`, so no test reaches api.cursor.com and none needs a real key.
 The helper never reads the macOS keychain or `cursor-agent`'s stored credentials: those are undocumented, are not supported Cursor API credentials, and grant no access beyond the documented user key.
 
 Every subcommand is a GET, so this surface cannot create, steer, cancel, archive, or delete an agent.
@@ -335,7 +334,7 @@ An agent therefore belongs to its environment rather than to any repository insi
 ### Default Cursor environment (config/cursor-environment)
 
 `config/cursor-environment` optionally records this home's default environment name.
-It is local and gitignored, like every other `config/` item.
+It is local and gitignored, like every other `config/` item, and it is not part of secondmate inherited configuration, so each home names its own default.
 The first non-empty, non-comment line is used, with surrounding whitespace trimmed and a trailing newline tolerated, matching how `bin/fm-harness.sh` reads `config/secondmate-harness`.
 The name is used verbatim otherwise, because Cursor environment names contain spaces and are case-sensitive.
 An absent file, or one holding only blank and comment lines, means this home has no default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -306,6 +306,44 @@ The locked bootstrap inheritance pass uses the same per-home changed-set and rer
 That live discovery starts from `state/*.meta` records with `kind=secondmate`; `data/secondmates.md` only backfills `home=` for older or incomplete meta records.
 Skipped items, such as a destination checkout that does not yet gitignore the item, are visible warnings but not hard failures.
 
+## Cursor Cloud agent view (.env)
+
+`bin/fm-cursor.sh` gives firstmate a read-only view of the operator's own Cursor Cloud agents.
+It is inert unless the firstmate home's gitignored `.env` contains a non-empty `CURSOR_API_KEY`, and it reports that condition instead of failing with an authentication error.
+Generate a user API key from [Cursor Dashboard -> API Keys](https://cursor.com/dashboard/api); the Cloud Agents API also accepts a team service account key, which only a Cursor team admin can create.
+A user API key sees only that user's own agents, so this view is per-operator rather than fleet-wide.
+
+The key is read from that `.env` file only.
+Unlike X mode, an ambient `CURSOR_API_KEY` in the environment does not activate this helper and does not override the file, because an inherited variable would silently change which Cursor account firstmate speaks for.
+`FM_CURSOR_ENV_FILE` can point the helper at another `.env`-style file, which is how its tests stay hermetic.
+The helper never reads the macOS keychain or `cursor-agent`'s stored credentials: those are undocumented, are not supported Cursor API credentials, and grant no access beyond the documented user key.
+
+Every subcommand is a GET, so this surface cannot create, steer, cancel, archive, or delete an agent.
+It also creates no task records and registers no watcher check, which is what keeps a cloud agent - an agent with no window and no worktree - from being mistaken for a stalled local crewmate by session-start recovery.
+Cursor Cloud is deliberately neither a runtime backend nor a harness; `.agents/skills/firstmate-cursor-cloud/SKILL.md` owns that boundary and the operating procedure, and the script header owns its exact command syntax.
+
+One behavior is worth stating here because it is the easiest thing to misread: an agent's `status` field is lifecycle only, with the enum `ACTIVE|ARCHIVED`, and Cursor documents execution status as living on runs instead.
+`ACTIVE` therefore means "not archived", never "currently running", so `bin/fm-cursor.sh list` resolves each agent's latest run and reports the run status enum as its primary column.
+`curl` and `jq` are required, the same pair X mode requires.
+
+A Cursor agent maps onto a firstmate task, and a Cursor *environment* maps onto a project.
+An environment is a named, multi-repo, secret-bearing context, and `POST /v1/agents` accepts either a named environment or a bare repository list, which the API documents as mutually exclusive.
+An agent therefore belongs to its environment rather than to any repository inside it, so a change spanning a front end and a back end is one agent in one environment instead of several tasks.
+`list` and `show` lead with the environment for that reason, and an agent created from a bare repository list has no environment name and displays as the ad-hoc case with none of a named environment's predefined secrets.
+
+### Default Cursor environment (config/cursor-environment)
+
+`config/cursor-environment` optionally records this home's default environment name.
+It is local and gitignored, like every other `config/` item.
+The first non-empty, non-comment line is used, with surrounding whitespace trimmed and a trailing newline tolerated, matching how `bin/fm-harness.sh` reads `config/secondmate-harness`.
+The name is used verbatim otherwise, because Cursor environment names contain spaces and are case-sensitive.
+An absent file, or one holding only blank and comment lines, means this home has no default.
+
+The default is the intended *target* for a future operation that needs an environment, not a view preference.
+It therefore never filters implicitly: `bin/fm-cursor.sh list` always shows every environment and marks the default with `*`, because silently hiding the agents outside the default would misrepresent the fleet.
+Pass `--env` to narrow to the default, or `--env <name>` for another environment.
+Cursor's list endpoint has no environment filter, so `--env` narrows the fetched page locally: `--limit` bounds the fetch rather than the matches, the footer reports both counts, and filtering runs before latest-run resolution so a narrow `--env` costs far fewer requests.
+
 ## X mode (.env)
 
 X mode lets a firstmate instance answer public `@myfirstmate` mentions and act on normal reversible mention requests through firstmate's normal lifecycle.
@@ -441,6 +479,10 @@ FM_CODEX_WATCH_CHECKPOINT=180   # seconds per foreground watcher checkpoint in C
 FM_CREW_STATE_NM_TIMEOUT=10   # seconds allowed per no-mistakes query inside fm-crew-state.sh
 FM_CREW_STATE_RUNS_LIMIT=200  # recent no-mistakes run rows scanned when axi status cannot be attributed to the current code
 FM_CREW_STATE_BIN=bin/fm-crew-state.sh   # test override for the current-state reader used by working/paused watcher triage
+CURSOR_API_KEY=         # Cursor Cloud read-only view opt-in; .env only, an ambient value is ignored
+FM_CURSOR_ENV_FILE=     # optional alternate .env file for bin/fm-cursor.sh
+FM_CURSOR_API_BASE=https://api.cursor.com   # Cursor Cloud Agents API base URL
+FM_CURSOR_TIMEOUT=30    # seconds allowed per Cursor Cloud Agents API request
 FMX_PAIRING_TOKEN=      # X mode pairing token; .env opt-in authorizes replies and eligible lifecycle actions
 FMX_RELAY_URL=https://myfirstmate.io   # optional X relay override, mainly for local relay development
 FMX_ENV_FILE=           # optional alternate .env file for direct X client invocations; bootstrap still checks $FM_HOME/.env

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -140,6 +140,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/firstmate-cursor-cloud/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/firstmate-orca/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -100,3 +100,4 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-public-followup-lib.sh` | Shared relay-activation gate, O(1) presence checks, and private transport paths for promised public replies |
 | `fm-public-followup.sh`  | Reconcile typed terminal work results into a public commitment and deliver its final reply once |
 | `fm-public-followup-emit.sh` | Report one typed terminal work result into the home that owes the public reply    |
+| `fm-cursor.sh`           | Read-only view of this operator's own Cursor Cloud agents by environment              |

--- a/tests/fm-cursor.test.sh
+++ b/tests/fm-cursor.test.sh
@@ -27,6 +27,12 @@
 #   (n) config/cursor-environment: absent means no default; present marks the
 #       default in list WITHOUT filtering it away; --env filters, a bare --env
 #       uses the default, and filtering happens before run resolution
+#   (o) an --env that matches nothing still reports the fetched count and the
+#       --limit caveat, so an empty view never reads as an empty fleet
+#   (p) a per-agent run request that fails degrades that ONE agent to an unknown
+#       run status and the listing still prints; show stays strict
+#   (q) FM_CURSOR_ENV_FILE takes precedence over $FM_HOME/.env
+#   (r) FM_CURSOR_TIMEOUT is validated before it reaches curl's config file
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -143,12 +149,34 @@ run_cursor() {
   set -e
 }
 
+# run_cursor with extra environment assignments, for the cases that are ABOUT the
+# environment rather than the arguments. The later `env` assignments win, so a
+# case can override FM_HOME or supply a value the shell could not pass inline.
+run_cursor_env() {  # <VAR=VALUE>... -- <args>...
+  local envs=()
+  while [ "$#" -gt 0 ] && [ "$1" != -- ]; do
+    envs+=("$1")
+    shift
+  done
+  [ "$#" -eq 0 ] || shift
+  : > "$CALLS"
+  : > "$VIOLATIONS"
+  : > "$CFGS"
+  set +e
+  OUT=$(PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" FM_CONFIG_OVERRIDE="$CONFIG_DIR" \
+    FM_CURSOR_API_BASE="https://api.cursor.com" env "${envs[@]}" "$CURSOR" "$@" 2>&1)
+  RC=$?
+  set -e
+}
+
 # --- fixtures ----------------------------------------------------------------
 
 AGENT_MULTI=bc-1111aaaa
 AGENT_SINGLE=bc-2222bbbb
 AGENT_NORUNID=bc-3333cccc
 AGENT_ARCHIVED=bc-4444dddd
+AGENT_STALERUN=bc-5555eeee
+AGENT_STALERUN_SHOW=bc-6666ffff
 
 fixture "/v1/agents?limit=20&includeArchived=false" '{"items":[
   {"id":"bc-1111aaaa","name":"Severity sorting","status":"ACTIVE","latestRunId":"run-aaa1",
@@ -191,6 +219,25 @@ fixture "/v1/agents/$AGENT_ARCHIVED/runs/run-ddd1" \
 # The fallback path: this agent had no latestRunId in the list payload.
 fixture "/v1/agents/$AGENT_NORUNID/runs?limit=1" \
   '{"items":[{"id":"run-ccc9","status":"ERROR","createdAt":"2026-07-28T09:10:00.000Z","durationMs":4200,"git":{"branches":[]}}]}'
+
+# A page whose second agent points at a run that no longer resolves: latestRunId
+# is not in Cursor's published schema, so a stale pointer is an expected shape.
+# NEITHER of its run requests has a fixture, so the fake curl answers both with
+# 404 and this page exercises a completely failed resolution.
+fixture "/v1/agents?limit=5&includeArchived=false" '{"items":[
+  {"id":"bc-1111aaaa","name":"Severity sorting","status":"ACTIVE","latestRunId":"run-aaa1",
+   "createdAt":"2026-07-30T14:57:06.760Z","updatedAt":"2026-07-31T11:44:22.735Z",
+   "url":"https://cursor.com/agents/bc-1111aaaa","env":{"type":"cloud","name":"AgentScan E2E"},
+   "repos":[{"url":"https://github.com/snyk/agent-scan"}]},
+  {"id":"bc-5555eeee","name":"Stale run pointer","status":"ACTIVE","latestRunId":"run-gone",
+   "createdAt":"2026-07-27T09:00:00.000Z","updatedAt":"2026-07-27T10:00:00.000Z",
+   "url":"https://cursor.com/agents/bc-5555eeee","env":{"type":"cloud","name":"AgentScan E2E"},
+   "repos":[{"url":"https://github.com/snyk/minired"}]}
+]}'
+# The same stale pointer through show, where a hard failure is the right outcome:
+# the latest run IS what a single-agent view was asked for.
+fixture "/v1/agents/$AGENT_STALERUN_SHOW" \
+  '{"id":"bc-6666ffff","name":"Stale run pointer","status":"ACTIVE","latestRunId":"run-gone2","createdAt":"2026-07-27T09:00:00.000Z","updatedAt":"2026-07-27T10:00:00.000Z","url":"https://cursor.com/agents/bc-6666ffff","env":{"type":"cloud","name":"AgentScan E2E"},"repos":[{"url":"https://github.com/snyk/minired"}]}'
 
 fixture "/v1/agents/$AGENT_SINGLE" \
   '{"id":"bc-2222bbbb","name":"Single repo work","status":"ACTIVE","latestRunId":"run-bbb1","createdAt":"2026-07-29T09:00:00.000Z","updatedAt":"2026-07-29T10:00:00.000Z","url":"https://cursor.com/agents/bc-2222bbbb","env":{"type":"cloud","name":"prod"},"repos":[{"url":"https://github.com/snyk/minired"}]}'
@@ -435,6 +482,12 @@ run_cursor list --env "Nonexistent Env"
 expect_code 0 "$RC" "an --env with no matches still succeeds"
 assert_contains "$OUT" "No Cursor Cloud agents found." "an unmatched --env reports an empty result"
 assert_not_contains "$OUT" "AgentScan E2E *" "an unmatched --env must not fall back to the default"
+# (o) An empty view under a filter must not read as "this home has no agents":
+# the fetched count and the --limit caveat are exactly what turns "none" into
+# "none on this page of the fetch".
+assert_contains "$OUT" "0 of 3 fetched" "an unmatched --env still counts matches against the fetch"
+assert_contains "$OUT" "--limit bounds the fetch" "an unmatched --env still carries the --limit caveat"
+assert_contains "$OUT" "not an empty fleet" "an unmatched --env says agents were fetched"
 run_cursor list --env ""
 expect_code 2 "$RC" "an empty --env name exits 2 rather than selecting ad-hoc agents"
 assert_contains "$OUT" "non-empty environment name" "an empty --env name is refused explicitly"
@@ -451,5 +504,80 @@ printf '%s' "$OUT" | jq -e '.defaultEnvironment == "AgentScan E2E" and .environm
 printf '%s' "$OUT" | jq -e '.fetched == 3 and .count == 3' >/dev/null \
   || fail "an unfiltered list --json must report fetched == count"
 pass "list --json reports the default environment separately from any filter"
+
+# --- (p) one failed run resolution must not discard the listing --------------
+
+run_cursor list --limit 5
+expect_code 0 "$RC" "a failed per-agent run resolution must not abort the listing"
+assert_contains "$OUT" "RUNNING" "the agent whose run resolves is still reported"
+assert_contains "$OUT" "Stale run pointer" "the agent whose run failed is still listed"
+assert_contains "$OUT" "2 agent(s) shown" "every fetched agent survives a failed resolution"
+assert_contains "$OUT" "unknown" "an unresolvable latest run degrades to unknown"
+assert_contains "$OUT" "could not be fetched" "the footer states how many runs went unresolved"
+# The fast path failing must fall THROUGH to the runs-list fallback, not abort.
+assert_grep "/v1/agents/$AGENT_STALERUN/runs/run-gone" "$CALLS" \
+  "the stale latestRunId is still tried first"
+assert_grep "/v1/agents/$AGENT_STALERUN/runs?limit=1" "$CALLS" \
+  "a failed fast path must fall through to the runs-list fallback"
+pass "a per-agent run request that fails costs one row, not the whole view"
+
+run_cursor list --limit 5 --json
+expect_code 0 "$RC" "list --json succeeds with a failed resolution"
+printf '%s' "$OUT" | jq -e '.count == 2' >/dev/null \
+  || fail "a failed resolution must not drop the agent from --json"
+printf '%s' "$OUT" | jq -e '[.agents[] | select(.runStatusSource == "resolution-failed")]
+  | length == 1 and .[0].runStatus == "unknown"' >/dev/null \
+  || fail "--json must distinguish a failed resolution: $(printf '%s' "$OUT" | jq -c '[.agents[] | {runStatus, runStatusSource}]')"
+printf '%s' "$OUT" | jq -e '[.agents[] | select(.runStatusSource == "latestRunId")] | length == 1' >/dev/null \
+  || fail "--json must still record the fast path for the agent that resolved"
+pass "runStatusSource tells a failed resolution apart from the fast path, fallback, and --no-runs"
+
+# show is deliberately NOT tolerant: the latest run is what it was asked for.
+run_cursor show "$AGENT_STALERUN_SHOW"
+expect_code 4 "$RC" "show still fails hard when its latest run cannot be fetched"
+assert_contains "$OUT" "not found" "show reports the API status it got"
+assert_not_contains "$OUT" "$KEY" "a failed show never contains the key"
+pass "list degrades per agent while show, runs, and usage still fail loudly"
+
+# --- (q) FM_CURSOR_ENV_FILE --------------------------------------------------
+
+ALT_ENV="$TMP_ROOT/alt.env"
+printf 'CURSOR_API_KEY=%s\n' "$KEY" > "$ALT_ENV"
+DECOY_HOME="$TMP_ROOT/decoyhome"
+mkdir -p "$DECOY_HOME"
+printf 'CURSOR_API_KEY=decoy_key_from_the_home_env\n' > "$DECOY_HOME/.env"
+run_cursor_env FM_HOME="$DECOY_HOME" FM_CURSOR_ENV_FILE="$ALT_ENV" -- list --no-runs
+expect_code 0 "$RC" "FM_CURSOR_ENV_FILE supplies the key"
+# The fake curl asserts the config file carries the FIXTURE key, so a decoy key in
+# $FM_HOME/.env winning would be recorded as a missing header rather than pass.
+[ ! -s "$VIOLATIONS" ] || fail "FM_CURSOR_ENV_FILE must take precedence over \$FM_HOME/.env: $(cat "$VIOLATIONS")"
+assert_not_contains "$OUT" "decoy_key_from_the_home_env" "no key is ever echoed back"
+
+KEYLESS_ENV="$TMP_ROOT/keyless.env"
+printf '# no key here\n' > "$KEYLESS_ENV"
+run_cursor_env FM_CURSOR_ENV_FILE="$KEYLESS_ENV" -- list
+expect_code 3 "$RC" "a keyless FM_CURSOR_ENV_FILE is not configured, even with a good \$FM_HOME/.env"
+assert_contains "$OUT" "$KEYLESS_ENV" "the not-configured message names the overridden file"
+[ ! -s "$CALLS" ] || fail "a keyless FM_CURSOR_ENV_FILE must be refused before any request"
+pass "FM_CURSOR_ENV_FILE is the key's source when set, in both directions"
+
+# --- (r) FM_CURSOR_TIMEOUT validation ----------------------------------------
+
+# The timeout is interpolated into the same 0600 config file that carries the
+# bearer header, and curl config syntax is one directive per line, so a value
+# holding a newline would append directives of the attacker's choosing.
+run_cursor_env FM_CURSOR_TIMEOUT="$(printf '30\nproxy = http://127.0.0.1:9')" -- list
+expect_code 3 "$RC" "a timeout carrying a newline is refused"
+assert_contains "$OUT" "FM_CURSOR_TIMEOUT" "the refusal names the variable"
+[ ! -s "$CALLS" ] || fail "an injectable timeout must be refused before any request"
+run_cursor_env FM_CURSOR_TIMEOUT=abc -- list
+expect_code 3 "$RC" "a non-numeric timeout is refused instead of degrading to a reach error"
+run_cursor_env FM_CURSOR_TIMEOUT=0 -- list
+expect_code 3 "$RC" "a zero timeout is refused"
+run_cursor_env FM_CURSOR_TIMEOUT=99999 -- list
+expect_code 3 "$RC" "an out-of-range timeout is refused"
+run_cursor_env FM_CURSOR_TIMEOUT=5 -- list --no-runs
+expect_code 0 "$RC" "a plain numeric timeout is accepted"
+pass "FM_CURSOR_TIMEOUT is validated before it can inject into the key's config file"
 
 printf '\nall fm-cursor tests passed\n'

--- a/tests/fm-cursor.test.sh
+++ b/tests/fm-cursor.test.sh
@@ -29,8 +29,11 @@
 #       uses the default, and filtering happens before run resolution
 #   (o) an --env that matches nothing still reports the fetched count and the
 #       --limit caveat, so an empty view never reads as an empty fleet
-#   (p) a per-agent run request that fails degrades that ONE agent to an unknown
-#       run status and the listing still prints; show stays strict
+#   (p) a run request that fails degrades only that run to an unknown status,
+#       carrying the reason so a 429 never reads like a 404 or a rejected key:
+#       list keeps every other row, show still renders the agent it fetched, and
+#       only a top-level fetch still exits 4. The ad-hoc environment label is
+#       asserted through show as well as list, since each has its own renderer
 #   (q) FM_CURSOR_ENV_FILE takes precedence over $FM_HOME/.env
 #   (r) FM_CURSOR_TIMEOUT is validated before it reaches curl's config file
 set -u
@@ -177,6 +180,8 @@ AGENT_NORUNID=bc-3333cccc
 AGENT_ARCHIVED=bc-4444dddd
 AGENT_STALERUN=bc-5555eeee
 AGENT_STALERUN_SHOW=bc-6666ffff
+AGENT_ADHOC_SHOW=bc-7777gggg
+AGENT_THROTTLED=bc-8888hhhh
 
 fixture "/v1/agents?limit=20&includeArchived=false" '{"items":[
   {"id":"bc-1111aaaa","name":"Severity sorting","status":"ACTIVE","latestRunId":"run-aaa1",
@@ -234,10 +239,29 @@ fixture "/v1/agents?limit=5&includeArchived=false" '{"items":[
    "url":"https://cursor.com/agents/bc-5555eeee","env":{"type":"cloud","name":"AgentScan E2E"},
    "repos":[{"url":"https://github.com/snyk/minired"}]}
 ]}'
-# The same stale pointer through show, where a hard failure is the right outcome:
-# the latest run IS what a single-agent view was asked for.
+# The same stale pointer through show, where the agent's OWN fetch succeeds: the
+# run alone is unresolvable, so show must render the agent and report unknown.
 fixture "/v1/agents/$AGENT_STALERUN_SHOW" \
   '{"id":"bc-6666ffff","name":"Stale run pointer","status":"ACTIVE","latestRunId":"run-gone2","createdAt":"2026-07-27T09:00:00.000Z","updatedAt":"2026-07-27T10:00:00.000Z","url":"https://cursor.com/agents/bc-6666ffff","env":{"type":"cloud","name":"AgentScan E2E"},"repos":[{"url":"https://github.com/snyk/minired"}]}'
+
+# An agent built from a bare repo list, for the show side of the ad-hoc label.
+fixture "/v1/agents/$AGENT_ADHOC_SHOW" \
+  '{"id":"bc-7777gggg","name":"Ad-hoc repo list","status":"ACTIVE","latestRunId":"run-ggg1","createdAt":"2026-07-26T09:00:00.000Z","updatedAt":"2026-07-26T10:00:00.000Z","url":"https://cursor.com/agents/bc-7777gggg","env":{"type":"cloud"},"repos":[{"url":"https://github.com/snyk/minired"}]}'
+fixture "/v1/agents/$AGENT_ADHOC_SHOW/runs/run-ggg1" \
+  '{"id":"run-ggg1","agentId":"bc-7777gggg","status":"FINISHED","createdAt":"2026-07-26T09:10:00.000Z","durationMs":1000,"git":{"branches":[]}}'
+
+# A page whose only agent is throttled on BOTH run requests. A 429 and a 404 must
+# never produce the same output, because the operator's next move differs.
+fixture "/v1/agents?limit=6&includeArchived=false" '{"items":[
+  {"id":"bc-8888hhhh","name":"Throttled resolution","status":"ACTIVE","latestRunId":"run-throttled",
+   "createdAt":"2026-07-25T09:00:00.000Z","updatedAt":"2026-07-25T10:00:00.000Z",
+   "url":"https://cursor.com/agents/bc-8888hhhh","env":{"type":"cloud","name":"AgentScan E2E"},
+   "repos":[{"url":"https://github.com/snyk/minired"}]}
+]}'
+fixture "/v1/agents/$AGENT_THROTTLED/runs/run-throttled" '{"code":"error","message":"Too Many Requests"}'
+fixture_code "/v1/agents/$AGENT_THROTTLED/runs/run-throttled" 429
+fixture "/v1/agents/$AGENT_THROTTLED/runs?limit=1" '{"code":"error","message":"Too Many Requests"}'
+fixture_code "/v1/agents/$AGENT_THROTTLED/runs?limit=1" 429
 
 fixture "/v1/agents/$AGENT_SINGLE" \
   '{"id":"bc-2222bbbb","name":"Single repo work","status":"ACTIVE","latestRunId":"run-bbb1","createdAt":"2026-07-29T09:00:00.000Z","updatedAt":"2026-07-29T10:00:00.000Z","url":"https://cursor.com/agents/bc-2222bbbb","env":{"type":"cloud","name":"prod"},"repos":[{"url":"https://github.com/snyk/minired"}]}'
@@ -514,12 +538,33 @@ assert_contains "$OUT" "Stale run pointer" "the agent whose run failed is still 
 assert_contains "$OUT" "2 agent(s) shown" "every fetched agent survives a failed resolution"
 assert_contains "$OUT" "unknown" "an unresolvable latest run degrades to unknown"
 assert_contains "$OUT" "could not be fetched" "the footer states how many runs went unresolved"
+# A bare count cannot be acted on: the footer must name the reason too.
+assert_contains "$OUT" "1 of them: not found (HTTP 404)" \
+  "the footer names the reason a run went unresolved, grouped by reason"
+assert_not_contains "$OUT" "$KEY" "no footer reason ever contains the key"
 # The fast path failing must fall THROUGH to the runs-list fallback, not abort.
 assert_grep "/v1/agents/$AGENT_STALERUN/runs/run-gone" "$CALLS" \
   "the stale latestRunId is still tried first"
 assert_grep "/v1/agents/$AGENT_STALERUN/runs?limit=1" "$CALLS" \
   "a failed fast path must fall through to the runs-list fallback"
 pass "a per-agent run request that fails costs one row, not the whole view"
+
+# A 429 and a 401 must never read identically: the operator's next move differs.
+run_cursor list --limit 6
+expect_code 0 "$RC" "a rate-limited run resolution must not abort the listing"
+assert_contains "$OUT" "rate limited by the Cursor API (HTTP 429)" \
+  "a throttled resolution is reported as rate limiting, not as a missing run"
+assert_contains "$OUT" "Too Many Requests" "the API's own message is carried into the reason"
+assert_not_contains "$OUT" "not found" "a 429 must not be reported as a 404"
+assert_not_contains "$OUT" "rejected the key" "a 429 must not be reported as a key problem"
+run_cursor list --limit 6 --json
+printf '%s' "$OUT" | jq -e '[.agents[] | select(.runStatusSource == "resolution-failed")
+  | .runStatusReason] | length == 1 and (.[0] | test("429"))' >/dev/null \
+  || fail "--json must carry the per-agent reason: $(printf '%s' "$OUT" | jq -c '[.agents[] | {runStatusSource, runStatusReason}]')"
+printf '%s' "$OUT" | jq -e --arg k "$KEY" '[.agents[] | .runStatusReason // ""]
+  | map(select(contains($k))) | length == 0' >/dev/null \
+  || fail "a per-agent reason must never contain the key"
+pass "a degraded row carries WHY, so rate limiting and a rejected key never look alike"
 
 run_cursor list --limit 5 --json
 expect_code 0 "$RC" "list --json succeeds with a failed resolution"
@@ -530,14 +575,49 @@ printf '%s' "$OUT" | jq -e '[.agents[] | select(.runStatusSource == "resolution-
   || fail "--json must distinguish a failed resolution: $(printf '%s' "$OUT" | jq -c '[.agents[] | {runStatus, runStatusSource}]')"
 printf '%s' "$OUT" | jq -e '[.agents[] | select(.runStatusSource == "latestRunId")] | length == 1' >/dev/null \
   || fail "--json must still record the fast path for the agent that resolved"
+printf '%s' "$OUT" | jq -e '[.agents[] | select(.runStatusSource == "latestRunId")
+  | .runStatusReason] == [null]' >/dev/null \
+  || fail "a resolved agent must carry no reason"
 pass "runStatusSource tells a failed resolution apart from the fast path, fallback, and --no-runs"
 
-# show is deliberately NOT tolerant: the latest run is what it was asked for.
+# show degrades the same way list does. Dying with "not found (HTTP 404)" would
+# read as "no such agent" for an agent GET /v1/agents/<id> just proved exists.
 run_cursor show "$AGENT_STALERUN_SHOW"
-expect_code 4 "$RC" "show still fails hard when its latest run cannot be fetched"
-assert_contains "$OUT" "not found" "show reports the API status it got"
-assert_not_contains "$OUT" "$KEY" "a failed show never contains the key"
-pass "list degrades per agent while show, runs, and usage still fail loudly"
+expect_code 0 "$RC" "show renders the agent it fetched even when the latest run will not resolve"
+assert_contains "$OUT" "latest run   unknown" "an unresolvable latest run shows as unknown"
+assert_contains "$OUT" "not found (HTTP 404)" "show names why the run is unknown"
+assert_contains "$OUT" "not because the agent is idle" "show says unknown is an absence of data"
+assert_contains "$OUT" "Stale run pointer" "the agent's own detail is still rendered"
+assert_not_contains "$OUT" "$KEY" "a degraded show never contains the key"
+assert_grep "/v1/agents/$AGENT_STALERUN_SHOW/runs?limit=1" "$CALLS" \
+  "show must try the runs-list fallback before giving up on the run"
+run_cursor show "$AGENT_STALERUN_SHOW" --json
+expect_code 0 "$RC" "show --json succeeds with an unresolvable latest run"
+printf '%s' "$OUT" | jq -e '.latestRun.status == "unknown"
+  and .latestRun.source == "resolution-failed"
+  and (.latestRun.reason | test("404"))' >/dev/null \
+  || fail "show --json must carry the unknown status with its reason: $(printf '%s' "$OUT" | jq -c .latestRun)"
+printf '%s' "$OUT" | jq -e '.agent.id == "bc-6666ffff"' >/dev/null \
+  || fail "show --json must still carry the agent that was fetched successfully"
+pass "show reports an unresolvable run as unknown with the reason instead of dying"
+
+# The TOP-LEVEL fetch of a subcommand is where a non-200 still means failure.
+run_cursor show bc-9999zzzz
+expect_code 4 "$RC" "a failed top-level agent fetch still exits 4"
+run_cursor runs bc-9999zzzz
+expect_code 4 "$RC" "a failed runs fetch still exits 4"
+run_cursor usage bc-9999zzzz
+expect_code 4 "$RC" "a failed usage fetch still exits 4"
+pass "run resolution degrades while every top-level fetch still fails loudly"
+
+# The ad-hoc environment label has two owners now - the shell env_label used by
+# show and the inline jq used by list - so assert the show side too.
+run_cursor show "$AGENT_ADHOC_SHOW"
+expect_code 0 "$RC" "show succeeds for an agent with no named environment"
+assert_contains "$OUT" "environment  (ad-hoc cloud) (cloud)" \
+  "show renders an unnamed environment with the same ad-hoc label list uses"
+assert_contains "$OUT" "created from a repository list" "show explains the ad-hoc case"
+pass "list and show describe an unnamed environment identically"
 
 # --- (q) FM_CURSOR_ENV_FILE --------------------------------------------------
 

--- a/tests/fm-cursor.test.sh
+++ b/tests/fm-cursor.test.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-cursor.sh - the read-only Cursor Cloud agent view.
+#
+# Hermetic: a fake `curl` on PATH answers every request from canned fixtures, so
+# no test here reaches api.cursor.com and none needs a real API key. The fake is
+# also the credential assertion - it inspects its own argv and the curl config
+# file it was handed, so "the key never reaches a process argument" is proven by
+# the same mechanism that serves the responses rather than by reading the source.
+#
+# Cases:
+#   (a) absent key                     -> exit 3, actionable message, no request
+#   (b) key with unsafe characters     -> exit 3, refused before any request
+#   (c) ambient CURSOR_API_KEY ignored -> .env is the only source
+#   (d) usage errors                   -> exit 2 (no subcommand, unknown sub/opt,
+#                                        missing id, bad id, out-of-range limit)
+#   (e) the key never appears in curl's argv, and its config file is mode 0600
+#   (f) list reports LATEST RUN status, not the ACTIVE|ARCHIVED lifecycle field
+#   (g) latestRunId is the fast path; a missing one falls back to the runs list
+#   (h) --no-runs resolves nothing and says so
+#   (i) the ENVIRONMENT is the agent's identity: a named environment is surfaced,
+#       an agent built from a bare repo list shows as ad-hoc, and a multi-repo
+#       agent reports its repository count rather than reading as single-repo
+#   (j) --json emits the documented schema names and summary counts
+#   (k) archived agents are hidden by default and included with --all
+#   (l) HTTP failures report the API's message, never the raw body
+#   (m) a temp key/response file never survives the run
+#   (n) config/cursor-environment: absent means no default; present marks the
+#       default in list WITHOUT filtering it away; --env filters, a bare --env
+#       uses the default, and filtering happens before run resolution
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CURSOR="$ROOT/bin/fm-cursor.sh"
+TMP_ROOT=$(fm_test_tmproot fm-cursor)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+
+# A key shaped like a real one: URL-safe base64, no characters the config-file
+# writer would have to escape.
+KEY=key_0123456789abcdefABCDEF-_
+HOME_DIR="$TMP_ROOT/home"
+mkdir -p "$HOME_DIR"
+printf 'CURSOR_API_KEY=%s\n' "$KEY" > "$HOME_DIR/.env"
+
+FIXTURES="$TMP_ROOT/fixtures"
+mkdir -p "$FIXTURES"
+
+# --- fake curl ---------------------------------------------------------------
+#
+# Serves $FIXTURES/<slug>.json for a request path, where <slug> is the path with
+# non-alphanumerics folded to '_'. Writes the HTTP code configured in
+# $FIXTURES/<slug>.code (default 200) to stdout, exactly as the real
+# `curl -w '%{http_code}'` does. Records every invocation for later assertions.
+cat > "$FAKEBIN/curl" <<'SH'
+#!/usr/bin/env bash
+set -u
+# Snapshot argv BEFORE parsing: the parse loop below consumes "$@", so the
+# credential check has to inspect a copy or it silently inspects nothing.
+ARGV=("$0" "$@")
+out=
+url=
+cfg=
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    --config) cfg=$2; shift 2 ;;
+    -o) out=$2; shift 2 ;;
+    -w) shift 2 ;;
+    -*) shift ;;
+    *) url=$1; shift ;;
+  esac
+done
+: >> "$FM_CURSOR_TEST_CALLS"
+printf '%s\n' "$url" >> "$FM_CURSOR_TEST_CALLS"
+# Credential guarantees, asserted at the moment of use.
+if [ -n "${FM_CURSOR_TEST_KEY:-}" ]; then
+  for a in "${ARGV[@]}"; do
+    case $a in
+      *"$FM_CURSOR_TEST_KEY"*) printf 'KEY_IN_ARGV\n' >> "$FM_CURSOR_TEST_VIOLATIONS" ;;
+    esac
+  done
+fi
+if [ -n "$cfg" ]; then
+  perms=$(stat -f '%Lp' "$cfg" 2>/dev/null || stat -c '%a' "$cfg" 2>/dev/null || echo unknown)
+  [ "$perms" = 600 ] || printf 'CFG_PERMS=%s\n' "$perms" >> "$FM_CURSOR_TEST_VIOLATIONS"
+  grep -q "Authorization: Bearer ${FM_CURSOR_TEST_KEY}" "$cfg" \
+    || printf 'CFG_MISSING_HEADER\n' >> "$FM_CURSOR_TEST_VIOLATIONS"
+  printf '%s\n' "$cfg" >> "$FM_CURSOR_TEST_CFGS"
+fi
+slug=$(printf '%s' "${url#*://}" | sed 's/[^A-Za-z0-9]/_/g')
+body="$FM_CURSOR_TEST_FIXTURES/$slug.json"
+code_file="$FM_CURSOR_TEST_FIXTURES/$slug.code"
+code=200
+[ ! -f "$code_file" ] || code=$(cat "$code_file")
+if [ -f "$body" ]; then
+  [ -z "$out" ] || cp "$body" "$out"
+else
+  [ -z "$out" ] || printf '{"message":"no fixture for %s"}' "$slug" > "$out"
+  code=404
+fi
+printf '%s' "$code"
+SH
+chmod +x "$FAKEBIN/curl"
+
+export FM_CURSOR_TEST_FIXTURES="$FIXTURES"
+export FM_CURSOR_TEST_KEY="$KEY"
+CALLS="$TMP_ROOT/calls"
+VIOLATIONS="$TMP_ROOT/violations"
+CFGS="$TMP_ROOT/cfgs"
+export FM_CURSOR_TEST_CALLS="$CALLS" FM_CURSOR_TEST_VIOLATIONS="$VIOLATIONS" FM_CURSOR_TEST_CFGS="$CFGS"
+
+fixture() {  # <url-path> <json>
+  local slug
+  slug=$(printf '%s' "api.cursor.com$1" | sed 's/[^A-Za-z0-9]/_/g')
+  printf '%s' "$2" > "$FIXTURES/$slug.json"
+}
+
+fixture_code() {  # <url-path> <http-code>
+  local slug
+  slug=$(printf '%s' "api.cursor.com$1" | sed 's/[^A-Za-z0-9]/_/g')
+  printf '%s' "$2" > "$FIXTURES/$slug.code"
+}
+
+# run_cursor <args...>: run the helper with the fake curl and the fixture home,
+# leaving combined output in $OUT and the exit status in $RC.
+#
+# Deliberately NOT `out=$(run_cursor ...)`: assigning RC inside a command
+# substitution sets it in the subshell only, so the caller would read a stale
+# status from an earlier call and every exit-code assertion would silently pass.
+RC=0
+OUT=
+CONFIG_DIR="$TMP_ROOT/config"
+mkdir -p "$CONFIG_DIR"
+
+run_cursor() {
+  : > "$CALLS"
+  : > "$VIOLATIONS"
+  : > "$CFGS"
+  set +e
+  OUT=$(PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" FM_CONFIG_OVERRIDE="$CONFIG_DIR" \
+    FM_CURSOR_API_BASE="https://api.cursor.com" "$CURSOR" "$@" 2>&1)
+  RC=$?
+  set -e
+}
+
+# --- fixtures ----------------------------------------------------------------
+
+AGENT_MULTI=bc-1111aaaa
+AGENT_SINGLE=bc-2222bbbb
+AGENT_NORUNID=bc-3333cccc
+AGENT_ARCHIVED=bc-4444dddd
+
+fixture "/v1/agents?limit=20&includeArchived=false" '{"items":[
+  {"id":"bc-1111aaaa","name":"Severity sorting","status":"ACTIVE","latestRunId":"run-aaa1",
+   "createdAt":"2026-07-30T14:57:06.760Z","updatedAt":"2026-07-31T11:44:22.735Z",
+   "url":"https://cursor.com/agents/bc-1111aaaa","env":{"type":"cloud","name":"AgentScan E2E"},
+   "repos":[{"url":"https://github.com/snyk/invariant-mcp-scan-backend"},
+            {"url":"https://github.com/snyk/agent-scan"},
+            {"url":"https://github.com/snyk/maverick"},
+            {"url":"https://github.com/snyk/maverick-ui"}]},
+  {"id":"bc-2222bbbb","name":"Single repo work","status":"ACTIVE","latestRunId":"run-bbb1",
+   "createdAt":"2026-07-29T09:00:00.000Z","updatedAt":"2026-07-29T10:00:00.000Z",
+   "url":"https://cursor.com/agents/bc-2222bbbb","env":{"type":"cloud"},
+   "repos":[{"url":"https://github.com/snyk/minired"}]},
+  {"id":"bc-3333cccc","name":"No latest run id","status":"ACTIVE",
+   "createdAt":"2026-07-28T09:00:00.000Z","updatedAt":"2026-07-28T10:00:00.000Z",
+   "url":"https://cursor.com/agents/bc-3333cccc","env":{"type":"cloud"},
+   "repos":[{"url":"https://github.com/snyk/prompt-siren"}]}
+]}'
+
+fixture "/v1/agents?limit=20&includeArchived=true" '{"items":[
+  {"id":"bc-1111aaaa","name":"Severity sorting","status":"ACTIVE","latestRunId":"run-aaa1",
+   "createdAt":"2026-07-30T14:57:06.760Z","updatedAt":"2026-07-31T11:44:22.735Z",
+   "url":"https://cursor.com/agents/bc-1111aaaa","env":{"type":"cloud"},
+   "repos":[{"url":"https://github.com/snyk/invariant-mcp-scan-backend"},
+            {"url":"https://github.com/snyk/agent-scan"}]},
+  {"id":"bc-4444dddd","name":"Old archived thing","status":"ARCHIVED","latestRunId":"run-ddd1",
+   "createdAt":"2026-06-01T09:00:00.000Z","updatedAt":"2026-06-02T10:00:00.000Z",
+   "url":"https://cursor.com/agents/bc-4444dddd","env":{"type":"cloud"},
+   "repos":[{"url":"https://github.com/snyk/minired"}]}
+]}'
+
+# A RUNNING latest run on an ACTIVE agent, and a FINISHED one on another ACTIVE
+# agent: the pair that proves lifecycle and execution are independent.
+fixture "/v1/agents/$AGENT_MULTI/runs/run-aaa1" \
+  '{"id":"run-aaa1","agentId":"bc-1111aaaa","status":"RUNNING","createdAt":"2026-07-31T11:09:10.326Z","durationMs":null,"git":{"branches":[]}}'
+fixture "/v1/agents/$AGENT_SINGLE/runs/run-bbb1" \
+  '{"id":"run-bbb1","agentId":"bc-2222bbbb","status":"FINISHED","createdAt":"2026-07-29T09:10:00.000Z","durationMs":79396,"git":{"branches":[{"repoUrl":"github.com/snyk/minired","branch":"cursor/x","prUrl":"https://github.com/snyk/minired/pull/94"}]}}'
+fixture "/v1/agents/$AGENT_ARCHIVED/runs/run-ddd1" \
+  '{"id":"run-ddd1","agentId":"bc-4444dddd","status":"FINISHED","createdAt":"2026-06-01T09:10:00.000Z","durationMs":1000,"git":{"branches":[]}}'
+# The fallback path: this agent had no latestRunId in the list payload.
+fixture "/v1/agents/$AGENT_NORUNID/runs?limit=1" \
+  '{"items":[{"id":"run-ccc9","status":"ERROR","createdAt":"2026-07-28T09:10:00.000Z","durationMs":4200,"git":{"branches":[]}}]}'
+
+fixture "/v1/agents/$AGENT_SINGLE" \
+  '{"id":"bc-2222bbbb","name":"Single repo work","status":"ACTIVE","latestRunId":"run-bbb1","createdAt":"2026-07-29T09:00:00.000Z","updatedAt":"2026-07-29T10:00:00.000Z","url":"https://cursor.com/agents/bc-2222bbbb","env":{"type":"cloud","name":"prod"},"repos":[{"url":"https://github.com/snyk/minired"}]}'
+fixture "/v1/agents/$AGENT_SINGLE/runs?limit=20" \
+  '{"items":[{"id":"run-bbb1","status":"FINISHED","createdAt":"2026-07-29T09:10:00.000Z","durationMs":135000,"git":{"branches":[{"repoUrl":"github.com/snyk/minired","branch":"cursor/x","prUrl":"https://github.com/snyk/minired/pull/94"}]}},{"id":"run-bbb0","status":"CANCELLED","createdAt":"2026-07-29T09:05:00.000Z","durationMs":30000,"git":{"branches":[]}}]}'
+fixture "/v1/agents/$AGENT_SINGLE/usage" \
+  '{"totalUsage":{"inputTokens":465689,"outputTokens":126637,"cacheWriteTokens":982426,"cacheReadTokens":45216792,"totalTokens":46791544},"runs":[{"id":"run-bbb1","usage":{"inputTokens":465689,"outputTokens":126637,"cacheWriteTokens":982426,"cacheReadTokens":45216792,"totalTokens":46791544}}]}'
+
+# --- (a) absent key ----------------------------------------------------------
+
+NOKEY_HOME="$TMP_ROOT/nokey"
+mkdir -p "$NOKEY_HOME"
+set +e
+OUT=$(PATH="$FAKEBIN:$PATH" FM_HOME="$NOKEY_HOME" "$CURSOR" list 2>&1)
+RC=$?
+set -e
+expect_code 3 "$RC" "absent key exits 3"
+assert_contains "$OUT" "not configured" "absent key names the condition"
+assert_contains "$OUT" "CURSOR_API_KEY" "absent key names the variable"
+assert_contains "$OUT" "$NOKEY_HOME/.env" "absent key names the file to edit"
+pass "absent CURSOR_API_KEY is inert and actionable, not a confusing auth error"
+
+# --- (b) unsafe key ----------------------------------------------------------
+
+BADKEY_HOME="$TMP_ROOT/badkey"
+mkdir -p "$BADKEY_HOME"
+printf 'CURSOR_API_KEY="key with spaces and \\"quotes\\""\n' > "$BADKEY_HOME/.env"
+: > "$CALLS"
+set +e
+OUT=$(PATH="$FAKEBIN:$PATH" FM_HOME="$BADKEY_HOME" "$CURSOR" list 2>&1)
+RC=$?
+set -e
+expect_code 3 "$RC" "unsafe key exits 3"
+assert_contains "$OUT" "unexpected characters" "unsafe key is reported as malformed"
+assert_not_contains "$OUT" "key with spaces" "the rejected key is never echoed back"
+[ ! -s "$CALLS" ] || fail "unsafe key must be refused before any API request"
+pass "a key that would break config quoting is refused before any request"
+
+# --- (c) ambient environment key is ignored ----------------------------------
+
+set +e
+OUT=$(PATH="$FAKEBIN:$PATH" FM_HOME="$NOKEY_HOME" CURSOR_API_KEY=ambient-key-value \
+  "$CURSOR" list 2>&1)
+RC=$?
+set -e
+expect_code 3 "$RC" "an ambient CURSOR_API_KEY must not activate the helper"
+assert_contains "$OUT" "not configured" "ambient key is ignored in favour of .env"
+pass "the key comes from .env only, never from the ambient environment"
+
+# --- (d) usage errors --------------------------------------------------------
+
+run_cursor; expect_code 2 "$RC" "no subcommand exits 2"
+run_cursor frobnicate; expect_code 2 "$RC" "unknown subcommand exits 2"
+assert_contains "$OUT" "unknown subcommand" "unknown subcommand is named"
+run_cursor list --bogus; expect_code 2 "$RC" "unknown list option exits 2"
+run_cursor show; expect_code 2 "$RC" "show without an id exits 2"
+assert_contains "$OUT" "needs an agent id" "show explains the missing id"
+run_cursor show 'bc-../../etc/passwd'; expect_code 2 "$RC" "a path-y agent id is refused"
+assert_contains "$OUT" "not a valid agent id" "bad id is named as invalid"
+run_cursor list --limit 0; expect_code 2 "$RC" "limit below range exits 2"
+run_cursor list --limit 101; expect_code 2 "$RC" "limit above range exits 2"
+run_cursor list --limit abc; expect_code 2 "$RC" "non-numeric limit exits 2"
+run_cursor runs "$AGENT_SINGLE" "$AGENT_MULTI"; expect_code 2 "$RC" "two ids are refused"
+pass "usage errors exit 2 with a message that names the problem"
+
+# --- (e)(f)(g)(i) list -------------------------------------------------------
+
+run_cursor list
+expect_code 0 "$RC" "list succeeds"
+[ ! -s "$VIOLATIONS" ] || fail "credential violations recorded: $(cat "$VIOLATIONS")"
+pass "the key never reaches curl's argv and its config file is mode 0600"
+
+assert_contains "$OUT" "RUNNING" "list surfaces the RUNNING latest run"
+assert_contains "$OUT" "FINISHED" "list surfaces the FINISHED latest run"
+assert_contains "$OUT" "ERROR" "list surfaces the fallback-resolved ERROR run"
+assert_not_contains "$OUT" "ACTIVE" "the lifecycle enum is not presented as execution status"
+pass "list reports latest RUN status, so ACTIVE is never mistaken for running"
+
+grep -q "/v1/agents/$AGENT_MULTI/runs/run-aaa1" "$CALLS" \
+  || fail "latestRunId should be the fast path for an agent that has one"
+grep -q "/v1/agents/$AGENT_NORUNID/runs?limit=1" "$CALLS" \
+  || fail "an agent with no latestRunId should fall back to the runs list"
+assert_no_grep "/v1/agents/$AGENT_MULTI/runs?limit=1" "$CALLS" \
+  "the fallback must not fire when latestRunId is present"
+pass "latestRunId is preferred and its absence falls back to the runs list"
+
+assert_contains "$OUT" "AgentScan E2E" "the named environment is surfaced in list"
+assert_contains "$OUT" "ENVIRONMENT" "list leads with an ENVIRONMENT column"
+assert_contains "$OUT" "(ad-hoc cloud)" "an agent with no named environment shows as ad-hoc"
+assert_contains "$OUT" "named environment(s)" "the footer counts named environments"
+assert_contains "$OUT" "not to any single repository" "list states that an agent belongs to its environment"
+# The four-repo agent must report 4, so a multi-repo agent can never read as
+# single-repo. Its row is the one carrying the named environment.
+printf '%s\n' "$OUT" | grep -E "AgentScan E2E +4 " >/dev/null \
+  || fail "the four-repo agent must report its repository count next to its environment"
+pass "the environment is the unit of work and a multi-repo agent reports its repo count"
+
+# --- (h) --no-runs -----------------------------------------------------------
+
+run_cursor list --no-runs
+expect_code 0 "$RC" "list --no-runs succeeds"
+assert_contains "$OUT" "unresolved" "--no-runs marks run status unresolved"
+assert_contains "$OUT" "was not resolved" "--no-runs says nothing claims to know what is running"
+assert_no_grep "/runs/run-aaa1" "$CALLS" "--no-runs must issue no per-agent run request"
+pass "--no-runs costs one request and admits it knows nothing about execution"
+
+# --- (j) --json --------------------------------------------------------------
+
+run_cursor list --json
+expect_code 0 "$RC" "list --json succeeds"
+printf '%s' "$OUT" | jq -e '.schema == "fm-cursor-list.v1"' >/dev/null \
+  || fail "list --json must carry schema fm-cursor-list.v1"
+printf '%s' "$OUT" | jq -e '.count == 3 and .summary.running == 1 and .summary.multiRepo == 1' >/dev/null \
+  || fail "list --json summary counts are wrong: $(printf '%s' "$OUT" | jq -c .summary)"
+printf '%s' "$OUT" | jq -e '.summary.byRunStatus.RUNNING == 1 and .summary.byRunStatus.ERROR == 1' >/dev/null \
+  || fail "list --json byRunStatus is wrong"
+printf '%s' "$OUT" | jq -e '[.agents[] | .runStatusSource] | contains(["latestRunId"]) and contains(["runs-list"])' >/dev/null \
+  || fail "list --json must record which source answered per agent"
+printf '%s' "$OUT" | jq -e '[.agents[] | select((.repos | length) == 4)] | length == 1' >/dev/null \
+  || fail "list --json must expose every repository, not just the first"
+printf '%s' "$OUT" | jq -e '.summary.namedEnvironments == ["AgentScan E2E"]' >/dev/null \
+  || fail "list --json must list the named environments present"
+printf '%s' "$OUT" | jq -e '.summary.byEnvironment["AgentScan E2E"] == 1 and .summary.byEnvironment["(ad-hoc)"] == 2' >/dev/null \
+  || fail "list --json must group agents by environment: $(printf '%s' "$OUT" | jq -c .summary.byEnvironment)"
+printf '%s' "$OUT" | jq -e '[.agents[] | select(.envName == "AgentScan E2E")] | length == 1' >/dev/null \
+  || fail "list --json must carry each agent's environment name"
+pass "list --json emits fm-cursor-list.v1 with honest summary and per-agent provenance"
+
+run_cursor show "$AGENT_SINGLE" --json
+expect_code 0 "$RC" "show --json succeeds"
+printf '%s' "$OUT" | jq -e '.schema == "fm-cursor-show.v1" and .latestRun.status == "FINISHED"' >/dev/null \
+  || fail "show --json must carry its schema and the resolved latest run"
+
+run_cursor show "$AGENT_SINGLE"
+expect_code 0 "$RC" "show succeeds"
+assert_contains "$OUT" "environment  prod (cloud)" "show names the environment and its type"
+assert_contains "$OUT" "repositories 1 in this environment" "show frames repositories as belonging to the environment"
+assert_contains "$OUT" "does not belong to any single repository" "show states the environment-is-the-unit rule"
+pass "show leads with the environment rather than a repository"
+
+run_cursor runs "$AGENT_SINGLE" --json
+expect_code 0 "$RC" "runs --json succeeds"
+printf '%s' "$OUT" | jq -e '.schema == "fm-cursor-runs.v1" and .count == 2' >/dev/null \
+  || fail "runs --json must carry its schema and run count"
+printf '%s' "$OUT" | jq -e '.runs[0].branches[0].prUrl == "https://github.com/snyk/minired/pull/94"' >/dev/null \
+  || fail "runs --json must expose the PR URL"
+
+run_cursor usage "$AGENT_SINGLE" --json
+expect_code 0 "$RC" "usage --json succeeds"
+printf '%s' "$OUT" | jq -e '.schema == "fm-cursor-usage.v1" and .costAvailable == false' >/dev/null \
+  || fail "usage --json must carry its schema and declare cost unavailable"
+printf '%s' "$OUT" | jq -e '.totalUsage.totalTokens == 46791544' >/dev/null \
+  || fail "usage --json must pass through the token totals"
+pass "show, runs, and usage each emit their documented schema"
+
+run_cursor usage "$AGENT_SINGLE"
+assert_contains "$OUT" "tokens only" "human usage states that no cost figure exists"
+assert_contains "$OUT" "46791544" "human usage reports the token total"
+pass "usage says plainly that Cursor reports tokens and no cost"
+
+# --- (k) archived ------------------------------------------------------------
+
+run_cursor list
+assert_not_contains "$OUT" "Old archived thing" "archived agents are hidden by default"
+assert_contains "$OUT" "pass --all" "the default view points at --all"
+run_cursor list --all
+assert_contains "$OUT" "Old archived thing" "--all includes archived agents"
+assert_contains "$OUT" "archived" "--all shows the lifecycle column"
+pass "archived agents are hidden by default and included with --all"
+
+# --- (l) HTTP failures -------------------------------------------------------
+
+fixture "/v1/agents/bc-9999zzzz" '{"code":"error","message":"Invalid User API Key"}'
+fixture_code "/v1/agents/bc-9999zzzz" 401
+run_cursor show bc-9999zzzz
+expect_code 4 "$RC" "an API rejection exits 4"
+assert_contains "$OUT" "rejected the key" "a 401 is explained as a key problem"
+assert_contains "$OUT" "Invalid User API Key" "the API's own message is surfaced"
+assert_not_contains "$OUT" "$KEY" "a failure message never contains the key"
+
+fixture "/v1/agents/bc-8888yyyy" '{"code":"error","message":"Too Many Requests"}'
+fixture_code "/v1/agents/bc-8888yyyy" 429
+run_cursor show bc-8888yyyy
+expect_code 4 "$RC" "a rate limit exits 4"
+assert_contains "$OUT" "rate limited" "a 429 is explained as rate limiting"
+pass "HTTP failures exit 4 with the API's message and never leak the key"
+
+# --- (m) no temp credential file survives ------------------------------------
+
+run_cursor list
+while IFS= read -r cfg; do
+  [ -n "$cfg" ] || continue
+  assert_absent "$cfg" "the curl config holding the key must not survive the run"
+done < "$CFGS"
+[ -s "$CFGS" ] || fail "the fake curl should have recorded at least one config file"
+pass "the temporary file holding the key is removed on exit"
+
+# --- (n) default environment -------------------------------------------------
+
+# Absent config: no default, no marker, and a bare --env has nothing to resolve.
+assert_absent "$CONFIG_DIR/cursor-environment" "the fixture home starts with no default environment"
+run_cursor list
+expect_code 0 "$RC" "list works with no default environment configured"
+assert_not_contains "$OUT" "default environment" "no default configured means no default footnote"
+assert_not_contains "$OUT" "AgentScan E2E *" "no default configured means no marker"
+run_cursor list --env
+expect_code 2 "$RC" "a bare --env with no configured default exits 2"
+assert_contains "$OUT" "cursor-environment" "the error names the config file to create"
+pass "an absent config/cursor-environment means no default and a bare --env refuses"
+
+# Present config, with a trailing newline and a comment line to prove the parse.
+printf '# this home works on the shared stack\n\nAgentScan E2E\n' > "$CONFIG_DIR/cursor-environment"
+run_cursor list
+expect_code 0 "$RC" "list works with a default environment configured"
+assert_contains "$OUT" "AgentScan E2E *" "the default environment is marked with *"
+assert_contains "$OUT" "every environment is still listed" "the default must not silently filter"
+# The whole point: a default must not hide the rest of the fleet.
+printf '%s\n' "$OUT" | grep -q "(ad-hoc cloud)" \
+  || fail "configuring a default must not hide agents outside it"
+printf '%s\n' "$OUT" | grep -q "Single repo work" \
+  || fail "configuring a default must not hide agents outside it"
+pass "a configured default is marked but never filters list implicitly"
+
+# A bare --env resolves to the configured default and narrows the view.
+run_cursor list --env
+expect_code 0 "$RC" "a bare --env succeeds once a default is configured"
+assert_contains "$OUT" "AgentScan E2E" "the filtered view keeps the environment"
+assert_not_contains "$OUT" "Single repo work" "--env excludes agents in other environments"
+assert_contains "$OUT" "1 of 3 fetched" "the filtered footer reports matches against the fetch"
+assert_contains "$OUT" "--limit bounds the fetch" "the filtered footer warns that --limit bounds the fetch"
+# Filtering must precede run resolution, or a narrow filter costs a request per
+# agent it is about to discard.
+assert_no_grep "/v1/agents/bc-2222bbbb/runs/run-bbb1" "$CALLS" \
+  "an agent filtered out by --env must not have its run resolved"
+assert_grep "/v1/agents/bc-1111aaaa/runs/run-aaa1" "$CALLS" \
+  "an agent kept by --env must still have its run resolved"
+pass "a bare --env uses the configured default and filters before resolving runs"
+
+# An explicit --env overrides the default, including to an environment with no
+# agents, which must be an empty result rather than a silent fallback.
+run_cursor list --env "Nonexistent Env"
+expect_code 0 "$RC" "an --env with no matches still succeeds"
+assert_contains "$OUT" "No Cursor Cloud agents found." "an unmatched --env reports an empty result"
+assert_not_contains "$OUT" "AgentScan E2E *" "an unmatched --env must not fall back to the default"
+run_cursor list --env ""
+expect_code 2 "$RC" "an empty --env name exits 2 rather than selecting ad-hoc agents"
+assert_contains "$OUT" "non-empty environment name" "an empty --env name is refused explicitly"
+
+run_cursor list --env=AgentScan --json
+expect_code 0 "$RC" "--env=<name> is accepted"
+printf '%s' "$OUT" | jq -e '.environmentFilter == "AgentScan" and .count == 0' >/dev/null \
+  || fail "--env=<name> must filter on the exact name, not a prefix"
+pass "an explicit --env overrides the default and matches exactly"
+
+run_cursor list --json
+printf '%s' "$OUT" | jq -e '.defaultEnvironment == "AgentScan E2E" and .environmentFilter == null' >/dev/null \
+  || fail "list --json must report the default without implying a filter"
+printf '%s' "$OUT" | jq -e '.fetched == 3 and .count == 3' >/dev/null \
+  || fail "an unfiltered list --json must report fetched == count"
+pass "list --json reports the default environment separately from any filter"
+
+printf '\nall fm-cursor tests passed\n'


### PR DESCRIPTION
## Why

Firstmate had no way to see or drive the Cursor Cloud agents that the team's work actually runs on. Cloud agents run on Cursor's infrastructure, so they fit none of firstmate's existing seams: there is no pane to capture, no composer to submit into, and no local worktree to isolate.

## How

`bin/fm-cursor.sh`, a guarded helper over the Cloud Agents API using `curl` and `jq` - the same pair X mode already requires, so no new runtime dependency.

Deliberately **not** a runtime backend and **not** a harness. Most of `bin/fm-backend.sh`'s adapter contract could only be stubbed with lies, and a cloud spawn could never satisfy the worktree-isolation assertion in `bin/fm-spawn.sh`, which protects a real safety invariant. It follows the companion-surface precedent already set for Codex Desktop threads. `bin/fm-backend.sh`, `bin/fm-spawn.sh` and `FM_BACKEND_KNOWN` are untouched, and it creates no task records and registers no watcher check - which is what stops a windowless, worktreeless agent from being read as a stalled crewmate by session-start recovery.

Two API facts drive the shape, both verified against the live API:

- An agent's `status` is **lifecycle only** (`ACTIVE|ARCHIVED`); execution status lives on runs. `ACTIVE` means "not archived", never "currently running" - 12 of 12 sampled ACTIVE agents had FINISHED latest runs, some six weeks old. `list` therefore resolves each agent's latest run and reports the run status as the primary column.
- A Cursor **agent** maps onto a firstmate task and a Cursor **environment** maps onto a project. `POST /v1/agents` takes either a named environment or a bare repo list, documented as mutually exclusive, and the environment is what carries the predefined secrets and MCP configuration. An agent belongs to its environment, never to one repository inside it, so `list` and `show` lead with the environment.

`config/cursor-environment` optionally names a default environment. It is a **target** for operations that need one, not a view preference, so it marks the default with `*` and never filters `list` implicitly.

## Credential handling

Presence-gated on `CURSOR_API_KEY` in the gitignored `.env`, read from that file only - never an ambient variable, which would silently change which account firstmate speaks for, and never the macOS keychain or `cursor-agent`'s stored credentials. The key reaches `curl` through a mode-0600 config file, never `argv`, since a process argument is readable via `ps`. Both the key charset and the timeout are validated before touching that file, because it carries the bearer header and its syntax is injectable.

Work in progress: read-only `list`/`show`/`runs`/`usage` is complete and validated; steering and creation are being added to this branch.