### PR TITLE
feat(bin): enforce brief external-tool allowlist before ship execution

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -69,6 +69,13 @@ The primary integrations for `claude`, `codex`, `opencode`, `pi`, `pi-signed`, a
 `opencode`, `pi`, and `pi-signed` block by throwing from `tool.execute.before` / returning `{block: true}` from `tool_call`.
 The exact hook files, commands, output-shaping quirks (Claude Code only honors the deny when stdout is empty), and validation transcripts are owned by `docs/arm-pretool-check.md`.
 When changing any watcher-arm PreToolUse hook, validate the real harness behavior in a scratch project before trusting it, then update that doc.
+
+## Ship external-tool policy
+
+Every ship launch and every generated promotable scout must connect the machine-readable policy in its brief before the first worker turn.
+Claude, Codex, OpenCode, Pi, pi-signed, and Grok have verified thin before-tool adapters; Kimi ship launches and every unverified or raw ship harness launch refuse instead of running without interception.
+`docs/external-tool-policy.md` owns the policy format, classifier boundary, adapter mechanics, runtime-backend applicability, and validation pointer.
+
 ## Primary delegation-shape guard
 
 Claude exposes built-in delegation, scheduling, and worktree tools that a primary session can use to create work with no `state/<id>.meta`, which makes the whole guard stack inert because every guard counts that metadata.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,7 @@ A completed scout must leave a self-contained report before its scratch worktree
 A report may recommend implementation but does not authorize it.
 Before treating the investigation or any visual review as complete, load `decision-hold-lifecycle`; teardown enforces that shared completion gate.
 When implementation is separately authorized, promote the existing scout through `bin/fm-promote.sh` rather than creating a duplicate task.
+A scout launched without enforced external-tool interception cannot become a live ship; the promotion command refuses it and requires a new generated ship brief instead.
 The promoted worker must inventory scratch state, return to a clean default-branch base, carry over only intended fix changes, create the ship branch, and follow the project's selected delivery path while leaving scratch commits and debug edits behind and turning a reproduced bug into the regression test.
 
 ## 8. Supervision protocol
@@ -459,6 +460,7 @@ Use its scaffold as the contract, then replace every `{TASK}` placeholder with a
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
+Every ship brief must also retain its machine-readable external-tool policy; `bin/fm-spawn.sh` refuses a ship whose selected harness cannot enforce that brief policy before tool execution.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.

--- a/bin/fm-arm-command-policy.mjs
+++ b/bin/fm-arm-command-policy.mjs
@@ -666,6 +666,53 @@ function evalPayload(position) {
   return payloads.map((payload) => payload.value).join(" ");
 }
 
