### PR TITLE
feat: add Windows-to-WSL launcher bridge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
       # re-spell the shellcheck command here; keep CI and the pre-push gate on it.
       - run: bin/fm-lint.sh
 
+  windows-launcher:
+    name: Windows launcher bridge
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Exercise the batch command and WSL entry contracts
+        shell: bash
+        run: bash tests/fm-wsl-entry.test.sh
+
   # Deterministic proof that portable parallel shards + portable serial + Herdr
   # equal the complete tests/*.test.sh inventory with no missing or duplicates.
   test-coverage:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Hard rules, in priority order:
    If work failed, say so plainly with the evidence.
 
 You may maintain this repo's private operational state directly.
-Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and public `skills/`.
+Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `firstmate.bat`, `bin/`, `.agents/skills/`, and public `skills/`.
 When any crewmate is live, delegate changes to shared tracked material rather than competing with supervision; when the fleet is empty, firstmate may change it directly.
 This repo is a shared template, while `.env`, `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` are captain-private and gitignored.
 Ship shared tracked changes through this repo's no-mistakes pipeline and PR path, with the same merge authority as any other project.
@@ -62,6 +62,7 @@ README.md            public overview and development notes
 .agents/skills/      firstmate-loaded internal skills, committed; each carries metadata.internal=true for installers
 .claude/skills       symlink to .agents/skills for claude compatibility
 skills/              standalone public installer-facing skills, committed; not loaded by firstmate
+firstmate.bat        Windows-to-WSL launcher bridge, committed; docs/windows-launcher.md owns setup
 bin/                 helper scripts, committed; read each script's header before first use
 .env                 optional X-mode pairing token; LOCAL, gitignored; presence-gates section 14
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (section 4)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 - This repo is a template for running a firstmate orchestrator agent.
   `AGENTS.md` is the agent's main job description and names when to load bundled firstmate skills; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
-- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/`.
+- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `firstmate.bat`, `bin/`, `.agents/skills/`, and `skills/`.
   `.agents/skills/` holds agent-loaded skills that assume a live firstmate home and carry `metadata.internal: true` so installers such as [skills.sh](https://skills.sh) hide them from discovery; `skills/` holds standalone, installer-facing public skills with no firstmate dependency (see the README's "Two-tier skill layout").
   Everything personal to one captain's fleet (`.env`, `data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.
   The root `.tasks.toml` is tracked `tasks-axi` config for `data/backlog.md`; compatible `tasks-axi` is the default backend for routine backlog mutations, with the compatibility definition owned by [`docs/configuration.md`](docs/configuration.md) ("Backlog backend").
@@ -56,7 +56,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 ## Development
 
-Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/` - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
+Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `firstmate.bat`, `bin/`, `.agents/skills/`, and `skills/` - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
 Before making any such change, load the agent-only `firstmate-coding-guidelines` skill (`.agents/skills/firstmate-coding-guidelines/SKILL.md`).
 It has the knowledge-placement rules that keep `AGENTS.md` from regrowing after each diet pass.
 There is no reliable way for `bin/fm-brief.sh`'s scaffold to detect that a task's repo is firstmate itself, so firstmate adds this skill's load line to firstmate-repo briefs by hand.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ FM_PI_HARNESS=pi-signed pi-signed
 
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
+On Windows with WSL and Herdr, the repository-root `firstmate.bat` opens the optional harness menu without requiring a remembered terminal command; see [the Windows launcher guide](docs/windows-launcher.md).
 Pi's `/calm` toggle hides supported transcript chrome, including canonically classified Firstmate operational user rows, and uses a Calm-only animated working boat during active runs while preserving all model context and session data.
 The hidden operational inputs remain ordinary user-role messages with unchanged delivery, ordering, authority, persistence, and exports.
 The preference persists for the effective Firstmate home, and toggling it off restores ordinary rendering.
@@ -198,6 +199,7 @@ Firstmate's skills live in two separate places with different audiences:
 
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
+- [docs/windows-launcher.md](docs/windows-launcher.md) - launch the Herdr-backed harness menu from Windows through WSL.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - current setup and limits for the tmux reference backend.

--- a/bin/fm-wsl-entry.sh
+++ b/bin/fm-wsl-entry.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# fm-wsl-entry.sh - deterministic WSL-side entry for repository-root
+# firstmate.bat.
+#
+# Usage:
+#   bin/fm-wsl-entry.sh [fm-launch.sh arguments...]
+#
+# firstmate.bat starts /bin/bash directly with the repository as WSL's working
+# directory.  This script then resolves the repository from its own location,
+# changes there, and replaces itself with bin/fm-launch.sh.  It neither depends
+# on the Windows launch directory nor starts a second WSL process.  Every
+# argument and the launcher's exit status pass through unchanged.
+set -u
+
+fm_wsl_entry_error() {
+  printf 'fm-wsl-entry: %s\n' "$1" >&2
+}
+
+SCRIPT_DIR=$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P) || {
+  fm_wsl_entry_error "cannot resolve the Firstmate bin directory."
+  fm_wsl_entry_error "Move the repository to a path WSL can read, then retry firstmate.bat."
+  exit 1
+}
+FM_ROOT=$(CDPATH='' cd "$SCRIPT_DIR/.." 2>/dev/null && pwd -P) || {
+  fm_wsl_entry_error "cannot resolve the Firstmate repository root."
+  fm_wsl_entry_error "Move the repository to a path WSL can read, then retry firstmate.bat."
+  exit 1
+}
+LAUNCHER="$FM_ROOT/bin/fm-launch.sh"
+
+if [ ! -r "$LAUNCHER" ]; then
+  fm_wsl_entry_error "cannot read $LAUNCHER."
+  fm_wsl_entry_error "Update this Firstmate copy so bin/fm-launch.sh is present, then retry firstmate.bat."
+  exit 1
+fi
+
+if ! cd "$FM_ROOT"; then
+  fm_wsl_entry_error "cannot enter the Firstmate repository at $FM_ROOT."
+  fm_wsl_entry_error "Move the repository to a path WSL can read, then retry firstmate.bat."
+  exit 1
+fi
+
+exec /bin/bash "$LAUNCHER" "$@"

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -25,6 +25,7 @@
   ],
   "readmeSetupTargets": [
     "docs/configuration.md",
+    "docs/windows-launcher.md",
     "docs/wedge-alarm.md",
     "docs/tmux-backend.md",
     "docs/herdr-backend.md",
@@ -325,6 +326,10 @@
     },
     {
       "path": "docs/watcher-continuity.md",
+      "audience": "operator-current"
+    },
+    {
+      "path": "docs/windows-launcher.md",
       "audience": "operator-current"
     },
     {

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -39,6 +39,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervision-instructions.sh` | Render the session-start primary-harness supervision block or the one-line repair instruction |
 | `fm-home-seed.sh`        | Transactionally provision a secondmate home and maintain `data/secondmates.md`       |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
+| `fm-wsl-entry.sh`        | Enter the fleet launcher deterministically from the repository-root Windows batch bridge |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer-content classification for all backends          |

--- a/docs/windows-launcher.md
+++ b/docs/windows-launcher.md
@@ -1,0 +1,47 @@
+# Windows WSL launcher
+
+The repository-root `firstmate.bat` opens Firstmate's Herdr-backed harness menu from Windows.
+Double-click the file in Explorer, or run it from Command Prompt or PowerShell.
+
+## Prerequisites
+
+- Install WSL with `wsl --install` and finish the distribution's first-run setup.
+- Install Firstmate's Linux-side prerequisites, Herdr, and the harnesses you want to use inside that WSL distribution.
+- Keep the Firstmate repository somewhere the distribution can read.
+  Windows drive paths, including paths containing spaces, are supported through WSL's `--cd` mapping.
+
+The bridge uses the current default WSL distribution.
+If more than one distribution is installed, select the one that contains Firstmate's dependencies before launching:
+
+```powershell
+wsl --list --verbose
+wsl --set-default Ubuntu
+```
+
+## Launch
+
+Double-click `firstmate.bat` at the repository root.
+The window opens the existing harness menu, and the selected session follows the same Herdr launch and attach flow as `bin/fm-launch.sh`.
+If startup fails, the window prints the underlying error, reports the exit status, gives the WSL installation repair when relevant, and stays open for acknowledgment.
+
+The batch entry accepts the launcher's existing arguments and returns its exit status:
+
+```bat
+firstmate.bat --print-menu
+firstmate.bat --verbose
+firstmate.bat --help
+```
+
+The bridge starts one WSL process, sets its working directory to the batch file's repository, selects `/bin/bash` directly, and enters through `bin/fm-wsl-entry.sh`.
+The WSL helper resolves the repository from its own location and replaces itself with `bin/fm-launch.sh`, so the current Windows directory and shell profiles cannot redirect the launch.
+
+## Troubleshooting
+
+If Windows says WSL is missing, run `wsl --install`, restart Windows if prompted, finish the distribution setup, and retry.
+If the helper reports that `bin/fm-launch.sh` is absent, update the repository before retrying.
+If the menu reports a Herdr or harness problem, install or configure that dependency inside the default WSL distribution rather than only on Windows.
+
+## Maintaining this file
+
+This file is the operator-facing owner of the Windows-to-WSL launcher bridge.
+Keep menu behavior and Herdr lifecycle details with their existing script owners, and keep exact bridge mechanics in `firstmate.bat` and `bin/fm-wsl-entry.sh`.

