### PR TITLE
docs(skills): add infisical-secrets operator reference skill

### DIFF
--- a/.agents/skills/infisical-secrets/SKILL.md
+++ b/.agents/skills/infisical-secrets/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: infisical-secrets
+description: Agent-only reference for operating this fleet's self-hosted Infisical instance (secrets for service access like the Coolify token, and per-project environment variables). Use before creating, reading, rotating, or syncing any secret, and before wiring a project's CI/deploy pipeline to pull secrets.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# infisical-secrets
+
+Infisical is this fleet's secrets manager: service-access credentials (for example the Coolify API token) and per-project environment variables both live here, not in any repo or `config/` file.
+The instance is self-hosted via Coolify at `http://keys.dev.hic2h.com`, verified reachable and healthy (`curl http://keys.dev.hic2h.com/api/status` returns 200).
+The `infisical` CLI (v0.43.114 at last check) is already installed and already logged in as the captain's account; `~/.infisical/infisical-config.json` records the domain and vault backend.
+Never hand-edit that config file or the keyring.
+
+## Core model
+
+`Organization -> Project -> Environment -> Secret`, with secrets additionally organized into folder paths (`--path=/apps/foo`) within an environment.
+A directory is linked to one project via `infisical init`, which writes `.infisical.json`.
+That file records project/environment identity only, never secret values, so it is safe to commit to the project's repo.
+
+## Reading secrets
+
+Prefer `infisical run` over anything that writes secrets to disk.
+It injects secrets as environment variables directly into a child process and nothing else touches them:
+
+```sh
+infisical run --env=dev --path=/apps/firefly -- npm run dev
+infisical run --env=prod --path=/apps/backend -- ./scripts/deploy.sh "$PROD_APP_UUID"
+```
+
+`infisical export --format=dotenv-export > .env` or `--format=yaml` writes secrets to a real file - only use this when the consumer genuinely requires a file (for example seeding Coolify's own env store, see below), and treat that file exactly like any other secret material: never commit it, delete it once consumed.
+`infisical secrets get <name> --env=<env> --path=<path>` reads one secret by name.
+
+## Writing and managing secrets
+
+`infisical secrets set <name>=<value> --env=<env> --path=<path>` creates or updates one secret.
+`infisical secrets delete <name> --env=<env> --path=<path>` removes one.
+`infisical secrets folders` manages the folder structure within an environment.
+
+## Non-interactive auth (CI, deploy scripts, anything not an interactive captain session)
+
+The logged-in interactive session is a human identity, not something a script should rely on.
+For any automation, use a machine identity with universal auth instead:
+
+```sh
+export INFISICAL_TOKEN=$(infisical login --method=universal-auth \
+  --client-id=<id> --client-secret=<secret> --silent --plain)
+```
+
+Then every subsequent `infisical` command in that process picks up `INFISICAL_TOKEN` automatically.
+Service tokens (`export INFISICAL_TOKEN=<service-token>`) are the older, project-scoped alternative; prefer machine identities for anything new.
+Scope each machine identity to the narrowest project/environment it needs, the same least-privilege discipline the deploy-pipeline plan applies to Coolify's own `deploy`-ability tokens (`data/deploy-pipeline/deploy-pipeline-plan/report.md` section 8.3).
+
+## Coolify integration: no native path exists, two candidate patterns
+
+Checked 2026-07-31: there is no native Infisical-to-Coolify sync (Infisical's own secret-sync integrations cover GitHub, Vercel, AWS, Terraform, and others, but not Coolify; tracked as open requests on both projects' issue trackers, e.g. `Infisical/infisical#1350`, `coollabsio/coolify#7956`).
+This is a fact about the ecosystem right now, not a permanent gap - re-check before assuming it still holds.
+
+Two viable patterns until a native integration lands, neither implemented yet:
+
+1. **Runtime pull inside the container.**
+   Bake the `infisical` CLI into the image and wrap the container's start command with `infisical run -- <real start command>`, authenticated via a machine identity whose credentials Coolify itself injects as plain env vars.
+   Secrets never sit in Coolify's own env store at all.
+2. **Push-sync into Coolify's env store.**
+   `infisical export --format=dotenv-export` (or targeted `secrets get` calls) feeds `coolify app env sync` (see `data/deploy-pipeline/deploy-pipeline-plan/report.md` section 8.2), run at bootstrap/deploy time from an operator or CI context.
+   Coolify's own env delivery stays the runtime mechanism; Infisical is the authoring and audit layer above it.
+
+Which pattern this fleet actually adopts is an open decision for the planned Infisical-plus-Coolify test, not something this skill prescribes.
+Pattern 2 fits the existing deploy-pipeline design most naturally (Coolify env vars already the documented runtime-config home), but pattern 1 gives tighter secret scoping per container.
+Record the decision and the concrete wiring here once the test settles it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -492,6 +492,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `infisical-secrets` - load before creating, reading, rotating, or syncing any secret in the fleet's self-hosted Infisical instance, or before wiring a project's CI/deploy pipeline to pull secrets from it.
 
 ## 14. X mode
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -152,6 +152,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/infisical-secrets/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/project-management/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

The developer wants to standardize secrets management across their infrastructure using the already-authenticated Infisical CLI, covering both service-level credentials (e.g., the Coolify API token) and per-project environment variables. They asked the assistant to learn how Infisical's CLI usage works and turn that knowledge into a reusable skill/operator reference documenting it, so it can guide future work. The stated next step, once the skill exists, is to test the Infisical setup together with Coolify integration. This follows the developer's established pattern from earlier in the session of shipping such changes (branch, run through the no-mistakes validation pipeline, then PR) rather than editing files ad hoc.

## What Changed

- Add `.agents/skills/infisical-secrets/SKILL.md`, a reusable skill documenting Infisical CLI usage for managing both service-level credentials (e.g. Coolify API token) and per-project environment variables.
- Register the new skill in `AGENTS.md` so it's discoverable alongside other skills.
- Add the skill to `docs/documentation-audiences.json` so it's included in the documentation audience inventory.

## Risk Assessment

✅ Low: Documentation-only addition of a new skill reference file plus a one-line AGENTS.md index entry; all cited CLI commands/flags were verified against the installed infisical binary and the referenced data/ paths follow the repo's existing gitignored-runtime-doc convention.

## Testing

test

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `a`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