+/** Walks literal shell execution positions, including nested shells, substitutions, groups, eval, and stdin payloads. */
+export function walkShellCommandTree(command, maxDepth = 12) {
+  const commands = [];
+  const errors = [];
+  const opaquePayloads = [];
+
+  function walk(source, depth) {
+    if (depth > maxDepth) {
+      errors.push({ source, reason: "recursion limit" });
+      return;
+    }
+    const lexed = new Lexer(source).tokenize();
+    if (lexed.error) {
+      errors.push({ source, reason: lexed.error });
+      return;
+    }
+    const program = splitProgram(lexed.tokens);
+    for (const tokens of program.nodes) {
+      const position = commandPosition(tokens);
+      commands.push({ source, tokens, position });
+
+      for (const payload of position.wrapperPayloads) walk(payload, depth + 1);
+      for (const token of tokens) {
+        if (token.type === "group") walk(token.content, depth + 1);
+        if (token.type !== "word") continue;
+        for (const substitution of token.subs) walk(substitution.content, depth + 1);
+      }
+
+      const shell = shellInvocation(position);
+      if (shell?.kind === "command" && shell.payload) {
+        if (shell.payload.literal && shell.payload.subs.length === 0) {
+          walk(shell.payload.value, depth + 1);
+        } else {
+          opaquePayloads.push({ source, value: shell.payload.value });
+        }
+      }
+      const literalEvalPayload = evalPayload(position);
+      if (literalEvalPayload !== null) walk(literalEvalPayload, depth + 1);
+      for (const payload of shellHeredocPayloads(tokens, position)) walk(payload, depth + 1);
+      for (const payload of shellHereStringPayloads(tokens, position)) walk(payload, depth + 1);
+    }
+  }
+
+  walk(command, 0);
+  return { commands, errors, opaquePayloads };
+}
+
 function wordReferencesAny(word, names) {
   if (!word || names.size === 0) return false;
   for (const match of word.value.matchAll(/\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g)) {

--- a/bin/fm-arm-command-policy.mjs
+++ b/bin/fm-arm-command-policy.mjs
@@ -671,24 +671,24 @@ export function walkShellCommandTree(command, maxDepth = 12) {
   const commands = [];
   const errors = [];
   const opaquePayloads = [];
-+  const leadingExecutionKeywords = new Set(["!", "do", "elif", "else", "if", "then", "time", "until", "while"]);
-+  const controlOnlyKeywords = new Set(["case", "done", "esac", "fi", "for", "function", "select"]);
-+
-+  function shellExecutionPosition(tokens) {
-+    let remaining = tokens;
-+    while (remaining.length > 0) {
-+      const position = commandPosition(remaining);
-+      const name = basename(position.command?.value || "");
-+      if (!name || controlOnlyKeywords.has(name)) return null;
-+      if (!leadingExecutionKeywords.has(name)) return position;
-+      const commandIndex = remaining.indexOf(position.command);
-+      if (commandIndex < 0) return null;
-+      remaining = remaining.slice(commandIndex + 1);
-+    }
-+    return null;
-+  }
-+
-+  function walk(source, depth) {
+  const leadingExecutionKeywords = new Set(["!", "do", "elif", "else", "if", "then", "time", "until", "while"]);
+  const controlOnlyKeywords = new Set(["case", "done", "esac", "fi", "for", "function", "select"]);
+
+  function shellExecutionPosition(tokens) {
+    let remaining = tokens;
+    while (remaining.length > 0) {
+      const position = commandPosition(remaining);
+      const name = basename(position.command?.value || "");
+      if (!name || controlOnlyKeywords.has(name)) return null;
+      if (!leadingExecutionKeywords.has(name)) return position;
+      const commandIndex = remaining.indexOf(position.command);
+      if (commandIndex < 0) return null;
+      remaining = remaining.slice(commandIndex + 1);
+    }
+    return null;
+  }
+
+  function walk(source, depth) {
     if (depth > maxDepth) {
       errors.push({ source, reason: "recursion limit" });
       return;
@@ -700,10 +700,10 @@ export function walkShellCommandTree(command, maxDepth = 12) {
     }
     const program = splitProgram(lexed.tokens);
     for (const tokens of program.nodes) {
-+      const position = shellExecutionPosition(tokens);
-+      if (position) commands.push({ source, tokens, position });
-+
-+      for (const payload of position?.wrapperPayloads || []) walk(payload, depth + 1);
+      const position = shellExecutionPosition(tokens);
+      if (position) commands.push({ source, tokens, position });
+
+      for (const payload of position?.wrapperPayloads || []) walk(payload, depth + 1);
       for (const token of tokens) {
         if (token.type === "group") walk(token.content, depth + 1);
         if (token.type !== "word") continue;

--- a/bin/fm-arm-command-policy.mjs
+++ b/bin/fm-arm-command-policy.mjs
@@ -671,8 +671,24 @@ export function walkShellCommandTree(command, maxDepth = 12) {
   const commands = [];
   const errors = [];
   const opaquePayloads = [];
-
-  function walk(source, depth) {
++  const leadingExecutionKeywords = new Set(["!", "do", "elif", "else", "if", "then", "time", "until", "while"]);
++  const controlOnlyKeywords = new Set(["case", "done", "esac", "fi", "for", "function", "select"]);
++
++  function shellExecutionPosition(tokens) {
++    let remaining = tokens;
++    while (remaining.length > 0) {
++      const position = commandPosition(remaining);
++      const name = basename(position.command?.value || "");
++      if (!name || controlOnlyKeywords.has(name)) return null;
++      if (!leadingExecutionKeywords.has(name)) return position;
++      const commandIndex = remaining.indexOf(position.command);
++      if (commandIndex < 0) return null;
++      remaining = remaining.slice(commandIndex + 1);
++    }
++    return null;
++  }
++
++  function walk(source, depth) {
     if (depth > maxDepth) {
       errors.push({ source, reason: "recursion limit" });
       return;
@@ -684,17 +700,17 @@ export function walkShellCommandTree(command, maxDepth = 12) {
     }
     const program = splitProgram(lexed.tokens);
     for (const tokens of program.nodes) {
-      const position = commandPosition(tokens);
-      commands.push({ source, tokens, position });
-
-      for (const payload of position.wrapperPayloads) walk(payload, depth + 1);
++      const position = shellExecutionPosition(tokens);
++      if (position) commands.push({ source, tokens, position });
++
++      for (const payload of position?.wrapperPayloads || []) walk(payload, depth + 1);
       for (const token of tokens) {
         if (token.type === "group") walk(token.content, depth + 1);
         if (token.type !== "word") continue;
         for (const substitution of token.subs) walk(substitution.content, depth + 1);
       }
 
-      const shell = shellInvocation(position);
+      const shell = position ? shellInvocation(position) : null;
       if (shell?.kind === "command" && shell.payload) {
         if (shell.payload.literal && shell.payload.subs.length === 0) {
           walk(shell.payload.value, depth + 1);
@@ -702,10 +718,12 @@ export function walkShellCommandTree(command, maxDepth = 12) {
           opaquePayloads.push({ source, value: shell.payload.value });
         }
       }
-      const literalEvalPayload = evalPayload(position);
+      const literalEvalPayload = position ? evalPayload(position) : null;
       if (literalEvalPayload !== null) walk(literalEvalPayload, depth + 1);
-      for (const payload of shellHeredocPayloads(tokens, position)) walk(payload, depth + 1);
-      for (const payload of shellHereStringPayloads(tokens, position)) walk(payload, depth + 1);
+      if (position) {
+        for (const payload of shellHeredocPayloads(tokens, position)) walk(payload, depth + 1);
+        for (const payload of shellHereStringPayloads(tokens, position)) walk(payload, depth + 1);
+      }
     }
   }
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -33,6 +33,10 @@
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
+# Every ship and promotable scout brief includes one machine-readable
+# firstmate.external-tools.v1 policy block. bin/fm-spawn.sh reads that block
+# directly and refuses to launch declared policy work unless the selected
+# harness can enforce it before every tool call.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Every scaffold's status protocol distinguishes the configured
@@ -247,12 +251,26 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+IFS= read -r -d '' EXTERNAL_TOOL_POLICY_SECTION <<'EOF' || true
+# External tool policy
+The JSON below is the only authorization source for controlled external tools.
+Spawn validates and connects this policy before your first turn.
+Project development commands such as tests, lint, builds, and local servers remain available.
+
+```firstmate-external-tools
+{"schema":"firstmate.external-tools.v1","shell":{"allow":["gh-axi","chrome-devtools-axi"]},"native":{"allow":["agent_browser"]}}
+```
+EOF
+EXTERNAL_TOOL_POLICY_SECTION=${EXTERNAL_TOOL_POLICY_SECTION%$'\n'}
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 # Task
 {TASK}
+
+$EXTERNAL_TOOL_POLICY_SECTION
 
 $HERDR_SECTION
 
@@ -265,7 +283,9 @@ The report is the only thing that survives, so anything worth keeping must be in
 # Rules
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+3. Use \`gh-axi\` for GitHub operations and \`chrome-devtools-axi\` for browser operations.
+   Use the native \`agent_browser\` tool only as a fallback when \`chrome-devtools-axi\` cannot complete the required evidence.
+   Never drive browser automation through a shell command unless the policy block explicitly authorizes that shell tool.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -362,6 +382,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 # Task
 {TASK}
 
+$EXTERNAL_TOOL_POLICY_SECTION
+
 $HERDR_SECTION
 
 # Setup
@@ -376,7 +398,9 @@ If the top-level path is the primary checkout or not the worktree you were launc
 # Rules
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+3. Use \`gh-axi\` for GitHub operations and \`chrome-devtools-axi\` for browser operations.
+   Use the native \`agent_browser\` tool only as a fallback when \`chrome-devtools-axi\` cannot complete the required evidence.
+   Never drive browser automation through a shell command unless the policy block explicitly authorizes that shell tool.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/bin/fm-external-tool-command-policy.mjs
+++ b/bin/fm-external-tool-command-policy.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+// Semantic external-tool policy for Firstmate protected task commands and native tools.
+//
+// The machine-readable policy lives only in the task brief. This classifier
+// reads that brief on every decision and reuses fm-arm-command-policy.mjs for
+// shell tokenization and nested execution traversal. It never executes,
+// expands, sources, or imports submitted command bytes.
+
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { walkShellCommandTree } from "./fm-arm-command-policy.mjs";
+
+const POLICY_SCHEMA = "firstmate.external-tools.v1";
+const POLICY_FENCE = "firstmate-external-tools";
+
+const BROWSER_SHELL_TOOLS = new Set([
+  "agent-browser",
+  "browser-use",
+  "chrome-devtools-axi",
+  "chromedriver",
+  "chromium",
+  "cypress",
+  "firefox",
+  "geckodriver",
+  "google-chrome",
+  "nightwatch",
+  "playwright",
+  "puppeteer",
+  "selenium",
+  "testcafe",
+  "webdriverio",
+  "webdriver-manager",
+]);
+const GITHUB_SHELL_TOOLS = new Set(["gh", "gh-axi"]);
+const PACKAGE_RUNNERS = new Set(["bunx", "npx", "pnpx", "uvx"]);
+const PACKAGE_MANAGERS = new Set(["bun", "npm", "pnpm", "yarn", "yarnpkg"]);
+const PYTHON_COMMANDS = new Set(["python", "python3", "python3.11", "python3.12", "python3.13"]);
+const PIP_COMMANDS = new Set(["pip", "pip3", "pip3.11", "pip3.12", "pip3.13"]);
+const SYSTEM_PACKAGE_MANAGERS = new Set(["apt", "apt-get", "brew", "dnf", "flatpak", "pacman", "snap", "yum"]);
+
+function parseArguments(argv) {
+  const result = { brief: "", tool: "", inputJson: "{}", command: "", validate: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    if (name === "--validate") {
+      result.validate = true;
+      continue;
+    }
+    if (["--brief", "--tool", "--input-json", "--command"].includes(name)) {
+      if (index + 1 >= argv.length) throw new Error(`${name} requires a value`);
+      result[name.slice(2).replace("-json", "Json")] = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${name}`);
+  }
+  if (!result.brief) throw new Error("--brief is required");
+  return result;
+}
+
+function exactObjectKeys(value, expected, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.join("\0") !== wanted.join("\0")) throw new Error(`${label} keys must be exactly: ${wanted.join(", ")}`);
+}
+
+function validateToolAllowList(value, label) {
+  exactObjectKeys(value, ["allow"], label);
+  if (!Array.isArray(value.allow)) throw new Error(`${label}.allow must be an array`);
+  const seen = new Set();
+  for (const item of value.allow) {
+    if (typeof item !== "string" || !/^[A-Za-z0-9@._/+:-]+$/.test(item)) {
+      throw new Error(`${label}.allow entries must be non-empty literal tool names`);
+    }
+    if (seen.has(item)) throw new Error(`${label}.allow contains duplicate tool '${item}'`);
+    seen.add(item);
+  }
+  return seen;
+}
+
+/** Reads and validates the only external-tool authorization source: the fenced JSON in one ship brief. */
+export function readExternalToolPolicy(briefPath) {
+  const source = readFileSync(briefPath, "utf8");
+  const fenceStart = `\`\`\`${POLICY_FENCE}`;
+  const start = source.indexOf(fenceStart);
+  if (start < 0) throw new Error(`brief lacks the ${POLICY_FENCE} policy fence`);
+  if (source.indexOf(fenceStart, start + fenceStart.length) >= 0) throw new Error(`brief contains more than one ${POLICY_FENCE} policy fence`);
+  const jsonStart = source.indexOf("\n", start + fenceStart.length);
+  if (jsonStart < 0) throw new Error(`${POLICY_FENCE} policy fence has no JSON body`);
+  const end = source.indexOf("\n```", jsonStart + 1);
+  if (end < 0) throw new Error(`${POLICY_FENCE} policy fence is not closed`);
+  let parsed;
+  try {
+    parsed = JSON.parse(source.slice(jsonStart + 1, end));
+  } catch (error) {
+    throw new Error(`${POLICY_FENCE} policy is invalid JSON: ${error.message}`);
+  }
+  exactObjectKeys(parsed, ["native", "schema", "shell"], "external-tool policy");
+  if (parsed.schema !== POLICY_SCHEMA) throw new Error(`external-tool policy schema must be '${POLICY_SCHEMA}'`);
+  return {
+    schema: parsed.schema,
+    briefPath,
+    shellAllow: validateToolAllowList(parsed.shell, "external-tool policy shell"),
+    nativeAllow: validateToolAllowList(parsed.native, "external-tool policy native"),
+  };
+}
+
+function executableBasename(value) {
+  return String(value || "").split("/").filter(Boolean).at(-1)?.toLowerCase() || "";
+}
+
+function stripPackageVersion(value) {
+  let item = String(value || "").toLowerCase().replace(/^npm:/, "");
+  item = item.split("#", 1)[0].split("?", 1)[0];
+  if (item.startsWith("@")) {
+    const versionAt = item.indexOf("@", item.indexOf("/") + 1);
+    if (versionAt > 0) item = item.slice(0, versionAt);
+  } else {
+    item = item.split("@", 1)[0];
+  }
+  return item.replace(/(?:==|~=|>=|<=|>|<).*/, "").replace(/\[[^\]]*\]$/, "");
+}
+
+function browserToolFromValue(value) {
+  const item = stripPackageVersion(value).replace(/\\/g, "/");
+  const base = executableBasename(item);
+  if (base === "agent-browser" || base === "agent_browser") return "agent-browser";
+  if (/(^|[/._-])playwright(?:$|[/._-])/.test(item) || item === "@playwright/test") return "playwright";
+  if (/(^|[/._-])puppeteer(?:$|[/._-])/.test(item) || item === "@puppeteer/browsers") return "puppeteer";
+  if (/(^|[/._-])selenium(?:$|[/._-])/.test(item) || base === "selenium-side-runner") return "selenium";
+  if (/(^|[/._-])webdriverio(?:$|[/._-])/.test(item) || base === "wdio") return "webdriverio";
+  if (/(^|[/._-])cypress(?:$|[/._-])/.test(item)) return "cypress";
+  if (/(^|[/._-])testcafe(?:$|[/._-])/.test(item)) return "testcafe";
+  if (/(^|[/._-])nightwatch(?:$|[/._-])/.test(item)) return "nightwatch";
+  if (/(^|[/._-])browser-use(?:$|[/._-])/.test(item)) return "browser-use";
+  if (/(^|[/._-])webdriver-manager(?:$|[/._-])/.test(item)) return "webdriver-manager";
+  if (/(^|[/._-])chromedriver(?:$|[/._-])/.test(item)) return "chromedriver";
+  if (/(^|[/._-])geckodriver(?:$|[/._-])/.test(item)) return "geckodriver";
+  if (/(^|[/._-])chrome-for-testing(?:$|[/._-])/.test(item)) return "google-chrome";
+  if (["chromium", "chromium-browser"].includes(base)) return "chromium";
+  if (["google-chrome", "google-chrome-stable", "chrome"].includes(base)) return "google-chrome";
+  if (["firefox", "firefox-esr"].includes(base)) return "firefox";
+  return "";
+}
+
+function browserToolFromText(value) {
+  const direct = browserToolFromValue(value);
+  if (direct) return direct;
+  const candidates = String(value || "").split(/[^A-Za-z0-9@._/+:-]+/).filter(Boolean);
+  for (const candidate of candidates) {
+    const tool = browserToolFromValue(candidate);
+    if (tool) return tool;
+  }
+  return "";
+}
+
+function request(tool, category, channel = "shell") {
+  return { tool, category, channel };
+}
+
+function firstNonOption(values, start = 0) {
+  for (let index = start; index < values.length; index += 1) {
+    if (values[index] === "--") return index + 1 < values.length ? index + 1 : -1;
+    if (!values[index].startsWith("-") || values[index] === "-") return index;
+  }
+  return -1;
+}
+
+function browserRequestsFromValues(values) {
+  const requests = [];
+  for (const value of values) {
+    if (value.startsWith("-")) continue;
+    const tool = browserToolFromValue(value);
+    if (tool) requests.push(request(tool, "browser"));
+  }
+  return requests;
+}
+
+function packageRunnerRequests(name, args) {
+  const requests = [];
+  let commandIndex = -1;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value === "--") {
+      commandIndex = index + 1;
+      break;
+    }
+    if (value === "-p" || value === "--package") {
+      if (args[index + 1]) requests.push(...browserRequestsFromValues([args[index + 1]]));
+      index += 1;
+      continue;
+    }
+    if (value === "-c" || value === "--call") {
+      if (args[index + 1]) requests.push(...classifyExternalShellCommand(args[index + 1]));
+      index += 1;
+      continue;
+    }
+    if (value.startsWith("--package=")) {
+      requests.push(...browserRequestsFromValues([value.slice("--package=".length)]));
+      continue;
+    }
+    if (value.startsWith("--call=")) {
+      requests.push(...classifyExternalShellCommand(value.slice("--call=".length)));
+      continue;
+    }
+    if (!value.startsWith("-")) {
+      commandIndex = index;
+      break;
+    }
+  }
+  if (commandIndex >= 0 && args[commandIndex]) requests.push(...directExecutableRequests(args[commandIndex], args.slice(commandIndex + 1)));
+  if (name === "uvx" && commandIndex < 0) requests.push(...browserRequestsFromValues(args));
+  return requests;
+}
+
+function packageManagerRequests(name, args) {
+  const commandAt = firstNonOption(args);
+  if (commandAt < 0) return [];
+  const subcommand = args[commandAt].toLowerCase();
+  const rest = args.slice(commandAt + 1);
+  if (["exec", "x", "dlx"].includes(subcommand)) return packageRunnerRequests(name, rest);
+  if (["add", "i", "install"].includes(subcommand)) return browserRequestsFromValues(rest);
+  if (["yarn", "yarnpkg"].includes(name)) return directExecutableRequests(subcommand, rest);
+  return [];
+}
+
+function pythonRequests(args) {
+  for (let index = 0; index < args.length - 1; index += 1) {
+    if (args[index] !== "-m") continue;
+    const tool = browserToolFromValue(args[index + 1]);
+    return tool ? [request(tool, "browser")] : [];
+  }
+  const codeIndex = args.findIndex((value) => value === "-c");
+  if (codeIndex >= 0 && args[codeIndex + 1]) {
+    const tool = browserToolFromText(args[codeIndex + 1]);
+    return tool ? [request(tool, "browser")] : [];
+  }
+  return [];
+}
+
+function nodeRequests(args) {
+  const scriptAt = firstNonOption(args);
+  if (scriptAt >= 0) {
+    const tool = browserToolFromValue(args[scriptAt]);
+    if (tool) return [request(tool, "browser")];
+  }
+  const evalIndex = args.findIndex((value) => value === "-e" || value === "--eval");
+  if (evalIndex >= 0 && args[evalIndex + 1]) {
+    const tool = browserToolFromText(args[evalIndex + 1]);
+    if (tool) return [request(tool, "browser")];
+  }
+  return [];
+}
+
+function systemPackageManagerRequests(name, args) {
+  const commandAt = firstNonOption(args);
+  if (commandAt < 0) return [];
+  const subcommand = args[commandAt].toLowerCase();
+  const installCommands = new Set(["add", "install", "reinstall"]);
+  if (name === "pacman") {
+    if (!args.some((value) => /^-[^-]*S/.test(value))) return [];
+    return browserRequestsFromValues(args);
+  }
+  if (!installCommands.has(subcommand)) return [];
+  return browserRequestsFromValues(args.slice(commandAt + 1));
+}
+
+function directExecutableRequests(executable, args) {
+  const name = executableBasename(executable);
+  if (["bash", "sh", "zsh"].includes(name)) {
+    const commandAt = args.findIndex((value) => /^-[A-Za-z]*c[A-Za-z]*$/.test(value));
+    if (commandAt >= 0 && args[commandAt + 1]) return classifyExternalShellCommand(args[commandAt + 1]);
+  }
+  if (name === "chrome-devtools-axi") return [request(name, "browser")];
+  if (name === "gh" || name === "gh-axi") return [request(name, "github")];
+  const directBrowser = browserToolFromValue(executable);
+  if (directBrowser) return [request(directBrowser, "browser")];
+  if (PACKAGE_RUNNERS.has(name)) return packageRunnerRequests(name, args);
+  if (PACKAGE_MANAGERS.has(name)) return packageManagerRequests(name, args);
+  if (name === "corepack" && args.length > 0) return directExecutableRequests(args[0], args.slice(1));
+  if (PYTHON_COMMANDS.has(name)) return pythonRequests(args);
+  if (PIP_COMMANDS.has(name)) {
+    const commandAt = firstNonOption(args);
+    return commandAt >= 0 && args[commandAt] === "install" ? browserRequestsFromValues(args.slice(commandAt + 1)) : [];
+  }
+  if (name === "pipx") {
+    const commandAt = firstNonOption(args);
+    return commandAt >= 0 && ["install", "run"].includes(args[commandAt]) ? browserRequestsFromValues(args.slice(commandAt + 1, commandAt + 2)) : [];
+  }
+  if (name === "uv" && args[0] === "pip" && args[1] === "install") return browserRequestsFromValues(args.slice(2));
+  if (name === "node" || /^nodejs?$/.test(name)) return nodeRequests(args);
+  if (SYSTEM_PACKAGE_MANAGERS.has(name)) return systemPackageManagerRequests(name, args);
+  return [];
+}
+
+function rawMentionsControlledBrowser(value) {
+  return Boolean(browserToolFromText(value));
+}
+
+/** Classifies controlled external tools in shell execution positions without evaluating the command. */
+export function classifyExternalShellCommand(command) {
+  const tree = walkShellCommandTree(command);
+  const requests = [];
+  for (const entry of tree.commands) {
+    const position = entry.position;
+    if (!position.command) continue;
+    const args = position.words.slice(position.index + 1).map((word) => word.value);
+    requests.push(...directExecutableRequests(position.command.value, args));
+  }
+  if ((tree.errors.length > 0 || tree.opaquePayloads.length > 0) && rawMentionsControlledBrowser(command)) {
+    requests.push(request("unclassifiable-browser-command", "browser"));
+  }
+  const seen = new Set();
+  return requests.filter((item) => {
+    const key = `${item.channel}\0${item.category}\0${item.tool}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function nativeToolRequest(toolName) {
+  const normalized = String(toolName || "").toLowerCase().replace(/[.:-]/g, "_");
+  if (normalized === "agent_browser" || normalized.endsWith("__agent_browser") || normalized.endsWith("_agent_browser")) {
+    return request("agent_browser", "browser", "native");
+  }
+  return null;
+}
+
+function browserAlternatives(policy) {
+  const shell = [...policy.shellAllow].filter((item) => BROWSER_SHELL_TOOLS.has(browserToolFromValue(item) || item));
+  const native = [...policy.nativeAllow].filter((item) => item === "agent_browser");
+  const alternatives = [];
+  if (shell.length > 0) alternatives.push(`shell: ${shell.join(", ")}`);
+  if (native.length > 0) alternatives.push(`native: ${native.join(", ")}`);
+  return alternatives.join("; ") || "none";
+}
+
+function githubAlternatives(policy) {
+  const shell = [...policy.shellAllow].filter((item) => GITHUB_SHELL_TOOLS.has(item));
+  return shell.length > 0 ? `shell: ${shell.join(", ")}` : "none";
+}
+
+function requestAllowed(policy, item) {
+  if (item.channel === "native") return policy.nativeAllow.has(item.tool);
+  if (policy.shellAllow.has(item.tool)) return true;
+  if (item.category === "browser" && item.tool === "playwright") {
+    return policy.shellAllow.has("@playwright/test");
+  }
+  return false;
+}
+
+function denyExternalTool(policy, item) {
+  const alternatives = item.category === "github" ? githubAlternatives(policy) : browserAlternatives(policy);
+  return {
+    decision: "deny",
+    code: "external-tool-denied",
+    reason: `requested ${item.category} ${item.channel} tool '${item.tool}' is not authorized by ${policy.schema} in brief ${policy.briefPath}; authorized alternatives: ${alternatives}`,
+  };
+}
+
+/** Applies one brief policy to a harness tool call. Uncontrolled project-development tools remain allowed. */
+export function decideExternalToolCall(policy, toolName, input, commandOverride = "") {
+  const nativeRequest = nativeToolRequest(toolName);
+  if (nativeRequest && !requestAllowed(policy, nativeRequest)) return denyExternalTool(policy, nativeRequest);
+  const command = commandOverride || (input && typeof input.command === "string" ? input.command : "");
+  if (!command) return { decision: "allow" };
+  for (const item of classifyExternalShellCommand(command)) {
+    if (!requestAllowed(policy, item)) return denyExternalTool(policy, item);
+  }
+  return { decision: "allow" };
+}
+
+function invokedDirectly() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(entry) === realpathSync(self);
+  } catch {
+    return entry === self;
+  }
+}
+
+if (invokedDirectly()) {
+  try {
+    const args = parseArguments(process.argv.slice(2));
+    const policy = readExternalToolPolicy(args.brief);
+    if (args.validate) {
+      process.stdout.write("allow\n");
+    } else {
+      let input;
+      try {
+        input = JSON.parse(args.inputJson || "{}");
+      } catch (error) {
+        throw new Error(`--input-json is invalid JSON: ${error.message}`);
+      }
+      const result = decideExternalToolCall(policy, args.tool, input, args.command);
+      if (result.decision === "allow") process.stdout.write("allow\n");
+      else process.stdout.write(`deny\t${result.code}\t${result.reason}\n`);
+    }
+  } catch (error) {
+    process.stderr.write(`fm-external-tool-policy: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/bin/fm-external-tool-pretool-check.sh
+++ b/bin/fm-external-tool-pretool-check.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Stable harness transport for the machine-readable external-tool policy in a protected task brief.
+#
+# The brief is the only authorization source. This wrapper extracts native hook
+# payload fields, invokes bin/fm-external-tool-command-policy.mjs, and renders
+# the harness-specific deny shape. It never classifies command semantics.
+#
+# Usage:
+#   <PreToolUse JSON on stdin> | fm-external-tool-pretool-check.sh --brief <path> [--format claude|grok|plain]
+#   fm-external-tool-pretool-check.sh --brief <path> --tool <name> --input-json <json> [--format plain]
+#   fm-external-tool-pretool-check.sh --brief <path> --command <command> [--format plain]
+#   fm-external-tool-pretool-check.sh --brief <path> --validate
+#
+# Allow exits 0 silently. Deny exits 2. Invalid transport, unavailable policy
+# runtime, and invalid or missing brief policy also exit 2 so a protected ship
+# or promotable scout never loses enforcement after spawn validation.
+set -u
+
+BRIEF=
+TOOL=
+INPUT_JSON='{}'
+COMMAND=
+FORMAT=plain
+VALIDATE=0
+TOOL_SET=0
+INPUT_SET=0
+COMMAND_SET=0
+
+usage() {
+  sed -n '2,16{s/^# \{0,1\}//;p;}' "$0"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --brief) [ "$#" -gt 1 ] || { echo "error: --brief requires a value" >&2; exit 2; }; BRIEF=$2; shift 2 ;;
+    --brief=*) BRIEF=${1#--brief=}; shift ;;
+    --tool) [ "$#" -gt 1 ] || { echo "error: --tool requires a value" >&2; exit 2; }; TOOL=$2; TOOL_SET=1; shift 2 ;;
+    --tool=*) TOOL=${1#--tool=}; TOOL_SET=1; shift ;;
+    --input-json) [ "$#" -gt 1 ] || { echo "error: --input-json requires a value" >&2; exit 2; }; INPUT_JSON=$2; INPUT_SET=1; shift 2 ;;
+    --input-json=*) INPUT_JSON=${1#--input-json=}; INPUT_SET=1; shift ;;
+    --command) [ "$#" -gt 1 ] || { echo "error: --command requires a value" >&2; exit 2; }; COMMAND=$2; COMMAND_SET=1; shift 2 ;;
+    --command=*) COMMAND=${1#--command=}; COMMAND_SET=1; shift ;;
+    --format) [ "$#" -gt 1 ] || { echo "error: --format requires a value" >&2; exit 2; }; FORMAT=$2; shift 2 ;;
+    --format=*) FORMAT=${1#--format=}; shift ;;
+    --validate) VALIDATE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+case "$FORMAT" in claude|grok|plain) ;; *) echo "error: --format must be claude, grok, or plain" >&2; exit 2 ;; esac
+[ -n "$BRIEF" ] || { echo "fm-external-tool-policy: --brief is required" >&2; exit 2; }
+
+render_deny() {
+  local detail=$1 escaped
+  escaped=$(printf '%s' "$detail" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr '\n' ' ')
+  case "$FORMAT" in
+    claude)
+      printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"%s"}\n' "$escaped" >&2
+      ;;
+    grok)
+      printf '%s\n' "$detail" >&2
+      printf '{"decision":"deny","reason":"%s"}\n' "$escaped"
+      ;;
+    plain)
+      printf '%s\n' "$detail" >&2
+      ;;
+  esac
+  exit 2
+}
+
+if [ "$VALIDATE" -eq 0 ] && [ "$TOOL_SET" -eq 0 ] && [ "$INPUT_SET" -eq 0 ] && [ "$COMMAND_SET" -eq 0 ]; then
+  PAYLOAD=$(cat 2>/dev/null || true)
+  [ -n "$PAYLOAD" ] || render_deny '[external-tool-policy-error] PreToolUse payload is empty; refusing an unclassified ship tool call'
+  command -v jq >/dev/null 2>&1 || render_deny '[external-tool-policy-error] jq is unavailable; refusing an unclassified ship tool call'
+  TOOL=$(printf '%s' "$PAYLOAD" | jq -er '(.tool_name // .toolName) | strings | select(length > 0)' 2>/dev/null) \
+    || render_deny '[external-tool-policy-error] PreToolUse payload lacks a tool name; refusing an unclassified ship tool call'
+  INPUT_JSON=$(printf '%s' "$PAYLOAD" | jq -cer '(.tool_input // .toolInput // {}) | objects' 2>/dev/null) \
+    || render_deny '[external-tool-policy-error] PreToolUse payload has invalid tool input; refusing an unclassified ship tool call'
+fi
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P) \
+  || render_deny '[external-tool-policy-error] policy code root is unavailable; refusing the ship tool call'
+POLICY="$SCRIPT_DIR/fm-external-tool-command-policy.mjs"
+command -v node >/dev/null 2>&1 \
+  || render_deny '[external-tool-policy-error] Node.js is unavailable; refusing the ship tool call'
+[ -f "$POLICY" ] \
+  || render_deny '[external-tool-policy-error] semantic policy executable is unavailable; refusing the ship tool call'
+
+ARGS=(--brief "$BRIEF")
+if [ "$VALIDATE" -eq 1 ]; then
+  ARGS+=(--validate)
+else
+  ARGS+=(--tool "$TOOL" --input-json "$INPUT_JSON")
+  [ "$COMMAND_SET" -eq 0 ] || ARGS+=(--command "$COMMAND")
+fi
+ERR_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-external-tool-policy.XXXXXX") \
+  || render_deny '[external-tool-policy-error] cannot create a private policy error buffer; refusing the ship tool call'
+POLICY_OUTPUT=$(node "$POLICY" "${ARGS[@]}" 2>"$ERR_FILE")
+STATUS=$?
+POLICY_ERROR=$(cat "$ERR_FILE" 2>/dev/null || true)
+rm -f "$ERR_FILE"
+if [ "$STATUS" -ne 0 ]; then
+  [ -n "$POLICY_ERROR" ] || POLICY_ERROR='semantic policy failed without a reason'
+  render_deny "[external-tool-policy-error] $POLICY_ERROR"
+fi
+[ "$VALIDATE" -eq 0 ] || exit 0
+
+TAB=$(printf '\t')
+DECISION=${POLICY_OUTPUT%%"$TAB"*}
+case "$DECISION" in
+  allow) exit 0 ;;
+  deny)
+    REST=${POLICY_OUTPUT#*"$TAB"}
+    [ "$REST" != "$POLICY_OUTPUT" ] || render_deny '[external-tool-policy-error] semantic policy returned an invalid deny result'
+    CODE=${REST%%"$TAB"*}
+    REASON=${REST#*"$TAB"}
+    [ -n "$CODE" ] && [ -n "$REASON" ] && [ "$REASON" != "$REST" ] \
+      || render_deny '[external-tool-policy-error] semantic policy returned an incomplete deny result'
+    render_deny "[$CODE] $REASON"
+    ;;
+  *) render_deny '[external-tool-policy-error] semantic policy returned an invalid decision' ;;
+esac

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -2,7 +2,9 @@
 # Promote a scout task to a ship task in place: the crewmate keeps its window,
 # worktree, and loaded context; only the contract changes. Flips kind= to ship in
 # state/<task-id>.meta so fm-teardown.sh applies the full ship-task teardown protection
-# again. After promoting, send the crewmate its ship instructions via fm-send.sh
+# again. Promotion is allowed only when spawn recorded an enforced external-tool
+# policy and that same brief policy still validates, so the live worker never
+# becomes an unprotected ship. After promoting, send the crewmate its ship instructions via fm-send.sh
 # (inventory scratch state, reset to a clean default-branch base, carry over only
 # intended fix changes, create branch fm/<task-id>, implement, then report done
 # according to the project's delivery mode).
@@ -13,11 +15,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1
 META="$STATE/$ID.meta"
+BRIEF="$DATA/$ID/brief.md"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
 grep -qx 'kind=scout' "$META" || { echo "error: task $ID is not a scout task (kind=scout not in meta)" >&2; exit 1; }
+grep -qx 'external_tool_policy=enforced' "$META" || {
+  echo "error: scout $ID was launched without enforceable external-tool interception and cannot be promoted into an unprotected ship; start a new ship with a generated brief" >&2
+  exit 1
+}
+[ -f "$BRIEF" ] || { echo "error: scout $ID policy brief is missing at $BRIEF" >&2; exit 1; }
+"$FM_ROOT/bin/fm-external-tool-pretool-check.sh" --brief "$BRIEF" --validate || {
+  echo "error: scout $ID external-tool policy no longer validates; refusing promotion" >&2
+  exit 1
+}
 
 TMP="$META.tmp"
 grep -v '^kind=' "$META" > "$TMP"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -4,7 +4,9 @@
 # Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
-#   positional harness arg still works for back-compat.
+#   positional harness arg still works for back-compat. A raw launch command remains
+#   available for adapter-verification scouts and secondmates, but ship spawns
+#   refuse it because no verified before-tool policy adapter is attached.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
@@ -71,7 +73,9 @@
 #   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
-#   new adapters. pi-signed launches that exact executable name from PATH and
+#   new adapters with scouts or secondmates. Ships refuse raw commands before
+#   endpoint creation because their tool policy cannot be intercepted reliably.
+#   pi-signed launches that exact executable name from PATH and
 #   refuses before endpoint creation when it is unavailable; it never falls back to pi.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
@@ -102,10 +106,16 @@
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
 #   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
 #   $vars and silently breaks ad-hoc `for ... in $pairs` loops).
+#   Every generated ship and promotable scout brief carries one
+#   firstmate.external-tools.v1 policy block. Before endpoint launch, spawn
+#   validates that block from the brief itself and installs a verified
+#   PreToolUse adapter for the selected harness. A ship on a
+#   harness without reliable interception is refused instead of running unguarded.
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
+#     __HOOKTRUSTFLAG__ Codex hook-trust bypass only after a task policy adapter is installed
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
@@ -465,7 +475,9 @@ launch_template() {
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        # Spawn fills __HOOKTRUSTFLAG__ only after it installs the otherwise-empty
+        # task worktree .codex/hooks.json for a declared external-tool policy.
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG____HOOKTRUSTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
@@ -538,6 +550,24 @@ esac
 # retain the literal name in the launch command and task metadata.
 if [ "$HARNESS" = pi-signed ] && ! command -v pi-signed >/dev/null 2>&1; then
   echo "error: pi-signed executable not found on PATH; install the signed Pi wrapper or select a different verified harness" >&2
+  exit 1
+fi
+
+external_tool_policy_harness_supported() {
+  case "$1" in
+    claude|codex|opencode|pi|pi-signed|grok) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# A ship must have a verified before-tool interception path before spawn performs
+# any harness-specific installation or creates a runtime endpoint.
+if [ "$KIND" = ship ] && ! external_tool_policy_harness_supported "$HARNESS"; then
+  if [ "$HARNESS" = kimi ]; then
+    echo "error: refusing ship spawn on harness 'kimi': no reliable pre-tool interception is verified; select claude, codex, opencode, pi, pi-signed, or grok" >&2
+  else
+    echo "error: refusing ship spawn on harness '${HARNESS:-unknown}': no verified external-tool policy adapter can intercept commands before execution" >&2
+  fi
   exit 1
 fi
 
@@ -849,6 +879,26 @@ fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
 BRIEF_DIR_REAL=$(cd "$(dirname "$BRIEF")" && pwd -P)
 BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
+
+TOOL_POLICY_ENABLED=0
+TOOL_POLICY_DECLARED=0
+TOOL_POLICY_CHECK="$FM_ROOT/bin/fm-external-tool-pretool-check.sh"
+grep -Fq '```firstmate-external-tools' "$BRIEF_REAL" && TOOL_POLICY_DECLARED=1
+if [ "$KIND" = ship ] || [ "$TOOL_POLICY_DECLARED" -eq 1 ]; then
+  external_tool_policy_harness_supported "$HARNESS" || {
+    echo "error: refusing $KIND spawn on harness '${HARNESS:-unknown}': the brief declares an external-tool policy but this harness cannot intercept tools before execution" >&2
+    exit 1
+  }
+  [ -x "$TOOL_POLICY_CHECK" ] || {
+    echo "error: refusing $KIND spawn because the external-tool policy checker is unavailable at $TOOL_POLICY_CHECK" >&2
+    exit 1
+  }
+  "$TOOL_POLICY_CHECK" --brief "$BRIEF_REAL" --validate || {
+    echo "error: refusing $KIND spawn because $BRIEF_REAL has no valid machine-readable external-tool policy" >&2
+    exit 1
+  }
+  TOOL_POLICY_ENABLED=1
+fi
 
 # PROJ_ABS can still carry a symlinked path component (e.g. macOS's /tmp ->
 # /private/tmp) when it came from the ship/scout branch's logical `pwd` above.
@@ -1366,6 +1416,40 @@ exclude_path() {
   mkdir -p "$(dirname "$EXCL")"
   grep -qxF "$rel" "$EXCL" 2>/dev/null || echo "$rel" >> "$EXCL"
 }
+TOOL_POLICY_OWNER="$WT/.fm-external-tool-policy-owner"
+if [ "$TOOL_POLICY_ENABLED" -eq 1 ]; then
+  expected_tool_policy_owner=$(printf 'schema=firstmate.external-tools.v1\nharness=%s' "$HARNESS")
+  if [ -e "$TOOL_POLICY_OWNER" ]; then
+    actual_tool_policy_owner=$(cat "$TOOL_POLICY_OWNER" 2>/dev/null || true)
+    if [ "$actual_tool_policy_owner" != "$expected_tool_policy_owner" ]; then
+      echo "error: refusing ship spawn because $TOOL_POLICY_OWNER belongs to another harness or policy schema" >&2
+      exit 1
+    fi
+  else
+    case "$HARNESS" in
+      claude)
+        [ ! -e "$WT/.claude/settings.local.json" ] || {
+          echo "error: refusing Claude ship spawn because $WT/.claude/settings.local.json already exists and cannot be replaced safely" >&2
+          exit 1
+        }
+        ;;
+      codex)
+        [ ! -e "$WT/.codex/hooks.json" ] || {
+          echo "error: refusing Codex ship spawn because $WT/.codex/hooks.json already exists and cannot be replaced safely" >&2
+          exit 1
+        }
+        ;;
+      opencode)
+        [ ! -e "$WT/.opencode/plugins/fm-external-tool-policy.js" ] || {
+          echo "error: refusing OpenCode ship spawn because its external-tool policy plugin path already exists" >&2
+          exit 1
+        }
+        ;;
+    esac
+    printf '%s\n' "$expected_tool_policy_owner" > "$TOOL_POLICY_OWNER"
+  fi
+  exclude_path '.fm-external-tool-policy-owner'
+fi
 if [ "$KIND" != secondmate ]; then
   # Arm the semantic busy-state contract (bin/fm-busy-lib.sh) for every
   # adapter with a verified semantic source. The launch brief sent below IS a