--- a/docs/windows-launcher.md
+++ b/docs/windows-launcher.md
@@ -7,6 +7,8 @@ Double-click the file in Explorer, or run it from Command Prompt or PowerShell.
 
 - Install WSL with `wsl --install` and finish the distribution's first-run setup.
 - Install Firstmate's Linux-side prerequisites, Herdr, and the harnesses you want to use inside that WSL distribution.
+- Use a Firstmate revision that includes the `bin/fm-launch.sh` launcher dependency.
+  The bridge reports an actionable error instead of starting when that dependency is absent.
 - Keep the Firstmate repository somewhere the distribution can read.
   Windows drive paths, including paths containing spaces, are supported through WSL's `--cd` mapping.
 
@@ -24,13 +26,8 @@ Double-click `firstmate.bat` at the repository root.
 The window opens the existing harness menu, and the selected session follows the same Herdr launch and attach flow as `bin/fm-launch.sh`.
 If startup fails, the window prints the underlying error, reports the exit status, gives the WSL installation repair when relevant, and stays open for acknowledgment.
 
-The batch entry accepts the launcher's existing arguments and returns its exit status:
-
-```bat
-firstmate.bat --print-menu
-firstmate.bat --verbose
-firstmate.bat --help
-```
+Arguments supplied to the batch entry pass through to `bin/fm-launch.sh`, and the batch entry returns the launcher's exit status.
+Use the launcher's own usage text for its supported arguments.
 
 The bridge starts one WSL process, sets its working directory to the batch file's repository, selects `/bin/bash` directly, and enters through `bin/fm-wsl-entry.sh`.
 The WSL helper resolves the repository from its own location and replaces itself with `bin/fm-launch.sh`, so the current Windows directory and shell profiles cannot redirect the launch.

--- a/firstmate.bat
+++ b/firstmate.bat
@@ -1,0 +1,41 @@
+@echo off
+rem firstmate.bat - Windows front door for the Firstmate launcher in WSL.
+rem
+rem Double-click this file, or run:
+rem   firstmate.bat [fm-launch.sh arguments...]
+rem
+rem The repository path is passed to wsl.exe through --cd.  Appending "." keeps
+rem the quoted Windows path from ending in a backslash, including when the path
+rem contains spaces.  --exec selects /bin/bash directly instead of depending on
+rem the WSL distribution's login shell or profile.
+setlocal EnableExtensions DisableDelayedExpansion
+
+if defined FIRSTMATE_WSL_EXE (
+  set "FIRSTMATE_WSL_COMMAND=%FIRSTMATE_WSL_EXE%"
+) else (
+  set "FIRSTMATE_WSL_COMMAND=%SystemRoot%\System32\wsl.exe"
+)
+
+if not exist "%FIRSTMATE_WSL_COMMAND%" (
+  >&2 echo Firstmate could not find WSL at "%FIRSTMATE_WSL_COMMAND%".
+  >&2 echo Install it with "wsl --install", restart Windows if prompted, then retry.
+  if not defined FIRSTMATE_NO_PAUSE pause
+  endlocal & exit /b 127
+)
+
+if defined FIRSTMATE_WSL_EXE (
+  rem Test seam: a batch-command fake needs CALL so control returns here.
+  call "%FIRSTMATE_WSL_COMMAND%" --cd "%~dp0." --exec /bin/bash ./bin/fm-wsl-entry.sh %*
+) else (
+  "%FIRSTMATE_WSL_COMMAND%" --cd "%~dp0." --exec /bin/bash ./bin/fm-wsl-entry.sh %*
+)
+set "FIRSTMATE_EXIT=%ERRORLEVEL%"
+
+if not "%FIRSTMATE_EXIT%"=="0" (
+  >&2 echo.
+  >&2 echo Firstmate could not start through WSL. Exit status: %FIRSTMATE_EXIT%
+  >&2 echo Review the error above. If WSL itself did not start, run "wsl --install" and retry.
+  if not defined FIRSTMATE_NO_PAUSE pause
+)
+
+endlocal & exit /b %FIRSTMATE_EXIT%

