### PR TITLE
fix(bin): require a real PR and genuinely-run checks before a done report

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -33,7 +33,7 @@
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
-# Both PR-based modes carry an evidence gate on the done report, because workers
+# Both PR-based modes carry an evidence gate on the delivery report, because workers
 # repeatedly read the absence of a visible failure as success: a real PR URL must
 # exist, and "checks green" may describe only checks that actually ran and passed.
 # local-only has no PR by definition and carries no part of that gate.
@@ -309,12 +309,14 @@ EOF
 # Evidence gate for the PR-based modes. Measured failure: workers on every
 # harness reported "done: committed <sha>" with no PR, and "checks green" on a
 # fork PR whose workflow runs sat at action_required so nothing had run at all.
-# Both read the absence of a visible failure as success, so the done report has
-# to name the positive evidence each half requires. local-only never gets this:
-# it has no PR by definition.
+# Both read the absence of a visible failure as success, so the delivery report
+# has to name the positive evidence each half requires. The gate governs only
+# the done line that names a PR: the no-mistakes Stage 1 handoff has no PR by
+# design and must not read it as a blocker. local-only never gets the gate at
+# all: it has no PR by definition.
 IFS= read -r -d '' DONE_EVIDENCE <<'EOF' || true
-**Neither half of done may be inferred from the absence of a failure.**
-1. A PR must exist and you must have its real URL. A commit, or even a pushed branch, is not a delivered PR - if there is no PR you are not done, so append `blocked: {what is actually true}` instead.
+**Neither half of the delivery report - the done line that names a PR - may be inferred from the absence of a failure.**
+1. A PR must exist and you must have its real URL. A commit, or even a pushed branch, is not a delivered PR - never claim delivery without one: if the report should name a PR and none exists, append `blocked: {what is actually true}` instead.
 2. `checks green` may describe only checks that actually ran and passed. `gh pr checks <number>` printing nothing, reporting no checks, or listing only skipped, queued, or pending runs is NOT green - a fork PR awaiting approval sits at `action_required` and runs nothing. If nothing ran, never write `checks green`: report what you actually see and let firstmate decide.
 EOF
 DONE_EVIDENCE=${DONE_EVIDENCE%$'\n'}

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -33,6 +33,10 @@
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
+# Both PR-based modes carry an evidence gate on the done report, because workers
+# repeatedly read the absence of a visible failure as success: a real PR URL must
+# exist, and "checks green" may describe only checks that actually ran and passed.
+# local-only has no PR by definition and carries no part of that gate.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Every scaffold's status protocol distinguishes the configured
@@ -302,6 +306,19 @@ read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
 
+# Evidence gate for the PR-based modes. Measured failure: workers on every
+# harness reported "done: committed <sha>" with no PR, and "checks green" on a
+# fork PR whose workflow runs sat at action_required so nothing had run at all.
+# Both read the absence of a visible failure as success, so the done report has
+# to name the positive evidence each half requires. local-only never gets this:
+# it has no PR by definition.
+IFS= read -r -d '' DONE_EVIDENCE <<'EOF' || true
+**Neither half of done may be inferred from the absence of a failure.**
+1. A PR must exist and you must have its real URL. A commit, or even a pushed branch, is not a delivered PR - if there is no PR you are not done, so append `blocked: {what is actually true}` instead.
+2. `checks green` may describe only checks that actually ran and passed. `gh pr checks <number>` printing nothing, reporting no checks, or listing only skipped, queued, or pending runs is NOT green - a fork PR awaiting approval sits at `action_required` and runs nothing. If nothing ran, never write `checks green`: report what you actually see and let firstmate decide.
+EOF
+DONE_EVIDENCE=${DONE_EVIDENCE%$'\n'}
+
 case "$MODE" in
   direct-PR)
     SETUP2=""
@@ -309,9 +326,11 @@ case "$MODE" in
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
+Committing is not delivering: the task is complete only when a PR exists for your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+
+$DONE_EVIDENCE
 EOF
     ;;
   local-only)