@@ -1419,8 +1503,13 @@ if [ "$KIND" != secondmate ]; then
       j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
       j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
       j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
+      tool_policy_hook=
+      if [ "$TOOL_POLICY_ENABLED" -eq 1 ]; then
+        j_tool_policy=$(json_escape "$(shell_quote "$TOOL_POLICY_CHECK") --brief $(shell_quote "$BRIEF_REAL") --format claude")
+        tool_policy_hook=",\"PreToolUse\":[{\"matcher\":\".*\",\"hooks\":[{\"type\":\"command\",\"command\":\"$j_tool_policy\",\"timeout\":10}]}]"
+      fi
       cat > "$WT/.claude/settings.local.json" <<EOF
-{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
+{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]$tool_policy_hook}}
 EOF
       exclude_path '.claude/settings.local.json'
       ;;
@@ -1476,6 +1565,30 @@ export const FmBusyState = async () => {
 };
 EOF
       exclude_path '.opencode/plugins/fm-busy-state.js'
+      if [ "$TOOL_POLICY_ENABLED" -eq 1 ]; then
+        cat > "$WT/.opencode/plugins/fm-external-tool-policy.js" <<EOF
+// Firstmate ship external-tool policy adapter; the brief remains the only
+// authorization source. OpenCode blocks a tool call when this hook throws.
+import { spawn } from "node:child_process";
+const runPolicy = (args) => new Promise((resolve) => {
+  const child = spawn("$TOOL_POLICY_CHECK", args, { stdio: ["ignore", "ignore", "pipe"] });
+  let stderr = "";
+  child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+  child.on("error", (error) => resolve({ code: 126, stderr: error.message }));
+  child.on("close", (code) => resolve({ code: code ?? 126, stderr }));
+});
+export const FmExternalToolPolicy = async () => ({
+  "tool.execute.before": async (input, output) => {
+    const tool = String(input && input.tool || "");
+    const inputJson = JSON.stringify(output && output.args || {});
+    const result = await runPolicy(["--brief", "$BRIEF_REAL", "--tool", tool, "--input-json", inputJson]);
+    if (result.code === 0) return;
+    throw new Error(result.stderr.trim() || "external-tool policy refused the ship tool call");
+  },
+});
+EOF
+        exclude_path '.opencode/plugins/fm-external-tool-policy.js'
+      fi
       ;;
     pi|pi-signed)
       # Written OUTSIDE the worktree: pi's project-trust gate fires on any extension