--- a/tests/fm-wsl-entry.test.sh
+++ b/tests/fm-wsl-entry.test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Behavior tests for the repository-root Windows batch launcher and its
+# deterministic WSL-side entrypoint.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ENTRY="$ROOT/bin/fm-wsl-entry.sh"
+BATCH="$ROOT/firstmate.bat"
+TMP_ROOT=$(fm_test_tmproot fm-wsl-entry)
+
+make_entry_fixture() {  # <root>
+  local fixture=$1
+  mkdir -p "$fixture/bin"
+  cp "$ENTRY" "$fixture/bin/fm-wsl-entry.sh"
+  chmod +x "$fixture/bin/fm-wsl-entry.sh"
+}
+
+make_fake_launcher() {  # <root>
+  cat > "$1/bin/fm-launch.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'cwd=[%s]\n' "$PWD"
+i=0
+for arg in "$@"; do
+  i=$((i + 1))
+  printf 'arg%d=[%s]\n' "$i" "$arg"
+done
+exit "${FM_FAKE_LAUNCH_EXIT:-0}"
+SH
+  chmod +x "$1/bin/fm-launch.sh"
+}
+
+test_wsl_entry_preserves_root_arguments_and_status() {
+  local fixture="$TMP_ROOT/Firstmate repo with spaces" out status=0
+  make_entry_fixture "$fixture"
+  make_fake_launcher "$fixture"
+
+  out=$(cd / && FM_FAKE_LAUNCH_EXIT=23 "$fixture/bin/fm-wsl-entry.sh" \
+    --print-menu "value with spaces" "" 2>&1) || status=$?
+
+  expect_code 23 "$status" "WSL entry launcher status"
+  assert_contains "$out" "cwd=[$fixture]" \
+    "the WSL entry must launch from the repository it belongs to"
+  assert_contains "$out" "arg1=[--print-menu]" \
+    "the first launcher argument must pass through"
+  assert_contains "$out" "arg2=[value with spaces]" \
+    "an argument containing spaces must remain one argument"
+  assert_contains "$out" "arg3=[]" \
+    "an empty launcher argument must remain present"
+  pass "fm-wsl-entry: repository paths with spaces, arguments, and exit status pass through unchanged"
+}
+
+test_wsl_entry_missing_launcher_is_actionable() {
+  local fixture="$TMP_ROOT/missing launcher" out status=0
+  make_entry_fixture "$fixture"
+
+  out=$("$fixture/bin/fm-wsl-entry.sh" 2>&1) || status=$?
+
+  expect_code 1 "$status" "missing launcher status"
+  assert_contains "$out" "$fixture/bin/fm-launch.sh" \
+    "the refusal must name the missing launcher"
+  assert_contains "$out" "Update this Firstmate copy" \
+    "the refusal must tell the operator how to repair the copy"
+  pass "fm-wsl-entry: a missing fleet launcher refuses with an actionable repair"
+}
+
+to_windows_path() {  # <path>
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -aw "$1"
+  elif command -v wslpath >/dev/null 2>&1; then
+    wslpath -aw "$1"
+  else
+    return 1
+  fi
+}
+
+test_batch_constructs_one_deterministic_wsl_command() {
+  local case_root="$TMP_ROOT/batch case" batch_root="$TMP_ROOT/batch case/Firstmate root with spaces"
+  local fake="$case_root/fake-wsl.cmd" runner="$case_root/run-test.cmd" log="$case_root/wsl-args.log"
+  local fake_win runner_win log_win batch_root_win out status=0
+
+  if ! command -v cmd.exe >/dev/null 2>&1; then
+    pass "firstmate.bat: native command construction is covered on the Windows CI lane"
+    return 0
+  fi
+
+  mkdir -p "$batch_root/bin"
+  cp "$BATCH" "$batch_root/firstmate.bat"
+  : > "$batch_root/bin/fm-wsl-entry.sh"
+
+  fake_win=$(to_windows_path "$fake") || fail "could not map the fake WSL command to Windows"
+  runner_win=$(to_windows_path "$runner") || fail "could not map the batch test runner to Windows"
+  log_win=$(to_windows_path "$log") || fail "could not map the batch log to Windows"
+  batch_root_win=$(to_windows_path "$batch_root") || fail "could not map the batch fixture to Windows"
+
+  printf '%s\r\n' \
+    '@echo off' \
+    '> "%FIRSTMATE_WSL_TEST_LOG%" echo arg1=[%~1]' \
+    '>> "%FIRSTMATE_WSL_TEST_LOG%" echo arg2=[%~2]' \
+    '>> "%FIRSTMATE_WSL_TEST_LOG%" echo arg3=[%~3]' \
+    '>> "%FIRSTMATE_WSL_TEST_LOG%" echo arg4=[%~4]' \
+    '>> "%FIRSTMATE_WSL_TEST_LOG%" echo arg5=[%~5]' \
+    '>> "%FIRSTMATE_WSL_TEST_LOG%" echo arg6=[%~6]' \
+    '>> "%FIRSTMATE_WSL_TEST_LOG%" echo arg7=[%~7]' \
+    'exit /b %FIRSTMATE_FAKE_EXIT%' > "$fake"
+
+  printf '%s\r\n' \
+    '@echo off' \
+    "set \"FIRSTMATE_WSL_EXE=$fake_win\"" \
+    "set \"FIRSTMATE_WSL_TEST_LOG=$log_win\"" \
+    'set "FIRSTMATE_FAKE_EXIT=37"' \
+    'set "FIRSTMATE_NO_PAUSE=1"' \
+    "call \"$batch_root_win\\firstmate.bat\" --print-menu \"two words\"" \
+    'exit /b %ERRORLEVEL%' > "$runner"
+
+  out=$(MSYS2_ARG_CONV_EXCL='*' cmd.exe /d /c "$runner_win" 2>&1) || status=$?
+
+  expect_code 37 "$status" "Windows batch bridge status"
+  assert_grep 'arg1=[--cd]' "$log" "the batch bridge must set WSL's working directory"
+  assert_grep "arg2=[$batch_root_win\\.]" "$log" \
+    "the quoted Windows repository path must remain one argument"
+  assert_grep 'arg3=[--exec]' "$log" "the batch bridge must bypass the distribution login shell"
+  assert_grep 'arg4=[/bin/bash]' "$log" "the batch bridge must select bash explicitly"
+  assert_grep 'arg5=[./bin/fm-wsl-entry.sh]' "$log" \
+    "the batch bridge must enter through the tracked WSL helper"
+  assert_grep 'arg6=[--print-menu]' "$log" "the first forwarded argument must be unchanged"
+  assert_grep 'arg7=[two words]' "$log" "a forwarded argument with spaces must stay intact"
+  assert_contains "$out" "Exit status: 37" \
+    "a failed WSL command must report its propagated status"
+  assert_contains "$out" "wsl --install" \
+    "a failed WSL command must print an actionable WSL repair"
+  pass "firstmate.bat: one explicit WSL command preserves a spaced root, arguments, and exit status"
+}
+
+test_wsl_entry_preserves_root_arguments_and_status
+test_wsl_entry_missing_launcher_is_actionable
+test_batch_constructs_one_deterministic_wsl_command