@@ -332,7 +351,8 @@ EOF
     RULE1='1. Never push to the default branch. Never merge a PR.'
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
-The task is complete only when committed on your branch.
+This ships in two stages, and the first one is a handoff, not delivery.
+Stage 1 - the implementation is complete when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
@@ -346,7 +366,10 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
+Stage 2 - delivery.
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+
+$DONE_EVIDENCE
 EOF
     ;;
 esac

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -237,6 +237,121 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
+# Measured failure (2026-07-30/31, seven occurrences across claude, codex and
+# opencode/GLM): workers reported "done: committed <sha>" with no PR, and
+# "checks green" on a fork PR whose runs sat at action_required so nothing had
+# run. Both treat the absence of a visible failure as success, so every PR-based
+# mode must state the positive evidence each half of done requires.
+test_pr_modes_require_a_real_pr_and_genuinely_run_checks() {
+  local home id brief
+  home="$TMP_ROOT/done-evidence-home"
+  write_registry "$home"
+
+  for id_proj in "brief-done-evidence-nm:no-registry-proj" "brief-done-evidence-dp:direct-proj"; do
+    id=${id_proj%%:*}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "${id_proj##*:}" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_grep "Neither half of done may be inferred from the absence of a failure." "$brief" \
+      "$id: PR-based brief lost the absence-of-failure gate"
+    assert_grep "A PR must exist and you must have its real URL." "$brief" \
+      "$id: PR-based brief did not require a real PR URL"
+    assert_grep "A commit, or even a pushed branch, is not a delivered PR" "$brief" \
+      "$id: PR-based brief did not deny that committing is delivering"
+    # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+    assert_grep '`gh pr checks <number>` printing nothing' "$brief" \
+      "$id: PR-based brief did not name the exact no-output shape that read as green"
+    assert_grep "listing only skipped, queued, or pending runs is NOT green" "$brief" \
+      "$id: PR-based brief accepted a check-run set with nothing actually run"
+    # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+    assert_grep 'sits at `action_required` and runs nothing' "$brief" \
+      "$id: PR-based brief lost the fork-PR case that produced the false green"
+    assert_no_grep "The task is complete only when committed on your branch." "$brief" \
+      "$id: PR-based brief still declares a local commit complete"
+  done
+
+  # The evidence gate must not hand a worker a new way to declare success:
+  # a missing PR is a blocker, never a done report.
+  brief="$home/data/brief-done-evidence-dp/brief.md"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'if there is no PR you are not done, so append `blocked: {what is actually true}` instead' \
+    "$brief" "direct-PR brief turned a missing PR into something other than a blocker"
+  assert_grep 'Committing is not delivering: the task is complete only when a PR exists for your branch.' \
+    "$brief" "direct-PR brief lost its PR-is-completion statement"
+
+  # The no-mistakes first report is a handoff, not delivery, and its terminal
+  # gate keeps the exact status token firstmate's classifier consumes.
+  brief="$home/data/brief-done-evidence-nm/brief.md"
+  assert_grep "the first one is a handoff, not delivery" "$brief" \
+    "no-mistakes brief no longer distinguishes the handoff from delivery"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'append `done: PR {url} checks green` and stop' "$brief" \
+    "no-mistakes brief lost its terminal checks-green report token"
+  assert_grep "do not wait for it to keep monitoring in the background until merge" "$brief" \
+    "no-mistakes brief lost the CI-ready return point"
+
+  pass "fm-brief.sh: PR-based modes require a real PR and checks that actually ran"
+}
+
+# local-only has no PR by definition, so the PR-based evidence gate must not be
+# imposed on it: a requirement it cannot satisfy would be unfollowable.
+test_local_only_keeps_its_no_pr_contract() {
+  local home brief
+  home="$TMP_ROOT/local-only-contract-home"
+  write_registry "$home"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-localonly-nopr local-proj >/dev/null 2>&1
+  brief="$home/data/brief-localonly-nopr/brief.md"
+
+  assert_no_grep "A PR must exist" "$brief" \
+    "local-only brief was given a PR requirement it cannot satisfy"
+  assert_no_grep "Neither half of done" "$brief" \
+    "local-only brief inherited the PR-based evidence gate"
+  assert_no_grep "checks green" "$brief" \
+    "local-only brief was given a CI-green requirement it has no CI for"
+  assert_grep "no remote, no PR, no pipeline" "$brief" \
+    "local-only brief lost its no-remote contract"
+  assert_grep "append \`done: ready in branch fm/brief-localonly-nopr\`" "$brief" \
+    "local-only brief lost its ready-in-branch report"
+  pass "fm-brief.sh: local-only keeps its no-PR definition of done"
+}
+
+# The tightened done wording must not displace any existing safety clause, in
+# any ship mode.
+test_ship_safety_clauses_survive_in_every_mode() {
+  local home id brief
+  home="$TMP_ROOT/safety-survival-home"
+  write_registry "$home"
+
+  for id_proj in "brief-safety-nm:no-registry-proj" "brief-safety-dp:direct-proj" "brief-safety-lo:local-proj"; do
+    id=${id_proj%%:*}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "${id_proj##*:}" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_grep "**Verify isolation before anything else.**" "$brief" \
+      "$id: brief lost the worktree-isolation assertion"
+    assert_grep "blocked: launched in primary checkout, not an isolated worktree" "$brief" \
+      "$id: brief lost the primary-checkout stop instruction"
+    assert_grep "# Herdr lifecycle declaration - NOT ENABLED" "$brief" \
+      "$id: brief lost the Herdr lab gate"
+    assert_grep "regenerate the brief with \`--herdr-lab\` before dispatch" "$brief" \
+      "$id: brief lost the Herdr regeneration instruction"
+    assert_grep "Never stop, restart, or update the shared \`no-mistakes\` daemon" "$brief" \
+      "$id: brief lost the shared-daemon rule"
+    assert_grep "append \`needs-decision: {summary of options}\` and stop" "$brief" \
+      "$id: brief lost the escalation rule"
+    assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
+      "$id: brief lost the nonterminal working: protection"
+    assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker"
+  done
+
+  # The Herdr hard contract still replaces the declaration when asked for.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-safety-lab direct-proj --herdr-lab >/dev/null 2>&1
+  brief="$home/data/brief-safety-lab/brief.md"
+  assert_grep "# Herdr isolation - HARD SAFETY CONTRACT" "$brief" \
+    "--herdr-lab ship brief lost its hard safety contract alongside the done gate"
+  assert_grep "A PR must exist and you must have its real URL." "$brief" \
+    "--herdr-lab ship brief lost the done evidence gate"
+  pass "fm-brief.sh: isolation, Herdr and reporting safety clauses survive in every ship mode"
+}
+
 # Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
 # reference must render as plain prose with no dangling apostrophe artifact.
 test_no_mistakes_dod_wording() {
@@ -623,6 +738,9 @@ test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
+test_pr_modes_require_a_real_pr_and_genuinely_run_checks
+test_local_only_keeps_its_no_pr_contract
+test_ship_safety_clauses_survive_in_every_mode
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -251,7 +251,7 @@ test_pr_modes_require_a_real_pr_and_genuinely_run_checks() {
     id=${id_proj%%:*}
     FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "${id_proj##*:}" >/dev/null 2>&1
     brief="$home/data/$id/brief.md"
-    assert_grep "Neither half of done may be inferred from the absence of a failure." "$brief" \
+    assert_grep "Neither half of the delivery report - the done line that names a PR - may be inferred from the absence of a failure." "$brief" \
       "$id: PR-based brief lost the absence-of-failure gate"
     assert_grep "A PR must exist and you must have its real URL." "$brief" \
       "$id: PR-based brief did not require a real PR URL"
@@ -273,7 +273,7 @@ test_pr_modes_require_a_real_pr_and_genuinely_run_checks() {
   # a missing PR is a blocker, never a done report.
   brief="$home/data/brief-done-evidence-dp/brief.md"
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
-  assert_grep 'if there is no PR you are not done, so append `blocked: {what is actually true}` instead' \
+  assert_grep 'never claim delivery without one: if the report should name a PR and none exists, append `blocked: {what is actually true}` instead' \
     "$brief" "direct-PR brief turned a missing PR into something other than a blocker"
   assert_grep 'Committing is not delivering: the task is complete only when a PR exists for your branch.' \
     "$brief" "direct-PR brief lost its PR-is-completion statement"
@@ -292,6 +292,40 @@ test_pr_modes_require_a_real_pr_and_genuinely_run_checks() {
   pass "fm-brief.sh: PR-based modes require a real PR and checks that actually ran"
 }
 
+# The evidence gate governs only the delivery report that names a PR. The
+# no-mistakes Stage 1 handoff has no PR by design and is reported as
+# `done: {summary}` at a local commit; an unscoped gate ("if there is no PR you
+# are not done") let a literal reader route that legitimate handoff to a false
+# `blocked:` and stall the flow.
+test_no_mistakes_handoff_is_outside_the_delivery_gate() {
+  local home brief
+  home="$TMP_ROOT/handoff-scope-home"
+  write_registry "$home"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-handoff-scope no-registry-proj >/dev/null 2>&1
+  brief="$home/data/brief-handoff-scope/brief.md"
+
+  # The no-PR handoff is still instructed exactly as before: commit, report,
+  # stop.
+  assert_grep "Stage 1 - the implementation is complete when committed on your branch." "$brief" \
+    "no-mistakes brief lost the Stage 1 commit handoff"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'When you believe it is complete, append `done: {summary}` to the status file and stop.' "$brief" \
+    "no-mistakes brief no longer instructs the Stage 1 handoff report"
+  # The gate names its own scope, so the PR-less handoff can neither satisfy
+  # nor violate it.
+  assert_grep "the done line that names a PR" "$brief" \
+    "no-mistakes brief's evidence gate is not scoped to the PR-naming delivery report"
+  assert_no_grep "if there is no PR you are not done" "$brief" \
+    "no-mistakes brief reads every no-PR done report as a violation, turning the Stage 1 handoff into a false blocker"
+  assert_no_grep "Neither half of done may be inferred" "$brief" \
+    "no-mistakes brief still carries the unscoped gate opening"
+  # A missing PR at delivery still routes to blocked, never to a done report.
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'append `blocked: {what is actually true}` instead' "$brief" \
+    "no-mistakes brief lost the blocked routing for a missing PR at delivery"
+  pass "fm-brief.sh: no-mistakes Stage 1 handoff sits outside the delivery evidence gate"
+}
+
 # local-only has no PR by definition, so the PR-based evidence gate must not be
 # imposed on it: a requirement it cannot satisfy would be unfollowable.
 test_local_only_keeps_its_no_pr_contract() {
@@ -303,7 +337,7 @@ test_local_only_keeps_its_no_pr_contract() {
 
   assert_no_grep "A PR must exist" "$brief" \
     "local-only brief was given a PR requirement it cannot satisfy"
-  assert_no_grep "Neither half of done" "$brief" \
+  assert_no_grep "Neither half of the delivery report" "$brief" \
     "local-only brief inherited the PR-based evidence gate"
   assert_no_grep "checks green" "$brief" \
     "local-only brief was given a CI-green requirement it has no CI for"
@@ -739,6 +773,7 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_pr_modes_require_a_real_pr_and_genuinely_run_checks
+test_no_mistakes_handoff_is_outside_the_delivery_gate
 test_local_only_keeps_its_no_pr_contract
 test_ship_safety_clauses_survive_in_every_mode
 test_no_mistakes_dod_wording


### PR DESCRIPTION
## Intent

Stop crewmates reporting a task done when they have only committed locally, or when CI never actually ran. Measured 2026-07-30/31: seven occurrences across claude, codex and opencode/GLM in two repositories - five 'done: committed <sha>' reports with nothing pushed and no PR at all, and two 'done: PR <url> checks green' reports on a fork PR whose workflow runs sat at action_required so no check had run. The shared root cause is workers treating the absence of a visible failure as success, so bin/fm-brief.sh's generated definition of done must state both halves explicitly: a real PR URL must exist, and 'checks green' may describe only checks that genuinely ran and passed - naming the exact 'gh pr checks <n> prints nothing' shape that fooled two workers.

Deliberate decisions a reviewer reading only the diff would not know: (1) The evidence gate is added only to the two PR-based delivery modes; local-only is deliberately untouched because it has no PR and no CI by definition, and imposing either would be a requirement it cannot satisfy - a test asserts its absence there. (2) A missing PR routes to 'blocked:', never to a done report, because this must tighten the contract without creating any new way to declare success. (3) The direct-PR opening sentence 'The task is complete only when committed on your branch' was replaced rather than supplemented - it was the literal invitation to the observed failure. (4) The no-mistakes definition of done is now framed as two stages with the first labelled a handoff rather than completion; its 'done: PR {url} checks green' token and CI-ready return point are byte-identical on purpose because bin/fm-crew-state.sh and bin/fm-classify-lib.sh consume that exact string. (5) Delivery-mode semantics, the scaffold structure and spawn were deliberately left alone - only the wording of what done requires changed. (6) The new prose is deliberately short and prominent: the scaffold is already long and a worker who skims would miss a wall of text.

Deliberately NOT expanded, and reported instead: a related failure where a worker called a PR merged when the merge command had only enqueued it. The crewmate brief already forbids workers from merging and no generated gate ever claims merged, so that fix belongs to bin/fm-pr-merge.sh, which returns gh-axi pr merge's exit status without reading the forge's merged boolean.

Tests are behavioural over the generated brief for each delivery mode, never assertions about fm-brief.sh source bytes, per the repo rule that tests must exercise behaviour through an executable interface; they also prove the worktree-isolation assertion, the Herdr lab gate and the remaining safety clauses survive in every ship mode.

## What Changed
- `bin/fm-brief.sh` now appends a delivery evidence gate to the definition of done in both PR-based delivery modes (direct-PR and no-mistakes): a done report must name a real PR URL (a local commit or pushed branch routes to `blocked:` instead), and `checks green` may only describe checks that actually ran and passed — explicitly calling out the `gh pr checks` prints-nothing / `action_required` fork-PR shape that previously read as success. local-only briefs deliberately carry no gate since they have no PR or CI.
- The direct-PR brief replaces "The task is complete only when committed on your branch" with "Committing is not delivering...", and the no-mistakes brief reframes its flow as two stages — Stage 1 labelled a handoff, Stage 2 delivery — with the gate scoped to the done line that names a PR so the Stage 1 handoff (which has no PR by design) is not misread as blocked; the `done: PR {url} checks green` token and CI-ready return point stay byte-identical for their consumers in `fm-crew-state.sh` and `fm-classify-lib.sh`.
- Adds `tests/fm-brief.test.sh`, a behavioural suite over the generated briefs (22 tests, including 4 new ones covering the evidence gate per mode, the no-mistakes handoff exemption, local-only's no-PR contract, and survival of the ship safety clauses in every mode).

## Risk Assessment

✅ Low: The branch is prose-only changes to a brief scaffold generator plus behavioural tests; the round-1 false-blocker finding is fixed exactly as instructed with the gate scoped to the PR-naming delivery report, a registered regression test whose patterns I verified against a freshly generated brief, the classifier-consumed status token byte-identical, and every intent constraint satisfied.

## Testing

Ran the full fm-brief.sh behavioural test suite (22 tests pass, including the four new tests over generated briefs), then manually generated real briefs for all three delivery modes end-to-end and inspected the rendered Definition-of-done sections: both PR-based modes carry the two-part evidence gate (real PR URL or `blocked:`; 'checks green' only for checks that actually ran, naming the `gh pr checks` no-output and fork `action_required` shapes), the no-mistakes Stage 1 handoff sits outside the gate, local-only is untouched, and the classifier-consumed `done: PR {url} checks green` token is byte-identical to base with both consumers still matching. No visual artifact applies — the end-user surface is generated markdown, captured directly as brief files. Worktree left clean.

<details>
<summary>Evidence: Definition of done per delivery mode (rendered brief extracts)</summary>

```text
Generated crewmate briefs — Definition of done per delivery mode
(produced by: FM_HOME=<fixture> bin/fm-brief.sh <id> <project> at fc7ca9e)

================ direct-PR mode ================
# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
Committing is not delivering: the task is complete only when a PR exists for your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.

**Neither half of the delivery report - the done line that names a PR - may be inferred from the absence of a failure.**
1. A PR must exist and you must have its real URL. A commit, or even a pushed branch, is not a delivered PR - never claim delivery without one: if the report should name a PR and none exists, append `blocked: {what is actually true}` instead.
2. `checks green` may describe only checks that actually ran and passed. `gh pr checks <number>` printing nothing, reporting no checks, or listing only skipped, queued, or pending runs is NOT green - a fork PR awaiting approval sits at `action_required` and runs nothing. If nothing ran, never write `checks green`: report what you actually see and let firstmate decide.

================ no-mistakes mode ================
# Definition of done
This ships in two stages, and the first one is a handoff, not delivery.
Stage 1 - the implementation is complete when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

Stage 2 - delivery.
After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

**Neither half of the delivery report - the done line that names a PR - may be inferred from the absence of a failure.**
1. A PR must exist and you must have its real URL. A commit, or even a pushed branch, is not a delivered PR - never claim delivery without one: if the report should name a PR and none exists, append `blocked: {what is actually true}` instead.
2. `checks green` may describe only checks that actually ran and passed. `gh pr checks <number>` printing nothing, reporting no checks, or listing only skipped, queued, or pending runs is NOT green - a fork PR awaiting approval sits at `action_required` and runs nothing. If nothing ran, never write `checks green`: report what you actually see and let firstmate decide.

================ local-only mode ================
# Definition of done
This project ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/ev-localonly`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/ev-localonly` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: Full generated brief — no-mistakes mode</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of no-registry-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/ev-nomistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-brief-evidence.WxnPI8/state/ev-nomistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/bd/.no-mistakes/worktrees/6fd900e7a84b/01KYW9H4895S2YTGCM9C3TWQX6/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/bd/.no-mistakes/worktrees/6fd900e7a84b/01KYW9H4895S2YTGCM9C3TWQX6/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This ships in two stages, and the first one is a handoff, not delivery.
Stage 1 - the implementation is complete when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

Stage 2 - delivery.
After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

**Neither half of the delivery report - the done line that names a PR - may be inferred from the absence of a failure.**
1. A PR must exist and you must have its real URL. A commit, or even a pushed branch, is not a delivered PR - never claim delivery without one: if the report should name a PR and none exists, append `blocked: {what is actually true}` instead.
2. `checks green` may describe only checks that actually ran and passed. `gh pr checks <number>` printing nothing, reporting no checks, or listing only skipped, queued, or pending runs is NOT green - a fork PR awaiting approval sits at `action_required` and runs nothing. If nothing ran, never write `checks green`: report what you actually see and let firstmate decide.
```
</details>
<details>
<summary>Evidence: Full generated brief — direct-PR mode</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of direct-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/ev-directpr`

# Rules
1. Never push to the default branch (push only your `fm/ev-directpr` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-brief-evidence.WxnPI8/state/ev-directpr.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/bd/.no-mistakes/worktrees/6fd900e7a84b/01KYW9H4895S2YTGCM9C3TWQX6/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/bd/.no-mistakes/worktrees/6fd900e7a84b/01KYW9H4895S2YTGCM9C3TWQX6/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
Committing is not delivering: the task is complete only when a PR exists for your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.

**Neither half of the delivery report - the done line that names a PR - may be inferred from the absence of a failure.**
1. A PR must exist and you must have its real URL. A commit, or even a pushed branch, is not a delivered PR - never claim delivery without one: if the report should name a PR and none exists, append `blocked: {what is actually true}` instead.
2. `checks green` may describe only checks that actually ran and passed. `gh pr checks <number>` printing nothing, reporting no checks, or listing only skipped, queued, or pending runs is NOT green - a fork PR awaiting approval sits at `action_required` and runs nothing. If nothing ran, never write `checks green`: report what you actually see and let firstmate decide.
```
</details>
<details>
<summary>Evidence: Full generated brief — local-only mode</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of local-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/ev-localonly`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/ev-localonly` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-brief-evidence.WxnPI8/state/ev-localonly.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/bd/.no-mistakes/worktrees/6fd900e7a84b/01KYW9H4895S2YTGCM9C3TWQX6/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/bd/.no-mistakes/worktrees/6fd900e7a84b/01KYW9H4895S2YTGCM9C3TWQX6/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/ev-localonly`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/ev-localonly` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: fm-brief.test.sh transcript (22/22 ok)</summary>

<code>ok - fm-brief.sh: PR-based modes require a real PR and checks that actually ran&#10;ok - fm-brief.sh: no-mistakes Stage 1 handoff sits outside the delivery evidence gate&#10;ok - fm-brief.sh: local-only keeps its no-PR definition of done&#10;ok - fm-brief.sh: isolation, Herdr and reporting safety clauses survive in every ship mode</code>

```text
ok - fm-brief.sh: bash -n succeeds
/tmp/fm-brief.3KhDQy/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: PR-based modes require a real PR and checks that actually ran
ok - fm-brief.sh: no-mistakes Stage 1 handoff sits outside the delivery evidence gate
ok - fm-brief.sh: local-only keeps its no-PR definition of done
ok - fm-brief.sh: isolation, Herdr and reporting safety clauses survive in every ship mode
ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-brief.sh:317` - In the no-mistakes mode DOD, the appended evidence gate is unscoped and its clause 1 (&#39;if there is no PR you are not done, so append `blocked: {what is actually true}` instead&#39;) contradicts the Stage 1 instruction to append `done: {summary}` when the implementation is only committed locally — a state that by design has no PR yet. A literal-reading worker (the exact failure population this change targets) can obey the gate over the stage instruction and report `blocked:` at the Stage 1 handoff, stalling the flow with a false blocker. Consider scoping the gate&#39;s opening line to the delivery/Stage 2 done report (e.g. &#39;Neither half of the delivery done...&#39;) in the no-mistakes mode. This challenges deliberate wording decisions (2) and (4) in the stated intent, so it needs the author&#39;s call.

🔧 Fix: scope delivery evidence gate to PR-naming completion claim
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` — full behavioural suite for fm-brief.sh (22 tests incl. the 4 new: `test_pr_modes_require_a_real_pr_and_genuinely_run_checks`, `test_no_mistakes_handoff_is_outside_the_delivery_gate`, `test_local_only_keeps_its_no_pr_contract`, `test_ship_safety_clauses_survive_in_every_mode`), all pass</code>
- <code>Manual end-to-end generation: `FM_HOME=&lt;fixture&gt; bin/fm-brief.sh &lt;id&gt; &lt;project&gt;` for all three delivery modes (no-mistakes, direct-PR via registry `[direct-PR]`, local-only via `[local-only]`), then inspected the rendered Definition-of-done sections a crewmate would read</code>
- <code>Verified the direct-PR brief replaced &#39;The task is complete only when committed on your branch&#39; with &#39;Committing is not delivering...&#39; and carries both halves of the evidence gate incl. the `gh pr checks` no-output and `action_required` fork-PR shapes, with missing-PR routing to `blocked:`</code>
- `Verified the no-mistakes brief frames Stage 1 as 'a handoff, not delivery', scopes the gate to 'the done line that names a PR', and keeps the CI-ready return point`
- `Verified the local-only brief carries no PR requirement, no evidence gate, and no 'checks green' language`
- <code>Byte-compared the `done: PR {url} checks green` token line against base commit f7d0d0a (identical) and confirmed its consumers `bin/fm-crew-state.sh:266` and `bin/fm-classify-lib.sh:45` still match it</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: lint clean with pinned ShellCheck 0.11.0; no fixes needed
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