@@ -1500,7 +1613,23 @@ const busyEvent = (state: string, event: string) =>
       "--gen", "$BUSY_GEN", "--source", "pi-ext", "--event", event,
     ], () => resolve());
   });
+const externalToolPolicyEnabled = "$TOOL_POLICY_ENABLED" === "1";
+const externalToolPolicy = (tool: string, input: unknown) =>
+  new Promise<{ code: number; reason: string }>((resolve) => {
+    execFile("$TOOL_POLICY_CHECK", [
+      "--brief", "$BRIEF_REAL", "--tool", tool,
+      "--input-json", JSON.stringify(input ?? {}),
+    ], { encoding: "utf8" }, (error, _stdout, stderr) => {
+      resolve({ code: error ? (Number(error.code) || 126) : 0, reason: String(stderr || "").trim() });
+    });
+  });
 export default function (pi: any) {
+  pi.on("tool_call", async (event: any) => {
+    if (!externalToolPolicyEnabled || !event || event.type !== "tool_call") return {};
+    const result = await externalToolPolicy(String(event.toolName || ""), event.input);
+    if (result.code === 0) return {};
+    return { block: true, reason: result.reason || "external-tool policy refused the ship tool call" };
+  });
   pi.on("agent_start", () => busyEvent("busy", "agent-start"));
   pi.on("agent_settled", (_event: any, ctx: any) => {
     if (ctx && typeof ctx.isIdle === "function" && !ctx.isIdle()) return;
@@ -1519,6 +1648,14 @@ EOF
       # an explicit reason rather than falling back to idle, and no busy
       # wiring is installed. The turn-end NOTIFICATION marker still rides
       # the launch command via -c notify=[...] and __TURNEND__.
+      if [ "$TOOL_POLICY_ENABLED" -eq 1 ]; then
+        mkdir -p "$WT/.codex"
+        j_tool_policy=$(json_escape "$(shell_quote "$TOOL_POLICY_CHECK") --brief $(shell_quote "$BRIEF_REAL") --format plain")
+        cat > "$WT/.codex/hooks.json" <<EOF
+{"hooks":{"PreToolUse":[{"matcher":".*","hooks":[{"type":"command","command":"$j_tool_policy","timeout":10}]}]}}
+EOF
+        exclude_path '.codex/hooks.json'
+      fi
       ;;
     grok*)
       # grok fires a Stop hook at every turn boundary (verified, grok 0.2.73), the
@@ -1568,6 +1705,64 @@ EOF
       printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$GROK_HOOKS_DIR/fm-turn-end.json"
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
+      if [ "$TOOL_POLICY_ENABLED" -eq 1 ]; then
+        GROK_TOOL_POLICY_AUTH_DIR="$GROK_HOOKS_DIR/fm-external-tool-policy.d"
+        mkdir -p "$GROK_TOOL_POLICY_AUTH_DIR"
+        chmod 700 "$GROK_TOOL_POLICY_AUTH_DIR"
+        previous_tool_policy_token=$(cat "$STATE/$ID.grok-tool-policy-token" 2>/dev/null || true)
+        case "$previous_tool_policy_token" in
+          fm.????????????)
+            case "$previous_tool_policy_token" in
+              *[!A-Za-z0-9._-]*) ;;
+              *) rm -f "$GROK_TOOL_POLICY_AUTH_DIR/$previous_tool_policy_token" ;;
+            esac
+            ;;
+        esac
+        old_umask=$(umask)
+        umask 077
+        tool_policy_auth_file=$(mktemp "$GROK_TOOL_POLICY_AUTH_DIR/fm.XXXXXXXXXXXX")
+        umask "$old_umask"
+        {
+          printf '%s\n' "$TOOL_POLICY_CHECK"
+          printf '%s\n' "$BRIEF_REAL"
+          printf '%s\n' "$WT"
+        } > "$tool_policy_auth_file"
+        tool_policy_token=${tool_policy_auth_file##*/}
+        printf '%s\n' "$tool_policy_token" > "$STATE/$ID.grok-tool-policy-token"
+        sq_grok_tool_policy_auth_dir=$(shell_quote "$GROK_TOOL_POLICY_AUTH_DIR")
+        cat > "$GROK_HOOKS_DIR/fm-external-tool-policy.sh" <<EOF
+#!/usr/bin/env bash
+# Firstmate Grok ship external-tool policy adapter. Managed by fm-spawn.sh.
+set -u
+deny() {
+  detail="[external-tool-policy-error] \$1"
+  escaped=\$(printf '%s' "\$detail" | sed -e 's/\\\\/\\\\\\\\/g' -e 's/"/\\\\"/g' | tr '\\n' ' ')
+  printf '%s\n' "\$detail" >&2
+  printf '{"decision":"deny","reason":"%s"}\\n' "\$escaped"
+  exit 2
+}
+payload=\$(cat 2>/dev/null || true)
+[ -n "\$payload" ] || deny 'PreToolUse payload is empty; refusing the ship tool call'
+token=\${FM_EXTERNAL_TOOL_POLICY_TOKEN:-}
+[ -n "\$token" ] || exit 0
+case "\$token" in fm.????????????) : ;; *) deny 'ship policy token is malformed' ;; esac
+case "\$token" in *[!A-Za-z0-9._-]*) deny 'ship policy token contains unsafe bytes' ;; esac
+auth_dir=$sq_grok_tool_policy_auth_dir
+record="\$auth_dir/\$token"
+[ -f "\$record" ] || deny 'ship policy token is not registered'
+checker=\$(sed -n '1p' "\$record")
+brief=\$(sed -n '2p' "\$record")
+expected_workspace=\$(sed -n '3p' "\$record")
+case "\$checker:\$brief:\$expected_workspace" in /*:/*:/*) : ;; *) deny 'ship policy registration is malformed' ;; esac
+workspace=\${GROK_WORKSPACE_ROOT:-}
+[ "\$workspace" = "\$expected_workspace" ] || deny 'ship policy workspace does not match the registered task'
+printf '%s' "\$payload" | "\$checker" --brief "\$brief" --format grok
+EOF
+        chmod 700 "$GROK_HOOKS_DIR/fm-external-tool-policy.sh"
+        tool_policy_hook_command=$(json_escape "bash $(shell_quote "$GROK_HOOKS_DIR/fm-external-tool-policy.sh")")
+        printf '{"hooks":{"PreToolUse":[{"matcher":".*","hooks":[{"type":"command","command":"%s","timeout":10}]}]}}\n' "$tool_policy_hook_command" > "$GROK_HOOKS_DIR/fm-external-tool-policy.json"
+        LAUNCH="FM_EXTERNAL_TOOL_POLICY_TOKEN=$(shell_quote "$tool_policy_token") $LAUNCH"
+      fi
       ;;
     kimi*)
       # Kimi's Stop hook is global, but it is inert unless cwd contains this
@@ -1617,6 +1812,7 @@ META_WINDOW=$T
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"
+  [ "$TOOL_POLICY_ENABLED" -eq 0 ] || echo "external_tool_policy=enforced"
   [ -z "${BUSY_GEN:-}" ] || echo "busy_gen=$BUSY_GEN"
   # backend= is written only for a non-default (non-tmux) backend, so the
   # default path's meta stays byte-identical (absent backend= means tmux;
@@ -1656,8 +1852,13 @@ sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+HOOKTRUSTFLAG=
+if [ "$HARNESS" = codex ] && [ "$TOOL_POLICY_ENABLED" -eq 1 ]; then
+  HOOKTRUSTFLAG='--dangerously-bypass-hook-trust '
+fi
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
+LAUNCH=${LAUNCH//__HOOKTRUSTFLAG__/$HOOKTRUSTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -275,6 +275,27 @@ remove_grok_turnend_auth() {
   rm -f "$hooks_dir/$token"
 }
 
+remove_grok_tool_policy_auth() {
+  local state_dir=$1 id=$2 token hooks_dir
+  token=$(cat "$state_dir/$id.grok-tool-policy-token" 2>/dev/null || true)
+  case "$token" in ''|*[!A-Za-z0-9._-]*) return 0 ;; esac
+  hooks_dir="${GROK_HOME:-$HOME/.grok}/hooks/fm-external-tool-policy.d"
+  rm -f "$hooks_dir/$token"
+}
+
+remove_ship_tool_policy_artifacts() {
+  local worktree=$1 owner harness
+  owner="$worktree/.fm-external-tool-policy-owner"
+  [ -f "$owner" ] || return 0
+  grep -qx 'schema=firstmate.external-tools.v1' "$owner" 2>/dev/null || return 0
+  harness=$(sed -n 's/^harness=//p' "$owner" 2>/dev/null | head -1)
+  case "$harness" in
+    codex) rm -f "$worktree/.codex/hooks.json" ;;
+    opencode) rm -f "$worktree/.opencode/plugins/fm-external-tool-policy.js" ;;
+  esac
+  rm -f "$owner"
+}
+
 remove_kimi_turnend_auth() {
   local state_dir=$1 id=$2 token hooks_dir
   token=$(cat "$state_dir/$id.kimi-turnend-token" 2>/dev/null || true)
@@ -1099,12 +1120,14 @@ cleanup_firstmate_home_children() {
     elif [ "$child_backend" = orca ]; then
       if [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
         validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
+        remove_ship_tool_policy_artifacts "$child_wt"
         rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
           "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
+      remove_ship_tool_policy_artifacts "$child_wt"
       rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
         "$child_wt/.opencode/plugins/fm-busy-state.js" \
         "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
@@ -1123,6 +1146,7 @@ cleanup_firstmate_home_children() {
       fi
     fi
     remove_grok_turnend_auth "$sub_state" "$child_id"
+    remove_grok_tool_policy_auth "$sub_state" "$child_id"
     remove_kimi_turnend_auth "$sub_state" "$child_id"
     remove_pr_poll_artifacts "$sub_state" "$child_id" || return 1
     child_busy_gen=$(meta_value "$child_meta" busy_gen)
@@ -1132,7 +1156,8 @@ cleanup_firstmate_home_children() {
     retire_busy_state "$sub_state" "$child_id" "$child_busy_gen" || return 1
     rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" \
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
-      "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token"
+      "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.grok-tool-policy-token" \
+      "$sub_state/$child_id.kimi-turnend-token"
   done
 }
 
@@ -1244,6 +1269,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
         git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
       fi
     fi
+    remove_ship_tool_policy_artifacts "$WT"
     rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
       "$WT/.opencode/plugins/fm-busy-state.js" \
       "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
@@ -1258,6 +1284,7 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
+  remove_ship_tool_policy_artifacts "$WT"
   rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
     "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   # Kills remaining processes in the worktree (including the agent), resets, returns
@@ -1338,6 +1365,7 @@ if [ "$KIND" = secondmate ]; then
   remove_secondmate_registry_entry "$ID"
 fi
 remove_grok_turnend_auth "$STATE" "$ID"
+remove_grok_tool_policy_auth "$STATE" "$ID"
 remove_kimi_turnend_auth "$STATE" "$ID"
 fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
@@ -1347,6 +1375,7 @@ remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
+  "$STATE/$ID.grok-tool-policy-token" \
   "$STATE/$ID.kimi-turnend-token"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -118,7 +118,7 @@ now_ms() {
 family_for_basename() {
   case "$1" in
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|\
-    fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
+    fm-brief.test.sh|fm-external-tool-policy.test.sh|fm-vendor-auth-probe.test.sh|\
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
@@ -381,8 +381,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -404,7 +404,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -422,8 +422,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -436,7 +436,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -4,7 +4,7 @@ This document is the authoritative human-readable contract for the watcher arm P
 `bin/fm-arm-command-policy.mjs` is the single semantic owner.
 `bin/fm-arm-pretool-check.sh` is only the stable harness transport and output renderer.
 The tracked harness adapters forward command text without classifying it.
-`bin/fm-arm-command-policy.mjs` is also the sole owner of firstmate's shell classification: it exports the tokenizer and command-position analysis, which the sibling cd-guard seatbelt (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`) reuses instead of duplicating shell lexing.
+`bin/fm-arm-command-policy.mjs` is also the sole owner of firstmate's shell classification: it exports the tokenizer and command-position analysis, which the sibling cd-guard seatbelt (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`) and the ship external-tool policy (`bin/fm-external-tool-command-policy.mjs`, `docs/external-tool-policy.md`) reuse instead of duplicating shell lexing.
 
 ## Purpose and boundary
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -70,6 +70,10 @@
       "target": "docs/verification/supervision.md"
     },
     {
+      "source": "docs/external-tool-policy.md",
+      "target": "docs/verification/external-tool-policy.md"
+    },
+    {
       "source": "docs/watcher-continuity.md",
       "target": "docs/verification/supervision.md"
     },
@@ -232,6 +236,10 @@
       "audience": "maintainer-architecture"
     },
     {
+      "path": "docs/external-tool-policy.md",
+      "audience": "maintainer-architecture"
+    },
+    {
       "path": "docs/examples/crew-dispatch.json",
       "audience": "operator-example"
     },
@@ -305,6 +313,10 @@
     },
     {
       "path": "docs/verification/dispatch-auth.md",
+      "audience": "maintainer-verification"
+    },
+    {
+      "path": "docs/verification/external-tool-policy.md",
       "audience": "maintainer-verification"
     },
     {

--- a/docs/external-tool-policy.md
+++ b/docs/external-tool-policy.md
@@ -1,0 +1,99 @@
+# Ship external-tool policy
+
+This document owns the machine-readable authorization contract for controlled external tools used by ship workers.
+`bin/fm-external-tool-command-policy.mjs` is the single semantic owner.
+`bin/fm-external-tool-pretool-check.sh` only translates harness payloads and deny responses.
+`bin/fm-spawn.sh` installs thin harness adapters and refuses a ship when reliable before-tool interception is unavailable.
+
+## Purpose
+
+A natural-language brief can tell a worker which external tools to use, but it cannot prevent a mistaken command.
+Every generated ship brief therefore carries an executable authorization policy that the selected harness checks before each tool call.
+Generated scout briefs carry the same policy so a protected scout can later become a ship without restarting its live worker.
+The checker reads the policy directly from the brief on every decision.
+No copied allowlist in task state, metadata, adapter code, or configuration can become a second authorization source.
+
+## Brief format
+
+A generated ship or scout brief contains exactly one `firstmate-external-tools` fenced JSON block.
+The JSON schema identifier is `firstmate.external-tools.v1`.
+The object has exactly three keys: `schema`, `shell`, and `native`.
+The `shell` and `native` objects each contain exactly one `allow` array of literal tool names.
+Duplicate names, unknown keys, missing keys, malformed JSON, a missing fence, or a second fence invalidate the policy.
+
+The standard generated policy authorizes `gh-axi` and `chrome-devtools-axi` through shell execution.
+It authorizes the native `agent_browser` tool as the browser fallback.
+It does not authorize the shell command `agent-browser`.
+A task that deliberately needs another controlled tool must add that tool to the correct allow array in its brief before spawn.
+
+## Controlled tools and ordinary development
+
+The policy controls external GitHub clients, browser automation systems, browser binaries, browser drivers, and browser installation packages.
+It recognizes browser families such as Playwright, Puppeteer, Selenium, WebdriverIO, Cypress, TestCafe, Nightwatch, browser-use, browser drivers, Chromium, Chrome, and Firefox.
+It recognizes direct executables, package runner forms, targeted dependency installation, Python modules, Node CLI paths, and targeted system-package installation.
+
+The policy does not turn package managers into a blanket deny list.
+Tests, lint, builds, local servers, ordinary package installation, and other project development commands remain allowed unless they execute a controlled tool.
+A data mention in `printf`, search text, a comment, or another non-executed argument is not a tool request.
+
+## Shell classification
+
+`bin/fm-arm-command-policy.mjs` remains the sole shell lexer and command-position owner.
+The external-tool policy imports its execution-tree walker instead of implementing another shell parser.
+The walker covers direct commands, wrappers, pipelines, redirections, command and process substitutions, parenthesized groups, literal `eval`, literal `sh`, `bash`, or `zsh` command payloads, heredocs, and here strings.
+A pipeline or redirection does not hide the controlled executable because each executed command position is classified before the outer shell starts.
+Malformed or opaque shell input that visibly names controlled browser automation is denied rather than guessed safe.
+
+The policy addresses mistaken tool selection, not hostile code already hidden inside a project script.
+The worker still follows the brief boundary against editing operational files outside its isolated copy.
+
+## Denial contract
+
+An unauthorized request exits with status 2 before the harness executes the requested tool call.
+The stable reason code is `external-tool-denied`.
+The message names the requested canonical tool, its shell or native channel, the `firstmate.external-tools.v1` policy and brief path, and the authorized alternatives for that category.
+
+An unavailable checker, malformed hook payload, missing Node.js or `jq`, missing brief, or invalid policy exits with status 2 and the stable reason code `external-tool-policy-error`.
+Spawn validates the checker and brief before endpoint launch, while runtime failures remain closed if that validated dependency later disappears.
+A legacy or adapter-verification scout without the policy fence may run only as a scout and records no enforcement receipt.
+
+## Harness adapters
+
+| Harness | Before-tool connection | Ship behavior |
+| --- | --- | --- |
+| Claude | Generated `.claude/settings.local.json` `PreToolUse` matcher for every tool | Checker exit 2 returns Claude's stderr-only native deny object. |
+| Codex | Generated `.codex/hooks.json` `PreToolUse` matcher for every tool | Spawn refuses an existing project hook file, then launches with hook trust bypassed only for the generated task hook. |
+| OpenCode | Generated `.opencode/plugins/fm-external-tool-policy.js` | `tool.execute.before` throws on every nonzero checker result. |
+| Pi | Generated state extension loaded with `-e` | `tool_call` returns `{block: true}` on every nonzero checker result. |
+| pi-signed | Same generated Pi extension and `tool_call` contract | The signed executable identity remains distinct while policy behavior matches Pi. |
+| Grok | Guarded global `PreToolUse` hook plus a private per-task registration token in the launch environment | The global hook is inert outside a registered ship and returns Grok's native deny object for that ship. |
+| Kimi | No reliable before-tool interception has been verified | Ship spawn is refused before harness installation or endpoint creation. |
+| Cursor | Cursor is not a verified Firstmate harness, and its installed CLI exposes no verified before-tool adapter | Named and raw Cursor ship launches are refused before endpoint creation. |
+
+Claude and Codex refuse to replace a pre-existing project hook path because silently merging or overwriting another owner's hook would make enforcement ambiguous.
+OpenCode uses a Firstmate-specific plugin path.
+Pi keeps its explicit extension outside the project to preserve its existing trust behavior.
+Grok uses its already verified always-trusted global hook surface because project hooks require folder trust before launch.
+
+## Runtime backends
+
+The runtime backend does not classify tools.
+The five spawn-capable backends `tmux`, `herdr`, `zellij`, `orca`, and `cmux` all converge in `bin/fm-spawn.sh` after the isolated worktree is resolved.
+Spawn installs the selected harness adapter at that common point and only then submits the harness launch command.
+This keeps one semantic policy across backends and preserves each backend's existing endpoint, supervision, and cleanup behavior.
+
+Teardown removes only Firstmate-owned generated project artifacts and private Grok registration tokens.
+It does not remove a project-owned Codex or OpenCode file that lacked the Firstmate ownership marker.
+
+## Scout promotion
+
+Spawn records `external_tool_policy=enforced` only after the declared brief policy validates and its harness adapter is installed.
+`bin/fm-promote.sh` requires that receipt and revalidates the same brief before changing `kind=scout` to `kind=ship`.
+A legacy scout, raw-adapter scout, Kimi scout, or other worker without reliable interception cannot become a live unprotected ship.
+The promotion command refuses that case and requires a new generated ship brief.
+
+## Verification
+
+[`verification/external-tool-policy.md`](verification/external-tool-policy.md) records the current harness and backend review evidence.
+`tests/fm-external-tool-policy.test.sh` owns the executable incident, bypass, allowed-command, adapter, and refusal matrix.
+`tests/fm-brief.test.sh` owns generated brief integrity.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -34,7 +34,9 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-kimi-turnend-hook.sh` | Surgically install or remove Kimi's guarded global crew turn-end hook                |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
-| `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |
+| `fm-arm-command-policy.mjs` | Semantic owner of shell tokenization and the watcher-arm PreToolUse policy (docs/arm-pretool-check.md) |
+| `fm-external-tool-pretool-check.sh` | Stable harness transport for each protected task brief's external-tool policy (docs/external-tool-policy.md) |
+| `fm-external-tool-command-policy.mjs` | Semantic owner of protected task external-tool authorization (docs/external-tool-policy.md) |
 | `fm-subagent-pretool-check.sh` | Primary-home delegation-shape PreToolUse guard (docs/subagent-guard.md) |
 | `fm-supervision-instructions.sh` | Render the session-start primary-harness supervision block or the one-line repair instruction |
 | `fm-home-seed.sh`        | Transactionally provision a secondmate home and maintain `data/secondmates.md`       |

--- a/docs/verification/external-tool-policy.md
+++ b/docs/verification/external-tool-policy.md
@@ -1,0 +1,138 @@
+# Ship external-tool policy verification
+
+This record supports the current guarantees in [`../external-tool-policy.md`](../external-tool-policy.md).
+It records active verification facts, not incident chronology.
+
+## Environment
+
+Verification date: 2026-07-31.
+
+Installed harness discovery returned:
+
+```text
+claude: 2.1.220
+codex: codex-cli 0.144.6
+opencode: 1.18.4
+pi: 0.83.0
+cursor-agent: 2026.07.23-e383d2b
+pi-signed: unavailable on PATH
+grok: unavailable on PATH
+kimi: unavailable on PATH
+```
+
+The unavailable binaries are not represented as live validation.
+The pi-signed adapter uses the same generated extension as Pi and retains a separate launch-identity assertion in the automated suite.
+The Grok adapter executes its generated global hook script and native deny response in an isolated fake home.
+Kimi and Cursor are refusal axes, not claimed enforcement axes.
+
+## Harness review
+
+The command was:
+
+```sh
+tests/fm-external-tool-policy.test.sh
+```
+
+The suite executed the generated Claude and Codex hook commands, imported and called the generated OpenCode plugin, imported and called both Pi identity extensions, and executed the generated Grok global hook with its registered task token.
+Each interceptable harness denied `npx playwright install chromium` before the requested command could run.
+Pi and pi-signed also allowed the native `agent_browser` fallback from the brief policy.
+A protected Pi scout recorded enforcement and promoted in place, while an unprotected raw-adapter scout remained a scout and promotion refused.
+Kimi and raw Cursor ship selections refused before the fake runtime endpoint received any command.
+
+The harness applicability review is:
+
+| Harness | Enforcement evidence | Applicability result |
+| --- | --- | --- |
+| Claude | Generated `PreToolUse` command executed through the Claude payload and response shape | Applicable and passing. |
+| Codex | Generated project hook executed through the Codex payload; launch included `--dangerously-bypass-hook-trust` | Applicable and passing. |
+| OpenCode | Generated `tool.execute.before` plugin imported and invoked | Applicable and passing. |
+| Pi | Generated `tool_call` extension imported and invoked | Applicable and passing. |
+| pi-signed | The same generated `tool_call` extension was invoked from a distinct pi-signed spawn identity | Applicable and passing without a live pi-signed binary. |
+| Grok | Generated global hook executed with a private registration token and produced `decision=deny` | Applicable and passing without a live Grok binary. |
+| Kimi | Spawn refusal occurred before any fake endpoint call | Enforcement is not applicable because reliable interception is unverified; refusal is passing. |
+| Cursor | Installed CLI help exposed `--plugin-dir` but no verified Firstmate before-tool adapter; raw launch refusal occurred before any fake endpoint call | Enforcement is not applicable because Cursor is unverified; refusal is passing. |
+
+## Backend review
+
+The backend review inspected the five adapters listed by `FM_BACKEND_SPAWN` in `bin/fm-backend.sh`: `tmux`, `herdr`, `zellij`, `orca`, and `cmux`.
+Each backend resolves or creates the isolated task worktree before returning to the shared `bin/fm-spawn.sh` handoff.
+The shared handoff installs the harness policy adapter before the first `spawn_send_literal` and Enter submission.
+No backend has a separate policy copy or a path that launches the worker before that handoff.
+
+The backend applicability review is:
+
+| Backend | Worktree or endpoint role | Applicability result |
+| --- | --- | --- |
+| tmux | Session provider | Applicable through the shared pre-launch handoff. |
+| herdr | Session provider | Applicable through the shared pre-launch handoff. |
+| zellij | Session provider | Applicable through the shared pre-launch handoff. |
+| orca | Worktree and terminal provider | Applicable after Orca returns the isolated worktree and before harness submission. |
+| cmux | Session provider | Applicable through the shared pre-launch handoff. |
+
+Existing backend behavior remains covered by `tests/fm-backend.test.sh` and the backend-specific suites.
+Raw launch commands in backend-only E2E tests now run as scouts because an unverified raw adapter can no longer represent a ship.
+
+## Command matrix
+
+The targeted matrix covered:
+
+```text
+npx playwright install chromium
+npm exec -- playwright install chromium
+pnpm dlx playwright install chromium
+yarn dlx @playwright/test install chromium
+./node_modules/.bin/playwright install chromium
+bash -lc 'npx playwright install chromium'
+npx playwright install chromium | tee install.log
+npx playwright install chromium >install.log 2>&1
+npm install --save-dev @playwright/test
+python -m playwright install chromium
+python -c 'from playwright.sync_api import sync_playwright'
+node node_modules/playwright/cli.js install chromium
+node -e 'require("puppeteer").launch()'
+agent-browser open http://localhost:3000
+apt-get install chromium
+```
+
+Every denied row returned `external-tool-denied` and named Playwright or the requested browser tool, the brief policy, and the authorized `chrome-devtools-axi` and `agent_browser` alternatives.
+
+Allowed rows covered:
+
+```text
+chrome-devtools-axi open http://localhost:3000
+native agent_browser
+npm test
+pnpm lint
+npm run build
+npm run dev -- --host 127.0.0.1
+npm install typescript
+printf '%s\n' 'npx playwright install chromium'
+```
+
+## Repository checks
+
+The required validation commands are:
+
+```sh
+tests/fm-external-tool-policy.test.sh
+tests/fm-brief.test.sh
+tests/fm-busy-adapter-wiring.test.sh
+tests/fm-spawn-dispatch-profile.test.sh
+tests/fm-grok-harness.test.sh
+tests/fm-kimi-harness.test.sh
+tests/fm-backend.test.sh
+tests/fm-arm-pretool-check.test.sh
+tests/fm-secondmate-harness.test.sh
+tests/fm-teardown.test.sh
+tests/fm-teardown-endpoint-safety.test.sh
+tests/fm-test-run.test.sh
+bin/fm-lint.sh
+bin/fm-doc-audience-check.sh
+```
+
+Every listed command completed with exit status 0 on 2026-07-31.
+The external-tool suite reported every denied and allowed matrix row as `ok`, all six interceptable harness adapters as passing, protected and refused scout-promotion cases as passing, and the Kimi, Cursor, and missing-policy pre-endpoint refusals as passing.
+The watcher-arm suite retained its complete prior shell-classification matrix after the shared execution-tree walker was exported.
+The backend, spawn, supervision-adapter, secondmate, and cleanup suites retained their existing passing behavior.
+`bin/fm-lint.sh` reported the pinned ShellCheck 0.11.0 line and no finding.
+`bin/fm-doc-audience-check.sh` reported `ok surfaces=61 local_links=169`.

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -103,7 +103,7 @@ env -u TMUX -u FM_BACKEND PATH="$PATH" HERDR_ENV=1 \
   FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
   FM_CONFIG_OVERRIDE="$CONFIG" FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" \
   FM_SPAWN_NO_GUARD=1 \
-  "$ROOT/bin/fm-spawn.sh" "$ID" "$PROJ" "sh -c 'echo autodetect-smoke-ok'" \
+  "$ROOT/bin/fm-spawn.sh" "$ID" "$PROJ" "sh -c 'echo autodetect-smoke-ok'" --scout \
   >"$OUT_FILE" 2>"$ERR_FILE"
 status=$?
 [ "$status" -eq 0 ] || fail "fm-spawn.sh did not succeed auto-detecting herdr"$'\n'"--- stdout ---"$'\n'"$(cat "$OUT_FILE")"$'\n'"--- stderr ---"$'\n'"$(cat "$ERR_FILE")"

--- a/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
+++ b/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
@@ -121,8 +121,10 @@ journal_field() {  # <presentation-journal> <key>
 # Herdr at all".
 SPAWN_OUT=; SPAWN_ERR=; SPAWN_RC=
 spawn_from_launcher() {
-  local pane=$1 home=$2 id=$3 proj=$4
+  local pane=$1 home=$2 id=$3 proj=$4 arg secondmate=0
   shift 4
+  for arg in "$@"; do [ "$arg" != --secondmate ] || secondmate=1; done
+  if [ "$secondmate" -eq 0 ]; then set -- "$@" --scout; fi
   SPAWN_OUT="$TMP_ROOT/$id.out"; SPAWN_ERR="$TMP_ROOT/$id.err"
   if [ -n "$pane" ]; then
     env HERDR_ENV=1 HERDR_PANE_ID="$pane" HERDR_SESSION="$HERDR_LAB_SESSION" \
@@ -273,7 +275,7 @@ cat > "$TMP_ROOT/spawn-in-pane.sh" <<SPAWN
 #!/usr/bin/env bash
 set -u
 FM_SPAWN_NO_GUARD=1 FM_HOME="$PRIMARY_HOME" FM_ROOT_OVERRIDE="$ROOT" \\
-  "$ROOT/bin/fm-spawn.sh" dupC "$PROJ" "sh -c 'echo launcher-ws-ok'" --backend herdr \\
+  "$ROOT/bin/fm-spawn.sh" dupC "$PROJ" "sh -c 'echo launcher-ws-ok'" --scout --backend herdr \\
   > "$TMP_ROOT/dupC.out" 2> "$TMP_ROOT/dupC.err"
 echo \$? > "$TMP_ROOT/dupC.rc"
 SPAWN

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -393,7 +393,7 @@ make_project() {  # <dir>
 spawn_task() {  # <id> <home> <project>
   local id=$1 home=$2 project=$3
   FM_GATE_REFUSE_BYPASS=1 FM_SPAWN_NO_GUARD=1 FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
-    "$ROOT/bin/fm-spawn.sh" "$id" "$project" "sh -c 'sleep 120'" --backend herdr
+    "$ROOT/bin/fm-spawn.sh" "$id" "$project" "sh -c 'sleep 120'" --scout --backend herdr
 }
 
 spawn_secondmate_task() {

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -111,7 +111,7 @@ PROJ2="$TMP_ROOT/scratch-project-2"; make_scratch_project "$PROJ2"
 
 CM1_OUT="$TMP_ROOT/cm1.out"; CM1_ERR="$TMP_ROOT/cm1.err"
 FM_SPAWN_NO_GUARD=1 FM_HOME="$PRIMARY_HOME" FM_ROOT_OVERRIDE="$ROOT" \
-  "$ROOT/bin/fm-spawn.sh" cm1 "$PROJ1" "sh -c 'echo primary-crew-ok'" --backend herdr \
+  "$ROOT/bin/fm-spawn.sh" cm1 "$PROJ1" "sh -c 'echo primary-crew-ok'" --scout --backend herdr \
   >"$CM1_OUT" 2>"$CM1_ERR"
 rc=$?
 [ "$rc" -eq 0 ] || fail "primary-shaped crewmate spawn failed"$'\n'"--- stdout ---"$'\n'"$(cat "$CM1_OUT")"$'\n'"--- stderr ---"$'\n'"$(cat "$CM1_ERR")"
@@ -166,7 +166,7 @@ pass "real herdr E2E: a --secondmate spawn by the PRIMARY lands in the SECONDMAT
 
 CM2_OUT="$TMP_ROOT/cm2.out"; CM2_ERR="$TMP_ROOT/cm2.err"
 FM_SPAWN_NO_GUARD=1 FM_HOME="$SM_HOME" FM_ROOT_OVERRIDE="$ROOT" \
-  "$ROOT/bin/fm-spawn.sh" cm2 "$PROJ2" "sh -c 'echo sm-crew-ok'" --backend herdr \
+  "$ROOT/bin/fm-spawn.sh" cm2 "$PROJ2" "sh -c 'echo sm-crew-ok'" --scout --backend herdr \
   >"$CM2_OUT" 2>"$CM2_ERR"
 rc=$?
 [ "$rc" -eq 0 ] || fail "a crewmate spawned FROM the secondmate-shaped home failed"$'\n'"--- stdout ---"$'\n'"$(cat "$CM2_OUT")"$'\n'"--- stderr ---"$'\n'"$(cat "$CM2_ERR")"

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -902,8 +902,7 @@ run_spawn_symlink_case() {  # <label> <physical|logical>
   esac
   fb=$(make_spawn_symlink_fakebin "$TMP_ROOT/symlink-fake-$label" "$initial_path" "$wt")
   data="$TMP_ROOT/symlink-data-$label"
-  mkdir -p "$data/$id"
-  printf 'test brief content\n' > "$data/$id/brief.md"
+  fm_write_ship_brief "$data/$id/brief.md" "test brief content"
   state="$TMP_ROOT/symlink-state-$label"; config="$TMP_ROOT/symlink-config-$label"
   mkdir -p "$state" "$config"
   log="$TMP_ROOT/symlink-spawn-$label.log"
@@ -1064,7 +1063,7 @@ test_spawn_default_backend_writes_no_meta_field() {
   fm_git_worktree "$proj" "$wt" "fm/$id"
   local fb
   fb=$(make_spawn_fakebin "$TMP_ROOT/nobackend-fake" "$wt")
-  mkdir -p "$data/$id"; printf 'brief\n' > "$data/$id/brief.md"
+  fm_write_ship_brief "$data/$id/brief.md" "backend spawn brief"
   state="$TMP_ROOT/nobackend-state"; config="$TMP_ROOT/nobackend-config"
   mkdir -p "$state" "$config"
 
@@ -1086,7 +1085,7 @@ test_spawn_explicit_backend_flag_beats_autodetect_herdr_env() {
   id="explicitbackendz4"
   fm_git_worktree "$proj" "$wt" "fm/$id"
   fb=$(make_spawn_fakebin "$TMP_ROOT/explicit-backend-fake" "$wt")
-  mkdir -p "$data/$id"; printf 'brief\n' > "$data/$id/brief.md"
+  fm_write_ship_brief "$data/$id/brief.md" "backend spawn brief"
   state="$TMP_ROOT/explicit-backend-state"; config="$TMP_ROOT/explicit-backend-config"
   mkdir -p "$state" "$config"
 
@@ -1110,7 +1109,7 @@ test_spawn_autodetect_nesting_resolves_tmux_silently() {
   id="nestbackendz5"
   fm_git_worktree "$proj" "$wt" "fm/$id"
   fb=$(make_spawn_fakebin "$TMP_ROOT/nest-fake" "$wt")
-  mkdir -p "$data/$id"; printf 'brief\n' > "$data/$id/brief.md"
+  fm_write_ship_brief "$data/$id/brief.md" "backend spawn brief"
   state="$TMP_ROOT/nest-state"; config="$TMP_ROOT/nest-config"
   mkdir -p "$state" "$config"
 

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -50,8 +50,7 @@ make_spawn_case() {  # <name> <harness> <id>
   printf '%s\n' "$harness" > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
   touch "$home/state/.last-watcher-beat"
-  mkdir -p "$home/data/$id"
-  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  fm_write_ship_brief "$home/data/$id/brief.md" "brief for $id"
   printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
 }
 
@@ -314,7 +313,9 @@ test_codex_unverified_until_a_semantic_source_exists() {
   expect_code 0 $? "codex spawn should succeed: $out"
   state="$HOME_DIR/state"
   assert_absent "$state/$id.busy-gen" "codex must not arm a busy contract with no verified semantic source"
-  assert_absent "$WT_DIR/.codex/hooks.json" "codex must not install unverified busy hooks"
+  assert_present "$WT_DIR/.codex/hooks.json" "codex ship spawn did not install its external-tool policy hook"
+  jq -e '.hooks.PreToolUse and (.hooks | has("UserPromptSubmit") | not)' "$WT_DIR/.codex/hooks.json" >/dev/null \
+    || fail "codex external-tool hook must not masquerade as unverified semantic busy wiring"
   assert_contains "$out" 'spawned '"$id"' harness=codex' "codex spawn did not complete normally"
   out=$(classify codex "$id" "$state")
   [ "$out" = "unknown codex-unverified" ] || fail "codex must classify 'unknown codex-unverified', got '$out'"

--- a/tests/fm-external-tool-policy.test.sh
+++ b/tests/fm-external-tool-policy.test.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# Behavior tests for ship brief external-tool authorization and harness wiring.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CHECK="$ROOT/bin/fm-external-tool-pretool-check.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-external-tool-policy)
+POLICY_BRIEF="$TMP_ROOT/policy-brief.md"
+fm_write_ship_brief "$POLICY_BRIEF" "external-tool policy fixture"
+
+run_policy_form() {  # <form> <command> <out-file> <err-file>
+  local form=$1 command=$2 out_file=$3 err_file=$4 payload
+  case "$form" in
+    claude)
+      payload=$(jq -cn --arg command "$command" '{tool_name:"Bash",tool_input:{command:$command}}')
+      printf '%s' "$payload" | "$CHECK" --brief "$POLICY_BRIEF" --format claude >"$out_file" 2>"$err_file"
+      ;;
+    codex)
+      payload=$(jq -cn --arg command "$command" '{tool_name:"Bash",tool_input:{command:$command}}')
+      printf '%s' "$payload" | "$CHECK" --brief "$POLICY_BRIEF" --format plain >"$out_file" 2>"$err_file"
+      ;;
+    grok)
+      payload=$(jq -cn --arg command "$command" '{toolName:"run_terminal_command",toolInput:{command:$command}}')
+      printf '%s' "$payload" | "$CHECK" --brief "$POLICY_BRIEF" --format grok >"$out_file" 2>"$err_file"
+      ;;
+    opencode|pi)
+      "$CHECK" --brief "$POLICY_BRIEF" --tool bash --input-json "$(jq -cn --arg command "$command" '{command:$command}')" >"$out_file" 2>"$err_file"
+      ;;
+    *) fail "unknown external-tool policy transport form: $form" ;;
+  esac
+}
+
+assert_command_matrix() {  # <id> <allow|deny> <command>
+  local id=$1 expected=$2 command=$3 form out_file err_file rc
+  for form in claude codex grok opencode pi; do
+    out_file="$TMP_ROOT/$id-$form.out"
+    err_file="$TMP_ROOT/$id-$form.err"
+    run_policy_form "$form" "$command" "$out_file" "$err_file"
+    rc=$?
+    if [ "$expected" = allow ]; then
+      expect_code 0 "$rc" "$id via $form should be allowed"
+      [ ! -s "$out_file" ] || fail "$id via $form allowed call wrote stdout: $(cat "$out_file")"
+      [ ! -s "$err_file" ] || fail "$id via $form allowed call wrote stderr: $(cat "$err_file")"
+    else
+      expect_code 2 "$rc" "$id via $form should be denied"
+      assert_grep '[external-tool-denied]' "$err_file" "$id via $form lacked the stable denial code"
+      assert_grep 'firstmate.external-tools.v1' "$err_file" "$id via $form did not name the applicable policy"
+      assert_grep 'chrome-devtools-axi' "$err_file" "$id via $form did not name the authorized primary alternative"
+      assert_grep 'agent_browser' "$err_file" "$id via $form did not name the authorized native fallback"
+      if [ "$form" = grok ]; then
+        jq -e '.decision == "deny"' "$out_file" >/dev/null || fail "$id Grok denial lacked decision=deny"
+      elif [ "$form" = claude ]; then
+        [ ! -s "$out_file" ] || fail "$id Claude denial must keep stdout empty"
+        jq -e '.hookSpecificOutput.permissionDecision == "deny"' "$err_file" >/dev/null \
+          || fail "$id Claude denial lacked the native hook response"
+      fi
+    fi
+  done
+  pass "external-tool policy matrix $id: $expected"
+}
+
+test_command_policy_matrix() {
+  assert_command_matrix incident deny 'npx playwright install chromium'
+  assert_command_matrix npm-exec deny 'npm exec -- playwright install chromium'
+  assert_command_matrix pnpm-dlx deny 'pnpm dlx playwright install chromium'
+  assert_command_matrix yarn-dlx deny 'yarn dlx @playwright/test install chromium'
+  assert_command_matrix npx-call deny "npx -c 'playwright install chromium'"
+  assert_command_matrix runner-shell deny "npm exec -- bash -lc 'playwright install chromium'"
+  assert_command_matrix direct-bin deny './node_modules/.bin/playwright install chromium'
+  assert_command_matrix nested-shell deny "bash -lc 'npx playwright install chromium'"
+  assert_command_matrix pipeline deny 'npx playwright install chromium | tee install.log'
+  assert_command_matrix redirection deny 'npx playwright install chromium >install.log 2>&1'
+  assert_command_matrix package-install deny 'npm install --save-dev @playwright/test'
+  assert_command_matrix python-module deny 'python -m playwright install chromium'
+  assert_command_matrix python-code deny "python -c 'from playwright.sync_api import sync_playwright'"
+  assert_command_matrix node-cli deny 'node node_modules/playwright/cli.js install chromium'
+  assert_command_matrix node-eval deny "node -e 'require(\"puppeteer\").launch()'"
+  assert_command_matrix browser-shell deny 'agent-browser open http://localhost:3000'
+  assert_command_matrix browser-package deny 'apt-get install chromium'
+  assert_command_matrix allowed-primary allow 'chrome-devtools-axi open http://localhost:3000'
+  assert_command_matrix allowed-test allow 'npm test'
+  assert_command_matrix allowed-lint allow 'pnpm lint'
+  assert_command_matrix allowed-build allow 'npm run build'
+  assert_command_matrix allowed-server allow 'npm run dev -- --host 127.0.0.1'
+  assert_command_matrix allowed-package allow 'npm install typescript'
+  assert_command_matrix data-mention allow "printf '%s\\n' 'npx playwright install chromium'"
+}
+
+test_github_tool_authorization() {
+  local out rc
+  "$CHECK" --brief "$POLICY_BRIEF" --command 'gh-axi repo view owner/name' \
+    || fail "authorized gh-axi command was denied"
+  out=$("$CHECK" --brief "$POLICY_BRIEF" --command 'gh repo view owner/name' 2>&1); rc=$?
+  expect_code 2 "$rc" "unlisted gh client must be denied"
+  assert_contains "$out" "requested github shell tool 'gh'" "GitHub denial did not name the requested client"
+  assert_contains "$out" "authorized alternatives: shell: gh-axi" "GitHub denial did not name gh-axi"
+  pass "GitHub external clients follow the brief shell authorization"
+}
+
+test_native_agent_browser_authorization() {
+  local out rc restricted="$TMP_ROOT/restricted.md"
+  "$CHECK" --brief "$POLICY_BRIEF" --tool agent_browser --input-json '{}' \
+    || fail "authorized native agent_browser fallback was denied"
+  cat > "$restricted" <<'EOF'
+```firstmate-external-tools
+{"schema":"firstmate.external-tools.v1","shell":{"allow":["gh-axi","chrome-devtools-axi"]},"native":{"allow":[]}}
+```
+EOF
+  out=$("$CHECK" --brief "$restricted" --tool agent_browser --input-json '{}' 2>&1); rc=$?
+  expect_code 2 "$rc" "native agent_browser must be denied when absent from the brief policy"
+  assert_contains "$out" "requested browser native tool 'agent_browser'" \
+    "native fallback denial did not name the requested tool and channel"
+  pass "native agent_browser follows the brief's native authorization"
+}
+
+test_generated_briefs_own_policy() {
+  local home="$TMP_ROOT/brief-home" brief scout_brief
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" generated-policy sample >/dev/null
+  brief="$home/data/generated-policy/brief.md"
+  "$CHECK" --brief "$brief" --validate || fail "generated ship brief policy did not validate"
+  assert_grep '```firstmate-external-tools' "$brief" "generated ship brief lacks the machine-readable policy fence"
+  assert_grep 'Never drive browser automation through a shell command' "$brief" \
+    "generated ship brief lost the human-readable browser boundary"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" generated-scout-policy sample --scout >/dev/null
+  scout_brief="$home/data/generated-scout-policy/brief.md"
+  "$CHECK" --brief "$scout_brief" --validate || fail "generated scout brief policy did not validate"
+  assert_grep 'Never drive browser automation through a shell command' "$scout_brief" \
+    "generated scout brief lost the human-readable browser boundary"
+  pass "generated ship and promotable scout briefs share one readable machine policy"
+}
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "${FM_FAKE_TMUX_LOG:?}"
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse pi-signed kimi cursor-agent
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {  # <name> <harness>
+  local name=$1 harness=$2 case_dir home proj wt fakebin id
+  case_dir="$TMP_ROOT/spawn-$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  id="policy-$name"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects" "$case_dir/grok"
+  printf '%s\n' "$harness" > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  fm_write_ship_brief "$home/data/$id/brief.md" "spawn adapter fixture $harness"
+  touch "$home/state/.last-watcher-beat"
+  : > "$case_dir/tmux.log"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$id"
+}
+
+run_spawn_case() {  # <record> [spawn extras...]
+  local record=$1 case_dir home proj wt fakebin id
+  shift
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$record
+EOF
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_DATA_OVERRIDE="$home/data" FM_PROJECTS_OVERRIDE="$home/projects" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_SPAWN_NO_GUARD=1 \
+    FM_FAKE_PANE_PATH="$wt" FM_FAKE_TMUX_LOG="$case_dir/tmux.log" \
+    TMUX='fake,1,0' GROK_HOME="$case_dir/grok" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" "$@" 2>&1
+}
+
+read_spawn_record() {
+  # shellcheck disable=SC2034 # The shared record shape exposes fields used by selected adapter cases.
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR SPAWN_ID <<EOF
+$1
+EOF
+}
+
+hook_denies_incident() {  # <command>
+  local command=$1 payload out rc
+  payload=$(jq -cn --arg command 'npx playwright install chromium' '{tool_name:"Bash",tool_input:{command:$command}}')
+  out=$(printf '%s' "$payload" | sh -c "$command" 2>&1); rc=$?
+  expect_code 2 "$rc" "spawn-installed hook must deny the reproduced incident"
+  assert_contains "$out" "requested browser shell tool 'playwright'" \
+    "spawn-installed hook denial did not name Playwright"
+}
+
+run_pi_policy_extension() {  # <extension> <tool> <input-json>
+  EXT_PATH=$1 TOOL_NAME=$2 TOOL_INPUT=$3 node --input-type=module 2>&1 <<'EOF'
+import { pathToFileURL } from "node:url";
+const mod = await import(pathToFileURL(process.env.EXT_PATH).href);
+const handlers = {};
+mod.default({ on: (name, fn) => { handlers[name] = fn; } });
+const result = await handlers.tool_call({
+  type: "tool_call",
+  toolName: process.env.TOOL_NAME,
+  input: JSON.parse(process.env.TOOL_INPUT),
+});
+process.stdout.write(JSON.stringify(result));
+EOF
+}
+
+test_spawn_installs_each_verified_harness_adapter() {
+  local rec out rc settings hook plugin ext result token payload
+
+  rec=$(make_spawn_case claude claude); read_spawn_record "$rec"
+  out=$(run_spawn_case "$rec"); rc=$?
+  expect_code 0 "$rc" "Claude policy spawn should succeed: $out"
+  settings="$WT_DIR/.claude/settings.local.json"
+  hook=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$settings")
+  hook_denies_incident "$hook"
+
+  rec=$(make_spawn_case codex codex); read_spawn_record "$rec"
+  out=$(run_spawn_case "$rec"); rc=$?
+  expect_code 0 "$rc" "Codex policy spawn should succeed: $out"
+  assert_contains "$(cat "$CASE_DIR/tmux.log")" '--dangerously-bypass-hook-trust' \
+    "Codex ship did not activate its pre-launch project hook without a trust gap"
+  hook=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$WT_DIR/.codex/hooks.json")
+  hook_denies_incident "$hook"
+
+  rec=$(make_spawn_case opencode opencode); read_spawn_record "$rec"
+  out=$(run_spawn_case "$rec"); rc=$?
+  expect_code 0 "$rc" "OpenCode policy spawn should succeed: $out"
+  plugin="$WT_DIR/.opencode/plugins/fm-external-tool-policy.js"
+  PLUGIN_PATH="$plugin" node --input-type=module 2>&1 <<'EOF' >/dev/null || rc=$?
+import { pathToFileURL } from "node:url";
+const mod = await import(pathToFileURL(process.env.PLUGIN_PATH).href);
+const hooks = await mod.FmExternalToolPolicy({});
+let denied = false;
+try {
+  await hooks["tool.execute.before"]({ tool: "bash" }, { args: { command: "npx playwright install chromium" } });
+} catch (error) {
+  denied = String(error.message).includes("playwright");
+}
+if (!denied) process.exit(1);
+EOF
+  expect_code 0 "${rc:-0}" "OpenCode generated plugin did not throw before the denied tool call"
+  unset rc
+
+  for harness in pi pi-signed; do
+    rec=$(make_spawn_case "$harness" "$harness"); read_spawn_record "$rec"
+    out=$(run_spawn_case "$rec"); rc=$?
+    expect_code 0 "$rc" "$harness policy spawn should succeed: $out"
+    ext="$HOME_DIR/state/$SPAWN_ID.pi-ext.ts"
+    result=$(run_pi_policy_extension "$ext" bash '{"command":"npx playwright install chromium"}') \
+      || fail "$harness generated extension could not execute: $result"
+    assert_contains "$result" '"block":true' "$harness generated extension did not block the incident"
+    result=$(run_pi_policy_extension "$ext" agent_browser '{}') \
+      || fail "$harness generated extension rejected the authorized native fallback: $result"
+    [ "$result" = '{}' ] || fail "$harness native fallback should be allowed, got: $result"
+  done
+
+  rec=$(make_spawn_case grok grok); read_spawn_record "$rec"
+  out=$(run_spawn_case "$rec"); rc=$?
+  expect_code 0 "$rc" "Grok policy spawn should succeed: $out"
+  token=$(cat "$HOME_DIR/state/$SPAWN_ID.grok-tool-policy-token")
+  payload=$(jq -cn --arg command 'npx playwright install chromium' '{toolName:"run_terminal_command",toolInput:{command:$command}}')
+  out=$(printf '%s' "$payload" | env FM_EXTERNAL_TOOL_POLICY_TOKEN="$token" \
+    GROK_WORKSPACE_ROOT="$WT_DIR" bash "$CASE_DIR/grok/hooks/fm-external-tool-policy.sh" 2>"$CASE_DIR/grok.err"); rc=$?
+  expect_code 2 "$rc" "Grok global hook must deny the incident"
+  jq -e '.decision == "deny" and (.reason | contains("playwright"))' <<<"$out" >/dev/null \
+    || fail "Grok global hook did not return its native deny object: $out"
+
+  pass "spawn installs working external-tool policy adapters for every interceptable harness"
+}
+
+test_spawn_refuses_uninterceptable_harnesses_before_endpoint_creation() {
+  local rec out rc
+  rec=$(make_spawn_case kimi kimi); read_spawn_record "$rec"
+  out=$(run_spawn_case "$rec"); rc=$?
+  [ "$rc" -ne 0 ] || fail "Kimi ship spawn must refuse without reliable pre-tool interception"
+  assert_contains "$out" "no reliable pre-tool interception is verified" "Kimi refusal did not name the missing guarantee"
+  [ ! -s "$CASE_DIR/tmux.log" ] || fail "Kimi refusal created or touched a runtime endpoint"
+
+  rec=$(make_spawn_case cursor pi); read_spawn_record "$rec"
+  out=$(run_spawn_case "$rec" "cursor-agent --force"); rc=$?
+  [ "$rc" -ne 0 ] || fail "raw Cursor ship spawn must refuse as an unverified adapter"
+  assert_contains "$out" "no verified external-tool policy adapter" "Cursor refusal did not name the missing policy adapter"
+  [ ! -s "$CASE_DIR/tmux.log" ] || fail "Cursor refusal created or touched a runtime endpoint"
+  pass "Kimi and Cursor ship paths refuse before endpoint creation when interception is unverified"
+}
+
+test_scout_promotion_requires_live_policy_enforcement() {
+  local rec out rc
+  rec=$(make_spawn_case protected-scout pi); read_spawn_record "$rec"
+  out=$(run_spawn_case "$rec" --scout); rc=$?
+  expect_code 0 "$rc" "protected scout spawn should succeed: $out"
+  assert_grep 'external_tool_policy=enforced' "$HOME_DIR/state/$SPAWN_ID.meta" \
+    "protected scout spawn did not record its enforcement receipt"
+  out=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
+    FM_DATA_OVERRIDE="$HOME_DIR/data" "$ROOT/bin/fm-promote.sh" "$SPAWN_ID" 2>&1); rc=$?
+  expect_code 0 "$rc" "protected scout promotion should succeed: $out"
+  assert_grep 'kind=ship' "$HOME_DIR/state/$SPAWN_ID.meta" "protected scout did not become a ship"
+
+  rec=$(make_spawn_case unprotected-scout pi); read_spawn_record "$rec"
+  printf 'adapter-verification scout without a declared tool policy\n' > "$HOME_DIR/data/$SPAWN_ID/brief.md"
+  out=$(run_spawn_case "$rec" "custom-agent --flag" --scout); rc=$?
+  expect_code 0 "$rc" "unprotected raw scout should remain available for adapter verification: $out"
+  assert_no_grep 'external_tool_policy=enforced' "$HOME_DIR/state/$SPAWN_ID.meta" \
+    "raw scout falsely recorded policy enforcement"
+  out=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
+    FM_DATA_OVERRIDE="$HOME_DIR/data" "$ROOT/bin/fm-promote.sh" "$SPAWN_ID" 2>&1); rc=$?
+  [ "$rc" -ne 0 ] || fail "unprotected raw scout was promoted into a ship"
+  assert_contains "$out" "cannot be promoted into an unprotected ship" \
+    "unprotected promotion refusal did not name the safety consequence"
+  assert_grep 'kind=scout' "$HOME_DIR/state/$SPAWN_ID.meta" "refused promotion changed the scout kind"
+  pass "only scouts with live external-tool enforcement can be promoted in place"
+}
+
+test_spawn_refuses_missing_policy_before_endpoint_creation() {
+  local rec out rc
+  rec=$(make_spawn_case missing-policy pi); read_spawn_record "$rec"
+  printf 'legacy brief without machine policy\n' > "$HOME_DIR/data/$SPAWN_ID/brief.md"
+  out=$(run_spawn_case "$rec"); rc=$?
+  [ "$rc" -ne 0 ] || fail "ship spawn accepted a brief without machine-readable authorization"
+  assert_contains "$out" "no valid machine-readable external-tool policy" \
+    "missing-policy refusal did not identify the invalid brief"
+  [ ! -s "$CASE_DIR/tmux.log" ] || fail "missing-policy refusal created or touched a runtime endpoint"
+  pass "spawn validates the brief policy before creating the worker endpoint"
+}
+
+test_command_policy_matrix
+test_github_tool_authorization
+test_native_agent_browser_authorization
+test_generated_briefs_own_policy
+test_spawn_installs_each_verified_harness_adapter
+test_spawn_refuses_uninterceptable_harnesses_before_endpoint_creation
+test_scout_promotion_requires_live_policy_enforcement
+test_spawn_refuses_missing_policy_before_endpoint_creation
+
+echo "all fm-external-tool-policy tests passed"

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -39,8 +39,8 @@ make_spawn_case() {
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
   grok_home="$case_dir/grok"
   id="grok-$name-x1"
-  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" "$grok_home"
-  printf 'brief\n' > "$home/data/$id/brief.md"
+  mkdir -p "$home/projects" "$home/state" "$home/config" "$grok_home"
+  fm_write_ship_brief "$home/data/$id/brief.md" "Grok harness test brief."
   fm_git_worktree "$proj" "$wt" "fm/$id"
   touch "$home/state/.last-watcher-beat"
   printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$grok_home|$id"
@@ -96,7 +96,7 @@ EOF
 }
 
 test_grok_teardown_removes_pointer_and_token() {
-  local rec case_dir home proj wt fakebin grok_home id out status token
+  local rec case_dir home proj wt fakebin grok_home id out status token tool_token
   rec=$(make_spawn_case teardown)
   IFS='|' read -r case_dir home proj wt fakebin grok_home id <<EOF
 $rec
@@ -105,6 +105,7 @@ EOF
   status=$?
   expect_code 0 "$status" "grok spawn should succeed before teardown"
   token=$(sed -n 's/^token=//p' "$wt/.fm-grok-turnend")
+  tool_token=$(cat "$home/state/$id.grok-tool-policy-token")
 
   FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
     GROK_HOME="$grok_home" PATH="$fakebin:$PATH" \
@@ -114,7 +115,9 @@ EOF
   assert_absent "$wt/.fm-grok-turnend" "grok pointer survived teardown"
   assert_absent "$grok_home/hooks/fm-turn-end.d/$token" "grok auth token survived teardown"
   assert_absent "$home/state/$id.grok-turnend-token" "grok state token survived teardown"
-  pass "grok teardown removes pointer and token state"
+  assert_absent "$grok_home/hooks/fm-external-tool-policy.d/$tool_token" "grok tool-policy auth token survived teardown"
+  assert_absent "$home/state/$id.grok-tool-policy-token" "grok tool-policy state token survived teardown"
+  pass "grok teardown removes turn-end and external-tool policy token state"
 }
 
 test_fm_lock_recognizes_grok_holder() {

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -167,7 +167,7 @@ run_spawn() {
     FM_FAKE_BRIEF_REAL="$(cd "$home/data/$id" && pwd -P)/brief.md" \
     FM_KIMI_READY_POLLS=2 FM_KIMI_DELIVERY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
     PATH="$fakebin:$BASE_PATH" \
-    "$SPAWN" "$id" "$proj" --harness kimi "$@" 2>&1
+    "$SPAWN" "$id" "$proj" --harness kimi --scout "$@" 2>&1
 }
 
 read_spawn_record() {

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -854,8 +854,8 @@ test_spawn_fallback_chain_and_crew_scout_unaffected() {
   wt="$w/crew-wt"
   fakebin=$(make_launch_capturing_tmux "$w/tmux-crew")
   fm_git_worktree "$proj" "$wt" "wt-crew"
-  mkdir -p "$home/data/$id" "$home/projects" "$home/state"
-  printf 'brief\n' > "$home/data/$id/brief.md"
+  mkdir -p "$home/projects" "$home/state"
+  fm_write_ship_brief "$home/data/$id/brief.md" "ordinary crew ship brief"
   : > "$launchlog"
   PATH="$fakebin:$BASE_PATH" TMUX="fake,1,0" CLAUDECODE=1 \
     FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -60,8 +60,7 @@ make_spawn_case() {
   fm_git_worktree "$proj" "$wt" "wt-$name"
   touch "$home/state/.last-watcher-beat"
   for id in "$@"; do
-    mkdir -p "$home/data/$id"
-    printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+    fm_write_ship_brief "$home/data/$id/brief.md" "brief for $id"
   done
   printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$launchlog"
 }
@@ -321,7 +320,7 @@ test_active_dispatch_profile_allows_explicit_harness() {
   assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox" \
     "explicit harness launch did not thread model and effort"
   pass "active crew-dispatch profile allows an explicit resolved harness"
 }
@@ -342,7 +341,7 @@ test_active_dispatch_profile_allows_positional_harness() {
   pass "active crew-dispatch profile allows the legacy positional harness form"
 }
 
-test_active_dispatch_profile_allows_raw_launch_command() {
+test_active_dispatch_profile_limits_raw_launch_command_to_non_ship_work() {
   local rec id out status launch
   id=profile-raw-z15
   rec=$(make_spawn_case profile-raw claude "$id")
@@ -352,12 +351,20 @@ test_active_dispatch_profile_allows_raw_launch_command() {
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
     "$id" "$PROJ_DIR" "custom-agent --flag")
   status=$?
-  expect_code 0 "$status" "raw launch command should satisfy active dispatch-profile requirement"
-  assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
+  [ "$status" -ne 0 ] || fail "raw unverified harness must refuse a ship spawn"
+  assert_contains "$out" "no verified external-tool policy adapter" \
+    "raw ship refusal did not name the missing pre-tool adapter"
+
+  printf 'raw adapter-verification scout without a declared policy\n' > "$HOME_DIR/data/$id/brief.md"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" "custom-agent --flag" --scout)
+  status=$?
+  expect_code 0 "$status" "raw launch command should remain available for adapter-verification scouts"
+  assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw scout harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default
   launch=$(cat "$LAUNCH_LOG")
-  [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
-  pass "active crew-dispatch profile allows the raw launch-command escape hatch"
+  [ "$launch" = "custom-agent --flag" ] || fail "raw scout launch command changed"$'\n'"actual: $launch"
+  pass "active dispatch profiles refuse raw ship harnesses but retain the verification-scout escape hatch"
 }
 
 test_claude_threads_model_and_effort() {
@@ -387,7 +394,7 @@ test_codex_threads_model_and_effort() {
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox" \
     "codex launch did not thread model and reasoning effort config"
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
@@ -403,7 +410,7 @@ test_codex_omits_invalid_max_effort() {
   expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox" \
     "codex launch did not preserve the model flag when max effort was omitted"
   assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
   pass "codex omits unsupported max effort instead of passing a bad config value"
@@ -676,7 +683,7 @@ test_active_dispatch_profile_requires_explicit_harness_for_ship
 test_active_dispatch_profile_requires_explicit_harness_for_scout
 test_active_dispatch_profile_allows_explicit_harness
 test_active_dispatch_profile_allows_positional_harness
-test_active_dispatch_profile_allows_raw_launch_command
+test_active_dispatch_profile_limits_raw_launch_command_to_non_ship_work
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_omits_invalid_max_effort

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -100,6 +100,21 @@ SH
   done
 }
 
+# fm_write_ship_brief <path> [task-text]: write the minimum valid ship brief
+# fixture, including the production machine-readable external-tool policy.
+fm_write_ship_brief() {
+  local path=$1 task_text=${2:-test ship brief}
+  mkdir -p "$(dirname "$path")"
+  cat > "$path" <<EOF
+$task_text
+
+# External tool policy
+\`\`\`firstmate-external-tools
+{"schema":"firstmate.external-tools.v1","shell":{"allow":["gh-axi","chrome-devtools-axi"]},"native":{"allow":["agent_browser"]}}
+\`\`\`
+EOF
+}
+
 # --- deterministic git identity and fixtures --------------------------------
 
 # fm_git_identity [name] [email]: export a fixed author/committer identity so


### PR DESCRIPTION
## Intent

Implemente uma trava executável para que ships usem somente as ferramentas externas autorizadas pelo brief. O incidente a impedir ocorreu quando um ship instruído a usar chrome-devtools-axi e, somente como fallback, agent_browser, com automação de navegador por shell proibida, executou npx playwright install chromium e ficou ativo por 8.355 segundos. Transforme a autorização do brief em política executável antes da execução do comando, sem depender da memória ou obediência do modelo e sem limitar a correção à string exata do incidente. Prefira uma única política semântica com adaptadores finos por harness e não crie uma segunda fonte de verdade paralela ao brief.

Critérios obrigatórios: todo ship gerado declara política legível por máquina; spawn instala ou conecta essa política antes do primeiro turno; npx playwright install chromium e variantes equivalentes por package runner, comando direto, shell aninhado, pipeline ou redirecionamento são negados antes do processo solicitado nascer; chrome-devtools-axi permanece permitido; o tool nativo agent_browser permanece permitido quando o brief o autoriza como fallback; testes, lint, build, servidor local e outros comandos normais de desenvolvimento continuam funcionando; a negação informa ferramenta pedida, política aplicável e alternativas autorizadas; harness sem interceptação confiável recusa o spawn do ship; a política não depende somente de strings exatas; testes cobrem incidente, bypasses e permitidos; a validação revisa claude, codex, opencode, pi, pi-signed, grok, kimi e cursor, com eixos não aplicáveis marcados somente por evidência; a política fica documentada no proprietário correto e AGENTS.md mantém somente a regra sempre necessária; testes direcionados, bin/fm-lint.sh e bin/fm-doc-audience-check.sh passam; supervisão, spawn, validação e limpeza existentes permanecem corretos.

Limites: não altere projetos de clientes; não encerre nem reinicie trabalhadores existentes; não bloqueie package managers de forma ampla sem distinguir desenvolvimento normal de automação externa não autorizada; não reduza a política a documentação ou prompt. A autorrevisão but-for-real encontrou e corrigiu o caminho de promoção de scout: scouts gerados agora iniciam protegidos, somente scouts com recibo de enforcement podem virar ships vivos, e scouts legados ou de adapter bruto recusam promoção. Ela também preservou scouts brutos somente para verificação de adapters e corrigiu a verificação de cobertura de testes para usar collation determinística. Não restam preocupações funcionais conhecidas, mas a revisão deve confirmar esses dois caminhos junto com todos os critérios acima.

## What Changed

- Add a semantic external-tool command policy (`bin/fm-external-tool-command-policy.mjs`) plus a per-harness pretool adapter (`bin/fm-external-tool-pretool-check.sh`) that classify a command across package runners, direct commands, nested shells, pipelines, and redirections, then deny unauthorized browser automation (e.g. `npx playwright install chromium`) while allowing `chrome-devtools-axi`, brief-authorized `agent_browser` fallback, and normal test/lint/build/dev/install commands; denials name the requested tool, the applicable policy, and authorized alternatives.
- Wire the policy into the lifecycle: `fm-brief.sh` emits machine-readable authorization in every generated ship, `fm-spawn.sh` installs or connects the policy before the first turn and refuses spawn on harnesses without reliable interception (kimi/cursor), and `fm-promote.sh` only promotes scouts carrying an enforcement receipt while refusing legacy or raw-adapter scouts; `fm-arm-command-policy.mjs` gains the shared compound-shell `walkShellCommandTree` helper.
- Add the `fm-external-tool-policy` behavior suite and coverage/collation fixes in `fm-test-run.sh`/`tests/lib.sh`, document the policy under its owner (`docs/external-tool-policy.md`, `docs/verification/external-tool-policy.md`, scripts/audiences docs) and keep only the always-needed rule in `AGENTS.md`.

## Risk Assessment

✅ Low: The Round 1 syntax-breaking corruption is now committed as e45d6e6 and verified as a pure marker-strip with intact logic; both policy modules parse and enforce correctly, leaving only one out-of-scope info hardening note.

## Testing

Ran the full external-tool policy behavior suite (all assertions pass) plus targeted manual verification producing two CLI transcripts: one showing the pre-tool check denying the reproduced 8,355s Playwright-install incident and every equivalent bypass while allowing the authorized primary browser, native fallback, and normal dev commands with denials that name tool/policy/alternatives; and one driving bin/fm-promote.sh to confirm a protected scout promotes to a ship while a raw adapter-verification scout is refused and stays a scout. Also ran the coverage guard (passes, exercising the deterministic-collation fix) and the required fm-lint.sh and fm-doc-audience-check.sh gates (both pass). This is a CLI/policy change with no rendered UI surface, so evidence is CLI transcripts rather than screenshots. Worktree left clean.

<details>
<summary>Evidence: Incident + bypass denial and allowed-command transcript (real generated ship brief)</summary>

```text
Firstmate external-tool policy - pre-tool check against a REAL generated ship brief
Brief policy fence: shell allow=[gh-axi, chrome-devtools-axi]  native allow=[agent_browser]
===========================================================================================

--- The reproduced incident (the 8,355s Playwright install) and equivalent bypasses ---
[DENY  rc=2] incident: package runner   $ npx playwright install chromium
             [external-tool-denied] requested browser shell tool 'playwright' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
[DENY  rc=2] npm exec bypass            $ npm exec -- playwright install chromium
             [external-tool-denied] requested browser shell tool 'playwright' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
[DENY  rc=2] pnpm dlx bypass            $ pnpm dlx playwright install chromium
             [external-tool-denied] requested browser shell tool 'playwright' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
[DENY  rc=2] yarn dlx bypass            $ yarn dlx @playwright/test install chromium
             [external-tool-denied] requested browser shell tool 'playwright' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
[DENY  rc=2] nested shell bypass        $ bash -lc 'npx playwright install chromium'
             [external-tool-denied] requested browser shell tool 'playwright' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
[DENY  rc=2] pipeline bypass            $ npx playwright install chromium | tee install.log
             [external-tool-denied] requested browser shell tool 'playwright' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
[DENY  rc=2] redirection bypass         $ npx playwright install chromium >install.log 2>&1
             [external-tool-denied] requested browser shell tool 'playwright' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
[DENY  rc=2] direct .bin bypass         $ ./node_modules/.bin/playwright install chromium
             [external-tool-denied] requested browser shell tool 'playwright' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
[DENY  rc=2] python -m bypass           $ python -m playwright install chromium
             [external-tool-denied] requested browser shell tool 'playwright' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
[DENY  rc=2] node -e bypass             $ node -e 'require("puppeteer").launch()'
             [external-tool-denied] requested browser shell tool 'puppeteer' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
[DENY  rc=2] raw shell browser drive    $ agent-browser open http://localhost:3000
             [external-tool-denied] requested browser shell tool 'agent-browser' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
[DENY  rc=2] unlisted gh client         $ gh repo view owner/name
             [external-tool-denied] requested github shell tool 'gh' is not authorized by firstmate.external-tools.v1 in brief /tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/brief-home/data/incident-repro/brief.md; authorized alternatives: shell: gh-axi

--- Authorized primary browser + normal development commands stay allowed ---
[ALLOW rc=0] authorized primary         $ chrome-devtools-axi open http://localhost:3000
[ALLOW rc=0] authorized gh-axi          $ gh-axi repo view owner/name
[ALLOW rc=0] unit tests                 $ npm test
[ALLOW rc=0] lint                       $ pnpm lint
[ALLOW rc=0] build                      $ npm run build
[ALLOW rc=0] local dev server           $ npm run dev -- --host 127.0.0.1
[ALLOW rc=0] normal package install     $ npm install typescript
[ALLOW rc=0] data mention (not exec)    $ printf '%s' 'npx playwright install chromium'
```
</details>
<details>
<summary>Evidence: Scout promotion enforcement transcript (protected promotes, raw refused)</summary>

```text
Scout promotion enforcement - end-user surface (bin/fm-promote.sh)
=================================================================

>>> Path A: PROTECTED scout (spawn recorded external_tool_policy=enforced, brief policy valid)
    meta before promote:
      kind=scout
      external_tool_policy=enforced
    promote rc=0
    stdout/stderr:
      ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
      ●  WATCHER DOWN - SUPERVISION IS OFF
      ●  2 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
      ●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
      ●  This is a supervision warning only; the guarded operation WILL still run.
      ●  repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task, never shell &.
      ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
      promoted protected-scout to ship (teardown protection restored)
      next: FM_HOME=/tmp/no-mistakes-evidence/01KYWBERGRJA8E5HR5HG95HCCA/scout/home bin/fm-send.sh fm-protected-scout '<ship instructions: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/protected-scout; implement; report done>'
    meta after promote:
      external_tool_policy=enforced
      kind=ship

>>> Path B: RAW adapter-verification scout (no enforcement receipt) - MUST be refused
    meta before promote:
      kind=scout
    promote rc=1 (non-zero = refused, correct)
    stderr:
      WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
      error: scout raw-scout was launched without enforceable external-tool interception and cannot be promoted into an unprotected ship; start a new ship with a generated brief
    meta after refusal (still a scout, unchanged):
      kind=scout
```
</details>
<details>
<summary>Evidence: Full denial payload naming tool, policy schema, and authorized alternatives</summary>

```text
[external-tool-denied] requested browser shell tool 'playwright' is not authorized by firstmate.external-tools.v1 in brief .../incident-repro/brief.md; authorized alternatives: shell: chrome-devtools-axi; native: agent_browser
```
</details>
<details>
<summary>Evidence: Coverage guard + required gates</summary>

```text
FM_TEST_COVERAGE ok total=102 parallel=24 serial=67 herdr=11 (rc=0)
fm-lint.sh rc=0
fm-doc-audience-check: ok surfaces=61 local_links=169 (rc=0)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `bin/fm-arm-command-policy.mjs:674` - Commit cf18ea9 committed 22 lines of bin/fm-arm-command-policy.mjs with a literal leading &#39;+&#39; diff marker (lines 674-706 region), making the file invalid JavaScript (SyntaxError: Unexpected token &#39;const&#39;). walkShellCommandTree is imported by the new fm-external-tool-command-policy.mjs, so the entire external-tool guard fails to load and every command classification throws; the watcher-arm policy also breaks. Auto-fixed by stripping the stray &#39;+&#39; markers, restoring valid syntax with the intended compound-position logic intact. Verified both files now parse and the classifier denies the incident and bypass vectors while allowing normal dev commands.
- ℹ️ `bin/fm-external-tool-command-policy.mjs:269` - The command classifier does not treat generic exec wrappers (nice, setsid, stdbuf, taskset, ionice, xargs) as pass-throughs, so &#39;nice npx playwright install chromium&#39; classifies as no controlled tool. The enumerated intent vectors (package runner, direct command, nested shell, pipeline, redirection) are all covered and the intent says the fix need not chase exact strings, so this is a hardening opportunity rather than a gap in the required surface.

🔧 Fix: strip stray diff markers from arm command policy
1 info still open:
- ℹ️ `bin/fm-external-tool-command-policy.mjs:269` - The command classifier does not treat generic exec wrappers (nice, setsid, stdbuf, taskset, ionice, xargs) as pass-throughs, so &#39;nice npx playwright install chromium&#39; classifies as no controlled tool. The enumerated intent vectors (package runner, direct command, nested shell, pipeline, redirection) are all covered and the intent says the fix need not chase exact strings, so this is a hardening opportunity rather than a gap in the required surface. Unchanged since Round 1.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-external-tool-policy.test.sh` — full behavior suite (command matrix, GitHub/native authorization, generated ship+scout briefs, per-harness adapter install for claude/codex/opencode/pi/pi-signed/grok, kimi/cursor spawn refusal, scout-promotion enforcement, missing-policy refusal) all pass</code>
- <code>Manual CLI transcript via `bin/fm-external-tool-pretool-check.sh --brief &lt;generated brief&gt; --command ...` denying the incident + 11 bypasses and allowing chrome-devtools-axi/gh-axi/npm test/pnpm lint/npm run build/npm run dev/npm install</code>
- <code>Manual `bin/fm-promote.sh` transcript: protected scout (external_tool_policy=enforced) promotes to ship (rc=0), raw scout refused (rc=1) and kept kind=scout</code>
- <code>`bash bin/fm-test-run.sh --check-coverage` — coverage guard passes (rc=0, total=102), exercising the LC_ALL=C deterministic collation fix</code>
- <code>`bash bin/fm-lint.sh` (rc=0) and `bash bin/fm-doc-audience-check.sh` (rc=0) — the two intent-required gates</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