--- a/tests/fm-wsl-entry.test.sh
+++ b/tests/fm-wsl-entry.test.sh
@@ -8,6 +8,7 @@ set -u
 
 ENTRY="$ROOT/bin/fm-wsl-entry.sh"
 BATCH="$ROOT/firstmate.bat"
+ATTRIBUTES="$ROOT/.gitattributes"
 TMP_ROOT=$(fm_test_tmproot fm-wsl-entry)
 mkdir -p "$TMP_ROOT"
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P) || fail "could not resolve the test temp root"
@@ -135,6 +136,28 @@ test_batch_constructs_one_deterministic_wsl_command() {
   pass "firstmate.bat: one explicit WSL command preserves a spaced root, arguments, and exit status"
 }
 
+test_checkout_pins_bridge_line_endings() {
+  local attrs
+
+  assert_present "$ATTRIBUTES" \
+    "the repository must ship .gitattributes so every checkout normalizes the bridge"
+
+  if ! git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    pass "bridge line endings: checkout normalization is covered from a git checkout"
+    return 0
+  fi
+
+  attrs=$(git -C "$ROOT" check-attr eol -- firstmate.bat bin/fm-wsl-entry.sh 2>&1) \
+    || fail "could not read the checkout attributes for the bridge"
+
+  assert_contains "$attrs" "firstmate.bat: eol: crlf" \
+    "cmd.exe terminates lines with CRLF, so checkouts must deliver firstmate.bat as CRLF"
+  assert_contains "$attrs" "bin/fm-wsl-entry.sh: eol: lf" \
+    "bash rejects CR-terminated scripts, so checkouts must deliver the WSL entry as LF"
+  pass "bridge line endings: checkouts deliver a CRLF batch launcher and an LF WSL entry"
+}
+
 test_wsl_entry_preserves_root_arguments_and_status
 test_wsl_entry_missing_launcher_is_actionable
 test_batch_constructs_one_deterministic_wsl_command
+test_checkout_pins_bridge_line_endings

--- a/tests/fm-wsl-entry.test.sh
+++ b/tests/fm-wsl-entry.test.sh
@@ -9,6 +9,8 @@ set -u
 ENTRY="$ROOT/bin/fm-wsl-entry.sh"
 BATCH="$ROOT/firstmate.bat"
 TMP_ROOT=$(fm_test_tmproot fm-wsl-entry)
+mkdir -p "$TMP_ROOT"
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P) || fail "could not resolve the test temp root"
 
 make_entry_fixture() {  # <root>
   local fixture=$1


### PR DESCRIPTION
## Intent

Implement the Windows-to-WSL launcher bridge for Firstmate by adding the repository-root firstmate.bat and bin/fm-wsl-entry.sh, so a Windows double-click reaches the existing bin/fm-launch.sh harness menu and Herdr launch/attach flow. The bridge must handle Windows repository paths containing spaces, enter WSL deterministically without relying on a login shell or caller working directory, propagate launcher arguments and exit status, and print actionable failures that remain visible after a double-click. Add executable regression coverage for the WSL entry and native batch command construction without requiring a live Windows/WSL session, plus current operator and contributor documentation. This is a new upstream contribution based only on origin/main; the pending launcher PR is a dependency and none of its commits may be copied into this branch. Keep the diff limited to the bridge, its tests/CI coverage, and documentation required to register and operate it. Do not place a launcher in E:/Agentic Engineering or retire any platform launcher in this change.

## What Changed

- Add a repository-root Windows batch launcher and deterministic WSL entrypoint that support spaced paths, forward arguments and exit codes, and keep actionable failures visible.
- Add regression coverage and a Windows CI lane for batch command construction, WSL entry behavior, and platform-specific line endings.
- Document Windows/WSL prerequisites, launch behavior, troubleshooting, and contributor ownership.

## Risk Assessment

✅ Low: The bridge is well-bounded, satisfies the source-verifiable intent, preserves the pending launcher as an uncopied dependency, and includes appropriate portable and native Windows regression coverage.

## Testing

Inspected the base-to-target scope and ancestry, ran the focused bridge suite twice—including its native Windows cmd.exe path—manually captured both sides of the bridge with nonzero status propagation and reviewer-visible CLI transcripts, verified CRLF/LF checkout behavior, and confirmed testing left the worktree clean; all targeted checks passed. No screenshot was captured because the changed end-user surface is a terminal launcher, for which exact native command transcripts are the direct rendered evidence.

<details>
<summary>Evidence: Native Windows batch command construction</summary>

<code>arg1=[--cd]&#10;arg2=[\\wsl.localhost\Ubuntu\tmp\no-mistakes-evidence\01KYWDZ0HAM6ZWX4JPBAGY4WE4\fm-wsl-entry.1Z36Z0\batch case\Firstmate root with spaces\.]&#10;arg3=[--exec]&#10;arg4=[/bin/bash]&#10;arg5=[./bin/fm-wsl-entry.sh]&#10;arg6=[--print-menu]&#10;arg7=[two words]</code>

```text
arg1=[--cd]
arg2=[\\wsl.localhost\Ubuntu\tmp\no-mistakes-evidence\01KYWDZ0HAM6ZWX4JPBAGY4WE4\fm-wsl-entry.1Z36Z0\batch case\Firstmate root with spaces\.]
arg3=[--exec]
arg4=[/bin/bash]
arg5=[./bin/fm-wsl-entry.sh]
arg6=[--print-menu]
arg7=[two words]
```
</details>
<details>
<summary>Evidence: Double-click-visible actionable failure</summary>

<code>Firstmate could not start through WSL. Exit status: 37&#10;Review the error above. If WSL itself did not start, run &#34;wsl --install&#34; and retry.</code>

```text
'\\wsl.localhost\Ubuntu\home\shane\.no-mistakes\worktrees\5f306883d81c\01KYWDZ0HAM6ZWX4JPBAGY4WE4'
CMD.EXE was started with the above path as the current directory.
UNC paths are not supported.  Defaulting to Windows directory.

Firstmate could not start through WSL. Exit status: 37
Review the error above. If WSL itself did not start, run "wsl --install" and retry.
```
</details>
<details>
<summary>Evidence: WSL entry-to-launcher behavior</summary>

<code>cwd=[/tmp/no-mistakes-evidence/01KYWDZ0HAM6ZWX4JPBAGY4WE4/fm-wsl-entry.1Z36Z0/Firstmate repo with spaces]&#10;arg1=[--print-menu]&#10;arg2=[value with spaces]&#10;arg3=[]</code>

```text
cwd=[/tmp/no-mistakes-evidence/01KYWDZ0HAM6ZWX4JPBAGY4WE4/fm-wsl-entry.1Z36Z0/Firstmate repo with spaces]
arg1=[--print-menu]
arg2=[value with spaces]
arg3=[]
```
</details>
<details>
<summary>Evidence: Focused bridge test log</summary>

`All focused launcher checks passed, including native cmd.exe execution.`

```text
ok - fm-wsl-entry: repository paths with spaces, arguments, and exit status pass through unchanged
ok - fm-wsl-entry: a missing fleet launcher refuses with an actionable repair
ok - firstmate.bat: one explicit WSL command preserves a spaced root, arguments, and exit status
ok - bridge line endings: checkouts deliver a CRLF batch launcher and an LF WSL entry
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --check f7d0d0a703a717880656709d7906615505b3f2c0..717739bbca8b9b800acf53491d23fcbd8bef453e`
- `bash tests/fm-wsl-entry.test.sh`
- `TMPDIR=/tmp/no-mistakes-evidence/01KYWDZ0HAM6ZWX4JPBAGY4WE4 bash tests/fm-wsl-entry.test.sh`
- <code>Native `cmd.exe /d /c run-test.cmd` execution using the suite’s fake WSL seam; verified spaced `--cd`, direct `/bin/bash`, entry script, forwarded arguments, visible repair text, and exit status 37</code>
- <code>Direct `bin/fm-wsl-entry.sh --print-menu &#34;value with spaces&#34; &#34;&#34;` fixture execution from `/`; verified repository resolution and exit status 23</code>
- <code>`file firstmate.bat bin/fm-wsl-entry.sh` and `git check-attr eol -- firstmate.bat bin/fm-wsl-entry.sh`</code>
- <code>Ancestry/scope checks with `git merge-base --is-ancestor`, `git diff --name-only`, and `git diff --quiet ... -- bin/fm-launch.sh`</code>
- <code>`git status --short` after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
